### PR TITLE
fix(teams): authenticate Bot Framework media downloads

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -31,7 +31,7 @@ import os
 import sys
 from contextlib import contextmanager
 from typing import Any, Dict, Iterator, Optional
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 # httpx is imported lazily — only the ``_write_summary_via_incoming_webhook``
 # code path actually constructs an ``AsyncClient``. Top-level import here
@@ -89,7 +89,7 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
-    cache_image_from_url,
+    cache_image_from_bytes,
     cache_media_bytes,
 )
 
@@ -149,6 +149,23 @@ def _coerce_port(value: Any, *, default: int = _DEFAULT_PORT) -> int:
         return int(value)
     except (TypeError, ValueError):
         return default
+
+
+_IMAGE_EXTENSIONS = {
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+}
+
+
+def _image_extension(content_type: str, filename: str = "") -> str:
+    """Choose a safe cache extension from a declared MIME type or filename."""
+    normalized = (content_type or "").split(";", 1)[0].strip().lower()
+    if normalized in _IMAGE_EXTENSIONS:
+        return _IMAGE_EXTENSIONS[normalized]
+    suffix = os.path.splitext(filename or "")[1].lower()
+    return suffix if suffix in set(_IMAGE_EXTENSIONS.values()) else ".jpg"
 
 
 class _StaticAccessTokenProvider:
@@ -871,12 +888,12 @@ class TeamsAdapter(BasePlatformAdapter):
         logger.info("[teams] Disconnected")
 
     async def _fetch_attachment_bytes(self, url: str, timeout: float = 30.0) -> bytes:
-        """Download attachment bytes with SSRF protection.
+        """Download attachment bytes with SSRF protection and Bot Framework auth.
 
-        Teams file attachments carry pre-authenticated SharePoint download
-        URLs (no extra auth header needed). Validates the URL against the
-        SSRF guard and follows redirects through the shared redirect guard,
-        matching the cache_*_from_url helpers in gateway.platforms.base.
+        Teams file attachments use pre-authenticated SharePoint URLs, while
+        Bot Framework media URLs (``smba.trafficmanager.net``) require the
+        bot's current access token.  Both paths keep the shared SSRF and
+        redirect protections before the request is made.
         """
         from tools.url_safety import create_ssrf_safe_async_client, is_safe_url
         from gateway.platforms.base import _ssrf_redirect_guard
@@ -884,15 +901,23 @@ class TeamsAdapter(BasePlatformAdapter):
         if not is_safe_url(url):
             raise ValueError("Blocked unsafe attachment URL (SSRF protection)")
 
+        headers = {"User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)"}
+        host = (urlparse(url).hostname or "").lower()
+        if host == "smba.trafficmanager.net" or host.endswith(".trafficmanager.net"):
+            if not self._app:
+                raise RuntimeError("Teams bot app is unavailable for attachment authentication")
+            token = await self._app._get_bot_token()
+            token_value = str(token or "").strip()
+            if not token_value:
+                raise RuntimeError("Teams bot token is unavailable for attachment authentication")
+            headers["Authorization"] = f"Bearer {token_value}"
+
         async with create_ssrf_safe_async_client(
             timeout=timeout,
             follow_redirects=True,
             event_hooks={"response": [_ssrf_redirect_guard]},
         ) as client:
-            response = await client.get(
-                url,
-                headers={"User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)"},
-            )
+            response = await client.get(url, headers=headers)
             response.raise_for_status()
             return response.content
 
@@ -996,7 +1021,11 @@ class TeamsAdapter(BasePlatformAdapter):
 
             if content_url and content_type.startswith("image/"):
                 try:
-                    cached = await cache_image_from_url(content_url)
+                    # Bot Framework image URLs (smba.trafficmanager.net) are
+                    # protected resources. Fetch through the adapter helper so
+                    # it can attach the bot token; anonymous URL caching gets 401.
+                    data = await self._fetch_attachment_bytes(content_url)
+                    cached = cache_image_from_bytes(data, _image_extension(content_type, att_name))
                     if cached:
                         media_urls.append(cached)
                         media_types.append(content_type)

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -576,22 +576,40 @@ class TestTeamsAttachmentClassification:
         assert event.media_types == ["application/pdf"]
 
     @pytest.mark.anyio
-    async def test_mixed_image_and_document_prefers_document(self):
+    async def test_image_attachment_uses_authenticated_fetch_before_caching(self, monkeypatch):
+        """Bot Framework image URLs require an auth token; never use the anonymous URL helper."""
+        from gateway.platforms.base import MessageType
+
+        adapter = self._make_adapter()
+        adapter._fetch_attachment_bytes = AsyncMock(return_value=b"\x89PNG\r\n\x1a\n fake")
+        monkeypatch.setattr(
+            _teams_mod, "cache_image_from_bytes", lambda *_a, **_k: "/tmp/img.png", raising=False
+        )
+        # The adapter must not regress to the anonymous URL helper.
+        assert not hasattr(_teams_mod, "cache_image_from_url")
+
+        await adapter._on_message(self._make_ctx(self._make_activity([self._image_attachment()])))
+
+        adapter._fetch_attachment_bytes.assert_awaited_once_with("https://smba.example.com/img.png")
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_urls == ["/tmp/img.png"]
+
+    @pytest.mark.anyio
+    async def test_mixed_image_and_document_prefers_document(self, monkeypatch):
         from gateway.platforms.base import MessageType
 
         adapter = self._make_adapter()
         adapter._fetch_attachment_bytes = AsyncMock(return_value=b"%PDF-1.4 fake")
+        monkeypatch.setattr(
+            _teams_mod, "cache_image_from_bytes", lambda *_a, **_k: "/tmp/img.png", raising=False
+        )
 
-        async def fake_cache_image(url, *a, **kw):
-            return "/tmp/img.png"
-
-        with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(_teams_mod, "cache_image_from_url", fake_cache_image)
-            activity = self._make_activity([
-                self._image_attachment(),
-                self._file_download_attachment(),
-            ])
-            await adapter._on_message(self._make_ctx(activity))
+        activity = self._make_activity([
+            self._image_attachment(),
+            self._file_download_attachment(),
+        ])
+        await adapter._on_message(self._make_ctx(activity))
 
         event = adapter.handle_message.call_args[0][0]
         assert event.message_type == MessageType.DOCUMENT


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

