### PR TITLE
fix(cron): distinguish outcomes and trip failure breaker

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1709,6 +1709,7 @@ def create_job(
         "last_status": None,
         "last_error": None,
         "last_delivery_error": None,
+        "consecutive_failures": 0,
         # Delivery configuration
         "deliver": deliver,
         "origin": origin,  # Tracks where job was created for "origin" delivery
@@ -1929,6 +1930,8 @@ def resume_job(job_id: str) -> Optional[Dict[str, Any]]:
             "state": "scheduled",
             "paused_at": None,
             "paused_reason": None,
+            "consecutive_failures": 0,
+            "circuit_breaker_tripped_at": None,
             "next_run_at": next_run_at,
         },
     )
@@ -2009,6 +2012,9 @@ def clear_preflight_alerted(job_id: str) -> None:
     _set_preflight_alerted(job_id, False)
 
 
+CRON_FAILURE_CIRCUIT_BREAKER_THRESHOLD = 3
+
+
 def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                  delivery_error: Optional[str] = None,
                  status: Optional[str] = None):
@@ -2026,6 +2032,10 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
     the pre-dispatch configuration validation refused to run the agent
     (T1-26), so `cronjob list` distinguishes "your config is broken" from
     "the run itself failed".
+
+    Recurring jobs are automatically paused after three consecutive failed
+    runs.  Only a successful run resets the streak; resuming a tripped job is
+    an explicit operator action.
     """
     with _jobs_lock():
         jobs = load_jobs()
@@ -2042,6 +2052,13 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                     job.pop("preflight_alerted", None)
                 # Track delivery failures separately — cleared on successful delivery
                 job["last_delivery_error"] = delivery_error
+                if success:
+                    job["consecutive_failures"] = 0
+                    job.pop("circuit_breaker_tripped_at", None)
+                else:
+                    job["consecutive_failures"] = int(
+                        job.get("consecutive_failures") or 0
+                    ) + 1
                 # Clear any external-fire claim so a re-armed recurring job can
                 # be claimed again on its next fire (Phase 4C CAS).
                 job["fire_claim"] = None
@@ -2087,7 +2104,7 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                         job["state"] = "completed"
                         job["next_run_at"] = None
                         save_jobs(jobs)
-                        return
+                        return _normalize_job_record(job)
                 
                 # Compute next run
                 job["next_run_at"] = compute_next_run(job["schedule"], now)
@@ -2118,11 +2135,26 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                     else:
                         job["enabled"] = False
                         job["state"] = "completed"
+                elif (
+                    not success
+                    and job.get("schedule", {}).get("kind") in {"cron", "interval"}
+                    and job["consecutive_failures"]
+                    >= CRON_FAILURE_CIRCUIT_BREAKER_THRESHOLD
+                ):
+                    job["enabled"] = False
+                    job["state"] = "paused"
+                    job["paused_at"] = now
+                    job["paused_reason"] = (
+                        "Circuit breaker: 3 consecutive failed runs; "
+                        "operator review required before resume."
+                    )
+                    job["circuit_breaker_tripped_at"] = now
+                    job["next_run_at"] = None
                 elif job.get("state") != "paused":
                     job["state"] = "scheduled"
 
                 save_jobs(jobs)
-                return
+                return _normalize_job_record(job)
 
         logger.warning("mark_job_run: job_id %s not found, skipping save", job_id)
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4636,7 +4636,12 @@ def run_one_job(
             # a real report that merely quoted "[SILENT]" mid-sentence (#51438,
             # #46917).  Keeps the intentional bracketed-prefix / trailing-line
             # tolerance the cron contract relies on.
-            if should_deliver and success and _is_cron_silence_response(deliver_content):
+            response_silent = (
+                should_deliver
+                and success
+                and _is_cron_silence_response(deliver_content)
+            )
+            if response_silent:
                 logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
                 should_deliver = False
 
@@ -4664,15 +4669,58 @@ def run_one_job(
             success = False
             error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
 
+        normalized_deliver = _normalize_deliver_value(job.get("deliver", "local"))
+        if blocked_config:
+            terminal_status = "blocked_config"
+        elif not success:
+            terminal_status = "error"
+        elif delivery_error:
+            terminal_status = "delivery_failed"
+        elif response_silent:
+            terminal_status = "silent"
+        elif should_deliver and unresolved_origin:
+            terminal_status = "delivery_not_configured"
+        elif should_deliver and normalized_deliver != "local":
+            terminal_status = "delivered"
+        else:
+            terminal_status = "completed_local"
+
+        marked_job = None
         if not _consume_interrupted_flag(job["id"]):
             if blocked_config:
-                mark_job_run(
+                marked_job = mark_job_run(
                     job["id"], success, error, delivery_error=delivery_error,
-                    status="blocked_config",
+                    status=terminal_status,
                 )
             else:
-                mark_job_run(job["id"], success, error, delivery_error=delivery_error)
-        normalized_deliver = _normalize_deliver_value(job.get("deliver", "local"))
+                marked_job = mark_job_run(
+                    job["id"], success, error,
+                    delivery_error=delivery_error, status=terminal_status,
+                )
+        if (
+            isinstance(marked_job, dict)
+            and marked_job.get("circuit_breaker_tripped_at")
+            == marked_job.get("last_run_at")
+        ):
+            breaker_notice = (
+                f"⏸ Cron '{job.get('name') or job['id']}' paused after "
+                "3 consecutive failed runs. Operator review and an explicit "
+                "resume are required."
+            )
+            try:
+                breaker_delivery_error = _deliver_result(
+                    job, breaker_notice, adapters=adapters, loop=loop,
+                )
+                if breaker_delivery_error:
+                    logger.error(
+                        "Circuit-breaker alert delivery failed for job %s: %s",
+                        job["id"], breaker_delivery_error,
+                    )
+            except Exception as de:
+                logger.error(
+                    "Circuit-breaker alert delivery raised for job %s: %s",
+                    job["id"], de,
+                )
         if delivery_error:
             delivery_outcome = "failed"
         elif should_deliver and unresolved_origin:

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -174,10 +174,17 @@ def cron_list(show_all: bool = False):
         last_status = job.get("last_status")
         if last_status:
             last_run = job.get("last_run_at", "?")
-            if last_status == "ok":
-                status_display = color("ok", Colors.GREEN)
+            if last_status in {"ok", "delivered", "completed_local"}:
+                status_display = color(last_status, Colors.GREEN)
+            elif last_status == "silent":
+                status_display = color("silent (intentionally suppressed)", Colors.DIM)
             else:
-                status_display = color(f"{last_status}: {job.get('last_error', '?')}", Colors.RED)
+                status_error = (
+                    job.get("last_delivery_error")
+                    if last_status in {"delivery_failed", "delivery_not_configured"}
+                    else job.get("last_error")
+                )
+                status_display = color(f"{last_status}: {status_error or '?'}", Colors.RED)
             print(f"    Last run:  {last_run}  {status_display}")
 
         latest_execution = job.get("latest_execution")

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -380,6 +380,43 @@ class TestMarkJobRun:
         assert updated["last_error"] is None
         assert updated["last_delivery_error"] == "platform 'telegram' not configured"
 
+    def test_three_consecutive_failures_pause_recurring_job(self, tmp_cron_dir):
+        job = create_job(prompt="Fail", schedule="every 1h")
+
+        for attempt in range(1, 4):
+            mark_job_run(job["id"], success=False, error=f"failure {attempt}")
+
+        updated = get_job(job["id"])
+        assert updated["consecutive_failures"] == 3
+        assert updated["enabled"] is False
+        assert updated["state"] == "paused"
+        assert updated["next_run_at"] is None
+        assert updated["circuit_breaker_tripped_at"]
+        assert "3 consecutive" in updated["paused_reason"]
+
+    def test_success_resets_failure_streak(self, tmp_cron_dir):
+        job = create_job(prompt="Flaky", schedule="every 1h")
+        mark_job_run(job["id"], success=False, error="failure 1")
+        mark_job_run(job["id"], success=False, error="failure 2")
+        mark_job_run(job["id"], success=True)
+
+        updated = get_job(job["id"])
+        assert updated["consecutive_failures"] == 0
+        assert updated["enabled"] is True
+        assert updated["state"] == "scheduled"
+
+    def test_resume_resets_tripped_failure_streak(self, tmp_cron_dir):
+        job = create_job(prompt="Fail", schedule="every 1h")
+        for attempt in range(3):
+            mark_job_run(job["id"], success=False, error=f"failure {attempt}")
+
+        updated = resume_job(job["id"])
+
+        assert updated["enabled"] is True
+        assert updated["state"] == "scheduled"
+        assert updated["consecutive_failures"] == 0
+        assert updated.get("circuit_breaker_tripped_at") is None
+
 
     def test_recurring_cron_not_disabled_when_croniter_missing(self, tmp_cron_dir, monkeypatch):
         """Regression test for issue #16265.

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -66,6 +66,70 @@ def test_run_one_job_success_sequence(monkeypatch):
     assert calls[-1] == ("mark", "j2", True)
 
 
