### PR TITLE
fix(memory): show where Telegram memory writes actually land

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -489,9 +489,12 @@ def cmd_status(args) -> None:
     mem_mark = "enabled ✓" if memory_enabled else "disabled ✗"
     user_mark = "enabled ✓" if user_profile_enabled else "disabled ✗"
 
-    # Check if the memory tool is enabled for the CLI platform via the
-    # canonical resolver (handles composite toolsets like hermes-cli).
+    # This command runs on the CLI, so qualify the platform instead of
+    # presenting this as a global tool state. Messaging platforms can have
+    # independent platform_toolsets selections.
     from hermes_cli.tools_config import _get_platform_tools
+    from tools.memory_tool import get_memory_dir
+
     cli_tools = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
     memory_tool_enabled = "memory" in cli_tools
     tool_mark = "enabled ✓" if memory_tool_enabled else "disabled ✗"
@@ -500,7 +503,8 @@ def cmd_status(args) -> None:
     print("  Built-in (MEMORY.md / USER.md):")
     print(f"    Memory injection:   {mem_mark}")
     print(f"    User profile:       {user_mark}")
-    print(f"    Memory tool:        {tool_mark}")
+    print(f"    Memory tool (CLI):  {tool_mark}")
+    print(f"    Storage:            {get_memory_dir()}")
     print(f"  Provider:  {provider_name or '(none — built-in only)'}")
 
     providers = _get_available_providers()

--- a/tests/hermes_cli/test_memory_status.py
+++ b/tests/hermes_cli/test_memory_status.py
@@ -11,7 +11,7 @@ import pytest
 from unittest.mock import patch
 
 
-def _run_cmd_status(capfd, mem_config=None, memory_tools=None):
+def _run_cmd_status(capfd, mem_config=None, memory_tools=None, platform_toolsets=None):
     """Run cmd_status with a mocked config and return captured stdout.
 
     Args:
@@ -21,7 +21,10 @@ def _run_cmd_status(capfd, mem_config=None, memory_tools=None):
     """
     from hermes_cli.memory_setup import cmd_status
 
-    config = {"memory": mem_config or {}}
+    config = {
+        "memory": mem_config or {},
+        "platform_toolsets": platform_toolsets or {},
+    }
     if memory_tools is None:
         memory_tools = {"memory"}
 
@@ -52,6 +55,20 @@ class TestMemoryStatusLabels:
         out = _run_cmd_status(capfd, mem_config={"memory_enabled": False})
         assert "Memory injection:" in out
         assert "disabled ✗" in out
