### PR TITLE
fix(search): pass native Windows paths and raw patterns to ripgrep

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -294,6 +294,32 @@ class TestShellFileOpsHelpers:
             "C:/Users/alice/notes.txt"
         ) == "'/c/Users/alice/notes.txt'"
 
+    def test_shell_quote_raw_preserves_regex_backslashes(self, file_ops):
+        # Regression: _bash_safe_path rewrites every backslash to "/",
+        # corrupting regex patterns on Windows (\.env -> /.env).
+        assert file_ops._shell_quote_raw(r"\.env") == "'\\.env'"
+        assert file_ops._shell_quote_raw(r"\d+") == "'\\d+'"
+        assert file_ops._shell_quote_raw(r"a\\nb") == "'a\\\\nb'"
+        assert file_ops._shell_quote_raw("it's") == "'it'\"'\"'s'"
+
+    def test_rg_path_arg_emits_native_windows_form(self, monkeypatch, file_ops):
+        # Regression: native rg.exe cannot read Git-Bash paths (/c/Users/x)
+        # when MSYS argument conversion is disabled (os error 3). The rg
+        # path arg must be in native C:/... form, understood by both
+        # native and MSYS builds of ripgrep.
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        assert file_ops._rg_path_arg("C:/Users/alice/notes.txt") == "'C:/Users/alice/notes.txt'"
+        assert file_ops._rg_path_arg("C:\\Users\\alice\\notes.txt") == "'C:/Users/alice/notes.txt'"
+        assert file_ops._rg_path_arg("/c/Users/alice/notes.txt") == "'C:/Users/alice/notes.txt'"
+
+    def test_rg_path_arg_noop_off_windows(self, monkeypatch, file_ops):
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
+        assert file_ops._rg_path_arg("/home/alice/notes.txt") == "'/home/alice/notes.txt'"
+
     def test_read_file_uses_bash_safe_windows_paths(self, mock_env, monkeypatch):
         import tools.environments.local as local_mod
 

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -996,6 +996,34 @@ class ShellFileOperations(FileOperations):
         # Use single quotes and escape any single quotes in the string
         return "'" + arg.replace("'", "'\"'\"'") + "'"
 
