### PR TITLE
fix(doctor): treat explicit memory.provider: builtin as built-in memory

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2619,7 +2619,7 @@ def run_doctor(args):
     except Exception:
         pass
 
-    if not _active_memory_provider:
+    if not _active_memory_provider or _active_memory_provider == "builtin":
         check_ok("Built-in memory active", "(no external provider configured — this is fine)")
     elif _active_memory_provider == "honcho":
         try:

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -271,6 +271,16 @@ class TestDoctorMemoryProviderSection:
         assert "Honcho API key" not in out
         assert "Mem0" not in out
 
+    def test_explicit_builtin_provider_shows_builtin_ok(self, monkeypatch, tmp_path):
+        # `memory.provider: builtin` is the documented way to select the
+        # built-in memory; doctor must not treat it as a missing external plugin.
+        out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="builtin")
+        assert "Memory Provider" in out
+        assert "Built-in memory active" in out
+        assert "plugin not found" not in out
+        assert "Honcho API key" not in out
+        assert "Mem0" not in out
+
 
     def test_mem0_provider_not_installed_shows_fail(self, monkeypatch, tmp_path):
         # Make mem0 import fail


### PR DESCRIPTION
## Summary

`hermes doctor`'s Memory Provider section only recognized an **absent** `memory.provider` as the built-in memory. An explicit `memory.provider: builtin` — the documented way to select the built-in provider — fell through to the generic plugin check, which called `load_memory_provider('builtin')` → `None` and reported:

```
⚠ builtin plugin not found run: hermes memory setup
```

This is a false positive: `builtin` is a valid provider value and memory is fully working in this state.

## Fix

`hermes_cli/doctor.py` — treat the literal `"builtin"` the same as an empty provider:

```python
if not _active_memory_provider or _active_memory_provider == "builtin":
    check_ok("Built-in memory active", "(no external provider configured — this is fine)")
```

## Test

Added `test_explicit_builtin_provider_shows_builtin_ok` to `tests/hermes_cli/test_doctor.py` asserting the built-in path reports active and does not emit "plugin not found".

Full `test_doctor.py` suite: 50 passed.