### PR TITLE
fix(gateway): stop scoring an authorization refusal as a successful turn

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6396,7 +6396,14 @@ class BasePlatformAdapter(ABC):
                         self.name, len(_response_pre_extract), event.source.chat_id,
                     )
 
-            # Determine overall success for the processing hook
+            # Determine overall success for the processing hook.
+            # A refused message never reached a turn, so `not bool(response)`
+            # would score it SUCCESS and paint the ack reaction — telling the
+            # sender the agent accepted them and then went silent. CANCELLED
+            # leaves the message unreacted, which is what a refusal looks like.
+            authorization_refused = bool(
+                getattr(event, "_hermes_authorization_refused", False)
+            )
             processing_ok = delivery_succeeded if delivery_attempted else not bool(response)
             # Clean up the per-turn streaming-TTS flag (#60671).
             self._streaming_tts_completed_turns.discard(
@@ -6407,10 +6414,16 @@ class BasePlatformAdapter(ABC):
                 )
                 or ""
             )
+            if authorization_refused:
+                _outcome = ProcessingOutcome.CANCELLED
+            else:
+                _outcome = (
+                    ProcessingOutcome.SUCCESS if processing_ok else ProcessingOutcome.FAILURE
+                )
             await self._run_processing_hook(
                 "on_processing_complete",
                 event,
-                ProcessingOutcome.SUCCESS if processing_ok else ProcessingOutcome.FAILURE,
+                _outcome,
             )
 
             # The active drain owns debounce state. If a queue-mode timer has

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14706,9 +14706,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # sender). Defer to _is_user_authorized so that path runs.
             if not self._is_user_authorized(source):
                 logger.debug("Ignoring message with no user_id from %s", source.platform.value)
+                # Mark the refusal so the reaction-ack flow does not score this
+                # as a completed turn (see _process_message_background).
+                event._hermes_authorization_refused = True
                 return None
         elif not self._is_user_authorized(source):
             logger.warning("Unauthorized user: %s (%s) on %s", source.user_id, source.user_name, source.platform.value)
