### PR TITLE
feat(model-metadata): recognize 'max_context' key in /models payloads

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -611,6 +611,7 @@ _CONTEXT_LENGTH_KEYS = (
     "context_window",
     "context_size",
     "max_context_length",
+    "max_context",
     "max_position_embeddings",
     "max_model_len",
     "max_input_tokens",


### PR DESCRIPTION
## Summary

Many OpenAI-compatible providers (e.g. vLLM-based endpoints such as ArliAI) report their context window as **`max_context`** in `/models` responses instead of `context_length`.

`_extract_context_length()` only looks at `_CONTEXT_LENGTH_KEYS`, which did **not** include `max_context`. As a result, automatic context-length detection for these custom endpoints silently failed and fell back to hardcoded family defaults (e.g. the DeepSeek catch-all of 1M), which can **overshoot the provider's real limit** and cause context-length-exceeded errors mid-conversation.

## Change

Add `"max_context"` to `_CONTEXT_LENGTH_KEYS` in `agent/model_metadata.py`.

## Why this matters

With this single key added, custom endpoints expose their true advertised context window via live `/models` probing (resolution step 2 in `get_model_context_length`), so the value auto-tracks whenever the provider raises or lowers the limit — no manual config edits needed.

Verified live against `https://api.arliai.com/v1/models`, which returns `max_context: 524288`; Hermes now resolves 524288 instead of the previous hardcoded 1M fallback.

## Test plan

- Unit: `_extract_context_length` now returns the integer for payloads with a `max_context` field.
- E2E: `get_model_context_length("DeepSeek-V4-Flash-0731", base_url="https://api.arliai.com/v1", api_key=..., provider="custom")` returns `524288`.