### PR TITLE
feat(desktop): add composer render edit bridge

### DIFF
--- a/apps/desktop/src/app/chat/composer/contrib-bridge.test.ts
+++ b/apps/desktop/src/app/chat/composer/contrib-bridge.test.ts
@@ -1,0 +1,293 @@
+import type { RefObject } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { type ComposerRenderContext, createComposerRenderContext } from './contrib'
+import { composerPlainText, placeCaretEnd, renderComposerContents } from './rich-editor'
+import { createComposerUndoHistory } from './undo-history'
+
+/**
+ * The render-area edit bridge is the acceptance surface of the composer
+ * render seam: a composer.actions plugin inserting text must (1) land on the
+ * app undo stack (recordUndoPoint fires BEFORE the DOM mutation), (2) be
+ * selection-aware (replaces the live selection, caret lands after the insert),
+ * (3) go through the app's own DOM pipeline (Range-based chip/text rendering,
+ * never innerHTML). The IME guard exists because inserting into a live preedit
+ * corrupts it — the exact bug class the execCommand path had.
+ */
+
+function makeEditor(text: string) {
+  const editor = document.createElement('div')
+  editor.dataset.slot = 'composer-rich-input'
+  editor.append(...text.split('\n').flatMap((line, i) => (i > 0 ? [document.createElement('br'), line] : [line])))
+  document.body.append(editor)
+
+  return editor
+}
+
+function selectRange(editor: HTMLElement, start: number, end: number) {
+  const findTextAt = (offset: number): { node: Text; offset: number } => {
+    const walker = document.createTreeWalker(editor, NodeFilter.SHOW_TEXT)
+    let remaining = offset
+    let node: Text | null
+
+    while ((node = walker.nextNode() as Text | null)) {
+      const length = node.textContent?.length ?? 0
+
+      if (remaining <= length) {
+        return { node, offset: remaining }
+      }
+
+      remaining -= length
+    }
+
+    throw new Error('offset past end of editor text')
+  }
+
+  const startPoint = findTextAt(start)
+  const endPoint = findTextAt(end)
+  const range = document.createRange()
+
+  range.setStart(startPoint.node, startPoint.offset)
+  range.setEnd(endPoint.node, endPoint.offset)
+
+  const selection = window.getSelection()!
+
+  selection.removeAllRanges()
+  selection.addRange(range)
+
+  return selection
+}
+
+function selectNode(node: Node) {
+  const range = document.createRange()
+  range.selectNode(node)
+
+  const selection = window.getSelection()!
+  selection.removeAllRanges()
+  selection.addRange(range)
+}
+
+interface Harness {
+  ctx: ComposerRenderContext
+  editor: HTMLElement
+  recordUndoPoint: ReturnType<typeof vi.fn>
+  scheduleFlushEditorToDraft: ReturnType<typeof vi.fn>
+  composing: { current: boolean }
+}
+
+function makeHarness(text: string): Harness {
+  const editor = makeEditor(text)
+  const composing = { current: false }
+  const recordUndoPoint = vi.fn()
+  const scheduleFlushEditorToDraft = vi.fn()
+
+  const ctx = createComposerRenderContext({
+    editorRef: { current: editor } as RefObject<HTMLDivElement | null>,
+    composingRef: composing,
+    recordUndoPoint,
+    scheduleFlushEditorToDraft
+  })
+
+  return { ctx, editor, recordUndoPoint, scheduleFlushEditorToDraft, composing }
+}
+
+afterEach(() => {
+  document.body.replaceChildren()
+})
+
+describe('createComposerRenderContext().insertText', () => {
+  it('replaces the live selection and lands the caret after the insert', () => {
+    const { ctx, editor } = makeHarness('hello world')
+    selectRange(editor, 0, 5)
+
+    ctx.insertText('**hello**')
+
+    expect(editor.textContent).toBe('**hello** world')
+
+    // Caret in composerPlainText coordinates sits right after the insert.
+    // (jsdom's Range.insertNode leaves a zero-length split node before the
+    // inserted text — same litter Chromium produces around chip edits — so
+    // assert position semantically, not by node identity.)
+    const caret = window.getSelection()!.getRangeAt(0)
+    const before = document.createRange()
+
+    before.selectNodeContents(editor)
+    before.setEnd(caret.startContainer, caret.startOffset)
+
+    const scratch = document.createElement('div')
+
+    scratch.append(before.cloneContents())
+
+    expect(scratch.textContent).toBe('**hello**')
+  })
+
+  it('inserts at the caret when the selection is collapsed', () => {
+    const { ctx, editor } = makeHarness('hello world')
+    selectRange(editor, 5, 5)
+
+    ctx.insertText(' there')
+
+    expect(editor.textContent).toBe('hello there world')
+  })
+
+  it('banks the pre-edit state BEFORE the DOM mutation (undo acceptance)', async () => {
+    const { ctx, editor, recordUndoPoint } = makeHarness('hello world')
+    selectRange(editor, 0, 5)
+
+    const calls: string[] = []
+
+    recordUndoPoint.mockImplementation(() => calls.push('record'))
+
+    const probe = new MutationObserver(() => calls.push('mutate'))
+
+    probe.observe(editor, { childList: true, subtree: true, characterData: true })
+    ctx.insertText('**hello**')
+
+    // The undo point is synchronous and lands before the first DOM mutation;
+    // the observer's callback fires on the microtask queue.
+    await new Promise(resolve => setTimeout(resolve, 0))
+    probe.disconnect()
+
+    expect(calls).toEqual(['record', 'mutate'])
+  })
+
+  it('no-ops without an editor', () => {
+    const recordUndoPoint = vi.fn()
+    const scheduleFlushEditorToDraft = vi.fn()
+
+    const noop = createComposerRenderContext({
+      editorRef: { current: null } as RefObject<HTMLDivElement | null>,
+      composingRef: { current: false },
+      recordUndoPoint,
+      scheduleFlushEditorToDraft
+    })
+
+    noop.insertText('**x**')
+
+    expect(recordUndoPoint).not.toHaveBeenCalled()
+    expect(scheduleFlushEditorToDraft).not.toHaveBeenCalled()
+  })
+
+  it('no-ops during IME composition (never corrupt a preedit)', () => {
+    const { ctx, editor, recordUndoPoint, scheduleFlushEditorToDraft, composing } = makeHarness('hello')
+    composing.current = true
+
+    ctx.insertText('**x**')
+
+    expect(editor.textContent).toBe('hello')
+    expect(recordUndoPoint).not.toHaveBeenCalled()
+    expect(scheduleFlushEditorToDraft).not.toHaveBeenCalled()
+  })
+
+  it('flushes the draft state after the insert', () => {
+    const { ctx, editor, scheduleFlushEditorToDraft } = makeHarness('hello')
+    selectRange(editor, 5, 5)
+
+    ctx.insertText('!')
+
+    expect(scheduleFlushEditorToDraft).toHaveBeenCalledWith(editor)
+  })
+
+  it('keeps an empty insert a true no-op without touching the undo hook', () => {
+    const { ctx, editor, recordUndoPoint, scheduleFlushEditorToDraft } = makeHarness('hello')
+    selectRange(editor, 5, 5)
+
+    ctx.insertText('')
+
+    expect(editor.textContent).toBe('hello')
+    expect(recordUndoPoint).not.toHaveBeenCalled()
+    expect(scheduleFlushEditorToDraft).not.toHaveBeenCalled()
+  })
+
+  it('deletes a non-collapsed selection when the replacement is empty', () => {
+    const { ctx, editor, recordUndoPoint, scheduleFlushEditorToDraft } = makeHarness('hello world')
+    selectRange(editor, 0, 5)
+
+    ctx.insertText('')
+
+    expect(editor.textContent).toBe(' world')
+    expect(recordUndoPoint).toHaveBeenCalledTimes(1)
+    expect(scheduleFlushEditorToDraft).toHaveBeenCalledWith(editor)
+  })
+
+  it('preserves redo after an empty insert', () => {
+    const editor = makeEditor('hello')
+    const history = createComposerUndoHistory()
+
+    const recordUndoPoint = vi.fn(() => {
+      const text = composerPlainText(editor)
+
+      history.record({ caret: text.length, text })
+    })
+
+    const ctx = createComposerRenderContext({
+      editorRef: { current: editor } as RefObject<HTMLDivElement | null>,
+      composingRef: { current: false },
+      recordUndoPoint,
+      scheduleFlushEditorToDraft: vi.fn()
+    })
+
+    selectRange(editor, 5, 5)
+    ctx.insertText('!')
+
+    const afterInsert = { caret: composerPlainText(editor).length, text: composerPlainText(editor) }
+    const undone = history.undo(afterInsert)
+
+    expect(undone?.text).toBe('hello')
+    editor.replaceChildren(document.createTextNode(undone!.text))
+    ctx.insertText('')
+
+    const redone = history.redo({ caret: composerPlainText(editor).length, text: composerPlainText(editor) })
+
+    expect(redone?.text).toBe('hello!')
+    expect(recordUndoPoint).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps an identical selection replacement a true no-op', () => {
+    const { ctx, editor, recordUndoPoint, scheduleFlushEditorToDraft } = makeHarness('hello world')
+    selectRange(editor, 0, 5)
+
+    ctx.insertText('hello')
+
+    expect(editor.textContent).toBe('hello world')
+    expect(recordUndoPoint).not.toHaveBeenCalled()
+    expect(scheduleFlushEditorToDraft).not.toHaveBeenCalled()
+  })
+
+  it('preserves redo for an identical chip replacement', () => {
+    const value = '@url:`https://example.dev`'
+    const editor = makeEditor(`hello ${value}`)
+    renderComposerContents(editor, `hello ${value}`)
+    const history = createComposerUndoHistory()
+
+    const recordUndoPoint = vi.fn(() => {
+      history.record({ caret: composerPlainText(editor).length, text: composerPlainText(editor) })
+    })
+
+    const ctx = createComposerRenderContext({
+      editorRef: { current: editor } as RefObject<HTMLDivElement | null>,
+      composingRef: { current: false },
+      recordUndoPoint,
+      scheduleFlushEditorToDraft: vi.fn()
+    })
+
+    placeCaretEnd(editor)
+    ctx.insertText('!')
+
+    const afterInsert = { caret: composerPlainText(editor).length, text: composerPlainText(editor) }
+    const undone = history.undo(afterInsert)
+
+    expect(undone?.text).toBe(`hello ${value}`)
+    renderComposerContents(editor, undone!.text)
+    const chip = editor.querySelector('[data-ref-text]')
+    expect(chip).not.toBeNull()
+    selectNode(chip!)
+
+    ctx.insertText(value)
+
+    const redone = history.redo({ caret: composerPlainText(editor).length, text: composerPlainText(editor) })
+
+    expect(redone?.text).toBe(afterInsert.text)
+    expect(recordUndoPoint).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/contrib-sdk-contract.test.ts
+++ b/apps/desktop/src/app/chat/composer/contrib-sdk-contract.test.ts
@@ -1,0 +1,61 @@
+import type { HermesPlugin, PluginContribution } from '@hermes/plugin-sdk'
+import { describe, expect, it } from 'vitest'
+
+import { COMPOSER_AREAS } from './contrib'
+import type { ComposerRenderContext } from './contrib'
+
+const typedContribution: PluginContribution = {
+  id: 'bold',
+  area: COMPOSER_AREAS.actions,
+  render: (bridge: ComposerRenderContext) => {
+    bridge.insertText('**x**')
+
+    return null
+  }
+}
+
+const typedPlugin: HermesPlugin = {
+  id: 'composer-types',
+  register(ctx) {
+    ctx.register({
+      id: 'inline',
+      area: COMPOSER_AREAS.actions,
+      render: bridge => {
+        bridge.insertText('__x__')
+
+        return null
+      }
+    })
+    ctx.registerMany([
+      {
+        id: 'batched',
+        area: COMPOSER_AREAS.actions,
+        render: bridge => {
+          bridge.insertText('~~x~~')
+
+          return null
+        }
+      }
+    ])
+  }
+}
+
+// @ts-expect-error Non-composer areas invoke render with no arguments.
+const invalidNonComposerContribution: PluginContribution = {
+  id: 'invalid-context',
+  area: 'statusBar.right',
+  render: (bridge: ComposerRenderContext) => {
+    bridge.insertText('must not type-check')
+
+    return null
+  }
+}
+
+void typedPlugin
+void invalidNonComposerContribution
+
+describe('composer SDK render contract', () => {
+  it('accepts typed composer callbacks at the public plugin seam', () => {
+    expect(typedContribution.area).toBe(COMPOSER_AREAS.actions)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/contrib-slot.test.tsx
+++ b/apps/desktop/src/app/chat/composer/contrib-slot.test.tsx
@@ -1,0 +1,95 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { registry } from '@/contrib/registry'
+
+import { COMPOSER_AREAS, type ComposerRenderContext } from './contrib'
+import { ComposerRenderSlot } from './contrib-slot'
+
+const disposers: Array<() => void> = []
+
+/** Register a composer render-area contribution whose render receives the
+ *  slot's context argument (the seam under test). */
+function contribute(
+  area: string,
+  render: (ctx: ComposerRenderContext | undefined) => ReactNode,
+  order?: number
+) {
+  disposers.push(
+    registry.register({
+      area,
+      id: `t-${disposers.length}`,
+      order,
+      render: render as (ctx?: unknown) => ReactNode
+    })
+  )
+}
+
+afterEach(() => {
+  disposers.splice(0).forEach(d => d())
+  cleanup()
+})
+
+describe('ComposerRenderSlot', () => {
+  const ctx: ComposerRenderContext = {
+    insertText: vi.fn()
+  }
+
+  it('renders nothing when the area is empty', () => {
+    const { container } = render(<ComposerRenderSlot area={COMPOSER_AREAS.actions} ctx={ctx} />)
+
+    expect(container.textContent).toBe('')
+  })
+
+  it('hands the composer edit bridge to render-area contributions', () => {
+    let seen: ComposerRenderContext | undefined
+
+    contribute(COMPOSER_AREAS.actions, c => {
+      seen = c
+
+      return <button type="button">bold</button>
+    })
+
+    render(<ComposerRenderSlot area={COMPOSER_AREAS.actions} ctx={ctx} />)
+
+    expect(screen.getByRole('button', { name: 'bold' })).toBeTruthy()
+    expect(seen?.insertText).toBe(ctx.insertText)
+  })
+
+  it('passes insertText through to the bridge implementation', () => {
+    let seen: ComposerRenderContext | undefined
+
+    contribute(COMPOSER_AREAS.actions, c => {
+      seen = c
+
+      return null
+    })
+
+    render(<ComposerRenderSlot area={COMPOSER_AREAS.actions} ctx={ctx} />)
+
+    seen?.insertText('**bold**')
+
+    expect(ctx.insertText).toHaveBeenCalledWith('**bold**')
+  })
+
+  it('renders contributions in registry order', () => {
+    contribute(COMPOSER_AREAS.actions, () => <span>first</span>, 20)
+    contribute(COMPOSER_AREAS.actions, () => <span>second</span>, 10)
+
+    const { container } = render(<ComposerRenderSlot area={COMPOSER_AREAS.actions} ctx={ctx} />)
+
+    expect(container.textContent).toBe('secondfirst')
+  })
+
+  it('keeps a crashing contribution isolated from the rest', () => {
+    contribute(COMPOSER_AREAS.actions, () => {
+      throw new Error('broken render')
+    })
+    contribute(COMPOSER_AREAS.actions, () => <span>fine</span>)
+
+    const { container } = render(<ComposerRenderSlot area={COMPOSER_AREAS.actions} ctx={ctx} />)
+
+    expect(container.textContent).toContain('fine')
+  })
+})

--- a/apps/desktop/src/app/chat/composer/contrib-slot.tsx
+++ b/apps/desktop/src/app/chat/composer/contrib-slot.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from 'react'
+
+import { ContribBoundary } from '@/contrib/react/boundary'
+import { useContributions } from '@/contrib/react/use-contributions'
+
+import type { ComposerRenderContext } from './contrib'
+
+export interface ComposerRenderSlotProps {
+  /** Composer render area id (`composer.actions`, `composer.top`, …). */
+  area: string
+  /** The composer's edit bridge, handed to every contribution's `render`. */
+  ctx: ComposerRenderContext
+}
+
+/**
+ * Renders a composer render-area contribution list (`composer.actions`,
+ * `composer.top`, …) — the composer-specific sibling of the generic `Slot`,
+ * differing in TWO ways: each contribution's `render` receives the composer's
+ * edit bridge (`ComposerRenderContext`) as its first argument, so a
+ * `composer.actions` plugin can insert text that lands on the app undo stack
+ * through the app's own DOM pipeline; and the render call itself is deferred
+ * into the boundary's subtree, so a plugin whose `render` throws directly
+ * degrades to the inline slot error instead of escaping to the app root.
+ * Contributions that ignore the context argument (a `render` written against
+ * the generic `() => ReactNode` shape) keep working untouched.
+ */
+export function ComposerRenderSlot({ area, ctx }: ComposerRenderSlotProps) {
+  const items = useContributions(area)
+
+  if (items.length === 0) {
+    return null
+  }
+
+  return (
+    <>
+      {items.map(c => (
+        <ContribBoundary id={c.id} key={`${c.source ?? 'core'}:${c.id}`} variant="chip">
+          <ContributionRender ctx={ctx} render={c.render} />
+        </ContribBoundary>
+      ))}
+    </>
+  )
+}
+
+interface ContributionRenderProps {
+  render: (() => ReactNode) | undefined
+  ctx: ComposerRenderContext
+}
+
+/** Invokes a contribution render with the composer edit bridge. The generic
+ *  `Contribution.render` type can't know the area's context, so the bridge is
+ *  narrowed here — the one place the two shapes meet. Being a component (not
+ *  an inline call) also puts the invocation INSIDE the boundary subtree, so a
+ *  direct throw from plugin render code is caught like any child crash. */
+function ContributionRender({ render, ctx }: ContributionRenderProps) {
+  return <>{render ? (render as (ctx?: ComposerRenderContext) => ReactNode)(ctx) : null}</>
+}

--- a/apps/desktop/src/app/chat/composer/contrib.ts
+++ b/apps/desktop/src/app/chat/composer/contrib.ts
@@ -21,12 +21,15 @@
  */
 
 import { useMemo } from 'react'
+import type { RefObject } from 'react'
 
 import { useContributions } from '@/contrib/react/use-contributions'
 import { registry } from '@/contrib/registry'
 import type { TodoItem } from '@/lib/todos'
 import type { ComposerAttachment } from '@/store/composer'
 import type { ComposerAction } from '@/store/composer-actions'
+
+import { composerInsertWouldChange, insertComposerContentsAtCaret } from './rich-editor'
 
 export const COMPOSER_AREAS = {
   top: 'composer.top',
@@ -38,6 +41,13 @@ export const COMPOSER_AREAS = {
   attachments: 'composer.attachments',
   microActions: 'composer.microActions'
 } as const
+
+export type ComposerRenderArea =
+  | typeof COMPOSER_AREAS.actions
+  | typeof COMPOSER_AREAS.bottom
+  | typeof COMPOSER_AREAS.leading
+  | typeof COMPOSER_AREAS.underside
+  | typeof COMPOSER_AREAS.top
 
 export interface ComposerDraft {
   text: string
@@ -53,6 +63,88 @@ export interface ComposerMiddleware {
 export interface ComposerAttachmentContext {
   insertText: (text: string) => void
 }
+
+/**
+ * Edit bridge handed to composer RENDER-area contributions (`composer.actions`,
+ * `composer.top`, `composer.bottom`, `composer.leading`, `composer.underside`)
+ * as the first argument of their `render` function.
+ *
+ * Backed by the composer's own undo stack and DOM pipeline — an insert here
+ * lands on the same ⌘Z history as typing, replaces the live selection, and
+ * hydrates directives into chips exactly like a paste. Plugins must NOT reach
+ * for `execCommand` or `innerHTML`; that bypasses both the app's undo stack and
+ * its chip/IME safety.
+ */
+export interface ComposerRenderContext {
+  /**
+   * Insert `text` at the caret, replacing any selection inside the composer
+   * editor. The pre-edit state is banked on the app undo stack first, so a
+   * single ⌘Z reverts the insert. Directives in the text (`@url:…`, `/…`)
+   * hydrate into chips through the app's own rendering pipeline.
+   *
+   * True no-op — nothing banked, redo preserved — only when the replacement
+   * would leave the serialized text AND DOM structure unchanged (empty insert
+   * at a collapsed caret, or text identical to what is already there).
+   * Replacing a non-collapsed selection with `''` deletes the selection, and a
+   * text-identical replacement that changes structure (plain `@kind:value`
+   * hydrating into a chip) is a real edit that banks its own undo point.
+   * Also a no-op while the editor is unmounted or during IME composition.
+   * Multi-insert sequences bank one undo point per call — bundle a wrapping
+   * edit into ONE `insertText` call (the full replacement string) so undo
+   * reverts the whole action at once.
+   */
+  insertText: (text: string) => void
+}
+
+export interface CreateComposerRenderContextArgs {
+  /** The rich-editor contentEditable, live. */
+  editorRef: RefObject<HTMLDivElement | null>
+  /** True while an IME preedit is being composed (see `composingRef` in
+   *  index.tsx). Inserts are suppressed during composition — landing DOM edits
+   *  inside a live preedit corrupts it (the execCommand bug class). */
+  composingRef: RefObject<boolean>
+  /** Bank the pre-edit state on the app undo stack. */
+  recordUndoPoint: () => void
+  /** Flush editor DOM → draft state after the edit (rAF-coalesced, like the
+   *  paste path). */
+  scheduleFlushEditorToDraft: (editor: HTMLDivElement) => void
+}
+
+/**
+ * Build the composer's edit bridge for render-area contributions. Mirrors the
+ * app's own paste path exactly — bank the pre-edit state on the app undo
+ * stack, mutate through the app's own DOM pipeline (`insertComposerContentsAtCaret`:
+ * Range-based, chips hydrate, never `execCommand`/`innerHTML`), then flush the
+ * draft state. Selection-aware by construction: the insert replaces whatever
+ * range the document selection holds inside the editor (a plugin's popover
+ * click does not destroy the editor's selection), else lands at the caret.
+ */
+export function createComposerRenderContext({
+  editorRef,
+  composingRef,
+  recordUndoPoint,
+  scheduleFlushEditorToDraft
+}: CreateComposerRenderContextArgs): ComposerRenderContext {
+  return {
+    insertText: (text: string) => {
+      const editor = editorRef.current
+
+      // No editor, or an IME preedit in flight — inserting would corrupt it.
+      if (!editor || composingRef.current) {
+        return
+      }
+
+      if (!composerInsertWouldChange(editor, text)) {
+        return
+      }
+
+      recordUndoPoint()
+      insertComposerContentsAtCaret(editor, text)
+      scheduleFlushEditorToDraft(editor)
+    }
+  }
+}
+
 
 /** Payload of a `composer.attachments` data contribution — an entry in the
  *  composer's "+" attach menu. */

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -4,7 +4,6 @@ import { type ClipboardEvent, type FormEvent, type KeyboardEvent, useCallback, u
 
 import { composerFill, composerFloatingStrip, composerSurfaceGlass } from '@/components/chat/composer-dock'
 import { Button } from '@/components/ui/button'
-import { Slot as ContribSlot } from '@/contrib/react/slot'
 import { useI18n } from '@/i18n'
 import { chatMessageText } from '@/lib/chat-messages'
 import { sanitizeComposerInput } from '@/lib/composer-input-sanitize'
@@ -30,7 +29,8 @@ import {
   slashArgStage
 } from './composer-utils'
 import { ContextMenu } from './context-menu'
-import { COMPOSER_AREAS, runComposerMiddleware } from './contrib'
+import { COMPOSER_AREAS, createComposerRenderContext, runComposerMiddleware } from './contrib'
+import { ComposerRenderSlot } from './contrib-slot'
 import { ComposerControls } from './controls'
 import { ComposerDirectiveActions } from './directive-actions'
 import { COMPOSER_DROP_ACTIVE_CLASS, COMPOSER_DROP_FADE_CLASS } from './drop-affordance'
@@ -374,7 +374,7 @@ export function ChatBar({
   // flushes to one per paint is lossless.
   const flushRafRef = useRef<number | undefined>(undefined)
 
-  const flushEditorToDraft = (editor: HTMLDivElement) => {
+  const flushEditorToDraft = useCallback((editor: HTMLDivElement) => {
     if (flushRafRef.current !== undefined) {
       window.cancelAnimationFrame(flushRafRef.current)
       flushRafRef.current = undefined
@@ -390,21 +390,38 @@ export function ChatBar({
     }
 
     window.setTimeout(refreshTrigger, 0)
-  }
+  }, [draftRef, refreshTrigger, setComposerText])
 
   // Coalesce the high-frequency input/paste flushes to one per frame. Immediate
   // paths (compositionend, Enter/keydown, submit) keep calling
   // flushEditorToDraft directly, which cancels any pending coalesced run first.
-  const scheduleFlushEditorToDraft = (editor: HTMLDivElement) => {
-    if (flushRafRef.current !== undefined) {
-      return
-    }
+  const scheduleFlushEditorToDraft = useCallback(
+    (editor: HTMLDivElement) => {
+      if (flushRafRef.current !== undefined) {
+        return
+      }
 
-    flushRafRef.current = window.requestAnimationFrame(() => {
-      flushRafRef.current = undefined
-      flushEditorToDraft(editor)
-    })
-  }
+      flushRafRef.current = window.requestAnimationFrame(() => {
+        flushRafRef.current = undefined
+        flushEditorToDraft(editor)
+      })
+    },
+    [flushEditorToDraft]
+  )
+
+  // The edit bridge handed to composer render-area contributions
+  // (composer.actions etc.). See createComposerRenderContext — it mirrors the
+  // paste path: undo point first, then the app's own DOM pipeline, then flush.
+  const composerRenderContext = useMemo(
+    () =>
+      createComposerRenderContext({
+        composingRef,
+        editorRef,
+        recordUndoPoint,
+        scheduleFlushEditorToDraft
+      }),
+    [composingRef, editorRef, recordUndoPoint, scheduleFlushEditorToDraft]
+  )
 
   useEffect(
     () => () => {
@@ -1213,7 +1230,7 @@ export function ChatBar({
                   {/* Contribution seams: banners above, a row below, inline
                     additions beside the "+" menu and before the controls.
                     All four render nothing until something contributes. */}
-                  <ContribSlot area={COMPOSER_AREAS.top} />
+                  <ComposerRenderSlot area={COMPOSER_AREAS.top} ctx={composerRenderContext} />
                   <VoiceActivity state={voiceActivityState} />
                   <VoicePlaybackActivity />
                   {queueEdit && editingQueuedPrompt && (
@@ -1251,15 +1268,15 @@ export function ChatBar({
                   >
                     <div className="flex translate-y-[3px] items-start gap-(--composer-control-gap) self-start [grid-area:menu]">
                       {contextMenu}
-                      <ContribSlot area={COMPOSER_AREAS.leading} />
+                      <ComposerRenderSlot area={COMPOSER_AREAS.leading} ctx={composerRenderContext} />
                     </div>
                     <div className="min-w-0 [grid-area:input]">{input}</div>
                     <div className="flex items-center justify-end gap-(--composer-control-gap) [grid-area:controls]">
-                      <ContribSlot area={COMPOSER_AREAS.actions} />
+                      <ComposerRenderSlot area={COMPOSER_AREAS.actions} ctx={composerRenderContext} />
                       {controls}
                     </div>
                   </div>
-                  <ContribSlot area={COMPOSER_AREAS.bottom} />
+                  <ComposerRenderSlot area={COMPOSER_AREAS.bottom} ctx={composerRenderContext} />
                 </div>
               </div>
             </div>
@@ -1269,7 +1286,7 @@ export function ChatBar({
               the pop-out drag region. Same px as the strip above, so the two
               bracket the composer on one vertical line. */}
           <div className={cn(composerFloatingStrip, 'px-[5px] pt-1.5 empty:hidden')}>
-            <ContribSlot area={COMPOSER_AREAS.underside} />
+            <ComposerRenderSlot area={COMPOSER_AREAS.underside} ctx={composerRenderContext} />
           </div>
         </div>
       </ComposerPrimitive.Unstable_TriggerPopoverRoot>

--- a/apps/desktop/src/app/chat/composer/rich-editor.ts
+++ b/apps/desktop/src/app/chat/composer/rich-editor.ts
@@ -244,6 +244,105 @@ function composerSelectionRange(editor: HTMLElement) {
   return { range, selection }
 }
 
+type ComposerSelectionHit = NonNullable<ReturnType<typeof composerSelectionRange>>
+
+function nodePath(root: Node, node: Node): number[] | null {
+  const path: number[] = []
+  let current: Node | null = node
+
+  while (current && current !== root) {
+    const parent: Node | null = current.parentNode
+
+    if (!parent) {
+      return null
+    }
+
+    const index = Array.from(parent.childNodes).indexOf(current as ChildNode)
+
+    if (index < 0) {
+      return null
+    }
+
+    path.unshift(index)
+    current = parent
+  }
+
+  return current === root ? path : null
+}
+
+function nodeAtPath(root: Node, path: number[]): Node | null {
+  let current: Node | null = root
+
+  for (const index of path) {
+    current = current?.childNodes[index] ?? null
+  }
+
+  return current
+}
+
+function cloneSelectionRange(editor: HTMLElement, clone: HTMLElement, hit: ComposerSelectionHit): Range | null {
+  const startPath = nodePath(editor, hit.range.startContainer)
+  const endPath = nodePath(editor, hit.range.endContainer)
+
+  if (!startPath || !endPath) {
+    return null
+  }
+
+  const start = nodeAtPath(clone, startPath)
+  const end = nodeAtPath(clone, endPath)
+
+  if (!start || !end) {
+    return null
+  }
+
+  const range = document.createRange()
+  range.setStart(start, hit.range.startOffset)
+  range.setEnd(end, hit.range.endOffset)
+
+  return range
+}
+
+/** Meaningful editor structure, with Chromium's empty text-node litter ignored
+ * and adjacent text nodes coalesced. Serialized text alone cannot tell plain
+ * directive text from the chip the insertion pipeline would hydrate it into. */
+function composerStructureSignature(node: Node): string {
+  if (node.nodeType === Node.TEXT_NODE) {
+    return node.textContent ? `text:${JSON.stringify(node.textContent)}` : ''
+  }
+
+  if (node.nodeType !== Node.ELEMENT_NODE) {
+    return ''
+  }
+
+  const element = node as HTMLElement
+
+  const attrs = Array.from(element.attributes)
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map(attr => `${attr.name}=${JSON.stringify(attr.value)}`)
+    .join(';')
+
+  const children: string[] = []
+
+  for (const child of element.childNodes) {
+    const signature = composerStructureSignature(child)
+
+    if (!signature) {
+      continue
+    }
+
+    if (child.nodeType === Node.TEXT_NODE && children.at(-1)?.startsWith('text:')) {
+      const previous = children.pop()!
+      const previousText = JSON.parse(previous.slice('text:'.length)) as string
+      const currentText = JSON.parse(signature.slice('text:'.length)) as string
+      children.push(`text:${JSON.stringify(previousText + currentText)}`)
+    } else {
+      children.push(signature)
+    }
+  }
+
+  return `element:${element.tagName.toLowerCase()}[${attrs}](${children.join('|')})`
+}
+
 /** Serialized text from the editor's start up to (`container`, `offset`).
  *
  *  Chips are ATOMIC here: each contributes an object-replacement placeholder
@@ -296,20 +395,12 @@ function atTokenBoundary(editor: HTMLElement, range: Range | null): boolean {
  *  `consumeBefore` characters immediately before the caret are swallowed by the
  *  insert. That's how a paste into an open `@url:` scope replaces the scope
  *  instead of stacking on it (`@url:@url:\`https://…\``). */
-export function insertComposerContentsAtCaret(editor: HTMLElement, text: string, consumeBefore = 0) {
-  const scoped = consumeBefore > 0 ? rangeBeforeCaret(editor, consumeBefore) : null
-
-  if (scoped) {
-    scoped.deleteContents()
-    scoped.collapse(true)
-
-    const selection = window.getSelection()
-
-    selection?.removeAllRanges()
-    selection?.addRange(scoped)
-  }
-
-  const hit = composerSelectionRange(editor)
+function insertComposerContentsAtSelection(
+  editor: HTMLElement,
+  text: string,
+  hit: ComposerSelectionHit | { range: Range; selection: null } | null,
+  fallbackSelection: Selection | null
+) {
   const fragment = document.createDocumentFragment()
 
   // Before measuring the boundary — a replaced selection puts the insertion
@@ -338,14 +429,60 @@ export function insertComposerContentsAtCaret(editor: HTMLElement, text: string,
     editor.append(fragment)
   }
 
+  const selection = hit?.selection ?? fallbackSelection
+
   if (tail) {
     const caret = document.createRange()
     caret.setStartAfter(tail)
     caret.collapse(true)
-    const selection = hit?.selection ?? window.getSelection()
     selection?.removeAllRanges()
     selection?.addRange(caret)
+  } else if (hit) {
+    hit.range.collapse(true)
+    selection?.removeAllRanges()
+    selection?.addRange(hit.range)
   }
+}
+
+export function insertComposerContentsAtCaret(editor: HTMLElement, text: string, consumeBefore = 0) {
+  const scoped = consumeBefore > 0 ? rangeBeforeCaret(editor, consumeBefore) : null
+
+  if (scoped) {
+    scoped.deleteContents()
+    scoped.collapse(true)
+
+    const selection = window.getSelection()
+
+    selection?.removeAllRanges()
+    selection?.addRange(scoped)
+  }
+
+  insertComposerContentsAtSelection(editor, text, composerSelectionRange(editor), window.getSelection())
+}
+
+/** True when the host pipeline would change the editor's serialized text or
+ * meaningful DOM structure. An empty replacement is a deletion when a live
+ * selection is non-collapsed. */
+export function composerInsertWouldChange(editor: HTMLElement, text: string): boolean {
+  const hit = composerSelectionRange(editor)
+  const clone = editor.cloneNode(true) as HTMLElement
+  const cloneRange = hit ? cloneSelectionRange(editor, clone, hit) : null
+
+  if (hit && !cloneRange) {
+    return true
+  }
+
+  insertComposerContentsAtSelection(
+    clone,
+    text,
+    cloneRange ? { range: cloneRange, selection: null } : null,
+    null
+  )
+
+  return (
+    composerPlainText(editor) !== composerPlainText(clone) ||
+    composerStructureSignature(editor) !== composerStructureSignature(clone)
+  )
 }
 
 /** Range covering exactly `length` serialized characters immediately before a

--- a/apps/desktop/src/contrib/plugin.ts
+++ b/apps/desktop/src/contrib/plugin.ts
@@ -12,6 +12,9 @@
  * through the plugin host loader (next phase); this is that seam.
  */
 
+import type { ReactNode } from 'react'
+
+import type { ComposerRenderArea, ComposerRenderContext } from '@/app/chat/composer/contrib'
 import { pluginRest, type PluginRestOptions, pluginSocket } from '@/hermes'
 import { createPluginI18n, type PluginI18n } from '@/i18n'
 import { readKey, writeKey } from '@/lib/storage'
@@ -25,7 +28,20 @@ export type { PluginNativeNotificationInput } from '@/store/native-notifications
 
 /** A contribution as a plugin author writes it — provenance + id scoping are
  *  the host's job, so those fields are off-limits here. */
-export type PluginContribution = Omit<Contribution, 'source' | 'id'> & { id: string }
+type PluginContributionBase = Omit<Contribution, 'source' | 'id' | 'render'> & {
+  id: string
+  /** Generic contribution areas invoke render without a context argument. */
+  render?: () => ReactNode
+}
+
+/** Render-area contributions receive the context the host actually supplies. */
+export type ComposerRenderContribution = Omit<PluginContributionBase, 'area' | 'render'> & {
+  area: ComposerRenderArea
+  render: (ctx: ComposerRenderContext) => ReactNode
+}
+
+/** A plugin contribution, with the composer render seam typed by its runtime contract. */
+export type PluginContribution = PluginContributionBase | ComposerRenderContribution
 
 /** Namespaced JSON persistence (the VS Code `globalState` analog). Keys live
  *  under `hermes.plugin.<id>.` — plugins can't read or clobber each other. */
@@ -60,9 +76,15 @@ export interface PluginContext {
   /** The resolved plugin source tag, e.g. `'plugin:cost-meter'`. */
   readonly source: string
   /** Register one contribution (id namespaced, source stamped). */
-  register: (c: PluginContribution) => () => void
+  register: {
+    (c: ComposerRenderContribution): () => void
+    (c: PluginContribution): () => void
+  }
   /** Register several at once; the returned disposer removes all of them. */
-  registerMany: (cs: PluginContribution[]) => () => void
+  registerMany: {
+    (cs: ComposerRenderContribution[]): () => void
+    (cs: PluginContribution[]): () => void
+  }
   /** Register an arbitrary cleanup to run on unload/disable — for side effects
    *  that aren't contributions or sockets (store subscriptions, timers). Runs
    *  alongside every other disposer when the plugin deactivates. */

--- a/apps/desktop/src/contrib/types.ts
+++ b/apps/desktop/src/contrib/types.ts
@@ -33,8 +33,11 @@ export interface Contribution {
   when?: () => boolean
   /** Soft disable without unregistering. `false` hides it. */
   enabled?: boolean
-  /** Renders the contribution's content (UI contributions). */
-  render?: () => ReactNode
+  /** Renders the contribution's content (UI contributions). Area-specific
+   *  plugin contracts refine this callback before registration; `never` keeps
+   *  the registry's storage shape compatible with every such callback while
+   *  still allowing zero-argument core renders. */
+  render?: (...args: never[]) => ReactNode
   /**
    * Declarative payload for data contributions (Family B): layout presets,
    * themes, commands — anything consumed by an engine rather than rendered.

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -116,7 +116,13 @@ export const host = {
 // Every contribution surface, plugin-reachable: register keybinds, palette
 // commands, routes, themes, panes, composer extensions, and bar items with
 // the same area ids + payload types core uses.
-export { COMPOSER_AREAS, type ComposerAttachmentProvider, type ComposerMiddleware } from '@/app/chat/composer/contrib'
+export {
+  COMPOSER_AREAS,
+  type ComposerAttachmentProvider,
+  type ComposerMiddleware,
+  type ComposerRenderArea,
+  type ComposerRenderContext
+} from '@/app/chat/composer/contrib'
 
 // -- ui: the design language --------------------------------------------------
 
@@ -197,6 +203,7 @@ export { Textarea } from '@/components/ui/textarea'
 export { Tip, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 export type { GatewayEventListener } from '@/contrib/events'
 export type {
+  ComposerRenderContribution,
   HermesPlugin,
   PluginContext,
   PluginContribution,

--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -338,6 +338,51 @@ ctx.register({ id: 'noir', area: THEMES_AREA, data: myDesktopTheme })
 attachment source, or transform a draft before it is sent (`ComposerMiddleware`
 with a `handler(draft) => draft | null`).
 
+**Render-area edit bridge.** The composer render areas (`top`, `bottom`,
+`leading`, `actions`, `underside`) hand every contribution's `render` a
+`ComposerRenderContext` as its first argument — the sanctioned way for a
+toolbar action to edit the draft:
+
+```javascript
+import { COMPOSER_AREAS } from '@hermes/plugin-sdk'
+
+ctx.register({
+  id: 'bold',
+  area: COMPOSER_AREAS.actions,
+  render: (bridge) =>
+    jsx('button', {
+      onClick: () => {
+        const selection = window.getSelection()?.toString()
+        bridge.insertText(`**${selection ?? ''}**`)
+      },
+      children: 'B'
+    })
+})
+```
+
+`bridge.insertText(text)` inserts at the caret (replacing the live selection),
+banks the pre-edit state on the **app's own undo stack** (one ⌘Z reverts the
+insert), and runs through the app's rendering pipeline — directives in the
+text hydrate into chips. The bridge is a true no-op — nothing is banked, so
+redo survives — only when the replacement would leave the editor's serialized
+text **and** DOM structure unchanged (an empty insert at a collapsed caret,
+or text identical to what is already there). Replacing a live (non-collapsed)
+selection with `''` is NOT a no-op: it deletes the selection. A replacement
+that changes structure even when the text reads the same — plain
+`@kind:value` text hydrating into a chip — is likewise a real edit that banks
+its own undo point; like any new edit, it invalidates an existing redo branch. The bridge is also a no-op while the
+composer is in IME composition. Never use `execCommand('insertText')`,
+`innerHTML`, or direct DOM mutation: those bypass the host's undo,
+normalization, draft-flush, and chip/IME safety. Bundle a wrapping edit into
+ONE `insertText` call so undo reverts the whole action at once.
+
+The context argument is only available on composer **render** areas: those are
+the areas whose `render` the runtime invokes with a `ComposerRenderContext`
+argument. Every other area's `render` is called with no arguments, and the SDK
+types (`ComposerRenderContribution` vs the plain `PluginContribution`) reject
+a context parameter there — a typed context callback compiles only where the
+host actually supplies one.
+
 ### Mount-scoped chrome (`Contribute`)
 
 `ctx.register` is for **permanent** contributions. When chrome should live and


### PR DESCRIPTION
## What does this PR do?

Adds the **composer render/edit bridge**: a typed surface that lets desktop plugins render content into the chat composer and edit the draft through the same undo-safe pipeline core uses.

Plugin contributions can now target composer render areas (`top`, `leading`, `actions`, `bottom`, `underside`) and receive a `ComposerRenderContext` — undo-point recording, caret-aware content insertion, and draft flushing — instead of only the zero-argument `render` callback.

Why this approach:

- The plugin SDK already exposes `COMPOSER_AREAS` and `register`; this widens the contribution contract (`ComposerRenderContribution`) so area-specific renders receive the context the host actually supplies.
- The registry storage shape stays compatible (`render?: (...args: never[]) => ReactNode`), so generic contributions keep working unchanged.
- Every plugin-driven edit routes through the existing paste pipeline (undo point → DOM insertion → flush to draft), so plugin edits are indistinguishable from user edits for undo/redo.

## Related Issue

No issue — feature contribution.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `apps/desktop/src/app/chat/composer/contrib.ts` — composer render areas, context factory, middleware run
- `apps/desktop/src/app/chat/composer/contrib-slot.tsx` — slot component rendering registered area contributions
- `apps/desktop/src/app/chat/composer/index.tsx` — mounts render slots in the five composer areas; builds the edit-bridge context (undo → insert → flush)
- `apps/desktop/src/app/chat/composer/rich-editor.ts` — caret-scoped insertion/selection helpers shared by the bridge
- `apps/desktop/src/contrib/plugin.ts`, `apps/desktop/src/contrib/types.ts` — typed `ComposerRenderContribution`; registry storage shape unchanged
- `apps/desktop/src/sdk/index.ts` — exports `ComposerRenderArea`, `ComposerRenderContext`, `ComposerRenderContribution`
- `website/docs/developer-guide/desktop-plugin-sdk.md` — documents the composer render areas
- Tests: `contrib-bridge.test.ts`, `contrib-sdk-contract.test.ts`, `contrib-slot.test.tsx`

## How to Test

1. `cd apps/desktop && npx vitest run --project ui` — full desktop UI suite: **405 files / 3602 tests passed**
2. `npm run typecheck` — clean on all three tsconfigs (renderer, electron, e2e)
3. `npx eslint` on all 10 changed TS/TSX files — clean
4. `git diff --check origin/main...HEAD` — clean

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(desktop): add composer render edit bridge`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (single commit on current `main`)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A for desktop; ran the desktop UI vitest suite instead (see How to Test)
- [x] I've added tests for my changes (293 + 61 + 95 lines of new tests)
- [x] I've tested on my platform: macOS 26

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/developer-guide/desktop-plugin-sdk.md`)
- [x] N/A — `cli-config.yaml.example`
- [x] N/A — `CONTRIBUTING.md` / `AGENTS.md`
- [x] I've considered cross-platform impact (Windows, macOS) — renderer-only change, no platform APIs
- [x] N/A — tool descriptions/schemas

## Related work / overlap note

- #79611 (declared cross-plugin read services) touches `apps/desktop/src/contrib/plugin.ts` and `apps/desktop/src/sdk/index.ts` for the `requires`/service-discovery path — adjacent file overlap, no composer render surface.
- #76179 (`host.selectModel`) touches `apps/desktop/src/sdk/index.ts` and the plugin SDK docs for the model-switch host API — adjacent.
- No open PR introduces plugin-rendered content into the composer or owns the editor render/edit bridge.

## Screenshots / Logs

Full UI suite: 405 test files passed, 3602 tests passed (`vitest run --project ui`). Typecheck and eslint clean.

## AI assistance

Developed with AI-assisted tooling under the author's direction; the change passed four independent AI code reviews before this submission.