+
+    def test_labels_cli_tool_scope_and_shows_profile_storage(
+        self, capfd, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+
+        out = _run_cmd_status(
+            capfd,
+            memory_tools={"memory"},
+            platform_toolsets={"cli": ["file"], "telegram": ["memory"]},
+        )
+
+        assert "Memory tool (CLI):" in out
+        assert f"Storage:            {tmp_path / 'profile' / 'memories'}" in out
 
 
 

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -158,6 +158,28 @@ class TestMemoryStoreAdd:
         assert "disk unavailable" in result["error"]
         assert store.memory_entries == []
 
+    def test_unicode_write_failure_returns_error_without_advancing_live_state(
+        self, store
+    ):
+        store.add("memory", "existing fact")
+        path = store._path_for("memory")
+        before = path.read_text(encoding="utf-8")
+        unpaired_surrogate = json.loads('"\\ud800"')
+
+        result = json.loads(
+            memory_tool(
+                action="add",
+                target="memory",
+                content=unpaired_surrogate,
+                store=store,
+            )
+        )
+
+        assert result["success"] is False
+        assert "surrogates not allowed" in result["error"]
+        assert store.memory_entries == ["existing fact"]
+        assert path.read_text(encoding="utf-8") == before
+
     def test_success_reports_the_persisted_file(self, store, tmp_path):
         result = json.loads(
             memory_tool(action="add", target="memory", content="durable fact", store=store)

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -142,6 +142,31 @@ class TestMemoryStoreAdd:
         assert result["success"] is False
         assert "Blocked" in result["error"]
 
+    def test_write_failure_returns_error_without_advancing_live_state(
+        self, store, monkeypatch
+    ):
+        def fail_write(*_args, **_kwargs):
+            raise RuntimeError("disk unavailable")
+
+        monkeypatch.setattr(store, "_write_file", fail_write)
+
+        result = json.loads(
+            memory_tool(action="add", target="memory", content="durable fact", store=store)
+        )
+
+        assert result["success"] is False
+        assert "disk unavailable" in result["error"]
+        assert store.memory_entries == []
+
+    def test_success_reports_the_persisted_file(self, store, tmp_path):
+        result = json.loads(
+            memory_tool(action="add", target="memory", content="durable fact", store=store)
+        )
+
+        assert result["success"] is True
+        assert result["path"] == str(tmp_path / "MEMORY.md")
+        assert "durable fact" in (tmp_path / "MEMORY.md").read_text(encoding="utf-8")
+
 
 class TestMemoryStoreReplace:
     def test_replace_entry(self, store):

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -373,7 +373,7 @@ class MemoryStore:
         path = self._path_for(target)
         try:
             self.save_to_disk(target, entries)
-        except (OSError, IOError, RuntimeError) as exc:
+        except Exception as exc:
             return {
                 "success": False,
                 "error": str(exc),

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -360,10 +360,27 @@ class MemoryStore:
         self._set_entries(target, fresh)
         return bak
 
-    def save_to_disk(self, target: str):
-        """Persist entries to the appropriate file. Called after every mutation."""
+    def save_to_disk(self, target: str, entries: Optional[List[str]] = None):
+        """Persist either a candidate state or the current live entries."""
         get_memory_dir().mkdir(parents=True, exist_ok=True)
-        self._write_file(self._path_for(target), self._entries_for(target))
+        persisted_entries = self._entries_for(target) if entries is None else entries
+        self._write_file(self._path_for(target), persisted_entries)
+
+    def _commit_entries(
+        self, target: str, entries: List[str]
+    ) -> Optional[Dict[str, Any]]:
+        """Persist a candidate state before publishing it to the live store."""
+        path = self._path_for(target)
+        try:
+            self.save_to_disk(target, entries)
+        except (OSError, IOError, RuntimeError) as exc:
+            return {
+                "success": False,
+                "error": str(exc),
+                "path": str(path),
+            }
+        self._set_entries(target, entries)
+        return None
 
     def _entries_for(self, target: str) -> List[str]:
         if target == "user":
@@ -440,9 +457,9 @@ class MemoryStore:
                     "usage": f"{current:,}/{limit:,}",
                 })
 
-            entries.append(content)
-            self._set_entries(target, entries)
-            self.save_to_disk(target)
+            write_error = self._commit_entries(target, new_entries)
+            if write_error:
+                return write_error
 
         return self._success_response(target, "Entry added.")
 
@@ -511,9 +528,9 @@ class MemoryStore:
                     "usage": f"{current:,}/{limit:,}",
                 })
 
-            entries[idx] = new_content
-            self._set_entries(target, entries)
-            self.save_to_disk(target)
+            write_error = self._commit_entries(target, test_entries)
+            if write_error:
+                return write_error
 
         return self._success_response(target, "Entry replaced.")
 
@@ -553,9 +570,11 @@ class MemoryStore:
                 # All identical -- safe to remove just the first
 
             idx = matches[0][0]
-            entries.pop(idx)
-            self._set_entries(target, entries)
-            self.save_to_disk(target)
+            new_entries = entries.copy()
+            new_entries.pop(idx)
+            write_error = self._commit_entries(target, new_entries)
+            if write_error:
+                return write_error
 
         return self._success_response(target, "Entry removed.")
 
@@ -663,8 +682,9 @@ class MemoryStore:
                 })
 
             # Commit.
-            self._set_entries(target, working)
-            self.save_to_disk(target)
+            write_error = self._commit_entries(target, working)
+            if write_error:
+                return write_error
 
         return self._success_response(target, f"Applied {len(operations)} operation(s).")
 