+def test_run_one_job_records_silent_as_distinct_terminal_status(monkeypatch):
+    _patch_pipeline(monkeypatch, silent_marker_in="[SILENT]")
+    marked = {}
+
+    def fake_mark(jid, ok, err=None, delivery_error=None, status=None):
+        marked.update(job_id=jid, success=ok, status=status)
+
+    monkeypatch.setattr(s, "mark_job_run", fake_mark)
+
+    assert s.run_one_job({"id": "silent-1", "name": "quiet"}) is True
+    assert marked == {
+        "job_id": "silent-1",
+        "success": True,
+        "status": "silent",
+    }
+
+
+def test_run_one_job_records_delivery_failure_in_last_status(monkeypatch):
+    _patch_pipeline(monkeypatch)
+    marked = {}
+    monkeypatch.setattr(
+        s, "_deliver_result", lambda *a, **k: "platform send failed: 502",
+    )
+
+    def fake_mark(jid, ok, err=None, delivery_error=None, status=None):
+        marked.update(
+            success=ok, delivery_error=delivery_error, status=status,
+        )
+
+    monkeypatch.setattr(s, "mark_job_run", fake_mark)
+
+    job = {"id": "delivery-1", "name": "report", "deliver": "telegram:ops"}
+    assert s.run_one_job(job) is True
+    assert marked["success"] is True
+    assert marked["delivery_error"] == "platform send failed: 502"
+    assert marked["status"] == "delivery_failed"
+
+
+def test_run_one_job_pages_when_failure_trips_circuit_breaker(monkeypatch):
+    calls = _patch_pipeline(monkeypatch, success=False, error="timeout")
+    delivered_content = []
+
+    def fake_deliver(job, content, adapters=None, loop=None):
+        calls.append(("deliver", job["id"]))
+        delivered_content.append(content)
+        return None
+
+    def fake_mark(jid, ok, err=None, delivery_error=None, status=None):
+        calls.append(("mark", jid, ok))
+        return {
+            "id": jid,
+            "last_run_at": "2026-08-08T01:00:00+00:00",
+            "circuit_breaker_tripped_at": "2026-08-08T01:00:00+00:00",
+        }
+
+    monkeypatch.setattr(s, "mark_job_run", fake_mark)
+    monkeypatch.setattr(s, "_deliver_result", fake_deliver)
+
+    assert s.run_one_job({"id": "breaker-1", "name": "report"}) is True
+    deliveries = [call for call in calls if call[0] == "deliver"]
+    assert len(deliveries) == 2
+    assert "paused after 3 consecutive failed runs" in delivered_content[-1]
+
+
 def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path):
     """Regression: under profile isolation (multiplex active), run_one_job must
     execute run_job inside a profile secret scope so credential reads
@@ -107,5 +171,3 @@ def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path
     assert scope_during_run["base_url"] == "https://openrouter.ai/api/v1"
     # And it was torn down after run_one_job returned (no leak).
     assert ss.current_secret_scope() is None
-
-

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1007,6 +1007,7 @@ class TestSilentDelivery:
             False,
             "Agent completed but produced empty response (model error, timeout, or misconfiguration)",
             delivery_error=None,
+            status="error",
         )
 
 
@@ -1974,5 +1975,4 @@ class TestSetCronSessionTitle:
         out = _set_cron_session_title(db, "sess-1", "Nightly Synthesis")
         assert out == "Nightly Synthesis #2"
         db.get_next_title_in_lineage.assert_called_once_with("Nightly Synthesis")
-
 


### PR DESCRIPTION
## Summary
- persist distinct cron outcomes for delivered, silent, delivery failure, config block, and local completion
- pause recurring jobs after 3 consecutive execution failures and emit an explicit operator alert
- reset the failure streak only on success or explicit resume
- show delivery failures from the correct error field in cron list

## Verification
- HEAD: 2b8e1035a2cdae7add4eed7373665eb6d3779bae
- full cron package: 508 passed, 3 warnings in 22.55s

No runtime deploy or fault injection was performed.