+    def _shell_quote_raw(self, s: str) -> str:
+        """Single-quote *s* for shell interpolation with NO path rewriting.
+
+        Unlike ``_escape_shell_arg`` this skips ``_bash_safe_path``, so
+        regex metacharacters written with backslashes (``\\.env``,
+        ``\\d+``, ``\\n``) survive intact. ``_bash_safe_path`` rewrites
+        every backslash to ``/`` on Windows, corrupting search patterns
+        (``\\.env`` becomes ``/.env`` — a different regex). Use for
+        non-path arguments only (search patterns, globs, etc.).
+        """
+        return "'" + s.replace("'", "'\"'\"'") + "'"
+
+    def _rg_path_arg(self, path: str) -> str:
+        """Shell-quote *path* for ripgrep invocations on the local backend.
+
+        On Windows the Hermes shell env disables MSYS argument path
+        conversion (MSYS_NO_PATHCONV=1 / MSYS2_ARG_CONV_EXCL=* — see
+        _apply_windows_msys_bash_env_defaults), so _escape_shell_arg's
+        Git-Bash form (/c/Users/x) would reach the native rg.exe raw and
+        fail with "os error 3" (ERROR_PATH_NOT_FOUND). Emit the native
+        Windows form (C:/Users/x) instead — accepted by both native and
+        MSYS builds of ripgrep. No-op off Windows.
+        """
+        from tools.environments.local import _IS_WINDOWS, _msys_to_windows_path
+        if _IS_WINDOWS:
+            path = _msys_to_windows_path(path).replace("\\", "/")
+        return self._shell_quote_raw(path)
+
     def _atomic_write(self, path: str, content: str) -> "ExecuteResult":
         """Write ``content`` to ``path`` atomically via temp-file + rename.
 
@@ -2311,7 +2339,7 @@ class ShellFileOperations(FileOperations):
         glob_expr = f" --glob {self._escape_shell_arg(file_glob)}" if file_glob else ""
         probe = self._exec(
             f"rg -i --count-matches{glob_expr} "
-            f"{self._escape_shell_arg(pattern)} {self._escape_shell_arg(path)} "
+            f"{self._shell_quote_raw(pattern)} {self._rg_path_arg(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -2333,7 +2361,7 @@ class ShellFileOperations(FileOperations):
         # missing from results).
         hidden = self._exec(
             f"rg --hidden --no-ignore --count-matches{glob_expr} "
-            f"{self._escape_shell_arg(pattern)} {self._escape_shell_arg(path)} "
+            f"{self._shell_quote_raw(pattern)} {self._rg_path_arg(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -2353,7 +2381,7 @@ class ShellFileOperations(FileOperations):
         if re.search(r"[.\[\](){}?*+^$\\|]", pattern):
             fixed = self._exec(
                 f"rg -F --count-matches{glob_expr} "
-                f"{self._escape_shell_arg(pattern)} {self._escape_shell_arg(path)} "
+                f"{self._shell_quote_raw(pattern)} {self._rg_path_arg(path)} "
                 f"2>/dev/null | head -50",
                 timeout=30,
             )
@@ -2475,7 +2503,7 @@ class ShellFileOperations(FileOperations):
         # Try mtime-sorted first (rg 13+); fall back to unsorted if not supported.
         cmd_sorted = (
             f"rg --files --sortr=modified -g {self._escape_shell_arg(glob_pattern)} "
-            f"{self._escape_shell_arg(path)} 2>/dev/null "
+            f"{self._rg_path_arg(path)} 2>/dev/null "
             f"| head -n {fetch_limit}"
         )
         result = self._exec(cmd_sorted, timeout=60)
@@ -2486,7 +2514,7 @@ class ShellFileOperations(FileOperations):
             # --sortr may have failed on older rg; retry without it.
             cmd_plain = (
                 f"rg --files -g {self._escape_shell_arg(glob_pattern)} "
-                f"{self._escape_shell_arg(path)} 2>/dev/null "
+                f"{self._rg_path_arg(path)} 2>/dev/null "
                 f"| head -n {fetch_limit}"
             )
             result = self._exec(cmd_plain, timeout=60)
@@ -2569,8 +2597,8 @@ class ShellFileOperations(FileOperations):
             cmd_parts.append("-c")  # Count per file
         
         # Add pattern and path
-        cmd_parts.append(self._escape_shell_arg(pattern))
-        cmd_parts.append(self._escape_shell_arg(path))
+        cmd_parts.append(self._shell_quote_raw(pattern))
+        cmd_parts.append(self._rg_path_arg(path))
         
         # Fetch extra rows so we can report the true total before slicing.
         # For context mode, rg emits separator lines ("--") between groups,
@@ -2705,7 +2733,7 @@ class ShellFileOperations(FileOperations):
             cmd_parts.append("-c")
         
         # Add pattern and path
-        cmd_parts.append(self._escape_shell_arg(pattern))
+        cmd_parts.append(self._shell_quote_raw(pattern))
         cmd_parts.append(self._escape_shell_arg(path))
         
         # Fetch generously so we can compute total before slicing


### PR DESCRIPTION
## Bug Description

On Windows, every `search_files` call fails with:

```
rg: /c/Users/... : IO error for operation on /c/Users/... : The system cannot find the path specified. (os error 3)
```

Additionally, regex patterns containing backslashes (`\.env`, `\d+`, `\n`) silently return **0 matches** — the pattern is corrupted before it reaches ripgrep.

## Root Cause

Hermes runs shell commands through Git Bash on Windows with **MSYS argument path conversion disabled** (`MSYS_NO_PATHCONV=1` / `MSYS2_ARG_CONV_EXCL=*` set by `_apply_windows_msys_bash_env_defaults` in `tools/environments/local.py` — intentional, to protect native commands like `tasklist`/`schtasks`/`wmic`).

However, `_escape_shell_arg()` → `_bash_safe_path()` rewrites **every argument** to Git-Bash form (`C:\Users\x` → `/c/Users/x`), assuming the conversion back will happen. With conversion off:

1. **Bug A (os error 3)** — the *path* reaches the native `rg.exe` (e.g. the WinGet/choco/scoop MSVC build) raw as `/c/Users/...` → `ERROR_PATH_NOT_FOUND`. MSYS-built tools (`grep`, `sed`, `find`) understand `/c/...`, which is why the grep fallback worked.
2. **Bug B (corrupted regex)** — the *pattern* also goes through `_bash_safe_path`, which rewrites every `\` to `/`: `\.env` → `/.env`, `\d+` → `/d+`, `\\n` → `//n`. Result: silent 0 matches or `rg: regex parse error`.

## Fix

- **`_rg_path_arg()`** — shell-quotes the search path in **native Windows form** (`C:/Users/x`), accepted by both native and MSYS builds of ripgrep. Used for the path in `_search_with_rg`, `_search_files_rg` (both `--files` variants) and `_zero_match_probe`.
- **`_shell_quote_raw()`** — shell-quotes **non-path arguments** (search patterns) without MSYS path rewriting, so regex backslashes survive intact. Used for the pattern in `_search_with_rg`, `_search_with_grep` and all three `_zero_match_probe` probes.
- Both helpers are no-ops off Windows; the grep fallback keeps the old path form (grep is MSYS-built and reads `/c/...` natively).

## How to Verify

1. On Windows with a native `rg.exe` (WinGet/choco/scoop): `search_files(pattern="seed", path="C:\\Users\\...")` — previously failed with `os error 3`, now returns matches.
2. Search a pattern containing a backslash, e.g. `\.env`, in a file whose content includes `.env` — previously 0 matches, now matches.
3. On Linux/macOS: behavior unchanged (both helpers are guarded and no-op off Windows).

## Test Plan

- [x] Added regression tests: `test_shell_quote_raw_preserves_regex_backslashes`, `test_rg_path_arg_emits_native_windows_form`, `test_rg_path_arg_noop_off_windows` (platform-independent via `_IS_WINDOWS` monkeypatch)
- [x] Existing tests still pass — `TestShellFileOpsHelpers`: 11 passed
- [x] Manual verification on Windows: 5 scenarios pass (native path, MSYS path, backslash regex, `--files` search, zero-match probe)
- [ ] Full CI suite — the remaining Windows failures in the local run are pre-existing environment issues unrelated to this change (CRLF fixtures in multiline tests, POSIX umask/symlink tests, and a subprocess mock that spawns `cmd.exe` instead of bash)

## Risk Assessment

**Low** — Windows-only behavior change in path/pattern shell-quoting for `rg` invocations. Off-Windows code paths are untouched (guards on `_IS_WINDOWS`), and the grep fallback path handling is unchanged.
