### PR TITLE
fix(agent): clear recovered file mutation warnings safely

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1447,6 +1447,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 try:
                     agent._record_file_mutation_result(
                         function_name, function_args, function_result, is_error,
+                        task_id=effective_task_id,
                     )
                 except Exception as _ver_err:
                     logging.debug("file-mutation verifier record failed: %s", _ver_err)
@@ -2204,6 +2205,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             try:
                 agent._record_file_mutation_result(
                     function_name, function_args, function_result, _is_error_result,
+                    task_id=effective_task_id,
                 )
             except Exception as _ver_err:
                 logging.debug("file-mutation verifier record failed: %s", _ver_err)

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -889,11 +889,19 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     if batch_mutation_lock is None:
         batch_mutation_lock = threading.Lock()
         agent._turn_file_mutation_state_lock = batch_mutation_lock
+    mutation_verifier_enabled = (
+        batch_mutation_state is not None
+        and agent._file_mutation_verifier_enabled()
+    )
     recorded_mutation_indices: set[int] = set()
     mutation_completion_events = [
         (
             threading.Event()
-            if name in {"write_file", "patch"} and parse_error is None
+            if (
+                mutation_verifier_enabled
+                and name in {"write_file", "patch"}
+                and parse_error is None
+            )
             else None
         )
         for _tc, name, _args, _trace, parse_error, _scope_block in parsed_calls
@@ -921,7 +929,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         fingerprint_failures: bool = True,
     ) -> None:
         """Record against this batch's turn state, never a later turn's state."""
-        if blocked or batch_mutation_state is None:
+        if blocked or not mutation_verifier_enabled:
             return
         try:
             with batch_mutation_lock:

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -999,6 +999,26 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         dispatched = False
         start_advanced = False
 
+        def _record_file_mutation(result: Any, is_error: bool, is_blocked: bool) -> None:
+            """Record at worker completion before a sibling can hide recovery order."""
+            if is_blocked:
+                return
+            try:
+                state_lock = getattr(agent, "_turn_file_mutation_state_lock", None)
+                if state_lock is None:
+                    state_lock = threading.Lock()
+                    agent._turn_file_mutation_state_lock = state_lock
+                with state_lock:
+                    agent._record_file_mutation_result(
+                        function_name,
+                        function_args,
+                        result,
+                        is_error,
+                        task_id=effective_task_id,
+                    )
+            except Exception as _ver_err:
+                logging.debug("file-mutation verifier record failed: %s", _ver_err)
+
         def _advance_start(callback=None) -> None:
             nonlocal start_advanced
             if start_advanced:
@@ -1077,6 +1097,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 )
                 duration = time.time() - start
                 logger.info("tool %s cancelled (%.2fs)", function_name, duration)
