### PR TITLE
fix(compression): split oversized active turns (#80449)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -5254,6 +5254,8 @@ This compaction should PRIORITISE preserving all information related to the focu
     def _find_tail_cut_by_tokens(
         self, messages: List[Dict[str, Any]], head_end: int,
         token_budget: int | None = None,
+        *,
+        allow_split_turn: bool = True,
     ) -> int:
         """Walk backward from the end of messages, accumulating tokens until
         the budget is reached. Returns the index where the tail starts.
@@ -5262,6 +5264,10 @@ This compaction should PRIORITISE preserving all information related to the focu
         derived from ``summary_target_ratio * context_length``, so it
         scales automatically with the model's context window.
 
+        ``allow_split_turn`` is disabled by rolling micro-compaction, whose
+        cursor consumes complete exchanges independently. Batch/manual
+        compaction enables it so an oversized active turn can make progress.
+
         Token budget is the primary criterion.  A bounded message-count floor
         keeps a short run of recent turns verbatim even when the budget is
         exhausted, but the budget is allowed to exceed by up to 1.5x to avoid
@@ -5269,8 +5275,12 @@ This compaction should PRIORITISE preserving all information related to the focu
         even that floor exceeds 1.5x the budget, the cut is placed right after
         the head so compression still runs.
 
-        Never cuts inside a tool_call/result group.  Always ensures the most
-        recent user message is in the tail (see ``_ensure_last_user_message_in_tail``).
+        Never cuts inside a tool_call/result group.  Normally ensures the most
+        recent user message is in the tail (see
+        ``_ensure_last_user_message_in_tail``).  When one in-progress turn alone
+        exceeds the soft ceiling, the clean mid-turn boundary wins instead: the
+        turn-opening user message enters the grounded compaction handoff and the
+        recent tool groups remain live after it (#80449).
         """
         if token_budget is None:
             token_budget = self.tail_token_budget
@@ -5339,19 +5349,69 @@ This compaction should PRIORITISE preserving all information related to the focu
         if cut_idx <= head_end:
             cut_idx = max(fallback_cut, head_end + 1)
 
-        # Align to avoid splitting tool groups
+        # Align to avoid splitting tool groups. Keep this pre-anchor boundary:
+        # it is the safe fallback when anchoring the opening user message would
+        # retain an entire oversized in-progress turn (#80449).
         cut_idx = self._align_boundary_backward(messages, cut_idx)
 
-        # Ensure the most recent user message is always in the tail so the
-        # active task is never lost to compression (fixes #10896).
-        cut_idx = self._ensure_last_user_message_in_tail(messages, cut_idx, head_end)
+        # Ensure the most recent user message is normally in the tail so the
+        # active task is never lost to compression (fixes #10896). One bounded
+        # exception is required: a single turn can contain many individually
+        # small tool groups whose aggregate size exceeds the soft ceiling. In
+        # that shape the anchor drags the cut back to the turn-opening user and
+        # defeats the token budget entirely. The summarised window already has
+        # deterministic task grounding, while SUMMARY_PREFIX explicitly treats
+        # following tool calls/results as an in-flight exchange, so retaining
+        # the clean tool-group boundary preserves both intent and progress.
+        last_user_idx = self._find_last_user_message_idx(messages, head_end)
+        user_anchored_cut = self._ensure_last_user_message_in_tail(
+            messages, cut_idx, head_end
+        )
+        split_oversized_turn = False
+        if (
+            allow_split_turn
+            and last_user_idx >= head_end
+            and last_user_idx < cut_idx
+            and user_anchored_cut < cut_idx
+            # A single oversized user message is indivisible and must remain
+            # verbatim in the tail. This exception is only for aggregate turn
+            # growth after a normally-sized opening request.
+            and _estimate_msg_budget_tokens(messages[last_user_idx]) <= soft_ceiling
+            and len(
+                _content_text_for_contains(
+                    messages[last_user_idx].get("content")
+                ).strip()
+            ) <= _ACTIVE_TASK_MAX_CHARS
+            and sum(
+                _estimate_msg_budget_tokens(message)
+                for message in messages[user_anchored_cut:]
+            ) > soft_ceiling
+        ):
+            split_oversized_turn = True
+            if not self.quiet_mode:
+                logger.info(
+                    "Active turn exceeds protected-tail soft ceiling; keeping "
+                    "tool-group-aligned mid-turn cut at index %d instead of "
+                    "anchoring user message %d (#80449)",
+                    cut_idx,
+                    last_user_idx,
+                )
+        else:
+            cut_idx = user_anchored_cut
 
         # Ensure the most recent assistant message is always in the tail
         # so the previously-visible reply isn't silently rolled into the
         # ``[CONTEXT COMPACTION — REFERENCE ONLY]`` block (fixes #29824).
-        # Each anchor only walks ``cut_idx`` backward, so chaining them is
-        # monotonic — the tail can only grow, never shrink.
-        cut_idx = self._ensure_last_assistant_message_in_tail(messages, cut_idx, head_end)
+        # Outside the bounded oversized-turn exception, each anchor only walks
+        # ``cut_idx`` backward, so chaining them is monotonic — the tail can
+        # only grow, never shrink.
+        assistant_anchored_cut = self._ensure_last_assistant_message_in_tail(messages, cut_idx, head_end)
+        # An older visible assistant reply can precede the active user turn. If
+        # the active turn was deliberately split above, pulling back to that
+        # reply would undo the bounded exception and recreate the oversized
+        # tail. A latest assistant already inside the chosen tail is unchanged.
+        if not split_oversized_turn or assistant_anchored_cut == cut_idx:
+            cut_idx = assistant_anchored_cut
 
         # Extend to the last N actionable user messages when configured
         # (compression.min_tail_user_messages > 1).  This prevents the
@@ -5368,7 +5428,12 @@ This compaction should PRIORITISE preserving all information related to the focu
         # (and plugin engines) skip __init__, so the attribute may be absent
         # (see the compression-path test-double pitfall).
         _min_tail_users = getattr(self, "min_tail_user_messages", 1)
-        if isinstance(_min_tail_users, int) and not isinstance(_min_tail_users, bool) and _min_tail_users > 1:
+        if (
+            not split_oversized_turn
+            and isinstance(_min_tail_users, int)
+            and not isinstance(_min_tail_users, bool)
+            and _min_tail_users > 1
+        ):
             cut_idx = self._ensure_last_n_user_messages_in_tail(
                 messages, cut_idx, head_end, _min_tail_users,
             )
@@ -5758,7 +5823,11 @@ This compaction should PRIORITISE preserving all information related to the focu
 
         head_size = self._protect_head_size(messages)
         compress_start = self._align_boundary_forward(messages, head_size)
-        compress_end = self._find_tail_cut_by_tokens(messages, compress_start)
+        compress_end = self._find_tail_cut_by_tokens(
+            messages,
+            compress_start,
+            allow_split_turn=False,
+        )
 
         if compress_start >= compress_end:
             return messages

--- a/tests/agent/test_split_turn_compaction_80449.py
+++ b/tests/agent/test_split_turn_compaction_80449.py
@@ -1,0 +1,188 @@
+"""Regression coverage for oversized single-turn compaction (#80449)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from agent.context_compressor import (
+    COMPRESSED_SUMMARY_METADATA_KEY,
+    ContextCompressor,
+    _estimate_msg_budget_tokens,
+)
+
+
+_ACTIVE_REQUEST = "Inspect every shard and preserve the active request exactly."
+_TOKEN_BUDGET = 250
+
+
+@pytest.fixture()
+def compressor() -> ContextCompressor:
+    with patch(
+        "agent.context_compressor.get_model_context_length",
+        return_value=100_000,
+    ):
+        instance = ContextCompressor(
+            model="test/model",
+            threshold_percent=0.85,
+            protect_first_n=0,
+            protect_last_n=3,
+            quiet_mode=True,
+        )
+        _ = instance.context_length
+    instance.tail_token_budget = _TOKEN_BUDGET
+    return instance
+
+
+def _tool_group(index: int) -> list[dict]:
+    call_id = f"call_{index}"
+    return [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {
+                        "name": "inspect_shard",
+                        # Large enough for the complete turn to exceed the
+                        # ceiling, but below the phase-1 argument-prune limit.
+                        "arguments": "x" * 440,
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": call_id,
+            # Keep each result below the phase-1 result-prune floor. The bug is
+            # aggregate turn size, not one individually oversized result.
+            "content": f"result-{index}:" + "r" * 110,
+        },
+    ]
+
+
+def _oversized_active_turn() -> list[dict]:
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "older request"},
+        {"role": "assistant", "content": "older request completed"},
+        {"role": "user", "content": _ACTIVE_REQUEST},
+    ]
+    for index in range(10):
+        messages.extend(_tool_group(index))
+    return messages
+
+
+def _assert_tool_pairs_are_complete(messages: list[dict]) -> None:
+    call_ids = {
+        call["id"]
+        for message in messages
+        for call in message.get("tool_calls") or []
+    }
+    result_ids = {
+        message["tool_call_id"]
+        for message in messages
+        if message.get("role") == "tool"
+    }
+    assert call_ids == result_ids
+
+
+def test_oversized_active_turn_uses_a_mid_turn_tool_boundary(
+    compressor: ContextCompressor,
+) -> None:
+    messages = _oversized_active_turn()
+    head_end = compressor._protect_head_size(messages)
+
+    cut = compressor._find_tail_cut_by_tokens(
+        messages,
+        head_end,
+        token_budget=_TOKEN_BUDGET,
+    )
+
+    active_user_idx = next(
+        index
+        for index, message in enumerate(messages)
+        if message.get("content") == _ACTIVE_REQUEST
+    )
+    tail_tokens = sum(_estimate_msg_budget_tokens(msg) for msg in messages[cut:])
+
+    assert cut > active_user_idx
+    # Tool-group alignment may retain one additional indivisible group beyond
+    # the scalar ceiling. It must not retain the whole active turn.
+    max_group_tokens = max(
+        sum(_estimate_msg_budget_tokens(msg) for msg in _tool_group(index))
+        for index in range(10)
+    )
+    assert tail_tokens <= int(_TOKEN_BUDGET * 1.5) + max_group_tokens
+    assert tail_tokens < sum(
+        _estimate_msg_budget_tokens(msg) for msg in messages[active_user_idx:]
+    )
+    assert messages[cut]["role"] == "assistant"
+    _assert_tool_pairs_are_complete(messages[head_end:cut])
+    _assert_tool_pairs_are_complete(messages[cut:])
+
+
+def test_individually_oversized_user_message_remains_verbatim_in_tail(
+    compressor: ContextCompressor,
+) -> None:
+    oversized_request = "u" * 1_600
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "older request"},
+        {"role": "assistant", "content": "older request completed"},
+        {"role": "user", "content": oversized_request},
+    ]
+    for index in range(10):
+        messages.extend(_tool_group(index))
+
+    cut = compressor._find_tail_cut_by_tokens(
+        messages,
+        compressor._protect_head_size(messages),
+        token_budget=_TOKEN_BUDGET,
+    )
+
+    assert cut <= 3
+    assert messages[3]["content"] == oversized_request
+
+
+def test_micro_compaction_can_require_a_whole_active_turn(
+    compressor: ContextCompressor,
+) -> None:
+    messages = _oversized_active_turn()
+
+    cut = compressor._find_tail_cut_by_tokens(
+        messages,
+        compressor._protect_head_size(messages),
+        token_budget=_TOKEN_BUDGET,
+        allow_split_turn=False,
+    )
+
+    assert cut <= 3
+
+
+def test_full_compaction_preserves_active_request_and_tool_pairs(
+    compressor: ContextCompressor,
+) -> None:
+    messages = _oversized_active_turn()
+
+    # Exercise the deterministic handoff too: even when the summary model is
+    # unavailable, splitting the turn must not lose the opening request.
+    with patch.object(compressor, "_generate_summary", return_value=None):
+        compressed = compressor.compress(messages, current_tokens=90_000)
+
+    summary_rows = [
+        message
+        for message in compressed
+        if message.get(COMPRESSED_SUMMARY_METADATA_KEY)
+    ]
+    assert len(summary_rows) == 1
+    assert _ACTIVE_REQUEST in str(summary_rows[0].get("content"))
+    assert sum(
+        _ACTIVE_REQUEST in str(message.get("content"))
+        for message in compressed
+    ) == 1
+    assert len(compressed) < len(messages)
+    _assert_tool_pairs_are_complete(compressed)


### PR DESCRIPTION
## What

Fixes #80449.

Batch context compaction can now split an oversized in-progress turn at a tool-group-aligned boundary instead of retaining the entire turn beyond the protected-tail budget.

## Root cause

`_find_tail_cut_by_tokens()` found a bounded, tool-safe cut, then the latest-user anchor pulled it back to the turn-opening request. The assistant and multi-user anchors could expand it further. A long run of individually small tool groups therefore made the whole active turn incompressible and could repeatedly hit the no-progress path.

## Fix

- Keep the pre-anchor, tool-group-aligned cut when anchoring a normally sized opening request would exceed the 1.5x tail ceiling.
- Let the existing grounded compaction handoff preserve the exact active request; the existing summary prefix already treats following tool calls/results as an in-flight exchange.
- Do not let an older visible assistant reply or `min_tail_user_messages` undo that bounded split.
- Keep individually oversized user messages verbatim in the tail.
- Leave rolling micro-compaction on its existing whole-exchange policy; only batch/manual compaction uses split-turn boundaries.

## Validation

RED on current main (`b3aa561faffd`):
- the regression cut landed before the active user (`cut=2`) and retained roughly the whole oversized turn;
- full compaction left the active request outside the generated handoff.

GREEN:
- `scripts/run_tests.sh` across the focused compressor, anchor, micro-compaction, pressure, and loop suites: 189 passed.
- Broad `tests/agent` + `tests/run_agent` run: 5,323 passed. Thirteen optional-provider failures passed after installing the declared `anthropic` extra. The sole remaining credential-pool failure reproduces unchanged on the exact main checkout and is outside this diff.
- `ruff check agent/context_compressor.py tests/agent/test_split_turn_compaction_80449.py`
- `git diff --check`

Sibling paths audited: manual preflight, batch compression, rolling micro-compaction, tool-pair sanitization, deterministic summary fallback, assistant anchoring, and multi-user tail protection.
