### PR TITLE
feat(sessions): stamp archived_at for Done/KPI archive-day credit

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5774,8 +5774,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         chains, archive the whole logical conversation. Desktop lists compression
         roots projected forward to their latest continuation; updating only the
         displayed tip lets the still-unarchived root resurrect it on refresh.
-        Returns True when at least one row was updated.
+
+        When archiving, ``archived_at`` is stamped with the current epoch so
+        Done/KPI surfaces can credit the calendar day the user actually
+        archived (not when the conversation last had activity). Unarchive
+        clears ``archived_at``. Returns True when at least one row was updated.
         """
+        archived_flag = 1 if archived else 0
+        archived_at = time.time() if archived else None
+
         def _do(conn):
             cursor = conn.execute(
                 """
@@ -5804,10 +5811,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     SELECT id FROM descendants
                   )
                 UPDATE sessions
-                SET archived = ?
+                SET archived = ?,
+                    archived_at = ?
                 WHERE id IN (SELECT id FROM lineage)
                 """,
-                (session_id, session_id, 1 if archived else 0),
+                (session_id, session_id, archived_flag, archived_at),
             )
             rowcount = cursor.rowcount
             if rowcount is None or rowcount < 0:
@@ -6241,6 +6249,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # level instead of fetching every row and sorting in Python, while
             # still surfacing old compression roots whose live tip is fresh.
             #
+            # Archived-only lists order by archive flip time (COALESCE
+            # archived_at, activity) so Done/KPI paging lands recently-archived
+            # old conversations on early pages instead of burying them by
+            # stale last_active.
+            order_expr = (
+                "COALESCE(s.archived_at, _effective_last_active)"
+                if archived_only
+                else "_effective_last_active"
+            )
             # The CTE seeds from rows the outer WHERE admits (roots + branch
             # children), then recursively joins forward through robust
             # compression-continuation edges. Do NOT require
@@ -6330,7 +6347,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 LEFT JOIN chain_max cm ON cm.root_id = s.id
                 {prompt_join}
                 {outer_where}
-                ORDER BY _effective_last_active DESC, s.started_at DESC, s.id DESC
+                ORDER BY {order_expr} DESC, s.started_at DESC, s.id DESC
                 LIMIT ? OFFSET ?
             """
             # WHERE params apply twice (CTE seed + outer select); the id filter
@@ -6448,6 +6465,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     "id", "ended_at", "end_reason", "message_count",
                     "tool_call_count", "title", "last_active", "preview",
                     "model", "system_prompt", "cwd", "git_branch", "git_repo_root",
+                    "archived", "archived_at",
                 ):
                     if key in tip_row:
                         merged[key] = tip_row[key]

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -164,7 +164,7 @@ def _sql_session_last_active_by_id(session_id_expr: str) -> str:
     )
 
 
-SCHEMA_VERSION = 25
+SCHEMA_VERSION = 26
 
 
 # FTS storage-layout version, tracked INDEPENDENTLY of SCHEMA_VERSION in the
@@ -256,6 +256,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     profile_name TEXT,
     rewind_count INTEGER NOT NULL DEFAULT 0,
     archived INTEGER NOT NULL DEFAULT 0,
+    archived_at REAL,
     pinned INTEGER NOT NULL DEFAULT 0,
     last_read_at REAL,
     FOREIGN KEY (parent_session_id) REFERENCES sessions(id),

--- a/tests/hermes_state/test_session_archiving.py
+++ b/tests/hermes_state/test_session_archiving.py
@@ -48,4 +48,29 @@ def test_unarchiving_compression_tip_unarchives_projected_root(db):
 
     assert db.get_session("root")["archived"] == 0
     assert db.get_session("tip")["archived"] == 0
+    assert db.get_session("tip")["archived_at"] is None
     assert [s["id"] for s in db.list_sessions_rich(order_by_last_active=True)] == ["tip"]
+
+
+def test_set_session_archived_stamps_archived_at(db):
+    before = time.time()
+    db.create_session("old", source="cli")
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, message_count = 1 WHERE id = 'old'",
+        (before - 86400 * 40,),
+    )
+    db._conn.commit()
+
+    assert db.set_session_archived("old", True) is True
+    row = db.get_session("old")
+    assert row["archived"] == 1
+    assert row["archived_at"] is not None
+    assert float(row["archived_at"]) >= before
+
+    # Archived-only + recent order surfaces by archive time, not stale activity.
+    listed = db.list_sessions_rich(order_by_last_active=True, archived_only=True)
+    assert [s["id"] for s in listed] == ["old"]
+    assert listed[0]["archived_at"] is not None
+
+    assert db.set_session_archived("old", False) is True
+    assert db.get_session("old")["archived_at"] is None


### PR DESCRIPTION
## Summary
- Add `sessions.archived_at` (SCHEMA_VERSION 26) and stamp it in `set_session_archived` (clear on unarchive).
- Archived-only + `order=recent` sorts by `COALESCE(archived_at, last_active)` so recently archived old chats surface first for Done/KPI paging.
- Project `archived` / `archived_at` through compression tip merge.

## Why
Hermes Focus “Done today” should credit the calendar day the user **archived**, even if the conversation is months old. Without an archive timestamp the client could only use `ended_at` / `last_active`.

## Test plan
- [x] `pytest tests/hermes_state/test_session_archiving.py`
- [ ] Archive an old session via PATCH → row has `archived_at` ≈ now
- [ ] GET `/api/sessions?archived=only&order=recent` returns `archived_at`