@@ -720,6 +740,7 @@ class MemoryStore:
             "success": True,
             "done": True,
             "target": target,
+            "path": str(self._path_for(target)),
             "usage": f"{pct}% — {current:,}/{limit:,} chars",
             "entry_count": len(entries),
         }


### PR DESCRIPTION
## What does this PR do?

Memory writes now persist a candidate state before publishing it to the live store, return a structured error with the target path when persistence fails, and include the exact persisted file in successful responses. `hermes memory status` now qualifies tool availability as CLI-specific and shows the active profile's storage directory, so Telegram users are not misled by a CLI-only status result or by inspecting the wrong default-profile path.

### Symptom

A Telegram memory call can return a terminal success response without identifying where the write landed, while `hermes memory status` can display an unqualified `Memory tool: disabled` result even when Telegram has the memory toolset enabled. If persistence itself raises, the live store could also advance ahead of the unchanged file.

### Impact

Operators can inspect the wrong profile path and conclude that a successful write was lost. A real persistence failure could leave the current process with memory state that does not match disk until the next reload.

### Bug Cause

**Trigger:** `MemoryStore.add`, `MemoryStore.replace`, `MemoryStore.remove`, and `MemoryStore.apply_batch` published candidate entries before `save_to_disk`; `cmd_status` resolved only the CLI platform but labeled the result as a global memory-tool state.

**Causal chain:**
1. A Telegram session mutates built-in memory or an operator checks memory status.
2. Mutation paths update live entries before persistence, success responses omit the target file, and status resolves only CLI toolsets without naming that scope.
3. A failed write can leave live state ahead of disk, while a successful default-profile write and CLI-only status can lead the operator to inspect the wrong file and infer a false success.

**Why it is wrong:** Persistence must be the commit point for live memory state, and platform-specific diagnostics must identify their scope. The default profile stores memory under `<HERMES_HOME>/memories`, not a named `profiles/default` directory.

**Working sibling / contrast:** Named profiles already resolve their storage under their own profile-scoped `HERMES_HOME`; the ambiguity is specific to the virtual default-profile layout and the unqualified CLI diagnostic.

**Ruled out:** Successful mutations do not swallow atomic-write exceptions; the existing code only returned success after the write call completed. The issue instead combines missing path diagnostics with an inconsistent failure-state transition and a CLI-only status label.

### Fix

A shared commit helper now writes copied candidate entries first and updates the live store only after persistence succeeds. All mutation actions return the same structured failure shape on write errors, success responses identify the exact file, and status output labels CLI availability while printing the active profile's memory directory.

## Related Issue

Fixes #81430

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/memory_tool.py` - make persistence the live-state commit point and report the target path on success or failure.
- `hermes_cli/memory_setup.py` - qualify CLI tool availability and display profile-scoped storage.
- `tests/tools/test_memory_tool.py` - cover injected and encoding write failures plus persisted-path reporting.
- `tests/hermes_cli/test_memory_status.py` - cover CLI-disabled and Telegram-enabled status output with profile storage.

## How to Test

1. Configure CLI toolsets without memory and Telegram toolsets with memory, then run `hermes memory status`; verify the output says `Memory tool (CLI)` and displays the active profile's storage directory.
2. Inject a write failure into a memory mutation; verify the response has `success: false`, reports the target path, and leaves live entries and disk unchanged.
3. Run the targeted regression suite and lint checks:

```bash
scripts/run_tests.sh tests/tools/test_memory_tool.py tests/hermes_cli/test_memory_status.py
C:/workspace/hermes-agent/.venv/Scripts/python.exe -m ruff check tools/memory_tool.py hermes_cli/memory_setup.py tests/tools/test_memory_tool.py tests/hermes_cli/test_memory_status.py
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all 40 tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] Documentation update: N/A - the command output is self-explanatory and no configuration keys changed
- [x] `cli-config.yaml.example` update: N/A - no configuration keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered - paths use the existing `Path`-based profile resolver
- [x] Tool description/schema update: N/A - the memory tool input schema is unchanged

## Screenshots / Logs

Targeted tests: 40 passed. Ruff: all checks passed.
