### PR TITLE
fix(agent): prefer explicit context overflow over generic body code

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1365,18 +1365,30 @@ def _classify_400(
             should_fallback=True,
         )
 
-    # Malformed message array (empty-content assistant stub, etc.). Must be
-    # checked BEFORE context_overflow: the input can be tiny, so the generic
-    # "400 + large session" heuristic would otherwise mis-route it into the
-    # compression loop and thrash until "Cannot compress further" on every
-    # retry (the request is unchanged, so compression cannot fix it). This is
-    # a deterministic request-shape rejection — fail fast as a non-retryable
-    # format_error and fall back. Checked against the message text AND the
-    # structured error code, since proxies (litellm/Bedrock) surface the
-    # signal in errorCode=INVALID_REQUEST_BODY.
+    # Malformed message array (empty-content assistant stub, etc.). Explicit
+    # transcript-shape wording is more specific than context overflow and must
+    # still fail fast. The generic ``invalid_request_body`` code is not: Copilot
+    # also stamps it on genuine context-window overflow responses. Let explicit
+    # overflow wording win over that generic code, otherwise a recoverable long
+    # session is permanently routed away from compression.
+    _has_context_overflow_signal = any(
+        p in error_msg for p in _CONTEXT_OVERFLOW_PATTERNS
+    )
+    _has_explicit_malformed_message_signal = any(
+        p in error_msg
+        for p in _INVALID_MESSAGE_BODY_PATTERNS
+        if p != "invalid_request_body"
+    )
+    _has_generic_invalid_body_signal = (
+        error_code_lower == "invalid_request_body"
+        or "invalid_request_body" in error_msg
+    )
     if (
-        any(p in error_msg for p in _INVALID_MESSAGE_BODY_PATTERNS)
-        or error_code_lower == "invalid_request_body"
+        _has_explicit_malformed_message_signal
+        or (
+            _has_generic_invalid_body_signal
+            and not _has_context_overflow_signal
+        )
     ):
         logger.warning(
             "Malformed message array 400 (invalid request body) classified as "
@@ -1404,7 +1416,7 @@ def _classify_400(
         )
 
     # Context overflow from 400
-    if any(p in error_msg for p in _CONTEXT_OVERFLOW_PATTERNS):
+    if _has_context_overflow_signal:
         return result_fn(
             FailoverReason.context_overflow,
             retryable=True,

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1051,6 +1051,36 @@ class TestThrottleVsOverflowDisambiguation:
 class TestExpandedOverflowPatterns:
     """New provider overflow wordings route into compression recovery."""
 
+    def test_copilot_invalid_request_body_with_explicit_overflow_compresses(self):
+        """A generic error code must not override explicit overflow wording."""
+        message = (
+            "Your input exceeds the context window of this model. "
+            "Please adjust your input and try again."
+        )
+        e = MockAPIError(
+            message,
+            status_code=400,
+            body={
+                "error": {
+                    "message": message,
+                    "code": "invalid_request_body",
+                }
+            },
+        )
+
+        result = classify_api_error(
+            e,
+            provider="copilot",
+            model="gpt-5.6-sol",
+            approx_tokens=805_000,
+            context_length=922_000,
+            num_messages=1_414,
+        )
+
+        assert result.reason == FailoverReason.context_overflow
+        assert result.retryable is True
+        assert result.should_compress is True
+
     def test_maximum_allowed_input_length_is_overflow(self):
         # Together/Fireworks-style wording — matched no pattern before.
         e = Exception(

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -326,6 +326,46 @@ class TestHTTP413Compression:
         assert result["completed"] is True
         assert result["final_response"] == "Recovered after compression"
 
+    def test_copilot_invalid_request_body_overflow_compresses_and_retries(self, agent):
+        """Copilot's generic code must not turn explicit overflow into an abort."""
+        message = (
+            "Your input exceeds the context window of this model. "
+            "Please adjust your input and try again."
+        )
+        err_400 = Exception(f"Error code: 400 - {message}")
+        err_400.status_code = 400
+        err_400.body = {
+            "error": {
+                "message": message,
+                "code": "invalid_request_body",
+            }
+        }
+        ok_resp = _mock_response(
+            content="Recovered from Copilot overflow", finish_reason="stop"
+        )
+        agent.client.chat.completions.create.side_effect = [err_400, ok_resp]
+
+        prefill = [
+            {"role": "user", "content": "previous question"},
+            {"role": "assistant", "content": "previous answer"},
+        ]
+
+        with (
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            mock_compress.return_value = (
+                [{"role": "user", "content": "compressed summary"}],
+                "compressed prompt",
+            )
+            result = agent.run_conversation("continue", conversation_history=prefill)
+
+        mock_compress.assert_called_once()
+        assert result.get("failed") is not True
+        assert result["completed"] is True
+        assert result["final_response"] == "Recovered from Copilot overflow"
 
     def test_provider_context_limit_is_cached_before_retry_succeeds(self, agent):
         """A confirmed limit survives when the recovery response omits usage."""


### PR DESCRIPTION
## Problem

I reproduced a long-running conversation that became permanently stuck on:

```text
HTTP 400: Your input exceeds the context window of this model. Please adjust your input and try again.
```

The response body also carried the generic code `invalid_request_body`. `_classify_400()` treated that code as an unconditional malformed-message signal before checking explicit context-overflow wording, so the request was classified as a non-retryable `format_error`. The existing compression-and-retry path never ran.

This is distinct from #61228. That PR addresses output-cap fitting and convergence on strict endpoints; this PR fixes classifier precedence when a provider uses a generic request code for an explicitly described input-context overflow.

## Fix

- Compute the explicit context-overflow signal once.
- Keep explicit malformed-transcript wording, such as non-empty-content violations, on the non-retryable `format_error` path.
- Treat the generic `invalid_request_body` signal as malformed only when no explicit context-overflow wording is present.
- Reuse the same overflow signal for the existing compression recovery branch.

## Verification

- `100 passed`:
  - `tests/agent/test_error_classifier.py`
  - `tests/run_agent/test_413_compression.py`
- `32 passed`:
  - `tests/run_agent/test_1630_context_overflow_loop.py`
  - `tests/run_agent/test_message_sequence_repair.py`
  - `tests/agent/test_turn_context.py`
- Mutation check: removing the new `and not _has_context_overflow_signal` guard makes both the classifier regression and real `run_conversation` recovery test fail; restoring it makes both pass.
- Live reproduction after loading the patch:
  - the same provider 400 entered context compression instead of aborting;
  - the request context compacted from 1,413 messages / about 820K rough tokens to 10 messages / about 127K rough tokens;
  - the continuation then completed multiple real Copilot API calls and tool calls with no further context-window 400.

## Scope

The change is limited to error classification and its classifier/loop regressions. It does not change compression policy, thresholds, or provider routing.

@teknium1 This fixes a production-reproduced classifier precedence gap and includes a real loop-level regression plus mutation proof.
