### PR TITLE
feat(buzz): publish native presence (kind 20001) from the adapter

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -107,6 +107,13 @@ _WS_MAX_MESSAGE_BYTES = 2_000_000
 _WS_MEMBERSHIP_KIND = 44100
 _WS_MEMBERSHIP_SUB_ID = "hermes-buzz-membership"
 
+# Presence heartbeat (kind 20001, ephemeral). The relay stores presence in
+# Redis with a 180s TTL; the Desktop re-publishes every 60s. Matching that
+# cadence (60s) keeps the agent green while the gateway runs — do NOT use
+# 120s+: cron-drift experience showed 2-minute intervals can exceed the TTL.
+_PRESENCE_KIND = 20001
+_PRESENCE_HEARTBEAT_INTERVAL = 60.0
+
 # Where to look for a credentials JSON (keys: nsec / private_key_hex) when
 # BUZZ_PRIVATE_KEY is not set.  Module-level so tests can point it at a tmpdir.
 _DEFAULT_CREDENTIALS_DIR = Path("~/.config/buzz").expanduser()
@@ -426,6 +433,14 @@ class BuzzAdapter(BasePlatformAdapter):
         self._ws_task: Optional[asyncio.Task] = None
         self._ws_ready: Optional[asyncio.Event] = None
         self._ws_active = False  # True while the WS loop owns inbound delivery
+        self._ws_connection = None  # live websocket, while connected (presence)
+        # Presence publishing (kind 20001 heartbeats) — disabled via
+        # BUZZ_NO_PRESENCE env var or ``no_presence: true`` in config extra,
+        # for parity with buzz-acp's BUZZ_ACP_NO_PRESENCE.
+        _no_presence = (
+            os.getenv("BUZZ_NO_PRESENCE") or str(extra.get("no_presence", False) or False)
+        ).strip().lower()
+        self._presence_enabled = _no_presence not in ("1", "true", "yes", "on")
         self._membership_since = 0
         self._lock_key: Optional[str] = None
         # channel_id -> {"chat_type", "last_ts", "seen": OrderedDict[event_id, None]}
@@ -580,6 +595,15 @@ class BuzzAdapter(BasePlatformAdapter):
                 pass
             self._lock_key = None
         self._ws_active = False
+        ws = self._ws_connection
+        if ws is not None and self._presence_enabled:
+            try:
+                await self._publish_presence(ws, "offline")
+            except Exception:
+                # Relay may already be gone; it auto-clears presence when the
+                # last WS connection for the pubkey closes anyway.
+                logger.info("Buzz: offline presence publish skipped (connection closing)")
+        self._ws_connection = None
         if self._ws_task and not self._ws_task.done():
             self._ws_task.cancel()
             try:
@@ -836,6 +860,46 @@ class BuzzAdapter(BasePlatformAdapter):
             await self._send_channel_subscription(websocket, subscription_id, channel_id)
             logger.info("Buzz: subscribed to new conversation %s", channel_id)
 
