### PR TITLE
feat(cron): run jobs in the current conversation

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -542,7 +542,7 @@ class SessionManager:
         # for the rest of the session (see hermes_state.get_messages_as_conversation).
         try:
             history = db.get_messages_as_conversation(
-                session_id, repair_alternation=True
+                session_id, repair_alternation=True, include_hidden=True
             )
         except Exception:
             logger.warning("Failed to load messages for ACP session %s", session_id, exc_info=True)
@@ -621,7 +621,7 @@ class SessionManager:
             if not isinstance(cfg, dict) or cfg.get("enabled", True) is not False
         ]
 
-        kwargs = {
+        kwargs: Dict[str, Any] = {
             "platform": "acp",
             "enabled_toolsets": _expand_acp_enabled_toolsets(
                 ["hermes-acp"],

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -470,6 +470,7 @@ def init_agent(
     max_iterations: int = 90,  # Default tool-calling iterations (shared with subagents)
     enabled_toolsets: List[str] = None,
     disabled_toolsets: List[str] = None,
+    allowed_tool_names: List[str] | set[str] | frozenset[str] | None = None,
     save_trajectories: bool = False,
     verbose_logging: bool = False,
     quiet_mode: bool = False,
@@ -532,6 +533,7 @@ def init_agent(
     checkpoint_max_file_size_mb: int = 10,
     pass_session_id: bool = False,
     requested_provider: str = None,
+    contextual_execution: bool = False,
 ):
     """
     Initialize the AI Agent.
@@ -620,6 +622,14 @@ def init_agent(
     # flag is the explicit single-switch off for both review paths.
     agent.skip_background_review = bool(skip_background_review)
     agent.pass_session_id = pass_session_id
+    # Private fail-closed execution mode for gateway-owned contextual cron.
+    # Provider middleware and alternate runtimes also consult this flag.
+    agent._contextual_execution = bool(contextual_execution)
+    if agent._contextual_execution:
+        # Contextual V1 is bound to the admitted direct provider route. Drop
+        # fallback configuration before both init-time recovery and runtime
+        # fallback-chain construction, regardless of which host created us.
+        fallback_model = None  # type: ignore[assignment]
     agent.log_prefix_chars = log_prefix_chars
     agent.log_prefix = f"{log_prefix} " if log_prefix else ""
     # Store effective base URL for feature detection (prompt caching, reasoning, etc.)
@@ -842,6 +852,9 @@ def init_agent(
     # Store toolset filtering options
     agent.enabled_toolsets = enabled_toolsets
     agent.disabled_toolsets = disabled_toolsets
+    agent.allowed_tool_names = (
+        frozenset(allowed_tool_names) if allowed_tool_names is not None else None
+    )
     
     # Model response configuration
     agent.max_tokens = max_tokens  # None = use model default
@@ -2426,11 +2439,12 @@ def init_agent(
     _selected_engine = None
     _copy_failed = False
     _engine_name = "compressor"  # default
-    try:
-        _ctx_cfg = _agent_cfg.get("context", {}) if isinstance(_agent_cfg, dict) else {}
-        _engine_name = _ctx_cfg.get("engine", "compressor") or "compressor"
-    except Exception:
-        pass
+    if not agent._contextual_execution:
+        try:
+            _ctx_cfg = _agent_cfg.get("context", {}) if isinstance(_agent_cfg, dict) else {}
+            _engine_name = _ctx_cfg.get("engine", "compressor") or "compressor"
+        except Exception:
+            pass
 
     if _engine_name != "compressor":
         # Try loading from plugins/context_engine/<name>/
@@ -2662,8 +2676,31 @@ def init_agent(
             agent._context_engine_tool_names.add(_tname)
             _existing_tool_names.add(_tname)
 
+    # Final-schema capability gate. This runs after dynamic memory/context
+    # engine schemas were appended, so plugin or provider-added tools cannot
+    # bypass an unattended execution policy by appearing after toolset
+    # resolution.
+    if agent.allowed_tool_names is not None:
+        agent.tools = [
+            schema
+            for schema in (agent.tools or [])
+            if isinstance(schema, dict)
+            and isinstance(schema.get("function"), dict)
+            and schema["function"].get("name") in agent.allowed_tool_names
+        ]
+        agent.valid_tool_names = {
+            schema["function"]["name"] for schema in agent.tools
+        }
+        agent._context_engine_tool_names.intersection_update(
+            agent.allowed_tool_names
+        )
+
     # Notify context engine of session start
-    if hasattr(agent, "context_compressor") and agent.context_compressor:
+    if (
+        not agent._contextual_execution
+        and hasattr(agent, "context_compressor")
+        and agent.context_compressor
+    ):
         try:
             agent.context_compressor.on_session_start(
                 agent.session_id,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2311,6 +2311,11 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     summary_call_outcome = "failed"
 
     def _managed_summary_call(request, callback, *, retry_count: int):
+        if getattr(agent, "_contextual_execution", False) is True:
+            # Contextual turns are admitted to one concrete provider route and
+            # must not re-enter the deferred Relay plane in the finalizer.
+            return callback(request)
+
         from agent import relay_llm
 
         return relay_llm.execute_current(

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -149,6 +149,10 @@ LEGACY_SUMMARY_PREFIX = "[CONTEXT SUMMARY]:"
 # "is_compressed_summary" would reach the wire and trip exactly that.
 COMPRESSED_SUMMARY_METADATA_KEY = "_compressed_summary"
 COMPRESSED_SUMMARY_HAS_USER_TURN_KEY = "_compressed_summary_has_user_turn"
+_HIDDEN_DERIVED_SUMMARY_DISPLAY_METADATA = {
+    "kind": "compression_summary",
+    "contains_hidden": True,
+}
 # Distinguishes rolling micro-compaction markers from batch-compaction
 # markers (both carry COMPRESSED_SUMMARY_METADATA_KEY so resume/handoff
 # treat them alike). Supersede/defrag/rehydration must only ever touch
@@ -6604,6 +6608,31 @@ This compaction should PRIORITISE preserving all information related to the focu
         else:
             self._summary_has_user_turn = real_user_present
 
+        # Privacy-taint summaries derived from internal transcript rows.  The
+        # flag is computed after restart-handoff rehydration has finalized the
+        # exact summarizer window, and it also follows a previously persisted
+        # tainted handoff across iterative compression.  ``display_metadata``
+        # is part of the durable message schema; the private ``_compressed_*``
+        # process markers are intentionally not.
+        _summary_contains_hidden = any(
+            message.get("display_kind") == "hidden"
+            for message in turns_to_summarize
+        )
+        if not _summary_contains_hidden:
+            for _summary_idx, _summary_body in summary_hits:
+                _summary_message = messages[_summary_idx]
+                _display_metadata = _summary_message.get("display_metadata")
+                if (
+                    _summary_message.get("display_kind") == "hidden"
+                    or (
+                        isinstance(_display_metadata, dict)
+                        and _display_metadata.get("kind") == "compression_summary"
+                        and _display_metadata.get("contains_hidden") is True
+                    )
+                ):
+                    _summary_contains_hidden = True
+                    break
+
         self._record_compression_regions(
             head_messages=messages[:compress_start],
             middle_messages=turns_to_summarize,
@@ -7008,14 +7037,20 @@ This compaction should PRIORITISE preserving all information related to the focu
             summary = summary + "\n\n" + _SUMMARY_END_MARKER
 
         if not _merge_summary_into_tail:
-            compressed.append({
+            _summary_message: Dict[str, Any] = {
                 "role": summary_role,
                 "content": summary,
                 COMPRESSED_SUMMARY_METADATA_KEY: True,
                 COMPRESSED_SUMMARY_HAS_USER_TURN_KEY: bool(
                     self._summary_has_user_turn
                 ),
-            })
+            }
+            if _summary_contains_hidden:
+                _summary_message["display_kind"] = "hidden"
+                _summary_message["display_metadata"] = dict(
+                    _HIDDEN_DERIVED_SUMMARY_DISPLAY_METADATA
+                )
+            compressed.append(_summary_message)
 
         # Default merge target: literal tail index 0. For an ordinary
         # alternation collision the summary only has to stay *invisible* to
@@ -7076,6 +7111,16 @@ This compaction should PRIORITISE preserving all information related to the focu
                 msg[COMPRESSED_SUMMARY_HAS_USER_TURN_KEY] = bool(
                     self._summary_has_user_turn
                 )
+                if _summary_contains_hidden:
+                    # A merged carrier can contain genuine tail content as
+                    # well as the derived summary.  Until the durable schema
+                    # has a separate safe public-content sidecar, fail closed:
+                    # hide the whole carrier rather than declassify internal
+                    # scheduled input through a visible summary.
+                    msg["display_kind"] = "hidden"
+                    msg["display_metadata"] = dict(
+                        _HIDDEN_DERIVED_SUMMARY_DISPLAY_METADATA
+                    )
                 # Content rewritten → the api_content sidecar (exact bytes
                 # previously sent) is stale; drop it so replay can't resend
                 # the pre-merge bytes without the summary.

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1223,7 +1223,7 @@ def _adopt_live_compression_child(
     if not child or not child.get("id"):
         return None
     child_session_id = str(child["id"])
-    recovered = loader(session_db, child_session_id)
+    recovered = loader(session_db, child_session_id, include_hidden=True)
     if not isinstance(recovered, list) or not recovered:
         return None
     # Revalidate after loading: the child may have rotated or a competing
@@ -2747,7 +2747,9 @@ def compress_context(
                 type(_lock_db), "get_messages_as_conversation", None
             )
             if callable(durable_loader):
-                durable_parent = durable_loader(_lock_db, _lock_sid)
+                durable_parent = durable_loader(
+                    _lock_db, _lock_sid, include_hidden=True
+                )
                 if isinstance(durable_parent, list) and len(durable_parent) > len(messages):
                     logger.info(
                         "compression: session=%s grew before lease "

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -157,6 +157,21 @@ _HANDOFF_SKIP_FINAL_RESPONSE = (
 )
 
 
+def _is_contextual_execution(agent: Any) -> bool:
+    """Return the gateway-owned contextual mode; callers cannot widen it."""
+    # Treat only the concrete private boolean as authority. Dynamic proxy/test
+    # objects (for example MagicMock) synthesize truthy missing attributes and
+    # must not accidentally suppress ordinary context-engine behavior.
+    if getattr(agent, "_contextual_execution", False) is True:
+        return True
+    try:
+        from gateway.session_context import _get_contextual_turn_authority
+
+        return _get_contextual_turn_authority() is not None
+    except Exception:
+        return False
+
+
 # Stable prefix of the local interrupt status string emitted when a turn is
 # cancelled while waiting on the provider. Surfaces (ACP, TUI) match on this
 # to treat it as cancellation metadata rather than assistant prose.
@@ -1251,6 +1266,8 @@ def _apply_context_engine_selection(
     value yields the unmodified ``api_messages``. The result is request-only —
     persisted conversation history is never mutated here.
     """
+    if _is_contextual_execution(agent):
+        return api_messages
     engine = getattr(agent, "context_compressor", None)
     if engine is None or not hasattr(engine, "select_context"):
         return api_messages
@@ -1336,6 +1353,8 @@ def _notify_context_engine_turn_complete(
     ``messages`` is passed as a shallow copy so the engine cannot mutate the
     persisted transcript.
     """
+    if _is_contextual_execution(agent):
+        return
     engine = getattr(agent, "context_compressor", None)
     hook = getattr(engine, "on_turn_complete", None)
     if engine is None or not callable(hook):
@@ -1409,7 +1428,13 @@ def run_conversation(
     Returns:
         Dict: Complete conversation result with final response and message history
     """
-    if moa_config is None:
+    _contextual_execution = _is_contextual_execution(agent)
+    if _contextual_execution:
+        # Contextual prompts are canonical internal text. They may not activate
+        # encoded MoA/delegation or streaming callback planes.
+        moa_config = None
+        stream_callback = None
+    elif moa_config is None:
         try:
             from hermes_cli.moa_config import decode_moa_turn
 
@@ -1466,6 +1491,7 @@ def run_conversation(
         # MoA turns append per-call aggregated context to the API copy of the
         # user message, so no byte-stable api_content sidecar can be stamped.
         moa_active=bool(moa_config),
+        contextual_execution=_contextual_execution,
     )
     user_message = _ctx.user_message
     original_user_message = _ctx.original_user_message
@@ -1501,6 +1527,18 @@ def run_conversation(
     truncated_tool_call_retries = 0
     truncated_response_parts: List[str] = []
     compression_attempts = 0
+
+    def _contextual_compression_failure(reason: str) -> Dict[str, Any]:
+        """Fail closed instead of crossing into any compression provider/engine."""
+        return {
+            "final_response": "",
+            "messages": messages,
+            "api_calls": api_call_count,
+            "failed": True,
+            "error": reason,
+            "contextual_failure": True,
+        }
+
     # One resolved per-turn compression attempt cap, shared by every site that
     # consumes ``compression_attempts``: the pre-API pressure gate, the
     # overflow/413 retry handlers, and the post-tool compaction gate.
@@ -1547,6 +1585,10 @@ def run_conversation(
     # See agent/transports/codex_app_server_session.py for the adapter
     # and references/codex-app-server-runtime.md for the rationale.
     if agent.api_mode == "codex_app_server":
+        if _contextual_execution:
+            raise RuntimeError(
+                "Contextual execution cannot use an alternate provider runtime."
+            )
         return agent._run_codex_app_server_turn(
             user_message=user_message,
             original_user_message=original_user_message,
@@ -2191,6 +2233,11 @@ def run_conversation(
                 agent._emit_status(_pre_api_status)
             _last_preflight_pressure = request_pressure_tokens
             _pre_api_input = messages
+            if _contextual_execution:
+                return _contextual_compression_failure(
+                    "Contextual cron request exceeded the direct provider context "
+                    "budget; compression is forbidden for hidden turns."
+                )
             messages, active_system_prompt = agent._compress_context(
                 messages,
                 system_message,
@@ -2431,35 +2478,38 @@ def run_conversation(
                     _xh["x-initiator"] = "user"
                     api_kwargs["extra_headers"] = _xh
                     agent._is_user_initiated_turn = False
-                try:
-                    from hermes_cli.middleware import apply_llm_request_middleware
+                _original_api_kwargs = dict(api_kwargs)
+                _llm_middleware_trace: list[dict[str, Any]] = []
+                if not _contextual_execution:
+                    try:
+                        from hermes_cli.middleware import apply_llm_request_middleware
 
-                    _llm_request_mw = apply_llm_request_middleware(
-                        api_kwargs,
-                        task_id=effective_task_id,
-                        turn_id=turn_id,
-                        api_request_id=api_request_id,
-                        session_id=agent.session_id or "",
-                        platform=agent.platform or "",
-                        model=agent.model,
-                        provider=agent.provider,
-                        base_url=agent.base_url,
-                        api_mode=agent.api_mode,
-                        api_call_count=api_call_count,
-                    )
-                    api_kwargs = _llm_request_mw.payload
-                    _original_api_kwargs = _llm_request_mw.original_payload
-                    _llm_middleware_trace = _llm_request_mw.trace
-                except Exception:
-                    _original_api_kwargs = dict(api_kwargs)
-                    _llm_middleware_trace = []
+                        _llm_request_mw = apply_llm_request_middleware(
+                            api_kwargs,
+                            task_id=effective_task_id,
+                            turn_id=turn_id,
+                            api_request_id=api_request_id,
+                            session_id=agent.session_id or "",
+                            platform=agent.platform or "",
+                            model=agent.model,
+                            provider=agent.provider,
+                            base_url=agent.base_url,
+                            api_mode=agent.api_mode,
+                            api_call_count=api_call_count,
+                        )
+                        api_kwargs = _llm_request_mw.payload
+                        _original_api_kwargs = _llm_request_mw.original_payload
+                        _llm_middleware_trace = _llm_request_mw.trace
+                    except Exception:
+                        _original_api_kwargs = dict(api_kwargs)
+                        _llm_middleware_trace = []
 
                 try:
                     from hermes_cli.lifecycle import (
                         has_hook,
                         invoke_hook as _invoke_hook,
                     )
-                    if has_hook("pre_api_request"):
+                    if not _contextual_execution and has_hook("pre_api_request"):
                         request_messages = api_kwargs.get("messages")
                         if not isinstance(request_messages, list):
                             request_messages = api_kwargs.get("input")
@@ -2540,7 +2590,7 @@ def run_conversation(
                     if agent.thinking_callback:
                         agent.thinking_callback("")
 
-                _use_streaming = True
+                _use_streaming = not _contextual_execution
                 # Provider signaled "stream not supported" on a previous
                 # attempt — switch to non-streaming for the rest of this
                 # session instead of re-failing every retry.
@@ -2587,6 +2637,8 @@ def run_conversation(
                         return agent._interruptible_streaming_api_call(
                             next_api_kwargs, on_first_delta=_stop_spinner
                         )
+                    if _contextual_execution:
+                        return agent._interruptible_api_call(next_api_kwargs)
                     from agent import relay_llm
 
                     return relay_llm.execute(
@@ -2610,8 +2662,6 @@ def run_conversation(
                         defer_logical_completion=True,
                     )
 
-                from hermes_cli.middleware import run_llm_execution_middleware
-
                 _model_request_active = getattr(agent, "_model_request_active", None)
                 _redirect_lock = getattr(agent, "_pending_redirect_lock", None)
                 if _redirect_lock is not None:
@@ -2622,22 +2672,27 @@ def run_conversation(
                     _model_request_active.set()
                 _redirect_crossed_response = False
                 try:
-                    response = run_llm_execution_middleware(
-                        api_kwargs,
-                        _perform_api_call,
-                        original_request=_original_api_kwargs,
-                        task_id=effective_task_id,
-                        turn_id=turn_id,
-                        api_request_id=api_request_id,
-                        session_id=agent.session_id or "",
-                        platform=agent.platform or "",
-                        model=agent.model,
-                        provider=agent.provider,
-                        base_url=agent.base_url,
-                        api_mode=agent.api_mode,
-                        api_call_count=api_call_count,
-                        middleware_trace=list(_llm_middleware_trace),
-                    )
+                    if _contextual_execution:
+                        response = _perform_api_call(api_kwargs)
+                    else:
+                        from hermes_cli.middleware import run_llm_execution_middleware
+
+                        response = run_llm_execution_middleware(
+                            api_kwargs,
+                            _perform_api_call,
+                            original_request=_original_api_kwargs,
+                            task_id=effective_task_id,
+                            turn_id=turn_id,
+                            api_request_id=api_request_id,
+                            session_id=agent.session_id or "",
+                            platform=agent.platform or "",
+                            model=agent.model,
+                            provider=agent.provider,
+                            base_url=agent.base_url,
+                            api_mode=agent.api_mode,
+                            api_call_count=api_call_count,
+                            middleware_trace=list(_llm_middleware_trace),
+                        )
                 finally:
                     if _redirect_lock is not None:
                         with _redirect_lock:
@@ -4662,6 +4717,11 @@ def run_conversation(
                         original_len = len(messages)
                         # Option A (LCM issue 441): overhead-aware request size so recovery arms on
                         # the true request (msgs + tools + system), not the tool-blind message count.
+                        if _contextual_execution:
+                            return _contextual_compression_failure(
+                                "Contextual cron provider reported a context limit; "
+                                "compression is forbidden for hidden turns."
+                            )
                         messages, active_system_prompt = agent._compress_context(
                             messages, system_message,
                             approx_tokens=estimate_request_tokens_rough(api_messages, tools=agent.tools or None),
@@ -4921,6 +4981,11 @@ def run_conversation(
                     _overflow_input = messages
                     # Option A (LCM issue 441): overhead-aware request size so recovery arms on the
                     # true request (msgs + tools + system), not the tool-blind message count.
+                    if _contextual_execution:
+                        return _contextual_compression_failure(
+                            "Contextual cron request was too large; compression is "
+                            "forbidden for hidden turns."
+                        )
                     messages, active_system_prompt = agent._compress_context(
                         messages, system_message,
                         approx_tokens=estimate_request_tokens_rough(api_messages, tools=agent.tools or None),
@@ -5068,6 +5133,11 @@ def run_conversation(
                             original_len = len(messages)
                             original_tokens = estimate_messages_tokens_rough(messages)
                             _overflow_input = messages
+                            if _contextual_execution:
+                                return _contextual_compression_failure(
+                                    "Contextual cron output-limit recovery would require "
+                                    "compression, which is forbidden for hidden turns."
+                                )
                             messages, active_system_prompt = agent._compress_context(
                                 messages, system_message,
                                 approx_tokens=request_input_estimate,
@@ -5222,6 +5292,11 @@ def run_conversation(
                     # schemas + system), not the tool-blind message count, so LCM forced-overflow
                     # recovery arms on the TRUE request that overflowed. See hermes-lcm engine
                     # _should_force_overflow_recovery. (approx_tokens stays for the status display.)
+                    if _contextual_execution:
+                        return _contextual_compression_failure(
+                            "Contextual cron overflow recovery would require compression, "
+                            "which is forbidden for hidden turns."
+                        )
                     messages, active_system_prompt = agent._compress_context(
                         messages, system_message,
                         approx_tokens=estimate_request_tokens_rough(api_messages, tools=agent.tools or None),
@@ -6004,7 +6079,7 @@ def run_conversation(
                     has_hook,
                     invoke_hook as _invoke_hook,
                 )
-                if has_hook("post_api_request"):
+                if not _contextual_execution and has_hook("post_api_request"):
                     _assistant_tool_calls = (
                         getattr(assistant_message, "tool_calls", None) or []
                     )
@@ -6772,6 +6847,11 @@ def run_conversation(
                     # Route the overhead-aware _real_tokens (computed above) into compression, not
                     # the bare last_prompt_tokens — which is 0 in the no-usage fallback, hiding the
                     # true request size from the engine's overflow guard (upstream PR #77169 review).
+                    if _contextual_execution:
+                        return _contextual_compression_failure(
+                            "Contextual cron post-tool context exceeded the provider "
+                            "budget; compression is forbidden for hidden turns."
+                        )
                     messages, active_system_prompt = agent._compress_context(
                         messages, system_message,
                         approx_tokens=_real_tokens,
@@ -7357,7 +7437,7 @@ def run_conversation(
                         verify_on_stop_enabled,
                     )
 
-                    if verify_on_stop_enabled():
+                    if not _contextual_execution and verify_on_stop_enabled():
                         _verify_nudge = build_verify_on_stop_nudge(
                             session_id=getattr(agent, "session_id", None),
                             changed_paths=getattr(agent, "_turn_file_mutation_paths", set()),
@@ -7423,7 +7503,12 @@ def run_conversation(
                     from hermes_cli.lifecycle import has_hook
                     from hermes_cli.plugins import get_pre_verify_continue_message
 
-                    if _edited and has_hook("pre_verify") and _attempt < max_verify_nudges():
+                    if (
+                        not _contextual_execution
+                        and _edited
+                        and has_hook("pre_verify")
+                        and _attempt < max_verify_nudges()
+                    ):
                         # Posture is fixed for the session — resolve once + cache.
                         coding = getattr(agent, "_resolved_is_coding", None)
                         if coding is None:

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -21,7 +21,7 @@ import random
 import threading
 import time
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 from agent.display import (
     KawaiiSpinner,
@@ -755,6 +755,38 @@ def _begin_tool_execution(
             pass
 
 
+def _tool_execution_policy_block(agent, function_name: str) -> Optional[str]:
+    """Reject tools outside a hard per-agent boundary before any side effect.
+
+    This is an execution authorization check, not a schema hint.  It runs on
+    the final resolved tool name (including tool-search unwrapping) before
+    middleware, hooks, inline dispatch, registry lookup, or worker launch.
+    """
+    try:
+        from gateway.session_context import _get_contextual_turn_authority
+
+        contextual_authority = _get_contextual_turn_authority()
+    except Exception:
+        contextual_authority = None
+    allowed = (
+        frozenset()
+        if contextual_authority is not None
+        else getattr(agent, "allowed_tool_names", None)
+    )
+    if allowed is None or function_name in allowed:
+        return None
+    return json.dumps(
+        {
+            "error": (
+                f"Tool '{function_name}' is not permitted by this execution policy."
+            ),
+            "error_type": "tool_execution_policy",
+            "tool": function_name,
+        },
+        ensure_ascii=False,
+    )
+
+
 def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0, *, finalize: bool = True) -> None:
     """Execute multiple tool calls concurrently using a thread pool.
 
@@ -806,7 +838,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
 
     # ── Parse args + pre-execution bookkeeping ───────────────────────
     # (tool call, resolved name, parsed args, middleware trace, parse error,
-    # tool-search scope block)
+    # tool-search scope block, hard execution-policy block)
     parsed_calls = []
     for tool_call in tool_calls:
         function_name = tool_call.function.name
@@ -816,6 +848,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         )
 
         if malformed_args_result is not None:
+            _policy_block = _tool_execution_policy_block(agent, function_name)
             parsed_calls.append(
                 (
                     tool_call,
@@ -824,6 +857,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     [],
                     malformed_args_result,
                     None,
+                    _policy_block,
                 )
             )
             continue
@@ -868,21 +902,72 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         except Exception:
             pass
 
+        _policy_block = _tool_execution_policy_block(agent, function_name)
         parsed_calls.append(
-            (tool_call, function_name, function_args, [], None, _ts_scope_block)
+            (
+                tool_call,
+                function_name,
+                function_args,
+                [],
+                None,
+                _ts_scope_block,
+                _policy_block,
+            )
         )
 
     # ── Logging / callbacks ──────────────────────────────────────────
-    tool_names_str = ", ".join(name for _, name, _, _, _, _ in parsed_calls)
+    tool_names_str = ", ".join(name for _, name, _, _, _, _, _ in parsed_calls)
     if not agent.quiet_mode and getattr(agent, "tool_progress_mode", "all") != "off":
         print(f"  ⚡ Concurrent: {num_tools} tool calls — {tool_names_str}")
 
     # ── Concurrent execution ─────────────────────────────────────────
     # Each slot holds (function_name, function_args, function_result, duration, error_flag, blocked_flag, middleware_trace)
-    results = [None] * num_tools
-    for i, (tc, name, args, middleware_trace, block_result, _scope_block) in enumerate(parsed_calls):
-        if block_result is not None:
-            results[i] = (name, args, block_result, 0.0, True, True, middleware_trace)
+    results: list[
+        Optional[
+            tuple[
+                str,
+                dict[str, Any],
+                Any,
+                float,
+                bool,
+                bool,
+                list[dict[str, Any]],
+            ]
+        ]
+    ] = cast(Any, [None] * num_tools)
+    for i, (
+        tc,
+        name,
+        args,
+        middleware_trace,
+        _parse_error,
+        _scope_block,
+        policy_block,
+    ) in enumerate(parsed_calls):
+        if policy_block is not None:
+            results[i] = (
+                name,
+                args,
+                policy_block,
+                0.0,
+                True,
+                True,
+                middleware_trace,
+            )
+        elif _parse_error is not None:
+            # Parse-invalid calls are intentionally excluded from
+            # ``runnable_calls``. Seed their terminal result here so the
+            # collector preserves the validation error instead of fabricating
+            # a missing-thread result for work correctly never submitted.
+            results[i] = (
+                name,
+                args,
+                _parse_error,
+                0.0,
+                True,
+                False,
+                middleware_trace,
+            )
 
     start_condition = threading.Condition()
     next_start_order = 0
@@ -1154,10 +1239,18 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     try:
         runnable_calls = [
             (i, tc, name, args, scope_block)
-            for i, (tc, name, args, _trace, parse_error, scope_block) in enumerate(
+            for i, (
+                tc,
+                name,
+                args,
+                _trace,
+                parse_error,
+                scope_block,
+                policy_block,
+            ) in enumerate(
                 parsed_calls
             )
-            if parse_error is None
+            if parse_error is None and policy_block is None
         ]
         futures = []
         future_to_index = {}
@@ -1352,9 +1445,15 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             spinner.stop(f"⚡ {completed}/{num_tools} tools completed in {total_dur:.1f}s total")
 
     # ── Post-execution: display per-tool results ─────────────────────
-    for i, (tc, name, args, middleware_trace, _parse_error, _scope_block) in enumerate(
-        parsed_calls
-    ):
+    for i, (
+        tc,
+        name,
+        args,
+        middleware_trace,
+        _parse_error,
+        _scope_block,
+        _policy_block,
+    ) in enumerate(parsed_calls):
         r = results[i]
         blocked = False
         is_error = True
@@ -1418,7 +1517,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             name = function_name
             args = function_args
             progress_function_name = function_name
-            if _parse_error is not None:
+            if _parse_error is not None and _policy_block is None:
                 _emit_terminal_post_tool_call(
                     agent,
                     function_name=function_name,
@@ -1718,6 +1817,24 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                         )
         except Exception:
             pass
+
+        _policy_block = _tool_execution_policy_block(agent, function_name)
+        if _policy_block is not None:
+            messages.append(
+                make_tool_result_message(
+                    function_name,
+                    _policy_block,
+                    tool_call.id,
+                    effect_disposition="none",
+                )
+            )
+            if not _flush_session_db_after_tool_progress(
+                agent,
+                messages,
+                stage=f"policy-blocked tool result {function_name}",
+            ):
+                return
+            continue
 
         middleware_trace: list[dict[str, Any]] = []
         _execution_blocked = False

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -130,6 +130,46 @@ def extract_api_content_sidecar(msg: Mapping[str, Any]) -> Optional[str]:
     return v if isinstance(v, str) else None
 
 
+def clone_transcript_message_for_branch(
+    msg: Mapping[str, Any],
+) -> Dict[str, Any]:
+    """Build the durable message payload used by every branch/fork surface.
+
+    Branching creates new rows, so storage-only fields such as row IDs and
+    active/compacted flags must not be copied.  Every replay, provenance, and
+    presentation sidecar consumed by ``SessionDB._insert_message_rows`` must be
+    preserved, however.  In particular, dropping ``display_kind`` declassifies
+    privileged hidden rows into ordinary public transcript content.
+
+    Keeping this projection in one helper prevents the CLI, gateway, TUI, and
+    delayed desktop branch seed from drifting as the durable message schema
+    grows.
+    """
+    return {
+        "role": msg.get("role", "user"),
+        "content": msg.get("content"),
+        "tool_name": msg.get("tool_name") or msg.get("name"),
+        "tool_calls": msg.get("tool_calls"),
+        "tool_call_id": msg.get("tool_call_id"),
+        "effect_disposition": msg.get("effect_disposition"),
+        "token_count": msg.get("token_count"),
+        "finish_reason": msg.get("finish_reason"),
+        "reasoning": msg.get("reasoning"),
+        "reasoning_content": msg.get("reasoning_content"),
+        "reasoning_details": msg.get("reasoning_details"),
+        "codex_reasoning_items": msg.get("codex_reasoning_items"),
+        "codex_message_items": msg.get("codex_message_items"),
+        "platform_message_id": (
+            msg.get("platform_message_id") or msg.get("message_id")
+        ),
+        "observed": msg.get("observed"),
+        "api_content": extract_api_content_sidecar(msg),
+        "display_kind": msg.get("display_kind"),
+        "display_metadata": msg.get("display_metadata"),
+        "timestamp": msg.get("timestamp"),
+    }
+
+
 def consume_gateway_turn_context_notes(agent: Any) -> str:
     """Pop the gateway's per-turn must-deliver notes off the agent (one-shot).
 
@@ -429,6 +469,7 @@ def build_turn_context(
     set_current_write_origin,
     ra,
     moa_active: bool = False,
+    contextual_execution: bool = False,
 ) -> TurnContext:
     """Run the once-per-turn setup and return the loop's input context.
 
@@ -442,7 +483,11 @@ def build_turn_context(
     # Recover a session rotated by another path before binding log/turn ids or
     # copying client-supplied history. Everything in this turn must consistently
     # belong to the canonical child, including observability metadata.
-    recovered_history = recover_rotated_compression_session(agent)
+    recovered_history = (
+        None
+        if contextual_execution
+        else recover_rotated_compression_session(agent)
+    )
     if recovered_history is not None:
         conversation_history = recovered_history
 
@@ -491,7 +536,10 @@ def build_turn_context(
     # or when the tool set is unchanged (``refresh_agent_mcp_tools`` diffs by
     # name and leaves the snapshot untouched on no-change).
     try:
-        if not getattr(agent, "_skip_mcp_refresh", False):
+        if (
+            not contextual_execution
+            and not getattr(agent, "_skip_mcp_refresh", False)
+        ):
             # Import-cost gate: ``tools.mcp_tool`` pulls in the whole ``mcp``
             # package (~0.4s measured) even when the user has zero MCP servers
             # configured.  MCP tools can only be registered by code that has
@@ -713,11 +761,12 @@ def build_turn_context(
     # persist lock as CLI close persistence.
     persist_lock = getattr(agent, "_session_persist_lock", None)
     try:
-        if persist_lock is None:
-            agent._ensure_db_session()
-        else:
-            with persist_lock:
+        if not contextual_execution:
+            if persist_lock is None:
                 agent._ensure_db_session()
+            else:
+                with persist_lock:
+                    agent._ensure_db_session()
     except Exception:
         logger.warning(
             "Turn-start session row creation failed for session=%s",
@@ -743,7 +792,12 @@ def build_turn_context(
     # the previous turn finished. The cheap gap pre-check gates the (more
     # expensive) token estimate, mirroring ``_should_run_preflight_estimate``.
     _idle_after = getattr(agent, "compression_idle_compact_after_seconds", 0)
-    if agent.compression_enabled and _idle_after > 0 and messages:
+    if (
+        not contextual_execution
+        and agent.compression_enabled
+        and _idle_after > 0
+        and messages
+    ):
         _idle_gap = time.time() - getattr(agent, "_last_activity_ts", time.time())
         if _idle_gap >= _idle_after:
             _compressor = agent.context_compressor
@@ -820,7 +874,7 @@ def build_turn_context(
     _preflight_compression_blocked = False
     agent._turn_received_provider_response = False
     agent._turn_preflight_display_snapshot = None
-    if agent.compression_enabled and _should_run_preflight_estimate(
+    if not contextual_execution and agent.compression_enabled and _should_run_preflight_estimate(
         messages,
         agent.context_compressor.protect_first_n,
         agent.context_compressor.protect_last_n,
@@ -1134,20 +1188,23 @@ def build_turn_context(
     # Plugin hook: pre_llm_call (context injected into user message, not system prompt).
     plugin_user_context = ""
     try:
-        from hermes_cli.lifecycle import invoke_hook as _invoke_hook
-        _pre_results = _invoke_hook(
-            "pre_llm_call",
-            session_id=agent.session_id,
-            task_id=effective_task_id,
-            turn_id=turn_id,
-            user_message=original_user_message,
-            conversation_history=list(messages),
-            is_first_turn=(not bool(conversation_history)),
-            model=agent.model,
-            platform=getattr(agent, "platform", None) or "",
-            parent_session_id=getattr(agent, "_parent_session_id", None) or "",
-            sender_id=getattr(agent, "_user_id", None) or "",
-        )
+        if contextual_execution:
+            _pre_results = []
+        else:
+            from hermes_cli.lifecycle import invoke_hook as _invoke_hook
+            _pre_results = _invoke_hook(
+                "pre_llm_call",
+                session_id=agent.session_id,
+                task_id=effective_task_id,
+                turn_id=turn_id,
+                user_message=original_user_message,
+                conversation_history=list(messages),
+                is_first_turn=(not bool(conversation_history)),
+                model=agent.model,
+                platform=getattr(agent, "platform", None) or "",
+                parent_session_id=getattr(agent, "_parent_session_id", None) or "",
+                sender_id=getattr(agent, "_user_id", None) or "",
+            )
         _ctx_parts: list[str] = []
         # Spill oversized per-hook context to disk so a runaway plugin
         # can't inflate every subsequent turn's prompt. Ported from
@@ -1191,7 +1248,9 @@ def build_turn_context(
     # One-shot: staged by the gateway right before this turn, consumed here.
     # Multimodal (list) content can't take the string sidecar — append a
     # durable text part instead of dropping the fact.
-    _gateway_notes = consume_gateway_turn_context_notes(agent)
+    _gateway_notes = (
+        "" if contextual_execution else consume_gateway_turn_context_notes(agent)
+    )
     if _gateway_notes:
         _gw_turn_content = (
             messages[current_turn_user_idx].get("content")
@@ -1228,7 +1287,7 @@ def build_turn_context(
         agent._interrupt_thread_signal_pending = False
 
     # Notify memory providers of the new turn (BEFORE prefetch_all).
-    if agent._memory_manager:
+    if agent._memory_manager and not contextual_execution:
         try:
             _turn_msg = original_user_message if isinstance(original_user_message, str) else ""
             agent._memory_manager.on_turn_start(agent._user_turn_count, _turn_msg)
@@ -1240,7 +1299,7 @@ def build_turn_context(
     # Skip prefetch on trivial prompts (greetings, acknowledgements) to
     # prevent memory-context injection on turns that carry no semantic signal.
     ext_prefetch_cache = ""
-    if agent._memory_manager:
+    if agent._memory_manager and not contextual_execution:
         try:
             _query = original_user_message if isinstance(original_user_message, str) else ""
             if not is_trivial_prompt(_query):
@@ -1312,6 +1371,8 @@ def build_turn_context(
     # critical section as CLI close persistence, and retry the row create if
     # the pre-compression attempt above failed transiently.
     def _ensure_and_persist() -> None:
+        if contextual_execution:
+            return
         agent._ensure_db_session()
         agent._persist_session(messages, conversation_history)
 

--- a/cron/contextual.py
+++ b/cron/contextual.py
@@ -1,0 +1,267 @@
+"""Contracts and validation for opt-in same-session cron jobs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Mapping, Optional
+
+SESSION_TARGET_ISOLATED = "isolated"
+SESSION_TARGET_CURRENT = "current"
+SESSION_TARGETS = frozenset({SESSION_TARGET_ISOLATED, SESSION_TARGET_CURRENT})
+
+
+@dataclass(frozen=True)
+class ContextualExecutionPolicy:
+    """Single fail-closed capability policy for unattended live-session turns."""
+
+    internal: bool = True
+    suppress_transport_output: bool = True
+    hidden_user_entry: bool = True
+    touch_human_activity: bool = False
+    consume_interactive_state: bool = False
+    async_delivery: bool = False
+    mirror_delivery: bool = False
+    allow_proxy: bool = False
+    use_agent_cache: bool = False
+    persist_agent_directly: bool = False
+    # V1 is intentionally model-only.  Name-only capability filtering cannot
+    # authenticate a registry handler, and even nominally safe mutation/search
+    # tools can cross the admitted conversation boundary.  Keep this empty
+    # until handlers can be identity-pinned and arguments sandboxed centrally.
+    allowed_tool_names: frozenset[str] = frozenset()
+
+
+CONTEXTUAL_EXECUTION_POLICY = ContextualExecutionPolicy()
+CONTEXTUAL_ALLOWED_TOOLSETS: tuple[str, ...] = ()
+CONTEXTUAL_DISABLED_TOOLSETS = (
+    "browser",
+    "clarify",
+    "code_execution",
+    "computer_use",
+    "cronjob",
+    "delegation",
+    "discord",
+    "discord_admin",
+    "homeassistant",
+    "image_gen",
+    "kanban",
+    "memory",
+    "messaging",
+    "project",
+    "skills",
+    "spotify",
+    "terminal",
+    "todo",
+    "tts",
+    "video_gen",
+    "yuanbao",
+)
+
+
+def normalize_session_target(value: Any) -> str:
+    target = str(value or SESSION_TARGET_ISOLATED).strip().lower()
+    if target not in SESSION_TARGETS:
+        raise ValueError("session_target must be 'isolated' or 'current'")
+    return target
+
+
+def capture_current_session_key() -> str:
+    """Read the trusted task-local key; callers cannot supply an arbitrary key."""
+    return capture_current_session_binding()["session_key"]
+
+
+def capture_current_session_binding() -> Dict[str, Any]:
+    """Capture one canonical live-gateway binding without process-env fallback."""
+    from gateway.session_context import (
+        NON_MESSAGING_SESSION_SURFACES,
+        get_bound_session_context,
+    )
+
+    binding = get_bound_session_context()
+    if binding is None:
+        raise ValueError(
+            "session_target='current' requires a gateway-bound messaging session; "
+            "process environment values are not trusted"
+        )
+    platform = binding["platform"].strip().lower()
+    if platform in NON_MESSAGING_SESSION_SURFACES:
+        raise ValueError(
+            "session_target='current' requires a gateway-bound messaging session"
+        )
+    session_id = str(binding.get("session_id") or "").strip()
+    if not session_id:
+        raise ValueError(
+            "session_target='current' requires a concrete live gateway session"
+        )
+    return {
+        "profile": binding.get("profile", ""),
+        "session_key": binding["session_key"],
+        "session_id": session_id,
+        "routing_revision": int(binding.get("routing_revision") or 0),
+        "platform": binding["platform"],
+        "chat_type": binding.get("chat_type", ""),
+        "chat_id": binding["chat_id"],
+        "thread_id": binding.get("thread_id", ""),
+        "user_id": binding["user_id"],
+    }
+
+
+def contextual_origin_from_binding(binding: Dict[str, Any]) -> Dict[str, Any]:
+    """Derive execution/delivery origin from the exact persisted binding."""
+    return {
+        "platform": str(binding.get("platform") or ""),
+        "chat_type": str(binding.get("chat_type") or ""),
+        "chat_id": str(binding.get("chat_id") or ""),
+        "thread_id": str(binding.get("thread_id") or "") or None,
+        "user_id": str(binding.get("user_id") or ""),
+        "profile": str(binding.get("profile") or ""),
+    }
+
+
+def _has(job: Dict[str, Any], field: str) -> bool:
+    value = job.get(field)
+    if isinstance(value, (list, tuple, dict, set)):
+        return bool(value)
+    return value not in (None, "", False)
+
+
+def _validate_contextual_scheduler_provider() -> None:
+    """V1 contextual turns require the gateway-owned in-process dispatcher."""
+    try:
+        from hermes_cli.config import cfg_get, load_config
+
+        configured = str(
+            cfg_get(load_config(), "cron", "provider", default="") or ""
+        ).strip().lower()
+    except Exception as exc:
+        raise ValueError(
+            "session_target='current' cannot verify the configured cron provider"
+        ) from exc
+
+    if configured not in {"", "builtin", "in-process", "inprocess"}:
+        raise ValueError(
+            "session_target='current' requires cron.provider='builtin'; "
+            f"configured provider {configured!r} cannot preserve gateway-bound authority"
+        )
+
+
+def contextual_definition_route(job: Mapping[str, Any]) -> tuple[str, int]:
+    """Return the immutable physical session captured with the definition."""
+    session_key = str(job.get("session_key") or "").strip()
+    binding = job.get("context_binding")
+    if not session_key or not isinstance(binding, Mapping):
+        raise ValueError(
+            "session_target='current' requires an immutable session binding"
+        )
+    if str(binding.get("session_key") or "").strip() != session_key:
+        raise ValueError(
+            "session_target='current' has a mismatched immutable session binding"
+        )
+    session_id = str(binding.get("session_id") or "").strip()
+    routing_revision = binding.get("routing_revision")
+    if (
+        not session_id
+        or isinstance(routing_revision, bool)
+        or not isinstance(routing_revision, int)
+        or routing_revision < 0
+    ):
+        raise ValueError(
+            "session_target='current' requires an immutable session-id and "
+            "routing-revision binding"
+        )
+    return session_id, routing_revision
+
+
+def validate_contextual_job_shape(job: Dict[str, Any]) -> None:
+    """Fail closed on settings whose runtime semantics diverge from live chat."""
+    if normalize_session_target(job.get("session_target")) != SESSION_TARGET_CURRENT:
+        return
+
+    _validate_contextual_scheduler_provider()
+    contextual_definition_route(job)
+
+    conflicts: list[str] = []
+    if bool(job.get("no_agent")):
+        conflicts.append("no_agent")
+    if _has(job, "script"):
+        conflicts.append("script")
+    if _has(job, "skills") or _has(job, "skill"):
+        conflicts.append("skills")
+    for field in (
+        "workdir",
+        "context_from",
+        "enabled_toolsets",
+        "model",
+        "provider",
+        "base_url",
+        "monitor_script",
+        "monitor_url",
+    ):
+        if _has(job, field):
+            conflicts.append(field)
+    if job.get("attach_to_session") is True:
+        conflicts.append("attach_to_session")
+
+    deliver = str(job.get("deliver") or "origin").strip().lower()
+    if deliver not in {"origin", "local"}:
+        conflicts.append("deliver")
+
+    if conflicts:
+        unique = ", ".join(dict.fromkeys(conflicts))
+        raise ValueError(
+            "session_target='current' is incompatible with: "
+            f"{unique}. Contextual jobs must use the live session's model, "
+            "tools, profile, source, and single-origin delivery."
+        )
+
+
+def contextual_live_tool_policy(enabled, disabled):
+    """Return the exact unattended toolset allowlist and defensive denylist."""
+    del enabled  # Current platform bundles are intentionally not inherited.
+    denied = list(disabled or [])
+    for name in CONTEXTUAL_DISABLED_TOOLSETS:
+        if name not in denied:
+            denied.append(name)
+    return list(CONTEXTUAL_ALLOWED_TOOLSETS), denied
+
+
+def contextual_allowed_tool_names() -> frozenset[str]:
+    return CONTEXTUAL_EXECUTION_POLICY.allowed_tool_names
+
+
+def filter_contextual_tool_schemas(schemas: Iterable[Any]) -> list[dict]:
+    """Final-schema capability gate; unknown/plugin tools fail closed."""
+    allowed = contextual_allowed_tool_names()
+    result: list[dict] = []
+    for schema in schemas or ():
+        if not isinstance(schema, dict):
+            continue
+        function = schema.get("function")
+        name = function.get("name") if isinstance(function, dict) else None
+        if isinstance(name, str) and name in allowed:
+            result.append(schema)
+    return result
+
+
+def contextual_fields_for_write(
+    target: Any,
+    *,
+    current_session_key: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Return canonical persisted fields, clearing stale keys for isolation."""
+    normalized = normalize_session_target(target)
+    if normalized == SESSION_TARGET_ISOLATED:
+        return {}
+    # Deliberately ignore any job/model-provided key.  Only the trusted
+    # task-local capture (or an explicitly injected test value) is accepted.
+    binding = capture_current_session_binding()
+    key = str(current_session_key or binding["session_key"]).strip()
+    if not key:
+        raise ValueError("session_target='current' requires a non-empty live session key")
+    if current_session_key is not None:
+        binding = {**binding, "session_key": key}
+    return {
+        "session_target": normalized,
+        "session_key": key,
+        "context_binding": binding,
+    }

--- a/cron/contextual.py
+++ b/cron/contextual.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Iterable, Mapping, Optional
 SESSION_TARGET_ISOLATED = "isolated"
 SESSION_TARGET_CURRENT = "current"
 SESSION_TARGETS = frozenset({SESSION_TARGET_ISOLATED, SESSION_TARGET_CURRENT})
+CONTEXTUAL_BINDING_VERSION_LOGICAL_ROUTE = 2
 
 
 @dataclass(frozen=True)
@@ -88,34 +89,71 @@ def capture_current_session_binding() -> Dict[str, Any]:
         raise ValueError(
             "session_target='current' requires a gateway-bound messaging session"
         )
-    session_id = str(binding.get("session_id") or "").strip()
-    if not session_id:
+    route_instance_id = str(binding.get("route_instance_id") or "").strip()
+    if not route_instance_id:
         raise ValueError(
-            "session_target='current' requires a concrete live gateway session"
+            "session_target='current' requires a concrete authenticated logical route"
+        )
+    route_principal = binding.get("route_principal")
+    if not isinstance(route_principal, dict):
+        raise ValueError(
+            "session_target='current' requires a trusted logical route principal"
         )
     return {
         "profile": binding.get("profile", ""),
         "session_key": binding["session_key"],
-        "session_id": session_id,
-        "routing_revision": int(binding.get("routing_revision") or 0),
+        "route_instance_id": route_instance_id,
         "platform": binding["platform"],
         "chat_type": binding.get("chat_type", ""),
         "chat_id": binding["chat_id"],
         "thread_id": binding.get("thread_id", ""),
         "user_id": binding["user_id"],
+        "scope_id": str(route_principal.get("scope_id") or ""),
+        "parent_chat_id": str(route_principal.get("parent_chat_id") or ""),
+        "user_id_alt": str(route_principal.get("user_id_alt") or ""),
+        "chat_id_alt": str(route_principal.get("chat_id_alt") or ""),
     }
+
+
+def validate_contextual_origin(origin: Any) -> Dict[str, Any]:
+    """Validate private immutable creator authority before an external effect."""
+    if not isinstance(origin, dict):
+        raise ValueError("Contextual creator authority is missing.")
+    normalized = dict(origin)
+    for field in ("platform", "chat_type", "chat_id", "user_id"):
+        raw_value = normalized.get(field)
+        if not isinstance(raw_value, str) or not raw_value.strip():
+            raise ValueError("Contextual creator authority is incomplete.")
+        normalized[field] = raw_value.strip()
+    for field in (
+        "profile",
+        "thread_id",
+        "scope_id",
+        "parent_chat_id",
+        "user_id_alt",
+        "chat_id_alt",
+    ):
+        raw_value = normalized.get(field)
+        if raw_value is not None and not isinstance(raw_value, str):
+            raise ValueError("Contextual creator authority is invalid.")
+    normalized["profile"] = str(normalized.get("profile") or "")
+    return normalized
 
 
 def contextual_origin_from_binding(binding: Dict[str, Any]) -> Dict[str, Any]:
     """Derive execution/delivery origin from the exact persisted binding."""
-    return {
+    return validate_contextual_origin({
         "platform": str(binding.get("platform") or ""),
         "chat_type": str(binding.get("chat_type") or ""),
         "chat_id": str(binding.get("chat_id") or ""),
         "thread_id": str(binding.get("thread_id") or "") or None,
         "user_id": str(binding.get("user_id") or ""),
         "profile": str(binding.get("profile") or ""),
-    }
+        "scope_id": str(binding.get("scope_id") or "") or None,
+        "parent_chat_id": str(binding.get("parent_chat_id") or "") or None,
+        "user_id_alt": str(binding.get("user_id_alt") or "") or None,
+        "chat_id_alt": str(binding.get("chat_id_alt") or "") or None,
+    })
 
 
 def _has(job: Dict[str, Any], field: str) -> bool:
@@ -146,7 +184,7 @@ def _validate_contextual_scheduler_provider() -> None:
 
 
 def contextual_definition_route(job: Mapping[str, Any]) -> tuple[str, int]:
-    """Return the immutable physical session captured with the definition."""
+    """Return a legacy-v1 immutable physical route binding."""
     session_key = str(job.get("session_key") or "").strip()
     binding = job.get("context_binding")
     if not session_key or not isinstance(binding, Mapping):
@@ -172,13 +210,47 @@ def contextual_definition_route(job: Mapping[str, Any]) -> tuple[str, int]:
     return session_id, routing_revision
 
 
+def contextual_definition_route_instance(job: Mapping[str, Any]) -> str:
+    """Return the immutable logical-route instance captured by a v2 definition."""
+    session_key = str(job.get("session_key") or "").strip()
+    binding = job.get("context_binding")
+    if not session_key or not isinstance(binding, Mapping):
+        raise ValueError(
+            "session_target='current' requires an immutable logical route binding"
+        )
+    if str(binding.get("session_key") or "").strip() != session_key:
+        raise ValueError(
+            "session_target='current' has a mismatched immutable logical route binding"
+        )
+    route_instance_id = str(binding.get("route_instance_id") or "").strip()
+    if not route_instance_id:
+        raise ValueError(
+            "session_target='current' requires an immutable route-instance binding"
+        )
+    for field in ("platform", "chat_id", "user_id"):
+        if not str(binding.get(field) or "").strip():
+            raise ValueError(
+                "session_target='current' requires an immutable authenticated "
+                f"logical route field: {field}"
+            )
+    return route_instance_id
+
+
 def validate_contextual_job_shape(job: Dict[str, Any]) -> None:
     """Fail closed on settings whose runtime semantics diverge from live chat."""
     if normalize_session_target(job.get("session_target")) != SESSION_TARGET_CURRENT:
         return
 
     _validate_contextual_scheduler_provider()
-    contextual_definition_route(job)
+    version = int(job.get("_contextual_binding_version") or 1)
+    if version == CONTEXTUAL_BINDING_VERSION_LOGICAL_ROUTE:
+        contextual_definition_route_instance(job)
+    elif version == 1:
+        contextual_definition_route(job)
+    else:
+        raise ValueError(
+            f"unsupported contextual binding version: {version}"
+        )
 
     conflicts: list[str] = []
     if bool(job.get("no_agent")):
@@ -264,4 +336,5 @@ def contextual_fields_for_write(
         "session_target": normalized,
         "session_key": key,
         "context_binding": binding,
+        "_contextual_binding_version": CONTEXTUAL_BINDING_VERSION_LOGICAL_ROUTE,
     }

--- a/cron/executions.py
+++ b/cron/executions.py
@@ -7,6 +7,8 @@ proved gone. Terminal states are immutable.
 
 from __future__ import annotations
 
+import json
+import logging
 import os
 import sqlite3
 import threading
@@ -17,49 +19,152 @@ from typing import Any, Dict, Iterator, List, Optional
 from hermes_constants import get_hermes_home
 from hermes_time import now as _hermes_now
 
+logger = logging.getLogger(__name__)
+
 EXECUTIONS_FILE = get_hermes_home().resolve() / "cron" / "executions.db"
+_IMPORT_EXECUTIONS_FILE = EXECUTIONS_FILE
 MAX_TERMINAL_EXECUTIONS = 1000
 _TERMINAL_STATES = ("completed", "failed", "unknown")
 _lock = threading.RLock()
 _PROCESS_ID = uuid.uuid4().hex
 
 
+def _current_executions_file():
+    """Resolve the ledger beside the active task-local cron store."""
+    if EXECUTIONS_FILE != _IMPORT_EXECUTIONS_FILE:
+        return EXECUTIONS_FILE
+    try:
+        from cron.jobs import _current_cron_store
+
+        return _current_cron_store().cron_dir / "executions.db"
+    except Exception:
+        return get_hermes_home().resolve() / "cron" / "executions.db"
+
+
 def _connect() -> sqlite3.Connection:
-    EXECUTIONS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    return sqlite3.connect(EXECUTIONS_FILE, timeout=5)
+    path = _current_executions_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return sqlite3.connect(path, timeout=5)
 
 
 def _initialize_schema(conn: sqlite3.Connection) -> None:
+    """Configure and migrate the ledger under a cross-process SQLite lock."""
     from hermes_state import apply_wal_with_fallback
 
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA busy_timeout=5000")
     apply_wal_with_fallback(conn, db_label="cron/executions.db")
     conn.execute("PRAGMA synchronous=FULL")
-    conn.execute(
-        """CREATE TABLE IF NOT EXISTS executions (
-             id TEXT PRIMARY KEY,
-             job_id TEXT NOT NULL,
-             source TEXT NOT NULL,
-             process_id TEXT NOT NULL,
-             pid INTEGER NOT NULL,
-             process_started_at INTEGER,
-             status TEXT NOT NULL CHECK(status IN
-               ('claimed','running','completed','failed','unknown')),
-             claimed_at TEXT NOT NULL,
-             started_at TEXT,
-             finished_at TEXT,
-             error TEXT
-           )"""
-    )
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_executions_job_claimed "
-        "ON executions(job_id, claimed_at DESC, id DESC)"
-    )
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_executions_status_claimed "
-        "ON executions(status, claimed_at DESC, id DESC)"
-    )
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS executions (
+                 id TEXT PRIMARY KEY,
+                 job_id TEXT NOT NULL,
+                 source TEXT NOT NULL,
+                 process_id TEXT NOT NULL,
+                 pid INTEGER NOT NULL,
+                 process_started_at INTEGER,
+                 status TEXT NOT NULL CHECK(status IN
+                   ('claimed','running','completed','failed','unknown')),
+                 claimed_at TEXT NOT NULL,
+                 started_at TEXT,
+                 finished_at TEXT,
+                 error TEXT,
+                 session_key TEXT,
+                 admitted_session_id TEXT,
+                 admitted_routing_revision INTEGER,
+                 admitted_at TEXT,
+                 outcome TEXT,
+                 result_json TEXT,
+                 phase TEXT,
+                 delivery_state TEXT,
+                 delivery_claimed_at TEXT,
+                 delivery_finished_at TEXT,
+                 delivery_error TEXT,
+                 retry_count INTEGER DEFAULT 0,
+                 next_retry_at TEXT,
+                 delivery_target_json TEXT,
+                 job_accounted INTEGER DEFAULT 0,
+                 requires_job_accounting INTEGER DEFAULT 0,
+                 transcript_session_id TEXT,
+                 transcript_json TEXT,
+                 transcript_state TEXT DEFAULT 'not_applicable',
+                 transcript_base_message_count INTEGER,
+                 transcript_base_revision INTEGER,
+                 transcript_last_prompt_tokens INTEGER
+               )"""
+        )
+        # Additive, versioned migration. BEGIN IMMEDIATE serializes the
+        # PRAGMA-table-info → ALTER sequence across gateway/desktop/scheduler
+        # processes so two starters cannot race the same ADD COLUMN.
+        columns = {
+            row[1] for row in conn.execute("PRAGMA table_info(executions)")
+        }
+        for name, sql_type in (
+            ("session_key", "TEXT"),
+            ("admitted_session_id", "TEXT"),
+            ("admitted_routing_revision", "INTEGER"),
+            ("admitted_at", "TEXT"),
+            ("outcome", "TEXT"),
+            ("result_json", "TEXT"),
+            ("phase", "TEXT"),
+            ("delivery_state", "TEXT"),
+            ("delivery_claimed_at", "TEXT"),
+            ("delivery_finished_at", "TEXT"),
+            ("delivery_error", "TEXT"),
+            ("retry_count", "INTEGER DEFAULT 0"),
+            ("next_retry_at", "TEXT"),
+            ("delivery_target_json", "TEXT"),
+            ("job_accounted", "INTEGER DEFAULT 0"),
+            ("requires_job_accounting", "INTEGER DEFAULT 0"),
+            ("transcript_session_id", "TEXT"),
+            ("transcript_json", "TEXT"),
+            ("transcript_state", "TEXT DEFAULT 'not_applicable'"),
+            ("transcript_base_message_count", "INTEGER"),
+            ("transcript_base_revision", "INTEGER"),
+            ("transcript_last_prompt_tokens", "INTEGER"),
+        ):
+            if name not in columns:
+                conn.execute(f"ALTER TABLE executions ADD COLUMN {name} {sql_type}")
+        conn.execute(
+            """UPDATE executions SET phase=CASE status
+                   WHEN 'claimed' THEN 'claimed'
+                   WHEN 'running' THEN 'running'
+                   WHEN 'completed' THEN 'completed'
+                   WHEN 'failed' THEN 'failed'
+                   ELSE 'unknown' END
+               WHERE phase IS NULL"""
+        )
+        conn.execute(
+            "UPDATE executions SET delivery_state='not_applicable' "
+            "WHERE delivery_state IS NULL"
+        )
+        conn.execute(
+            "UPDATE executions SET requires_job_accounting=1 "
+            "WHERE delivery_target_json IS NOT NULL"
+        )
+        conn.execute(
+            "UPDATE executions SET transcript_state='not_applicable' "
+            "WHERE transcript_state IS NULL"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_executions_job_claimed "
+            "ON executions(job_id, claimed_at DESC, id DESC)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_executions_status_claimed "
+            "ON executions(status, claimed_at DESC, id DESC)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_executions_pending_delivery "
+            "ON executions(delivery_state, phase, claimed_at)"
+        )
+        conn.execute("PRAGMA user_version=6")
+        conn.commit()
+    except BaseException:
+        conn.rollback()
+        raise
 
 
 @contextmanager
@@ -126,13 +231,17 @@ def _prune_unlocked(conn: sqlite3.Connection) -> None:
         """DELETE FROM executions WHERE id IN (
              SELECT id FROM executions
              WHERE status IN ('completed','failed','unknown')
+               AND (requires_job_accounting=0 OR job_accounted=1)
+               AND COALESCE(transcript_state, 'not_applicable') != 'pending'
              ORDER BY claimed_at DESC, id DESC LIMIT -1 OFFSET ?
            )""",
         (limit,),
     )
 
 
-def create_execution(job_id: str, *, source: str) -> Dict[str, Any]:
+def create_execution(
+    job_id: str, *, source: str, requires_job_accounting: bool = False
+) -> Dict[str, Any]:
     """Persist a claimed attempt before executor/provider dispatch."""
     now = _hermes_now().isoformat()
     execution_id = uuid.uuid4().hex
@@ -141,10 +250,12 @@ def create_execution(job_id: str, *, source: str) -> Dict[str, Any]:
         conn.execute(
             """INSERT INTO executions
                (id, job_id, source, process_id, pid, process_started_at,
-                status, claimed_at)
-               VALUES (?, ?, ?, ?, ?, ?, 'claimed', ?)""",
+                status, claimed_at, phase, delivery_state,
+                requires_job_accounting)
+               VALUES (?, ?, ?, ?, ?, ?, 'claimed', ?, 'claimed',
+                       'not_applicable', ?)""",
             (execution_id, str(job_id), str(source), _PROCESS_ID, pid,
-             _process_start_time(pid), now),
+             _process_start_time(pid), now, int(requires_job_accounting)),
         )
         row = conn.execute(
             "SELECT * FROM executions WHERE id=?", (execution_id,)
@@ -159,7 +270,8 @@ def mark_execution_running(execution_id: str) -> Optional[Dict[str, Any]]:
     now = _hermes_now().isoformat()
     with _transaction() as conn:
         cur = conn.execute(
-            """UPDATE executions SET status='running', started_at=?
+            """UPDATE executions
+               SET status='running', phase='running', started_at=?
                WHERE id=? AND status='claimed'""",
             (now, execution_id),
         )
@@ -172,6 +284,544 @@ def mark_execution_running(execution_id: str) -> Optional[Dict[str, Any]]:
     return record
 
 
+def get_execution(execution_id: str) -> Optional[Dict[str, Any]]:
+    """Return one durable execution occurrence by its stable identity."""
+    with _transaction() as conn:
+        row = conn.execute(
+            "SELECT * FROM executions WHERE id=?", (str(execution_id),)
+        ).fetchone()
+    return _record(row)
+
+
+def seal_contextual_admission(
+    execution_id: str,
+    *,
+    session_key: str,
+    admitted_session_id: str,
+    admitted_routing_revision: int = 0,
+) -> bool:
+    """Durably bind an occurrence to the exact live session before queueing.
+
+    The stable routing key remains the job target. The id is an occurrence
+    fence only, making the reset-before/reset-after admission boundary durable.
+    """
+    key = str(session_key or "").strip()
+    session_id = str(admitted_session_id or "").strip()
+    if not key or not session_id:
+        return False
+    admitted_at = _hermes_now().isoformat()
+    with _transaction() as conn:
+        cur = conn.execute(
+            """UPDATE executions
+               SET session_key=?, admitted_session_id=?,
+                   admitted_routing_revision=?, admitted_at=?, phase='admitted'
+               WHERE id=? AND status IN ('claimed','running')
+                 AND session_key IS NULL AND admitted_session_id IS NULL""",
+            (
+                key,
+                session_id,
+                int(admitted_routing_revision),
+                admitted_at,
+                execution_id,
+            ),
+        )
+        if cur.rowcount == 1:
+            return True
+        existing = conn.execute(
+            """SELECT status, session_key, admitted_session_id,
+                      admitted_routing_revision
+               FROM executions WHERE id=?""",
+            (execution_id,),
+        ).fetchone()
+        return bool(
+            existing
+            and existing["status"] in {"claimed", "running"}
+            and existing["session_key"] == key
+            and existing["admitted_session_id"] == session_id
+            and int(existing["admitted_routing_revision"] or 0)
+            == int(admitted_routing_revision)
+        )
+
+
+def seal_contextual_delivery_target(
+    execution_id: str,
+    *,
+    target: Dict[str, Any],
+) -> bool:
+    """Immutably snapshot the destination before contextual execution starts."""
+    payload = json.dumps(
+        target,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    with _transaction() as conn:
+        cur = conn.execute(
+            """UPDATE executions
+               SET delivery_target_json=?, requires_job_accounting=1
+               WHERE id=? AND status IN ('claimed','running')
+                 AND delivery_target_json IS NULL""",
+            (payload, str(execution_id)),
+        )
+        if cur.rowcount == 1:
+            return True
+        row = conn.execute(
+            "SELECT status, delivery_target_json FROM executions WHERE id=?",
+            (str(execution_id),),
+        ).fetchone()
+        return bool(
+            row
+            and row["status"] in {"claimed", "running"}
+            and row["delivery_target_json"] == payload
+        )
+
+
+def claim_contextual_job_accounting(execution_id: str) -> bool:
+    """Persist that idempotent job accounting completed for this occurrence."""
+    with _transaction() as conn:
+        cur = conn.execute(
+            """UPDATE executions SET job_accounted=1
+               WHERE id=? AND COALESCE(job_accounted, 0)=0""",
+            (str(execution_id),),
+        )
+        return cur.rowcount == 1
+
+
+def list_unaccounted_contextual_executions(*, limit: int = 1000) -> List[Dict[str, Any]]:
+    """Return terminal contextual occurrences whose job-file accounting is pending."""
+    with _transaction() as conn:
+        rows = conn.execute(
+            """SELECT * FROM executions
+               WHERE delivery_target_json IS NOT NULL
+                 AND COALESCE(job_accounted, 0)=0
+                 AND status IN ('completed','failed','unknown')
+               ORDER BY claimed_at ASC, id ASC
+               LIMIT ?""",
+            (max(1, min(int(limit), 10000)),),
+        ).fetchall()
+        return [dict(row) for row in rows]
+
+
+_CONTEXTUAL_OUTCOMES = {
+    "notify",
+    "no_action",
+    "retryable",
+    "rejected",
+    "stale",
+    "failure",
+    "unknown",
+}
+
+
+def persist_contextual_agent_result(
+    execution_id: str,
+    *,
+    outcome: str,
+    final_response: str = "",
+    error: Optional[str] = None,
+    transcript_session_id: Optional[str] = None,
+    transcript_entries: Optional[List[Dict[str, Any]]] = None,
+    transcript_base_message_count: Optional[int] = None,
+    transcript_base_revision: Optional[int] = None,
+    transcript_last_prompt_tokens: Optional[int] = None,
+) -> Optional[Dict[str, Any]]:
+    """Durably persist the agent result before any external delivery attempt.
+
+    ``notify`` remains non-terminal in ``agent_completed/pending``. All other
+    outcomes are terminal except ``retryable``, which stays in ``retry_wait``
+    for bounded scheduler-owned re-dispatch of the same occurrence.
+    """
+    kind = str(outcome or "unknown")
+    if kind not in _CONTEXTUAL_OUTCOMES:
+        kind = "unknown"
+        error = error or "Gateway returned an unrecognized contextual cron outcome."
+    response = str(final_response or "")
+    if kind == "notify" and not response.strip():
+        kind = "failure"
+        error = error or "Contextual cron notify outcome had no final response."
+
+    if kind == "notify":
+        status, phase, delivery_state, finished_at = (
+            "running",
+            "agent_completed",
+            "pending",
+            None,
+        )
+        detail = None
+    elif kind == "retryable":
+        status, phase, delivery_state, finished_at = (
+            "running",
+            "retry_wait",
+            "not_applicable",
+            None,
+        )
+        detail = str(error or "Contextual cron requested a retry.")
+    elif kind == "no_action":
+        status, phase, delivery_state = "completed", "completed", "not_applicable"
+        finished_at = _hermes_now().isoformat()
+        detail = None
+    elif kind == "unknown":
+        status, phase, delivery_state = "unknown", "unknown", "unknown"
+        finished_at = _hermes_now().isoformat()
+        detail = str(error or "Contextual cron terminal state is unknown.")
+    else:
+        status, phase, delivery_state = "failed", "failed", "not_applicable"
+        finished_at = _hermes_now().isoformat()
+        detail = str(error or f"Contextual cron ended with {kind}.")
+
+    result_json = json.dumps(
+        {"kind": kind, "final_response": response, "error": error},
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+    transcript_payload: Optional[str] = None
+    transcript_session: Optional[str] = None
+    if transcript_entries is not None or transcript_session_id is not None:
+        transcript_session = str(transcript_session_id or "").strip()
+        if not transcript_session or transcript_entries is None:
+            raise ValueError(
+                "contextual transcript outbox requires a session id and entries"
+            )
+        transcript_payload = json.dumps(
+            transcript_entries,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        if (
+            not isinstance(transcript_base_message_count, int)
+            or isinstance(transcript_base_message_count, bool)
+            or transcript_base_message_count < 0
+        ):
+            raise ValueError(
+                "contextual transcript outbox requires a valid base message count"
+            )
+        transcript_base_message_count = int(transcript_base_message_count)
+        if (
+            not isinstance(transcript_base_revision, int)
+            or isinstance(transcript_base_revision, bool)
+            or transcript_base_revision < 0
+        ):
+            raise ValueError(
+                "contextual transcript outbox requires a valid base revision"
+            )
+        transcript_base_revision = int(transcript_base_revision)
+    with _transaction() as conn:
+        cur = conn.execute(
+            """UPDATE executions
+               SET status=?, phase=?, delivery_state=?, finished_at=?, error=?,
+                   outcome=?, result_json=?, next_retry_at=NULL,
+                   transcript_session_id=COALESCE(?, transcript_session_id),
+                   transcript_json=COALESCE(?, transcript_json),
+                   transcript_state=CASE WHEN ? IS NULL THEN transcript_state
+                                         ELSE 'pending' END,
+                   transcript_base_message_count=
+                       COALESCE(?, transcript_base_message_count),
+                   transcript_base_revision=
+                       COALESCE(?, transcript_base_revision),
+                   transcript_last_prompt_tokens=
+                       COALESCE(?, transcript_last_prompt_tokens)
+               WHERE id=? AND status IN ('claimed','running')
+                 AND COALESCE(phase, status) IN
+                   ('claimed','running','admitted','retry_wait')""",
+            (
+                status,
+                phase,
+                delivery_state,
+                finished_at,
+                detail,
+                kind,
+                result_json,
+                transcript_session,
+                transcript_payload,
+                transcript_payload,
+                transcript_base_message_count,
+                transcript_base_revision,
+                (
+                    int(transcript_last_prompt_tokens)
+                    if transcript_last_prompt_tokens is not None
+                    else None
+                ),
+                execution_id,
+            ),
+        )
+        record = _record(
+            conn.execute(
+                "SELECT * FROM executions WHERE id=?", (execution_id,)
+            ).fetchone()
+        )
+        if cur.rowcount != 1:
+            # Idempotent join: gateway and scheduler may both acknowledge the
+            # same result, but neither may rewrite a different terminal value.
+            if not record or record.get("outcome") != kind:
+                return None
+            if record.get("result_json") != result_json:
+                return None
+            if transcript_payload is not None and (
+                record.get("transcript_session_id") != transcript_session
+                or record.get("transcript_json") != transcript_payload
+                or record.get("transcript_base_message_count")
+                != transcript_base_message_count
+                or record.get("transcript_base_revision")
+                != transcript_base_revision
+            ):
+                return None
+            if (
+                transcript_last_prompt_tokens is not None
+                and record.get("transcript_last_prompt_tokens")
+                != int(transcript_last_prompt_tokens)
+            ):
+                return None
+        if record and record.get("status") in _TERMINAL_STATES:
+            _prune_unlocked(conn)
+    _emit_execution_state(record)
+    return record
+
+
+def list_pending_contextual_transcripts(*, limit: int = 1000) -> List[Dict[str, Any]]:
+    """Return durable transcript outboxes that still need idempotent application."""
+    with _transaction() as conn:
+        rows = conn.execute(
+            """SELECT * FROM executions
+               WHERE transcript_state='pending'
+                 AND transcript_session_id IS NOT NULL
+                 AND transcript_json IS NOT NULL
+               ORDER BY claimed_at ASC, id ASC
+               LIMIT ?""",
+            (max(1, min(int(limit), 10000)),),
+        ).fetchall()
+        return [dict(row) for row in rows]
+
+
+def mark_contextual_transcript_conflict(
+    execution_id: str, *, error: str
+) -> bool:
+    """Terminalize a pending outbox that lost its immutable causal position."""
+    now = _hermes_now().isoformat()
+    detail = str(error or "Contextual transcript causal position is unknown.")
+    result_json = json.dumps(
+        {"kind": "unknown", "final_response": "", "error": detail},
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+    with _transaction() as conn:
+        cur = conn.execute(
+            """UPDATE executions
+               SET status='unknown', phase='unknown', outcome='unknown',
+                   result_json=?, error=?, finished_at=?,
+                   transcript_state='conflict', delivery_state='unknown',
+                   delivery_finished_at=?, delivery_error=?
+               WHERE id=? AND transcript_state='pending'
+                 AND status IN ('claimed','running','completed','failed','unknown')""",
+            (result_json, detail, now, now, detail, str(execution_id)),
+        )
+        if cur.rowcount == 1:
+            _prune_unlocked(conn)
+            record = _record(
+                conn.execute(
+                    "SELECT * FROM executions WHERE id=?", (str(execution_id),)
+                ).fetchone()
+            )
+        else:
+            record = None
+    if record is not None:
+        _emit_execution_state(record, delivery_outcome="unknown")
+    return cur.rowcount == 1
+
+
+def mark_contextual_transcript_applied(execution_id: str) -> bool:
+    """Acknowledge one fully applied transcript outbox exactly once."""
+    with _transaction() as conn:
+        cur = conn.execute(
+            """UPDATE executions SET transcript_state='applied'
+               WHERE id=? AND transcript_state='pending'""",
+            (str(execution_id),),
+        )
+        if cur.rowcount == 1:
+            _prune_unlocked(conn)
+        return cur.rowcount == 1
+
+
+def prepare_contextual_retry(execution_id: str) -> Optional[Dict[str, Any]]:
+    """Re-arm the same admitted occurrence after a typed transient outcome."""
+    with _transaction() as conn:
+        cur = conn.execute(
+            """UPDATE executions
+               SET phase=CASE WHEN admitted_session_id IS NULL
+                              THEN 'running' ELSE 'admitted' END,
+                   outcome=NULL, result_json=NULL, error=NULL,
+                   delivery_state='not_applicable', retry_count=retry_count+1,
+                   next_retry_at=NULL
+               WHERE id=? AND status='running' AND phase='retry_wait'
+                 AND outcome='retryable'""",
+            (execution_id,),
+        )
+        if cur.rowcount != 1:
+            return None
+        return _record(
+            conn.execute(
+                "SELECT * FROM executions WHERE id=?", (execution_id,)
+            ).fetchone()
+        )
+
+
+def claim_contextual_delivery(execution_id: str) -> Optional[Dict[str, Any]]:
+    """CAS-claim the one scheduler-owned external delivery attempt."""
+    now = _hermes_now().isoformat()
+    pid = os.getpid()
+    with _transaction() as conn:
+        cur = conn.execute(
+            """UPDATE executions
+               SET phase='delivering', delivery_state='claimed',
+                   delivery_claimed_at=?, process_id=?, pid=?,
+                   process_started_at=?
+               WHERE id=? AND status='running' AND phase='agent_completed'
+                 AND delivery_state='pending' AND outcome='notify'
+                 AND COALESCE(transcript_state, 'not_applicable') != 'pending'""",
+            (
+                now,
+                _PROCESS_ID,
+                pid,
+                _process_start_time(pid),
+                execution_id,
+            ),
+        )
+        if cur.rowcount != 1:
+            return None
+        record = _record(
+            conn.execute(
+                "SELECT * FROM executions WHERE id=?", (execution_id,)
+            ).fetchone()
+        )
+    _emit_execution_state(record, delivery_outcome="claimed")
+    return record
+
+
+def finish_contextual_delivery(
+    execution_id: str,
+    *,
+    delivery_state: str,
+    error: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Durably acknowledge the claimed delivery without automatic resend."""
+    state = str(delivery_state or "unknown")
+    if state not in {"sent", "failed", "unknown"}:
+        state = "unknown"
+        error = error or "Unrecognized contextual delivery result."
+    if state == "sent":
+        status, phase, detail = "completed", "completed", None
+    elif state == "failed":
+        status, phase = "failed", "failed"
+        detail = str(error or "Contextual cron delivery failed.")
+    else:
+        status, phase = "unknown", "unknown"
+        detail = str(
+            error
+            or "Contextual cron delivery may have occurred without durable acknowledgement."
+        )
+    now = _hermes_now().isoformat()
+    with _transaction() as conn:
+        cur = conn.execute(
+            """UPDATE executions
+               SET status=?, phase=?, delivery_state=?,
+                   delivery_finished_at=?, finished_at=?,
+                   delivery_error=?, error=?
+               WHERE id=? AND status='running' AND phase='delivering'
+                 AND delivery_state='claimed'""",
+            (
+                status,
+                phase,
+                state,
+                now,
+                now,
+                detail,
+                detail,
+                execution_id,
+            ),
+        )
+        if cur.rowcount != 1:
+            return None
+        _prune_unlocked(conn)
+        record = _record(
+            conn.execute(
+                "SELECT * FROM executions WHERE id=?", (execution_id,)
+            ).fetchone()
+        )
+    _emit_execution_state(record, delivery_outcome=state)
+    return record
+
+
+def suppress_contextual_delivery(
+    execution_id: str, *, error: str
+) -> Optional[Dict[str, Any]]:
+    """Fail a pending delivery before ownership is claimed or transport begins."""
+    now = _hermes_now().isoformat()
+    detail = str(error or "Contextual cron delivery was suppressed.")
+    with _transaction() as conn:
+        cur = conn.execute(
+            """UPDATE executions
+               SET status='failed', phase='failed', delivery_state='failed',
+                   delivery_finished_at=?, finished_at=?,
+                   delivery_error=?, error=?
+               WHERE id=? AND status='running' AND phase='agent_completed'
+                 AND delivery_state='pending'
+                 AND COALESCE(transcript_state, 'not_applicable') != 'pending'""",
+            (now, now, detail, detail, execution_id),
+        )
+        if cur.rowcount != 1:
+            return None
+        _prune_unlocked(conn)
+        record = _record(
+            conn.execute(
+                "SELECT * FROM executions WHERE id=?", (execution_id,)
+            ).fetchone()
+        )
+    _emit_execution_state(record, delivery_outcome="suppressed")
+    return record
+
+
+def list_pending_contextual_deliveries() -> List[Dict[str, Any]]:
+    """Return agent-complete occurrences that have not begun delivery."""
+    with _transaction() as conn:
+        rows = conn.execute(
+            """SELECT * FROM executions
+               WHERE status='running' AND phase='agent_completed'
+                 AND delivery_state='pending' AND outcome='notify'
+                 AND COALESCE(transcript_state, 'not_applicable') != 'pending'
+               ORDER BY claimed_at, id"""
+        ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def finish_contextual_execution(
+    execution_id: str,
+    *,
+    outcome: str,
+    final_response: str = "",
+    error: Optional[str] = None,
+    delivery_outcome: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Compatibility wrapper around result persistence and delivery ack."""
+    record = persist_contextual_agent_result(
+        execution_id,
+        outcome=outcome,
+        final_response=final_response,
+        error=error,
+    )
+    if record is None or record.get("outcome") != "notify" or not delivery_outcome:
+        return record
+    claimed = claim_contextual_delivery(execution_id)
+    if claimed is None:
+        return get_execution(execution_id)
+    if delivery_outcome == "failed":
+        return finish_contextual_delivery(
+            execution_id,
+            delivery_state="failed",
+            error=error or "Contextual cron delivery failed.",
+        )
+    return finish_contextual_delivery(execution_id, delivery_state="sent")
+
+
 def finish_execution(
     execution_id: str, *, success: bool, error: Optional[str] = None,
     delivery_outcome: Optional[str] = None,
@@ -182,9 +832,11 @@ def finish_execution(
     detail = None if success else (str(error) if error else "unknown failure")
     with _transaction() as conn:
         cur = conn.execute(
-            """UPDATE executions SET status=?, finished_at=?, error=?
+            """UPDATE executions
+               SET status=?, phase=?, delivery_state='not_applicable',
+                   finished_at=?, error=?
                WHERE id=? AND status IN ('claimed','running')""",
-            (status, now, detail, execution_id),
+            (status, status, now, detail, execution_id),
         )
         if cur.rowcount != 1:
             return None
@@ -197,33 +849,126 @@ def finish_execution(
 
 
 def recover_interrupted_executions() -> int:
-    """Mark provably abandoned attempts unknown without scheduling retries."""
+    """Terminalize abandoned attempts without consuming unclaimed occurrences."""
     now = _hermes_now().isoformat()
+    recovery_error = (
+        "Scheduler restarted after this execution's owner exited before a durable "
+        "terminal state; whether side effects ran is unknown."
+    )
     changed = 0
     recovered: List[Dict[str, Any]] = []
+
+    # Never acquire the jobs-file lock while holding the execution DB write
+    # transaction. Accounting takes those authorities in the opposite order.
     with _transaction() as conn:
-        rows = conn.execute(
-            """SELECT id, process_id, pid, process_started_at FROM executions
-               WHERE status IN ('claimed','running')"""
-        ).fetchall()
-        for row in rows:
-            if row["process_id"] == _PROCESS_ID:
-                continue
-            if _owner_is_live(int(row["pid"]), row["process_started_at"]):
-                continue
-            cur = conn.execute(
-                """UPDATE executions SET status='unknown', finished_at=?, error=?
-                   WHERE id=? AND status IN ('claimed','running')""",
-                (now,
-                 "Scheduler restarted after this execution's owner exited before a durable "
-                 "terminal state; whether side effects ran is unknown.",
-                 row["id"]),
+        rows = [
+            dict(row)
+            for row in conn.execute(
+                """SELECT * FROM executions
+                   WHERE status IN ('claimed','running')"""
+            ).fetchall()
+        ]
+
+    candidates: List[tuple[Dict[str, Any], bool]] = []
+    for row in rows:
+        if row["process_id"] == _PROCESS_ID:
+            continue
+        if _owner_is_live(int(row["pid"]), row["process_started_at"]):
+            continue
+        if (
+            row["phase"] == "agent_completed"
+            and row["delivery_state"] == "pending"
+            and row["outcome"] == "notify"
+        ):
+            continue
+
+        before_occurrence_claim = False
+        if (
+            row["status"] == "claimed"
+            and row["phase"] == "claimed"
+            and bool(row["requires_job_accounting"])
+        ):
+            from cron.jobs import contextual_occurrence_claim_state
+
+            claim_state = contextual_occurrence_claim_state(
+                str(row["job_id"]), execution_id=str(row["id"])
             )
+            if claim_state is None:
+                logger.error(
+                    "Deferred recovery for contextual execution %s because "
+                    "the jobs authority lock is unavailable",
+                    row["id"],
+                )
+                continue
+            before_occurrence_claim = claim_state is False
+        candidates.append((row, before_occurrence_claim))
+
+    with _transaction() as conn:
+        for row, before_occurrence_claim in candidates:
+            if before_occurrence_claim:
+                row_error = (
+                    "Scheduler owner exited before this occurrence acquired its "
+                    "jobs-store claim; the occurrence remains eligible to run."
+                )
+                row_result = json.dumps(
+                    {"kind": "rejected", "final_response": "", "error": row_error},
+                    ensure_ascii=False,
+                    sort_keys=True,
+                )
+                cur = conn.execute(
+                    """UPDATE executions
+                       SET status='failed', finished_at=?, error=?,
+                           outcome='rejected', result_json=?, phase='rejected',
+                           delivery_state='not_applicable', job_accounted=1
+                       WHERE id=? AND status='claimed' AND phase='claimed'""",
+                    (now, row_error, row_result, row["id"]),
+                )
+            else:
+                delivery_uncertain = (
+                    row["phase"] == "delivering"
+                    or row["delivery_state"] == "claimed"
+                )
+                row_error = (
+                    "Scheduler restarted after a contextual delivery began; the "
+                    "message may have been sent without durable acknowledgement."
+                    if delivery_uncertain
+                    else recovery_error
+                )
+                row_result = json.dumps(
+                    {"kind": "unknown", "final_response": "", "error": row_error},
+                    ensure_ascii=False,
+                    sort_keys=True,
+                )
+                cur = conn.execute(
+                    """UPDATE executions
+                       SET status='unknown', finished_at=?, error=?,
+                           outcome='unknown', result_json=?, phase='unknown',
+                           delivery_state=CASE WHEN ? THEN 'unknown'
+                                               ELSE delivery_state END,
+                           delivery_finished_at=CASE WHEN ? THEN ?
+                                                      ELSE delivery_finished_at END,
+                           delivery_error=CASE WHEN ? THEN ?
+                                               ELSE delivery_error END
+                       WHERE id=? AND status IN ('claimed','running')""",
+                    (
+                        now,
+                        row_error,
+                        row_result,
+                        delivery_uncertain,
+                        delivery_uncertain,
+                        now,
+                        delivery_uncertain,
+                        row_error,
+                        row["id"],
+                    ),
+                )
             changed += cur.rowcount
             if cur.rowcount:
-                record = _record(conn.execute(
-                    "SELECT * FROM executions WHERE id=?", (row["id"],)
-                ).fetchone())
+                record = _record(
+                    conn.execute(
+                        "SELECT * FROM executions WHERE id=?", (row["id"],)
+                    ).fetchone()
+                )
                 if record is not None:
                     recovered.append(record)
         if changed:

--- a/cron/executions.py
+++ b/cron/executions.py
@@ -72,6 +72,8 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
                  finished_at TEXT,
                  error TEXT,
                  session_key TEXT,
+                 admitted_binding_version INTEGER,
+                 admitted_route_instance_id TEXT,
                  admitted_session_id TEXT,
                  admitted_routing_revision INTEGER,
                  admitted_at TEXT,
@@ -103,6 +105,8 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
         }
         for name, sql_type in (
             ("session_key", "TEXT"),
+            ("admitted_binding_version", "INTEGER"),
+            ("admitted_route_instance_id", "TEXT"),
             ("admitted_session_id", "TEXT"),
             ("admitted_routing_revision", "INTEGER"),
             ("admitted_at", "TEXT"),
@@ -160,7 +164,7 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
             "CREATE INDEX IF NOT EXISTS idx_executions_pending_delivery "
             "ON executions(delivery_state, phase, claimed_at)"
         )
-        conn.execute("PRAGMA user_version=6")
+        conn.execute("PRAGMA user_version=8")
         conn.commit()
     except BaseException:
         conn.rollback()
@@ -299,6 +303,8 @@ def seal_contextual_admission(
     session_key: str,
     admitted_session_id: str,
     admitted_routing_revision: int = 0,
+    admitted_route_instance_id: Optional[str] = None,
+    admitted_binding_version: int = 1,
 ) -> bool:
     """Durably bind an occurrence to the exact live session before queueing.
 
@@ -307,18 +313,27 @@ def seal_contextual_admission(
     """
     key = str(session_key or "").strip()
     session_id = str(admitted_session_id or "").strip()
+    route_instance_id = str(admitted_route_instance_id or "").strip() or None
+    binding_version = int(admitted_binding_version)
+    if binding_version not in (1, 2):
+        raise ValueError("unsupported contextual binding version")
+    if binding_version == 2 and route_instance_id is None:
+        raise ValueError("v2 contextual admission requires a route instance")
     if not key or not session_id:
         return False
     admitted_at = _hermes_now().isoformat()
     with _transaction() as conn:
         cur = conn.execute(
             """UPDATE executions
-               SET session_key=?, admitted_session_id=?,
+               SET session_key=?, admitted_binding_version=?,
+                   admitted_route_instance_id=?, admitted_session_id=?,
                    admitted_routing_revision=?, admitted_at=?, phase='admitted'
                WHERE id=? AND status IN ('claimed','running')
                  AND session_key IS NULL AND admitted_session_id IS NULL""",
             (
                 key,
+                binding_version,
+                route_instance_id,
                 session_id,
                 int(admitted_routing_revision),
                 admitted_at,
@@ -328,15 +343,19 @@ def seal_contextual_admission(
         if cur.rowcount == 1:
             return True
         existing = conn.execute(
-            """SELECT status, session_key, admitted_session_id,
-                      admitted_routing_revision
+            """SELECT status, session_key, admitted_binding_version,
+                      admitted_route_instance_id,
+                      admitted_session_id, admitted_routing_revision
                FROM executions WHERE id=?""",
             (execution_id,),
         ).fetchone()
         return bool(
-            existing
+            existing is not None
             and existing["status"] in {"claimed", "running"}
             and existing["session_key"] == key
+            and int(existing["admitted_binding_version"] or 1) == binding_version
+            and (existing["admitted_route_instance_id"] or None)
+            == route_instance_id
             and existing["admitted_session_id"] == session_id
             and int(existing["admitted_routing_revision"] or 0)
             == int(admitted_routing_revision)

--- a/cron/executions.py
+++ b/cron/executions.py
@@ -224,9 +224,14 @@ def _owner_is_live(pid: int, started_at: Optional[int]) -> bool:
     except Exception:
         return True  # fail safe: inability to prove death must not rewrite state
     if started_at is None:
-        return pid == os.getpid()
+        # The PID exists, but the durable owner fingerprint was unavailable.
+        # Treat that ambiguity as live; recovery may rewrite state only after
+        # proving owner death or PID reuse.
+        return True
     current = _process_start_time(pid)
-    return current is not None and current == started_at
+    if current is None:
+        return True
+    return current == started_at
 
 
 def _prune_unlocked(conn: sqlite3.Connection) -> None:

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -9,6 +9,7 @@ import contextlib
 import copy
 from contextvars import ContextVar
 from dataclasses import dataclass
+import hashlib
 import json
 import logging
 import shutil
@@ -819,6 +820,106 @@ def _contextual_jobs_authority_marker() -> Path:
     return _current_cron_store().cron_dir / ".contextual-jobs-authority"
 
 
+def _contextual_jobs_authority_pending_marker() -> Path:
+    """Crash-recovery receipt for the first contextual jobs-file commit."""
+    return _current_cron_store().cron_dir / ".contextual-jobs-authority.pending"
+
+
+def _fsync_contextual_authority_dir_unlocked() -> None:
+    """Best-effort durability barrier for authority sidecar changes."""
+    marker = _contextual_jobs_authority_marker()
+    try:
+        dir_fd = os.open(marker.parent, os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    except OSError:
+        # Directory fsync is unavailable on some platforms/filesystems.
+        pass
+
+
+def _jobs_payload_sha256(path: Union[str, Path]) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _publish_contextual_jobs_authority_pending_unlocked(tmp_path: str) -> None:
+    """Durably record the exact payload expected to complete first authority."""
+    pending = _contextual_jobs_authority_pending_marker()
+    atomic_write_text(
+        pending,
+        json.dumps(
+            {
+                "version": 1,
+                "jobs_payload_sha256": _jobs_payload_sha256(tmp_path),
+            },
+            sort_keys=True,
+        ),
+        create_mode=0o600,
+    )
+    _fsync_contextual_authority_dir_unlocked()
+
+
+def _remove_contextual_authority_path_unlocked(path: Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+    _fsync_contextual_authority_dir_unlocked()
+
+
+def _recover_contextual_jobs_authority_unlocked(jobs_file: Path) -> bool:
+    """Resolve a crash-interrupted first-authority transition.
+
+    The pending receipt is durable before the permanent marker is published.
+    Therefore a matching jobs payload proves the first contextual commit
+    crossed the atomic replacement boundary; a mismatch proves that it did
+    not and both sidecars must be rolled back.
+    """
+    marker = _contextual_jobs_authority_marker()
+    pending = _contextual_jobs_authority_pending_marker()
+    if not pending.exists():
+        return marker.exists()
+
+    try:
+        payload = json.loads(pending.read_text(encoding="utf-8"))
+        expected = payload.get("jobs_payload_sha256")
+    except (OSError, ValueError, TypeError) as exc:
+        raise RuntimeError(
+            f"Unreadable contextual authority transition receipt {pending}"
+        ) from exc
+    if not isinstance(expected, str) or len(expected) != 64:
+        raise RuntimeError(
+            f"Invalid contextual authority transition receipt {pending}"
+        )
+
+    try:
+        committed = _jobs_payload_sha256(jobs_file) == expected
+    except FileNotFoundError:
+        committed = False
+
+    if committed:
+        if not marker.exists():
+            _publish_contextual_jobs_authority_unlocked()
+        _remove_contextual_authority_path_unlocked(pending)
+        return True
+
+    _remove_contextual_authority_path_unlocked(marker)
+    _remove_contextual_authority_path_unlocked(pending)
+    return False
+
+
+def _contextual_jobs_authority_enabled(jobs_file: Optional[Path] = None) -> bool:
+    """Return committed authority after resolving any interrupted transition."""
+    target = jobs_file or _current_cron_store().jobs_file
+    with contextual_authority_lock():
+        return _recover_contextual_jobs_authority_unlocked(target)
+
+
 def _publish_contextual_jobs_authority_unlocked() -> None:
     """Publish the marker while the caller holds contextual_authority_lock()."""
     marker = _contextual_jobs_authority_marker()
@@ -828,16 +929,7 @@ def _publish_contextual_jobs_authority_unlocked() -> None:
     finally:
         os.close(fd)
     _secure_file(marker)
-    try:
-        dir_fd = os.open(marker.parent, os.O_RDONLY)
-        try:
-            os.fsync(dir_fd)
-        finally:
-            os.close(dir_fd)
-    except OSError:
-        # Directory fsync is unavailable on some platforms/filesystems.
-        # The marker itself is still atomically visible to siblings.
-        pass
+    _fsync_contextual_authority_dir_unlocked()
 
 
 # =============================================================================
@@ -1527,11 +1619,12 @@ def _replace_jobs_payload_with_authority(
         for job in jobs
     )
     marker = _contextual_jobs_authority_marker()
+    pending = _contextual_jobs_authority_pending_marker()
     with contextual_authority_lock():
         cross_process_acquired = bool(
             getattr(_jobs_lock_state, "cross_process_acquired", False)
         )
-        marker_preexisting = marker.exists()
+        marker_preexisting = _recover_contextual_jobs_authority_unlocked(jobs_file)
         if not cross_process_acquired and (marker_preexisting or publishes_contextual):
             raise RuntimeError(
                 "Refusing a degraded jobs.json write after contextual jobs "
@@ -1539,26 +1632,24 @@ def _replace_jobs_payload_with_authority(
             )
 
         marker_created = publishes_contextual and not marker_preexisting
+        payload_replaced = False
         try:
             if marker_created:
+                _publish_contextual_jobs_authority_pending_unlocked(tmp_path)
                 _publish_contextual_jobs_authority_unlocked()
             atomic_replace(tmp_path, jobs_file)
-        except BaseException:
+            payload_replaced = True
             if marker_created:
+                _remove_contextual_authority_path_unlocked(pending)
+        except BaseException:
+            if marker_created and not payload_replaced:
                 try:
-                    marker.unlink()
-                    try:
-                        dir_fd = os.open(marker.parent, os.O_RDONLY)
-                        try:
-                            os.fsync(dir_fd)
-                        finally:
-                            os.close(dir_fd)
-                    except OSError:
-                        pass
+                    _remove_contextual_authority_path_unlocked(marker)
+                    _remove_contextual_authority_path_unlocked(pending)
                 except OSError:
                     logger.error(
-                        "Failed to roll back contextual authority marker %s",
-                        marker,
+                        "Failed to roll back contextual authority transition %s",
+                        pending,
                         exc_info=True,
                     )
             raise
@@ -1716,7 +1807,7 @@ def save_jobs(
     )
     with _jobs_lock() as cross_process_locked:
         if not cross_process_locked and (
-            publishes_contextual or _contextual_jobs_authority_marker().exists()
+            publishes_contextual or _contextual_jobs_authority_enabled()
         ):
             raise RuntimeError(
                 "Refusing a degraded jobs.json write for a profile with "

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -103,6 +103,7 @@ TICKER_INTERVAL_SECONDS = 60
 # concurrent mark_job_run / advance_next_run calls can clobber each other.
 _jobs_file_lock = threading.RLock()
 _jobs_lock_state = threading.local()
+_contextual_accounting_thread_lock = threading.RLock()
 
 # Upper bound on waiting for the cross-process .jobs.lock flock (#60703).
 # Every cron function in the process funnels through _jobs_lock(), and the
@@ -112,6 +113,7 @@ _jobs_lock_state = threading.local()
 # legitimate critical section (field updates only) while keeping the ticker's
 # worst-case stall well under one status-alarm threshold.
 _JOBS_LOCK_TIMEOUT_SECONDS = 30.0
+_CONTEXTUAL_ACCOUNTING_LOCK_TIMEOUT_SECONDS = 30.0
 OUTPUT_DIR = CRON_DIR / "output"
 ONESHOT_GRACE_SECONDS = 120
 
@@ -291,7 +293,7 @@ def _jobs_lock():
     if depth:
         _jobs_lock_state.depth = depth + 1
         try:
-            yield
+            yield bool(getattr(_jobs_lock_state, "cross_process_acquired", False))
         finally:
             _jobs_lock_state.depth -= 1
         return
@@ -304,6 +306,7 @@ def _jobs_lock():
         # section read it. Reset on entry/exit so stale stamps from unlocked
         # loads or prior sections can never suppress a needed merge.
         _jobs_lock_state.load_stamp = None
+        _jobs_lock_state.cross_process_acquired = False
         lock_fd = None
         try:
             try:
@@ -329,6 +332,7 @@ def _jobs_lock():
                     while True:
                         try:
                             fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                            _jobs_lock_state.cross_process_acquired = True
                             break
                         except (OSError, IOError):
                             if time.monotonic() >= _deadline:
@@ -349,13 +353,14 @@ def _jobs_lock():
                             time.sleep(0.1)
                 elif msvcrt is not None:
                     getattr(msvcrt, "locking")(lock_fd.fileno(), getattr(msvcrt, "LK_LOCK"), 1)
+                    _jobs_lock_state.cross_process_acquired = True
             except (OSError, IOError) as e:
                 # Never let a locking failure take down cron writes — fall back to
                 # in-process-only protection (still held via _jobs_file_lock).
                 logger.warning("jobs.json cross-process lock unavailable (%s); "
                                "proceeding with in-process lock only", e)
             try:
-                yield
+                yield bool(_jobs_lock_state.cross_process_acquired)
             finally:
                 if lock_fd is not None:
                     try:
@@ -370,12 +375,95 @@ def _jobs_lock():
         finally:
             _jobs_lock_state.depth = 0
             _jobs_lock_state.load_stamp = None
+            _jobs_lock_state.cross_process_acquired = False
+
+
+@contextlib.contextmanager
+def contextual_accounting_lock():
+    """Serialize the jobs-file + execution-ledger accounting transaction.
+
+    Unlike the general jobs lock this lock fails closed on acquisition errors.
+    Proceeding without cross-process exclusion can consume a finite repeat
+    twice, so reconciliation must retry later instead of degrading safety.
+    """
+    with _contextual_accounting_thread_lock:
+        ensure_dirs()
+        lock_path = _current_cron_store().cron_dir / ".contextual-accounting.lock"
+        lock_fd = open(lock_path, "a+b")
+        acquired = False
+        try:
+            if fcntl is not None:
+                deadline = time.monotonic() + _CONTEXTUAL_ACCOUNTING_LOCK_TIMEOUT_SECONDS
+                while True:
+                    try:
+                        fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                        acquired = True
+                        break
+                    except (OSError, IOError) as exc:
+                        if time.monotonic() >= deadline:
+                            raise TimeoutError(
+                                f"Timed out acquiring contextual accounting lock {lock_path}"
+                            ) from exc
+                        time.sleep(0.1)
+            elif msvcrt is not None:
+                if os.fstat(lock_fd.fileno()).st_size == 0:
+                    lock_fd.write(b"\0")
+                    lock_fd.flush()
+                lock_fd.seek(0)
+                deadline = time.monotonic() + _CONTEXTUAL_ACCOUNTING_LOCK_TIMEOUT_SECONDS
+                while True:
+                    try:
+                        getattr(msvcrt, "locking")(
+                            lock_fd.fileno(), getattr(msvcrt, "LK_NBLCK"), 1
+                        )
+                        acquired = True
+                        break
+                    except (OSError, IOError) as exc:
+                        if time.monotonic() >= deadline:
+                            raise TimeoutError(
+                                f"Timed out acquiring contextual accounting lock {lock_path}"
+                            ) from exc
+                        time.sleep(0.1)
+            else:  # pragma: no cover - supported hosts provide one primitive
+                raise RuntimeError("No cross-process file-lock primitive is available")
+
+            yield
+        finally:
+            if acquired:
+                try:
+                    if fcntl is not None:
+                        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                    elif msvcrt is not None:
+                        lock_fd.seek(0)
+                        getattr(msvcrt, "locking")(
+                            lock_fd.fileno(), getattr(msvcrt, "LK_UNLCK"), 1
+                        )
+                except (OSError, IOError):
+                    logger.error(
+                        "Failed to release contextual accounting lock %s",
+                        lock_path,
+                        exc_info=True,
+                    )
+            lock_fd.close()
+
+
+@contextlib.contextmanager
+def contextual_transcript_lock():
+    """Serialize transcript identity-check, append, and outbox acknowledgement.
+
+    The accounting lock is deliberately shared: both operations bridge the
+    execution ledger and another durable store, and neither critical section
+    calls the other. Reusing one fail-closed cross-process lock avoids a second
+    lock-order domain while keeping both crash gaps linearizable.
+    """
+    with contextual_accounting_lock():
+        yield
 
 # Fields on a cron job that must never change after creation. ``id`` is used
 # as a filesystem path component under ``OUTPUT_DIR``; allowing it to be
 # updated lets an unsafe value (``../escape``, absolute path, nested) leak
 # into output writes/deletes.
-_IMMUTABLE_JOB_FIELDS = frozenset({"id"})
+_IMMUTABLE_JOB_FIELDS = frozenset({"id", "session_key", "context_binding", "origin"})
 
 
 def _job_output_dir(job_id: str) -> Path:
@@ -452,6 +540,14 @@ def _normalize_job_record(job: Dict[str, Any]) -> Dict[str, Any]:
     ensure consumers never crash while formatting or running those records.
     """
     normalized = _apply_skill_fields(job)
+    # Migration-safe public default: jobs written before contextual cron are
+    # ordinary isolated jobs. Never infer context from a stray legacy key.
+    from cron.contextual import normalize_session_target
+    normalized["session_target"] = normalize_session_target(
+        normalized.get("session_target")
+    )
+    if normalized["session_target"] != "current":
+        normalized.pop("session_key", None)
     job_id = _coerce_job_text(normalized.get("id"), "unknown")
     prompt = _coerce_job_text(normalized.get("prompt"))
     normalized["id"] = job_id
@@ -520,6 +616,63 @@ def effective_job_state(job: Dict[str, Any]) -> str:
     return stored or "scheduled"
 
 
+_PRIVATE_CONTEXTUAL_JOB_FIELDS = frozenset(
+    {
+        "session_key",
+        "context_binding",
+        "_contextual_binding_version",
+        "_contextual_occurrence_claim",
+        "_pending_accounting_execution_ids",
+        "_last_accounted_execution_id",
+    }
+)
+_PUBLIC_EXECUTION_FIELDS = frozenset(
+    {
+        "id",
+        "status",
+        "outcome",
+        "phase",
+        "created_at",
+        "started_at",
+        "finished_at",
+        "updated_at",
+    }
+)
+
+
+def public_job_record(job: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the stable public API shape without routing or ledger authority.
+
+    Internal bindings, concrete session identities, result payloads, claims,
+    and delivery state are scheduler authority and must never cross a public
+    list/get/create/update boundary.
+    """
+    from cron.contextual import normalize_session_target
+
+    source = copy.deepcopy(dict(job))
+    public = source
+    for key in _PRIVATE_CONTEXTUAL_JOB_FIELDS:
+        public.pop(key, None)
+    public_target = normalize_session_target(source.get("session_target"))
+    if public_target == "current":
+        public["session_target"] = "current"
+        public.pop("origin", None)
+        # Contextual claim payloads are feature-private authority. Isolated
+        # jobs retain their legacy run/fire claim projection unchanged.
+        public.pop("run_claim", None)
+        public.pop("fire_claim", None)
+    else:
+        public.pop("session_target", None)
+    execution = source.get("latest_execution")
+    if public_target == "current" and isinstance(execution, dict):
+        public["latest_execution"] = {
+            key: execution.get(key)
+            for key in _PUBLIC_EXECUTION_FIELDS
+            if execution.get(key) is not None
+        }
+    return public
+
+
 def _secure_dir(path: Path):
     """Set directory to owner-only access (0700). No-op on Windows."""
     try:
@@ -582,6 +735,33 @@ def ensure_dirs():
     store.output_dir.mkdir(parents=True, exist_ok=True)
     _secure_dir(store.cron_dir)
     _secure_dir(store.output_dir)
+
+
+def _contextual_jobs_authority_marker() -> Path:
+    """Permanent profile marker that makes degraded whole-file writes strict."""
+    return _current_cron_store().cron_dir / ".contextual-jobs-authority"
+
+
+def _enable_contextual_jobs_authority() -> None:
+    """Publish contextual authority before its first jobs-lock acquisition."""
+    ensure_dirs()
+    marker = _contextual_jobs_authority_marker()
+    fd = os.open(marker, os.O_CREAT | os.O_WRONLY, 0o600)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+    _secure_file(marker)
+    try:
+        dir_fd = os.open(marker.parent, os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    except OSError:
+        # Directory fsync is unavailable on some platforms/filesystems. The
+        # marker itself is still atomically visible to sibling processes.
+        pass
 
 
 # =============================================================================
@@ -707,6 +887,19 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
         f"  - Cron: '0 9 * * *' (cron expression)\n"
         f"  - Timestamp: '2026-02-03T14:00:00' (one-shot at time)"
     )
+
+
+def _schedule_dict(job: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a structured schedule without mutating legacy persisted strings."""
+    value = job.get("schedule")
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            return parse_schedule(value)
+        except ValueError:
+            return {}
+    return {}
 
 
 def _ensure_aware(dt: datetime) -> datetime:
@@ -1337,6 +1530,16 @@ def _save_jobs_unlocked(
                         tmp_path = None
                         continue
 
+            if (
+                not bool(
+                    getattr(_jobs_lock_state, "cross_process_acquired", False)
+                )
+                and _contextual_jobs_authority_marker().exists()
+            ):
+                raise RuntimeError(
+                    "Refusing a degraded jobs.json write after contextual jobs "
+                    "authority was enabled for this profile"
+                )
             atomic_replace(tmp_path, jobs_file)
             tmp_path = None
             _secure_file(jobs_file)
@@ -1367,6 +1570,14 @@ def _save_jobs_unlocked(
             )
             f.flush()
             os.fsync(f.fileno())
+        if (
+            not bool(getattr(_jobs_lock_state, "cross_process_acquired", False))
+            and _contextual_jobs_authority_marker().exists()
+        ):
+            raise RuntimeError(
+                "Refusing a degraded jobs.json write after contextual jobs "
+                "authority was enabled for this profile"
+            )
         atomic_replace(tmp_path, jobs_file)
         tmp_path = None
         _secure_file(jobs_file)
@@ -1391,7 +1602,21 @@ def save_jobs(
     See ``_save_jobs_unlocked`` for ``removed_ids`` / ``replace`` semantics
     (shrink-merge guard against concurrent-create clobber, #80624).
     """
-    with _jobs_lock():
+    if any(
+        isinstance(job, dict)
+        and job.get("session_target", "isolated") == "current"
+        for job in jobs
+    ):
+        _enable_contextual_jobs_authority()
+    with _jobs_lock() as cross_process_locked:
+        if (
+            not cross_process_locked
+            and _contextual_jobs_authority_marker().exists()
+        ):
+            raise RuntimeError(
+                "Refusing a degraded jobs.json write for a profile with "
+                "contextual jobs authority"
+            )
         _save_jobs_unlocked(jobs, removed_ids=removed_ids, replace=replace)
 
 
@@ -1586,6 +1811,7 @@ def create_job(
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
+    session_target: str = "isolated",
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -1643,6 +1869,9 @@ def create_job(
         monitor_url: Optional http(s) URL used as the monitor source instead
                 of a script — fetched with a bounded GET each tick. Same
                 hash-suppression semantics as ``monitor_script``.
+        session_target: ``isolated`` (default) or explicit ``current`` to bind
+                the job immutably to the live gateway conversation. Contextual
+                jobs cannot use monitor mode or other isolated-run overrides.
 
     Returns:
         The created job dict
@@ -1681,17 +1910,28 @@ def create_job(
     normalized_monitor_url = normalized_monitor_url or None
 
     # Monitor-mode validation: exactly one source, and monitor mode only
-    # makes sense when there IS an agent to suppress/wake.
-    # no_agent jobs are meaningless without a script — the script IS the job.
-    # Surface these as clear ValueErrors at create time so bad configs never
-    # reach the scheduler (shared with update_job, see
-    # _validate_job_mode_invariants).
+    # makes sense when there IS an agent to suppress/wake. Surface failures at
+    # create time so bad configs never reach the scheduler.
     _validate_job_mode_invariants(
         normalized_monitor_script,
         normalized_monitor_url,
         normalized_no_agent,
         normalized_script,
     )
+
+    from cron.contextual import (
+        contextual_fields_for_write,
+        validate_contextual_job_shape,
+    )
+    contextual_fields = contextual_fields_for_write(session_target)
+    if contextual_fields.get("session_target") == "current":
+        _enable_contextual_jobs_authority()
+        contextual_fields["_contextual_binding_version"] = 1
+        from cron.contextual import contextual_origin_from_binding
+
+        # Execution identity and delivery identity are one atomic binding. A
+        # stale/caller-supplied origin may never diverge from the live key.
+        origin = contextual_origin_from_binding(contextual_fields["context_binding"])
 
     # Normalize context_from: accept str or list of str, store as list or None
     if isinstance(context_from, str):
@@ -1777,12 +2017,15 @@ def create_job(
         "origin": origin,  # Tracks where job was created for "origin" delivery
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
+        **contextual_fields,
     }
     # Only persist attach_to_session when explicitly set, so existing jobs and
     # the common case stay byte-identical (absent key => fall back to the
     # global cron.mirror_delivery config, default off).
     if normalized_attach is not None:
         job["attach_to_session"] = normalized_attach
+
+    validate_contextual_job_shape(job)
 
     with _jobs_lock():
         jobs = load_jobs()
@@ -1866,6 +2109,9 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
             f"Cron job field(s) cannot be updated: {', '.join(sorted(bad_fields))}"
         )
 
+    if str(updates.get("session_target") or "").strip().lower() == "current":
+        _enable_contextual_jobs_authority()
+
     with _jobs_lock():
         jobs = load_jobs()
         for i, job in enumerate(jobs):
@@ -1889,16 +2135,25 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     _mv = str(_mv).strip() if isinstance(_mv, str) else None
                     updates[_mon_field] = _mv or None
 
+            # Only an explicit session-target edit re-captures the trusted
+            # task-local gateway key. Ordinary edits (including pause/resume)
+            # preserve the original binding so they remain safe outside a live
+            # request context.
+            from cron.contextual import (
+                contextual_fields_for_write,
+                normalize_session_target,
+                validate_contextual_job_shape,
+            )
+            requested_target = normalize_session_target(
+                updates.get("session_target", job.get("session_target"))
+            )
+
             previous_inference_axes = _normalized_inference_axes(job)
             updated = _apply_skill_fields({**job, **updates})
 
             # Re-check execution-mode invariants on the MERGED record when
             # any participating field changes, so create-time invariants
-            # can't be violated through the update door (e.g. flipping
-            # no_agent=True on a monitor job would silently disable the
-            # monitor: the scheduler's no_agent short-circuit runs before
-            # the monitor gate). Scoped to changed fields so legacy records
-            # untouched by this update keep loading.
+            # cannot be violated through the update door.
             if {"monitor_script", "monitor_url", "no_agent", "script"}.intersection(updates):
                 _upd_script = updated.get("script")
                 _upd_script = str(_upd_script).strip() if isinstance(_upd_script, str) else None
@@ -1908,6 +2163,40 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     bool(updated.get("no_agent")),
                     _upd_script or None,
                 )
+
+            previous_target = normalize_session_target(job.get("session_target"))
+            was_contextual = bool(
+                job.get("_contextual_binding_version")
+                or previous_target == "current"
+                or job.get("session_key")
+                or job.get("context_binding")
+            )
+            if was_contextual and requested_target != "current":
+                raise ValueError(
+                    "A contextual cron job's session binding is permanent. "
+                    "Delete it and create a new isolated job instead."
+                )
+            if requested_target == "current":
+                if previous_target == "current" and job.get("session_key"):
+                    # V1 bindings are immutable. An explicit no-op current
+                    # update validates the shape but does not silently move the
+                    # job to the editing chat.
+                    updated["session_target"] = "current"
+                else:
+                    fields = contextual_fields_for_write("current")
+                    updated.update(fields)
+                    from cron.contextual import contextual_origin_from_binding
+
+                    updated["origin"] = contextual_origin_from_binding(
+                        fields["context_binding"]
+                    )
+                updated["_contextual_binding_version"] = 1
+            else:
+                updated.pop("session_target", None)
+                updated.pop("session_key", None)
+                updated.pop("context_binding", None)
+            validate_contextual_job_shape(updated)
+
             schedule_changed = "schedule" in updates
             inference_fields_changed = bool(
                 {"provider", "model", "base_url", "no_agent"}.intersection(updates)
@@ -2003,9 +2292,10 @@ def resume_job(job_id: str) -> Optional[Dict[str, Any]]:
     if not job:
         return None
 
-    next_run_at = compute_next_run(job["schedule"])
-    if next_run_at is None and job["schedule"].get("kind") == "once":
-        run_at = job["schedule"].get("run_at", "unknown")
+    schedule = _schedule_dict(job)
+    next_run_at = compute_next_run(schedule)
+    if next_run_at is None and schedule.get("kind") == "once":
+        run_at = schedule.get("run_at", "unknown")
         raise ValueError(
             f"Cannot resume: one-shot time {run_at} is in the past "
             f"(grace window: {ONESHOT_GRACE_SECONDS}s) and will never fire."
@@ -2108,9 +2398,16 @@ def clear_preflight_alerted(job_id: str) -> None:
     _set_preflight_alerted(job_id, False)
 
 
-def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
-                 delivery_error: Optional[str] = None,
-                 status: Optional[str] = None):
+def mark_job_run(
+    job_id: str,
+    success: bool,
+    error: Optional[str] = None,
+    delivery_error: Optional[str] = None,
+    status: Optional[str] = None,
+    *,
+    execution_id: Optional[str] = None,
+    require_cross_process_lock: bool = False,
+) -> bool:
     """
     Mark a job as having been run.
     
@@ -2126,10 +2423,27 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
     (T1-26), so `cronjob list` distinguishes "your config is broken" from
     "the run itself failed".
     """
-    with _jobs_lock():
+    with _jobs_lock() as cross_process_locked:
+        if require_cross_process_lock and not cross_process_locked:
+            logger.error(
+                "mark_job_run for contextual execution %s refused because the "
+                "jobs cross-process lock is unavailable",
+                execution_id or job_id,
+            )
+            return False
         jobs = load_jobs()
         for i, job in enumerate(jobs):
             if job["id"] == job_id:
+                if execution_id:
+                    markers = {
+                        str(item)
+                        for item in (job.get("_pending_accounting_execution_ids") or [])
+                        if str(item)
+                    }
+                    if str(execution_id) in markers:
+                        return True
+                    markers.add(str(execution_id))
+                    job["_pending_accounting_execution_ids"] = sorted(markers)
                 now = _hermes_now().isoformat()
                 job["last_run_at"] = now
                 job["last_status"] = status or ("ok" if success else "error")
@@ -2141,6 +2455,12 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                     job.pop("preflight_alerted", None)
                 # Track delivery failures separately — cleared on successful delivery
                 job["last_delivery_error"] = delivery_error
+                if execution_id:
+                    # The job file is the counter authority. Persist the
+                    # occurrence marker in the same atomic save as the counters
+                    # so restart recovery can replay accounting without double
+                    # incrementing repeat/completion state.
+                    job["_last_accounted_execution_id"] = str(execution_id)
                 # Clear any external-fire claim so a re-armed recurring job can
                 # be claimed again on its next fire (Phase 4C CAS).
                 job["fire_claim"] = None
@@ -2149,6 +2469,10 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                 # is claimable again. No-op if the job never carried a claim.
                 if job.get("run_claim") is not None:
                     job["run_claim"] = None
+                # The execution-specific admission marker has served its purpose;
+                # clear it in the same durable accounting write that re-anchors
+                # the job so a later occurrence may claim the cursor.
+                job.pop("_contextual_occurrence_claim", None)
                 
                 # Increment completed count.  Finite one-shot jobs are
                 # pre-claimed by claim_dispatch() BEFORE the side effect runs
@@ -2159,7 +2483,7 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                     repeat = job["repeat"]
                     times = repeat.get("times")
                     completed = repeat.get("completed", 0)
-                    kind = job.get("schedule", {}).get("kind")
+                    kind = _schedule_dict(job).get("kind")
                     preclaimed_oneshot = (
                         kind == "once"
                         and times is not None
@@ -2186,10 +2510,10 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                         job["state"] = "completed"
                         job["next_run_at"] = None
                         save_jobs(jobs)
-                        return
+                        return True
                 
                 # Compute next run
-                job["next_run_at"] = compute_next_run(job["schedule"], now)
+                job["next_run_at"] = compute_next_run(_schedule_dict(job), now)
 
                 # If no next run, decide whether this is terminal completion
                 # (one-shot) or a transient failure (recurring schedule couldn't
@@ -2198,7 +2522,7 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                 # missing runtime dep into "job completed" and the user's
                 # schedule quietly goes off. See issue #16265.
                 if job["next_run_at"] is None:
-                    kind = job.get("schedule", {}).get("kind")
+                    kind = _schedule_dict(job).get("kind")
                     if kind in {"cron", "interval"}:
                         job["state"] = "error"
                         if not job.get("last_error"):
@@ -2221,9 +2545,39 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                     job["state"] = "scheduled"
 
                 save_jobs(jobs)
-                return
+                return True
 
         logger.warning("mark_job_run: job_id %s not found, skipping save", job_id)
+        return False
+
+
+def clear_job_accounting_marker(job_id: str, execution_id: str) -> bool:
+    """Remove a crash-gap marker after the ledger confirms accounting."""
+    with _jobs_lock() as cross_process_locked:
+        if not cross_process_locked:
+            logger.error(
+                "Accounting marker cleanup for execution %s deferred because "
+                "the jobs cross-process lock is unavailable",
+                execution_id,
+            )
+            return False
+        jobs = load_jobs()
+        for i, job in enumerate(jobs):
+            if job["id"] != job_id:
+                continue
+            markers = [
+                str(item)
+                for item in (job.get("_pending_accounting_execution_ids") or [])
+                if str(item) and str(item) != str(execution_id)
+            ]
+            if markers:
+                job["_pending_accounting_execution_ids"] = sorted(set(markers))
+            else:
+                job.pop("_pending_accounting_execution_ids", None)
+            jobs[i] = job
+            save_jobs(jobs)
+            return True
+        return False
 
 
 def _write_wedged_oneshot_diagnostic(job: Dict[str, Any]) -> None:
@@ -2287,12 +2641,15 @@ def claim_dispatch(job_id: str) -> bool:
     Recurring jobs (they use ``advance_next_run``) and infinite-repeat / no-repeat
     jobs are left unchanged and always allowed to proceed.
     """
-    with _jobs_lock():
+    with _jobs_lock() as cross_process_locked:
+        if not cross_process_locked:
+            logger.error("claim_dispatch failed closed: jobs lock unavailable")
+            return False
         jobs = load_jobs()
         for i, job in enumerate(jobs):
             if job["id"] != job_id:
                 continue
-            if job.get("schedule", {}).get("kind") != "once":
+            if _schedule_dict(job).get("kind") != "once":
                 return True  # recurring jobs use advance_next_run(), not dispatch claims
             repeat = job.get("repeat")
             if not repeat:
@@ -2352,6 +2709,110 @@ def claim_dispatch(job_id: str) -> bool:
         return True
 
 
+def claim_contextual_occurrence(
+    job_id: str,
+    *,
+    execution_id: str,
+    expected_next_run_at: str,
+) -> bool:
+    """CAS one built-in contextual occurrence after its ledger row exists.
+
+    The execution id is persisted with the jobs-file claim so a worker can
+    prove it owns the exact occurrence it was handed. Recurring jobs advance
+    their cursor here; one-shots acquire their durable in-flight ``run_claim``
+    here. Finite repeat accounting remains the responsibility of
+    :func:`claim_dispatch` immediately before the worker side effect.
+    """
+    occurrence_id = str(execution_id or "").strip()
+    expected_cursor = str(expected_next_run_at or "").strip()
+    if not occurrence_id or not expected_cursor:
+        return False
+    with _jobs_lock() as cross_process_locked:
+        if not cross_process_locked:
+            logger.error(
+                "Contextual occurrence claim for job %s failed closed: jobs "
+                "lock unavailable",
+                job_id,
+            )
+            return False
+        jobs = load_jobs()
+        for job in jobs:
+            if job.get("id") != job_id:
+                continue
+            if job.get("session_target", "isolated") != "current":
+                return False
+            existing = job.get("_contextual_occurrence_claim")
+            if isinstance(existing, dict):
+                return (
+                    existing.get("execution_id") == occurrence_id
+                    and existing.get("scheduled_for") == expected_cursor
+                )
+            if str(job.get("next_run_at") or "") != expected_cursor:
+                return False
+            schedule = _schedule_dict(job)
+            kind = schedule.get("kind")
+            claimed_at = _hermes_now().isoformat()
+            if kind in {"cron", "interval"}:
+                new_next = compute_next_run(schedule, claimed_at)
+                if not new_next or new_next == expected_cursor:
+                    return False
+                job["next_run_at"] = new_next
+            elif kind == "once":
+                existing_run_claim = job.get("run_claim")
+                if isinstance(existing_run_claim, dict):
+                    return existing_run_claim.get("execution_id") == occurrence_id
+                job["run_claim"] = {
+                    "at": claimed_at,
+                    "by": _machine_id(),
+                    "durable": True,
+                    "execution_id": occurrence_id,
+                }
+            else:
+                return False
+            job["_contextual_occurrence_claim"] = {
+                "execution_id": occurrence_id,
+                "scheduled_for": expected_cursor,
+                "claimed_at": claimed_at,
+            }
+            save_jobs(jobs)
+            return True
+    return False
+
+
+def contextual_occurrence_claim_state(
+    job_id: str, *, execution_id: str
+) -> Optional[bool]:
+    """Return True/False for a definitive claim check, or None when unavailable."""
+    occurrence_id = str(execution_id or "").strip()
+    if not occurrence_id:
+        return False
+    with _jobs_lock() as cross_process_locked:
+        if not cross_process_locked:
+            return None
+        for job in load_jobs():
+            if job.get("id") != job_id:
+                continue
+            claim = job.get("_contextual_occurrence_claim")
+            if not isinstance(claim, dict) or claim.get("execution_id") != occurrence_id:
+                return False
+            if _schedule_dict(job).get("kind") == "once":
+                run_claim = job.get("run_claim")
+                return bool(
+                    isinstance(run_claim, dict)
+                    and run_claim.get("durable") is True
+                    and run_claim.get("execution_id") == occurrence_id
+                )
+            return True
+        return False
+
+
+def verify_contextual_occurrence_claim(job_id: str, *, execution_id: str) -> bool:
+    """Return whether ``execution_id`` still owns the live contextual occurrence."""
+    return contextual_occurrence_claim_state(
+        job_id, execution_id=execution_id
+    ) is True
+
+
 def heartbeat_run_claim(job_id: str, *, expected_owner: str) -> bool:
     """Refresh a one-shot's ``run_claim`` timestamp while its run is alive.
 
@@ -2368,12 +2829,14 @@ def heartbeat_run_claim(job_id: str, *, expected_owner: str) -> bool:
     Returns True if this owner's one-shot claim was refreshed; False when the
     job, claim, or ownership no longer matches.
     """
-    with _jobs_lock():
+    with _jobs_lock() as cross_process_locked:
+        if not cross_process_locked:
+            return False
         jobs = load_jobs()
         for job in jobs:
             if job.get("id") != job_id:
                 continue
-            if job.get("schedule", {}).get("kind") != "once":
+            if _schedule_dict(job).get("kind") != "once":
                 return False
             claim = job.get("run_claim")
             if not isinstance(claim, dict) or claim.get("by") != expected_owner:
@@ -2384,7 +2847,9 @@ def heartbeat_run_claim(job_id: str, *, expected_owner: str) -> bool:
     return False
 
 
-def advance_next_runs(job_ids) -> int:
+def advance_next_runs(
+    job_ids, *, require_cross_process_lock: bool = False
+) -> int:
     """Batch form of :func:`advance_next_run` for the due-dispatch loop.
 
     One ``load_jobs()`` + at most one ``save_jobs()`` for the whole due
@@ -2402,7 +2867,12 @@ def advance_next_runs(job_ids) -> int:
     ids = set(job_ids)
     if not ids:
         return 0
-    with _jobs_lock():
+    with _jobs_lock() as cross_process_locked:
+        if require_cross_process_lock and not cross_process_locked:
+            logger.error(
+                "advance_next_runs failed closed: jobs lock unavailable"
+            )
+            return 0
         jobs = load_jobs()
         now = _hermes_now().isoformat()
         advanced = 0
@@ -2421,7 +2891,9 @@ def advance_next_runs(job_ids) -> int:
         return advanced
 
 
-def advance_next_run(job_id: str) -> bool:
+def advance_next_run(
+    job_id: str, *, require_cross_process_lock: bool = False
+) -> bool:
     """Preemptively advance next_run_at for a recurring job before execution.
 
     Call this BEFORE run_job() so that if the process crashes mid-execution,
@@ -2435,7 +2907,12 @@ def advance_next_run(job_id: str) -> bool:
     """
     # >= 1 (not == 1): a corrupted jobs file with duplicate ids advances
     # every matching record; the wrapper still reports the advance.
-    return advance_next_runs([job_id]) >= 1
+    return (
+        advance_next_runs(
+            [job_id], require_cross_process_lock=require_cross_process_lock
+        )
+        >= 1
+    )
 
 
 def _machine_id() -> str:
@@ -2456,27 +2933,16 @@ def _machine_id() -> str:
 
 
 def claim_job_for_fire(job_id: str, *, claim_ttl_seconds: int = 300) -> bool:
-    """Atomically claim a job for a single external 'fire' (multi-machine
-    at-most-once). Returns True iff THIS caller won the claim.
+    """Atomically claim a job for one existing external-provider fire.
 
-    Used by the external-provider fire path (``CronScheduler.fire_due``) when an
-    external scheduler (Chronos) signals a job is due across N gateway replicas:
-    exactly one wins. Single-machine deployments always win.
-
-    Under the file lock: reject if the job is missing/disabled/paused. If a
-    fresh claim (younger than ``claim_ttl_seconds``) already exists, lose.
-    Otherwise stamp a ``fire_claim`` and, for recurring jobs, advance
-    ``next_run_at`` (mirrors ``advance_next_run``'s at-most-once bump so a stale
-    re-delivery for the old time can't re-fire). One-shots keep ``next_run_at``
-    but the fresh ``fire_claim`` blocks a duplicate retry for the same fire.
-    ``mark_job_run`` clears the claim on completion so a re-armed recurring job
-    is claimable again next fire.
-
-    The stale-claim TTL means a machine that crashed after claiming but before
-    completing doesn't wedge the job forever — after the TTL another fire can
-    reclaim it.
+    Contextual jobs are rejected at creation whenever an external provider is
+    configured; this function therefore preserves the isolated-cron behavior
+    that predates contextual V1.
     """
-    with _jobs_lock():
+    with _jobs_lock() as cross_process_locked:
+        if not cross_process_locked:
+            logger.error("claim_job_for_fire failed closed: jobs lock unavailable")
+            return False
         jobs = load_jobs()
         for job in jobs:
             if job["id"] != job_id:
@@ -2490,21 +2956,15 @@ def claim_job_for_fire(job_id: str, *, claim_ttl_seconds: int = 300) -> bool:
             if existing:
                 try:
                     claimed_at = _ensure_aware(datetime.fromisoformat(existing["at"]))
-                    # Bounded on BOTH sides (#60703): a claim stamped in the
-                    # future (clock/TZ skew across a restart, or a corrupted
-                    # timestamp) would otherwise have a negative age and stay
-                    # "fresh" forever — the job becomes permanently unfireable
-                    # and every manual `cron run` reports "already being
-                    # fired". Treat future-dated claims as stale/overwritable.
-                    _age = (now - claimed_at).total_seconds()
-                    if 0 <= _age < claim_ttl_seconds:
-                        return False  # someone holds a fresh claim
+                    age = (now - claimed_at).total_seconds()
+                    if 0 <= age < claim_ttl_seconds:
+                        return False
                 except Exception:
-                    pass  # malformed claim → overwrite
+                    pass
             job["fire_claim"] = {"at": now.isoformat(), "by": _machine_id()}
-            kind = job.get("schedule", {}).get("kind")
-            if kind in {"cron", "interval"}:
-                nxt = compute_next_run(job["schedule"], now.isoformat())
+            schedule = _schedule_dict(job)
+            if schedule.get("kind") in {"cron", "interval"}:
+                nxt = compute_next_run(schedule, now.isoformat())
                 if nxt:
                     job["next_run_at"] = nxt
             save_jobs(jobs)
@@ -2612,7 +3072,32 @@ def get_due_jobs() -> List[Dict[str, Any]]:
     Note: firing once on catch-up flows through ``mark_job_run``, so a job with
     a ``repeat.times`` limit consumes one of its runs on that catch-up fire.
     """
-    with _jobs_lock():
+    with _jobs_lock() as cross_process_locked:
+        if not cross_process_locked:
+            # jobs.json is a whole-file authority.  A degraded ordinary writer
+            # could otherwise rewrite stale contextual state even when it does
+            # not touch that job directly, so any store containing contextual
+            # records becomes read-only until cross-process exclusion recovers.
+            try:
+                contains_contextual = any(
+                    isinstance(job, dict)
+                    and job.get("session_target", "isolated") == "current"
+                    for job in load_jobs()
+                )
+            except Exception:
+                # Failure to inspect a potentially mixed store cannot authorize
+                # a whole-file rewrite without the advisory lock.
+                logger.exception(
+                    "Cron due scan skipped because degraded lock mode could not "
+                    "prove the store contains only isolated jobs"
+                )
+                return []
+            if contains_contextual:
+                logger.error(
+                    "Cron due scan skipped because jobs cross-process locking is "
+                    "unavailable for a store containing contextual jobs"
+                )
+                return []
         return _get_due_jobs_locked()
 
 
@@ -2641,22 +3126,27 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
     jobs = [_apply_skill_fields(j) for j in copy.deepcopy(raw_jobs)]
     due = []
 
-    # Normalize malformed "schedule" records (direct jobs.json edit, old writers,
-    # corruption, etc.). "schedule" must be a dict; a null/string/etc. value
-    # makes `schedule.get("kind")` or direct `schedule["kind"]` / ["expr"] /
-    # ["minutes"] later raise and abort the entire scan *before* save_jobs().
-    # Healthy jobs then lose their fast-forwarded next_run_at (exactly the
-    # failure mode of the id-less job bug fixed above). Repair early at the
-    # source so the rest of the tick can proceed and persist progress for
-    # siblings.
+    # Normalize schedules for execution without destroying supported legacy
+    # string schedules. Valid strings are parsed only in the working copy; the
+    # persisted public shape remains byte-for-byte compatible.
     for j in jobs:
-        if not isinstance(j.get("schedule"), dict):
+        value = j.get("schedule")
+        if isinstance(value, dict):
+            continue
+        parsed = _schedule_dict(j)
+        if parsed:
+            j["schedule"] = parsed
+        else:
             j["schedule"] = {}
             needs_save = True
     for rj in raw_jobs:
-        if not isinstance(rj.get("schedule"), dict):
-            rj["schedule"] = {}
-            needs_save = True
+        value = rj.get("schedule")
+        if isinstance(value, dict):
+            continue
+        if isinstance(value, str) and _schedule_dict(rj):
+            continue
+        rj["schedule"] = {}
+        needs_save = True
 
     # Normalize malformed "next_run_at" records (direct jobs.json edit,
     # corruption, migration, or buggy writer). If present but not a valid
@@ -2774,7 +3264,14 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
             # is treated as stale (the claiming tick died mid-run) and allowed
             # through so the job is recovered rather than wedged forever.
             existing_claim = job.get("run_claim")
-            if existing_claim and job.get("schedule", {}).get("kind") == "once":
+            if existing_claim and _schedule_dict(job).get("kind") == "once":
+                # Contextual one-shots are conservative: once dispatched, an
+                # unacknowledged run is never retried merely because a TTL
+                # elapsed. The execution ledger will classify a dead owner as
+                # unknown; an operator can then resolve it without risking a
+                # duplicate hidden turn or external notification.
+                if existing_claim.get("durable") is True:
+                    continue
                 try:
                     claimed_at = _ensure_aware(
                         datetime.fromisoformat(existing_claim["at"])
@@ -2974,8 +3471,15 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                 # stale claim that expires after the resolved run-claim TTL
                 # (_oneshot_run_claim_ttl_seconds, derived from HERMES_CRON_TIMEOUT),
                 # so the job is re-dispatched rather than wedged forever.
-                if kind == "once":
-                    claim = {"at": now.isoformat(), "by": _machine_id()}
+                if (
+                    kind == "once"
+                    and job.get("session_target", "isolated") != "current"
+                ):
+                    claim = {
+                        "at": now.isoformat(),
+                        "by": _machine_id(),
+                        "durable": job.get("session_target") == "current",
+                    }
                     job["run_claim"] = claim
                     for rj in raw_jobs:
                         if rj["id"] == job["id"]:

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -104,6 +104,7 @@ TICKER_INTERVAL_SECONDS = 60
 _jobs_file_lock = threading.RLock()
 _jobs_lock_state = threading.local()
 _contextual_accounting_thread_lock = threading.RLock()
+_contextual_authority_thread_lock = threading.RLock()
 
 # Upper bound on waiting for the cross-process .jobs.lock flock (#60703).
 # Every cron function in the process funnels through _jobs_lock(), and the
@@ -114,6 +115,7 @@ _contextual_accounting_thread_lock = threading.RLock()
 # worst-case stall well under one status-alarm threshold.
 _JOBS_LOCK_TIMEOUT_SECONDS = 30.0
 _CONTEXTUAL_ACCOUNTING_LOCK_TIMEOUT_SECONDS = 30.0
+_CONTEXTUAL_AUTHORITY_LOCK_TIMEOUT_SECONDS = 30.0
 OUTPUT_DIR = CRON_DIR / "output"
 ONESHOT_GRACE_SECONDS = 120
 
@@ -448,6 +450,76 @@ def contextual_accounting_lock():
 
 
 @contextlib.contextmanager
+def contextual_authority_lock():
+    """Serialize contextual-authority publication with every jobs replace.
+
+    This lock is intentionally separate from the ordinary jobs lock. The jobs
+    lock may degrade to process-local protection to keep legacy cron alive;
+    this transition lock never degrades because a check/replace race could
+    erase the first contextual job.
+    """
+    with _contextual_authority_thread_lock:
+        ensure_dirs()
+        lock_path = _current_cron_store().cron_dir / ".contextual-authority.lock"
+        lock_fd = open(lock_path, "a+b")
+        acquired = False
+        try:
+            if fcntl is not None:
+                deadline = time.monotonic() + _CONTEXTUAL_AUTHORITY_LOCK_TIMEOUT_SECONDS
+                while True:
+                    try:
+                        fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                        acquired = True
+                        break
+                    except (OSError, IOError) as exc:
+                        if time.monotonic() >= deadline:
+                            raise TimeoutError(
+                                f"Timed out acquiring contextual authority lock {lock_path}"
+                            ) from exc
+                        time.sleep(0.1)
+            elif msvcrt is not None:
+                if os.fstat(lock_fd.fileno()).st_size == 0:
+                    lock_fd.write(b"\0")
+                    lock_fd.flush()
+                lock_fd.seek(0)
+                deadline = time.monotonic() + _CONTEXTUAL_AUTHORITY_LOCK_TIMEOUT_SECONDS
+                while True:
+                    try:
+                        getattr(msvcrt, "locking")(
+                            lock_fd.fileno(), getattr(msvcrt, "LK_NBLCK"), 1
+                        )
+                        acquired = True
+                        break
+                    except (OSError, IOError) as exc:
+                        if time.monotonic() >= deadline:
+                            raise TimeoutError(
+                                f"Timed out acquiring contextual authority lock {lock_path}"
+                            ) from exc
+                        time.sleep(0.1)
+            else:  # pragma: no cover - supported hosts provide one primitive
+                raise RuntimeError("No cross-process file-lock primitive is available")
+
+            yield
+        finally:
+            if acquired:
+                try:
+                    if fcntl is not None:
+                        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                    elif msvcrt is not None:
+                        lock_fd.seek(0)
+                        getattr(msvcrt, "locking")(
+                            lock_fd.fileno(), getattr(msvcrt, "LK_UNLCK"), 1
+                        )
+                except (OSError, IOError):
+                    logger.error(
+                        "Failed to release contextual authority lock %s",
+                        lock_path,
+                        exc_info=True,
+                    )
+            lock_fd.close()
+
+
+@contextlib.contextmanager
 def contextual_transcript_lock():
     """Serialize transcript identity-check, append, and outbox acknowledgement.
 
@@ -463,7 +535,9 @@ def contextual_transcript_lock():
 # as a filesystem path component under ``OUTPUT_DIR``; allowing it to be
 # updated lets an unsafe value (``../escape``, absolute path, nested) leak
 # into output writes/deletes.
-_IMMUTABLE_JOB_FIELDS = frozenset({"id", "session_key", "context_binding", "origin"})
+_IMMUTABLE_JOB_FIELDS = frozenset(
+    {"id", "session_key", "context_binding", "origin", "_contextual_binding_version"}
+)
 
 
 def _job_output_dir(job_id: str) -> Path:
@@ -664,12 +738,15 @@ def public_job_record(job: Dict[str, Any]) -> Dict[str, Any]:
     else:
         public.pop("session_target", None)
     execution = source.get("latest_execution")
-    if public_target == "current" and isinstance(execution, dict):
-        public["latest_execution"] = {
-            key: execution.get(key)
-            for key in _PUBLIC_EXECUTION_FIELDS
-            if execution.get(key) is not None
-        }
+    if public_target == "current":
+        if isinstance(execution, dict):
+            public["latest_execution"] = {
+                key: execution.get(key)
+                for key in _PUBLIC_EXECUTION_FIELDS
+                if execution.get(key) is not None
+            }
+        else:
+            public.pop("latest_execution", None)
     return public
 
 
@@ -742,9 +819,8 @@ def _contextual_jobs_authority_marker() -> Path:
     return _current_cron_store().cron_dir / ".contextual-jobs-authority"
 
 
-def _enable_contextual_jobs_authority() -> None:
-    """Publish contextual authority before its first jobs-lock acquisition."""
-    ensure_dirs()
+def _publish_contextual_jobs_authority_unlocked() -> None:
+    """Publish the marker while the caller holds contextual_authority_lock()."""
     marker = _contextual_jobs_authority_marker()
     fd = os.open(marker, os.O_CREAT | os.O_WRONLY, 0o600)
     try:
@@ -759,8 +835,8 @@ def _enable_contextual_jobs_authority() -> None:
         finally:
             os.close(dir_fd)
     except OSError:
-        # Directory fsync is unavailable on some platforms/filesystems. The
-        # marker itself is still atomically visible to sibling processes.
+        # Directory fsync is unavailable on some platforms/filesystems.
+        # The marker itself is still atomically visible to siblings.
         pass
 
 
@@ -1439,6 +1515,55 @@ def _merge_unexpected_disk_jobs(
     return jobs + recovered
 
 
+def _replace_jobs_payload_with_authority(
+    tmp_path: str,
+    jobs_file: Path,
+    jobs: List[Dict[str, Any]],
+) -> None:
+    """Replace jobs.json while atomically enforcing contextual authority."""
+    publishes_contextual = any(
+        isinstance(job, dict)
+        and job.get("session_target", "isolated") == "current"
+        for job in jobs
+    )
+    marker = _contextual_jobs_authority_marker()
+    with contextual_authority_lock():
+        cross_process_acquired = bool(
+            getattr(_jobs_lock_state, "cross_process_acquired", False)
+        )
+        marker_preexisting = marker.exists()
+        if not cross_process_acquired and (marker_preexisting or publishes_contextual):
+            raise RuntimeError(
+                "Refusing a degraded jobs.json write after contextual jobs "
+                "authority was enabled for this profile"
+            )
+
+        marker_created = publishes_contextual and not marker_preexisting
+        try:
+            if marker_created:
+                _publish_contextual_jobs_authority_unlocked()
+            atomic_replace(tmp_path, jobs_file)
+        except BaseException:
+            if marker_created:
+                try:
+                    marker.unlink()
+                    try:
+                        dir_fd = os.open(marker.parent, os.O_RDONLY)
+                        try:
+                            os.fsync(dir_fd)
+                        finally:
+                            os.close(dir_fd)
+                    except OSError:
+                        pass
+                except OSError:
+                    logger.error(
+                        "Failed to roll back contextual authority marker %s",
+                        marker,
+                        exc_info=True,
+                    )
+            raise
+
+
 def _save_jobs_unlocked(
     jobs: List[Dict[str, Any]],
     *,
@@ -1530,17 +1655,7 @@ def _save_jobs_unlocked(
                         tmp_path = None
                         continue
 
-            if (
-                not bool(
-                    getattr(_jobs_lock_state, "cross_process_acquired", False)
-                )
-                and _contextual_jobs_authority_marker().exists()
-            ):
-                raise RuntimeError(
-                    "Refusing a degraded jobs.json write after contextual jobs "
-                    "authority was enabled for this profile"
-                )
-            atomic_replace(tmp_path, jobs_file)
+            _replace_jobs_payload_with_authority(tmp_path, jobs_file, jobs)
             tmp_path = None
             _secure_file(jobs_file)
             _preserve_file_ownership(jobs_file, _stat_before)
@@ -1570,15 +1685,7 @@ def _save_jobs_unlocked(
             )
             f.flush()
             os.fsync(f.fileno())
-        if (
-            not bool(getattr(_jobs_lock_state, "cross_process_acquired", False))
-            and _contextual_jobs_authority_marker().exists()
-        ):
-            raise RuntimeError(
-                "Refusing a degraded jobs.json write after contextual jobs "
-                "authority was enabled for this profile"
-            )
-        atomic_replace(tmp_path, jobs_file)
+        _replace_jobs_payload_with_authority(tmp_path, jobs_file, jobs)
         tmp_path = None
         _secure_file(jobs_file)
         _preserve_file_ownership(jobs_file, _stat_before)
@@ -1602,16 +1709,14 @@ def save_jobs(
     See ``_save_jobs_unlocked`` for ``removed_ids`` / ``replace`` semantics
     (shrink-merge guard against concurrent-create clobber, #80624).
     """
-    if any(
+    publishes_contextual = any(
         isinstance(job, dict)
         and job.get("session_target", "isolated") == "current"
         for job in jobs
-    ):
-        _enable_contextual_jobs_authority()
+    )
     with _jobs_lock() as cross_process_locked:
-        if (
-            not cross_process_locked
-            and _contextual_jobs_authority_marker().exists()
+        if not cross_process_locked and (
+            publishes_contextual or _contextual_jobs_authority_marker().exists()
         ):
             raise RuntimeError(
                 "Refusing a degraded jobs.json write for a profile with "
@@ -1925,8 +2030,6 @@ def create_job(
     )
     contextual_fields = contextual_fields_for_write(session_target)
     if contextual_fields.get("session_target") == "current":
-        _enable_contextual_jobs_authority()
-        contextual_fields["_contextual_binding_version"] = 1
         from cron.contextual import contextual_origin_from_binding
 
         # Execution identity and delivery identity are one atomic binding. A
@@ -2109,9 +2212,6 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
             f"Cron job field(s) cannot be updated: {', '.join(sorted(bad_fields))}"
         )
 
-    if str(updates.get("session_target") or "").strip().lower() == "current":
-        _enable_contextual_jobs_authority()
-
     with _jobs_lock():
         jobs = load_jobs()
         for i, job in enumerate(jobs):
@@ -2190,11 +2290,11 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updated["origin"] = contextual_origin_from_binding(
                         fields["context_binding"]
                     )
-                updated["_contextual_binding_version"] = 1
             else:
                 updated.pop("session_target", None)
                 updated.pop("session_key", None)
                 updated.pop("context_binding", None)
+                updated.pop("_contextual_binding_version", None)
             validate_contextual_job_shape(updated)
 
             schedule_changed = "schedule" in updates

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4724,6 +4724,38 @@ def _resume_contextual_delivery_record(
             error="Pending contextual delivery has no valid immutable destination.",
         )
         return False
+    try:
+        admitted_binding_version = int(record.get("admitted_binding_version") or 1)
+    except (TypeError, ValueError):
+        admitted_binding_version = 0
+    if admitted_binding_version not in (1, 2):
+        finish_contextual_execution(
+            execution_id,
+            outcome="unknown",
+            error="Pending contextual delivery has invalid binding authority.",
+        )
+        return False
+    if admitted_binding_version == 2:
+        if not record.get("admitted_route_instance_id"):
+            finish_contextual_execution(
+                execution_id,
+                outcome="unknown",
+                error="Pending contextual delivery has incomplete v2 authority.",
+            )
+            return False
+        from cron.contextual import validate_contextual_origin
+
+        try:
+            immutable_delivery_job["origin"] = validate_contextual_origin(
+                immutable_delivery_job.get("origin")
+            )
+        except ValueError:
+            finish_contextual_execution(
+                execution_id,
+                outcome="unknown",
+                error="Pending contextual delivery has invalid creator authority.",
+            )
+            return False
     authorizer = get_contextual_authorizer()
     try:
         authorized = bool(

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -34,7 +34,7 @@ except ImportError:
     except ImportError:
         msvcrt = None
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, List, Mapping, Optional, cast
 
 # Add parent directory to path for imports BEFORE repo-level imports.
 # Without this, standalone invocations (e.g. after `hermes update` reloads
@@ -57,6 +57,29 @@ from agent.delegation_context import (
 )
 
 logger = logging.getLogger(__name__)
+
+_CONTEXTUAL_DISPATCHER = None
+_CONTEXTUAL_AUTHORIZER = None
+
+
+def set_contextual_dispatcher(dispatcher) -> None:
+    """Install the live gateway bridge for built-in and external providers."""
+    global _CONTEXTUAL_DISPATCHER
+    _CONTEXTUAL_DISPATCHER = dispatcher
+
+
+def get_contextual_dispatcher():
+    return _CONTEXTUAL_DISPATCHER
+
+
+def set_contextual_authorizer(authorizer) -> None:
+    """Install the gateway-owned authorization check for destination effects."""
+    global _CONTEXTUAL_AUTHORIZER
+    _CONTEXTUAL_AUTHORIZER = authorizer
+
+
+def get_contextual_authorizer():
+    return _CONTEXTUAL_AUTHORIZER
 
 
 def _set_cron_session_title(session_db, session_id, base_title):
@@ -290,8 +313,34 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
-from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_runs, claim_dispatch, heartbeat_run_claim
-from cron.executions import create_execution, finish_execution, mark_execution_running
+from cron.jobs import (
+    advance_next_runs,
+    claim_contextual_occurrence,
+    claim_dispatch,
+    clear_job_accounting_marker,
+    contextual_accounting_lock,
+    get_due_jobs,
+    heartbeat_run_claim,
+    mark_job_run,
+    save_job_output,
+    verify_contextual_occurrence_claim,
+)
+from cron.executions import (
+    claim_contextual_delivery,
+    claim_contextual_job_accounting,
+    create_execution,
+    finish_contextual_delivery,
+    finish_contextual_execution,
+    finish_execution,
+    get_execution,
+    list_pending_contextual_deliveries,
+    list_unaccounted_contextual_executions,
+    mark_execution_running,
+    persist_contextual_agent_result,
+    prepare_contextual_retry,
+    seal_contextual_delivery_target,
+    suppress_contextual_delivery,
+)
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
 # response with this marker to suppress delivery.  Output is still saved
@@ -775,6 +824,12 @@ def _cron_mirror_delivery_enabled(job: dict, cfg: Optional[dict] = None) -> bool
     alternation- and cache-safe: the append lands at a turn boundary between
     user turns, never mid-loop, and never mutates the cached system prompt.
     """
+    # A current-session cron result is already persisted as the assistant side
+    # of the live contextual turn.  Mirroring it would append the same output a
+    # second time (often as a synthetic user row) and corrupt role order.
+    if str(job.get("session_target") or "isolated").strip().lower() == "current":
+        return False
+
     per_job = job.get("attach_to_session")
     if isinstance(per_job, bool):
         return per_job
@@ -1546,6 +1601,13 @@ def _confirm_adapter_delivery(send_result) -> bool:
     return bool(getattr(send_result, "success"))
 
 
+def _confirm_standalone_delivery(send_result) -> bool:
+    """Require a positive transport acknowledgement for contextual delivery."""
+    if isinstance(send_result, dict):
+        return send_result.get("success") is True or send_result.get("ok") is True
+    return _confirm_adapter_delivery(send_result)
+
+
 def _is_channel_dm_topic(
     runtime_adapter: Any,
     chat_id: Any,
@@ -1602,7 +1664,18 @@ def _is_channel_dm_topic(
     return is_channel
 
 
-def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
+class ContextualDeliveryUnknown(RuntimeError):
+    """A contextual send may have crossed the external side-effect boundary."""
+
+
+def _deliver_result(
+    job: dict,
+    content: str,
+    adapters=None,
+    loop=None,
+    *,
+    at_most_once: bool = False,
+) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
 
@@ -1666,6 +1739,8 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     from gateway.platforms.base import BasePlatformAdapter
     media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(delivery_content)
     media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+    if at_most_once and media_files:
+        return "Contextual cron delivery forbids native media attachments."
 
     # Resolve the delivery-mirror gate ONCE (default off). When on, each
     # successful delivery is also appended to the target chat's gateway session
@@ -1679,6 +1754,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     if mirror_enabled:
         _, mirror_text = BasePlatformAdapter.extract_media(content)
         mirror_text = (mirror_text or "").strip()
+    if at_most_once:
+        # Contextual delivery owns exactly one final transport effect. Mirroring,
+        # thread creation, and transcript seeding are separate side effects.
+        mirror_enabled = False
+        mirror_text = ""
 
     try:
         config = load_gateway_config()
@@ -1970,6 +2050,12 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         try:
                             send_result = future.result(timeout=60)
                         except TimeoutError:
+                            if at_most_once:
+                                future.cancel()
+                                raise ContextualDeliveryUnknown(
+                                    f"Live delivery to {platform_name}:{chat_id} "
+                                    "timed out after scheduling; acknowledgement is unknown."
+                                )
                             # #38922: a slow confirmation does NOT necessarily
                             # mean the send failed — but we must distinguish two
                             # cases via future.cancel()'s return value:
@@ -2011,6 +2097,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                                     job["id"], platform_name, chat_id,
                                 )
                         except Exception as ex:
+                            if at_most_once:
+                                raise ContextualDeliveryUnknown(
+                                    f"Live delivery to {platform_name}:{chat_id} "
+                                    f"raised after scheduling: {ex}"
+                                ) from ex
                             # A real send error (not a slow confirmation) — fall
                             # through to the standalone path so the message is
                             # still delivered.
@@ -2053,6 +2144,8 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                                     f"live adapter send to {platform_name}:{chat_id} "
                                     f"returned unconfirmed result ({shape}, error={err})"
                                 )
+                                if at_most_once:
+                                    raise ContextualDeliveryUnknown(msg)
                                 if transport is not None and transport.is_relay:
                                     logger.warning("Job '%s': %s", job["id"], msg)
                                 else:
@@ -2062,18 +2155,27 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                                     )
                                 target_errors.append(msg)
                                 adapter_ok = False  # fall through to standalone path
-                            elif (
-                                send_raw_response
-                                and thread_id
-                                and send_raw_response.get("thread_fallback")
-                            ):
-                                requested_thread_id = send_raw_response.get("requested_thread_id") or thread_id
-                                msg = (
-                                    f"configured thread_id {requested_thread_id} for "
-                                    f"{platform_name}:{chat_id} was not found; delivered without thread_id"
-                                )
-                                logger.warning("Job '%s': %s", job["id"], msg)
-                                delivery_errors.append(msg)
+                            elif send_success:
+                                # Once the transport has explicitly confirmed the
+                                # external effect, no response-metadata parsing or
+                                # local post-processing may reopen a fallback path.
+                                if at_most_once:
+                                    delivered = True
+                                if (
+                                    isinstance(send_raw_response, dict)
+                                    and thread_id
+                                    and send_raw_response.get("thread_fallback")
+                                ):
+                                    requested_thread_id = (
+                                        send_raw_response.get("requested_thread_id")
+                                        or thread_id
+                                    )
+                                    msg = (
+                                        f"configured thread_id {requested_thread_id} for "
+                                        f"{platform_name}:{chat_id} was not found; delivered without thread_id"
+                                    )
+                                    logger.warning("Job '%s': %s", job["id"], msg)
+                                    delivery_errors.append(msg)
 
                 # Send extracted media files as native attachments via the live
                 # adapter, using the same DM-topic-aware routing as the text send
@@ -2140,6 +2242,20 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         enabled=mirror_this_target and not thread_seeded and not inchannel_seeded,
                     )
             except Exception as e:
+                if at_most_once:
+                    if isinstance(e, ContextualDeliveryUnknown):
+                        raise
+                    if delivered:
+                        logger.warning(
+                            "Job '%s': post-send processing failed after confirmed "
+                            "delivery to %s:%s; suppressing fallback: %s",
+                            job["id"], platform_name, chat_id, e,
+                        )
+                        continue
+                    raise ContextualDeliveryUnknown(
+                        f"Live delivery to {platform_name}:{chat_id} failed without "
+                        f"a safe retry boundary: {e}"
+                    ) from e
                 err_msg = f"live adapter delivery to {platform_name}:{chat_id} failed: {e}"
                 if not any(err_msg in err for err in target_errors):
                     target_errors.append(err_msg)
@@ -2209,6 +2325,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     finally:
                         pool.shutdown(wait=False)
                 except Exception as e:
+                    if at_most_once:
+                        raise ContextualDeliveryUnknown(
+                            f"Standalone delivery to {platform_name}:{chat_id} "
+                            f"raised after its attempt began: {e}"
+                        ) from e
                     # A shutdown-race here is expected during teardown; downgrade
                     # to a warning so it doesn't read as a genuine failure.
                     if _interpreter_shutting_down(e):
@@ -2223,14 +2344,43 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     delivery_errors.extend(target_errors)
                     continue
             except Exception as e:
+                if at_most_once:
+                    raise ContextualDeliveryUnknown(
+                        f"Standalone delivery to {platform_name}:{chat_id} "
+                        f"raised after its attempt began: {e}"
+                    ) from e
                 msg = f"delivery to {platform_name}:{chat_id} failed: {e}"
                 logger.error("Job '%s': %s", job["id"], msg, exc_info=True)
                 target_errors.extend([msg])
                 delivery_errors.extend(target_errors)
                 continue
 
-            if result and result.get("error"):
-                msg = f"delivery error: {result['error']}"
+            if at_most_once and not _confirm_standalone_delivery(result):
+                result_mapping = (
+                    cast(Mapping[str, Any], result)
+                    if isinstance(result, Mapping)
+                    else {}
+                )
+                result_error = result_mapping.get("error")
+                detail = result_error or f"unacknowledged {type(result).__name__} result"
+                raise ContextualDeliveryUnknown(
+                    f"Standalone delivery to {platform_name}:{chat_id} "
+                    f"returned an unconfirmed result: {detail}"
+                )
+
+            result_mapping = (
+                cast(Mapping[str, Any], result)
+                if isinstance(result, Mapping)
+                else {}
+            )
+            result_error = result_mapping.get("error")
+            if result_error:
+                if at_most_once:
+                    raise ContextualDeliveryUnknown(
+                        f"Standalone delivery to {platform_name}:{chat_id} "
+                        f"returned an unconfirmed result: {result_error}"
+                    )
+                msg = f"delivery error: {result_error}"
                 logger.error("Job '%s': %s", job["id"], msg)
                 target_errors.extend([msg])
                 delivery_errors.extend(target_errors)
@@ -4500,8 +4650,222 @@ def _teardown_cron_agent(agent, job_id: str) -> None:
         logger.debug("Job '%s': failed to reap stale auxiliary clients: %s", job_id, e)
 
 
+def _account_contextual_job_run(
+    *,
+    execution_id: str,
+    job_id: str,
+    success: bool,
+    error: Optional[str],
+    delivery_error: Optional[str],
+) -> bool:
+    """Apply restart-idempotent job accounting without changing outcome truth."""
+    try:
+        with contextual_accounting_lock():
+            # Re-read only after acquiring the cross-process transaction lock.
+            # A reconciler may have observed job_accounted=0 before another
+            # process completed the jobs-file mutation and ledger acknowledgement.
+            durable = get_execution(execution_id)
+            if durable and durable.get("job_accounted"):
+                clear_job_accounting_marker(job_id, execution_id)
+                return True
+            if not mark_job_run(
+                job_id,
+                success,
+                error,
+                delivery_error=delivery_error,
+                execution_id=execution_id,
+                require_cross_process_lock=True,
+            ):
+                return False
+            newly_recorded = claim_contextual_job_accounting(execution_id)
+            durable = get_execution(execution_id)
+            if newly_recorded or (durable and durable.get("job_accounted")):
+                clear_job_accounting_marker(job_id, execution_id)
+                return True
+            return False
+    except Exception:
+        # The durable occurrence remains unaccounted and startup reconciliation
+        # retries this idempotent local mutation. Never misclassify a confirmed
+        # transport outcome because jobs.json accounting happened to fail.
+        logger.exception(
+            "Failed to account contextual execution %s for job %s",
+            execution_id,
+            job_id,
+        )
+        return False
+
+
+def _resume_contextual_delivery_record(
+    job: dict,
+    record: dict,
+    *,
+    adapters=None,
+    loop=None,
+) -> bool:
+    """Resume only a durable pre-send outbox item; never rerun its agent."""
+    execution_id = str(record.get("id") or "")
+    try:
+        payload = json.loads(record.get("result_json") or "{}")
+    except Exception:
+        payload = {}
+    content = str(payload.get("final_response") or "")
+    try:
+        immutable_delivery_job = json.loads(
+            record.get("delivery_target_json") or "null"
+        )
+    except Exception:
+        immutable_delivery_job = None
+    if not execution_id or not content.strip():
+        return False
+    if not isinstance(immutable_delivery_job, dict) or not immutable_delivery_job.get("id"):
+        finish_contextual_execution(
+            execution_id,
+            outcome="unknown",
+            error="Pending contextual delivery has no valid immutable destination.",
+        )
+        return False
+    authorizer = get_contextual_authorizer()
+    try:
+        authorized = bool(
+            callable(authorizer) and authorizer(immutable_delivery_job)
+        )
+    except Exception as auth_exc:
+        authorized = False
+        authorization_error = str(auth_exc) or type(auth_exc).__name__
+    else:
+        authorization_error = ""
+    if not authorized:
+        authorization_error = authorization_error or (
+            "Contextual cron authorization was revoked before delivery recovery."
+        )
+        suppress_contextual_delivery(execution_id, error=authorization_error)
+        _account_contextual_job_run(
+            execution_id=execution_id,
+            job_id=str(immutable_delivery_job["id"]),
+            success=False,
+            error=authorization_error,
+            delivery_error=authorization_error,
+        )
+        return False
+    if claim_contextual_delivery(execution_id) is None:
+        return False
+    try:
+        try:
+            save_job_output(str(immutable_delivery_job["id"]), content)
+        except Exception as exc:
+            logger.warning(
+                "Could not refresh output artifact while resuming contextual delivery %s: %s",
+                execution_id,
+                exc,
+            )
+        unresolved_origin = (
+            _normalize_deliver_value(immutable_delivery_job.get("deliver", "local"))
+            == "origin"
+            and not _resolve_delivery_targets(immutable_delivery_job)
+        )
+        if unresolved_origin:
+            delivery_error = "Contextual cron delivery origin could not be resolved."
+        else:
+            delivery_error = _deliver_result(
+                immutable_delivery_job,
+                content,
+                adapters=adapters,
+                loop=loop,
+                at_most_once=True,
+            )
+    except BaseException as exc:
+        # The send may have crossed the transport boundary. Preserve uncertainty
+        # and never auto-resend this occurrence.
+        finish_contextual_delivery(
+            execution_id,
+            delivery_state="unknown",
+            error=str(exc) or type(exc).__name__,
+        )
+        if not isinstance(exc, Exception):
+            raise
+        return False
+    if delivery_error:
+        finish_contextual_delivery(
+            execution_id,
+            delivery_state="failed",
+            error=str(delivery_error),
+        )
+        _account_contextual_job_run(
+            execution_id=execution_id,
+            job_id=str(immutable_delivery_job["id"]),
+            success=False,
+            error=str(delivery_error),
+            delivery_error=str(delivery_error),
+        )
+        return False
+    finish_contextual_delivery(execution_id, delivery_state="sent")
+    _account_contextual_job_run(
+        execution_id=execution_id,
+        job_id=str(immutable_delivery_job["id"]),
+        success=True,
+        error=None,
+        delivery_error=None,
+    )
+    return True
+
+
+def reconcile_contextual_job_accounting() -> int:
+    """Replay terminal occurrence accounting idempotently after a crash."""
+    reconciled = 0
+    for record in list_unaccounted_contextual_executions():
+        execution_id = str(record.get("id") or "")
+        try:
+            delivery_job = json.loads(record.get("delivery_target_json") or "null")
+        except Exception:
+            delivery_job = None
+        if not execution_id or not isinstance(delivery_job, dict) or not delivery_job.get("id"):
+            logger.error(
+                "Cannot reconcile contextual accounting for %s: immutable job target missing",
+                execution_id or "<missing>",
+            )
+            continue
+        outcome = str(record.get("outcome") or "unknown")
+        success = outcome in {"notify", "no_action"}
+        error = None if success else str(record.get("error") or outcome)
+        delivery_error = record.get("delivery_error")
+        if _account_contextual_job_run(
+            execution_id=execution_id,
+            job_id=str(delivery_job["id"]),
+            success=success,
+            error=error,
+            delivery_error=(str(delivery_error) if delivery_error else None),
+        ):
+            reconciled += 1
+    return reconciled
+
+
+def resume_pending_contextual_deliveries(*, adapters=None, loop=None) -> int:
+    """Drain restart-safe agent-complete/pre-send outbox rows."""
+    from cron.jobs import get_job
+
+    resumed = 0
+    for record in list_pending_contextual_deliveries():
+        job = get_job(str(record.get("job_id") or ""))
+        if job is None:
+            job = {"id": str(record.get("job_id") or "")}
+        if _resume_contextual_delivery_record(
+            job,
+            record,
+            adapters=adapters,
+            loop=loop,
+        ):
+            resumed += 1
+    reconcile_contextual_job_accounting()
+    return resumed
+
+
 def run_one_job(
-    job: dict, *, adapters=None, loop=None, verbose: bool = False,
+    job: dict,
+    *,
+    adapters=None,
+    loop=None,
+    verbose: bool = False,
+    contextual_dispatch=None,
     extra_prompt: Optional[str] = None,
 ) -> bool:
     """Run ONE due job end-to-end: execute → save output → deliver → mark.
@@ -4520,8 +4884,157 @@ def run_one_job(
     """
     execution_id = job.get("execution_id")
     if not execution_id:
-        execution_id = create_execution(job["id"], source="direct")["id"]
+        execution_id = create_execution(
+            job["id"],
+            source="direct",
+            requires_job_accounting=job.get("session_target") == "current",
+        )["id"]
+
+    # Normalize before *any* dispatch claim or executor selection.  A malformed
+    # persisted value must never downgrade to the isolated runner.
+    from cron.contextual import normalize_session_target
+    from gateway.contextual_cron import ContextualCronOutcome
+
     try:
+        session_target = normalize_session_target(job.get("session_target"))
+    except ValueError as exc:
+        error = str(exc)
+        try:
+            mark_job_run(job["id"], False, error)
+        finally:
+            finish_contextual_execution(
+                execution_id,
+                outcome="rejected",
+                error=error,
+                delivery_outcome="suppressed",
+            )
+        return True
+
+    existing_execution = get_execution(execution_id)
+    contextual_delivery_job = None
+    if session_target == "current":
+        contextual_delivery_job = {
+            "id": str(job.get("id") or ""),
+            "name": job.get("name"),
+            "deliver": _normalize_deliver_value(job.get("deliver") or "origin"),
+            "origin": dict(job.get("origin") or {}),
+        }
+        if (
+            existing_execution
+            and not existing_execution.get("delivery_target_json")
+            and existing_execution.get("phase") == "claimed"
+        ):
+            if not seal_contextual_delivery_target(
+                execution_id,
+                target=contextual_delivery_job,
+            ):
+                finish_contextual_execution(
+                    execution_id,
+                    outcome="unknown",
+                    error="Could not durably seal the contextual delivery destination.",
+                )
+                return True
+            existing_execution = get_execution(execution_id)
+        if existing_execution and not existing_execution.get("delivery_target_json"):
+            finish_contextual_execution(
+                execution_id,
+                outcome="unknown",
+                error="Contextual execution has no immutable delivery destination.",
+            )
+            return True
+        if existing_execution:
+            try:
+                sealed_delivery_job = json.loads(
+                    existing_execution.get("delivery_target_json") or "null"
+                )
+            except (TypeError, ValueError) as target_exc:
+                sealed_delivery_job = None
+                target_error = str(target_exc)
+            else:
+                target_error = ""
+            if (
+                not isinstance(sealed_delivery_job, dict)
+                or str(sealed_delivery_job.get("id") or "") != str(job.get("id") or "")
+            ):
+                corruption_error = (
+                    "Contextual execution has a malformed immutable delivery destination."
+                )
+                if target_error:
+                    corruption_error = f"{corruption_error} {target_error}"
+                occurrence_claimed = verify_contextual_occurrence_claim(
+                    str(job["id"]), execution_id=str(execution_id)
+                )
+                terminal = finish_contextual_execution(
+                    execution_id,
+                    outcome="unknown" if occurrence_claimed else "rejected",
+                    error=corruption_error,
+                    delivery_outcome="suppressed",
+                )
+                if occurrence_claimed and terminal is not None:
+                    _account_contextual_job_run(
+                        execution_id=execution_id,
+                        job_id=str(job["id"]),
+                        success=False,
+                        error=corruption_error,
+                        delivery_error=None,
+                    )
+                elif terminal is not None:
+                    claim_contextual_job_accounting(execution_id)
+                return True
+            contextual_delivery_job = sealed_delivery_job
+
+    # A terminal occurrence has already passed its scheduler-owned delivery
+    # boundary.  Replaying it is metadata lookup, never a fresh execution or
+    # notification.
+    if (
+        existing_execution
+        and existing_execution.get("status") == "running"
+        and existing_execution.get("phase") == "agent_completed"
+        and existing_execution.get("delivery_state") == "pending"
+    ):
+        _resume_contextual_delivery_record(
+            job,
+            existing_execution,
+            adapters=adapters,
+            loop=loop,
+        )
+        return True
+    if existing_execution and existing_execution.get("phase") == "delivering":
+        # A delivery claimant already owns the only external attempt.
+        return True
+    if existing_execution and existing_execution.get("status") in {
+        "completed",
+        "failed",
+        "unknown",
+    }:
+        return True
+    try:
+        # Built-in contextual ticks arrive with an execution-specific occurrence
+        # claim created only after the ledger and immutable destination exist.
+        # Revalidate that authority at the worker boundary. Manual/direct runs do
+        # not carry this private marker and retain legacy claim_dispatch behavior.
+        if session_target == "current" and job.get("_contextual_occurrence_preclaimed"):
+            if not verify_contextual_occurrence_claim(
+                str(job["id"]), execution_id=str(execution_id)
+            ):
+                claim_error = (
+                    "Contextual occurrence authority was lost before executor start."
+                )
+                terminal = finish_contextual_execution(
+                    execution_id,
+                    outcome="unknown",
+                    error=claim_error,
+                    delivery_outcome="suppressed",
+                )
+                if terminal is not None:
+                    _account_contextual_job_run(
+                        execution_id=execution_id,
+                        job_id=str(job["id"]),
+                        success=False,
+                        error=claim_error,
+                        delivery_error=None,
+                    )
+                return True
         # Pre-run dispatch claim (issue #38758): atomically commit a finite
         # one-shot's dispatch BEFORE its side effect runs, so a tick that dies
         # mid-execution (gateway kill, OOM, segfault, hard-timeout) cannot
@@ -4529,7 +5042,7 @@ def run_one_job(
         # use advance_next_run) and infinite/no-repeat jobs. This lives here in
         # the shared body so BOTH the built-in ticker and the external provider
         # (Chronos fire_due) get at-most-times semantics.
-        if not claim_dispatch(job["id"]):
+        elif not claim_dispatch(job["id"]):
             logger.info(
                 "Job '%s': one-shot dispatch limit reached — skipping",
                 job.get("name", job["id"]),
@@ -4543,7 +5056,10 @@ def run_one_job(
 
         # The attempt is claimed durably before executor/provider dispatch and
         # becomes running only immediately before the actual run.
-        mark_execution_running(execution_id)
+        if mark_execution_running(execution_id) is None:
+            # Another scheduler/process owns this occurrence, or it already
+            # advanced.  Only the claimed→running CAS winner may execute.
+            return True
 
         # Run the job under the profile's secret scope. get_secret() fails
         # closed outside a scope once profile isolation is in play (multiple
@@ -4569,11 +5085,71 @@ def run_one_job(
         # below once delivery is done. Defense-in-depth alongside the
         # interpreter-shutdown guard in _deliver_result.
         _deferred_agents: list = []
+        contextual_outcome = None
         try:
-            success, output, final_response, error = run_job(
-                job, defer_agent_teardown=_deferred_agents,
-                extra_prompt=extra_prompt,
-            )
+            if session_target == "current" and extra_prompt:
+                rejection_error = (
+                    "Transient per-run prompt context is not supported for "
+                    "session_target='current'. Store the instruction on the "
+                    "job so the hidden contextual turn is durable and auditable."
+                )
+                contextual_outcome = ContextualCronOutcome.rejected(rejection_error)
+                success = False
+                output = rejection_error
+                final_response = ""
+                error = rejection_error
+            elif session_target == "current":
+                from cron.contextual import validate_contextual_job_shape
+
+                try:
+                    validate_contextual_job_shape(job)
+                except ValueError as exc:
+                    contextual_outcome = ContextualCronOutcome.rejected(str(exc))
+                else:
+                    effective_contextual_dispatch = (
+                        contextual_dispatch or get_contextual_dispatcher()
+                    )
+                    if effective_contextual_dispatch is None:
+                        contextual_outcome = ContextualCronOutcome.rejected(
+                            "No live gateway contextual cron lane is available; isolation fallback is forbidden."
+                        )
+                    else:
+                        # Retry only typed pre-side-effect transient outcomes,
+                        # preserving the same occurrence/admission identity.
+                        for contextual_attempt in range(3):
+                            contextual_outcome = effective_contextual_dispatch(
+                                job, execution_id=execution_id
+                            )
+                            if getattr(contextual_outcome, "kind", None) != "retryable":
+                                break
+                            if contextual_attempt >= 2:
+                                contextual_outcome = ContextualCronOutcome.failure(
+                                    "Contextual cron retry budget exhausted."
+                                )
+                                break
+                            if prepare_contextual_retry(execution_id) is None:
+                                contextual_outcome = ContextualCronOutcome.unknown(
+                                    "Could not durably prepare the contextual retry."
+                                )
+                                break
+                            time.sleep(0.05 * (2 ** contextual_attempt))
+                kind = getattr(contextual_outcome, "kind", None)
+                final_response = str(
+                    getattr(contextual_outcome, "final_response", "") or ""
+                )
+                error = getattr(contextual_outcome, "error", None)
+                success = kind in {"notify", "no_action"}
+                output = final_response or str(error or "")
+                if kind == "no_action":
+                    final_response = ""
+                elif kind != "notify" and not error:
+                    error = f"Contextual cron ended with {kind or 'unknown'}."
+            else:
+                success, output, final_response, error = run_job(
+                    job,
+                    defer_agent_teardown=_deferred_agents,
+                    extra_prompt=extra_prompt,
+                )
         except BaseException:
             # run_job's finally still hands back the agent when it raises; tear
             # it down here so a failed run never leaks its async resources
@@ -4586,6 +5162,26 @@ def run_one_job(
         finally:
             reset_secret_scope(_scope_token)
 
+        # The typed contextual agent result is durable before any delivery
+        # claim. The live gateway normally writes this immediately before
+        # resolving its future; this idempotent scheduler acknowledgement also
+        # covers injected providers/test lanes.
+        if contextual_outcome is not None:
+            persisted_contextual = persist_contextual_agent_result(
+                execution_id,
+                outcome=getattr(contextual_outcome, "kind", "unknown"),
+                final_response=getattr(contextual_outcome, "final_response", ""),
+                error=getattr(contextual_outcome, "error", None),
+            )
+            if persisted_contextual is None:
+                contextual_outcome = ContextualCronOutcome.unknown(
+                    "Could not durably persist the contextual cron result."
+                )
+                success = False
+                final_response = ""
+                error = contextual_outcome.error
+                output = str(error or "")
+
         # Everything from here through delivery runs with the agent still live
         # (deferred teardown). Wrap it ALL in a try/finally so that if any step
         # between run_job returning and delivery — save_job_output, the [SILENT]
@@ -4594,6 +5190,7 @@ def run_one_job(
         # swallow the error and leak the agent's subprocesses/clients (#10200).
         delivery_error = None
         blocked_config = False
+        delivery_uncertain = False
         try:
             output_file = save_job_output(job["id"], output)
             if verbose:
@@ -4613,44 +5210,78 @@ def run_one_job(
                     "(tool subprocess was killed mid-flight)."
                 )
 
-            # Deliver the final response to the origin/target chat.
-            # If the agent responded with [SILENT], skip delivery (but
-            # output is already saved above).  Failed jobs always deliver.
-            #
-            # Exception: a run blocked by pre-dispatch config validation
-            # (T1-26) alerts exactly ONCE — the silent marker means the
-            # operator was already told on a previous tick, so re-delivering
-            # the same alert every tick would be spam (#73506 alert-once
-            # shape).
-            blocked_config_silent = (
-                bool(error) and BLOCKED_CONFIG_SILENT_MARKER in str(error)
+            # Contextual turns expose only an explicit notify as externally
+            # deliverable. Rejected/stale/failure/unknown details stay internal.
+            contextual_kind = (
+                getattr(contextual_outcome, "kind", None)
+                if contextual_outcome is not None
+                else None
             )
-            blocked_config = blocked_config_silent or (
-                bool(error) and BLOCKED_CONFIG_MARKER in str(error)
-            )
-            if blocked_config and not success:
-                # Blocked-config alert: bypass the generic failure summarizer
-                # (whose auth/timeout heuristics would mislabel this as a
-                # provider runtime failure) — say plainly that config
-                # validation blocked the run and nothing was spent.
-                _pf_text = re.sub(
-                    r"\[blocked_config[^\]]*\]\s*", "", str(error)
-                ).strip()
-                deliver_content = (
-                    f"⛔ Cron '{job.get('name') or job['id']}' blocked by "
-                    f"configuration validation (no LLM call was made): "
-                    f"{_pf_text} "
-                    "This alert is sent once; the job stays blocked until "
-                    "the configuration is fixed."
-                )
+            blocked_config_silent = False
+            if contextual_outcome is not None:
+                deliver_content = final_response if contextual_kind == "notify" else ""
             else:
-                deliver_content = final_response if success else _summarize_cron_failure_for_delivery(job, error)
+                # Ordinary isolated cron keeps the alert-once behavior for
+                # pre-dispatch configuration failures.
+                blocked_config_silent = (
+                    bool(error) and BLOCKED_CONFIG_SILENT_MARKER in str(error)
+                )
+                blocked_config = blocked_config_silent or (
+                    bool(error) and BLOCKED_CONFIG_MARKER in str(error)
+                )
+                if blocked_config and not success:
+                    _pf_text = re.sub(
+                        r"\[blocked_config[^\]]*\]\s*", "", str(error)
+                    ).strip()
+                    deliver_content = (
+                        f"⛔ Cron '{job.get('name') or job['id']}' blocked by "
+                        f"configuration validation (no LLM call was made): "
+                        f"{_pf_text} "
+                        "This alert is sent once; the job stays blocked until "
+                        "the configuration is fixed."
+                    )
+                else:
+                    deliver_content = (
+                        final_response
+                        if success
+                        else _summarize_cron_failure_for_delivery(job, error)
+                    )
             # Treat whitespace-only final responses the same as empty
             # responses: do not deliver a blank message, and let the
             # empty-response guard below mark the run as a soft failure.
             should_deliver = bool(deliver_content.strip())
             if blocked_config_silent:
                 should_deliver = False
+            contextual_delivery_claimed = False
+            if contextual_kind == "notify":
+                authorizer = get_contextual_authorizer()
+                authorization_error = None
+                try:
+                    authorized = bool(
+                        callable(authorizer)
+                        and authorizer(contextual_delivery_job or {})
+                    )
+                except Exception as auth_exc:
+                    authorized = False
+                    authorization_error = str(auth_exc) or type(auth_exc).__name__
+                if not authorized:
+                    authorization_error = authorization_error or (
+                        "Contextual cron authorization was revoked before delivery."
+                    )
+                    suppress_contextual_delivery(
+                        execution_id, error=authorization_error
+                    )
+                    should_deliver = False
+                    success = False
+                    error = authorization_error
+                    delivery_error = authorization_error
+                else:
+                    contextual_delivery_claimed = (
+                        claim_contextual_delivery(execution_id) is not None
+                    )
+                    if not contextual_delivery_claimed:
+                        # A concurrent/replayed scheduler does not own delivery.
+                        should_deliver = False
             unresolved_origin = False
             # Cron silence suppression — see _is_cron_silence_response.  Replaces the
             # old `SILENT_MARKER in ...upper()` substring check, which both leaked
@@ -4663,14 +5294,30 @@ def run_one_job(
                 should_deliver = False
 
             if should_deliver:
+                delivery_job = contextual_delivery_job or job
                 unresolved_origin = (
-                    _normalize_deliver_value(job.get("deliver", "local")) == "origin"
-                    and not _resolve_delivery_targets(job)
+                    _normalize_deliver_value(delivery_job.get("deliver", "local")) == "origin"
+                    and not _resolve_delivery_targets(delivery_job)
                 )
                 try:
-                    delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
+                    if contextual_outcome is not None:
+                        delivery_error = _deliver_result(
+                            delivery_job,
+                            deliver_content,
+                            adapters=adapters,
+                            loop=loop,
+                            at_most_once=True,
+                        )
+                    else:
+                        delivery_error = _deliver_result(
+                            delivery_job,
+                            deliver_content,
+                            adapters=adapters,
+                            loop=loop,
+                        )
                 except Exception as de:
                     delivery_error = str(de)
+                    delivery_uncertain = contextual_delivery_claimed
                     logger.error("Delivery failed for job %s: %s", job["id"], de)
         finally:
             # Tear down the deferred agent(s) now that save + delivery have run
@@ -4679,22 +5326,35 @@ def run_one_job(
             for _deferred_agent in _deferred_agents:
                 _teardown_cron_agent(_deferred_agent, job["id"])
 
-        # Treat empty final_response as a soft failure so last_status
-        # is not "ok" — the agent ran but produced nothing useful.
-        # (issue #8585)
-        if success and not final_response.strip():
+        # no_action is an explicit successful terminal state, not an empty
+        # model response. Preserve the legacy empty-response guard otherwise.
+        if success and not final_response.strip() and (
+            contextual_outcome is None
+            or getattr(contextual_outcome, "kind", None) != "no_action"
+        ):
             success = False
             error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
 
-        if not _consume_interrupted_flag(job["id"]):
+        should_account_job = not _consume_interrupted_flag(job["id"])
+        if should_account_job and contextual_outcome is None:
             if blocked_config:
                 mark_job_run(
-                    job["id"], success, error, delivery_error=delivery_error,
+                    job["id"],
+                    success,
+                    error,
+                    delivery_error=delivery_error,
                     status="blocked_config",
                 )
             else:
-                mark_job_run(job["id"], success, error, delivery_error=delivery_error)
-        normalized_deliver = _normalize_deliver_value(job.get("deliver", "local"))
+                mark_job_run(
+                    job["id"],
+                    success,
+                    error,
+                    delivery_error=delivery_error,
+                )
+        normalized_deliver = _normalize_deliver_value(
+            (contextual_delivery_job or job).get("deliver", "local")
+        )
         if delivery_error:
             delivery_outcome = "failed"
         elif should_deliver and unresolved_origin:
@@ -4703,12 +5363,43 @@ def run_one_job(
             delivery_outcome = "delivered"
         else:
             delivery_outcome = "suppressed"
-        finish_execution(
-            execution_id,
-            success=success,
-            error=error,
-            delivery_outcome=delivery_outcome,
-        )
+        if contextual_outcome is not None:
+            if contextual_kind == "notify" and contextual_delivery_claimed:
+                if delivery_uncertain:
+                    finish_contextual_delivery(
+                        execution_id,
+                        delivery_state="unknown",
+                        error=delivery_error,
+                    )
+                elif delivery_error or unresolved_origin:
+                    finish_contextual_delivery(
+                        execution_id,
+                        delivery_state="failed",
+                        error=(
+                            delivery_error
+                            or "Contextual cron delivery origin could not be resolved."
+                        ),
+                    )
+                else:
+                    finish_contextual_delivery(
+                        execution_id,
+                        delivery_state="sent",
+                    )
+        else:
+            finish_execution(
+                execution_id,
+                success=success,
+                error=error,
+                delivery_outcome=delivery_outcome,
+            )
+        if should_account_job and contextual_outcome is not None:
+            _account_contextual_job_run(
+                execution_id=execution_id,
+                job_id=str(job["id"]),
+                success=success,
+                error=error,
+                delivery_error=delivery_error,
+            )
         return True
 
     except BaseException as e:  # noqa: BLE001 — deliberate: see below
@@ -4723,22 +5414,69 @@ def run_one_job(
         # anything that isn't a plain Exception.
         _err_text = str(e) or type(e).__name__
         logger.error("Error processing job %s: %s", job['id'], _err_text)
-        try:
-            if not _consume_interrupted_flag(job["id"]):
-                mark_job_run(job["id"], False, _err_text)
-        except Exception as record_err:
-            # Never let bookkeeping mask the original interruption.
-            logger.error(
-                "Failed to record interrupted run for job %s: %s",
-                job["id"], record_err,
-            )
-        try:
-            finish_execution(execution_id, success=False, error=_err_text)
-        except Exception as record_err:
-            logger.error(
-                "Failed to finish execution record for job %s: %s",
-                job["id"], record_err,
-            )
+        should_account_interrupted_job = not _consume_interrupted_flag(job["id"])
+        contextual_terminal_durable = False
+        contextual_delivery_error = None
+        if session_target == "current" and execution_id:
+            try:
+                current_record = get_execution(execution_id)
+                if current_record:
+                    if (
+                        current_record.get("phase") == "delivering"
+                        and current_record.get("delivery_state") == "claimed"
+                    ):
+                        contextual_delivery_error = (
+                            "Contextual delivery was interrupted after its external "
+                            f"attempt began: {_err_text}"
+                        )
+                        contextual_terminal_durable = finish_contextual_delivery(
+                            execution_id,
+                            delivery_state="unknown",
+                            error=contextual_delivery_error,
+                        ) is not None
+                    elif (
+                        current_record.get("phase") == "agent_completed"
+                        and current_record.get("delivery_state") == "pending"
+                    ):
+                        # Safe restart point: the agent will not rerun; startup may
+                        # claim and resume only this not-yet-started delivery.
+                        pass
+                    else:
+                        contextual_terminal_durable = finish_contextual_execution(
+                            execution_id,
+                            outcome="failure",
+                            error=_err_text,
+                        ) is not None
+            except Exception as record_err:
+                logger.error(
+                    "Failed to finish execution record for job %s: %s",
+                    job["id"], record_err,
+                )
+            if should_account_interrupted_job and contextual_terminal_durable:
+                _account_contextual_job_run(
+                    execution_id=execution_id,
+                    job_id=str(job["id"]),
+                    success=False,
+                    error=_err_text,
+                    delivery_error=contextual_delivery_error,
+                )
+        else:
+            try:
+                if should_account_interrupted_job:
+                    mark_job_run(job["id"], False, _err_text)
+            except Exception as record_err:
+                # Never let bookkeeping mask the original interruption.
+                logger.error(
+                    "Failed to record interrupted run for job %s: %s",
+                    job["id"], record_err,
+                )
+            try:
+                finish_execution(execution_id, success=False, error=_err_text)
+            except Exception as record_err:
+                logger.error(
+                    "Failed to finish execution record for job %s: %s",
+                    job["id"], record_err,
+                )
         if not isinstance(e, Exception):
             raise
         return False
@@ -4796,14 +5534,14 @@ class CronSchedulerRegistrationError(RuntimeError):
 
 def create_job_with_scheduler_registration(**kwargs) -> dict:
     """Persist one job and register its first trigger with the active provider."""
-    from cron.jobs import create_job
+    from cron.jobs import create_job, get_job
     from cron.scheduler_provider import resolve_cron_scheduler
 
     job = create_job(**kwargs)
     try:
         resolve_cron_scheduler().register_job(job)
     except Exception as exc:
-        raise CronSchedulerRegistrationError(job, exc) from exc
+        raise CronSchedulerRegistrationError(get_job(job["id"]) or job, exc) from exc
     return job
 
 
@@ -4814,6 +5552,7 @@ def tick(
     sync: bool = True,
     *,
     can_dispatch=None,
+    contextual_dispatch=None,
 ):
     """
     Check and run all due jobs.
@@ -4885,13 +5624,16 @@ def tick(
         if verbose:
             logger.info("%s - %s job(s) due", _hermes_now().strftime('%H:%M:%S'), len(due_jobs))
 
-        # Advance next_run_at for all recurring jobs FIRST, under the file lock,
-        # before any execution begins.  This preserves at-most-once semantics.
-        # For parallel jobs that are already running, the advance keeps
-        # bumping next_run_at forward so the grace window never expires.
-        # mark_job_run() overwrites next_run_at on completion.
-        # Batched: one load + one save for the whole due set, not one per job.
-        advance_next_runs([job["id"] for job in due_jobs])
+        # Preserve upstream's O(1) batch advance for ordinary isolated jobs.
+        # Contextual occurrences are admitted later, one at a time, only after
+        # their ledger row and immutable delivery target exist.
+        advance_next_runs(
+            [
+                job["id"]
+                for job in due_jobs
+                if job.get("session_target", "isolated") != "current"
+            ]
+        )
 
         # Resolve max parallel workers: env var > config.yaml > unbounded.
         # Set HERMES_CRON_MAX_PARALLEL=1 to restore old serial behaviour.
@@ -4925,7 +5667,13 @@ def tick(
             module-level ``run_one_job`` so ``tick`` and external providers
             (Chronos ``fire_due``) use the identical execute→save→deliver→mark
             body."""
-            return run_one_job(job, adapters=adapters, loop=loop, verbose=verbose)
+            return run_one_job(
+                job,
+                adapters=adapters,
+                loop=loop,
+                verbose=verbose,
+                contextual_dispatch=contextual_dispatch,
+            )
 
         # Partition due jobs: those with a per-job workdir mutate
         # os.environ["TERMINAL_CWD"] inside run_job, which is process-global, so
@@ -4963,8 +5711,127 @@ def tick(
                 return None
             # Record the attempt before executor dispatch. Recovery classifies
             # abandoned records as unknown; it never automatically retries them.
-            execution = create_execution(job_id, source="builtin")
-            dispatched_job = dict(job, execution_id=execution["id"])
+            try:
+                execution = create_execution(
+                    job_id,
+                    source="builtin",
+                    requires_job_accounting=job.get("session_target") == "current",
+                )
+            except Exception as ledger_err:
+                with _running_lock:
+                    _running_job_ids.discard(job_id)
+                logger.error(
+                    "Job '%s' not dispatched because its execution ledger claim failed: %s",
+                    job.get("name", job_id),
+                    ledger_err,
+                )
+                return None
+            execution_id = str(execution["id"])
+            is_contextual = job.get("session_target", "isolated") == "current"
+            dispatched_job: dict[str, Any] = dict(job, execution_id=execution_id)
+            if is_contextual:
+                delivery_target = {
+                    "id": str(job_id),
+                    "name": job.get("name"),
+                    "deliver": _normalize_deliver_value(job.get("deliver") or "origin"),
+                    "origin": dict(job.get("origin") or {}),
+                }
+                try:
+                    sealed = seal_contextual_delivery_target(
+                        execution_id, target=delivery_target
+                    )
+                except BaseException as seal_err:
+                    release_running_job(job_id)
+                    error_text = str(seal_err) or type(seal_err).__name__
+                    terminal = finish_contextual_execution(
+                        execution_id,
+                        outcome="rejected",
+                        error=error_text,
+                        delivery_outcome="suppressed",
+                    )
+                    if terminal is not None:
+                        claim_contextual_job_accounting(execution_id)
+                    if not isinstance(seal_err, Exception):
+                        raise
+                    logger.error(
+                        "Contextual job '%s' not dispatched: %s",
+                        job.get("name", job_id),
+                        seal_err,
+                    )
+                    return None
+                if not sealed:
+                    release_running_job(job_id)
+                    error_text = (
+                        "Could not durably seal the contextual delivery destination."
+                    )
+                    terminal = finish_contextual_execution(
+                        execution_id,
+                        outcome="rejected",
+                        error=error_text,
+                        delivery_outcome="suppressed",
+                    )
+                    if terminal is not None:
+                        claim_contextual_job_accounting(execution_id)
+                    logger.error(
+                        "Contextual job '%s' not dispatched: %s",
+                        job.get("name", job_id),
+                        error_text,
+                    )
+                    return None
+                try:
+                    occurrence_claimed = claim_contextual_occurrence(
+                        job_id,
+                        execution_id=execution_id,
+                        expected_next_run_at=str(job.get("next_run_at") or ""),
+                    )
+                except BaseException as claim_err:
+                    # The jobs-file save may have crossed its atomic boundary;
+                    # classify the occurrence as unknown and account it rather
+                    # than assuming the cursor is untouched and retrying.
+                    release_running_job(job_id)
+                    error_text = str(claim_err) or type(claim_err).__name__
+                    terminal = finish_contextual_execution(
+                        execution_id,
+                        outcome="unknown",
+                        error=error_text,
+                        delivery_outcome="suppressed",
+                    )
+                    if terminal is not None:
+                        _account_contextual_job_run(
+                            execution_id=execution_id,
+                            job_id=str(job_id),
+                            success=False,
+                            error=error_text,
+                            delivery_error=None,
+                        )
+                    if not isinstance(claim_err, Exception):
+                        raise
+                    logger.error(
+                        "Contextual job '%s' admission became ambiguous: %s",
+                        job.get("name", job_id),
+                        claim_err,
+                    )
+                    return None
+                if not occurrence_claimed:
+                    release_running_job(job_id)
+                    error_text = (
+                        "The exact contextual schedule occurrence could not be claimed."
+                    )
+                    terminal = finish_contextual_execution(
+                        execution_id,
+                        outcome="rejected",
+                        error=error_text,
+                        delivery_outcome="suppressed",
+                    )
+                    if terminal is not None:
+                        claim_contextual_job_accounting(execution_id)
+                    logger.error(
+                        "Contextual job '%s' not dispatched: %s",
+                        job.get("name", job_id),
+                        error_text,
+                    )
+                    return None
+                dispatched_job["_contextual_occurrence_preclaimed"] = True
             _ctx = contextvars.copy_context()
 
             def _run_and_release(j=dispatched_job, ctx=_ctx):
@@ -4975,13 +5842,32 @@ def tick(
 
             try:
                 return pool.submit(_run_and_release)
-            except Exception as submit_err:
+            except BaseException as submit_err:
                 release_running_job(job_id)
-                finish_execution(
-                    execution["id"],
-                    success=False,
-                    error=f"Executor dispatch failed: {submit_err}",
-                )
+                dispatch_error = f"Executor dispatch failed: {submit_err}"
+                if is_contextual:
+                    terminal = finish_contextual_execution(
+                        execution_id,
+                        outcome="failure",
+                        error=dispatch_error,
+                        delivery_outcome="suppressed",
+                    )
+                    if terminal is not None:
+                        _account_contextual_job_run(
+                            execution_id=execution_id,
+                            job_id=str(job_id),
+                            success=False,
+                            error=dispatch_error,
+                            delivery_error=None,
+                        )
+                else:
+                    finish_execution(
+                        execution_id,
+                        success=False,
+                        error=dispatch_error,
+                    )
+                if not isinstance(submit_err, Exception):
+                    raise
                 # Interpreter began finalizing between the guard above and the
                 # submit — release the in-flight claim we just took and skip.
                 if isinstance(submit_err, RuntimeError) and _interpreter_shutting_down(submit_err):

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4808,7 +4808,16 @@ def _resume_contextual_delivery_record(
     delivery_claimed = bool(
         authorization_target.get("_contextual_delivery_claimed")
     )
-    if not delivery_claimed and claim_contextual_delivery(execution_id) is None:
+    delivery_claim_attempted = bool(
+        authorization_target.get("_contextual_delivery_claim_attempted")
+    )
+    if (
+        not delivery_claimed
+        and not delivery_claim_attempted
+        and claim_contextual_delivery(execution_id) is None
+    ):
+        return False
+    if not delivery_claimed and delivery_claim_attempted:
         return False
     try:
         try:
@@ -5344,7 +5353,19 @@ def run_one_job(
                 else:
                     contextual_delivery_claimed = bool(
                         authorization_target.get("_contextual_delivery_claimed")
-                    ) or (claim_contextual_delivery(execution_id) is not None)
+                    )
+                    contextual_delivery_claim_attempted = bool(
+                        authorization_target.get(
+                            "_contextual_delivery_claim_attempted"
+                        )
+                    )
+                    if (
+                        not contextual_delivery_claimed
+                        and not contextual_delivery_claim_attempted
+                    ):
+                        contextual_delivery_claimed = (
+                            claim_contextual_delivery(execution_id) is not None
+                        )
                     if not contextual_delivery_claimed:
                         # A concurrent/replayed scheduler does not own delivery.
                         should_deliver = False

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4695,6 +4695,20 @@ def _account_contextual_job_run(
         return False
 
 
+def _contextual_authorization_target(delivery_job: dict, record: dict) -> dict:
+    """Attach sealed admission authority for the gateway-only auth callback."""
+    target = dict(delivery_job)
+    target["_contextual_authority"] = {
+        "execution_id": str(record.get("id") or ""),
+        "session_key": str(record.get("session_key") or ""),
+        "binding_version": record.get("admitted_binding_version"),
+        "route_instance_id": str(record.get("admitted_route_instance_id") or ""),
+        "session_id": str(record.get("admitted_session_id") or ""),
+        "routing_revision": record.get("admitted_routing_revision"),
+    }
+    return target
+
+
 def _resume_contextual_delivery_record(
     job: dict,
     record: dict,
@@ -4757,9 +4771,12 @@ def _resume_contextual_delivery_record(
             )
             return False
     authorizer = get_contextual_authorizer()
+    authorization_target = _contextual_authorization_target(
+        immutable_delivery_job, record
+    )
     try:
         authorized = bool(
-            callable(authorizer) and authorizer(immutable_delivery_job)
+            callable(authorizer) and authorizer(authorization_target)
         )
     except Exception as auth_exc:
         authorized = False
@@ -4779,7 +4796,10 @@ def _resume_contextual_delivery_record(
             delivery_error=authorization_error,
         )
         return False
-    if claim_contextual_delivery(execution_id) is None:
+    delivery_claimed = bool(
+        authorization_target.get("_contextual_delivery_claimed")
+    )
+    if not delivery_claimed and claim_contextual_delivery(execution_id) is None:
         return False
     try:
         try:
@@ -5198,6 +5218,7 @@ def run_one_job(
         # claim. The live gateway normally writes this immediately before
         # resolving its future; this idempotent scheduler acknowledgement also
         # covers injected providers/test lanes.
+        persisted_contextual = None
         if contextual_outcome is not None:
             persisted_contextual = persist_contextual_agent_result(
                 execution_id,
@@ -5288,10 +5309,14 @@ def run_one_job(
             if contextual_kind == "notify":
                 authorizer = get_contextual_authorizer()
                 authorization_error = None
+                authorization_record = persisted_contextual or {}
+                authorization_target = _contextual_authorization_target(
+                    contextual_delivery_job or {}, authorization_record
+                )
                 try:
                     authorized = bool(
                         callable(authorizer)
-                        and authorizer(contextual_delivery_job or {})
+                        and authorizer(authorization_target)
                     )
                 except Exception as auth_exc:
                     authorized = False
@@ -5308,9 +5333,9 @@ def run_one_job(
                     error = authorization_error
                     delivery_error = authorization_error
                 else:
-                    contextual_delivery_claimed = (
-                        claim_contextual_delivery(execution_id) is not None
-                    )
+                    contextual_delivery_claimed = bool(
+                        authorization_target.get("_contextual_delivery_claimed")
+                    ) or (claim_contextual_delivery(execution_id) is not None)
                     if not contextual_delivery_claimed:
                         # A concurrent/replayed scheduler does not own delivery.
                         should_deliver = False

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -5324,6 +5324,7 @@ def run_one_job(
             if blocked_config_silent:
                 should_deliver = False
             contextual_delivery_claimed = False
+            contextual_delivery_claim_lost = False
             if contextual_kind == "notify":
                 authorizer = get_contextual_authorizer()
                 authorization_error = None
@@ -5369,6 +5370,7 @@ def run_one_job(
                     if not contextual_delivery_claimed:
                         # A concurrent/replayed scheduler does not own delivery.
                         should_deliver = False
+                        contextual_delivery_claim_lost = True
             unresolved_origin = False
             # Cron silence suppression — see _is_cron_silence_response.  Replaces the
             # old `SILENT_MARKER in ...upper()` substring check, which both leaked
@@ -5412,6 +5414,11 @@ def run_one_job(
             # their subprocesses/clients (#10200).
             for _deferred_agent in _deferred_agents:
                 _teardown_cron_agent(_deferred_agent, job["id"])
+
+        if contextual_delivery_claim_lost:
+            # Another worker owns (or already consumed) this delivery CAS.
+            # Leave terminalization and accounting to that owner.
+            return False
 
         # no_action is an explicit successful terminal state, not an empty
         # model response. Preserve the legacy empty-response guard otherwise.

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2268,6 +2268,15 @@ def _deliver_result(
                     )
 
         if not delivered:
+            if at_most_once:
+                detail = "; ".join(target_errors) or (
+                    f"no confirmed live adapter delivery path for "
+                    f"{platform_name}:{chat_id}"
+                )
+                raise ContextualDeliveryUnknown(
+                    f"Contextual delivery requires the gateway-owned live "
+                    f"transport; standalone fallback is forbidden: {detail}"
+                )
             if transport is not None and transport.is_relay:
                 # Relay owns the logical destination and its connector owns the
                 # platform credential. A native retry could duplicate delivery

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -98,27 +98,27 @@ class CronScheduler(ABC):
 
         return recover_interrupted_executions()
 
+    def resume_pending_deliveries(self, *, adapters=None, loop=None) -> int:
+        """Resume only durable agent-complete deliveries that never began."""
+        from cron.scheduler import resume_pending_contextual_deliveries
+
+        return resume_pending_contextual_deliveries(adapters=adapters, loop=loop)
+
     def fire_due(self, job_id: str, *, adapters: Any = None, loop: Any = None) -> bool:
-        """Run a single job NOW via the shared orchestrator. Called by the
-        inbound fire webhook when an external scheduler signals a job is due.
+        """Run a single job NOW via the existing external-provider path.
 
-        The default claims the job with a store-level compare-and-set
-        (multi-machine at-most-once), then runs it via the shared
-        ``run_one_job`` body. Built-in never calls this (it has its own tick
-        loop); an external provider routes its inbound fire here.
-
-        Returns True if THIS caller claimed and ran the job, False if the claim
-        was lost (another machine/retry won it) or the job no longer exists.
+        Contextual jobs cannot be created while an external provider is
+        configured, so this compatibility path remains isolated-only in V1.
         """
         from cron.jobs import claim_job_for_fire, get_job
         from cron.executions import create_execution
         from cron.scheduler import run_one_job
 
         if not claim_job_for_fire(job_id):
-            return False  # another machine already claimed this fire
+            return False
         job = get_job(job_id)
         if job is None:
-            return False  # job removed (e.g. repeat-N exhausted) between arm and fire
+            return False
         job["execution_id"] = create_execution(job_id, source=self.name)["id"]
         return run_one_job(job, adapters=adapters, loop=loop)
 
@@ -192,6 +192,8 @@ class InProcessCronScheduler(CronScheduler):
         interval=60,
         can_dispatch=None,
         profile_homes=None,
+        profile_adapters=None,
+        contextual_transcript_recover=None,
     ):
         import logging
         from cron.scheduler import tick as cron_tick
@@ -215,10 +217,12 @@ class InProcessCronScheduler(CronScheduler):
             self._start_multiplex(
                 stop_event,
                 profile_homes=profile_homes,
+                profile_adapters=profile_adapters,
                 adapters=adapters,
                 loop=loop,
                 interval=interval,
                 can_dispatch=can_dispatch,
+                contextual_transcript_recover=contextual_transcript_recover,
             )
             return
 
@@ -229,12 +233,26 @@ class InProcessCronScheduler(CronScheduler):
                 "Marked %d interrupted cron execution(s) unknown after restart",
                 recovered,
             )
+        if contextual_transcript_recover is not None:
+            try:
+                contextual_transcript_recover()
+            except BaseException:
+                logger.error(
+                    "Contextual transcript startup recovery deferred",
+                    exc_info=True,
+                )
+        resumed = self.resume_pending_deliveries(adapters=adapters, loop=loop)
+        if resumed:
+            logger.info("Resumed %d pending contextual cron delivery(s)", resumed)
         # Heartbeat once before the first sleep so `hermes cron status` sees a
         # live ticker immediately after startup, not only after the first tick.
         record_ticker_heartbeat()
         while not stop_event.is_set():
             ok = False
             try:
+                if contextual_transcript_recover is not None:
+                    contextual_transcript_recover()
+                    self.resume_pending_deliveries(adapters=adapters, loop=loop)
                 if can_dispatch is not None and not can_dispatch():
                     logger.debug("Cron dispatch paused while gateway drains existing work")
                 else:
@@ -275,10 +293,12 @@ class InProcessCronScheduler(CronScheduler):
         stop_event,
         *,
         profile_homes,
+        profile_adapters=None,
         adapters=None,
         loop=None,
         interval=60,
         can_dispatch=None,
+        contextual_transcript_recover=None,
     ):
         """Tick every served profile's cron store when multiplex_profiles is on.
 
@@ -305,63 +325,130 @@ class InProcessCronScheduler(CronScheduler):
             [p[0] if isinstance(p, tuple) else p for p in profile_homes],
         )
 
-        # Recovery + initial heartbeat for every profile.
+        adapter_maps = profile_adapters or {}
+        if profile_adapters is None and adapters:
+            logger.error(
+                "Multiplex cron received only a process-wide adapter map; "
+                "live delivery is disabled rather than risking cross-profile transport reuse"
+            )
+
+        def _entry_parts(entry):
+            if isinstance(entry, tuple):
+                return str(entry[0]), entry[1]
+            return str(entry), entry
+
+        # Recovery + initial heartbeat are isolated per profile. One corrupt
+        # profile must not prevent later profiles from recovering or ticking.
         for entry in profile_homes:
-            home = entry[1] if isinstance(entry, tuple) else entry
+            profile_name, home = _entry_parts(entry)
+            live_adapters = adapter_maps.get(profile_name, {})
             home_token = set_hermes_home_override(str(home))
             try:
                 with use_cron_store(home):
-                    recovered = self.recover_interrupted()
-                    if recovered:
-                        logger.warning(
-                            "Marked %d interrupted cron execution(s) for profile at %s",
-                            recovered,
-                            home,
+                    try:
+                        recovered = self.recover_interrupted()
+                        if recovered:
+                            logger.warning(
+                                "Marked %d interrupted cron execution(s) for profile %s",
+                                recovered,
+                                profile_name,
+                            )
+                        if contextual_transcript_recover is not None:
+                            contextual_transcript_recover()
+                        resumed = self.resume_pending_deliveries(
+                            adapters=live_adapters,
+                            loop=loop,
                         )
-                    record_ticker_heartbeat()
+                        if resumed:
+                            logger.info(
+                                "Resumed %d pending contextual delivery(s) for profile %s",
+                                resumed,
+                                profile_name,
+                            )
+                        record_ticker_heartbeat(success=True)
+                        clear_ticker_error()
+                    except BaseException as exc:
+                        logger.error(
+                            "Cron recovery failed for profile %s: %s",
+                            profile_name,
+                            exc,
+                            exc_info=True,
+                        )
+                        try:
+                            record_ticker_heartbeat(success=False)
+                            record_ticker_error(f"{type(exc).__name__}: {exc}")
+                        except BaseException:
+                            logger.error(
+                                "Could not record cron recovery failure for profile %s",
+                                profile_name,
+                                exc_info=True,
+                            )
+            except BaseException as exc:
+                logger.error(
+                    "Could not open cron store for profile %s during recovery: %s",
+                    profile_name,
+                    exc,
+                    exc_info=True,
+                )
             finally:
                 reset_hermes_home_override(home_token)
 
         while not stop_event.is_set():
-            ok = False
-            try:
-                if can_dispatch is not None and not can_dispatch():
-                    logger.debug("Cron dispatch paused while gateway drains existing work")
-                else:
-                    for entry in profile_homes:
-                        home = entry[1] if isinstance(entry, tuple) else entry
-                        home_token = set_hermes_home_override(str(home))
+            dispatch_allowed = can_dispatch is None or can_dispatch()
+            if not dispatch_allowed:
+                logger.debug("Cron dispatch paused while gateway drains existing work")
+
+            for entry in profile_homes:
+                profile_name, home = _entry_parts(entry)
+                live_adapters = adapter_maps.get(profile_name, {})
+                home_token = set_hermes_home_override(str(home))
+                try:
+                    with use_cron_store(home):
+                        ok = False
+                        tick_error = None
                         try:
-                            with use_cron_store(home):
+                            if contextual_transcript_recover is not None:
+                                contextual_transcript_recover()
+                                self.resume_pending_deliveries(
+                                    adapters=live_adapters,
+                                    loop=loop,
+                                )
+                            if dispatch_allowed:
                                 cron_tick(
                                     verbose=False,
-                                    adapters=adapters,
+                                    adapters=live_adapters,
                                     loop=loop,
                                     sync=False,
                                     can_dispatch=can_dispatch,
                                 )
-                        finally:
-                            reset_hermes_home_override(home_token)
-                ok = True
-            except BaseException as e:
-                logger.error("Cron tick error: %s", e, exc_info=True)
-                _tick_error = f"{type(e).__name__}: {e}"
-            else:
-                _tick_error = None
-            # Record per-profile heartbeat after each tick cycle.
-            for entry in profile_homes:
-                home = entry[1] if isinstance(entry, tuple) else entry
-                home_token = set_hermes_home_override(str(home))
-                try:
-                    with use_cron_store(home):
-                        record_ticker_heartbeat(success=ok)
-                        # Surface the failure reason (or clear it) per profile
-                        # so `hermes cron status` can show WHY ticks fail
-                        # (#68483).
-                        if ok:
-                            clear_ticker_error()
-                        elif _tick_error:
-                            record_ticker_error(_tick_error)
+                            ok = True
+                        except BaseException as exc:
+                            tick_error = f"{type(exc).__name__}: {exc}"
+                            logger.error(
+                                "Cron tick failed for profile %s: %s",
+                                profile_name,
+                                exc,
+                                exc_info=True,
+                            )
+                        try:
+                            record_ticker_heartbeat(success=ok)
+                            if ok:
+                                clear_ticker_error()
+                            elif tick_error:
+                                record_ticker_error(tick_error)
+                        except BaseException:
+                            logger.error(
+                                "Could not record cron heartbeat for profile %s",
+                                profile_name,
+                                exc_info=True,
+                            )
+                except BaseException as exc:
+                    logger.error(
+                        "Could not open cron store for profile %s during tick: %s",
+                        profile_name,
+                        exc,
+                        exc_info=True,
+                    )
                 finally:
                     reset_hermes_home_override(home_token)
             stop_event.wait(interval)

--- a/gateway/contextual_cron.py
+++ b/gateway/contextual_cron.py
@@ -17,6 +17,13 @@ from collections import defaultdict, deque
 from dataclasses import dataclass
 from typing import Any, Callable, Deque, Dict, Optional
 
+from gateway.session import (
+    ContextualRouteInstanceMismatch,
+    Platform,
+    SessionSource,
+    canonical_route_coordinates,
+)
+
 logger = logging.getLogger(__name__)
 
 _CONTEXTUAL_KINDS = frozenset(
@@ -90,6 +97,8 @@ class ContextualCronQueueItem:
     source: Any
     future: asyncio.Future
     admitted_routing_revision: int = 0
+    admitted_route_instance_id: Optional[str] = None
+    admitted_binding_version: int = 1
     turn_lease_token: Any = None
     adapter: Any = None
     adapter_guard: Any = None
@@ -135,6 +144,8 @@ class ContextualCronGateway:
         session_key: str,
         session_id: str,
         routing_revision: int,
+        route_instance_id: Optional[str] = None,
+        binding_version: int = 1,
     ) -> bool:
         from cron.executions import seal_contextual_admission
 
@@ -144,6 +155,8 @@ class ContextualCronGateway:
                 session_key=session_key,
                 admitted_session_id=session_id,
                 admitted_routing_revision=routing_revision,
+                admitted_route_instance_id=route_instance_id,
+                admitted_binding_version=binding_version,
             )
         )
 
@@ -153,21 +166,50 @@ class ContextualCronGateway:
         session_key: str,
         session_id: str,
         routing_revision: int,
+        route_instance_id: Optional[str] = None,
+        binding_version: int = 1,
     ) -> bool:
-        """Call production four-field seal while retaining old test doubles."""
+        """Call production v2 seal while retaining old test doubles."""
         try:
             params = inspect.signature(self._seal_admission).parameters.values()
-            supports_revision = any(
+            variadic = any(
                 p.kind is inspect.Parameter.VAR_POSITIONAL for p in params
-            ) or sum(
+            )
+            positional_count = sum(
                 p.kind in {
                     inspect.Parameter.POSITIONAL_ONLY,
                     inspect.Parameter.POSITIONAL_OR_KEYWORD,
                 }
                 for p in params
-            ) >= 4
+            )
+            supports_binding_version = variadic or positional_count >= 6
+            supports_route_instance = variadic or positional_count >= 5
+            supports_revision = variadic or positional_count >= 4
         except (TypeError, ValueError):
+            supports_binding_version = True
+            supports_route_instance = True
             supports_revision = True
+        if supports_binding_version:
+            return bool(
+                self._seal_admission(
+                    execution_id,
+                    session_key,
+                    session_id,
+                    routing_revision,
+                    route_instance_id,
+                    binding_version,
+                )
+            )
+        if supports_route_instance:
+            return bool(
+                self._seal_admission(
+                    execution_id,
+                    session_key,
+                    session_id,
+                    routing_revision,
+                    route_instance_id,
+                )
+            )
         if supports_revision:
             return bool(
                 self._seal_admission(
@@ -177,9 +219,7 @@ class ContextualCronGateway:
                     routing_revision,
                 )
             )
-        return bool(
-            self._seal_admission(execution_id, session_key, session_id)
-        )
+        return bool(self._seal_admission(execution_id, session_key, session_id))
 
     @staticmethod
     def _default_load_execution(execution_id: str) -> Optional[Dict[str, Any]]:
@@ -303,6 +343,9 @@ class ContextualCronGateway:
         session_key: str,
         admitted_session_id: Optional[str] = None,
         admitted_routing_revision: Optional[int] = None,
+        admitted_route_instance_id: Optional[str] = None,
+        authorization_source: Optional[SessionSource] = None,
+        propagate_authorization_errors: bool = False,
     ):
         entry = self._peek_entry(session_key)
         if entry is None or not getattr(entry, "origin", None):
@@ -312,6 +355,14 @@ class ContextualCronGateway:
         if admitted_session_id is not None and entry.session_id != admitted_session_id:
             return None, ContextualCronOutcome.stale(
                 "The target session was reset after this occurrence was admitted."
+            )
+        if (
+            admitted_route_instance_id is not None
+            and str(getattr(entry, "route_instance_id", ""))
+            != admitted_route_instance_id
+        ):
+            return None, ContextualCronOutcome.stale(
+                "The originating logical route changed after this occurrence was admitted."
             )
         if (
             admitted_routing_revision is not None
@@ -334,14 +385,65 @@ class ContextualCronGateway:
                     "The target source could not be revalidated."
                 )
         try:
-            authorized = bool(self.runner._is_user_authorized(source))
+            authorized = bool(
+                self.runner._is_user_authorized(authorization_source or source)
+            )
         except Exception:
+            if propagate_authorization_errors:
+                raise
             authorized = False
         if not authorized:
             return None, ContextualCronOutcome.rejected(
-                "The target session source is no longer authorized."
+                "The target session authorization is no longer valid."
             )
         return entry, None
+
+    @staticmethod
+    def _source_from_logical_binding(binding: Dict[str, Any]) -> SessionSource:
+        """Reconstruct the immutable creator authority for a v2 occurrence."""
+        return SessionSource(
+            platform=Platform(str(binding.get("platform") or "")),
+            chat_type=str(binding.get("chat_type") or "dm"),
+            chat_id=str(binding.get("chat_id") or ""),
+            thread_id=str(binding.get("thread_id") or "") or None,
+            user_id=str(binding.get("user_id") or "") or None,
+            scope_id=str(binding.get("scope_id") or "") or None,
+            parent_chat_id=str(binding.get("parent_chat_id") or "") or None,
+            user_id_alt=str(binding.get("user_id_alt") or "") or None,
+            chat_id_alt=str(binding.get("chat_id_alt") or "") or None,
+            profile=str(binding.get("profile") or "") or None,
+        )
+
+    @staticmethod
+    def _logical_binding_rejection(entry, binding) -> Optional[ContextualCronOutcome]:
+        """Require exact immutable conversation-route equality for v2 jobs."""
+        route_instance_id = str(binding.get("route_instance_id") or "").strip()
+        if not route_instance_id or entry.route_instance_id != route_instance_id:
+            return ContextualCronOutcome.stale(
+                "The originating logical conversation no longer exists."
+            )
+        source = entry.origin
+        chat_type, chat_id, thread_id, parent_chat_id = canonical_route_coordinates(
+            source
+        )
+        actual = {
+            "profile": str(getattr(source, "profile", None) or ""),
+            "platform": str(
+                getattr(getattr(source, "platform", None), "value", "") or ""
+            ),
+            "chat_type": chat_type,
+            "chat_id": chat_id,
+            "thread_id": thread_id,
+            "scope_id": str(getattr(source, "scope_id", None) or ""),
+            "parent_chat_id": parent_chat_id,
+            "chat_id_alt": str(getattr(source, "chat_id_alt", None) or ""),
+        }
+        for field, current in actual.items():
+            if str(binding.get(field) or "") != current:
+                return ContextualCronOutcome.stale(
+                    "The originating conversation's authenticated route changed."
+                )
+        return None
 
     async def dispatch(self, job: Dict[str, Any], *, execution_id: str) -> ContextualCronOutcome:
         """Seal and enqueue one contextual occurrence.
@@ -383,15 +485,32 @@ class ContextualCronGateway:
 
         captured_session_id = None
         captured_routing_revision = None
-        if job.get("context_binding") is not None or int(
-            job.get("_contextual_binding_version") or 0
-        ) >= 1:
-            from cron.contextual import contextual_definition_route
+        captured_route_instance_id = None
+        captured_authorization_source: Optional[SessionSource] = None
+        binding = job.get("context_binding")
+        raw_binding_version = int(job.get("_contextual_binding_version") or 0)
+        binding_version = raw_binding_version or (1 if binding is not None else 0)
+        if binding is not None or raw_binding_version >= 1:
+            from cron.contextual import (
+                contextual_definition_route,
+                contextual_definition_route_instance,
+            )
 
             try:
-                captured_session_id, captured_routing_revision = (
-                    contextual_definition_route(job)
-                )
+                if binding_version == 2:
+                    captured_route_instance_id = contextual_definition_route_instance(job)
+                    assert isinstance(binding, dict)
+                    captured_authorization_source = self._source_from_logical_binding(
+                        binding
+                    )
+                elif binding_version == 1:
+                    captured_session_id, captured_routing_revision = (
+                        contextual_definition_route(job)
+                    )
+                else:
+                    raise ValueError(
+                        f"unsupported contextual binding version: {binding_version}"
+                    )
             except (TypeError, ValueError) as exc:
                 return finish_pre_admission(
                     ContextualCronOutcome.rejected(str(exc))
@@ -401,10 +520,16 @@ class ContextualCronGateway:
             session_key,
             admitted_session_id=captured_session_id,
             admitted_routing_revision=captured_routing_revision,
+            authorization_source=captured_authorization_source,
         )
         if rejection is not None:
             return finish_pre_admission(rejection)
         assert entry is not None
+        if binding_version == 2:
+            assert isinstance(binding, dict)
+            rejection = self._logical_binding_rejection(entry, binding)
+            if rejection is not None:
+                return finish_pre_admission(rejection)
 
         routing_revision = int(getattr(entry, "routing_revision", 0))
         try:
@@ -414,12 +539,42 @@ class ContextualCronGateway:
                 None,
             )
             if callable(linearize):
-                sealed_entry = await asyncio.to_thread(
-                    linearize,
-                    session_key,
-                    execution_id,
-                    self._seal_occurrence,
+                seal_resolved = (
+                    lambda admitted_execution_id, admitted_key, admitted_session_id, admitted_revision: self._seal_occurrence(
+                        admitted_execution_id,
+                        admitted_key,
+                        admitted_session_id,
+                        admitted_revision,
+                        captured_route_instance_id,
+                        binding_version or 1,
+                    )
                 )
+                try:
+                    linearize_params = inspect.signature(linearize).parameters.values()
+                    linearize_supports_route_instance = any(
+                        parameter.kind is inspect.Parameter.VAR_POSITIONAL
+                        for parameter in linearize_params
+                    ) or sum(
+                        parameter.kind
+                        in {
+                            inspect.Parameter.POSITIONAL_ONLY,
+                            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                        }
+                        for parameter in linearize_params
+                    ) >= 4
+                except (TypeError, ValueError):
+                    linearize_supports_route_instance = True
+                linearize_args = (
+                    (
+                        session_key,
+                        execution_id,
+                        seal_resolved,
+                        captured_route_instance_id,
+                    )
+                    if linearize_supports_route_instance
+                    else (session_key, execution_id, seal_resolved)
+                )
+                sealed_entry = await asyncio.to_thread(linearize, *linearize_args)
                 sealed = sealed_entry is not None
                 if sealed_entry is not None:
                     entry = sealed_entry
@@ -427,12 +582,20 @@ class ContextualCronGateway:
                         getattr(sealed_entry, "routing_revision", 0)
                     )
             else:
+                if binding_version == 2:
+                    rejection = self._logical_binding_rejection(entry, binding)
+                    if rejection is not None:
+                        return finish_pre_admission(rejection)
                 sealed = self._seal_occurrence(
                     execution_id,
                     session_key,
                     entry.session_id,
                     routing_revision,
+                    captured_route_instance_id,
+                    binding_version or 1,
                 )
+        except ContextualRouteInstanceMismatch as exc:
+            return finish_pre_admission(ContextualCronOutcome.stale(str(exc)))
         except asyncio.CancelledError:
             finish_pre_admission(
                 ContextualCronOutcome.unknown(
@@ -458,7 +621,13 @@ class ContextualCronGateway:
             session_key=session_key,
             admitted_session_id=entry.session_id,
             admitted_routing_revision=routing_revision,
-            source=entry.origin,
+            admitted_route_instance_id=captured_route_instance_id,
+            admitted_binding_version=binding_version or 1,
+            source=(
+                captured_authorization_source
+                if captured_authorization_source is not None
+                else getattr(entry, "origin", None)
+            ),
             future=future,
         )
         # Admission is durable before this append.  That ordering is the reset
@@ -516,6 +685,8 @@ class ContextualCronGateway:
                     item.session_key,
                     admitted_session_id=item.admitted_session_id,
                     admitted_routing_revision=item.admitted_routing_revision,
+                    admitted_route_instance_id=item.admitted_route_instance_id,
+                    authorization_source=item.source,
                 )
                 if rejection is not None:
                     return rejection
@@ -591,8 +762,13 @@ class ContextualCronGateway:
                     outcome = ContextualCronOutcome.failure(str(exc))
 
                 try:
-                    authorized_after_model = bool(
-                        self.runner._is_user_authorized(item.source)
+                    _, commit_rejection = self._validate_entry(
+                        item.session_key,
+                        admitted_session_id=item.admitted_session_id,
+                        admitted_routing_revision=item.admitted_routing_revision,
+                        admitted_route_instance_id=item.admitted_route_instance_id,
+                        authorization_source=item.source,
+                        propagate_authorization_errors=True,
                     )
                 except Exception as auth_exc:
                     outcome = ContextualCronOutcome.retryable(
@@ -601,10 +777,8 @@ class ContextualCronGateway:
                     )
                     item.transcript_entries = None
                 else:
-                    if not authorized_after_model:
-                        outcome = ContextualCronOutcome.rejected(
-                            "Contextual cron authorization was revoked before commit."
-                        )
+                    if commit_rejection is not None:
+                        outcome = commit_rejection
                         item.transcript_entries = None
 
                 try:
@@ -626,7 +800,17 @@ class ContextualCronGateway:
                         retry_delay = self._transcript_retry_seconds
                         while True:
                             try:
-                                if not self.runner._is_user_authorized(item.source):
+                                authorized_for_apply = bool(
+                                    self.runner._is_user_authorized(item.source)
+                                )
+                            except Exception:
+                                outcome = ContextualCronOutcome.unknown(
+                                    "Contextual transcript application was deferred because "
+                                    "authorization could not be revalidated."
+                                )
+                                break
+                            try:
+                                if not authorized_for_apply:
                                     raise ContextualCronTranscriptConflict(
                                         "Contextual cron authorization was revoked "
                                         "before transcript application."

--- a/gateway/contextual_cron.py
+++ b/gateway/contextual_cron.py
@@ -1,0 +1,739 @@
+"""Gateway-owned execution lane for opt-in same-session cron jobs.
+
+The scheduler is deliberately kept out of SessionDB.  It hands an occurrence to
+this bridge; the live gateway resolves the stable routing key, seals the exact
+session-id admission in the cron ledger, and serializes the synthetic turn
+behind any active user turn.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import inspect
+import json
+import logging
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from typing import Any, Callable, Deque, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+_CONTEXTUAL_KINDS = frozenset(
+    {"notify", "no_action", "retryable", "rejected", "stale", "failure", "unknown"}
+)
+
+
+class ContextualCronGuardBusy(RuntimeError):
+    """Compatibility seam for transient pre-awaitable adapter contention."""
+
+
+class ContextualCronTranscriptConflict(RuntimeError):
+    """A later transcript turn overtook a pending contextual outbox."""
+
+
+@dataclass(frozen=True)
+class ContextualCronOutcome:
+    """Typed result returned from the gateway lane to the scheduler."""
+
+    kind: str
+    final_response: str = ""
+    error: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.kind not in _CONTEXTUAL_KINDS:
+            raise ValueError(f"unknown contextual cron outcome: {self.kind}")
+
+    @property
+    def success(self) -> bool:
+        return self.kind in {"notify", "no_action"}
+
+    @classmethod
+    def notify(cls, text: str) -> "ContextualCronOutcome":
+        return cls("notify", final_response=str(text or ""))
+
+    @classmethod
+    def no_action(cls) -> "ContextualCronOutcome":
+        return cls("no_action")
+
+    @classmethod
+    def rejected(cls, error: str) -> "ContextualCronOutcome":
+        return cls("rejected", error=str(error))
+
+    @classmethod
+    def stale(cls, error: str) -> "ContextualCronOutcome":
+        return cls("stale", error=str(error))
+
+    @classmethod
+    def failure(cls, error: str) -> "ContextualCronOutcome":
+        return cls("failure", error=str(error))
+
+    @classmethod
+    def retryable(cls, error: str) -> "ContextualCronOutcome":
+        return cls("retryable", error=str(error))
+
+    @classmethod
+    def unknown(cls, error: str) -> "ContextualCronOutcome":
+        return cls("unknown", error=str(error))
+
+    def to_dict(self) -> Dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+@dataclass
+class ContextualCronQueueItem:
+    job_id: str
+    execution_id: str
+    prompt: str
+    session_key: str
+    admitted_session_id: str
+    source: Any
+    future: asyncio.Future
+    admitted_routing_revision: int = 0
+    turn_lease_token: Any = None
+    adapter: Any = None
+    adapter_guard: Any = None
+    transcript_session_id: Optional[str] = None
+    transcript_entries: Optional[list[Dict[str, Any]]] = None
+    transcript_base_message_count: Optional[int] = None
+    transcript_base_revision: Optional[int] = None
+    last_prompt_tokens: Optional[int] = None
+
+
+class ContextualCronGateway:
+    """Dedicated per-session FIFO owned by one live :class:`GatewayRunner`."""
+
+    def __init__(
+        self,
+        runner: Any,
+        *,
+        seal_admission: Optional[Callable[..., bool]] = None,
+        finish_admission: Optional[Callable[..., Any]] = None,
+        load_execution: Optional[Callable[[str], Optional[Dict[str, Any]]]] = None,
+        busy_poll_seconds: float = 0.02,
+        transcript_retry_seconds: float = 0.1,
+    ) -> None:
+        self.runner = runner
+        self._seal_admission: Callable[..., bool] = (
+            seal_admission or self._default_seal_admission
+        )
+        # Persist the typed agent result before resolving the scheduler future.
+        # The scheduler remains the sole owner of the external delivery claim.
+        self._finish_admission = finish_admission or self._default_finish_admission
+        self._load_execution = load_execution or self._default_load_execution
+        self._busy_poll_seconds = max(0.001, float(busy_poll_seconds))
+        self._transcript_retry_seconds = max(
+            0.001, float(transcript_retry_seconds)
+        )
+        self._queues: Dict[str, Deque[ContextualCronQueueItem]] = defaultdict(deque)
+        self._drainers: Dict[str, asyncio.Task] = {}
+        self._execution_futures: Dict[str, asyncio.Future] = {}
+
+    @staticmethod
+    def _default_seal_admission(
+        execution_id: str,
+        session_key: str,
+        session_id: str,
+        routing_revision: int,
+    ) -> bool:
+        from cron.executions import seal_contextual_admission
+
+        return bool(
+            seal_contextual_admission(
+                execution_id,
+                session_key=session_key,
+                admitted_session_id=session_id,
+                admitted_routing_revision=routing_revision,
+            )
+        )
+
+    def _seal_occurrence(
+        self,
+        execution_id: str,
+        session_key: str,
+        session_id: str,
+        routing_revision: int,
+    ) -> bool:
+        """Call production four-field seal while retaining old test doubles."""
+        try:
+            params = inspect.signature(self._seal_admission).parameters.values()
+            supports_revision = any(
+                p.kind is inspect.Parameter.VAR_POSITIONAL for p in params
+            ) or sum(
+                p.kind in {
+                    inspect.Parameter.POSITIONAL_ONLY,
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                }
+                for p in params
+            ) >= 4
+        except (TypeError, ValueError):
+            supports_revision = True
+        if supports_revision:
+            return bool(
+                self._seal_admission(
+                    execution_id,
+                    session_key,
+                    session_id,
+                    routing_revision,
+                )
+            )
+        return bool(
+            self._seal_admission(execution_id, session_key, session_id)
+        )
+
+    @staticmethod
+    def _default_load_execution(execution_id: str) -> Optional[Dict[str, Any]]:
+        from cron.executions import get_execution
+
+        return get_execution(execution_id)
+
+    @staticmethod
+    def _default_finish_admission(
+        execution_id: str,
+        outcome: ContextualCronOutcome,
+        item: Optional[ContextualCronQueueItem] = None,
+    ) -> Any:
+        from cron.executions import persist_contextual_agent_result
+
+        return persist_contextual_agent_result(
+            execution_id,
+            outcome=outcome.kind,
+            final_response=outcome.final_response,
+            error=outcome.error,
+            transcript_session_id=(
+                item.transcript_session_id if item is not None else None
+            ),
+            transcript_entries=(item.transcript_entries if item is not None else None),
+            transcript_base_message_count=(
+                item.transcript_base_message_count if item is not None else None
+            ),
+            transcript_base_revision=(
+                item.transcript_base_revision if item is not None else None
+            ),
+            transcript_last_prompt_tokens=(
+                item.last_prompt_tokens if item is not None else None
+            ),
+        )
+
+    def _finish_occurrence(
+        self,
+        item: ContextualCronQueueItem,
+        outcome: ContextualCronOutcome,
+    ) -> Any:
+        """Pass the private transcript outbox while retaining old test doubles."""
+        try:
+            params = inspect.signature(self._finish_admission).parameters.values()
+            supports_item = any(
+                p.kind is inspect.Parameter.VAR_POSITIONAL for p in params
+            ) or sum(
+                p.kind in {
+                    inspect.Parameter.POSITIONAL_ONLY,
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                }
+                for p in params
+            ) >= 3
+        except (TypeError, ValueError):
+            supports_item = True
+        if supports_item:
+            return self._finish_admission(item.execution_id, outcome, item)
+        return self._finish_admission(item.execution_id, outcome)
+
+    def _persisted_outcome(self, execution_id: str) -> Optional[ContextualCronOutcome]:
+        """Replay a scheduler-owned terminal result after future eviction."""
+        try:
+            record = self._load_execution(execution_id)
+        except Exception:
+            logger.exception("Failed to read contextual cron execution %s", execution_id)
+            return ContextualCronOutcome.unknown(
+                "Could not read the durable contextual cron occurrence."
+            )
+        if not record:
+            return None
+        phase = str(record.get("phase") or "")
+        has_durable_result = bool(record.get("result_json") and record.get("outcome"))
+        if record.get("status") not in {"completed", "failed", "unknown"}:
+            if has_durable_result and phase in {
+                "agent_completed",
+                "delivering",
+                "retry_wait",
+            }:
+                pass
+            # A previously sealed, non-terminal occurrence with no durable
+            # result crossed an unknown-crash boundary. Never enqueue its model
+            # side effect again.
+            elif (
+                phase == "admitted"
+                and int(record.get("retry_count") or 0) > 0
+                and not has_durable_result
+            ):
+                # Scheduler explicitly cleared a typed retryable result and
+                # re-armed this same sealed occurrence. Admission is
+                # idempotent; the concrete session/revision must still match.
+                return None
+            elif record.get("admitted_session_id") or record.get("session_key"):
+                return ContextualCronOutcome.unknown(
+                    "This contextual cron occurrence was already admitted, but "
+                    "its in-process result is unavailable."
+                )
+            else:
+                return None
+        try:
+            payload = json.loads(record.get("result_json") or "{}")
+            return ContextualCronOutcome(
+                str(payload.get("kind") or record.get("outcome") or "unknown"),
+                final_response=str(payload.get("final_response") or ""),
+                error=payload.get("error") or record.get("error"),
+            )
+        except Exception:
+            return ContextualCronOutcome.unknown(
+                str(record.get("error") or "Persisted contextual cron result is unreadable.")
+            )
+
+    def _peek_entry(self, session_key: str):
+        store = self.runner.session_store
+        peek = getattr(store, "peek_session_entry", None)
+        if callable(peek):
+            return peek(session_key)
+        # Compatibility with an older SessionStore while the additive public
+        # read helper rolls out.  This is still the live store, never SessionDB.
+        return getattr(store, "_sessions", {}).get(session_key)
+
+    def _validate_entry(
+        self,
+        session_key: str,
+        admitted_session_id: Optional[str] = None,
+        admitted_routing_revision: Optional[int] = None,
+    ):
+        entry = self._peek_entry(session_key)
+        if entry is None or not getattr(entry, "origin", None):
+            return None, ContextualCronOutcome.rejected(
+                "The target gateway session is missing; contextual cron never falls back to isolation."
+            )
+        if admitted_session_id is not None and entry.session_id != admitted_session_id:
+            return None, ContextualCronOutcome.stale(
+                "The target session was reset after this occurrence was admitted."
+            )
+        if (
+            admitted_routing_revision is not None
+            and int(getattr(entry, "routing_revision", 0))
+            != int(admitted_routing_revision)
+        ):
+            return None, ContextualCronOutcome.stale(
+                "The target session route changed after this occurrence was admitted."
+            )
+        source = entry.origin
+        key_builder = getattr(self.runner, "_session_key_for_source", None)
+        if callable(key_builder):
+            try:
+                if key_builder(source) != session_key:
+                    return None, ContextualCronOutcome.rejected(
+                        "The stored source no longer owns the target session key."
+                    )
+            except Exception:
+                return None, ContextualCronOutcome.rejected(
+                    "The target source could not be revalidated."
+                )
+        try:
+            authorized = bool(self.runner._is_user_authorized(source))
+        except Exception:
+            authorized = False
+        if not authorized:
+            return None, ContextualCronOutcome.rejected(
+                "The target session source is no longer authorized."
+            )
+        return entry, None
+
+    async def dispatch(self, job: Dict[str, Any], *, execution_id: str) -> ContextualCronOutcome:
+        """Seal and enqueue one contextual occurrence.
+
+        Repeated dispatch of the same execution id shares one future in this
+        process.  Durable terminal idempotency is enforced by the execution
+        ledger's compare-and-set update.
+        """
+        if str(job.get("session_target") or "isolated").lower() != "current":
+            return ContextualCronOutcome.rejected("Job is not a contextual cron job.")
+        session_key = str(job.get("session_key") or "").strip()
+        if not session_key:
+            return ContextualCronOutcome.rejected(
+                "Contextual cron job has no captured session key; no fallback was attempted."
+            )
+        prompt = str(job.get("prompt") or "").strip()
+        if not prompt:
+            return ContextualCronOutcome.rejected("Contextual cron job has no prompt.")
+
+        # Reserve the durable occurrence before the first suspension. Event-loop
+        # task scheduling makes setdefault linearizable here: exactly one owner
+        # performs admission, while every concurrent duplicate joins its future.
+        loop = asyncio.get_running_loop()
+        future = loop.create_future()
+        shared = self._execution_futures.setdefault(execution_id, future)
+        if shared is not future:
+            return await asyncio.shield(shared)
+
+        def finish_pre_admission(outcome: ContextualCronOutcome) -> ContextualCronOutcome:
+            if not future.done():
+                future.set_result(outcome)
+            if self._execution_futures.get(execution_id) is future:
+                self._execution_futures.pop(execution_id, None)
+            return outcome
+
+        persisted = self._persisted_outcome(execution_id)
+        if persisted is not None:
+            return finish_pre_admission(persisted)
+
+        captured_session_id = None
+        captured_routing_revision = None
+        if job.get("context_binding") is not None or int(
+            job.get("_contextual_binding_version") or 0
+        ) >= 1:
+            from cron.contextual import contextual_definition_route
+
+            try:
+                captured_session_id, captured_routing_revision = (
+                    contextual_definition_route(job)
+                )
+            except (TypeError, ValueError) as exc:
+                return finish_pre_admission(
+                    ContextualCronOutcome.rejected(str(exc))
+                )
+
+        entry, rejection = self._validate_entry(
+            session_key,
+            admitted_session_id=captured_session_id,
+            admitted_routing_revision=captured_routing_revision,
+        )
+        if rejection is not None:
+            return finish_pre_admission(rejection)
+        assert entry is not None
+
+        routing_revision = int(getattr(entry, "routing_revision", 0))
+        try:
+            linearize = getattr(
+                self.runner.session_store,
+                "seal_contextual_admission",
+                None,
+            )
+            if callable(linearize):
+                sealed_entry = await asyncio.to_thread(
+                    linearize,
+                    session_key,
+                    execution_id,
+                    self._seal_occurrence,
+                )
+                sealed = sealed_entry is not None
+                if sealed_entry is not None:
+                    entry = sealed_entry
+                    routing_revision = int(
+                        getattr(sealed_entry, "routing_revision", 0)
+                    )
+            else:
+                sealed = self._seal_occurrence(
+                    execution_id,
+                    session_key,
+                    entry.session_id,
+                    routing_revision,
+                )
+        except asyncio.CancelledError:
+            finish_pre_admission(
+                ContextualCronOutcome.unknown(
+                    "Contextual cron admission was cancelled before enqueue."
+                )
+            )
+            raise
+        except Exception as exc:
+            outcome = ContextualCronOutcome.unknown(
+                f"Could not durably seal contextual cron admission: {exc}"
+            )
+            return finish_pre_admission(outcome)
+        if not sealed:
+            outcome = ContextualCronOutcome.unknown(
+                "Contextual cron admission was already sealed or terminal."
+            )
+            return finish_pre_admission(outcome)
+
+        item = ContextualCronQueueItem(
+            job_id=str(job.get("id") or ""),
+            execution_id=str(execution_id),
+            prompt=prompt,
+            session_key=session_key,
+            admitted_session_id=entry.session_id,
+            admitted_routing_revision=routing_revision,
+            source=entry.origin,
+            future=future,
+        )
+        # Admission is durable before this append.  That ordering is the reset
+        # boundary: reset-before-admission targets the new id; reset-after is stale.
+        self._queues[session_key].append(item)
+        if session_key not in self._drainers:
+            self._drainers[session_key] = asyncio.create_task(
+                self._drain(session_key),
+                name=f"contextual-cron:{session_key}",
+            )
+        return await asyncio.shield(future)
+
+    async def _run_queued_item(
+        self, item: ContextualCronQueueItem
+    ) -> ContextualCronOutcome:
+        """Acquire adapter guard then resolved-session lease, revalidate, run."""
+        adapter_for_source = getattr(self.runner, "_adapter_for_source", None)
+        adapter = adapter_for_source(item.source) if callable(adapter_for_source) else None
+        adapter_guard = None
+        lease_registry = getattr(self.runner, "_turn_leases", None)
+        lease_token = None
+        try:
+            if adapter is not None:
+                acquire_guard = getattr(adapter, "acquire_contextual_cron_guard", None)
+                if callable(acquire_guard):
+                    pending_guard = acquire_guard(item.session_key)
+                    adapter_guard = (
+                        await pending_guard
+                        if inspect.isawaitable(pending_guard)
+                        else pending_guard
+                    )
+                    item.adapter = adapter
+                    item.adapter_guard = adapter_guard
+
+            if lease_registry is not None:
+                lease_token = await lease_registry.acquire(
+                    item.admitted_session_id,
+                    owner_key=f"contextual-cron:{item.execution_id}",
+                    generation=0,
+                )
+                if getattr(lease_token, "degraded", False):
+                    outcome = ContextualCronOutcome.retryable(
+                        "The live session turn lease timed out; the scheduled turn was not run."
+                    )
+                    await self._release_item_ownership(item)
+                    return outcome
+                item.turn_lease_token = lease_token
+            else:
+                # Lightweight providers/test doubles may lack the live registry.
+                while bool(self.runner._contextual_cron_session_busy(item.session_key)):
+                    await asyncio.sleep(self._busy_poll_seconds)
+
+            while True:
+                entry, rejection = self._validate_entry(
+                    item.session_key,
+                    admitted_session_id=item.admitted_session_id,
+                    admitted_routing_revision=item.admitted_routing_revision,
+                )
+                if rejection is not None:
+                    return rejection
+                history, transcript_revision = (
+                    await self.runner.async_session_store.load_transcript_with_fence_strict(
+                        item.admitted_session_id
+                    )
+                )
+                item.transcript_base_message_count = len(history)
+                item.transcript_base_revision = transcript_revision
+                try:
+                    outcome = await self.runner._run_contextual_cron_turn(
+                        item, entry, history
+                    )
+                except ContextualCronGuardBusy:
+                    # Real adapters block in acquire_contextual_cron_guard above.
+                    # Retain this bounded compatibility seam for older providers
+                    # and deterministic doubles without terminally dropping the
+                    # occurrence.
+                    await asyncio.sleep(self._busy_poll_seconds)
+                    continue
+                if not isinstance(outcome, ContextualCronOutcome):
+                    return ContextualCronOutcome.failure(
+                        "Gateway contextual cron executor returned an invalid outcome."
+                    )
+                return outcome
+        except BaseException:
+            await self._release_item_ownership(item)
+            raise
+
+    async def _release_item_ownership(self, item: ContextualCronQueueItem) -> None:
+        """Release the human-turn fence only after transcript application."""
+        lease_token = item.turn_lease_token
+        lease_registry = getattr(self.runner, "_turn_leases", None)
+        adapter = item.adapter
+        adapter_guard = item.adapter_guard
+        item.turn_lease_token = None
+        try:
+            if (
+                lease_token is not None
+                and lease_registry is not None
+                and not getattr(lease_token, "degraded", False)
+            ):
+                lease_registry.release(lease_token)
+        finally:
+            try:
+                if adapter is not None and adapter_guard is not None:
+                    release_guard = getattr(adapter, "release_contextual_cron_guard", None)
+                    if callable(release_guard):
+                        released = release_guard(item.session_key, adapter_guard)
+                        if inspect.isawaitable(released):
+                            release_task = asyncio.ensure_future(released)
+                            try:
+                                await asyncio.shield(release_task)
+                            except asyncio.CancelledError:
+                                await release_task
+                                raise
+            finally:
+                item.adapter_guard = None
+                item.adapter = None
+
+    async def _drain(self, session_key: str) -> None:
+        queue = self._queues[session_key]
+        try:
+            while queue:
+                item = queue[0]
+                try:
+                    outcome = await self._run_queued_item(item)
+                except (TimeoutError, ConnectionError) as exc:
+                    outcome = ContextualCronOutcome.retryable(str(exc))
+                except Exception as exc:
+                    logger.exception("Contextual cron execution failed: %s", item.execution_id)
+                    outcome = ContextualCronOutcome.failure(str(exc))
+
+                try:
+                    authorized_after_model = bool(
+                        self.runner._is_user_authorized(item.source)
+                    )
+                except Exception as auth_exc:
+                    outcome = ContextualCronOutcome.retryable(
+                        "Contextual cron authorization check failed before commit: "
+                        f"{auth_exc}"
+                    )
+                    item.transcript_entries = None
+                else:
+                    if not authorized_after_model:
+                        outcome = ContextualCronOutcome.rejected(
+                            "Contextual cron authorization was revoked before commit."
+                        )
+                        item.transcript_entries = None
+
+                try:
+                    persisted = self._finish_occurrence(item, outcome)
+                    if inspect.isawaitable(persisted):
+                        persisted = await persisted
+                    if item.transcript_entries is not None:
+                        if persisted is None:
+                            raise RuntimeError(
+                                "contextual result and transcript outbox were not persisted"
+                            )
+                        apply_transcript = getattr(
+                            self.runner, "_apply_contextual_cron_transcript", None
+                        )
+                        if not callable(apply_transcript):
+                            raise RuntimeError(
+                                "gateway cannot apply the durable contextual transcript outbox"
+                            )
+                        retry_delay = self._transcript_retry_seconds
+                        while True:
+                            try:
+                                if not self.runner._is_user_authorized(item.source):
+                                    raise ContextualCronTranscriptConflict(
+                                        "Contextual cron authorization was revoked "
+                                        "before transcript application."
+                                    )
+                                applied = apply_transcript(item)
+                                if inspect.isawaitable(applied):
+                                    await applied
+                                break
+                            except ContextualCronTranscriptConflict as conflict:
+                                from cron.executions import (
+                                    get_execution,
+                                    mark_contextual_transcript_conflict,
+                                )
+
+                                conflict_error = str(conflict)
+                                while True:
+                                    try:
+                                        marked = await asyncio.to_thread(
+                                            mark_contextual_transcript_conflict,
+                                            item.execution_id,
+                                            error=conflict_error,
+                                        )
+                                        if not marked:
+                                            record = await asyncio.to_thread(
+                                                get_execution, item.execution_id
+                                            )
+                                            if not record or record.get(
+                                                "transcript_state"
+                                            ) != "conflict":
+                                                raise RuntimeError(
+                                                    "contextual transcript conflict acknowledgement failed"
+                                                )
+                                        break
+                                    except asyncio.CancelledError:
+                                        raise
+                                    except Exception:
+                                        logger.exception(
+                                            "Contextual transcript conflict acknowledgement deferred"
+                                        )
+                                        await asyncio.sleep(retry_delay)
+                                        retry_delay = min(5.0, retry_delay * 2)
+                                outcome = ContextualCronOutcome.unknown(conflict_error)
+                                break
+                            except asyncio.CancelledError:
+                                raise
+                            except Exception:
+                                # Keep the owning turn fenced until the durable
+                                # outbox is visible. Releasing it here would let
+                                # a human turn overtake a completed hidden turn.
+                                logger.exception(
+                                    "Contextual transcript application deferred; retrying: %s",
+                                    item.execution_id,
+                                )
+                                await asyncio.sleep(retry_delay)
+                                retry_delay = min(5.0, retry_delay * 2)
+                except Exception as exc:
+                    logger.exception(
+                        "Failed to persist contextual cron result: %s",
+                        item.execution_id,
+                    )
+                    outcome = ContextualCronOutcome.unknown(
+                        f"Could not durably persist contextual cron result: {exc}"
+                    )
+
+                await self._release_item_ownership(item)
+                queue.popleft()
+                if not item.future.done():
+                    item.future.set_result(outcome)
+                self._execution_futures.pop(item.execution_id, None)
+        except asyncio.CancelledError:
+            # Cancellation is a lane-wide shutdown boundary. Resolve the active
+            # and every queued occurrence honestly, then preserve cancellation;
+            # do not swallow it and continue executing later side effects.
+            if queue:
+                release_task = asyncio.create_task(
+                    self._release_item_ownership(queue[0])
+                )
+                await asyncio.shield(release_task)
+            unknown = ContextualCronOutcome.unknown(
+                "Gateway stopped before contextual cron reached a terminal outcome."
+            )
+            while queue:
+                pending = queue.popleft()
+                if not pending.future.done():
+                    pending.future.set_result(unknown)
+                self._execution_futures.pop(pending.execution_id, None)
+            raise
+        finally:
+            self._queues.pop(session_key, None)
+            self._drainers.pop(session_key, None)
+
+    def dispatch_from_scheduler(
+        self,
+        job: Dict[str, Any],
+        *,
+        execution_id: str,
+        loop: asyncio.AbstractEventLoop,
+        timeout: Optional[float] = None,
+    ) -> ContextualCronOutcome:
+        """Thread-safe blocking bridge used by the scheduler ticker thread."""
+        future = asyncio.run_coroutine_threadsafe(
+            self.dispatch(job, execution_id=execution_id), loop
+        )
+        try:
+            return future.result(timeout=timeout)
+        except TimeoutError:
+            future.cancel()
+            return ContextualCronOutcome.unknown(
+                "Timed out waiting for the gateway contextual cron lane."
+            )

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -57,7 +57,7 @@ import threading
 import time
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, cast
 
 # Sentinel returned by _resolve_request_profile when a /p/<profile>/ prefix
 # names a profile this gateway does not serve (→ 404). Distinct from None
@@ -1280,6 +1280,7 @@ def _derive_chat_session_id(
 
 
 _CRON_AVAILABLE = False
+_cron_public_job: Optional[Callable[[dict[str, Any]], dict[str, Any]]]
 try:
     from cron.jobs import (
         list_jobs as _cron_list,
@@ -1287,6 +1288,7 @@ try:
         update_job as _cron_update,
         remove_job as _cron_remove,
         pause_job as _cron_pause,
+        public_job_record as _cron_public_job_impl,
         resume_job as _cron_resume,
         trigger_job as _cron_trigger,
     )
@@ -1294,6 +1296,7 @@ try:
         CronSchedulerRegistrationError as _CronSchedulerRegistrationError,
         create_job_with_scheduler_registration as _cron_create,
     )
+    _cron_public_job = _cron_public_job_impl
     _CRON_AVAILABLE = True
 except ImportError:
     _cron_list = None
@@ -1302,6 +1305,7 @@ except ImportError:
     _cron_update = None
     _cron_remove = None
     _cron_pause = None
+    _cron_public_job = None
     _cron_resume = None
     _cron_trigger = None
 
@@ -2888,7 +2892,7 @@ class APIServerAdapter(BasePlatformAdapter):
             else GatewayRunner._load_reasoning_config(model)
         )
 
-        agent_kwargs = {
+        agent_kwargs: Dict[str, Any] = {
             "model": model,
             **runtime_kwargs,
             **_checkpoint_agent_kwargs(user_config),
@@ -3315,8 +3319,14 @@ class APIServerAdapter(BasePlatformAdapter):
         # Offload the blocking SQLite read off the event loop (CWE/perf: the
         # API server is single-threaded aiohttp; a sync SessionDB call here
         # freezes every in-flight request, see PR discussion on event-loop
-        # blocking SQLite in the gateway surface).
-        session = await asyncio.to_thread(db.get_session, session_id)
+        # blocking SQLite in the gateway surface). The rich-row projection
+        # replaces hidden-inclusive durable counters with public visible counts.
+        rich_reader = getattr(db, "get_session_rich_row", None)
+        reader = rich_reader if callable(rich_reader) else db.get_session
+        session = cast(
+            Optional[Dict[str, Any]],
+            await asyncio.to_thread(reader, session_id),
+        )
         if not session:
             return None, web.json_response(_openai_error(f"Session not found: {session_id}", code="session_not_found"), status=404)
         return session, None
@@ -3326,7 +3336,11 @@ class APIServerAdapter(BasePlatformAdapter):
         if db is None:
             return []
         try:
-            return await asyncio.to_thread(db.get_messages_as_conversation, session_id)
+            return await asyncio.to_thread(
+                db.get_messages_as_conversation,
+                session_id,
+                include_hidden=True,
+            )
         except Exception as exc:
             logger.warning("Failed to load session history for %s: %s", session_id, exc)
             return []
@@ -3550,6 +3564,7 @@ class APIServerAdapter(BasePlatformAdapter):
         if err:
             return err
         db = await self._ensure_session_db_async()
+        assert db is not None  # _get_existing_session_or_404 already fenced this path
         resolved_id = await asyncio.to_thread(db.resolve_resume_session_id, session_id)
         raw_limit = request.query.get("limit")
         raw_offset = request.query.get("offset", "0")
@@ -3586,16 +3601,23 @@ class APIServerAdapter(BasePlatformAdapter):
             limit=limit,
             offset=offset,
             latest=latest_page,
+            include_hidden=False,
         )
+
+        public_messages = [
+            self._message_response(message)
+            for message in messages
+            if message.get("display_kind") != "hidden"
+        ]
         return web.json_response({
             "object": "list",
             "session_id": resolved_id,
-            "data": [self._message_response(m) for m in messages],
+            "data": public_messages,
             "pagination": {
                 "limit": limit,
                 "offset": offset,
                 "order": order or ("latest" if default_page else "oldest"),
-                "returned": len(messages),
+                "returned": len(public_messages),
             },
         })
 
@@ -3612,6 +3634,7 @@ class APIServerAdapter(BasePlatformAdapter):
         if err:
             return err
         db = await self._ensure_session_db_async()
+        assert db is not None  # _get_existing_session_or_404 already fenced this path
         fork_id = str(body.get("id") or body.get("session_id") or f"api_{int(time.time())}_{uuid.uuid4().hex[:8]}").strip()
         if not fork_id or re.search(r'[\r\n\x00]', fork_id):
             return web.json_response(_openai_error("Invalid session ID", code="invalid_session_id"), status=400)
@@ -3630,7 +3653,9 @@ class APIServerAdapter(BasePlatformAdapter):
             system_prompt=source.get("system_prompt"),
             parent_session_id=source_id,
         )
-        messages = await asyncio.to_thread(db.get_messages, source_id)
+        messages = await asyncio.to_thread(
+            db.get_messages, source_id, include_hidden=True
+        )
         await asyncio.to_thread(db.replace_messages, fork_id, messages)
         title = body.get("title")
         if title is None:
@@ -4126,7 +4151,11 @@ class APIServerAdapter(BasePlatformAdapter):
             try:
                 db = await self._ensure_session_db_async()
                 if db is not None:
-                    history = await asyncio.to_thread(db.get_messages_as_conversation, session_id)
+                    history = await asyncio.to_thread(
+                        db.get_messages_as_conversation,
+                        session_id,
+                        include_hidden=True,
+                    )
             except Exception as e:
                 logger.warning("Failed to load session history for %s: %s", session_id, e)
                 history = []
@@ -5553,6 +5582,22 @@ class APIServerAdapter(BasePlatformAdapter):
             )
         return None
 
+    @staticmethod
+    def _cron_job_response(job: Dict[str, Any]) -> Any:
+        """Serialize one cron job without leaking contextual authority state."""
+        assert web is not None
+        assert _cron_public_job is not None
+        return web.json_response({"job": _cron_public_job(job)})
+
+    @staticmethod
+    def _cron_jobs_response(jobs: List[Dict[str, Any]]) -> Any:
+        """Serialize cron jobs through the same fail-closed public projection."""
+        assert web is not None
+        assert _cron_public_job is not None
+        return web.json_response(
+            {"jobs": [_cron_public_job(job) for job in jobs]}
+        )
+
     def _check_job_id(self, request: "web.Request") -> tuple:
         """Validate and extract job_id. Returns (job_id, error_response)."""
         job_id = request.match_info["job_id"]
@@ -5578,7 +5623,7 @@ class APIServerAdapter(BasePlatformAdapter):
         try:
             include_disabled = request.query.get("include_disabled", "").lower() in {"true", "1"}
             jobs = _cron_list(include_disabled=include_disabled)
-            return web.json_response({"jobs": jobs})
+            return self._cron_jobs_response(jobs)
         except Exception as e:
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
 
@@ -5631,7 +5676,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 kwargs["repeat"] = repeat
 
             job = _cron_create(**kwargs)
-            return web.json_response({"job": job})
+            return self._cron_job_response(job)
         except _CronSchedulerRegistrationError as e:
             return web.json_response(e.to_dict(), status=424)
         except Exception as e:
@@ -5652,7 +5697,7 @@ class APIServerAdapter(BasePlatformAdapter):
             job = _cron_get(job_id)
             if not job:
                 return web.json_response({"error": "Job not found"}, status=404)
-            return web.json_response({"job": job})
+            return self._cron_job_response(job)
         except Exception as e:
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
 
@@ -5690,7 +5735,7 @@ class APIServerAdapter(BasePlatformAdapter):
             if not job:
                 return web.json_response({"error": "Job not found"}, status=404)
             _notify_cron_provider_jobs_changed()
-            return web.json_response({"job": job})
+            return self._cron_job_response(job)
         except Exception as e:
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
 
@@ -5730,7 +5775,7 @@ class APIServerAdapter(BasePlatformAdapter):
             if not job:
                 return web.json_response({"error": "Job not found"}, status=404)
             _notify_cron_provider_jobs_changed()
-            return web.json_response({"job": job})
+            return self._cron_job_response(job)
         except Exception as e:
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
 
@@ -5750,7 +5795,7 @@ class APIServerAdapter(BasePlatformAdapter):
             if not job:
                 return web.json_response({"error": "Job not found"}, status=404)
             _notify_cron_provider_jobs_changed()
-            return web.json_response({"job": job})
+            return self._cron_job_response(job)
         except Exception as e:
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
 
@@ -5772,7 +5817,7 @@ class APIServerAdapter(BasePlatformAdapter):
             job = _cron_trigger(job_id)
             if not job:
                 return web.json_response({"error": "Job not found"}, status=404)
-            return web.json_response({"job": job})
+            return self._cron_job_response(job)
         except Exception as e:
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3014,6 +3014,10 @@ class BasePlatformAdapter(ABC):
         self._active_sessions: Dict[str, asyncio.Event] = {}
         self._pending_messages: Dict[str, MessageEvent] = {}
         self._session_tasks: Dict[str, asyncio.Task] = {}
+        # FIFO waiters for gateway-owned contextual turns. They share the
+        # adapter's existing routing-key guard instead of creating a third lock
+        # domain beside the adapter guard and resolved-session turn lease.
+        self._contextual_cron_waiters: Dict[str, list[asyncio.Future]] = {}
         # Legacy busy_text_mode env var; when unset the runner syncs the
         # resolved value (driven by busy_input_mode) onto the adapter after
         # construction (gateway/run.py). Default to "interrupt" so a stray
@@ -5653,6 +5657,87 @@ class BasePlatformAdapter(ABC):
         if guard is not None and current_guard is not guard:
             return
         del self._active_sessions[session_key]
+        self._wake_next_contextual_cron_waiter(session_key)
+
+    def _wake_next_contextual_cron_waiter(self, session_key: str) -> None:
+        waiters = self._contextual_cron_waiters.get(session_key) or []
+        while waiters:
+            waiter = waiters.pop(0)
+            if not waiter.done():
+                waiter.set_result(None)
+                break
+        if not waiters:
+            self._contextual_cron_waiters.pop(session_key, None)
+
+    async def acquire_contextual_cron_guard(
+        self, session_key: str
+    ) -> asyncio.Event:
+        """Wait for and atomically claim the normal adapter serialization lane.
+
+        Human pending/debounced input is handed off first. The wait is
+        event-driven and cancellation-safe; no scheduler polling is involved.
+        """
+        while True:
+            await self._flush_text_debounce_now(session_key)
+            if session_key not in self._active_sessions:
+                pending = self._pending_messages.pop(session_key, None)
+                if pending is not None:
+                    if self._start_session_processing(pending, session_key):
+                        continue
+                    self._pending_messages[session_key] = pending
+                else:
+                    guard = self.claim_contextual_cron_guard(session_key)
+                    if guard is not None:
+                        return guard
+
+            waiter = asyncio.get_running_loop().create_future()
+            self._contextual_cron_waiters.setdefault(session_key, []).append(waiter)
+            # Close the check→enqueue race if the previous owner released just
+            # before this future became visible.
+            if session_key not in self._active_sessions:
+                self._wake_next_contextual_cron_waiter(session_key)
+            try:
+                await waiter
+            except asyncio.CancelledError:
+                waiters = self._contextual_cron_waiters.get(session_key) or []
+                if waiter in waiters:
+                    waiters.remove(waiter)
+                if not waiters:
+                    self._contextual_cron_waiters.pop(session_key, None)
+                raise
+
+    def claim_contextual_cron_guard(self, session_key: str) -> Optional[asyncio.Event]:
+        """Claim the adapter serialization lane for a gateway-owned cron item."""
+        if session_key in self._active_sessions:
+            return None
+        guard = asyncio.Event()
+        self._active_sessions[session_key] = guard
+        task = asyncio.current_task()
+        if task is not None:
+            self._session_tasks[session_key] = task
+        return guard
+
+    async def release_contextual_cron_guard(
+        self, session_key: str, guard: asyncio.Event
+    ) -> None:
+        """Release a cron lane and hand the oldest queued user turn to the adapter."""
+        if self._active_sessions.get(session_key) is not guard:
+            return
+        # Transfer any late debounce burst while contextual ownership is still
+        # installed, so input cannot be stranded between flush and release.
+        await self._flush_text_debounce_now(session_key)
+        if self._session_tasks.get(session_key) is asyncio.current_task():
+            self._session_tasks.pop(session_key, None)
+        pending = self._pending_messages.pop(session_key, None)
+        if pending is not None:
+            # Human input has priority. Avoid waking a cron waiter in the tiny
+            # handoff gap between deleting the old guard and installing the new.
+            self._active_sessions.pop(session_key, None)
+            if not self._start_session_processing(pending, session_key):
+                self._pending_messages[session_key] = pending
+                self._wake_next_contextual_cron_waiter(session_key)
+            return
+        self._release_session_guard(session_key, guard=guard)
 
     def _session_task_is_stale(self, session_key: str) -> bool:
         """Return True if the owner task for ``session_key`` is done/cancelled.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16774,17 +16774,64 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
 
     def _authorize_contextual_delivery_from_scheduler(self, target) -> bool:
-        """Reconstruct and reauthorize the immutable delivery principal."""
+        """Reauthorize and claim delivery under the live routing fence."""
         from gateway.session import SessionSource
 
         origin = target.get("origin") if isinstance(target, dict) else None
-        if not isinstance(origin, dict):
+        authority = (
+            target.get("_contextual_authority")
+            if isinstance(target, dict)
+            else None
+        )
+        if not isinstance(origin, dict) or not isinstance(authority, dict):
             return False
         try:
             source = SessionSource.from_dict(origin)
+            execution_id = str(authority.get("execution_id") or "").strip()
+            session_key = str(authority.get("session_key") or "").strip()
+            binding_version = int(authority.get("binding_version") or 0)
+            route_instance_id = str(
+                authority.get("route_instance_id") or ""
+            ).strip()
+            session_id = str(authority.get("session_id") or "").strip()
+            routing_revision = int(authority.get("routing_revision") or 0)
         except (KeyError, TypeError, ValueError):
             return False
-        return bool(self._is_user_authorized(source))
+        if (
+            not execution_id
+            or not session_key
+            or binding_version not in (1, 2)
+            or not session_id
+            or (binding_version == 2 and not route_instance_id)
+        ):
+            return False
+        claim_authority = getattr(
+            self.session_store, "claim_contextual_delivery_authority", None
+        )
+        if not callable(claim_authority):
+            return False
+
+        from cron.executions import claim_contextual_delivery
+
+        authorization_result = claim_authority(
+            session_key,
+            source=source,
+            binding_version=binding_version,
+            expected_route_instance_id=(route_instance_id or None),
+            expected_session_id=session_id,
+            expected_routing_revision=routing_revision,
+            authorize=lambda: bool(self._is_user_authorized(source)),
+            claim=lambda: claim_contextual_delivery(execution_id) is not None,
+        )
+        if (
+            not isinstance(authorization_result, tuple)
+            or len(authorization_result) != 2
+        ):
+            return False
+        authorized, claimed = authorization_result
+        if claimed:
+            target["_contextual_delivery_claimed"] = True
+        return bool(authorized)
 
     async def _write_or_stage_transcript_entry(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2390,6 +2390,7 @@ from gateway.session import (
     build_session_context_prompt,
     build_channel_continuity_note,
     build_session_key,
+    canonical_route_coordinates,
     is_shared_multi_user_session,
     neutralize_untrusted_inline_text,
 )
@@ -17107,6 +17108,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         lease_token = None
         session_key = str(getattr(item, "session_key", "") or "")
         session_id = str(getattr(item, "admitted_session_id", "") or "")
+        route_instance_id = str(
+            getattr(item, "admitted_route_instance_id", "") or ""
+        )
         try:
             session_store = getattr(self, "session_store", None)
             receipt_lookup = getattr(
@@ -17121,6 +17125,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             entry = peek(session_key) if callable(peek) else None
             route_current = bool(
                 entry is not None
+                and (
+                    not route_instance_id
+                    or str(getattr(entry, "route_instance_id", ""))
+                    == route_instance_id
+                )
                 and str(getattr(entry, "session_id", "")) == session_id
                 and int(getattr(entry, "routing_revision", 0))
                 == int(getattr(item, "admitted_routing_revision", 0))
@@ -17132,8 +17141,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
             if route_current:
                 adapter_for_source = getattr(self, "_adapter_for_source", None)
+                recovery_source = getattr(item, "source", None) or getattr(
+                    entry, "origin", None
+                )
                 adapter = (
-                    adapter_for_source(getattr(entry, "origin", None))
+                    adapter_for_source(recovery_source)
                     if callable(adapter_for_source)
                     else None
                 )
@@ -17180,6 +17192,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             entry = peek(session_key) if callable(peek) else None
             route_current = bool(
                 entry is not None
+                and (
+                    not route_instance_id
+                    or str(getattr(entry, "route_instance_id", ""))
+                    == route_instance_id
+                )
                 and str(getattr(entry, "session_id", "")) == session_id
                 and int(getattr(entry, "routing_revision", 0))
                 == int(getattr(item, "admitted_routing_revision", 0))
@@ -17190,7 +17207,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "Contextual transcript route changed while recovery waited for its fences."
                 )
             if receipt is None:
-                source = getattr(entry, "origin", None)
+                source = getattr(item, "source", None) or getattr(entry, "origin", None)
                 authorize = getattr(self, "_is_user_authorized", None)
                 if source is None or not callable(authorize) or not authorize(source):
                     raise ContextualCronTranscriptConflict(
@@ -17237,6 +17254,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             mark_contextual_transcript_conflict,
         )
         from cron.jobs import use_cron_store
+        from cron.contextual import validate_contextual_origin
         from gateway.contextual_cron import ContextualCronTranscriptConflict
 
         scope = use_cron_store(cron_home) if cron_home is not None else nullcontext()
@@ -17256,6 +17274,37 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         raise ContextualCronTranscriptConflict(
                             "Contextual transcript outbox payload is invalid."
                         )
+                    admitted_route_instance_id = (
+                        str(record.get("admitted_route_instance_id") or "") or None
+                    )
+                    admitted_binding_version = int(
+                        record.get("admitted_binding_version") or 1
+                    )
+                    if admitted_binding_version not in (1, 2):
+                        raise ContextualCronTranscriptConflict(
+                            "Contextual binding-version receipt is invalid."
+                        )
+                    creator_source = None
+                    raw_delivery_target = record.get("delivery_target_json")
+                    if raw_delivery_target:
+                        try:
+                            delivery_target = json.loads(raw_delivery_target)
+                            creator_origin = delivery_target.get("origin")
+                            if not isinstance(creator_origin, dict):
+                                raise TypeError("missing creator origin")
+                            creator_source = SessionSource.from_dict(
+                                validate_contextual_origin(creator_origin)
+                            )
+                        except (AttributeError, TypeError, ValueError) as exc:
+                            raise ContextualCronTranscriptConflict(
+                                "Contextual creator authority receipt is invalid."
+                            ) from exc
+                    if admitted_binding_version == 2 and (
+                        admitted_route_instance_id is None or creator_source is None
+                    ):
+                        raise ContextualCronTranscriptConflict(
+                            "Contextual v2 authority receipt is incomplete."
+                        )
                     item = SimpleNamespace(
                         job_id=str(record.get("job_id") or ""),
                         execution_id=str(record.get("id") or ""),
@@ -17266,6 +17315,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         admitted_routing_revision=int(
                             record.get("admitted_routing_revision") or 0
                         ),
+                        admitted_route_instance_id=admitted_route_instance_id,
+                        admitted_binding_version=admitted_binding_version,
+                        source=creator_source,
                         transcript_session_id=str(
                             record.get("transcript_session_id") or ""
                         ),
@@ -17408,9 +17460,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "conversation's existing context. Do not mention this wrapper.]\n\n"
             + item.prompt
         )
+        creator_source = getattr(item, "source", None) or entry.origin
         event = MessageEvent(
             text=internal_prompt,
-            source=entry.origin,
+            source=creator_source,
             internal=True,
             metadata={
                 "contextual_cron": True,
@@ -17427,7 +17480,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 ),
             },
         )
-        adapter = self._adapter_for_source(entry.origin)
+        adapter = self._adapter_for_source(creator_source)
         guard = getattr(item, "adapter_guard", None)
         guard_owned_by_lane = guard is not None
         if adapter is not None and guard is None:
@@ -17442,7 +17495,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     raise ContextualCronGuardBusy()
 
         active_lease, limit_message = self._claim_active_session_slot(
-            item.session_key, entry.origin
+            item.session_key, creator_source
         )
         if limit_message is not None:
             if adapter is not None and guard is not None and not guard_owned_by_lane:
@@ -17473,9 +17526,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 session_key=item.session_key,
                 admitted_session_id=item.admitted_session_id,
                 admitted_routing_revision=item.admitted_routing_revision,
+                admitted_route_instance_id=getattr(
+                    item, "admitted_route_instance_id", None
+                ),
+                creator_source=creator_source,
             ), suppress_lifecycle_hooks():
                 response = await self._handle_message_with_agent(
-                    event, entry.origin, item.session_key, run_generation
+                    event, creator_source, item.session_key, run_generation
                 )
         finally:
             self._restore_moa_one_shot(event, item.session_key)
@@ -17596,6 +17653,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _contextual_authority
             else None
         )
+        _admitted_route_instance_id = (
+            _contextual_authority.admitted_route_instance_id
+            if _contextual_authority
+            else None
+        )
         if _is_contextual_cron:
             if (
                 _contextual_authority.session_key != _quick_key
@@ -17608,13 +17670,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 }
                 return None
             session_entry = await self.async_session_store.peek_session_entry(_quick_key)
+            creator_source = _contextual_authority.creator_source or source
             if (
                 session_entry is None
                 or session_entry.session_id != _admitted_session_id
+                or (
+                    _admitted_route_instance_id is not None
+                    and session_entry.route_instance_id
+                    != _admitted_route_instance_id
+                )
                 or session_entry.routing_revision != _admitted_routing_revision
                 or session_entry.origin is None
                 or self._session_key_for_source(session_entry.origin) != _quick_key
-                or not self._is_user_authorized(session_entry.origin)
+                or not isinstance(creator_source, SessionSource)
+                or self._session_key_for_source(creator_source) != _quick_key
+                or not self._is_user_authorized(creator_source)
             ):
                 logger.info("contextual cron stale before turn: admitted route is no longer valid")
                 _event_metadata["contextual_cron_result"] = {
@@ -17623,7 +17693,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "error": "The target session route changed after admission.",
                 }
                 return None
-            source = session_entry.origin
+            source = creator_source
             event.source = source
         else:
             # Topic-mode DMs: rewrite a stale/foreign thread_id to the user's
@@ -17738,7 +17808,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # path (#9893). Covers daily/idle/suspended auto-reset.
             self._evict_cached_agent(session_key)
             session_entry.was_auto_reset = False
-        
+
         # Emit session:start for new or auto-reset sessions
         _is_new_session = (not _is_contextual_cron) and (
             session_entry.created_at == session_entry.updated_at
@@ -17756,13 +17826,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "session_id": session_entry.session_id,
                 "session_key": session_key,
             })
-        
+
         # Build session context
         context = build_session_context(source, self.config, session_entry)
-        
+
         # Set session context variables for tools (task-local, concurrency-safe)
         _session_env_tokens = self._set_session_env(context)
-        
+
         # Read privacy.redact_pii from config (re-read per message)
         _redact_pii = False
         persist_user_message = None
@@ -23045,6 +23115,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if (
                 _contextual_authority.session_key != context.session_key
                 or _contextual_authority.admitted_session_id != context.session_id
+                or (
+                    _contextual_authority.admitted_route_instance_id is not None
+                    and _contextual_authority.admitted_route_instance_id
+                    != context.route_instance_id
+                )
                 or _contextual_authority.admitted_routing_revision
                 != int(context.routing_revision)
             ):
@@ -23067,18 +23142,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _adapter = _adapters.get(context.source.platform)
             _async_delivery = getattr(_adapter, "supports_async_delivery", True)
             _cron_session = ""
+        (
+            canonical_chat_type,
+            canonical_chat_id,
+            canonical_thread_id,
+            canonical_parent_chat_id,
+        ) = canonical_route_coordinates(context.source)
         return set_session_vars(
             platform=context.source.platform.value,
-            chat_id=context.source.chat_id,
-            chat_type=(
-                str(context.source.chat_type) if context.source.chat_type else ""
-            ),
+            chat_id=canonical_chat_id,
+            chat_type=canonical_chat_type,
             chat_name=context.source.chat_name or "",
-            thread_id=str(context.source.thread_id) if context.source.thread_id else "",
+            thread_id=canonical_thread_id,
             user_id=str(context.source.user_id) if context.source.user_id else "",
             user_name=str(context.source.user_name) if context.source.user_name else "",
             session_key=context.session_key,
             session_id=context.session_id,
+            route_instance_id=context.route_instance_id,
+            route_principal={
+                "scope_id": str(context.source.scope_id or ""),
+                "parent_chat_id": canonical_parent_chat_id,
+                "user_id_alt": str(context.source.user_id_alt or ""),
+                "chat_id_alt": str(context.source.chat_id_alt or ""),
+            },
             routing_revision=context.routing_revision,
             message_id=str(context.source.message_id) if context.source.message_id else "",
             profile=getattr(context.source, "profile", "") or "",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16829,6 +16829,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ):
             return False
         authorized, claimed = authorization_result
+        if authorized:
+            # This was the one route-locked claim attempt.  The scheduler must
+            # not retry a lost CAS after the route lock is released because a
+            # reset/recreate can occur in that gap.
+            target["_contextual_delivery_claim_attempted"] = True
         if claimed:
             target["_contextual_delivery_claimed"] = True
         return bool(authorized)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3612,6 +3612,24 @@ def _is_gateway_hidden_reasoning_incomplete_turn(agent_result: dict) -> bool:
     return not final_response or final_response == error_text
 
 
+def _apply_contextual_transcript_visibility(
+    entry: Dict[str, Any],
+    *,
+    contextual: bool,
+    intentional_silence: bool,
+) -> Dict[str, Any]:
+    """Apply the public-display policy for one generated gateway row.
+
+    Contextual user prompts are always privileged internal input.  When the
+    typed turn outcome is intentional silence/no-action, every generated row
+    is also internal: assistant tool-call envelopes and tool results can carry
+    prompt-derived arguments or output even though no final answer is shown.
+    """
+    if contextual and (intentional_silence or entry.get("role") == "user"):
+        entry["display_kind"] = "hidden"
+    return entry
+
+
 def _should_clear_resume_pending_after_turn(agent_result: dict) -> bool:
     """Return True only when a gateway turn really completed successfully.
 
@@ -4557,6 +4575,7 @@ class TurnRunner:
                 source=ctx.source,
                 session_key=ctx.session_key,
                 user_config=ctx.user_config,
+                ignore_one_turn_override=ctx.suppress_output,
             )
             logger.debug(
                 "run_agent resolved: model=%s provider=%s session=%s",
@@ -4608,7 +4627,7 @@ class TurnRunner:
         _want_stream_deltas = _streaming_enabled
         _want_interim_messages = ctx.interim_assistant_messages_enabled
         _want_interim_consumer = _want_interim_messages
-        if _want_stream_deltas or _want_interim_consumer:
+        if not ctx.suppress_output and (_want_stream_deltas or _want_interim_consumer):
             try:
                 from gateway.stream_consumer import GatewayStreamConsumer
                 _adapter = self._runner._adapter_for_source(ctx.source)
@@ -4676,6 +4695,21 @@ class TurnRunner:
             )
 
         turn_route = self._runner._resolve_turn_agent_config(ctx.message, model, runtime_kwargs)
+        if ctx.suppress_output:
+            contextual_runtime = dict(turn_route.get("runtime") or {})
+            api_mode = str(contextual_runtime.get("api_mode") or "").strip().lower()
+            provider = str(contextual_runtime.get("provider") or "").strip().lower()
+            base_url = str(contextual_runtime.get("base_url") or "").strip().lower()
+            if (
+                api_mode == "codex_app_server"
+                or contextual_runtime.get("command")
+                or contextual_runtime.get("acp_command")
+                or provider in {"moa", "copilot-acp"}
+                or base_url.startswith(("acp://", "acp+tcp://"))
+            ):
+                raise RuntimeError(
+                    "Contextual execution requires a direct provider runtime."
+                )
 
         # Per-platform skip_context_files — messaging platforms can opt out
         # of filesystem-heavy context-file discovery (SOUL.md, AGENTS.md,
@@ -4703,8 +4737,16 @@ class TurnRunner:
         )
         agent = None
         reused_cached_agent = False
-        _cache_lock = getattr(self._runner, "_agent_cache_lock", None)
-        _cache = getattr(self._runner, "_agent_cache", None)
+        _cache_allowed = not ctx.suppress_output and bool(
+            ctx.execution_policy is None
+            or getattr(ctx.execution_policy, "use_agent_cache", True)
+        )
+        _cache_lock = (
+            getattr(self._runner, "_agent_cache_lock", None)
+            if _cache_allowed
+            else None
+        )
+        _cache = getattr(self._runner, "_agent_cache", None) if _cache_allowed else None
 
         # Peek at the cached entry's snapshot session_id (if any) so we can
         # check, OUTSIDE the cache lock, whether THAT session_id is a DEAD
@@ -4911,6 +4953,7 @@ class TurnRunner:
                 verbose_logging=False,
                 enabled_toolsets=ctx.enabled_toolsets,
                 disabled_toolsets=ctx.disabled_toolsets,
+                allowed_tool_names=ctx.allowed_tool_names,
                 ephemeral_system_prompt=combined_ephemeral or None,
                 prefill_messages=self._runner._prefill_messages or None,
                 reasoning_config=reasoning_config,
@@ -4932,8 +4975,15 @@ class TurnRunner:
                 chat_type=ctx.source.chat_type,
                 thread_id=ctx.source.thread_id,
                 gateway_session_key=ctx.session_key,
-                session_db=getattr(self._runner._session_db, "_db", self._runner._session_db),
-                # Reload from disk — do not reuse the startup snapshot (#60955).
+                session_db=(
+                    None
+                    if ctx.suppress_output
+                    else getattr(self._runner._session_db, "_db", self._runner._session_db)
+                ),
+                skip_memory=bool(ctx.suppress_output),
+                contextual_execution=bool(ctx.suppress_output),
+                # Always refresh the ordinary gateway chain at construction.
+                # create_agent() centrally discards it for contextual turns.
                 fallback_model=self._runner._refresh_fallback_model(),
                 skip_context_files=skip_context_files,
                 # Keep the persona even with minimal context: soul identity is
@@ -4963,7 +5013,7 @@ class TurnRunner:
         # who set thinking_progress:true but kept tool_progress:off got a
         # None callback — so _thinking scratch bubbles never relayed even
         # though the progress queue was created for them.
-        agent.tool_progress_callback = (
+        agent.tool_progress_callback = (None if ctx.suppress_output else (
             ctx.progress_callback
             if (
                 ctx.needs_progress_queue
@@ -4971,16 +5021,22 @@ class TurnRunner:
                 or ctx._live_status_adapter is not None
             )
             else None
-        )
+        ))
         # Discord voice verbal-ack hook (fires once per turn on first tool
         # call; armed only when in a voice channel with the mixer running).
-        agent.tool_start_callback = (
+        agent.tool_start_callback = (None if ctx.suppress_output else (
             ctx.voice_ack_callback if ctx._voice_ack_guild[0] is not None else None
+        ))
+        agent.step_callback = (
+            ctx._step_callback_sync
+            if not ctx.suppress_output and ctx._hooks_ref.loaded_hooks
+            else None
         )
-        agent.step_callback = ctx._step_callback_sync if ctx._hooks_ref.loaded_hooks else None
-        agent.stream_delta_callback = _stream_delta_cb
-        agent.interim_assistant_callback = _interim_assistant_cb if _want_interim_messages else None
-        agent.status_callback = ctx._status_callback_sync
+        agent.stream_delta_callback = (None if ctx.suppress_output else _stream_delta_cb)
+        agent.interim_assistant_callback = (None if ctx.suppress_output else (
+            _interim_assistant_cb if _want_interim_messages else None
+        ))
+        agent.status_callback = (None if ctx.suppress_output else ctx._status_callback_sync)
         # Credits / out-of-band notices (usage bands, depletion, restored).
         # Messaging has no persistent status bar, so each notice is a
         # standalone push: render to a single plaintext line and deliver via
@@ -5010,9 +5066,9 @@ class TurnRunner:
                 log_message="notice_callback delivery scheduling error",
             )
 
-        agent.notice_callback = _notice_callback_sync
+        agent.notice_callback = None if ctx.suppress_output else _notice_callback_sync
         agent.notice_clear_callback = None
-        agent.event_callback = ctx._event_callback_sync
+        agent.event_callback = None if ctx.suppress_output else ctx._event_callback_sync
         agent.reasoning_config = reasoning_config
         agent.service_tier = self._runner._service_tier
         agent.request_overrides = turn_route.get("request_overrides") or {}
@@ -5021,8 +5077,12 @@ class TurnRunner:
         # _handle_message_with_agent (auto-reset note, first-contact
         # intro, voice-channel change).  Assigned unconditionally so a
         # reused cached agent never replays a stale note.
-        agent._gateway_turn_context_notes = "\n\n".join(
-            self._runner._consume_pending_turn_sidecar_notes(ctx.session_key)
+        agent._gateway_turn_context_notes = (
+            ""
+            if ctx.suppress_output
+            else "\n\n".join(
+                self._runner._consume_pending_turn_sidecar_notes(ctx.session_key)
+            )
         )
 
         _bg_review_release = threading.Event()
@@ -5062,10 +5122,10 @@ class TurnRunner:
                         return
             _deliver_bg_review_message(message)
 
-        agent.background_review_callback = _bg_review_send
+        agent.background_review_callback = None if ctx.suppress_output else _bg_review_send
         # Register the release hook on the adapter so base.py's finally
         # block can fire it after delivering the main response.
-        if ctx._status_adapter and ctx.session_key:
+        if not ctx.suppress_output and ctx._status_adapter and ctx.session_key:
             if getattr(type(ctx._status_adapter), "register_post_delivery_callback", None) is not None:
                 ctx._status_adapter.register_post_delivery_callback(
                     ctx.session_key,
@@ -5178,12 +5238,12 @@ class TurnRunner:
                 return f"[user did not respond within {int(timeout / 60)}m]"
             return response
 
-        agent.clarify_callback = _clarify_callback_sync
+        agent.clarify_callback = None if ctx.suppress_output else _clarify_callback_sync
 
         # Show assistant thinking between tool calls — independent of
         # tool_progress mode. Mattermost needs an explicit per-platform
         # opt-in so global scratch-text display does not leak into threads.
-        agent.thinking_progress = ctx._thinking_enabled
+        agent.thinking_progress = False if ctx.suppress_output else ctx._thinking_enabled
         # Store agent reference for interrupt support
         ctx.agent_holder[0] = agent
         # Wire the platform thread-rename lane onto the agent, because the
@@ -5361,7 +5421,11 @@ class TurnRunner:
 
         # Prepend pending model switch note so the model knows about the switch
         _pending_notes = getattr(self._runner, '_pending_model_notes', {})
-        _msn = _pending_notes.pop(ctx.session_key, None) if ctx.session_key else None
+        _msn = (
+            _pending_notes.pop(ctx.session_key, None)
+            if ctx.session_key and not ctx.suppress_output
+            else None
+        )
         if _msn:
             ctx.message = _msn + "\n\n" + ctx.message
 
@@ -5394,7 +5458,7 @@ class TurnRunner:
         )
 
         _resume_entry = None
-        if ctx.session_key:
+        if ctx.session_key and not ctx.suppress_output:
             try:
                 _resume_entry = self._runner.session_store._entries.get(ctx.session_key)
             except Exception:
@@ -5430,7 +5494,7 @@ class TurnRunner:
             and _interruption_is_fresh
         )
 
-        if _is_resume_pending:
+        if _is_resume_pending and not ctx.suppress_output:
             _reason = getattr(_resume_entry, "resume_reason", None) or "restart_timeout"
             _persist_user_message_override = ctx.message
             # The empty-message case is the auto-resume startup turn
@@ -5448,7 +5512,7 @@ class TurnRunner:
             ctx.message = build_resume_recovery_note(
                 _reason, ctx.message, interactive=_interactive_resume,
             )
-        elif _has_fresh_tool_tail:
+        elif _has_fresh_tool_tail and not ctx.suppress_output:
             _persist_user_message_override = ctx.message
             ctx.message = (
                 "[System note: A new message has arrived. The conversation "
@@ -5464,7 +5528,12 @@ class TurnRunner:
         # clear. Nothing was written to the transcript out-of-band, so
         # message alternation stays intact.
         _pending_notes = getattr(self._runner, "_pending_skills_reload_notes", None)
-        if _pending_notes and ctx.session_key and ctx.session_key in _pending_notes:
+        if (
+            not ctx.suppress_output
+            and _pending_notes
+            and ctx.session_key
+            and ctx.session_key in _pending_notes
+        ):
             _srn = _pending_notes.pop(ctx.session_key, None)
             if _srn:
                 ctx.message = _srn + "\n\n" + ctx.message
@@ -5498,13 +5567,18 @@ class TurnRunner:
 
         _approval_session_key = ctx.session_key or ""
         _approval_session_token = set_current_session_key(_approval_session_key)
-        register_gateway_notify(_approval_session_key, _approval_notify_sync)
+        if not ctx.suppress_output:
+            register_gateway_notify(_approval_session_key, _approval_notify_sync)
         try:
             # If _prepare_inbound_message_text buffered image paths for native
             # attachment, wrap the user turn as an OpenAI-style multimodal
             # content list. Consume-and-clear so subsequent turns on the same
             # runner instance don't re-attach stale images.
-            _native_imgs = self._runner._consume_pending_native_image_paths(ctx.session_key)
+            _native_imgs = (
+                []
+                if ctx.suppress_output
+                else self._runner._consume_pending_native_image_paths(ctx.session_key)
+            )
             if _native_imgs:
                 try:
                     from agent.image_routing import build_native_content_parts
@@ -5547,17 +5621,21 @@ class TurnRunner:
                 _conversation_kwargs["moa_config"] = ctx.moa_config
             if _persist_user_timestamp_override is not None:
                 _conversation_kwargs["persist_user_timestamp"] = _persist_user_timestamp_override
+            if ctx.persist_user_display_kind is not None:
+                _conversation_kwargs["persist_user_display_kind"] = ctx.persist_user_display_kind
             result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
         finally:
-            unregister_gateway_notify(_approval_session_key)
-            # Cancel any pending clarify entries so blocked agent
-            # threads don't hang past the end of the run (interrupt,
-            # completion, gateway shutdown).  Idempotent.
-            try:
-                from tools.clarify_gateway import clear_session as _clear_clarify_session
-                _clear_clarify_session(_approval_session_key)
-            except Exception:
-                pass
+            if not ctx.suppress_output:
+                unregister_gateway_notify(_approval_session_key)
+            # Cancel only clarify entries owned by an interactive run. A
+            # contextual turn cannot register clarify and must not consume
+            # pending human-turn state left on the same stable session key.
+            if not ctx.suppress_output:
+                try:
+                    from tools.clarify_gateway import clear_session as _clear_clarify_session
+                    _clear_clarify_session(_approval_session_key)
+                except Exception:
+                    pass
             reset_current_session_key(_approval_session_token)
         ctx.result_holder[0] = result
 
@@ -5600,80 +5678,23 @@ class TurnRunner:
         _compacted_in_place = bool(getattr(agent, "_last_compaction_in_place", False)) if agent else False
         agent_session_id = getattr(agent, 'session_id', ctx.session_id) if agent else ctx.session_id
         if agent and ctx.session_key and agent_session_id != ctx.session_id:
+            if ctx.suppress_output:
+                # Contextual admission is immutable. Never publish a compression
+                # child into the shared route; the durable outbox stays bound to
+                # the admitted physical session and this occurrence fails closed.
+                raise RuntimeError(
+                    "Contextual execution attempted to rotate its admitted session."
+                )
             _session_was_split = True
             logger.info(
                 "Session split detected: %s → %s (compression)",
                 ctx.session_id, agent_session_id,
             )
-            entry = self._runner.session_store._entries.get(ctx.session_key)
-            _session_split_entry_persisted = False
-            if entry:
-                entry_session_id = getattr(entry, "session_id", None)
-                if not ctx._run_still_current():
-                    logger.info(
-                        "Skipping session split sync for stale run %s — "
-                        "generation %s is no longer current",
-                        ctx.session_key or "?",
-                        ctx.run_generation,
-                    )
-                elif entry_session_id == agent_session_id:
-                    _session_split_entry_persisted = True
-                elif entry_session_id != ctx.session_id:
-                    logger.info(
-                        "Skipping session split sync for %s because the "
-                        "session binding moved from %s to %s before "
-                        "compression finished",
-                        ctx.session_key or "?",
-                        ctx.session_id,
-                        entry_session_id,
-                    )
-                else:
-                    entry.session_id = agent_session_id
-                    self._runner.session_store._save()
-                    self._runner.session_store._record_gateway_session_peer(
-                        agent_session_id,
-                        ctx.session_key,
-                        ctx.source,
-                    )
-                    _session_split_entry_persisted = True
-
-            # If this is a Telegram DM and source.thread_id was lost during
-            # the session split (synthetic / recovered event), restore it
-            # from the binding so _thread_metadata_for_source produces the
-            # correct message_thread_id instead of routing to the General
-            # thread.  Failure here is non-fatal — we log and continue;
-            # worst case the message lands in General, which is the
-            # pre-fix behaviour. Only do this after this run successfully
-            # published its session split; a stale /stop→/new predecessor
-            # must not mutate routing/binding state for the fresh session.
-            if _session_split_entry_persisted and (
-                getattr(ctx.source, "platform", None) == Platform.TELEGRAM
-                and getattr(ctx.source, "chat_type", None) == "dm"
-                and getattr(ctx.source, "thread_id", None) is None
-                and self._runner._session_db is not None
-            ):
-                try:
-                    # run_sync is off-loop (executor); sync DB is fine.
-                    _binding = self._runner._session_db._db.get_telegram_topic_binding_by_session(
-                        session_id=agent_session_id,
-                    )
-                    if _binding and _binding.get("thread_id"):
-                        ctx.source.thread_id = str(_binding["thread_id"])
-                        logger.debug(
-                            "Restored source.thread_id=%s from binding after session split %s → %s",
-                            ctx.source.thread_id,
-                            ctx.session_id,
-                            agent_session_id,
-                        )
-                except Exception:
-                    logger.debug(
-                        "Failed to restore thread_id from binding after session split",
-                        exc_info=True,
-                    )
-            if _session_split_entry_persisted:
-                self._runner._sync_telegram_topic_binding(
-                    ctx.source, entry, reason="agent-run-compression",
-                )
+            # Do not mutate the shared route from this executor thread. The event
+            # loop publishes ``agent_session_id`` only through
+            # ``_publish_gateway_compression_route()``, which atomically couples
+            # the SessionStore CAS, routing-revision increment, and turn-lease
+            # rebind before any topic binding is updated.
 
         effective_session_id = agent_session_id
         self._runner._sync_session_model_from_agent(effective_session_id, agent)
@@ -5808,6 +5829,18 @@ class TurnRunner:
             "agent_persisted": (ctx.result_holder[0].get("agent_persisted", True) if ctx.result_holder[0] else True),
         }
 
+
+
+def _ensure_contextual_user_delta(
+    messages: List[Dict[str, Any]], *, content: str, timestamp: Any
+) -> List[Dict[str, Any]]:
+    """Preserve the scheduled user turn when agent-side DB persistence is fenced."""
+    if any(str(item.get("role") or "").lower() == "user" for item in messages):
+        return messages
+    return [
+        {"role": "user", "content": content, "timestamp": timestamp},
+        *messages,
+    ]
 
 
 class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
@@ -5986,6 +6019,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Sync helpers keep using ``session_store`` directly; async gateway
         # handlers call this facade and await every operation.
         self._async_session_store = AsyncSessionStore(self.session_store)
+        from gateway.contextual_cron import ContextualCronGateway
+        self.contextual_cron = ContextualCronGateway(self)
         self.delivery_router = DeliveryRouter(self.config)
         self._running = False
         self._gateway_loop: Optional[asyncio.AbstractEventLoop] = None
@@ -6990,14 +7025,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         source: Optional[SessionSource] = None,
         session_key: Optional[str] = None,
         user_config: Optional[dict] = None,
+        ignore_one_turn_override: bool = False,
     ) -> tuple[str, dict]:
         """Resolve model/runtime for a session.
 
         Priority (highest first): session ``/model`` → ``channel_overrides`` →
         global config/env (``_resolve_gateway_model(user_config)`` and default
-        provider resolution).
+        provider resolution). Contextual turns use the pre-``--once`` runtime.
         """
         resolved_session_key = session_key
+        if not ignore_one_turn_override:
+            try:
+                from gateway.session_context import _get_contextual_turn_authority
+
+                ignore_one_turn_override = _get_contextual_turn_authority() is not None
+            except Exception:
+                ignore_one_turn_override = False
         if not resolved_session_key and source is not None:
             try:
                 resolved_session_key = self._session_key_for_source(source)
@@ -7012,9 +7055,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if resolved_session_key
             else None
         )
-        override = (
-            _override_state.conversation.model_override if _override_state else None
-        )
+        override = _override_state.conversation.model_override if _override_state else None
+        if ignore_one_turn_override and _override_state is not None:
+            _restore = _override_state.conversation.one_turn_restore
+            if _restore:
+                override = (
+                    _restore.get("override")
+                    if _restore.get("had_override")
+                    else None
+                )
         if override:
             override_model = override.get("model", model)
             override_runtime = {
@@ -11638,9 +11687,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # in the ledger — redelivering it (and clearing resume_pending for
         # that session) is strictly cheaper and more correct than re-running
         # the whole turn.
-        await self._redeliver_pending_obligations()
-        self._schedule_resume_pending_sessions()
-        await self._finish_startup_restore()
+        # Contextual transcript rows are per-profile execution-ledger outboxes.
+        # Keep every startup resume/redelivery fence closed until all served
+        # profile homes have recovered; the periodic watcher retries this gate.
+        self._contextual_startup_recovery_pending = not (
+            await self._release_startup_restore_after_contextual_recovery()
+        )
+        if self._contextual_startup_recovery_pending:
+            logger.error(
+                "Startup redelivery and resume remain fenced until every served "
+                "profile's contextual transcript outbox recovers"
+            )
 
         # Drain any recovered process watchers (from crash recovery checkpoint)
         try:
@@ -11664,6 +11721,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     await asyncio.sleep(0)
         except Exception as e:
             logger.error("Recovered watcher setup error: %s", e)
+
+        # Retry contextual execution-ledger transcript outboxes independently
+        # of the selected cron trigger provider. This covers secondary profiles
+        # and transient startup failures without waiting for another restart.
+        self._spawn_supervised(
+            self._contextual_transcript_recovery_watcher,
+            "contextual_transcript_recovery_watcher",
+        )
 
         # Start background session expiry watcher to finalize expired sessions
         self._spawn_supervised(self._session_expiry_watcher, "session_expiry_watcher")
@@ -16619,6 +16684,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._async_session_store = facade
         return facade
 
+
     async def _mark_durable_active_turn(
         self,
         event: "MessageEvent",
@@ -16685,6 +16751,796 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 except AttributeError:
                     pass
 
+    def _contextual_cron_session_busy(self, session_key: str) -> bool:
+        state = self._peek_session_state(session_key)
+        if state is not None and state.turn.agent is not None:
+            return True
+        entry = self.session_store.peek_session_entry(session_key)
+        adapter = self._adapter_for_source(entry.origin) if entry and entry.origin else None
+        return bool(adapter and session_key in getattr(adapter, "_active_sessions", {}))
+
+    def _dispatch_contextual_cron_from_scheduler(self, job, *, execution_id):
+        loop = self._gateway_loop
+        if loop is None or loop.is_closed():
+            from gateway.contextual_cron import ContextualCronOutcome
+            return ContextualCronOutcome.rejected(
+                "The live gateway event loop is unavailable; no fallback was attempted."
+            )
+        return self.contextual_cron.dispatch_from_scheduler(
+            job,
+            execution_id=execution_id,
+            loop=loop,
+        )
+
+    def _authorize_contextual_delivery_from_scheduler(self, target) -> bool:
+        """Reconstruct and reauthorize the immutable delivery principal."""
+        from gateway.session import SessionSource
+
+        origin = target.get("origin") if isinstance(target, dict) else None
+        if not isinstance(origin, dict):
+            return False
+        try:
+            source = SessionSource.from_dict(origin)
+        except (KeyError, TypeError, ValueError):
+            return False
+        return bool(self._is_user_authorized(source))
+
+    async def _write_or_stage_transcript_entry(
+        self,
+        event,
+        session_id: str,
+        entry: Dict[str, Any],
+        *,
+        skip_db: bool,
+        contextual_execution_id: Optional[str],
+    ) -> None:
+        """Stage contextual rows in the execution outbox; write ordinary rows now."""
+        if contextual_execution_id:
+            metadata = getattr(event, "metadata", None)
+            if not isinstance(metadata, dict):
+                raise RuntimeError("contextual event metadata is unavailable")
+            staged_session = metadata.get("contextual_cron_transcript_session_id")
+            if staged_session is not None and staged_session != session_id:
+                raise RuntimeError("contextual transcript session changed while staging")
+            staged = metadata.setdefault("contextual_cron_transcript_entries", [])
+            if not isinstance(staged, list):
+                raise RuntimeError("contextual transcript staging state is invalid")
+            durable_entry = dict(entry)
+            durable_entry["message_id"] = (
+                f"contextual-cron:{contextual_execution_id}:{len(staged)}"
+            )
+            metadata["contextual_cron_transcript_session_id"] = session_id
+            staged.append(durable_entry)
+            return
+        store = getattr(self, "_async_session_store", None)
+        if store is None:
+            store = self.async_session_store
+        await store.append_to_transcript(session_id, entry, skip_db=skip_db)
+
+    @staticmethod
+    def _contextual_transcript_applied_prefix(item, history) -> int:
+        """Prove the outbox is the exact tail after its immutable causal base."""
+        from gateway.contextual_cron import ContextualCronTranscriptConflict
+
+        entries = getattr(item, "transcript_entries", None)
+        base_count = getattr(item, "transcript_base_message_count", None)
+        if not isinstance(entries, list):
+            raise ContextualCronTranscriptConflict(
+                "Contextual transcript outbox entries are invalid."
+            )
+        if (
+            not isinstance(base_count, int)
+            or isinstance(base_count, bool)
+            or base_count < 0
+        ):
+            raise ContextualCronTranscriptConflict(
+                "Contextual transcript has no valid durable causal base."
+            )
+        if not isinstance(history, list):
+            raise RuntimeError("session transcript lookup returned an invalid value")
+        expected_ids = [
+            f"contextual-cron:{item.execution_id}:{index}"
+            for index in range(len(entries))
+        ]
+        for index, raw_entry in enumerate(entries):
+            if not isinstance(raw_entry, dict):
+                raise ContextualCronTranscriptConflict(
+                    "Contextual transcript outbox entry is invalid."
+                )
+            if str(raw_entry.get("message_id") or "") != expected_ids[index]:
+                raise ContextualCronTranscriptConflict(
+                    "Contextual transcript outbox identity is invalid."
+                )
+        if len(history) < base_count:
+            raise ContextualCronTranscriptConflict(
+                "Contextual transcript was rewritten before outbox recovery."
+            )
+        base_ids = {
+            str(row.get("message_id") or row.get("platform_message_id") or "")
+            for row in history[:base_count]
+            if isinstance(row, dict)
+        }
+        if any(message_id in base_ids for message_id in expected_ids):
+            raise ContextualCronTranscriptConflict(
+                "Contextual transcript outbox identity predates its causal base."
+            )
+        tail = history[base_count:]
+        if len(tail) > len(expected_ids):
+            raise ContextualCronTranscriptConflict(
+                "Contextual transcript advanced before the pending outbox was applied."
+            )
+        for index, row in enumerate(tail):
+            actual_id = (
+                str(row.get("message_id") or row.get("platform_message_id") or "")
+                if isinstance(row, dict)
+                else ""
+            )
+            if actual_id != expected_ids[index]:
+                raise ContextualCronTranscriptConflict(
+                    "Contextual transcript advanced before the pending outbox was applied."
+                )
+        return len(tail)
+
+    def _apply_contextual_cron_transcript_sync(self, store, item) -> None:
+        """Apply one outbox under the profile's fail-closed process/file lock."""
+        from cron.executions import (
+            get_execution,
+            mark_contextual_transcript_applied,
+        )
+        from cron.jobs import contextual_transcript_lock
+
+        session_id = str(getattr(item, "transcript_session_id", "") or "").strip()
+        if not session_id or session_id != str(item.admitted_session_id):
+            from gateway.contextual_cron import ContextualCronTranscriptConflict
+
+            raise ContextualCronTranscriptConflict(
+                "Contextual transcript outbox session binding is invalid."
+            )
+        entries = getattr(item, "transcript_entries", None)
+        if not isinstance(entries, list):
+            from gateway.contextual_cron import ContextualCronTranscriptConflict
+
+            raise ContextualCronTranscriptConflict(
+                "Contextual transcript outbox entries are invalid."
+            )
+
+        with contextual_transcript_lock():
+            atomic_apply = getattr(store, "apply_contextual_transcript_outbox", None)
+            if callable(atomic_apply):
+                from hermes_state import ContextualTranscriptCASMismatch
+
+                base_revision = getattr(item, "transcript_base_revision", None)
+                if (
+                    not isinstance(base_revision, int)
+                    or isinstance(base_revision, bool)
+                    or base_revision < 0
+                ):
+                    from gateway.contextual_cron import ContextualCronTranscriptConflict
+
+                    raise ContextualCronTranscriptConflict(
+                        "Contextual transcript has no valid durable revision."
+                    )
+                try:
+                    application = atomic_apply(
+                        execution_id=item.execution_id,
+                        session_id=session_id,
+                        entries=entries,
+                        base_count=item.transcript_base_message_count,
+                        base_revision=base_revision,
+                        last_prompt_tokens=getattr(item, "last_prompt_tokens", None),
+                    )
+                except ContextualTranscriptCASMismatch as exc:
+                    from gateway.contextual_cron import ContextualCronTranscriptConflict
+
+                    raise ContextualCronTranscriptConflict(str(exc)) from exc
+
+                last_prompt_tokens = getattr(item, "last_prompt_tokens", None)
+                route_current = bool(
+                    getattr(item, "contextual_route_current", True)
+                )
+                application_status = (
+                    str(application.get("status") or "")
+                    if isinstance(application, dict)
+                    else ""
+                )
+                if last_prompt_tokens is not None and (
+                    application_status == "applied" or route_current
+                ):
+                    store.update_session(
+                        item.session_key,
+                        last_prompt_tokens=int(last_prompt_tokens),
+                        touch_activity=False,
+                    )
+                marked = mark_contextual_transcript_applied(item.execution_id)
+                if not marked:
+                    record = get_execution(item.execution_id)
+                    if not record or record.get("transcript_state") != "applied":
+                        raise RuntimeError(
+                            "contextual transcript outbox acknowledgement failed"
+                        )
+                return
+
+            # Compatibility fallback for non-production stores. Production uses
+            # one state.db transaction plus a durable application receipt above.
+            history = store.load_transcript_strict(session_id)
+            applied_prefix = self._contextual_transcript_applied_prefix(
+                item, history
+            )
+            for index, raw_entry in enumerate(entries):
+                if not isinstance(raw_entry, dict):
+                    raise RuntimeError("contextual transcript outbox entry is invalid")
+                entry = dict(raw_entry)
+                expected_id = f"contextual-cron:{item.execution_id}:{index}"
+                if str(entry.get("message_id") or "") != expected_id:
+                    raise RuntimeError("contextual transcript outbox identity is invalid")
+                if index >= applied_prefix:
+                    store.append_contextual_transcript_message_once(session_id, entry)
+                    if not store.has_platform_message_id_strict(session_id, expected_id):
+                        raise RuntimeError(
+                            "contextual transcript row was not durably persisted"
+                        )
+
+            final_history = store.load_transcript_strict(session_id)
+            if self._contextual_transcript_applied_prefix(item, final_history) != len(
+                entries
+            ):
+                raise RuntimeError("contextual transcript turn was not fully persisted")
+
+            last_prompt_tokens = getattr(item, "last_prompt_tokens", None)
+            if last_prompt_tokens is not None:
+                store.update_session(
+                    item.session_key,
+                    last_prompt_tokens=int(last_prompt_tokens),
+                    touch_activity=False,
+                )
+            marked = mark_contextual_transcript_applied(item.execution_id)
+            if not marked:
+                record = get_execution(item.execution_id)
+                if not record or record.get("transcript_state") != "applied":
+                    raise RuntimeError(
+                        "contextual transcript outbox acknowledgement failed"
+                    )
+
+    async def _apply_contextual_cron_transcript_async_fake(self, store, item) -> None:
+        """Async-store fallback used by tests and nonstandard store facades."""
+        from cron.executions import (
+            get_execution,
+            mark_contextual_transcript_applied,
+        )
+
+        session_id = str(getattr(item, "transcript_session_id", "") or "").strip()
+        if not session_id or session_id != str(item.admitted_session_id):
+            from gateway.contextual_cron import ContextualCronTranscriptConflict
+
+            raise ContextualCronTranscriptConflict(
+                "Contextual transcript outbox session binding is invalid."
+            )
+        entries = getattr(item, "transcript_entries", None)
+        if not isinstance(entries, list):
+            from gateway.contextual_cron import ContextualCronTranscriptConflict
+
+            raise ContextualCronTranscriptConflict(
+                "Contextual transcript outbox entries are invalid."
+            )
+        strict_lookup = getattr(store, "has_platform_message_id_strict", None)
+        lookup = strict_lookup if callable(strict_lookup) else getattr(
+            store, "has_platform_message_id", None
+        )
+        if not callable(lookup):
+            raise RuntimeError("session store cannot verify transcript identities")
+        strict_load = getattr(store, "load_transcript_strict", None)
+        if not callable(strict_load):
+            raise RuntimeError("session store cannot verify transcript causal position")
+        history = strict_load(session_id)
+        if inspect.isawaitable(history):
+            history = await history
+        applied_prefix = self._contextual_transcript_applied_prefix(item, history)
+
+        for index, raw_entry in enumerate(entries):
+            if not isinstance(raw_entry, dict):
+                raise RuntimeError("contextual transcript outbox entry is invalid")
+            entry = dict(raw_entry)
+            expected_id = f"contextual-cron:{item.execution_id}:{index}"
+            if str(entry.get("message_id") or "") != expected_id:
+                raise RuntimeError("contextual transcript outbox identity is invalid")
+            if index >= applied_prefix:
+                await store.append_to_transcript(session_id, entry, skip_db=False)
+                if not await lookup(session_id, expected_id):
+                    raise RuntimeError(
+                        "contextual transcript row was not durably persisted"
+                    )
+
+        final_history = strict_load(session_id)
+        if inspect.isawaitable(final_history):
+            final_history = await final_history
+        if self._contextual_transcript_applied_prefix(item, final_history) != len(entries):
+            raise RuntimeError("contextual transcript turn was not fully persisted")
+
+        last_prompt_tokens = getattr(item, "last_prompt_tokens", None)
+        if last_prompt_tokens is not None:
+            await store.update_session(
+                item.session_key,
+                last_prompt_tokens=int(last_prompt_tokens),
+                touch_activity=False,
+            )
+        marked = await asyncio.to_thread(
+            mark_contextual_transcript_applied, item.execution_id
+        )
+        if not marked:
+            record = await asyncio.to_thread(get_execution, item.execution_id)
+            if not record or record.get("transcript_state") != "applied":
+                raise RuntimeError("contextual transcript outbox acknowledgement failed")
+
+    async def _apply_contextual_cron_transcript(self, item) -> None:
+        """Idempotently apply one already-durable contextual transcript outbox."""
+        store = getattr(self, "_async_session_store", None)
+        if store is None:
+            store = self.async_session_store
+        sync_store = getattr(store, "_store", None)
+        if sync_store is not None:
+            await asyncio.to_thread(
+                self._apply_contextual_cron_transcript_sync,
+                sync_store,
+                item,
+            )
+            return
+
+        # Test doubles and custom facades do not expose the synchronous backing
+        # store. Serialize those in-process so the same identity-check/append
+        # race is still closed; production additionally holds the file lock.
+        apply_lock = getattr(self, "_contextual_transcript_apply_lock", None)
+        if apply_lock is None:
+            apply_lock = asyncio.Lock()
+            self._contextual_transcript_apply_lock = apply_lock
+        async with apply_lock:
+            await self._apply_contextual_cron_transcript_async_fake(store, item)
+
+    async def _apply_contextual_cron_transcript_with_recovery_fence(self, item) -> None:
+        """Join recovery to the same adapter/turn serialization domain as humans."""
+        from gateway.contextual_cron import (
+            ContextualCronGuardBusy,
+            ContextualCronTranscriptConflict,
+        )
+
+        adapter = None
+        adapter_guard = None
+        lease_token = None
+        session_key = str(getattr(item, "session_key", "") or "")
+        session_id = str(getattr(item, "admitted_session_id", "") or "")
+        try:
+            session_store = getattr(self, "session_store", None)
+            receipt_lookup = getattr(
+                session_store, "get_contextual_transcript_application", None
+            )
+            receipt = (
+                receipt_lookup(item.execution_id)
+                if callable(receipt_lookup)
+                else None
+            )
+            peek = getattr(session_store, "peek_session_entry", None)
+            entry = peek(session_key) if callable(peek) else None
+            route_current = bool(
+                entry is not None
+                and str(getattr(entry, "session_id", "")) == session_id
+                and int(getattr(entry, "routing_revision", 0))
+                == int(getattr(item, "admitted_routing_revision", 0))
+            )
+            item.contextual_route_current = route_current
+            if receipt is None and not route_current:
+                raise ContextualCronTranscriptConflict(
+                    "Contextual transcript route changed before its outbox was applied."
+                )
+            if route_current:
+                adapter_for_source = getattr(self, "_adapter_for_source", None)
+                adapter = (
+                    adapter_for_source(getattr(entry, "origin", None))
+                    if callable(adapter_for_source)
+                    else None
+                )
+            if adapter is not None:
+                acquire_guard = getattr(adapter, "acquire_contextual_cron_guard", None)
+                if callable(acquire_guard):
+                    pending_guard = acquire_guard(session_key)
+                    adapter_guard = (
+                        await pending_guard
+                        if inspect.isawaitable(pending_guard)
+                        else pending_guard
+                    )
+                else:
+                    claim_guard = getattr(adapter, "claim_contextual_cron_guard", None)
+                    if not callable(claim_guard):
+                        raise RuntimeError(
+                            "session adapter cannot fence contextual transcript recovery"
+                        )
+                    adapter_guard = claim_guard(session_key)
+                    if adapter_guard is None:
+                        raise ContextualCronGuardBusy()
+
+            lease_registry = getattr(self, "_turn_leases", None)
+            if lease_registry is not None:
+                lease_token = await lease_registry.acquire(
+                    session_id,
+                    owner_key=f"contextual-cron-recovery:{item.execution_id}",
+                    generation=0,
+                )
+                if getattr(lease_token, "degraded", False):
+                    raise TimeoutError(
+                        "contextual transcript recovery turn lease timed out"
+                    )
+
+            # Both serialization fences are now held. Re-read the durable
+            # receipt and live route inside those fences: a reset may have won
+            # while recovery waited for either guard. A pre-existing receipt is
+            # still safe to acknowledge idempotently after a later route move.
+            receipt = (
+                receipt_lookup(item.execution_id)
+                if callable(receipt_lookup)
+                else None
+            )
+            entry = peek(session_key) if callable(peek) else None
+            route_current = bool(
+                entry is not None
+                and str(getattr(entry, "session_id", "")) == session_id
+                and int(getattr(entry, "routing_revision", 0))
+                == int(getattr(item, "admitted_routing_revision", 0))
+            )
+            item.contextual_route_current = route_current
+            if receipt is None and not route_current:
+                raise ContextualCronTranscriptConflict(
+                    "Contextual transcript route changed while recovery waited for its fences."
+                )
+            if receipt is None:
+                source = getattr(entry, "origin", None)
+                authorize = getattr(self, "_is_user_authorized", None)
+                if source is None or not callable(authorize) or not authorize(source):
+                    raise ContextualCronTranscriptConflict(
+                        "Contextual cron authorization was revoked before "
+                        "transcript recovery."
+                    )
+            await self._apply_contextual_cron_transcript(item)
+        finally:
+            if lease_token is not None:
+                lease_registry = getattr(self, "_turn_leases", None)
+                if (
+                    lease_registry is not None
+                    and not getattr(lease_token, "degraded", False)
+                ):
+                    lease_registry.release(lease_token)
+            if adapter is not None and adapter_guard is not None:
+                release_guard = getattr(adapter, "release_contextual_cron_guard", None)
+                if callable(release_guard):
+                    released = release_guard(session_key, adapter_guard)
+                    if inspect.isawaitable(released):
+                        await released
+
+    def _recover_contextual_cron_transcripts_from_scheduler(self) -> int:
+        """Bridge the profile-scoped ticker thread into the gateway event loop."""
+        from hermes_constants import get_hermes_home
+
+        loop = self._gateway_loop
+        if loop is None or loop.is_closed():
+            raise RuntimeError("gateway loop is unavailable for transcript recovery")
+        profile_home = get_hermes_home()
+        future = asyncio.run_coroutine_threadsafe(
+            self._recover_contextual_cron_transcripts(cron_home=profile_home),
+            loop,
+        )
+        return int(future.result(timeout=30.0))
+
+    async def _recover_contextual_cron_transcripts(self, *, cron_home=None) -> int:
+        """Replay durable transcript outboxes without re-running model turns."""
+        from contextlib import nullcontext
+        from types import SimpleNamespace
+
+        from cron.executions import (
+            list_pending_contextual_transcripts,
+            mark_contextual_transcript_conflict,
+        )
+        from cron.jobs import use_cron_store
+        from gateway.contextual_cron import ContextualCronTranscriptConflict
+
+        scope = use_cron_store(cron_home) if cron_home is not None else nullcontext()
+        with scope:
+            records = await asyncio.to_thread(list_pending_contextual_transcripts)
+            recovered = 0
+            deferred = 0
+            for record in records:
+                try:
+                    try:
+                        entries = json.loads(record.get("transcript_json") or "")
+                    except (TypeError, ValueError) as exc:
+                        raise ContextualCronTranscriptConflict(
+                            "Contextual transcript outbox payload is invalid."
+                        ) from exc
+                    if not isinstance(entries, list):
+                        raise ContextualCronTranscriptConflict(
+                            "Contextual transcript outbox payload is invalid."
+                        )
+                    item = SimpleNamespace(
+                        job_id=str(record.get("job_id") or ""),
+                        execution_id=str(record.get("id") or ""),
+                        session_key=str(record.get("session_key") or ""),
+                        admitted_session_id=str(
+                            record.get("admitted_session_id") or ""
+                        ),
+                        admitted_routing_revision=int(
+                            record.get("admitted_routing_revision") or 0
+                        ),
+                        transcript_session_id=str(
+                            record.get("transcript_session_id") or ""
+                        ),
+                        transcript_entries=entries,
+                        transcript_base_message_count=record.get(
+                            "transcript_base_message_count"
+                        ),
+                        transcript_base_revision=record.get(
+                            "transcript_base_revision"
+                        ),
+                        last_prompt_tokens=record.get(
+                            "transcript_last_prompt_tokens"
+                        ),
+                    )
+                    await self._apply_contextual_cron_transcript_with_recovery_fence(
+                        item
+                    )
+                    recovered += 1
+                except ContextualCronTranscriptConflict as conflict:
+                    try:
+                        await asyncio.to_thread(
+                            mark_contextual_transcript_conflict,
+                            str(record.get("id") or ""),
+                            error=str(conflict),
+                        )
+                    except Exception:
+                        deferred += 1
+                        logger.exception(
+                            "Contextual transcript conflict acknowledgement deferred"
+                        )
+                except Exception:
+                    deferred += 1
+                    logger.exception(
+                        "Contextual transcript recovery deferred"
+                    )
+            if deferred:
+                raise RuntimeError(
+                    f"{deferred} contextual transcript recovery obligation(s) "
+                    "remain deferred"
+                )
+            return recovered
+
+    def _served_contextual_cron_profile_homes(self) -> list[str]:
+        """Return each profile home served by this gateway exactly once."""
+        from hermes_constants import get_hermes_home
+
+        homes = [get_hermes_home()]
+        if getattr(self.config, "multiplex_profiles", False):
+            from hermes_cli.profiles import profiles_to_serve
+
+            homes.extend(
+                entry[1] if isinstance(entry, tuple) else entry
+                for entry in profiles_to_serve(multiplex=True)
+            )
+        resolved_homes: list[str] = []
+        seen: set[str] = set()
+        for home in homes:
+            resolved = str(Path(home).resolve())
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            resolved_homes.append(resolved)
+        return resolved_homes
+
+    async def _recover_served_contextual_cron_transcripts(self) -> bool:
+        """Recover every served profile; false keeps startup work fenced."""
+        all_recovered = True
+        try:
+            homes = self._served_contextual_cron_profile_homes()
+        except Exception:
+            logger.exception("Contextual transcript profile discovery deferred")
+            return False
+        for home in homes:
+            try:
+                recovered = await self._recover_contextual_cron_transcripts(
+                    cron_home=home
+                )
+                if recovered:
+                    logger.info(
+                        "Recovered %d contextual cron transcript outbox(es) from %s",
+                        recovered,
+                        home,
+                    )
+            except Exception:
+                all_recovered = False
+                logger.exception(
+                    "Contextual transcript recovery deferred for profile home %s",
+                    home,
+                )
+        return all_recovered
+
+    async def _release_startup_restore_after_contextual_recovery(self) -> bool:
+        """Release redelivery/resume work only after all profile outboxes recover."""
+        if not await self._recover_served_contextual_cron_transcripts():
+            return False
+        await self._redeliver_pending_obligations()
+        self._schedule_resume_pending_sessions()
+        await self._finish_startup_restore()
+        return True
+
+    async def _contextual_transcript_recovery_watcher(self) -> None:
+        """Retry every profile's durable transcript outbox independent of provider."""
+        while self._running:
+            if getattr(self, "_contextual_startup_recovery_pending", False):
+                if await self._release_startup_restore_after_contextual_recovery():
+                    self._contextual_startup_recovery_pending = False
+            else:
+                await self._recover_served_contextual_cron_transcripts()
+            await asyncio.sleep(30.0)
+
+    async def _run_contextual_cron_turn(self, item, entry, history):
+        """Execute one admitted hidden turn without the incoming-message handler."""
+        from gateway.contextual_cron import ContextualCronOutcome
+        from cron.scheduler import _is_cron_silence_response
+
+        # V1 cannot preserve the contextual contract through the remote proxy
+        # protocol (hidden prompt, restricted tools, no interim/asynchronous
+        # output, role repair, activity fencing).  Reject before constructing an
+        # event or touching an adapter; isolation fallback is forbidden.
+        if self._get_proxy_url():
+            return ContextualCronOutcome.rejected(
+                "Contextual cron does not support gateway proxy mode in V1."
+            )
+
+        preheld_turn_lease = getattr(item, "turn_lease_token", None)
+        lease_registry = getattr(self, "_turn_leases", None)
+        validate_lease = getattr(lease_registry, "is_current_holder", None)
+        if not callable(validate_lease) or not validate_lease(
+            preheld_turn_lease,
+            session_id=item.admitted_session_id,
+            owner_key=f"contextual-cron:{item.execution_id}",
+            generation=0,
+        ):
+            return ContextualCronOutcome.rejected(
+                "Contextual cron lost its admitted live-session turn lease."
+            )
+
+        internal_prompt = (
+            "[Internal scheduled turn: execute the task below using this "
+            "conversation's existing context. Do not mention this wrapper.]\n\n"
+            + item.prompt
+        )
+        event = MessageEvent(
+            text=internal_prompt,
+            source=entry.origin,
+            internal=True,
+            metadata={
+                "contextual_cron": True,
+                "contextual_cron_execution_id": item.execution_id,
+                "contextual_cron_admitted_session_id": item.admitted_session_id,
+                "contextual_cron_admitted_routing_revision": int(
+                    item.admitted_routing_revision
+                ),
+                # The dedicated FIFO owns the resolved-session lease. The agent
+                # path adopts that exact token for compression rebind/cleanup.
+                "contextual_cron_lease_preheld": True,
+                "contextual_cron_lease_token": getattr(
+                    item, "turn_lease_token", None
+                ),
+            },
+        )
+        adapter = self._adapter_for_source(entry.origin)
+        guard = getattr(item, "adapter_guard", None)
+        guard_owned_by_lane = guard is not None
+        if adapter is not None and guard is None:
+            acquire_guard = getattr(adapter, "acquire_contextual_cron_guard", None)
+            if callable(acquire_guard):
+                guard = await acquire_guard(item.session_key)
+            else:
+                guard = adapter.claim_contextual_cron_guard(item.session_key)
+                if guard is None:
+                    from gateway.contextual_cron import ContextualCronGuardBusy
+
+                    raise ContextualCronGuardBusy()
+
+        active_lease, limit_message = self._claim_active_session_slot(
+            item.session_key, entry.origin
+        )
+        if limit_message is not None:
+            if adapter is not None and guard is not None and not guard_owned_by_lane:
+                released = adapter.release_contextual_cron_guard(item.session_key, guard)
+                if inspect.isawaitable(released):
+                    await released
+            return ContextualCronOutcome.retryable(limit_message)
+        state = self._session_state(item.session_key)
+        if active_lease is not None:
+            state.turn.lease = active_lease
+        state.turn.agent = _AGENT_PENDING_SENTINEL
+        state.turn.started_ts = time.time()
+        self._persist_active_agents()
+        run_generation = self._begin_session_run_generation(item.session_key)
+        if preheld_turn_lease is not None:
+            # The contextual lane acquired the shared concrete-session lease
+            # before entering the runner. Publish that exact token into the
+            # normal turn state so compression can atomically rebind it.
+            state.turn.lease_token = preheld_turn_lease
+            state.turn.lease_generation = run_generation
+
+        try:
+            from gateway.session_context import _bind_contextual_turn_authority
+            from hermes_cli.lifecycle import suppress_lifecycle_hooks
+
+            with _bind_contextual_turn_authority(
+                execution_id=item.execution_id,
+                session_key=item.session_key,
+                admitted_session_id=item.admitted_session_id,
+                admitted_routing_revision=item.admitted_routing_revision,
+            ), suppress_lifecycle_hooks():
+                response = await self._handle_message_with_agent(
+                    event, entry.origin, item.session_key, run_generation
+                )
+        finally:
+            self._restore_moa_one_shot(event, item.session_key)
+            # A pending /model --once restore belongs to the next human turn.
+            # Contextual cron never consumes that override, so it must not
+            # restore/pop it during its own unwind.
+            self._release_running_agent_state(
+                item.session_key,
+                run_generation=run_generation,
+            )
+            if preheld_turn_lease is None:
+                self._release_turn_lease(item.session_key, run_generation)
+            else:
+                # The contextual FIFO owns this token until its durable
+                # transcript outbox is applied.  Detach it from the ordinary
+                # turn state without releasing the registry lease here; the
+                # lane releases the exact token after transcript acknowledgement.
+                self._detach_preheld_turn_lease(
+                    item.session_key,
+                    run_generation,
+                    preheld_turn_lease,
+                )
+            if adapter is not None and guard is not None and not guard_owned_by_lane:
+                released = adapter.release_contextual_cron_guard(item.session_key, guard)
+                if inspect.isawaitable(released):
+                    await released
+        staged_entries = event.metadata.get("contextual_cron_transcript_entries")
+        if staged_entries is not None:
+            item.transcript_session_id = str(
+                event.metadata.get("contextual_cron_transcript_session_id") or ""
+            )
+            item.transcript_entries = [dict(entry) for entry in staged_entries]
+            item.last_prompt_tokens = int(
+                event.metadata.get("contextual_cron_last_prompt_tokens") or 0
+            )
+        text = str(response or "").strip()
+        details = event.metadata.get("contextual_cron_result") or {}
+        if details.get("outcome") == "stale":
+            return ContextualCronOutcome.stale(
+                str(details.get("error") or "The admitted session route changed.")
+            )
+        if details.get("outcome") == "rejected":
+            return ContextualCronOutcome.rejected(
+                str(details.get("error") or "The contextual turn was rejected.")
+            )
+        if details.get("completed") is not True:
+            return ContextualCronOutcome.failure(
+                str(details.get("error") or "Contextual cron model turn failed closed.")
+            )
+        if details.get("intentional_silence") or _is_cron_silence_response(text):
+            return ContextualCronOutcome.no_action()
+        if not text:
+            return ContextualCronOutcome.failure(
+                "Contextual cron turn completed without a final response."
+            )
+        if any(
+            marker in text
+            for marker in ("MEDIA:", "[[audio_as_voice]]", "[[audio_as_file]]")
+        ):
+            return ContextualCronOutcome.failure(
+                "Contextual cron final responses cannot contain media directives."
+            )
+        return ContextualCronOutcome.notify(text)
+
+
     def _get_cached_session_source(self, session_key: str):
         if not session_key:
             return None
@@ -16701,34 +17557,91 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""
+        from gateway.session_context import _get_contextual_turn_authority
+
+        _contextual_authority = _get_contextual_turn_authority()
+        _is_contextual_cron = _contextual_authority is not None
+
+        def _route_log_value(value):
+            return "[contextual]" if _is_contextual_cron else value
+
         _msg_start_time = time.time()
         _platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
-        _msg_preview = (event.text or "")[:80].replace("\n", " ")
-        _reply_id = getattr(event, "reply_to_message_id", None)
-        _reply_txt = (getattr(event, "reply_to_text", None) or "")[:80].replace("\n", " ")
+        if _is_contextual_cron:
+            _log_user = "[contextual]"
+            _log_chat = "[contextual]"
+            _msg_preview = "[hidden contextual cron turn]"
+            _reply_id = None
+            _reply_txt = ""
+        else:
+            _log_user = source.user_name or source.user_id or "unknown"
+            _log_chat = source.chat_id or "unknown"
+            _msg_preview = (event.text or "")[:80].replace("\n", " ")
+            _reply_id = getattr(event, "reply_to_message_id", None)
+            _reply_txt = (getattr(event, "reply_to_text", None) or "")[:80].replace("\n", " ")
         logger.info(
             "inbound message: platform=%s user=%s chat=%s msg=%r reply_to_id=%s reply_to_text=%r",
-            _platform_name, source.user_name or source.user_id or "unknown",
-            source.chat_id or "unknown", _msg_preview, _reply_id, _reply_txt,
+            _platform_name, _log_user, _log_chat, _msg_preview, _reply_id, _reply_txt,
         )
 
-        # Get or create session
-        # Topic-mode DMs: rewrite a stale/foreign thread_id to the user's
-        # last-active topic so a cross-topic Reply or stripped plain reply
-        # doesn't fragment the conversation across sessions.
-        recovered = await asyncio.to_thread(self._recover_telegram_topic_thread_id, source)
-        if recovered is not None:
-            logger.info(
-                "telegram topic recovery: chat=%s user=%s %r -> %s",
-                source.chat_id, source.user_id, source.thread_id, recovered,
-            )
-            source = dataclasses.replace(source, thread_id=recovered)
-            try:
-                event.source = source
-            except Exception:
-                pass
+        # Get or create session. Contextual cron is admitted against a live
+        # mapping and must only peek that exact mapping: never create, reset,
+        # topic-recover, or fall back to a new isolated session.
+        _event_metadata = getattr(event, "metadata", None) or {}
+        _admitted_session_id = (
+            _contextual_authority.admitted_session_id if _contextual_authority else ""
+        )
+        _admitted_routing_revision = (
+            _contextual_authority.admitted_routing_revision
+            if _contextual_authority
+            else None
+        )
+        if _is_contextual_cron:
+            if (
+                _contextual_authority.session_key != _quick_key
+                or not _contextual_authority.execution_id
+            ):
+                _event_metadata["contextual_cron_result"] = {
+                    "completed": False,
+                    "outcome": "rejected",
+                    "error": "Contextual cron task-local authority is invalid.",
+                }
+                return None
+            session_entry = await self.async_session_store.peek_session_entry(_quick_key)
+            if (
+                session_entry is None
+                or session_entry.session_id != _admitted_session_id
+                or session_entry.routing_revision != _admitted_routing_revision
+                or session_entry.origin is None
+                or self._session_key_for_source(session_entry.origin) != _quick_key
+                or not self._is_user_authorized(session_entry.origin)
+            ):
+                logger.info("contextual cron stale before turn: admitted route is no longer valid")
+                _event_metadata["contextual_cron_result"] = {
+                    "completed": False,
+                    "outcome": "stale",
+                    "error": "The target session route changed after admission.",
+                }
+                return None
+            source = session_entry.origin
+            event.source = source
+        else:
+            # Topic-mode DMs: rewrite a stale/foreign thread_id to the user's
+            # last-active topic so a cross-topic Reply or stripped plain reply
+            # doesn't fragment the conversation across sessions.
+            recovered = await asyncio.to_thread(self._recover_telegram_topic_thread_id, source)
+            if recovered is not None:
+                logger.info(
+                    "telegram topic recovery: chat=%s user=%s %r -> %s",
+                    source.chat_id, source.user_id, source.thread_id, recovered,
+                )
+                source = dataclasses.replace(source, thread_id=recovered)
+                try:
+                    event.source = source
+                except Exception:
+                    pass
 
-        session_entry = await self.async_session_store.get_or_create_session(source)
+            session_entry = await self.async_session_store.get_or_create_session(source)
         session_key = session_entry.session_key
         pinned_session_id = str(
             (getattr(event, "metadata", None) or {}).get("gateway_session_id") or ""
@@ -16742,7 +17655,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return
             session_entry = resolved_entry
         self._cache_session_source(session_key, source)
-        if await asyncio.to_thread(self._is_telegram_topic_lane, source):
+        if (
+            not _is_contextual_cron
+            and await asyncio.to_thread(self._is_telegram_topic_lane, source)
+        ):
             try:
                 binding = (await self._session_db.get_telegram_topic_binding(
                     chat_id=str(source.chat_id),
@@ -16802,7 +17718,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Capture and immediately consume was_auto_reset so it does not
         # re-fire on subsequent messages — preventing the cleanup from
         # wiping model/reasoning overrides set between turns (Closes #48031).
-        _was_auto_reset = getattr(session_entry, "was_auto_reset", False)
+        _was_auto_reset = (
+            False if _is_contextual_cron
+            else getattr(session_entry, "was_auto_reset", False)
+        )
         if _was_auto_reset:
             # Treat auto-reset as a full conversation boundary — clear every
             # conversation-scoped per-session dict in one funnel call so the
@@ -16821,14 +17740,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             session_entry.was_auto_reset = False
         
         # Emit session:start for new or auto-reset sessions
-        _is_new_session = (
+        _is_new_session = (not _is_contextual_cron) and (
             session_entry.created_at == session_entry.updated_at
             or _was_auto_reset
             or getattr(session_entry, "is_fresh_reset", False)
         )
         # Consume the is_fresh_reset flag immediately so it doesn't leak
         # onto subsequent messages in the same session (issue #6508).
-        if getattr(session_entry, "is_fresh_reset", False):
+        if not _is_contextual_cron and getattr(session_entry, "is_fresh_reset", False):
             session_entry.is_fresh_reset = False
         if _is_new_session:
             await self.hooks.emit("session:start", {
@@ -17007,7 +17926,37 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # _release_turn_lease — granted per (routing key, run generation) so a
         # stale unwind can't release a newer turn's lease.
         _lease_registry = getattr(self, "_turn_leases", None)
-        if _lease_registry is not None:
+        _preheld_turn_lease = (
+            _event_metadata.get("contextual_cron_lease_token")
+            if _is_contextual_cron
+            and _event_metadata.get("contextual_cron_lease_preheld")
+            else None
+        )
+        if _preheld_turn_lease is not None:
+            _validate_preheld_lease = getattr(
+                _lease_registry, "is_current_holder", None
+            )
+            if not callable(_validate_preheld_lease) or not _validate_preheld_lease(
+                _preheld_turn_lease,
+                session_id=session_entry.session_id,
+                owner_key=f"contextual-cron:{_contextual_authority.execution_id}",
+                generation=0,
+            ):
+                # The broad session-context cleanup finally starts later in
+                # this method, so this early authority rejection owns cleanup.
+                self._clear_session_env(_session_env_tokens)
+                _event_metadata["contextual_cron_result"] = {
+                    "completed": False,
+                    "outcome": "rejected",
+                    "error": (
+                        "Contextual cron lost its admitted live-session turn lease."
+                    ),
+                }
+                return None
+            _lease_state = self._session_state(_quick_key).turn
+            _lease_state.lease_token = _preheld_turn_lease
+            _lease_state.lease_generation = run_generation
+        elif _lease_registry is not None:
             try:
                 _lease_token = await _lease_registry.acquire(
                     session_entry.session_id,
@@ -17052,7 +18001,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         #    by 30-50% on code/JSON-heavy sessions, but that just
         #    means hygiene fires a bit early — safe and harmless.
         # -----------------------------------------------------------------
-        if history and len(history) >= 4:
+        if not _is_contextual_cron and history and len(history) >= 4:
             from agent.model_metadata import (
                 estimate_messages_tokens_rough,
                 get_model_context_length_async,
@@ -17341,6 +18290,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                     quiet_mode=True,
                                     skip_memory=True,
                                     enabled_toolsets=["memory"],
+                                    allowed_tool_names=(
+                                        frozenset() if _is_contextual_cron else None
+                                    ),
                                     session_id=session_entry.session_id,
                                     session_db=_hyg_session_db,
                                 )
@@ -17556,8 +18508,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                     # a new session_id.  Write compressed messages into
                                     # the NEW session so the old transcript stays intact
                                     # and searchable via session_search.
+                                    _hyg_old_sid = session_entry.session_id
                                     _hyg_new_sid = _hyg_agent.session_id
-                                    _hyg_rotated = _hyg_new_sid != session_entry.session_id
+                                    _hyg_rotated = _hyg_new_sid != _hyg_old_sid
                                     _hyg_in_place = bool(
                                         getattr(_hyg_agent, "_last_compaction_in_place", False)
                                     )
@@ -17606,20 +18559,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                             _hyg_rotated = False
                                             _hyg_in_place = False
                                         else:
-                                            session_entry.session_id = _hyg_new_sid
-                                            # The held turn lease follows the
-                                            # rotation so an alias key resolving
-                                            # the fresh child still serializes
-                                            # against this turn (#64934).
-                                            self._rebind_turn_lease(
-                                                _quick_key, run_generation, _hyg_new_sid
+                                            _advanced_entry = await self._publish_gateway_compression_route(
+                                                _quick_key,
+                                                _hyg_old_sid,
+                                                _hyg_new_sid,
+                                                run_generation,
                                             )
-                                            await self.async_session_store._save()
-                                            await asyncio.to_thread(
-                                                self._sync_telegram_topic_binding,
-                                                source, session_entry,
-                                                reason="hygiene-compression",
-                                            )
+                                            if _advanced_entry is None:
+                                                logger.error(
+                                                    "Session hygiene: compression child %s was persisted, "
+                                                    "but the stable route/lease CAS from %s failed; keeping "
+                                                    "the live session on the parent",
+                                                    _hyg_new_sid,
+                                                    _hyg_old_sid,
+                                                )
+                                                _hyg_rotated = False
+                                                _hyg_in_place = False
+                                            else:
+                                                session_entry = _advanced_entry
+                                                await asyncio.to_thread(
+                                                    self._sync_telegram_topic_binding,
+                                                    source,
+                                                    session_entry,
+                                                    reason="hygiene-compression",
+                                                )
 
                                     if _hyg_rotated:
                                         # Reset stored token count — transcript rewritten
@@ -17790,7 +18753,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Delivered on the current user message (sidecar), NOT the ephemeral
         # system prompt: present-on-turn-1/absent-on-turn-2 was a guaranteed
         # system-prompt diff and agent rebuild.
-        if not history and not await self.async_session_store.has_any_sessions():
+        if (
+            not _is_contextual_cron
+            and not history
+            and not await self.async_session_store.has_any_sessions()
+        ):
             # Default first-contact note: a brief self-introduction.
             _intro_note = (
                 "[System note: This is the user's very first message ever. "
@@ -17829,7 +18796,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         
         # One-time prompt if no home channel is set for this platform
         # Skip for webhooks - they deliver directly to configured targets (github_comment, etc.)
-        if not history and source.platform and source.platform != Platform.LOCAL and source.platform != Platform.WEBHOOK:
+        if (
+            not _is_contextual_cron
+            and not history
+            and source.platform
+            and source.platform != Platform.LOCAL
+            and source.platform != Platform.WEBHOOK
+        ):
             platform_name = source.platform.value
             env_key = _home_target_env_var(platform_name)
             # Multiplex: home channel may live only in the profile secret
@@ -17907,12 +18880,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # attachments (documents, audio, etc.) are not sent to the vision
         # tool even when they appear in the same message.
         # -----------------------------------------------------------------
-        message_text = await self._prepare_profile_scoped_inbound_message_text(
-            event=event,
-            source=source,
-            history=history,
-            session_key=session_key,
-        )
+        if _is_contextual_cron:
+            # V1 contextual prompts are already internal, canonical task text.
+            # Generic inbound preprocessing can read files, run Git, fetch URLs,
+            # invoke vision, or send adapter warnings outside the durable
+            # scheduler-owned delivery path, so it is not an admissible part of
+            # a zero-capability contextual turn.
+            message_text = event.text or ""
+        else:
+            message_text = await self._prepare_profile_scoped_inbound_message_text(
+                event=event,
+                source=source,
+                history=history,
+                session_key=session_key,
+            )
         if message_text is None:
             return
 
@@ -17962,11 +18943,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Bind this gateway run generation to the adapter's active-session
         # event so deferred post-delivery callbacks can be released by the
         # same run that registered them.
-        self._bind_adapter_run_generation(
-            self._adapter_for_source(source),
-            session_key,
-            run_generation,
-        )
+        if not _is_contextual_cron:
+            self._bind_adapter_run_generation(
+                self._adapter_for_source(source),
+                session_key,
+                run_generation,
+            )
 
         try:
             # Emit agent:start hook
@@ -17977,9 +18959,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "thread_id": str(getattr(source, "thread_id", None)) if getattr(source, "thread_id", None) else "",
                 "chat_type": getattr(source, "chat_type", "") or "",
                 "session_id": session_entry.session_id,
-                "message": message_text[:500],
+                "message": ("[contextual cron]" if _is_contextual_cron else message_text[:500]),
             }
-            await self.hooks.emit("agent:start", hook_ctx)
+            if not _is_contextual_cron:
+                await self.hooks.emit("agent:start", hook_ctx)
 
             # Run the agent. Capture the session id that this run was launched
             # against so post-run compression publication can be identity-guarded
@@ -18001,6 +18984,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
                 message_type=event.message_type,
+                persist_user_display_kind=("hidden" if _is_contextual_cron else None),
+                suppress_output=_is_contextual_cron,
             )
             _turn_seconds = time.monotonic() - _turn_started_monotonic
 
@@ -18008,7 +18993,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Slack AI status is scoped to a thread/workspace, so preserve the
             # same routing metadata used by the response delivery path.
             try:
-                _typing_adapter = self._adapter_for_source(source)
+                _typing_adapter = (
+                    None if _is_contextual_cron else self._adapter_for_source(source)
+                )
                 _stop_with_metadata = getattr(
                     type(_typing_adapter), "_stop_typing_with_metadata", None
                 )
@@ -18028,17 +19015,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if not self._is_session_run_current(_quick_key, run_generation):
                 logger.info(
                     "Discarding stale agent result for %s — generation %d is no longer current",
-                    _quick_key or "?",
+                    _route_log_value(_quick_key or "?"),
                     run_generation,
                 )
-                _stale_adapter = self._adapter_for_source(source)
-                if getattr(type(_stale_adapter), "pop_post_delivery_callback", None) is not None:
-                    _stale_adapter.pop_post_delivery_callback(
-                        _quick_key,
-                        generation=run_generation,
-                    )
-                elif _stale_adapter and hasattr(_stale_adapter, "_post_delivery_callbacks"):
-                    _stale_adapter._post_delivery_callbacks.pop(_quick_key, None)
+                if not _is_contextual_cron:
+                    _stale_adapter = self._adapter_for_source(source)
+                    if getattr(type(_stale_adapter), "pop_post_delivery_callback", None) is not None:
+                        _stale_adapter.pop_post_delivery_callback(
+                            _quick_key,
+                            generation=run_generation,
+                        )
+                    elif _stale_adapter and hasattr(_stale_adapter, "_post_delivery_callbacks"):
+                        _stale_adapter._post_delivery_callbacks.pop(_quick_key, None)
                 return None
 
             response = agent_result.get("final_response") or ""
@@ -18075,7 +19063,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _resp_len = len(response)
             logger.info(
                 "response ready: platform=%s chat=%s time=%.1fs api_calls=%d response=%d chars",
-                _platform_name, source.chat_id or "unknown",
+                _platform_name, _route_log_value(source.chat_id or "unknown"),
                 _response_time, _api_calls, _resp_len,
             )
 
@@ -18094,7 +19082,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # shutdown) — the turn ran to completion, so recovery
             # succeeded and subsequent messages should no longer receive
             # the restart-interruption system note.
-            if session_key and _should_clear_resume_pending_after_turn(agent_result):
+            if (
+                session_key
+                and not _is_contextual_cron
+                and _should_clear_resume_pending_after_turn(agent_result)
+            ):
                 self._clear_restart_failure_count(session_key)
                 try:
                     await self.async_session_store.clear_resume_pending(session_key)
@@ -18111,39 +19103,90 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     agent_result, response, history_len=len(history),
                 )
                 response = _sanitize_gateway_final_response(source.platform, response)
+            if _is_contextual_cron:
+                event.metadata["contextual_cron_result"] = {
+                    "completed": agent_result.get("completed") is True,
+                    "intentional_silence": bool(_intentional_silence),
+                    "error": agent_result.get("error"),
+                }
 
             # Ordering contract: the agent thread already updated the contextvar
             # in conversation_compression.py; propagate to SessionEntry + _save().
             # If the agent's session_id changed during compression, update
             # session_entry so transcript writes below go to the right session.
+            # The contextual runner has no live SessionDB authority, so any
+            # agent-result route rotation is unverified and cannot produce a
+            # replayable transcript binding. In-memory compression remains
+            # available; V1 fails closed rather than publishing a new session.
+            if (
+                _is_contextual_cron
+                and agent_result.get("session_id")
+                and agent_result["session_id"] != session_entry.session_id
+            ):
+                raise RuntimeError(
+                    "Contextual cron cannot publish an in-turn session rotation."
+                )
             if agent_result.get("session_id") and agent_result["session_id"] != session_entry.session_id:
                 if session_entry.session_id == _run_start_session_id:
-                    session_entry.session_id = agent_result["session_id"]
-                    # The held turn lease follows the rotation: the transcript
-                    # persistence below writes to the NEW id, so the
-                    # serialization boundary must move with it or an alias
-                    # key resolving the fresh child could interleave (#64934).
-                    self._rebind_turn_lease(
-                        _quick_key, run_generation, session_entry.session_id
+                    _compressed_sid = str(agent_result["session_id"])
+                    _advanced_entry = await self._publish_gateway_compression_route(
+                        _quick_key,
+                        _run_start_session_id,
+                        _compressed_sid,
+                        run_generation,
                     )
-                    await self.async_session_store._save()
-                    await self.async_session_store._record_gateway_session_peer(
-                        session_entry.session_id,
-                        session_key,
-                        source,
-                    )
-                    await asyncio.to_thread(
-                        self._sync_telegram_topic_binding,
-                        source, session_entry, reason="agent-result-compression",
-                    )
+                    if _advanced_entry is None:
+                        logger.error(
+                            "Refusing agent-result compression route %s -> %s: "
+                            "lease rebind or backing-store CAS failed",
+                            _route_log_value(_run_start_session_id),
+                            _route_log_value(_compressed_sid),
+                        )
+                        raise RuntimeError(
+                            "Compressed session could not be published atomically"
+                        )
+                    else:
+                        session_entry = _advanced_entry
+                        # Preserve upstream's Telegram-DM thread restoration, but
+                        # only after the compression route CAS and lease rebind
+                        # succeeded. A stale worker must never mutate routing state.
+                        if (
+                            getattr(source, "platform", None) == Platform.TELEGRAM
+                            and getattr(source, "chat_type", None) == "dm"
+                            and getattr(source, "thread_id", None) is None
+                            and self._session_db is not None
+                        ):
+                            try:
+                                _binding = await asyncio.to_thread(
+                                    self._session_db._db.get_telegram_topic_binding_by_session,
+                                    session_id=session_entry.session_id,
+                                )
+                                if _binding and _binding.get("thread_id"):
+                                    source.thread_id = str(_binding["thread_id"])
+                            except Exception:
+                                logger.debug(
+                                    "Failed to restore thread_id after compression route publication",
+                                    exc_info=True,
+                                )
+                        await self.async_session_store._record_gateway_session_peer(
+                            session_entry.session_id,
+                            session_key,
+                            source,
+                        )
+                        await asyncio.to_thread(
+                            self._sync_telegram_topic_binding,
+                            source,
+                            session_entry,
+                            reason="agent-result-compression",
+                        )
                 else:
                     logger.info(
                         "Skipping agent-result session split sync for %s because "
                         "the session binding moved from %s to %s before "
                         "compression finished",
-                        session_key or "?",
-                        _run_start_session_id,
-                        session_entry.session_id,
+                        _route_log_value(session_key or "?"),
+                        _route_log_value(_run_start_session_id),
+                        _route_log_value(session_entry.session_id),
                     )
 
             # Prepend reasoning/thinking if display is enabled (per-platform).
@@ -18164,6 +19207,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if source.platform == Platform.MATTERMOST
                     else getattr(self, "_show_reasoning", False)
                 )
+            if _is_contextual_cron:
+                _show_reasoning_effective = False
             if _show_reasoning_effective and response and not _intentional_silence:
                 last_reasoning = agent_result.get("last_reasoning")
                 if last_reasoning:
@@ -18223,29 +19268,37 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)
                 _footer_line = ""
-            if _footer_line and response and not agent_result.get("already_sent") and not _intentional_silence:
+            if (
+                not _is_contextual_cron
+                and _footer_line
+                and response
+                and not agent_result.get("already_sent")
+                and not _intentional_silence
+            ):
                 response = f"{response}\n\n{_footer_line}"
 
             # Emit agent:end hook
-            await self.hooks.emit("agent:end", {
-                **hook_ctx,
-                "response": (response or "")[:500],
-                "model": agent_result.get("model", ""),
-                "provider": agent_result.get("provider", ""),
-            })
-            
+            if not _is_contextual_cron:
+                await self.hooks.emit("agent:end", {
+                    **hook_ctx,
+                    "response": (response or "")[:500],
+                    "model": agent_result.get("model", ""),
+                    "provider": agent_result.get("provider", ""),
+                })
+
             # Check for pending process watchers (check_interval on background processes)
             try:
-                from tools.process_registry import process_registry
-                # Detach the current batch atomically (see crash-recovery drain
-                # above): reassign to a fresh list so a watcher appended by a
-                # concurrent session during the yield isn't dropped by clear().
-                watchers = process_registry.pending_watchers
-                process_registry.pending_watchers = []
-                for i, watcher in enumerate(watchers):
-                    asyncio.create_task(self._run_process_watcher(watcher))
-                    if i % 100 == 99:
-                        await asyncio.sleep(0)
+                if not _is_contextual_cron:
+                    from tools.process_registry import process_registry
+                    # Detach the current batch atomically (see crash-recovery drain
+                    # above): reassign to a fresh list so a watcher appended by a
+                    # concurrent session during the yield isn't dropped by clear().
+                    watchers = process_registry.pending_watchers
+                    process_registry.pending_watchers = []
+                    for i, watcher in enumerate(watchers):
+                        asyncio.create_task(self._run_process_watcher(watcher))
+                        if i % 100 == 99:
+                            await asyncio.sleep(0)
             except Exception as e:
                 logger.error("Process watcher setup error: %s", e)
 
@@ -18259,15 +19312,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # boot), which covers both the idle and post-turn cases with a
             # single consumer — so we leave them on the queue here.
             try:
-                from tools.process_registry import process_registry as _pr
-                _watch_events = _drain_gateway_watch_events(_pr.completion_queue)
-                for evt in _watch_events:
-                    synth_text = _format_gateway_process_notification(evt)
-                    if synth_text:
-                        try:
-                            await self._inject_watch_notification(synth_text, evt)
-                        except Exception as e2:
-                            logger.error("Watch notification injection error: %s", e2)
+                if not _is_contextual_cron:
+                    from tools.process_registry import process_registry as _pr
+                    _watch_events = _drain_gateway_watch_events(_pr.completion_queue)
+                    for evt in _watch_events:
+                        synth_text = _format_gateway_process_notification(evt)
+                        if synth_text:
+                            try:
+                                await self._inject_watch_notification(synth_text, evt)
+                            except Exception as e2:
+                                logger.error("Watch notification injection error: %s", e2)
             except Exception as e:
                 logger.debug("Watch queue drain error: %s", e)
 
@@ -18317,20 +19371,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.info(
                     "Skipping transcript persistence for context-overflow "
                     "failure in session %s to prevent session growth loop.",
-                    session_entry.session_id,
+                    _route_log_value(session_entry.session_id),
                 )
             elif agent_failed_early:
                 logger.info(
                     "Transient agent failure in session %s — persisting user "
                     "message so conversation context is preserved on retry.",
-                    session_entry.session_id,
+                    _route_log_value(session_entry.session_id),
                 )
             elif hidden_reasoning_incomplete:
                 logger.warning(
                     "Suppressing hidden-reasoning-only incomplete gateway turn "
                     "for session %s: %s",
-                    session_entry.session_id,
-                    agent_result.get("error", "processing incomplete"),
+                    _route_log_value(session_entry.session_id),
+                    (
+                        "[contextual]"
+                        if _is_contextual_cron
+                        else agent_result.get("error", "processing incomplete")
+                    ),
                 )
 
             # When compression is exhausted, the session is permanently too
@@ -18348,9 +19406,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "Compression deferred for session %s — the compression "
                     "lock is held by a concurrent compressor. Keeping the "
                     "session intact; the next message retries normally.",
-                    session_entry.session_id if session_entry else "?",
+                    _route_log_value(
+                        session_entry.session_id if session_entry else "?"
+                    ),
                 )
-            elif agent_result.get("compression_exhausted") and session_entry and session_key:
+            elif (
+                not _is_contextual_cron
+                and agent_result.get("compression_exhausted")
+                and session_entry
+                and session_key
+            ):
                 logger.info(
                     "Auto-resetting session %s after compression exhaustion.",
                     session_entry.session_id,
@@ -18396,7 +19461,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pass  # Skip all transcript writes — don't grow a broken session
             elif not history:
                 tool_defs = agent_result.get("tools", [])
-                await self.async_session_store.append_to_transcript(
+                await self._write_or_stage_transcript_entry(
+                    event,
                     session_entry.session_id,
                     {
                         "role": "session_meta",
@@ -18404,7 +19470,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "model": _resolve_gateway_model(),
                         "platform": source.platform.value if source.platform else "",
                         "timestamp": ts,
-                    }
+                    },
+                    skip_db=False,
+                    contextual_execution_id=(
+                        _contextual_authority.execution_id
+                        if _is_contextual_cron
+                        else None
+                    ),
                 )
             
             # The agent already persisted these messages to SQLite via
@@ -18417,7 +19489,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # the flag (default = self._session_db is not None) keeps the
             # persistence contract explicit and lets any future non-persisting
             # runtime opt into a gateway-side write by returning False.
-            agent_persisted = agent_result.get("agent_persisted", self._session_db is not None)
+            agent_persisted = (
+                False
+                if _is_contextual_cron
+                else agent_result.get("agent_persisted", self._session_db is not None)
+            )
 
             # Find only the NEW messages from this turn (skip history we loaded).
             # Use the filtered history length (history_offset) that was actually
@@ -18446,6 +19522,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         else ts
                     ),
                 }
+                if _is_contextual_cron:
+                    _user_entry["display_kind"] = "hidden"
                 if event.message_id:
                     _user_entry["message_id"] = str(event.message_id)
                 # Dedupe: skip if this platform message_id is already in the
@@ -18464,11 +19542,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         event.message_id, session_entry.session_id,
                     )
                 else:
-                    await self.async_session_store.append_to_transcript(
+                    await self._write_or_stage_transcript_entry(
+                        event,
                         session_entry.session_id,
                         _user_entry,
                         skip_db=agent_persisted,
+                        contextual_execution_id=(
+                            _contextual_authority.execution_id
+                            if _is_contextual_cron
+                            else None
+                        ),
                     )
+                    if _is_contextual_cron:
+                        await self._write_or_stage_transcript_entry(
+                            event,
+                            session_entry.session_id,
+                            {
+                                "role": "assistant",
+                                "content": "[contextual cron failed before producing a response]",
+                                "display_kind": "hidden",
+                                "timestamp": ts,
+                            },
+                            skip_db=False,
+                            contextual_execution_id=_contextual_authority.execution_id,
+                        )
             else:
                 history_len = agent_result.get("history_offset", len(history))
                 new_messages = agent_messages[history_len:] if len(agent_messages) > history_len else []
@@ -18488,20 +19585,61 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             else ts
                         ),
                     }
+                    _apply_contextual_transcript_visibility(
+                        _user_entry,
+                        contextual=_is_contextual_cron,
+                        intentional_silence=_intentional_silence,
+                    )
                     if event.message_id:
                         _user_entry["message_id"] = str(event.message_id)
-                    await self.async_session_store.append_to_transcript(
+                    await self._write_or_stage_transcript_entry(
+                        event,
                         session_entry.session_id,
                         _user_entry,
                         skip_db=agent_persisted,
+                        contextual_execution_id=(
+                            _contextual_authority.execution_id
+                            if _is_contextual_cron
+                            else None
+                        ),
                     )
                     if response:
-                        await self.async_session_store.append_to_transcript(
+                        _assistant_entry = {
+                            "role": "assistant",
+                            "content": response,
+                            "timestamp": ts,
+                        }
+                        _apply_contextual_transcript_visibility(
+                            _assistant_entry,
+                            contextual=_is_contextual_cron,
+                            intentional_silence=_intentional_silence,
+                        )
+                        await self._write_or_stage_transcript_entry(
+                            event,
                             session_entry.session_id,
-                            {"role": "assistant", "content": response, "timestamp": ts},
+                            _assistant_entry,
                             skip_db=agent_persisted,
+                            contextual_execution_id=(
+                                _contextual_authority.execution_id
+                                if _is_contextual_cron
+                                else None
+                            ),
                         )
                 else:
+                    if _is_contextual_cron:
+                        new_messages = _ensure_contextual_user_delta(
+                            new_messages,
+                            content=(
+                                persist_user_message
+                                if persist_user_message is not None
+                                else message_text
+                            ),
+                            timestamp=(
+                                persist_user_timestamp
+                                if persist_user_timestamp is not None
+                                else ts
+                            ),
+                        )
                     # Attach the inbound platform message_id to the first user
                     # entry written this turn so platform-level quote-resolution
                     # (e.g. Yuanbao QuoteContextMiddleware's transcript fallback)
@@ -18513,6 +19651,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             continue
                         # Add timestamp to each message for debugging
                         entry = {**msg, "timestamp": ts}
+                        _apply_contextual_transcript_visibility(
+                            entry,
+                            contextual=_is_contextual_cron,
+                            intentional_silence=_intentional_silence,
+                        )
                         if (
                             not _user_msg_id_attached
                             and msg.get("role") == "user"
@@ -18521,18 +19664,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         ):
                             entry["message_id"] = str(event.message_id)
                             _user_msg_id_attached = True
-                        await self.async_session_store.append_to_transcript(
-                            session_entry.session_id, entry,
+                        await self._write_or_stage_transcript_entry(
+                            event,
+                            session_entry.session_id,
+                            entry,
                             skip_db=agent_persisted,
+                            contextual_execution_id=(
+                                _contextual_authority.execution_id
+                                if _is_contextual_cron
+                                else None
+                            ),
                         )
             
             # Token counts and model are now persisted by the agent directly.
             # Keep only last_prompt_tokens here for context-window tracking and
             # compression decisions.
-            await self.async_session_store.update_session(
-                session_entry.session_key,
-                last_prompt_tokens=agent_result.get("last_prompt_tokens", 0),
-            )
+            if _is_contextual_cron:
+                event.metadata["contextual_cron_last_prompt_tokens"] = int(
+                    agent_result.get("last_prompt_tokens", 0) or 0
+                )
+            else:
+                await self.async_session_store.update_session(
+                    session_entry.session_key,
+                    last_prompt_tokens=agent_result.get("last_prompt_tokens", 0),
+                    touch_activity=True,
+                )
 
             # Re-baseline the cached agent's message_count snapshot now that
             # ALL of this turn's transcript writes are done — the agent's
@@ -18564,20 +19720,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _intentional_silence:
                 logger.info(
                     "Suppressing intentional silence marker for session %s",
-                    session_entry.session_id,
+                    _route_log_value(session_entry.session_id),
                 )
                 response = ""
 
             # Auto voice reply: send TTS audio before the text response
             _already_sent = bool(agent_result.get("already_sent"))
             # Skip when streaming TTS already delivered audio for this turn (#60671).
-            _stts_adapter = self._adapter_for_source(source)
+            _stts_adapter = (
+                None if _is_contextual_cron else self._adapter_for_source(source)
+            )
             _streaming_tts_done = (
                 _stts_adapter is not None
                 and bool(getattr(_stts_adapter, "_streaming_tts_turn_completed", lambda *_a, **_k: False)(session_key, run_generation))
             )
             if (
-                not _streaming_tts_done
+                not _is_contextual_cron
+                and not _streaming_tts_done
                 and self._should_send_voice_reply(event, response, agent_messages, already_sent=_already_sent)
             ):
                 await self._send_voice_reply(event, response)
@@ -18593,7 +19752,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # content the user hasn't seen (streaming only sent earlier
             # partial output before the failure).  Without this guard,
             # users see the agent "stop responding without explanation."
-            if agent_result.get("already_sent") and not agent_result.get("failed"):
+            if (
+                not _is_contextual_cron
+                and agent_result.get("already_sent")
+                and not agent_result.get("failed")
+            ):
                 if response:
                     _media_adapter = self._adapter_for_source(source)
                     if _media_adapter:
@@ -18623,7 +19786,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Stop typing indicator on error too, retaining Slack thread/workspace
             # routing so a failed turn cannot leave its status visible.
             try:
-                _err_adapter = self._adapter_for_source(source)
+                _err_adapter = (
+                    None if _is_contextual_cron else self._adapter_for_source(source)
+                )
                 _stop_with_metadata = getattr(
                     type(_err_adapter), "_stop_typing_with_metadata", None
                 )
@@ -18639,7 +19804,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     await _err_adapter.stop_typing(source.chat_id)
             except Exception:
                 pass
-            logger.exception("Agent error in session %s", session_key)
+            if _is_contextual_cron:
+                logger.error("Contextual cron agent execution failed.")
+            else:
+                logger.exception(
+                    "Agent error in session %s",
+                    _route_log_value(session_key),
+                )
             # Crash-resilience for failures that happen before AIAgent enters
             # run_conversation() (for example: provider/httpx client init
             # failures). In that path the agent cannot persist the current
@@ -18649,10 +19820,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             try:
                 if 'message_text' in locals() and message_text is not None and session_entry is not None:
                     _already_persisted = False
-                    try:
-                        _recent_transcript = await self.async_session_store.load_transcript(session_entry.session_id)
-                    except Exception:
-                        _recent_transcript = []
+                    if _is_contextual_cron:
+                        _recent_transcript = _event_metadata.get(
+                            "contextual_cron_transcript_entries", []
+                        )
+                        if not isinstance(_recent_transcript, list):
+                            _recent_transcript = []
+                    else:
+                        try:
+                            _recent_transcript = await self.async_session_store.load_transcript(
+                                session_entry.session_id
+                            )
+                        except Exception:
+                            _recent_transcript = []
                     for _msg in reversed(_recent_transcript[-10:]):
                         if _msg.get("role") == "user":
                             _expected_user_content = (
@@ -18676,14 +19856,56 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 else time.time()
                             ),
                         }
+                        if _is_contextual_cron:
+                            _user_entry["display_kind"] = "hidden"
                         if getattr(event, "message_id", None):
                             _user_entry["message_id"] = str(event.message_id)
-                        await self.async_session_store.append_to_transcript(
+                        await self._write_or_stage_transcript_entry(
+                            event,
                             session_entry.session_id,
                             _user_entry,
+                            skip_db=False,
+                            contextual_execution_id=(
+                                _contextual_authority.execution_id
+                                if _is_contextual_cron
+                                else None
+                            ),
                         )
             except Exception:
                 logger.debug("Failed to persist inbound user message after agent exception", exc_info=True)
+            if _is_contextual_cron:
+                _event_metadata["contextual_cron_result"] = {
+                    "completed": False,
+                    "outcome": "failure",
+                    "error": "Contextual cron agent execution failed.",
+                }
+                # Preserve transcript alternation without exposing provider or
+                # exception details to the next human turn.
+                try:
+                    _recent_transcript = _event_metadata.get(
+                        "contextual_cron_transcript_entries", []
+                    )
+                    if not isinstance(_recent_transcript, list):
+                        _recent_transcript = []
+                    if _recent_transcript and _recent_transcript[-1].get("role") == "user":
+                        await self._write_or_stage_transcript_entry(
+                            event,
+                            session_entry.session_id,
+                            {
+                                "role": "assistant",
+                                "content": "[Scheduled contextual turn failed.]",
+                                "display_kind": "hidden",
+                                "timestamp": time.time(),
+                            },
+                            skip_db=False,
+                            contextual_execution_id=_contextual_authority.execution_id,
+                        )
+                except Exception:
+                    logger.debug(
+                        "Failed to repair contextual transcript alternation",
+                        exc_info=True,
+                    )
+                return None
             # Log full details server-side only; never expose raw exception
             # types or messages to end users (info-leakage risk).
             status_hint = ""
@@ -21809,17 +23031,42 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         Returns a list of reset tokens; pass them to ``_clear_session_env``
         in a ``finally`` block.
         """
-        from gateway.session_context import set_session_vars
-        # Propagate the adapter's async-delivery capability so async tools
-        # (terminal notify_on_complete / watch_patterns, delegate_task
-        # background=True) know whether this channel can wake a later turn.
-        # Default True keeps CLI / unknown paths working; stateless adapters
-        # (api_server) declare supports_async_delivery=False. Use getattr so
-        # bare runners built via object.__new__ (tests) without self.adapters
-        # don't blow up — they simply default to supported.
-        _adapters = getattr(self, "adapters", None) or {}
-        _adapter = _adapters.get(context.source.platform)
-        _async_delivery = getattr(_adapter, "supports_async_delivery", True)
+        from gateway.session_context import (
+            _get_contextual_turn_authority,
+            set_session_vars,
+        )
+
+        # Contextual status comes only from the gateway-owned task-local
+        # admission authority.  Event metadata and the human adapter are not
+        # capability authorities for an unattended scheduled turn.
+        _contextual_authority = _get_contextual_turn_authority()
+        _is_contextual = _contextual_authority is not None
+        if _is_contextual:
+            if (
+                _contextual_authority.session_key != context.session_key
+                or _contextual_authority.admitted_session_id != context.session_id
+                or _contextual_authority.admitted_routing_revision
+                != int(context.routing_revision)
+            ):
+                raise RuntimeError(
+                    "contextual session environment does not match admitted authority"
+                )
+            from cron.contextual import CONTEXTUAL_EXECUTION_POLICY
+
+            _async_delivery = CONTEXTUAL_EXECUTION_POLICY.async_delivery
+            _cron_session = "1"
+        else:
+            # Propagate the adapter's async-delivery capability so async tools
+            # (terminal notify_on_complete / watch_patterns, delegate_task
+            # background=True) know whether this channel can wake a later turn.
+            # Default True keeps CLI / unknown paths working; stateless adapters
+            # (api_server) declare supports_async_delivery=False. Use getattr so
+            # bare runners built via object.__new__ (tests) without self.adapters
+            # don't blow up — they simply default to supported.
+            _adapters = getattr(self, "adapters", None) or {}
+            _adapter = _adapters.get(context.source.platform)
+            _async_delivery = getattr(_adapter, "supports_async_delivery", True)
+            _cron_session = ""
         return set_session_vars(
             platform=context.source.platform.value,
             chat_id=context.source.chat_id,
@@ -21831,10 +23078,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             user_id=str(context.source.user_id) if context.source.user_id else "",
             user_name=str(context.source.user_name) if context.source.user_name else "",
             session_key=context.session_key,
+            session_id=context.session_id,
+            routing_revision=context.routing_revision,
             message_id=str(context.source.message_id) if context.source.message_id else "",
             profile=getattr(context.source, "profile", "") or "",
             async_delivery=_async_delivery,
-            cron_session="",
+            cron_session=_cron_session,
         )
 
     def _clear_session_env(self, tokens: list) -> None:
@@ -23328,6 +24577,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._persist_active_agents()
         return True
 
+    def _detach_preheld_turn_lease(
+        self,
+        session_key: str,
+        run_generation: int,
+        expected_token: object,
+    ) -> bool:
+        """Clear turn-local ownership without releasing a lane-owned lease."""
+        if not session_key:
+            return False
+        state = self._peek_session_state(session_key)
+        if state is None:
+            return False
+        turn = state.turn
+        if (
+            turn.lease_token is not expected_token
+            or turn.lease_generation != run_generation
+        ):
+            return False
+        turn.lease_token = None
+        turn.lease_generation = None
+        return True
+
     def _release_turn_lease(self, session_key: str, run_generation: int) -> bool:
         """Release the turn lease acquired by (``session_key``, ``run_generation``).
 
@@ -23385,6 +24656,145 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             logger.debug("Failed to rebind turn lease", exc_info=True)
             return False
+
+    async def _publish_gateway_compression_route(
+        self,
+        session_key: str,
+        expected_session_id: str,
+        new_session_id: str,
+        run_generation: Optional[int],
+    ) -> Optional[Any]:
+        """Move lease then CAS the backing route, rolling the lease back on failure."""
+        if run_generation is None:
+            # Compatibility for direct ``_run_agent`` callers outside the gateway
+            # turn lifecycle. Real admitted gateway turns always carry a generation
+            # and use the strict lease/revision CAS path below.
+            entries = getattr(self.session_store, "_entries", {})
+            entry = entries.get(session_key) if isinstance(entries, dict) else None
+            if entry is None or str(getattr(entry, "session_id", "")) != str(
+                expected_session_id
+            ):
+                return None
+            entry.session_id = new_session_id
+            if hasattr(entry, "routing_revision"):
+                entry.routing_revision = int(getattr(entry, "routing_revision", 0)) + 1
+            save = getattr(self.session_store, "_save", None)
+            if callable(save):
+                save()
+            return entry
+
+        state = self._peek_session_state(session_key)
+        turn = state.turn if state is not None else None
+        lease_token = turn.lease_token if turn is not None else None
+        held_token = bool(
+            turn is not None
+            and lease_token is not None
+            and turn.lease_generation == run_generation
+        )
+        route_before = None
+        peek_route = getattr(self.session_store, "peek_session_entry", None)
+        if callable(peek_route):
+            route_before = peek_route(session_key)
+        expected_revision = (
+            int(getattr(route_before, "routing_revision", 0))
+            if route_before is not None
+            and str(getattr(route_before, "session_id", "")) == expected_session_id
+            else None
+        )
+        lease_rebound = False
+        if held_token:
+            lease_rebound = self._rebind_turn_lease(
+                session_key,
+                run_generation,
+                new_session_id,
+            )
+            if not lease_rebound:
+                logger.error(
+                    "Refusing session compression route %s -> %s: the held turn "
+                    "lease could not be rebound without merging live domains",
+                    expected_session_id,
+                    new_session_id,
+                )
+                return None
+        try:
+            advanced = await self.async_session_store.advance_compression_session(
+                session_key,
+                expected_session_id,
+                new_session_id,
+            )
+        except BaseException:
+            if lease_rebound and not self._rebind_turn_lease(
+                session_key,
+                run_generation,
+                expected_session_id,
+            ):
+                logger.critical(
+                    "Compression route publication failed and the lease could not "
+                    "be rolled back from %s to %s",
+                    new_session_id,
+                    expected_session_id,
+                )
+            raise
+        if advanced is None and lease_rebound:
+            if not self._rebind_turn_lease(
+                session_key,
+                run_generation,
+                expected_session_id,
+            ):
+                raise RuntimeError(
+                    "Compression route CAS failed and turn-lease rollback failed"
+                )
+        if advanced is None:
+            return None
+
+        advanced_revision = int(getattr(advanced, "routing_revision", -1))
+        publication_matches = bool(
+            str(getattr(advanced, "session_key", "")) == session_key
+            and str(getattr(advanced, "session_id", "")) == new_session_id
+            and (
+                expected_revision is None
+                or advanced_revision == expected_revision + 1
+            )
+        )
+        live_route = peek_route(session_key) if callable(peek_route) else None
+        route_still_current = bool(
+            live_route is not None
+            and str(getattr(live_route, "session_id", "")) == new_session_id
+            and int(getattr(live_route, "routing_revision", -1))
+            == advanced_revision
+        )
+
+        ownership_current = True
+        if held_token:
+            current_state = self._peek_session_state(session_key)
+            current_turn = current_state.turn if current_state is not None else None
+            registry = getattr(self, "_turn_leases", None)
+            validate_holder = getattr(registry, "is_current_holder", None)
+            ownership_current = bool(
+                current_turn is not None
+                and current_turn.lease_token is lease_token
+                and current_turn.lease_generation == run_generation
+                and callable(validate_holder)
+                and validate_holder(
+                    lease_token,
+                    session_id=new_session_id,
+                    owner_key=getattr(lease_token, "owner_key", ""),
+                    generation=int(getattr(lease_token, "generation", -1)),
+                )
+            )
+
+        if not (publication_matches and route_still_current and ownership_current):
+            logger.error(
+                "Discarding stale compression route publication %s -> %s: "
+                "publication=%s route=%s owner=%s",
+                expected_session_id,
+                new_session_id,
+                publication_matches,
+                route_still_current,
+                ownership_current,
+            )
+            return None
+        return advanced
 
     def _clear_conversation_scope(self, session_key: str, *, reason: str) -> None:
         """Clear ALL conversation-scoped per-session state for ``session_key``.
@@ -24786,6 +26196,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
         message_type: Optional[str] = None,
+        persist_user_display_kind: Optional[str] = None,
+        suppress_output: bool = False,
     ) -> Dict[str, Any]:
         """Profile-scoping wrapper around the agent run.
 
@@ -24797,7 +26209,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         change for single-profile gateways.
         """
         if not getattr(getattr(self, "config", None), "multiplex_profiles", False):
-            return await self._run_agent_inner(
+            result = await self._run_agent_inner(
                 message, context_prompt, history, source, session_id,
                 session_key=session_key, run_generation=run_generation,
                 _interrupt_depth=_interrupt_depth, event_message_id=event_message_id,
@@ -24805,19 +26217,51 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
                 message_type=message_type,
+                persist_user_display_kind=persist_user_display_kind,
+                suppress_output=suppress_output,
             )
+        else:
+            profile_home = self._resolve_profile_home_for_source(source)
+            with _profile_runtime_scope(profile_home):
+                result = await self._run_agent_inner(
+                    message, context_prompt, history, source, session_id,
+                    session_key=session_key, run_generation=run_generation,
+                    _interrupt_depth=_interrupt_depth, event_message_id=event_message_id,
+                    channel_prompt=channel_prompt, moa_config=moa_config,
+                    persist_user_message=persist_user_message,
+                    persist_user_timestamp=persist_user_timestamp,
+                    message_type=message_type,
+                    persist_user_display_kind=persist_user_display_kind,
+                    suppress_output=suppress_output,
+                )
 
-        profile_home = self._resolve_profile_home_for_source(source)
-        with _profile_runtime_scope(profile_home):
-            return await self._run_agent_inner(
-                message, context_prompt, history, source, session_id,
-                session_key=session_key, run_generation=run_generation,
-                _interrupt_depth=_interrupt_depth, event_message_id=event_message_id,
-                channel_prompt=channel_prompt, moa_config=moa_config,
-                persist_user_message=persist_user_message,
-                persist_user_timestamp=persist_user_timestamp,
-                message_type=message_type,
+        legacy_session_id = result.get("session_id")
+        if (
+            run_generation is None
+            and session_key
+            and legacy_session_id
+            and str(legacy_session_id) != str(session_id)
+        ):
+            advanced = await self._publish_gateway_compression_route(
+                session_key,
+                session_id,
+                str(legacy_session_id),
+                None,
             )
+            if advanced is not None:
+                record_peer = getattr(
+                    self.session_store,
+                    "_record_gateway_session_peer",
+                    None,
+                )
+                if callable(record_peer):
+                    record_peer(str(legacy_session_id), session_key, source)
+                self._sync_telegram_topic_binding(
+                    source,
+                    advanced,
+                    reason="agent-run-compression",
+                )
+        return result
 
     def _profile_name_for_source(self, source: SessionSource) -> Optional[str]:
         """Resolve the profile name for an inbound source via configured routes.
@@ -24939,6 +26383,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
         message_type: Optional[str] = None,
+        persist_user_display_kind: Optional[str] = None,
+        suppress_output: bool = False,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -24954,6 +26400,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         # ---- Proxy mode: delegate to remote API server ----
         if self._get_proxy_url():
+            if suppress_output:
+                return {
+                    "final_response": "",
+                    "messages": [],
+                    "api_calls": 0,
+                    "tools": [],
+                    "completed": False,
+                    "error": "Contextual/internal turns cannot execute through gateway proxy mode.",
+                }
             return await self._run_agent_via_proxy(
                 message=message,
                 context_prompt=context_prompt,
@@ -24980,6 +26435,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
         agent_cfg_local = user_config.get("agent") or {}
         disabled_toolsets = agent_cfg_local.get("disabled_toolsets") or None
+        execution_policy = None
+        allowed_tool_names = None
+        if suppress_output:
+            from cron.contextual import (
+                CONTEXTUAL_EXECUTION_POLICY,
+                contextual_allowed_tool_names,
+                contextual_live_tool_policy,
+            )
+
+            execution_policy = CONTEXTUAL_EXECUTION_POLICY
+            enabled_toolsets, disabled_toolsets = contextual_live_tool_policy(
+                enabled_toolsets, disabled_toolsets
+            )
+            allowed_tool_names = contextual_allowed_tool_names()
 
         display_config = user_config.get("display", {})
         if not isinstance(display_config, dict):
@@ -25086,7 +26555,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _live_status_mode = resolve_display_setting(
             user_config, platform_key, "live_status", "full"
         )
-        _live_status_adapter = self._adapter_for_source(source)
+        _live_status_adapter = (
+            None if suppress_output else self._adapter_for_source(source)
+        )
         if not getattr(_live_status_adapter, "supports_status_text", False):
             _live_status_adapter = None
         if _live_status_mode == "off":
@@ -25118,6 +26589,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
         _thinking_enabled = _thinking_mode != "off"
         needs_progress_queue = tool_progress_enabled or _thinking_enabled
+        if suppress_output:
+            progress_mode = "off"
+            tool_progress_enabled = False
+            log_mode_enabled = False
+            log_queue = None
+            interim_assistant_messages_enabled = False
+            _thinking_enabled = False
+            needs_progress_queue = False
+            _live_status_adapter = None
 
 
         # Queue for progress messages (thread-safe)
@@ -25139,7 +26619,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # other platform / when not in a voice channel.
         _voice_ack_fired = [False]
         _voice_ack_guild: List[Optional[int]] = [None]
-        if source.platform == Platform.DISCORD:
+        if not suppress_output and source.platform == Platform.DISCORD:
             _va = self.adapters.get(Platform.DISCORD)
             # source.chat_id is the linked text channel; resolve the guild whose
             # voice connection is bound to it (mirrors DiscordAdapter.play_tts).
@@ -25160,7 +26640,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # from the tool-progress / "⏳ Working — N min" / status-callback bubbles
         # are collected here and deleted after the final response lands.
         # Failed runs skip cleanup so the bubbles remain as breadcrumbs.
-        _cleanup_progress = bool(
+        _cleanup_progress = (not suppress_output) and bool(
             resolve_display_setting(user_config, platform_key, "cleanup_progress")
         )
         _cleanup_adapter = self._adapter_for_source(source) if _cleanup_progress else None
@@ -25206,6 +26686,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             user_config=user_config,
             enabled_toolsets=enabled_toolsets,
             disabled_toolsets=disabled_toolsets,
+            allowed_tool_names=allowed_tool_names,
+            execution_policy=execution_policy,
             log_mode_enabled=log_mode_enabled,
             interim_assistant_messages_enabled=interim_assistant_messages_enabled,
             needs_progress_queue=needs_progress_queue,
@@ -25220,9 +26702,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             run_generation=run_generation,
             _interrupt_depth=_interrupt_depth,
             event_message_id=event_message_id,
-            moa_config=moa_config,
+            moa_config=None if suppress_output else moa_config,
             persist_user_message=persist_user_message,
             persist_user_timestamp=persist_user_timestamp,
+            persist_user_display_kind=persist_user_display_kind,
+            suppress_output=suppress_output,
+            message_type=message_type,
         )
         turn_runner = TurnRunner(self, turn_ctx)
         # Callback invoked by agent on tool lifecycle events — extracted to
@@ -25247,7 +26732,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # would otherwise create a thread that all subsequent replies
         # (including the final answer) would inherit (#18859).
         _progress_reply_in_thread = True
-        if source.platform == Platform.SLACK:
+        if not suppress_output and source.platform == Platform.SLACK:
             _slack_adapter_for_progress = self._adapter_for_source(source)
             if _slack_adapter_for_progress is not None:
                 try:
@@ -25411,7 +26896,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         turn_ctx._event_callback_sync = turn_runner._event_callback_sync
 
         # Bridge sync status_callback → async adapter.send for context pressure
-        _status_adapter = self._adapter_for_source(source)
+        _status_adapter = None if suppress_output else self._adapter_for_source(source)
         _status_chat_id = source.chat_id
         if source.platform == Platform.FEISHU and source.thread_id and event_message_id:
             # Feishu topics only keep messages inside the topic when they are
@@ -25458,13 +26943,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         #
         # Gates: voice input, auto-TTS enabled for this chat, adapter
         # supports streaming, and a usable streaming TTS provider configured.
-        _stts_adapter = self._adapter_for_source(source)
+        _stts_adapter = None if suppress_output else self._adapter_for_source(source)
         _is_voice_input = (
             message_type is not None
             and str(getattr(message_type, "value", message_type)).lower() == "voice"
         )
         if (
-            _stts_adapter is not None
+            not suppress_output
+            and _stts_adapter is not None
             and _is_voice_input
             and _stts_adapter._should_auto_tts_for_chat(source.chat_id)
         ):
@@ -25520,7 +27006,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     return
                 await asyncio.sleep(0.05)
 
-        stream_task = asyncio.create_task(_start_stream_consumer())
+        if not suppress_output:
+            stream_task = asyncio.create_task(_start_stream_consumer())
         
         # Track this agent as running for this session (for interrupt support)
         # We do this in a callback after the agent is created
@@ -25619,7 +27106,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 except Exception as _mon_err:
                     logger.debug("monitor_for_interrupt error (will retry): %s", _mon_err)
         
-        interrupt_monitor = asyncio.create_task(monitor_for_interrupt())
+        interrupt_monitor = (
+            None
+            if suppress_output
+            else asyncio.create_task(monitor_for_interrupt())
+        )
 
         # Periodic "still working" notifications for long-running tasks.
         # Fires every N seconds so the user knows the agent hasn't died.
@@ -25727,7 +27218,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 except Exception as _ne:
                     logger.debug("Long-running notification error: %s", _ne)
 
-        _notify_task = asyncio.create_task(_notify_long_running())
+        _notify_task = (
+            None if suppress_output else asyncio.create_task(_notify_long_running())
+        )
 
         def _stream_confirmed_final_delivery(
             consumer,
@@ -25867,7 +27360,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         break
                     # Backup interrupt check: if the monitor task died or
                     # missed the interrupt, catch it here.
-                    if not _interrupt_detected.is_set() and session_key:
+                    if (
+                        not suppress_output
+                        and not _interrupt_detected.is_set()
+                        and session_key
+                    ):
                         _backup_adapter = self._adapter_for_source(source)
                         _backup_agent = agent_holder[0]
                         if (_backup_adapter and _backup_agent
@@ -25892,7 +27389,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 "Backup interrupt detected for session %s "
                                 "(monitor task state: %s)",
                                 session_key,
-                                "done" if interrupt_monitor.done() else "running",
+                                "done"
+                                if interrupt_monitor is not None and interrupt_monitor.done()
+                                else "running",
                             )
                             _backup_agent.interrupt(_bp_text)
                             _interrupt_detected.set()
@@ -25933,7 +27432,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         except Exception:
                             pass
                     # Staged warning: fire once before escalating to full timeout.
-                    if (not _warning_fired and _agent_warning is not None
+                    if (not suppress_output and not _warning_fired and _agent_warning is not None
                             and _idle_secs >= _agent_warning):
                         _warning_fired = True
                         _warn_adapter = self._adapter_for_source(source)
@@ -25969,7 +27468,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         ).start()
                         break
                     # Backup interrupt check (same as unlimited path).
-                    if not _interrupt_detected.is_set() and session_key:
+                    if (
+                        not suppress_output
+                        and not _interrupt_detected.is_set()
+                        and session_key
+                    ):
                         _backup_adapter = self._adapter_for_source(source)
                         _backup_agent = agent_holder[0]
                         if (_backup_adapter and _backup_agent
@@ -25994,7 +27497,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 "Backup interrupt detected for session %s "
                                 "(monitor task state: %s)",
                                 session_key,
-                                "done" if interrupt_monitor.done() else "running",
+                                "done"
+                                if interrupt_monitor is not None and interrupt_monitor.done()
+                                else "running",
                             )
                             _backup_agent.interrupt(_bp_text)
                             _interrupt_detected.set()
@@ -26137,7 +27642,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Use session_key (not source.chat_id) to match adapter's storage keys.
             pending_event = None
             pending = None
-            if result and adapter and session_key:
+            if not suppress_output and result and adapter and session_key:
                 pending_event = _dequeue_pending_event(adapter, session_key)
                 # /queue overflow: after consuming the adapter's "next-up"
                 # slot, promote the next queued event into it so the
@@ -26443,8 +27948,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 progress_task.cancel()
             if log_task:
                 log_task.cancel()
-            interrupt_monitor.cancel()
-            _notify_task.cancel()
+            if interrupt_monitor:
+                interrupt_monitor.cancel()
+            if _notify_task:
+                _notify_task.cancel()
 
             # Wait for stream consumer to finish its final edit
             if stream_task:
@@ -27534,9 +29041,20 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # may arm a schedule and return. Pass the event loop so cron delivery can
     # use live adapters (E2EE support).
     from cron.scheduler_provider import InProcessCronScheduler, resolve_cron_scheduler
+    from cron.scheduler import set_contextual_authorizer, set_contextual_dispatcher
     cron_stop = threading.Event()
     cron_provider = resolve_cron_scheduler()
-    cron_start_kwargs: Dict[str, Any] = {"adapters": runner.adapters, "loop": asyncio.get_running_loop()}
+    set_contextual_dispatcher(runner._dispatch_contextual_cron_from_scheduler)
+    set_contextual_authorizer(runner._authorize_contextual_delivery_from_scheduler)
+    gateway_loop = asyncio.get_running_loop()
+    cron_start_kwargs: Dict[str, Any] = {
+        "adapters": runner.adapters,
+        "loop": gateway_loop,
+    }
+    if isinstance(cron_provider, InProcessCronScheduler):
+        cron_start_kwargs["contextual_transcript_recover"] = (
+            runner._recover_contextual_cron_transcripts_from_scheduler
+        )
 
     # Multiplex profiles: tell the built-in ticker which profile homes to
     # tick so secondary-profile cron jobs actually fire (#69377).
@@ -27549,11 +29067,15 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         and getattr(runner.config, "multiplex_profiles", False)
     ):
         try:
-            from hermes_cli.profiles import profiles_to_serve
+            from hermes_cli.profiles import get_active_profile_name, profiles_to_serve
 
             profile_homes = list(profiles_to_serve(multiplex=True))
             if profile_homes:
                 cron_start_kwargs["profile_homes"] = profile_homes
+                active_profile = get_active_profile_name() or "default"
+                profile_adapters = dict(runner._profile_adapters)
+                profile_adapters[active_profile] = runner.adapters
+                cron_start_kwargs["profile_adapters"] = profile_adapters
                 logger.info(
                     "Cron scheduler will tick %d profile(s) under multiplex: %s",
                     len(profile_homes),
@@ -27634,6 +29156,8 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             "Cron ticker did not exit within %.0fs of shutdown — an in-flight "
             "delivery may have been dropped.", _CRON_SHUTDOWN_DRAIN_TIMEOUT,
         )
+    set_contextual_dispatcher(None)
+    set_contextual_authorizer(None)
     await _await_thread_exit(
         housekeeping_thread, timeout=_HOUSEKEEPING_SHUTDOWN_DRAIN_TIMEOUT
     )

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -18,7 +18,7 @@ import uuid
 from pathlib import Path
 from datetime import datetime, timedelta
 from dataclasses import dataclass, field, replace
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, Callable, cast
 
 logger = logging.getLogger(__name__)
 
@@ -328,6 +328,7 @@ class SessionContext:
     # Session metadata
     session_key: str = ""
     session_id: str = ""
+    routing_revision: int = 0
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
     
@@ -790,6 +791,11 @@ class SessionEntry:
     platform: Optional[Platform] = None
     chat_type: str = "dm"
 
+    # Monotonic revision of the stable-key → concrete-session route. Metadata
+    # and token updates do not change it. Reset/resume/compression publication
+    # do, preventing an ABA route (old→new→old) from satisfying a sealed cron.
+    routing_revision: int = 0
+
     # Lightweight persisted key/value state scoped to this session entry
     # (e.g. Slack thread-context watermarks). Survives gateway restarts via
     # the routing index; must stay small and JSON-serializable.
@@ -907,6 +913,11 @@ class SessionEntry:
             "reset_had_activity": self.reset_had_activity,
             "prev_session_id": self.prev_session_id,
         }
+        # Keep legacy/default session records byte-compatible. Revision zero
+        # is the implicit pre-contextual value; only routes that have actually
+        # moved need the persisted field.
+        if self.routing_revision:
+            result["routing_revision"] = self.routing_revision
         if self.model_override:
             # Defence-in-depth: strip credentials even if a caller stored an
             # unsanitized dict directly on the entry.
@@ -978,6 +989,7 @@ class SessionEntry:
             display_name=data.get("display_name"),
             platform=platform,
             chat_type=data.get("chat_type", "dm"),
+            routing_revision=int(data.get("routing_revision", 0) or 0),
             metadata=dict(data.get("metadata") or {}),
             input_tokens=data.get("input_tokens", 0),
             output_tokens=data.get("output_tokens", 0),
@@ -2492,6 +2504,7 @@ class SessionStore:
         db_create_kwargs = None
         existing_session_id = None
         force_new_observed_entry = None
+        replacement_routing_revision = 0
 
         # ---- Phase 0: lock read -- existing session_id for compression tip ----
         if not force_new:
@@ -2515,6 +2528,10 @@ class SessionStore:
             self._ensure_loaded_locked()
             if force_new:
                 force_new_observed_entry = self._entries.get(session_key)
+                if force_new_observed_entry is not None:
+                    replacement_routing_revision = (
+                        int(force_new_observed_entry.routing_revision) + 1
+                    )
             if session_key in self._entries and not force_new:
                 _entry_for_checks = self._entries[session_key]
                 _stale_session_id = _entry_for_checks.session_id
@@ -2575,6 +2592,9 @@ class SessionStore:
                 _healed = self._heal_compression_tip_locked(
                     entry, existing_session_id, canonical_existing_session_id
                 )
+                if _healed:
+                    entry.routing_revision += 1
+                    _needs_save = True
 
                 if _is_stale and entry.session_id == _stale_session_id:
                     # Stale routing self-heal (#54878): the in-memory entry
@@ -2592,6 +2612,10 @@ class SessionStore:
                         session_key, entry.session_id,
                     )
                     self._entries.pop(session_key, None)
+                    replacement_routing_revision = max(
+                        replacement_routing_revision,
+                        int(entry.routing_revision) + 1,
+                    )
                     # If an expiry watcher (daily/idle reset) already finalized
                     # this session, honour the reset decision instead of silently
                     # reopening it via recovery.
@@ -2618,6 +2642,10 @@ class SessionStore:
                         db_end_session_id = entry.session_id
                         prev_session_id = entry.session_id
                         self._entries.pop(session_key, None)
+                        replacement_routing_revision = max(
+                            replacement_routing_revision,
+                            int(entry.routing_revision) + 1,
+                        )
                         entry = None
                         _needs_recover = True
                     else:
@@ -2638,6 +2666,10 @@ class SessionStore:
                 session_key=session_key, source=source, now=now,
             )
             if recovered is not None:
+                recovered.routing_revision = max(
+                    int(recovered.routing_revision),
+                    replacement_routing_revision,
+                )
                 with self._lock:
                     published = self._entries.get(session_key)
                     if published is None:
@@ -2659,6 +2691,7 @@ class SessionStore:
                 display_name=source.chat_name,
                 platform=source.platform,
                 chat_type=source.chat_type,
+                routing_revision=replacement_routing_revision,
                 was_auto_reset=was_auto_reset,
                 auto_reset_reason=auto_reset_reason,
                 reset_had_activity=reset_had_activity,
@@ -2678,6 +2711,7 @@ class SessionStore:
             entry = published
             _needs_save = True
             if entry is candidate:
+                assert session_id is not None
                 db_create_kwargs = {
                     "session_id": session_id,
                     "source": source.platform.value,
@@ -2717,7 +2751,7 @@ class SessionStore:
 
         if self._db and db_create_kwargs:
             try:
-                self._db.create_session(**db_create_kwargs)
+                cast(Any, self._db.create_session)(**db_create_kwargs)
                 self._record_gateway_session_peer(
                     session_id,
                     session_key,
@@ -2733,14 +2767,21 @@ class SessionStore:
         self,
         session_key: str,
         last_prompt_tokens: int = None,
+        *,
+        touch_activity: bool = True,
     ) -> None:
-        """Update lightweight session metadata after an interaction."""
+        """Update lightweight session metadata after an interaction.
+
+        Internal contextual cron turns pass ``touch_activity=False`` so they do
+        not move the human-idle reset clock.
+        """
         with self._lock:
             self._ensure_loaded_locked()
             entry = self._entries.get(session_key)
             if entry is None:
                 return
-            entry.updated_at = _now()
+            if touch_activity:
+                entry.updated_at = _now()
             if last_prompt_tokens is not None:
                 entry.last_prompt_tokens = last_prompt_tokens
             # Snapshot peer fields while still holding _lock: a concurrent
@@ -3140,11 +3181,13 @@ class SessionStore:
                 display_name=display_name if display_name is not None else old_entry.display_name,
                 platform=old_entry.platform,
                 chat_type=old_entry.chat_type,
+                routing_revision=old_entry.routing_revision + 1,
                 is_fresh_reset=True,
             )
 
             self._entries[session_key] = new_entry
             self._save()
+            assert session_id is not None
             db_create_kwargs = {
                 "session_id": session_id,
                 "source": old_entry.platform.value if old_entry.platform else "unknown",
@@ -3172,7 +3215,7 @@ class SessionStore:
 
         if self._db and db_create_kwargs:
             try:
-                self._db.create_session(**db_create_kwargs)
+                cast(Any, self._db.create_session)(**db_create_kwargs)
                 self._record_gateway_session_peer(
                     session_id,
                     session_key,
@@ -3210,14 +3253,25 @@ class SessionStore:
                 return entry
             if entry.session_id != expected_session_id:
                 return None
+            old_session_id = entry.session_id
+            old_revision = entry.routing_revision
+            old_updated_at = entry.updated_at
             if not self._heal_compression_tip_locked(
                 entry,
                 expected_session_id,
                 target_session_id,
             ):
                 return None
+            entry.routing_revision += 1
             entry.updated_at = _now()
-            self._save()
+            try:
+                self._save()
+            except BaseException:
+                entry.session_id = old_session_id
+                entry.routing_revision = old_revision
+                entry.updated_at = old_updated_at
+                self._routing_generation += 1
+                raise
             return entry
 
     def switch_session(self, session_key: str, target_session_id: str) -> Optional[SessionEntry]:
@@ -3256,6 +3310,7 @@ class SessionStore:
                 display_name=old_entry.display_name,
                 platform=old_entry.platform,
                 chat_type=old_entry.chat_type,
+                routing_revision=old_entry.routing_revision + 1,
             )
 
             self._entries[session_key] = new_entry
@@ -3330,6 +3385,47 @@ class SessionStore:
             self._ensure_loaded_locked()
             entry = self._entries.get(session_key)
             return getattr(entry, "session_id", None) if entry else None
+
+    def peek_session_entry(self, session_key: str) -> Optional[SessionEntry]:
+        """Snapshot a live routing entry without creating/resetting/touching it."""
+        if not session_key:
+            return None
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None:
+                return None
+            origin = replace(entry.origin) if entry.origin is not None else None
+            return replace(entry, origin=origin, metadata=dict(entry.metadata))
+
+    def seal_contextual_admission(
+        self,
+        session_key: str,
+        execution_id: str,
+        seal: Callable[[str, str, str, int], bool],
+    ) -> Optional[SessionEntry]:
+        """Linearize durable cron admission with reset/resume route mutations.
+
+        The short ledger CAS runs while the existing routing lock is held. Thus
+        either a reset publishes first and admission seals the new route, or
+        admission seals first and the later revision change makes it stale.
+        """
+        if not session_key or not execution_id:
+            return None
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None or entry.origin is None:
+                return None
+            if not seal(
+                execution_id,
+                session_key,
+                entry.session_id,
+                int(entry.routing_revision),
+            ):
+                return None
+            origin = replace(entry.origin)
+            return replace(entry, origin=origin, metadata=dict(entry.metadata))
     
     def append_to_transcript(self, session_id: str, message: Dict[str, Any], skip_db: bool = False) -> None:
         """Serialize transcript draining across queue migration boundaries."""
@@ -3481,6 +3577,25 @@ class SessionStore:
                     msg = pending[0]
                 continue
 
+    def append_contextual_transcript_message_once(
+        self, session_id: str, message: Dict[str, Any]
+    ) -> None:
+        """Durably append one contextual-outbox row without a memory retry queue.
+
+        Contextual executions retry from their SQLite outbox. Enqueuing the same
+        row in the generic in-memory retry buffer creates a second, independent
+        replay authority and permits duplicate rows after a crash. The
+        ``contextual-cron:`` message identity is protected by a partial UNIQUE
+        index in ``SessionDB`` and ``append_message`` returns the existing row
+        for a duplicate identity.
+        """
+        message_id = message.get("platform_message_id") or message.get("message_id")
+        if not isinstance(message_id, str) or not message_id.startswith(
+            "contextual-cron:"
+        ):
+            raise ValueError("contextual transcript rows require a stable identity")
+        self._append_transcript_message(session_id, message)
+
     def _append_transcript_message(self, session_id: str, message: Dict[str, Any]) -> None:
         """Write one transcript row. Caller handles retry queuing."""
         self._db.append_message(
@@ -3503,6 +3618,8 @@ class SessionStore:
             # any gateway-side persistence path or the next turn's
             # replay diverges at this row.
             api_content=extract_api_content_sidecar(message),
+            display_kind=message.get("display_kind"),
+            display_metadata=message.get("display_metadata"),
         )
 
     # Maximum in-memory pending messages per session before dropping the
@@ -3565,6 +3682,14 @@ class SessionStore:
             self._dirty_transcripts.pop(session_id, None)
             self._transcript_append_failures.pop(session_id, None)
     
+    def has_platform_message_id_strict(
+        self, session_id: str, platform_message_id: str
+    ) -> bool:
+        """Durably query transcript identity or raise when it cannot be proved."""
+        if not self._db:
+            raise RuntimeError("durable session database is unavailable")
+        return self._db.has_platform_message_id(session_id, platform_message_id)
+
     def has_platform_message_id(
         self, session_id: str, platform_message_id: str
     ) -> bool:
@@ -3635,11 +3760,67 @@ class SessionStore:
             # would otherwise re-trigger the pre-request repair on every
             # request forever — heal it once at the restore boundary.
             return self._db.get_messages_as_conversation(
-                session_id, repair_alternation=True
+                session_id, repair_alternation=True, include_hidden=True
             )
         except Exception as e:
             logger.debug("Could not load messages from DB: %s", e)
             return []
+
+    def load_transcript_with_fence_strict(
+        self, session_id: str
+    ) -> tuple[List[Dict[str, Any]], int]:
+        """Load one self-consistent transcript snapshot and its durable revision."""
+        if not self._db:
+            raise RuntimeError("Session database is unavailable")
+        for _attempt in range(3):
+            before_count, before_revision = self._db.get_transcript_fence(session_id)
+            messages = self._db.get_messages_as_conversation(
+                session_id, include_ancestors=False, include_hidden=True
+            )
+            after_count, after_revision = self._db.get_transcript_fence(session_id)
+            if (
+                before_count == after_count == len(messages)
+                and before_revision == after_revision
+            ):
+                return messages, after_revision
+        raise RuntimeError("Session transcript changed while its causal fence was loaded")
+
+    def get_contextual_transcript_application(
+        self, execution_id: str
+    ) -> Optional[Dict[str, Any]]:
+        if not self._db:
+            raise RuntimeError("Session database is unavailable")
+        return self._db.get_contextual_transcript_application(execution_id)
+
+    def apply_contextual_transcript_outbox(
+        self,
+        *,
+        execution_id: str,
+        session_id: str,
+        entries: List[Dict[str, Any]],
+        base_count: int,
+        base_revision: int,
+        last_prompt_tokens: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Atomically apply a fenced contextual outbox in the canonical state DB."""
+        if not self._db:
+            raise RuntimeError("Session database is unavailable")
+        return self._db.apply_contextual_transcript_outbox(
+            execution_id=execution_id,
+            session_id=session_id,
+            entries=entries,
+            base_count=base_count,
+            base_revision=base_revision,
+            last_prompt_tokens=last_prompt_tokens,
+        )
+
+    def load_transcript_strict(self, session_id: str) -> List[Dict[str, Any]]:
+        """Load the durable transcript or raise when its causal base is unknown."""
+        if not self._db:
+            raise RuntimeError("durable session database is unavailable")
+        return self._db.get_messages_as_conversation(
+            session_id, repair_alternation=False, include_hidden=True
+        )
 
     def rewind_session(self, session_id: str, n: int = 1) -> Optional[Dict[str, Any]]:
         """Back up ``n`` user turns via soft-delete, keeping rows for audit.
@@ -3727,6 +3908,7 @@ def build_session_context(
     if session_entry:
         context.session_key = session_entry.session_key
         context.session_id = session_entry.session_id
+        context.routing_revision = int(getattr(session_entry, "routing_revision", 0))
         context.created_at = session_entry.created_at
         context.updated_at = session_entry.updated_at
     

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -22,10 +22,96 @@ from typing import Dict, List, Optional, Any, Callable, cast
 
 logger = logging.getLogger(__name__)
 
+_ROUTING_AUTHORITY_LEASES_LOCK = threading.Lock()
+_ROUTING_AUTHORITY_LEASES: Dict[str, tuple[int, Any]] = {}
+
+
+def _acquire_routing_authority_lease(sessions_dir: Path) -> None:
+    """Hold one cross-process routing authority lease for this process lifetime."""
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = sessions_dir.resolve() / ".routing-authority.lock"
+    key = str(lock_path)
+    pid = os.getpid()
+    with _ROUTING_AUTHORITY_LEASES_LOCK:
+        existing = _ROUTING_AUTHORITY_LEASES.get(key)
+        if existing is not None:
+            existing_pid, existing_fd = existing
+            if existing_pid == pid:
+                return
+            try:
+                existing_fd.close()
+            except Exception:
+                pass
+            _ROUTING_AUTHORITY_LEASES.pop(key, None)
+
+        lock_fd = open(lock_path, "a+b")
+        try:
+            if os.name == "posix":
+                import fcntl
+
+                fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            elif os.name == "nt":  # pragma: no cover - exercised on Windows CI
+                import msvcrt
+
+                if os.fstat(lock_fd.fileno()).st_size == 0:
+                    lock_fd.write(b"\0")
+                    lock_fd.flush()
+                lock_fd.seek(0)
+                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_NBLCK, 1)
+            else:  # pragma: no cover - supported hosts are POSIX or Windows
+                raise RuntimeError("No routing-authority lock primitive is available")
+        except (OSError, IOError) as exc:
+            lock_fd.close()
+            raise RuntimeError(
+                f"Another gateway process owns routing authority for {sessions_dir}"
+            ) from exc
+        except Exception:
+            lock_fd.close()
+            raise
+
+        lock_fd.seek(0)
+        lock_fd.truncate()
+        lock_fd.write(f"{pid}\n".encode("ascii"))
+        lock_fd.flush()
+        os.fsync(lock_fd.fileno())
+        _ROUTING_AUTHORITY_LEASES[key] = (pid, lock_fd)
+
+
+def _reset_routing_authority_leases_after_fork() -> None:
+    """Drop inherited lock descriptors immediately in a passive fork child."""
+    global _ROUTING_AUTHORITY_LEASES_LOCK, _ROUTING_AUTHORITY_LEASES
+    for _, handle in list(_ROUTING_AUTHORITY_LEASES.values()):
+        try:
+            handle.close()
+        except Exception:
+            pass
+    _ROUTING_AUTHORITY_LEASES = {}
+    _ROUTING_AUTHORITY_LEASES_LOCK = threading.Lock()
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_routing_authority_leases_after_fork)
+
+
+class ContextualRouteInstanceMismatch(RuntimeError):
+    """A contextual job's logical route was deleted, recreated, or rebound."""
+
 
 def _now() -> datetime:
     """Return the current local time."""
     return datetime.now()
+
+
+def _legacy_route_instance_id(data: Dict[str, Any]) -> str:
+    """Derive a restart-stable identity for pre-v2 persisted route records."""
+    seed = "\x00".join(
+        (
+            str(data.get("session_key") or ""),
+            str(data.get("session_id") or ""),
+            str(data.get("created_at") or ""),
+        )
+    )
+    return uuid.uuid5(uuid.NAMESPACE_URL, f"hermes-logical-route:{seed}").hex
 
 
 # Default auto-continue freshness window in seconds (1 hour).  A session
@@ -307,7 +393,51 @@ class SessionSource:
             auto_thread_initial_name=data.get("auto_thread_initial_name"),
             prospective_thread_id=data.get("prospective_thread_id"),
         )
-    
+
+
+def canonical_route_coordinates(
+    source: SessionSource,
+) -> tuple[str, str, str, str]:
+    """Canonical chat/thread coordinates shared by routing and cron authority."""
+    effective_thread_id = source.thread_id or source.prospective_thread_id
+    chat_type = str(source.chat_type or "")
+    chat_id = str(source.chat_id or "")
+    parent_chat_id = str(source.parent_chat_id or "")
+    if source.platform == Platform.DISCORD and effective_thread_id:
+        if source.prospective_thread_id and not source.thread_id:
+            parent_chat_id = parent_chat_id or chat_id
+        chat_type = "thread"
+        chat_id = str(effective_thread_id)
+    elif source.prospective_thread_id and not source.thread_id:
+        chat_type = "thread"
+    return chat_type, chat_id, str(effective_thread_id or ""), parent_chat_id
+
+
+def _route_principal_identity(source: Optional[SessionSource]) -> tuple[str, ...]:
+    """Return conversation/account dimensions that may retain a route UUID."""
+    if source is None:
+        return ()
+    canonical_chat_type, canonical_chat_id, effective_thread_id, parent_chat_id = (
+        canonical_route_coordinates(source)
+    )
+    return (
+        str(getattr(source.platform, "value", source.platform) or ""),
+        canonical_chat_type,
+        canonical_chat_id,
+        effective_thread_id,
+        str(source.profile or ""),
+        str(source.scope_id or ""),
+        parent_chat_id,
+        str(source.chat_id_alt or ""),
+    )
+
+
+def _same_route_identity(
+    existing: Optional[SessionSource], incoming: Optional[SessionSource]
+) -> bool:
+    return bool(existing is not None and incoming is not None) and (
+        _route_principal_identity(existing) == _route_principal_identity(incoming)
+    )
 
 
 @dataclass
@@ -328,6 +458,7 @@ class SessionContext:
     # Session metadata
     session_key: str = ""
     session_id: str = ""
+    route_instance_id: str = ""
     routing_revision: int = 0
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
@@ -791,6 +922,12 @@ class SessionEntry:
     platform: Optional[Platform] = None
     chat_type: str = "dm"
 
+    # Stable identity of this authenticated logical route. It survives physical
+    # transcript rollover (/new, reset, resume, verified compression) but a
+    # newly created/rebound route receives a new value, fencing delete/recreate
+    # ABA from reviving durable contextual jobs.
+    route_instance_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+
     # Monotonic revision of the stable-key → concrete-session route. Metadata
     # and token updates do not change it. Reset/resume/compression publication
     # do, preventing an ABA route (old→new→old) from satisfying a sealed cron.
@@ -883,6 +1020,7 @@ class SessionEntry:
             "display_name": self.display_name,
             "platform": self.platform.value if self.platform else None,
             "chat_type": self.chat_type,
+            "route_instance_id": self.route_instance_id,
             "metadata": self.metadata,
             "input_tokens": self.input_tokens,
             "output_tokens": self.output_tokens,
@@ -989,6 +1127,9 @@ class SessionEntry:
             display_name=data.get("display_name"),
             platform=platform,
             chat_type=data.get("chat_type", "dm"),
+            route_instance_id=str(
+                data.get("route_instance_id") or _legacy_route_instance_id(data)
+            ),
             routing_revision=int(data.get("routing_revision", 0) or 0),
             metadata=dict(data.get("metadata") or {}),
             input_tokens=data.get("input_tokens", 0),
@@ -1194,16 +1335,15 @@ def build_session_key(
     # when keying on a prospective id so the two byte-match. (Real-thread events
     # already carry chat_type="thread", so this only rewrites the initiating
     # channel message's slot.)
-    effective_thread_id = source.thread_id or source.prospective_thread_id
-    chat_type_slot = source.chat_type
-    if source.prospective_thread_id and not source.thread_id:
-        chat_type_slot = "thread"
+    chat_type_slot, canonical_chat_id, effective_thread_id, _ = (
+        canonical_route_coordinates(source)
+    )
     key_parts = [ns, platform, chat_type_slot]
 
     if slack_scope_id:
         key_parts.append(slack_scope_id)
-    if source.chat_id:
-        key_parts.append(source.chat_id)
+    if canonical_chat_id:
+        key_parts.append(canonical_chat_id)
     if effective_thread_id:
         key_parts.append(effective_thread_id)
 
@@ -1256,6 +1396,7 @@ class SessionStore:
                  has_active_processes_fn=None):
         self.sessions_dir = sessions_dir
         self.config = config
+        _acquire_routing_authority_lease(self.sessions_dir)
         self._entries: Dict[str, SessionEntry] = {}
         self._loaded = False
         self._lock = threading.Lock()
@@ -2505,6 +2646,7 @@ class SessionStore:
         existing_session_id = None
         force_new_observed_entry = None
         replacement_routing_revision = 0
+        replacement_route_instance_id: Optional[str] = None
 
         # ---- Phase 0: lock read -- existing session_id for compression tip ----
         if not force_new:
@@ -2532,6 +2674,12 @@ class SessionStore:
                     replacement_routing_revision = (
                         int(force_new_observed_entry.routing_revision) + 1
                     )
+                    if _same_route_identity(
+                        force_new_observed_entry.origin, source
+                    ):
+                        replacement_route_instance_id = (
+                            force_new_observed_entry.route_instance_id
+                        )
             if session_key in self._entries and not force_new:
                 _entry_for_checks = self._entries[session_key]
                 _stale_session_id = _entry_for_checks.session_id
@@ -2616,6 +2764,8 @@ class SessionStore:
                         replacement_routing_revision,
                         int(entry.routing_revision) + 1,
                     )
+                    if _same_route_identity(entry.origin, source):
+                        replacement_route_instance_id = entry.route_instance_id
                     # If an expiry watcher (daily/idle reset) already finalized
                     # this session, honour the reset decision instead of silently
                     # reopening it via recovery.
@@ -2646,6 +2796,8 @@ class SessionStore:
                             replacement_routing_revision,
                             int(entry.routing_revision) + 1,
                         )
+                        if _same_route_identity(entry.origin, source):
+                            replacement_route_instance_id = entry.route_instance_id
                         entry = None
                         _needs_recover = True
                     else:
@@ -2670,6 +2822,8 @@ class SessionStore:
                     int(recovered.routing_revision),
                     replacement_routing_revision,
                 )
+                if replacement_route_instance_id:
+                    recovered.route_instance_id = replacement_route_instance_id
                 with self._lock:
                     published = self._entries.get(session_key)
                     if published is None:
@@ -2682,6 +2836,9 @@ class SessionStore:
             # Create a candidate outside the lock, then publish only if another
             # worker has not already populated this routing key.
             session_id = f"{now.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
+            candidate_route_instance_id = (
+                replacement_route_instance_id or uuid.uuid4().hex
+            )
             candidate = SessionEntry(
                 session_key=session_key,
                 session_id=session_id,
@@ -2691,6 +2848,7 @@ class SessionStore:
                 display_name=source.chat_name,
                 platform=source.platform,
                 chat_type=source.chat_type,
+                route_instance_id=candidate_route_instance_id,
                 routing_revision=replacement_routing_revision,
                 was_auto_reset=was_auto_reset,
                 auto_reset_reason=auto_reset_reason,
@@ -3181,6 +3339,7 @@ class SessionStore:
                 display_name=display_name if display_name is not None else old_entry.display_name,
                 platform=old_entry.platform,
                 chat_type=old_entry.chat_type,
+                route_instance_id=old_entry.route_instance_id,
                 routing_revision=old_entry.routing_revision + 1,
                 is_fresh_reset=True,
             )
@@ -3310,6 +3469,7 @@ class SessionStore:
                 display_name=old_entry.display_name,
                 platform=old_entry.platform,
                 chat_type=old_entry.chat_type,
+                route_instance_id=old_entry.route_instance_id,
                 routing_revision=old_entry.routing_revision + 1,
             )
 
@@ -3403,12 +3563,15 @@ class SessionStore:
         session_key: str,
         execution_id: str,
         seal: Callable[[str, str, str, int], bool],
+        expected_route_instance_id: Optional[str] = None,
     ) -> Optional[SessionEntry]:
         """Linearize durable cron admission with reset/resume route mutations.
 
         The short ledger CAS runs while the existing routing lock is held. Thus
         either a reset publishes first and admission seals the new route, or
         admission seals first and the later revision change makes it stale.
+        A v2 logical binding also verifies its stable route instance under this
+        same fence, preventing delete/recreate ABA from sealing the wrong route.
         """
         if not session_key or not execution_id:
             return None
@@ -3417,6 +3580,13 @@ class SessionStore:
             entry = self._entries.get(session_key)
             if entry is None or entry.origin is None:
                 return None
+            if (
+                expected_route_instance_id is not None
+                and entry.route_instance_id != expected_route_instance_id
+            ):
+                raise ContextualRouteInstanceMismatch(
+                    "the originating logical route was deleted, recreated, or rebound"
+                )
             if not seal(
                 execution_id,
                 session_key,
@@ -3908,6 +4078,7 @@ def build_session_context(
     if session_entry:
         context.session_key = session_entry.session_key
         context.session_id = session_entry.session_id
+        context.route_instance_id = session_entry.route_instance_id
         context.routing_revision = int(getattr(session_entry, "routing_revision", 0))
         context.created_at = session_entry.created_at
         context.updated_at = session_entry.updated_at

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3596,6 +3596,46 @@ class SessionStore:
                 return None
             origin = replace(entry.origin)
             return replace(entry, origin=origin, metadata=dict(entry.metadata))
+
+    def claim_contextual_delivery_authority(
+        self,
+        session_key: str,
+        *,
+        source: SessionSource,
+        binding_version: int,
+        expected_route_instance_id: Optional[str],
+        expected_session_id: str,
+        expected_routing_revision: int,
+        authorize: Callable[[], bool],
+        claim: Callable[[], bool],
+    ) -> tuple[bool, bool]:
+        """Linearize destination authorization and the durable send claim.
+
+        Route deletion/reset/rebind takes the same lock, so a successful claim
+        is ordered before any later mutation. The transport may run after the
+        lock is released without reopening a check-then-send race.
+        """
+        if not session_key or binding_version not in (1, 2):
+            return False, False
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None or entry.origin is None:
+                return False, False
+            if not _same_route_identity(entry.origin, source):
+                return False, False
+            if entry.session_id != expected_session_id:
+                return False, False
+            if int(entry.routing_revision) != int(expected_routing_revision):
+                return False, False
+            if (
+                binding_version == 2
+                and entry.route_instance_id != expected_route_instance_id
+            ):
+                return False, False
+            if not authorize():
+                return False, False
+            return True, bool(claim())
     
     def append_to_transcript(self, session_id: str, message: Dict[str, Any], skip_db: bool = False) -> None:
         """Serialize transcript draining across queue migration boundaries."""

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -38,6 +38,7 @@ needs to replace the import + call site:
 
 from contextlib import contextmanager
 from contextvars import ContextVar
+from dataclasses import dataclass
 from typing import Any, Iterator
 
 # Sentinel to distinguish "never set in this context" from "explicitly set to empty".
@@ -81,6 +82,9 @@ _SESSION_USER_ID: ContextVar = ContextVar("HERMES_SESSION_USER_ID", default=_UNS
 _SESSION_USER_NAME: ContextVar = ContextVar("HERMES_SESSION_USER_NAME", default=_UNSET)
 _SESSION_KEY: ContextVar = ContextVar("HERMES_SESSION_KEY", default=_UNSET)
 _SESSION_ID: ContextVar = ContextVar("HERMES_SESSION_ID", default=_UNSET)
+_SESSION_ROUTING_REVISION: ContextVar = ContextVar(
+    "hermes_session_routing_revision", default=_UNSET
+)
 # In-process UI session/window id for multi-session desktop/TUI hosts. This is
 # intentionally separate from HERMES_SESSION_ID: the latter is the durable
 # conversation/session-db id, while the UI id is the live frontend tab/window
@@ -126,6 +130,45 @@ _SESSION_ASYNC_DELIVERY: ContextVar = ContextVar("HERMES_SESSION_ASYNC_DELIVERY"
 _CRON_AUTO_DELIVER_PLATFORM: ContextVar = ContextVar("HERMES_CRON_AUTO_DELIVER_PLATFORM", default=_UNSET)
 _CRON_AUTO_DELIVER_CHAT_ID: ContextVar = ContextVar("HERMES_CRON_AUTO_DELIVER_CHAT_ID", default=_UNSET)
 _CRON_AUTO_DELIVER_THREAD_ID: ContextVar = ContextVar("HERMES_CRON_AUTO_DELIVER_THREAD_ID", default=_UNSET)
+
+
+@dataclass(frozen=True)
+class _ContextualTurnAuthority:
+    execution_id: str
+    session_key: str
+    admitted_session_id: str
+    admitted_routing_revision: int
+
+
+_CONTEXTUAL_TURN_AUTHORITY: ContextVar = ContextVar(
+    "HERMES_CONTEXTUAL_TURN_AUTHORITY", default=None
+)
+
+
+@contextmanager
+def _bind_contextual_turn_authority(
+    *,
+    execution_id: str,
+    session_key: str,
+    admitted_session_id: str,
+    admitted_routing_revision: int,
+):
+    """Bind immutable gateway-owned contextual authority to this task only."""
+    authority = _ContextualTurnAuthority(
+        execution_id=str(execution_id),
+        session_key=str(session_key),
+        admitted_session_id=str(admitted_session_id),
+        admitted_routing_revision=int(admitted_routing_revision),
+    )
+    token = _CONTEXTUAL_TURN_AUTHORITY.set(authority)
+    try:
+        yield authority
+    finally:
+        _CONTEXTUAL_TURN_AUTHORITY.reset(token)
+
+
+def _get_contextual_turn_authority():
+    return _CONTEXTUAL_TURN_AUTHORITY.get()
 
 _VAR_MAP = {
     "HERMES_SESSION_PLATFORM": _SESSION_PLATFORM,
@@ -214,6 +257,7 @@ def set_session_vars(
     user_name: str = "",
     session_key: str = "",
     session_id: str = "",
+    routing_revision: int = 0,
     message_id: str = "",
     profile: str = "",
     cwd: str = "",
@@ -256,6 +300,7 @@ def set_session_vars(
         _SESSION_USER_NAME.set(user_name),
         _SESSION_KEY.set(session_key),
         _SESSION_ID.set(session_id),
+        _SESSION_ROUTING_REVISION.set(int(routing_revision)),
         _SESSION_UI_SESSION_ID.set(ui_session_id),
         _SESSION_MESSAGE_ID.set(message_id),
         _SESSION_PROFILE.set(profile),
@@ -293,6 +338,7 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_USER_NAME,
         _SESSION_KEY,
         _SESSION_ID,
+        _SESSION_ROUTING_REVISION,
         _SESSION_UI_SESSION_ID,
         _SESSION_MESSAGE_ID,
         _SESSION_PROFILE,
@@ -348,6 +394,7 @@ def reset_session_vars() -> None:
     """
     for var in _VAR_MAP.values():
         var.set(_UNSET)
+    _SESSION_ROUTING_REVISION.set(_UNSET)
     # Reset the async-delivery capability to "never bound here" (_UNSET) for the
     # same inheritance-leak reason as the mapped vars above — see clear_session_vars,
     # which resets this var on the handler-exit path for the symmetric concern.
@@ -384,6 +431,39 @@ def get_session_env(name: str, default: str = "") -> str:
             return value
     # Fall back to os.environ for CLI, cron, and test compatibility
     return os.getenv(name, default)
+
+
+def get_bound_session_context() -> dict[str, Any] | None:
+    """Return the explicitly task-bound gateway identity without env fallback.
+
+    Contextual cron is a security boundary: a process-level
+    ``HERMES_SESSION_KEY`` must never be accepted as proof that a model tool is
+    running inside a live gateway turn.  This accessor reads the ContextVars
+    directly and therefore returns ``None`` for CLI/scheduler/process-only
+    environments even when similarly named environment variables exist.
+    """
+    values = {
+        "platform": _SESSION_PLATFORM.get(),
+        "source": _SESSION_SOURCE.get(),
+        "chat_id": _SESSION_CHAT_ID.get(),
+        "chat_type": _SESSION_CHAT_TYPE.get(),
+        "thread_id": _SESSION_THREAD_ID.get(),
+        "user_id": _SESSION_USER_ID.get(),
+        "session_key": _SESSION_KEY.get(),
+        "session_id": _SESSION_ID.get(),
+        "routing_revision": _SESSION_ROUTING_REVISION.get(),
+        "profile": _SESSION_PROFILE.get(),
+    }
+    if any(value is _UNSET for value in values.values()):
+        return None
+    routing_revision = int(values.pop("routing_revision") or 0)
+    normalized: dict[str, Any] = {
+        name: str(value or "").strip() for name, value in values.items()
+    }
+    normalized["routing_revision"] = routing_revision
+    if not all(normalized.get(name) for name in ("platform", "chat_id", "user_id", "session_key")):
+        return None
+    return normalized
 
 
 # Surfaces that are not a human chat channel. The gateway binds a platform

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -39,7 +39,7 @@ needs to replace the import + call site:
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
-from typing import Any, Iterator
+from typing import Any, Iterator, Optional
 
 # Sentinel to distinguish "never set in this context" from "explicitly set to empty".
 # When a contextvar holds _UNSET, we fall back to os.environ (CLI/cron compat).
@@ -82,6 +82,12 @@ _SESSION_USER_ID: ContextVar = ContextVar("HERMES_SESSION_USER_ID", default=_UNS
 _SESSION_USER_NAME: ContextVar = ContextVar("HERMES_SESSION_USER_NAME", default=_UNSET)
 _SESSION_KEY: ContextVar = ContextVar("HERMES_SESSION_KEY", default=_UNSET)
 _SESSION_ID: ContextVar = ContextVar("HERMES_SESSION_ID", default=_UNSET)
+_SESSION_ROUTE_INSTANCE_ID: ContextVar = ContextVar(
+    "hermes_session_route_instance_id", default=_UNSET
+)
+_SESSION_ROUTE_PRINCIPAL: ContextVar = ContextVar(
+    "hermes_session_route_principal", default=_UNSET
+)
 _SESSION_ROUTING_REVISION: ContextVar = ContextVar(
     "hermes_session_routing_revision", default=_UNSET
 )
@@ -138,6 +144,8 @@ class _ContextualTurnAuthority:
     session_key: str
     admitted_session_id: str
     admitted_routing_revision: int
+    admitted_route_instance_id: Optional[str] = None
+    creator_source: Any = None
 
 
 _CONTEXTUAL_TURN_AUTHORITY: ContextVar = ContextVar(
@@ -152,6 +160,8 @@ def _bind_contextual_turn_authority(
     session_key: str,
     admitted_session_id: str,
     admitted_routing_revision: int,
+    admitted_route_instance_id: Optional[str] = None,
+    creator_source: Any = None,
 ):
     """Bind immutable gateway-owned contextual authority to this task only."""
     authority = _ContextualTurnAuthority(
@@ -159,6 +169,10 @@ def _bind_contextual_turn_authority(
         session_key=str(session_key),
         admitted_session_id=str(admitted_session_id),
         admitted_routing_revision=int(admitted_routing_revision),
+        admitted_route_instance_id=(
+            str(admitted_route_instance_id) if admitted_route_instance_id else None
+        ),
+        creator_source=creator_source,
     )
     token = _CONTEXTUAL_TURN_AUTHORITY.set(authority)
     try:
@@ -257,6 +271,8 @@ def set_session_vars(
     user_name: str = "",
     session_key: str = "",
     session_id: str = "",
+    route_instance_id: str = "",
+    route_principal: Optional[dict[str, str]] = None,
     routing_revision: int = 0,
     message_id: str = "",
     profile: str = "",
@@ -300,6 +316,8 @@ def set_session_vars(
         _SESSION_USER_NAME.set(user_name),
         _SESSION_KEY.set(session_key),
         _SESSION_ID.set(session_id),
+        _SESSION_ROUTE_INSTANCE_ID.set(route_instance_id),
+        _SESSION_ROUTE_PRINCIPAL.set(dict(route_principal or {})),
         _SESSION_ROUTING_REVISION.set(int(routing_revision)),
         _SESSION_UI_SESSION_ID.set(ui_session_id),
         _SESSION_MESSAGE_ID.set(message_id),
@@ -338,6 +356,8 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_USER_NAME,
         _SESSION_KEY,
         _SESSION_ID,
+        _SESSION_ROUTE_INSTANCE_ID,
+        _SESSION_ROUTE_PRINCIPAL,
         _SESSION_ROUTING_REVISION,
         _SESSION_UI_SESSION_ID,
         _SESSION_MESSAGE_ID,
@@ -394,6 +414,8 @@ def reset_session_vars() -> None:
     """
     for var in _VAR_MAP.values():
         var.set(_UNSET)
+    _SESSION_ROUTE_INSTANCE_ID.set(_UNSET)
+    _SESSION_ROUTE_PRINCIPAL.set(_UNSET)
     _SESSION_ROUTING_REVISION.set(_UNSET)
     # Reset the async-delivery capability to "never bound here" (_UNSET) for the
     # same inheritance-leak reason as the mapped vars above — see clear_session_vars,
@@ -451,14 +473,23 @@ def get_bound_session_context() -> dict[str, Any] | None:
         "user_id": _SESSION_USER_ID.get(),
         "session_key": _SESSION_KEY.get(),
         "session_id": _SESSION_ID.get(),
+        "route_instance_id": _SESSION_ROUTE_INSTANCE_ID.get(),
+        "route_principal": _SESSION_ROUTE_PRINCIPAL.get(),
         "routing_revision": _SESSION_ROUTING_REVISION.get(),
         "profile": _SESSION_PROFILE.get(),
     }
     if any(value is _UNSET for value in values.values()):
         return None
     routing_revision = int(values.pop("routing_revision") or 0)
+    route_principal = values.pop("route_principal")
+    if not isinstance(route_principal, dict):
+        return None
     normalized: dict[str, Any] = {
         name: str(value or "").strip() for name, value in values.items()
+    }
+    normalized["route_principal"] = {
+        str(name): str(value or "").strip()
+        for name, value in route_principal.items()
     }
     normalized["routing_revision"] = routing_revision
     if not all(normalized.get(name) for name in ("platform", "chat_id", "user_id", "session_key")):

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -31,7 +31,7 @@ from typing import Any, Optional, Union
 
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.i18n import t
-from agent.turn_context import extract_api_content_sidecar
+from agent.turn_context import clone_transcript_message_for_branch
 from gateway.config import HomeChannel, Platform, PlatformConfig, persist_home_channel
 from gateway.platforms.base import EphemeralReply, MessageEvent, MessageType
 from gateway.session import (
@@ -4808,27 +4808,7 @@ class GatewaySlashCommandsMixin:
         try:
             await self._session_db.append_messages_batch(
                 new_session_id,
-                [
-                    {
-                        "role": msg.get("role", "user"),
-                        "content": msg.get("content"),
-                        "tool_name": msg.get("tool_name") or msg.get("name"),
-                        "tool_calls": msg.get("tool_calls"),
-                        "tool_call_id": msg.get("tool_call_id"),
-                        "finish_reason": msg.get("finish_reason"),
-                        "reasoning": msg.get("reasoning"),
-                        "reasoning_content": msg.get("reasoning_content"),
-                        "reasoning_details": msg.get("reasoning_details"),
-                        "codex_reasoning_items": msg.get("codex_reasoning_items"),
-                        "codex_message_items": msg.get("codex_message_items"),
-                        # Keep the api_content sidecar so the branch's first turn
-                        # replays the parent's exact wire bytes (warm provider
-                        # prompt cache) instead of a full cold prefill.
-                        "api_content": extract_api_content_sidecar(msg),
-                        "timestamp": msg.get("timestamp"),
-                    }
-                    for msg in history
-                ],
+                [clone_transcript_message_for_branch(msg) for msg in history],
                 chunk_rows=500,
             )
         except Exception:

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -91,9 +91,14 @@ class TurnContext:
     moa_config: Optional[dict] = None
     persist_user_message: Optional[Any] = None
     persist_user_timestamp: Optional[float] = None
+    persist_user_display_kind: Optional[str] = None
+    suppress_output: bool = False
+    message_type: Optional[str] = None
     user_config: Any = None
     enabled_toolsets: Any = None
     disabled_toolsets: Any = None
+    allowed_tool_names: Any = None
+    execution_policy: Any = None
     log_mode_enabled: bool = False
     interim_assistant_messages_enabled: bool = False
     needs_progress_queue: bool = False

--- a/gateway/turn_lease.py
+++ b/gateway/turn_lease.py
@@ -263,6 +263,36 @@ class SessionTurnLeaseRegistry:
         lease.last_used = lease.acquired_at
         return token
 
+    def is_current_holder(
+        self,
+        token: object,
+        *,
+        session_id: str,
+        owner_key: str,
+        generation: int,
+    ) -> bool:
+        """Return whether ``token`` is the exact live holder for this authority.
+
+        This is a read-only capability check for callers adopting a lease that
+        was acquired by another layer.  Matching token fields alone is never
+        sufficient: the registry slot must still hold this exact object and its
+        lock must remain acquired.
+        """
+        if not isinstance(token, TurnLeaseToken) or token.released:
+            return False
+        if (
+            token.session_id != session_id
+            or token.owner_key != owner_key
+            or token.generation != int(generation)
+        ):
+            return False
+        lease = self._leases.get(session_id)
+        return bool(
+            lease is not None
+            and lease.lock.locked()
+            and lease.holder is token
+        )
+
     def rebind(self, token: Optional[TurnLeaseToken], new_session_id: str) -> bool:
         """Alias a HELD lease onto ``new_session_id`` after mid-turn rotation.
 

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -421,7 +421,7 @@ class CLIAgentSetupMixin:
                     )
                 return False
             restored = self._session_db.get_messages_as_conversation(
-                self.session_id, repair_alternation=True
+                self.session_id, repair_alternation=True, include_hidden=True
             )
             if restored:
                 restored = [m for m in restored if m.get("role") != "session_meta"]

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -28,7 +28,7 @@ from rich.markup import escape as _escape
 from rich.panel import Panel
 
 from hermes_constants import display_hermes_home, is_termux as _is_termux_environment
-from agent.turn_context import extract_api_content_sidecar
+from agent.turn_context import clone_transcript_message_for_branch
 from hermes_cli.browser_connect import (
     DEFAULT_BROWSER_CDP_URL,
     discover_local_cdp_url,
@@ -1256,19 +1256,7 @@ class CLICommandsMixin:
             self._session_db.append_messages_batch(
                 new_session_id,
                 [
-                    {
-                        "role": msg.get("role", "user"),
-                        "content": msg.get("content"),
-                        "tool_name": msg.get("tool_name") or msg.get("name"),
-                        "tool_calls": msg.get("tool_calls"),
-                        "tool_call_id": msg.get("tool_call_id"),
-                        "reasoning": msg.get("reasoning"),
-                        # Keep the api_content sidecar so the branch's first turn
-                        # replays the parent's exact wire bytes (warm provider
-                        # prompt cache) instead of a full cold prefill.
-                        "api_content": extract_api_content_sidecar(msg),
-                        "timestamp": msg.get("timestamp"),
-                    }
+                    clone_transcript_message_for_branch(msg)
                     for msg in self.conversation_history
                 ],
                 chunk_rows=500,

--- a/hermes_cli/context_switch_guard.py
+++ b/hermes_cli/context_switch_guard.py
@@ -187,7 +187,9 @@ def enrich_model_switch_warnings_for_gateway(
     if db is not None and store is not None:
         try:
             entry = store.get_or_create_session(source)
-            messages = db.get_messages_as_conversation(entry.session_id)
+            messages = db.get_messages_as_conversation(
+                entry.session_id, include_hidden=True
+            )
         except Exception:
             pass
 

--- a/hermes_cli/lifecycle.py
+++ b/hermes_cli/lifecycle.py
@@ -3,13 +3,31 @@
 from __future__ import annotations
 
 import logging
+from contextlib import contextmanager
+from contextvars import ContextVar
 from typing import Any, List
 
 logger = logging.getLogger(__name__)
 
+_hooks_suppressed: ContextVar[bool] = ContextVar(
+    "hermes_lifecycle_hooks_suppressed", default=False
+)
+
+
+@contextmanager
+def suppress_lifecycle_hooks():
+    """Task-local fail-closed boundary for internal unattended execution."""
+    token = _hooks_suppressed.set(True)
+    try:
+        yield
+    finally:
+        _hooks_suppressed.reset(token)
+
 
 def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
     """Notify first-party observers, then invoke compatibility plugin hooks."""
+    if _hooks_suppressed.get():
+        return []
     try:
         from hermes_cli.observability import observe_lifecycle
 
@@ -24,6 +42,8 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
 
 def has_hook(hook_name: str) -> bool:
     """Return whether a first-party observer or plugin consumes a hook."""
+    if _hooks_suppressed.get():
+        return False
     try:
         from hermes_cli.observability import handles_hook
 
@@ -39,6 +59,8 @@ def has_hook(hook_name: str) -> bool:
 
 def finalize_session(**kwargs: Any) -> List[Any]:
     """Notify observers and hard-close one core-owned Relay conversation."""
+    if _hooks_suppressed.get():
+        return []
     try:
         from hermes_cli.observability import observe_lifecycle
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11841,9 +11841,16 @@ def _call_cron_for_profile(target_profile: Optional[str], func_name: str, *args,
         reset_hermes_home_override(token)
 
     if isinstance(result, list):
-        return [_annotate_cron_job(j, profile_name, home) for j in result]
+        return [
+            _annotate_cron_job(
+                cron_jobs.public_job_record(job), profile_name, home
+            )
+            for job in result
+        ]
     if isinstance(result, dict):
-        return _annotate_cron_job(result, profile_name, home)
+        return _annotate_cron_job(
+            cron_jobs.public_job_record(result), profile_name, home
+        )
     return result
 
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2026,6 +2026,10 @@ class SessionCompressionInProgressError(CompressionSessionBusyError):
     """
 
 
+class ContextualTranscriptCASMismatch(RuntimeError):
+    """A contextual outbox no longer matches its immutable transcript fence."""
+
+
 def _connect_tracked_db(path, tracking_path=None, **kwargs):
     """``sqlite3.connect`` that registers the open fd for lock-safety.
 
@@ -6610,7 +6614,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             where_clauses.append(clause)
             params.extend(clause_params)
         if min_message_count > 0:
-            where_clauses.append("s.message_count >= ?")
+            where_clauses.append(
+                "(SELECT COUNT(*) FROM messages _visible_count "
+                "WHERE _visible_count.session_id = s.id "
+                "AND COALESCE(_visible_count.display_kind, '') != 'hidden') >= ?"
+            )
             params.append(min_message_count)
         if archived_only:
             where_clauses.append("s.archived = 1")
@@ -6727,6 +6735,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         (SELECT {_PREVIEW_RAW_SELECT}
                          FROM messages m
                          WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
+                           AND COALESCE(m.display_kind, '') != 'hidden'
                          ORDER BY m.timestamp, m.id LIMIT 1),
                         ''
                     ) AS _preview_raw,
@@ -6750,6 +6759,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         (SELECT {_PREVIEW_RAW_SELECT}
                          FROM messages m
                          WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
+                           AND COALESCE(m.display_kind, '') != 'hidden'
                          ORDER BY m.timestamp, m.id LIMIT 1),
                         ''
                     ) AS _preview_raw,
@@ -6789,13 +6799,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         (SELECT {_PREVIEW_RAW_SELECT}
                          FROM messages m
                          WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
+                           AND COALESCE(m.display_kind, '') != 'hidden'
                          ORDER BY m.timestamp, m.id LIMIT 1),
                         ''
                     ) AS _preview_raw,
-                    COALESCE(
-                        (SELECT MAX(m2.timestamp) FROM messages m2 WHERE m2.session_id = s.id),
-                        s.started_at
-                    ) AS last_active
+                    {_sql_session_last_active("s")} AS last_active
                 FROM sessions s
                 {prompt_join}
                 {pinned_where}
@@ -6860,6 +6868,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 merged["_lineage_root_id"] = s["id"]
                 projected.append(merged)
             sessions = projected
+
+        # Durable counters include hidden model-context rows for transcript
+        # fencing. Public listings replace them in one batch after tip
+        # projection so every count corresponds to the surfaced session ID.
+        self._apply_visible_session_counts(sessions)
 
         # Derive read state per surfaced conversation. ``last_read_at`` is
         # lineage-stamped by set_session_read, so a projected row's root
@@ -7014,6 +7027,192 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return None
         return meta
 
+    def get_transcript_fence(self, session_id: str) -> tuple[int, int]:
+        """Return the active message count and monotonic model-transcript revision."""
+        with self._lock:
+            conn = self._conn
+            if conn is None:
+                raise RuntimeError("Session database is unavailable")
+            row = conn.execute(
+                "SELECT transcript_revision FROM sessions "
+                "WHERE id = ? AND ended_at IS NULL",
+                (session_id,),
+            ).fetchone()
+            if row is None:
+                raise KeyError(f"Unknown or ended session: {session_id}")
+            count_row = conn.execute(
+                "SELECT COUNT(*) FROM messages WHERE session_id = ? AND active = 1",
+                (session_id,),
+            ).fetchone()
+        return int(count_row[0]), int(row[0])
+
+    def get_contextual_transcript_application(
+        self, execution_id: str
+    ) -> Optional[Dict[str, Any]]:
+        """Return the durable state-db application receipt, if one exists."""
+        with self._lock:
+            conn = self._conn
+            if conn is None:
+                raise RuntimeError("Session database is unavailable")
+            row = conn.execute(
+                "SELECT * FROM contextual_transcript_applications WHERE execution_id = ?",
+                (execution_id,),
+            ).fetchone()
+        return dict(row) if row is not None else None
+
+    def apply_contextual_transcript_outbox(
+        self,
+        *,
+        execution_id: str,
+        session_id: str,
+        entries: List[Dict[str, Any]],
+        base_count: int,
+        base_revision: int,
+        last_prompt_tokens: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """CAS-apply one contextual outbox and its durable receipt atomically.
+
+        The state-db receipt is authoritative after a crash between this commit
+        and the separate cron-ledger acknowledgement. Ordinary human rows may
+        advance the session afterwards without making that completed application
+        ambiguous on recovery.
+        """
+        entry_ids = []
+        for index, entry in enumerate(entries):
+            identity = entry.get("platform_message_id") or entry.get("message_id")
+            expected_identity = f"contextual-cron:{execution_id}:{index}"
+            if identity != expected_identity:
+                raise ValueError("contextual transcript rows require their deterministic identity")
+            entry_ids.append(identity)
+        entry_ids_json = json.dumps(entry_ids, separators=(",", ":"))
+        entries_digest = hashlib.sha256(
+            json.dumps(
+                entries,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest()
+
+        def _do(conn):
+            receipt = conn.execute(
+                "SELECT * FROM contextual_transcript_applications WHERE execution_id = ?",
+                (execution_id,),
+            ).fetchone()
+            if receipt is not None:
+                if (
+                    str(receipt["session_id"]) != session_id
+                    or int(receipt["base_revision"]) != int(base_revision)
+                    or int(receipt["base_count"]) != int(base_count)
+                    or str(receipt["entry_ids_json"]) != entry_ids_json
+                    or str(receipt["entries_digest"]) != entries_digest
+                ):
+                    raise ContextualTranscriptCASMismatch(
+                        "Contextual transcript receipt does not match the immutable outbox."
+                    )
+                return {
+                    "status": "already_applied",
+                    "applied_revision": int(receipt["applied_revision"]),
+                    "last_prompt_tokens": receipt["last_prompt_tokens"],
+                }
+
+            session = conn.execute(
+                "SELECT ended_at, end_reason, transcript_revision FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            if session is None:
+                raise ContextualTranscriptCASMismatch(
+                    "Contextual transcript session no longer exists."
+                )
+            if session["ended_at"] is not None:
+                raise ContextualTranscriptCASMismatch(
+                    "Contextual transcript session is no longer active."
+                )
+            active_lock = conn.execute(
+                "SELECT holder FROM compression_locks WHERE session_id = ? AND expires_at > ?",
+                (session_id, time.time()),
+            ).fetchone()
+            if active_lock is not None:
+                raise ContextualTranscriptCASMismatch(
+                    "Contextual transcript session is being compressed."
+                )
+
+            tail = conn.execute(
+                "SELECT platform_message_id FROM messages "
+                "WHERE session_id = ? AND active = 1 ORDER BY id LIMIT ? OFFSET ?",
+                (session_id, len(entry_ids) + 1, int(base_count)),
+            ).fetchall()
+            tail_ids = [str(row[0] or "") for row in tail]
+            current_count = int(
+                conn.execute(
+                    "SELECT COUNT(*) FROM messages WHERE session_id = ? AND active = 1",
+                    (session_id,),
+                ).fetchone()[0]
+            )
+            current_revision = int(session["transcript_revision"])
+            revision_delta = current_revision - int(base_revision)
+            count_delta = current_count - int(base_count)
+            if revision_delta != count_delta or revision_delta < 0:
+                raise ContextualTranscriptCASMismatch(
+                    "Contextual transcript revision no longer matches the admitted base."
+                )
+
+            prefix = 0
+            for actual, expected in zip(tail_ids, entry_ids):
+                if actual != expected:
+                    break
+                prefix += 1
+            if prefix != min(len(tail_ids), len(entry_ids)):
+                raise ContextualTranscriptCASMismatch(
+                    "Contextual transcript advanced before the pending outbox was applied."
+                )
+            if len(tail_ids) > len(entry_ids):
+                # A receipt-less legacy application may be followed by humans,
+                # but only after the entire deterministic outbox.
+                prefix = len(entry_ids)
+            elif prefix < len(tail_ids):
+                raise ContextualTranscriptCASMismatch(
+                    "Contextual transcript outbox is interleaved with another writer."
+                )
+
+            missing = entries[prefix:]
+            inserted, tool_calls = self._insert_message_rows(conn, session_id, missing)
+            if inserted:
+                conn.execute(
+                    "UPDATE sessions SET message_count = message_count + ?, "
+                    "tool_call_count = tool_call_count + ? WHERE id = ?",
+                    (inserted, tool_calls, session_id),
+                )
+            applied_revision = int(
+                conn.execute(
+                    "SELECT transcript_revision FROM sessions WHERE id = ?", (session_id,)
+                ).fetchone()[0]
+            )
+            conn.execute(
+                "INSERT INTO contextual_transcript_applications "
+                "(execution_id, session_id, base_revision, base_count, entry_ids_json, "
+                "entries_digest, applied_revision, last_prompt_tokens, applied_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    execution_id,
+                    session_id,
+                    int(base_revision),
+                    int(base_count),
+                    entry_ids_json,
+                    entries_digest,
+                    applied_revision,
+                    int(last_prompt_tokens) if last_prompt_tokens is not None else None,
+                    time.time(),
+                ),
+            )
+            return {
+                "status": "applied",
+                "applied_revision": applied_revision,
+                "last_prompt_tokens": last_prompt_tokens,
+            }
+
+        return self._execute_write(_do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S)
+
     def append_message(
         self,
         session_id: str,
@@ -7101,8 +7300,22 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         num_tool_calls = 0
         if tool_calls is not None:
             num_tool_calls = len(tool_calls) if isinstance(tool_calls, list) else 1
+        contextual_identity = (
+            platform_message_id
+            if isinstance(platform_message_id, str)
+            and platform_message_id.startswith("contextual-cron:")
+            else None
+        )
 
         def _do(conn):
+            if contextual_identity is not None:
+                existing = conn.execute(
+                    "SELECT id FROM messages WHERE session_id = ? "
+                    "AND platform_message_id = ? LIMIT 1",
+                    (session_id, contextual_identity),
+                ).fetchone()
+                if existing is not None:
+                    return int(existing["id"])
             self._check_transcript_write_guards(
                 conn, session_id, compression_lock_holder
             )
@@ -7760,6 +7973,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         offset: int = 0,
         latest: bool = False,
         after_id: Optional[int] = None,
+        include_hidden: bool = False,
     ) -> List[Dict[str, Any]]:
         """Load messages for a session in insertion order.
 
@@ -7787,10 +8001,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if after_id is not None and (latest or offset):
             raise ValueError("after_id is incompatible with latest/offset paging")
         active_clause = "" if include_inactive else " AND active = 1"
+        hidden_clause = (
+            "" if include_hidden else " AND COALESCE(display_kind, '') != 'hidden'"
+        )
         keyset_clause = " AND id > ?" if after_id is not None else ""
         sql = (
             "SELECT * FROM messages WHERE session_id = ?"
-            f"{active_clause}{keyset_clause} ORDER BY id {'DESC' if latest else 'ASC'}"
+            f"{active_clause}{hidden_clause}{keyset_clause} "
+            f"ORDER BY id {'DESC' if latest else 'ASC'}"
         )
         params: list = [session_id]
         if after_id is not None:
@@ -7825,6 +8043,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         session_id: str,
         around_message_id: int,
         window: int = 5,
+        include_hidden: bool = False,
     ) -> Dict[str, Any]:
         """Load a window of messages anchored on a specific message id.
 
@@ -7847,10 +8066,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """
         if window < 0:
             window = 0
+        hidden_clause = (
+            "" if include_hidden else " AND COALESCE(display_kind, '') != 'hidden'"
+        )
         with self._read_ctx() as conn:
             # Confirm the anchor exists in this session.
             anchor_exists = conn.execute(
-                "SELECT 1 FROM messages WHERE id = ? AND session_id = ? LIMIT 1",
+                "SELECT 1 FROM messages WHERE id = ? AND session_id = ?"
+                f"{hidden_clause} LIMIT 1",
                 (around_message_id, session_id),
             ).fetchone()
             if not anchor_exists:
@@ -7860,13 +8083,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # (ASC, take window). Final order is id ASC.
             before_rows = conn.execute(
                 "SELECT * FROM messages "
-                "WHERE session_id = ? AND id <= ? "
+                f"WHERE session_id = ? AND id <= ?{hidden_clause} "
                 "ORDER BY id DESC LIMIT ?",
                 (session_id, around_message_id, window + 1),
             ).fetchall()
             after_rows = conn.execute(
                 "SELECT * FROM messages "
-                "WHERE session_id = ? AND id > ? "
+                f"WHERE session_id = ? AND id > ?{hidden_clause} "
                 "ORDER BY id ASC LIMIT ?",
                 (session_id, around_message_id, window),
             ).fetchall()
@@ -7996,6 +8219,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         include_inactive: bool = False,
         repair_alternation: bool = False,
         include_row_ids: bool = False,
+        include_hidden: bool = False,
     ) -> List[Dict[str, Any]]:
         """
         Load messages in the OpenAI conversation format (role + content dicts).
@@ -8020,6 +8244,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             session_ids = self._session_lineage_root_to_tip(session_id)
 
         active_clause = "" if include_inactive else " AND active = 1"
+        hidden_clause = (
+            "" if include_hidden else " AND COALESCE(display_kind, '') != 'hidden'"
+        )
         with self._read_ctx() as conn:
             placeholders = ",".join("?" for _ in session_ids)
             rows = conn.execute(
@@ -8033,7 +8260,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 # after its tool response, breaking tool-call/response adjacency
                 # and triggering an HTTP 400 on replay. This matches get_messages
                 # — see c03acca50 for the original fix.
-                f"{active_clause} ORDER BY id",
+                f"{active_clause}{hidden_clause} ORDER BY id",
                 tuple(session_ids),
             ).fetchall()
 
@@ -8230,8 +8457,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             repair_alternation=True,
             include_row_ids=True,
         )
+        display_rows = [
+            row
+            for row in rows
+            if (row["display_kind"] or "") != "hidden"
+        ]
         display_history = self._rows_to_conversation(
-            rows,
+            display_rows,
             session_id=session_id,
             include_ancestors=True,
             repair_alternation=False,
@@ -8354,7 +8586,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "ORDER BY id",
                 tuple(session_ids),
             ).fetchall()
-        ancestor_rows = [r for r in rows if r["session_id"] != session_id]
+        ancestor_rows = [
+            r
+            for r in rows
+            if r["session_id"] != session_id
+            and (r["display_kind"] or "") != "hidden"
+        ]
         if not ancestor_rows:
             return []
         return self._rows_to_conversation(
@@ -8630,7 +8867,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             where_clauses.append(clause)
             params.extend(clause_params)
         if min_message_count > 0:
-            where_clauses.append("s.message_count >= ?")
+            where_clauses.append(
+                "(SELECT COUNT(*) FROM messages _visible_count "
+                "WHERE _visible_count.session_id = s.id "
+                "AND COALESCE(_visible_count.display_kind, '') != 'hidden') >= ?"
+            )
             params.append(min_message_count)
         if archived_only:
             where_clauses.append("s.archived = 1")
@@ -10112,6 +10353,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                             (SELECT {_PREVIEW_RAW_SELECT}
                              FROM messages m
                              WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
+                           AND COALESCE(m.display_kind, '') != 'hidden'
                              ORDER BY m.timestamp, m.id LIMIT 1),
                             ''
                         ) AS _preview_raw,
@@ -10142,6 +10384,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                             (SELECT {_PREVIEW_RAW_SELECT}
                              FROM messages m
                              WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
+                           AND COALESCE(m.display_kind, '') != 'hidden'
                              ORDER BY m.timestamp, m.id LIMIT 1),
                             ''
                         ) AS _preview_raw,

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -126,7 +126,8 @@ def _sql_session_last_active(alias: str = "s") -> str:
     """
     msg_max = (
         f"(SELECT MAX(_act_m.timestamp) FROM messages _act_m "
-        f"WHERE _act_m.session_id = {alias}.id)"
+        f"WHERE _act_m.session_id = {alias}.id "
+        f"AND COALESCE(_act_m.display_kind, '') != 'hidden')"
     )
     return (
         f"COALESCE("
@@ -143,7 +144,8 @@ def _sql_session_last_active_by_id(session_id_expr: str) -> str:
     """Same freshest-of expression keyed by a session-id SQL expression."""
     msg_max = (
         f"(SELECT MAX(_act_m.timestamp) FROM messages _act_m "
-        f"WHERE _act_m.session_id = {session_id_expr})"
+        f"WHERE _act_m.session_id = {session_id_expr} "
+        f"AND COALESCE(_act_m.display_kind, '') != 'hidden')"
     )
     activity = (
         f"(SELECT last_activity_at FROM sessions _act_s "
@@ -164,7 +166,7 @@ def _sql_session_last_active_by_id(session_id_expr: str) -> str:
     )
 
 
-SCHEMA_VERSION = 25
+SCHEMA_VERSION = 26
 
 
 # FTS storage-layout version, tracked INDEPENDENTLY of SCHEMA_VERSION in the
@@ -256,6 +258,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     compression_ineffective_count INTEGER NOT NULL DEFAULT 0,
     profile_name TEXT,
     rewind_count INTEGER NOT NULL DEFAULT 0,
+    transcript_revision INTEGER NOT NULL DEFAULT 0,
     archived INTEGER NOT NULL DEFAULT 0,
     pinned INTEGER NOT NULL DEFAULT 0,
     last_read_at REAL,
@@ -331,6 +334,18 @@ CREATE TABLE IF NOT EXISTS compression_locks (
     expires_at REAL NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS contextual_transcript_applications (
+    execution_id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    base_revision INTEGER NOT NULL,
+    base_count INTEGER NOT NULL,
+    entry_ids_json TEXT NOT NULL,
+    entries_digest TEXT NOT NULL,
+    applied_revision INTEGER NOT NULL,
+    last_prompt_tokens INTEGER,
+    applied_at REAL NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS async_delegations (
     delegation_id TEXT PRIMARY KEY,
     origin_session TEXT NOT NULL,
@@ -383,6 +398,33 @@ CREATE INDEX IF NOT EXISTS idx_messages_session_active
     ON messages(session_id, active, timestamp);
 CREATE INDEX IF NOT EXISTS idx_messages_active_null
     ON messages(active) WHERE active IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_contextual_cron_identity
+    ON messages(session_id, platform_message_id)
+    WHERE platform_message_id LIKE 'contextual-cron:%';
+CREATE TRIGGER IF NOT EXISTS messages_transcript_revision_insert
+AFTER INSERT ON messages
+BEGIN
+    UPDATE sessions SET transcript_revision = transcript_revision + 1
+    WHERE id = new.session_id;
+END;
+CREATE TRIGGER IF NOT EXISTS messages_transcript_revision_delete
+AFTER DELETE ON messages
+BEGIN
+    UPDATE sessions SET transcript_revision = transcript_revision + 1
+    WHERE id = old.session_id;
+END;
+CREATE TRIGGER IF NOT EXISTS messages_transcript_revision_update
+AFTER UPDATE OF session_id, role, content, tool_call_id, tool_calls, tool_name,
+    effect_disposition, token_count, finish_reason, reasoning,
+    reasoning_content, reasoning_details, codex_reasoning_items,
+    codex_message_items, platform_message_id, active, compacted, api_content
+ON messages
+BEGIN
+    UPDATE sessions SET transcript_revision = transcript_revision + 1
+    WHERE id = old.session_id;
+    UPDATE sessions SET transcript_revision = transcript_revision + 1
+    WHERE id = new.session_id AND new.session_id IS NOT old.session_id;
+END;
 CREATE INDEX IF NOT EXISTS idx_sessions_session_key
     ON sessions(session_key, started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_sessions_gateway_peer

--- a/hermes_state_portability.py
+++ b/hermes_state_portability.py
@@ -11,7 +11,7 @@ module-level constants live in hermes_state_common.
 import logging
 import json
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 from agent.skill_commands import SKILL_SCAFFOLD_SQL_LIKE
 from hermes_state_common import (
@@ -41,6 +41,50 @@ class SessionPortabilityMixin:
                 if name not in cls._SESSION_COMPACT_EXCLUDED
             )
         return cls._session_compact_cols_sql
+
+    def _apply_visible_session_counts(
+        self, sessions: List[Dict[str, Any]]
+    ) -> None:
+        """Replace durable total counters with one batched public projection."""
+        session_ids = sorted(
+            {str(session.get("id") or "") for session in sessions if session.get("id")}
+        )
+        if not session_ids:
+            return
+        placeholders = ",".join("?" for _ in session_ids)
+        query = f"""
+            SELECT session_id,
+                   COUNT(*) AS message_count,
+                   COALESCE(SUM(
+                       CASE
+                           WHEN tool_calls IS NULL THEN 0
+                           WHEN json_valid(tool_calls) = 0 THEN 1
+                           WHEN json_type(tool_calls) = 'array'
+                               THEN json_array_length(tool_calls)
+                           ELSE 1
+                       END
+                   ), 0) AS tool_call_count
+            FROM messages
+            WHERE session_id IN ({placeholders})
+              AND COALESCE(display_kind, '') != 'hidden'
+            GROUP BY session_id
+        """
+        host = cast(Any, self)
+        with host._lock:
+            rows = host._conn.execute(query, session_ids).fetchall()
+        counts = {
+            str(row["session_id"]): (
+                int(row["message_count"] or 0),
+                int(row["tool_call_count"] or 0),
+            )
+            for row in rows
+        }
+        for session in sessions:
+            message_count, tool_call_count = counts.get(
+                str(session.get("id") or ""), (0, 0)
+            )
+            session["message_count"] = message_count
+            session["tool_call_count"] = tool_call_count
 
     def distinct_session_cwds(self, include_archived: bool = False) -> List[Dict[str, Any]]:
         """Distinct non-empty session cwds with usage stats, for repo discovery.
@@ -107,6 +151,7 @@ class SessionPortabilityMixin:
                     (SELECT {_PREVIEW_RAW_SELECT}
                      FROM messages m
                      WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
+                       AND COALESCE(m.display_kind, '') != 'hidden'
                      ORDER BY m.timestamp, m.id LIMIT 1),
                     ''
                 ) AS _preview_raw,
@@ -191,6 +236,7 @@ class SessionPortabilityMixin:
                     (SELECT {_PREVIEW_RAW_SELECT}
                      FROM messages m
                      WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
+                       AND COALESCE(m.display_kind, '') != 'hidden'
                      ORDER BY m.timestamp, m.id LIMIT 1),
                     ''
                 ) AS _preview_raw,
@@ -207,6 +253,7 @@ class SessionPortabilityMixin:
             s = self._session_row_dict(row)
             s["preview"] = _shape_preview(s.pop("_preview_raw", ""))
             result[s["id"]] = s
+        self._apply_visible_session_counts(list(result.values()))
         return result
 
     def get_session_rich_row(self, session_id: str, compact_rows: bool = False) -> Optional[Dict[str, Any]]:
@@ -235,6 +282,7 @@ class SessionPortabilityMixin:
                     SELECT m2.id FROM messages m2
                     WHERE m2.session_id = s.id AND m2.role = 'user'
                       AND m2.content IS NOT NULL
+                      AND COALESCE(m2.display_kind, '') != 'hidden'
                     ORDER BY m2.timestamp, m2.id LIMIT 1
                 )
                 WHERE s.title IS NOT NULL AND m.content LIKE ?
@@ -255,6 +303,7 @@ class SessionPortabilityMixin:
             row = self._conn.execute(
                 "SELECT content FROM messages "
                 "WHERE session_id = ? AND role = 'assistant' AND content IS NOT NULL "
+                "AND COALESCE(display_kind, '') != 'hidden' "
                 "ORDER BY timestamp, id LIMIT 1",
                 (session_id,),
             ).fetchone()
@@ -263,13 +312,23 @@ class SessionPortabilityMixin:
         decoded = self._decode_content(row["content"])
         return decoded if isinstance(decoded, str) else ""
 
-    def export_session(self, session_id: str) -> Optional[Dict[str, Any]]:
+    def export_session(
+        self, session_id: str, *, include_hidden: bool = False
+    ) -> Optional[Dict[str, Any]]:
         """Export a single session with all its messages as a dict."""
         session = self.get_session(session_id)
         if not session:
             return None
-        messages = self.get_messages(session_id)
-        return {**session, "messages": messages}
+        messages = self.get_messages(session_id, include_hidden=include_hidden)
+        tool_call_count = sum(
+            len(message.get("tool_calls") or []) for message in messages
+        )
+        return {
+            **session,
+            "message_count": len(messages),
+            "tool_call_count": tool_call_count,
+            "messages": messages,
+        }
 
     def export_session_lineage(self, session_id: str) -> Optional[Dict[str, Any]]:
         """Export a compression lineage as one logical session dict."""
@@ -300,7 +359,17 @@ class SessionPortabilityMixin:
         results = []
         for session in sessions:
             messages = self.get_messages(session["id"])
-            results.append({**session, "messages": messages})
+            tool_call_count = sum(
+                len(message.get("tool_calls") or []) for message in messages
+            )
+            results.append(
+                {
+                    **session,
+                    "message_count": len(messages),
+                    "tool_call_count": tool_call_count,
+                    "messages": messages,
+                }
+            )
         return results
 
     @staticmethod

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -668,6 +668,17 @@ class SessionSchemaMixin:
         # column (idx_messages_session_active) — same ordering constraint.
         cursor.executescript(DEFERRED_INDEX_SQL)
 
+        # v24 causal fence: legacy databases have no transcript revision history.
+        # Seed a deterministic non-zero generation from the rows present at
+        # migration time; all subsequent model-visible message mutations are
+        # tracked by the deferred triggers above.
+        cursor.execute(
+            "UPDATE sessions SET transcript_revision = "
+            "(SELECT COUNT(*) FROM messages WHERE messages.session_id = sessions.id) "
+            "WHERE transcript_revision = 0 AND EXISTS "
+            "(SELECT 1 FROM messages WHERE messages.session_id = sessions.id)"
+        )
+
         # Heal NULL ``active`` rows unconditionally on every startup.
         # On real-world DBs the reconciler-added ``active`` column can lack
         # its NOT NULL DEFAULT 1 (older reconciler builds reconstructed the

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -961,6 +961,7 @@ class SessionSearchMixin:
         window: int = 5,
         bookend: int = 3,
         keep_roles: Optional[Tuple[str, ...]] = ("user", "assistant"),
+        include_hidden: bool = False,
     ) -> Dict[str, Any]:
         """Return an anchored window plus session bookends.
 
@@ -994,7 +995,10 @@ class SessionSearchMixin:
         # Reuse the primitive — handles anchor-existence, content decoding,
         # tool_calls deserialisation, and boundary counts.
         primitive = self.get_messages_around(
-            session_id, around_message_id, window=window
+            session_id,
+            around_message_id,
+            window=window,
+            include_hidden=include_hidden,
         )
         window_rows = primitive["window"]
         if not window_rows:
@@ -1027,6 +1031,11 @@ class SessionSearchMixin:
         bookend_end_rows: List[Any] = []
         if bookend > 0:
             with self._read_ctx() as conn:
+                hidden_clause = (
+                    ""
+                    if include_hidden
+                    else " AND COALESCE(display_kind, '') != 'hidden'"
+                )
                 role_clause = ""
                 role_params: list = []
                 if keep_roles is not None:
@@ -1038,6 +1047,7 @@ class SessionSearchMixin:
                     f"SELECT * FROM messages "
                     f"WHERE session_id = ? AND id < ?{role_clause} "
                     f"AND length(content) > 0 "
+                    f"{hidden_clause} "
                     f"ORDER BY id ASC LIMIT ?",
                     (session_id, window_min_id, *role_params, bookend),
                 ).fetchall()
@@ -1046,6 +1056,7 @@ class SessionSearchMixin:
                     f"SELECT * FROM messages "
                     f"WHERE session_id = ? AND id > ?{role_clause} "
                     f"AND length(content) > 0 "
+                    f"{hidden_clause} "
                     f"ORDER BY id DESC LIMIT ?",
                     (session_id, window_max_id, *role_params, bookend),
                 ).fetchall()
@@ -1308,6 +1319,7 @@ class SessionSearchMixin:
         table: str = "messages_fts_trigram",
         order_by_sql: str,
         include_inactive: bool,
+        include_hidden: bool = False,
         source_filter: List[str] = None,
         exclude_sources: List[str] = None,
         role_filter: List[str] = None,
@@ -1343,6 +1355,8 @@ class SessionSearchMixin:
         tri_params: list = [trigram_query]
         if not include_inactive:
             tri_where.append("(m.active = 1 OR m.compacted = 1)")
+        if not include_hidden:
+            tri_where.append("COALESCE(m.display_kind, '') != 'hidden'")
         if source_filter is not None:
             tri_where.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
             tri_params.extend(source_filter)
@@ -1391,6 +1405,7 @@ class SessionSearchMixin:
         sort: str = None,
         include_inactive: bool = False,
         fields: Optional[Collection[str]] = None,
+        include_hidden: bool = False,
     ) -> List[Dict[str, Any]]:
         """Instrumented wrapper around :meth:`_search_messages_impl`.
 
@@ -1413,6 +1428,7 @@ class SessionSearchMixin:
                 sort=sort,
                 include_inactive=include_inactive,
                 fields=fields,
+                include_hidden=include_hidden,
             )
             return rows
         finally:
@@ -1463,6 +1479,7 @@ class SessionSearchMixin:
         sort: str = None,
         include_inactive: bool = False,
         fields: Optional[Collection[str]] = None,
+        include_hidden: bool = False,
     ) -> List[Dict[str, Any]]:
         """
         Full-text search across session messages using FTS5.
@@ -1534,6 +1551,8 @@ class SessionSearchMixin:
             # are discoverable; only rewind/undo rows (active=0, compacted=0)
             # are hidden. See archive_and_compact() / #38763.
             where_clauses.append("(m.active = 1 OR m.compacted = 1)")
+        if not include_hidden:
+            where_clauses.append("COALESCE(m.display_kind, '') != 'hidden'")
 
         if source_filter is not None:
             source_placeholders = ",".join("?" for _ in source_filter)
@@ -1634,6 +1653,8 @@ class SessionSearchMixin:
                 cjk_params: list = [cjk_query]
                 if not include_inactive:
                     cjk_where.append("(m.active = 1 OR m.compacted = 1)")
+                if not include_hidden:
+                    cjk_where.append("COALESCE(m.display_kind, '') != 'hidden'")
                 if source_filter is not None:
                     cjk_where.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
                     cjk_params.extend(source_filter)
@@ -1723,6 +1744,8 @@ class SessionSearchMixin:
                 tri_params: list = [trigram_query]
                 if not include_inactive:
                     tri_where.append("(m.active = 1 OR m.compacted = 1)")
+                if not include_hidden:
+                    tri_where.append("COALESCE(m.display_kind, '') != 'hidden'")
                 if source_filter is not None:
                     tri_where.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
                     tri_params.extend(source_filter)
@@ -1817,6 +1840,8 @@ class SessionSearchMixin:
                     # compaction-archived rows are discoverable; rewind/undo
                     # rows (active=0, compacted=0) are hidden (#38763).
                     like_where.append("(m.active = 1 OR m.compacted = 1)")
+                if not include_hidden:
+                    like_where.append("COALESCE(m.display_kind, '') != 'hidden'")
                 if source_filter is not None:
                     like_where.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
                     like_params.extend(source_filter)
@@ -1882,6 +1907,7 @@ class SessionSearchMixin:
                     query,
                     limit - len(matches),
                     include_inactive=include_inactive,
+                    include_hidden=include_hidden,
                     source_filter=source_filter,
                     exclude_sources=exclude_sources,
                     role_filter=role_filter,
@@ -1920,6 +1946,7 @@ class SessionSearchMixin:
                     table="messages_fts_cjk",
                     order_by_sql=order_by_sql,
                     include_inactive=include_inactive,
+                    include_hidden=include_hidden,
                     source_filter=source_filter,
                     exclude_sources=exclude_sources,
                     role_filter=role_filter,
@@ -1937,6 +1964,7 @@ class SessionSearchMixin:
                     _fb_query,
                     order_by_sql=order_by_sql,
                     include_inactive=include_inactive,
+                    include_hidden=include_hidden,
                     source_filter=source_filter,
                     exclude_sources=exclude_sources,
                     role_filter=role_filter,
@@ -1955,35 +1983,52 @@ class SessionSearchMixin:
         )
         for match in context_matches:
             try:
+                context_hidden_clause = (
+                    ""
+                    if include_hidden
+                    else " AND COALESCE(m.display_kind, '') != 'hidden'"
+                )
+                target_hidden_clause = (
+                    ""
+                    if include_hidden
+                    else " AND COALESCE(display_kind, '') != 'hidden'"
+                )
+                center_hidden_clause = (
+                    ""
+                    if include_hidden
+                    else " AND COALESCE(center.display_kind, '') != 'hidden'"
+                )
                 with self._read_ctx() as conn:
                     ctx_cursor = conn.execute(
-                        """WITH target AS (
+                        f"""WITH target AS (
                                SELECT session_id, timestamp, id
                                FROM messages
-                               WHERE id = ?
+                               WHERE id = ?{target_hidden_clause}
                            )
                            SELECT role, content
                            FROM (
                                SELECT m.id, m.timestamp, m.role, m.content
                                FROM messages m
                                JOIN target t ON t.session_id = m.session_id
-                               WHERE (m.timestamp < t.timestamp)
-                                  OR (m.timestamp = t.timestamp AND m.id < t.id)
+                               WHERE ((m.timestamp < t.timestamp)
+                                  OR (m.timestamp = t.timestamp AND m.id < t.id))
+                                 {context_hidden_clause}
                                ORDER BY m.timestamp DESC, m.id DESC
                                LIMIT 1
                            )
                            UNION ALL
                            SELECT role, content
-                           FROM messages
-                           WHERE id = ?
+                           FROM messages center
+                           WHERE center.id = ?{center_hidden_clause}
                            UNION ALL
                            SELECT role, content
                            FROM (
                                SELECT m.id, m.timestamp, m.role, m.content
                                FROM messages m
                                JOIN target t ON t.session_id = m.session_id
-                               WHERE (m.timestamp > t.timestamp)
-                                  OR (m.timestamp = t.timestamp AND m.id > t.id)
+                               WHERE ((m.timestamp > t.timestamp)
+                                  OR (m.timestamp = t.timestamp AND m.id > t.id))
+                                 {context_hidden_clause}
                                ORDER BY m.timestamp ASC, m.id ASC
                                LIMIT 1
                            )""",
@@ -2031,6 +2076,7 @@ class SessionSearchMixin:
         limit: int,
         *,
         include_inactive: bool = False,
+        include_hidden: bool = False,
         source_filter: Optional[List[str]] = None,
         exclude_sources: Optional[List[str]] = None,
         role_filter: Optional[List[str]] = None,
@@ -2070,6 +2116,8 @@ class SessionSearchMixin:
             params += [f"%{esc}%"] * 3
         if not include_inactive:
             where.append("(m.active = 1 OR m.compacted = 1)")
+        if not include_hidden:
+            where.append("COALESCE(m.display_kind, '') != 'hidden'")
         if source_filter is not None:
             where.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
             params.extend(source_filter)

--- a/run_agent.py
+++ b/run_agent.py
@@ -447,6 +447,7 @@ class AIAgent:
         tool_delay: float = None,  # Deprecated: accepted for compatibility, ignored
         enabled_toolsets: List[str] = None,
         disabled_toolsets: List[str] = None,
+        allowed_tool_names: List[str] | set[str] | frozenset[str] | None = None,
         save_trajectories: bool = False,
         verbose_logging: bool = False,
         quiet_mode: bool = False,
@@ -509,6 +510,7 @@ class AIAgent:
         checkpoint_max_file_size_mb: int = 10,
         pass_session_id: bool = False,
         requested_provider: str = None,
+        contextual_execution: bool = False,
     ):
         """Forwarder — see ``agent.agent_init.init_agent``."""
         if tool_delay is not None:
@@ -525,6 +527,7 @@ class AIAgent:
             api_key=api_key,
             provider=provider,
             requested_provider=requested_provider,
+            contextual_execution=contextual_execution,
             api_mode=api_mode,
             acp_command=acp_command,
             acp_args=acp_args,
@@ -534,6 +537,7 @@ class AIAgent:
             max_iterations=max_iterations,
             enabled_toolsets=enabled_toolsets,
             disabled_toolsets=disabled_toolsets,
+            allowed_tool_names=allowed_tool_names,
             save_trajectories=save_trajectories,
             verbose_logging=verbose_logging,
             quiet_mode=quiet_mode,

--- a/tests/agent/test_api_content_sidecar.py
+++ b/tests/agent/test_api_content_sidecar.py
@@ -712,7 +712,7 @@ class TestFlushCompressedSummaryOverrideGuard:
             agent._persist_user_message_timestamp = None
             agent._flush_messages_to_session_db(messages, None)
 
-            msgs = db.get_messages_as_conversation(sid)
+            msgs = db.get_messages_as_conversation(sid, include_hidden=True)
             assert msgs[0]["content"] == merged  # summary survives
             assert "api_content" not in msgs[0]  # wire == row, no sidecar
         finally:

--- a/tests/agent/test_contextual_hidden_compression.py
+++ b/tests/agent/test_contextual_hidden_compression.py
@@ -1,0 +1,240 @@
+"""Privacy regressions for compression derived from hidden contextual rows."""
+
+from unittest.mock import patch
+
+from agent.context_compressor import (
+    COMPRESSED_SUMMARY_HAS_USER_TURN_KEY,
+    COMPRESSED_SUMMARY_METADATA_KEY,
+    SUMMARY_PREFIX,
+    ContextCompressor,
+    _MERGED_SUMMARY_DELIMITER,
+    _SUMMARY_END_MARKER,
+)
+from hermes_state import SessionDB
+
+
+_HIDDEN_DERIVATION_METADATA = {
+    "kind": "compression_summary",
+    "contains_hidden": True,
+}
+
+
+def _compressor(*, protect_first_n: int = 0) -> ContextCompressor:
+    with patch(
+        "agent.context_compressor.get_model_context_length",
+        return_value=100_000,
+    ):
+        instance = ContextCompressor(
+            model="test/model",
+            threshold_percent=0.50,
+            protect_first_n=protect_first_n,
+            protect_last_n=1,
+            quiet_mode=True,
+        )
+    instance.tail_token_budget = 1
+    return instance
+
+
+def _summary_rows(messages):
+    return [
+        message
+        for message in messages
+        if message.get(COMPRESSED_SUMMARY_METADATA_KEY)
+    ]
+
+
+def _persist_compaction(tmp_path, session_id, original, compressed):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(session_id, source="test", model="test/model")
+    db.append_messages_batch(session_id, original)
+    db.archive_and_compact(session_id, compressed)
+    return db
+
+
+def test_standalone_summary_derived_from_hidden_row_is_hidden_after_persistence(
+    tmp_path,
+):
+    canary = "HIDDEN-CONTEXT-COMPRESSION-CANARY"
+    messages = [
+        {"role": "system", "content": "system prompt"},
+        {
+            "role": "user",
+            "content": canary + (" x" * 300),
+            "display_kind": "hidden",
+            "display_metadata": {"execution_id": "exec-hidden"},
+        },
+        {"role": "assistant", "content": "historical answer 1 " + ("x" * 400)},
+        {"role": "user", "content": "historical request 2 " + ("x" * 400)},
+        {"role": "assistant", "content": "historical answer 2 " + ("x" * 400)},
+        {"role": "user", "content": "historical request 3 " + ("x" * 400)},
+        {"role": "assistant", "content": "historical answer 3 " + ("x" * 400)},
+        {"role": "user", "content": "historical request 4 " + ("x" * 400)},
+        {"role": "assistant", "content": "visible protected tail " + ("x" * 400)},
+    ]
+    compressor = _compressor()
+
+    with patch.object(
+        compressor,
+        "_generate_summary",
+        return_value=f"{SUMMARY_PREFIX}\nsummary derived from {canary}",
+    ):
+        compressed = compressor.compress(
+            messages,
+            current_tokens=900_000,
+            force=True,
+        )
+
+    summaries = _summary_rows(compressed)
+    assert len(summaries) == 1
+    assert summaries[0]["display_kind"] == "hidden"
+    assert summaries[0]["display_metadata"] == _HIDDEN_DERIVATION_METADATA
+
+    db = _persist_compaction(
+        tmp_path,
+        "hidden-standalone-summary",
+        messages,
+        compressed,
+    )
+    try:
+        public = db.get_messages("hidden-standalone-summary")
+        privileged = db.get_messages(
+            "hidden-standalone-summary",
+            include_hidden=True,
+        )
+    finally:
+        db.close()
+
+    assert canary not in repr(public)
+    persisted_summary = next(
+        message for message in privileged if canary in str(message.get("content"))
+    )
+    assert persisted_summary["display_kind"] == "hidden"
+    assert persisted_summary["display_metadata"] == _HIDDEN_DERIVATION_METADATA
+
+
+def test_merged_summary_derived_from_hidden_row_fails_closed_as_hidden():
+    canary = "HIDDEN-MERGED-COMPRESSION-CANARY"
+    visible_tail = "visible request retained as the merge carrier"
+    messages = [
+        {
+            "role": "user",
+            "content": canary + (" x" * 300),
+            "display_kind": "hidden",
+            "display_metadata": {"execution_id": "exec-hidden-merge"},
+        },
+        {"role": "assistant", "content": "historical answer 1 " + ("x" * 400)},
+        {"role": "user", "content": "historical request 2 " + ("x" * 400)},
+        {"role": "assistant", "content": "historical answer 2 " + ("x" * 400)},
+        {"role": "user", "content": "historical request 3 " + ("x" * 400)},
+        {"role": "assistant", "content": "historical answer 3 " + ("x" * 400)},
+        {"role": "user", "content": "historical request 4 " + ("x" * 400)},
+        {"role": "assistant", "content": "historical answer 4 " + ("x" * 400)},
+        {"role": "user", "content": visible_tail + (" x" * 300)},
+    ]
+    compressor = _compressor(protect_first_n=0)
+
+    with patch.object(
+        compressor,
+        "_generate_summary",
+        return_value=f"{SUMMARY_PREFIX}\nsummary derived from {canary}",
+    ):
+        compressed = compressor.compress(
+            messages,
+            current_tokens=900_000,
+            force=True,
+        )
+
+    summaries = _summary_rows(compressed)
+    assert len(summaries) == 1
+    merged = summaries[0]
+    merged_content = str(merged["content"])
+    assert (
+        _MERGED_SUMMARY_DELIMITER in merged_content
+        or (
+            _SUMMARY_END_MARKER in merged_content
+            and not merged_content.rstrip().endswith(_SUMMARY_END_MARKER)
+        )
+    )
+    assert canary in merged_content
+    assert merged["display_kind"] == "hidden"
+    assert merged["display_metadata"] == _HIDDEN_DERIVATION_METADATA
+
+
+def test_hidden_summary_taint_survives_sqlite_round_trip_and_recompression(tmp_path):
+    first_canary = "HIDDEN-ROLLING-SUMMARY-CANARY"
+    first_messages = [
+        {"role": "system", "content": "system prompt"},
+        {
+            "role": "user",
+            "content": first_canary + (" x" * 300),
+            "display_kind": "hidden",
+        },
+        {"role": "assistant", "content": "historical answer 1 " + ("x" * 400)},
+        {"role": "user", "content": "historical request 2 " + ("x" * 400)},
+        {"role": "assistant", "content": "historical answer 2 " + ("x" * 400)},
+        {"role": "user", "content": "historical request 3 " + ("x" * 400)},
+        {"role": "assistant", "content": "historical answer 3 " + ("x" * 400)},
+        {"role": "user", "content": "historical request 4 " + ("x" * 400)},
+        {"role": "assistant", "content": "protected tail " + ("x" * 400)},
+    ]
+    first_compressor = _compressor()
+    with patch.object(
+        first_compressor,
+        "_generate_summary",
+        return_value=f"{SUMMARY_PREFIX}\nfirst summary with {first_canary}",
+    ):
+        first = first_compressor.compress(
+            first_messages,
+            current_tokens=900_000,
+            force=True,
+        )
+
+    db = _persist_compaction(
+        tmp_path,
+        "hidden-summary-restart",
+        first_messages,
+        first,
+    )
+    try:
+        resumed_messages = db.get_messages_as_conversation(
+            "hidden-summary-restart",
+            include_hidden=True,
+        )
+    finally:
+        db.close()
+
+    persisted = next(
+        message
+        for message in resumed_messages
+        if first_canary in str(message.get("content"))
+    )
+    assert COMPRESSED_SUMMARY_METADATA_KEY not in persisted
+    assert COMPRESSED_SUMMARY_HAS_USER_TURN_KEY not in persisted
+    assert persisted["display_kind"] == "hidden"
+    assert persisted["display_metadata"] == _HIDDEN_DERIVATION_METADATA
+
+    resumed = _compressor()
+    second_input = [
+        *resumed_messages,
+        {"role": "user", "content": "new visible request 1 " + ("x" * 400)},
+        {"role": "assistant", "content": "new visible work 1 " + ("x" * 400)},
+        {"role": "user", "content": "new visible request 2 " + ("x" * 400)},
+        {"role": "assistant", "content": "new visible work 2 " + ("x" * 400)},
+        {"role": "user", "content": "new visible request 3 " + ("x" * 400)},
+        {"role": "assistant", "content": "new protected tail " + ("x" * 400)},
+    ]
+    with patch.object(
+        resumed,
+        "_generate_summary",
+        return_value=f"{SUMMARY_PREFIX}\nfresh rolling summary",
+    ):
+        second = resumed.compress(
+            second_input,
+            current_tokens=900_000,
+            force=True,
+        )
+
+    second_summaries = _summary_rows(second)
+    assert len(second_summaries) == 1
+    assert second_summaries[0]["display_kind"] == "hidden"
+    assert second_summaries[0]["display_metadata"] == _HIDDEN_DERIVATION_METADATA

--- a/tests/agent/test_contextual_max_iterations.py
+++ b/tests/agent/test_contextual_max_iterations.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+from types import SimpleNamespace
+
+
+def test_contextual_max_iteration_summary_bypasses_relay(monkeypatch):
+    from agent import chat_completion_helpers, relay_llm
+
+    calls = []
+
+    class _Completions:
+        @staticmethod
+        def create(**kwargs):
+            calls.append(kwargs)
+            return object()
+
+    class _Client:
+        chat = SimpleNamespace(completions=_Completions())
+
+    class _Transport:
+        @staticmethod
+        def normalize_response(_response):
+            return SimpleNamespace(content="direct contextual summary")
+
+    agent = SimpleNamespace(
+        max_iterations=3,
+        provider="openai",
+        model="gpt-test",
+        api_mode="chat_completions",
+        _contextual_execution=True,
+        _cached_system_prompt="",
+        ephemeral_system_prompt=None,
+        prefill_messages=[],
+        max_tokens=None,
+        reasoning_config=None,
+        base_url="https://provider.invalid/v1",
+        _base_url_lower="https://provider.invalid/v1",
+        openrouter_min_coding_score=None,
+        providers_allowed=None,
+        providers_ignored=None,
+        providers_order=None,
+        provider_sort=None,
+        provider_price=None,
+        provider_require_parameters=False,
+        provider_data_collection=None,
+        session_id="session-1",
+        _safe_print=lambda *_args, **_kwargs: None,
+        _should_sanitize_tool_calls=lambda: False,
+        _copy_reasoning_content_for_api=lambda _source, _target: None,
+        _sanitize_api_messages=lambda messages: messages,
+        _drop_thinking_only_and_merge_users=lambda messages: messages,
+        _supports_reasoning_extra_body=lambda: False,
+        _is_openrouter_url=lambda: False,
+        _ensure_primary_openai_client=lambda **_kwargs: _Client(),
+        _get_transport=lambda: _Transport(),
+    )
+
+    monkeypatch.setattr(
+        relay_llm,
+        "execute_current",
+        lambda *_a, **_k: (_ for _ in ()).throw(
+            AssertionError("contextual summary must not enter Relay")
+        ),
+    )
+    monkeypatch.setattr(relay_llm, "complete_logical_call", lambda *_a, **_k: None)
+
+    result = chat_completion_helpers.handle_max_iterations(
+        agent,
+        [{"role": "user", "content": "continue"}],
+        api_call_count=3,
+    )
+
+    assert result == "direct contextual summary"
+    assert len(calls) == 1
+
+
+def test_every_compression_site_fails_closed_for_contextual_execution():
+    from agent import conversation_loop
+
+    tree = ast.parse(
+        textwrap.dedent(inspect.getsource(conversation_loop.run_conversation))
+    )
+    guarded_calls = 0
+
+    for node in ast.walk(tree):
+        for _field, value in ast.iter_fields(node):
+            if not isinstance(value, list):
+                continue
+            for index, statement in enumerate(value):
+                if not isinstance(statement, ast.Assign):
+                    continue
+                calls = [
+                    call
+                    for call in ast.walk(statement.value)
+                    if isinstance(call, ast.Call)
+                    and isinstance(call.func, ast.Attribute)
+                    and call.func.attr == "_compress_context"
+                ]
+                if not calls:
+                    continue
+                assert index > 0
+                guard = value[index - 1]
+                assert isinstance(guard, ast.If)
+                assert isinstance(guard.test, ast.Name)
+                assert guard.test.id == "_contextual_execution"
+                assert any(isinstance(item, ast.Return) for item in guard.body)
+                guarded_calls += len(calls)
+
+    assert guarded_calls == 6

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import threading
 import types
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -286,12 +287,52 @@ def test_applies_agent_side_effects():
     assert agent._current_turn_id
 
 
+def test_contextual_prologue_skips_all_extension_and_persistence_planes():
+    """A hidden scheduled turn cannot escape through prologue side effects."""
+    agent = _FakeAgent()
+    agent_any = cast(Any, agent)
+    agent.compression_enabled = True
+    agent.context_compressor.threshold_tokens = 1
+    agent.context_compressor.should_compress_info = lambda tokens=None: (
+        True,
+        "threshold",
+    )
+    agent_any._compress_context = MagicMock(
+        side_effect=AssertionError("contextual prologue attempted compression")
+    )
+    agent._memory_manager = MagicMock()
+    agent._memory_manager.prefetch_all.return_value = "PRIVATE MEMORY"
+    agent_any._gateway_turn_context_notes = "human-only gateway note"
+    agent_any._ensure_db_session = MagicMock(
+        side_effect=AssertionError("contextual prologue attempted persistence")
+    )
 
+    with (
+        patch(
+            "agent.turn_context.recover_rotated_compression_session",
+            side_effect=AssertionError("contextual prologue followed a rotated route"),
+        ) as recover,
+        patch("hermes_cli.lifecycle.invoke_hook") as invoke_hook,
+    ):
+        ctx = _build(
+            agent,
+            contextual_execution=True,
+            user_message="inspect the entire private transcript",
+            conversation_history=[
+                {"role": "user", "content": "private history " * 100}
+            ],
+        )
 
-
-
-
-
+    recover.assert_not_called()
+    invoke_hook.assert_not_called()
+    agent_any._compress_context.assert_not_called()
+    agent._memory_manager.on_turn_start.assert_not_called()
+    agent._memory_manager.prefetch_all.assert_not_called()
+    agent_any._ensure_db_session.assert_not_called()
+    assert agent._persist_calls == 0
+    assert agent_any._gateway_turn_context_notes == "human-only gateway note"
+    assert ctx.plugin_user_context == ""
+    assert ctx.ext_prefetch_cache == ""
 
 
 def test_pending_cli_message_uses_clean_override_for_api_local_note():

--- a/tests/cli/test_branch_command.py
+++ b/tests/cli/test_branch_command.py
@@ -85,7 +85,37 @@ class TestBranchCommandCLI:
         messages = session_db.get_messages_as_conversation(cli_instance.session_id)
         assert len(messages) == 4  # All 4 messages copied
 
+    def test_branch_preserves_hidden_rows_without_public_declassification(
+        self, cli_instance, session_db
+    ):
+        """A branch must preserve hidden labels for privileged replay only."""
+        from cli import HermesCLI
 
+        canary = "CONTEXTUAL-BRANCH-SECRET"
+        metadata = {"execution_id": "exec-branch-private"}
+        cli_instance.conversation_history.insert(
+            1,
+            {
+                "role": "user",
+                "content": canary,
+                "display_kind": "hidden",
+                "display_metadata": metadata,
+                "api_content": f"{canary}-WIRE",
+            },
+        )
+
+        HermesCLI._handle_branch_command(cli_instance, "/branch")
+
+        public = session_db.get_messages(cli_instance.session_id)
+        privileged = session_db.get_messages(
+            cli_instance.session_id, include_hidden=True
+        )
+        hidden = next(row for row in privileged if row["content"] == canary)
+
+        assert canary not in repr(public)
+        assert hidden["display_kind"] == "hidden"
+        assert hidden["display_metadata"] == metadata
+        assert hidden["api_content"] == f"{canary}-WIRE"
 
     def test_branch_with_custom_name(self, cli_instance, session_db):
         """Custom branch name should be used as the title."""

--- a/tests/cron/test_contextual_cron.py
+++ b/tests/cron/test_contextual_cron.py
@@ -1,0 +1,1542 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import timedelta
+import json
+from typing import Any, cast
+
+import pytest
+
+
+def _point_store(monkeypatch, tmp_path):
+    import cron.jobs as jobs
+
+    monkeypatch.setattr(jobs, "CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr(jobs, "JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr(jobs, "OUTPUT_DIR", tmp_path / "cron" / "output")
+    return jobs
+
+
+def _bind_session(key: str, *, session_id: str = "sid", routing_revision: int = 0):
+    from gateway.session_context import set_session_vars
+
+    return set_session_vars(
+        platform="telegram",
+        chat_id="42",
+        chat_type="dm",
+        user_id="42",
+        session_key=key,
+        session_id=session_id,
+        routing_revision=routing_revision,
+    )
+
+
+def _physical_binding(session_key: str = "stable") -> dict[str, Any]:
+    return {
+        "context_binding": {
+            "session_key": session_key,
+            "session_id": "session-1",
+            "routing_revision": 0,
+        }
+    }
+
+
+def test_public_job_record_redacts_contextual_binding_and_execution_internals():
+    from cron.jobs import public_job_record
+
+    secret_values = {
+        "session_key": "telegram:dm:42:42",
+        "admitted_session_id": "session-private",
+        "routing_revision": 19,
+        "agent_result_json": '{"message":"private model result"}',
+        "delivery_claim_owner": "scheduler-private",
+    }
+    public = public_job_record(
+        {
+            "id": "job-public",
+            "name": "safe name",
+            "prompt": "safe prompt",
+            "schedule": {"kind": "interval", "minutes": 5},
+            "session_target": "current",
+            "session_key": secret_values["session_key"],
+            "context_binding": {
+                "session_key": secret_values["session_key"],
+                "chat_id": "42",
+                "user_id": "42",
+            },
+            "origin": {"platform": "telegram", "chat_id": "42"},
+            "provider_snapshot": "legacy-provider",
+            "model_snapshot": "legacy-model",
+            "run_claim": {"execution_id": "exec-private"},
+            "_pending_accounting_execution_ids": ["exec-private"],
+            "latest_execution": {
+                "id": "exec-public",
+                "status": "completed",
+                "outcome": "notify",
+                "phase": "terminal",
+                "started_at": "2026-07-31T00:00:00Z",
+                **secret_values,
+            },
+        }
+    )
+
+    assert public["session_target"] == "current"
+    assert public["latest_execution"] == {
+        "id": "exec-public",
+        "status": "completed",
+        "outcome": "notify",
+        "phase": "terminal",
+        "started_at": "2026-07-31T00:00:00Z",
+    }
+    assert "origin" not in public
+    assert public["provider_snapshot"] == "legacy-provider"
+    assert public["model_snapshot"] == "legacy-model"
+    encoded = json.dumps(public, sort_keys=True)
+    for field in (
+        "session_key",
+        "context_binding",
+        "admitted_session_id",
+        "routing_revision",
+        "agent_result_json",
+        "delivery_claim_owner",
+    ):
+        assert field not in encoded
+    for value in (
+        "telegram:dm:42:42",
+        "session-private",
+        "private model result",
+        "exec-private",
+    ):
+        assert value not in encoded
+
+
+def test_public_job_record_preserves_legacy_isolated_api_shape():
+    from cron.jobs import public_job_record
+
+    legacy = {
+        "id": "legacy",
+        "origin": {"platform": "telegram", "chat_id": "42"},
+        "provider_snapshot": "provider",
+        "model_snapshot": "model",
+        "run_claim": {"at": "then", "by": "machine"},
+        "fire_claim": {"at": "then"},
+        "latest_execution": {
+            "id": "legacy-exec",
+            "job_id": "legacy",
+            "source": "cron",
+            "claimed_at": "then",
+            "error": "legacy error",
+            "owner_pid": 123,
+            "custom_future_execution": {"kept": True},
+        },
+        "custom_future_field": {"kept": True},
+    }
+    public = public_job_record(legacy)
+
+    assert public == legacy
+
+
+def test_legacy_job_defaults_to_isolated_without_session_key(monkeypatch, tmp_path):
+    jobs = _point_store(monkeypatch, tmp_path)
+    jobs.save_jobs(
+        [
+            {
+                "id": "legacy",
+                "prompt": "standalone",
+                "schedule": {"kind": "interval", "minutes": 5},
+                "enabled": True,
+            }
+        ]
+    )
+
+    loaded = jobs.get_job("legacy")
+
+    assert loaded["session_target"] == "isolated"
+    assert "session_key" not in loaded
+
+
+def test_degraded_jobs_lock_makes_mixed_contextual_store_read_only(
+    monkeypatch, tmp_path
+):
+    jobs = _point_store(monkeypatch, tmp_path)
+    due_at = (jobs._hermes_now() - timedelta(minutes=1)).isoformat()
+    jobs.save_jobs(
+        [
+            {
+                "id": "ordinary-due",
+                "prompt": "ordinary",
+                "schedule": {"kind": "interval", "minutes": 5},
+                "next_run_at": due_at,
+                "enabled": True,
+            },
+            {
+                "id": "contextual-due",
+                "prompt": "contextual",
+                "schedule": {"kind": "once", "run_at": due_at},
+                "next_run_at": due_at,
+                "enabled": True,
+                "session_target": "current",
+                "session_key": "telegram:dm:42:42",
+                **_physical_binding("telegram:dm:42:42"),
+            },
+        ]
+    )
+    before = jobs.JOBS_FILE.read_bytes()
+
+    @contextmanager
+    def degraded_lock():
+        yield False
+
+    monkeypatch.setattr(jobs, "_jobs_lock", degraded_lock)
+
+    assert jobs.get_due_jobs() == []
+    assert jobs.JOBS_FILE.read_bytes() == before
+
+
+def test_degraded_jobs_lock_preserves_ordinary_only_due_scan(monkeypatch, tmp_path):
+    jobs = _point_store(monkeypatch, tmp_path)
+    due_at = (jobs._hermes_now() - timedelta(seconds=1)).isoformat()
+    jobs.save_jobs(
+        [
+            {
+                "id": "ordinary-due",
+                "prompt": "ordinary",
+                "schedule": {"kind": "interval", "minutes": 5},
+                "next_run_at": due_at,
+                "enabled": True,
+            }
+        ]
+    )
+
+    @contextmanager
+    def degraded_lock():
+        yield False
+
+    monkeypatch.setattr(jobs, "_jobs_lock", degraded_lock)
+
+    assert [job["id"] for job in jobs.get_due_jobs()] == ["ordinary-due"]
+
+
+def test_degraded_jobs_lock_rejects_ordinary_writer_for_mixed_contextual_store(
+    monkeypatch, tmp_path
+):
+    jobs = _point_store(monkeypatch, tmp_path)
+    due_at = (jobs._hermes_now() - timedelta(minutes=1)).isoformat()
+    jobs.save_jobs(
+        [
+            {
+                "id": "ordinary",
+                "prompt": "ordinary",
+                "schedule": {"kind": "interval", "minutes": 5},
+                "next_run_at": due_at,
+                "enabled": True,
+                "session_target": "isolated",
+            },
+            {
+                "id": "contextual",
+                "prompt": "contextual",
+                "schedule": {"kind": "interval", "minutes": 5},
+                "next_run_at": due_at,
+                "enabled": True,
+                "session_target": "current",
+                "_contextual_binding_version": 1,
+                **_physical_binding(),
+            },
+        ]
+    )
+    jobs_file = jobs._current_cron_store().jobs_file
+    before = jobs_file.read_bytes()
+
+    @contextmanager
+    def degraded_lock():
+        yield False
+
+    monkeypatch.setattr(jobs, "_jobs_lock", degraded_lock)
+    with pytest.raises(RuntimeError, match="contextual jobs"):
+        jobs.update_job("ordinary", {"enabled": False})
+
+    assert jobs_file.read_bytes() == before
+
+
+def test_degraded_jobs_lock_preserves_ordinary_only_writer(monkeypatch, tmp_path):
+    jobs = _point_store(monkeypatch, tmp_path)
+    jobs.save_jobs(
+        [
+            {
+                "id": "ordinary",
+                "prompt": "ordinary",
+                "schedule": {"kind": "interval", "minutes": 5},
+                "enabled": True,
+            }
+        ]
+    )
+
+    @contextmanager
+    def degraded_lock():
+        yield False
+
+    monkeypatch.setattr(jobs, "_jobs_lock", degraded_lock)
+    updated = jobs.update_job("ordinary", {"enabled": False})
+
+    assert updated is not None
+    assert jobs.get_job("ordinary")["enabled"] is False
+
+
+def test_contextual_oneshot_due_scan_does_not_claim_before_ledger(
+    monkeypatch, tmp_path
+):
+    jobs = _point_store(monkeypatch, tmp_path)
+    due_at = (jobs._hermes_now() - timedelta(seconds=1)).isoformat()
+    jobs.save_jobs(
+        [
+            {
+                "id": "contextual-once",
+                "prompt": "continue",
+                "schedule": {"kind": "once", "run_at": due_at},
+                "next_run_at": due_at,
+                "enabled": True,
+                "session_target": "current",
+                "session_key": "telegram:dm:42:42",
+                **_physical_binding("telegram:dm:42:42"),
+            }
+        ]
+    )
+
+    assert [job["id"] for job in jobs.get_due_jobs()] == ["contextual-once"]
+    assert jobs.get_job("contextual-once").get("run_claim") is None
+
+
+def test_contextual_occurrence_claim_is_exact_and_execution_specific(
+    monkeypatch, tmp_path
+):
+    jobs = _point_store(monkeypatch, tmp_path)
+    due_at = (jobs._hermes_now() - timedelta(seconds=1)).isoformat()
+    jobs.save_jobs(
+        [
+            {
+                "id": "contextual-once",
+                "prompt": "continue",
+                "schedule": {"kind": "once", "run_at": due_at},
+                "next_run_at": due_at,
+                "enabled": True,
+                "session_target": "current",
+            }
+        ]
+    )
+
+    assert jobs.claim_contextual_occurrence(
+        "contextual-once",
+        execution_id="execution-1",
+        expected_next_run_at=due_at,
+    )
+    assert jobs.verify_contextual_occurrence_claim(
+        "contextual-once", execution_id="execution-1"
+    )
+    assert not jobs.claim_contextual_occurrence(
+        "contextual-once",
+        execution_id="execution-2",
+        expected_next_run_at=due_at,
+    )
+    stored = jobs.get_job("contextual-once")
+    assert stored is not None
+    assert stored["run_claim"]["execution_id"] == "execution-1"
+
+
+def test_contextual_recurring_occurrence_cas_advances_only_exact_cursor(
+    monkeypatch, tmp_path
+):
+    jobs = _point_store(monkeypatch, tmp_path)
+    due_at = (jobs._hermes_now() - timedelta(seconds=1)).isoformat()
+    jobs.save_jobs(
+        [
+            {
+                "id": "contextual-recurring",
+                "prompt": "continue",
+                "schedule": {"kind": "interval", "minutes": 5},
+                "next_run_at": due_at,
+                "enabled": True,
+                "session_target": "current",
+            }
+        ]
+    )
+
+    assert not jobs.claim_contextual_occurrence(
+        "contextual-recurring",
+        execution_id="stale-execution",
+        expected_next_run_at="2020-01-01T00:00:00+00:00",
+    )
+    assert jobs.claim_contextual_occurrence(
+        "contextual-recurring",
+        execution_id="execution-1",
+        expected_next_run_at=due_at,
+    )
+    stored = jobs.get_job("contextual-recurring")
+    assert stored["next_run_at"] != due_at
+    assert stored["_contextual_occurrence_claim"]["execution_id"] == "execution-1"
+    assert jobs.verify_contextual_occurrence_claim(
+        "contextual-recurring", execution_id="execution-1"
+    )
+
+
+@pytest.mark.parametrize("kind", ["once", "interval"])
+def test_tick_ledger_failure_never_claims_contextual_occurrence(
+    monkeypatch, tmp_path, kind
+):
+    import cron.scheduler as scheduler
+
+    scheduler._running_job_ids.clear()
+    due_at = "2026-08-08T00:00:00+00:00"
+    schedule = (
+        {"kind": "once", "run_at": due_at}
+        if kind == "once"
+        else {"kind": "interval", "minutes": 5}
+    )
+    job = {
+        "id": f"contextual-{kind}",
+        "name": f"contextual-{kind}",
+        "prompt": "continue",
+        "schedule": schedule,
+        "next_run_at": due_at,
+        "enabled": True,
+        "session_target": "current",
+        "deliver": "local",
+    }
+    mutations = []
+    monkeypatch.setattr(scheduler, "get_due_jobs", lambda: [job])
+    monkeypatch.setattr(scheduler, "advance_next_runs", lambda _ids: 0)
+    monkeypatch.setattr(
+        scheduler,
+        "claim_contextual_occurrence",
+        lambda *_a, **_k: mutations.append("claim") or True,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "create_execution",
+        lambda *_a, **_k: (_ for _ in ()).throw(OSError("ledger unavailable")),
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_get_lock_paths",
+        lambda: (tmp_path / "cron", tmp_path / "cron" / ".tick.lock"),
+    )
+
+    assert scheduler.tick(verbose=False) == 0
+    assert mutations == []
+
+
+def test_tick_executor_rejection_terminalizes_and_accounts_claimed_contextual_occurrence(
+    monkeypatch, tmp_path
+):
+    import cron.scheduler as scheduler
+
+    scheduler._running_job_ids.clear()
+    events = []
+    job = {
+        "id": "contextual-recurring",
+        "name": "contextual-recurring",
+        "prompt": "continue",
+        "schedule": {"kind": "interval", "minutes": 5},
+        "next_run_at": "2026-08-08T00:00:00+00:00",
+        "enabled": True,
+        "session_target": "current",
+        "deliver": "local",
+    }
+
+    class RejectingPool:
+        def submit(self, _callable):
+            events.append("submit")
+            raise RuntimeError("executor rejected")
+
+    monkeypatch.setattr(scheduler, "get_due_jobs", lambda: [job])
+    monkeypatch.setattr(scheduler, "advance_next_runs", lambda _ids: 0)
+    monkeypatch.setattr(
+        scheduler,
+        "create_execution",
+        lambda *_a, **_k: events.append("ledger") or {"id": "execution-1"},
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "seal_contextual_delivery_target",
+        lambda *_a, **_k: events.append("seal-target") or True,
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "claim_contextual_occurrence",
+        lambda *_a, **_k: events.append("claim-occurrence") or True,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "finish_contextual_execution",
+        lambda *_a, **_k: events.append("finish-contextual") or {},
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_account_contextual_job_run",
+        lambda **_k: events.append("account-job") or True,
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "finish_execution",
+        lambda *_a, **_k: events.append("finish-ordinary") or {},
+    )
+    monkeypatch.setattr(scheduler, "_get_parallel_pool", lambda _workers: RejectingPool())
+    monkeypatch.setattr(
+        scheduler,
+        "_get_lock_paths",
+        lambda: (tmp_path / "cron", tmp_path / "cron" / ".tick.lock"),
+    )
+
+    assert scheduler.tick(verbose=False) == 0
+    assert events == [
+        "ledger",
+        "seal-target",
+        "claim-occurrence",
+        "submit",
+        "finish-contextual",
+        "account-job",
+    ]
+
+
+@pytest.mark.parametrize("interrupt_at", ["claim", "submit"])
+def test_tick_interruption_after_ledger_is_terminal_and_releases_guard(
+    monkeypatch, tmp_path, interrupt_at
+):
+    import cron.scheduler as scheduler
+
+    scheduler._running_job_ids.clear()
+    events = []
+    job = {
+        "id": "contextual-interrupted",
+        "name": "contextual-interrupted",
+        "prompt": "continue",
+        "schedule": {"kind": "interval", "minutes": 5},
+        "next_run_at": "2026-08-08T00:00:00+00:00",
+        "enabled": True,
+        "session_target": "current",
+        "deliver": "local",
+    }
+
+    class InterruptingPool:
+        def submit(self, _callable):
+            events.append("submit")
+            raise KeyboardInterrupt("submit interrupted")
+
+    def claim_occurrence(*_args, **_kwargs):
+        events.append("claim-occurrence")
+        if interrupt_at == "claim":
+            raise KeyboardInterrupt("claim interrupted")
+        return True
+
+    monkeypatch.setattr(scheduler, "get_due_jobs", lambda: [job])
+    monkeypatch.setattr(scheduler, "advance_next_runs", lambda _ids: 0)
+    monkeypatch.setattr(
+        scheduler,
+        "create_execution",
+        lambda *_a, **_k: events.append("ledger") or {"id": "execution-1"},
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "seal_contextual_delivery_target",
+        lambda *_a, **_k: events.append("seal-target") or True,
+    )
+    monkeypatch.setattr(scheduler, "claim_contextual_occurrence", claim_occurrence)
+    monkeypatch.setattr(
+        scheduler,
+        "finish_contextual_execution",
+        lambda *_a, **_k: events.append("finish-contextual") or {},
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_account_contextual_job_run",
+        lambda **_k: events.append("account-job") or True,
+    )
+    monkeypatch.setattr(scheduler, "_get_parallel_pool", lambda _workers: InterruptingPool())
+    monkeypatch.setattr(
+        scheduler,
+        "_get_lock_paths",
+        lambda: (tmp_path / "cron", tmp_path / "cron" / ".tick.lock"),
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        scheduler.tick(verbose=False)
+
+    expected = ["ledger", "seal-target", "claim-occurrence"]
+    if interrupt_at == "submit":
+        expected.append("submit")
+    expected.extend(["finish-contextual", "account-job"])
+    assert events == expected
+    assert "contextual-interrupted" not in scheduler._running_job_ids
+
+
+def test_legacy_isolated_reads_are_byte_preserving(monkeypatch, tmp_path):
+    jobs = _point_store(monkeypatch, tmp_path)
+    jobs.CRON_DIR.mkdir(parents=True, exist_ok=True)
+    legacy_bytes = (
+        b'{\n  "version": 1,\n  "jobs": [\n    {\n'
+        b'      "id": "legacy-bytes",\n'
+        b'      "prompt": "standalone",\n'
+        b'      "schedule": {"kind": "interval", "minutes": 5},\n'
+        b'      "enabled": true\n'
+        b'    }\n  ]\n}\n'
+    )
+    jobs.JOBS_FILE.write_bytes(legacy_bytes)
+
+    loaded = jobs.get_job("legacy-bytes")
+    listed = jobs.list_jobs()
+
+    assert loaded["session_target"] == "isolated"
+    assert listed[0]["session_target"] == "isolated"
+    assert jobs.JOBS_FILE.read_bytes() == legacy_bytes
+
+
+def test_legacy_isolated_update_keeps_contextual_fields_absent_on_disk(
+    monkeypatch, tmp_path
+):
+    jobs = _point_store(monkeypatch, tmp_path)
+    jobs.save_jobs(
+        [
+            {
+                "id": "legacy-update",
+                "prompt": "standalone",
+                "schedule": {"kind": "interval", "minutes": 5},
+                "enabled": True,
+            }
+        ]
+    )
+
+    jobs.update_job("legacy-update", {"name": "still isolated"})
+    raw = json.loads(jobs.JOBS_FILE.read_text())["jobs"][0]
+
+    assert raw["name"] == "still isolated"
+    assert "session_target" not in raw
+    assert "session_key" not in raw
+    assert "context_binding" not in raw
+
+
+def test_current_update_binding_is_immutable(monkeypatch, tmp_path):
+    jobs = _point_store(monkeypatch, tmp_path)
+    _bind_session("telegram:dm:42:42")
+    created = jobs.create_job(
+        prompt="continue the discussion",
+        schedule="every 1h",
+        origin={"platform": "telegram", "chat_id": "42", "user_id": "42"},
+        session_target="current",
+    )
+    assert created["session_target"] == "current"
+    assert created["session_key"] == "telegram:dm:42:42"
+    assert created["context_binding"]["session_id"] == "sid"
+    assert created["context_binding"]["routing_revision"] == 0
+
+    _bind_session(
+        "telegram:dm:99:99", session_id="different-session", routing_revision=7
+    )
+    updated = jobs.update_job(created["id"], {"name": "renamed"})
+    assert updated["session_key"] == "telegram:dm:42:42"
+
+    recaptured = jobs.update_job(created["id"], {"session_target": "current"})
+    assert recaptured["session_key"] == "telegram:dm:42:42"
+    assert recaptured["context_binding"]["chat_id"] == "42"
+    assert recaptured["context_binding"]["session_id"] == "sid"
+    assert recaptured["context_binding"]["routing_revision"] == 0
+    assert recaptured["origin"]["chat_id"] == "42"
+
+    with pytest.raises(ValueError, match="binding is permanent"):
+        jobs.update_job(created["id"], {"session_target": "isolated"})
+
+    still_contextual = jobs.get_job(created["id"])
+    assert still_contextual is not None
+    assert still_contextual["session_target"] == "current"
+    assert still_contextual["session_key"] == "telegram:dm:42:42"
+
+
+def test_contextual_validation_rejects_missing_physical_session_binding(monkeypatch):
+    from cron import contextual
+
+    monkeypatch.setattr(contextual, "_validate_contextual_scheduler_provider", lambda: None)
+    with pytest.raises(ValueError, match="immutable session"):
+        contextual.validate_contextual_job_shape(
+            {
+                "id": "missing-physical-binding",
+                "prompt": "continue",
+                "session_target": "current",
+                "session_key": "telegram:dm:42:42",
+                "context_binding": {
+                    "session_key": "telegram:dm:42:42",
+                    "platform": "telegram",
+                    "chat_id": "42",
+                    "user_id": "42",
+                },
+                "deliver": "origin",
+            }
+        )
+
+
+def test_current_rejects_when_no_live_session_is_bound(monkeypatch, tmp_path):
+    jobs = _point_store(monkeypatch, tmp_path)
+    from gateway.session_context import reset_session_vars
+
+    reset_session_vars()
+    with pytest.raises(ValueError, match="gateway-bound"):
+        jobs.create_job(
+            prompt="continue",
+            schedule="every 1h",
+            session_target="current",
+        )
+
+
+def test_current_rejects_incompatible_scheduler_before_persistence(
+    monkeypatch, tmp_path
+):
+    jobs = _point_store(monkeypatch, tmp_path)
+    _bind_session("telegram:dm:42:42")
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"cron": {"provider": "chronos"}},
+    )
+
+    with pytest.raises(ValueError, match="requires cron.provider='builtin'"):
+        jobs.create_job(
+            prompt="continue",
+            schedule="every 1h",
+            session_target="current",
+        )
+
+    assert jobs.load_jobs() == []
+
+
+def test_current_capture_rejects_process_environment_spoof(monkeypatch, tmp_path):
+    jobs = _point_store(monkeypatch, tmp_path)
+    from gateway.session_context import reset_session_vars
+
+    reset_session_vars()
+    monkeypatch.setenv("HERMES_SESSION_KEY", "telegram:dm:attacker:attacker")
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "attacker")
+    monkeypatch.setenv("HERMES_SESSION_USER_ID", "attacker")
+
+    with pytest.raises(ValueError, match="gateway-bound"):
+        jobs.create_job(
+            prompt="continue",
+            schedule="every 1h",
+            session_target="current",
+        )
+
+
+def test_current_create_derives_origin_from_same_trusted_binding(monkeypatch, tmp_path):
+    jobs = _point_store(monkeypatch, tmp_path)
+    _bind_session("telegram:dm:42:42")
+
+    created = jobs.create_job(
+        prompt="continue",
+        schedule="every 1h",
+        origin={"platform": "telegram", "chat_id": "WRONG", "user_id": "WRONG"},
+        session_target="current",
+    )
+
+    assert created["context_binding"]["session_key"] == "telegram:dm:42:42"
+    assert created["origin"]["platform"] == "telegram"
+    assert created["origin"]["chat_id"] == "42"
+    assert created["origin"]["user_id"] == "42"
+
+
+def test_new_isolated_job_omits_contextual_fields_on_disk(monkeypatch, tmp_path):
+    jobs = _point_store(monkeypatch, tmp_path)
+    created = jobs.create_job(prompt="standalone", schedule="every 1h")
+
+    raw = json.loads(jobs.JOBS_FILE.read_text())["jobs"][0]
+    assert raw["id"] == created["id"]
+    assert "session_target" not in raw
+    assert "session_key" not in raw
+    assert "context_binding" not in raw
+
+
+def test_contextual_delivery_never_uses_session_mirroring():
+    from cron.scheduler import _cron_mirror_delivery_enabled
+
+    contextual = {
+        "session_target": "current",
+        "attach_to_session": True,
+    }
+    assert not _cron_mirror_delivery_enabled(
+        contextual,
+        {"cron": {"mirror_delivery": True}},
+    )
+    assert _cron_mirror_delivery_enabled(
+        {"attach_to_session": True},
+        {"cron": {"mirror_delivery": False}},
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("no_agent", True),
+        ("script", "/tmp/task.py"),
+        ("skills", ["web"]),
+        ("workdir", "/tmp"),
+        ("context_from", ["upstream"]),
+        ("enabled_toolsets", ["web"]),
+        ("model", "other"),
+        ("provider", "other"),
+        ("base_url", "https://example.invalid"),
+        ("monitor_script", "watch.py"),
+        ("monitor_url", "https://example.invalid/watch"),
+        ("attach_to_session", True),
+        ("deliver", "all"),
+        ("deliver", "telegram:other"),
+    ],
+)
+def test_contextual_shape_rejects_incompatible_settings(field, value):
+    from cron.contextual import validate_contextual_job_shape
+
+    with pytest.raises(ValueError, match=field):
+        validate_contextual_job_shape(
+            {
+                "session_target": "current",
+                "session_key": "stable",
+                **_physical_binding(),
+                "prompt": "continue",
+                field: value,
+            }
+        )
+
+
+def test_contextual_live_tool_policy_is_an_explicit_fail_closed_allowlist():
+    from cron.contextual import (
+        CONTEXTUAL_ALLOWED_TOOLSETS,
+        CONTEXTUAL_DISABLED_TOOLSETS,
+        contextual_live_tool_policy,
+    )
+
+    enabled, disabled = contextual_live_tool_policy(
+        ["web", "cronjob", "messaging", "clarify", "plugin_side_channel"],
+        ["terminal"],
+    )
+
+    assert enabled == list(CONTEXTUAL_ALLOWED_TOOLSETS)
+    assert enabled == []
+    assert disabled[0] == "terminal"
+    assert set(CONTEXTUAL_DISABLED_TOOLSETS).issubset(disabled)
+    assert "plugin_side_channel" not in enabled
+    assert len(disabled) == len(set(disabled))
+
+
+def test_contextual_final_schema_gate_rejects_unknown_and_side_effect_tools():
+    from cron.contextual import filter_contextual_tool_schemas
+
+    def schema(name):
+        return {"type": "function", "function": {"name": name}}
+
+    assert filter_contextual_tool_schemas(
+        [
+            schema("read_file"),
+            schema("web_search"),
+            schema("terminal"),
+            schema("delegate_task"),
+            schema("send_message"),
+            schema("plugin_side_channel"),
+            {"type": "function", "function": {}},
+            "malformed",
+        ]
+    ) == []
+
+
+def test_task_local_contextual_authority_blocks_even_a_widened_agent_allowlist():
+    from types import SimpleNamespace
+
+    from agent.tool_executor import _tool_execution_policy_block
+    from gateway.session_context import _bind_contextual_turn_authority
+
+    agent = SimpleNamespace(allowed_tool_names=frozenset({"terminal"}))
+    assert _tool_execution_policy_block(agent, "terminal") is None
+
+    with _bind_contextual_turn_authority(
+        execution_id="execution-1",
+        session_key="telegram:dm:42:42",
+        admitted_session_id="session-1",
+        admitted_routing_revision=7,
+    ):
+        blocked = _tool_execution_policy_block(agent, "terminal")
+
+    assert blocked is not None
+    assert "not permitted by this execution policy" in blocked
+
+
+def test_model_schema_exposes_target_but_no_raw_session_key():
+    from tools.cronjob_tools import CRONJOB_SCHEMA
+
+    properties = cast(Any, CRONJOB_SCHEMA)["parameters"]["properties"]
+    assert properties["session_target"]["enum"] == ["isolated", "current"]
+    assert "session_key" not in properties
+
+
+def test_model_tool_cannot_synchronously_run_current_session_job(monkeypatch):
+    """A tool call runs inside the human turn that contextual execution waits on."""
+    import tools.cronjob_tools as cron_tools
+
+    job = {
+        "id": "job-current",
+        "name": "current",
+        "session_target": "current",
+    }
+    executed = []
+    monkeypatch.setattr(cron_tools, "resolve_job_ref", lambda _ref: job)
+    monkeypatch.setattr(
+        cron_tools,
+        "_execute_job_now",
+        lambda _job: executed.append(_job) or {"claimed": True, "success": True},
+    )
+
+    result = json.loads(cron_tools.cronjob(action="run", job_id=job["id"]))
+
+    assert result["success"] is False
+    assert "after the active human turn" in result["error"]
+    assert executed == []
+
+
+def _patch_scheduler_bookkeeping(monkeypatch, scheduler):
+    monkeypatch.setattr(
+        scheduler, "_CONTEXTUAL_AUTHORIZER", lambda _target: True
+    )
+    monkeypatch.setattr(scheduler, "claim_dispatch", lambda _job_id: True)
+    monkeypatch.setattr(scheduler, "get_execution", lambda _id: None)
+    monkeypatch.setattr(scheduler, "mark_execution_running", lambda _id: {"status": "running"})
+    monkeypatch.setattr(scheduler, "save_job_output", lambda *_: "output.json")
+    monkeypatch.setattr(scheduler, "mark_job_run", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        scheduler,
+        "claim_contextual_job_accounting",
+        lambda _execution_id: True,
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "seal_contextual_delivery_target",
+        lambda *_args, **_kwargs: True,
+    )
+    monkeypatch.setattr(scheduler, "finish_contextual_execution", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        scheduler,
+        "persist_contextual_agent_result",
+        lambda execution_id, **kwargs: {
+            "id": execution_id,
+            "outcome": kwargs.get("outcome"),
+            "delivery_state": (
+                "pending" if kwargs.get("outcome") == "notify" else "not_applicable"
+            ),
+        },
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "claim_contextual_delivery",
+        lambda execution_id: {"id": execution_id, "delivery_state": "claimed"},
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "finish_contextual_delivery",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "suppress_contextual_delivery",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "prepare_contextual_retry",
+        lambda execution_id: {"id": execution_id},
+    )
+    monkeypatch.setattr(scheduler, "finish_execution", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(scheduler, "_resolve_delivery_targets", lambda _job: [{"platform": "telegram"}])
+    monkeypatch.setattr(scheduler, "_consume_interrupted_flag", lambda _job_id: False)
+
+
+def test_contextual_execution_rejects_malformed_sealed_delivery_target(monkeypatch):
+    import cron.scheduler as scheduler
+
+    _patch_scheduler_bookkeeping(monkeypatch, scheduler)
+    monkeypatch.setattr(
+        scheduler,
+        "get_execution",
+        lambda _id: {
+            "id": "execution",
+            "status": "claimed",
+            "phase": "claimed",
+            "delivery_target_json": "{malformed",
+        },
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "verify_contextual_occurrence_claim",
+        lambda *_args, **_kwargs: False,
+    )
+    finished = []
+    accounted = []
+    monkeypatch.setattr(
+        scheduler,
+        "finish_contextual_execution",
+        lambda execution_id, **kwargs: finished.append((execution_id, kwargs)) or {},
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "claim_contextual_job_accounting",
+        lambda execution_id: accounted.append(execution_id) or True,
+    )
+
+    assert scheduler.run_one_job(
+        {
+            "id": "job",
+            "execution_id": "execution",
+            "session_target": "current",
+            "session_key": "stable",
+            **_physical_binding(),
+            "prompt": "must not run",
+            "deliver": "origin",
+        },
+        contextual_dispatch=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("malformed target must fail before gateway dispatch")
+        ),
+    ) is True
+    assert finished[0][1]["outcome"] == "rejected"
+    assert "malformed" in finished[0][1]["error"]
+    assert accounted == ["execution"]
+
+
+def test_scheduler_routes_contextual_job_only_through_gateway_and_delivers_once(monkeypatch):
+    import cron.scheduler as scheduler
+    from gateway.contextual_cron import ContextualCronOutcome
+
+    _patch_scheduler_bookkeeping(monkeypatch, scheduler)
+    monkeypatch.setattr(
+        scheduler,
+        "run_job",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("isolated runner must not be used")
+        ),
+    )
+    delivered = []
+    monkeypatch.setattr(
+        scheduler,
+        "_deliver_result",
+        lambda job, content, **kwargs: delivered.append(content) or None,
+    )
+
+    assert scheduler.run_one_job(
+        {
+            "id": "job",
+            "execution_id": "execution",
+            "session_target": "current",
+            "session_key": "stable",
+            **_physical_binding(),
+            "prompt": "continue",
+            "deliver": "origin",
+        },
+        contextual_dispatch=lambda job, *, execution_id: ContextualCronOutcome.notify(
+            "one final notification"
+        ),
+    ) is True
+    assert delivered == ["one final notification"]
+
+
+def test_contextual_delivery_rechecks_authorization_before_claim(monkeypatch):
+    import cron.scheduler as scheduler
+    from gateway.contextual_cron import ContextualCronOutcome
+
+    _patch_scheduler_bookkeeping(monkeypatch, scheduler)
+    monkeypatch.setattr(scheduler, "_CONTEXTUAL_AUTHORIZER", lambda _target: False)
+    monkeypatch.setattr(
+        scheduler,
+        "claim_contextual_delivery",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("revoked delivery must not be claimed")
+        ),
+    )
+    delivered = []
+    suppressed = []
+    monkeypatch.setattr(
+        scheduler,
+        "_deliver_result",
+        lambda *_args, **_kwargs: delivered.append(1),
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "suppress_contextual_delivery",
+        lambda execution_id, **kwargs: suppressed.append((execution_id, kwargs)) or {},
+    )
+
+    assert scheduler.run_one_job(
+        {
+            "id": "job",
+            "execution_id": "execution",
+            "session_target": "current",
+            "session_key": "stable",
+            **_physical_binding(),
+            "prompt": "continue",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "42", "user_id": "42"},
+        },
+        contextual_dispatch=lambda *_args, **_kwargs: ContextualCronOutcome.notify(
+            "must not send"
+        ),
+    ) is True
+    assert delivered == []
+    assert suppressed == [
+        (
+            "execution",
+            {"error": "Contextual cron authorization was revoked before delivery."},
+        )
+    ]
+
+
+def test_contextual_delivery_recovery_rechecks_authorization_before_claim(monkeypatch):
+    import json
+
+    import cron.scheduler as scheduler
+
+    events = []
+    monkeypatch.setattr(scheduler, "_CONTEXTUAL_AUTHORIZER", lambda _target: False)
+    monkeypatch.setattr(
+        scheduler,
+        "claim_contextual_delivery",
+        lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("claim forbidden")),
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "suppress_contextual_delivery",
+        lambda *_a, **_k: events.append("suppressed") or {},
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_account_contextual_job_run",
+        lambda **_k: events.append("accounted") or True,
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_deliver_result",
+        lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("send forbidden")),
+    )
+
+    resumed = scheduler._resume_contextual_delivery_record(
+        {"id": "job"},
+        {
+            "id": "execution",
+            "result_json": json.dumps({"final_response": "notify"}),
+            "delivery_target_json": json.dumps(
+                {
+                    "id": "job",
+                    "deliver": "origin",
+                    "origin": {
+                        "platform": "telegram",
+                        "chat_id": "42",
+                        "user_id": "42",
+                    },
+                }
+            ),
+        },
+    )
+
+    assert resumed is False
+    assert events == ["suppressed", "accounted"]
+
+
+def test_contextual_delivery_exception_is_persisted_unknown_without_retry(monkeypatch):
+    import cron.scheduler as scheduler
+    from gateway.contextual_cron import ContextualCronOutcome
+
+    _patch_scheduler_bookkeeping(monkeypatch, scheduler)
+    sends = []
+    finishes = []
+
+    def uncertain_send(*_args, **_kwargs):
+        sends.append(1)
+        raise scheduler.ContextualDeliveryUnknown("acknowledgement lost")
+
+    monkeypatch.setattr(scheduler, "_deliver_result", uncertain_send)
+    monkeypatch.setattr(
+        scheduler,
+        "finish_contextual_delivery",
+        lambda execution_id, **kwargs: finishes.append((execution_id, kwargs)),
+    )
+
+    assert scheduler.run_one_job(
+        {
+            "id": "job",
+            "execution_id": "execution",
+            "session_target": "current",
+            "session_key": "stable",
+            **_physical_binding(),
+            "prompt": "continue",
+            "deliver": "origin",
+        },
+        contextual_dispatch=lambda *_args, **_kwargs: ContextualCronOutcome.notify(
+            "one final notification"
+        ),
+    )
+
+    assert sends == [1]
+    assert finishes == [
+        (
+            "execution",
+            {"delivery_state": "unknown", "error": "acknowledgement lost"},
+        )
+    ]
+
+
+def test_contextual_no_action_is_successful_and_silent(monkeypatch):
+    import cron.scheduler as scheduler
+    from gateway.contextual_cron import ContextualCronOutcome
+
+    _patch_scheduler_bookkeeping(monkeypatch, scheduler)
+    delivered = []
+    marks = []
+    monkeypatch.setattr(scheduler, "_deliver_result", lambda *_args, **_kwargs: delivered.append(1))
+    monkeypatch.setattr(
+        scheduler,
+        "mark_job_run",
+        lambda job_id, success, error, **kwargs: marks.append((success, error)),
+    )
+
+    scheduler.run_one_job(
+        {
+            "id": "job",
+            "execution_id": "execution",
+            "session_target": "current",
+            "session_key": "stable",
+            **_physical_binding(),
+            "prompt": "check",
+            "deliver": "origin",
+        },
+        contextual_dispatch=lambda job, *, execution_id: ContextualCronOutcome.no_action(),
+    )
+    assert delivered == []
+    assert marks == [(True, None)]
+
+
+def test_contextual_retryable_reuses_occurrence_then_delivers_once(monkeypatch):
+    import cron.scheduler as scheduler
+    from gateway.contextual_cron import ContextualCronOutcome
+
+    _patch_scheduler_bookkeeping(monkeypatch, scheduler)
+    outcomes = [
+        ContextualCronOutcome.retryable("human turn still finishing"),
+        ContextualCronOutcome.notify("after the wait"),
+    ]
+    prepared = []
+    delivered = []
+    monkeypatch.setattr(
+        scheduler,
+        "prepare_contextual_retry",
+        lambda execution_id: prepared.append(execution_id) or {"id": execution_id},
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_deliver_result",
+        lambda _job, content, **_kwargs: delivered.append(content) or None,
+    )
+
+    assert scheduler.run_one_job(
+        {
+            "id": "job",
+            "execution_id": "same-execution",
+            "session_target": "current",
+            "session_key": "stable",
+            **_physical_binding(),
+            "prompt": "continue",
+            "deliver": "origin",
+        },
+        contextual_dispatch=lambda *_args, **_kwargs: outcomes.pop(0),
+    ) is True
+
+    assert prepared == ["same-execution"]
+    assert delivered == ["after the wait"]
+
+
+def test_contextual_without_gateway_is_rejected_never_isolated(monkeypatch):
+    import cron.scheduler as scheduler
+
+    _patch_scheduler_bookkeeping(monkeypatch, scheduler)
+    scheduler.set_contextual_dispatcher(None)
+    monkeypatch.setattr(
+        scheduler,
+        "run_job",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("no isolation fallback")
+        ),
+    )
+    marks = []
+    monkeypatch.setattr(
+        scheduler,
+        "mark_job_run",
+        lambda job_id, success, error, **kwargs: marks.append((success, error)),
+    )
+    monkeypatch.setattr(scheduler, "_deliver_result", lambda *_args, **_kwargs: None)
+
+    scheduler.run_one_job(
+        {
+            "id": "job",
+            "execution_id": "execution",
+            "session_target": "current",
+            "session_key": "stable",
+            **_physical_binding(),
+            "prompt": "continue",
+            "deliver": "local",
+        }
+    )
+    assert marks[0][0] is False
+    assert "fallback" in marks[0][1]
+
+
+def test_scheduler_revalidates_persisted_contextual_shape_before_dispatch(monkeypatch):
+    import cron.scheduler as scheduler
+
+    _patch_scheduler_bookkeeping(monkeypatch, scheduler)
+    dispatched = []
+    marks = []
+    monkeypatch.setattr(
+        scheduler,
+        "mark_job_run",
+        lambda job_id, success, error, **kwargs: marks.append((success, error)),
+    )
+    monkeypatch.setattr(scheduler, "_deliver_result", lambda *_args, **_kwargs: None)
+
+    scheduler.run_one_job(
+        {
+            "id": "job",
+            "execution_id": "execution",
+            "session_target": "current",
+            "session_key": "stable",
+            **_physical_binding(),
+            "prompt": "continue",
+            "deliver": "telegram:other-user",
+        },
+        contextual_dispatch=lambda *_args, **_kwargs: dispatched.append(True),
+    )
+
+    assert dispatched == []
+    assert marks and marks[0][0] is False
+    assert "deliver" in marks[0][1]
+
+
+def test_invalid_session_target_never_falls_back_to_isolated(monkeypatch):
+    import cron.scheduler as scheduler
+
+    _patch_scheduler_bookkeeping(monkeypatch, scheduler)
+    isolated = []
+    marks = []
+    monkeypatch.setattr(scheduler, "run_job", lambda *_a, **_k: isolated.append(True))
+    monkeypatch.setattr(
+        scheduler,
+        "mark_job_run",
+        lambda job_id, success, error, **kwargs: marks.append((success, error)),
+    )
+    monkeypatch.setattr(scheduler, "_deliver_result", lambda *_a, **_k: None)
+
+    scheduler.run_one_job(
+        {
+            "id": "job",
+            "execution_id": "execution",
+            "session_target": "typo",
+            "prompt": "must not run",
+            "deliver": "local",
+        }
+    )
+
+    assert isolated == []
+    assert marks and marks[0][0] is False
+    assert "session_target" in marks[0][1]
+
+
+def test_terminal_contextual_occurrence_is_not_dispatched_or_redelivered(monkeypatch):
+    import cron.scheduler as scheduler
+
+    monkeypatch.setattr(
+        scheduler,
+        "get_execution",
+        lambda _execution_id: {"status": "completed", "outcome": "notify"},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "claim_dispatch",
+        lambda _job_id: (_ for _ in ()).throw(AssertionError("must not reclaim")),
+    )
+    dispatched = []
+
+    assert scheduler.run_one_job(
+        {
+            "id": "job",
+            "execution_id": "already-terminal",
+            "session_target": "current",
+            "session_key": "stable",
+            **_physical_binding(),
+            "prompt": "must not repeat",
+            "deliver": "origin",
+        },
+        contextual_dispatch=lambda *_a, **_k: dispatched.append(True),
+    ) is True
+    assert dispatched == []
+
+
+def test_contextual_delivery_ack_is_durable_before_job_success_accounting(monkeypatch):
+    import cron.contextual as contextual
+    import cron.scheduler as scheduler
+    from gateway.contextual_cron import ContextualCronOutcome
+
+    monkeypatch.setattr(scheduler, "_CONTEXTUAL_AUTHORIZER", lambda _target: True)
+    events = []
+    monkeypatch.setattr(
+        scheduler,
+        "get_execution",
+        lambda _execution_id: {
+            "status": "claimed",
+            "phase": "claimed",
+            "delivery_target_json": '{"id":"job"}',
+        },
+    )
+    monkeypatch.setattr(scheduler, "claim_dispatch", lambda _job_id: True)
+    monkeypatch.setattr(
+        scheduler, "mark_execution_running", lambda _execution_id: {"status": "running"}
+    )
+    monkeypatch.setattr(
+        scheduler, "persist_contextual_agent_result", lambda *_a, **_k: {"phase": "agent_completed"}
+    )
+    monkeypatch.setattr(scheduler, "save_job_output", lambda *_a, **_k: "output")
+    monkeypatch.setattr(scheduler, "claim_contextual_delivery", lambda *_a, **_k: {})
+    monkeypatch.setattr(
+        scheduler,
+        "_deliver_result",
+        lambda *_a, **_k: events.append("send") or None,
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "finish_contextual_delivery",
+        lambda *_a, **_k: events.append("delivery-ack") or {},
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_account_contextual_job_run",
+        lambda **_k: events.append("job-accounting") or True,
+    )
+    monkeypatch.setattr(contextual, "validate_contextual_job_shape", lambda _job: None)
+
+    assert scheduler.run_one_job(
+        {
+            "id": "job",
+            "execution_id": "execution",
+            "session_target": "current",
+            "session_key": "telegram:dm:42:42",
+            "prompt": "continue",
+            "deliver": "telegram",
+            "origin": {"platform": "telegram", "chat_id": "42", "user_id": "42"},
+        },
+        contextual_dispatch=lambda *_a, **_k: ContextualCronOutcome.notify("done"),
+    ) is True
+
+    assert events == ["send", "delivery-ack", "job-accounting"]
+
+
+def test_recovered_contextual_delivery_ack_precedes_job_success_accounting(monkeypatch):
+    import cron.scheduler as scheduler
+
+    monkeypatch.setattr(scheduler, "_CONTEXTUAL_AUTHORIZER", lambda _target: True)
+    events = []
+    monkeypatch.setattr(scheduler, "claim_contextual_delivery", lambda *_a, **_k: {})
+    monkeypatch.setattr(scheduler, "save_job_output", lambda *_a, **_k: "output")
+    monkeypatch.setattr(
+        scheduler,
+        "_deliver_result",
+        lambda *_a, **_k: events.append("send") or None,
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "finish_contextual_delivery",
+        lambda *_a, **_k: events.append("delivery-ack") or {},
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_account_contextual_job_run",
+        lambda **_k: events.append("job-accounting") or True,
+    )
+
+    assert scheduler._resume_contextual_delivery_record(
+        {"id": "job"},
+        {
+            "id": "execution",
+            "result_json": '{"final_response":"done"}',
+            "delivery_target_json": '{"id":"job","deliver":"telegram",'
+            '"origin":{"platform":"telegram","chat_id":"42"}}',
+        },
+    ) is True
+
+    assert events == ["send", "delivery-ack", "job-accounting"]
+
+
+def test_interrupted_contextual_delivery_records_unknown_before_job_accounting(monkeypatch):
+    import cron.contextual as contextual
+    import cron.scheduler as scheduler
+    from gateway.contextual_cron import ContextualCronOutcome
+
+    monkeypatch.setattr(scheduler, "_CONTEXTUAL_AUTHORIZER", lambda _target: True)
+    events = []
+    records = iter(
+        [
+            {
+                "status": "claimed",
+                "phase": "claimed",
+                "delivery_target_json": '{"id":"job"}',
+            },
+            {
+                "status": "running",
+                "phase": "delivering",
+                "delivery_state": "claimed",
+            },
+        ]
+    )
+    monkeypatch.setattr(scheduler, "get_execution", lambda _execution_id: next(records))
+    monkeypatch.setattr(scheduler, "claim_dispatch", lambda _job_id: True)
+    monkeypatch.setattr(
+        scheduler, "mark_execution_running", lambda _execution_id: {"status": "running"}
+    )
+    monkeypatch.setattr(
+        scheduler, "persist_contextual_agent_result", lambda *_a, **_k: {"phase": "agent_completed"}
+    )
+    monkeypatch.setattr(scheduler, "save_job_output", lambda *_a, **_k: "output")
+    monkeypatch.setattr(scheduler, "claim_contextual_delivery", lambda *_a, **_k: {})
+
+    def _interrupt(*_args, **_kwargs):
+        events.append("send")
+        raise KeyboardInterrupt("transport boundary crossed")
+
+    monkeypatch.setattr(scheduler, "_deliver_result", _interrupt)
+    monkeypatch.setattr(
+        scheduler,
+        "finish_contextual_delivery",
+        lambda *_a, **_k: events.append("delivery-unknown") or {},
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_account_contextual_job_run",
+        lambda **_k: events.append("job-accounting") or True,
+    )
+    monkeypatch.setattr(contextual, "validate_contextual_job_shape", lambda _job: None)
+
+    with pytest.raises(KeyboardInterrupt, match="transport boundary crossed"):
+        scheduler.run_one_job(
+            {
+                "id": "job",
+                "execution_id": "execution",
+                "session_target": "current",
+                "session_key": "telegram:dm:42:42",
+                "prompt": "continue",
+                "deliver": "telegram",
+                "origin": {
+                    "platform": "telegram",
+                    "chat_id": "42",
+                    "user_id": "42",
+                },
+            },
+            contextual_dispatch=lambda *_a, **_k: ContextualCronOutcome.notify("done"),
+        )
+
+    assert events == ["send", "delivery-unknown", "job-accounting"]

--- a/tests/cron/test_contextual_cron.py
+++ b/tests/cron/test_contextual_cron.py
@@ -1540,6 +1540,53 @@ def test_v2_delivery_recovery_passes_sealed_route_authority_to_gateway(monkeypat
     }
 
 
+def test_recovery_never_retries_a_lost_route_locked_delivery_claim(monkeypatch):
+    import json
+
+    import cron.scheduler as scheduler
+
+    def authorize(target):
+        target["_contextual_delivery_claim_attempted"] = True
+        return True
+
+    monkeypatch.setattr(scheduler, "_CONTEXTUAL_AUTHORIZER", authorize)
+    monkeypatch.setattr(
+        scheduler,
+        "claim_contextual_delivery",
+        lambda *_a, **_k: pytest.fail("claim retried outside the route lock"),
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_deliver_result",
+        lambda *_a, **_k: pytest.fail("lost claim must not deliver"),
+    )
+
+    assert scheduler._resume_contextual_delivery_record(
+        {"id": "job"},
+        {
+            "id": "execution",
+            "session_key": "telegram:dm:42",
+            "admitted_binding_version": 2,
+            "admitted_route_instance_id": "route-instance-a",
+            "admitted_session_id": "session-a",
+            "admitted_routing_revision": 7,
+            "result_json": json.dumps({"final_response": "notify"}),
+            "delivery_target_json": json.dumps(
+                {
+                    "id": "job",
+                    "deliver": "origin",
+                    "origin": {
+                        "platform": "telegram",
+                        "chat_type": "dm",
+                        "chat_id": "42",
+                        "user_id": "42",
+                    },
+                }
+            ),
+        },
+    ) is False
+
+
 def test_contextual_delivery_exception_is_persisted_unknown_without_retry(monkeypatch):
     import cron.scheduler as scheduler
     from gateway.contextual_cron import ContextualCronOutcome

--- a/tests/cron/test_contextual_cron.py
+++ b/tests/cron/test_contextual_cron.py
@@ -199,6 +199,8 @@ def test_contextual_authority_marker_and_degraded_replace_are_linearized(
     assert not creator.is_alive()
     assert errors == []
     assert {job["id"] for job in jobs.load_jobs()} == {"ordinary", "contextual"}
+    assert jobs._contextual_jobs_authority_marker().exists()
+    assert not jobs._contextual_jobs_authority_pending_marker().exists()
 
 
 def test_missing_contextual_update_does_not_publish_authority(monkeypatch, tmp_path):
@@ -300,6 +302,93 @@ def test_failed_authority_publication_rolls_back_marker(monkeypatch, tmp_path):
     monkeypatch.setattr(jobs, "_jobs_lock", degraded_jobs_lock)
     jobs.save_jobs([{**ordinary, "name": "after"}])
     assert jobs.load_jobs()[0]["name"] == "after"
+
+
+@pytest.mark.skipif(not hasattr(__import__("os"), "fork"), reason="requires POSIX fork")
+def test_crash_before_first_contextual_commit_does_not_publish_false_authority(
+    monkeypatch, tmp_path
+):
+    import contextlib
+    import os
+
+    import cron.jobs as jobs
+
+    jobs = _point_store(monkeypatch, tmp_path)
+    ordinary = {"id": "ordinary", "session_target": "isolated", "name": "before"}
+    contextual = {"id": "contextual", "session_target": "current"}
+    jobs.save_jobs([ordinary])
+
+    original_replace = jobs.atomic_replace
+
+    def crash_before_replace(_source, _destination):
+        os._exit(73)
+
+    monkeypatch.setattr(jobs, "atomic_replace", crash_before_replace)
+    child = os.fork()
+    if child == 0:  # pragma: no cover - child exits without returning to pytest
+        jobs.save_jobs([ordinary, contextual])
+        os._exit(74)
+
+    _pid, status = os.waitpid(child, 0)
+    assert os.waitstatus_to_exitcode(status) == 73
+    monkeypatch.setattr(jobs, "atomic_replace", original_replace)
+
+    # The durable jobs payload never crossed the replacement boundary, so a
+    # restart must not treat contextual authority as successfully committed.
+    assert [job["id"] for job in jobs.load_jobs()] == ["ordinary"]
+    assert jobs._contextual_jobs_authority_pending_marker().exists()
+
+    @contextlib.contextmanager
+    def degraded_jobs_lock():
+        previous = getattr(jobs._jobs_lock_state, "cross_process_acquired", False)
+        jobs._jobs_lock_state.cross_process_acquired = False
+        try:
+            yield False
+        finally:
+            jobs._jobs_lock_state.cross_process_acquired = previous
+
+    monkeypatch.setattr(jobs, "_jobs_lock", degraded_jobs_lock)
+    jobs.save_jobs([{**ordinary, "name": "after"}])
+
+    assert jobs.load_jobs()[0]["name"] == "after"
+    assert not jobs._contextual_jobs_authority_marker().exists()
+    assert not jobs._contextual_jobs_authority_pending_marker().exists()
+
+
+def test_successful_contextual_commit_keeps_permanent_authority(
+    monkeypatch, tmp_path
+):
+    import contextlib
+
+    import cron.jobs as jobs
+
+    jobs = _point_store(monkeypatch, tmp_path)
+    ordinary = {"id": "ordinary", "session_target": "isolated", "name": "before"}
+    contextual = {"id": "contextual", "session_target": "current"}
+
+    jobs.save_jobs([ordinary, contextual])
+    assert jobs._contextual_jobs_authority_marker().exists()
+    assert not jobs._contextual_jobs_authority_pending_marker().exists()
+
+    # Removing the last contextual job does not revoke the profile's authority.
+    jobs.save_jobs([ordinary])
+
+    @contextlib.contextmanager
+    def degraded_jobs_lock():
+        previous = getattr(jobs._jobs_lock_state, "cross_process_acquired", False)
+        jobs._jobs_lock_state.cross_process_acquired = False
+        try:
+            yield False
+        finally:
+            jobs._jobs_lock_state.cross_process_acquired = previous
+
+    monkeypatch.setattr(jobs, "_jobs_lock", degraded_jobs_lock)
+    with pytest.raises(RuntimeError, match="degraded jobs.json write"):
+        jobs.save_jobs([{**ordinary, "name": "must-not-commit"}])
+
+    assert jobs.load_jobs()[0]["name"] == "before"
+    assert jobs._contextual_jobs_authority_marker().exists()
+    assert not jobs._contextual_jobs_authority_pending_marker().exists()
 
 
 def test_public_job_record_preserves_legacy_isolated_api_shape():

--- a/tests/cron/test_contextual_cron.py
+++ b/tests/cron/test_contextual_cron.py
@@ -1587,6 +1587,49 @@ def test_recovery_never_retries_a_lost_route_locked_delivery_claim(monkeypatch):
     ) is False
 
 
+def test_live_completion_never_accounts_a_lost_route_locked_claim(monkeypatch):
+    import cron.scheduler as scheduler
+    from gateway.contextual_cron import ContextualCronOutcome
+
+    _patch_scheduler_bookkeeping(monkeypatch, scheduler)
+
+    def authorize(target):
+        target["_contextual_delivery_claim_attempted"] = True
+        return True
+
+    monkeypatch.setattr(scheduler, "_CONTEXTUAL_AUTHORIZER", authorize)
+    monkeypatch.setattr(
+        scheduler,
+        "claim_contextual_delivery",
+        lambda *_a, **_k: pytest.fail("claim retried outside the route lock"),
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_deliver_result",
+        lambda *_a, **_k: pytest.fail("lost claim must not deliver"),
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_account_contextual_job_run",
+        lambda **_k: pytest.fail("non-owner must not account the occurrence"),
+    )
+
+    assert scheduler.run_one_job(
+        {
+            "id": "job",
+            "execution_id": "execution",
+            "session_target": "current",
+            "session_key": "stable",
+            **_physical_binding(),
+            "prompt": "continue",
+            "deliver": "origin",
+        },
+        contextual_dispatch=lambda *_a, **_k: ContextualCronOutcome.notify(
+            "private result"
+        ),
+    ) is False
+
+
 def test_contextual_delivery_exception_is_persisted_unknown_without_retry(monkeypatch):
     import cron.scheduler as scheduler
     from gateway.contextual_cron import ContextualCronOutcome

--- a/tests/cron/test_contextual_cron.py
+++ b/tests/cron/test_contextual_cron.py
@@ -324,7 +324,7 @@ def test_crash_before_first_contextual_commit_does_not_publish_false_authority(
         os._exit(73)
 
     monkeypatch.setattr(jobs, "atomic_replace", crash_before_replace)
-    child = os.fork()
+    child = os.fork()  # windows-footgun: ok - test is skip-gated on os.fork
     if child == 0:  # pragma: no cover - child exits without returning to pytest
         jobs.save_jobs([ordinary, contextual])
         os._exit(74)

--- a/tests/cron/test_contextual_cron.py
+++ b/tests/cron/test_contextual_cron.py
@@ -888,7 +888,7 @@ def test_legacy_isolated_update_keeps_contextual_fields_absent_on_disk(
     )
 
     jobs.update_job("legacy-update", {"name": "still isolated"})
-    raw = json.loads(jobs.JOBS_FILE.read_text())["jobs"][0]
+    raw = json.loads(jobs.JOBS_FILE.read_text(encoding="utf-8"))["jobs"][0]
 
     assert raw["name"] == "still isolated"
     assert "session_target" not in raw
@@ -1041,7 +1041,7 @@ def test_new_isolated_job_omits_contextual_fields_on_disk(monkeypatch, tmp_path)
     jobs = _point_store(monkeypatch, tmp_path)
     created = jobs.create_job(prompt="standalone", schedule="every 1h")
 
-    raw = json.loads(jobs.JOBS_FILE.read_text())["jobs"][0]
+    raw = json.loads(jobs.JOBS_FILE.read_text(encoding="utf-8"))["jobs"][0]
     assert raw["id"] == created["id"]
     assert "session_target" not in raw
     assert "session_key" not in raw

--- a/tests/cron/test_contextual_cron.py
+++ b/tests/cron/test_contextual_cron.py
@@ -17,7 +17,14 @@ def _point_store(monkeypatch, tmp_path):
     return jobs
 
 
-def _bind_session(key: str, *, session_id: str = "sid", routing_revision: int = 0):
+def _bind_session(
+    key: str,
+    *,
+    session_id: str = "sid",
+    routing_revision: int = 0,
+    route_instance_id: str = "route-instance-a",
+    route_principal=None,
+):
     from gateway.session_context import set_session_vars
 
     return set_session_vars(
@@ -27,6 +34,8 @@ def _bind_session(key: str, *, session_id: str = "sid", routing_revision: int = 
         user_id="42",
         session_key=key,
         session_id=session_id,
+        route_instance_id=route_instance_id,
+        route_principal=route_principal,
         routing_revision=routing_revision,
     )
 
@@ -108,6 +117,189 @@ def test_public_job_record_redacts_contextual_binding_and_execution_internals():
         "exec-private",
     ):
         assert value not in encoded
+
+
+def test_public_job_record_drops_malformed_contextual_execution_payload():
+    from cron.jobs import public_job_record
+
+    public = public_job_record(
+        {
+            "id": "bad-current",
+            "session_target": "current",
+            "latest_execution": "ROUTE-SECRET-CANARY",
+        }
+    )
+
+    assert public["id"] == "bad-current"
+    assert "latest_execution" not in public
+
+
+def test_contextual_authority_marker_and_degraded_replace_are_linearized(
+    monkeypatch, tmp_path
+):
+    import contextlib
+    import threading
+    import time
+
+    import cron.jobs as jobs
+
+    jobs = _point_store(monkeypatch, tmp_path)
+    ordinary = {"id": "ordinary", "session_target": "isolated"}
+    contextual = {"id": "contextual", "session_target": "current"}
+    jobs.save_jobs([ordinary])
+
+    original_replace = jobs.atomic_replace
+    writer_at_replace = threading.Event()
+    release_writer = threading.Event()
+    errors = []
+
+    def blocked_replace(source, destination):
+        if threading.current_thread().name == "degraded-writer":
+            writer_at_replace.set()
+            assert release_writer.wait(timeout=5)
+        return original_replace(source, destination)
+
+    @contextlib.contextmanager
+    def fake_jobs_lock():
+        previous = getattr(jobs._jobs_lock_state, "cross_process_acquired", False)
+        acquired = threading.current_thread().name != "degraded-writer"
+        jobs._jobs_lock_state.cross_process_acquired = acquired
+        try:
+            yield acquired
+        finally:
+            jobs._jobs_lock_state.cross_process_acquired = previous
+
+    monkeypatch.setattr(jobs, "atomic_replace", blocked_replace)
+    monkeypatch.setattr(jobs, "_jobs_lock", fake_jobs_lock)
+
+    def degraded_write():
+        try:
+            jobs.save_jobs([ordinary])
+        except Exception as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    def first_contextual_write():
+        try:
+            jobs.save_jobs([ordinary, contextual])
+        except Exception as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    writer = threading.Thread(target=degraded_write, name="degraded-writer")
+    creator = threading.Thread(target=first_contextual_write, name="creator")
+    writer.start()
+    assert writer_at_replace.wait(timeout=5)
+    creator.start()
+    time.sleep(0.05)
+    assert creator.is_alive(), "marker publication must wait for the staged replace"
+    release_writer.set()
+    writer.join(timeout=5)
+    creator.join(timeout=5)
+
+    assert not writer.is_alive()
+    assert not creator.is_alive()
+    assert errors == []
+    assert {job["id"] for job in jobs.load_jobs()} == {"ordinary", "contextual"}
+
+
+def test_missing_contextual_update_does_not_publish_authority(monkeypatch, tmp_path):
+    import contextlib
+
+    import cron.jobs as jobs
+
+    jobs = _point_store(monkeypatch, tmp_path)
+    ordinary = {"id": "ordinary", "session_target": "isolated", "name": "before"}
+    jobs.save_jobs([ordinary])
+
+    assert jobs.update_job("missing", {"session_target": "current"}) is None
+    assert not jobs._contextual_jobs_authority_marker().exists()
+
+    @contextlib.contextmanager
+    def degraded_jobs_lock():
+        previous = getattr(jobs._jobs_lock_state, "cross_process_acquired", False)
+        jobs._jobs_lock_state.cross_process_acquired = False
+        try:
+            yield False
+        finally:
+            jobs._jobs_lock_state.cross_process_acquired = previous
+
+    monkeypatch.setattr(jobs, "_jobs_lock", degraded_jobs_lock)
+    jobs.save_jobs([{**ordinary, "name": "after"}])
+    assert jobs.load_jobs()[0]["name"] == "after"
+
+
+def test_rejected_contextual_mutations_do_not_publish_authority(monkeypatch, tmp_path):
+    import cron.jobs as jobs
+
+    jobs = _point_store(monkeypatch, tmp_path)
+    _bind_session("telegram:dm:42:42")
+
+    with pytest.raises(ValueError):
+        jobs.create_job(
+            prompt="never",
+            schedule="2000-01-01T00:00:00+00:00",
+            name="rejected-create",
+            session_target="current",
+        )
+    assert not jobs._contextual_jobs_authority_marker().exists()
+    assert jobs.load_jobs() == []
+
+    ordinary = jobs.create_job(
+        prompt="ordinary",
+        schedule="0 9 * * *",
+        name="ordinary",
+    )
+    with pytest.raises(ValueError):
+        jobs.update_job(
+            ordinary["id"],
+            {
+                "session_target": "current",
+                "schedule": "2000-01-01T00:00:00+00:00",
+            },
+        )
+    assert not jobs._contextual_jobs_authority_marker().exists()
+    stored = jobs.get_job(ordinary["id"])
+    assert stored is not None
+    assert stored.get("session_target", "isolated") == "isolated"
+
+
+def test_failed_authority_publication_rolls_back_marker(monkeypatch, tmp_path):
+    import contextlib
+
+    import cron.jobs as jobs
+
+    jobs = _point_store(monkeypatch, tmp_path)
+    ordinary = {"id": "ordinary", "session_target": "isolated", "name": "before"}
+    contextual = {"id": "contextual", "session_target": "current"}
+    jobs.save_jobs([ordinary])
+
+    def partially_publish_then_fail():
+        marker = jobs._contextual_jobs_authority_marker()
+        marker.touch()
+        raise OSError("injected marker fsync failure")
+
+    monkeypatch.setattr(
+        jobs,
+        "_publish_contextual_jobs_authority_unlocked",
+        partially_publish_then_fail,
+    )
+    with pytest.raises(OSError, match="marker fsync failure"):
+        jobs.save_jobs([ordinary, contextual])
+
+    assert not jobs._contextual_jobs_authority_marker().exists()
+    assert [job["id"] for job in jobs.load_jobs()] == ["ordinary"]
+
+    @contextlib.contextmanager
+    def degraded_jobs_lock():
+        previous = getattr(jobs._jobs_lock_state, "cross_process_acquired", False)
+        jobs._jobs_lock_state.cross_process_acquired = False
+        try:
+            yield False
+        finally:
+            jobs._jobs_lock_state.cross_process_acquired = previous
+
+    monkeypatch.setattr(jobs, "_jobs_lock", degraded_jobs_lock)
+    jobs.save_jobs([{**ordinary, "name": "after"}])
+    assert jobs.load_jobs()[0]["name"] == "after"
 
 
 def test_public_job_record_preserves_legacy_isolated_api_shape():
@@ -617,7 +809,15 @@ def test_legacy_isolated_update_keeps_contextual_fields_absent_on_disk(
 
 def test_current_update_binding_is_immutable(monkeypatch, tmp_path):
     jobs = _point_store(monkeypatch, tmp_path)
-    _bind_session("telegram:dm:42:42")
+    _bind_session(
+        "telegram:dm:42:42",
+        route_principal={
+            "scope_id": "tenant-a",
+            "parent_chat_id": "parent-a",
+            "user_id_alt": "user-alt-a",
+            "chat_id_alt": "chat-alt-a",
+        },
+    )
     created = jobs.create_job(
         prompt="continue the discussion",
         schedule="every 1h",
@@ -626,8 +826,14 @@ def test_current_update_binding_is_immutable(monkeypatch, tmp_path):
     )
     assert created["session_target"] == "current"
     assert created["session_key"] == "telegram:dm:42:42"
-    assert created["context_binding"]["session_id"] == "sid"
-    assert created["context_binding"]["routing_revision"] == 0
+    assert created["context_binding"]["route_instance_id"] == "route-instance-a"
+    assert created["context_binding"]["scope_id"] == "tenant-a"
+    assert created["context_binding"]["parent_chat_id"] == "parent-a"
+    assert created["context_binding"]["user_id_alt"] == "user-alt-a"
+    assert created["context_binding"]["chat_id_alt"] == "chat-alt-a"
+    assert "session_id" not in created["context_binding"]
+    assert "routing_revision" not in created["context_binding"]
+    assert created["_contextual_binding_version"] == 2
 
     _bind_session(
         "telegram:dm:99:99", session_id="different-session", routing_revision=7
@@ -638,8 +844,9 @@ def test_current_update_binding_is_immutable(monkeypatch, tmp_path):
     recaptured = jobs.update_job(created["id"], {"session_target": "current"})
     assert recaptured["session_key"] == "telegram:dm:42:42"
     assert recaptured["context_binding"]["chat_id"] == "42"
-    assert recaptured["context_binding"]["session_id"] == "sid"
-    assert recaptured["context_binding"]["routing_revision"] == 0
+    assert recaptured["context_binding"]["route_instance_id"] == "route-instance-a"
+    assert "session_id" not in recaptured["context_binding"]
+    assert "routing_revision" not in recaptured["context_binding"]
     assert recaptured["origin"]["chat_id"] == "42"
 
     with pytest.raises(ValueError, match="binding is permanent"):
@@ -1138,6 +1345,57 @@ def test_contextual_delivery_recovery_rechecks_authorization_before_claim(monkey
 
     assert resumed is False
     assert events == ["suppressed", "accounted"]
+
+
+def test_v2_delivery_recovery_rejects_incomplete_creator_authority(monkeypatch):
+    import json
+
+    import cron.scheduler as scheduler
+
+    finished = []
+    monkeypatch.setattr(
+        scheduler,
+        "finish_contextual_execution",
+        lambda execution_id, **kwargs: finished.append((execution_id, kwargs)) or True,
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_CONTEXTUAL_AUTHORIZER",
+        lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("auth forbidden")),
+    )
+
+    resumed = scheduler._resume_contextual_delivery_record(
+        {"id": "job"},
+        {
+            "id": "execution",
+            "admitted_route_instance_id": "route-instance-a",
+            "admitted_binding_version": 2,
+            "result_json": json.dumps({"final_response": "notify"}),
+            "delivery_target_json": json.dumps(
+                {
+                    "id": "job",
+                    "deliver": "origin",
+                    "origin": {
+                        "platform": "telegram",
+                        "chat_type": "dm",
+                        "chat_id": "42",
+                        "user_id": "",
+                    },
+                }
+            ),
+        },
+    )
+
+    assert resumed is False
+    assert finished == [
+        (
+            "execution",
+            {
+                "outcome": "unknown",
+                "error": "Pending contextual delivery has invalid creator authority.",
+            },
+        )
+    ]
 
 
 def test_contextual_delivery_exception_is_persisted_unknown_without_retry(monkeypatch):

--- a/tests/cron/test_contextual_cron.py
+++ b/tests/cron/test_contextual_cron.py
@@ -1487,6 +1487,59 @@ def test_v2_delivery_recovery_rejects_incomplete_creator_authority(monkeypatch):
     ]
 
 
+def test_v2_delivery_recovery_passes_sealed_route_authority_to_gateway(monkeypatch):
+    import json
+
+    import cron.scheduler as scheduler
+
+    seen = []
+    monkeypatch.setattr(
+        scheduler,
+        "_CONTEXTUAL_AUTHORIZER",
+        lambda target: seen.append(target) or False,
+    )
+    monkeypatch.setattr(
+        scheduler, "suppress_contextual_delivery", lambda *_a, **_k: {}
+    )
+    monkeypatch.setattr(
+        scheduler, "_account_contextual_job_run", lambda **_k: True
+    )
+
+    assert scheduler._resume_contextual_delivery_record(
+        {"id": "job"},
+        {
+            "id": "execution",
+            "session_key": "telegram:dm:42",
+            "admitted_binding_version": 2,
+            "admitted_route_instance_id": "route-instance-a",
+            "admitted_session_id": "session-a",
+            "admitted_routing_revision": 7,
+            "result_json": json.dumps({"final_response": "notify"}),
+            "delivery_target_json": json.dumps(
+                {
+                    "id": "job",
+                    "deliver": "origin",
+                    "origin": {
+                        "platform": "telegram",
+                        "chat_type": "dm",
+                        "chat_id": "42",
+                        "user_id": "42",
+                    },
+                }
+            ),
+        },
+    ) is False
+
+    assert seen[0]["_contextual_authority"] == {
+        "execution_id": "execution",
+        "session_key": "telegram:dm:42",
+        "binding_version": 2,
+        "route_instance_id": "route-instance-a",
+        "session_id": "session-a",
+        "routing_revision": 7,
+    }
+
+
 def test_contextual_delivery_exception_is_persisted_unknown_without_retry(monkeypatch):
     import cron.scheduler as scheduler
     from gateway.contextual_cron import ContextualCronOutcome

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -27,16 +27,14 @@ def hermes_env(tmp_path, monkeypatch):
 
     monkeypatch.setenv("HERMES_HOME", str(home))
 
-    # Reload modules that cache get_hermes_home() at import time.
-    import importlib
-    import hermes_constants
-    importlib.reload(hermes_constants)
-    import cron.jobs
-    importlib.reload(cron.jobs)
-    import cron.scheduler
-    importlib.reload(cron.scheduler)
+    # Route storage dynamically instead of reloading shared modules. Reloading
+    # cron.scheduler replaces exception classes and function globals under
+    # tests that imported them during collection, making the broad suite
+    # collection-order dependent.
+    import cron.jobs as jobs
 
-    return home
+    with jobs.use_cron_store(home):
+        yield home
 
 
 # ---------------------------------------------------------------------------
@@ -55,7 +53,7 @@ def test_update_job_roundtrips_no_agent_flag(hermes_env):
     from cron.jobs import create_job, update_job, get_job
 
     script_path = hermes_env / "scripts" / "w.sh"
-    script_path.write_text("echo hi\n")
+    script_path.write_text("echo hi\n", encoding="utf-8")
     job = create_job(prompt=None, schedule="every 5m", script="w.sh", no_agent=True, deliver="local")
 
     update_job(job["id"], {"no_agent": False})
@@ -93,7 +91,9 @@ def test_run_job_no_agent_success_returns_script_stdout(hermes_env):
     from cron.scheduler import run_job
 
     script_path = hermes_env / "scripts" / "alert.sh"
-    script_path.write_text("#!/bin/bash\necho 'RAM 92% on host'\n")
+    script_path.write_text(
+        "#!/bin/bash\necho 'RAM 92% on host'\n", encoding="utf-8"
+    )
 
     job = create_job(
         prompt=None, schedule="every 5m", script="alert.sh", no_agent=True, deliver="local"

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
+from datetime import timedelta
 import json
 import os
 import sqlite3
 import subprocess
 import sys
+import threading
+import time
 from pathlib import Path
+from typing import Any, cast
 
 
 def _point_ledger(monkeypatch, tmp_path):
@@ -15,6 +20,607 @@ def _point_ledger(monkeypatch, tmp_path):
 
     monkeypatch.setattr(executions, "EXECUTIONS_FILE", tmp_path / "cron" / "executions.db")
     return executions
+
+
+def test_schema_v6_migrates_every_legacy_version_without_pending_side_effects(
+    monkeypatch, tmp_path
+):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    for legacy_version in range(6):
+        path = tmp_path / f"legacy-{legacy_version}.db"
+        monkeypatch.setattr(executions, "EXECUTIONS_FILE", path)
+        with sqlite3.connect(path) as conn:
+            conn.execute(
+                """CREATE TABLE executions (
+                     id TEXT PRIMARY KEY,
+                     job_id TEXT NOT NULL,
+                     source TEXT NOT NULL,
+                     process_id TEXT NOT NULL,
+                     pid INTEGER NOT NULL,
+                     process_started_at INTEGER,
+                     status TEXT NOT NULL,
+                     claimed_at TEXT NOT NULL,
+                     started_at TEXT,
+                     finished_at TEXT,
+                     error TEXT
+                   )"""
+            )
+            conn.execute(
+                """INSERT INTO executions
+                   (id, job_id, source, process_id, pid, status, claimed_at,
+                    finished_at)
+                   VALUES ('legacy', 'job', 'builtin', 'old-process', 1,
+                           'completed', '2026-07-30T00:00:00+00:00',
+                           '2026-07-30T00:00:01+00:00')"""
+            )
+            conn.execute(f"PRAGMA user_version={legacy_version}")
+
+        migrated = executions.get_execution("legacy")
+        assert migrated is not None
+        assert migrated["phase"] == "completed"
+        assert migrated["delivery_state"] == "not_applicable"
+        assert migrated["transcript_state"] == "not_applicable"
+        assert migrated["requires_job_accounting"] == 0
+        assert executions.list_pending_contextual_transcripts() == []
+        with sqlite3.connect(path) as conn:
+            assert conn.execute("PRAGMA user_version").fetchone()[0] == 6
+
+
+def test_contextual_admission_and_typed_outcomes_are_durable(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    record = executions.create_execution("contextual", source="builtin")
+    executions.mark_execution_running(record["id"])
+
+    assert executions.seal_contextual_admission(
+        record["id"],
+        session_key="telegram:dm:42:42",
+        admitted_session_id="session-1",
+    ) is True
+    assert executions.seal_contextual_admission(
+        record["id"],
+        session_key="telegram:dm:42:42",
+        admitted_session_id="session-2",
+    ) is False
+    admitted = executions.get_execution(record["id"])
+    assert admitted["admitted_at"]
+
+    finished = executions.finish_contextual_execution(
+        record["id"],
+        outcome="no_action",
+    )
+    assert finished["status"] == "completed"
+    assert finished["outcome"] == "no_action"
+    assert finished["session_key"] == "telegram:dm:42:42"
+    assert finished["admitted_session_id"] == "session-1"
+    assert json.loads(finished["result_json"])["kind"] == "no_action"
+    assert executions.finish_contextual_execution(
+        record["id"], outcome="notify", final_response="duplicate"
+    ) is None
+
+
+def test_contextual_result_atomically_stages_immutable_transcript_outbox(
+    monkeypatch, tmp_path
+):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    record = executions.create_execution("contextual-transcript", source="builtin")
+    executions.mark_execution_running(record["id"])
+    entries = [
+        {
+            "role": "user",
+            "content": "hidden trigger",
+            "display_kind": "hidden",
+            "message_id": f"contextual-cron:{record['id']}:0",
+        },
+        {
+            "role": "assistant",
+            "content": "final answer",
+            "message_id": f"contextual-cron:{record['id']}:1",
+        },
+    ]
+
+    staged = executions.persist_contextual_agent_result(
+        record["id"],
+        outcome="notify",
+        final_response="final answer",
+        transcript_session_id="session-1",
+        transcript_entries=entries,
+        transcript_base_message_count=4,
+        transcript_base_revision=9,
+        transcript_last_prompt_tokens=77,
+    )
+
+    assert staged is not None
+    assert staged["phase"] == "agent_completed"
+    assert staged["transcript_state"] == "pending"
+    assert staged["transcript_session_id"] == "session-1"
+    assert staged["transcript_base_message_count"] == 4
+    assert staged["transcript_last_prompt_tokens"] == 77
+    assert json.loads(staged["transcript_json"]) == entries
+    assert [item["id"] for item in executions.list_pending_contextual_transcripts()] == [
+        record["id"]
+    ]
+
+    # The result + outbox join is idempotent for the same immutable payload,
+    # but neither side may be rewritten independently after the transaction.
+    assert executions.persist_contextual_agent_result(
+        record["id"],
+        outcome="notify",
+        final_response="final answer",
+        transcript_session_id="session-1",
+        transcript_entries=entries,
+        transcript_base_message_count=4,
+        transcript_base_revision=9,
+    ) is not None
+    assert executions.persist_contextual_agent_result(
+        record["id"],
+        outcome="notify",
+        final_response="final answer",
+        transcript_session_id="session-1",
+        transcript_entries=[{**entries[0], "content": "retargeted"}],
+        transcript_base_message_count=4,
+        transcript_base_revision=9,
+    ) is None
+
+    assert executions.mark_contextual_transcript_applied(record["id"]) is True
+    assert executions.mark_contextual_transcript_applied(record["id"]) is False
+    applied = executions.get_execution(record["id"])
+    assert applied is not None
+    assert applied["transcript_state"] == "applied"
+    assert executions.list_pending_contextual_transcripts() == []
+
+
+def test_contextual_transcript_outbox_rejects_invalid_base_counts(
+    monkeypatch, tmp_path
+):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    pytest = __import__("pytest")
+    entries = [
+        {
+            "role": "assistant",
+            "content": "answer",
+            "message_id": "contextual-cron:invalid-base:0",
+        }
+    ]
+    for invalid in (-1, True, "0"):
+        record = executions.create_execution(
+            f"invalid-base-{invalid!r}", source="builtin"
+        )
+        executions.mark_execution_running(record["id"])
+        with pytest.raises(ValueError, match="base message count"):
+            executions.persist_contextual_agent_result(
+                record["id"],
+                outcome="no_action",
+                transcript_session_id="session-1",
+                transcript_entries=entries,
+                transcript_base_message_count=cast(Any, invalid),
+                transcript_base_revision=0,
+            )
+
+
+def test_contextual_transcript_causal_conflict_is_terminal_and_not_deliverable(
+    monkeypatch, tmp_path
+):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    record = executions.create_execution("contextual-conflict", source="builtin")
+    executions.mark_execution_running(record["id"])
+    staged = executions.persist_contextual_agent_result(
+        record["id"],
+        outcome="notify",
+        final_response="scheduled answer",
+        transcript_session_id="session-1",
+        transcript_entries=[
+            {
+                "role": "assistant",
+                "content": "scheduled answer",
+                "message_id": f"contextual-cron:{record['id']}:0",
+            }
+        ],
+        transcript_base_message_count=2,
+        transcript_base_revision=5,
+    )
+    assert staged is not None
+
+    assert executions.mark_contextual_transcript_conflict(
+        record["id"],
+        error="Transcript advanced before recovery.",
+    ) is True
+    assert executions.mark_contextual_transcript_conflict(
+        record["id"],
+        error="duplicate",
+    ) is False
+
+    conflicted = executions.get_execution(record["id"])
+    assert conflicted is not None
+    assert conflicted["status"] == "unknown"
+    assert conflicted["phase"] == "unknown"
+    assert conflicted["transcript_state"] == "conflict"
+    assert conflicted["delivery_state"] == "unknown"
+    assert conflicted["error"] == "Transcript advanced before recovery."
+    assert executions.list_pending_contextual_transcripts() == []
+    assert executions.claim_contextual_delivery(record["id"]) is None
+
+
+def test_retention_preserves_terminal_execution_until_transcript_outbox_applies(
+    monkeypatch, tmp_path
+):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    monkeypatch.setattr(executions, "MAX_TERMINAL_EXECUTIONS", 0)
+    record = executions.create_execution("contextual-transcript", source="builtin")
+    executions.mark_execution_running(record["id"])
+
+    staged = executions.persist_contextual_agent_result(
+        record["id"],
+        outcome="no_action",
+        transcript_session_id="session-1",
+        transcript_entries=[
+            {
+                "role": "user",
+                "content": "hidden trigger",
+                "display_kind": "hidden",
+                "message_id": f"contextual-cron:{record['id']}:0",
+            }
+        ],
+        transcript_base_message_count=0,
+        transcript_base_revision=0,
+    )
+
+    assert staged is not None
+    assert executions.get_execution(record["id"]) is not None
+    assert executions.mark_contextual_transcript_applied(record["id"]) is True
+    assert executions.get_execution(record["id"]) is None
+
+
+def test_execution_ledger_follows_task_local_cron_store_after_import(monkeypatch, tmp_path):
+    import cron.executions as executions
+    from cron.jobs import use_cron_store
+
+    monkeypatch.setattr(executions, "EXECUTIONS_FILE", executions._IMPORT_EXECUTIONS_FILE)
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    with use_cron_store(first):
+        executions.create_execution("first-job", source="test")
+    with use_cron_store(second):
+        executions.create_execution("second-job", source="test")
+
+    assert (first / "cron" / "executions.db").is_file()
+    assert (second / "cron" / "executions.db").is_file()
+    with sqlite3.connect(first / "cron" / "executions.db") as conn:
+        assert conn.execute("SELECT job_id FROM executions").fetchall() == [("first-job",)]
+    with sqlite3.connect(second / "cron" / "executions.db") as conn:
+        assert conn.execute("SELECT job_id FROM executions").fetchall() == [("second-job",)]
+
+
+def test_contextual_delivery_target_and_job_accounting_are_immutable(monkeypatch, tmp_path):
+    import concurrent.futures
+
+    executions = _point_ledger(monkeypatch, tmp_path)
+    record = executions.create_execution("immutable-target", source="builtin")
+    first = {
+        "id": "immutable-target",
+        "deliver": "origin",
+        "origin": {"platform": "telegram", "chat_id": "42"},
+    }
+    second = {
+        "id": "immutable-target",
+        "deliver": "origin",
+        "origin": {"platform": "telegram", "chat_id": "99"},
+    }
+
+    assert executions.seal_contextual_delivery_target(record["id"], target=first)
+    assert not executions.seal_contextual_delivery_target(record["id"], target=second)
+    stored = executions.get_execution(record["id"])
+    assert json.loads(stored["delivery_target_json"]) == first
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        claims = list(
+            pool.map(
+                lambda _index: executions.claim_contextual_job_accounting(record["id"]),
+                range(8),
+            )
+        )
+    assert claims.count(True) == 1
+
+
+def test_contextual_job_accounting_reconciles_without_double_increment(monkeypatch, tmp_path):
+    import cron.scheduler as scheduler
+    from cron import jobs as cron_jobs
+
+    executions = _point_ledger(monkeypatch, tmp_path)
+    with cron_jobs.use_cron_store(tmp_path):
+        job = cron_jobs.create_job(
+            prompt="account once",
+            schedule="every 1h",
+            repeat=5,
+            deliver="local",
+        )
+        record = executions.create_execution(job["id"], source="builtin")
+        assert executions.seal_contextual_delivery_target(
+            record["id"],
+            target={"id": job["id"], "deliver": "local", "origin": {}},
+        )
+        executions.mark_execution_running(record["id"])
+        executions.persist_contextual_agent_result(record["id"], outcome="no_action")
+
+        # Simulate a crash after jobs.json committed but before the ledger's
+        # job_accounted bit was acknowledged.
+        cron_jobs.mark_job_run(
+            job["id"],
+            True,
+            None,
+            execution_id=record["id"],
+        )
+        assert scheduler.reconcile_contextual_job_accounting() == 1
+        assert scheduler.reconcile_contextual_job_accounting() == 0
+
+        stored = cron_jobs.get_job(job["id"])
+        assert stored is not None
+        assert stored["repeat"]["completed"] == 1
+        assert "_pending_accounting_execution_ids" not in stored
+        accounted = executions.get_execution(record["id"])
+        assert accounted is not None
+        assert accounted["job_accounted"] == 1
+
+
+def test_contextual_accounting_waits_for_jobs_lock_then_retries(
+    monkeypatch, tmp_path
+):
+    import cron.scheduler as scheduler
+    from cron import jobs as cron_jobs
+
+    executions = _point_ledger(monkeypatch, tmp_path)
+    with cron_jobs.use_cron_store(tmp_path):
+        job = cron_jobs.create_job(
+            prompt="retry protected accounting",
+            schedule="every 1h",
+            repeat=5,
+            deliver="local",
+        )
+        record = executions.create_execution(
+            job["id"], source="builtin", requires_job_accounting=True
+        )
+        executions.finish_contextual_execution(record["id"], outcome="no_action")
+        jobs_file = cron_jobs._current_cron_store().jobs_file
+        before = jobs_file.read_bytes()
+        real_jobs_lock = cron_jobs._jobs_lock
+
+        @contextmanager
+        def degraded_lock():
+            yield False
+
+        monkeypatch.setattr(cron_jobs, "_jobs_lock", degraded_lock)
+
+        assert scheduler._account_contextual_job_run(
+            execution_id=record["id"],
+            job_id=job["id"],
+            success=True,
+            error=None,
+            delivery_error=None,
+        ) is False
+        assert jobs_file.read_bytes() == before
+        unaccounted = executions.get_execution(record["id"])
+        assert unaccounted is not None
+        assert unaccounted["job_accounted"] == 0
+
+        monkeypatch.setattr(cron_jobs, "_jobs_lock", real_jobs_lock)
+        assert scheduler._account_contextual_job_run(
+            execution_id=record["id"],
+            job_id=job["id"],
+            success=True,
+            error=None,
+            delivery_error=None,
+        ) is True
+        stored = cron_jobs.get_job(job["id"])
+        assert stored is not None
+        assert stored["repeat"]["completed"] == 1
+        accounted = executions.get_execution(record["id"])
+        assert accounted is not None
+        assert accounted["job_accounted"] == 1
+
+
+def test_reconcile_multiple_crash_gap_markers_never_double_counts(monkeypatch, tmp_path):
+    from cron import executions
+    from cron import jobs as cron_jobs
+    from cron import scheduler
+
+    executions = _point_ledger(monkeypatch, tmp_path)
+    with cron_jobs.use_cron_store(tmp_path):
+        job = cron_jobs.create_job(
+            "count once each",
+            "every 1h",
+            repeat=10,
+            deliver="local",
+        )
+        records = []
+        for _ in range(2):
+            record = executions.create_execution(job["id"], source="builtin")
+            executions.seal_contextual_delivery_target(
+                record["id"],
+                target={"id": job["id"], "deliver": "local"},
+            )
+            executions.persist_contextual_agent_result(
+                record["id"],
+                outcome="no_action",
+            )
+            cron_jobs.mark_job_run(
+                job["id"],
+                True,
+                execution_id=record["id"],
+            )
+            records.append(record)
+
+        before = cron_jobs.get_job(job["id"])
+        assert before is not None
+        assert before["repeat"]["completed"] == 2
+        assert set(before["_pending_accounting_execution_ids"]) == {
+            record["id"] for record in records
+        }
+
+        assert scheduler.reconcile_contextual_job_accounting() == 2
+        after = cron_jobs.get_job(job["id"])
+        assert after is not None
+        assert after["repeat"]["completed"] == 2
+        assert "_pending_accounting_execution_ids" not in after
+        assert scheduler.reconcile_contextual_job_accounting() == 0
+
+
+def test_concurrent_contextual_accounting_has_one_linearization_winner(
+    monkeypatch, tmp_path
+):
+    from cron import jobs as cron_jobs
+    from cron import scheduler
+
+    executions = _point_ledger(monkeypatch, tmp_path)
+    with cron_jobs.use_cron_store(tmp_path):
+        job = cron_jobs.create_job(
+            "concurrent accounting",
+            "every 1h",
+            repeat=10,
+            deliver="local",
+        )
+        record = executions.create_execution(job["id"], source="builtin")
+        executions.persist_contextual_agent_result(record["id"], outcome="no_action")
+
+    claim_entered = threading.Event()
+    release_claim = threading.Event()
+    real_claim = scheduler.claim_contextual_job_accounting
+
+    def slow_claim(execution_id):
+        claim_entered.set()
+        assert release_claim.wait(timeout=5)
+        return real_claim(execution_id)
+
+    monkeypatch.setattr(scheduler, "claim_contextual_job_accounting", slow_claim)
+    results = []
+
+    def account():
+        with cron_jobs.use_cron_store(tmp_path):
+            results.append(
+                scheduler._account_contextual_job_run(
+                    execution_id=record["id"],
+                    job_id=job["id"],
+                    success=True,
+                    error=None,
+                    delivery_error=None,
+                )
+            )
+
+    first = threading.Thread(target=account)
+    second = threading.Thread(target=account)
+    first.start()
+    assert claim_entered.wait(timeout=5)
+    second.start()
+    time.sleep(0.1)
+    assert second.is_alive(), "second reconciler bypassed the accounting transaction lock"
+    release_claim.set()
+    first.join(timeout=5)
+    second.join(timeout=5)
+
+    assert not first.is_alive() and not second.is_alive()
+    assert results == [True, True]
+    with cron_jobs.use_cron_store(tmp_path):
+        stored = cron_jobs.get_job(job["id"])
+    assert stored is not None
+    assert stored["repeat"]["completed"] == 1
+
+
+def test_retention_never_prunes_unaccounted_contextual_occurrence(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    monkeypatch.setattr(executions, "MAX_TERMINAL_EXECUTIONS", 1)
+
+    protected = executions.create_execution(
+        "protected",
+        source="builtin",
+        requires_job_accounting=True,
+    )
+    executions.finish_contextual_execution(protected["id"], outcome="no_action")
+
+    for index in range(3):
+        ordinary = executions.create_execution(f"ordinary-{index}", source="builtin")
+        executions.finish_execution(ordinary["id"], success=True)
+
+    retained = executions.get_execution(protected["id"])
+    assert retained is not None
+    assert retained["job_accounted"] == 0
+    assert retained["requires_job_accounting"] == 1
+
+
+def test_pending_delivery_uses_ledger_snapshot_not_mutated_job(monkeypatch, tmp_path):
+    import cron.scheduler as scheduler
+
+    monkeypatch.setattr(scheduler, "_CONTEXTUAL_AUTHORIZER", lambda _target: True)
+    executions = _point_ledger(monkeypatch, tmp_path)
+    record = executions.create_execution("snapshot-job", source="builtin")
+    executions.mark_execution_running(record["id"])
+    original = {
+        "id": "snapshot-job",
+        "deliver": "origin",
+        "origin": {"platform": "telegram", "chat_id": "42", "user_id": "42"},
+    }
+    assert executions.seal_contextual_delivery_target(record["id"], target=original)
+    executions.persist_contextual_agent_result(
+        record["id"], outcome="notify", final_response="one message"
+    )
+    record = executions.get_execution(record["id"])
+
+    delivered = []
+    monkeypatch.setattr(scheduler, "save_job_output", lambda *_args: None)
+    monkeypatch.setattr(scheduler, "_resolve_delivery_targets", lambda _job: [object()])
+    monkeypatch.setattr(
+        scheduler,
+        "_deliver_result",
+        lambda job, content, **_kwargs: delivered.append((job, content)) or None,
+    )
+    monkeypatch.setattr(scheduler, "mark_job_run", lambda *_args, **_kwargs: None)
+
+    assert scheduler._resume_contextual_delivery_record(
+        {
+            "id": "snapshot-job",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "99"},
+        },
+        record,
+    )
+    assert delivered == [(original, "one message")]
+
+
+def test_contextual_columns_migrate_an_existing_ledger(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    executions.EXECUTIONS_FILE.parent.mkdir(parents=True)
+    conn = sqlite3.connect(executions.EXECUTIONS_FILE)
+    conn.execute(
+        """CREATE TABLE executions (
+             id TEXT PRIMARY KEY, job_id TEXT NOT NULL, source TEXT NOT NULL,
+             process_id TEXT NOT NULL, pid INTEGER NOT NULL,
+             process_started_at INTEGER,
+             status TEXT NOT NULL, claimed_at TEXT NOT NULL,
+             started_at TEXT, finished_at TEXT, error TEXT
+           )"""
+    )
+    conn.commit()
+    conn.close()
+
+    executions.create_execution("migrated", source="builtin")
+    conn = sqlite3.connect(executions.EXECUTIONS_FILE)
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(executions)")}
+    conn.close()
+    assert {
+        "session_key",
+        "admitted_session_id",
+        "admitted_at",
+        "outcome",
+        "result_json",
+    } <= columns
+
+
+def test_typed_failure_preserves_status_compatibility(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    record = executions.create_execution("stale", source="builtin")
+    result = executions.finish_contextual_execution(
+        record["id"], outcome="stale", error="reset after admission"
+    )
+    assert result["status"] == "failed"
+    assert result["outcome"] == "stale"
+    assert result["error"] == "reset after admission"
 
 
 def test_execution_transitions_are_durable(monkeypatch, tmp_path):
@@ -158,11 +764,103 @@ def test_restart_marks_interrupted_execution_unknown_without_requeue(tmp_path):
     assert len(records) == 1
     assert records[0]["id"] == execution_id
     assert records[0]["status"] == "unknown"
+    assert records[0]["outcome"] == "unknown"
+    assert json.loads(records[0]["result_json"])["kind"] == "unknown"
     assert records[0]["finished_at"]
     assert "restart" in records[0]["error"].lower()
     # Recovery only classifies the old attempt. It must not manufacture a new
     # claimed record (which would imply an automatic retry).
     assert [r["status"] for r in records] == ["unknown"]
+
+
+def test_recovery_does_not_consume_contextual_job_before_occurrence_claim(
+    monkeypatch, tmp_path
+):
+    import cron.jobs as cron_jobs
+
+    executions = _point_ledger(monkeypatch, tmp_path)
+    with cron_jobs.use_cron_store(tmp_path):
+        due_at = (cron_jobs._hermes_now() - timedelta(minutes=1)).isoformat()
+        cron_jobs.save_jobs(
+            [
+                {
+                    "id": "pre-claim",
+                    "prompt": "continue",
+                    "schedule": {"kind": "interval", "minutes": 5},
+                    "next_run_at": due_at,
+                    "enabled": True,
+                    "session_target": "current",
+                }
+            ]
+        )
+        record = executions.create_execution(
+            "pre-claim", source="builtin", requires_job_accounting=True
+        )
+        assert executions.seal_contextual_delivery_target(
+            record["id"], target={"deliver": "local"}
+        )
+        with executions._transaction() as conn:
+            conn.execute(
+                "UPDATE executions SET process_id='dead-owner', pid=999999 WHERE id=?",
+                (record["id"],),
+            )
+        before = cron_jobs._current_cron_store().jobs_file.read_bytes()
+
+        assert executions.recover_interrupted_executions() == 1
+        recovered = executions.get_execution(record["id"])
+        assert recovered is not None
+        assert recovered["status"] == "failed"
+        assert recovered["outcome"] == "rejected"
+        assert recovered["job_accounted"] == 1
+        assert cron_jobs._current_cron_store().jobs_file.read_bytes() == before
+        job = cron_jobs.get_job("pre-claim")
+        assert job is not None
+        assert job["next_run_at"] == due_at
+        assert job.get("last_run_at") is None
+
+
+def test_recovery_classifies_contextual_job_after_occurrence_claim_unknown(
+    monkeypatch, tmp_path
+):
+    import cron.jobs as cron_jobs
+
+    executions = _point_ledger(monkeypatch, tmp_path)
+    with cron_jobs.use_cron_store(tmp_path):
+        due_at = (cron_jobs._hermes_now() - timedelta(minutes=1)).isoformat()
+        cron_jobs.save_jobs(
+            [
+                {
+                    "id": "post-claim",
+                    "prompt": "continue",
+                    "schedule": {"kind": "interval", "minutes": 5},
+                    "next_run_at": due_at,
+                    "enabled": True,
+                    "session_target": "current",
+                }
+            ]
+        )
+        record = executions.create_execution(
+            "post-claim", source="builtin", requires_job_accounting=True
+        )
+        assert executions.seal_contextual_delivery_target(
+            record["id"], target={"deliver": "local"}
+        )
+        assert cron_jobs.claim_contextual_occurrence(
+            "post-claim",
+            execution_id=record["id"],
+            expected_next_run_at=due_at,
+        )
+        with executions._transaction() as conn:
+            conn.execute(
+                "UPDATE executions SET process_id='dead-owner', pid=999999 WHERE id=?",
+                (record["id"],),
+            )
+
+        assert executions.recover_interrupted_executions() == 1
+        recovered = executions.get_execution(record["id"])
+        assert recovered is not None
+        assert recovered["status"] == "unknown"
+        assert recovered["job_accounted"] == 0
 
 
 def test_generic_submit_failure_finishes_attempt_and_releases_guard(monkeypatch):
@@ -202,7 +900,9 @@ def test_run_one_job_records_running_then_terminal(monkeypatch):
     monkeypatch.setattr(
         scheduler,
         "mark_execution_running",
-        lambda execution_id: events.append(("running", execution_id)),
+        lambda execution_id: (
+            events.append(("running", execution_id)) or {"status": "running"}
+        ),
         raising=False,
     )
     monkeypatch.setattr(
@@ -320,8 +1020,8 @@ def test_ledger_operations_close_every_connection(monkeypatch, tmp_path):
     executions.latest_executions(["leak-check"])
     executions.recover_interrupted_executions()
 
-    assert len(opened) == 6
-    assert len(closed) == 6
+    assert len(opened) == 7
+    assert len(closed) == 7
     assert set(opened) == set(closed)
 
 
@@ -397,3 +1097,197 @@ def test_job_listing_exposes_latest_execution(monkeypatch, tmp_path):
     listed = jobs.list_jobs(include_disabled=True)
     assert listed[0]["latest_execution"]["id"] == record["id"]
     assert listed[0]["latest_execution"]["status"] == "running"
+
+
+def test_contextual_delivery_waits_until_transcript_outbox_is_applied(
+    monkeypatch, tmp_path
+):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    record = executions.create_execution("job", source="builtin")
+    executions.mark_execution_running(record["id"])
+    executions.persist_contextual_agent_result(
+        record["id"],
+        outcome="notify",
+        final_response="final",
+        transcript_session_id="session-1",
+        transcript_entries=[
+            {
+                "role": "assistant",
+                "content": "final",
+                "message_id": f"contextual-cron:{record['id']}:0",
+            }
+        ],
+        transcript_base_message_count=0,
+        transcript_base_revision=0,
+    )
+
+    assert executions.claim_contextual_delivery(record["id"]) is None
+    executions.mark_contextual_transcript_applied(record["id"])
+    assert executions.claim_contextual_delivery(record["id"]) is not None
+
+
+def test_contextual_delivery_has_one_durable_claim_winner(monkeypatch, tmp_path):
+    import concurrent.futures
+
+    executions = _point_ledger(monkeypatch, tmp_path)
+    record = executions.create_execution("deliver-once", source="builtin")
+    executions.mark_execution_running(record["id"])
+    executions.persist_contextual_agent_result(
+        record["id"],
+        outcome="notify",
+        final_response="one message",
+    )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        claims = list(
+            pool.map(
+                lambda _index: executions.claim_contextual_delivery(record["id"]),
+                range(8),
+            )
+        )
+
+    winners = [claim for claim in claims if claim is not None]
+    assert len(winners) == 1
+    assert winners[0]["phase"] == "delivering"
+    assert winners[0]["delivery_state"] == "claimed"
+
+    finished = executions.finish_contextual_delivery(
+        record["id"],
+        delivery_state="sent",
+    )
+    assert finished["status"] == "completed"
+    assert finished["phase"] == "completed"
+    assert finished["delivery_state"] == "sent"
+
+
+def test_safe_pending_delivery_survives_restart_but_inflight_send_becomes_unknown(
+    monkeypatch, tmp_path
+):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    pending = executions.create_execution("pending", source="builtin")
+    executions.mark_execution_running(pending["id"])
+    executions.persist_contextual_agent_result(
+        pending["id"], outcome="notify", final_response="safe to resume"
+    )
+
+    inflight = executions.create_execution("inflight", source="builtin")
+    executions.mark_execution_running(inflight["id"])
+    executions.persist_contextual_agent_result(
+        inflight["id"], outcome="notify", final_response="may have sent"
+    )
+    executions.claim_contextual_delivery(inflight["id"])
+
+    with executions._transaction() as conn:
+        conn.execute(
+            "UPDATE executions SET process_id='dead-owner', pid=? "
+            "WHERE id IN (?, ?)",
+            (999999, pending["id"], inflight["id"]),
+        )
+
+    assert executions.recover_interrupted_executions() == 1
+    pending_after = executions.get_execution(pending["id"])
+    inflight_after = executions.get_execution(inflight["id"])
+    assert pending_after["status"] == "running"
+    assert pending_after["delivery_state"] == "pending"
+    assert inflight_after["status"] == "unknown"
+    assert inflight_after["delivery_state"] == "unknown"
+    assert "delivery" in inflight_after["error"].lower()
+    assert [row["id"] for row in executions.list_pending_contextual_deliveries()] == [
+        pending["id"]
+    ]
+
+
+def test_non_notify_contextual_result_finalizes_without_delivery(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    record = executions.create_execution("silent", source="builtin")
+    executions.mark_execution_running(record["id"])
+
+    finished = executions.persist_contextual_agent_result(
+        record["id"], outcome="no_action"
+    )
+
+    assert finished["status"] == "completed"
+    assert finished["phase"] == "completed"
+    assert finished["delivery_state"] == "not_applicable"
+    assert executions.claim_contextual_delivery(record["id"]) is None
+
+
+def test_scheduler_persists_notify_before_claiming_delivery(monkeypatch):
+    import cron.scheduler as scheduler
+
+    monkeypatch.setattr(scheduler, "_CONTEXTUAL_AUTHORIZER", lambda _target: True)
+    events = []
+    outcome = type(
+        "Outcome",
+        (),
+        {"kind": "notify", "final_response": "hello", "error": None},
+    )()
+    monkeypatch.setattr(
+        scheduler,
+        "get_execution",
+        lambda _id: {
+            "status": "claimed",
+            "phase": "claimed",
+            "delivery_target_json": '{"id":"job","deliver":"origin"}',
+        },
+    )
+    monkeypatch.setattr(scheduler, "claim_dispatch", lambda _id: True)
+    monkeypatch.setattr(
+        scheduler,
+        "mark_execution_running",
+        lambda execution_id: {"id": execution_id, "status": "running"},
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "persist_contextual_agent_result",
+        lambda execution_id, **kwargs: events.append(("persist", kwargs))
+        or {"id": execution_id, "delivery_state": "pending"},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "claim_contextual_delivery",
+        lambda execution_id: events.append(("claim", execution_id))
+        or {"id": execution_id},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "finish_contextual_delivery",
+        lambda execution_id, **kwargs: events.append(("finish_delivery", kwargs)),
+        raising=False,
+    )
+    monkeypatch.setattr(scheduler, "save_job_output", lambda *_args: None)
+    monkeypatch.setattr(
+        scheduler,
+        "_deliver_result",
+        lambda *_args, **_kwargs: events.append(("send", None)) or None,
+    )
+    monkeypatch.setattr(scheduler, "mark_job_run", lambda *_args, **_kwargs: None)
+
+    job = {
+        "id": "job",
+        "execution_id": "exec",
+        "session_target": "current",
+        "session_key": "telegram:dm:42:42",
+        "context_binding": {
+            "platform": "telegram",
+            "chat_id": "42",
+            "chat_type": "dm",
+            "user_id": "42",
+            "session_key": "telegram:dm:42:42",
+            "session_id": "session-1",
+            "routing_revision": 0,
+            "profile": "",
+        },
+        "deliver": "origin",
+        "origin": {"platform": "telegram", "chat_id": "42", "user_id": "42"},
+    }
+    assert scheduler.run_one_job(
+        job,
+        contextual_dispatch=lambda *_args, **_kwargs: outcome,
+    ) is True
+
+    names = [event[0] for event in events]
+    assert names.index("persist") < names.index("claim") < names.index("send")
+    assert names.count("send") == 1

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -22,11 +22,11 @@ def _point_ledger(monkeypatch, tmp_path):
     return executions
 
 
-def test_schema_v6_migrates_every_legacy_version_without_pending_side_effects(
+def test_schema_v8_migrates_every_legacy_version_without_pending_side_effects(
     monkeypatch, tmp_path
 ):
     executions = _point_ledger(monkeypatch, tmp_path)
-    for legacy_version in range(6):
+    for legacy_version in range(8):
         path = tmp_path / f"legacy-{legacy_version}.db"
         monkeypatch.setattr(executions, "EXECUTIONS_FILE", path)
         with sqlite3.connect(path) as conn:
@@ -61,9 +61,11 @@ def test_schema_v6_migrates_every_legacy_version_without_pending_side_effects(
         assert migrated["delivery_state"] == "not_applicable"
         assert migrated["transcript_state"] == "not_applicable"
         assert migrated["requires_job_accounting"] == 0
+        assert migrated["admitted_binding_version"] is None
+        assert migrated["admitted_route_instance_id"] is None
         assert executions.list_pending_contextual_transcripts() == []
         with sqlite3.connect(path) as conn:
-            assert conn.execute("PRAGMA user_version").fetchone()[0] == 6
+            assert conn.execute("PRAGMA user_version").fetchone()[0] == 8
 
 
 def test_contextual_admission_and_typed_outcomes_are_durable(monkeypatch, tmp_path):
@@ -75,6 +77,8 @@ def test_contextual_admission_and_typed_outcomes_are_durable(monkeypatch, tmp_pa
         record["id"],
         session_key="telegram:dm:42:42",
         admitted_session_id="session-1",
+        admitted_route_instance_id="route-instance-a",
+        admitted_binding_version=2,
     ) is True
     assert executions.seal_contextual_admission(
         record["id"],
@@ -88,9 +92,12 @@ def test_contextual_admission_and_typed_outcomes_are_durable(monkeypatch, tmp_pa
         record["id"],
         outcome="no_action",
     )
+    assert finished is not None
     assert finished["status"] == "completed"
     assert finished["outcome"] == "no_action"
     assert finished["session_key"] == "telegram:dm:42:42"
+    assert finished["admitted_binding_version"] == 2
+    assert finished["admitted_route_instance_id"] == "route-instance-a"
     assert finished["admitted_session_id"] == "session-1"
     assert json.loads(finished["result_json"])["kind"] == "no_action"
     assert executions.finish_contextual_execution(

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -22,6 +22,18 @@ def _point_ledger(monkeypatch, tmp_path):
     return executions
 
 
+def test_owner_liveness_fails_safe_when_start_time_is_unavailable(monkeypatch):
+    """A live PID with unprovable birth time must never be recovered as dead."""
+    import cron.executions as executions
+    import gateway.status as status
+
+    monkeypatch.setattr(status, "_pid_exists", lambda _pid: True)
+    monkeypatch.setattr(executions, "_process_start_time", lambda _pid: None)
+
+    assert executions._owner_is_live(424242, None) is True
+    assert executions._owner_is_live(424242, 123456) is True
+
+
 def test_schema_v8_migrates_every_legacy_version_without_pending_side_effects(
     monkeypatch, tmp_path
 ):

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1029,7 +1029,7 @@ class TestCronOutputRetention:
         d.mkdir(parents=True, exist_ok=True)
         names = [f"2026-06-25_10-00-{i:02d}.md" for i in range(count)]
         for n in names:
-            (d / n).write_text("x")
+            (d / n).write_text("x", encoding="utf-8")
         return names
 
     def test_prune_keeps_newest_n(self, tmp_path):

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -20,6 +20,7 @@ from cron.jobs import (
     mark_job_run,
     advance_next_run,
     claim_dispatch,
+    claim_contextual_occurrence,
     claim_job_for_fire,
     heartbeat_run_claim,
     get_due_jobs,
@@ -73,6 +74,36 @@ class TestParseSchedule:
         result = parse_schedule("every 2h")
         assert result["kind"] == "interval"
         assert result["minutes"] == 120
+
+    def test_legacy_string_interval_survives_builtin_and_external_paths(
+        self, tmp_cron_dir
+    ):
+        fire_at = "2000-01-01T00:00:00+00:00"
+        legacy = {
+            "id": "legacy-string",
+            "name": "legacy",
+            "prompt": "check",
+            "schedule": "every 5m",
+            "next_run_at": fire_at,
+            "enabled": True,
+            "repeat": {"times": 0, "completed": 0},
+        }
+        save_jobs([legacy])
+
+        assert [row["id"] for row in get_due_jobs()] == ["legacy-string"]
+        assert load_jobs()[0]["schedule"] == "every 5m"
+        mark_job_run("legacy-string", True)
+        persisted = load_jobs()[0]
+        assert persisted["schedule"] == "every 5m"
+        assert persisted["enabled"] is True
+        assert persisted["next_run_at"] is not None
+
+        legacy["next_run_at"] = fire_at
+        save_jobs([legacy])
+        assert claim_job_for_fire("legacy-string") is True
+        external = load_jobs()[0]
+        assert external["schedule"] == "every 5m"
+        assert external["next_run_at"] != fire_at
 
 
     def test_cron_expression(self):
@@ -1032,6 +1063,30 @@ class TestClaimDispatch:
         assert claim_dispatch("os1") is True
         # Persisted BEFORE any side effect — survives a crash.
         assert load_jobs()[0]["repeat"]["completed"] == 1
+
+    def test_durable_one_shot_claim_does_not_expire_while_run_is_unacknowledged(
+        self, tmp_cron_dir
+    ):
+        job = self._oneshot(times=2, completed=0)
+        job["session_target"] = "current"
+        job["schedule"]["run_at"] = "2000-01-01T00:00:00+00:00"
+        job["next_run_at"] = "2000-01-01T00:00:00+00:00"
+        save_jobs([job])
+
+        assert [row["id"] for row in get_due_jobs()] == ["os1"]
+        assert claim_contextual_occurrence(
+            "os1",
+            execution_id="execution-1",
+            expected_next_run_at="2000-01-01T00:00:00+00:00",
+        )
+        jobs = load_jobs()
+        jobs[0]["run_claim"]["at"] = "2000-01-01T00:00:00+00:00"
+        save_jobs(jobs)
+
+        assert get_due_jobs() == []
+        persisted = load_jobs()[0]
+        assert persisted["repeat"]["completed"] == 0
+        assert persisted["run_claim"]["durable"] is True
 
     def test_already_dispatched_oneshot_is_removed(self, tmp_cron_dir):
         # A prior tick claimed (completed==times) then died before mark_job_run

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1017,7 +1017,7 @@ class TestSaveJobOutput:
     def test_creates_output_file(self, tmp_cron_dir):
         output_file = save_job_output("test123", "# Results\nEverything ok.")
         assert output_file.exists()
-        assert output_file.read_text() == "# Results\nEverything ok."
+        assert output_file.read_text(encoding="utf-8") == "# Results\nEverything ok."
         assert "test123" in str(output_file)
 
 

--- a/tests/cron/test_monitor_kind.py
+++ b/tests/cron/test_monitor_kind.py
@@ -38,18 +38,15 @@ def hermes_env(tmp_path, monkeypatch):
 
     monkeypatch.setenv("HERMES_HOME", str(home))
 
-    # Reload modules that cache get_hermes_home() at import time.
-    import importlib
-    import hermes_constants
-    importlib.reload(hermes_constants)
-    import cron.jobs
-    importlib.reload(cron.jobs)
-    import cron.monitor
-    importlib.reload(cron.monitor)
-    import cron.scheduler
-    importlib.reload(cron.scheduler)
+    # Route storage dynamically instead of reloading shared modules. Reloading
+    # cron.scheduler replaces exception classes and function globals underneath
+    # already-collected test modules, making later tests depend on file order.
+    import cron.jobs as jobs
+    import cron.scheduler as scheduler
 
-    return home
+    monkeypatch.setattr(scheduler, "_hermes_home", home)
+    with jobs.use_cron_store(home):
+        yield home
 
 
 def _write_script(home, name: str, body: str) -> str:
@@ -337,9 +334,10 @@ def test_changed_output_injects_diff(hermes_env, monkeypatch):
 
 
 def test_hash_persists_across_scheduler_restart(hermes_env, monkeypatch):
-    """Suppression state must survive a scheduler restart (module reload)."""
-    import importlib
+    """Suppression state must survive a fresh interpreter restart."""
+    import subprocess
 
+    from cron.jobs import get_job
     from cron.scheduler import run_job
 
     job = _make_monitor_job(hermes_env, "echo 'state A'\n")
@@ -349,20 +347,33 @@ def test_hash_persists_across_scheduler_restart(hermes_env, monkeypatch):
     run_job(job)
     assert observed["agent_runs"] == 1
 
-    # Simulate restart: reload the cron modules, dropping in-memory state.
-    import cron.jobs
-    importlib.reload(cron.jobs)
-    import cron.monitor
-    importlib.reload(cron.monitor)
-    import cron.scheduler
-    importlib.reload(cron.scheduler)
-    _install_agent_stubs(monkeypatch, observed)
+    # A fresh interpreter must observe the durable hash without mutating the
+    # shared module identities used by later tests in this pytest process.
+    probe = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from cron.jobs import get_job; "
+                "from cron.monitor import check_monitor; "
+                f"job=get_job({job['id']!r}); "
+                "outcome=check_monitor(job); "
+                "assert outcome.ok and not outcome.changed"
+            ),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert probe.returncode == 0, probe.stderr
 
-    job = cron.jobs.get_job(job["id"])
+    job = get_job(job["id"])
+    assert job is not None
     assert job["monitor_state"]["last_output_hash"]
-    success, doc, final, error = cron.scheduler.run_job(job)
+    success, doc, final, error = run_job(job)
     assert success is True
-    assert final == cron.scheduler.SILENT_MARKER
+    from cron.scheduler import SILENT_MARKER
+    assert final == SILENT_MARKER
     assert observed["agent_runs"] == 1  # still suppressed after restart
 
 

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -27,7 +27,7 @@ def _patch_pipeline(monkeypatch, *, success=True, output="out", final="final res
         calls.append(("save", jid))
         return f"/tmp/{jid}.txt"
 
-    def fake_deliver(job, content, adapters=None, loop=None):
+    def fake_deliver(job, content, adapters=None, loop=None, at_most_once=False):
         calls.append(("deliver", job["id"]))
         return None
 

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -78,7 +78,9 @@ def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path
     from agent import secret_scope as ss
 
     # Point cron's home resolution at a profile whose .env carries a secret.
-    (tmp_path / ".env").write_text("OPENROUTER_BASE_URL=https://openrouter.ai/api/v1\n")
+    (tmp_path / ".env").write_text(
+        "OPENROUTER_BASE_URL=https://openrouter.ai/api/v1\n", encoding="utf-8"
+    )
     monkeypatch.setattr(s, "_get_hermes_home", lambda: tmp_path)
 
     scope_during_run = {}

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
-from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt, _resolve_cron_enabled_toolsets, _merge_mcp_into_per_job_toolsets
+from cron.scheduler import ContextualDeliveryUnknown, _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt, _resolve_cron_enabled_toolsets, _merge_mcp_into_per_job_toolsets
 from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
 
@@ -593,6 +593,44 @@ class TestRunJobSessionPersistence:
             assert tick(verbose=False, sync=True, can_dispatch=lambda: False) == 0
 
         advance.assert_not_called()
+        run_one.assert_not_called()
+
+    def test_tick_does_not_dispatch_contextual_recurring_job_when_schedule_claim_fails(
+        self, tmp_path
+    ):
+        from cron.scheduler import tick
+
+        job = {
+            "id": "unclaimed-recurring-job",
+            "name": "unclaimed recurring job",
+            "schedule": {"kind": "interval", "seconds": 60},
+            "next_run_at": "2020-01-01T00:00:00+00:00",
+            "enabled": True,
+            "session_target": "current",
+        }
+        lock_dir = tmp_path / "locks"
+        with patch("cron.scheduler._get_lock_paths", return_value=(lock_dir, lock_dir / "tick.lock")), patch(
+            "cron.scheduler.get_due_jobs", return_value=[job]
+        ), patch(
+            "cron.scheduler.create_execution", return_value={"id": "execution-1"}
+        ), patch(
+            "cron.scheduler.seal_contextual_delivery_target", return_value=True
+        ), patch(
+            "cron.scheduler.claim_contextual_occurrence", return_value=False
+        ) as claim, patch(
+            "cron.scheduler.finish_contextual_execution", return_value={}
+        ), patch(
+            "cron.scheduler.claim_contextual_job_accounting", return_value=True
+        ), patch(
+            "cron.scheduler.run_one_job"
+        ) as run_one:
+            assert tick(verbose=False, sync=True) == 0
+
+        claim.assert_called_once_with(
+            job["id"],
+            execution_id="execution-1",
+            expected_next_run_at=job["next_run_at"],
+        )
         run_one.assert_not_called()
 
 
@@ -1414,6 +1452,46 @@ class TestDeliverResultTimeoutCancelsFuture:
         #    an in-flight confirmation timeout is assume-delivered, not a resend.
         standalone_send.assert_not_awaited()
 
+    def test_contextual_timeout_is_unknown_and_never_falls_back(self):
+        from gateway.config import Platform
+
+        adapter = AsyncMock()
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+        loop = MagicMock()
+        loop.is_running.return_value = True
+        captured_future = MagicMock()
+        captured_future.cancel.return_value = True
+        captured_future.result.side_effect = TimeoutError("timed out")
+
+        def fake_run_coro(coro, _loop):
+            coro.close()
+            return captured_future
+
+        job = {
+            "id": "contextual-timeout",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "123"},
+        }
+        standalone_send = AsyncMock(return_value={"success": True})
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro), \
+             patch("tools.send_message_tool._send_to_platform", new=standalone_send):
+            with pytest.raises(ContextualDeliveryUnknown, match="acknowledgement is unknown"):
+                _deliver_result(
+                    job,
+                    "Hello world",
+                    adapters={Platform.TELEGRAM: adapter},
+                    loop=loop,
+                    at_most_once=True,
+                )
+
+        captured_future.cancel.assert_called_once()
+        standalone_send.assert_not_awaited()
+
 
 class TestDeliverResultLiveAdapterUnconfirmed:
     """Regression for #47056.
@@ -1475,6 +1553,79 @@ class TestDeliverResultLiveAdapterUnconfirmed:
         silent "delivered" log."""
         result, standalone_send = self._run(None)
         assert result is None, f"standalone should have delivered, got: {result!r}"
+        standalone_send.assert_awaited_once()
+
+    def test_contextual_confirmed_send_with_malformed_metadata_never_resends(self):
+        from concurrent.futures import Future
+        from gateway.config import Platform
+
+        confirmed = MagicMock(success=True)
+        confirmed.raw_response = "malformed-success-response"
+        completed_future = Future()
+        completed_future.set_result(confirmed)
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        def fake_run_coro(coro, _loop):
+            coro.close()
+            return completed_future
+
+        standalone_send = AsyncMock(return_value={"success": True})
+        job = {
+            "id": "confirmed-malformed-metadata",
+            "deliver": "origin",
+            "origin": {
+                "platform": "telegram",
+                "chat_id": "123",
+                "thread_id": "7",
+            },
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro), \
+             patch("tools.send_message_tool._send_to_platform", new=standalone_send):
+            result = _deliver_result(
+                job,
+                "Hello world",
+                adapters={Platform.TELEGRAM: AsyncMock()},
+                loop=loop,
+                at_most_once=True,
+            )
+
+        assert result is None
+        standalone_send.assert_not_awaited()
+
+    def test_contextual_standalone_requires_explicit_positive_ack(self):
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+        standalone_send = AsyncMock(return_value=None)
+        job = {
+            "id": "standalone-unacknowledged",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "123"},
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("tools.send_message_tool._send_to_platform", new=standalone_send):
+            with pytest.raises(ContextualDeliveryUnknown, match="unconfirmed result"):
+                _deliver_result(
+                    job,
+                    "Hello world",
+                    adapters={},
+                    at_most_once=True,
+                )
+
         standalone_send.assert_awaited_once()
 
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1611,16 +1611,16 @@ class TestDeliverResultLiveAdapterUnconfirmed:
         assert result is None
         standalone_send.assert_not_awaited()
 
-    def test_contextual_standalone_requires_explicit_positive_ack(self):
+    def test_contextual_never_uses_standalone_transport(self):
         from gateway.config import Platform
 
         pconfig = MagicMock()
         pconfig.enabled = True
         mock_cfg = MagicMock()
         mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
-        standalone_send = AsyncMock(return_value=None)
+        standalone_send = AsyncMock(return_value={"success": True})
         job = {
-            "id": "standalone-unacknowledged",
+            "id": "standalone-forbidden",
             "deliver": "origin",
             "origin": {"platform": "telegram", "chat_id": "123"},
         }
@@ -1628,7 +1628,9 @@ class TestDeliverResultLiveAdapterUnconfirmed:
         with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
              patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
              patch("tools.send_message_tool._send_to_platform", new=standalone_send):
-            with pytest.raises(ContextualDeliveryUnknown, match="unconfirmed result"):
+            with pytest.raises(
+                ContextualDeliveryUnknown, match="standalone fallback is forbidden"
+            ):
                 _deliver_result(
                     job,
                     "Hello world",
@@ -1636,7 +1638,7 @@ class TestDeliverResultLiveAdapterUnconfirmed:
                     at_most_once=True,
                 )
 
-        standalone_send.assert_awaited_once()
+        standalone_send.assert_not_awaited()
 
 
 class TestDeliverOriginUnresolvableIsLocal:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -640,7 +640,7 @@ class TestRunJobConfigLogging:
     def test_bad_config_yaml_is_logged(self, caplog, tmp_path):
         """When config.yaml is malformed, a warning should be logged."""
         bad_yaml = tmp_path / "config.yaml"
-        bad_yaml.write_text("invalid: yaml: [[[bad")
+        bad_yaml.write_text("invalid: yaml: [[[bad", encoding="utf-8")
 
         job = {
             "id": "test-job",
@@ -686,7 +686,9 @@ class TestRunJobConfigEnvVarExpansion:
 
     def test_model_env_ref_in_config_yaml_is_expanded(self, tmp_path, monkeypatch):
         """${VAR} in config.yaml model: is expanded using env after .env is loaded."""
-        (tmp_path / "config.yaml").write_text("model: ${_HERMES_TEST_CRON_MODEL}\n")
+        (tmp_path / "config.yaml").write_text(
+            "model: ${_HERMES_TEST_CRON_MODEL}\n", encoding="utf-8"
+        )
         monkeypatch.setenv("_HERMES_TEST_CRON_MODEL", "gpt-4o-mini-cron-test")
 
         job = {"id": "env-job", "name": "env test", "prompt": "hi"}
@@ -772,7 +774,9 @@ class TestRunJobConfigEnvVarExpansion:
 
     def test_unexpanded_ref_passthrough_when_var_unset(self, tmp_path, monkeypatch):
         """When the env var is not set, the literal ${VAR} is kept verbatim (not crashed)."""
-        (tmp_path / "config.yaml").write_text("model: ${_HERMES_TEST_CRON_UNSET_VAR}\n")
+        (tmp_path / "config.yaml").write_text(
+            "model: ${_HERMES_TEST_CRON_UNSET_VAR}\n", encoding="utf-8"
+        )
         monkeypatch.delenv("_HERMES_TEST_CRON_UNSET_VAR", raising=False)
 
         job = {"id": "unset-job", "name": "unset var test", "prompt": "hi"}
@@ -817,7 +821,7 @@ class TestRunJobModelResolution:
 
     def test_null_job_model_falls_back_to_env(self, tmp_path, monkeypatch):
         """``model: null`` on the job uses HERMES_MODEL when set."""
-        (tmp_path / "config.yaml").write_text("")
+        (tmp_path / "config.yaml").write_text("", encoding="utf-8")
         monkeypatch.setenv("HERMES_MODEL", "env-model")
 
         job = {"id": "null-model-job", "name": "null model", "prompt": "hi", "model": None}
@@ -843,7 +847,7 @@ class TestRunJobModelResolution:
 
     def test_no_model_anywhere_fails_with_actionable_error(self, tmp_path, monkeypatch):
         """All three sources empty → fail fast with a clear message, not an opaque 400."""
-        (tmp_path / "config.yaml").write_text("")
+        (tmp_path / "config.yaml").write_text("", encoding="utf-8")
         monkeypatch.delenv("HERMES_MODEL", raising=False)
 
         job = {"id": "no-model-job", "name": "no model anywhere", "prompt": "hi", "model": None}
@@ -875,7 +879,9 @@ class TestRunJobModelResolution:
         resolver mirrors that so a config that works in the CLI also works in
         cron.
         """
-        (tmp_path / "config.yaml").write_text("model:\n  model: alias-key-model\n")
+        (tmp_path / "config.yaml").write_text(
+            "model:\n  model: alias-key-model\n", encoding="utf-8"
+        )
         monkeypatch.delenv("HERMES_MODEL", raising=False)
 
         job = {"id": "alias-job", "name": "alias", "prompt": "hi", "model": None}
@@ -900,7 +906,9 @@ class TestRunJobModelResolution:
 
     def test_corrupt_config_yaml_does_not_crash_with_job_model(self, tmp_path, monkeypatch):
         """A malformed config.yaml degrades gracefully when the job has a model."""
-        (tmp_path / "config.yaml").write_text("{{{invalid yaml!!!")
+        (tmp_path / "config.yaml").write_text(
+            "{{{invalid yaml!!!", encoding="utf-8"
+        )
         monkeypatch.delenv("HERMES_MODEL", raising=False)
 
         job = {"id": "corrupt-job", "name": "corrupt", "prompt": "hi", "model": "explicit-model"}
@@ -1201,7 +1209,9 @@ class TestBuildJobPromptAbsoluteSkillPath:
         skills_dir = tmp_path / "skills"
         skill_dir = skills_dir / "alpha-skill"
         skill_dir.mkdir(parents=True)
-        (skill_dir / "SKILL.md").write_text("# Alpha\nDo alpha.")
+        (skill_dir / "SKILL.md").write_text(
+            "# Alpha\nDo alpha.", encoding="utf-8"
+        )
         absolute_path = str(skill_dir)
         seen_names: list[str] = []
 

--- a/tests/cron/test_ticker_stall_60703.py
+++ b/tests/cron/test_ticker_stall_60703.py
@@ -107,6 +107,34 @@ class TestBoundedJobsLock:
         assert time.monotonic() - start < 5
         assert not [r for r in caplog.records if "Timed out" in r.message]
 
+    def test_external_claim_fails_closed_on_lock_timeout(self, monkeypatch):
+        job = create_job(name="strict claim", schedule="every 5m", prompt="x")
+        before = get_job(job["id"])
+        assert before is not None
+
+        jobs_mod.ensure_dirs()
+        lock_path = jobs_mod._jobs_lock_file()
+        lock_path.touch()
+        monkeypatch.setattr(jobs_mod, "_JOBS_LOCK_TIMEOUT_SECONDS", 0.05)
+        release = threading.Event()
+        held = threading.Event()
+        holder = threading.Thread(
+            target=_hold_jobs_flock, args=(lock_path, release, held), daemon=True
+        )
+        holder.start()
+        assert held.wait(timeout=10)
+        try:
+            assert claim_job_for_fire(job["id"]) is False
+        finally:
+            release.set()
+            holder.join(timeout=10)
+
+        after = get_job(job["id"])
+        assert after is not None
+        assert after["next_run_at"] == before["next_run_at"]
+        assert after.get("last_external_fire_at") is None
+        assert after.get("fire_claim") is None
+
     def test_reentrant_nesting_still_works(self):
         with _jobs_lock():
             with _jobs_lock():  # must not deadlock or re-flock

--- a/tests/gateway/test_compression_session_id_persistence.py
+++ b/tests/gateway/test_compression_session_id_persistence.py
@@ -25,6 +25,7 @@ import textwrap
 from unittest.mock import MagicMock, call
 
 from gateway import run as gateway_run
+from gateway.session import SessionStore
 from gateway.session_context import set_current_session_id, get_session_env
 
 
@@ -110,10 +111,15 @@ def test_every_post_compression_session_id_assignment_persists():
     """
     source = inspect.getsource(gateway_run)
     assignments = _session_id_assignments_followed_by_save(source)
-    assert assignments, (
-        "No ``session_entry.session_id = ...`` assignments found in gateway/run.py — "
-        "either the structure changed or the AST walker is broken."
-    )
+    if not assignments:
+        # Newer gateways centralize route publication in SessionStore so the
+        # route CAS, routing-revision bump, and durable save share one lock.
+        # This is stronger than scattered run.py assignment/save pairs.
+        assert "_publish_gateway_compression_route(" in source
+        publisher = inspect.getsource(SessionStore.advance_compression_session)
+        assert "entry.session_id != expected_session_id" in publisher
+        assert "self._save()" in publisher
+        return
     missing = [lineno for lineno, saved in assignments if not saved]
     assert not missing, (
         f"{len(missing)} ``session_entry.session_id = ...`` site(s) in gateway/run.py "

--- a/tests/gateway/test_contextual_cron.py
+++ b/tests/gateway/test_contextual_cron.py
@@ -212,6 +212,28 @@ def test_zero_routing_revision_preserves_legacy_session_record_shape():
     assert entry.to_dict()["routing_revision"] == 1
 
 
+def test_route_instance_identity_round_trips():
+    now = datetime.now(timezone.utc)
+    entry = SessionEntry(
+        session_key="telegram:u:c",
+        session_id="session-1",
+        created_at=now,
+        updated_at=now,
+        route_instance_id="route-instance-a",
+    )
+
+    stored = entry.to_dict()
+    assert stored["route_instance_id"] == "route-instance-a"
+    assert SessionEntry.from_dict(stored).route_instance_id == "route-instance-a"
+
+    legacy = dict(stored)
+    legacy.pop("route_instance_id")
+    first = SessionEntry.from_dict(legacy).route_instance_id
+    second = SessionEntry.from_dict(legacy).route_instance_id
+    assert first
+    assert first == second
+
+
 @pytest.mark.asyncio
 async def test_contextual_cron_tracer_recovers_only_the_stable_session_context():
     """The opt-in lane sees live history; the legacy isolated control does not."""
@@ -482,6 +504,63 @@ async def test_post_model_authorization_error_resolves_item_and_lane_continues()
     assert second.kind == "notify"
     assert runner.started == ["first", "second"]
     assert finished == [("first", "retryable"), ("second", "notify")]
+
+
+@pytest.mark.asyncio
+async def test_late_authorization_error_defers_outbox_and_releases_lane():
+    import asyncio
+
+    runner = _OutboxRunner(_LiveStore(_entry(), []))
+    late_failure = True
+    auth_calls = 0
+
+    def authorize(source):
+        del source
+        nonlocal auth_calls
+        auth_calls += 1
+        if late_failure and auth_calls >= 4:
+            raise RuntimeError("late auth backend unavailable")
+        return True
+
+    runner._is_user_authorized = authorize
+    gateway = ContextualCronGateway(
+        runner,
+        busy_poll_seconds=0.001,
+        transcript_retry_seconds=0.001,
+        seal_admission=lambda *_: True,
+        finish_admission=lambda *_: {"transcript_state": "pending"},
+    )
+
+    first_task = asyncio.create_task(
+        gateway.dispatch(
+            {
+                "id": "job",
+                "prompt": "first",
+                "session_target": "current",
+                "session_key": "telegram:dm:42:42",
+            },
+            execution_id="late-auth-first",
+        )
+    )
+    first = await asyncio.wait_for(first_task, timeout=0.5)
+    late_failure = False
+    second = await asyncio.wait_for(
+        gateway.dispatch(
+            {
+                "id": "job",
+                "prompt": "second",
+                "session_target": "current",
+                "session_key": "telegram:dm:42:42",
+            },
+            execution_id="late-auth-second",
+        ),
+        timeout=0.5,
+    )
+
+    assert first.kind == "unknown"
+    assert "authorization" in str(first.error).lower()
+    assert second.kind == "no_action"
+    assert runner.events.count("run") == 2
 
 
 @pytest.mark.asyncio
@@ -1216,6 +1295,52 @@ async def test_recovery_route_revision_change_terminalizes_unapplied_outbox(monk
 
 
 @pytest.mark.asyncio
+async def test_recovery_route_instance_change_terminalizes_unapplied_outbox(
+    monkeypatch,
+):
+    record = {
+        "id": "recover-route-aba",
+        "job_id": "job-1",
+        "session_key": "telegram:dm:42:42",
+        "admitted_route_instance_id": "route-instance-a",
+        "admitted_binding_version": 2,
+        "delivery_target_json": (
+            '{"origin":{"platform":"telegram","chat_type":"dm",'
+            '"chat_id":"42","user_id":"42","profile":""}}'
+        ),
+        "admitted_session_id": "session-1",
+        "admitted_routing_revision": 0,
+        "transcript_session_id": "session-1",
+        "transcript_json": '[{"role":"assistant","content":"scheduled",'
+        '"message_id":"contextual-cron:recover-route-aba:0"}]',
+        "transcript_base_message_count": 0,
+        "transcript_base_revision": 0,
+        "transcript_last_prompt_tokens": None,
+    }
+    monkeypatch.setattr(
+        "cron.executions.list_pending_contextual_transcripts", lambda: [record]
+    )
+    conflicts = []
+    monkeypatch.setattr(
+        "cron.executions.mark_contextual_transcript_conflict",
+        lambda execution_id, *, error: conflicts.append((execution_id, error)) or True,
+    )
+    entry = _entry()
+    entry.route_instance_id = "route-instance-b"
+    runner = object.__new__(GatewayRunner)
+    cast(Any, runner).session_store = _LiveStore(entry, [])
+    applied = []
+    cast(Any, runner)._apply_contextual_cron_transcript = applied.append
+
+    recovered = await GatewayRunner._recover_contextual_cron_transcripts(runner)
+
+    assert recovered == 0
+    assert applied == []
+    assert conflicts and conflicts[0][0] == "recover-route-aba"
+    assert "route changed" in conflicts[0][1]
+
+
+@pytest.mark.asyncio
 async def test_recovery_preserves_nonzero_admitted_route_revision_for_current_route(
     monkeypatch,
 ):
@@ -1259,6 +1384,71 @@ async def test_recovery_preserves_nonzero_admitted_route_revision_for_current_ro
     assert len(applied) == 1
     assert applied[0].admitted_routing_revision == 7
     assert applied[0].contextual_route_current is True
+
+
+@pytest.mark.asyncio
+async def test_v2_recovery_reauthorizes_sealed_creator_not_route_origin(monkeypatch):
+    import json
+
+    record = {
+        "id": "recover-shared-creator",
+        "job_id": "job-1",
+        "session_key": "telegram:dm:42:42",
+        "admitted_session_id": "session-1",
+        "admitted_routing_revision": 0,
+        "admitted_route_instance_id": "route-instance-a",
+        "admitted_binding_version": 2,
+        "delivery_target_json": json.dumps(
+            {
+                "id": "job-1",
+                "deliver": "local",
+                "origin": {
+                    "platform": "telegram",
+                    "chat_type": "dm",
+                    "chat_id": "42",
+                    "user_id": "creator-b",
+                    "profile": "",
+                },
+            }
+        ),
+        "transcript_session_id": "session-1",
+        "transcript_json": '[{"role":"assistant","content":"scheduled",'
+        '"message_id":"contextual-cron:recover-shared-creator:0"}]',
+        "transcript_base_message_count": 0,
+        "transcript_base_revision": 0,
+        "transcript_last_prompt_tokens": None,
+    }
+    monkeypatch.setattr(
+        "cron.executions.list_pending_contextual_transcripts", lambda: [record]
+    )
+    conflicts = []
+    monkeypatch.setattr(
+        "cron.executions.mark_contextual_transcript_conflict",
+        lambda execution_id, *, error: conflicts.append((execution_id, error)) or True,
+    )
+    route_entry = _entry()
+    route_entry.route_instance_id = "route-instance-a"
+    assert route_entry.origin is not None
+    route_entry.origin.user_id = "creator-a"
+    runner = object.__new__(GatewayRunner)
+    cast(Any, runner).session_store = _LiveStore(route_entry, [])
+    authorized_users = []
+    cast(Any, runner)._is_user_authorized = lambda source: (
+        authorized_users.append(source.user_id) or source.user_id == "creator-b"
+    )
+    applied = []
+
+    async def apply(item):
+        applied.append(item)
+
+    cast(Any, runner)._apply_contextual_cron_transcript = apply
+
+    recovered = await GatewayRunner._recover_contextual_cron_transcripts(runner)
+
+    assert recovered == 1
+    assert conflicts == []
+    assert authorized_users == ["creator-b"]
+    assert applied[0].source.user_id == "creator-b"
 
 
 @pytest.mark.asyncio
@@ -1706,8 +1896,50 @@ async def test_contextual_drainer_cancellation_resolves_all_pending_unknown():
 
 
 @pytest.mark.asyncio
-async def test_reset_before_admission_is_stale_against_definition_binding():
-    store = _LiveStore(_entry("replacement-session"), [])
+async def test_v1_reset_before_admission_remains_strictly_stale():
+    replacement = _entry("replacement-session")
+    store = _LiveStore(replacement, [])
+    runner = _QueueRunner(store)
+    sealed = []
+    gateway = ContextualCronGateway(
+        runner,
+        seal_admission=lambda *args: sealed.append(args) or True,
+        finish_admission=lambda *_args: None,
+        busy_poll_seconds=0.001,
+    )
+
+    outcome = await gateway.dispatch(
+        {
+            "id": "legacy-reset-before-admission",
+            "session_target": "current",
+            "session_key": "telegram:dm:42:42",
+            "context_binding": {
+                "profile": "",
+                "session_key": "telegram:dm:42:42",
+                "session_id": "original-session",
+                "routing_revision": 0,
+                "platform": "telegram",
+                "chat_type": "dm",
+                "chat_id": "42",
+                "thread_id": "",
+                "user_id": "42",
+            },
+            "_contextual_binding_version": 1,
+            "prompt": "legacy strict binding",
+        },
+        execution_id="legacy-reset-before-admission",
+    )
+
+    assert outcome.kind == "stale"
+    assert sealed == []
+    assert runner.started == []
+
+
+@pytest.mark.asyncio
+async def test_reset_before_admission_follows_same_logical_route():
+    replacement = _entry("replacement-session")
+    replacement.route_instance_id = "route-instance-a"
+    store = _LiveStore(replacement, [])
     runner = _QueueRunner(store)
     sealed = []
     gateway = ContextualCronGateway(
@@ -1722,18 +1954,274 @@ async def test_reset_before_admission_is_stale_against_definition_binding():
             "prompt": "continue",
             "session_target": "current",
             "session_key": "telegram:dm:42:42",
+            "_contextual_binding_version": 2,
             "context_binding": {
                 "session_key": "telegram:dm:42:42",
-                "session_id": "captured-session",
-                "routing_revision": 0,
+                "route_instance_id": "route-instance-a",
+                "profile": "",
+                "platform": "telegram",
+                "chat_type": "dm",
+                "chat_id": "42",
+                "thread_id": "",
+                "user_id": "42",
             },
         },
         execution_id="reset-before-admission",
     )
 
+    assert outcome.kind == "notify"
+    assert sealed == [
+        (
+            "reset-before-admission",
+            "telegram:dm:42:42",
+            "replacement-session",
+            0,
+            "route-instance-a",
+            2,
+        )
+    ]
+    assert runner.started == ["reset-before-admission"]
+
+
+@pytest.mark.asyncio
+async def test_v2_route_delete_recreate_aba_is_stale_before_seal():
+    recreated = _entry("replacement-session")
+    recreated.route_instance_id = "route-instance-b"
+    store = _LiveStore(recreated, [])
+    runner = _QueueRunner(store)
+    sealed = []
+    gateway = ContextualCronGateway(
+        runner,
+        seal_admission=lambda *args: sealed.append(args) or True,
+        finish_admission=lambda *_: None,
+    )
+
+    outcome = await gateway.dispatch(
+        {
+            "id": "job",
+            "prompt": "continue",
+            "session_target": "current",
+            "session_key": recreated.session_key,
+            "_contextual_binding_version": 2,
+            "context_binding": {
+                "session_key": recreated.session_key,
+                "route_instance_id": "route-instance-a",
+                "profile": "",
+                "platform": "telegram",
+                "chat_type": "dm",
+                "chat_id": "42",
+                "thread_id": "",
+                "user_id": "42",
+            },
+        },
+        execution_id="route-aba",
+    )
+
     assert outcome.kind == "stale"
     assert sealed == []
     assert runner.started == []
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("scope_id", "workspace-b"),
+        ("parent_chat_id", "parent-b"),
+        ("chat_id_alt", "chat-alt-b"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_v2_same_route_instance_with_principal_drift_is_stale(field, value):
+    changed = _entry("same-session")
+    changed.route_instance_id = "route-instance-a"
+    assert changed.origin is not None
+    setattr(changed.origin, field, value)
+    store = _LiveStore(changed, [])
+    runner = _QueueRunner(store)
+    sealed = []
+    gateway = ContextualCronGateway(
+        runner,
+        seal_admission=lambda *args: sealed.append(args) or True,
+        finish_admission=lambda *_: None,
+    )
+
+    outcome = await gateway.dispatch(
+        {
+            "id": "job",
+            "prompt": "continue",
+            "session_target": "current",
+            "session_key": changed.session_key,
+            "_contextual_binding_version": 2,
+            "context_binding": {
+                "session_key": changed.session_key,
+                "route_instance_id": "route-instance-a",
+                "profile": "",
+                "platform": "telegram",
+                "chat_type": "dm",
+                "chat_id": "42",
+                "thread_id": "",
+                "user_id": "42",
+            },
+        },
+        execution_id="principal-drift",
+    )
+
+    assert outcome.kind == "stale"
+    assert sealed == []
+    assert runner.started == []
+
+
+def test_v2_prospective_thread_and_real_thread_are_one_logical_route():
+    from dataclasses import replace
+
+    from gateway.session import _same_route_identity, build_session_key
+
+    entry = _entry("thread-session")
+    assert entry.origin is not None
+    prospective = replace(
+        entry.origin,
+        platform=Platform.DISCORD,
+        chat_type="channel",
+        chat_id="channel-1",
+        parent_chat_id=None,
+        thread_id=None,
+        prospective_thread_id="thread-42",
+    )
+    realized = replace(
+        entry.origin,
+        platform=Platform.DISCORD,
+        chat_type="thread",
+        chat_id="thread-42",
+        parent_chat_id="channel-1",
+        thread_id="thread-42",
+        prospective_thread_id=None,
+    )
+    entry.origin = realized
+    entry.route_instance_id = "route-instance-a"
+
+    assert build_session_key(prospective) == build_session_key(realized)
+    assert _same_route_identity(prospective, realized)
+    assert (
+        ContextualCronGateway._logical_binding_rejection(
+            entry,
+            {
+                "route_instance_id": "route-instance-a",
+                "profile": "",
+                "platform": "discord",
+                "chat_type": "thread",
+                "chat_id": "thread-42",
+                "thread_id": "thread-42",
+                "user_id": "42",
+                "scope_id": "",
+                "parent_chat_id": "channel-1",
+                "user_id_alt": "",
+                "chat_id_alt": "",
+            },
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_v2_shared_thread_uses_captured_creator_authority():
+    from gateway.session import build_session_key
+
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_type="thread",
+        chat_id="thread-42",
+        parent_chat_id="channel-1",
+        thread_id="thread-42",
+        user_id="creator-a",
+    )
+    now = datetime.now(timezone.utc)
+    entry = SessionEntry(
+        session_key=build_session_key(source),
+        session_id="thread-session",
+        created_at=now,
+        updated_at=now,
+        origin=source,
+        route_instance_id="route-instance-a",
+    )
+    runner = _QueueRunner(_LiveStore(entry, []))
+    gateway = ContextualCronGateway(
+        runner,
+        seal_admission=lambda *_: True,
+        finish_admission=lambda *_: None,
+    )
+
+    outcome = await gateway.dispatch(
+        {
+            "id": "job-b",
+            "prompt": "continue",
+            "session_target": "current",
+            "session_key": entry.session_key,
+            "_contextual_binding_version": 2,
+            "context_binding": {
+                "session_key": entry.session_key,
+                "route_instance_id": "route-instance-a",
+                "profile": "",
+                "platform": "discord",
+                "chat_type": "thread",
+                "chat_id": "thread-42",
+                "thread_id": "thread-42",
+                "user_id": "creator-b",
+                "scope_id": "",
+                "parent_chat_id": "channel-1",
+                "user_id_alt": "",
+                "chat_id_alt": "",
+            },
+        },
+        execution_id="shared-creator-b",
+    )
+
+    assert outcome.kind == "notify"
+    assert runner.started == ["shared-creator-b"]
+
+
+@pytest.mark.asyncio
+async def test_v2_route_instance_swap_during_model_is_stale_before_commit():
+    entry = _entry("session-1")
+    entry.route_instance_id = "route-instance-a"
+    store = _LiveStore(entry, [])
+    runner = _QueueRunner(store)
+
+    async def run_turn(item, _entry_value, _history):
+        runner.started.append(item.execution_id)
+        store.entry.route_instance_id = "route-instance-b"
+        return ContextualCronOutcome.notify("must-not-commit")
+
+    setattr(cast(Any, runner), "_run_contextual_cron_turn", run_turn)
+    gateway = ContextualCronGateway(
+        runner,
+        seal_admission=lambda *_: True,
+        finish_admission=lambda *_: None,
+    )
+
+    outcome = await gateway.dispatch(
+        {
+            "id": "job",
+            "prompt": "continue",
+            "session_target": "current",
+            "session_key": entry.session_key,
+            "_contextual_binding_version": 2,
+            "context_binding": {
+                "session_key": entry.session_key,
+                "route_instance_id": "route-instance-a",
+                "profile": "",
+                "platform": "telegram",
+                "chat_type": "dm",
+                "chat_id": "42",
+                "thread_id": "",
+                "user_id": "42",
+            },
+        },
+        execution_id="route-swap-during-model",
+    )
+
+    assert runner.started == ["route-swap-during-model"]
+    assert outcome.kind == "stale"
+    assert outcome.final_response == ""
 
 
 @pytest.mark.asyncio
@@ -1899,6 +2387,8 @@ async def test_runner_internal_turn_is_hidden_and_intentional_silence_is_no_acti
         authority = _get_contextual_turn_authority()
         assert authority.execution_id == "execution"
         assert authority.admitted_session_id == "session-1"
+        assert authority.creator_source is source
+        assert source.user_id == "creator-b"
         assert has_hook("agent:start") is False
         assert invoke_hook("agent:start") == []
         event.metadata["contextual_cron_result"] = {
@@ -1932,6 +2422,10 @@ async def test_runner_internal_turn_is_hidden_and_intentional_silence_is_no_acti
     runner._release_running_agent_state = lambda *_args, **_kwargs: True
     runner._release_turn_lease = lambda *_args, **_kwargs: True
     loop = __import__("asyncio").get_running_loop()
+    creator = _entry().origin
+    assert creator is not None
+    creator.user_id = "creator-b"
+    route_entry = _entry()
     item = ContextualCronQueueItem(
         job_id="job",
         execution_id="execution",
@@ -1939,7 +2433,7 @@ async def test_runner_internal_turn_is_hidden_and_intentional_silence_is_no_acti
         session_key="telegram:dm:42:42",
         admitted_session_id="session-1",
         admitted_routing_revision=3,
-        source=_entry().origin,
+        source=creator,
         future=loop.create_future(),
     )
     cast(Any, runner)._detach_preheld_turn_lease = lambda *_args: True
@@ -1948,7 +2442,7 @@ async def test_runner_internal_turn_is_hidden_and_intentional_silence_is_no_acti
         outcome = await GatewayRunner._run_contextual_cron_turn(
             runner,
             item,
-            _entry(),
+            route_entry,
             [],
         )
     finally:
@@ -2418,6 +2912,7 @@ def test_auto_reset_then_resume_keeps_route_revision_monotonic():
     key = _entry().session_key
     old = _entry()
     old.routing_revision = 1
+    old.route_instance_id = "route-instance-a"
     store = object.__new__(SessionStore)
     store._lock = threading.Lock()
     store._loaded = True
@@ -2433,11 +2928,53 @@ def test_auto_reset_then_resume_keeps_route_revision_monotonic():
     reset = store._get_or_create_session_impl(source)
     assert reset.session_id != old.session_id
     assert reset.routing_revision == 2
+    assert reset.route_instance_id == "route-instance-a"
 
     resumed = store.switch_session(key, old.session_id)
     assert resumed is not None
     assert resumed.session_id == old.session_id
     assert resumed.routing_revision == 3
+    assert resumed.route_instance_id == "route-instance-a"
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "preserves_route"),
+    [
+        ("user_id", "99", True),
+        ("user_id_alt", "user-alt-b", True),
+        ("scope_id", "workspace-b", False),
+    ],
+)
+def test_auto_reset_separates_conversation_identity_from_participant_authority(
+    field, value, preserves_route
+):
+    import threading
+    from dataclasses import replace
+
+    from gateway.session import SessionStore
+
+    old = _entry()
+    assert old.origin is not None
+    old.route_instance_id = "route-instance-a"
+    incoming = replace(old.origin, **{field: value})
+    store = object.__new__(SessionStore)
+    store_any = cast(Any, store)
+    store_any._lock = threading.Lock()
+    store_any._loaded = True
+    store_any._entries = {old.session_key: old}
+    store_any._db = None
+    store_any._save_entries = lambda: None
+    store_any._save = lambda: None
+    store_any._generate_session_key = lambda _source: old.session_key
+    store_any._compression_tip_for_session_id = lambda session_id: session_id
+    store_any._is_session_ended_in_db = lambda _session_id: False
+    store_any._should_reset = lambda _entry, _source: "idle"
+
+    reset = store._get_or_create_session_impl(incoming)
+
+    assert reset.routing_revision == 1
+    assert (reset.route_instance_id == "route-instance-a") is preserves_route
+    assert reset.origin is incoming
 
 
 def test_admission_and_reset_share_one_routing_linearization_lock():
@@ -2487,6 +3024,30 @@ def test_admission_and_reset_share_one_routing_linearization_lock():
     assert admitted == [("exec", entry.session_key, "session-1", 0)]
     assert reset_result[0].session_id != "session-1"
     assert reset_result[0].routing_revision == 1
+
+
+def test_admission_seal_rejects_route_instance_swap_inside_routing_lock():
+    import threading
+
+    from gateway.session import ContextualRouteInstanceMismatch, SessionStore
+
+    store = object.__new__(SessionStore)
+    store._lock = threading.Lock()
+    store._loaded = True
+    entry = _entry("replacement-session")
+    entry.route_instance_id = "route-instance-b"
+    store._entries = {entry.session_key: entry}
+    sealed = []
+
+    with pytest.raises(ContextualRouteInstanceMismatch):
+        store.seal_contextual_admission(
+            entry.session_key,
+            "route-race",
+            lambda *args: sealed.append(args) or True,
+            expected_route_instance_id="route-instance-a",
+        )
+
+    assert sealed == []
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_contextual_cron.py
+++ b/tests/gateway/test_contextual_cron.py
@@ -1,0 +1,2735 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from dataclasses import replace
+import inspect
+import logging
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from gateway.contextual_cron import (
+    ContextualCronGateway,
+    ContextualCronOutcome,
+)
+from gateway.session import Platform, SessionEntry, SessionSource
+from gateway.run import GatewayRunner, TurnRunner
+
+
+class _LiveStore:
+    def __init__(self, entry: SessionEntry, transcript: list[dict]):
+        self.entry = entry
+        self.transcript = transcript
+
+    def peek_session_entry(self, session_key: str):
+        if self.entry is None:
+            return None
+        return self.entry if session_key == self.entry.session_key else None
+
+    async def load_transcript(self, session_id: str):
+        assert session_id == self.entry.session_id
+        return list(self.transcript)
+
+    async def load_transcript_with_fence_strict(self, session_id: str):
+        return await self.load_transcript(session_id), len(self.transcript)
+
+
+async def _hold_contextual_turn_lease(runner, item):
+    from gateway.turn_lease import SessionTurnLeaseRegistry
+
+    registry = SessionTurnLeaseRegistry()
+    token = await registry.acquire(
+        item.admitted_session_id,
+        owner_key=f"contextual-cron:{item.execution_id}",
+        generation=0,
+        timeout=1,
+    )
+    assert token is not None
+    cast(Any, runner)._turn_leases = registry
+    item.turn_lease_token = token
+    return registry, token
+
+
+class _TracerRunner:
+    def __init__(self, store: _LiveStore):
+        self.session_store = store
+        self.async_session_store = store
+        self.seen_histories: list[list[dict]] = []
+
+    def _is_user_authorized(self, source: SessionSource) -> bool:
+        return True
+
+    def _contextual_cron_session_busy(self, session_key: str) -> bool:
+        return False
+
+    async def _run_contextual_cron_turn(self, item, entry, history):
+        self.seen_histories.append(list(history))
+        chosen = next(
+            (
+                message["content"].split("chosen word is ", 1)[1].rstrip(".")
+                for message in history
+                if message.get("role") == "user"
+                and "chosen word is " in str(message.get("content"))
+            ),
+            "unknown",
+        )
+        return ContextualCronOutcome.notify(f"Recovered chosen word: {chosen}")
+
+
+def test_contextual_error_and_already_sent_paths_are_transport_fail_closed():
+    source = inspect.getsource(GatewayRunner._handle_message_with_agent)
+    assert (
+        "if not _is_contextual_cron:\n            self._bind_adapter_run_generation("
+        in source
+    )
+    assert (
+        'not _is_contextual_cron\n                and agent_result.get("already_sent")'
+        in source
+    )
+    assert "_err_adapter = (\n                    None if _is_contextual_cron" in source
+    assert "_stts_adapter = (\n                None if _is_contextual_cron" in source
+    assert "_apply_contextual_transcript_visibility(" in source
+    assert "_get_contextual_turn_authority" in source
+    preprocessing = source.split("# V1 contextual prompts", maxsplit=1)[1].split(
+        "if message_text is None", maxsplit=1
+    )[0]
+    assert 'message_text = event.text or ""' in preprocessing
+    assert "else:" in preprocessing
+    assert "self._prepare_profile_scoped_inbound_message_text(" in preprocessing
+    assert "_get_contextual_turn_authority" in source
+    assert (
+        "not _is_contextual_cron\n            and not history\n"
+        "            and not await self.async_session_store.has_any_sessions()"
+        in source
+    )
+    home_notice_guard = source.split(
+        "# One-time prompt if no home channel is set", maxsplit=1
+    )[1].split("platform_name =", maxsplit=1)[0]
+    assert "not _is_contextual_cron" in home_notice_guard
+    assert "await self._deliver_platform_notice" in source
+    assert "_contextual_authority.admitted_routing_revision" in source
+    assert "session_entry.routing_revision != _admitted_routing_revision" in source
+    assert (
+        "if (\n                _is_contextual_cron\n"
+        "                and agent_result.get(\"session_id\")\n"
+        "                and agent_result[\"session_id\"] != session_entry.session_id"
+        in source
+    )
+
+    run_source = inspect.getsource(TurnRunner.run_sync)
+    for callback in (
+        "tool_progress_callback",
+        "tool_start_callback",
+        "stream_delta_callback",
+        "interim_assistant_callback",
+        "status_callback",
+    ):
+        assert f"agent.{callback} = (None if ctx.suppress_output else" in run_source
+    assert (
+        "agent._gateway_turn_context_notes = (\n"
+        "            \"\"\n"
+        "            if ctx.suppress_output"
+        in run_source
+    )
+    assert (
+        "_native_imgs = (\n"
+        "                []\n"
+        "                if ctx.suppress_output"
+        in run_source
+    )
+    assert "if not ctx.suppress_output:\n                unregister_gateway_notify" in run_source
+    assert "if not ctx.suppress_output:\n                try:\n                    from tools.clarify_gateway" in run_source
+    assert "if not ctx.suppress_output and ctx._status_adapter and ctx.session_key:" in run_source
+    assert "agent.thinking_progress = False if ctx.suppress_output else ctx._thinking_enabled" in run_source
+    assert "contextual_execution=bool(ctx.suppress_output)" in run_source
+    assert "api_mode == \"codex_app_server\"" in run_source
+    assert "fallback_model=self._runner._refresh_fallback_model()" in run_source
+    from agent import agent_init
+
+    init_source = inspect.getsource(agent_init.init_agent)
+    assert "if agent._contextual_execution:" in init_source
+    assert "fallback_model = None" in init_source
+    assert "Contextual execution attempted to rotate its admitted session" in run_source
+
+
+def test_contextual_model_boundary_bypasses_extension_planes():
+    from agent import conversation_loop
+
+    class _Engine:
+        def __init__(self):
+            self.called = False
+            self.context_length = 100
+
+        def select_context(self, *args, **kwargs):
+            self.called = True
+            return []
+
+        def on_turn_complete(self, *args, **kwargs):
+            self.called = True
+
+    engine = _Engine()
+    agent = SimpleNamespace(
+        _contextual_execution=True,
+        context_compressor=engine,
+        session_id="session-1",
+    )
+    messages = [{"role": "user", "content": "hello"}]
+    selected = conversation_loop._apply_context_engine_selection(
+        agent,
+        messages,
+        messages,
+        messages[-1],
+        logger=logging.getLogger(__name__),
+    )
+    conversation_loop._notify_context_engine_turn_complete(
+        agent,
+        messages,
+        logger=logging.getLogger(__name__),
+    )
+
+    assert selected is messages
+    assert engine.called is False
+    source = inspect.getsource(conversation_loop.run_conversation)
+    assert "_use_streaming = not _contextual_execution" in source
+    assert "if _contextual_execution:\n                        return agent._interruptible_api_call" in source
+    assert "if _contextual_execution:\n                        response = _perform_api_call" in source
+
+
+def test_zero_routing_revision_preserves_legacy_session_record_shape():
+    now = datetime.now(timezone.utc)
+    entry = SessionEntry(
+        session_key="telegram:u:c",
+        session_id="session-1",
+        created_at=now,
+        updated_at=now,
+    )
+
+    assert "routing_revision" not in entry.to_dict()
+    assert SessionEntry.from_dict(entry.to_dict()).routing_revision == 0
+
+    entry.routing_revision = 1
+    assert entry.to_dict()["routing_revision"] == 1
+
+
+@pytest.mark.asyncio
+async def test_contextual_cron_tracer_recovers_only_the_stable_session_context():
+    """The opt-in lane sees live history; the legacy isolated control does not."""
+
+    session_key = "telegram:dm:42:42"
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="42",
+        chat_type="dm",
+        user_id="42",
+    )
+    now = datetime.now(timezone.utc)
+    entry = SessionEntry(
+        session_id="session-marzipan",
+        session_key=session_key,
+        created_at=now,
+        updated_at=now,
+        origin=source,
+    )
+    store = _LiveStore(
+        entry,
+        [
+            {"role": "user", "content": "The chosen word is marzipan."},
+            {"role": "assistant", "content": "I will remember it."},
+        ],
+    )
+    runner = _TracerRunner(store)
+    sealed: list[tuple[str, str, str]] = []
+    gateway = ContextualCronGateway(
+        runner,
+        seal_admission=lambda execution_id, key, session_id: sealed.append(
+            (execution_id, key, session_id)
+        )
+        or True,
+    )
+
+    contextual = await gateway.dispatch(
+        {
+            "id": "contextual",
+            "prompt": "What was the chosen word?",
+            "session_target": "current",
+            "session_key": session_key,
+        },
+        execution_id="execution-1",
+    )
+
+    # Deterministic isolated control: the existing isolated lane starts with an
+    # empty history, so the same tracer cannot recover the seeded value.
+    isolated = await runner._run_contextual_cron_turn(
+        SimpleNamespace(prompt="What was the chosen word?"),
+        entry,
+        [],
+    )
+
+    assert contextual.kind == "notify"
+    assert "marzipan" in contextual.final_response
+    assert "marzipan" not in isolated.final_response
+    assert sealed == [("execution-1", session_key, "session-marzipan")]
+    assert runner.seen_histories[0] == store.transcript
+
+
+@pytest.mark.asyncio
+async def test_contextual_turn_fails_closed_when_fenced_transcript_load_fails():
+    class BrokenStore(_LiveStore):
+        async def load_transcript_with_fence_strict(self, session_id: str):
+            del session_id
+            raise RuntimeError("session db unavailable")
+
+    store = BrokenStore(_entry(), [{"role": "user", "content": "secret"}])
+    runner = _QueueRunner(store)
+    finished = []
+    gateway = _queue_gateway(runner, [], finished)
+
+    outcome = await gateway.dispatch(
+        {
+            "id": "strict-load",
+            "prompt": "must not run",
+            "session_target": "current",
+            "session_key": store.entry.session_key,
+        },
+        execution_id="strict-load",
+    )
+
+    assert outcome.kind == "failure"
+    assert "session db unavailable" in str(outcome.error)
+    assert runner.started == []
+    assert finished == [("strict-load", "failure")]
+
+
+@pytest.mark.asyncio
+async def test_contextual_turn_rejects_proxy_before_any_execution(monkeypatch):
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    monkeypatch.setattr(runner, "_get_proxy_url", lambda: "http://proxy.invalid")
+    item = SimpleNamespace(
+        execution_id="proxy-exec",
+        admitted_session_id="session-1",
+        session_key="telegram:dm:42:42",
+        prompt="do not send",
+    )
+
+    outcome = await runner._run_contextual_cron_turn(item, _entry(), [])
+
+    assert outcome.kind == "rejected"
+    assert "proxy" in str(outcome.error).lower()
+
+
+class _QueueRunner(_TracerRunner):
+    def __init__(self, store):
+        super().__init__(store)
+        self.busy = False
+        self.authorized = True
+        self.started: list[str] = []
+        self.release_first = __import__("asyncio").Event()
+
+    def _is_user_authorized(self, source):
+        return self.authorized
+
+    def _contextual_cron_session_busy(self, session_key):
+        return self.busy
+
+    async def _run_contextual_cron_turn(self, item, entry, history):
+        self.started.append(item.execution_id)
+        if item.execution_id == "first":
+            await self.release_first.wait()
+        return ContextualCronOutcome.notify(item.execution_id)
+
+
+def _entry(session_id="session-1"):
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="42",
+        chat_type="dm",
+        user_id="42",
+    )
+    now = datetime.now(timezone.utc)
+    return SessionEntry(
+        session_id=session_id,
+        session_key="telegram:dm:42:42",
+        created_at=now,
+        updated_at=now,
+        origin=source,
+    )
+
+
+def _queue_gateway(runner, sealed, finished=None):
+    return ContextualCronGateway(
+        runner,
+        busy_poll_seconds=0.001,
+        seal_admission=lambda execution_id, key, sid: sealed.append(
+            (execution_id, key, sid)
+        )
+        or True,
+        finish_admission=(
+            (lambda execution_id, outcome: finished.append((execution_id, outcome.kind)))
+            if finished is not None
+            else None
+        ),
+    )
+
+
+class _OutboxRunner(_QueueRunner):
+    def __init__(self, store):
+        super().__init__(store)
+        self.events: list[str] = []
+        self.fail_apply = False
+
+    async def _run_contextual_cron_turn(self, item, entry, history):
+        self.events.append("run")
+        item.transcript_session_id = entry.session_id
+        item.transcript_entries = [
+            {
+                "role": "user",
+                "content": "hidden trigger",
+                "display_kind": "hidden",
+                "message_id": f"contextual-cron:{item.execution_id}:0",
+            }
+        ]
+        return ContextualCronOutcome.no_action()
+
+    async def _apply_contextual_cron_transcript(self, item):
+        self.events.append("apply")
+        if self.fail_apply:
+            self.fail_apply = False
+            raise RuntimeError("session store unavailable")
+
+
+@pytest.mark.asyncio
+async def test_contextual_queue_reauthorizes_after_model_before_commit():
+    import asyncio
+
+    runner = _QueueRunner(_LiveStore(_entry(), []))
+    finished = []
+    gateway = _queue_gateway(runner, [], finished)
+    pending = asyncio.create_task(
+        gateway.dispatch(
+            {
+                "id": "job",
+                "prompt": "check",
+                "session_target": "current",
+                "session_key": "telegram:dm:42:42",
+            },
+            execution_id="first",
+        )
+    )
+    while runner.started != ["first"]:
+        await asyncio.sleep(0)
+    runner.authorized = False
+    runner.release_first.set()
+
+    outcome = await pending
+
+    assert outcome.kind == "rejected"
+    assert "authorization" in str(outcome.error).lower()
+    assert finished == [("first", "rejected")]
+
+
+@pytest.mark.asyncio
+async def test_post_model_authorization_error_resolves_item_and_lane_continues():
+    import asyncio
+
+    runner = _QueueRunner(_LiveStore(_entry(), []))
+    finished = []
+    raised = False
+
+    def authorize(source):
+        del source
+        nonlocal raised
+        if runner.release_first.is_set() and runner.started == ["first"] and not raised:
+            raised = True
+            raise RuntimeError("auth backend unavailable")
+        return True
+
+    runner._is_user_authorized = authorize
+    gateway = _queue_gateway(runner, [], finished)
+    first_task = asyncio.create_task(
+        gateway.dispatch(
+            {
+                "id": "job",
+                "prompt": "continue",
+                "session_target": "current",
+                "session_key": "telegram:dm:42:42",
+            },
+            execution_id="first",
+        )
+    )
+    while runner.started != ["first"]:
+        await asyncio.sleep(0)
+    runner.release_first.set()
+
+    first = await asyncio.wait_for(first_task, timeout=1)
+    second = await asyncio.wait_for(
+        gateway.dispatch(
+            {
+                "id": "job",
+                "prompt": "continue again",
+                "session_target": "current",
+                "session_key": "telegram:dm:42:42",
+            },
+            execution_id="second",
+        ),
+        timeout=1,
+    )
+
+    assert first.kind == "retryable"
+    assert "auth backend unavailable" in str(first.error)
+    assert second.kind == "notify"
+    assert runner.started == ["first", "second"]
+    assert finished == [("first", "retryable"), ("second", "notify")]
+
+
+@pytest.mark.asyncio
+async def test_contextual_queue_stages_outbox_before_applying_transcript():
+    runner = _OutboxRunner(_LiveStore(_entry(), []))
+
+    def finish(execution_id, outcome, item):
+        assert execution_id == "outbox-order"
+        assert outcome.kind == "no_action"
+        assert item.transcript_session_id == "session-1"
+        assert item.transcript_entries[0]["display_kind"] == "hidden"
+        runner.events.append("persist")
+        return {"transcript_state": "pending"}
+
+    gateway = ContextualCronGateway(
+        runner,
+        seal_admission=lambda *_args: True,
+        finish_admission=finish,
+    )
+    outcome = await gateway.dispatch(
+        {
+            "id": "job",
+            "prompt": "check",
+            "session_target": "current",
+            "session_key": "telegram:dm:42:42",
+        },
+        execution_id="outbox-order",
+    )
+
+    assert outcome.kind == "no_action"
+    assert runner.events == ["run", "persist", "apply"]
+
+
+@pytest.mark.asyncio
+async def test_contextual_queue_retries_durable_outbox_before_resolving():
+    runner = _OutboxRunner(_LiveStore(_entry(), []))
+    runner.fail_apply = True
+
+    def finish(_execution_id, _outcome, _item):
+        runner.events.append("persist")
+        return {"transcript_state": "pending"}
+
+    gateway = ContextualCronGateway(
+        runner,
+        seal_admission=lambda *_args: True,
+        finish_admission=finish,
+        transcript_retry_seconds=0.001,
+    )
+    outcome = await gateway.dispatch(
+        {
+            "id": "job",
+            "prompt": "check",
+            "session_target": "current",
+            "session_key": "telegram:dm:42:42",
+        },
+        execution_id="outbox-recovery",
+    )
+
+    assert outcome.kind == "no_action"
+    assert runner.events == ["run", "persist", "apply", "apply"]
+
+
+@pytest.mark.asyncio
+async def test_contextual_queue_terminalizes_causal_conflict_without_retrying(
+    monkeypatch,
+):
+    import asyncio
+    import threading
+
+    from gateway.contextual_cron import ContextualCronTranscriptConflict
+
+    class ConflictRunner(_OutboxRunner):
+        async def _apply_contextual_cron_transcript(self, item):
+            del item
+            self.events.append("apply")
+            raise ContextualCronTranscriptConflict(
+                "Contextual transcript advanced before outbox application."
+            )
+
+    runner = ConflictRunner(_LiveStore(_entry(), []))
+    marked = []
+    marked_signal = threading.Event()
+
+    def mark_conflict(execution_id, *, error):
+        marked.append((execution_id, error))
+        marked_signal.set()
+        return True
+
+    monkeypatch.setattr(
+        "cron.executions.mark_contextual_transcript_conflict",
+        mark_conflict,
+    )
+
+    def finish(_execution_id, _outcome, _item):
+        runner.events.append("persist")
+        return {"transcript_state": "pending"}
+
+    gateway = ContextualCronGateway(
+        runner,
+        seal_admission=lambda *_args: True,
+        finish_admission=finish,
+        transcript_retry_seconds=0.001,
+    )
+    dispatch = asyncio.create_task(
+        gateway.dispatch(
+            {
+                "id": "job",
+                "prompt": "check",
+                "session_target": "current",
+                "session_key": "telegram:dm:42:42",
+            },
+            execution_id="outbox-conflict",
+        )
+    )
+    await asyncio.wait_for(asyncio.to_thread(marked_signal.wait, 1), timeout=1.1)
+    try:
+        outcome = await asyncio.wait_for(dispatch, timeout=1)
+        assert outcome.kind == "unknown"
+        assert marked == [
+            (
+                "outbox-conflict",
+                "Contextual transcript advanced before outbox application.",
+            )
+        ]
+        assert runner.events == ["run", "persist", "apply"]
+    finally:
+        drainer = gateway._drainers.get("telegram:dm:42:42")
+        if drainer is not None and not drainer.done():
+            drainer.cancel()
+            await asyncio.gather(drainer, return_exceptions=True)
+        if not dispatch.done():
+            dispatch.cancel()
+            await asyncio.gather(dispatch, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_contextual_transcript_entries_stage_without_touching_session_store():
+    class Store:
+        def __init__(self):
+            self.appended = []
+
+        async def append_to_transcript(self, *args, **kwargs):
+            self.appended.append((args, kwargs))
+
+    runner = object.__new__(GatewayRunner)
+    runner._async_session_store = Store()
+    event = SimpleNamespace(metadata={})
+
+    await GatewayRunner._write_or_stage_transcript_entry(
+        runner,
+        event,
+        "session-1",
+        {"role": "user", "content": "hidden trigger", "display_kind": "hidden"},
+        skip_db=False,
+        contextual_execution_id="stage-only",
+    )
+    await GatewayRunner._write_or_stage_transcript_entry(
+        runner,
+        event,
+        "session-1",
+        {"role": "assistant", "content": "answer"},
+        skip_db=False,
+        contextual_execution_id="stage-only",
+    )
+
+    assert runner._async_session_store.appended == []
+    assert event.metadata["contextual_cron_transcript_session_id"] == "session-1"
+    assert [
+        entry["message_id"]
+        for entry in event.metadata["contextual_cron_transcript_entries"]
+    ] == ["contextual-cron:stage-only:0", "contextual-cron:stage-only:1"]
+
+
+@pytest.mark.asyncio
+async def test_ordinary_transcript_entry_keeps_direct_persistence_path():
+    class Store:
+        def __init__(self):
+            self.appended = []
+
+        async def append_to_transcript(self, *args, **kwargs):
+            self.appended.append((args, kwargs))
+
+    runner = object.__new__(GatewayRunner)
+    runner._async_session_store = Store()
+    event = SimpleNamespace(metadata={})
+    entry = {"role": "user", "content": "hello", "message_id": "platform-1"}
+
+    await GatewayRunner._write_or_stage_transcript_entry(
+        runner,
+        event,
+        "session-1",
+        entry,
+        skip_db=True,
+        contextual_execution_id=None,
+    )
+
+    assert runner._async_session_store.appended == [
+        (("session-1", entry), {"skip_db": True})
+    ]
+    assert event.metadata == {}
+
+
+@pytest.mark.asyncio
+async def test_contextual_transcript_outbox_applies_idempotently_before_ack(
+    monkeypatch,
+):
+    from gateway.contextual_cron import ContextualCronQueueItem
+
+    class Store:
+        def __init__(self):
+            self.persisted = {"contextual-cron:outbox-apply:0"}
+            self.appended = []
+            self.history = [
+                {
+                    "role": "user",
+                    "content": "hidden trigger",
+                    "display_kind": "hidden",
+                    "message_id": "contextual-cron:outbox-apply:0",
+                }
+            ]
+
+        async def load_transcript_strict(self, _session_id):
+            return [dict(entry) for entry in self.history]
+
+        async def has_platform_message_id(self, _session_id, message_id):
+            return message_id in self.persisted
+
+        async def append_to_transcript(self, session_id, entry, *, skip_db=False):
+            assert session_id == "session-1"
+            assert skip_db is False
+            self.appended.append(dict(entry))
+            self.persisted.add(entry["message_id"])
+            self.history.append(dict(entry))
+
+        async def update_session(self, session_key, **updates):
+            assert session_key == "telegram:dm:42:42"
+            assert updates == {"last_prompt_tokens": 77, "touch_activity": False}
+
+    store = Store()
+    runner = object.__new__(GatewayRunner)
+    runner._async_session_store = store
+    applied = []
+    monkeypatch.setattr(
+        "cron.executions.mark_contextual_transcript_applied",
+        lambda execution_id: applied.append(execution_id) or True,
+    )
+    loop = __import__("asyncio").get_running_loop()
+    item = ContextualCronQueueItem(
+        job_id="job",
+        execution_id="outbox-apply",
+        prompt="check",
+        session_key="telegram:dm:42:42",
+        admitted_session_id="session-1",
+        source=_entry().origin,
+        future=loop.create_future(),
+        transcript_session_id="session-1",
+        transcript_entries=[
+            {
+                "role": "user",
+                "content": "hidden trigger",
+                "display_kind": "hidden",
+                "message_id": "contextual-cron:outbox-apply:0",
+            },
+            {
+                "role": "assistant",
+                "content": "answer",
+                "message_id": "contextual-cron:outbox-apply:1",
+            },
+        ],
+        transcript_base_message_count=0,
+        transcript_base_revision=0,
+        last_prompt_tokens=77,
+    )
+
+    await GatewayRunner._apply_contextual_cron_transcript(runner, item)
+
+    assert [entry["message_id"] for entry in store.appended] == [
+        "contextual-cron:outbox-apply:1"
+    ]
+    assert applied == ["outbox-apply"]
+
+
+@pytest.mark.asyncio
+async def test_contextual_transcript_outbox_stays_pending_after_partial_apply(
+    monkeypatch,
+):
+    from gateway.contextual_cron import ContextualCronQueueItem
+
+    class FailingStore:
+        async def load_transcript_strict(self, _session_id):
+            return []
+
+        async def has_platform_message_id(self, _session_id, _message_id):
+            return False
+
+        async def append_to_transcript(self, *_args, **_kwargs):
+            raise RuntimeError("session db unavailable")
+
+    runner = object.__new__(GatewayRunner)
+    runner._async_session_store = FailingStore()
+    applied = []
+    monkeypatch.setattr(
+        "cron.executions.mark_contextual_transcript_applied",
+        lambda execution_id: applied.append(execution_id) or True,
+    )
+    loop = __import__("asyncio").get_running_loop()
+    item = ContextualCronQueueItem(
+        job_id="job",
+        execution_id="outbox-pending",
+        prompt="check",
+        session_key="telegram:dm:42:42",
+        admitted_session_id="session-1",
+        source=_entry().origin,
+        future=loop.create_future(),
+        transcript_session_id="session-1",
+        transcript_entries=[
+            {
+                "role": "user",
+                "content": "hidden trigger",
+                "display_kind": "hidden",
+                "message_id": "contextual-cron:outbox-pending:0",
+            }
+        ],
+        transcript_base_message_count=0,
+        transcript_base_revision=0,
+    )
+
+    with pytest.raises(RuntimeError, match="session db unavailable"):
+        await GatewayRunner._apply_contextual_cron_transcript(runner, item)
+
+    assert applied == []
+
+
+def test_contextual_transcript_persistence_preserves_hidden_display_metadata():
+    from gateway.session import SessionStore
+
+    captured = []
+
+    class DB:
+        def append_message(self, **kwargs):
+            captured.append(kwargs)
+            return 1
+
+    store = object.__new__(SessionStore)
+    cast(Any, store)._db = DB()
+    store._append_transcript_message(
+        "session-1",
+        {
+            "role": "user",
+            "content": "hidden prompt",
+            "message_id": "contextual-cron:hidden:0",
+            "display_kind": "hidden",
+            "display_metadata": {"producer": "contextual_cron"},
+        },
+    )
+
+    assert captured[0]["display_kind"] == "hidden"
+    assert captured[0]["display_metadata"] == {"producer": "contextual_cron"}
+
+
+@pytest.mark.asyncio
+async def test_contextual_transcript_apply_rejects_a_later_human_turn(
+    monkeypatch,
+):
+    from gateway.contextual_cron import (
+        ContextualCronQueueItem,
+        ContextualCronTranscriptConflict,
+    )
+
+    class AdvancedStore:
+        def __init__(self):
+            self.messages = [
+                {"role": "user", "content": "later human turn", "message_id": "human:1"}
+            ]
+            self.appended = []
+
+        async def load_transcript_strict(self, _session_id):
+            return list(self.messages)
+
+        async def has_platform_message_id_strict(self, _session_id, candidate):
+            return any(row.get("message_id") == candidate for row in self.messages)
+
+        async def append_to_transcript(self, _session_id, entry, *, skip_db=False):
+            self.appended.append(dict(entry))
+            self.messages.append(dict(entry))
+
+    store = AdvancedStore()
+    runner = object.__new__(GatewayRunner)
+    runner._async_session_store = store
+    monkeypatch.setattr(
+        "cron.executions.mark_contextual_transcript_applied", lambda _execution_id: True
+    )
+    loop = __import__("asyncio").get_running_loop()
+    item = ContextualCronQueueItem(
+        job_id="job",
+        execution_id="causal-conflict",
+        prompt="check",
+        session_key="telegram:dm:42:42",
+        admitted_session_id="session-1",
+        source=_entry().origin,
+        future=loop.create_future(),
+        transcript_session_id="session-1",
+        transcript_entries=[
+            {
+                "role": "assistant",
+                "content": "scheduled answer",
+                "message_id": "contextual-cron:causal-conflict:0",
+            }
+        ],
+        transcript_base_message_count=0,
+        transcript_base_revision=0,
+    )
+
+    with pytest.raises(ContextualCronTranscriptConflict, match="advanced"):
+        await GatewayRunner._apply_contextual_cron_transcript(runner, item)
+
+    assert store.appended == []
+    assert store.messages == [
+        {"role": "user", "content": "later human turn", "message_id": "human:1"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_transcript_recovery_has_one_application_winner(
+    monkeypatch, tmp_path
+):
+    import asyncio
+    import cron.executions as executions
+    from gateway.contextual_cron import ContextualCronQueueItem
+
+    monkeypatch.setattr(
+        executions, "EXECUTIONS_FILE", tmp_path / "cron" / "executions.db"
+    )
+    record = executions.create_execution("job", source="builtin")
+    executions.mark_execution_running(record["id"])
+    message_id = f"contextual-cron:{record['id']}:0"
+    entries = [
+        {
+            "role": "user",
+            "content": "hidden",
+            "display_kind": "hidden",
+            "message_id": message_id,
+        }
+    ]
+    executions.persist_contextual_agent_result(
+        record["id"],
+        outcome="no_action",
+        transcript_session_id="session-1",
+        transcript_entries=entries,
+        transcript_base_message_count=0,
+        transcript_base_revision=0,
+    )
+
+    class RacingStore:
+        def __init__(self):
+            self.persisted = set()
+            self.history = []
+            self.append_calls = 0
+            self.first_append_entered = asyncio.Event()
+            self.release_first_append = asyncio.Event()
+
+        async def load_transcript_strict(self, _session_id):
+            return [dict(entry) for entry in self.history]
+
+        async def has_platform_message_id_strict(self, _session_id, candidate):
+            return candidate in self.persisted
+
+        async def append_to_transcript(self, _session_id, entry, *, skip_db=False):
+            assert skip_db is False
+            self.append_calls += 1
+            if self.append_calls == 1:
+                self.first_append_entered.set()
+                await self.release_first_append.wait()
+            self.persisted.add(entry["message_id"])
+            self.history.append(dict(entry))
+
+    store = RacingStore()
+    runner = object.__new__(GatewayRunner)
+    runner._async_session_store = store
+    loop = asyncio.get_running_loop()
+    item = ContextualCronQueueItem(
+        job_id="job",
+        execution_id=record["id"],
+        prompt="check",
+        session_key="telegram:dm:42:42",
+        admitted_session_id="session-1",
+        source=_entry().origin,
+        future=loop.create_future(),
+        transcript_session_id="session-1",
+        transcript_entries=entries,
+        transcript_base_message_count=0,
+        transcript_base_revision=0,
+    )
+
+    first = asyncio.create_task(
+        GatewayRunner._apply_contextual_cron_transcript(runner, item)
+    )
+    await asyncio.wait_for(store.first_append_entered.wait(), timeout=1)
+    second = asyncio.create_task(
+        GatewayRunner._apply_contextual_cron_transcript(runner, item)
+    )
+    await asyncio.sleep(0.05)
+    assert store.append_calls == 1
+    store.release_first_append.set()
+    await asyncio.gather(first, second)
+
+    assert store.append_calls == 1
+    applied_record = executions.get_execution(record["id"])
+    assert applied_record is not None
+    assert applied_record["transcript_state"] == "applied"
+
+
+def test_cross_process_transcript_recovery_has_one_append_winner(
+    monkeypatch, tmp_path
+):
+    import multiprocessing
+    import os
+    import sqlite3
+    import time
+    from pathlib import Path
+    from types import SimpleNamespace
+
+    import cron.executions as executions
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    executions.EXECUTIONS_FILE = tmp_path / "executions.db"
+    record = executions.create_execution(
+        "job", source="builtin", requires_job_accounting=True
+    )
+    assert executions.seal_contextual_admission(
+        record["id"],
+        session_key="telegram:1",
+        admitted_session_id="session-1",
+    ) is True
+    executions.persist_contextual_agent_result(
+        record["id"],
+        outcome="notify",
+        final_response="done",
+        transcript_session_id="session-1",
+        transcript_entries=[
+            {
+                "role": "assistant",
+                "content": "done",
+                "message_id": f"contextual-cron:{record['id']}:0",
+                "display_kind": "normal",
+            }
+        ],
+        transcript_base_message_count=0,
+        transcript_base_revision=0,
+    )
+
+    transcript_db = tmp_path / "transcript.db"
+    with sqlite3.connect(transcript_db) as conn:
+        conn.execute("CREATE TABLE messages (message_id TEXT NOT NULL)")
+
+    gate = multiprocessing.get_context("fork").Event()
+    ready = multiprocessing.get_context("fork").Queue()
+
+    def apply_in_process() -> None:
+        os.environ["HERMES_HOME"] = str(tmp_path / "home")
+        executions.EXECUTIONS_FILE = Path(tmp_path / "executions.db")
+
+        class Store:
+            def load_transcript_strict(self, _session_id):
+                with sqlite3.connect(transcript_db) as conn:
+                    return [
+                        {"message_id": row[0]}
+                        for row in conn.execute(
+                            "SELECT message_id FROM messages ORDER BY rowid"
+                        )
+                    ]
+
+            def has_platform_message_id_strict(self, _session_id, message_id):
+                with sqlite3.connect(transcript_db) as conn:
+                    return conn.execute(
+                        "SELECT 1 FROM messages WHERE message_id=? LIMIT 1",
+                        (message_id,),
+                    ).fetchone() is not None
+
+            def append_contextual_transcript_message_once(self, _session_id, entry):
+                # Widen the unprotected race window: without the process/file
+                # lock both workers observe absence and both append.
+                time.sleep(0.1)
+                with sqlite3.connect(transcript_db) as conn:
+                    conn.execute(
+                        "INSERT INTO messages(message_id) VALUES (?)",
+                        (entry["message_id"],),
+                    )
+
+            def update_session(self, *_args, **_kwargs):
+                return None
+
+        item = SimpleNamespace(
+            execution_id=record["id"],
+            admitted_session_id="session-1",
+            transcript_session_id="session-1",
+            transcript_entries=[
+                {
+                    "role": "assistant",
+                    "content": "done",
+                    "message_id": f"contextual-cron:{record['id']}:0",
+                    "display_kind": "normal",
+                }
+            ],
+            transcript_base_message_count=0,
+            transcript_base_revision=0,
+            last_prompt_tokens=None,
+            session_key="telegram:1",
+        )
+        ready.put(True)
+        gate.wait(timeout=5)
+        runner = object.__new__(GatewayRunner)
+        GatewayRunner._apply_contextual_cron_transcript_sync(runner, Store(), item)
+
+    ctx = multiprocessing.get_context("fork")
+    workers = [ctx.Process(target=apply_in_process) for _ in range(2)]
+    for worker in workers:
+        worker.start()
+    assert ready.get(timeout=5) is True
+    assert ready.get(timeout=5) is True
+    gate.set()
+    for worker in workers:
+        worker.join(timeout=10)
+        assert worker.exitcode == 0
+
+    with sqlite3.connect(transcript_db) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0] == 1
+    applied_record = executions.get_execution(record["id"])
+    assert applied_record is not None
+    assert applied_record["transcript_state"] == "applied"
+
+
+@pytest.mark.asyncio
+async def test_gateway_startup_replays_every_valid_pending_contextual_transcript(
+    monkeypatch,
+):
+    records = [
+        {
+            "id": "malformed",
+            "job_id": "job-0",
+            "session_key": "telegram:dm:42:42",
+            "admitted_session_id": "session-1",
+            "transcript_session_id": "session-1",
+            "transcript_json": "not-json",
+            "transcript_base_message_count": None,
+            "transcript_base_revision": None,
+            "transcript_last_prompt_tokens": 1,
+        },
+        {
+            "id": "recover-1",
+            "job_id": "job-1",
+            "session_key": "telegram:dm:42:42",
+            "admitted_session_id": "session-1",
+            "transcript_session_id": "session-1",
+            "transcript_json": '[{"role":"user","content":"hidden",'
+            '"display_kind":"hidden",'
+            '"message_id":"contextual-cron:recover-1:0"}]',
+            "transcript_base_message_count": 0,
+            "transcript_base_revision": 0,
+            "transcript_last_prompt_tokens": 42,
+        },
+    ]
+    monkeypatch.setattr(
+        "cron.executions.list_pending_contextual_transcripts", lambda: records
+    )
+    runner = object.__new__(GatewayRunner)
+    cast(Any, runner).session_store = _LiveStore(_entry(), [])
+    cast(Any, runner)._is_user_authorized = lambda _source: True
+    seen = []
+    conflicts = []
+    monkeypatch.setattr(
+        "cron.executions.mark_contextual_transcript_conflict",
+        lambda execution_id, *, error: conflicts.append((execution_id, error)) or True,
+    )
+
+    async def apply(item):
+        seen.append(item)
+
+    runner._apply_contextual_cron_transcript = apply
+
+    recovered = await GatewayRunner._recover_contextual_cron_transcripts(runner)
+
+    assert recovered == 1
+    assert [item.execution_id for item in seen] == ["recover-1"]
+    assert seen[0].transcript_session_id == "session-1"
+    assert seen[0].transcript_base_message_count == 0
+    assert seen[0].last_prompt_tokens == 42
+    assert conflicts == [
+        ("malformed", "Contextual transcript outbox payload is invalid.")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_recovery_route_revision_change_terminalizes_unapplied_outbox(monkeypatch):
+    record = {
+        "id": "recover-stale-route",
+        "job_id": "job-1",
+        "session_key": "telegram:dm:42:42",
+        "admitted_session_id": "session-1",
+        "admitted_routing_revision": 1,
+        "transcript_session_id": "session-1",
+        "transcript_json": '[{"role":"assistant","content":"scheduled",'
+        '"message_id":"contextual-cron:recover-stale-route:0"}]',
+        "transcript_base_message_count": 0,
+        "transcript_base_revision": 0,
+        "transcript_last_prompt_tokens": None,
+    }
+    monkeypatch.setattr(
+        "cron.executions.list_pending_contextual_transcripts", lambda: [record]
+    )
+    conflicts = []
+    monkeypatch.setattr(
+        "cron.executions.mark_contextual_transcript_conflict",
+        lambda execution_id, *, error: conflicts.append((execution_id, error)) or True,
+    )
+    entry = replace(_entry(), routing_revision=2)
+    runner = object.__new__(GatewayRunner)
+    cast(Any, runner).session_store = _LiveStore(entry, [])
+    applied = []
+
+    async def apply(item):
+        applied.append(item)
+
+    cast(Any, runner)._apply_contextual_cron_transcript = apply
+
+    recovered = await GatewayRunner._recover_contextual_cron_transcripts(runner)
+
+    assert recovered == 0
+    assert applied == []
+    assert conflicts and conflicts[0][0] == "recover-stale-route"
+    assert "route changed" in conflicts[0][1]
+
+
+@pytest.mark.asyncio
+async def test_recovery_preserves_nonzero_admitted_route_revision_for_current_route(
+    monkeypatch,
+):
+    record = {
+        "id": "recover-current-nonzero-route",
+        "job_id": "job-1",
+        "session_key": "telegram:dm:42:42",
+        "admitted_session_id": "session-1",
+        "admitted_routing_revision": 7,
+        "transcript_session_id": "session-1",
+        "transcript_json": '[{"role":"assistant","content":"scheduled",'
+        '"message_id":"contextual-cron:recover-current-nonzero-route:0"}]',
+        "transcript_base_message_count": 0,
+        "transcript_base_revision": 0,
+        "transcript_last_prompt_tokens": None,
+    }
+    monkeypatch.setattr(
+        "cron.executions.list_pending_contextual_transcripts", lambda: [record]
+    )
+    conflicts = []
+    monkeypatch.setattr(
+        "cron.executions.mark_contextual_transcript_conflict",
+        lambda execution_id, *, error: conflicts.append((execution_id, error)) or True,
+    )
+    runner = object.__new__(GatewayRunner)
+    cast(Any, runner).session_store = _LiveStore(
+        replace(_entry(), routing_revision=7), []
+    )
+    cast(Any, runner)._is_user_authorized = lambda _source: True
+    applied = []
+
+    async def apply(item):
+        applied.append(item)
+
+    cast(Any, runner)._apply_contextual_cron_transcript = apply
+
+    recovered = await GatewayRunner._recover_contextual_cron_transcripts(runner)
+
+    assert recovered == 1
+    assert conflicts == []
+    assert len(applied) == 1
+    assert applied[0].admitted_routing_revision == 7
+    assert applied[0].contextual_route_current is True
+
+
+@pytest.mark.asyncio
+async def test_recovery_receipt_can_be_acknowledged_after_route_revision_change(
+    monkeypatch,
+):
+    record = {
+        "id": "recover-receipted",
+        "job_id": "job-1",
+        "session_key": "telegram:dm:42:42",
+        "admitted_session_id": "session-1",
+        "admitted_routing_revision": 1,
+        "transcript_session_id": "session-1",
+        "transcript_json": '[{"role":"assistant","content":"scheduled",'
+        '"message_id":"contextual-cron:recover-receipted:0"}]',
+        "transcript_base_message_count": 0,
+        "transcript_base_revision": 0,
+        "transcript_last_prompt_tokens": None,
+    }
+    monkeypatch.setattr(
+        "cron.executions.list_pending_contextual_transcripts", lambda: [record]
+    )
+
+    class ReceiptedStore(_LiveStore):
+        def get_contextual_transcript_application(self, execution_id):
+            assert execution_id == "recover-receipted"
+            return {"execution_id": execution_id}
+
+    runner = object.__new__(GatewayRunner)
+    cast(Any, runner).session_store = ReceiptedStore(
+        replace(_entry(), routing_revision=2), []
+    )
+    applied = []
+
+    async def apply(item):
+        applied.append(item)
+
+    cast(Any, runner)._apply_contextual_cron_transcript = apply
+
+    recovered = await GatewayRunner._recover_contextual_cron_transcripts(runner)
+
+    assert recovered == 1
+    assert len(applied) == 1
+    assert applied[0].contextual_route_current is False
+
+
+@pytest.mark.asyncio
+async def test_contextual_transcript_recovery_propagates_deferred_record(
+    monkeypatch,
+):
+    record = {
+        "id": "recover-deferred",
+        "job_id": "job-1",
+        "session_key": "telegram:dm:42:42",
+        "admitted_session_id": "session-1",
+        "admitted_routing_revision": 0,
+        "transcript_session_id": "session-1",
+        "transcript_json": '[{"role":"assistant","content":"scheduled",'
+        '"message_id":"contextual-cron:recover-deferred:0"}]',
+        "transcript_base_message_count": 0,
+        "transcript_base_revision": 0,
+        "transcript_last_prompt_tokens": 42,
+    }
+    monkeypatch.setattr(
+        "cron.executions.list_pending_contextual_transcripts", lambda: [record]
+    )
+    runner = object.__new__(GatewayRunner)
+    cast(Any, runner).session_store = _LiveStore(_entry(), [])
+
+    async def apply(_item):
+        raise RuntimeError("state db unavailable")
+
+    cast(Any, runner)._apply_contextual_cron_transcript_with_recovery_fence = apply
+
+    with pytest.raises(RuntimeError, match="remain deferred"):
+        await GatewayRunner._recover_contextual_cron_transcripts(runner)
+
+
+@pytest.mark.asyncio
+async def test_contextual_transcript_recovery_reauthorizes_before_apply():
+    from gateway.contextual_cron import ContextualCronTranscriptConflict
+
+    runner = object.__new__(GatewayRunner)
+    cast(Any, runner).session_store = _LiveStore(_entry(), [])
+    cast(Any, runner)._is_user_authorized = lambda _source: False
+    applied = []
+
+    async def apply(item):
+        applied.append(item)
+
+    cast(Any, runner)._apply_contextual_cron_transcript = apply
+    item = SimpleNamespace(
+        execution_id="revoked",
+        session_key="telegram:dm:42:42",
+        admitted_session_id="session-1",
+        admitted_routing_revision=0,
+    )
+
+    with pytest.raises(ContextualCronTranscriptConflict, match="authorization"):
+        await GatewayRunner._apply_contextual_cron_transcript_with_recovery_fence(
+            runner, item
+        )
+    assert applied == []
+
+
+@pytest.mark.asyncio
+async def test_contextual_transcript_recovery_waits_for_the_session_turn_lease(
+    monkeypatch,
+):
+    import asyncio
+
+    from gateway.turn_lease import SessionTurnLeaseRegistry
+
+    record = {
+        "id": "recover-after-human",
+        "job_id": "job-1",
+        "session_key": "telegram:dm:42:42",
+        "admitted_session_id": "session-1",
+        "admitted_routing_revision": 0,
+        "transcript_session_id": "session-1",
+        "transcript_json": '[{"role":"assistant","content":"scheduled",'
+        '"message_id":"contextual-cron:recover-after-human:0"}]',
+        "transcript_base_message_count": 0,
+        "transcript_base_revision": 0,
+        "transcript_last_prompt_tokens": 42,
+    }
+    monkeypatch.setattr(
+        "cron.executions.list_pending_contextual_transcripts", lambda: [record]
+    )
+    runner = object.__new__(GatewayRunner)
+    cast(Any, runner).session_store = _LiveStore(_entry(), [])
+    cast(Any, runner)._is_user_authorized = lambda _source: True
+    runner._turn_leases = SessionTurnLeaseRegistry()
+    apply_started = asyncio.Event()
+
+    async def apply(item):
+        del item
+        apply_started.set()
+
+    runner._apply_contextual_cron_transcript = apply
+    held = await runner._turn_leases.acquire(
+        "session-1", owner_key="human-turn", generation=1
+    )
+    recovery = asyncio.create_task(
+        GatewayRunner._recover_contextual_cron_transcripts(runner)
+    )
+    await asyncio.sleep(0.03)
+    assert apply_started.is_set() is False
+    assert recovery.done() is False
+
+    runner._turn_leases.release(held)
+    assert await asyncio.wait_for(recovery, timeout=1) == 1
+    assert apply_started.is_set() is True
+
+
+@pytest.mark.asyncio
+async def test_contextual_transcript_recovery_waits_for_the_adapter_guard():
+    import asyncio
+
+    class Adapter:
+        def __init__(self):
+            self.lock = asyncio.Lock()
+
+        async def acquire_contextual_cron_guard(self, _session_key):
+            await self.lock.acquire()
+            return object()
+
+        async def release_contextual_cron_guard(self, _session_key, _guard):
+            self.lock.release()
+
+    adapter = Adapter()
+    human_guard = await adapter.acquire_contextual_cron_guard("telegram:dm:42:42")
+    runner = object.__new__(GatewayRunner)
+    cast(Any, runner).session_store = _LiveStore(_entry(), [])
+    cast(Any, runner)._is_user_authorized = lambda _source: True
+    runner._adapter_for_source = lambda source: adapter
+    apply_started = asyncio.Event()
+
+    async def apply(item):
+        del item
+        apply_started.set()
+
+    runner._apply_contextual_cron_transcript = apply
+    item = SimpleNamespace(
+        execution_id="recover-after-adapter",
+        session_key="telegram:dm:42:42",
+        admitted_session_id="session-1",
+    )
+    recovery = asyncio.create_task(
+        GatewayRunner._apply_contextual_cron_transcript_with_recovery_fence(
+            runner, item
+        )
+    )
+    await asyncio.sleep(0.03)
+    assert apply_started.is_set() is False
+
+    await adapter.release_contextual_cron_guard(
+        "telegram:dm:42:42", human_guard
+    )
+    await asyncio.wait_for(recovery, timeout=1)
+    assert apply_started.is_set() is True
+    assert adapter.lock.locked() is False
+
+
+@pytest.mark.asyncio
+async def test_contextual_transcript_recovery_revalidates_route_inside_both_fences():
+    from gateway.contextual_cron import ContextualCronTranscriptConflict
+    from gateway.turn_lease import SessionTurnLeaseRegistry
+
+    store = _LiveStore(_entry(), [])
+
+    class RouteChangingAdapter:
+        async def acquire_contextual_cron_guard(self, _session_key):
+            store.entry = replace(
+                store.entry,
+                session_id="replacement-session",
+                routing_revision=1,
+            )
+            return object()
+
+        async def release_contextual_cron_guard(self, _session_key, _guard):
+            return None
+
+    runner = cast(Any, object.__new__(GatewayRunner))
+    runner.session_store = store
+    runner._turn_leases = SessionTurnLeaseRegistry()
+    runner._adapter_for_source = lambda _source: RouteChangingAdapter()
+    applied = []
+
+    async def apply(item):
+        applied.append(item)
+
+    runner._apply_contextual_cron_transcript = apply
+    item = SimpleNamespace(
+        execution_id="recover-route-race",
+        session_key="telegram:dm:42:42",
+        admitted_session_id="session-1",
+        admitted_routing_revision=0,
+    )
+
+    with pytest.raises(ContextualCronTranscriptConflict, match="route changed"):
+        await GatewayRunner._apply_contextual_cron_transcript_with_recovery_fence(
+            runner, item
+        )
+
+    assert applied == []
+
+
+@pytest.mark.asyncio
+async def test_contextual_transcript_recovery_terminalizes_a_causal_conflict(
+    monkeypatch,
+):
+    from gateway.contextual_cron import ContextualCronTranscriptConflict
+
+    record = {
+        "id": "recover-conflict",
+        "job_id": "job-1",
+        "session_key": "telegram:dm:42:42",
+        "admitted_session_id": "session-1",
+        "admitted_routing_revision": 0,
+        "transcript_session_id": "session-1",
+        "transcript_json": '[{"role":"assistant","content":"scheduled",'
+        '"message_id":"contextual-cron:recover-conflict:0"}]',
+        "transcript_base_message_count": 0,
+        "transcript_base_revision": 0,
+    }
+    monkeypatch.setattr(
+        "cron.executions.list_pending_contextual_transcripts", lambda: [record]
+    )
+    marked = []
+    monkeypatch.setattr(
+        "cron.executions.mark_contextual_transcript_conflict",
+        lambda execution_id, *, error: marked.append((execution_id, error)) or True,
+    )
+    runner = object.__new__(GatewayRunner)
+
+    async def apply_with_fence(item):
+        del item
+        raise ContextualCronTranscriptConflict(
+            "Contextual transcript advanced before recovery."
+        )
+
+    runner._apply_contextual_cron_transcript_with_recovery_fence = apply_with_fence
+
+    recovered = await GatewayRunner._recover_contextual_cron_transcripts(runner)
+
+    assert recovered == 0
+    assert marked == [
+        ("recover-conflict", "Contextual transcript advanced before recovery.")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_contextual_queue_is_fifo_and_waits_behind_active_user_turn():
+    import asyncio
+
+    runner = _QueueRunner(_LiveStore(_entry(), []))
+    runner.busy = True
+    gateway = _queue_gateway(runner, [])
+    job = {
+        "id": "job",
+        "prompt": "continue",
+        "session_target": "current",
+        "session_key": "telegram:dm:42:42",
+    }
+    first = asyncio.create_task(gateway.dispatch(job, execution_id="first"))
+    second = asyncio.create_task(gateway.dispatch(job, execution_id="second"))
+    await asyncio.sleep(0.01)
+    assert runner.started == []
+
+    runner.busy = False
+    await asyncio.sleep(0.01)
+    assert runner.started == ["first"]
+    runner.release_first.set()
+
+    assert (await first).final_response == "first"
+    assert (await second).final_response == "second"
+    assert runner.started == ["first", "second"]
+
+
+@pytest.mark.asyncio
+async def test_contextual_lane_waits_on_resolved_session_turn_lease():
+    import asyncio
+
+    from gateway.turn_lease import SessionTurnLeaseRegistry
+
+    runner = _QueueRunner(_LiveStore(_entry(), []))
+    turn_leases = SessionTurnLeaseRegistry()
+    cast(Any, runner)._turn_leases = turn_leases
+    held = await turn_leases.acquire(
+        "session-1", owner_key="human-turn", generation=1
+    )
+    gateway = ContextualCronGateway(
+        runner,
+        seal_admission=lambda *_: True,
+        finish_admission=lambda *_: None,
+    )
+    job = {
+        "id": "job",
+        "prompt": "continue",
+        "session_target": "current",
+        "session_key": "telegram:dm:42:42",
+    }
+
+    task = asyncio.create_task(gateway.dispatch(job, execution_id="exec-lease"))
+    await asyncio.sleep(0.03)
+    assert runner.started == []
+
+    turn_leases.release(held)
+    result = await asyncio.wait_for(task, timeout=1)
+    assert result.kind == "notify"
+    assert runner.started == ["exec-lease"]
+
+
+@pytest.mark.asyncio
+async def test_contextual_lane_holds_turn_lease_until_outbox_is_applied():
+    import asyncio
+
+    from gateway.turn_lease import SessionTurnLeaseRegistry
+
+    class Runner(_QueueRunner):
+        def __init__(self, store):
+            super().__init__(store)
+            self._turn_leases = SessionTurnLeaseRegistry()
+            self.apply_started = asyncio.Event()
+            self.allow_apply = asyncio.Event()
+
+        async def _run_contextual_cron_turn(self, item, entry, history):
+            item.transcript_session_id = entry.session_id
+            item.transcript_entries = [
+                {
+                    "role": "assistant",
+                    "content": "done",
+                    "display_kind": "normal",
+                    "message_id": f"contextual-cron:{item.execution_id}:0",
+                }
+            ]
+            return ContextualCronOutcome.notify("done")
+
+        async def _apply_contextual_cron_transcript(self, _item):
+            self.apply_started.set()
+            await self.allow_apply.wait()
+
+    runner = Runner(_LiveStore(_entry(), []))
+    gateway = ContextualCronGateway(
+        runner,
+        seal_admission=lambda *_: True,
+        finish_admission=lambda *_: {"transcript_state": "pending"},
+    )
+    dispatch = asyncio.create_task(
+        gateway.dispatch(
+            {
+                "id": "job",
+                "prompt": "continue",
+                "session_target": "current",
+                "session_key": "telegram:dm:42:42",
+            },
+            execution_id="lease-through-outbox",
+        )
+    )
+    await asyncio.wait_for(runner.apply_started.wait(), timeout=1)
+
+    human = asyncio.create_task(
+        runner._turn_leases.acquire(
+            "session-1", owner_key="human-after-cron", generation=1
+        )
+    )
+    await asyncio.sleep(0.02)
+    assert human.done() is False
+    assert dispatch.done() is False
+
+    runner.allow_apply.set()
+    assert (await asyncio.wait_for(dispatch, timeout=1)).kind == "notify"
+    human_token = await asyncio.wait_for(human, timeout=1)
+    runner._turn_leases.release(human_token)
+
+
+@pytest.mark.asyncio
+async def test_contextual_drainer_cancellation_resolves_all_pending_unknown():
+    import asyncio
+
+    runner = _QueueRunner(_LiveStore(_entry(), []))
+    gateway = _queue_gateway(runner, [])
+    job = {
+        "id": "job",
+        "prompt": "continue",
+        "session_target": "current",
+        "session_key": "telegram:dm:42:42",
+    }
+    first = asyncio.create_task(gateway.dispatch(job, execution_id="first"))
+    second = asyncio.create_task(gateway.dispatch(job, execution_id="second"))
+    for _ in range(20):
+        if runner.started:
+            break
+        await asyncio.sleep(0.005)
+    assert runner.started == ["first"]
+
+    gateway._drainers["telegram:dm:42:42"].cancel()
+    first_outcome, second_outcome = await asyncio.wait_for(
+        asyncio.gather(first, second), timeout=1
+    )
+    assert first_outcome.kind == "unknown"
+    assert second_outcome.kind == "unknown"
+    assert runner.started == ["first"]
+
+
+@pytest.mark.asyncio
+async def test_reset_before_admission_is_stale_against_definition_binding():
+    store = _LiveStore(_entry("replacement-session"), [])
+    runner = _QueueRunner(store)
+    sealed = []
+    gateway = ContextualCronGateway(
+        runner,
+        seal_admission=lambda *args: sealed.append(args) or True,
+        finish_admission=lambda *_: None,
+    )
+
+    outcome = await gateway.dispatch(
+        {
+            "id": "job",
+            "prompt": "continue",
+            "session_target": "current",
+            "session_key": "telegram:dm:42:42",
+            "context_binding": {
+                "session_key": "telegram:dm:42:42",
+                "session_id": "captured-session",
+                "routing_revision": 0,
+            },
+        },
+        execution_id="reset-before-admission",
+    )
+
+    assert outcome.kind == "stale"
+    assert sealed == []
+    assert runner.started == []
+
+
+@pytest.mark.asyncio
+async def test_reset_after_admission_is_stale():
+    store = _LiveStore(_entry("new-before-admission"), [])
+    runner = _QueueRunner(store)
+    sealed = []
+
+    def seal(execution_id, key, session_id):
+        sealed.append((execution_id, key, session_id))
+        store.entry = _entry("reset-after-admission")
+        return True
+
+    gateway = ContextualCronGateway(
+        runner,
+        seal_admission=seal,
+        finish_admission=lambda *_: None,
+        busy_poll_seconds=0.001,
+    )
+    outcome = await gateway.dispatch(
+        {
+            "id": "job",
+            "prompt": "continue",
+            "session_target": "current",
+            "session_key": "telegram:dm:42:42",
+            "context_binding": {
+                "session_key": "telegram:dm:42:42",
+                "session_id": "new-before-admission",
+                "routing_revision": 0,
+            },
+        },
+        execution_id="reset-boundary",
+    )
+
+    assert sealed[0][2] == "new-before-admission"
+    assert outcome.kind == "stale"
+    assert runner.started == []
+
+
+@pytest.mark.asyncio
+async def test_missing_or_revoked_session_is_rejected_without_fallback():
+    missing_store = _LiveStore(_entry(), [])
+    missing_store.entry = None
+    missing_runner = _QueueRunner(missing_store)
+    missing = await _queue_gateway(missing_runner, []).dispatch(
+        {
+            "id": "job",
+            "prompt": "continue",
+            "session_target": "current",
+            "session_key": "telegram:dm:42:42",
+        },
+        execution_id="missing",
+    )
+    assert missing.kind == "rejected"
+    assert missing_runner.started == []
+
+    store = _LiveStore(_entry(), [])
+    revoked_runner = _QueueRunner(store)
+    revoked_runner.busy = True
+    gateway = _queue_gateway(revoked_runner, [])
+    task = __import__("asyncio").create_task(
+        gateway.dispatch(
+            {
+                "id": "job",
+                "prompt": "continue",
+                "session_target": "current",
+                "session_key": "telegram:dm:42:42",
+            },
+            execution_id="revoked",
+        )
+    )
+    await __import__("asyncio").sleep(0.01)
+    revoked_runner.authorized = False
+    revoked_runner.busy = False
+    revoked = await task
+    assert revoked.kind == "rejected"
+    assert revoked_runner.started == []
+
+
+def test_contextual_no_action_hides_every_generated_tool_row(tmp_path):
+    from gateway.run import _apply_contextual_transcript_visibility
+    from hermes_state import SessionDB
+
+    canary = "CONTEXTUAL-NO-ACTION-TOOL-CANARY"
+    generated = [
+        {"role": "user", "content": "internal scheduled prompt"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-secret",
+                    "function": {
+                        "name": "terminal",
+                        "arguments": '{"command":"' + canary + '"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-secret",
+            "content": canary,
+        },
+        {"role": "assistant", "content": "[SILENT]"},
+    ]
+    staged = [
+        _apply_contextual_transcript_visibility(
+            dict(message),
+            contextual=True,
+            intentional_silence=True,
+        )
+        for message in generated
+    ]
+    assert all(message.get("display_kind") == "hidden" for message in staged)
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("contextual-no-action", source="test", model="test/model")
+    db.append_messages_batch("contextual-no-action", staged)
+    try:
+        assert db.get_messages("contextual-no-action") == []
+        privileged = db.get_messages(
+            "contextual-no-action",
+            include_hidden=True,
+        )
+    finally:
+        db.close()
+    assert canary in repr(privileged)
+
+    notifying_tool = _apply_contextual_transcript_visibility(
+        {"role": "tool", "content": "public tool result"},
+        contextual=True,
+        intentional_silence=False,
+    )
+    assert "display_kind" not in notifying_tool
+
+
+@pytest.mark.asyncio
+async def test_runner_internal_turn_is_hidden_and_intentional_silence_is_no_action(
+    monkeypatch,
+):
+    from unittest.mock import AsyncMock
+
+    from gateway.run import GatewayRunner
+    from gateway.contextual_cron import ContextualCronQueueItem
+
+    runner = object.__new__(GatewayRunner)
+    runner._adapter_for_source = lambda _source: None
+    hook_calls = []
+    monkeypatch.setattr(
+        "hermes_cli.plugins.invoke_hook",
+        lambda *args, **kwargs: hook_calls.append((args, kwargs)),
+    )
+
+    async def handle(event, source, session_key, generation):
+        from gateway.session_context import _get_contextual_turn_authority
+        from hermes_cli.lifecycle import has_hook, invoke_hook
+
+        assert event.internal is True
+        assert event.metadata["contextual_cron"] is True
+        assert event.metadata["contextual_cron_admitted_session_id"] == "session-1"
+        assert event.metadata["contextual_cron_admitted_routing_revision"] == 3
+        authority = _get_contextual_turn_authority()
+        assert authority.execution_id == "execution"
+        assert authority.admitted_session_id == "session-1"
+        assert has_hook("agent:start") is False
+        assert invoke_hook("agent:start") == []
+        event.metadata["contextual_cron_result"] = {
+            "completed": True,
+            "intentional_silence": True,
+            "error": None,
+        }
+        event.metadata["contextual_cron_transcript_session_id"] = "session-1"
+        event.metadata["contextual_cron_transcript_entries"] = [
+            {
+                "role": "user",
+                "content": "hidden",
+                "display_kind": "hidden",
+                "message_id": "contextual-cron:execution:0",
+            }
+        ]
+        event.metadata["contextual_cron_last_prompt_tokens"] = 17
+        return ""
+
+    state = SimpleNamespace(turn=SimpleNamespace(lease=None, agent=None, started_ts=0))
+    runner._handle_message_with_agent = handle
+    runner._claim_active_session_slot = lambda _key, _source: (None, None)
+    runner._session_state = lambda _key: state
+    runner._persist_active_agents = lambda: None
+    runner._begin_session_run_generation = lambda _key: 1
+    runner._restore_moa_one_shot = lambda *_args: None
+    restored_one_turn = []
+    runner._restore_pending_one_turn_model_override = (
+        lambda *args: restored_one_turn.append(args)
+    )
+    runner._release_running_agent_state = lambda *_args, **_kwargs: True
+    runner._release_turn_lease = lambda *_args, **_kwargs: True
+    loop = __import__("asyncio").get_running_loop()
+    item = ContextualCronQueueItem(
+        job_id="job",
+        execution_id="execution",
+        prompt="check quietly",
+        session_key="telegram:dm:42:42",
+        admitted_session_id="session-1",
+        admitted_routing_revision=3,
+        source=_entry().origin,
+        future=loop.create_future(),
+    )
+    cast(Any, runner)._detach_preheld_turn_lease = lambda *_args: True
+    registry, token = await _hold_contextual_turn_lease(runner, item)
+    try:
+        outcome = await GatewayRunner._run_contextual_cron_turn(
+            runner,
+            item,
+            _entry(),
+            [],
+        )
+    finally:
+        assert registry.release(token) is True
+    assert outcome.kind == "no_action"
+    assert item.transcript_session_id == "session-1"
+    assert item.transcript_entries is not None
+    assert item.transcript_entries[0]["message_id"] == "contextual-cron:execution:0"
+    assert item.last_prompt_tokens == 17
+    assert restored_one_turn == []
+    assert hook_calls == []
+
+
+@pytest.mark.asyncio
+async def test_contextual_turn_fails_closed_without_explicit_completion_metadata():
+    from gateway.contextual_cron import ContextualCronQueueItem
+
+    runner = object.__new__(GatewayRunner)
+    runner._adapter_for_source = lambda _source: None
+
+    async def incomplete_handler(*_args):
+        return "provider error rendered as text"
+
+    state = SimpleNamespace(turn=SimpleNamespace(lease=None, agent=None, started_ts=0))
+    runner._handle_message_with_agent = incomplete_handler
+    runner._claim_active_session_slot = lambda _key, _source: (None, None)
+    runner._session_state = lambda _key: state
+    runner._persist_active_agents = lambda: None
+    runner._begin_session_run_generation = lambda _key: 1
+    runner._restore_moa_one_shot = lambda *_args: None
+    runner._release_running_agent_state = lambda *_args, **_kwargs: True
+    runner._release_turn_lease = lambda *_args, **_kwargs: True
+    runner._detach_preheld_turn_lease = lambda *_args, **_kwargs: True
+    runner_any = cast(Any, runner)
+    runner_any._turn_leases = SimpleNamespace(
+        is_current_holder=lambda *_args, **_kwargs: True
+    )
+    turn_lease_token = object()
+    loop = __import__("asyncio").get_running_loop()
+
+    outcome = await GatewayRunner._run_contextual_cron_turn(
+        runner,
+        ContextualCronQueueItem(
+            job_id="job",
+            execution_id="incomplete",
+            prompt="check",
+            session_key="telegram:dm:42:42",
+            admitted_session_id="session-1",
+            admitted_routing_revision=0,
+            source=_entry().origin,
+            future=loop.create_future(),
+            turn_lease_token=turn_lease_token,
+        ),
+        _entry(),
+        [],
+    )
+
+    assert outcome.kind == "failure"
+    assert "failed closed" in str(outcome.error)
+
+
+def test_internal_session_metadata_update_does_not_touch_human_activity_clock():
+    import threading
+
+    from gateway.session import SessionStore
+
+    entry = _entry()
+    original = entry.updated_at
+    store = object.__new__(SessionStore)
+    store._lock = threading.Lock()
+    store._loaded = True
+    store._entries = {entry.session_key: entry}
+    store._save_entry = lambda session_key: None
+    store._record_gateway_session_peer = lambda *_args, **_kwargs: None
+
+    store.update_session(
+        entry.session_key,
+        last_prompt_tokens=123,
+        touch_activity=False,
+    )
+
+    assert entry.updated_at == original
+    assert entry.last_prompt_tokens == 123
+
+
+@pytest.mark.asyncio
+async def test_duplicate_after_future_eviction_replays_scheduler_terminal_result(
+    monkeypatch, tmp_path
+):
+    """The gateway admits/runs; the scheduler alone persists and can replay."""
+    import cron.executions as executions
+
+    monkeypatch.setattr(
+        executions, "EXECUTIONS_FILE", tmp_path / "cron" / "executions.db"
+    )
+    record = executions.create_execution("job", source="builtin")
+    executions.mark_execution_running(record["id"])
+
+    runner = _QueueRunner(_LiveStore(_entry(), []))
+    gateway = ContextualCronGateway(runner)
+    job = {
+        "id": "job",
+        "prompt": "continue",
+        "session_target": "current",
+        "session_key": "telegram:dm:42:42",
+    }
+
+    first = await gateway.dispatch(job, execution_id=record["id"])
+    assert first == ContextualCronOutcome.notify(record["id"])
+    # Gateway queue/future eviction does not race the scheduler's delivery-aware
+    # terminal write with a second, less-informed terminal update.
+    persisted = executions.get_execution(record["id"])
+    assert persisted is not None
+    assert persisted["status"] == "running"
+
+    finished = executions.finish_contextual_execution(
+        record["id"],
+        outcome=first.kind,
+        final_response=first.final_response,
+    )
+    assert finished is not None
+
+    duplicate = await gateway.dispatch(job, execution_id=record["id"])
+    assert duplicate == first
+    assert runner.started == [record["id"]]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_duplicate_dispatch_has_one_admission_and_one_execution():
+    import asyncio
+    import threading
+
+    store = _LiveStore(_entry(), [])
+    seal_started = threading.Event()
+    allow_seal = threading.Event()
+    seals = []
+
+    def seal_contextual_admission(session_key, execution_id, seal):
+        seals.append(execution_id)
+        seal_started.set()
+        assert allow_seal.wait(1)
+        assert seal(execution_id, session_key, store.entry.session_id, 0)
+        return store.entry
+
+    cast(Any, store).seal_contextual_admission = seal_contextual_admission
+    runner = _QueueRunner(store)
+    gateway = ContextualCronGateway(
+        runner,
+        seal_admission=lambda *_args: True,
+    )
+    job = {
+        "id": "job",
+        "prompt": "continue",
+        "session_target": "current",
+        "session_key": store.entry.session_key,
+    }
+
+    first = asyncio.create_task(gateway.dispatch(job, execution_id="duplicate"))
+    assert await asyncio.to_thread(seal_started.wait, 1)
+    second = asyncio.create_task(gateway.dispatch(job, execution_id="duplicate"))
+    await asyncio.sleep(0)
+    allow_seal.set()
+    outcomes = await asyncio.gather(first, second)
+
+    assert outcomes == [
+        ContextualCronOutcome.notify("duplicate"),
+        ContextualCronOutcome.notify("duplicate"),
+    ]
+    assert seals == ["duplicate"]
+    assert runner.started == ["duplicate"]
+
+
+@pytest.mark.asyncio
+async def test_live_contextual_turn_bypasses_normal_incoming_handler():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    calls = []
+
+    async def forbidden_incoming_handler(_event):
+        raise AssertionError("contextual cron entered the normal incoming handler")
+
+    async def live_agent_handler(event, source, session_key, generation):
+        calls.append((event, source, session_key, generation))
+        event.metadata["contextual_cron_result"] = {"completed": True}
+        return "scheduled result"
+
+    runner._handle_message = forbidden_incoming_handler
+    runner._handle_message_with_agent = live_agent_handler
+    runner._adapter_for_source = lambda _source: None
+    state = SimpleNamespace(turn=SimpleNamespace(lease=None, agent=None, started_ts=0))
+    runner._claim_active_session_slot = lambda _key, _source: (None, None)
+    runner._session_state = lambda _key: state
+    runner._persist_active_agents = lambda: None
+    runner._begin_session_run_generation = lambda _key: 9
+    runner._restore_moa_one_shot = lambda *_args: None
+    runner._restore_pending_one_turn_model_override = lambda *_args: None
+    runner._release_running_agent_state = lambda *_args, **_kwargs: True
+    runner._release_turn_lease = lambda *_args, **_kwargs: True
+
+    item = SimpleNamespace(
+        prompt="continue",
+        execution_id="exec-live",
+        session_key="telegram:dm:42:42",
+        admitted_session_id="session-1",
+        admitted_routing_revision=7,
+    )
+    entry = _entry()
+    cast(Any, runner)._detach_preheld_turn_lease = lambda *_args: True
+    registry, token = await _hold_contextual_turn_lease(runner, item)
+
+    try:
+        outcome = await GatewayRunner._run_contextual_cron_turn(
+            runner, item, entry, [{"role": "user", "content": "prior"}]
+        )
+    finally:
+        assert registry.release(token) is True
+
+    assert outcome == ContextualCronOutcome.notify("scheduled result")
+    assert len(calls) == 1
+    event, source, session_key, generation = calls[0]
+    assert source is entry.origin
+    assert session_key == entry.session_key
+    assert generation == 9
+    assert event.internal is True
+    assert event.metadata["contextual_cron_lease_preheld"] is True
+    assert event.metadata["contextual_cron_admitted_routing_revision"] == 7
+
+
+@pytest.mark.asyncio
+async def test_live_contextual_turn_rejects_forged_lease_before_state_publication():
+    from gateway.turn_lease import SessionTurnLeaseRegistry
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner_any = cast(Any, runner)
+    registry = SessionTurnLeaseRegistry()
+    genuine = await registry.acquire(
+        "session-1",
+        owner_key="contextual-cron:exec-forged",
+        generation=0,
+        timeout=1,
+    )
+    assert genuine is not None
+    runner_any._get_proxy_url = lambda: None
+    runner_any._turn_leases = registry
+    runner_any._claim_active_session_slot = pytest.fail
+    runner_any._handle_message_with_agent = pytest.fail
+    item = SimpleNamespace(
+        prompt="continue",
+        execution_id="exec-forged",
+        session_key="telegram:dm:42:42",
+        admitted_session_id="session-1",
+        admitted_routing_revision=7,
+        turn_lease_token=object(),
+    )
+    try:
+        outcome = await GatewayRunner._run_contextual_cron_turn(
+            runner,
+            item,
+            _entry(),
+            [{"role": "user", "content": "prior"}],
+        )
+    finally:
+        assert registry.release(genuine) is True
+
+    assert outcome.kind == "rejected"
+
+
+@pytest.mark.asyncio
+async def test_live_contextual_turn_does_not_release_lane_owned_turn_lease():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner_any = cast(Any, runner)
+
+    async def live_agent_handler(event, _source, _session_key, _generation):
+        event.metadata["contextual_cron_result"] = {"completed": True}
+        return "scheduled result"
+
+    state = SimpleNamespace(
+        turn=SimpleNamespace(
+            lease=None,
+            agent=None,
+            started_ts=0,
+            lease_token=None,
+            lease_generation=None,
+        )
+    )
+    runner_any._get_proxy_url = lambda: None
+    runner_any._handle_message_with_agent = live_agent_handler
+    runner_any._adapter_for_source = lambda _source: None
+    runner_any._claim_active_session_slot = lambda _key, _source: (None, None)
+    runner_any._session_state = lambda _key: state
+    runner_any._peek_session_state = lambda _key: state
+    runner_any._persist_active_agents = lambda: None
+    runner_any._begin_session_run_generation = lambda _key: 9
+    runner_any._restore_moa_one_shot = lambda *_args: None
+    runner_any._release_running_agent_state = lambda *_args, **_kwargs: True
+
+    item = SimpleNamespace(
+        prompt="continue",
+        execution_id="exec-live-lease",
+        session_key="telegram:dm:42:42",
+        admitted_session_id="session-1",
+        admitted_routing_revision=7,
+    )
+    registry, token = await _hold_contextual_turn_lease(runner, item)
+    try:
+        outcome = await GatewayRunner._run_contextual_cron_turn(
+            runner, item, _entry(), [{"role": "user", "content": "prior"}]
+        )
+        assert registry.is_current_holder(
+            token,
+            session_id="session-1",
+            owner_key="contextual-cron:exec-live-lease",
+            generation=0,
+        )
+    finally:
+        assert registry.release(token) is True
+
+    assert outcome == ContextualCronOutcome.notify("scheduled result")
+    assert state.turn.lease_token is None
+    assert state.turn.lease_generation is None
+
+
+def test_contextual_user_delta_prepends_missing_prompt_source():
+    from gateway.run import _ensure_contextual_user_delta
+
+    assistant_only = [{"role": "assistant", "content": "done"}]
+    result = _ensure_contextual_user_delta(
+        assistant_only, content="scheduled prompt", timestamp="then"
+    )
+
+    assert result == [
+        {"role": "user", "content": "scheduled prompt", "timestamp": "then"},
+        {"role": "assistant", "content": "done"},
+    ]
+    assert _ensure_contextual_user_delta(
+        result, content="duplicate", timestamp="later"
+    ) is result
+
+
+@pytest.mark.asyncio
+async def test_contextual_turn_logs_redact_hidden_prompt_and_route_identity(caplog):
+    from gateway.platforms.base import MessageEvent
+    from gateway.run import GatewayRunner
+    from gateway.session_context import _bind_contextual_turn_authority
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner_any = cast(Any, runner)
+    entry = _entry("session-private-route")
+    assert entry.origin is not None
+
+    async def missing_entry(_session_key):
+        return None
+
+    store = SimpleNamespace()
+    runner_any.session_store = store
+    runner_any._async_session_store = SimpleNamespace(
+        _store=store,
+        peek_session_entry=missing_entry,
+    )
+    event = MessageEvent(
+        text="do-not-log-contextual-secret",
+        source=entry.origin,
+        internal=True,
+    )
+    caplog.set_level(logging.INFO, logger="gateway.run")
+
+    with _bind_contextual_turn_authority(
+        execution_id="exec-private-log",
+        session_key=entry.session_key,
+        admitted_session_id=entry.session_id,
+        admitted_routing_revision=0,
+    ):
+        result = await GatewayRunner._handle_message_with_agent(
+            runner, event, entry.origin, entry.session_key, 1
+        )
+
+    assert result is None
+    rendered = "\n".join(record.getMessage() for record in caplog.records)
+    assert "do-not-log-contextual-secret" not in rendered
+    assert entry.session_key not in rendered
+    assert entry.session_id not in rendered
+    assert "contextual cron" in rendered.lower()
+
+
+def test_agent_exception_path_uses_stage_aware_transcript_writer():
+    from gateway.run import GatewayRunner
+
+    source = inspect.getsource(GatewayRunner._handle_message_with_agent)
+    exception_path = source.split("except Exception as e:", maxsplit=1)[1]
+
+    assert "await self._write_or_stage_transcript_entry(" in exception_path
+    assert "await self.async_session_store.append_to_transcript(" not in exception_path
+    assert (
+        'if _is_contextual_cron:\n                logger.error("Contextual cron agent execution failed.")'
+        in exception_path
+    )
+
+
+@pytest.mark.asyncio
+async def test_adapter_guard_race_retries_without_terminally_dropping_occurrence():
+    from gateway.contextual_cron import ContextualCronGuardBusy
+
+    runner = _QueueRunner(_LiveStore(_entry(), []))
+    calls = 0
+
+    async def race_once(item, entry, history):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise ContextualCronGuardBusy()
+        return ContextualCronOutcome.notify("after-user-turn")
+
+    cast(Any, runner)._run_contextual_cron_turn = race_once
+    gateway = _queue_gateway(runner, [])
+
+    outcome = await gateway.dispatch(
+        {
+            "id": "job",
+            "prompt": "continue",
+            "session_target": "current",
+            "session_key": "telegram:dm:42:42",
+        },
+        execution_id="guard-race",
+    )
+
+    assert outcome == ContextualCronOutcome.notify("after-user-turn")
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_route_revision_detects_reset_resume_aba_after_admission():
+    import asyncio
+    from dataclasses import replace
+
+    store = _LiveStore(_entry(), [])
+    runner = _QueueRunner(store)
+    runner.busy = True
+    gateway = _queue_gateway(runner, [])
+    job = {
+        "id": "job",
+        "prompt": "continue",
+        "session_target": "current",
+        "session_key": "telegram:dm:42:42",
+    }
+
+    task = asyncio.create_task(gateway.dispatch(job, execution_id="aba"))
+    await asyncio.sleep(0.01)
+    # Simulate old→new→old. Concrete id alone matches again, but the route
+    # revision proves the admitted mapping changed in between.
+    store.entry = replace(store.entry, routing_revision=2)
+    runner.busy = False
+
+    outcome = await asyncio.wait_for(task, timeout=1)
+    assert outcome.kind == "stale"
+    assert runner.started == []
+
+
+def test_auto_reset_then_resume_keeps_route_revision_monotonic():
+    import threading
+
+    from gateway.session import SessionStore
+
+    source = _entry().origin
+    key = _entry().session_key
+    old = _entry()
+    old.routing_revision = 1
+    store = object.__new__(SessionStore)
+    store._lock = threading.Lock()
+    store._loaded = True
+    store._entries = {key: old}
+    store._db = None
+    store._save_entries = lambda: None
+    store._save = lambda: None
+    store._generate_session_key = lambda _source: key
+    store._compression_tip_for_session_id = lambda session_id: session_id
+    store._is_session_ended_in_db = lambda _session_id: False
+    store._should_reset = lambda _entry, _source: "idle"
+
+    reset = store._get_or_create_session_impl(source)
+    assert reset.session_id != old.session_id
+    assert reset.routing_revision == 2
+
+    resumed = store.switch_session(key, old.session_id)
+    assert resumed is not None
+    assert resumed.session_id == old.session_id
+    assert resumed.routing_revision == 3
+
+
+def test_admission_and_reset_share_one_routing_linearization_lock():
+    import threading
+    import time
+
+    from gateway.session import SessionStore
+
+    entry = _entry()
+    store = object.__new__(SessionStore)
+    store._lock = threading.Lock()
+    store._loaded = True
+    store._entries = {entry.session_key: entry}
+    store._save = lambda: None
+    store._db = None
+
+    seal_started = threading.Event()
+    allow_seal = threading.Event()
+    admitted = []
+    reset_result = []
+
+    def seal(execution_id, key, session_id, revision):
+        seal_started.set()
+        assert allow_seal.wait(1)
+        admitted.append((execution_id, key, session_id, revision))
+        return True
+
+    admit_thread = threading.Thread(
+        target=lambda: store.seal_contextual_admission(
+            entry.session_key, "exec", seal
+        )
+    )
+    admit_thread.start()
+    assert seal_started.wait(1)
+
+    reset_thread = threading.Thread(
+        target=lambda: reset_result.append(store.reset_session(entry.session_key))
+    )
+    reset_thread.start()
+    time.sleep(0.02)
+    assert reset_thread.is_alive(), "reset crossed the admission seal boundary"
+
+    allow_seal.set()
+    admit_thread.join(1)
+    reset_thread.join(1)
+
+    assert admitted == [("exec", entry.session_key, "session-1", 0)]
+    assert reset_result[0].session_id != "session-1"
+    assert reset_result[0].routing_revision == 1
+
+
+@pytest.mark.asyncio
+async def test_compression_route_refuses_to_publish_when_lease_rebind_is_blocked():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    token = object()
+    state = SimpleNamespace(
+        turn=SimpleNamespace(lease_token=token, lease_generation=7)
+    )
+    calls = []
+    setattr(runner, "_peek_session_state", lambda session_key: state)
+    setattr(runner, "_rebind_turn_lease", lambda *args: False)
+
+    async def route(*_args):
+        calls.append("route")
+        return object()
+
+    fake_store = object()
+    setattr(runner, "session_store", fake_store)
+    setattr(runner, "_async_session_store", SimpleNamespace(
+        _store=fake_store,
+        advance_compression_session=route,
+    ))
+
+    advanced = await runner._publish_gateway_compression_route(
+        "telegram:u:c",
+        "parent",
+        "child",
+        7,
+    )
+
+    assert advanced is None
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_compression_route_rolls_lease_back_when_backing_cas_loses():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    state = SimpleNamespace(
+        turn=SimpleNamespace(lease_token=object(), lease_generation=8)
+    )
+    rebinds = []
+    setattr(runner, "_peek_session_state", lambda session_key: state)
+    setattr(
+        runner,
+        "_rebind_turn_lease",
+        lambda session_key, run_generation, new_session_id: (
+            rebinds.append(new_session_id) or True
+        ),
+    )
+
+    async def lose_cas(*_args):
+        return None
+
+    fake_store = object()
+    setattr(runner, "session_store", fake_store)
+    setattr(runner, "_async_session_store", SimpleNamespace(
+        _store=fake_store,
+        advance_compression_session=lose_cas,
+    ))
+
+    advanced = await runner._publish_gateway_compression_route(
+        "telegram:u:c",
+        "parent",
+        "child",
+        8,
+    )
+
+    assert advanced is None
+    assert rebinds == ["child", "parent"]
+
+
+@pytest.mark.asyncio
+async def test_compression_route_rejects_success_after_turn_owner_is_invalidated():
+    from gateway.run import GatewayRunner
+    from gateway.turn_lease import SessionTurnLeaseRegistry
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    route = _entry()
+    state = SimpleNamespace(
+        turn=SimpleNamespace(lease_token=None, lease_generation=9)
+    )
+    registry = SessionTurnLeaseRegistry()
+    token = await registry.acquire(
+        route.session_id,
+        owner_key=route.session_key,
+        generation=9,
+    )
+    state.turn.lease_token = token
+    runner_any = cast(Any, runner)
+    runner_any._turn_leases = registry
+    runner_any._peek_session_state = lambda _key: state
+
+    class Store:
+        def __init__(self):
+            self.entry = route
+
+        def peek_session_entry(self, _key):
+            return self.entry
+
+    store = Store()
+
+    async def advance(*_args):
+        advanced = replace(route, session_id="child", routing_revision=1)
+        store.entry = advanced
+        state.turn = SimpleNamespace(lease_token=None, lease_generation=10)
+        registry.release(token)
+        return advanced
+
+    runner_any.session_store = store
+    runner_any._async_session_store = SimpleNamespace(
+        _store=store,
+        advance_compression_session=advance,
+    )
+
+    published = await runner._publish_gateway_compression_route(
+        route.session_key,
+        route.session_id,
+        "child",
+        9,
+    )
+
+    assert published is None
+
+
+def test_compression_route_cas_mutates_backing_entry_and_rolls_back_save_failure():
+    import threading
+    from datetime import datetime, timezone
+
+    from gateway.session import SessionEntry, SessionStore
+
+    store = SessionStore.__new__(SessionStore)
+    store._lock = threading.Lock()
+    store._loaded = True
+    store._db = None
+    store._routing_generation = 0
+    store._entries = {
+        "telegram:u:c": SessionEntry(
+            session_key="telegram:u:c",
+            session_id="parent",
+            created_at=datetime(2026, 7, 31, tzinfo=timezone.utc),
+            updated_at=datetime(2026, 7, 31, tzinfo=timezone.utc),
+        )
+    }
+    store._save = lambda: None
+
+    advanced = store.advance_compression_session(
+        "telegram:u:c",
+        "parent",
+        "child",
+    )
+    assert advanced is not None
+    assert advanced.session_id == "child"
+    assert store._entries["telegram:u:c"].session_id == "child"
+    assert store._entries["telegram:u:c"].routing_revision == 1
+
+    def fail_save():
+        raise OSError("disk full")
+
+    store._save = fail_save
+    with pytest.raises(OSError, match="disk full"):
+        store.advance_compression_session(
+            "telegram:u:c",
+            "child",
+            "grandchild",
+        )
+    assert store._entries["telegram:u:c"].session_id == "child"
+    assert store._entries["telegram:u:c"].routing_revision == 1
+def test_served_contextual_cron_profile_homes_are_deduplicated(
+    monkeypatch, tmp_path
+):
+    import hermes_constants
+    import hermes_cli.profiles as profiles
+
+    primary = tmp_path / "primary"
+    secondary = tmp_path / "secondary"
+    primary.mkdir()
+    secondary.mkdir()
+    runner = cast(Any, object.__new__(GatewayRunner))
+    runner.config = SimpleNamespace(multiplex_profiles=True)
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: primary)
+    monkeypatch.setattr(
+        profiles,
+        "profiles_to_serve",
+        lambda **_kwargs: [
+            ("primary", primary),
+            ("secondary", secondary),
+            ("secondary-copy", secondary),
+        ],
+    )
+
+    assert runner._served_contextual_cron_profile_homes() == [
+        str(primary.resolve()),
+        str(secondary.resolve()),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_contextual_startup_recovery_fences_resume_until_all_profiles_succeed(
+    tmp_path,
+):
+    primary = str((tmp_path / "primary").resolve())
+    secondary = str((tmp_path / "secondary").resolve())
+    events: list[str] = []
+    failing = {secondary}
+    runner = cast(Any, object.__new__(GatewayRunner))
+    runner._served_contextual_cron_profile_homes = lambda: [primary, secondary]
+
+    async def recover(*, cron_home):
+        events.append(f"recover:{cron_home}")
+        if cron_home in failing:
+            raise RuntimeError("secondary unavailable")
+        return 1
+
+    async def redeliver():
+        events.append("redeliver")
+
+    def resume():
+        events.append("resume")
+
+    async def finish_restore():
+        events.append("release")
+
+    runner._recover_contextual_cron_transcripts = recover
+    runner._redeliver_pending_obligations = redeliver
+    runner._schedule_resume_pending_sessions = resume
+    runner._finish_startup_restore = finish_restore
+
+    assert not await runner._release_startup_restore_after_contextual_recovery()
+    assert events == [f"recover:{primary}", f"recover:{secondary}"]
+
+    failing.clear()
+    assert await runner._release_startup_restore_after_contextual_recovery()
+    assert events == [
+        f"recover:{primary}",
+        f"recover:{secondary}",
+        f"recover:{primary}",
+        f"recover:{secondary}",
+        "redeliver",
+        "resume",
+        "release",
+    ]

--- a/tests/gateway/test_contextual_cron.py
+++ b/tests/gateway/test_contextual_cron.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from dataclasses import replace
 import inspect
 import logging
+import threading
 from types import SimpleNamespace
 from typing import Any, cast
 
@@ -13,8 +14,84 @@ from gateway.contextual_cron import (
     ContextualCronGateway,
     ContextualCronOutcome,
 )
-from gateway.session import Platform, SessionEntry, SessionSource
+from gateway.session import Platform, SessionEntry, SessionSource, SessionStore
 from gateway.run import GatewayRunner, TurnRunner
+
+
+def test_delivery_authorizer_rejects_a_deleted_sealed_route():
+    runner = object.__new__(GatewayRunner)
+    cast(Any, runner).session_store = SimpleNamespace(
+        peek_session_entry=lambda _key: None
+    )
+    cast(Any, runner)._is_user_authorized = lambda source: True
+
+    assert runner._authorize_contextual_delivery_from_scheduler(
+        {
+            "origin": {
+                "platform": "telegram",
+                "chat_type": "dm",
+                "chat_id": "42",
+                "user_id": "42",
+            },
+            "_contextual_authority": {
+                "execution_id": "execution",
+                "session_key": "telegram:dm:42",
+                "binding_version": 2,
+                "route_instance_id": "route-instance-a",
+                "session_id": "session-a",
+                "routing_revision": 7,
+            },
+        }
+    ) is False
+
+
+def test_delivery_authority_claim_is_linearized_with_the_route():
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        chat_id="42",
+        user_id="42",
+    )
+    now = datetime.now(timezone.utc)
+    entry = SessionEntry(
+        session_key="telegram:dm:42",
+        session_id="session-a",
+        route_instance_id="route-instance-a",
+        routing_revision=7,
+        created_at=now,
+        updated_at=now,
+        origin=source,
+    )
+    store = object.__new__(SessionStore)
+    cast(Any, store)._lock = threading.RLock()
+    cast(Any, store)._entries = {entry.session_key: entry}
+    cast(Any, store)._ensure_loaded_locked = lambda: None
+    events = []
+
+    assert store.claim_contextual_delivery_authority(
+        entry.session_key,
+        source=source,
+        binding_version=2,
+        expected_route_instance_id=entry.route_instance_id,
+        expected_session_id=entry.session_id,
+        expected_routing_revision=entry.routing_revision,
+        authorize=lambda: events.append("authorized") or True,
+        claim=lambda: events.append("claimed") or True,
+    ) == (True, True)
+    assert events == ["authorized", "claimed"]
+
+    events.clear()
+    assert store.claim_contextual_delivery_authority(
+        entry.session_key,
+        source=source,
+        binding_version=2,
+        expected_route_instance_id="recreated-route",
+        expected_session_id=entry.session_id,
+        expected_routing_revision=entry.routing_revision,
+        authorize=lambda: events.append("authorized") or True,
+        claim=lambda: events.append("claimed") or True,
+    ) == (False, False)
+    assert events == []
 
 
 class _LiveStore:

--- a/tests/gateway/test_contextual_cron.py
+++ b/tests/gateway/test_contextual_cron.py
@@ -45,6 +45,34 @@ def test_delivery_authorizer_rejects_a_deleted_sealed_route():
     ) is False
 
 
+def test_delivery_authorizer_marks_a_lost_locked_claim_as_attempted():
+    runner = object.__new__(GatewayRunner)
+    cast(Any, runner).session_store = SimpleNamespace(
+        claim_contextual_delivery_authority=lambda *_a, **_k: (True, False)
+    )
+    cast(Any, runner)._is_user_authorized = lambda source: True
+    target = {
+        "origin": {
+            "platform": "telegram",
+            "chat_type": "dm",
+            "chat_id": "42",
+            "user_id": "42",
+        },
+        "_contextual_authority": {
+            "execution_id": "execution",
+            "session_key": "telegram:dm:42",
+            "binding_version": 2,
+            "route_instance_id": "route-instance-a",
+            "session_id": "session-a",
+            "routing_revision": 7,
+        },
+    }
+
+    assert runner._authorize_contextual_delivery_from_scheduler(target) is True
+    assert target["_contextual_delivery_claim_attempted"] is True
+    assert "_contextual_delivery_claimed" not in target
+
+
 def test_delivery_authority_claim_is_linearized_with_the_route():
     source = SessionSource(
         platform=Platform.TELEGRAM,

--- a/tests/gateway/test_contextual_cron_adapter_guard.py
+++ b/tests/gateway/test_contextual_cron_adapter_guard.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.contextual_cron import ContextualCronGateway, ContextualCronQueueItem
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType
+from gateway.session import SessionSource, build_session_key
+
+
+class _StubAdapter(BasePlatformAdapter):
+    async def connect(self, *, is_reconnect: bool = False):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return None
+
+    async def get_chat_info(self, chat_id):
+        return {}
+
+
+def _adapter() -> _StubAdapter:
+    return _StubAdapter(
+        PlatformConfig(enabled=True, token="test"),
+        Platform.TELEGRAM,
+    )
+
+
+def _event(text: str = "human follow-up") -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="42",
+            chat_type="dm",
+            user_id="42",
+        ),
+    )
+
+
+def _key() -> str:
+    return build_session_key(_event().source)
+
+
+@pytest.mark.asyncio
+async def test_contextual_guard_waits_on_adapter_guard_without_polling():
+    adapter = _adapter()
+    key = _key()
+    human_guard = asyncio.Event()
+    adapter._active_sessions[key] = human_guard
+    owner = asyncio.current_task()
+    assert owner is not None
+    adapter._session_tasks[key] = owner
+
+    waiter = asyncio.create_task(adapter.acquire_contextual_cron_guard(key))
+    await asyncio.sleep(0)
+    assert not waiter.done()
+
+    adapter._release_session_guard(key, guard=human_guard)
+    cron_guard = await asyncio.wait_for(waiter, timeout=1)
+
+    assert adapter._active_sessions[key] is cron_guard
+    await adapter.release_contextual_cron_guard(key, cron_guard)
+    assert key not in adapter._active_sessions
+
+
+@pytest.mark.asyncio
+async def test_contextual_release_flushes_debounce_and_hands_human_turn_first(monkeypatch):
+    adapter = _adapter()
+    key = _key()
+    cron_guard = await adapter.acquire_contextual_cron_guard(key)
+    adapter._busy_text_debounce_seconds = 60.0
+    adapter._busy_text_hard_cap_seconds = 60.0
+    await adapter._queue_text_debounce(key, _event())
+
+    handed_off: list[MessageEvent] = []
+
+    def start_human(event: MessageEvent, session_key: str, **_kwargs) -> bool:
+        assert session_key == key
+        handed_off.append(event)
+        adapter._active_sessions[key] = asyncio.Event()
+        return True
+
+    monkeypatch.setattr(adapter, "_start_session_processing", start_human)
+    await adapter.release_contextual_cron_guard(key, cron_guard)
+
+    assert [event.text for event in handed_off] == ["human follow-up"]
+    assert key in adapter._active_sessions
+    assert key not in adapter._pending_messages
+    assert key not in adapter._text_debounce
+
+
+def _queue_item() -> ContextualCronQueueItem:
+    loop = asyncio.get_running_loop()
+    return ContextualCronQueueItem(
+        job_id="job",
+        execution_id="execution",
+        prompt="check",
+        session_key=_key(),
+        admitted_session_id="session-1",
+        admitted_routing_revision=0,
+        source=_event().source,
+        future=loop.create_future(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_degraded_turn_lease_releases_contextual_adapter_guard():
+    adapter = _adapter()
+
+    class Leases:
+        async def acquire(self, *_args, **_kwargs):
+            return type("Token", (), {"degraded": True})()
+
+    runner = type(
+        "Runner",
+        (),
+        {
+            "_turn_leases": Leases(),
+            "_adapter_for_source": lambda self, _source: adapter,
+        },
+    )()
+    gateway = ContextualCronGateway(runner)
+    outcome = await gateway._run_queued_item(_queue_item())
+
+    assert outcome.kind == "retryable"
+    assert _key() not in adapter._active_sessions
+
+
+@pytest.mark.asyncio
+async def test_raising_turn_lease_releases_contextual_adapter_guard():
+    adapter = _adapter()
+
+    class Leases:
+        async def acquire(self, *_args, **_kwargs):
+            raise RuntimeError("lease failed")
+
+    runner = type(
+        "Runner",
+        (),
+        {
+            "_turn_leases": Leases(),
+            "_adapter_for_source": lambda self, _source: adapter,
+        },
+    )()
+    gateway = ContextualCronGateway(runner)
+
+    with pytest.raises(RuntimeError, match="lease failed"):
+        await gateway._run_queued_item(_queue_item())
+    assert _key() not in adapter._active_sessions
+
+
+@pytest.mark.asyncio
+async def test_cancelled_turn_lease_wait_releases_contextual_adapter_guard():
+    adapter = _adapter()
+    entered = asyncio.Event()
+
+    class Leases:
+        async def acquire(self, *_args, **_kwargs):
+            entered.set()
+            await asyncio.Event().wait()
+
+    runner = type(
+        "Runner",
+        (),
+        {
+            "_turn_leases": Leases(),
+            "_adapter_for_source": lambda self, _source: adapter,
+        },
+    )()
+    gateway = ContextualCronGateway(runner)
+    task = asyncio.create_task(gateway._run_queued_item(_queue_item()))
+    await entered.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert _key() not in adapter._active_sessions

--- a/tests/gateway/test_dedupe_user_turns.py
+++ b/tests/gateway/test_dedupe_user_turns.py
@@ -6,6 +6,8 @@ Telegram message must not stack duplicate user turns in the transcript.
 The dedupe guard checks has_platform_message_id before persisting.
 """
 
+import pytest
+
 from gateway.session import SessionStore
 from hermes_state import SessionDB
 
@@ -43,6 +45,51 @@ class TestHasPlatformMessageId:
         store._db = db
         assert store.has_platform_message_id("s1", "msg-456")
         assert not store.has_platform_message_id("s1", "msg-000")
+
+    def test_contextual_message_identity_is_durable_and_idempotent(self, tmp_path):
+        db = self._make_db(tmp_path)
+        identity = "contextual-cron:execution-1:0"
+
+        first = db.append_message(
+            session_id="s1",
+            role="user",
+            content="hidden task",
+            platform_message_id=identity,
+        )
+        second = db.append_message(
+            session_id="s1",
+            role="user",
+            content="hidden task",
+            platform_message_id=identity,
+        )
+
+        assert second == first
+        assert [row["platform_message_id"] for row in db.get_messages("s1")] == [
+            identity
+        ]
+        session = db.get_session("s1")
+        assert session is not None
+        assert session["message_count"] == 1
+
+    def test_contextual_direct_append_does_not_enter_generic_retry_queue(self):
+        class BrokenDB:
+            def append_message(self, **_kwargs):
+                raise OSError("sqlite busy")
+
+        store = SessionStore.__new__(SessionStore)
+        store._db = BrokenDB()
+
+        with pytest.raises(OSError, match="sqlite busy"):
+            store.append_contextual_transcript_message_once(
+                "s1",
+                {
+                    "role": "user",
+                    "content": "hidden task",
+                    "message_id": "contextual-cron:execution-1:0",
+                },
+            )
+
+        assert not getattr(store, "_dirty_transcripts", {})
 
 
 class TestDedupeOnTransientFailure:

--- a/tests/gateway/test_incomplete_gateway_turns.py
+++ b/tests/gateway/test_incomplete_gateway_turns.py
@@ -3,6 +3,7 @@
 import asyncio
 from datetime import datetime
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -141,7 +142,7 @@ async def test_incomplete_codex_turn_stays_out_of_slack_transcript(monkeypatch, 
     await adapter._process_message_background(event, build_session_key(event.source))
 
     assert adapter.sent == []
-    assert runner.session_store.update_session.called
+    assert cast(Any, runner.session_store.update_session).called
 
     transcript_roles = [
         call.args[1]["role"]

--- a/tests/gateway/test_routing_authority_lease.py
+++ b/tests/gateway/test_routing_authority_lease.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import multiprocessing
+import os
+from pathlib import Path
+import signal
+import time
+
+import pytest
+
+_START_METHODS = ["spawn"] + (
+    ["fork"] if "fork" in multiprocessing.get_all_start_methods() else []
+)
+
+
+def _passive_fork_owner(path: str, queue) -> None:
+    from gateway.session import _acquire_routing_authority_lease
+
+    _acquire_routing_authority_lease(Path(path))
+    child_pid = os.fork()
+    if child_pid == 0:
+        time.sleep(10)
+        os._exit(0)
+    queue.put(child_pid)
+    queue.close()
+    queue.join_thread()
+
+
+def _try_acquire(path: str, queue) -> None:
+    from gateway.session import _acquire_routing_authority_lease
+
+    try:
+        _acquire_routing_authority_lease(Path(path))
+    except RuntimeError:
+        queue.put("blocked")
+    else:
+        queue.put("acquired")
+
+
+@pytest.mark.parametrize("start_method", _START_METHODS)
+def test_routing_authority_lease_fails_closed_across_processes(
+    tmp_path, start_method
+):
+    from gateway.session import _acquire_routing_authority_lease
+
+    sessions_dir = tmp_path / "sessions"
+    _acquire_routing_authority_lease(sessions_dir)
+
+    context = multiprocessing.get_context(start_method)
+    queue = context.Queue()
+    process = context.Process(target=_try_acquire, args=(str(sessions_dir), queue))
+    process.start()
+    process.join(timeout=10)
+
+    assert process.exitcode == 0
+    assert queue.get(timeout=1) == "blocked"
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="POSIX fork only")
+def test_passive_fork_child_does_not_retain_routing_lease(tmp_path):
+    sessions_dir = tmp_path / "sessions"
+    context = multiprocessing.get_context("spawn")
+    owner_queue = context.Queue()
+    owner = context.Process(
+        target=_passive_fork_owner,
+        args=(str(sessions_dir), owner_queue),
+    )
+    owner.start()
+    passive_child_pid = owner_queue.get(timeout=10)
+    owner.join(timeout=10)
+    assert owner.exitcode == 0
+
+    contender_queue = context.Queue()
+    contender = context.Process(
+        target=_try_acquire,
+        args=(str(sessions_dir), contender_queue),
+    )
+    contender.start()
+    contender.join(timeout=10)
+    try:
+        assert contender.exitcode == 0
+        assert contender_queue.get(timeout=1) == "acquired"
+    finally:
+        try:
+            os.kill(passive_child_pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass

--- a/tests/gateway/test_routing_authority_lease.py
+++ b/tests/gateway/test_routing_authority_lease.py
@@ -17,7 +17,7 @@ def _passive_fork_owner(path: str, queue) -> None:
     from gateway.session import _acquire_routing_authority_lease
 
     _acquire_routing_authority_lease(Path(path))
-    child_pid = os.fork()
+    child_pid = os.fork()  # windows-footgun: ok - test is skip-gated on os.fork
     if child_pid == 0:
         time.sleep(10)
         os._exit(0)

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1042,6 +1042,12 @@ async def test_base_processing_stops_typing_before_hung_post_delivery_callback(
 ):
     """A stuck post-delivery callback must not keep the typing task alive."""
     monkeypatch.setattr(base_platform, "_POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS", 0.01)
+    # This test exercises typing/callback ordering, not the durable delivery
+    # ledger. Disable the unrelated sqlite/thread hop so parallel suite load
+    # cannot consume its one-second end-to-end budget before the callback runs.
+    import gateway.delivery_ledger as delivery_ledger
+
+    monkeypatch.setattr(delivery_ledger, "ledger_enabled", lambda: False)
     adapter = ProgressCaptureAdapter()
     events = []
 

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -110,6 +110,27 @@ async def test_session_messages_default_to_latest_bounded_page(adapter, session_
 
 
 @pytest.mark.asyncio
+async def test_session_messages_omits_hidden_contextual_rows(adapter, session_db):
+    session_id = session_db.create_session("hidden-session", "api_server")
+    session_db.append_message(
+        session_id,
+        role="user",
+        content="HIDDEN-PROMPT-CANARY",
+        display_kind="hidden",
+    )
+    session_db.append_message(session_id, role="assistant", content="visible answer")
+
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.get(f"/api/sessions/{session_id}/messages")
+        assert resp.status == 200
+        data = await resp.json()
+
+    assert [message["content"] for message in data["data"]] == ["visible answer"]
+    assert "HIDDEN-PROMPT-CANARY" not in str(data)
+
+
+@pytest.mark.asyncio
 async def test_run_agent_binds_api_session_context_for_tool_env(adapter, monkeypatch):
     """API-server request sessions should reach tools and terminal subprocess env."""
     monkeypatch.setenv("HERMES_SESSION_ID", "stale-session")

--- a/tests/gateway/test_session_context_inheritance.py
+++ b/tests/gateway/test_session_context_inheritance.py
@@ -27,6 +27,7 @@ session a few steps later.
 """
 import asyncio
 from contextvars import copy_context
+from typing import Any, cast
 
 import pytest
 
@@ -133,7 +134,7 @@ def test_reset_session_vars_closes_inheritance_leak():
     (stripped, because they are _UNSET in this context and the process is
     engaged) — NOT the parent's MINE_*. B's own bind then takes effect normally.
     """
-    set_session_vars(**MINE)  # parent A binds in the current context
+    cast(Any, set_session_vars)(**MINE)  # parent A binds in the current context
 
     captured = asyncio.run(_child_turn(reset_first=True))
 
@@ -190,7 +191,9 @@ def test_reset_session_vars_closes_async_delivery_leak():
     default-supported behavior (True) — NOT the stateless sibling's False — so a
     real gateway turn isn't wrongly told its channel can't route async delivery.
     """
-    set_session_vars(**FOREIGN, async_delivery=False)  # stateless sibling A
+    cast(Any, set_session_vars)(
+        **FOREIGN, async_delivery=False
+    )  # stateless sibling A
 
     captured = asyncio.run(_child_async_delivery(reset_first=True))
 

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -240,6 +240,54 @@ async def test_run_in_executor_with_context_preserves_session_env(monkeypatch):
 
 
 
+def test_contextual_session_env_binds_cron_and_disables_async_delivery():
+    from types import SimpleNamespace
+
+    from gateway.session_context import (
+        _bind_contextual_turn_authority,
+        async_delivery_supported,
+    )
+
+    runner = object.__new__(GatewayRunner)
+    runner.__dict__["adapters"] = {
+        Platform.TELEGRAM: SimpleNamespace(supports_async_delivery=True)
+    }
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="42",
+        chat_type="dm",
+        user_id="42",
+    )
+    context = SessionContext(
+        source=source,
+        connected_platforms=[],
+        home_channels={},
+        session_key="telegram:dm:42:42",
+        session_id="session-1",
+        routing_revision=3,
+    )
+
+    with _bind_contextual_turn_authority(
+        execution_id="execution-1",
+        session_key=context.session_key,
+        admitted_session_id=context.session_id,
+        admitted_routing_revision=context.routing_revision,
+    ):
+        tokens = runner._set_session_env(context)
+        try:
+            assert async_delivery_supported() is False
+            assert get_session_env("HERMES_CRON_SESSION") == "1"
+        finally:
+            runner._clear_session_env(tokens)
+
+    ordinary_tokens = runner._set_session_env(context)
+    try:
+        assert async_delivery_supported() is True
+        assert get_session_env("HERMES_CRON_SESSION") == ""
+    finally:
+        runner._clear_session_env(ordinary_tokens)
+
+
 def test_cron_session_contextvar_preserves_legacy_env_fallback(monkeypatch):
     """Unset cron ContextVar keeps old env-only cron callers working."""
     monkeypatch.setenv("HERMES_CRON_SESSION", "1")

--- a/tests/gateway/test_session_model_override_routing.py
+++ b/tests/gateway/test_session_model_override_routing.py
@@ -54,6 +54,7 @@ def _make_runner():
     runner._background_tasks = set()
     runner._session_db = None
     runner._session_model_overrides = {}
+    runner._pending_one_turn_model_restores = {}
     runner._session_reasoning_overrides = {}
     runner._pending_model_notes = {}
     runner._pending_approvals = {}
@@ -135,5 +136,35 @@ fallback_providers:
     assert model == "minimax/minimax-m2.7"
     assert runtime_kwargs["provider"] == "openrouter"
     assert runtime_kwargs["api_key"] == "sk-openrouter"
+
+
+def test_contextual_runtime_uses_pre_once_model_without_consuming_restore():
+    runner = _make_runner()
+    session_key = "telegram:u:c"
+    prior = {
+        "model": "stable-model",
+        "provider": "stable-provider",
+        "api_key": "stable-key",
+        "base_url": "https://stable.invalid",
+        "api_mode": "chat_completions",
+    }
+    runner._session_model_overrides[session_key] = {
+        **prior,
+        "model": "human-once-model",
+        "provider": "human-once-provider",
+    }
+    snapshot = {"had_override": True, "override": dict(prior)}
+    runner._pending_one_turn_model_restores[session_key] = snapshot
+
+    model, runtime = runner._resolve_session_agent_runtime(
+        session_key=session_key,
+        user_config={"model": {"default": "global-model"}},
+        ignore_one_turn_override=True,
+    )
+
+    assert model == "stable-model"
+    assert runtime["provider"] == "stable-provider"
+    assert runner._session_model_overrides[session_key]["model"] == "human-once-model"
+    assert runner._pending_one_turn_model_restores[session_key] == snapshot
 
 

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -19,9 +19,14 @@ from tests.gateway._plugin_adapter_loader import load_plugin_adapter
 # ---------------------------------------------------------------------------
 
 def _ensure_teams_mock():
-    """Install a teams SDK mock in sys.modules if the real package isn't present."""
-    if "microsoft_teams" in sys.modules and hasattr(sys.modules["microsoft_teams"], "__file__"):
-        return
+    """Install a deterministic Teams SDK mock in ``sys.modules``.
+
+    Other gateway test modules import plugin discovery during collection.  If
+    the optional Teams SDK is present but incomplete for this interpreter,
+    that can leave a partial real module tree behind before this file is
+    collected.  These unit tests must not depend on that collection order or
+    attempt a live lazy install, so replace the hierarchy unconditionally.
+    """
 
     # Build the module hierarchy
     microsoft_teams = types.ModuleType("microsoft_teams")
@@ -159,7 +164,7 @@ def _ensure_teams_mock():
         "microsoft_teams.apps.http": microsoft_teams_apps_http,
         "microsoft_teams.apps.http.adapter": microsoft_teams_apps_http_adapter,
     }.items():
-        sys.modules.setdefault(name, mod)
+        sys.modules[name] = mod
 
 
 _ensure_teams_mock()

--- a/tests/gateway/test_turn_lease.py
+++ b/tests/gateway/test_turn_lease.py
@@ -20,11 +20,16 @@ Covers:
 """
 
 import asyncio
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from gateway.turn_lease import SessionTurnLeaseRegistry, TurnLeaseTimeoutError
+from gateway.turn_lease import (
+    SessionTurnLeaseRegistry,
+    TurnLeaseTimeoutError,
+    TurnLeaseToken,
+)
 
 
 def _run(coro):
@@ -84,6 +89,72 @@ def test_distinct_sessions_do_not_contend():
     order = _run(scenario())
     # Both started before either finished — no serialization across sessions.
     assert order[:2] == ["start:sess-a", "start:sess-b"]
+
+
+@pytest.mark.asyncio
+async def test_current_holder_validation_rejects_forged_released_and_foreign_tokens():
+    registry = SessionTurnLeaseRegistry()
+    owner = "contextual-cron:execution-1"
+    genuine = await registry.acquire(
+        "session-1",
+        owner_key=owner,
+        generation=0,
+        timeout=1,
+    )
+    foreign = await registry.acquire(
+        "session-2",
+        owner_key=owner,
+        generation=0,
+        timeout=1,
+    )
+    assert genuine is not None
+    assert foreign is not None
+
+    assert registry.is_current_holder(
+        genuine,
+        session_id="session-1",
+        owner_key=owner,
+        generation=0,
+    )
+    assert not registry.is_current_holder(
+        object(),
+        session_id="session-1",
+        owner_key=owner,
+        generation=0,
+    )
+    assert not registry.is_current_holder(
+        TurnLeaseToken("session-1", owner, 0),
+        session_id="session-1",
+        owner_key=owner,
+        generation=0,
+    )
+    assert not registry.is_current_holder(
+        foreign,
+        session_id="session-1",
+        owner_key=owner,
+        generation=0,
+    )
+    assert not registry.is_current_holder(
+        genuine,
+        session_id="session-1",
+        owner_key="contextual-cron:other",
+        generation=0,
+    )
+    assert not registry.is_current_holder(
+        genuine,
+        session_id="session-1",
+        owner_key=owner,
+        generation=1,
+    )
+
+    assert registry.release(genuine) is True
+    assert not registry.is_current_holder(
+        genuine,
+        session_id="session-1",
+        owner_key=owner,
+        generation=0,
+    )
+    assert registry.release(foreign) is True
 
 
 # ---------------------------------------------------------------------------
@@ -168,6 +239,82 @@ async def test_agent_path_propagates_timed_out_lease_before_loading_transcript(
         assert runner._turn_leases.release(holder) is True
 
     runner.session_store.load_transcript.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("variant", ["fabricated", "released", "foreign", "stale"])
+async def test_contextual_preheld_lease_is_revalidated_before_transcript_load(
+    monkeypatch,
+    tmp_path,
+    variant,
+):
+    from gateway.session_context import _bind_contextual_turn_authority
+    from tests.gateway.test_42039_duplicate_user_message import (
+        _bootstrap,
+        _event,
+        _source,
+    )
+
+    runner = _bootstrap(monkeypatch, tmp_path)
+    runner_any = cast(Any, runner)
+    registry = SessionTurnLeaseRegistry()
+    runner_any._turn_leases = registry
+    live_entry = runner_any.session_store.get_or_create_session.return_value
+    live_entry.origin = _source()
+    runner_any.async_session_store.peek_session_entry = AsyncMock(
+        return_value=live_entry
+    )
+    owner = "contextual-cron:execution-1"
+    cleanup_token = None
+    if variant == "fabricated":
+        token = object()
+    elif variant == "released":
+        token = await registry.acquire(
+            "sess-dedup", owner_key=owner, generation=0, timeout=1
+        )
+        assert token is not None
+        assert registry.release(token) is True
+    elif variant == "foreign":
+        token = await registry.acquire(
+            "other-session", owner_key=owner, generation=0, timeout=1
+        )
+        assert token is not None
+        cleanup_token = token
+    else:
+        token = TurnLeaseToken("sess-dedup", owner, 0)
+
+    event = _event()
+    event.internal = True
+    event.metadata.update(
+        {
+            "contextual_cron": True,
+            "contextual_cron_lease_preheld": True,
+            "contextual_cron_lease_token": token,
+        }
+    )
+    runner.session_store.load_transcript.side_effect = AssertionError(
+        "invalid preheld authority must fail before transcript load"
+    )
+    try:
+        with _bind_contextual_turn_authority(
+            execution_id="execution-1",
+            session_key="agent:main:telegram:group:-1001:12345",
+            admitted_session_id="sess-dedup",
+            admitted_routing_revision=live_entry.routing_revision,
+        ):
+            result = await runner._handle_message_with_agent(
+                event,
+                _source(),
+                "agent:main:telegram:group:-1001:12345",
+                1,
+            )
+    finally:
+        if cleanup_token is not None:
+            assert registry.release(cleanup_token) is True
+
+    runner.session_store.load_transcript.assert_not_called()
+    assert result is None
+    assert event.metadata["contextual_cron_result"]["outcome"] == "rejected"
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch, MagicMock
 
+import pytest
+
 from hermes_cli.nous_account import NousPortalAccountInfo
 from hermes_cli.models import (
     OPENROUTER_MODELS, fetch_openrouter_models, model_ids, detect_provider_for_model,
@@ -11,6 +13,36 @@ from hermes_cli.models import (
     union_with_portal_paid_recommendations,
 )
 import hermes_cli.models as _models_mod
+
+
+@pytest.fixture(autouse=True)
+def _bind_current_models_module(monkeypatch):
+    """Keep module-level imports aligned after broad-suite module eviction.
+
+    Some earlier integration tests deliberately remove and re-import Hermes
+    modules.  Pytest collected this file before those tests ran, so its direct
+    imports can otherwise point at a detached ``hermes_cli.models`` object
+    while ``patch("hermes_cli.models…")`` targets the replacement object.
+    Rebind every imported symbol to the currently registered module for each
+    test, keeping mocks and the code under test on the same globals.
+    """
+    import importlib
+
+    current = importlib.import_module("hermes_cli.models")
+    monkeypatch.setitem(globals(), "_models_mod", current)
+    for name in (
+        "OPENROUTER_MODELS",
+        "fetch_openrouter_models",
+        "model_ids",
+        "detect_provider_for_model",
+        "is_nous_free_tier",
+        "partition_nous_models_by_tier",
+        "check_nous_free_tier",
+        "_FREE_TIER_CACHE_TTL",
+        "union_with_portal_free_recommendations",
+        "union_with_portal_paid_recommendations",
+    ):
+        monkeypatch.setitem(globals(), name, getattr(current, name))
 
 LIVE_OPENROUTER_MODELS = [
     ("anthropic/claude-opus-4.6", "recommended"),

--- a/tests/hermes_cli/test_web_server_cron_profiles.py
+++ b/tests/hermes_cli/test_web_server_cron_profiles.py
@@ -82,6 +82,93 @@ def test_fire_cron_job_scopes_store_and_runtime_home_together(
         reset_hermes_home_override(outer_token)
 
 
+@pytest.mark.parametrize(
+    ("func_name", "returns_list"),
+    [
+        ("list_jobs", True),
+        ("get_job", False),
+        ("create_job", False),
+        ("update_job", False),
+        ("pause_job", False),
+        ("resume_job", False),
+        ("trigger_job", False),
+    ],
+)
+def test_profile_call_redacts_contextual_authority_before_dashboard_annotation(
+    isolated_profiles,
+    monkeypatch,
+    func_name,
+    returns_list,
+):
+    """Every dashboard job result uses one private-authority-safe projection."""
+    from cron import jobs as cron_jobs
+    from cron import scheduler
+    from hermes_cli import web_server
+
+    canary = "DASHBOARD-PRIVATE-SESSION-CANARY"
+    raw_job = {
+        "id": "contextual-private-job",
+        "name": "private contextual job",
+        "prompt": "safe public prompt",
+        "schedule": {"kind": "interval", "minutes": 60},
+        "session_target": "current",
+        "session_key": canary,
+        "context_binding": {
+            "session_key": canary,
+            "session_id": "physical-private-session",
+            "routing_revision": 7,
+        },
+        "origin": {"chat_id": canary},
+        "_contextual_binding_version": 1,
+        "latest_execution": {
+            "id": "exec-public-id",
+            "status": "completed",
+            "transcript_json": canary,
+            "delivery_target": canary,
+        },
+    }
+    raw_result = [raw_job] if returns_list else raw_job
+
+    if func_name == "create_job":
+        monkeypatch.setattr(
+            scheduler,
+            "create_job_with_scheduler_registration",
+            lambda *args, **kwargs: raw_result,
+        )
+    else:
+        monkeypatch.setattr(
+            cron_jobs,
+            func_name,
+            lambda *args, **kwargs: raw_result,
+        )
+
+    result = web_server._call_cron_for_profile("worker_alpha", func_name)
+    if returns_list:
+        assert isinstance(result, list)
+        projected = result[0]
+    else:
+        assert isinstance(result, dict)
+        projected = result
+    assert isinstance(projected, dict)
+
+    assert projected["id"] == "contextual-private-job"
+    assert projected["session_target"] == "current"
+    assert projected["profile"] == "worker_alpha"
+    assert projected["profile_name"] == "worker_alpha"
+    assert projected["latest_execution"] == {
+        "id": "exec-public-id",
+        "status": "completed",
+    }
+    assert canary not in repr(result)
+    for private_key in (
+        "session_key",
+        "context_binding",
+        "origin",
+        "_contextual_binding_version",
+    ):
+        assert private_key not in projected
+
+
 def test_create_registers_scheduler_inside_target_profile(
     isolated_profiles,
     monkeypatch,

--- a/tests/hermes_state/test_get_anchored_view.py
+++ b/tests/hermes_state/test_get_anchored_view.py
@@ -89,3 +89,40 @@ class TestSessionIsolation:
         # All bookend messages should have session_id = s1 (or session_id col)
         for m in view["bookend_start"] + view["bookend_end"]:
             assert m.get("session_id") == "s1"
+
+
+class TestHiddenProjection:
+    def test_hidden_rows_are_filtered_before_window_and_bookend_limits(self, db):
+        db.create_session("s1", source="cli")
+        visible_start = db.append_message("s1", role="user", content="visible start")
+        db.append_message(
+            "s1", role="assistant", content="HIDDEN-START", display_kind="hidden"
+        )
+        anchor = db.append_message("s1", role="user", content="visible anchor")
+        db.append_message(
+            "s1", role="assistant", content="HIDDEN-END", display_kind="hidden"
+        )
+        visible_end = db.append_message("s1", role="assistant", content="visible end")
+
+        view = db.get_anchored_view("s1", anchor, window=0, bookend=1)
+        contents = [
+            row["content"]
+            for row in view["bookend_start"] + view["window"] + view["bookend_end"]
+        ]
+        assert contents == ["visible start", "visible anchor", "visible end"]
+        assert [row["id"] for row in view["bookend_start"]] == [visible_start]
+        assert [row["id"] for row in view["bookend_end"]] == [visible_end]
+
+    def test_hidden_anchor_is_not_addressable_without_privileged_opt_in(self, db):
+        db.create_session("s1", source="cli")
+        db.append_message("s1", role="user", content="visible")
+        hidden = db.append_message(
+            "s1", role="assistant", content="HIDDEN-ANCHOR", display_kind="hidden"
+        )
+        db.append_message("s1", role="user", content="visible tail")
+
+        assert db.get_anchored_view("s1", hidden, window=1, bookend=1)["window"] == []
+        privileged = db.get_anchored_view(
+            "s1", hidden, window=0, bookend=0, include_hidden=True
+        )
+        assert [row["content"] for row in privileged["window"]] == ["HIDDEN-ANCHOR"]

--- a/tests/hermes_state/test_hidden_contextual_privacy.py
+++ b/tests/hermes_state/test_hidden_contextual_privacy.py
@@ -1,0 +1,225 @@
+"""Internal contextual transcript rows stay private on public state surfaces."""
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+def _preview(rows, session_id: str) -> str:
+    return next(row["preview"] for row in rows if row["id"] == session_id)
+
+
+def test_search_export_and_preview_hide_internal_contextual_rows(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("s1", source="cli")
+    db.append_message(
+        "s1",
+        role="user",
+        content="contextual-secret-needle",
+        display_kind="hidden",
+    )
+    db.append_message("s1", role="user", content="visible opening")
+    db.append_message("s1", role="assistant", content="visible response")
+
+    assert db.search_messages("contextual-secret-needle") == []
+    privileged = db.search_messages(
+        "contextual-secret-needle", include_hidden=True
+    )
+    assert len(privileged) == 1
+    assert "contextual-secret-needle" in privileged[0]["snippet"]
+
+    exported = db.export_session("s1")
+    assert exported is not None
+    assert [row["content"] for row in exported["messages"]] == [
+        "visible opening",
+        "visible response",
+    ]
+    assert exported["message_count"] == len(exported["messages"]) == 2
+
+    privileged_export = db.export_session("s1", include_hidden=True)
+    assert privileged_export is not None
+    assert "contextual-secret-needle" in [
+        row["content"] for row in privileged_export["messages"]
+    ]
+    assert privileged_export["message_count"] == len(
+        privileged_export["messages"]
+    ) == 3
+
+    rich = db.get_session_rich_row("s1")
+    assert rich is not None
+    assert rich["preview"] == "visible opening"
+
+
+@pytest.mark.parametrize("order_by_last_active", [False, True])
+def test_list_session_preview_filters_hidden_before_limit(
+    tmp_path, order_by_last_active
+):
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("s1", source="cli")
+    db.append_message(
+        "s1", role="user", content="HIDDEN-PREVIEW", display_kind="hidden"
+    )
+    db.append_message("s1", role="user", content="visible preview")
+
+    rows = db.list_sessions_rich(
+        order_by_last_active=order_by_last_active,
+        min_message_count=1,
+    )
+    assert _preview(rows, "s1") == "visible preview"
+    assert "HIDDEN-PREVIEW" not in repr(rows)
+
+
+def test_pinned_backfill_preview_filters_hidden_before_limit(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("old", source="cli")
+    db.append_message(
+        "old", role="user", content="HIDDEN-PINNED", display_kind="hidden"
+    )
+    db.append_message("old", role="user", content="visible pinned")
+    db.set_session_pinned("old", True)
+
+    db.create_session("new", source="cli")
+    db.append_message("new", role="user", content="newer visible")
+
+    rows = db.list_sessions_rich(
+        limit=1,
+        min_message_count=1,
+        order_by_last_active=True,
+        include_pinned=True,
+    )
+    assert _preview(rows, "old") == "visible pinned"
+    assert "HIDDEN-PINNED" not in repr(rows)
+
+
+@pytest.mark.parametrize("create_binding_table", [False, True])
+def test_telegram_session_picker_preview_filters_hidden_before_limit(
+    tmp_path, create_binding_table
+):
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("tg", source="telegram", user_id="user-1")
+    db.append_message(
+        "tg", role="user", content="HIDDEN-TELEGRAM", display_kind="hidden"
+    )
+    db.append_message("tg", role="user", content="visible telegram")
+    if create_binding_table:
+        with db._lock:
+            assert db._conn is not None
+            db._conn.execute(
+                "CREATE TABLE telegram_dm_topic_bindings (session_id TEXT)"
+            )
+            db._conn.commit()
+
+    rows = db.list_unlinked_telegram_sessions_for_user(
+        chat_id="chat-1", user_id="user-1"
+    )
+    assert _preview(rows, "tg") == "visible telegram"
+    assert "HIDDEN-TELEGRAM" not in repr(rows)
+
+
+def test_search_context_hydration_skips_hidden_neighbors(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("s1", source="cli")
+    db.append_message("s1", role="user", content="visible before")
+    db.append_message(
+        "s1", role="assistant", content="HIDDEN-BEFORE", display_kind="hidden"
+    )
+    db.append_message("s1", role="user", content="visible unique match")
+    db.append_message(
+        "s1", role="assistant", content="HIDDEN-AFTER", display_kind="hidden"
+    )
+    db.append_message("s1", role="assistant", content="visible after")
+
+    result = db.search_messages(
+        "visible unique match", fields=("snippet", "context")
+    )
+    assert len(result) == 1
+    assert [row["content"] for row in result[0]["context"]] == [
+        "visible before",
+        "visible unique match",
+        "visible after",
+    ]
+    assert "HIDDEN-" not in repr(result)
+
+    privileged = db.search_messages(
+        "visible unique match",
+        fields=("snippet", "context"),
+        include_hidden=True,
+    )
+    assert [row["content"] for row in privileged[0]["context"]] == [
+        "HIDDEN-BEFORE",
+        "visible unique match",
+        "HIDDEN-AFTER",
+    ]
+
+
+def test_first_assistant_text_ignores_hidden_scaffold(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("s1", source="cli")
+    db.append_message(
+        "s1", role="assistant", content="HIDDEN-TITLE", display_kind="hidden"
+    )
+    db.append_message("s1", role="assistant", content="visible title source")
+
+    assert db.get_first_assistant_text("s1") == "visible title source"
+
+
+def test_hidden_rows_do_not_affect_public_counts_filters_exports_or_recency(
+    tmp_path,
+):
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("older-visible", source="cli")
+    db.append_message(
+        "older-visible", role="user", content="visible old", timestamp=100
+    )
+    db.append_message(
+        "older-visible",
+        role="assistant",
+        content="visible tool request",
+        tool_calls=[{"id": "visible-call"}],
+        timestamp=101,
+    )
+    db.append_message(
+        "older-visible",
+        role="assistant",
+        content="hidden late activity",
+        tool_calls=[{"id": "hidden-1"}, {"id": "hidden-2"}],
+        display_kind="hidden",
+        timestamp=300,
+    )
+
+    db.create_session("newer-visible", source="cli")
+    db.append_message(
+        "newer-visible", role="user", content="visible new", timestamp=200
+    )
+
+    db.create_session("hidden-only", source="cli")
+    db.append_message(
+        "hidden-only",
+        role="user",
+        content="hidden only",
+        display_kind="hidden",
+        timestamp=400,
+    )
+
+    rows = db.list_sessions_rich(
+        order_by_last_active=True,
+        min_message_count=1,
+        project_compression_tips=False,
+    )
+    assert [row["id"] for row in rows] == ["newer-visible", "older-visible"]
+    older = next(row for row in rows if row["id"] == "older-visible")
+    assert older["message_count"] == 2
+    assert older["tool_call_count"] == 1
+    assert older["last_active"] == 101
+
+    rich = db.get_session_rich_row("older-visible")
+    assert rich is not None
+    assert rich["message_count"] == 2
+    assert rich["tool_call_count"] == 1
+    assert rich["last_active"] == 101
+
+    exported = next(
+        row for row in db.export_all() if row["id"] == "older-visible"
+    )
+    assert exported["message_count"] == len(exported["messages"]) == 2
+    assert exported["tool_call_count"] == 1

--- a/tests/integration/test_builtin_contextual_cron_e2e.py
+++ b/tests/integration/test_builtin_contextual_cron_e2e.py
@@ -72,7 +72,7 @@ class _ComposedGatewayRunner:
 async def test_builtin_current_session_composes_scheduler_gateway_transcript_and_single_delivery(
     monkeypatch, tmp_path
 ):
-    """Real V1 composition: built-in run -> live lane -> outbox -> one delivery."""
+    """Real V2 composition follows a reset logical route and delivers once."""
     import cron.executions as executions
     import cron.jobs as jobs
     import cron.scheduler as scheduler
@@ -114,6 +114,7 @@ async def test_builtin_current_session_composes_scheduler_gateway_transcript_and
         user_id="42",
         session_key=session_key,
         session_id=session_id,
+        route_instance_id=entry.route_instance_id,
     )
     try:
         job = jobs.create_job(
@@ -124,6 +125,18 @@ async def test_builtin_current_session_composes_scheduler_gateway_transcript_and
         )
     finally:
         clear_session_vars(tokens)
+
+    assert job["_contextual_binding_version"] == 2
+    assert job["context_binding"]["route_instance_id"] == entry.route_instance_id
+    reset_entry = store.reset_session(session_key)
+    assert reset_entry is not None
+    assert reset_entry.session_id != session_id
+    assert reset_entry.route_instance_id == entry.route_instance_id
+    store.append_to_transcript(
+        reset_entry.session_id,
+        {"role": "user", "content": "The chosen word is nougat."},
+        skip_db=False,
+    )
 
     async_store = AsyncSessionStore(store)
     lane = ContextualCronGateway(
@@ -165,18 +178,22 @@ async def test_builtin_current_session_composes_scheduler_gateway_transcript_and
     assert record["outcome"] == "notify"
     assert record["delivery_state"] == "sent"
     assert record["transcript_state"] == "applied"
-    history = store.load_transcript_strict(entry.session_id)
+    assert record["admitted_binding_version"] == 2
+    assert record["admitted_route_instance_id"] == entry.route_instance_id
+    assert record["admitted_session_id"] == reset_entry.session_id
+    history = store.load_transcript_strict(reset_entry.session_id)
     assert [item["message_id"] for item in history[-2:]] == [
         f"contextual-cron:{record['id']}:0",
         f"contextual-cron:{record['id']}:1",
     ]
     assert history[-2]["display_kind"] == "hidden"
-    assert "marzipan" in history[-1]["content"]
+    assert "nougat" in history[-1]["content"]
+    assert len(store.load_transcript_strict(entry.session_id)) == 1
     refreshed_entry = store.peek_session_entry(entry.session_key)
     assert refreshed_entry is not None
     assert refreshed_entry.last_prompt_tokens == 23
     assert send.await_count == 1
-    assert "marzipan" in str(send.await_args)
+    assert "nougat" in str(send.await_args)
 
     replay = dict(job, execution_id=record["id"])
     assert await asyncio.to_thread(
@@ -186,4 +203,4 @@ async def test_builtin_current_session_composes_scheduler_gateway_transcript_and
         contextual_dispatch=dispatch,
     )
     assert send.await_count == 1
-    assert len(store.load_transcript_strict(entry.session_id)) == 3
+    assert len(store.load_transcript_strict(reset_entry.session_id)) == 3

--- a/tests/integration/test_builtin_contextual_cron_e2e.py
+++ b/tests/integration/test_builtin_contextual_cron_e2e.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import asyncio
+from types import MethodType, SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+class _ComposedGatewayRunner:
+    def __init__(self, store, async_store):
+        from gateway.run import GatewayRunner
+
+        self.session_store = store
+        self.async_session_store = async_store
+        self._async_session_store = async_store
+        self._contextual_transcript_apply_lock = None
+        self._contextual_transcript_applied_prefix = (
+            GatewayRunner._contextual_transcript_applied_prefix
+        )
+        self._apply_contextual_cron_transcript_sync = MethodType(
+            GatewayRunner._apply_contextual_cron_transcript_sync, self
+        )
+        self._apply_contextual_cron_transcript_async_fake = MethodType(
+            GatewayRunner._apply_contextual_cron_transcript_async_fake, self
+        )
+        self._apply_contextual_cron_transcript = MethodType(
+            GatewayRunner._apply_contextual_cron_transcript, self
+        )
+
+    def _is_user_authorized(self, _source) -> bool:
+        return True
+
+    def _session_key_for_source(self, source) -> str:
+        from gateway.session import build_session_key
+
+        return build_session_key(source)
+
+    def _contextual_cron_session_busy(self, _session_key: str) -> bool:
+        return False
+
+    async def _run_contextual_cron_turn(self, item, entry, history):
+        from gateway.contextual_cron import ContextualCronOutcome
+
+        chosen = next(
+            message["content"].split("chosen word is ", 1)[1].rstrip(".")
+            for message in history
+            if message.get("role") == "user"
+            and "chosen word is " in str(message.get("content"))
+        )
+        item.transcript_session_id = entry.session_id
+        assert isinstance(item.transcript_base_message_count, int)
+        assert isinstance(item.transcript_base_revision, int)
+        item.last_prompt_tokens = 23
+        item.transcript_entries = [
+            {
+                "role": "user",
+                "content": item.prompt,
+                "display_kind": "hidden",
+                "message_id": f"contextual-cron:{item.execution_id}:0",
+            },
+            {
+                "role": "assistant",
+                "content": f"Recovered chosen word: {chosen}",
+                "message_id": f"contextual-cron:{item.execution_id}:1",
+            },
+        ]
+        return ContextualCronOutcome.notify(f"Recovered chosen word: {chosen}")
+
+
+@pytest.mark.asyncio
+async def test_builtin_current_session_composes_scheduler_gateway_transcript_and_single_delivery(
+    monkeypatch, tmp_path
+):
+    """Real V1 composition: built-in run -> live lane -> outbox -> one delivery."""
+    import cron.executions as executions
+    import cron.jobs as jobs
+    import cron.scheduler as scheduler
+    from gateway.config import GatewayConfig, Platform as ConfigPlatform
+    from gateway.contextual_cron import ContextualCronGateway
+    from gateway.session import AsyncSessionStore, Platform, SessionSource, SessionStore
+    from gateway.session_context import clear_session_vars, set_session_vars
+
+    profile_home = tmp_path / "profile"
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    cron_dir = profile_home / "cron"
+    monkeypatch.setattr(jobs, "CRON_DIR", cron_dir)
+    monkeypatch.setattr(jobs, "JOBS_FILE", cron_dir / "jobs.json")
+    monkeypatch.setattr(jobs, "OUTPUT_DIR", cron_dir / "output")
+    monkeypatch.setattr(executions, "EXECUTIONS_FILE", cron_dir / "executions.db")
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config", lambda: {"cron": {"provider": "builtin"}}
+    )
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="42",
+        chat_type="dm",
+        user_id="42",
+    )
+    store = SessionStore(profile_home / "sessions", GatewayConfig())
+    entry = store.get_or_create_session(source, force_new=True)
+    store.append_to_transcript(
+        entry.session_id,
+        {"role": "user", "content": "The chosen word is marzipan."},
+        skip_db=False,
+    )
+    session_key = entry.session_key
+    session_id = entry.session_id
+    tokens = set_session_vars(
+        platform="telegram",
+        chat_id="42",
+        chat_type="dm",
+        user_id="42",
+        session_key=session_key,
+        session_id=session_id,
+    )
+    try:
+        job = jobs.create_job(
+            prompt="Continue the conversation and report the chosen word.",
+            schedule="every 1h",
+            deliver="origin",
+            session_target="current",
+        )
+    finally:
+        clear_session_vars(tokens)
+
+    async_store = AsyncSessionStore(store)
+    lane = ContextualCronGateway(
+        _ComposedGatewayRunner(store, async_store), busy_poll_seconds=0.001
+    )
+    loop = asyncio.get_running_loop()
+
+    platform_cfg = SimpleNamespace(enabled=True)
+    monkeypatch.setattr(
+        "gateway.config.load_gateway_config",
+        lambda: SimpleNamespace(platforms={ConfigPlatform.TELEGRAM: platform_cfg}),
+    )
+    send = AsyncMock(return_value={"success": True})
+    monkeypatch.setattr("tools.send_message_tool._send_to_platform", send)
+    monkeypatch.setattr(
+        scheduler,
+        "_CONTEXTUAL_AUTHORIZER",
+        lambda target: target.get("origin", {}).get("user_id") == "42",
+    )
+
+    def dispatch(bound_job, *, execution_id):
+        return lane.dispatch_from_scheduler(
+            bound_job,
+            execution_id=execution_id,
+            loop=loop,
+            timeout=5,
+        )
+
+    assert await asyncio.to_thread(
+        scheduler.run_one_job,
+        job,
+        loop=loop,
+        contextual_dispatch=dispatch,
+    )
+
+    record = executions.latest_execution(job["id"])
+    assert record is not None
+    assert record["status"] == "completed"
+    assert record["outcome"] == "notify"
+    assert record["delivery_state"] == "sent"
+    assert record["transcript_state"] == "applied"
+    history = store.load_transcript_strict(entry.session_id)
+    assert [item["message_id"] for item in history[-2:]] == [
+        f"contextual-cron:{record['id']}:0",
+        f"contextual-cron:{record['id']}:1",
+    ]
+    assert history[-2]["display_kind"] == "hidden"
+    assert "marzipan" in history[-1]["content"]
+    refreshed_entry = store.peek_session_entry(entry.session_key)
+    assert refreshed_entry is not None
+    assert refreshed_entry.last_prompt_tokens == 23
+    assert send.await_count == 1
+    assert "marzipan" in str(send.await_args)
+
+    replay = dict(job, execution_id=record["id"])
+    assert await asyncio.to_thread(
+        scheduler.run_one_job,
+        replay,
+        loop=loop,
+        contextual_dispatch=dispatch,
+    )
+    assert send.await_count == 1
+    assert len(store.load_transcript_strict(entry.session_id)) == 3

--- a/tests/integration/test_builtin_contextual_cron_e2e.py
+++ b/tests/integration/test_builtin_contextual_cron_e2e.py
@@ -149,8 +149,14 @@ async def test_builtin_current_session_composes_scheduler_gateway_transcript_and
         "gateway.config.load_gateway_config",
         lambda: SimpleNamespace(platforms={ConfigPlatform.TELEGRAM: platform_cfg}),
     )
-    send = AsyncMock(return_value={"success": True})
-    monkeypatch.setattr("tools.send_message_tool._send_to_platform", send)
+    standalone_send = AsyncMock(return_value={"success": True})
+    monkeypatch.setattr(
+        "tools.send_message_tool._send_to_platform", standalone_send
+    )
+    live_adapter = AsyncMock()
+    live_adapter.send.return_value = SimpleNamespace(
+        success=True, raw_response=None
+    )
     monkeypatch.setattr(
         scheduler,
         "_CONTEXTUAL_AUTHORIZER",
@@ -168,6 +174,7 @@ async def test_builtin_current_session_composes_scheduler_gateway_transcript_and
     assert await asyncio.to_thread(
         scheduler.run_one_job,
         job,
+        adapters={ConfigPlatform.TELEGRAM: live_adapter},
         loop=loop,
         contextual_dispatch=dispatch,
     )
@@ -192,15 +199,18 @@ async def test_builtin_current_session_composes_scheduler_gateway_transcript_and
     refreshed_entry = store.peek_session_entry(entry.session_key)
     assert refreshed_entry is not None
     assert refreshed_entry.last_prompt_tokens == 23
-    assert send.await_count == 1
-    assert "nougat" in str(send.await_args)
+    assert live_adapter.send.await_count == 1
+    assert "nougat" in str(live_adapter.send.await_args)
+    standalone_send.assert_not_awaited()
 
     replay = dict(job, execution_id=record["id"])
     assert await asyncio.to_thread(
         scheduler.run_one_job,
         replay,
+        adapters={ConfigPlatform.TELEGRAM: live_adapter},
         loop=loop,
         contextual_dispatch=dispatch,
     )
-    assert send.await_count == 1
+    assert live_adapter.send.await_count == 1
+    standalone_send.assert_not_awaited()
     assert len(store.load_transcript_strict(reset_entry.session_id)) == 3

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1495,6 +1495,69 @@ class TestExecuteToolCalls:
         assert messages[0]["role"] == "tool"
         assert "search result" in messages[0]["content"]
 
+    def test_contextual_allowlist_blocks_unadvertised_registry_tool_before_dispatch(
+        self, agent
+    ):
+        agent.allowed_tool_names = frozenset()
+        tc = _mock_tool_call(name="terminal", arguments='{"command":"id"}', call_id="c1")
+        messages = []
+        with patch("run_agent.handle_function_call") as dispatch:
+            agent._execute_tool_calls_sequential(
+                _mock_assistant_msg(content="", tool_calls=[tc]),
+                messages,
+                "task-1",
+            )
+
+        dispatch.assert_not_called()
+        assert len(messages) == 1
+        assert "not permitted by this execution policy" in messages[0]["content"]
+
+    def test_contextual_allowlist_blocks_unadvertised_inline_tool_before_dispatch(
+        self, agent
+    ):
+        agent.allowed_tool_names = frozenset()
+        tc = _mock_tool_call(name="delegate_task", arguments='{"goal":"escape"}', call_id="c1")
+        messages = []
+        with patch.object(agent, "_dispatch_delegate_task") as dispatch:
+            agent._execute_tool_calls_sequential(
+                _mock_assistant_msg(content="", tool_calls=[tc]),
+                messages,
+                "task-1",
+            )
+
+        dispatch.assert_not_called()
+        assert "not permitted by this execution policy" in messages[0]["content"]
+
+    def test_contextual_allowlist_blocks_concurrent_tools_before_workers_or_hooks(
+        self, agent, monkeypatch
+    ):
+        agent.allowed_tool_names = frozenset()
+        calls = [
+            _mock_tool_call(name="terminal", arguments='{"command":"id"}', call_id="c1"),
+            _mock_tool_call(name="web_search", arguments='{"query":"x"}', call_id="c2"),
+        ]
+        messages = []
+        hook_calls = []
+        monkeypatch.setattr(
+            "hermes_cli.lifecycle.invoke_hook",
+            lambda *args, **kwargs: hook_calls.append((args, kwargs)) or [],
+        )
+        monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda _name: True)
+        with patch.object(agent, "_invoke_tool") as dispatch:
+            agent._execute_tool_calls_concurrent(
+                _mock_assistant_msg(content="", tool_calls=calls),
+                messages,
+                "task-1",
+            )
+
+        dispatch.assert_not_called()
+        assert hook_calls == []
+        assert len(messages) == 2
+        assert all(
+            "not permitted by this execution policy" in message["content"]
+            for message in messages
+        )
+
     def test_sequential_tool_calls_run_without_delay(self, agent):
         """Two sequential tool calls execute back-to-back with no sleep between them."""
         tc1 = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -201,6 +201,234 @@ class TestConnectionLifecycle:
 
 
 # =========================================================================
+# Contextual transcript causal fencing
+# =========================================================================
+
+
+class TestContextualTranscriptCausalFence:
+    @staticmethod
+    def _entries(execution_id="exec-1"):
+        return [
+            {
+                "role": "user",
+                "content": "hidden prompt",
+                "message_id": f"contextual-cron:{execution_id}:0",
+                "display_kind": "hidden",
+            },
+            {
+                "role": "assistant",
+                "content": "scheduled answer",
+                "message_id": f"contextual-cron:{execution_id}:1",
+            },
+        ]
+
+    def test_same_count_rewrite_invalidates_the_durable_revision(self, db):
+        from hermes_state import ContextualTranscriptCASMismatch
+
+        db.create_session(session_id="s1", source="telegram")
+        db.append_message("s1", role="user", content="original user")
+        db.append_message("s1", role="assistant", content="original answer")
+        base_count, base_revision = db.get_transcript_fence("s1")
+
+        db.replace_messages(
+            "s1",
+            [
+                {"role": "user", "content": "rewritten user"},
+                {"role": "assistant", "content": "rewritten answer"},
+            ],
+        )
+
+        assert db.get_transcript_fence("s1")[0] == base_count
+        with pytest.raises(ContextualTranscriptCASMismatch, match="revision"):
+            db.apply_contextual_transcript_outbox(
+                execution_id="exec-rewrite",
+                session_id="s1",
+                entries=self._entries("exec-rewrite"),
+                base_count=base_count,
+                base_revision=base_revision,
+            )
+
+    def test_atomic_receipt_survives_later_human_rows_and_preserves_hidden_kind(self, db):
+        db.create_session(session_id="s1", source="telegram")
+        db.append_message("s1", role="user", content="existing")
+        base_count, base_revision = db.get_transcript_fence("s1")
+        entries = self._entries()
+
+        first = db.apply_contextual_transcript_outbox(
+            execution_id="exec-1",
+            session_id="s1",
+            entries=entries,
+            base_count=base_count,
+            base_revision=base_revision,
+            last_prompt_tokens=77,
+        )
+        db.append_message("s1", role="user", content="later human")
+        replay = db.apply_contextual_transcript_outbox(
+            execution_id="exec-1",
+            session_id="s1",
+            entries=entries,
+            base_count=base_count,
+            base_revision=base_revision,
+            last_prompt_tokens=77,
+        )
+
+        assert first["status"] == "applied"
+        assert replay["status"] == "already_applied"
+        changed_entries = [dict(entry) for entry in entries]
+        changed_entries[1]["content"] = "tampered answer"
+        from hermes_state import ContextualTranscriptCASMismatch
+
+        with pytest.raises(ContextualTranscriptCASMismatch, match="receipt"):
+            db.apply_contextual_transcript_outbox(
+                execution_id="exec-1",
+                session_id="s1",
+                entries=changed_entries,
+                base_count=base_count,
+                base_revision=base_revision,
+                last_prompt_tokens=77,
+            )
+        messages = db.get_messages_as_conversation("s1", include_hidden=True)
+        assert [row["content"] for row in messages] == [
+            "existing",
+            "hidden prompt",
+            "scheduled answer",
+            "later human",
+        ]
+        assert messages[1]["display_kind"] == "hidden"
+        assert [
+            row["content"] for row in db.get_messages_as_conversation("s1")
+        ] == ["existing", "scheduled answer", "later human"]
+        receipt = db.get_contextual_transcript_application("exec-1")
+        assert receipt is not None
+        assert receipt["last_prompt_tokens"] == 77
+
+    def test_ended_session_rejects_fence_and_new_atomic_application(self, db):
+        from hermes_state import ContextualTranscriptCASMismatch
+
+        db.create_session(session_id="s1", source="telegram")
+        db.append_message("s1", role="user", content="before")
+        base_count, base_revision = db.get_transcript_fence("s1")
+        db.end_session("s1", end_reason="session_reset")
+        entries = [
+            {
+                "role": "user",
+                "content": "must not land",
+                "platform_message_id": "contextual-cron:exec-ended:0",
+            }
+        ]
+
+        with pytest.raises(KeyError, match="ended session"):
+            db.get_transcript_fence("s1")
+        with pytest.raises(ContextualTranscriptCASMismatch, match="no longer active"):
+            db.apply_contextual_transcript_outbox(
+                execution_id="exec-ended",
+                session_id="s1",
+                entries=entries,
+                base_count=base_count,
+                base_revision=base_revision,
+            )
+
+        assert db.get_contextual_transcript_application("exec-ended") is None
+        assert [
+            message["content"] for message in db.get_messages_as_conversation("s1")
+        ] == ["before"]
+
+    def test_multirow_application_is_contiguous_against_an_ordinary_writer(self, db):
+        import threading
+
+        db.create_session(session_id="s1", source="telegram")
+        base_count, base_revision = db.get_transcript_fence("s1")
+        paused = threading.Event()
+        release = threading.Event()
+        errors = []
+        peer = SessionDB(db_path=db.db_path)
+
+        def pause_after_first_row():
+            paused.set()
+            if not release.wait(timeout=5):
+                raise RuntimeError("test barrier timed out")
+            return 0
+
+        assert db._conn is not None
+        assert peer._conn is not None
+        db._conn.create_function("pause_contextual_apply", 0, pause_after_first_row)
+        peer._conn.create_function("pause_contextual_apply", 0, lambda: 0)
+        db._conn.execute(
+            """CREATE TRIGGER pause_first_contextual AFTER INSERT ON messages
+               WHEN NEW.platform_message_id = 'contextual-cron:exec-race:0'
+               BEGIN SELECT pause_contextual_apply(); END"""
+        )
+
+        def apply_outbox():
+            try:
+                db.apply_contextual_transcript_outbox(
+                    execution_id="exec-race",
+                    session_id="s1",
+                    entries=self._entries("exec-race"),
+                    base_count=base_count,
+                    base_revision=base_revision,
+                )
+            except BaseException as exc:
+                errors.append(exc)
+
+        def append_human():
+            try:
+                peer.append_message("s1", role="user", content="racing human")
+            except BaseException as exc:
+                errors.append(exc)
+
+        apply_thread = threading.Thread(target=apply_outbox)
+        human_thread = threading.Thread(target=append_human)
+        try:
+            apply_thread.start()
+            assert paused.wait(timeout=5)
+            human_thread.start()
+            assert human_thread.is_alive()
+            release.set()
+            apply_thread.join(timeout=5)
+            human_thread.join(timeout=5)
+        finally:
+            release.set()
+            peer.close()
+
+        assert not errors
+        assert not apply_thread.is_alive()
+        assert not human_thread.is_alive()
+        assert [
+            row["content"]
+            for row in db.get_messages_as_conversation("s1", include_hidden=True)
+        ] == [
+            "hidden prompt",
+            "scheduled answer",
+            "racing human",
+        ]
+        assert [
+            row["content"] for row in db.get_messages_as_conversation("s1")
+        ] == ["scheduled answer", "racing human"]
+
+    def test_multirow_application_rolls_back_without_a_receipt(self, db):
+        db.create_session(session_id="s1", source="telegram")
+        base_count, base_revision = db.get_transcript_fence("s1")
+        db._conn.execute(
+            """CREATE TRIGGER reject_second_contextual BEFORE INSERT ON messages
+               WHEN NEW.platform_message_id = 'contextual-cron:exec-fail:1'
+               BEGIN SELECT RAISE(ABORT, 'injected second-row failure'); END"""
+        )
+
+        with pytest.raises(sqlite3.IntegrityError, match="second-row"):
+            db.apply_contextual_transcript_outbox(
+                execution_id="exec-fail",
+                session_id="s1",
+                entries=self._entries("exec-fail"),
+                base_count=base_count,
+                base_revision=base_revision,
+            )
+
+        assert db.get_messages_as_conversation("s1") == []
+        assert db.get_contextual_transcript_application("exec-fail") is None
+
+
+# =========================================================================
 # Session lifecycle
 # =========================================================================
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1497,8 +1497,8 @@ class TestBulkDeleteSessions:
         bulk-delete CLI / web flows don't leak files."""
         db.create_session(session_id="s1", source="cli")
         db.create_session(session_id="s2", source="cli")
-        (tmp_path / "s1.jsonl").write_text("")
-        (tmp_path / "s2.json").write_text("{}")
+        (tmp_path / "s1.jsonl").write_text("", encoding="utf-8")
+        (tmp_path / "s2.json").write_text("{}", encoding="utf-8")
 
         deleted = db.delete_sessions(["s1", "s2"], sessions_dir=tmp_path)
         assert deleted == 2
@@ -1561,9 +1561,9 @@ class TestDeleteEmptySessions:
         db.end_session("empty_with_dump", end_reason="done")
 
         dump = tmp_path / "request_dump_empty_with_dump_0.json"
-        dump.write_text("{}")
+        dump.write_text("{}", encoding="utf-8")
         transcript = tmp_path / "empty_with_dump.jsonl"
-        transcript.write_text("")
+        transcript.write_text("", encoding="utf-8")
 
         deleted = db.delete_empty_sessions(sessions_dir=tmp_path)
         assert deleted == 1
@@ -2647,10 +2647,12 @@ class TestAutoMaintenance:
         db.create_session(session_id="new", source="cli")  # active
 
         # Transcript files mimicking real gateway/CLI layout
-        (sessions_dir / "old1.json").write_text("{}")
-        (sessions_dir / "old1.jsonl").write_text("{}\n")
-        (sessions_dir / "old2.jsonl").write_text("{}\n")
-        (sessions_dir / "request_dump_old1_001.json").write_text("{}")
+        (sessions_dir / "old1.json").write_text("{}", encoding="utf-8")
+        (sessions_dir / "old1.jsonl").write_text("{}\n", encoding="utf-8")
+        (sessions_dir / "old2.jsonl").write_text("{}\n", encoding="utf-8")
+        (sessions_dir / "request_dump_old1_001.json").write_text(
+            "{}", encoding="utf-8"
+        )
         (sessions_dir / "new.jsonl").write_text("{}\n")  # active, must survive
 
         result = db.maybe_auto_prune_and_vacuum(
@@ -4675,7 +4677,7 @@ class TestPerformancePragmasEndToEnd:
         home.mkdir()
         monkeypatch.setenv("HERMES_HOME", str(home))
         if config_text is not None:
-            (home / "config.yaml").write_text(config_text)
+            (home / "config.yaml").write_text(config_text, encoding="utf-8")
         return home
 
     def test_configured_pragmas_reach_all_connection_types(

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2653,7 +2653,9 @@ class TestAutoMaintenance:
         (sessions_dir / "request_dump_old1_001.json").write_text(
             "{}", encoding="utf-8"
         )
-        (sessions_dir / "new.jsonl").write_text("{}\n")  # active, must survive
+        (sessions_dir / "new.jsonl").write_text(
+            "{}\n", encoding="utf-8"
+        )  # active, must survive
 
         result = db.maybe_auto_prune_and_vacuum(
             retention_days=90, sessions_dir=sessions_dir

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5742,7 +5742,7 @@ def test_config_set_yolo_global_scope_writes_approvals_mode(tmp_path, monkeypatc
     )
     assert resp_on["result"]["value"] == "1"
     assert resp_on["result"]["scope"] == "global"
-    assert yaml.safe_load(cfg_path.read_text())["approvals"]["mode"] == "off"
+    assert yaml.safe_load(cfg_path.read_text(encoding="utf-8"))["approvals"]["mode"] == "off"
 
     resp_off = server.handle_request(
         {
@@ -5752,7 +5752,7 @@ def test_config_set_yolo_global_scope_writes_approvals_mode(tmp_path, monkeypatc
         }
     )
     assert resp_off["result"]["value"] == "0"
-    assert yaml.safe_load(cfg_path.read_text())["approvals"]["mode"] == "manual"
+    assert yaml.safe_load(cfg_path.read_text(encoding="utf-8"))["approvals"]["mode"] == "manual"
 
 
 def test_config_get_approval_mode_uses_smart_default_when_key_is_missing(
@@ -5839,7 +5839,7 @@ def test_config_set_approval_mode_persists_three_way_value_and_emits_live_status
         server._sessions.clear()
 
     assert resp["result"] == {"key": "approvals.mode", "value": "manual"}
-    assert yaml.safe_load((tmp_path / "config.yaml").read_text())["approvals"]["mode"] == "manual"
+    assert yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))["approvals"]["mode"] == "manual"
     assert emitted and emitted[0][0:2] == ("session.info", "sid")
     assert emitted[0][2]["approval_mode"] == "manual"
 
@@ -5878,7 +5878,7 @@ def test_config_set_yolo_global_scope_honors_explicit_value(tmp_path, monkeypatc
         }
     )
     assert resp["result"]["value"] == "1"
-    assert yaml.safe_load(cfg_path.read_text())["approvals"]["mode"] == "off"
+    assert yaml.safe_load(cfg_path.read_text(encoding="utf-8"))["approvals"]["mode"] == "off"
 
     # Setting it on again is idempotent — stays off.
     resp_again = server.handle_request(
@@ -5889,7 +5889,7 @@ def test_config_set_yolo_global_scope_honors_explicit_value(tmp_path, monkeypatc
         }
     )
     assert resp_again["result"]["value"] == "1"
-    assert yaml.safe_load(cfg_path.read_text())["approvals"]["mode"] == "off"
+    assert yaml.safe_load(cfg_path.read_text(encoding="utf-8"))["approvals"]["mode"] == "off"
 
 
 def test_config_set_fast_updates_live_agent_session_scoped(monkeypatch):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -11709,9 +11709,20 @@ def test_session_branch_writes_to_parent_profile_db(monkeypatch, tmp_path):
             self.model = "test-model"
             self.session_id = None
 
+    hidden_canary = "TUI-BRANCH-HIDDEN-CANARY"
+    hidden_metadata = {"execution_id": "exec-tui-branch"}
     parent = {
         "session_key": "parent-key",
-        "history": [{"role": "user", "content": "hi"}],
+        "history": [
+            {
+                "role": "user",
+                "content": hidden_canary,
+                "display_kind": "hidden",
+                "display_metadata": hidden_metadata,
+                "api_content": f"{hidden_canary}-WIRE",
+            },
+            {"role": "assistant", "content": "visible answer"},
+        ],
         "history_lock": __import__("threading").Lock(),
         "running": False,
         "cols": 80,
@@ -11753,7 +11764,13 @@ def test_session_branch_writes_to_parent_profile_db(monkeypatch, tmp_path):
         # profile, not left NULL for aggregators to mis-tag as "default".
         assert seen.get("profile_name") == "mlperf"
         assert seen.get("title") == (seen["created"], "forked")
-        assert len(seen["msgs"]) == 1
+        assert len(seen["msgs"]) == 2
+        copied_hidden = next(
+            msg for msg in seen["msgs"] if msg["content"] == hidden_canary
+        )
+        assert copied_hidden["display_kind"] == "hidden"
+        assert copied_hidden["display_metadata"] == hidden_metadata
+        assert copied_hidden["api_content"] == f"{hidden_canary}-WIRE"
         assert seen.get("launch") is None
         assert seen.get("launch_create") is None
         child_sid = resp["result"]["session_id"]
@@ -11765,6 +11782,50 @@ def test_session_branch_writes_to_parent_profile_db(monkeypatch, tmp_path):
     finally:
         for k in list(server._sessions):
             server._sessions.pop(k, None)
+
+
+def test_desktop_branch_seed_preserves_hidden_replay_metadata(monkeypatch):
+    """The delayed desktop branch seed must not declassify hidden parent rows."""
+    hidden_canary = "DESKTOP-BRANCH-HIDDEN-CANARY"
+    hidden_metadata = {"execution_id": "exec-desktop-branch"}
+    seen: list[dict] = []
+
+    class FakeDB:
+        def append_messages_batch(self, _session_id, messages, **_kwargs):
+            seen.extend(messages)
+            return len(messages)
+
+    class DBContext:
+        def __enter__(self):
+            return FakeDB()
+
+        def __exit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(server, "_session_db", lambda _session: DBContext())
+    session = {
+        "session_key": "desktop-child",
+        "parent_session_id": "desktop-parent",
+        "history_lock": threading.Lock(),
+        "history": [
+            {
+                "role": "user",
+                "content": hidden_canary,
+                "display_kind": "hidden",
+                "display_metadata": hidden_metadata,
+                "api_content": f"{hidden_canary}-WIRE",
+            },
+            {"role": "assistant", "content": "visible answer"},
+        ],
+    }
+
+    server._persist_branch_seed(session)
+
+    copied_hidden = next(msg for msg in seen if msg["content"] == hidden_canary)
+    assert copied_hidden["display_kind"] == "hidden"
+    assert copied_hidden["display_metadata"] == hidden_metadata
+    assert copied_hidden["api_content"] == f"{hidden_canary}-WIRE"
+    assert session["_branch_seed_persisted"] is True
 
 
 def test_session_branch_installs_parent_profile_secret_scope(monkeypatch, tmp_path):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5728,7 +5728,9 @@ def test_config_set_yolo_global_scope_writes_approvals_mode(tmp_path, monkeypatc
     import yaml
 
     cfg_path = tmp_path / "config.yaml"
-    cfg_path.write_text(yaml.safe_dump({"approvals": {"mode": "manual"}}))
+    cfg_path.write_text(
+        yaml.safe_dump({"approvals": {"mode": "manual"}}), encoding="utf-8"
+    )
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
 
     resp_on = server.handle_request(
@@ -5863,7 +5865,9 @@ def test_config_set_yolo_global_scope_honors_explicit_value(tmp_path, monkeypatc
     import yaml
 
     cfg_path = tmp_path / "config.yaml"
-    cfg_path.write_text(yaml.safe_dump({"approvals": {"mode": "manual"}}))
+    cfg_path.write_text(
+        yaml.safe_dump({"approvals": {"mode": "manual"}}), encoding="utf-8"
+    )
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
 
     resp = server.handle_request(
@@ -6107,7 +6111,7 @@ def test_config_set_statusbar_survives_non_dict_display(tmp_path, monkeypatch):
     import yaml
 
     cfg_path = tmp_path / "config.yaml"
-    cfg_path.write_text(yaml.safe_dump({"display": "broken"}))
+    cfg_path.write_text(yaml.safe_dump({"display": "broken"}), encoding="utf-8")
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
 
     resp = server.handle_request(
@@ -6119,7 +6123,7 @@ def test_config_set_statusbar_survives_non_dict_display(tmp_path, monkeypatch):
     )
 
     assert resp["result"]["value"] == "bottom"
-    saved = yaml.safe_load(cfg_path.read_text())
+    saved = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
     assert saved["display"]["tui_statusbar"] == "bottom"
 
 
@@ -6143,7 +6147,7 @@ def test_config_set_details_mode_pins_all_sections(tmp_path, monkeypatch):
     )
 
     assert resp["result"] == {"key": "details_mode", "value": "collapsed"}
-    saved = yaml.safe_load(cfg_path.read_text())
+    saved = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
     assert saved["display"]["details_mode"] == "collapsed"
     assert saved["display"]["sections"] == {
         "thinking": "collapsed",
@@ -6168,7 +6172,7 @@ def test_config_set_section_writes_per_section_override(tmp_path, monkeypatch):
     )
 
     assert resp["result"] == {"key": "details_mode.activity", "value": "hidden"}
-    saved = yaml.safe_load(cfg_path.read_text())
+    saved = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
     assert saved["display"]["sections"] == {"activity": "hidden"}
 
 
@@ -6192,7 +6196,7 @@ def test_config_set_section_clears_override_on_empty_value(tmp_path, monkeypatch
     )
 
     assert resp["result"] == {"key": "details_mode.activity", "value": ""}
-    saved = yaml.safe_load(cfg_path.read_text())
+    saved = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
     assert saved["display"]["sections"] == {"tools": "expanded"}
 
 
@@ -14091,7 +14095,7 @@ def test_session_save_writes_under_hermes_home_with_system_prompt(monkeypatch, t
     assert saved_file.parent == saved_dir
     assert saved_file.exists()
 
-    payload = json.loads(saved_file.read_text())
+    payload = json.loads(saved_file.read_text(encoding="utf-8"))
     assert payload["model"] == "hermes-test"
     assert payload["session_id"] == "20260101_120000_abc123"
     assert payload["session_start"] == "2026-01-01T12:00:00"
@@ -15434,7 +15438,7 @@ def test_persist_model_switch_preserves_sibling_model_keys(tmp_path, monkeypatch
         new_model="new-model", target_provider="anthropic", base_url=None
     )
     server._persist_model_switch(result)
-    saved = yaml.safe_load(cfg_path.read_text())
+    saved = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
 
     # The switched fields updated...
     assert saved["model"]["default"] == "new-model"
@@ -15468,7 +15472,7 @@ def test_persist_model_switch_clears_stale_base_url(tmp_path, monkeypatch):
         new_model="claude-haiku", target_provider="anthropic", base_url=None
     )
     server._persist_model_switch(result)
-    saved = yaml.safe_load(cfg_path.read_text())
+    saved = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
 
     assert saved["model"]["default"] == "claude-haiku"
     assert saved["model"]["provider"] == "anthropic"

--- a/tests/tools/test_refresh_agent_mcp_tools.py
+++ b/tests/tools/test_refresh_agent_mcp_tools.py
@@ -27,6 +27,34 @@ def _agent(tool_names, *, enabled=None, disabled=None):
     return a
 
 
+def test_refresh_keeps_agent_capability_allowlist_fail_closed(monkeypatch):
+    """Late plugin/MCP discovery cannot widen an unattended agent's tools."""
+    agent = _agent(["read_file"], enabled=["file", "web"])
+    agent.allowed_tool_names = frozenset({"read_file", "web_search"})
+
+    import model_tools
+
+    monkeypatch.setattr(
+        model_tools,
+        "get_tool_definitions",
+        lambda **kw: [
+            _tool("read_file"),
+            _tool("web_search"),
+            _tool("terminal"),
+            _tool("mcp_late_side_channel"),
+        ],
+    )
+
+    added = mcp_tool.refresh_agent_mcp_tools(agent)
+
+    assert added == {"web_search"}
+    assert agent.valid_tool_names == {"read_file", "web_search"}
+    assert [tool["function"]["name"] for tool in agent.tools] == [
+        "read_file",
+        "web_search",
+    ]
+
+
 def test_refresh_adds_late_landing_tools(monkeypatch):
     """A server that registers after build → its tools land in the snapshot."""
     agent = _agent(["read_file", "terminal"])

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -594,6 +594,7 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    result["session_target"] = job.get("session_target", "isolated")
     return result
 
 
@@ -1052,6 +1053,7 @@ def cronjob(
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
+    session_target: Optional[str] = None,
     task_id: str = None,
     session_id: Optional[str] = None,
 ) -> str:
@@ -1140,6 +1142,7 @@ def cronjob(
                     attach_to_session=attach_to_session,
                     monitor_script=_normalize_optional_job_value(monitor_script),
                     monitor_url=_normalize_optional_job_value(monitor_url),
+                    session_target=session_target or "isolated",
                 )
             except CronSchedulerRegistrationError as exc:
                 _partial = exc.to_dict()
@@ -1228,6 +1231,21 @@ def cronjob(
             return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
 
         if normalized in {"run", "run_now", "trigger"}:
+            # This model tool executes synchronously inside the current agent
+            # turn. A contextual occurrence deliberately waits for that human
+            # turn's adapter guard and session lease, so running it here would
+            # deadlock the caller against itself. Scheduled fires and the
+            # authenticated REST trigger are outside the owning turn and remain
+            # supported.
+            if job.get("session_target", "isolated") == "current":
+                return tool_error(
+                    "A current-session cron job cannot be run synchronously "
+                    "from the cronjob model tool because contextual execution "
+                    "starts only after the active human turn finishes. Let the "
+                    "scheduler fire it, or trigger it through the REST API "
+                    "outside the conversation turn.",
+                    success=False,
+                )
             # Per-run context (#57331, salvaged from #57342/@liuhao1024 and
             # #57360/@ghedeselmabot): `prompt` on the run action is transient
             # context appended to the stored prompt for THIS fire only, never
@@ -1413,6 +1431,8 @@ def cronjob(
                             success=False,
                         )
                 updates["no_agent"] = target_no_agent
+            if session_target is not None:
+                updates["session_target"] = session_target
             if repeat is not None:
                 # Normalize: treat 0 or negative as None (infinite)
                 normalized_repeat = None if repeat <= 0 else repeat
@@ -1451,7 +1471,10 @@ action='run' fires the job immediately in the BACKGROUND (like delegate_task): t
 
 To stop a job the user no longer wants: first action='list' to find the job_id, then action='remove' with that job_id. Never guess job IDs — always list first.
 
-Jobs run in a fresh session with no current-chat context, so prompts must be self-contained.
+Jobs run in a fresh isolated session by default, so prompts must be self-contained.
+Set session_target='current' only when the user explicitly wants the scheduled turn
+to continue this live conversation; the gateway captures the current routing key and
+fails closed if the session is reset, missing, or no longer authorized.
 If skills are provided on create, the future cron run loads those skills in order, then follows the prompt as the task instruction.
 On update, passing skills=[] clears attached skills.
 
@@ -1552,6 +1575,12 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "boolean",
                 "description": "When True, this job becomes CONTINUABLE: the user can reply to its delivery and the agent has the brief in context instead of asking 'what is that?'. On thread-capable platforms (Telegram topics, Discord/Slack threads) a dedicated thread is opened for the job and its replies; on DM-only platforms (WhatsApp/Signal) the brief is mirrored into the origin DM session. Use this for conversational recurring jobs the user will reply to — daily briefings, reminders that kick off follow-up work. Leave unset for fire-and-forget alerts/watchdogs. Overrides the global cron.mirror_delivery config for this one job. Only the origin chat is touched (never fan-out targets); no effect when deliver='local'."
             },
+            "session_target": {
+                "type": "string",
+                "enum": ["isolated", "current"],
+                "default": "isolated",
+                "description": "Opt in to the live conversation with 'current'. The gateway captures the current stable session key; callers cannot provide one. Omit for the legacy isolated cron session. Contextual jobs must be model-backed, use origin/local delivery, and cannot set skills, workdir, context_from, enabled_toolsets, model/provider/base_url, monitor_script/monitor_url, or attach_to_session."
+            },
         },
         "required": ["action"]
     }
@@ -1611,6 +1640,7 @@ registry.register(
         no_agent=args.get("no_agent"),
         monitor_script=args.get("monitor_script"),
         monitor_url=args.get("monitor_url"),
+        session_target=args.get("session_target"),
         task_id=kw.get("task_id"),
         session_id=kw.get("session_id"),
     ),

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -7164,6 +7164,15 @@ def refresh_agent_mcp_tools(
     # this rebuild actually appended (matching agent_init's dedup-aware add).
     staged_engine_names = _reinject_post_build_tools(agent, new_defs, new_names)
 
+    # Contextual turns receive a gateway-owned hard allowlist. Re-apply it
+    # after late MCP/plugin discovery so refresh cannot widen capabilities.
+    allowed_tool_names = getattr(agent, "allowed_tool_names", None)
+    if allowed_tool_names is not None:
+        allowed = frozenset(allowed_tool_names)
+        new_defs = [t for t in new_defs if t["function"]["name"] in allowed]
+        new_names = {t["function"]["name"] for t in new_defs}
+        staged_engine_names.intersection_update(new_names)
+
     # Single atomic read-diff-publish so the returned ``added`` is consistent
     # with what was actually published, even under concurrent callers, and a
     # stale (older-generation) rebuild can't overwrite a newer published one.

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -5,6 +5,7 @@ are rebound onto server.py's globals at install time — see method_ctx.py.
 """
 
 from .method_ctx import HandlerRegistry
+from agent.turn_context import clone_transcript_message_for_branch
 
 _registry = HandlerRegistry()
 method = _registry.method
@@ -456,7 +457,11 @@ def _(rid, params: dict) -> dict:
                 # history becomes the resumed session record's working conversation),
                 # so heal a durable ``user;user`` violation once here instead of
                 # re-firing the pre-request repair on every subsequent turn.
-                history = db.get_messages_as_conversation(target, repair_alternation=True)
+                history = db.get_messages_as_conversation(
+                    target,
+                    repair_alternation=True,
+                    include_hidden=True,
+                )
             except Exception as e:
                 if lease is not None:
                     lease.release()
@@ -538,7 +543,9 @@ def _(rid, params: dict) -> dict:
                 # inspection/export must show what is actually stored.
                 if omit_messages:
                     raw_history = db.get_messages_as_conversation(
-                        target, repair_alternation=True
+                        target,
+                        repair_alternation=True,
+                        include_hidden=True,
                     )
                     display_history = []
                 else:
@@ -624,7 +631,9 @@ def _(rid, params: dict) -> dict:
             # display copy stays verbatim.
             if omit_messages:
                 raw_history = db.get_messages_as_conversation(
-                    target, repair_alternation=True
+                    target,
+                    repair_alternation=True,
+                    include_hidden=True,
                 )
                 display_history = []
             else:
@@ -2816,16 +2825,7 @@ def _(rid, params: dict) -> dict:
             # were the write-amplification pattern removed in #23254.
             db.append_messages_batch(
                 new_key,
-                [
-                    {
-                        "role": msg.get("role", "user"),
-                        "content": msg.get("content"),
-                        # Preserve the parent's original message timestamps —
-                        # branch copies are history, not new activity (9d73006ad).
-                        "timestamp": msg.get("timestamp"),
-                    }
-                    for msg in history
-                ],
+                [clone_transcript_message_for_branch(msg) for msg in history],
                 chunk_rows=500,
             )
             db.set_session_title(new_key, title)

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -885,7 +885,11 @@ def _(rid, params: dict) -> dict:
         # lands on a durable user;user pair would otherwise re-fire the
         # pre-request repair on every request from here on.
         try:
-            active = db.get_messages_as_conversation(session_key, repair_alternation=True)
+            active = db.get_messages_as_conversation(
+                session_key,
+                repair_alternation=True,
+                include_hidden=True,
+            )
         except Exception:
             active = []
         with session["history_lock"]:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -37,6 +37,7 @@ from tools.environments.local import hermes_subprocess_env
 from agent.replay_cleanup import sanitize_replay_history
 from agent.skill_commands import describe_skill_invocation
 from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
+from agent.turn_context import clone_transcript_message_for_branch
 from tui_gateway import git_probe
 from tui_gateway.turn_marker import (
     clear_turn_marker,
@@ -2860,17 +2861,7 @@ def _persist_branch_seed(session: dict) -> None:
             # _branch_seed_persisted unset).
             db.append_messages_batch(
                 key,
-                [
-                    {
-                        "role": msg.get("role", "user"),
-                        "content": msg.get("content"),
-                        # Preserve the parent's original message timestamps —
-                        # append_message would otherwise stamp time.time() and the
-                        # branch's copied history would all appear authored "now".
-                        "timestamp": msg.get("timestamp"),
-                    }
-                    for msg in seed
-                ],
+                [clone_transcript_message_for_branch(msg) for msg in seed],
                 chunk_rows=500,
             )
             session["_branch_seed_persisted"] = True

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -265,24 +265,42 @@ What they do:
 ### Opt in to the current conversation
 
 Model-backed jobs created from a live gateway conversation may set
-`session_target: "current"` to continue that same conversation when they run.
-Hermes captures the conversation's stable gateway routing key; callers cannot
-supply an arbitrary session key through the `cronjob` tool. At each occurrence,
-the gateway durably seals the concrete session ID before queueing the turn,
-serializes it through the same resolved-session turn lease used by human turns,
-and revalidates the mapping and authorization immediately before execution.
+`session_target: "current"` to continue that same logical conversation when they
+run. Hermes captures an immutable gateway-owned route instance plus the exact
+profile, tenant/workspace, platform, account-bound chat, canonical thread, user,
+and adapter-alias dimensions; callers cannot supply an arbitrary session key or
+route identity through the `cronjob` tool. At each
+occurrence, the gateway resolves the physical transcript currently owned by that
+logical route under the same routing fence used by reset, durably seals the
+route instance, concrete session ID, and routing revision, then serializes the
+turn through the same resolved-session turn lease used by human turns.
 
-A contextual job's concrete session binding is immutable from creation. Any
-`/new` or reset that changes that route before or after occurrence admission
-makes the occurrence `stale`; Hermes does not retarget it or fall back to an
-isolated session. Recreate the job from the new conversation to bind it there.
+A normal `/new` or reset preserves the logical route instance. An occurrence
+admitted afterward therefore follows the new transcript in that same
+conversation. Once an occurrence is admitted, its physical target is immutable:
+a later reset makes that occurrence `stale` rather than retargeting it, while a
+future recurring occurrence may resolve the newer transcript. Deletion,
+recreation, account/chat/thread route drift, authorization loss, or any
+unprovable continuity fails closed. In shared threads, participant activity does
+not redefine the conversation route: each job is reauthorized as its own
+captured creator before execution and transcript application. Hermes never
+follows the currently focused UI conversation and never falls back to an
+isolated session. Existing persisted v1 jobs retain their original strict
+physical-session binding and must be recreated to opt into logical-route
+rollover.
+
+The gateway acquires a persistent cross-process routing-authority lease for each
+session-store scope. Starting another gateway process against the same scope
+fails closed instead of allowing two once-loaded routing caches to disagree
+about reset/admission order.
+
 The scheduled prompt is stored as a hidden
 internal transcript row, progress and streaming output are suppressed, and only
 the final `notify` result goes through the normal cron delivery path. An
 intentional `no_action` result is silent and scheduled turns do not refresh the
 human-interaction timestamp.
 
-Contextual v1 jobs are same-session, model-backed jobs only. They cannot use
+Contextual jobs are same-conversation, model-backed jobs only. They cannot use
 script/`no_agent` execution, attached skills, `workdir`, `context_from`, custom
 toolset or model/provider overrides, `attach_to_session`, or fan-out/cross-user
 delivery. Omit `session_target` (or use `"isolated"`) for the existing isolated
@@ -310,7 +328,8 @@ On each tick Hermes:
 1. loads jobs from `~/.hermes/cron/jobs.json`
 2. checks `next_run_at` against the current time
 3. starts a fresh `AIAgent` session for each isolated job, or admits an opt-in
-   contextual job into its immutable live gateway session
+   contextual job into the currently resolved transcript of its immutable
+   logical gateway route
 4. optionally injects one or more attached skills into isolated sessions
 5. runs the prompt to completion
 6. delivers the final response

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -260,7 +260,39 @@ What they do:
 
 ## How it works
 
-**Cron execution is handled by the gateway daemon.** The gateway ticks the scheduler every 60 seconds, running any due jobs in isolated agent sessions.
+**Cron execution is handled by the gateway daemon.** The gateway ticks the scheduler every 60 seconds. Jobs use fresh isolated agent sessions by default.
+
+### Opt in to the current conversation
+
+Model-backed jobs created from a live gateway conversation may set
+`session_target: "current"` to continue that same conversation when they run.
+Hermes captures the conversation's stable gateway routing key; callers cannot
+supply an arbitrary session key through the `cronjob` tool. At each occurrence,
+the gateway durably seals the concrete session ID before queueing the turn,
+serializes it through the same resolved-session turn lease used by human turns,
+and revalidates the mapping and authorization immediately before execution.
+
+A contextual job's concrete session binding is immutable from creation. Any
+`/new` or reset that changes that route before or after occurrence admission
+makes the occurrence `stale`; Hermes does not retarget it or fall back to an
+isolated session. Recreate the job from the new conversation to bind it there.
+The scheduled prompt is stored as a hidden
+internal transcript row, progress and streaming output are suppressed, and only
+the final `notify` result goes through the normal cron delivery path. An
+intentional `no_action` result is silent and scheduled turns do not refresh the
+human-interaction timestamp.
+
+Contextual v1 jobs are same-session, model-backed jobs only. They cannot use
+script/`no_agent` execution, attached skills, `workdir`, `context_from`, custom
+toolset or model/provider overrides, `attach_to_session`, or fan-out/cross-user
+delivery. Omit `session_target` (or use `"isolated"`) for the existing isolated
+behavior.
+
+The agent-facing `cronjob(action="run")` call is rejected for contextual jobs:
+that tool is executing inside the human turn whose lease the scheduled turn must
+wait for, so a synchronous run would deadlock against itself. Let the scheduler
+fire the job, or use the authenticated REST trigger from outside the conversation
+turn.
 
 ```bash
 hermes gateway install     # Install as a user service
@@ -277,8 +309,9 @@ On each tick Hermes:
 
 1. loads jobs from `~/.hermes/cron/jobs.json`
 2. checks `next_run_at` against the current time
-3. starts a fresh `AIAgent` session for each due job
-4. optionally injects one or more attached skills into that fresh session
+3. starts a fresh `AIAgent` session for each isolated job, or admits an opt-in
+   contextual job into its immutable live gateway session
+4. optionally injects one or more attached skills into isolated sessions
 5. runs the prompt to completion
 6. delivers the final response
 7. updates run metadata and the next scheduled time
@@ -290,10 +323,14 @@ A file lock at `~/.hermes/cron/.tick.lock` prevents overlapping scheduler ticks 
 Hermes records each claimed cron attempt in the profile-local
 `~/.hermes/cron/executions.db` before executor or provider dispatch. Attempts
 move through `claimed`, `running`, and one immutable terminal state:
-`completed`, `failed`, or `unknown`. After restart, Hermes marks an abandoned
+`completed`, `failed`, or `unknown`. After restart, Hermes first checks whether
+an abandoned contextual attempt ever acquired its execution-specific jobs-store
+occurrence claim. If it did not, the attempt is rejected and the occurrence
+remains due. If it did, Hermes marks the
 attempt `unknown` only when the original PID and process-start fingerprint prove
-that its owner is gone. Unknown attempts are audit records and are never
-automatically rerun.
+that its owner is gone; that occurrence is intentionally consumed under
+at-most-once semantics and is never automatically rerun. Unknown attempts remain
+inspectable audit records.
 
 Inspect recent attempts with `hermes cron runs [job-id] --limit 20` (alias:
 `history`). Terminal history is bounded; active attempts are never pruned. The


### PR DESCRIPTION
## Summary

- add `session_target: "current"` for model-backed cron jobs created from a live gateway conversation
- resolve each occurrence against an immutable gateway-owned logical route, then serialize it through the same resolved-session turn lease used by human turns
- preserve route continuity across normal `/new` resets while fencing admitted occurrences against reset/delete/recreate ABA, authorization drift, and cross-account/chat/thread/workspace movement
- stage hidden scheduled prompts and transcript updates through a durable contextual outbox; suppress streaming/progress rows and deliver only explicit final `notify` results
- add persistent cross-process routing authority, execution-ledger occurrence claims, crash-safe jobs-store authority transition, recovery, and extensive unit/integration coverage

## Why

Cron jobs currently always run in fresh isolated sessions. Some reminders and scheduled follow-ups need the context of the conversation that created them, but simply persisting a physical session ID is unsafe: resets, shared threads, route recreation, concurrent human turns, and process crashes can retarget or duplicate work.

This change makes same-conversation execution explicit and fail-closed. Existing jobs remain isolated unless they opt in.

## Safety and compatibility

- callers cannot provide arbitrary session keys or route identities through the model tool
- gateway captures profile, tenant/workspace, platform, account, chat, canonical thread, creator, route instance, and routing revision
- each occurrence is durably admitted and sealed before model execution
- normal reset preserves the logical route for future occurrences; an already-admitted occurrence becomes `stale` rather than silently retargeting
- route deletion/recreation, creator authorization loss, or unprovable continuity fails closed
- contextual turns never fall back to standalone/isolated delivery
- final delivery requires an explicit positive acknowledgement; timeout or unconfirmed delivery is `unknown`
- contextual prompts and tool rows stay hidden; only the final public response is appended/delivered
- script/`no_agent`, attached skills, `workdir`, `context_from`, toolset/model overrides, fan-out, and cross-user delivery remain isolated-only
- persisted v1 jobs preserve strict physical-session semantics and must be recreated to opt into rollover
- public cron API records preserve the legacy isolated shape
- the first contextual jobs-store commit uses a durable pending receipt plus authority marker; crash recovery distinguishes an interrupted pre-commit transition from committed authority

## Validation

Exact candidate:

- commit: `78dc1aea50edef99dabfc21c16c1ecc435d4c89d`
- base: `3e6a081d60e8d04a03d37008464f44555bc88832`
- deterministic `git archive` SHA-256: `bbc0849504ba834749b1dbf9d385c926c928e8e3bde84ee0205458513a7423b4`

Results:

- affected per-file suite: **1,253 passed, 0 failed** across 19 files
- broad in-process candidate: **10,222 passed, 161 failed, 45 skipped**
- broad in-process exact upstream: **10,015 passed, 165 failed, 45 skipped**
- exact broad failure-identity delta: **0 candidate-only**, 4 upstream-only
- canonical full candidate: **28,965 passed, 60 failed**, 0 flaky files
- canonical full exact upstream: **28,767 passed, 61 failed**, 2 files passed on retry
- exact canonical terminal failure-identity delta: **0 candidate-only**, 1 upstream-only
- `ty` affected-source comparison: 734 candidate diagnostics vs 743 upstream; **0 candidate-only**
- Windows footgun scan: **0 findings** across 73 changed files
- exact-source image: `hermes-context-cron:df17-78dc1aea5` / image ID `sha256:8984ac047b0904dae5896ac0ad45634457e563fbd0f0e9f22b3088e8e7e86f67`
- bounded live-model image E2E: **passed** — reset rollover resolved the replacement transcript, produced `LIVE_ROLLOVER_OK_nougat`, applied one hidden prompt row and one public assistant row, and recorded `execution_status=completed`, `delivery_state=sent`
- independent exact-fingerprint reviews: **3× CLEAR; P0=0, P1=0** (stateful correctness, privacy/authorization, integration/regression)

The repository-wide suite is not clean on upstream, so broad and canonical judgments use exact failure identities against a clean exact-base snapshot rather than totals alone.

## Checklist

- [x] Read and followed `CONTRIBUTING.md`
- [x] Added regression, concurrency, crash/recovery, authorization, privacy, and integration tests
- [x] Added user-facing documentation for `session_target: "current"`
- [x] Preserved backward compatibility for existing isolated jobs and public records
- [x] Ran Windows footgun scan
- [x] Ran affected suite, broad candidate/upstream comparison, canonical candidate/upstream comparison, exact-source image E2E, and bounded live-model validation
- [x] Searched open/closed issues and PRs for duplicate contextual/current-session cron work; none found

<!-- No linked issue: this is a standalone feature contribution. -->
