### PR TITLE
fix(email): handle IMAP fetch framing bytes

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -709,35 +709,38 @@ class EmailAdapter(BasePlatformAdapter):
                 for uid in data[0].split():
                     if uid in self._seen_uids:
                         continue
-                    self._seen_uids.add(uid)
-                    # Trim periodically to prevent unbounded memory growth
-                    if len(self._seen_uids) > self._seen_uids_max:
-                        self._trim_seen_uids()
 
                     status, msg_data = imap.uid("fetch", uid, "(RFC822)")
                     if status != "OK":
                         continue
 
-                    # IMAP fetch can return unexpected structures (e.g. a
-                    # single bytes item instead of a list of tuples). Guard
-                    # against IndexError / TypeError so one malformed response
-                    # doesn't abort the batch — the UID is already in
-                    # _seen_uids, so an abort would permanently skip the
-                    # remaining messages in this batch.
-                    try:
-                        raw_email = msg_data[0][1]
-                    except (IndexError, TypeError):
+                    # Providers may include closing bytes alongside the RFC822
+                    # tuple. Find the first actual byte payload rather than
+                    # assuming it is always msg_data[0][1]. Crucially, do not
+                    # mark a UID seen until its raw message was fetched: a
+                    # transient malformed response must be retried next poll,
+                    # not silently discarded forever.
+                    raw_email = None
+                    if isinstance(msg_data, (list, tuple)):
+                        for item in msg_data:
+                            if (
+                                isinstance(item, tuple)
+                                and len(item) >= 2
+                                and isinstance(item[1], (bytes, bytearray))
+                            ):
+                                raw_email = item[1]
+                                break
+                    if raw_email is None:
                         logger.warning(
-                            "[Email] Unexpected IMAP response structure for UID %s, skipping",
+                            "[Email] Unexpected IMAP response structure for UID %s; will retry",
                             uid,
                         )
                         continue
-                    if not isinstance(raw_email, (bytes, bytearray)):
-                        logger.warning(
-                            "[Email] Non-bytes IMAP payload for UID %s, skipping", uid
-                        )
-                        continue
                     msg = email_lib.message_from_bytes(raw_email)
+                    self._seen_uids.add(uid)
+                    # Trim periodically to prevent unbounded memory growth
+                    if len(self._seen_uids) > self._seen_uids_max:
+                        self._trim_seen_uids()
 
                     sender_raw = msg.get("From", "")
                     sender_addr = _extract_email_address(sender_raw)

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -531,6 +531,34 @@ class TestFetchNewMessages(unittest.TestCase):
         self.assertEqual(results[0]["sender_addr"], "user@test.com")
         self.assertIn(b"3", adapter._seen_uids)
 
+    def test_fetch_accepts_payload_after_imap_closing_bytes(self):
+        """Fetch results may contain non-payload bytes before the RFC822 tuple."""
+        adapter = self._make_adapter()
+        raw_email = MIMEText("Hello", "plain", "utf-8")
+        raw_email["From"] = "user@test.com"
+        raw_email["Subject"] = "Test"
+        raw_email["Message-ID"] = "<msg@test.com>"
+
+        mock_imap = MagicMock()
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"1"])
+            if command == "fetch":
+                # Some IMAP servers add protocol-closing bytes to the result.
+                # The adapter must find the actual RFC822 tuple rather than
+                # assuming the payload is always data[0][1].
+                return ("OK", [b")", (b"1", raw_email.as_bytes())])
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["sender_addr"], "user@test.com")
+        self.assertIn(b"1", adapter._seen_uids)
+
 
 class TestPollLoop(unittest.TestCase):
     """Test the async polling loop."""


### PR DESCRIPTION
## Summary
- locate the RFC822 tuple in IMAP FETCH responses instead of assuming it is always `data[0][1]`
- only mark a UID seen after extracting a valid raw message, so malformed/transient responses retry
- add regression coverage for protocol-framing bytes preceding the payload

## Verification
- `/Users/claw/.hermes/hermes-agent/venv/bin/python -m unittest tests.gateway.test_email -v` (33 tests passed)

## Reproduction
AgentMail returned an IMAP FETCH response containing non-payload framing bytes alongside the RFC822 tuple. The prior fixed-index extraction could skip the message permanently after marking its UID seen.