+            # Every exit below is a refusal: no turn runs, whether we stay
+            # silent or answer with a pairing code. Mark it once here so the
+            # reaction-ack flow leaves the message unreacted instead of ✅.
+            event._hermes_authorization_refused = True
             # In DMs: offer pairing code. In groups: silently ignore.
             if (
                 source.chat_type == "dm"

--- a/tests/gateway/test_authz_reaction_outcome.py
+++ b/tests/gateway/test_authz_reaction_outcome.py
@@ -1,0 +1,148 @@
+"""An authorization refusal must not paint the success reaction.
+
+`_process_message_background` scored a turn with `not bool(response)`, which
+cannot tell "the handler deliberately produced no output" from "the message
+was refused before any handler ran". A rejected sender therefore saw the
+in-progress reaction swapped for the ack reaction and no reply: it reads as
+"the agent acknowledged me and then broke".
+
+`ProcessingOutcome.CANCELLED` already means "leave the message unreacted",
+which is exactly what a refusal should look like.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.platforms.base import ProcessingOutcome
+
+
+class _Recorder:
+    """Minimal stand-in for the shared reaction-ack flow."""
+
+    _OK_EMOJI = "✅"
+    _FAIL_EMOJI = "❌"
+
+    def __init__(self):
+        self.added: list[str] = []
+        self.removed = 0
+
+    async def _add_reaction(self, chat_id, message_id, emoji):
+        self.added.append(emoji)
+
+    async def _remove_reaction(self, chat_id, message_id):
+        self.removed += 1
+
+
+class _Source:
+    chat_id = "c1"
+
+
+class _Event:
+    def __init__(self):
+        self.source = _Source()
+        self.message_id = "m1"
+
+
+async def _run_hook(outcome: ProcessingOutcome) -> _Recorder:
+    from gateway.platforms.base import BasePlatformAdapter
+
+    rec = _Recorder()
+    await BasePlatformAdapter.on_processing_complete(rec, _Event(), outcome)
+    return rec
+
+
+@pytest.mark.asyncio
+async def test_cancelled_leaves_the_message_unreacted():
+    """The contract this fix relies on: CANCELLED paints nothing."""
+    rec = await _run_hook(ProcessingOutcome.CANCELLED)
+
+    assert rec.added == [], "a cancelled turn must not paint any reaction"
+    assert rec.removed == 1, "the in-progress reaction must still be cleared"
+
+
+@pytest.mark.asyncio
+async def test_success_still_paints_the_ack():
+    """Guard: ordinary completed turns keep their ack reaction."""
+    rec = await _run_hook(ProcessingOutcome.SUCCESS)
+
+    assert rec.added == ["✅"]
+
+
+@pytest.mark.asyncio
+async def test_failure_still_paints_the_failure_reaction():
+    """Guard: genuine failures keep their failure reaction."""
+    rec = await _run_hook(ProcessingOutcome.FAILURE)
+
+    assert rec.added == ["❌"]
+
+
+def test_refused_event_maps_to_cancelled():
+    """The mapping the background path applies, exercised directly.
+
+    Mirrors the expression in _process_message_background: a refused event
+    short-circuits to CANCELLED regardless of the response/delivery scoring
+    that would otherwise have produced SUCCESS.
+    """
+
+    def _outcome(event, *, delivery_attempted=False, delivery_succeeded=False, response=None):
+        authorization_refused = bool(
+            getattr(event, "_hermes_authorization_refused", False)
+        )
+        processing_ok = delivery_succeeded if delivery_attempted else not bool(response)
+        if authorization_refused:
+            return ProcessingOutcome.CANCELLED
+        return ProcessingOutcome.SUCCESS if processing_ok else ProcessingOutcome.FAILURE
+
+    refused = _Event()
+    refused._hermes_authorization_refused = True
+    # The reported shape: no delivery, no response. Pre-fix this scored SUCCESS.
+    assert _outcome(refused) is ProcessingOutcome.CANCELLED
+
+    # An ordinary suppressed/no-op turn is unchanged.
+    assert _outcome(_Event()) is ProcessingOutcome.SUCCESS
+    # A delivered turn is unchanged.
+    assert _outcome(
+        _Event(), delivery_attempted=True, delivery_succeeded=True
+    ) is ProcessingOutcome.SUCCESS
+    # A failed delivery is unchanged.
+    assert _outcome(
+        _Event(), delivery_attempted=True, delivery_succeeded=False
+    ) is ProcessingOutcome.FAILURE
+
+
+@pytest.mark.asyncio
+async def test_handle_message_marks_an_unauthorized_sender(monkeypatch, tmp_path):
+    """End of the chain: the real refusal path sets the marker the hook reads.
+
+    Drives ``GatewayRunner._handle_message`` with an unauthorized group sender
+    (the reported shape: allowed channel, no allowlist entry for the user), so
+    the marker is proven to come from production code rather than the test.
+    """
+    from gateway.config import GatewayConfig, Platform
+    from gateway.platforms.base import MessageEvent
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    (tmp_path / "config.yaml").write_text("", encoding="utf-8")
+
+    runner = GatewayRunner(GatewayConfig())
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="chan-1",
+        chat_type="group",
+        user_id="9999",
+        user_name="stranger",
+    )
+    event = MessageEvent(text="hello", source=source, internal=False)
+
+    assert runner._is_user_authorized(source) is False, "test needs an unauthorized sender"
+
+    result = await runner._handle_message(event)
+
+    assert result is None
+    assert getattr(event, "_hermes_authorization_refused", False) is True, (
+        "the refusal was not marked, so the reaction flow would still score it SUCCESS"
+    )


### PR DESCRIPTION
## What does this PR do?

A sender the bot is not authorized for gets the in-progress reaction, then the ack reaction, and no reply. It reads as "the agent acknowledged me and then broke". It is actually a clean authorization refusal being scored as a successful turn.

`_process_message_background` classifies the turn like this:

```python
processing_ok = delivery_succeeded if delivery_attempted else not bool(response)
await self._run_processing_hook(
    "on_processing_complete",
    event,
    ProcessingOutcome.SUCCESS if processing_ok else ProcessingOutcome.FAILURE,
)
```

`_handle_message` logs `Unauthorized user: ...` and returns `None`, so `delivery_attempted` is False and `response` is None. `not bool(None)` is True, so the refusal scores SUCCESS and the adapter swaps the in-progress reaction for the ack.

`not bool(response)` exists to cover "the handler deliberately produced no output", a suppressed or no-op turn. It cannot tell that apart from "the message was refused before any handler ran", and those two deserve opposite feedback.

### The fix

`ProcessingOutcome` already has the right value. The shared reaction flow documents it:

```
CANCELLED outcomes leave the message unreacted.
```

That is exactly what a refusal should look like: the in-progress reaction is cleared, nothing is painted in its place. So this PR does not add a new outcome or change what any existing one means. It marks the refusal on the event where it happens and maps that one case to CANCELLED.

The marker is set once, covering every exit of the unauthorized branch. That includes the DM pairing-code path: a pairing code is a reply about enrolment, not the answer to the message, so painting the ack there is the same lie in a quieter form.

## Related Issue

Fixes #81440 (P2, `comp/gateway`, `platform/discord`). Searched open and merged PRs first, per CONTRIBUTING's search-first section:

```
gh search prs --repo NousResearch/hermes-agent "81440"                      --limit 20  # 0
gh search prs --repo NousResearch/hermes-agent "discord reaction authorization" --limit 20  # 0
gh search prs --repo NousResearch/hermes-agent "discord unauthorized reaction"  --limit 20  # 0
gh search prs --repo NousResearch/hermes-agent "discord silent drop"        --limit 20  # nothing on this path
```

Nothing addresses the outcome classification for refused messages.

## Type of Change

Bug fix (non-breaking). No new outcome value, no change to the meaning of SUCCESS, FAILURE or CANCELLED, and no change to authorization itself.

## Changes Made

- `gateway/run.py` - `_handle_message` marks `event._hermes_authorization_refused` on both unauthorized exits (missing user id, and the unauthorized branch that covers the silent and pairing-code paths).
- `gateway/platforms/base.py` - `_process_message_background` maps a marked event to `ProcessingOutcome.CANCELLED` and leaves every other classification exactly as it was.
- `tests/gateway/test_authz_reaction_outcome.py` - new, 5 tests.

## How to Test

```
pytest tests/gateway/test_authz_reaction_outcome.py -q
```

5 passed.

The last one drives the real `GatewayRunner._handle_message` with an unauthorized group sender, which is the reported shape (allowed channel, sender not in the allowlist), so the marker is proven to come from production code rather than from the test.

Reverting only `gateway/run.py` and `gateway/platforms/base.py` and rerunning:

```
FAILED test_handle_message_marks_an_unauthorized_sender
1 failed, 4 passed
```

with

```
E  AssertionError: the refusal was not marked, so the reaction flow would still
E                  score it SUCCESS
E  assert False is True
```

The other four pass both before and after by design. Three of them pin the contract this fix leans on and must not disturb: CANCELLED paints nothing while still clearing the in-progress reaction, SUCCESS still paints the ack, FAILURE still paints the failure reaction. The fourth pins the classification table itself, including that an ordinary no-op turn, a delivered turn and a failed delivery all keep their previous outcome.

Full `tests/gateway/` suite, this branch vs `main`, same environment, run serially:

```
main:   8 failed, 4982 passed, 30 skipped, 1 xfailed
branch: 7 failed, 4988 passed, 30 skipped, 1 xfailed
```

Comparing the failing sets rather than the counts: **zero regressions**, nothing fails here that does not already fail on `main`. One test fails on `main` and passes on this branch (`test_api_server.py::TestHealthDetailedEndpoint::test_health_detailed_returns_ok`); that is a health-probe test with no path to this change, so I read it as environmental flake rather than something this PR fixed. The +6 is this PR's 5 new tests plus that flake.

Those failures are pre-existing in a non-hermetic single-process `pytest tests/gateway/` run; CI's per-file isolation via `run_tests_parallel.py` is the supported path.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(gateway): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (queries above)
- [x] My PR contains only changes related to this fix
- [x] I've run the affected suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation; both edits carry comments recording why a refusal is not a completed turn
- [x] `cli-config.yaml.example` is N/A, no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` are N/A
- [x] Cross-platform impact is N/A; the change is in shared gateway code and is platform-agnostic
- [x] Tool descriptions/schemas are N/A

## Notes for the reviewer

The fix is in shared code, so every adapter that opts into the reaction-ack flow gets it, not just Discord. That is deliberate: the misclassification was never Discord-specific, Discord is just where it is most visible because it paints two reactions.

I used an event marker rather than a new return sentinel from `_handle_message`. A sentinel would change that method's contract for every caller, and `_hermes_`-prefixed event attributes are already the established way to carry per-turn state through this path. If you would rather see an explicit `ProcessingOutcome.REFUSED` so refusals are distinguishable from user cancellations in adapter hooks, say so and I will follow that shape instead; I stayed with CANCELLED because its documented behaviour already matches and it needs no per-adapter updates.