+    # ── Presence (kind 20001 heartbeats) ─────────────────────────────────
+
+    async def _publish_presence(self, websocket, status: str) -> None:
+        """Sign and publish a presence event over the authenticated WS.
+
+        Ephemeral kinds are rejected by the relay's HTTP bridge, so presence
+        always goes over the live WebSocket. Fire-and-forget from the caller's
+        perspective: the relay answers OK but we do not wait for it — a missed
+        heartbeat is healed by the next one.
+        """
+        build_presence_event = _load_nostr_auth().build_presence_event
+        # Pure-Python secp256k1 signing is CPU-bound (~50ms/event); run it in
+        # the default executor so the inbound event pump is never stalled.
+        event = await asyncio.get_running_loop().run_in_executor(
+            None,
+            lambda: build_presence_event(
+                private_key=self._private_key, status=status
+            ),
+        )
+        await websocket.send(json.dumps(["EVENT", event], separators=(",", ":")))
+
+    async def _presence_heartbeat(self, websocket, status: str) -> None:
+        """Publish presence immediately, then every 60s until cancelled.
+
+        Runs as a side task on the live WS connection so the inbound event
+        pump is never blocked. Failures are logged and retried on the next
+        tick — presence is best-effort.
+        """
+        try:
+            while True:
+                try:
+                    await self._publish_presence(websocket, status)
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.warning("Buzz: presence publish failed", exc_info=True)
+                await asyncio.sleep(_PRESENCE_HEARTBEAT_INTERVAL)
+        except asyncio.CancelledError:
+            raise
+
     async def _websocket_loop(self) -> None:
         """Persistent authenticated subscription with bounded reconnect
         backoff. Events route through _handle_event() — identical semantics
@@ -859,35 +923,55 @@ class BuzzAdapter(BasePlatformAdapter):
                         await self._authenticate_websocket(websocket)
                         subscriptions = await self._subscribe_websocket(websocket)
                         self._ws_active = True
+                        self._ws_connection = websocket
                         if self._ws_ready is not None:
                             self._ws_ready.set()
                         backoff = 1.0
-                        async for raw in websocket:
-                            try:
-                                message = json.loads(raw)
-                            except (ValueError, TypeError):
-                                logger.warning("Buzz: ignoring malformed WebSocket frame")
-                                continue
-                            if not isinstance(message, list) or not message:
-                                continue
-                            if message[0] == "EVENT" and len(message) >= 3:
-                                subscription_id = str(message[1])
-                                event = message[2]
-                                if not isinstance(event, dict):
+                        # Presence heartbeats run as a side task on this same
+                        # connection (ephemeral kinds must go over WS, never
+                        # the HTTP bridge). It publishes "online" immediately,
+                        # then every 60s; cancelled when the connection drops.
+                        presence_task = None
+                        if self._presence_enabled:
+                            presence_task = asyncio.create_task(
+                                self._presence_heartbeat(websocket, "online")
+                            )
+                        try:
+                            async for raw in websocket:
+                                try:
+                                    message = json.loads(raw)
+                                except (ValueError, TypeError):
+                                    logger.warning("Buzz: ignoring malformed WebSocket frame")
                                     continue
-                                if subscription_id == _WS_MEMBERSHIP_SUB_ID:
-                                    await self._handle_membership_event(websocket, subscriptions, event)
+                                if not isinstance(message, list) or not message:
                                     continue
-                                channel_id = subscriptions.get(subscription_id)
-                                state = self._channel_state.get(channel_id or "")
-                                if channel_id and state is not None:
-                                    await self._handle_event(channel_id, state, event)
-                                    self._trim_seen(state)
-                            elif message[0] == "CLOSED":
-                                detail = message[-1] if len(message) > 2 else "subscription closed"
-                                raise ConnectionError(str(detail))
-                            elif message[0] == "NOTICE":
-                                logger.warning("Buzz: relay notice: %s", message[-1])
+                                if message[0] == "EVENT" and len(message) >= 3:
+                                    subscription_id = str(message[1])
+                                    event = message[2]
+                                    if not isinstance(event, dict):
+                                        continue
+                                    if subscription_id == _WS_MEMBERSHIP_SUB_ID:
+                                        await self._handle_membership_event(websocket, subscriptions, event)
+                                        continue
+                                    channel_id = subscriptions.get(subscription_id)
+                                    state = self._channel_state.get(channel_id or "")
+                                    if channel_id and state is not None:
+                                        await self._handle_event(channel_id, state, event)
+                                        self._trim_seen(state)
+                                elif message[0] == "CLOSED":
+                                    detail = message[-1] if len(message) > 2 else "subscription closed"
+                                    raise ConnectionError(str(detail))
+                                elif message[0] == "NOTICE":
+                                    logger.warning("Buzz: relay notice: %s", message[-1])
+                        finally:
+                            if presence_task is not None:
+                                presence_task.cancel()
+                                try:
+                                    await presence_task
+                                except asyncio.CancelledError:
+                                    pass
+                            if self._ws_connection is websocket:
+                                self._ws_connection = None
                 except asyncio.CancelledError:
                     raise
                 except Exception as e:

--- a/plugins/platforms/buzz/nostr_auth.py
+++ b/plugins/platforms/buzz/nostr_auth.py
@@ -228,3 +228,52 @@ def build_auth_event(
             auxiliary_randomness=auxiliary_randomness,
         ).hex(),
     }
+
+
+# Kind 20001 — ephemeral presence heartbeat (relay stores with a 180s TTL;
+# desktop and agents re-publish every 60s).
+KIND_PRESENCE_UPDATE = 20001
+
+
+def build_presence_event(
+    *,
+    private_key: str,
+    status: str,
+    created_at: Optional[int] = None,
+    auxiliary_randomness: Optional[bytes] = None,
+) -> dict[str, Any]:
+    """Build a self-signed kind 20001 presence event.
+
+    ``status`` must be ``"online"``, ``"away"``, or ``"offline"``. The bare
+    status string is the content (the relay and Desktop read it there); a
+    ``["status", status]`` tag mirrors buzz-sdk's ``build_presence_update``
+    for structured access. No p-tags — the Desktop's live path trusts
+    author = subject.
+
+    Ephemeral kinds (20000-29999) are rejected by the relay's HTTP bridge, so
+    this event must be published over an authenticated WebSocket.
+    """
+    if status not in ("online", "away", "offline"):
+        raise ValueError("status must be online, away, or offline")
+    pubkey = public_key_hex(private_key)
+    timestamp = int(time.time()) if created_at is None else int(created_at)
+    tags: list[list[str]] = [["status", status]]
+    serialized = json.dumps(
+        [0, pubkey, timestamp, KIND_PRESENCE_UPDATE, tags, status],
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode()
+    event_id = hashlib.sha256(serialized).digest()
+    return {
+        "id": event_id.hex(),
+        "pubkey": pubkey,
+        "created_at": timestamp,
+        "kind": KIND_PRESENCE_UPDATE,
+        "tags": tags,
+        "content": status,
+        "sig": schnorr_sign(
+            event_id,
+            private_key,
+            auxiliary_randomness=auxiliary_randomness,
+        ).hex(),
+    }

--- a/tests/gateway/test_buzz_websocket.py
+++ b/tests/gateway/test_buzz_websocket.py
@@ -8,6 +8,7 @@ lifecycle as wired into BuzzAdapter.
 
 import asyncio
 import json
+import sys
 import time
 
 import pytest
@@ -117,5 +118,129 @@ async def test_websocket_auth_raises_on_rejection():
 
     with pytest.raises(ConnectionError):
         await adapter._authenticate_websocket(RejectingWs())
+
+
+# ── Presence (kind 20001 heartbeats) ────────────────────────────────────
+
+
+def test_build_presence_event_shape():
+    event = nostr_auth.build_presence_event(
+        private_key=TEST_PRIVATE_KEY,
+        status="online",
+        created_at=1_700_000_000,
+        auxiliary_randomness=bytes(32),
+    )
+    assert event["kind"] == 20001
+    assert event["content"] == "online"
+    assert event["tags"] == [["status", "online"]]
+    assert event["pubkey"] == nostr_auth.public_key_hex(TEST_PRIVATE_KEY)
+    assert len(bytes.fromhex(event["sig"])) == 64
+    # No p-tags — the Desktop's live path trusts author = subject.
+    assert not any(tag[0] == "p" for tag in event["tags"])
+
+
+def test_build_presence_event_rejects_bad_status():
+    with pytest.raises(ValueError):
+        nostr_auth.build_presence_event(private_key=TEST_PRIVATE_KEY, status="brb")
+
+
+@pytest.mark.asyncio
+async def test_publish_presence_sends_event_over_ws():
+    adapter = _make_adapter()
+    ws = _FakeWebSocket()
+    await adapter._publish_presence(ws, "online")
+    assert len(ws.sent) == 1
+    frame = ws.sent[0]
+    assert frame[0] == "EVENT"
+    event = frame[1]
+    assert event["kind"] == 20001
+    assert event["content"] == "online"
+    assert event["pubkey"] == nostr_auth.public_key_hex(TEST_PRIVATE_KEY)
+
+
+@pytest.mark.asyncio
+async def test_presence_heartbeat_publishes_immediately_then_cancels():
+    adapter = _make_adapter()
+    ws = _FakeWebSocket()
+    task = asyncio.create_task(adapter._presence_heartbeat(ws, "online"))
+    await asyncio.sleep(0.3)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert len(ws.sent) >= 1
+    assert ws.sent[0][1]["content"] == "online"
+
+
+def test_presence_disabled_via_env(monkeypatch):
+    monkeypatch.setenv("BUZZ_NO_PRESENCE", "1")
+    assert _make_adapter()._presence_enabled is False
+    monkeypatch.delenv("BUZZ_NO_PRESENCE")
+    assert _make_adapter()._presence_enabled is True
+
+
+class _ConnectCtx:
+    def __init__(self, ws_factory):
+        self._ws_factory = ws_factory
+
+    async def __aenter__(self):
+        return self._ws_factory()
+
+    async def __aexit__(self, *args):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_websocket_loop_publishes_presence_and_cancels_task(monkeypatch):
+    adapter = _make_adapter()
+    adapter._channel_state = {CHANNEL: {"chat_type": "group", "last_ts": 0, "seen": {}}}
+    adapter._membership_since = int(time.time())
+    sent = []
+
+    class LoopWs:
+        def __init__(self):
+            self.sent = sent
+
+        async def recv(self):
+            if not any(f[0] == "AUTH" for f in self.sent):
+                return json.dumps(["AUTH", "relay-challenge"])
+            if self.sent and self.sent[0][0] == "AUTH":
+                auth_event = self.sent[0][1]
+                return json.dumps(["OK", auth_event["id"], True, "ok"])
+            await asyncio.sleep(60)  # hang until the loop is cancelled
+
+        async def send(self, raw):
+            sent.append(json.loads(raw))
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            await asyncio.sleep(60)  # hang until the loop is cancelled
+            raise StopAsyncIteration
+
+    import types
+
+    fake_websockets = types.SimpleNamespace(connect=lambda *a, **k: _ConnectCtx(LoopWs))
+    monkeypatch.setitem(sys.modules, "websockets", fake_websockets)
+
+    task = asyncio.create_task(adapter._websocket_loop())
+    try:
+        for _ in range(100):
+            if any(
+                f[0] == "EVENT" and f[1].get("kind") == 20001 for f in sent
+            ):
+                break
+            await asyncio.sleep(0.02)
+        presence_frames = [
+            f for f in sent if f[0] == "EVENT" and f[1].get("kind") == 20001
+        ]
+        assert presence_frames, "presence event was never published"
+        assert presence_frames[0][1]["content"] == "online"
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
 
 

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -118,6 +118,7 @@ Check status with `hermes gateway status` — Buzz connection state is reported 
 ## Notes and limitations
 
 - **Inbound is polled, not streamed.** The `buzz` CLI is request/response, so the adapter polls `buzz messages get` per watched channel every `poll_interval` seconds (default 4). Expect up to one interval of latency on inbound messages. A future optimization is a websocket transport (the Buzz repo ships `buzz-ws-client` for true streaming).
+- **Presence is native.** When the WebSocket transport is active, the adapter publishes kind 20001 presence heartbeats ("online" on connect, then every 60s, "offline" on graceful shutdown) over the authenticated socket, so Buzz Desktop shows the agent online while the gateway runs. Disable with `BUZZ_NO_PRESENCE=1` or `no_presence: true` in the adapter's config extra.
 - On (re)connect the adapter seeds its high-water mark from the newest events, so channel history is never replayed into the agent.
 - New DM conversations are discovered automatically (every few poll sweeps).
 - The private key is passed to the CLI via the subprocess environment — it never appears in argv or logs.


### PR DESCRIPTION
## What
The Buzz adapter now publishes kind 20001 presence heartbeats over the authenticated WebSocket: "online" on connect, then every 60s, "offline" on graceful shutdown. Disable via `BUZZ_NO_PRESENCE` env or `no_presence: true` in the adapter's config extra.

## Why
Buzz presence is not derived from a live socket. It is kind 20001 ephemeral heartbeat events stored in Redis with a 180s TTL (contract: publish on connect, heartbeat every 60s). The adapter sent none, so agents always read as offline in Buzz Desktop after 3 minutes, even with the socket connected and messages flowing. Ephemeral kinds (20000-29999) are rejected by the relay HTTP bridge, so presence must go over the WS path.

## Implementation notes
- `_publish_presence` signs in the default executor (pure-Python secp256k1 is ~50ms/event) so the inbound pump is never stalled
- Heartbeat runs as a side task on the WS loop; cancelled on disconnect
- No p-tags (Desktop's live path trusts author = subject); content is the bare status string
- Presence is a side task — no synthetic user messages, no prompt-cache impact

## Tests
6 new tests in tests/gateway/test_buzz_websocket.py: event shape (kind 20001, content "online", no p-tags), bad-status rejection, publish over mock WS, heartbeat publish+cancel, env toggle, and a full WS-loop lifecycle test (presence task starts and cancels cleanly). 33/33 buzz tests pass.

## Watch for
- The WS-loop restructure wraps the inbound `async for` in try/finally to cancel the presence task — verify no regressions in reconnect behavior.