### PR TITLE
fix(cron): name the real cause when no model resolves

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1354,6 +1354,45 @@ class _CronJobConfig:
     cron_default_provider: str
 
 
+def _no_model_configured_message(
+    *,
+    job_name: str,
+    job_id: str,
+    job_model: Any,
+    env_model: str,
+    config_load_error: Optional[str] = None,
+) -> str:
+    """Explain why a cron job resolved no model, naming the real cause.
+
+    The loader downgrades any ``config.yaml`` failure to a WARNING and carries
+    on with defaults, so this raise can fire without the file ever being read.
+    Asserting ``model.default`` is "missing or empty" in that case sends the
+    operator to inspect config fields when the file's ownership, permissions or
+    YAML syntax is what actually needs fixing (#81420); the field is frequently
+    populated correctly in a file the service user simply cannot open.
+
+    The remedy follows the cause. ``hermes model <name>`` is dropped from the
+    unreadable branch on purpose: it writes to the very file that cannot be
+    read, so suggesting it sends the operator in a circle.
+    """
+    if config_load_error:
+        cause = f"config.yaml could not be read: {config_load_error}"
+        remedy = (
+            "Fix that file's ownership/permissions or its YAML syntax, or set a "
+            f"per-job model via `hermes cron edit {job_id} --model <name>`."
+        )
+    else:
+        cause = "config.yaml model.default missing or empty"
+        remedy = (
+            f"Set a per-job model via `hermes cron edit {job_id} --model <name>` "
+            "or set a default with `hermes model <name>`."
+        )
+    return (
+        f"Cron job '{job_name}' has no model configured "
+        f"(job.model={job_model!r}, HERMES_MODEL={env_model!r}, {cause}). {remedy}"
+    )
+
+
 def _load_cron_job_config(job: dict, job_id: str, job_name: str) -> _CronJobConfig:
     """Load config.yaml and resolve the run's model: per-job override > cron.model (fleet default) >
     HERMES_MODEL > config ``model:``. Re-read every tick (no cache) so ``hermes cron edit --model``
@@ -1362,6 +1401,9 @@ def _load_cron_job_config(job: dict, job_id: str, job_name: str) -> _CronJobConf
     _cron_default_provider = ""
     _cfg: dict = {}
     _model_cfg: Any = {}
+    # Remembered so a later "no model configured" failure can name the real
+    # cause: an unreadable file says nothing about model.default.
+    _config_load_error: Optional[str] = None
     try:
         from hermes_cli.config import read_user_config_raw
         _cfg_path = str(_get_hermes_home() / "config.yaml")
@@ -1388,19 +1430,20 @@ def _load_cron_job_config(job: dict, job_id: str, job_name: str) -> _CronJobConf
                     if _global_model:
                         model = _global_model
     except Exception as e:
+        _config_load_error = f"{type(e).__name__}: {e}"
         logger.warning("Job '%s': failed to load config.yaml, using defaults: %s", job_id, e)
 
     # Fail fast: an empty model otherwise reaches the provider as an opaque 400.
     # See #23979.
     if not (isinstance(model, str) and model.strip()):
         raise RuntimeError(
-            f"Cron job '{job_name}' has no model configured "
-            f"(job.model={job.get('model')!r}, "
-            f"HERMES_MODEL={os.getenv('HERMES_MODEL', '')!r}, "
-            "config.yaml model.default missing or empty). "
-            f"Set a per-job model via "
-            f"`hermes cron edit {job_id} --model <name>` or set a "
-            "default with `hermes model <name>`."
+            _no_model_configured_message(
+                job_name=job_name,
+                job_id=job_id,
+                job_model=job.get("model"),
+                env_model=os.getenv("HERMES_MODEL", ""),
+                config_load_error=_config_load_error,
+            )
         )
 
     with contextlib.suppress(Exception):

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -650,6 +650,39 @@ def _shutdown_parallel_pool() -> None:
 atexit.register(_shutdown_parallel_pool)
 # Per-fire usage audit log for cron token spend instrumentation.
 # Resolves through _get_hermes_home() so profile-scoped paths work correctly.
+def _no_model_configured_message(
+    *,
+    job_name: str,
+    job_id: str,
+    job_model: Any,
+    env_model: str,
+    config_load_error: Optional[str] = None,
+) -> str:
+    """Explain why a cron job resolved no model, naming the real cause.
+
+    When ``config.yaml`` could not be read, nothing is known about
+    ``model.default`` — asserting it is "missing or empty" sends operators to
+    inspect config fields when the file's ownership, permissions or YAML syntax
+    is what actually needs fixing (#81420). The remedy line follows the cause.
+    """
+    if config_load_error:
+        cause = f"config.yaml could not be read: {config_load_error}"
+        remedy = (
+            "Fix that file's ownership/permissions or its YAML syntax, or set a "
+            f"per-job model via `cronjob action=update job_id={job_id} model=<name>`."
+        )
+    else:
+        cause = "config.yaml model.default missing or empty"
+        remedy = (
+            f"Set a per-job model via `cronjob action=update job_id={job_id} "
+            "model=<name>` or set a default with `hermes model <name>`."
+        )
+    return (
+        f"Cron job '{job_name}' has no model configured "
+        f"(job.model={job_model!r}, HERMES_MODEL={env_model!r}, {cause}). {remedy}"
+    )
+
+
 def _usage_audit_path() -> Path:
     return _get_hermes_home() / "cron" / "usage_audit.jsonl"
 
@@ -3667,6 +3700,10 @@ def run_job(
         # Load config.yaml for model, reasoning, prefill, toolsets, provider routing
         _cfg = {}
         _model_cfg = {}
+        # Remembered so a later "no model configured" failure can name the real
+        # cause. An unreadable file tells us nothing about model.default, so
+        # reporting it as "missing or empty" points operators at the wrong thing.
+        _config_load_error: Optional[str] = None
         try:
             from hermes_cli.config import read_user_config_raw
             _cfg_path = str(_get_hermes_home() / "config.yaml")
@@ -3707,19 +3744,20 @@ def run_job(
                         if _default:
                             model = _default
         except Exception as e:
+            _config_load_error = f"{type(e).__name__}: {e}"
             logger.warning("Job '%s': failed to load config.yaml, using defaults: %s", job_id, e)
 
         # Fail fast if no model resolved from job / env / config.yaml: an empty
         # model otherwise reaches the provider as an opaque 400 (#23979).
         if not (isinstance(model, str) and model.strip()):
             raise RuntimeError(
-                f"Cron job '{job_name}' has no model configured "
-                f"(job.model={job.get('model')!r}, "
-                f"HERMES_MODEL={os.getenv('HERMES_MODEL', '')!r}, "
-                "config.yaml model.default missing or empty). "
-                f"Set a per-job model via "
-                f"`cronjob action=update job_id={job_id} model=<name>` or set a "
-                "default with `hermes model <name>`."
+                _no_model_configured_message(
+                    job_name=job_name,
+                    job_id=job_id,
+                    job_model=job.get("model"),
+                    env_model=os.getenv("HERMES_MODEL", ""),
+                    config_load_error=_config_load_error,
+                )
             )
 
         # Apply IPv4 preference if configured.

--- a/tests/cron/test_no_model_error_cause.py
+++ b/tests/cron/test_no_model_error_cause.py
@@ -1,0 +1,109 @@
+"""A cron job that resolves no model must name the cause it actually observed.
+
+``_load_cron_job_config`` downgrades any ``config.yaml`` failure to a WARNING
+and carries on with defaults. The fail-fast raise below then asserted
+``config.yaml model.default missing or empty`` unconditionally, so an operator
+whose file was merely unreadable (permission denied, bad YAML) was sent to
+inspect config fields instead of the file's ownership and permissions.
+"""
+
+from __future__ import annotations
+
+
+def _message(**kwargs):
+    from cron.scheduler import _no_model_configured_message
+
+    base = {
+        "job_name": "Morning Briefing",
+        "job_id": "abc123",
+        "job_model": None,
+        "env_model": "",
+    }
+    base.update(kwargs)
+    return _no_model_configured_message(**base)
+
+
+def test_unreadable_config_is_not_reported_as_a_missing_field():
+    """The bug: a permission error was reported as 'model.default missing'."""
+    msg = _message(
+        config_load_error="PermissionError: [Errno 13] Permission denied: "
+        "'/home/svc/.hermes/config.yaml'"
+    )
+
+    assert "missing or empty" not in msg, (
+        "an unreadable config was still described as a missing field"
+    )
+    assert "could not be read" in msg
+    assert "Permission denied" in msg
+
+
+def test_unreadable_config_points_at_the_file_not_the_field():
+    """The remedy must follow the cause, or the message is still misleading."""
+    msg = _message(config_load_error="PermissionError: [Errno 13] Permission denied")
+
+    assert "ownership/permissions" in msg
+    # `hermes model <name>` writes to the file that cannot be read.
+    assert "hermes model <name>" not in msg
+
+
+def test_readable_config_keeps_the_original_diagnosis():
+    """Guard: the genuine missing-field case must read as it did before."""
+    msg = _message()
+
+    assert "config.yaml model.default missing or empty" in msg
+    assert "hermes model <name>" in msg
+    assert "could not be read" not in msg
+
+
+def test_message_still_reports_the_other_two_sources():
+    for err in (None, "OSError: boom"):
+        msg = _message(job_model="", env_model="", config_load_error=err)
+        assert "job.model=''" in msg
+        assert "HERMES_MODEL=''" in msg
+        assert "Morning Briefing" in msg
+
+
+def test_the_suggested_command_is_the_current_one():
+    """The remedy must be runnable as printed, in both branches.
+
+    Pinned deliberately: the CLI moved from ``cronjob action=update`` to
+    ``hermes cron edit``, and a stale command in an error message is its own
+    small bug.
+    """
+    for err in (None, "OSError: boom"):
+        msg = _message(job_id="deadbeef", config_load_error=err)
+        assert "hermes cron edit deadbeef --model <name>" in msg
+        assert "cronjob action=update" not in msg
+
+
+def test_end_to_end_unreadable_config_names_the_file(tmp_path, monkeypatch):
+    """Behavioural probe: drive the real loader with a config it cannot read.
+
+    Imported inside the test so the module still collects when the helper is
+    absent, which is what makes the revert failure behavioural rather than an
+    ImportError.
+    """
+    import pytest
+
+    from cron import scheduler as sched
+
+    (tmp_path / "config.yaml").write_text("model:\n  default: gpt-4o\n", encoding="utf-8")
+    monkeypatch.setattr(sched, "_get_hermes_home", lambda: tmp_path)
+
+    def _boom(_path):
+        raise PermissionError(13, "Permission denied", str(tmp_path / "config.yaml"))
+
+    monkeypatch.setattr(
+        "hermes_cli.config.read_user_config_raw", _boom, raising=False
+    )
+    monkeypatch.delenv("HERMES_MODEL", raising=False)
+
+    with pytest.raises(RuntimeError) as exc:
+        sched._load_cron_job_config({"id": "abc123"}, "abc123", "Morning Briefing")
+
+    msg = str(exc.value)
+    assert "could not be read" in msg, (
+        "the unreadable config was still reported as a missing field: " + msg
+    )
+    assert "Permission denied" in msg
+    assert "missing or empty" not in msg

--- a/tests/cron/test_no_model_error_cause.py
+++ b/tests/cron/test_no_model_error_cause.py
@@ -1,0 +1,71 @@
+"""A cron job that resolves no model must name the cause it actually observed.
+
+When ``config.yaml`` fails to load (permission denied, missing, unparseable),
+the loader downgrades it to a WARNING and carries on with defaults. The
+fail-fast error below then claimed ``config.yaml model.default missing or
+empty`` unconditionally, so an operator whose file was merely unreadable was
+sent to inspect config fields instead of the file's ownership and permissions.
+"""
+
+from __future__ import annotations
+
+
+def _message(**kwargs):
+    from cron.scheduler import _no_model_configured_message
+
+    base = {
+        "job_name": "Morning Briefing",
+        "job_id": "abc123",
+        "job_model": None,
+        "env_model": "",
+    }
+    base.update(kwargs)
+    return _no_model_configured_message(**base)
+
+
+def test_unreadable_config_is_not_reported_as_a_missing_field():
+    """The bug: a permission error was reported as 'model.default missing'."""
+    msg = _message(
+        config_load_error="PermissionError: [Errno 13] Permission denied: "
+        "'/home/svc/.hermes/config.yaml'"
+    )
+
+    assert "missing or empty" not in msg, (
+        "an unreadable config was still described as a missing field"
+    )
+    assert "could not be read" in msg
+    assert "Permission denied" in msg
+
+
+def test_unreadable_config_points_at_the_file_not_the_field():
+    """The remedy must follow the cause, or the message is still misleading."""
+    msg = _message(config_load_error="PermissionError: [Errno 13] Permission denied")
+
+    assert "ownership/permissions" in msg
+    # 'hermes model <name>' cannot help while the file is unreadable.
+    assert "hermes model <name>" not in msg
+
+
+def test_readable_config_keeps_the_original_diagnosis():
+    """Guard: the genuine missing-field case must read exactly as before."""
+    msg = _message()
+
+    assert "config.yaml model.default missing or empty" in msg
+    assert "hermes model <name>" in msg
+    assert "could not be read" not in msg
+
+
+def test_message_still_reports_the_other_two_sources():
+    """Both non-config sources stay in the message for either cause."""
+    for err in (None, "OSError: boom"):
+        msg = _message(job_model="", env_model="", config_load_error=err)
+        assert "job.model=''" in msg
+        assert "HERMES_MODEL=''" in msg
+        assert "Morning Briefing" in msg
+
+
+def test_job_id_is_carried_into_the_remedy_command():
+    """The suggested command must be runnable as printed, for either cause."""
+    for err in (None, "OSError: boom"):
+        msg = _message(job_id="deadbeef", config_load_error=err)
+        assert "job_id=deadbeef" in msg


### PR DESCRIPTION
## What does this PR do?

`run_job` loads `config.yaml` inside a try/except that downgrades any failure to a WARNING and carries on with defaults:

```python
except Exception as e:
    logger.warning("Job '%s': failed to load config.yaml, using defaults: %s", job_id, e)

if not (isinstance(model, str) and model.strip()):
    raise RuntimeError(
        f"Cron job '{job_name}' has no model configured "
        f"(job.model={job.get('model')!r}, "
        f"HERMES_MODEL={os.getenv('HERMES_MODEL', '')!r}, "
        "config.yaml model.default missing or empty). "        # <- asserted unconditionally
        ...
    )
```

The error text asserts `model.default missing or empty` whether or not the file was ever read. When the load failed, nothing is known about `model.default` - it is frequently populated correctly in a file the service user simply cannot open.

The two lines an operator sees therefore disagree, and the louder one is wrong:

```
WARNING cron.scheduler: Job '<id>': failed to load config.yaml, using defaults:
                        [Errno 13] Permission denied: '/home/<svc>/.hermes/config.yaml'
ERROR   cron.scheduler: Job 'Morning Briefing' failed: RuntimeError: ... config.yaml
                        model.default missing or empty ...
```

This is easy to reach by accident: any sudo'd installer that rewrites `config.yaml` as root leaves it unreadable by the service user.

### Before and after

Same failure, permission-denied on `config.yaml`:

```
OLD: ... (job.model=None, HERMES_MODEL='', config.yaml model.default missing or empty).
     Set a per-job model via `cronjob action=update job_id=abc123 model=<name>` or set a
     default with `hermes model <name>`.

NEW: ... (job.model=None, HERMES_MODEL='', config.yaml could not be read:
     PermissionError: [Errno 13] Permission denied: '/home/svc/.hermes/config.yaml').
     Fix that file's ownership/permissions or its YAML syntax, or set a per-job model via
     `cronjob action=update job_id=abc123 model=<name>`.
```

The remedy follows the cause. `hermes model <name>` is dropped from the unreadable-config branch on purpose: it writes to the very file that cannot be read, so recommending it sends the operator in a circle.

### The shape of the fix

The load error is remembered, and message construction moves into `_no_model_configured_message()`, a pure module-level helper. That keeps the wording testable without standing up a cron fire, storage, and an agent, which is why this failure had no test coverage before.

## Related Issue

Fixes #81420 (P2, `comp/cron`, `area/config`). Searched open and merged PRs first, per CONTRIBUTING's search-first section:

```
gh search prs --repo NousResearch/hermes-agent "81420"                --limit 20   # 0
gh search prs --repo NousResearch/hermes-agent "model.default missing" --limit 20  # only #50011
gh search prs --repo NousResearch/hermes-agent "cron model resolution" --limit 20  # #50011, #44650
gh search prs --repo NousResearch/hermes-agent "config unreadable"     --limit 20  # nothing on this path
```

#50011 (merged) is what introduced this fail-fast, and it was right to: an empty model reaches the provider as an opaque 400 (#23979). This PR keeps that behaviour exactly and only corrects what the failure claims about its own cause.

## Type of Change

Bug fix (non-breaking) - diagnostics only. The raise condition, its timing, and the exception type are unchanged.

## Changes Made

- `cron/scheduler.py` - added `_no_model_configured_message()`; the config-load `except` now records the error, and the fail-fast raise renders through the helper.
- `tests/cron/test_no_model_error_cause.py` - new, 5 tests.

## How to Test

```
pytest tests/cron/test_no_model_error_cause.py -q
```

5 passed: an unreadable config is not described as a missing field; its remedy points at the file rather than at `hermes model`; the genuine missing-field case still reads exactly as before; both non-config sources survive in either branch; and the printed `cronjob` command carries the real job id in either branch.

Because the helper is new code rather than an edited branch, the before/after proof is the direct rendering comparison shown above: the pre-fix template, copied verbatim from `run_job`, against the shipped helper on the issue's own scenario.

`test_readable_config_keeps_the_original_diagnosis` is the regression probe in the other direction - it fails if this change disturbs the message for a config that loaded fine.

Full `tests/cron/` suite, this branch vs `main`, same environment, run serially:

```
main:   1 failed, 501 passed
branch: 1 failed, 506 passed
```

Comparing the failing sets rather than the counts: **zero regressions**, the two sets are identical. The one failure is pre-existing on both sides (`test_execution_ledger.py::test_restart_marks_interrupted_execution_unknown_without_requeue`). The +5 is this PR's new tests.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(cron): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (queries above)
- [x] My PR contains only changes related to this fix
- [x] I've run the affected suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation - the helper's docstring records why an unreadable file cannot be reported as a missing field
- [x] `cli-config.yaml.example` - N/A, no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` - N/A
- [x] Cross-platform impact - N/A, string formatting; the permission shape in the report is POSIX but the branch is driven by the exception, not the platform
- [x] Tool descriptions/schemas - N/A

## Notes for the reviewer

The exception text carries the config path into the `RuntimeError`. That path is already in the WARNING line immediately above it, so this is not new disclosure, and it is the single most useful token in the message for the reported failure.

One neighbouring case I deliberately left alone: the loader is guarded by `if os.path.exists(_cfg_path)`, so a genuinely absent `config.yaml` raises nothing and still reports `model.default missing or empty`. That reading is defensible (there is no default to find) and no one reported it, so widening the change to a third branch felt like scope I had not earned. Say the word if you would rather it named the absent file too.
