### PR TITLE
fix(browser): scroll target into view before click

### DIFF
--- a/tests/tools/test_browser_private_page_action_guard.py
+++ b/tests/tools/test_browser_private_page_action_guard.py
@@ -56,7 +56,10 @@ def test_click_still_runs_when_current_page_is_public(monkeypatch):
     out = json.loads(browser_tool.browser_click("e1", task_id="task-1"))
 
     assert out == {"success": True, "clicked": "@e1"}
-    assert calls == [("task-1", "click", ["@e1"])]
+    assert calls == [
+        ("task-1", "scrollintoview", ["@e1"]),
+        ("task-1", "click", ["@e1"]),
+    ]
 
 
 def test_guard_inactive_does_not_block_or_probe(monkeypatch):
@@ -82,7 +85,35 @@ def test_guard_inactive_does_not_block_or_probe(monkeypatch):
     out = json.loads(browser_tool.browser_click("@e1", task_id="task-1"))
 
     assert out == {"success": True, "clicked": "@e1"}
-    assert calls == [("task-1", "click", ["@e1"])]
+    assert calls == [
+        ("task-1", "scrollintoview", ["@e1"]),
+        ("task-1", "click", ["@e1"]),
+    ]
+
+
+def test_click_scrolls_into_view_before_click(monkeypatch):
+    """Off-screen targets get a no-op success from agent-browser click unless
+    scrolled into view first. browser_click must call scrollintoview before
+    click, and must still click even if scrollintoview fails."""
+    calls = []
+
+    monkeypatch.setattr(browser_tool, "_eval_ssrf_guard_active", lambda task_id: False)
+
+    def fake_run(task_id, command, args):
+        calls.append((command, list(args)))
+        if command == "scrollintoview":
+            return {"success": False, "error": "unknown ref"}
+        return {"success": True}
+
+    monkeypatch.setattr(browser_tool, "_run_browser_command", fake_run)
+
+    out = json.loads(browser_tool.browser_click("@e7", task_id="task-1"))
+
+    assert out == {"success": True, "clicked": "@e7"}
+    assert calls == [
+        ("scrollintoview", ["@e7"]),
+        ("click", ["@e7"]),
+    ]
 
 
 def test_camofox_short_circuits_before_guard(monkeypatch):

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -3292,6 +3292,12 @@ def browser_click(ref: str, task_id: Optional[str] = None) -> str:
     if not ref.startswith("@"):
         ref = f"@{ref}"
 
+    # agent-browser's click does not reliably auto-scroll targets into view.
+    # Off-screen elements report success while firing zero DOM click/submit
+    # events. Scroll first; ignore scroll failures so CSS-selector clicks and
+    # already-visible targets still proceed.
+    _run_browser_command(effective_task_id, "scrollintoview", [ref])
+
     result = _run_browser_command(effective_task_id, "click", [ref])
 
     if result.get("success"):


### PR DESCRIPTION
## Bug Description

`browser_click` reports success for elements that are outside the viewport, but the underlying `agent-browser click` fires **zero** DOM click/submit events. Agents then believe they clicked Submit (or any below-the-fold control) when nothing happened.

## Root Cause

`agent-browser` does not reliably auto-scroll the click target into view. On a default headless viewport (~633px tall), controls further down the page (common on long forms and multi-section pages) sit below the fold. A click at those coordinates is a silent no-op while still returning success.

## Fix

Call `scrollintoview` on the target ref immediately before `click` in `browser_click`. Scroll failures are ignored so already-visible targets and CSS-selector clicks still proceed.

```python
_run_browser_command(effective_task_id, "scrollintoview", [ref])
result = _run_browser_command(effective_task_id, "click", [ref])
```

## How to Verify

1. Open a page where the click target is below the fold (long form, tall layout).
2. Take a snapshot and note the Submit / button ref.
3. Without this fix: `browser_click` returns success, page state unchanged, no DOM events.
4. With this fix: target scrolls into view, click fires, page advances / form submits.

## Test Plan

- [x] Added regression test: `test_click_scrolls_into_view_before_click` (scroll called first; click still runs if scroll fails)
- [x] Updated existing `browser_click` call-sequence assertions
- [x] `pytest tests/tools/test_browser_private_page_action_guard.py` — 10 passed
- [x] Manual verification on a long form (below-fold Submit)

## Risk Assessment

**Low** — one extra best-effort `scrollintoview` before every click. Failures are ignored; private-page SSRF guard still runs first; Camofox path is unchanged.