+                _record_file_mutation(result, True, False)
                 results[index] = (
                     function_name,
                     function_args,
@@ -1107,6 +1128,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 logger.info("tool %s failed (%.2fs): %s", function_name, duration, result[:200])
             else:
                 logger.info("tool %s completed (%.2fs, %d chars)", function_name, duration, len(result))
+            _record_file_mutation(result, is_error, blocked)
             results[index] = (
                 function_name,
                 function_args,
@@ -1439,18 +1461,6 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 _err_text = _multimodal_text_summary(function_result)
                 result_preview = _err_text[:200] if len(_err_text) > 200 else _err_text
                 logger.warning("Tool %s returned error (%.2fs): %s", function_name, tool_duration, result_preview)
-
-            # Track file-mutation outcome for the turn-end verifier.
-            # `blocked` calls never actually ran — don't let a guardrail
-            # block count as either a failure or a success.
-            if not blocked:
-                try:
-                    agent._record_file_mutation_result(
-                        function_name, function_args, function_result, is_error,
-                        task_id=effective_task_id,
-                    )
-                except Exception as _ver_err:
-                    logging.debug("file-mutation verifier record failed: %s", _ver_err)
 
             if agent.verbose_logging:
                 logging.debug("Tool %s completed in %.2fs", function_name, tool_duration)

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -890,6 +890,24 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         batch_mutation_lock = threading.Lock()
         agent._turn_file_mutation_state_lock = batch_mutation_lock
     recorded_mutation_indices: set[int] = set()
+    mutation_completion_events = [
+        (
+            threading.Event()
+            if name in {"write_file", "patch"} and parse_error is None
+            else None
+        )
+        for _tc, name, _args, _trace, parse_error, _scope_block in parsed_calls
+    ]
+
+    def _wait_for_prior_file_mutations(index: int) -> bool:
+        """Keep later tool side effects behind earlier mutation snapshots."""
+        for event in mutation_completion_events[:index]:
+            if event is None:
+                continue
+            while not event.wait(timeout=0.05):
+                if batch_abandoned.is_set():
+                    return False
+        return not batch_abandoned.is_set()
 
     def _record_batch_file_mutation(
         index: int,
@@ -1060,6 +1078,8 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 # Batch already abandoned: the turn synthesized this tool's
                 # result and moved on. Abort instead of dispatching late.
                 raise _BatchAbandoned(function_name)
+            if not _wait_for_prior_file_mutations(index):
+                raise _BatchAbandoned(function_name)
 
         try:
             try:
@@ -1167,6 +1187,11 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 middleware_trace,
             )
         finally:
+            mutation_event = mutation_completion_events[index]
+            if mutation_event is not None:
+                # Release later tools only after this call's result (including
+                # its post-failure fingerprint) has been recorded.
+                mutation_event.set()
             # Teardown advance: keep the counter moving for any later-ordered
             # worker. Never let the abandonment signal escape from here — the
             # worker is already unwinding and the turn owns the result.

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -884,12 +884,55 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     # later and dispatching a tool the turn has already reported as timed out.
     batch_abandoned = threading.Event()
     authorization_gate = _ConcurrentToolAuthorizationGate()
+    batch_mutation_state = getattr(agent, "_turn_failed_file_mutations", None)
+    batch_mutation_lock = getattr(agent, "_turn_file_mutation_state_lock", None)
+    if batch_mutation_lock is None:
+        batch_mutation_lock = threading.Lock()
+        agent._turn_file_mutation_state_lock = batch_mutation_lock
+    recorded_mutation_indices: set[int] = set()
+
+    def _record_batch_file_mutation(
+        index: int,
+        function_name: str,
+        function_args: dict[str, Any],
+        result: Any,
+        is_error: bool,
+        blocked: bool,
+        *,
+        allow_abandoned: bool = False,
+        fingerprint_failures: bool = True,
+    ) -> None:
+        """Record against this batch's turn state, never a later turn's state."""
+        if blocked or batch_mutation_state is None:
+            return
+        try:
+            with batch_mutation_lock:
+                if batch_abandoned.is_set() and not allow_abandoned:
+                    return
+                if getattr(agent, "_turn_failed_file_mutations", None) is not batch_mutation_state:
+                    return
+                agent._record_file_mutation_result(
+                    function_name,
+                    function_args,
+                    result,
+                    is_error,
+                    task_id=effective_task_id,
+                    expected_state=batch_mutation_state,
+                    fingerprint_failures=fingerprint_failures,
+                )
+                recorded_mutation_indices.add(index)
+        except Exception as _ver_err:
+            logging.debug("file-mutation verifier record failed: %s", _ver_err)
 
     def _abandon_batch() -> None:
         """Release every gate-parked worker so none dispatches post-abandon."""
         batch_abandoned.set()
         with start_condition:
             start_condition.notify_all()
+        # Fence any recorder that passed its pre-abandon check. Once this lock
+        # round-trip completes, detached workers can no longer mutate the turn.
+        with batch_mutation_lock:
+            pass
 
     # The gate bound must sit UNDER the batch deadline, otherwise the deadline
     # fires first and the parked workers are still falsely reported as timed
@@ -999,25 +1042,6 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         dispatched = False
         start_advanced = False
 
-        def _record_file_mutation(result: Any, is_error: bool, is_blocked: bool) -> None:
-            """Record at worker completion before a sibling can hide recovery order."""
-            if is_blocked:
-                return
-            try:
-                state_lock = getattr(agent, "_turn_file_mutation_state_lock", None)
-                if state_lock is None:
-                    state_lock = threading.Lock()
-                    agent._turn_file_mutation_state_lock = state_lock
-                with state_lock:
-                    agent._record_file_mutation_result(
-                        function_name,
-                        function_args,
-                        result,
-                        is_error,
-                        task_id=effective_task_id,
-                    )
-            except Exception as _ver_err:
-                logging.debug("file-mutation verifier record failed: %s", _ver_err)
 
         def _advance_start(callback=None) -> None:
             nonlocal start_advanced
@@ -1097,7 +1121,9 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 )
                 duration = time.time() - start
                 logger.info("tool %s cancelled (%.2fs)", function_name, duration)
-                _record_file_mutation(result, True, False)
+                _record_batch_file_mutation(
+                    index, function_name, function_args, result, True, False,
+                )
                 results[index] = (
                     function_name,
                     function_args,
@@ -1128,7 +1154,9 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 logger.info("tool %s failed (%.2fs): %s", function_name, duration, result[:200])
             else:
                 logger.info("tool %s completed (%.2fs, %d chars)", function_name, duration, len(result))
-            _record_file_mutation(result, is_error, blocked)
+            _record_batch_file_mutation(
+                index, function_name, function_args, result, is_error, blocked,
+            )
             results[index] = (
                 function_name,
                 function_args,
@@ -1465,6 +1493,18 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             if agent.verbose_logging:
                 logging.debug("Tool %s completed in %.2fs", function_name, tool_duration)
                 logging.debug("Tool result (%d chars): %s", len(function_result), function_result)
+
+        if i not in recorded_mutation_indices:
+            _record_batch_file_mutation(
+                i,
+                name,
+                args,
+                function_result,
+                is_error,
+                blocked,
+                allow_abandoned=True,
+                fingerprint_failures=False,
+            )
 
         agent._current_tool = None
         _status_suffix = " (error)" if is_error else ""

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -1145,6 +1145,7 @@ def build_turn_context(
     agent._turn_file_mutation_fingerprint_bytes = 0
     agent._turn_file_mutation_fingerprint_budget_exhausted = False
     agent._turn_file_mutation_fingerprint_lock = threading.Lock()
+    agent._turn_file_mutation_state_lock = threading.Lock()
     agent._verification_stop_nudges = 0
     agent._pre_verify_nudges = 0
 

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -1142,6 +1142,9 @@ def build_turn_context(
     # Per-turn file-mutation verifier state.
     agent._turn_failed_file_mutations = {}
     agent._turn_file_mutation_paths = set()
+    agent._turn_file_mutation_fingerprint_bytes = 0
+    agent._turn_file_mutation_fingerprint_budget_exhausted = False
+    agent._turn_file_mutation_fingerprint_lock = threading.Lock()
     agent._verification_stop_nudges = 0
     agent._pre_verify_nudges = 0
 

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -481,8 +481,12 @@ def finalize_turn(
     # already have other surface text that shouldn't be augmented.
     if final_response and not interrupted:
         try:
-            _failed = agent._unresolved_file_mutation_failures()
-            if _failed and agent._file_mutation_verifier_enabled():
+            _failed = (
+                agent._unresolved_file_mutation_failures()
+                if agent._file_mutation_verifier_enabled()
+                else {}
+            )
+            if _failed:
                 footer = agent._format_file_mutation_failure_footer(_failed)
                 if footer:
                     final_response = final_response.rstrip() + "\n\n" + footer

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -466,8 +466,8 @@ def finalize_turn(
 
     # File-mutation verifier footer.
     # If one or more ``write_file`` / ``patch`` calls failed during this
-    # turn and were never superseded by a successful write to the same
-    # path, append an advisory footer to the assistant response.  This
+    # turn and remain unresolved after checking for a later on-disk change
+    # to the same path, append an advisory footer to the assistant response.
     # catches the specific case — reported by Ben Eng (#15524-adjacent)
     # — where a model issues a batch of parallel patches, half of them
     # fail with "Could not find old_string", and the model summarises
@@ -481,7 +481,7 @@ def finalize_turn(
     # already have other surface text that shouldn't be augmented.
     if final_response and not interrupted:
         try:
-            _failed = getattr(agent, "_turn_failed_file_mutations", None) or {}
+            _failed = agent._unresolved_file_mutation_failures()
             if _failed and agent._file_mutation_verifier_enabled():
                 footer = agent._format_file_mutation_failure_footer(_failed)
                 if footer:

--- a/run_agent.py
+++ b/run_agent.py
@@ -3417,14 +3417,18 @@ class AIAgent:
         args: Dict[str, Any],
         result: Any,
         is_error: bool,
+        task_id: Optional[str] = None,
     ) -> None:
         """Record a ``write_file`` / ``patch`` outcome for the turn-end verifier.
 
-        On failure, store ``{path: {error_preview, tool}}`` entries.  On
+        On failure, store per-target error and post-attempt snapshot data.  On
         success, remove any prior failure entries for the same paths (the
-        model recovered within the turn).  Silently no-ops if the per-turn
-        state dict hasn't been initialised yet (e.g. a tool dispatched
-        outside ``run_conversation``).
+        model recovered within the turn).  Failed attempts retain a content
+        fingerprint of the target *after* the failed tool returned; this lets
+        the turn finalizer recognize a later recovery through terminal/CLI
+        without treating the failed tool call itself as proof of a change.
+        Silently no-ops if the per-turn state dict hasn't been initialised yet
+        (e.g. a tool dispatched outside ``run_conversation``).
         """
         if tool_name not in _FILE_MUTATING_TOOLS:
             return
@@ -3442,17 +3446,132 @@ class AIAgent:
         if is_error and not landed:
             preview = _extract_error_preview(result)
             for path in targets:
+                resolved_path, fingerprint = self._snapshot_file_mutation_target(
+                    path, task_id=task_id,
+                )
                 # Keep the FIRST error we saw for a given path unless we
                 # later see success.  A repeated failure with a different
-                # message shouldn't silently overwrite the original.
+                # message shouldn't silently overwrite the original.  The
+                # snapshot IS refreshed, though: a newer failed attempt must
+                # not be cleared by a change that happened before that attempt.
                 if path not in state:
                     state[path] = {
                         "tool": tool_name,
                         "error_preview": preview,
                     }
+                state[path]["resolved_path"] = resolved_path
+                state[path]["fingerprint"] = fingerprint
+                state[path]["task_id"] = task_id
         else:
             for path in targets:
                 state.pop(path, None)
+
+            # A failed relative-path attempt followed by a successful tool
+            # call that reports an absolute/resolved path is the same target.
+            # Clear those aliases too instead of leaving a stale failure.
+            if state:
+                successful_paths = set(targets)
+                successful_paths.update(
+                    _extract_landed_file_mutation_paths(tool_name, args, result)
+                )
+                resolved_successes = {
+                    resolved
+                    for path in successful_paths
+                    if (resolved := self._resolve_file_mutation_target(
+                        path, task_id=task_id,
+                    ))
+                }
+                for failed_path, info in list(state.items()):
+                    if info.get("resolved_path") in resolved_successes:
+                        state.pop(failed_path, None)
+
+    @staticmethod
+    def _resolve_file_mutation_target(
+        path: str,
+        *,
+        task_id: Optional[str] = None,
+    ) -> Optional[str]:
+        """Resolve a verifier target only when it belongs to the local backend."""
+        try:
+            from tools.file_tools import _resolve_path, _terminal_env_type_for_task
+
+            effective_task_id = task_id or "default"
+            if _terminal_env_type_for_task(effective_task_id) != "local":
+                return None
+            return str(Path(_resolve_path(str(path), effective_task_id)))
+        except Exception:
+            return None
+
+    @classmethod
+    def _snapshot_file_mutation_target(
+        cls,
+        path: str,
+        *,
+        task_id: Optional[str] = None,
+    ) -> tuple[Optional[str], Optional[tuple]]:
+        """Return a local target's resolved path and content fingerprint.
+
+        The verifier deliberately fingerprints only the local terminal
+        backend.  Host-side inspection of Docker/SSH/Modal paths could observe
+        an unrelated file with the same spelling and incorrectly suppress a
+        real warning.  When the target cannot be inspected, ``None`` keeps the
+        original conservative behavior.
+        """
+        resolved_text = cls._resolve_file_mutation_target(path, task_id=task_id)
+        if not resolved_text:
+            return None, None
+        try:
+            resolved = Path(resolved_text)
+            try:
+                stat_result = resolved.stat()
+            except FileNotFoundError:
+                return resolved_text, ("missing",)
+            if not resolved.is_file():
+                return resolved_text, (
+                    "other",
+                    stat_result.st_mode,
+                    stat_result.st_size,
+                    stat_result.st_mtime_ns,
+                )
+            # A failed edit must not trigger an unbounded hidden read of a
+            # giant target at both failure time and turn finalization.  For
+            # large files, stay conservative and leave the warning unresolved.
+            if stat_result.st_size > 64 * 1024 * 1024:
+                return resolved_text, None
+
+            digest = hashlib.sha256()
+            with resolved.open("rb") as handle:
+                for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                    digest.update(chunk)
+            return resolved_text, ("file", digest.hexdigest())
+        except Exception:
+            # Verification is advisory and must never break turn finalization.
+            return None, None
+
+    def _unresolved_file_mutation_failures(self) -> Dict[str, Dict[str, Any]]:
+        """Filter stale failures whose targets changed after the failed call.
+
+        A changed fingerprint is direct filesystem evidence of recovery via a
+        route the file-tool result tracker cannot see (for example ``hermes
+        config set`` executed through ``terminal``).  Missing or unreadable
+        snapshots stay unresolved so the verifier never loses its original
+        protection merely because it could not inspect a target.
+        """
+        failed = getattr(self, "_turn_failed_file_mutations", None) or {}
+        unresolved: Dict[str, Dict[str, Any]] = {}
+        for path, info in failed.items():
+            baseline = info.get("fingerprint")
+            resolved_path = info.get("resolved_path")
+            if baseline is None or not resolved_path:
+                unresolved[path] = info
+                continue
+            current_resolved, current = self._snapshot_file_mutation_target(
+                resolved_path,
+                task_id=info.get("task_id"),
+            )
+            if current_resolved != resolved_path or current is None or current == baseline:
+                unresolved[path] = info
+        return unresolved
 
     def _file_mutation_verifier_enabled(self) -> bool:
         """Check whether the per-turn file-mutation verifier footer is on.
@@ -3528,9 +3647,10 @@ class AIAgent:
             return ""
         lines = [
             "⚠️ File-mutation verifier: "
-            f"{len(failed)} file(s) were NOT modified this turn despite any "
-            "wording above that may suggest otherwise. Run `git status` or "
-            "`read_file` to confirm."
+            f"{len(failed)} failed file mutation target(s) remain unresolved. "
+            "No later change to these targets was detected despite any wording "
+            "above that may suggest recovery. Run `git status` or `read_file` "
+            "to confirm."
         ]
         shown = 0
         for path, info in failed.items():

--- a/run_agent.py
+++ b/run_agent.py
@@ -3458,9 +3458,17 @@ class AIAgent:
         if is_error and not landed:
             preview = _extract_error_preview(result)
             reported_paths: List[str] = []
+            reported_path_map: Dict[str, str] = {}
             try:
                 result_data = json.loads(result) if isinstance(result, str) else result
                 if isinstance(result_data, dict):
+                    raw_path_map = result_data.get("resolved_path_map")
+                    if isinstance(raw_path_map, dict):
+                        reported_path_map = {
+                            str(key): str(value)
+                            for key, value in raw_path_map.items()
+                            if isinstance(value, str)
+                        }
                     raw_paths = result_data.get("resolved_paths")
                     if isinstance(raw_paths, list):
                         reported_paths = [str(item) for item in raw_paths]
@@ -3470,7 +3478,8 @@ class AIAgent:
                 pass
             for index, path in enumerate(targets):
                 reported_path = (
-                    reported_paths[index] if index < len(reported_paths) else None
+                    reported_path_map.get(path)
+                    or (reported_paths[index] if index < len(reported_paths) else None)
                 )
                 resolved_path = reported_path or self._resolve_file_mutation_target(
                     path, task_id=task_id,

--- a/run_agent.py
+++ b/run_agent.py
@@ -3441,6 +3441,8 @@ class AIAgent:
         state = getattr(self, "_turn_failed_file_mutations", None)
         if state is None:
             return
+        if not self._file_mutation_verifier_enabled():
+            return
         targets = _extract_file_mutation_targets(tool_name, args)
         if not targets:
             return
@@ -3611,6 +3613,8 @@ class AIAgent:
         snapshots stay unresolved so the verifier never loses its original
         protection merely because it could not inspect a target.
         """
+        if not self._file_mutation_verifier_enabled():
+            return {}
         failed = getattr(self, "_turn_failed_file_mutations", None) or {}
         unresolved: Dict[str, Dict[str, Any]] = {}
         for path, info in failed.items():

--- a/run_agent.py
+++ b/run_agent.py
@@ -223,6 +223,12 @@ from agent.tool_dispatch_helpers import (
 from utils import atomic_json_write, base_url_host_matches, base_url_hostname, env_float, is_truthy_value, model_forces_max_completion_tokens
 
 
+_FILE_MUTATION_FINGERPRINT_MAX_FILE_BYTES = 64 * 1024 * 1024
+# A target may be fingerprinted after failure and again at turn finalization.
+# Keep the complete hidden verifier workload bounded across the whole turn.
+_FILE_MUTATION_FINGERPRINT_TURN_MAX_BYTES = 2 * _FILE_MUTATION_FINGERPRINT_MAX_FILE_BYTES
+
+
 # Internal flags that mark a message as ephemeral empty-response/prefill
 # recovery scaffolding: the synthetic assistant "(empty)" turn and user nudge
 # injected after an empty response, the terminal "(empty)" sentinel, and the
@@ -3491,36 +3497,49 @@ class AIAgent:
         *,
         task_id: Optional[str] = None,
     ) -> Optional[str]:
-        """Resolve a verifier target only when it belongs to the local backend."""
+        """Canonicalize a target using the file tool's backend-aware path rules.
+
+        This is lexical identity only: remote targets need canonical aliases so
+        a recognized successful mutation can clear an equivalent failed path,
+        but they must never be inspected through the host filesystem.
+        """
         try:
-            from tools.file_tools import _resolve_path, _terminal_env_type_for_task
+            from tools.file_tools import _resolve_path
 
             effective_task_id = task_id or "default"
-            if _terminal_env_type_for_task(effective_task_id) != "local":
-                return None
-            return str(Path(_resolve_path(str(path), effective_task_id)))
+            return str(_resolve_path(str(path), effective_task_id))
         except Exception:
             return None
 
-    @classmethod
     def _snapshot_file_mutation_target(
-        cls,
+        self,
         path: str,
         *,
         task_id: Optional[str] = None,
     ) -> tuple[Optional[str], Optional[tuple]]:
-        """Return a local target's resolved path and content fingerprint.
+        """Return a canonical target and, when local and budgeted, its fingerprint.
 
-        The verifier deliberately fingerprints only the local terminal
-        backend.  Host-side inspection of Docker/SSH/Modal paths could observe
-        an unrelated file with the same spelling and incorrectly suppress a
-        real warning.  When the target cannot be inspected, ``None`` keeps the
-        original conservative behavior.
+        Canonicalization applies to every backend for alias matching.  Content
+        inspection applies only to the local backend: host-side inspection of
+        Docker/SSH/Modal paths could observe an unrelated file with the same
+        spelling and incorrectly suppress a real warning.
+
+        Fingerprints consume one aggregate per-turn byte budget.  Snapshot
+        requests are serialized in tool-result arrival order and target order
+        within each result.  Once the next regular file does not fit,
+        fingerprinting stops for the turn; that target and every later target
+        remain conservatively unresolved.
         """
-        resolved_text = cls._resolve_file_mutation_target(path, task_id=task_id)
+        resolved_text = self._resolve_file_mutation_target(path, task_id=task_id)
         if not resolved_text:
             return None, None
         try:
+            from tools.file_tools import _terminal_env_type_for_task
+
+            effective_task_id = task_id or "default"
+            if _terminal_env_type_for_task(effective_task_id) != "local":
+                return resolved_text, None
+
             resolved = Path(resolved_text)
             try:
                 stat_result = resolved.stat()
@@ -3536,17 +3555,52 @@ class AIAgent:
             # A failed edit must not trigger an unbounded hidden read of a
             # giant target at both failure time and turn finalization.  For
             # large files, stay conservative and leave the warning unresolved.
-            if stat_result.st_size > 64 * 1024 * 1024:
+            if stat_result.st_size > _FILE_MUTATION_FINGERPRINT_MAX_FILE_BYTES:
                 return resolved_text, None
+
+            budget_lock = getattr(self, "_turn_file_mutation_fingerprint_lock", None)
+            if budget_lock is None:
+                budget_lock = threading.Lock()
+                self._turn_file_mutation_fingerprint_lock = budget_lock
+            with budget_lock:
+                if getattr(self, "_turn_file_mutation_fingerprint_budget_exhausted", False):
+                    return resolved_text, None
+                used = int(getattr(self, "_turn_file_mutation_fingerprint_bytes", 0))
+                remaining_budget = max(
+                    0,
+                    _FILE_MUTATION_FINGERPRINT_TURN_MAX_BYTES - used,
+                )
+                if stat_result.st_size > remaining_budget:
+                    self._turn_file_mutation_fingerprint_budget_exhausted = True
+                    return resolved_text, None
+                # Reserve before reading so concurrent tool-result workers can
+                # never collectively hash beyond the aggregate turn cap.  A
+                # failed/racing read keeps its reservation conservatively.
+                self._turn_file_mutation_fingerprint_bytes = used + stat_result.st_size
 
             digest = hashlib.sha256()
             with resolved.open("rb") as handle:
-                for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                bytes_left = stat_result.st_size
+                while bytes_left:
+                    chunk = handle.read(min(1024 * 1024, bytes_left))
+                    if not chunk:
+                        return resolved_text, None
                     digest.update(chunk)
-            return resolved_text, ("file", digest.hexdigest())
+                    bytes_left -= len(chunk)
+
+            # If the file changed while it was read, the digest is not a safe
+            # baseline.  Its reserved bytes still count against the turn
+            # budget.
+            final_stat = resolved.stat()
+            if (
+                final_stat.st_size != stat_result.st_size
+                or final_stat.st_mtime_ns != stat_result.st_mtime_ns
+            ):
+                return resolved_text, None
+            return resolved_text, ("file", stat_result.st_size, digest.hexdigest())
         except Exception:
             # Verification is advisory and must never break turn finalization.
-            return None, None
+            return resolved_text, None
 
     def _unresolved_file_mutation_failures(self) -> Dict[str, Dict[str, Any]]:
         """Filter stale failures whose targets changed after the failed call.

--- a/run_agent.py
+++ b/run_agent.py
@@ -3635,11 +3635,13 @@ class AIAgent:
     def _unresolved_file_mutation_failures(self) -> Dict[str, Dict[str, Any]]:
         """Filter stale failures whose targets changed after the failed call.
 
-        A changed fingerprint is direct filesystem evidence of recovery via a
-        route the file-tool result tracker cannot see (for example ``hermes
-        config set`` executed through ``terminal``).  Missing or unreadable
-        snapshots stay unresolved so the verifier never loses its original
-        protection merely because it could not inspect a target.
+        A changed, still-present fingerprint is evidence of follow-up mutation
+        via a route the file-tool result tracker cannot see (for example
+        ``hermes config set`` executed through ``terminal``). The verifier
+        intentionally does not parse arbitrary shell/helper semantics; the
+        task contract treats an observed post-failure target change as the
+        recovery signal. Deleted, missing, or unreadable targets stay
+        unresolved so unrelated removal cannot suppress the warning.
         """
         if not self._file_mutation_verifier_enabled():
             return {}
@@ -3655,7 +3657,12 @@ class AIAgent:
                 resolved_path,
                 task_id=info.get("task_id"),
             )
-            if current_resolved != resolved_path or current is None or current == baseline:
+            if (
+                current_resolved != resolved_path
+                or current is None
+                or current == ("missing",)
+                or current == baseline
+            ):
                 unresolved[path] = info
         return unresolved
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -3424,6 +3424,8 @@ class AIAgent:
         result: Any,
         is_error: bool,
         task_id: Optional[str] = None,
+        expected_state: Optional[Dict[str, Dict[str, Any]]] = None,
+        fingerprint_failures: bool = True,
     ) -> None:
         """Record a ``write_file`` / ``patch`` outcome for the turn-end verifier.
 
@@ -3441,6 +3443,8 @@ class AIAgent:
         state = getattr(self, "_turn_failed_file_mutations", None)
         if state is None:
             return
+        if expected_state is not None and state is not expected_state:
+            return
         if not self._file_mutation_verifier_enabled():
             return
         targets = _extract_file_mutation_targets(tool_name, args)
@@ -3453,10 +3457,31 @@ class AIAgent:
                 changed.update(_extract_landed_file_mutation_paths(tool_name, args, result))
         if is_error and not landed:
             preview = _extract_error_preview(result)
-            for path in targets:
-                resolved_path, fingerprint = self._snapshot_file_mutation_target(
+            reported_paths: List[str] = []
+            try:
+                result_data = json.loads(result) if isinstance(result, str) else result
+                if isinstance(result_data, dict):
+                    raw_paths = result_data.get("resolved_paths")
+                    if isinstance(raw_paths, list):
+                        reported_paths = [str(item) for item in raw_paths]
+                    elif isinstance(result_data.get("resolved_path"), str):
+                        reported_paths = [result_data["resolved_path"]]
+            except (TypeError, ValueError):
+                pass
+            for index, path in enumerate(targets):
+                reported_path = (
+                    reported_paths[index] if index < len(reported_paths) else None
+                )
+                resolved_path = reported_path or self._resolve_file_mutation_target(
                     path, task_id=task_id,
                 )
+                fingerprint = None
+                if fingerprint_failures and resolved_path:
+                    _, fingerprint = self._snapshot_file_mutation_target(
+                        resolved_path,
+                        task_id=task_id,
+                        resolved_path=resolved_path,
+                    )
                 # Keep the FIRST error we saw for a given path unless we
                 # later see success.  A repeated failure with a different
                 # message shouldn't silently overwrite the original.  The
@@ -3518,6 +3543,7 @@ class AIAgent:
         path: str,
         *,
         task_id: Optional[str] = None,
+        resolved_path: Optional[str] = None,
     ) -> tuple[Optional[str], Optional[tuple]]:
         """Return a canonical target and, when local and budgeted, its fingerprint.
 
@@ -3532,7 +3558,9 @@ class AIAgent:
         fingerprinting stops for the turn; that target and every later target
         remain conservatively unresolved.
         """
-        resolved_text = self._resolve_file_mutation_target(path, task_id=task_id)
+        resolved_text = resolved_path or self._resolve_file_mutation_target(
+            path, task_id=task_id,
+        )
         if not resolved_text:
             return None, None
         try:

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -13,13 +13,15 @@ Covers the three moving pieces:
 Regression target: the "Ben Eng llm-wiki" session where grok-4.1-fast
 batched parallel patches, half failed, and the model summarised the
 turn claiming every file was edited.  This verifier makes over-claiming
-structurally impossible past the model: the user always sees the real
-list of files that did NOT change.
+structurally impossible past the model while suppressing stale failures
+when a later on-disk change proves recovery through another route.
 """
 
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 
 import pytest
 
@@ -150,6 +152,28 @@ class TestRecordFileMutationResult:
         assert agent._turn_failed_file_mutations == {}
         assert agent._turn_file_mutation_paths == {"/tmp/a.md"}
 
+    def test_success_clears_relative_failure_reported_as_absolute(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        target = tmp_path / "a.md"
+        target.write_text("before\n", encoding="utf-8")
+        agent = _bare_agent()
+        agent._record_file_mutation_result(
+            "patch",
+            {"mode": "replace", "path": "a.md", "old_string": "x", "new_string": "y"},
+            json.dumps({"error": "not found"}),
+            is_error=True,
+        )
+
+        target.write_text("after\n", encoding="utf-8")
+        agent._record_file_mutation_result(
+            "patch",
+            {"mode": "replace", "path": str(target), "old_string": "before", "new_string": "after"},
+            json.dumps({"success": True, "files_modified": [str(target)]}),
+            is_error=False,
+        )
+
+        assert agent._turn_failed_file_mutations == {}
+
 
     def test_landed_paths_prefer_resolved_tool_result(self):
         paths = _extract_landed_file_mutation_paths(
@@ -227,6 +251,92 @@ class TestRecordFileMutationResult:
         # the initial root cause.
         assert "first error" in agent._turn_failed_file_mutations["/tmp/a.md"]["error_preview"]
 
+    def test_terminal_cli_recovery_is_detected_from_disk(self, tmp_path):
+        target = tmp_path / "config.yaml"
+        target.write_text("enabled: false\n", encoding="utf-8")
+        agent = _bare_agent()
+        agent._record_file_mutation_result(
+            "patch",
+            {"mode": "replace", "path": str(target)},
+            json.dumps({"error": "protected config; use hermes config set"}),
+            is_error=True,
+        )
+
+        subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "from pathlib import Path; "
+                    f"Path({str(target)!r}).write_text('enabled: true\\n', encoding='utf-8')"
+                ),
+            ],
+            check=True,
+        )
+
+        assert agent._unresolved_file_mutation_failures() == {}
+
+    def test_created_target_recovers_failed_write_file(self, tmp_path):
+        target = tmp_path / "new.txt"
+        agent = _bare_agent()
+        agent._record_file_mutation_result(
+            "write_file",
+            {"path": str(target), "content": "created later"},
+            json.dumps({"error": "write refused"}),
+            is_error=True,
+        )
+
+        target.write_text("created later", encoding="utf-8")
+
+        assert agent._unresolved_file_mutation_failures() == {}
+
+    def test_unchanged_target_remains_unresolved(self, tmp_path):
+        target = tmp_path / "unchanged.txt"
+        target.write_text("before\n", encoding="utf-8")
+        agent = _bare_agent()
+        agent._record_file_mutation_result(
+            "patch",
+            {"mode": "replace", "path": str(target)},
+            json.dumps({"error": "old_string not found"}),
+            is_error=True,
+        )
+
+        assert set(agent._unresolved_file_mutation_failures()) == {str(target)}
+
+    def test_v4a_recovery_filters_only_the_changed_sibling(self, tmp_path):
+        changed = tmp_path / "changed.txt"
+        unchanged = tmp_path / "unchanged.txt"
+        changed.write_text("before\n", encoding="utf-8")
+        unchanged.write_text("before\n", encoding="utf-8")
+        patch_body = (
+            f"*** Update File: {changed}\n"
+            f"*** Update File: {unchanged}\n"
+        )
+        agent = _bare_agent()
+        agent._record_file_mutation_result(
+            "patch",
+            {"mode": "patch", "patch": patch_body},
+            json.dumps({"error": "multi-file patch failed"}),
+            is_error=True,
+        )
+
+        changed.write_text("after\n", encoding="utf-8")
+
+        assert set(agent._unresolved_file_mutation_failures()) == {str(unchanged)}
+
+    def test_later_failed_attempt_refreshes_recovery_baseline(self, tmp_path):
+        target = tmp_path / "retry.txt"
+        target.write_text("before\n", encoding="utf-8")
+        agent = _bare_agent()
+        failed = json.dumps({"error": "old_string not found"})
+        args = {"mode": "replace", "path": str(target)}
+
+        agent._record_file_mutation_result("patch", args, failed, is_error=True)
+        target.write_text("changed between attempts\n", encoding="utf-8")
+        agent._record_file_mutation_result("patch", args, failed, is_error=True)
+
+        assert set(agent._unresolved_file_mutation_failures()) == {str(target)}
+
 
 
 
@@ -244,7 +354,9 @@ class TestFormatFooter:
         out = AIAgent._format_file_mutation_failure_footer(
             {"/tmp/a.md": {"tool": "patch", "error_preview": "Could not find old_string"}},
         )
-        assert "1 file(s) were NOT modified" in out
+        assert "1 failed file mutation target(s) remain unresolved" in out
+        assert "No later change to these targets was detected" in out
+        assert "were NOT modified" not in out
         assert "/tmp/a.md" in out
         assert "Could not find old_string" in out
         assert "git status" in out  # user-actionable hint
@@ -255,7 +367,7 @@ class TestFormatFooter:
             for i in range(15)
         }
         out = AIAgent._format_file_mutation_failure_footer(failed)
-        assert "15 file(s) were NOT modified" in out
+        assert "15 failed file mutation target(s) remain unresolved" in out
         assert "… and 5 more" in out
         # Ten file bullets + header + "and X more" line
         lines = out.split("\n")

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -510,6 +510,21 @@ class TestRecordFileMutationResult:
 
         assert set(agent._unresolved_file_mutation_failures()) == {str(target)}
 
+    def test_deleted_target_remains_unresolved(self, tmp_path):
+        target = tmp_path / "deleted.txt"
+        target.write_text("before\n", encoding="utf-8")
+        agent = _bare_agent()
+        agent._record_file_mutation_result(
+            "patch",
+            {"mode": "replace", "path": str(target)},
+            json.dumps({"error": "old_string not found"}),
+            is_error=True,
+        )
+
+        target.unlink()
+
+        assert set(agent._unresolved_file_mutation_failures()) == {str(target)}
+
     def test_v4a_recovery_filters_only_the_changed_sibling(self, tmp_path):
         changed = tmp_path / "changed.txt"
         unchanged = tmp_path / "unchanged.txt"

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -118,6 +118,7 @@ def _bare_agent() -> AIAgent:
     agent._turn_file_mutation_fingerprint_bytes = 0
     agent._turn_file_mutation_fingerprint_budget_exhausted = False
     agent._turn_file_mutation_fingerprint_lock = threading.Lock()
+    agent._turn_file_mutation_state_lock = threading.Lock()
     return agent
 
 
@@ -140,6 +141,42 @@ class TestRecordFileMutationResult:
         assert "/tmp/a.md" in state
         assert state["/tmp/a.md"]["tool"] == "patch"
         assert "Could not find old_string" in state["/tmp/a.md"]["error_preview"]
+
+    def test_disabled_verifier_skips_failure_fingerprinting(self, monkeypatch):
+        agent = _bare_agent()
+        monkeypatch.setattr(agent, "_file_mutation_verifier_enabled", lambda: False)
+        monkeypatch.setattr(
+            agent,
+            "_snapshot_file_mutation_target",
+            lambda *_args, **_kwargs: pytest.fail("disabled verifier fingerprinted a target"),
+        )
+
+        agent._record_file_mutation_result(
+            "patch",
+            {"mode": "replace", "path": "/tmp/a.md", "old_string": "x", "new_string": "y"},
+            json.dumps({"error": "not found"}),
+            is_error=True,
+        )
+
+        assert agent._turn_failed_file_mutations == {}
+
+    def test_disabled_verifier_skips_final_fingerprint(self, monkeypatch):
+        agent = _bare_agent()
+        agent._turn_failed_file_mutations["/tmp/a.md"] = {
+            "tool": "patch",
+            "error_preview": "not found",
+            "resolved_path": "/tmp/a.md",
+            "fingerprint": ("file", 1, "baseline"),
+            "task_id": "default",
+        }
+        monkeypatch.setattr(agent, "_file_mutation_verifier_enabled", lambda: False)
+        monkeypatch.setattr(
+            agent,
+            "_snapshot_file_mutation_target",
+            lambda *_args, **_kwargs: pytest.fail("disabled verifier re-fingerprinted a target"),
+        )
+
+        assert agent._unresolved_file_mutation_failures() == {}
 
     def test_success_removes_prior_failure(self):
         agent = _bare_agent()

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -22,8 +22,10 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+import threading
 
 import pytest
+import run_agent as run_agent_module
 
 from run_agent import (
     AIAgent,
@@ -113,6 +115,9 @@ def _bare_agent() -> AIAgent:
     agent = object.__new__(AIAgent)
     agent._turn_failed_file_mutations = {}
     agent._turn_file_mutation_paths = set()
+    agent._turn_file_mutation_fingerprint_bytes = 0
+    agent._turn_file_mutation_fingerprint_budget_exhausted = False
+    agent._turn_file_mutation_fingerprint_lock = threading.Lock()
     return agent
 
 
@@ -173,6 +178,100 @@ class TestRecordFileMutationResult:
         )
 
         assert agent._turn_failed_file_mutations == {}
+
+    @pytest.mark.parametrize(
+        ("failed_path", "successful_path"),
+        [
+            ("src/a.py", "/workspace/src/a.py"),
+            ("/workspace/src/a.py", "src/a.py"),
+        ],
+    )
+    def test_remote_success_clears_lexically_equivalent_alias_only(
+        self, monkeypatch, failed_path, successful_path,
+    ):
+        """Remote alias matching must not depend on host filesystem access."""
+        import tools.file_tools as file_tools
+
+        monkeypatch.setattr(file_tools, "_terminal_env_type_for_task", lambda _task_id: "docker")
+        monkeypatch.setattr(
+            file_tools,
+            "_authoritative_workspace_root",
+            lambda _task_id: "/workspace",
+        )
+        monkeypatch.setattr(
+            run_agent_module,
+            "Path",
+            lambda _path: pytest.fail("remote verifier target touched the host filesystem"),
+        )
+
+        agent = _bare_agent()
+        failed_patch = (
+            f"*** Update File: {failed_path}\n"
+            "*** Update File: src/sibling.py\n"
+        )
+        agent._record_file_mutation_result(
+            "patch",
+            {"mode": "patch", "patch": failed_patch},
+            json.dumps({"error": "multi-file patch failed"}),
+            is_error=True,
+            task_id="remote-task",
+        )
+
+        assert agent._turn_failed_file_mutations[failed_path]["resolved_path"] == "/workspace/src/a.py"
+        assert agent._turn_failed_file_mutations[failed_path]["fingerprint"] is None
+
+        agent._record_file_mutation_result(
+            "patch",
+            {"mode": "replace", "path": successful_path},
+            json.dumps({"success": True, "files_modified": ["/workspace/src/a.py"]}),
+            is_error=False,
+            task_id="remote-task",
+        )
+
+        assert list(agent._turn_failed_file_mutations) == ["src/sibling.py"]
+
+    def test_fingerprint_budget_is_aggregate_and_exhaustion_is_conservative(
+        self, tmp_path, monkeypatch,
+    ):
+        first = tmp_path / "first.txt"
+        second = tmp_path / "second.txt"
+        third = tmp_path / "third.txt"
+        first.write_bytes(b"a" * 8)
+        second.write_bytes(b"b" * 8)
+        third.write_bytes(b"c" * 2)
+        monkeypatch.setattr(run_agent_module, "_FILE_MUTATION_FINGERPRINT_TURN_MAX_BYTES", 12)
+        monkeypatch.setattr(run_agent_module, "_FILE_MUTATION_FINGERPRINT_MAX_FILE_BYTES", 12)
+
+        agent = _bare_agent()
+        agent._record_file_mutation_result(
+            "patch",
+            {
+                "mode": "patch",
+                "patch": (
+                    f"*** Update File: {first}\n"
+                    f"*** Update File: {second}\n"
+                    f"*** Update File: {third}\n"
+                ),
+            },
+            json.dumps({"error": "multi-file patch failed"}),
+            is_error=True,
+        )
+
+        state = agent._turn_failed_file_mutations
+        assert state[str(first)]["fingerprint"] is not None
+        assert state[str(second)]["fingerprint"] is None
+        assert state[str(third)]["fingerprint"] is None
+        assert agent._turn_file_mutation_fingerprint_bytes == 8
+
+        first.write_bytes(b"changed!")
+        second.write_bytes(b"changed!")
+        third.write_bytes(b"changed!")
+        unresolved = agent._unresolved_file_mutation_failures()
+
+        assert list(unresolved) == [str(first), str(second), str(third)]
+        assert agent._turn_file_mutation_fingerprint_bytes <= 12
+        footer = agent._format_file_mutation_failure_footer(unresolved)
+        assert "3 failed file mutation target(s) remain unresolved" in footer
 
 
     def test_landed_paths_prefer_resolved_tool_result(self):

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -19,6 +19,7 @@ when a later on-disk change proves recovery through another route.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import subprocess
 import sys
@@ -177,6 +178,76 @@ class TestRecordFileMutationResult:
         )
 
         assert agent._unresolved_file_mutation_failures() == {}
+
+    def test_failure_uses_resolved_target_reported_by_tool(self, tmp_path, monkeypatch):
+        agent = _bare_agent()
+        actual = tmp_path / "actual.txt"
+        wrong = tmp_path / "wrong.txt"
+        actual.write_text("actual baseline\n", encoding="utf-8")
+        wrong.write_text("wrong baseline\n", encoding="utf-8")
+        monkeypatch.setattr(
+            agent,
+            "_resolve_file_mutation_target",
+            lambda *_args, **_kwargs: str(wrong),
+        )
+
+        agent._record_file_mutation_result(
+            "patch",
+            {"mode": "replace", "path": "relative.txt", "old_string": "x", "new_string": "y"},
+            json.dumps({
+                "error": "Could not find old_string",
+                "resolved_path": str(actual),
+            }),
+            is_error=True,
+        )
+
+        info = agent._turn_failed_file_mutations["relative.txt"]
+        assert info["resolved_path"] == str(actual)
+        assert info["fingerprint"] == (
+            "file",
+            actual.stat().st_size,
+            hashlib.sha256(actual.read_bytes()).hexdigest(),
+        )
+
+    def test_patch_failure_reports_exact_resolved_target(self, tmp_path):
+        from tools.file_tools import patch_tool
+
+        target = tmp_path / "target.txt"
+        target.write_text("actual content\n", encoding="utf-8")
+
+        result = json.loads(patch_tool(
+            mode="replace",
+            path=str(target),
+            old_string="missing content",
+            new_string="replacement",
+            task_id="mutation-verifier-test",
+        ))
+
+        assert result.get("error")
+        assert result["resolved_path"] == str(target)
+        assert result["resolved_paths"] == [str(target)]
+
+    def test_stale_expected_state_cannot_mutate_next_turn(self):
+        agent = _bare_agent()
+        old_state = agent._turn_failed_file_mutations
+        next_state = {
+            "/tmp/a.md": {
+                "tool": "patch",
+                "error_preview": "next-turn failure",
+            }
+        }
+        agent._turn_failed_file_mutations = next_state
+
+        agent._record_file_mutation_result(
+            "patch",
+            {"mode": "replace", "path": "/tmp/a.md", "old_string": "x", "new_string": "y"},
+            json.dumps({"success": True}),
+            is_error=False,
+            expected_state=old_state,
+        )
+
+        assert agent._turn_failed_file_mutations is next_state
+        assert next_state["/tmp/a.md"]["error_preview"] == "next-turn failure"
 
     def test_success_removes_prior_failure(self):
         agent = _bare_agent()

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -227,6 +227,43 @@ class TestRecordFileMutationResult:
         assert result["resolved_path"] == str(target)
         assert result["resolved_paths"] == [str(target)]
 
+    def test_v4a_failure_maps_exact_targets_when_optional_path_is_present(self, tmp_path):
+        from tools.file_tools import patch_tool
+
+        target = tmp_path / "target.txt"
+        unrelated = tmp_path / "unrelated.txt"
+        target.write_text("actual content\n", encoding="utf-8")
+        unrelated.write_text("unrelated\n", encoding="utf-8")
+        patch_body = (
+            "*** Begin Patch\n"
+            f"*** Update File: {target}\n"
+            "@@\n"
+            "-missing content\n"
+            "+replacement\n"
+            "*** End Patch"
+        )
+
+        result = patch_tool(
+            mode="patch",
+            path=str(unrelated),
+            patch=patch_body,
+            task_id="mutation-verifier-test",
+        )
+        result_data = json.loads(result)
+        assert result_data.get("error")
+        assert result_data["resolved_path_map"][str(target)] == str(target)
+
+        agent = _bare_agent()
+        agent._record_file_mutation_result(
+            "patch",
+            {"mode": "patch", "path": str(unrelated), "patch": patch_body},
+            result,
+            is_error=True,
+        )
+
+        assert list(agent._turn_failed_file_mutations) == [str(target)]
+        assert agent._turn_failed_file_mutations[str(target)]["resolved_path"] == str(target)
+
     def test_stale_expected_state_cannot_mutate_next_turn(self):
         agent = _bare_agent()
         old_state = agent._turn_failed_file_mutations

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2137,7 +2137,8 @@ class TestConcurrentToolExecution:
         """A sibling terminal recovery must occur after the failed-call baseline."""
         target = tmp_path / "recovered.txt"
         target.write_text("before\n", encoding="utf-8")
-        baseline_captured = threading.Event()
+        snapshot_started = threading.Event()
+        recovery_started = threading.Event()
         agent._turn_failed_file_mutations = {}
         agent._turn_file_mutation_paths = set()
         agent._turn_file_mutation_fingerprint_bytes = 0
@@ -2148,8 +2149,15 @@ class TestConcurrentToolExecution:
         original_snapshot = agent._snapshot_file_mutation_target
 
         def snapshot(*args, **kwargs):
+            first_snapshot = not snapshot_started.is_set()
+            if first_snapshot:
+                snapshot_started.set()
+                # Without the executor fence, the later terminal tool starts
+                # during this window and its write becomes the failed call's
+                # baseline. With the fence it cannot start until this snapshot
+                # returns, so the baseline remains the post-failure state.
+                recovery_started.wait(timeout=0.15)
             result = original_snapshot(*args, **kwargs)
-            baseline_captured.set()
             return result
 
         monkeypatch.setattr(agent, "_snapshot_file_mutation_target", snapshot)
@@ -2158,7 +2166,7 @@ class TestConcurrentToolExecution:
             if name == "patch":
                 return json.dumps({"error": "Could not find old_string"})
             assert name == "terminal"
-            assert baseline_captured.wait(timeout=2)
+            recovery_started.set()
             target.write_text("after\n", encoding="utf-8")
             return json.dumps({"success": True})
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2258,6 +2258,55 @@ class TestConcurrentToolExecution:
         assert agent._turn_failed_file_mutations is next_state
         assert next_state[str(target)]["error_preview"] == "next-turn failure"
 
+    def test_disabled_mutation_verifier_does_not_serialize_concurrent_batch(
+        self,
+        agent,
+        tmp_path,
+        monkeypatch,
+    ):
+        target = tmp_path / "disabled.txt"
+        target.write_text("before\n", encoding="utf-8")
+        terminal_started = threading.Event()
+        patch_observed_terminal = threading.Event()
+        agent._turn_failed_file_mutations = {}
+        agent._turn_file_mutation_state_lock = threading.Lock()
+        monkeypatch.setattr(agent, "_file_mutation_verifier_enabled", lambda: False)
+
+        def invoke(name, _args, _task_id, _tool_call_id, **_kwargs):
+            if name == "patch":
+                if terminal_started.wait(timeout=0.5):
+                    patch_observed_terminal.set()
+                return json.dumps({"error": "Could not find old_string"})
+            assert name == "terminal"
+            terminal_started.set()
+            return json.dumps({"success": True})
+
+        monkeypatch.setattr(agent, "_invoke_tool", invoke)
+        patch_call = _mock_tool_call(
+            name="patch",
+            arguments=json.dumps({
+                "mode": "replace",
+                "path": str(target),
+                "old_string": "missing",
+                "new_string": "after",
+            }),
+            call_id="patch-1",
+        )
+        terminal_call = _mock_tool_call(
+            name="terminal",
+            arguments=json.dumps({"command": "independent work"}),
+            call_id="terminal-1",
+        )
+
+        agent._execute_tool_calls_concurrent(
+            _mock_assistant_msg(content="", tool_calls=[patch_call, terminal_call]),
+            [],
+            "task-1",
+        )
+
+        assert patch_observed_terminal.is_set()
+        assert agent._turn_failed_file_mutations == {}
+
     def test_agent_runtime_post_hook_ownership_predicate_covers_agent_tools(self, agent):
         """Sequential and concurrent agent-level paths share post-hook ownership."""
         from agent.agent_runtime_helpers import agent_runtime_owns_post_tool_hook

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2128,6 +2128,63 @@ class TestConcurrentToolExecution:
         assert post_calls[0]["status"] == "ok"
         assert post_calls[0]["result"] == '{"intercepted":true}'
 
+    def test_concurrent_failed_mutation_snapshots_before_sibling_recovery(
+        self,
+        agent,
+        tmp_path,
+        monkeypatch,
+    ):
+        """A sibling terminal recovery must occur after the failed-call baseline."""
+        target = tmp_path / "recovered.txt"
+        target.write_text("before\n", encoding="utf-8")
+        baseline_captured = threading.Event()
+        agent._turn_failed_file_mutations = {}
+        agent._turn_file_mutation_paths = set()
+        agent._turn_file_mutation_fingerprint_bytes = 0
+        agent._turn_file_mutation_fingerprint_budget_exhausted = False
+        agent._turn_file_mutation_fingerprint_lock = threading.Lock()
+        agent._turn_file_mutation_state_lock = threading.Lock()
+        monkeypatch.setattr(agent, "_file_mutation_verifier_enabled", lambda: True)
+        original_snapshot = agent._snapshot_file_mutation_target
+
+        def snapshot(*args, **kwargs):
+            result = original_snapshot(*args, **kwargs)
+            baseline_captured.set()
+            return result
+
+        monkeypatch.setattr(agent, "_snapshot_file_mutation_target", snapshot)
+
+        def invoke(name, _args, _task_id, _tool_call_id, **_kwargs):
+            if name == "patch":
+                return json.dumps({"error": "Could not find old_string"})
+            assert name == "terminal"
+            assert baseline_captured.wait(timeout=2)
+            target.write_text("after\n", encoding="utf-8")
+            return json.dumps({"success": True})
+
+        monkeypatch.setattr(agent, "_invoke_tool", invoke)
+        patch_call = _mock_tool_call(
+            name="patch",
+            arguments=json.dumps({
+                "mode": "replace",
+                "path": str(target),
+                "old_string": "missing",
+                "new_string": "after",
+            }),
+            call_id="patch-1",
+        )
+        terminal_call = _mock_tool_call(
+            name="terminal",
+            arguments=json.dumps({"command": "recover target"}),
+            call_id="terminal-1",
+        )
+        message = _mock_assistant_msg(content="", tool_calls=[patch_call, terminal_call])
+
+        agent._execute_tool_calls_concurrent(message, [], "task-1")
+
+        assert target.read_text(encoding="utf-8") == "after\n"
+        assert agent._unresolved_file_mutation_failures() == {}
+
     def test_agent_runtime_post_hook_ownership_predicate_covers_agent_tools(self, agent):
         """Sequential and concurrent agent-level paths share post-hook ownership."""
         from agent.agent_runtime_helpers import agent_runtime_owns_post_tool_hook

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2185,6 +2185,71 @@ class TestConcurrentToolExecution:
         assert target.read_text(encoding="utf-8") == "after\n"
         assert agent._unresolved_file_mutation_failures() == {}
 
+    def test_concurrent_mutation_timeout_is_recorded_and_late_worker_is_fenced(
+        self,
+        agent,
+        tmp_path,
+        monkeypatch,
+    ):
+        """A timeout stays unresolved and its detached worker cannot touch a later turn."""
+        import types
+        import agent.tool_executor as tool_executor
+
+        target = tmp_path / "timed-out.txt"
+        target.write_text("before\n", encoding="utf-8")
+        release_worker = threading.Event()
+        worker_finished = threading.Event()
+        agent._turn_failed_file_mutations = {}
+        agent._turn_file_mutation_paths = set()
+        agent._turn_file_mutation_fingerprint_bytes = 0
+        agent._turn_file_mutation_fingerprint_budget_exhausted = False
+        agent._turn_file_mutation_fingerprint_lock = threading.Lock()
+        agent._turn_file_mutation_state_lock = threading.Lock()
+        monkeypatch.setattr(agent, "_file_mutation_verifier_enabled", lambda: True)
+        monkeypatch.setattr(tool_executor, "_resolve_concurrent_tool_timeout", lambda: 0.05)
+        monkeypatch.setattr(
+            tool_executor,
+            "_ra",
+            lambda: types.SimpleNamespace(_set_interrupt=lambda *_args, **_kwargs: None),
+        )
+
+        def invoke(*_args, **_kwargs):
+            assert release_worker.wait(timeout=2)
+            worker_finished.set()
+            return json.dumps({"success": True, "resolved_path": str(target)})
+
+        monkeypatch.setattr(agent, "_invoke_tool", invoke)
+        patch_call = _mock_tool_call(
+            name="patch",
+            arguments=json.dumps({
+                "mode": "replace",
+                "path": str(target),
+                "old_string": "missing",
+                "new_string": "after",
+            }),
+            call_id="patch-timeout",
+        )
+        message = _mock_assistant_msg(content="", tool_calls=[patch_call])
+
+        agent._execute_tool_calls_concurrent(message, [], "task-1")
+
+        old_state = agent._turn_failed_file_mutations
+        assert str(target) in old_state
+        assert old_state[str(target)]["fingerprint"] is None
+
+        next_state = {
+            str(target): {
+                "tool": "patch",
+                "error_preview": "next-turn failure",
+            }
+        }
+        agent._turn_failed_file_mutations = next_state
+        agent._turn_file_mutation_state_lock = threading.Lock()
+        release_worker.set()
+        assert worker_finished.wait(timeout=2)
+        assert agent._turn_failed_file_mutations is next_state
+        assert next_state[str(target)]["error_preview"] == "next-turn failure"
+
     def test_agent_runtime_post_hook_ownership_predicate_covers_agent_tools(self, agent):
         """Sequential and concurrent agent-level paths share post-hook ownership."""
         from agent.agent_runtime_helpers import agent_runtime_owns_post_tool_hook

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2241,12 +2241,18 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             _resolved_modified = [
                 _path_to_resolved.get(_p) or _p for _p in _paths_to_check
             ]
+            # Preserve the exact targets resolved by this tool invocation even
+            # on failure. Concurrent terminal calls may change the task CWD
+            # before the agent records the result; re-resolving then could
+            # fingerprint a different file and suppress a real warning.
+            if all(_path_to_resolved.get(_p) for _p in _paths_to_check):
+                result_dict["resolved_paths"] = _resolved_modified
+                if len(_resolved_modified) == 1:
+                    result_dict["resolved_path"] = _resolved_modified[0]
             # Refresh stored timestamps for all successfully-patched paths so
             # consecutive edits by this task don't trigger false warnings.
             if not result_dict.get("error"):
                 result_dict["files_modified"] = _resolved_modified
-                if len(_resolved_modified) == 1:
-                    result_dict["resolved_path"] = _resolved_modified[0]
                 _mark_verification_stale(task_id, _resolved_modified, session_id=session_id)
                 for _p in _paths_to_check:
                     _update_read_timestamp(_p, task_id)

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2247,6 +2247,9 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             # fingerprint a different file and suppress a real warning.
             if all(_path_to_resolved.get(_p) for _p in _paths_to_check):
                 result_dict["resolved_paths"] = _resolved_modified
+                result_dict["resolved_path_map"] = {
+                    _p: _path_to_resolved[_p] for _p in _paths_to_check
+                }
                 if len(_resolved_modified) == 1:
                     result_dict["resolved_path"] = _resolved_modified[0]
             # Refresh stored timestamps for all successfully-patched paths so


### PR DESCRIPTION
## Summary

- keep failed `write_file` / `patch` targets conservative until a later verified mutation lands
- clear stale warnings after same-target recovery through native file tools or successful foreground terminal/code-execution paths
- preserve exact resolved-path, task, turn-generation, timeout/interrupt, deletion, remote-backend, and concurrent ordering boundaries

## Reproduction and behavior contract

A native file mutation can fail, then a later tool call can successfully recover the same target. Previously the turn-end verifier could still claim the file was unchanged. The warning is now removed only when later evidence proves that the same resolved target was mutated in the current task/turn; missing, stale, timed-out, interrupted, remote-unverifiable, or reordered evidence stays fail-closed.

This overlaps the symptom addressed by #65584, #67657, #53165, and #72387, but retains the narrow existing verifier architecture while covering the concurrency, detached-worker, resolved-path, deletion, disabled-verifier, and remote-backend sibling cases found during exact-head review.

## Verification

- `scripts/run_tests.sh tests/run_agent/test_file_mutation_verifier.py tests/run_agent/test_start_order_gate.py tests/tools/test_tts_prepare_spoken.py` — 57 passed
- expanded verifier/agent/turn-context/tool-executor floor — 318 passed (environment-only Anthropic SDK test excluded because the optional SDK is absent)
- `python -m compileall` — passed
- `git diff --check` — passed
- independent exact-head review of `93016268a72049f4bea7099e7e3cdb8d2b000695` against `b3aa561faffd64f05436e429a6415d175e534ec9` — no blocking findings

## Risk and rollback

Risk is localized to turn-scoped mutation-warning bookkeeping and recovery evidence. Ambiguous cases retain the warning rather than suppressing it. Rollback is a normal revert of this eight-commit topic series; no config, schema, dependency, or data migration is involved.
