### PR TITLE
feat(kanban): immutable runtime snapshot + reviewer execution hardening

### DIFF
--- a/agent/i18n.py
+++ b/agent/i18n.py
@@ -154,7 +154,19 @@ def _load_catalog(lang: str) -> dict[str, str]:
             return cached
 
     path = _locales_dir() / f"{lang}.yaml"
-    if not path.is_file():
+    try:
+        from hermes_cli.kanban_runtime_snapshot import (
+            sealed_resource_text,
+            snapshot_bootstrap_capability,
+        )
+
+        sealed_text = (
+            sealed_resource_text(f"locales/{lang}.yaml")
+            if snapshot_bootstrap_capability() is not None else None
+        )
+    except ImportError:
+        sealed_text = None
+    if sealed_text is None and not path.is_file():
         logger.debug("i18n catalog missing for %s at %s", lang, path)
         with _catalog_lock:
             _catalog_cache[lang] = {}
@@ -162,8 +174,7 @@ def _load_catalog(lang: str) -> dict[str, str]:
 
     try:
         import yaml  # PyYAML is already a hermes dependency
-        with path.open("r", encoding="utf-8") as f:
-            raw = yaml.safe_load(f) or {}
+        raw = yaml.safe_load(sealed_text if sealed_text is not None else path.read_text(encoding="utf-8")) or {}
     except Exception as exc:
         logger.warning("Failed to load i18n catalog %s: %s", path, exc)
         with _catalog_lock:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -65,6 +65,48 @@ from hermes_cli.colors import Colors, color
 
 logger = logging.getLogger(__name__)
 
+_GATEWAY_NOFILE_SOFT_TARGET = 4096
+
+
+def _raise_gateway_nofile_soft_limit(
+    target: int = _GATEWAY_NOFILE_SOFT_TARGET,
+    *,
+    resource_module=None,
+) -> tuple[int | None, int | None]:
+    """Raise a low POSIX gateway ``RLIMIT_NOFILE`` soft limit, best-effort.
+
+    The gateway owns many concurrent SQLite, HTTP, browser, subprocess, and
+    messaging descriptors.  A launchd-inherited soft limit of 256 can be
+    exhausted by supported concurrency even while the system-wide file table
+    has ample headroom.  Never lower an existing limit, never change the hard
+    limit, and fail open on unsupported or denied platforms.
+
+    Returns ``(previous_soft, effective_soft)`` when the limit is readable,
+    otherwise ``(None, None)``.
+    """
+    if os.name != "posix" and resource_module is None:
+        return (None, None)
+    try:
+        if resource_module is None:
+            import resource as resource_module  # noqa: PLC0415
+
+        soft, hard = resource_module.getrlimit(resource_module.RLIMIT_NOFILE)
+        target_soft = max(soft, int(target))
+        infinity = getattr(resource_module, "RLIM_INFINITY", -1)
+        if hard != infinity:
+            target_soft = min(target_soft, hard)
+        if target_soft > soft:
+            try:
+                resource_module.setrlimit(
+                    resource_module.RLIMIT_NOFILE, (target_soft, hard)
+                )
+            except (OSError, ValueError, PermissionError):
+                return (soft, soft)
+        return (soft, target_soft)
+    except (ImportError, AttributeError, OSError, ValueError, PermissionError):
+        return (None, None)
+
+
 # =============================================================================
 # Process Management (for manual gateway runs)
 # =============================================================================
@@ -4905,6 +4947,11 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False, fo
     _guard_supervised_gateway_conflict(force=force)
     _guard_existing_gateway_process_conflict(replace=replace)
     sys.path.insert(0, str(PROJECT_ROOT))
+
+    # Raise only the gateway process's soft descriptor limit before importing
+    # the runtime and creating SQLite/HTTP/browser/messaging resources. This
+    # leaves the hard limit and unrelated processes untouched.
+    _raise_gateway_nofile_soft_limit()
 
     # Detached Windows gateway runs must ignore console-control broadcasts
     # from sibling CLI processes, but foreground `hermes gateway run` still

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -77,17 +77,19 @@ import os
 import re
 import random
 import secrets
+import signal
 import shutil
 import sqlite3
 import subprocess
 import sys
+import tempfile
 import threading
 import logging
 import time
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterable, Mapping, Optional
+from typing import Any, Iterable, Mapping, Optional, Sequence
 
 from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missing
 from toolsets import get_toolset_names
@@ -4008,6 +4010,18 @@ def _end_run(
     if not row or not row["current_run_id"]:
         return None
     run_id = int(row["current_run_id"])
+    existing = conn.execute(
+        "SELECT metadata FROM task_runs WHERE id=?", (run_id,),
+    ).fetchone()
+    if existing and existing["metadata"]:
+        try:
+            merged_metadata = json.loads(existing["metadata"])
+        except (TypeError, json.JSONDecodeError):
+            merged_metadata = {}
+        if isinstance(merged_metadata, dict):
+            if metadata is not None:
+                merged_metadata.update(metadata)
+            metadata = merged_metadata
     conn.execute(
         """
         UPDATE task_runs
@@ -4028,7 +4042,7 @@ def _end_run(
             outcome,
             summary,
             error,
-            json.dumps(metadata, ensure_ascii=False) if metadata else None,
+            json.dumps(metadata, ensure_ascii=False) if metadata is not None else None,
             now,
             run_id,
         ),
@@ -4090,7 +4104,7 @@ def _synthesize_ended_run(
             task_id, profile, step_key,
             outcome, outcome,
             summary, error,
-            json.dumps(metadata, ensure_ascii=False) if metadata else None,
+            json.dumps(metadata, ensure_ascii=False) if metadata is not None else None,
             now, now,
         ),
     )
@@ -4132,11 +4146,11 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
     """
     row = conn.execute(
         "SELECT kind FROM task_events "
-        "WHERE task_id = ? AND kind IN ('blocked', 'unblocked') "
+        "WHERE task_id = ? AND kind IN ('blocked', 'review_blocked', 'unblocked') "
         "ORDER BY id DESC LIMIT 1",
         (task_id,),
     ).fetchone()
-    return bool(row) and row["kind"] == "blocked"
+    return bool(row) and row["kind"] in {"blocked", "review_blocked"}
 
 
 def recompute_ready(
@@ -4847,6 +4861,37 @@ class RoleCompletionContractError(ValueError):
 _JEROME_WORKFLOW_TEMPLATE = "jerome-kanban-v1"
 _JEROME_WORKFLOW_MARKER = "WORKFLOW_CONTRACT: jerome-kanban-v1"
 _HEX_REVISION_RE = re.compile(r"^[0-9a-fA-F]{7,64}$")
+_IMMUTABLE_RUNTIME_LAUNCHER = r'''
+import os
+import runpy
+import sys
+
+object_root, manifest_sha256, cache_key, raw_bindings = sys.argv[1:5]
+worker_argv = sys.argv[5:]
+payload_root = os.path.join(object_root, "payload")
+sys.path[:] = [payload_root]
+from hermes_cli.kanban_runtime_snapshot import install_snapshot_bootstrap_capability, runtime_bindings_from_json, snapshot_runtime_sys_path, verify_published_snapshot, with_runtime_bindings
+spec = verify_published_snapshot(object_root, manifest_sha256, cache_key)
+spec = with_runtime_bindings(spec, runtime_bindings_from_json(raw_bindings))
+sys.path[:] = snapshot_runtime_sys_path(spec)
+install_snapshot_bootstrap_capability(spec)
+os.environ["HERMES_KANBAN_RUNTIME_ROOT"] = payload_root
+os.environ["HERMES_KANBAN_SNAPSHOT_CACHE_KEY"] = cache_key
+os.environ["PYTHONNOUSERSITE"] = "1"
+os.environ["PYTHONDONTWRITEBYTECODE"] = "1"
+for name in ("PYTHONPATH", "PYTHONHOME", "PYTHONSTARTUP", "PYTHONINSPECT"):
+    os.environ.pop(name, None)
+sys.argv = ["hermes", *worker_argv]
+runpy.run_module("hermes_cli.main", run_name="__main__", alter_sys=False)
+'''
+
+
+def _is_jerome_workflow_task(task: Task) -> bool:
+    """Recognize both immutable typed cards and the supported legacy marker."""
+    return (
+        task.workflow_template_id == _JEROME_WORKFLOW_TEMPLATE
+        or _JEROME_WORKFLOW_MARKER in (task.body or "")
+    )
 
 
 def _typed_verdict(summary: str, allowed: set[str]) -> Optional[str]:
@@ -4927,11 +4972,7 @@ def _validate_role_completion_contract(
     summary: Optional[str],
     metadata: Optional[dict],
 ) -> None:
-    typed = (
-        task.workflow_template_id == _JEROME_WORKFLOW_TEMPLATE
-        or _JEROME_WORKFLOW_MARKER in (task.body or "")
-    )
-    if not typed:
+    if not _is_jerome_workflow_task(task):
         return
     if task.status == "blocked":
         raise RoleCompletionContractError(
@@ -4955,9 +4996,15 @@ def _validate_role_completion_contract(
                 "Critic verdict must be exactly one OKAY; ITERATE/REJECT must block"
             )
     elif role in {"architect", "verifier"}:
-        if _typed_verdict(text, {"CLEAR", "WATCH", "BLOCK"}) not in {"CLEAR", "WATCH"}:
+        verdict = _typed_verdict(text, {"CLEAR", "WATCH", "BLOCK"})
+        allowed_verdicts = (
+            {"CLEAR", "WATCH", "BLOCK"}
+            if role == "architect"
+            else {"CLEAR", "WATCH"}
+        )
+        if verdict not in allowed_verdicts:
             raise RoleCompletionContractError(
-                f"{role} verdict must be exactly one CLEAR or WATCH"
+                f"{role} verdict must be exactly one of {sorted(allowed_verdicts)}"
             )
         if role == "verifier":
             reviewed = meta.get("reviewed_commit")
@@ -5061,14 +5108,25 @@ def complete_task(
     """
     now = int(time.time())
 
-    task_for_contract = get_task(conn, task_id)
-    if task_for_contract is None:
-        return False
-    _validate_role_completion_contract(
-        task_for_contract,
-        summary=summary if summary is not None else result,
-        metadata=metadata,
-    )
+    if metadata is not None:
+        if not isinstance(metadata, dict):
+            raise TypeError(
+                f"metadata must be an object/dict, got {type(metadata).__name__}"
+            )
+        try:
+            metadata_json = json.dumps(
+                metadata,
+                ensure_ascii=False,
+                allow_nan=False,
+            )
+            normalized_metadata = json.loads(metadata_json)
+        except (TypeError, ValueError) as exc:
+            raise TypeError("metadata must be a JSON-safe object/dict") from exc
+        if normalized_metadata != metadata:
+            raise TypeError("metadata must contain only JSON-safe object values")
+        metadata = normalized_metadata
+    _reject_reserved_run_metadata(metadata)
+
 
     # Gate: verify created_cards BEFORE the main write txn. A rejected
     # completion still needs an auditable event, so we emit it in a
@@ -5100,12 +5158,46 @@ def complete_task(
     metadata = _merge_completion_prose_artifacts(
         conn, task_id, metadata, summary=summary, result=result,
     )
+    review_blocked = False
+    canonical_receipt = summary if summary is not None else result
     with write_txn(conn):
+        task_for_contract = get_task(conn, task_id)
+        if task_for_contract is None:
+            return False
+        if _is_jerome_workflow_task(task_for_contract) and summary and result:
+            summary_verdict = _typed_verdict(
+                summary, {"OKAY", "ITERATE", "REJECT", "CLEAR", "WATCH", "BLOCK"}
+            )
+            result_verdict = _typed_verdict(
+                result, {"OKAY", "ITERATE", "REJECT", "CLEAR", "WATCH", "BLOCK"}
+            )
+            if summary_verdict != result_verdict:
+                raise RoleCompletionContractError(
+                    "conflicting typed workflow result and summary verdicts"
+                )
+        _validate_role_completion_contract(
+            task_for_contract,
+            summary=canonical_receipt,
+            metadata=metadata,
+        )
+        role = (
+            task_for_contract.current_step_key
+            or task_for_contract.assignee
+            or ""
+        ).strip().lower()
+        review_blocked = (
+            _is_jerome_workflow_task(task_for_contract)
+            and role == "architect"
+            and _typed_verdict(canonical_receipt or "", {"CLEAR", "WATCH", "BLOCK"})
+            == "BLOCK"
+        )
+        target_status = "blocked" if review_blocked else "done"
+        stored_result = canonical_receipt if review_blocked else result
         if expected_run_id is None:
             cur = conn.execute(
                 """
                 UPDATE tasks
-                   SET status       = 'done',
+                   SET status       = ?,
                        result       = ?,
                        completed_at = ?,
                        claim_lock   = NULL,
@@ -5116,13 +5208,13 @@ def complete_task(
                  WHERE id = ?
                    AND status IN ('running', 'ready', 'blocked')
                 """,
-                (result, now, task_id),
+                (target_status, stored_result, now, task_id),
             )
         else:
             cur = conn.execute(
                 """
                 UPDATE tasks
-                   SET status       = 'done',
+                   SET status       = ?,
                        result       = ?,
                        completed_at = ?,
                        claim_lock   = NULL,
@@ -5134,7 +5226,7 @@ def complete_task(
                    AND status IN ('running', 'ready', 'blocked')
                    AND current_run_id = ?
                 """,
-                (result, now, task_id, int(expected_run_id)),
+                (target_status, stored_result, now, task_id, int(expected_run_id)),
             )
         if cur.rowcount != 1:
             return False
@@ -5152,8 +5244,9 @@ def complete_task(
                 )
         run_id = _end_run(
             conn, task_id,
-            outcome="completed", status="done",
-            summary=summary if summary is not None else result,
+            outcome="review_blocked" if review_blocked else "completed",
+            status="blocked" if review_blocked else "done",
+            summary=canonical_receipt,
             metadata=metadata,
         )
         # If complete_task was called on a never-claimed task (ready or
@@ -5163,8 +5256,8 @@ def complete_task(
         if run_id is None and (summary or metadata or result):
             run_id = _synthesize_ended_run(
                 conn, task_id,
-                outcome="completed",
-                summary=summary if summary is not None else result,
+                outcome="review_blocked" if review_blocked else "completed",
+                summary=canonical_receipt,
                 metadata=metadata,
             )
         # Carry the handoff summary in the event payload so gateway
@@ -5177,6 +5270,8 @@ def complete_task(
             "result_len": len(result) if result else 0,
             "summary": ev_summary or None,
         }
+        if metadata is not None:
+            completed_payload["metadata"] = metadata
         if verified_cards:
             completed_payload["verified_cards"] = verified_cards
         # Carry artifact paths in the event payload so the gateway
@@ -5194,10 +5289,21 @@ def complete_task(
                 if cleaned_artifacts:
                     completed_payload["artifacts"] = cleaned_artifacts
         _append_event(
-            conn, task_id, "completed",
+            conn, task_id, "review_blocked" if review_blocked else "completed",
             completed_payload,
             run_id=run_id,
         )
+    if review_blocked:
+        _blocked_task = get_task(conn, task_id)
+        _fire_kanban_lifecycle_hook(
+            "kanban_task_blocked",
+            task_id,
+            board=get_current_board(),
+            assignee=_blocked_task.assignee if _blocked_task else None,
+            run_id=run_id,
+            reason=canonical_receipt,
+        )
+        return True
     # Prose-scan the summary + result for t_<hex> references that do
     # not resolve. Advisory — does not block the completion. Runs in
     # its own txn so the completion itself is already durable by the
@@ -5818,6 +5924,7 @@ def block_task(
     *,
     reason: Optional[str] = None,
     kind: Optional[str] = None,
+    metadata: Optional[dict] = None,
     expected_run_id: Optional[int] = None,
 ) -> bool:
     """Transition ``running``/``ready`` → ``blocked`` (or route elsewhere).
@@ -5851,8 +5958,33 @@ def block_task(
         raise ValueError(
             f"block kind must be one of {sorted(VALID_BLOCK_KINDS)} or None"
         )
+    _reject_reserved_run_metadata(metadata)
     recurrences = 0
     with write_txn(conn):
+        if kind == "dependency":
+            task = get_task(conn, task_id)
+            role = (
+                (task.current_step_key or task.assignee or "").strip().lower()
+                if task is not None
+                else ""
+            )
+            if (
+                task is not None
+                and _is_jerome_workflow_task(task)
+                and role in {"architect", "critic", "verifier"}
+            ):
+                unfinished_parent = conn.execute(
+                    "SELECT 1 FROM task_links l "
+                    "JOIN tasks p ON p.id = l.parent_id "
+                    "WHERE l.child_id = ? "
+                    "AND p.status NOT IN ('done', 'archived') LIMIT 1",
+                    (task_id,),
+                ).fetchone()
+                if unfinished_parent is None:
+                    raise RoleCompletionContractError(
+                        "typed review verdict is an output: complete the review card; "
+                        "dependency block requires an unfinished declared parent"
+                    )
         cur_row = conn.execute(
             "SELECT status, block_kind, block_recurrences FROM tasks WHERE id = ?",
             (task_id,),
@@ -7045,6 +7177,48 @@ class DispatchResult:
     actively preventing two dispatchers from racing on ``kanban.db``."""
 
 
+@dataclass(frozen=True)
+class SpawnedWorker:
+    """Structured spawn result for launch probes and custom spawners."""
+
+    pid: int
+    returncode: Optional[int] = None
+    log_path: Optional[Path] = None
+    pid_committed: bool = False
+
+
+@dataclass(frozen=True)
+class WorkerRuntimeSpec:
+    """Hermes CLI argv plus a sealed runtime selected for one worker."""
+
+    argv: list[str]
+    env: dict[str, str] = field(default_factory=dict)
+    snapshot: Optional[Any] = None
+    lease: Optional[Any] = None
+    pass_fds: tuple[int, ...] = ()
+
+
+class WorkerRuntimeMismatch(RuntimeError):
+    """The live worker imported Hermes from outside its approved revision."""
+
+
+class ReservedRunMetadataError(ValueError):
+    """Caller metadata attempted to write a system-owned run field."""
+
+
+_RESERVED_RUN_METADATA_KEYS = frozenset({"runtime_provenance"})
+
+
+def _reject_reserved_run_metadata(metadata: Optional[dict]) -> None:
+    if not metadata:
+        return
+    collisions = sorted(_RESERVED_RUN_METADATA_KEYS.intersection(metadata))
+    if collisions:
+        raise ReservedRunMetadataError(
+            f"run metadata keys are reserved for the system: {', '.join(collisions)}"
+        )
+
+
 # Bounded registry of recently-reaped worker child exits, populated by the
 # reap loop at the top of ``dispatch_once`` and consulted by
 # ``detect_crashed_workers`` to classify a dead-pid task.
@@ -7774,67 +7948,16 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
 
             pid = int(row["worker_pid"])
             kind, code = _classify_worker_exit(pid)
-            rate_limited_exit = False
-            if kind == "clean_exit":
-                # Worker subprocess returned 0 but its task is still
-                # ``running`` in the DB — it exited without calling
-                # ``kanban_complete`` / ``kanban_block``. Overwhelmingly the
-                # work itself succeeded and only the paperwork was skipped, so
-                # a retry usually completes; the corrective sentence below is
-                # surfaced to the retry worker via the prior-attempt error in
-                # ``build_worker_context`` (guidance approach from #61817).
-                protocol_violation = True
-                error_text = (
-                    "worker exited cleanly (rc=0) without calling "
-                    "kanban_complete or kanban_block — protocol violation. "
-                    "If the prior run already did the work, verify it and "
-                    "report the result via kanban_complete; a run that ends "
-                    "without a terminal kanban call counts as failed no "
-                    "matter what it did."
-                )
-                event_kind = "protocol_violation"
-                event_payload = {
-                    "pid": pid,
-                    "claimer": row["claim_lock"],
-                    "exit_code": code,
-                    # Durable marker for _protocol_violation_streak: _end_run
-                    # copies this payload into the run metadata, which is how
-                    # the violation-only retry budget is derived later.
-                    "protocol_violation": True,
-                }
-            elif kind == "rate_limited":
-                # Worker bailed because the provider rate-limited / exhausted
-                # quota (EX_TEMPFAIL sentinel). This is NOT a task failure —
-                # the task is fine, the account just hit a wall. Release it
-                # back to ``ready`` so the respawn guard defers it until the
-                # quota window clears, and crucially do NOT count a failure
-                # (skip ``_record_task_failure``) so a long quota window can't
-                # trip the circuit breaker and permanently block the card.
-                protocol_violation = False
-                rate_limited_exit = True
-                error_text = (
-                    f"pid {pid} exited rate-limited (quota wall) — "
-                    f"requeued without counting a failure"
-                )
-                event_kind = "rate_limited"
-                event_payload = {
-                    "pid": pid,
-                    "claimer": row["claim_lock"],
-                    "exit_code": code,
-                }
-            else:
-                protocol_violation = False
-                if kind == "nonzero_exit":
-                    error_text = f"pid {pid} exited with code {code}"
-                elif kind == "signaled":
-                    error_text = f"pid {pid} killed by signal {code}"
-                else:
-                    error_text = f"pid {pid} not alive"
-                event_kind = "crashed"
-                event_payload = {"pid": pid, "claimer": row["claim_lock"]}
-                if code is not None and kind != "unknown":
-                    event_payload["exit_kind"] = kind
-                    event_payload["exit_code"] = code
+            (
+                _run_outcome,
+                error_text,
+                event_kind,
+                event_payload,
+                protocol_violation,
+                rate_limited_exit,
+            ) = _worker_exit_record(
+                kind, code, pid=pid, claimer=row["claim_lock"],
+            )
 
             cur = conn.execute(
                 "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
@@ -7847,7 +7970,6 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 # Rate-limited requeues are a clean release, not a crash —
                 # record the run outcome as ``rate_limited`` so the board
                 # history doesn't show a phantom crash for a quota wall.
-                _run_outcome = "rate_limited" if rate_limited_exit else "crashed"
                 run_id = _end_run(
                     conn, row["id"],
                     outcome=_run_outcome, status=_run_outcome,
@@ -8163,6 +8285,190 @@ def _record_spawn_failure(
     )
 
 
+def _worker_log_tail(log_path: Optional[Path], *, limit: int = 2000) -> str:
+    """Read and redact a bounded worker-log suffix for durable diagnostics."""
+    if log_path is None:
+        return ""
+    try:
+        with open(log_path, "rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            size = handle.tell()
+            handle.seek(max(0, size - limit), os.SEEK_SET)
+            text = handle.read(limit).decode("utf-8", errors="replace").strip()
+    except OSError:
+        return ""
+    from agent.redact import redact_sensitive_text
+
+    return redact_sensitive_text(text, force=True)
+
+
+def _classify_returncode(returncode: int) -> tuple[str, int]:
+    """Map ``Popen.returncode`` to the canonical worker exit taxonomy."""
+    code = int(returncode)
+    if code == 0:
+        return ("clean_exit", 0)
+    if code == KANBAN_RATE_LIMIT_EXIT_CODE:
+        return ("rate_limited", code)
+    if code < 0:
+        return ("signaled", abs(code))
+    return ("nonzero_exit", code)
+
+
+def _worker_exit_record(
+    kind: str,
+    code: Optional[int],
+    *,
+    pid: int,
+    claimer: Optional[str],
+    tail: str = "",
+) -> tuple[str, str, str, dict, bool, bool]:
+    """Return canonical outcome/error/event metadata for every exit observer."""
+    payload: dict[str, Any] = {"pid": int(pid), "claimer": claimer}
+    protocol_violation = False
+    rate_limited = False
+    if code is not None:
+        payload["exit_code"] = int(code)
+    if kind == "clean_exit":
+        protocol_violation = True
+        error = (
+            "worker exited cleanly (rc=0) without calling kanban_complete or "
+            "kanban_block — protocol violation. If the prior run already did "
+            "the work, verify it and report the result via kanban_complete; a "
+            "run that ends without a terminal kanban call counts as failed no "
+            "matter what it did."
+        )
+        event_kind = "protocol_violation"
+        payload["protocol_violation"] = True
+    elif kind == "rate_limited":
+        rate_limited = True
+        error = (
+            f"pid {pid} exited rate-limited (quota wall) — requeued without "
+            "counting a failure"
+        )
+        event_kind = "rate_limited"
+    elif kind == "nonzero_exit":
+        error = f"pid {pid} exited with code {code}"
+        event_kind = "crashed"
+        payload["exit_kind"] = kind
+    elif kind == "signaled":
+        error = f"pid {pid} killed by signal {code}"
+        event_kind = "crashed"
+        payload["exit_kind"] = kind
+    else:
+        error = f"pid {pid} not alive"
+        event_kind = "crashed"
+    if tail:
+        error = f"{error}: {tail}"
+    outcome = "rate_limited" if rate_limited else "crashed"
+    return outcome, error, event_kind, payload, protocol_violation, rate_limited
+
+
+def record_worker_exit(
+    task_id: str,
+    run_id: Optional[int],
+    pid: int,
+    returncode: int,
+    *,
+    log_path: Optional[Path] = None,
+    db_path: Optional[Path] = None,
+) -> bool:
+    """Promptly classify a detached child exit with a run/pid CAS guard."""
+    tail = _worker_log_tail(log_path)
+    kind, code = _classify_returncode(returncode)
+    with connect_closing(db_path=db_path) as exit_conn:
+        with write_txn(exit_conn):
+            row = exit_conn.execute(
+                "SELECT claim_lock FROM tasks WHERE id=? AND status='running' "
+                "AND current_run_id IS ? AND worker_pid=?",
+                (task_id, run_id, int(pid)),
+            ).fetchone()
+            if row is None:
+                return False
+            outcome, error, event_kind, payload, protocol_violation, rate_limited = (
+                _worker_exit_record(
+                    kind, code, pid=int(pid), claimer=row["claim_lock"], tail=tail,
+                )
+            )
+            cur = exit_conn.execute(
+                "UPDATE tasks SET status='ready', claim_lock=NULL, "
+                "claim_expires=NULL, worker_pid=NULL WHERE id=? "
+                "AND status='running' AND current_run_id IS ? AND worker_pid=?",
+                (task_id, run_id, int(pid)),
+            )
+            if cur.rowcount != 1:
+                return False
+            ended_run = _end_run(
+                exit_conn, task_id, outcome=outcome, status=outcome,
+                error=error[:500],
+                metadata=payload,
+            )
+            _append_event(
+                exit_conn, task_id, event_kind, payload,
+                run_id=ended_run,
+            )
+            exit_conn.execute(
+                "UPDATE tasks SET last_failure_error=? WHERE id=?",
+                (error[:500], task_id),
+            )
+        if protocol_violation:
+            streak = _protocol_violation_streak(exit_conn, task_id)
+            task = get_task(exit_conn, task_id)
+            limit = (
+                int(task.max_retries)
+                if task is not None and task.max_retries is not None
+                else _PROTOCOL_VIOLATION_FAILURE_LIMIT
+            )
+            if streak >= limit:
+                _record_task_failure(
+                    exit_conn, task_id, error, outcome="crashed",
+                    failure_limit=limit, force_trip=True,
+                    release_claim=False, end_run=False,
+                    event_payload_extra={
+                        "pid": int(pid), "protocol_violations": streak,
+                        "protocol_violation_limit": limit,
+                    },
+                )
+        elif not rate_limited:
+            _record_task_failure(
+                exit_conn, task_id, error,
+                outcome="crashed", release_claim=False, end_run=False,
+            )
+    return True
+
+
+def _watch_worker_exit(
+    proc: Any,
+    task_id: str,
+    run_id: Optional[int],
+    log_path: Path,
+    db_path: Path,
+    snapshot_lease: Optional[Any] = None,
+) -> None:
+    """Wait off-thread and promptly classify one detached worker exit.
+
+    The child can exit between ``Popen`` and the dispatcher's subsequent
+    ``_set_worker_pid`` transaction. Retry the CAS briefly so that race is
+    classified here instead of falling through to the next 60-second tick.
+    """
+    try:
+        returncode = int(proc.wait())
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if record_worker_exit(
+                task_id, run_id, int(proc.pid), returncode,
+                log_path=log_path, db_path=db_path,
+            ):
+                return
+            time.sleep(0.02)
+    except Exception:
+        _log.debug("kanban worker exit watcher failed", exc_info=True)
+    finally:
+        if snapshot_lease is not None:
+            from hermes_cli.kanban_runtime_snapshot import release_snapshot_lease
+
+            release_snapshot_lease(snapshot_lease)
+
+
 def _set_worker_pid(conn: sqlite3.Connection, task_id: str, pid: int) -> None:
     """Record the spawned child's pid + emit a ``spawned`` event.
 
@@ -8182,6 +8488,481 @@ def _set_worker_pid(conn: sqlite3.Connection, task_id: str, pid: int) -> None:
                 (int(pid), run_id),
             )
         _append_event(conn, task_id, "spawned", {"pid": int(pid)}, run_id=run_id)
+
+
+class ReviewerAuthorityError(RuntimeError):
+    """A typed reviewer bootstrap failed closed before activation."""
+
+
+class ReviewerActivationStartFailed(ReviewerAuthorityError):
+    """PID was committed, but the child never completed READY+EOF."""
+
+
+_REVIEWER_ROLES = frozenset({"planner", "architect", "critic", "verifier"})
+_REVIEWER_HANDSHAKE_TIMEOUT = 10.0
+_REVIEWER_TERMINATE_GRACE = 2.0
+
+
+class HandshakeOwner:
+    """Single owner for a reviewer process until READY+EOF handoff."""
+
+    _TRANSITIONS = {
+        "CREATED": "CHILD_STARTED",
+        "CHILD_STARTED": "HELLO_ACCEPTED",
+        "HELLO_ACCEPTED": "PID_COMMITTED",
+        "PID_COMMITTED": "GRANT_SENT",
+        "GRANT_SENT": "READY",
+        "READY": "HANDED_OFF",
+    }
+
+    def __init__(self, proc: Any, descriptors: Sequence[int]):
+        self.proc = proc
+        self.descriptors = list(descriptors)
+        self.state = "CREATED"
+        self._closed = False
+
+    def advance(self, expected: str) -> None:
+        if self._TRANSITIONS.get(self.state) != expected:
+            raise ReviewerAuthorityError("bootstrap_protocol_violation")
+        self.state = expected
+
+    def close_descriptors(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        for descriptor in self.descriptors:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+
+    def abort_and_reap(self) -> None:
+        if self.state == "HANDED_OFF":
+            return
+        self.state = "ABORTING"
+        self.close_descriptors()
+        if self.proc.poll() is not None:
+            try:
+                self.proc.wait(timeout=2)
+            except Exception:
+                pass
+            self.state = "REAPED"
+            return
+        terminate = (
+            self.proc.terminate
+            if _IS_WINDOWS
+            else lambda: os.killpg(self.proc.pid, signal.SIGTERM)
+        )
+        kill = (
+            self.proc.kill
+            if _IS_WINDOWS
+            else lambda: os.killpg(self.proc.pid, signal.SIGKILL)
+        )
+        try:
+            terminate()
+        except (OSError, ProcessLookupError):
+            pass
+        grace_deadline = time.monotonic() + _REVIEWER_TERMINATE_GRACE
+        while self.proc.poll() is None and time.monotonic() < grace_deadline:
+            time.sleep(0.01)
+        if self.proc.poll() is None:
+            try:
+                kill()
+            except (OSError, ProcessLookupError):
+                pass
+        try:
+            self.proc.wait(timeout=2)
+        except Exception:
+            pass
+        self.state = "REAPED"
+
+
+def _activation_start_failed(
+    conn: sqlite3.Connection, task: Task, pid: int, error: str,
+) -> None:
+    """Terminally close a PID-committed bootstrap without making it reusable."""
+    if task.current_run_id is None:
+        raise ReviewerAuthorityError("activation_start_failed_without_run")
+    run_id = int(task.current_run_id)
+    clean = str(error)[:500]
+    now = int(time.time())
+    with write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET status='blocked', current_run_id=NULL, "
+            "claim_lock=NULL, claim_expires=NULL, last_failure_error=? "
+            "WHERE id=? AND current_run_id=? AND worker_pid=?",
+            (clean, task.id, run_id, int(pid)),
+        )
+        conn.execute(
+            "UPDATE task_runs SET status='activation_start_failed', "
+            "outcome='activation_start_failed', error=?, ended_at=?, "
+            "claim_lock=NULL, claim_expires=NULL "
+            "WHERE id=? AND task_id=? AND worker_pid=? AND ended_at IS NULL",
+            (clean, now, run_id, task.id, int(pid)),
+        )
+        _append_event(
+            conn, task.id, "activation_start_failed",
+            {"pid": int(pid), "error": clean}, run_id=run_id,
+        )
+
+
+def _commit_reviewer_authority(
+    conn: sqlite3.Connection,
+    task: Task,
+    pid: int,
+    *,
+    parent_pid: int,
+) -> dict[str, Any]:
+    """Atomically bind a typed reviewer run to ``pid`` on ``conn``.
+
+    The caller owns the authoritative connection selected before claim.  This
+    function deliberately never resolves or reopens a database path.
+    """
+    role = (task.current_step_key or "").strip().lower()
+    if not _is_jerome_workflow_task(task) or role not in _REVIEWER_ROLES:
+        raise ReviewerAuthorityError("reviewer_authority_not_applicable")
+    if not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0:
+        raise ReviewerAuthorityError("worker_pid_cas_failed")
+    if not isinstance(parent_pid, int) or isinstance(parent_pid, bool) or parent_pid <= 0:
+        raise ReviewerAuthorityError("grant_binding_mismatch")
+    if task.current_run_id is None or not task.claim_lock or task.claim_expires is None:
+        raise ReviewerAuthorityError("worker_pid_cas_failed")
+
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        row = conn.execute(
+            """
+            SELECT t.id, t.status, t.assignee, t.claim_lock, t.claim_expires,
+                   t.current_run_id, t.worker_pid, t.workflow_template_id,
+                   t.current_step_key, r.profile, r.status AS run_status,
+                   r.claim_lock AS run_claim_lock, r.claim_expires AS run_claim_expires,
+                   r.worker_pid AS run_worker_pid, r.ended_at
+              FROM tasks t JOIN task_runs r ON r.id=t.current_run_id
+             WHERE t.id=? AND t.current_run_id=? AND r.task_id=t.id
+            """,
+            (task.id, int(task.current_run_id)),
+        ).fetchone()
+        if row is None or any(
+            (
+                row["status"] != "running",
+                row["run_status"] != "running",
+                row["ended_at"] is not None,
+                row["assignee"] != task.assignee,
+                row["profile"] != task.assignee,
+                row["claim_lock"] != task.claim_lock,
+                row["run_claim_lock"] != task.claim_lock,
+                row["claim_expires"] != task.claim_expires,
+                row["run_claim_expires"] != task.claim_expires,
+                row["workflow_template_id"] != _JEROME_WORKFLOW_TEMPLATE,
+                (row["current_step_key"] or "").strip().lower() != role,
+                row["worker_pid"] is not None,
+                row["run_worker_pid"] is not None,
+            )
+        ):
+            raise ReviewerAuthorityError("worker_pid_cas_failed")
+        task_update = conn.execute(
+            """
+            UPDATE tasks SET worker_pid=?
+             WHERE id=? AND status='running' AND current_run_id=?
+               AND claim_lock=? AND claim_expires=? AND worker_pid IS NULL
+               AND workflow_template_id=? AND current_step_key=?
+            """,
+            (
+                pid, task.id, int(task.current_run_id), task.claim_lock,
+                int(task.claim_expires), _JEROME_WORKFLOW_TEMPLATE, role,
+            ),
+        )
+        run_update = conn.execute(
+            """
+            UPDATE task_runs SET worker_pid=?
+             WHERE id=? AND task_id=? AND status='running' AND ended_at IS NULL
+               AND claim_lock=? AND claim_expires=? AND worker_pid IS NULL
+               AND profile=?
+            """,
+            (
+                pid, int(task.current_run_id), task.id, task.claim_lock,
+                int(task.claim_expires), task.assignee,
+            ),
+        )
+        if task_update.rowcount != 1 or run_update.rowcount != 1:
+            raise ReviewerAuthorityError("worker_pid_cas_failed")
+        grant = {
+            "v": 1,
+            "task_id": task.id,
+            "run_id": int(task.current_run_id),
+            "claim_lock": task.claim_lock,
+            "role": role,
+            "profile": task.assignee,
+            "workflow": _JEROME_WORKFLOW_TEMPLATE,
+            "pid": pid,
+            "parent_pid": parent_pid,
+            "expires_at": int(task.claim_expires),
+            "grant_id": secrets.token_hex(32),
+        }
+        _append_event(conn, task.id, "spawned", {"pid": pid}, run_id=task.current_run_id)
+        conn.commit()
+        return grant
+    except ReviewerAuthorityError:
+        conn.rollback()
+        raise
+    except Exception as exc:
+        conn.rollback()
+        raise ReviewerAuthorityError("sqlite_authority_commit_failed") from exc
+
+
+def _commit_generic_worker_binding(
+    conn: sqlite3.Connection,
+    task: Task,
+    pid: int,
+    *,
+    parent_pid: int,
+) -> dict[str, Any]:
+    """Atomically bind a generic run before allowing user code to execute."""
+    if task.current_run_id is None or not task.claim_lock or task.claim_expires is None:
+        raise ReviewerAuthorityError("worker_pid_cas_failed")
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        task_update = conn.execute(
+            """UPDATE tasks SET worker_pid=?
+                 WHERE id=? AND status='running' AND current_run_id=?
+                   AND claim_lock=? AND claim_expires=? AND worker_pid IS NULL""",
+            (pid, task.id, int(task.current_run_id), task.claim_lock, int(task.claim_expires)),
+        )
+        run_update = conn.execute(
+            """UPDATE task_runs SET worker_pid=?
+                 WHERE id=? AND task_id=? AND status='running' AND ended_at IS NULL
+                   AND claim_lock=? AND claim_expires=? AND worker_pid IS NULL
+                   AND profile=?""",
+            (pid, int(task.current_run_id), task.id, task.claim_lock,
+             int(task.claim_expires), task.assignee),
+        )
+        if task_update.rowcount != 1 or run_update.rowcount != 1:
+            raise ReviewerAuthorityError("worker_pid_cas_failed")
+        grant = {
+            "v": 1, "task_id": task.id, "run_id": int(task.current_run_id),
+            "claim_lock": task.claim_lock, "role": "worker",
+            "profile": task.assignee, "workflow": "generic", "pid": pid,
+            "parent_pid": parent_pid, "expires_at": int(task.claim_expires),
+            "grant_id": secrets.token_hex(32),
+        }
+        _append_event(conn, task.id, "spawned", {"pid": pid}, run_id=task.current_run_id)
+        conn.commit()
+        return grant
+    except ReviewerAuthorityError:
+        conn.rollback()
+        raise
+    except Exception as exc:
+        conn.rollback()
+        raise ReviewerAuthorityError("sqlite_authority_commit_failed") from exc
+
+
+def _posix_pipe() -> tuple[int, int]:
+    if hasattr(os, "pipe2"):
+        return os.pipe2(os.O_CLOEXEC)
+    pair = os.pipe()
+    try:
+        for descriptor in pair:
+            os.set_inheritable(descriptor, False)
+    except BaseException:
+        for descriptor in pair:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+        raise
+    return pair
+
+
+def _spawn_posix_reviewer(
+    conn: sqlite3.Connection,
+    task: Task,
+    cmd: Sequence[str],
+    *,
+    cwd: Optional[str],
+    env: Mapping[str, str],
+    stdout: Any,
+    runtime: Optional[WorkerRuntimeSpec] = None,
+    generic: bool = False,
+) -> Any:
+    """Run HELLO→commit→GRANT→READY+EOF and return a handed-off process."""
+    if _IS_WINDOWS:
+        raise ReviewerAuthorityError(
+            "UNVERIFIED_PENDING_WINDOWS_CI: secure_job_unavailable"
+        )
+    from tools.reviewer_authority import (
+        BootstrapHandshakeTimeoutError,
+        read_bootstrap_frame,
+        require_bootstrap_eof,
+        write_bootstrap_frame,
+    )
+
+    bootstrap = Path(__file__).with_name("reviewer_bootstrap.py")
+    child_env = dict(env)
+    try:
+        cli_start = list(cmd).index("-p")
+    except ValueError as exc:
+        raise ReviewerAuthorityError("bootstrap_protocol_violation") from exc
+    launch_argv = list(cmd)[cli_start:]
+    review_role = (task.current_step_key or "").strip().lower()
+    if not generic and (
+        len(launch_argv) < 3
+        or launch_argv[0] != "-p"
+        or launch_argv[1] != review_role
+        or review_role not in _REVIEWER_ROLES
+    ):
+        raise ReviewerAuthorityError("bootstrap_protocol_violation")
+    child_env["HERMES_KANBAN_REVIEW_LAUNCH_ARGV"] = json.dumps(launch_argv)
+    child_env["HERMES_KANBAN_REVIEW_PYTHONPATH"] = str(bootstrap.parents[1])
+    child_env["HERMES_KANBAN_BOOTSTRAP_MODE"] = "generic" if generic else "reviewer"
+    child_env.pop("HERMES_KANBAN_REVIEW_ROLE", None)
+    all_descriptors: list[int] = []
+    bundle_fd: Optional[int] = None
+    bundle_handle: Optional[Any] = None
+    try:
+        c2p_r, c2p_w = _posix_pipe()
+        all_descriptors.extend((c2p_r, c2p_w))
+        p2c_r, p2c_w = _posix_pipe()
+        all_descriptors.extend((p2c_r, p2c_w))
+        bootstrap_cmd = [sys.executable, "-I", str(bootstrap), str(c2p_w), str(p2c_r)]
+        if runtime is not None and runtime.snapshot is not None:
+            from hermes_cli.kanban_runtime_snapshot import (
+                manifest_resource_bytes,
+                verified_snapshot_bundle,
+            )
+
+            bootstrap_bytes = manifest_resource_bytes(
+                runtime.snapshot, "hermes_cli/reviewer_bootstrap.py"
+            )
+            bundle = verified_snapshot_bundle(runtime.snapshot)
+            bundle_handle = tempfile.TemporaryFile(mode="w+", encoding="utf-8")
+            json.dump(bundle, bundle_handle, sort_keys=True, separators=(",", ":"))
+            bundle_handle.flush()
+            bundle_handle.seek(0)
+            bundle_fd = int(bundle_handle.fileno())
+            all_descriptors.append(bundle_fd)
+            child_env["HERMES_KANBAN_VERIFIED_SNAPSHOT_FD"] = str(bundle_fd)
+            bootstrap_cmd = [
+                sys.executable, "-I", "-c",
+                "import sys;_b=bytes.fromhex(sys.argv.pop(1));exec(compile(_b,'hermes_cli/reviewer_bootstrap.py','exec'))",
+                bootstrap_bytes.hex(), str(c2p_w), str(p2c_r),
+                str(runtime.snapshot.object_root),
+                runtime.snapshot.manifest_sha256,
+                runtime.snapshot.cache_key,
+            ]
+        proc = subprocess.Popen(
+            bootstrap_cmd,
+            cwd=cwd,
+            stdin=subprocess.DEVNULL,
+            stdout=stdout,
+            stderr=subprocess.STDOUT,
+            env=child_env,
+            close_fds=True,
+            pass_fds=tuple(dict.fromkeys((
+                c2p_w,
+                p2c_r,
+                *((bundle_fd,) if bundle_fd is not None else ()),
+                *((runtime.pass_fds) if runtime is not None else ()),
+            ))),
+            start_new_session=True,
+        )
+    except BaseException:
+        for descriptor in all_descriptors:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+        raise
+    owner = HandshakeOwner(proc, (c2p_r, c2p_w, p2c_r, p2c_w))
+    deadline = time.monotonic() + _REVIEWER_HANDSHAKE_TIMEOUT
+    owner.advance("CHILD_STARTED")
+    os.close(c2p_w)
+    os.close(p2c_r)
+    owner.descriptors = [c2p_r, p2c_w]
+    try:
+        with os.fdopen(c2p_r, "rb", buffering=0) as child_stream, os.fdopen(
+            p2c_w, "wb", buffering=0
+        ) as parent_stream:
+            owner.descriptors = []
+            hello = read_bootstrap_frame(
+                child_stream,
+                max_bytes=1024,
+                fields={"challenge": str, "pid": int, "ppid": int, "v": int},
+                deadline=deadline,
+            )
+            if hello != {
+                "challenge": hello["challenge"],
+                "pid": proc.pid,
+                "ppid": os.getpid(),
+                "v": 1,
+            }:
+                raise ReviewerAuthorityError("grant_binding_mismatch")
+            owner.advance("HELLO_ACCEPTED")
+            grant = (
+                _commit_generic_worker_binding(conn, task, proc.pid, parent_pid=os.getpid())
+                if generic
+                else _commit_reviewer_authority(conn, task, proc.pid, parent_pid=os.getpid())
+            )
+            grant["challenge"] = hello["challenge"]
+            owner.advance("PID_COMMITTED")
+            write_bootstrap_frame(parent_stream, grant, max_bytes=4096, deadline=deadline)
+            owner.advance("GRANT_SENT")
+            ready = read_bootstrap_frame(
+                child_stream,
+                max_bytes=1024,
+                fields={"grant_id": str, "pid": int, "v": int},
+                deadline=deadline,
+            )
+            if ready != {"grant_id": grant["grant_id"], "pid": proc.pid, "v": 1}:
+                raise ReviewerAuthorityError("grant_binding_mismatch")
+            owner.advance("READY")
+            require_bootstrap_eof(child_stream, deadline=deadline)
+            if runtime is not None and runtime.lease is not None:
+                from hermes_cli.kanban_runtime_snapshot import (
+                    bind_snapshot_lease,
+                    mark_snapshot_lease_ready,
+                )
+
+                runtime = WorkerRuntimeSpec(
+                    argv=runtime.argv,
+                    env=runtime.env,
+                    snapshot=runtime.snapshot,
+                    lease=bind_snapshot_lease(
+                        mark_snapshot_lease_ready(runtime.lease, pid=proc.pid),
+                        pid=proc.pid,
+                    ),
+                    pass_fds=runtime.pass_fds,
+                )
+            # EOF on the grant/release pipe is the execution capability. Keep
+            # it withheld until READY+child EOF and durable lease binding have
+            # both succeeded, so generic payload code cannot race the bind.
+            parent_stream.close()
+        owner.advance("HANDED_OFF")
+        return proc
+    except Exception as exc:
+        pid_committed = owner.state in {"PID_COMMITTED", "GRANT_SENT", "READY"}
+        owner.abort_and_reap()
+        if pid_committed:
+            _activation_start_failed(conn, task, proc.pid, str(exc))
+            raise ReviewerActivationStartFailed("activation_start_failed") from exc
+        if isinstance(exc, BootstrapHandshakeTimeoutError):
+            raise ReviewerAuthorityError("bootstrap_handshake_timeout") from exc
+        raise
+
+
+def _spawn_posix_generic_worker(
+    conn: sqlite3.Connection,
+    task: Task,
+    cmd: Sequence[str],
+    *,
+    cwd: Optional[str],
+    env: Mapping[str, str],
+    stdout: Any,
+    runtime: Optional[WorkerRuntimeSpec] = None,
+) -> Any:
+    return _spawn_posix_reviewer(
+        conn, task, cmd, cwd=cwd, env=env, stdout=stdout,
+        runtime=runtime, generic=True,
+    )
 
 
 def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
@@ -8396,6 +9177,69 @@ def has_spawnable_review(conn: sqlite3.Connection) -> bool:
         if profile_exists(row["assignee"]):
             return True
     return False
+
+
+def _dispatch_preflight_error(task: Task) -> Optional[str]:
+    """Validate deterministic worker startup prerequisites before claiming."""
+    if not task.assignee:
+        return "missing assignee"
+    from hermes_cli.profiles import profile_exists, resolve_profile_env
+    if not profile_exists(task.assignee):
+        return f"unknown profile '{task.assignee}'"
+    try:
+        profile_home = resolve_profile_env(task.assignee)
+    except (FileNotFoundError, ValueError) as exc:
+        return str(exc)
+
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+    token = set_hermes_home_override(profile_home)
+    try:
+        from hermes_cli.plugins import discover_plugins
+
+        discover_plugins()
+        if task.skills:
+            from tools.skills_tool import skill_view
+            for skill in task.skills:
+                try:
+                    resolved = json.loads(skill_view(str(skill), preprocess=False))
+                except (TypeError, ValueError, json.JSONDecodeError) as exc:
+                    return f"could not resolve skill '{skill}': {exc}"
+                if not resolved.get("success"):
+                    return f"unknown skill '{skill}' for profile '{task.assignee}'"
+        from hermes_cli.config import load_config
+        from toolsets import validate_toolset
+        cfg = load_config()
+        requested = ((cfg.get("platform_toolsets") or {}).get("cli") or [])
+        mcp_names = set((cfg.get("mcp_servers") or {}).keys())
+        for toolset in requested:
+            name = str(toolset)
+            if not validate_toolset(name) and name not in mcp_names:
+                return f"unknown toolset '{name}' for profile '{task.assignee}'"
+        effective = _resolve_worker_cli_toolsets(profile_home) or []
+        for toolset in effective:
+            if not validate_toolset(toolset) and toolset not in mcp_names:
+                return f"unavailable toolset '{toolset}' for profile '{task.assignee}'"
+    finally:
+        reset_hermes_home_override(token)
+    return None
+
+
+def _block_preflight_failure(
+    conn: sqlite3.Connection, task_id: str, error: str,
+) -> None:
+    """Atomically block an invalid card without creating/consuming a run."""
+    from agent.redact import redact_sensitive_text
+
+    clean = redact_sensitive_text(error, force=True)[:500]
+    with write_txn(conn):
+        cur = conn.execute(
+            "UPDATE tasks SET status='blocked', last_failure_error=?, "
+            "claim_lock=NULL, claim_expires=NULL, worker_pid=NULL "
+            "WHERE id=? AND status IN ('ready', 'review') AND claim_lock IS NULL",
+            (clean, task_id),
+        )
+        if cur.rowcount == 1:
+            _append_event(conn, task_id, "preflight_failed", {"error": clean})
 
 
 def dispatch_once(
@@ -8672,13 +9516,9 @@ def _dispatch_once_locked(
         except Exception:
             profile_exists = None  # type: ignore[assignment]
         if profile_exists is not None and not profile_exists(row_assignee):
-            # Bucket separately from skipped_unassigned: the operator
-            # cannot fix this by assigning a profile (the assignee IS the
-            # intended owner — a terminal lane). Health telemetry uses
-            # this distinction to suppress spurious "stuck" warnings on
-            # multi-lane setups where the ready queue is steadily full
-            # of human-pulled work.
-            result.skipped_nonspawnable.append(row["id"])
+            _block_preflight_failure(
+                conn, row["id"], f"unknown profile '{row_assignee}'",
+            )
             continue
         # Per-profile concurrency cap (#21582): even if there's global
         # headroom, refuse to spawn for an assignee that's already at
@@ -8725,6 +9565,13 @@ def _dispatch_once_locked(
                     _per_profile_running.get(row_assignee, 0) + 1
                 )
             continue
+        task_for_preflight = get_task(conn, row["id"])
+        if task_for_preflight is None:
+            continue
+        preflight_error = _dispatch_preflight_error(task_for_preflight)
+        if preflight_error:
+            _block_preflight_failure(conn, row["id"], preflight_error)
+            continue
         claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
             continue
@@ -8755,14 +9602,30 @@ def _dispatch_once_locked(
             import inspect
             try:
                 sig = inspect.signature(_spawn)
-                if "board" in sig.parameters:
+                if "authority_conn" in sig.parameters:
+                    pid = _spawn(
+                        claimed, str(workspace), board=board, authority_conn=conn,
+                    )
+                elif "board" in sig.parameters:
                     pid = _spawn(claimed, str(workspace), board=board)
                 else:
                     pid = _spawn(claimed, str(workspace))
             except (TypeError, ValueError):
                 pid = _spawn(claimed, str(workspace))
-            if pid:
-                _set_worker_pid(conn, claimed.id, int(pid))
+            spawn_result = (
+                pid if isinstance(pid, SpawnedWorker)
+                else SpawnedWorker(pid=int(pid or 0))
+            )
+            if spawn_result.returncode is not None:
+                _set_worker_pid(conn, claimed.id, spawn_result.pid)
+                record_worker_exit(
+                    claimed.id, claimed.current_run_id, spawn_result.pid,
+                    spawn_result.returncode, log_path=spawn_result.log_path,
+                    db_path=kanban_db_path(board=board),
+                )
+                continue
+            if spawn_result.pid and not spawn_result.pid_committed:
+                _set_worker_pid(conn, claimed.id, spawn_result.pid)
             # NOTE: we intentionally do NOT reset consecutive_failures
             # here. A successful spawn proves the worker can start but
             # doesn't prove the run will succeed. Under unified
@@ -8779,6 +9642,8 @@ def _dispatch_once_locked(
                 _per_profile_running[claimed.assignee] = (
                     _per_profile_running.get(claimed.assignee, 0) + 1
                 )
+        except ReviewerActivationStartFailed:
+            continue
         except Exception as exc:
             auto = _record_spawn_failure(
                 conn, claimed.id, str(exc),
@@ -8807,15 +9672,18 @@ def _dispatch_once_locked(
         if not row["assignee"]:
             result.skipped_unassigned.append(row["id"])
             continue
-        try:
-            from hermes_cli.profiles import profile_exists
-        except Exception:
-            profile_exists = None  # type: ignore[assignment]
-        if profile_exists is not None and not profile_exists(row["assignee"]):
-            result.skipped_nonspawnable.append(row["id"])
-            continue
         if dry_run:
             result.spawned.append((row["id"], row["assignee"], ""))
+            continue
+        task_for_preflight = get_task(conn, row["id"])
+        if task_for_preflight is None:
+            continue
+        task_for_preflight.skills = list(task_for_preflight.skills or [])
+        if "sdlc-review" not in task_for_preflight.skills:
+            task_for_preflight.skills.append("sdlc-review")
+        preflight_error = _dispatch_preflight_error(task_for_preflight)
+        if preflight_error:
+            _block_preflight_failure(conn, row["id"], preflight_error)
             continue
         claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
@@ -8844,22 +9712,42 @@ def _dispatch_once_locked(
         # kanban lifecycle is already injected into every worker's system
         # prompt via KANBAN_GUIDANCE, so this is the only extra skill the
         # review agent needs.
-        claimed.skills = ["sdlc-review"]
+        claimed.skills = list(claimed.skills or [])
+        if "sdlc-review" not in claimed.skills:
+            claimed.skills.append("sdlc-review")
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:
             import inspect
             try:
                 sig = inspect.signature(_spawn)
-                if "board" in sig.parameters:
+                if "authority_conn" in sig.parameters:
+                    pid = _spawn(
+                        claimed, str(workspace), board=board, authority_conn=conn,
+                    )
+                elif "board" in sig.parameters:
                     pid = _spawn(claimed, str(workspace), board=board)
                 else:
                     pid = _spawn(claimed, str(workspace))
             except (TypeError, ValueError):
                 pid = _spawn(claimed, str(workspace))
-            if pid:
-                _set_worker_pid(conn, claimed.id, int(pid))
+            spawn_result = (
+                pid if isinstance(pid, SpawnedWorker)
+                else SpawnedWorker(pid=int(pid or 0))
+            )
+            if spawn_result.returncode is not None:
+                _set_worker_pid(conn, claimed.id, spawn_result.pid)
+                record_worker_exit(
+                    claimed.id, claimed.current_run_id, spawn_result.pid,
+                    spawn_result.returncode, log_path=spawn_result.log_path,
+                    db_path=kanban_db_path(board=board),
+                )
+                continue
+            if spawn_result.pid and not spawn_result.pid_committed:
+                _set_worker_pid(conn, claimed.id, spawn_result.pid)
             result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
             spawned += 1
+        except ReviewerActivationStartFailed:
+            continue
         except Exception as exc:
             auto = _record_spawn_failure(
                 conn, claimed.id, str(exc),
@@ -9068,6 +9956,193 @@ def _resolve_hermes_argv() -> list[str]:
     return _module_hermes_argv()
 
 
+def _git_revision(path: Path | str) -> Optional[str]:
+    """Return the immutable Git revision containing ``path``, if available."""
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(path), "rev-parse", "HEAD"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    revision = completed.stdout.strip()
+    return revision if completed.returncode == 0 and _HEX_REVISION_RE.fullmatch(revision) else None
+
+
+def _git_output(path: Path | str, *args: str) -> Optional[str]:
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(path), *args],
+            stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL, text=True, check=False, timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    value = completed.stdout.strip()
+    return value if completed.returncode == 0 and value else None
+
+
+def _git_checkout_identity(path: Path | str) -> Optional[dict[str, str]]:
+    """Return a worktree-stable, repository-specific Git identity."""
+    root_raw = _git_output(path, "rev-parse", "--show-toplevel")
+    common_raw = _git_output(
+        path, "rev-parse", "--path-format=absolute", "--git-common-dir",
+    )
+    revision = _git_revision(path)
+    roots_raw = _git_output(path, "rev-list", "--max-parents=0", "HEAD")
+    if not root_raw or not common_raw or not revision or not roots_raw:
+        return None
+    root = Path(root_raw).resolve(strict=True)
+    common = Path(common_raw).resolve(strict=True)
+    repository_id = hashlib.sha256(
+        (str(common) + "\0" + "\n".join(sorted(roots_raw.splitlines()))).encode()
+    ).hexdigest()
+    return {
+        "root": str(root),
+        "git_common_dir": str(common),
+        "repository_id": repository_id,
+        "revision": revision,
+    }
+
+
+def _dispatcher_runtime_identity() -> Optional[dict[str, str]]:
+    return _git_checkout_identity(Path(__file__).resolve().parents[1])
+
+
+def _trusted_runtime_source_root(workspace: Path | str) -> Optional[tuple[Path, dict[str, str]]]:
+    """Return an exact same-repository root; generic workspaces remain unchanged."""
+    candidate = Path(workspace).expanduser()
+    try:
+        if candidate.absolute() != candidate.resolve(strict=True):
+            return None
+    except OSError:
+        return None
+    if not (candidate / ".git").exists():
+        return None
+    workspace_identity = _git_checkout_identity(candidate)
+    dispatcher_identity = _dispatcher_runtime_identity()
+    if not workspace_identity or not dispatcher_identity:
+        return None
+    if (
+        workspace_identity["git_common_dir"] != dispatcher_identity["git_common_dir"]
+        or workspace_identity["repository_id"] != dispatcher_identity["repository_id"]
+    ):
+        return None
+    root = Path(workspace_identity["root"])
+    if candidate.resolve(strict=True) != root:
+        return None
+    return root, workspace_identity
+
+
+def _runtime_snapshot_cache_root() -> Path:
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home() / "kanban" / "runtime-snapshots" / "v1"
+
+
+def _worker_runtime_spec(task: Task, workspace: Path | str) -> WorkerRuntimeSpec:
+    """Build a sealed snapshot for same-repository workers, else use installed Hermes."""
+    selected = _trusted_runtime_source_root(workspace)
+    if selected is None:
+        return WorkerRuntimeSpec(argv=_resolve_hermes_argv())
+    root, identity = selected
+    from hermes_cli.kanban_runtime_snapshot import (
+        build_runtime_snapshot,
+        dispatcher_runtime_bindings,
+        prepare_snapshot_lease,
+        runtime_binding_pass_fds,
+        runtime_bindings_json,
+        with_runtime_bindings,
+    )
+
+    snapshot = build_runtime_snapshot(
+        root,
+        repository_id=identity["repository_id"],
+        source_revision=identity["revision"],
+        source_dirty=bool(_git_output(root, "status", "--porcelain", "--untracked-files=all")),
+        cache_root=_runtime_snapshot_cache_root(),
+    )
+    snapshot = with_runtime_bindings(snapshot, dispatcher_runtime_bindings())
+    if task.current_run_id is None:
+        from hermes_cli.kanban_runtime_snapshot import RuntimeSnapshotError
+
+        raise RuntimeSnapshotError("snapshot_lease_missing_run")
+    lease = prepare_snapshot_lease(
+        snapshot,
+        cache_root=_runtime_snapshot_cache_root(),
+        task_id=task.id,
+        run_id=int(task.current_run_id),
+    )
+    return WorkerRuntimeSpec(
+        argv=[
+            sys.executable, "-I", "-S", "-c", _IMMUTABLE_RUNTIME_LAUNCHER,
+            str(snapshot.object_root), snapshot.manifest_sha256, snapshot.cache_key,
+            runtime_bindings_json(snapshot),
+        ],
+        env={"HERMES_KANBAN_RUNTIME_REVISION": snapshot.source_revision},
+        snapshot=snapshot,
+        lease=lease,
+        pass_fds=runtime_binding_pass_fds(snapshot.runtime_bindings),
+    )
+
+
+def _verify_worker_runtime_provenance(*, capability=None) -> Optional[dict[str, Any]]:
+    """Derive provenance solely from the bootstrap-installed capability."""
+    from hermes_cli.kanban_runtime_snapshot import snapshot_bootstrap_capability
+
+    installed = snapshot_bootstrap_capability()
+    if installed is None:
+        return None
+    if capability is not None and capability is not installed:
+        raise WorkerRuntimeMismatch("pinned runtime bootstrap capability mismatch")
+    spec = installed.spec
+    return {
+        "revision": spec.source_revision,
+        "dirty": spec.source_dirty,
+        "snapshot_cache_key": spec.cache_key,
+        "manifest_sha256": spec.manifest_sha256,
+        "content_root_sha256": spec.content_root_sha256,
+        "runtime_root": str(spec.payload_root),
+        "guard_version": installed.guard_version,
+    }
+
+
+def record_worker_runtime_provenance(*, capability=None) -> Optional[dict[str, Any]]:
+    """Durably attach sealed runtime provenance for the active worker run."""
+    receipt = _verify_worker_runtime_provenance(capability=capability)
+    if receipt is None:
+        return None
+    task_id = os.environ.get("HERMES_KANBAN_TASK", "").strip()
+    run_id_raw = os.environ.get("HERMES_KANBAN_RUN_ID", "").strip()
+    if not task_id or not run_id_raw:
+        raise WorkerRuntimeMismatch("pinned runtime is missing task/run identity")
+    try:
+        run_id = int(run_id_raw)
+    except ValueError as exc:
+        raise WorkerRuntimeMismatch("pinned runtime has invalid run identity") from exc
+    with connect_closing() as conn:
+        with write_txn(conn):
+            row = conn.execute(
+                "SELECT metadata FROM task_runs WHERE id=? AND task_id=? AND status='running'",
+                (run_id, task_id),
+            ).fetchone()
+            if row is None:
+                raise WorkerRuntimeMismatch("pinned runtime run is not active")
+            metadata = json.loads(row["metadata"]) if row["metadata"] else {}
+            metadata["runtime_provenance"] = receipt
+            conn.execute(
+                "UPDATE task_runs SET metadata=? WHERE id=?",
+                (json.dumps(metadata, ensure_ascii=False), run_id),
+            )
+            _append_event(conn, task_id, "runtime_provenance", receipt, run_id=run_id)
+    return receipt
+
+
 def _worker_terminal_timeout_env(
     max_runtime_seconds: Optional[int],
     current_timeout: Optional[str],
@@ -9098,7 +10173,11 @@ def _worker_terminal_timeout_env(
     return str(desired)
 
 
-def _resolve_worker_cli_toolsets(hermes_home: Optional[str]) -> Optional[list[str]]:
+def _resolve_worker_cli_toolsets(
+    hermes_home: Optional[str],
+    *,
+    task: Optional[Task] = None,
+) -> Optional[list[str]]:
     """Return the assigned profile's effective CLI toolsets for a worker.
 
     Dispatcher-spawned workers are launched from a long-lived gateway process,
@@ -9129,6 +10208,17 @@ def _resolve_worker_cli_toolsets(hermes_home: Optional[str]) -> Optional[list[st
                 toolsets = [ts for ts in toolsets if ts != "kanban"]
                 if "kanban-worker-lifecycle" not in toolsets:
                     toolsets.append("kanban-worker-lifecycle")
+            role = (
+                (task.current_step_key or "").strip().lower()
+                if task is not None and _is_jerome_workflow_task(task)
+                else ""
+            )
+            if role in {"planner", "architect", "critic", "verifier"}:
+                # Do not preserve unknown/profile plugin toolsets: a custom
+                # composite can re-export a mutation tool under any name.
+                toolsets = [
+                    "review-readonly", "kanban-worker-lifecycle", "review-exec",
+                ]
         finally:
             reset_hermes_home_override(token)
         return toolsets or None
@@ -9172,7 +10262,8 @@ def _default_spawn(
     workspace: str,
     *,
     board: Optional[str] = None,
-) -> Optional[int]:
+    authority_conn: Optional[sqlite3.Connection] = None,
+) -> Optional[int | SpawnedWorker]:
     """Fire-and-forget ``hermes -p <profile> chat -q ...`` subprocess.
 
     Returns the spawned child's PID so the dispatcher can detect crashes
@@ -9224,6 +10315,17 @@ def _default_spawn(
         env["HERMES_TENANT"] = task.tenant
     env["HERMES_KANBAN_TASK"] = task.id
     env["HERMES_KANBAN_WORKSPACE"] = workspace
+    review_role = (
+        (task.current_step_key or "").strip().lower()
+        if _is_jerome_workflow_task(task)
+        else ""
+    )
+    # Reviewer authority is transferred only by the two-pipe bootstrap. An
+    # inherited role marker is attacker-spoofable and must never activate or
+    # identify a typed reviewer process.
+    env.pop("HERMES_KANBAN_REVIEW_ROLE", None)
+    if review_role in _REVIEWER_ROLES and authority_conn is None:
+        raise ReviewerAuthorityError("reviewer_authority_unavailable")
     # Tag the worker's session so it lands in state.db as `kanban`, not as an
     # untitled `cli` row. A worker is a dispatcher-owned run whose transcript is
     # read on the board and in `hermes kanban log` — it is not a conversation
@@ -9299,8 +10401,10 @@ def _default_spawn(
     # older hermes builds on PATH that predate the flag's precedence.
     env.pop("HERMES_TUI", None)
 
+    runtime = _worker_runtime_spec(task, workspace)
+    env.update(runtime.env)
     cmd = [
-        *_resolve_hermes_argv(),
+        *runtime.argv,
         "-p", profile_arg,
         "--cli",
         # Worker subprocesses switch to a profile-scoped HERMES_HOME above,
@@ -9331,7 +10435,7 @@ def _default_spawn(
     # branch, not a nested one.
     if task.reasoning_effort:
         cmd.extend(["--reasoning", task.reasoning_effort])
-    worker_toolsets = _resolve_worker_cli_toolsets(env.get("HERMES_HOME"))
+    worker_toolsets = _resolve_worker_cli_toolsets(env.get("HERMES_HOME"), task=task)
     if worker_toolsets:
         cmd.extend(["--toolsets", ",".join(worker_toolsets)])
     cmd.extend([
@@ -9355,30 +10459,55 @@ def _default_spawn(
     rotate_bytes, backup_count = worker_log_rotation_config()
     _rotate_worker_log(log_path, rotate_bytes, backup_count)
 
+    # Windows has no trusted runtime proof for the secure Job Object adapter on
+    # this release. Fail before Popen for generic and typed workers alike; never
+    # fall back to CREATE_NEW_PROCESS_GROUP/taskkill or a single-process kill.
+    if _IS_WINDOWS:
+        raise ReviewerAuthorityError("UNVERIFIED_PENDING_WINDOWS_CI: secure_job_unavailable")
+
     # Use 'a' so a re-run on unblock appends rather than overwrites.
     log_f = open(log_path, "ab")
     try:
-        proc = subprocess.Popen(  # noqa: S603 -- argv is a fixed list built above
-            cmd,
-            cwd=workspace if os.path.isdir(workspace) else None,
-            stdin=subprocess.DEVNULL,
-            stdout=log_f,
-            stderr=subprocess.STDOUT,
-            env=env,
-            start_new_session=True,
-            creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
-        )
+        if review_role in _REVIEWER_ROLES and authority_conn is not None:
+            proc = _spawn_posix_reviewer(
+                authority_conn, task, cmd,
+                cwd=workspace if os.path.isdir(workspace) else None,
+                env=env, stdout=log_f, runtime=runtime,
+            )
+        else:
+            if authority_conn is None:
+                raise ReviewerAuthorityError("worker_binding_authority_unavailable")
+            proc = _spawn_posix_generic_worker(
+                authority_conn, task, cmd,
+                cwd=workspace if os.path.isdir(workspace) else None,
+                env=env, stdout=log_f, runtime=runtime,
+            )
     except FileNotFoundError:
         log_f.close()
         raise RuntimeError(
             "`hermes` executable not found on PATH. "
             "Install Hermes Agent or activate its venv before running the kanban dispatcher."
         )
+    watcher = threading.Thread(
+        target=_watch_worker_exit,
+        args=(
+            proc, task.id, task.current_run_id, log_path, kanban_db_path(board=board),
+            runtime.lease,
+        ),
+        name=f"kanban-exit-{task.id}",
+        daemon=True,
+    )
+    watcher.start()
     # NOTE: we intentionally do NOT close log_f here — we want Popen's
     # child process to keep writing after this function returns.  The
     # handle is kept alive by the child's inheritance.  The parent's
     # reference goes out of scope and is GC'd, but the OS-level FD stays
     # open in the child until the child exits.
+    if (
+        (review_role in _REVIEWER_ROLES and authority_conn is not None)
+        or runtime.lease is not None
+    ):
+        return SpawnedWorker(pid=proc.pid, pid_committed=True)
     return proc.pid
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2903,6 +2903,8 @@ def create_task(
     goal_max_turns: Optional[int] = None,
     initial_status: str = "running",
     session_id: Optional[str] = None,
+    workflow_template_id: Optional[str] = None,
+    current_step_key: Optional[str] = None,
     board: Optional[str] = None,
     project_id: Optional[str] = None,
     project_source_task_id: Optional[str] = None,
@@ -3217,8 +3219,9 @@ def create_task(
                         max_runtime_seconds,
                         skills, max_retries, model_override, provider_override,
                         reasoning_effort,
-                        goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        goal_mode, goal_max_turns, session_id,
+                        workflow_template_id, current_step_key
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -3244,6 +3247,8 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
+                        workflow_template_id,
+                        current_step_key,
                     ),
                 )
                 for pid in parents:
@@ -3268,6 +3273,8 @@ def create_task(
                         "goal_mode": bool(goal_mode) or None,
                         "model_override": model_override,
                         "provider_override": provider_override,
+                        "workflow_template_id": workflow_template_id,
+                        "current_step_key": current_step_key,
                     },
                 )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
@@ -4833,6 +4840,187 @@ class ArtifactPreservationError(RuntimeError):
     """Raised when a declared scratch deliverable cannot be preserved."""
 
 
+class RoleCompletionContractError(ValueError):
+    """Raised when a Jerome typed-workflow card lacks a safe receipt."""
+
+
+_JEROME_WORKFLOW_TEMPLATE = "jerome-kanban-v1"
+_JEROME_WORKFLOW_MARKER = "WORKFLOW_CONTRACT: jerome-kanban-v1"
+_HEX_REVISION_RE = re.compile(r"^[0-9a-fA-F]{7,64}$")
+
+
+def _typed_verdict(summary: str, allowed: set[str]) -> Optional[str]:
+    found: list[str] = []
+    for raw_line in summary.splitlines():
+        line = raw_line.strip().upper()
+        value = line if line in allowed else None
+        match = re.match(
+            r"^(?:VERDICT|ARCHITECTURAL STATUS|STATUS)\s*:\s*([A-Z]+)\s*$",
+            line,
+        )
+        if value is None and match and match.group(1) in allowed:
+            value = match.group(1)
+        if value is not None:
+            found.append(value)
+    return found[0] if len(found) == 1 else None
+
+
+def _valid_verification_receipts(value: object, revision: str) -> bool:
+    if not isinstance(value, list) or not value:
+        return False
+    for receipt in value:
+        if not isinstance(receipt, dict):
+            return False
+        command = receipt.get("command")
+        result = receipt.get("result")
+        head = receipt.get("head")
+        exit_code = receipt.get("exit_code")
+        if not isinstance(command, str) or not command.strip():
+            return False
+        if not isinstance(result, str) or not result.strip():
+            return False
+        if exit_code != 0 or head != revision:
+            return False
+    return True
+
+
+def _revision_exists_in_task_repo(task: Task, revision: str) -> bool:
+    workspace = task.workspace_path
+    if not workspace or not os.path.isabs(workspace) or not os.path.isdir(workspace):
+        return False
+    try:
+        proc = subprocess.run(
+            ["git", "cat-file", "-e", f"{revision}^{{commit}}"],
+            cwd=workspace,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return proc.returncode == 0
+
+
+def _task_repo_head(task: Task) -> Optional[str]:
+    workspace = task.workspace_path
+    if not workspace or not os.path.isabs(workspace) or not os.path.isdir(workspace):
+        return None
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "--verify", "HEAD^{commit}"],
+            cwd=workspace,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return proc.stdout.strip() if proc.returncode == 0 else None
+
+
+def _validate_role_completion_contract(
+    task: Task,
+    *,
+    summary: Optional[str],
+    metadata: Optional[dict],
+) -> None:
+    typed = (
+        task.workflow_template_id == _JEROME_WORKFLOW_TEMPLATE
+        or _JEROME_WORKFLOW_MARKER in (task.body or "")
+    )
+    if not typed:
+        return
+    if task.status == "blocked":
+        raise RoleCompletionContractError(
+            "typed workflow blocked task must be explicitly unblocked before completion"
+        )
+
+    role = (task.current_step_key or task.assignee or "").strip().lower()
+    text = summary or ""
+    meta = metadata if isinstance(metadata, dict) else {}
+
+    valid_roles = {
+        "planner", "orchestrator", "architect", "critic",
+        "executor", "integrator", "verifier",
+    }
+    if role not in valid_roles:
+        raise RoleCompletionContractError(f"unknown typed workflow role: {role!r}")
+
+    if role == "critic":
+        if _typed_verdict(text, {"OKAY", "ITERATE", "REJECT"}) != "OKAY":
+            raise RoleCompletionContractError(
+                "Critic verdict must be exactly one OKAY; ITERATE/REJECT must block"
+            )
+    elif role in {"architect", "verifier"}:
+        if _typed_verdict(text, {"CLEAR", "WATCH", "BLOCK"}) not in {"CLEAR", "WATCH"}:
+            raise RoleCompletionContractError(
+                f"{role} verdict must be exactly one CLEAR or WATCH"
+            )
+        if role == "verifier":
+            reviewed = meta.get("reviewed_commit")
+            integration_head = meta.get("integration_head")
+            reviewer = meta.get("reviewer_identity")
+            author = meta.get("author_identity")
+            if (
+                not isinstance(reviewed, str)
+                or not _HEX_REVISION_RE.fullmatch(reviewed)
+                or reviewed != integration_head
+            ):
+                raise RoleCompletionContractError(
+                    "verifier requires matching reviewed_commit and integration_head"
+                )
+            if _task_repo_head(task) != reviewed:
+                raise RoleCompletionContractError(
+                    "verifier reviewed_commit must equal the task repository HEAD"
+                )
+            if not isinstance(reviewer, str) or not reviewer.strip():
+                raise RoleCompletionContractError("verifier requires reviewer_identity")
+            if not isinstance(author, str) or not author.strip():
+                raise RoleCompletionContractError("verifier requires author_identity")
+            if author == reviewer:
+                raise RoleCompletionContractError(
+                    "verifier identity must differ from author_identity"
+                )
+            if not _valid_verification_receipts(meta.get("verification"), reviewed):
+                raise RoleCompletionContractError(
+                    "verifier requires typed passing verification receipts"
+                )
+    elif role == "executor":
+        revision = meta.get("commit") or meta.get("source_revision")
+        if not isinstance(meta.get("changed_files"), list) or not meta["changed_files"]:
+            raise RoleCompletionContractError("executor completion requires changed_files")
+        if not isinstance(revision, str) or not _HEX_REVISION_RE.fullmatch(revision):
+            raise RoleCompletionContractError("executor completion requires a hexadecimal source revision")
+        if not _revision_exists_in_task_repo(task, revision):
+            raise RoleCompletionContractError("executor source revision must exist in the task repository")
+        if not _valid_verification_receipts(meta.get("verification"), revision):
+            raise RoleCompletionContractError("executor completion requires typed passing verification receipts")
+    elif role == "integrator":
+        revision = meta.get("integrated_head")
+        commits = meta.get("included_commits")
+        if not isinstance(revision, str) or not _HEX_REVISION_RE.fullmatch(revision):
+            raise RoleCompletionContractError("integrator completion requires a hexadecimal integrated_head")
+        if not isinstance(commits, list) or not commits or not all(
+            isinstance(item, str) and _HEX_REVISION_RE.fullmatch(item) for item in commits
+        ):
+            raise RoleCompletionContractError("integrator completion requires hexadecimal included_commits")
+        if not _revision_exists_in_task_repo(task, revision) or not all(
+            _revision_exists_in_task_repo(task, item) for item in commits
+        ):
+            raise RoleCompletionContractError(
+                "integrator revisions must exist in the task repository"
+            )
+        if _task_repo_head(task) != revision:
+            raise RoleCompletionContractError(
+                "integrator integrated_head must equal the task repository HEAD"
+            )
+        if not _valid_verification_receipts(meta.get("verification"), revision):
+            raise RoleCompletionContractError("integrator completion requires typed passing verification receipts")
+
+
 def complete_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -4872,6 +5060,15 @@ def complete_task(
     and never blocks.
     """
     now = int(time.time())
+
+    task_for_contract = get_task(conn, task_id)
+    if task_for_contract is None:
+        return False
+    _validate_role_completion_contract(
+        task_for_contract,
+        summary=summary if summary is not None else result,
+        metadata=metadata,
+    )
 
     # Gate: verify created_cards BEFORE the main write txn. A rejected
     # completion still needs an auditable event, so we emit it in a
@@ -8923,6 +9120,15 @@ def _resolve_worker_cli_toolsets(hermes_home: Optional[str]) -> Optional[list[st
         try:
             cfg = load_config()
             toolsets = sorted(_get_platform_tools(cfg, "cli"))
+            configured_cli = ((cfg.get("platform_toolsets") or {}).get("cli") or [])
+            if "review-readonly" in configured_cli:
+                toolsets = [ts for ts in toolsets if ts != "kanban"]
+                if "kanban-worker-lifecycle" not in toolsets:
+                    toolsets.append("kanban-worker-lifecycle")
+            elif "integration-worker" in configured_cli:
+                toolsets = [ts for ts in toolsets if ts != "kanban"]
+                if "kanban-worker-lifecycle" not in toolsets:
+                    toolsets.append("kanban-worker-lifecycle")
         finally:
             reset_hermes_home_override(token)
         return toolsets or None

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -249,6 +249,32 @@ def _format_roster(roster: list[dict]) -> str:
     return "\n".join(lines)
 
 
+def _validate_parent_indices(
+    parents: object,
+    *,
+    task_index: int,
+    task_count: int,
+) -> list[int]:
+    """Fail closed on malformed dependency references.
+
+    Silently dropping a bad parent can turn a gated implementation card into
+    immediately runnable work.  Preserve order, de-duplicate valid indices,
+    and reject every malformed, out-of-range, or self reference.
+    """
+    if not isinstance(parents, list):
+        raise ValueError("parents must be a list of task indices")
+    invalid = [
+        p for p in parents
+        if isinstance(p, bool)
+        or not isinstance(p, int)
+        or not (0 <= p < task_count)
+        or p == task_index
+    ]
+    if invalid:
+        raise ValueError(f"invalid parent index value(s): {invalid}")
+    return list(dict.fromkeys(parents))
+
+
 def _normalize_assignee_choice(
     assignee: object,
     *,
@@ -417,11 +443,15 @@ def decompose_task(
                 "routing to default_assignee %r",
                 task_id, idx, assignee, default_assignee,
             )
-        parents = entry.get("parents") or []
-        if not isinstance(parents, list):
-            parents = []
-        # Clean parent indices: drop non-int and out-of-range.
-        clean_parents = [p for p in parents if isinstance(p, int) and 0 <= p < len(raw_tasks) and p != idx]
+        parents = entry.get("parents", [])
+        try:
+            clean_parents = _validate_parent_indices(
+                parents,
+                task_index=idx,
+                task_count=len(raw_tasks),
+            )
+        except ValueError as exc:
+            return DecomposeOutcome(task_id, False, f"tasks[{idx}] {exc}")
         children.append({
             "title": title.strip()[:200],
             "body": body.strip(),

--- a/hermes_cli/kanban_runtime_snapshot.py
+++ b/hermes_cli/kanban_runtime_snapshot.py
@@ -1,0 +1,1284 @@
+"""Immutable, content-addressed runtime snapshots for Kanban workers.
+
+This module is deliberately stdlib-only.  It is imported by the already-running
+Kanban dispatcher before any code from a candidate worktree is executed.
+"""
+
+from __future__ import annotations
+
+import ast
+import contextlib
+import errno
+import hashlib
+import importlib.abc
+import importlib.machinery
+import io
+import json
+import os
+import shutil
+import stat
+import sys
+import sysconfig
+import tempfile
+import threading
+import time
+import unicodedata
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import BinaryIO, Iterator, Mapping, Optional
+
+
+_SCHEMA_VERSION = 1
+_SELECTION_POLICY_VERSION = 5
+_SELECTED_DIRECTORIES = (
+    "agent", "cron", "gateway", "hermes_cli", "plugins", "providers", "skills",
+    "tools", "tui_gateway", "acp_adapter", "locales",
+)
+_SELECTED_TOP_LEVEL = frozenset({"pyproject.toml", "package.json"})
+_EXCLUDED_DIRECTORIES = frozenset({
+    ".git", ".hg", ".svn", ".tox", ".nox", ".mypy_cache", ".pytest_cache",
+    ".ruff_cache", "node_modules", "__pycache__", "dist", "build", ".worktrees",
+    ".hermes", ".venv", "venv",
+})
+_NATIVE_SUFFIXES = (".so", ".dylib", ".dll", ".pyd")
+_MAX_FILE_BYTES = 64 * 1024 * 1024
+_MAX_TOTAL_BYTES = 1024 * 1024 * 1024
+_MAX_FILES = 50_000
+_BUFFER = 1024 * 1024
+_CAPABILITY_LOCK = threading.Lock()
+_INSTALLED_CAPABILITY: Optional["SnapshotCapability"] = None
+_INSTALLED_IMPORT_GUARD: Optional["_SnapshotImportGuard"] = None
+
+
+class RuntimeSnapshotError(RuntimeError):
+    """Stable fail-closed snapshot error."""
+
+    def __init__(self, code: str, relative_path: Optional[str] = None):
+        self.code = code
+        self.relative_path = relative_path
+        suffix = f": {relative_path}" if relative_path else ""
+        super().__init__(f"{code}{suffix}")
+
+
+@dataclass(frozen=True)
+class SnapshotFile:
+    path: str
+    size: int
+    sha256: str
+    executable: bool
+    mode_class: str
+
+    def as_dict(self) -> dict:
+        return {
+            "path": self.path,
+            "kind": "regular",
+            "size": self.size,
+            "sha256": self.sha256,
+            "executable": self.executable,
+            "mode_class": self.mode_class,
+        }
+
+
+@dataclass(frozen=True)
+class RuntimeSnapshotSpec:
+    object_root: Path
+    payload_root: Path
+    manifest_path: Path
+    cache_key: str
+    manifest_sha256: str
+    content_root_sha256: str
+    source_revision: str
+    source_dirty: bool
+    total_files: int
+    total_bytes: int
+    reused: bool = False
+    verified_bytes: Mapping[str, bytes] = field(
+        default_factory=dict, repr=False, compare=False,
+    )
+    runtime_bindings: tuple["RuntimeDirectoryBinding", ...] = field(
+        default_factory=tuple, repr=False, compare=False,
+    )
+
+
+@dataclass(frozen=True)
+class RuntimeDirectoryBinding:
+    role: str
+    path: Path
+    handle: int
+    device: int
+    inode: int
+    owner: int
+    mode: int
+
+
+@dataclass(frozen=True)
+class SnapshotLease:
+    cache_key: str
+    run_id: int
+    path: Path
+    nonce: str
+    state: str = "prepared"
+
+
+@dataclass(frozen=True)
+class SnapshotCapability:
+    spec: RuntimeSnapshotSpec
+    manifest: Mapping[str, object]
+    guard_version: int = 1
+
+
+@dataclass(frozen=True)
+class SealedResourceFile:
+    path: str
+    pass_fds: tuple[int, ...]
+
+
+class _VerifiedSourceLoader(importlib.abc.Loader):
+    """Execute source bytes retained by the verified snapshot capability."""
+
+    def __init__(self, fullname: str, origin: str, source: bytes, *, is_package: bool):
+        self.fullname = fullname
+        self.origin = origin
+        self.source = source
+        self.is_package = is_package
+
+    def create_module(self, spec):
+        return None
+
+    def exec_module(self, module) -> None:
+        module.__file__ = self.origin
+        module.__loader__ = self
+        if self.is_package:
+            module.__package__ = self.fullname
+            module.__path__ = [str(Path(self.origin).parent)]
+        exec(compile(self.source, self.origin, "exec"), module.__dict__)
+
+    def get_code(self, fullname: str):
+        if fullname != self.fullname:
+            raise ImportError(fullname)
+        return compile(self.source, self.origin, "exec")
+
+    def get_source(self, fullname: str) -> str:
+        if fullname != self.fullname:
+            raise ImportError(fullname)
+        return self.source.decode("utf-8")
+
+
+class _SnapshotImportGuard:
+    """Resolve imports once, then reject mutable first/third-party origins."""
+
+    def __init__(self, capability: SnapshotCapability):
+        self.capability = capability
+        self.payload_root = capability.spec.payload_root.resolve(strict=True)
+        raw_files = capability.manifest.get("files")
+        if not isinstance(raw_files, list):
+            raise RuntimeSnapshotError("snapshot_manifest_invalid")
+        self.manifest_paths = frozenset(
+            str(entry["path"]) for entry in raw_files if isinstance(entry, dict)
+        )
+        self.first_party = frozenset(
+            path.split("/", 1)[0].removesuffix(".py")
+            for path in self.manifest_paths
+            if path.endswith(".py")
+        )
+        try:
+            self.payload_handle, payload_info = _open_directory_no_follow(
+                capability.spec.payload_root,
+            )
+        except (OSError, RuntimeSnapshotError) as exc:
+            raise RuntimeSnapshotError("snapshot_import_origin_forbidden") from exc
+        self.payload_identity = (int(payload_info.st_dev), int(payload_info.st_ino))
+        self.runtime_identities = frozenset(
+            (binding.device, binding.inode) for binding in capability.spec.runtime_bindings
+        )
+
+    def close(self) -> None:
+        with contextlib.suppress(OSError):
+            os.close(self.payload_handle)
+
+    def _location_class(self, raw_path: str) -> Optional[str]:
+        path = Path(raw_path)
+        if not path.is_absolute() or ".." in path.parts:
+            return None
+        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        directory_flags = flags | getattr(os, "O_DIRECTORY", 0)
+        descriptor = os.open(path.anchor, directory_flags)
+        matched: Optional[str] = None
+        try:
+            for index, component in enumerate(path.parts[1:]):
+                final = index == len(path.parts[1:]) - 1
+                try:
+                    next_descriptor = os.open(component, directory_flags, dir_fd=descriptor)
+                except NotADirectoryError:
+                    if not final:
+                        raise
+                    next_descriptor = os.open(component, flags, dir_fd=descriptor)
+                os.close(descriptor)
+                descriptor = next_descriptor
+                opened = os.fstat(descriptor)
+                identity = (int(opened.st_dev), int(opened.st_ino))
+                if identity == self.payload_identity:
+                    matched = "payload"
+                elif identity in self.runtime_identities:
+                    matched = "runtime"
+            return matched
+        except OSError:
+            return None
+        finally:
+            with contextlib.suppress(OSError):
+                os.close(descriptor)
+
+    def _validate_spec_locations(self, fullname: str, spec) -> None:
+        locations: list[str] = []
+        origin = getattr(spec, "origin", None)
+        loader = getattr(spec, "loader", None)
+        search_locations = getattr(spec, "submodule_search_locations", None)
+        if origin in {"built-in", "frozen"}:
+            expected_loader = (
+                importlib.machinery.BuiltinImporter
+                if origin == "built-in"
+                else importlib.machinery.FrozenImporter
+            )
+            if loader is not expected_loader or search_locations:
+                raise RuntimeSnapshotError("snapshot_import_origin_forbidden", fullname)
+            return
+        if origin not in {None, "built-in", "frozen"}:
+            locations.append(str(origin))
+        get_filename = getattr(loader, "get_filename", None)
+        if callable(get_filename):
+            try:
+                loader_filename = get_filename(fullname)
+            except (ImportError, OSError, TypeError) as exc:
+                raise RuntimeSnapshotError("snapshot_import_origin_forbidden", fullname) from exc
+            if loader_filename:
+                locations.append(str(loader_filename))
+        if search_locations is not None:
+            locations.extend(str(location) for location in search_locations)
+        if origin is None and not locations:
+            raise RuntimeSnapshotError("snapshot_import_origin_forbidden", fullname)
+        for location in locations:
+            if self._location_class(location) is None:
+                raise RuntimeSnapshotError("snapshot_import_origin_forbidden", fullname)
+
+    def find_spec(self, fullname: str, path=None, target=None):
+        parts = fullname.split(".")
+        module_relative = "/".join(parts) + ".py"
+        package_relative = "/".join((*parts, "__init__.py"))
+        for relative, is_package in (
+            (module_relative, False),
+            (package_relative, True),
+        ):
+            source = self.capability.spec.verified_bytes.get(relative)
+            if source is None or relative not in self.manifest_paths:
+                continue
+            origin = str(self.payload_root.joinpath(*PurePosixPath(relative).parts))
+            loader = _VerifiedSourceLoader(
+                fullname, origin, bytes(source), is_package=is_package,
+            )
+            return importlib.machinery.ModuleSpec(
+                fullname,
+                loader,
+                origin=origin,
+                is_package=is_package,
+            )
+        spec = importlib.machinery.PathFinder.find_spec(fullname, path, target)
+        if spec is None:
+            return None
+        self._validate_spec_locations(fullname, spec)
+        origin = getattr(spec, "origin", None)
+        if origin in {"built-in", "frozen"}:
+            return spec
+        if origin is None:
+            return spec
+        origin_class = self._location_class(str(origin))
+        if origin_class == "runtime":
+            return spec
+        try:
+            relative = Path(origin).relative_to(self.payload_root).as_posix()
+        except ValueError as exc:
+            raise RuntimeSnapshotError("snapshot_import_origin_forbidden", fullname) from exc
+        source_relative = relative[:-1] if relative.endswith((".pyc", ".pyo")) else relative
+        if source_relative not in self.manifest_paths:
+            raise RuntimeSnapshotError("snapshot_import_origin_forbidden", fullname)
+        manifest_resource_bytes(self.capability.spec, source_relative)
+        return spec
+
+
+def _canonical_json(value: object) -> bytes:
+    return (json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False) + "\n").encode("utf-8")
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _sha256_stream(handle: BinaryIO) -> tuple[str, int, bytes]:
+    digest = hashlib.sha256()
+    chunks: list[bytes] = []
+    size = 0
+    while True:
+        chunk = handle.read(_BUFFER)
+        if not chunk:
+            break
+        size += len(chunk)
+        if size > _MAX_FILE_BYTES:
+            raise RuntimeSnapshotError("source_limits_exceeded")
+        digest.update(chunk)
+        chunks.append(chunk)
+    return digest.hexdigest(), size, b"".join(chunks)
+
+
+def _normalized_relative(path: Path, root: Path) -> str:
+    try:
+        parts = path.relative_to(root).parts
+    except ValueError as exc:
+        raise RuntimeSnapshotError("source_path_invalid") from exc
+    if not parts or any(part in {"", ".", ".."} or "\x00" in part for part in parts):
+        raise RuntimeSnapshotError("source_path_invalid")
+    normalized = unicodedata.normalize("NFC", PurePosixPath(*parts).as_posix())
+    if normalized.startswith("/") or ".." in PurePosixPath(normalized).parts:
+        raise RuntimeSnapshotError("source_path_invalid", normalized)
+    return normalized
+
+
+def _selected_roots(source_root: Path) -> list[Path]:
+    roots = [source_root / name for name in _SELECTED_DIRECTORIES if (source_root / name).exists()]
+    roots.extend(
+        path for path in sorted(source_root.glob("*.py"), key=lambda item: item.name.encode())
+        if path.name not in _SELECTED_TOP_LEVEL
+    )
+    roots.extend(source_root / name for name in sorted(_SELECTED_TOP_LEVEL) if (source_root / name).exists())
+    return roots
+
+
+def iter_selected_entries(source_root: Path | str) -> Iterator[tuple[str, Path, os.stat_result]]:
+    """Yield the deterministic selected closure without following links."""
+    root = Path(source_root).resolve(strict=True)
+    seen_names: dict[str, str] = {}
+    seen_identity: dict[tuple[int, int], str] = {}
+    selected: list[tuple[str, Path, os.stat_result]] = []
+
+    def visit(path: Path) -> None:
+        relative = _normalized_relative(path, root)
+        try:
+            info = path.lstat()
+        except OSError as exc:
+            raise RuntimeSnapshotError("source_unstable", relative) from exc
+        if stat.S_ISLNK(info.st_mode):
+            raise RuntimeSnapshotError("source_link", relative)
+        if stat.S_ISDIR(info.st_mode):
+            if path.name in _EXCLUDED_DIRECTORIES or path.name.startswith("venv-"):
+                return
+            try:
+                children = sorted(path.iterdir(), key=lambda item: unicodedata.normalize("NFC", item.name).encode("utf-8"))
+            except OSError as exc:
+                raise RuntimeSnapshotError("source_unstable", relative) from exc
+            for child in children:
+                visit(child)
+            return
+        if not stat.S_ISREG(info.st_mode):
+            raise RuntimeSnapshotError("source_special_file", relative)
+        if relative.endswith((".pyc", ".pyo")) or path.name == ".DS_Store" or path.name.endswith(("~", ".swp", ".swo")):
+            return
+        if relative.lower().endswith(_NATIVE_SUFFIXES):
+            raise RuntimeSnapshotError("first_party_native_unsupported", relative)
+        if getattr(info, "st_nlink", 1) != 1:
+            raise RuntimeSnapshotError("source_link", relative)
+        collision_key = unicodedata.normalize("NFC", relative).casefold()
+        previous = seen_names.get(collision_key)
+        if previous is not None and previous != relative:
+            raise RuntimeSnapshotError("source_case_collision", relative)
+        seen_names[collision_key] = relative
+        identity = (int(info.st_dev), int(info.st_ino))
+        previous_identity = seen_identity.get(identity)
+        if previous_identity is not None and previous_identity != relative:
+            raise RuntimeSnapshotError("source_link", relative)
+        seen_identity[identity] = relative
+        selected.append((relative, path, info))
+
+    for selected_root in _selected_roots(root):
+        visit(selected_root)
+    selected.sort(key=lambda row: row[0].encode("utf-8"))
+    yield from selected
+
+
+def _supported_languages(data: bytes) -> set[str]:
+    try:
+        tree = ast.parse(data.decode("utf-8"), filename="agent/i18n.py")
+    except (UnicodeError, SyntaxError) as exc:
+        raise RuntimeSnapshotError("snapshot_resource_inventory_incomplete", "agent/i18n.py") from exc
+    for node in tree.body:
+        if isinstance(node, (ast.Assign, ast.AnnAssign)):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            if any(isinstance(target, ast.Name) and target.id == "SUPPORTED_LANGUAGES" for target in targets):
+                value = node.value
+                if isinstance(value, ast.Dict):
+                    keys = {key.value for key in value.keys if isinstance(key, ast.Constant) and isinstance(key.value, str)}
+                    if keys:
+                        return keys
+                if isinstance(value, (ast.Set, ast.List, ast.Tuple)):
+                    keys = {item.value for item in value.elts if isinstance(item, ast.Constant) and isinstance(item.value, str)}
+                    if keys:
+                        return keys
+    return set()
+
+
+def _validate_locales(staged_bytes: Mapping[str, bytes]) -> None:
+    i18n_bytes = staged_bytes.get("agent/i18n.py")
+    if i18n_bytes is None:
+        return
+    languages = _supported_languages(i18n_bytes)
+    if not languages:
+        return
+    selected_paths = set(staged_bytes)
+    expected = {f"locales/{language}.yaml" for language in languages}
+    missing = sorted(expected - selected_paths)
+    if missing:
+        raise RuntimeSnapshotError("snapshot_locale_missing", missing[0])
+    actual = {path for path in selected_paths if path.startswith("locales/") and path.endswith(".yaml")}
+    if actual != expected:
+        extra = sorted(actual - expected)
+        raise RuntimeSnapshotError("snapshot_locale_unsupported", extra[0] if extra else None)
+
+
+def _resource_inventory(files: list[SnapshotFile]) -> list[dict[str, str]]:
+    """Describe the policy for every executable Python input deterministically."""
+    return [
+        {
+            "path": entry.path,
+            "policy": "sealed-resource" if entry.path == "agent/i18n.py" else "sealed-import",
+        }
+        for entry in files
+        if entry.path.endswith(".py")
+    ]
+
+
+def _content_root(files: list[SnapshotFile]) -> str:
+    digest = hashlib.sha256(b"hermes-runtime-snapshot-content-v1\0")
+    for entry in files:
+        digest.update(entry.path.encode("utf-8") + b"\0")
+        digest.update(str(entry.size).encode("ascii") + b"\0")
+        digest.update((b"1" if entry.executable else b"0") + b"\0")
+        digest.update(entry.sha256.encode("ascii") + b"\n")
+    return digest.hexdigest()
+
+
+def _cache_key(identity: Mapping[str, object], content_root: str) -> str:
+    value = {
+        "repository_id": identity["repository_id"],
+        "source_revision": identity["source_revision"],
+        "source_dirty": identity["source_dirty"],
+        "selection_policy_version": _SELECTION_POLICY_VERSION,
+        "python_implementation": sys.implementation.name,
+        "python_major_minor": f"{sys.version_info.major}.{sys.version_info.minor}",
+        "python_abi_tag": sysconfig.get_config_var("SOABI") or "none",
+        "platform_tag": sys.platform,
+        "content_root_sha256": content_root,
+    }
+    return _sha256_bytes(b"hermes-runtime-snapshot-key-v1\0" + _canonical_json(value))
+
+
+def _manifest_to_spec(
+    object_root: Path,
+    manifest: Mapping[str, object],
+    manifest_sha256: str,
+    *,
+    reused: bool,
+    verified_bytes: Optional[Mapping[str, bytes]] = None,
+) -> RuntimeSnapshotSpec:
+    return RuntimeSnapshotSpec(
+        object_root=object_root,
+        payload_root=object_root / "payload",
+        manifest_path=object_root / "manifest.json",
+        cache_key=str(manifest["cache_key"]),
+        manifest_sha256=manifest_sha256,
+        content_root_sha256=str(manifest["content_root_sha256"]),
+        source_revision=str(manifest["source_revision"]),
+        source_dirty=bool(manifest["source_dirty"]),
+        total_files=int(manifest["total_files"]),
+        total_bytes=int(manifest["total_bytes"]),
+        reused=reused,
+        verified_bytes=dict(verified_bytes or {}),
+    )
+
+
+def _open_directory_no_follow(path: Path) -> tuple[int, os.stat_result]:
+    """Open an absolute directory component-wise without following links."""
+    if os.name != "posix" or not hasattr(os, "O_NOFOLLOW"):
+        raise RuntimeSnapshotError("snapshot_runtime_binding_unsupported")
+    absolute = path.absolute()
+    if not absolute.is_absolute() or any(part in {"", ".", ".."} for part in absolute.parts[1:]):
+        raise RuntimeSnapshotError("snapshot_runtime_binding_invalid")
+    flags = (
+        os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | os.O_NOFOLLOW
+        | getattr(os, "O_DIRECTORY", 0)
+    )
+    descriptor = os.open(absolute.anchor, flags)
+    try:
+        for component in absolute.parts[1:]:
+            next_descriptor = os.open(component, flags, dir_fd=descriptor)
+            os.close(descriptor)
+            descriptor = next_descriptor
+        opened = os.fstat(descriptor)
+        if not stat.S_ISDIR(opened.st_mode):
+            raise RuntimeSnapshotError("snapshot_runtime_binding_invalid")
+        return descriptor, opened
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+def _scan_runtime_startup_files(role: str, descriptor: int) -> None:
+    """Reject interpreter startup hooks using the already-bound directory fd."""
+    if role not in {"base_site", "venv_site"}:
+        return
+    try:
+        for name in sorted(os.listdir(descriptor), key=lambda value: value.encode("utf-8")):
+            os.stat(name, dir_fd=descriptor, follow_symlinks=False)
+            if name in {"sitecustomize.py", "usercustomize.py"} or name.endswith(".pth"):
+                raise RuntimeSnapshotError("snapshot_runtime_startup_forbidden", name)
+    except RuntimeSnapshotError:
+        raise
+    except OSError as exc:
+        raise RuntimeSnapshotError("snapshot_runtime_binding_invalid", role) from exc
+
+
+def runtime_binding_for_directory(role: str, path: Path | str) -> RuntimeDirectoryBinding:
+    """Open and bind one dispatcher-selected runtime directory capability."""
+    if role not in {"stdlib", "base_site", "venv_site"}:
+        raise RuntimeSnapshotError("snapshot_runtime_binding_invalid", role)
+    candidate = Path(path).absolute()
+    descriptor = -1
+    try:
+        descriptor, opened = _open_directory_no_follow(candidate)
+    except (OSError, RuntimeSnapshotError) as exc:
+        raise RuntimeSnapshotError("snapshot_runtime_binding_invalid", role) from exc
+    current_uid = getattr(os, "getuid", lambda: int(opened.st_uid))()
+    if int(opened.st_uid) not in {0, current_uid} or opened.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+        os.close(descriptor)
+        raise RuntimeSnapshotError("snapshot_runtime_binding_permissions", role)
+    try:
+        _scan_runtime_startup_files(role, descriptor)
+    except RuntimeSnapshotError:
+        os.close(descriptor)
+        raise
+    return RuntimeDirectoryBinding(
+        role=role,
+        path=candidate,
+        handle=descriptor,
+        device=int(opened.st_dev),
+        inode=int(opened.st_ino),
+        owner=int(opened.st_uid),
+        mode=int(opened.st_mode),
+    )
+
+
+def with_runtime_bindings(
+    spec: RuntimeSnapshotSpec,
+    bindings: tuple[RuntimeDirectoryBinding, ...],
+) -> RuntimeSnapshotSpec:
+    """Return a snapshot spec carrying ordered dispatcher-verified bindings."""
+    return RuntimeSnapshotSpec(
+        object_root=spec.object_root,
+        payload_root=spec.payload_root,
+        manifest_path=spec.manifest_path,
+        cache_key=spec.cache_key,
+        manifest_sha256=spec.manifest_sha256,
+        content_root_sha256=spec.content_root_sha256,
+        source_revision=spec.source_revision,
+        source_dirty=spec.source_dirty,
+        total_files=spec.total_files,
+        total_bytes=spec.total_bytes,
+        reused=spec.reused,
+        verified_bytes=spec.verified_bytes,
+        runtime_bindings=bindings,
+    )
+
+
+def snapshot_runtime_sys_path(spec: RuntimeSnapshotSpec) -> list[str]:
+    """Return the complete sealed child path in fixed role order."""
+    expected_order = {"stdlib": 0, "base_site": 1, "venv_site": 2}
+    previous = -1
+    result = [str(spec.payload_root)]
+    seen: dict[tuple[int, int], str] = {}
+    for binding in spec.runtime_bindings:
+        order = expected_order[binding.role]
+        if order < previous:
+            raise RuntimeSnapshotError("snapshot_runtime_binding_order")
+        previous = order
+        identity = (binding.device, binding.inode)
+        prior_role = seen.get(identity)
+        if prior_role is not None:
+            if prior_role != binding.role:
+                raise RuntimeSnapshotError("snapshot_runtime_binding_collision")
+            continue
+        seen[identity] = binding.role
+        result.append(str(binding.path))
+    return result
+
+
+def dispatcher_runtime_bindings() -> tuple[RuntimeDirectoryBinding, ...]:
+    """Resolve roots from the already-running dispatcher interpreter."""
+    # Python installations commonly expose convenience symlinks (Homebrew's
+    # ``opt`` path, for example). Resolve those before the strict no-follow
+    # walk so the sealed binding itself contains no link component.
+    stdlib = Path(sysconfig.get_path("stdlib")).resolve(strict=True)
+    bindings = [runtime_binding_for_directory("stdlib", stdlib)]
+    dynload = stdlib / "lib-dynload"
+    if dynload.is_dir():
+        bindings.append(runtime_binding_for_directory("stdlib", dynload))
+    purelib = sysconfig.get_path("purelib")
+    if purelib:
+        role = "venv_site" if sys.prefix != sys.base_prefix else "base_site"
+        bindings.append(
+            runtime_binding_for_directory(role, Path(purelib).resolve(strict=True))
+        )
+    return tuple(bindings)
+
+
+def runtime_bindings_json(spec: RuntimeSnapshotSpec) -> str:
+    return json.dumps(
+        [
+            {
+                "role": item.role, "path": str(item.path), "handle": item.handle,
+                "device": item.device,
+                "inode": item.inode, "owner": item.owner, "mode": item.mode,
+            }
+            for item in spec.runtime_bindings
+        ],
+        sort_keys=True, separators=(",", ":"),
+    )
+
+
+def runtime_bindings_from_json(raw: str) -> tuple[RuntimeDirectoryBinding, ...]:
+    try:
+        values = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeSnapshotError("snapshot_runtime_binding_mismatch") from exc
+    if not isinstance(values, list):
+        raise RuntimeSnapshotError("snapshot_runtime_binding_mismatch")
+    result = []
+    for value in values:
+        if not isinstance(value, dict) or set(value) != {
+            "role", "path", "handle", "device", "inode", "owner", "mode",
+        }:
+            raise RuntimeSnapshotError("snapshot_runtime_binding_mismatch")
+        expected = RuntimeDirectoryBinding(
+            str(value["role"]), Path(str(value["path"])), int(value["handle"]),
+            int(value["device"]),
+            int(value["inode"]), int(value["owner"]), int(value["mode"]),
+        )
+        path_descriptor: Optional[int] = None
+        try:
+            opened = os.fstat(expected.handle)
+            path_descriptor, path_info = _open_directory_no_follow(expected.path)
+        except (OSError, RuntimeSnapshotError) as exc:
+            raise RuntimeSnapshotError("snapshot_runtime_binding_mismatch", expected.role) from exc
+        finally:
+            if path_descriptor is not None:
+                os.close(path_descriptor)
+        recorded = (expected.device, expected.inode, expected.owner, expected.mode)
+        actual = (int(opened.st_dev), int(opened.st_ino), int(opened.st_uid), int(opened.st_mode))
+        path_actual = (
+            int(path_info.st_dev), int(path_info.st_ino),
+            int(path_info.st_uid), int(path_info.st_mode),
+        )
+        if actual != recorded or path_actual != recorded:
+            raise RuntimeSnapshotError("snapshot_runtime_binding_mismatch", expected.role)
+        _scan_runtime_startup_files(expected.role, expected.handle)
+        result.append(expected)
+    return tuple(result)
+
+
+def runtime_binding_pass_fds(bindings: tuple[RuntimeDirectoryBinding, ...]) -> tuple[int, ...]:
+    """Return dispatcher-opened directory capabilities for child inheritance."""
+    return tuple(dict.fromkeys(binding.handle for binding in bindings))
+
+
+def build_runtime_snapshot(
+    source_root: Path | str,
+    *,
+    repository_id: str,
+    source_revision: str,
+    source_dirty: bool,
+    cache_root: Path | str,
+) -> RuntimeSnapshotSpec:
+    """Capture, verify, seal, and atomically publish selected source bytes."""
+    source = Path(source_root).resolve(strict=True)
+    cache = Path(cache_root)
+    cache.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if cache.is_symlink():
+        raise RuntimeSnapshotError("cache_permissions")
+    for child in ("staging", "objects", "leases", "locks", "quarantine"):
+        (cache / child).mkdir(exist_ok=True, mode=0o700)
+    staging = Path(tempfile.mkdtemp(prefix="build-", dir=cache / "staging"))
+    payload = staging / "payload"
+    payload.mkdir(mode=0o700)
+    files: list[SnapshotFile] = []
+    staged_bytes: dict[str, bytes] = {}
+    total = 0
+    initial = list(iter_selected_entries(source))
+    if len(initial) > _MAX_FILES:
+        raise RuntimeSnapshotError("source_limits_exceeded")
+    try:
+        for relative, path, before in initial:
+            destination = payload.joinpath(*PurePosixPath(relative).parts)
+            destination.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+            flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+            try:
+                descriptor = os.open(path, flags)
+            except OSError as exc:
+                raise RuntimeSnapshotError("source_unstable", relative) from exc
+            try:
+                opened = os.fstat(descriptor)
+                if not stat.S_ISREG(opened.st_mode) or opened.st_nlink != 1:
+                    raise RuntimeSnapshotError("source_link", relative)
+                with os.fdopen(os.dup(descriptor), "rb", closefd=True) as handle:
+                    first_hash, size, data = _sha256_stream(handle)
+                os.lseek(descriptor, 0, os.SEEK_SET)
+                with os.fdopen(os.dup(descriptor), "rb", closefd=True) as handle:
+                    second_hash, second_size, _ = _sha256_stream(handle)
+                after = os.fstat(descriptor)
+            finally:
+                os.close(descriptor)
+            stable_fields = ("st_dev", "st_ino", "st_mode", "st_size", "st_mtime_ns", "st_ctime_ns", "st_nlink")
+            if any(getattr(before, field) != getattr(after, field) for field in stable_fields) or first_hash != second_hash or size != second_size:
+                raise RuntimeSnapshotError("source_unstable", relative)
+            total += size
+            if total > _MAX_TOTAL_BYTES:
+                raise RuntimeSnapshotError("source_limits_exceeded", relative)
+            with destination.open("xb") as output:
+                output.write(data)
+                output.flush()
+                os.fsync(output.fileno())
+            if _sha256_bytes(destination.read_bytes()) != first_hash:
+                raise RuntimeSnapshotError("snapshot_content_mismatch", relative)
+            executable = bool(before.st_mode & stat.S_IXUSR)
+            destination.chmod(0o500 if executable else 0o400)
+            files.append(SnapshotFile(relative, size, first_hash, executable, "executable" if executable else "data"))
+            staged_bytes[relative] = data
+        final = list(iter_selected_entries(source))
+        initial_shape = [(r, s.st_dev, s.st_ino, s.st_size, s.st_mtime_ns, s.st_ctime_ns, s.st_nlink) for r, _p, s in initial]
+        final_shape = [(r, s.st_dev, s.st_ino, s.st_size, s.st_mtime_ns, s.st_ctime_ns, s.st_nlink) for r, _p, s in final]
+        if initial_shape != final_shape:
+            raise RuntimeSnapshotError("source_unstable")
+        _validate_locales(staged_bytes)
+        content_root = _content_root(files)
+        identity = {"repository_id": repository_id, "source_revision": source_revision, "source_dirty": bool(source_dirty)}
+        key = _cache_key(identity, content_root)
+        manifest = {
+            "schema_version": _SCHEMA_VERSION,
+            "selection_policy_version": _SELECTION_POLICY_VERSION,
+            "hash_algorithm": "sha256",
+            **identity,
+            "python_implementation": sys.implementation.name,
+            "python_major_minor": f"{sys.version_info.major}.{sys.version_info.minor}",
+            "python_abi_tag": sysconfig.get_config_var("SOABI") or "none",
+            "platform_tag": sys.platform,
+            "files": [entry.as_dict() for entry in files],
+            "resource_inventory": _resource_inventory(files),
+            "total_files": len(files),
+            "total_bytes": total,
+            "content_root_sha256": content_root,
+            "cache_key": key,
+        }
+        manifest_bytes = _canonical_json(manifest)
+        manifest_hash = _sha256_bytes(manifest_bytes)
+        manifest_path = staging / "manifest.json"
+        with manifest_path.open("xb") as output:
+            output.write(manifest_bytes)
+            output.flush()
+            os.fsync(output.fileno())
+        manifest_path.chmod(0o400)
+        (staging / "SEALED").write_bytes(b"")
+        (staging / "SEALED").chmod(0o400)
+        for directory, dirs, _names in os.walk(payload, topdown=False):
+            Path(directory).chmod(0o500)
+        target = cache / "objects" / key
+        try:
+            staging.rename(target)
+            target.chmod(0o500)
+            reused = False
+        except OSError as exc:
+            if exc.errno not in {errno.EACCES, errno.EEXIST, errno.ENOTEMPTY} or not target.exists():
+                raise
+            verified = verify_published_snapshot(target, manifest_hash, key)
+            if verified.content_root_sha256 != content_root:
+                raise RuntimeSnapshotError("cache_collision")
+            shutil.rmtree(staging, ignore_errors=True)
+            return verified
+        return _manifest_to_spec(
+            target, manifest, manifest_hash, reused=reused,
+            verified_bytes=staged_bytes,
+        )
+    except Exception:
+        if staging.exists():
+            try:
+                staging.chmod(0o700)
+                for directory, dirs, names in os.walk(staging):
+                    Path(directory).chmod(0o700)
+                    for name in names:
+                        with contextlib.suppress(OSError):
+                            (Path(directory) / name).chmod(0o600)
+                shutil.rmtree(staging)
+            except OSError:
+                pass
+        raise
+
+
+def _load_canonical_manifest(object_root: Path, expected_hash: str) -> tuple[dict, bytes]:
+    try:
+        data = (object_root / "manifest.json").read_bytes()
+        manifest = json.loads(data)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeSnapshotError("snapshot_manifest_invalid") from exc
+    if not isinstance(manifest, dict) or data != _canonical_json(manifest) or _sha256_bytes(data) != expected_hash:
+        raise RuntimeSnapshotError("snapshot_manifest_invalid")
+    allowed = {
+        "schema_version", "selection_policy_version", "hash_algorithm", "repository_id",
+        "source_revision", "source_dirty", "python_implementation", "python_major_minor",
+        "python_abi_tag", "platform_tag", "files", "total_files", "total_bytes",
+        "content_root_sha256", "cache_key", "resource_inventory",
+    }
+    if set(manifest) != allowed or manifest.get("schema_version") != 1 or manifest.get("hash_algorithm") != "sha256":
+        raise RuntimeSnapshotError("snapshot_manifest_invalid")
+    expected_inventory = _resource_inventory([
+        SnapshotFile(
+            str(raw["path"]), int(raw["size"]), str(raw["sha256"]),
+            bool(raw["executable"]), str(raw["mode_class"]),
+        )
+        for raw in manifest.get("files", []) if isinstance(raw, dict)
+    ])
+    if manifest.get("resource_inventory") != expected_inventory:
+        raise RuntimeSnapshotError("snapshot_resource_inventory_incomplete")
+    return manifest, data
+
+
+def verify_published_snapshot(object_root: Path | str, expected_manifest_sha256: str, expected_cache_key: str) -> RuntimeSnapshotSpec:
+    """Rehash every published byte and reject any unmanifested object."""
+    root = Path(object_root)
+    if root.is_symlink() or not (root / "SEALED").is_file():
+        raise RuntimeSnapshotError("snapshot_manifest_invalid")
+    manifest, _ = _load_canonical_manifest(root, expected_manifest_sha256)
+    if manifest.get("cache_key") != expected_cache_key or root.name != expected_cache_key:
+        raise RuntimeSnapshotError("snapshot_manifest_invalid")
+    entries: list[SnapshotFile] = []
+    verified_bytes: dict[str, bytes] = {}
+    expected_paths: set[str] = set()
+    for raw in manifest["files"]:
+        if not isinstance(raw, dict) or raw.get("kind") != "regular":
+            raise RuntimeSnapshotError("snapshot_manifest_invalid")
+        relative = str(raw.get("path", ""))
+        if relative in expected_paths or _normalized_relative(root / "payload" / relative, root / "payload") != relative:
+            raise RuntimeSnapshotError("snapshot_manifest_invalid")
+        expected_paths.add(relative)
+        path = root / "payload" / relative
+        try:
+            info = path.lstat()
+        except OSError as exc:
+            raise RuntimeSnapshotError("snapshot_content_mismatch", relative) from exc
+        if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode) or info.st_nlink != 1:
+            raise RuntimeSnapshotError("snapshot_content_mismatch", relative)
+        data = path.read_bytes()
+        if len(data) != raw.get("size") or _sha256_bytes(data) != raw.get("sha256"):
+            raise RuntimeSnapshotError("snapshot_content_mismatch", relative)
+        verified_bytes[relative] = bytes(data)
+        entries.append(SnapshotFile(relative, len(data), raw["sha256"], bool(raw["executable"]), str(raw["mode_class"])))
+    actual_paths = {
+        _normalized_relative(path, root / "payload")
+        for path in (root / "payload").rglob("*")
+        if path.is_file() or path.is_symlink()
+    }
+    if actual_paths != expected_paths or _content_root(entries) != manifest.get("content_root_sha256"):
+        raise RuntimeSnapshotError("snapshot_content_mismatch")
+    identity = {key: manifest[key] for key in ("repository_id", "source_revision", "source_dirty")}
+    if _cache_key(identity, str(manifest["content_root_sha256"])) != expected_cache_key:
+        raise RuntimeSnapshotError("snapshot_manifest_invalid")
+    return _manifest_to_spec(
+        root, manifest, expected_manifest_sha256, reused=True,
+        verified_bytes=verified_bytes,
+    )
+
+
+def _entry_for(spec: RuntimeSnapshotSpec, relative_path: str) -> Mapping[str, object]:
+    normalized = PurePosixPath(relative_path)
+    if normalized.is_absolute() or ".." in normalized.parts or normalized.as_posix() != relative_path:
+        raise RuntimeSnapshotError("snapshot_resource_path_forbidden")
+    manifest, _ = _load_canonical_manifest(spec.object_root, spec.manifest_sha256)
+    for entry in manifest["files"]:
+        if entry["path"] == relative_path:
+            return entry
+    raise RuntimeSnapshotError("snapshot_resource_path_forbidden", relative_path)
+
+
+def manifest_resource_bytes(spec: RuntimeSnapshotSpec, relative_path: str) -> bytes:
+    normalized = PurePosixPath(relative_path)
+    if normalized.is_absolute() or ".." in normalized.parts or normalized.as_posix() != relative_path:
+        raise RuntimeSnapshotError("snapshot_resource_path_forbidden")
+    verified = spec.verified_bytes.get(relative_path)
+    if verified is not None:
+        return bytes(verified)
+    entry = _entry_for(spec, relative_path)
+    path = spec.payload_root.joinpath(*normalized.parts)
+    try:
+        info = path.lstat()
+        data = path.read_bytes()
+    except OSError as exc:
+        raise RuntimeSnapshotError("snapshot_content_mismatch", relative_path) from exc
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode) or len(data) != entry["size"] or _sha256_bytes(data) != entry["sha256"]:
+        raise RuntimeSnapshotError("snapshot_content_mismatch", relative_path)
+    return bytes(data)
+
+
+def verified_snapshot_bundle(spec: RuntimeSnapshotSpec) -> dict[str, object]:
+    """Serialize only bytes already retained by verification for child bootstrap."""
+    manifest, _ = _load_canonical_manifest(spec.object_root, spec.manifest_sha256)
+    expected = {str(entry["path"]) for entry in manifest["files"]}
+    if set(spec.verified_bytes) != expected:
+        raise RuntimeSnapshotError("snapshot_content_mismatch")
+    return {
+        "object_root": str(spec.object_root),
+        "manifest_sha256": spec.manifest_sha256,
+        "manifest": manifest,
+        "verified_bytes": {
+            path: data.hex() for path, data in spec.verified_bytes.items()
+        },
+        "runtime_bindings": [
+            {
+                "role": binding.role,
+                "path": str(binding.path),
+                "handle": binding.handle,
+                "device": binding.device,
+                "inode": binding.inode,
+                "owner": binding.owner,
+                "mode": binding.mode,
+            }
+            for binding in spec.runtime_bindings
+        ],
+    }
+
+
+def runtime_snapshot_from_verified_bundle(bundle: Mapping[str, object]) -> RuntimeSnapshotSpec:
+    """Reconstruct a snapshot capability without reopening its payload paths."""
+    if set(bundle) != {
+        "object_root", "manifest_sha256", "manifest", "verified_bytes",
+        "runtime_bindings",
+    }:
+        raise RuntimeSnapshotError("snapshot_manifest_invalid")
+    manifest = bundle["manifest"]
+    raw_bytes = bundle["verified_bytes"]
+    if not isinstance(manifest, dict) or not isinstance(raw_bytes, dict):
+        raise RuntimeSnapshotError("snapshot_manifest_invalid")
+    manifest_hash = str(bundle["manifest_sha256"])
+    if _sha256_bytes(_canonical_json(manifest)) != manifest_hash:
+        raise RuntimeSnapshotError("snapshot_manifest_invalid")
+    expected = {str(entry["path"]): entry for entry in manifest.get("files", [])}
+    try:
+        verified = {str(path): bytes.fromhex(str(data)) for path, data in raw_bytes.items()}
+    except ValueError as exc:
+        raise RuntimeSnapshotError("snapshot_content_mismatch") from exc
+    if set(verified) != set(expected):
+        raise RuntimeSnapshotError("snapshot_content_mismatch")
+    for path, data in verified.items():
+        entry = expected[path]
+        if len(data) != entry["size"] or _sha256_bytes(data) != entry["sha256"]:
+            raise RuntimeSnapshotError("snapshot_content_mismatch", path)
+    raw_bindings = bundle["runtime_bindings"]
+    if not isinstance(raw_bindings, list):
+        raise RuntimeSnapshotError("snapshot_runtime_binding_mismatch")
+    bindings: list[RuntimeDirectoryBinding] = []
+    for raw in raw_bindings:
+        if not isinstance(raw, dict) or set(raw) != {
+            "role", "path", "handle", "device", "inode", "owner", "mode",
+        }:
+            raise RuntimeSnapshotError("snapshot_runtime_binding_mismatch")
+        expected = RuntimeDirectoryBinding(
+            role=str(raw["role"]),
+            path=Path(str(raw["path"])),
+            handle=int(raw["handle"]),
+            device=int(raw["device"]),
+            inode=int(raw["inode"]),
+            owner=int(raw["owner"]),
+            mode=int(raw["mode"]),
+        )
+        path_descriptor: Optional[int] = None
+        try:
+            opened = os.fstat(expected.handle)
+            path_descriptor, path_info = _open_directory_no_follow(expected.path)
+        except (OSError, RuntimeSnapshotError) as exc:
+            raise RuntimeSnapshotError(
+                "snapshot_runtime_binding_mismatch", expected.role,
+            ) from exc
+        finally:
+            if path_descriptor is not None:
+                os.close(path_descriptor)
+        actual = (int(opened.st_dev), int(opened.st_ino), int(opened.st_uid), int(opened.st_mode))
+        path_actual = (
+            int(path_info.st_dev), int(path_info.st_ino),
+            int(path_info.st_uid), int(path_info.st_mode),
+        )
+        recorded = (expected.device, expected.inode, expected.owner, expected.mode)
+        if actual != recorded or path_actual != recorded:
+            raise RuntimeSnapshotError("snapshot_runtime_binding_mismatch", str(raw["role"]))
+        _scan_runtime_startup_files(expected.role, expected.handle)
+        bindings.append(expected)
+    root = Path(str(bundle["object_root"]))
+    return with_runtime_bindings(_manifest_to_spec(
+        root, manifest, manifest_hash, reused=True, verified_bytes=verified,
+    ), tuple(bindings))
+
+
+def manifest_resource_text(spec: RuntimeSnapshotSpec, relative_path: str, encoding: str = "utf-8") -> str:
+    return manifest_resource_bytes(spec, relative_path).decode(encoding)
+
+
+def manifest_resource_stream(spec: RuntimeSnapshotSpec, relative_path: str) -> io.BytesIO:
+    return io.BytesIO(manifest_resource_bytes(spec, relative_path))
+
+
+def sealed_resource_bytes(relative_path: str) -> bytes:
+    capability = snapshot_bootstrap_capability()
+    if capability is None:
+        raise RuntimeSnapshotError("snapshot_authority_unavailable")
+    return manifest_resource_bytes(capability.spec, relative_path)
+
+
+def sealed_resource_text(relative_path: str, encoding: str = "utf-8") -> str:
+    return sealed_resource_bytes(relative_path).decode(encoding)
+
+
+def sealed_python_argv(relative_path: str) -> tuple[str, list[str]]:
+    """Return a Python command that executes the verified in-memory source."""
+    import base64
+
+    source = sealed_resource_bytes(relative_path)
+    encoded = base64.b64encode(source).decode("ascii")
+    launcher = (
+        "import base64,sys;"
+        f"_p={relative_path!r};"
+        f"_b=base64.b64decode({encoded!r});"
+        "sys.argv[0]=_p;exec(compile(_b,_p,'exec'),{'__name__':'__main__','__file__':_p})"
+    )
+    return sys.executable, ["-c", launcher]
+
+
+@contextlib.contextmanager
+def sealed_resource_file(relative_path: str) -> Iterator[SealedResourceFile]:
+    """Expose verified bytes through an inherited fd, never the snapshot path."""
+    data = sealed_resource_bytes(relative_path)
+    handle = tempfile.TemporaryFile()
+    try:
+        handle.write(data)
+        handle.flush()
+        handle.seek(0)
+        descriptor = handle.fileno()
+        path = f"/dev/fd/{descriptor}" if Path("/dev/fd").exists() else f"/proc/self/fd/{descriptor}"
+        yield SealedResourceFile(path=path, pass_fds=(descriptor,))
+    finally:
+        handle.close()
+
+
+def sealed_resource_path(relative_path: str) -> Path:
+    """Return an audited sealed absolute path for helper-process execution only."""
+    capability = snapshot_bootstrap_capability()
+    if capability is None:
+        raise RuntimeSnapshotError("snapshot_authority_unavailable")
+    manifest_resource_bytes(capability.spec, relative_path)
+    return capability.spec.payload_root.joinpath(*PurePosixPath(relative_path).parts)
+
+
+def install_snapshot_bootstrap_capability(spec: RuntimeSnapshotSpec) -> SnapshotCapability:
+    """Single-assignment bootstrap hook; environment values cannot activate it."""
+    global _INSTALLED_CAPABILITY, _INSTALLED_IMPORT_GUARD
+    manifest, _ = _load_canonical_manifest(spec.object_root, spec.manifest_sha256)
+    capability = SnapshotCapability(spec=spec, manifest=manifest)
+    with _CAPABILITY_LOCK:
+        if _INSTALLED_CAPABILITY is not None:
+            raise RuntimeSnapshotError("launcher_handshake_failed")
+        _INSTALLED_CAPABILITY = capability
+        guard = _SnapshotImportGuard(capability)
+        _INSTALLED_IMPORT_GUARD = guard
+        sys.meta_path.insert(0, guard)
+        for name, module in tuple(sys.modules.items()):
+            if name.split(".", 1)[0] not in guard.first_party or not hasattr(module, "__path__"):
+                continue
+            package_dir = capability.spec.payload_root.joinpath(*name.split("."))
+            if package_dir.is_dir():
+                module.__path__ = [str(package_dir)]
+    return capability
+
+
+def snapshot_bootstrap_capability() -> Optional[SnapshotCapability]:
+    return _INSTALLED_CAPABILITY
+
+
+def clear_snapshot_bootstrap_capability_after_fork() -> None:
+    global _INSTALLED_CAPABILITY, _INSTALLED_IMPORT_GUARD
+    if _INSTALLED_IMPORT_GUARD is not None:
+        with contextlib.suppress(ValueError):
+            sys.meta_path.remove(_INSTALLED_IMPORT_GUARD)
+        _INSTALLED_IMPORT_GUARD.close()
+    _INSTALLED_IMPORT_GUARD = None
+    _INSTALLED_CAPABILITY = None
+
+
+_LOCK_STATE = threading.local()
+_PROCESS_LOCKS: dict[str, threading.Lock] = {}
+_PROCESS_LOCKS_GUARD = threading.Lock()
+
+
+@contextlib.contextmanager
+def _ordered_lock(cache_root: Path | str, cache_key: str, kind: str):
+    """Take cache then lease locks and reject the reverse order."""
+    if kind not in {"cache", "lease"}:
+        raise ValueError("unknown snapshot lock kind")
+    held = list(getattr(_LOCK_STATE, "held", []))
+    if kind == "cache" and "lease" in held:
+        raise RuntimeSnapshotError("cache_lock_order_violation")
+    lock_name = f"{Path(cache_root).resolve()}:{cache_key}:{kind}"
+    with _PROCESS_LOCKS_GUARD:
+        lock = _PROCESS_LOCKS.setdefault(lock_name, threading.Lock())
+    lock.acquire()
+    held.append(kind)
+    _LOCK_STATE.held = held
+    try:
+        yield
+    finally:
+        held.pop()
+        _LOCK_STATE.held = held
+        lock.release()
+
+
+def prepare_snapshot_lease(
+    spec: RuntimeSnapshotSpec,
+    *,
+    cache_root: Path | str,
+    task_id: str,
+    run_id: int,
+) -> SnapshotLease:
+    """Verify an object and create a durable prepared lease under lock order."""
+    cache = Path(cache_root)
+    with _ordered_lock(cache, spec.cache_key, "cache"):
+        verify_published_snapshot(spec.object_root, spec.manifest_sha256, spec.cache_key)
+        with _ordered_lock(cache, spec.cache_key, "lease"):
+            directory = cache / "leases" / spec.cache_key
+            directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+            path = directory / f"{int(run_id)}.json"
+            nonce = os.urandom(32).hex()
+            record = {
+                "schema_version": 1,
+                "task_id": task_id,
+                "run_id": int(run_id),
+                "state": "prepared",
+                "cache_key": spec.cache_key,
+                "nonce": nonce,
+                "dispatcher_pid": os.getpid(),
+                "created_at": int(time.time()),
+            }
+            data = _canonical_json(record)
+            flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0)
+            descriptor = os.open(path, flags, 0o600)
+            try:
+                os.write(descriptor, data)
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+            return SnapshotLease(spec.cache_key, int(run_id), path, nonce)
+
+
+def _transition_snapshot_lease(
+    lease: SnapshotLease,
+    *,
+    expected_state: str,
+    next_state: str,
+    pid: int,
+) -> SnapshotLease:
+    if not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0:
+        raise RuntimeSnapshotError("snapshot_lease_binding_mismatch")
+    with _ordered_lock(lease.path.parents[2], lease.cache_key, "lease"):
+        try:
+            raw = lease.path.read_bytes()
+            record = json.loads(raw)
+        except (OSError, json.JSONDecodeError) as exc:
+            raise RuntimeSnapshotError("snapshot_lease_binding_mismatch") from exc
+        if (
+            not isinstance(record, dict)
+            or raw != _canonical_json(record)
+            or record.get("cache_key") != lease.cache_key
+            or record.get("run_id") != lease.run_id
+            or record.get("nonce") != lease.nonce
+            or record.get("state") != expected_state
+            or lease.state != expected_state
+            or ("pid" in record and record.get("pid") != pid)
+        ):
+            raise RuntimeSnapshotError("snapshot_lease_binding_mismatch")
+        record["state"] = next_state
+        record["pid"] = pid
+        data = _canonical_json(record)
+        replacement = lease.path.with_name(f".{lease.path.name}.{os.urandom(8).hex()}.tmp")
+        descriptor = os.open(
+            replacement,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0),
+            0o600,
+        )
+        try:
+            os.write(descriptor, data)
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        replacement.replace(lease.path)
+        return SnapshotLease(
+            lease.cache_key, lease.run_id, lease.path, lease.nonce, next_state,
+        )
+
+
+def mark_snapshot_lease_ready(lease: SnapshotLease, *, pid: int) -> SnapshotLease:
+    return _transition_snapshot_lease(
+        lease, expected_state="prepared", next_state="ready", pid=pid,
+    )
+
+
+def bind_snapshot_lease(lease: SnapshotLease, *, pid: int) -> SnapshotLease:
+    return _transition_snapshot_lease(
+        lease, expected_state="ready", next_state="bound", pid=pid,
+    )
+
+
+def release_snapshot_lease(lease: SnapshotLease) -> None:
+    with contextlib.suppress(FileNotFoundError):
+        lease.path.unlink()
+    with contextlib.suppress(OSError):
+        lease.path.parent.rmdir()
+
+
+def gc_runtime_snapshots(cache_root: Path | str, *, max_objects: int) -> list[Path]:
+    """Quarantine excess unleased objects using cache→lease ordering."""
+    cache = Path(cache_root)
+    objects = cache / "objects"
+    if not objects.exists():
+        return []
+    candidates = sorted(
+        (path for path in objects.iterdir() if path.is_dir()),
+        key=lambda path: (path.stat().st_mtime_ns, path.name),
+    )
+    remove_count = max(0, len(candidates) - max(0, int(max_objects)))
+    quarantined: list[Path] = []
+    for candidate in candidates[:remove_count]:
+        cache_key = candidate.name
+        with _ordered_lock(cache, cache_key, "cache"):
+            with _ordered_lock(cache, cache_key, "lease"):
+                lease_dir = cache / "leases" / cache_key
+                if lease_dir.exists() and any(lease_dir.iterdir()):
+                    continue
+                quarantine = cache / "quarantine"
+                quarantine.mkdir(parents=True, exist_ok=True, mode=0o700)
+                target = quarantine / f"gc-{cache_key}-{os.urandom(8).hex()}"
+                candidate.chmod(0o700)
+                candidate.rename(target)
+                target.chmod(0o500)
+                quarantined.append(target)
+    return quarantined
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=clear_snapshot_bootstrap_capability_after_fork)

--- a/hermes_cli/kanban_windows_spawn.py
+++ b/hermes_cli/kanban_windows_spawn.py
@@ -1,0 +1,271 @@
+"""Windows Job Object process spawning for bounded Kanban subprocesses.
+
+The public adapter remains fail-closed until it has run on trusted Windows CI.
+The verified core is dependency-injected so its ordering and cleanup invariants
+can be exercised on non-Windows development hosts without claiming runtime proof.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from typing import Mapping, Optional, Protocol, Sequence
+
+
+UNVERIFIED_PENDING_WINDOWS_CI = "UNVERIFIED_PENDING_WINDOWS_CI"
+_ERROR_EXIT_CODE = 1
+
+
+class WindowsSecureSpawnError(RuntimeError):
+    """A secure Windows process could not be created or contained."""
+
+
+@dataclass(frozen=True)
+class WindowsSpawnSpec:
+    argv: Sequence[str]
+    cwd: Optional[str]
+    env: Mapping[str, str]
+    stdin_handle: int
+    stdout_handle: int
+    stderr_handle: int
+    inherit_handles: Sequence[int]
+
+
+@dataclass(frozen=True)
+class _CreatedChild:
+    pid: int
+    process_handle: int
+    thread_handle: int
+
+
+class _WindowsApi(Protocol):
+    def create_suspended(self, spec: WindowsSpawnSpec) -> _CreatedChild: ...
+    def create_job(self) -> int: ...
+    def set_kill_on_close(self, job: int) -> None: ...
+    def assign_process_to_job(self, job: int, process: int) -> None: ...
+    def resume_thread(self, thread: int) -> None: ...
+    def terminate_job(self, job: int, code: int) -> None: ...
+    def terminate_process(self, process: int, code: int) -> None: ...
+    def wait_process(self, process: int, timeout_ms: int) -> int: ...
+    def get_exit_code(self, process: int) -> int: ...
+    def close_handle(self, handle: int) -> None: ...
+
+
+class WindowsJobProcess:
+    """Own a process and its kill-on-close Job Object handles exactly once."""
+
+    def __init__(self, child: _CreatedChild, job_handle: int, api: _WindowsApi):
+        self.pid = child.pid
+        self._process_handle: Optional[int] = child.process_handle
+        self._job_handle: Optional[int] = job_handle
+        self._api = api
+        self.returncode: Optional[int] = None
+
+    def poll(self) -> Optional[int]:
+        if self.returncode is not None:
+            return self.returncode
+        process = self._process_handle
+        if process is None:
+            return self.returncode
+        if self._api.wait_process(process, 0) != 0:
+            return None
+        self.returncode = int(self._api.get_exit_code(process))
+        return self.returncode
+
+    def wait(self, timeout: Optional[float] = None) -> int:
+        process = self._process_handle
+        if process is None:
+            return int(self.returncode or 0)
+        timeout_ms = 0xFFFFFFFF if timeout is None else max(0, int(timeout * 1000))
+        if self._api.wait_process(process, timeout_ms) != 0:
+            raise subprocess.TimeoutExpired(tuple(), timeout)
+        self.returncode = int(self._api.get_exit_code(process))
+        return self.returncode
+
+    def terminate_tree(self, *, exit_code: int = _ERROR_EXIT_CODE) -> None:
+        if self._job_handle is not None:
+            self._api.terminate_job(self._job_handle, int(exit_code))
+
+    def terminate(self) -> None:
+        self.terminate_tree()
+
+    def kill(self) -> None:
+        self.terminate_tree()
+
+    def close(self) -> None:
+        process, job = self._process_handle, self._job_handle
+        self._process_handle = None
+        self._job_handle = None
+        if process is not None:
+            self._api.close_handle(process)
+        if job is not None:
+            self._api.close_handle(job)
+
+
+def _validate_spec(spec: WindowsSpawnSpec) -> None:
+    if not spec.argv or not all(isinstance(value, str) and value for value in spec.argv):
+        raise WindowsSecureSpawnError("invalid_argv")
+    expected = {spec.stdin_handle, spec.stdout_handle, spec.stderr_handle}
+    actual = set(spec.inherit_handles)
+    if actual != expected or len(tuple(spec.inherit_handles)) != len(actual):
+        raise WindowsSecureSpawnError("handle_list_mismatch")
+    if any(not isinstance(handle, int) or isinstance(handle, bool) or handle <= 0 for handle in actual):
+        raise WindowsSecureSpawnError("handle_list_mismatch")
+
+
+def _spawn_windows_secure_verified(
+    spec: WindowsSpawnSpec, *, api: _WindowsApi,
+) -> WindowsJobProcess:
+    """Create suspended, contain, then resume; fail closed at every boundary."""
+    _validate_spec(spec)
+    child: Optional[_CreatedChild] = None
+    job: Optional[int] = None
+    thread_closed = False
+    try:
+        child = api.create_suspended(spec)
+        job = api.create_job()
+        api.set_kill_on_close(job)
+        api.assign_process_to_job(job, child.process_handle)
+        api.resume_thread(child.thread_handle)
+        api.close_handle(child.thread_handle)
+        thread_closed = True
+        return WindowsJobProcess(child, job, api)
+    except BaseException as exc:
+        if child is not None:
+            try:
+                if job is not None:
+                    api.terminate_job(job, _ERROR_EXIT_CODE)
+                else:
+                    api.terminate_process(child.process_handle, _ERROR_EXIT_CODE)
+            except OSError:
+                pass
+            if not thread_closed:
+                api.close_handle(child.thread_handle)
+            api.close_handle(child.process_handle)
+        if job is not None:
+            api.close_handle(job)
+        if isinstance(exc, WindowsSecureSpawnError):
+            raise
+        raise WindowsSecureSpawnError(f"secure_spawn_failed: {exc}") from exc
+
+
+def spawn_windows_secure(
+    spec: WindowsSpawnSpec, *, api: Optional[_WindowsApi] = None,
+) -> WindowsJobProcess:
+    """Fail before child creation until the native adapter passes Windows CI."""
+    del spec, api
+    raise WindowsSecureSpawnError(UNVERIFIED_PENDING_WINDOWS_CI)
+
+
+class NativeWindowsApi:
+    """Native STARTUPINFOEX/Job Object API, importable only on Windows."""
+
+    _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000
+    _JOB_OBJECT_EXTENDED_LIMIT_INFORMATION = 9
+    _WAIT_OBJECT_0 = 0
+
+    def __init__(self) -> None:
+        if os.name != "nt":
+            raise WindowsSecureSpawnError(UNVERIFIED_PENDING_WINDOWS_CI)
+        import ctypes
+        from ctypes import wintypes
+
+        self.ctypes = ctypes
+        self.wintypes = wintypes
+        self.kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+    def _checked(self, result, name: str):
+        if not result:
+            raise OSError(self.ctypes.get_last_error(), name)
+        return result
+
+    def create_suspended(self, spec: WindowsSpawnSpec) -> _CreatedChild:
+        startup = subprocess.STARTUPINFO()
+        startup.dwFlags |= subprocess.STARTF_USESTDHANDLES
+        startup.hStdInput = spec.stdin_handle
+        startup.hStdOutput = spec.stdout_handle
+        startup.hStdError = spec.stderr_handle
+        startup.lpAttributeList = {"handle_list": list(spec.inherit_handles)}
+        proc = subprocess.Popen(
+            list(spec.argv), cwd=spec.cwd, env=dict(spec.env),
+            stdin=None, stdout=None, stderr=None, close_fds=True,
+            startupinfo=startup,
+            creationflags=subprocess.CREATE_SUSPENDED
+            | getattr(subprocess, "EXTENDED_STARTUPINFO_PRESENT", 0x00080000)
+            | subprocess.CREATE_NO_WINDOW,
+        )
+        process_handle = int(proc._handle)  # native Popen contract on Windows
+        thread_handle = int(getattr(proc, "_thread", 0))
+        if not thread_handle:
+            proc.kill()
+            proc.wait()
+            raise WindowsSecureSpawnError("thread_handle_unavailable")
+        return _CreatedChild(proc.pid, process_handle, thread_handle)
+
+    def create_job(self) -> int:
+        return int(self._checked(self.kernel32.CreateJobObjectW(None, None), "CreateJobObjectW"))
+
+    def set_kill_on_close(self, job: int) -> None:
+        class _BASIC_LIMITS(self.ctypes.Structure):
+            _fields_ = [
+                ("PerProcessUserTimeLimit", self.ctypes.c_int64),
+                ("PerJobUserTimeLimit", self.ctypes.c_int64),
+                ("LimitFlags", self.wintypes.DWORD),
+                ("MinimumWorkingSetSize", self.ctypes.c_size_t),
+                ("MaximumWorkingSetSize", self.ctypes.c_size_t),
+                ("ActiveProcessLimit", self.wintypes.DWORD),
+                ("Affinity", self.ctypes.c_size_t),
+                ("PriorityClass", self.wintypes.DWORD),
+                ("SchedulingClass", self.wintypes.DWORD),
+            ]
+
+        class _IO_COUNTERS(self.ctypes.Structure):
+            _fields_ = [(name, self.ctypes.c_uint64) for name in (
+                "ReadOperationCount", "WriteOperationCount", "OtherOperationCount",
+                "ReadTransferCount", "WriteTransferCount", "OtherTransferCount",
+            )]
+
+        class _EXTENDED(self.ctypes.Structure):
+            _fields_ = [
+                ("BasicLimitInformation", _BASIC_LIMITS),
+                ("IoInfo", _IO_COUNTERS),
+                ("ProcessMemoryLimit", self.ctypes.c_size_t),
+                ("JobMemoryLimit", self.ctypes.c_size_t),
+                ("PeakProcessMemoryUsed", self.ctypes.c_size_t),
+                ("PeakJobMemoryUsed", self.ctypes.c_size_t),
+            ]
+
+        limits = _EXTENDED()
+        limits.BasicLimitInformation.LimitFlags = self._JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+        self._checked(
+            self.kernel32.SetInformationJobObject(
+                job, self._JOB_OBJECT_EXTENDED_LIMIT_INFORMATION,
+                self.ctypes.byref(limits), self.ctypes.sizeof(limits),
+            ),
+            "SetInformationJobObject",
+        )
+
+    def assign_process_to_job(self, job: int, process: int) -> None:
+        self._checked(self.kernel32.AssignProcessToJobObject(job, process), "AssignProcessToJobObject")
+
+    def resume_thread(self, thread: int) -> None:
+        if self.kernel32.ResumeThread(thread) == 0xFFFFFFFF:
+            raise OSError(self.ctypes.get_last_error(), "ResumeThread")
+
+    def terminate_job(self, job: int, code: int) -> None:
+        self._checked(self.kernel32.TerminateJobObject(job, code), "TerminateJobObject")
+
+    def terminate_process(self, process: int, code: int) -> None:
+        self._checked(self.kernel32.TerminateProcess(process, code), "TerminateProcess")
+
+    def wait_process(self, process: int, timeout_ms: int) -> int:
+        return 0 if self.kernel32.WaitForSingleObject(process, timeout_ms) == self._WAIT_OBJECT_0 else 1
+
+    def get_exit_code(self, process: int) -> int:
+        value = self.wintypes.DWORD()
+        self._checked(self.kernel32.GetExitCodeProcess(process, self.ctypes.byref(value)), "GetExitCodeProcess")
+        return int(value.value)
+
+    def close_handle(self, handle: int) -> None:
+        self._checked(self.kernel32.CloseHandle(handle), "CloseHandle")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11150,6 +11150,13 @@ def cmd_claw(args):
 
 def main():
     """Main entry point for hermes CLI."""
+    from hermes_cli.kanban_runtime_snapshot import snapshot_bootstrap_capability
+
+    runtime_capability = snapshot_bootstrap_capability()
+    if runtime_capability is not None:
+        from hermes_cli.kanban_db import record_worker_runtime_provenance
+
+        record_worker_runtime_provenance(capability=runtime_capability)
     # Cosmetic: make the process show up as 'hermes' instead of 'python3.11'
     # in ps/top/htop.  Non-fatal — just a nicer UX.
     _set_process_title()

--- a/hermes_cli/npm_engine.py
+++ b/hermes_cli/npm_engine.py
@@ -122,7 +122,17 @@ def _repo_npm_range() -> str | None:
     """Return ``engines.npm`` from the checkout's root ``package.json``."""
     package_json = Path(__file__).resolve().parent.parent / "package.json"
     try:
-        data = json.loads(package_json.read_text(encoding="utf-8"))
+        from hermes_cli.kanban_runtime_snapshot import (
+            sealed_resource_text,
+            snapshot_bootstrap_capability,
+        )
+
+        text = (
+            sealed_resource_text("package.json")
+            if snapshot_bootstrap_capability() is not None
+            else package_json.read_text(encoding="utf-8")
+        )
+        data = json.loads(text)
     except (OSError, ValueError):
         return None
     engines = data.get("engines")

--- a/hermes_cli/reviewer_bootstrap.py
+++ b/hermes_cli/reviewer_bootstrap.py
@@ -1,0 +1,176 @@
+"""Stdlib-only typed-reviewer bootstrap entry point."""
+
+from __future__ import annotations
+
+import json
+import os
+import runpy
+
+import secrets
+import struct
+import sys
+import time
+import types
+from typing import Any, NoReturn
+
+_child: Any
+_parent: Any
+
+
+def _write(value: dict[str, Any]) -> None:
+    raw = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+    if not raw or len(raw) > 1024:
+        raise ValueError("bootstrap_protocol_violation")
+    _child.write(struct.pack(">I", len(raw)) + raw)
+    _child.flush()
+
+
+def _write_partial(value: dict[str, Any], phase: str) -> None:
+    raw = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+    wire = struct.pack(">I", len(raw)) + raw
+    cutoff = 2 if phase.endswith("header") else 4 + max(1, len(raw) // 2)
+    _child.write(wire[:cutoff])
+    _child.flush()
+    time.sleep(1)
+    raise SystemExit(75)
+
+
+def _fail(reason: str) -> NoReturn:
+    try:
+        _write({"reason": reason, "v": 1})
+    except Exception:
+        pass
+    raise SystemExit(74)
+
+
+def _exact(handle: Any, size: int) -> bytes:
+    value = bytearray()
+    while len(value) < size:
+        chunk = handle.read(size - len(value))
+        if not chunk:
+            _fail("bootstrap_protocol_violation")
+        value.extend(chunk)
+    return bytes(value)
+
+
+def _pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            _fail("bootstrap_protocol_violation")
+        value[key] = item
+    return value
+
+
+def _read(max_bytes: int) -> dict[str, Any]:
+    size = struct.unpack(">I", _exact(_parent, 4))[0]
+    if size < 1 or size > max_bytes:
+        _fail("bootstrap_protocol_violation")
+    raw = _exact(_parent, size)
+    try:
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=_pairs)
+    except Exception:
+        _fail("bootstrap_protocol_violation")
+    if not isinstance(value, dict):
+        _fail("bootstrap_protocol_violation")
+    if json.dumps(value, sort_keys=True, separators=(",", ":")).encode() != raw:
+        _fail("bootstrap_protocol_violation")
+    return value
+
+
+if len(sys.argv) not in {3, 6}:
+    raise SystemExit(74)
+_child = os.fdopen(int(sys.argv[1]), "wb", buffering=0)
+_parent = os.fdopen(int(sys.argv[2]), "rb", buffering=0)
+if len(sys.argv) == 6:
+    bundle_fd = int(os.environ.pop("HERMES_KANBAN_VERIFIED_SNAPSHOT_FD"))
+    with os.fdopen(bundle_fd, "r", encoding="utf-8") as bundle_stream:
+        snapshot_bundle = json.load(bundle_stream)
+    if not isinstance(snapshot_bundle, dict):
+        raise SystemExit(74)
+    raw_verified = snapshot_bundle.get("verified_bytes")
+    if not isinstance(raw_verified, dict):
+        raise SystemExit(74)
+    try:
+        snapshot_source = bytes.fromhex(
+            str(raw_verified["hermes_cli/kanban_runtime_snapshot.py"])
+        )
+    except (KeyError, ValueError):
+        raise SystemExit(74)
+    snapshot_module = types.ModuleType("hermes_cli.kanban_runtime_snapshot")
+    snapshot_module.__file__ = os.path.join(
+        str(snapshot_bundle["object_root"]),
+        "payload", "hermes_cli", "kanban_runtime_snapshot.py",
+    )
+    sys.modules["hermes_cli.kanban_runtime_snapshot"] = snapshot_module
+    exec(compile(snapshot_source, snapshot_module.__file__, "exec"), snapshot_module.__dict__)
+    spec = snapshot_module.runtime_snapshot_from_verified_bundle(snapshot_bundle)
+    sys.path[:] = snapshot_module.snapshot_runtime_sys_path(spec)
+    snapshot_module.install_snapshot_bootstrap_capability(spec)
+    payload_root = str(spec.payload_root)
+marker = os.environ.pop("HERMES_REVIEWER_BOOTSTRAP_PID_MARKER", "")
+if marker:
+    with open(marker, "w", encoding="ascii") as handle:
+        handle.write(str(os.getpid()))
+if os.environ.pop("HERMES_REVIEWER_BOOTSTRAP_HANG_BEFORE_HELLO", "") == "1":
+    time.sleep(60)
+challenge = secrets.token_hex(32)
+partial_phase = os.environ.pop("HERMES_REVIEWER_BOOTSTRAP_PARTIAL_PHASE", "")
+hello = {"challenge": challenge, "pid": os.getpid(), "ppid": os.getppid(), "v": 1}
+if partial_phase.startswith("hello_"):
+    _write_partial(hello, partial_phase)
+_write(hello)
+if os.environ.pop("HERMES_REVIEWER_BOOTSTRAP_HANG_AFTER_HELLO", "") == "1":
+    time.sleep(60)
+grant = _read(4096)
+required = {
+    "v", "challenge", "task_id", "run_id", "claim_lock", "role", "profile",
+    "workflow", "pid", "parent_pid", "expires_at", "grant_id",
+}
+if set(grant) != required or grant.get("v") != 1:
+    _fail("grant_binding_mismatch")
+if grant.get("challenge") != challenge or grant.get("pid") != os.getpid():
+    _fail("grant_binding_mismatch")
+if grant.get("parent_pid") != os.getppid():
+    _fail("grant_binding_mismatch")
+if not isinstance(grant.get("expires_at"), int):
+    _fail("grant_binding_mismatch")
+if grant["expires_at"] <= int(time.time()):
+    _fail("grant_expired")
+
+bootstrap_mode = os.environ.pop("HERMES_KANBAN_BOOTSTRAP_MODE", "reviewer")
+if bootstrap_mode not in {"reviewer", "generic"}:
+    _fail("bootstrap_protocol_violation")
+pythonpath = os.environ.pop("HERMES_KANBAN_REVIEW_PYTHONPATH", "")
+if len(sys.argv) == 3:
+    for entry in reversed([part for part in pythonpath.split(os.pathsep) if part]):
+        if entry not in sys.path:
+            sys.path.insert(0, entry)
+if bootstrap_mode == "reviewer":
+    from tools.reviewer_authority import activate_reviewer
+
+    activate_reviewer(grant)
+if os.environ.pop("HERMES_REVIEWER_BOOTSTRAP_EXIT_AFTER_GRANT", "") == "1":
+    raise SystemExit(75)
+ready = {"grant_id": grant["grant_id"], "pid": os.getpid(), "v": 1}
+if partial_phase.startswith("ready_"):
+    if partial_phase == "ready_eof":
+        _write(ready)
+        time.sleep(1)
+        raise SystemExit(75)
+    _write_partial(ready, partial_phase)
+_write(ready)
+_child.close()
+if _parent.read(1) != b"":
+    _fail("bootstrap_protocol_violation")
+_parent.close()
+
+launch = json.loads(os.environ.pop("HERMES_KANBAN_REVIEW_LAUNCH_ARGV"))
+if not isinstance(launch, list) or not launch or not all(isinstance(value, str) for value in launch):
+    raise SystemExit(74)
+payload = launch[2:] if len(launch) >= 2 and launch[0] == "-p" else launch
+if payload[0] == "__run_path__" and len(payload) == 2:
+    runpy.run_path(payload[1], run_name="__main__")
+else:
+    sys.argv = ["hermes", *launch]
+    runpy.run_module("hermes_cli.main", run_name="__main__", alter_sys=False)

--- a/model_tools.py
+++ b/model_tools.py
@@ -315,6 +315,14 @@ def get_tool_definitions(
     Returns:
         Filtered list of OpenAI-format tool definitions.
     """
+    from tools.reviewer_surface import canonical_reviewer_definitions, typed_reviewer_active
+
+    if typed_reviewer_active():
+        definitions = canonical_reviewer_definitions()
+        global _last_resolved_tool_names
+        _last_resolved_tool_names = [item["function"]["name"] for item in definitions]
+        return definitions
+
     # Fast path: memoized result when the caller doesn't need stdout prints.
     # The cache key captures every argument-level input; the registry
     # generation captures registry mutations (MCP refresh, plugin load).
@@ -348,7 +356,6 @@ def get_tool_definitions(
         if cached is not None:
             # Update _last_resolved_tool_names so downstream callers see
             # consistent state even on a cache hit.
-            global _last_resolved_tool_names
             _last_resolved_tool_names = [t["function"]["name"] for t in cached]
             # Return a shallow copy of the list but share the dict references —
             # schemas are treated as read-only by all known callers.
@@ -735,7 +742,13 @@ def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
     if not args or not isinstance(args, dict):
         return args
 
-    schema = registry.get_schema(tool_name)
+    from tools.reviewer_surface import canonical_reviewer_schema, typed_reviewer_active
+
+    schema = (
+        canonical_reviewer_schema(tool_name)
+        if typed_reviewer_active()
+        else registry.get_schema(tool_name)
+    )
     if not schema:
         return args
 
@@ -1134,10 +1147,29 @@ def handle_function_call(
     Returns:
         Function result as a JSON string.
     """
+    from tools.reviewer_surface import canonical_reviewer_handler, typed_reviewer_active
+
+    reviewer_active = typed_reviewer_active()
+    canonical_handler = canonical_reviewer_handler(function_name) if reviewer_active else None
+    if reviewer_active and canonical_handler is None:
+        return tool_error(f"Unknown tool: {function_name}")
+
     # Coerce string arguments to their schema-declared types (e.g. "42"→42)
     function_args = coerce_tool_args(function_name, function_args)
     if not isinstance(function_args, dict):
         function_args = {}
+    if canonical_handler is not None:
+        # Reviewer activation is a security boundary. Dispatch before every
+        # generic/plugin request, execution, hook, transform, and registry seam.
+        handler, is_async = canonical_handler
+        try:
+            if is_async:
+                return _run_async(handler(function_args, task_id=task_id, session_id=session_id))
+            return handler(function_args, task_id=task_id, session_id=session_id)
+        except Exception as exc:
+            error_msg = f"Error executing {function_name}: {exc}"
+            logger.exception(error_msg)
+            return tool_error(_sanitize_tool_error(error_msg))
     _tool_middleware_trace = list(tool_request_middleware_trace or [])
 
     # ── Tool Search bridge dispatch ──────────────────────────────────

--- a/model_tools.py
+++ b/model_tools.py
@@ -392,13 +392,13 @@ def _compute_tool_definitions(
             os.environ.get("HERMES_KANBAN_TASK")
             and not _is_delegated_child_context()
             and "kanban" not in effective_enabled_toolsets
+            and "kanban-worker-lifecycle" not in effective_enabled_toolsets
         ):
             # Dispatcher-spawned workers are scoped by HERMES_KANBAN_TASK and
-            # must always receive the lifecycle handoff tools. Assignee
-            # profiles may intentionally restrict their normal chat toolsets
-            # (for token/cost reasons), but that should not strip the kanban
-            # worker's completion/block/heartbeat surface.
-            effective_enabled_toolsets.append("kanban")
+            # must always receive their own lifecycle handoff tools. Graph
+            # routing and attachment mutation remain explicit orchestrator
+            # capabilities rather than ambient worker authority.
+            effective_enabled_toolsets.append("kanban-worker-lifecycle")
         for toolset_name in effective_enabled_toolsets:
             if validate_toolset(toolset_name):
                 resolved = resolve_toolset(toolset_name)

--- a/plugins/web/ddgs/provider.py
+++ b/plugins/web/ddgs/provider.py
@@ -173,6 +173,18 @@ def _run_ddgs_search_bounded(query: str, safe_limit: int) -> list[dict[str, Any]
         )
 
     worker_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "_search_worker.py")
+    worker_argv = [sys.executable, worker_path]
+    try:
+        from hermes_cli.kanban_runtime_snapshot import (
+            sealed_python_argv,
+            snapshot_bootstrap_capability,
+        )
+
+        if snapshot_bootstrap_capability() is not None:
+            command, args = sealed_python_argv("plugins/web/ddgs/_search_worker.py")
+            worker_argv = [command, *args]
+    except ImportError:
+        pass
     # Platform-only spawn knobs — stdin/stdout/stderr must stay as explicit
     # keyword args on the Popen call so scripts/check_subprocess_stdin.py can
     # see them (TUI gateway inherits stdin; #14036).
@@ -185,7 +197,7 @@ def _run_ddgs_search_bounded(query: str, safe_limit: int) -> list[dict[str, Any]
         extra_kwargs["start_new_session"] = True
 
     proc = subprocess.Popen(
-        [sys.executable, worker_path],
+        worker_argv,
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         # DEVNULL avoids the classic deadlock where a chatty child fills the

--- a/tests/hermes_cli/test_gateway_resource_limits.py
+++ b/tests/hermes_cli/test_gateway_resource_limits.py
@@ -1,0 +1,138 @@
+"""Gateway startup resource-limit hardening tests."""
+
+import os
+import subprocess
+import sys
+from types import ModuleType
+
+import hermes_cli.gateway as gateway
+
+
+class FakeResource:
+    RLIMIT_NOFILE = 7
+    RLIM_INFINITY = -1
+
+    def __init__(self, limits):
+        self.limits = limits
+        self.set_calls = []
+
+    def getrlimit(self, resource_id):
+        assert resource_id == self.RLIMIT_NOFILE
+        return self.limits
+
+    def setrlimit(self, resource_id, limits):
+        assert resource_id == self.RLIMIT_NOFILE
+        self.set_calls.append(limits)
+        self.limits = limits
+
+
+class DeniedResource(FakeResource):
+    def setrlimit(self, resource_id, limits):
+        raise PermissionError("denied")
+
+
+def test_raise_gateway_nofile_soft_limit_from_256_to_4096():
+    resource = FakeResource((256, 8192))
+
+    result = gateway._raise_gateway_nofile_soft_limit(resource_module=resource)
+
+    assert result == (256, 4096)
+    assert resource.set_calls == [(4096, 8192)]
+
+
+def test_raise_gateway_nofile_soft_limit_clamps_to_finite_hard_limit():
+    resource = FakeResource((256, 1024))
+
+    result = gateway._raise_gateway_nofile_soft_limit(resource_module=resource)
+
+    assert result == (256, 1024)
+    assert resource.set_calls == [(1024, 1024)]
+
+
+def test_raise_gateway_nofile_soft_limit_never_lowers_existing_limit():
+    resource = FakeResource((8192, 16384))
+
+    result = gateway._raise_gateway_nofile_soft_limit(resource_module=resource)
+
+    assert result == (8192, 8192)
+    assert resource.set_calls == []
+
+
+def test_raise_gateway_nofile_soft_limit_fails_open_when_setrlimit_is_denied():
+    resource = DeniedResource((256, 8192))
+
+    result = gateway._raise_gateway_nofile_soft_limit(resource_module=resource)
+
+    assert result == (256, 256)
+
+
+def test_run_gateway_raises_nofile_before_gateway_runtime_import(monkeypatch):
+    events = []
+
+    monkeypatch.setattr(gateway, "_guard_official_docker_root_gateway", lambda: None)
+    monkeypatch.setattr(
+        gateway, "_guard_named_profile_under_multiplexer", lambda force=False: None
+    )
+    monkeypatch.setattr(
+        gateway, "_guard_supervised_gateway_conflict", lambda force=False: None
+    )
+    monkeypatch.setattr(
+        gateway,
+        "_guard_existing_gateway_process_conflict",
+        lambda replace=False: None,
+    )
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(
+        gateway,
+        "_raise_gateway_nofile_soft_limit",
+        lambda: events.append("raise-limit") or (256, 4096),
+    )
+
+    async def start_gateway(*, replace, verbosity):
+        events.append("start-gateway")
+        return False
+
+    fake_run = ModuleType("gateway.run")
+    setattr(fake_run, "start_gateway", start_gateway)
+
+    def exit_after_graceful_shutdown(code):
+        raise SystemExit(code)
+
+    setattr(fake_run, "_exit_after_graceful_shutdown", exit_after_graceful_shutdown)
+    monkeypatch.setitem(sys.modules, "gateway.run", fake_run)
+
+    try:
+        gateway.run_gateway()
+    except SystemExit:
+        pass
+
+    assert events[:2] == ["raise-limit", "start-gateway"]
+
+
+def test_real_child_process_raises_soft_limit_from_256_to_4096():
+    if os.name != "posix":
+        import pytest
+
+        pytest.skip("POSIX resource limits only")
+
+    script = """
+import resource
+from hermes_cli.gateway import _raise_gateway_nofile_soft_limit
+_, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+resource.setrlimit(resource.RLIMIT_NOFILE, (256, hard))
+print(resource.getrlimit(resource.RLIMIT_NOFILE)[0])
+print(_raise_gateway_nofile_soft_limit())
+print(resource.getrlimit(resource.RLIMIT_NOFILE)[0])
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=os.fspath(gateway.PROJECT_ROOT),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.splitlines() == ["256", "(256, 4096)", "4096"]

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -100,6 +100,45 @@ def test_dependency_then_parent_done_promotes(kanban_home: Path) -> None:
         assert kb.get_task(conn, child).status == "ready"
 
 
+def test_typed_review_task_with_completed_parent_rejects_dependency_block(
+    kanban_home: Path,
+) -> None:
+    """A review verdict is an output, not a lifecycle dependency wait.
+
+    Once every declared parent is complete, parking a typed review card as a
+    dependency would make ``recompute_ready`` promote it immediately and
+    respawn the same goal-mode review forever.
+    """
+    with kb.connect_closing() as conn:
+        parent = kb.create_task(conn, title="approved plan", assignee="planner")
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (parent,))
+        assert kb.claim_task(conn, parent, claimer="planner") is not None
+        assert kb.complete_task(conn, parent, summary="plan complete")
+
+        child = kb.create_task(
+            conn,
+            title="adverse architecture review",
+            assignee="architect",
+            parents=[parent],
+            workflow_template_id="jerome-kanban-v1",
+            current_step_key="architect",
+            goal_mode=True,
+        )
+        assert kb.claim_task(conn, child, claimer="architect") is not None
+
+        with pytest.raises(kb.RoleCompletionContractError, match="review verdict"):
+            kb.block_task(
+                conn,
+                child,
+                reason="BLOCK: design mismatch",
+                kind="dependency",
+                expected_run_id=kb.get_task(conn, child).current_run_id,
+            )
+
+        assert kb.get_task(conn, child).status == "running"
+
+
 # ---------------------------------------------------------------------------
 # Completion resets loop memory
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -275,7 +275,15 @@ class TestWorkerSpawnEnv:
             tenant=None,
         )
 
-        kb._default_spawn(task, str(fresh_home / "ws"), board="spawntest")
+        monkeypatch.setattr(
+            kb,
+            "_spawn_posix_generic_worker",
+            lambda _conn, _task, cmd, **kwargs: fake_popen(cmd, **kwargs),
+        )
+        kb._default_spawn(
+            task, str(fresh_home / "ws"), board="spawntest",
+            authority_conn=object(),  # type: ignore[arg-type]
+        )
 
         env = captured["env"]
         assert env["HERMES_KANBAN_BOARD"] == "spawntest"

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -722,9 +722,15 @@ def test_default_spawn_does_not_auto_load_any_skill(kanban_home, monkeypatch):
         tid = kb.create_task(conn, title="skill-loading test",
                              assignee="some-profile")
         task = kb.get_task(conn, tid)
+        assert task is not None
         workspace = kb.resolve_workspace(task)
-        pid = kb._default_spawn(task, str(workspace))
-        assert pid == 99999
+        monkeypatch.setattr(
+            kb,
+            "_spawn_posix_generic_worker",
+            lambda _conn, _task, cmd, **kwargs: fake_popen(cmd, **kwargs),
+        )
+        spawned = kb._default_spawn(task, str(workspace), authority_conn=conn)
+        assert spawned == 99999
     finally:
         conn.close()
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -835,7 +835,14 @@ class TestSharedBoardPaths:
             tenant=None,
             branch_name="wt/t_dispatch_env",
         )
-        kb._default_spawn(task, str(tmp_path / "ws"))
+        monkeypatch.setattr(
+            kb,
+            "_spawn_posix_generic_worker",
+            lambda _conn, _task, cmd, **kwargs: _FakePopen(cmd, **kwargs),
+        )
+        kb._default_spawn(
+            task, str(tmp_path / "ws"), authority_conn=object(),  # type: ignore[arg-type]
+        )
 
         env = captured["env"]
         assert env["HERMES_KANBAN_DB"] == str(default_home / "kanban.db")

--- a/tests/hermes_cli/test_kanban_dispatch_preflight.py
+++ b/tests/hermes_cli/test_kanban_dispatch_preflight.py
@@ -1,0 +1,332 @@
+from __future__ import annotations
+
+import json
+import signal
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def isolated_board(tmp_path: Path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    review_skill = home / "skills" / "sdlc-review"
+    review_skill.mkdir(parents=True)
+    (review_skill / "SKILL.md").write_text(
+        "---\nname: sdlc-review\ndescription: Review changes.\n---\n# Review\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.create_board(slug="default", name="Test")
+    with kb.connect_closing() as conn:
+        yield conn, home
+
+
+def _ready_task(conn, **kwargs) -> str:
+    status = kwargs.pop("status", "ready")
+    task_id = kb.create_task(conn, title="preflight", assignee=kwargs.pop("assignee", "default"), **kwargs)
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET status=? WHERE id=?", (status, task_id))
+    return task_id
+
+
+def _assert_preflight_blocked_without_run(conn, task_id: str, expected: str) -> None:
+    task = kb.get_task(conn, task_id)
+    assert task is not None
+    assert task.status == "blocked"
+    assert task.current_run_id is None
+    assert task.consecutive_failures == 0
+    assert expected in (task.last_failure_error or "")
+    assert conn.execute("SELECT COUNT(*) FROM task_runs WHERE task_id=?", (task_id,)).fetchone()[0] == 0
+    event = conn.execute(
+        "SELECT kind, payload FROM task_events WHERE task_id=? ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    assert event["kind"] == "preflight_failed"
+    assert expected in json.loads(event["payload"])["error"]
+
+
+def test_unknown_profile_fails_before_claim(isolated_board):
+    conn, _home = isolated_board
+    task_id = _ready_task(conn, assignee="missing-profile")
+    spawned = []
+
+    kb.dispatch_once(conn, spawn_fn=lambda *args: spawned.append(args) or 123)
+
+    assert spawned == []
+    _assert_preflight_blocked_without_run(conn, task_id, "unknown profile 'missing-profile'")
+
+
+def test_unknown_forced_skill_fails_before_claim(isolated_board):
+    conn, _home = isolated_board
+    task_id = _ready_task(conn, skills=["missing-skill"])
+
+    kb.dispatch_once(conn, spawn_fn=lambda *_args: 123)
+
+    _assert_preflight_blocked_without_run(conn, task_id, "unknown skill 'missing-skill'")
+
+
+def test_invalid_profile_toolset_fails_before_claim(isolated_board):
+    conn, home = isolated_board
+    (home / "config.yaml").write_text(
+        "platform_toolsets:\n  cli:\n    - terminal\n    - missing-toolset\n",
+        encoding="utf-8",
+    )
+    task_id = _ready_task(conn)
+
+    kb.dispatch_once(conn, spawn_fn=lambda *_args: 123)
+
+    _assert_preflight_blocked_without_run(conn, task_id, "unknown toolset 'missing-toolset'")
+
+
+@pytest.mark.parametrize(
+    ("task_kwargs", "config", "expected"),
+    [
+        ({"assignee": "missing-profile"}, None, "unknown profile 'missing-profile'"),
+        ({"skills": ["missing-skill"]}, None, "unknown skill 'missing-skill'"),
+        ({}, "platform_toolsets:\n  cli:\n    - missing-toolset\n", "unknown toolset 'missing-toolset'"),
+    ],
+)
+def test_review_dispatch_preflight_fails_before_claim(
+    isolated_board, task_kwargs, config, expected,
+):
+    conn, home = isolated_board
+    if config:
+        (home / "config.yaml").write_text(config, encoding="utf-8")
+    task_id = _ready_task(conn, status="review", **task_kwargs)
+    spawned = []
+
+    kb.dispatch_once(conn, spawn_fn=lambda *args: spawned.append(args) or 123)
+
+    assert spawned == []
+    _assert_preflight_blocked_without_run(conn, task_id, expected)
+
+
+def test_preflight_uses_skill_view_resolver_for_qualified_skill(
+    isolated_board, monkeypatch,
+):
+    conn, _home = isolated_board
+    task_id = _ready_task(conn, skills=["sample:qualified"])
+    calls = []
+
+    def fake_skill_view(name, **_kwargs):
+        calls.append(name)
+        return json.dumps({"success": True, "name": name})
+
+    monkeypatch.setattr("tools.skills_tool.skill_view", fake_skill_view)
+
+    result = kb.dispatch_once(conn, spawn_fn=lambda *_args: 123)
+
+    assert calls == ["sample:qualified"]
+    assert [row[0] for row in result.spawned] == [task_id]
+
+
+def test_preflight_discovers_plugin_toolsets_before_validation(
+    isolated_board, monkeypatch,
+):
+    conn, home = isolated_board
+    (home / "config.yaml").write_text(
+        "platform_toolsets:\n  cli:\n    - plugin-dynamic\n", encoding="utf-8",
+    )
+    task_id = _ready_task(conn)
+    discovered = []
+
+    def fake_discover_plugins():
+        from toolsets import create_custom_toolset
+
+        discovered.append(True)
+        create_custom_toolset("plugin-dynamic", "test plugin toolset")
+
+    monkeypatch.setattr("hermes_cli.plugins.discover_plugins", fake_discover_plugins)
+
+    result = kb.dispatch_once(conn, spawn_fn=lambda *_args: 123)
+
+    assert discovered
+    assert [row[0] for row in result.spawned] == [task_id]
+
+
+def test_valid_preflight_preserves_per_profile_capacity(isolated_board):
+    conn, _home = isolated_board
+    first = _ready_task(conn)
+    second = _ready_task(conn)
+
+    result = kb.dispatch_once(
+        conn,
+        spawn_fn=lambda task, _workspace: 1000 if task.id == first else 1001,
+        max_in_progress_per_profile=1,
+    )
+
+    assert [row[0] for row in result.spawned] == [first]
+    assert result.skipped_per_profile_capped == [(second, "default", 1)]
+    assert kb.get_task(conn, first).status == "running"
+    assert kb.get_task(conn, second).status == "ready"
+
+
+def test_immediate_spawn_exit_is_recorded_with_log_tail(isolated_board, tmp_path, monkeypatch):
+    conn, _home = isolated_board
+    task_id = _ready_task(conn)
+    log_path = tmp_path / "worker.log"
+    leaked = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ123456"
+    log_path.write_text(
+        f"startup failed: Unknown skill {leaked}\n", encoding="utf-8",
+    )
+
+    result = kb.dispatch_once(
+        conn,
+        spawn_fn=lambda *_args: kb.SpawnedWorker(pid=4242, returncode=1, log_path=log_path),
+    )
+
+    assert result.spawned == []
+    task = kb.get_task(conn, task_id)
+    assert task.status == "ready"
+    assert task.consecutive_failures == 1
+    run = conn.execute("SELECT outcome, error FROM task_runs WHERE task_id=?", (task_id,)).fetchone()
+    assert run["outcome"] == "crashed"
+    assert "exited with code 1" in run["error"]
+    assert "Unknown skill" in run["error"]
+    assert leaked not in run["error"]
+
+
+@pytest.mark.parametrize(
+    ("returncode", "outcome", "event_kind", "failure_count", "error_fragment"),
+    [
+        (0, "crashed", "protocol_violation", 0, "protocol violation"),
+        (kb.KANBAN_RATE_LIMIT_EXIT_CODE, "rate_limited", "rate_limited", 0, "rate-limited"),
+        (1, "crashed", "crashed", 1, "exited with code 1"),
+        (-signal.SIGTERM, "crashed", "crashed", 1, f"signal {signal.SIGTERM}"),
+    ],
+)
+@pytest.mark.parametrize("status", ["ready", "review"])
+def test_immediate_exit_uses_canonical_worker_taxonomy(
+    isolated_board, returncode, outcome, event_kind, failure_count, error_fragment,
+    status,
+):
+    conn, _home = isolated_board
+    task_id = _ready_task(conn, status=status)
+
+    kb.dispatch_once(
+        conn,
+        spawn_fn=lambda *_args: kb.SpawnedWorker(pid=4242, returncode=returncode),
+    )
+
+    task = kb.get_task(conn, task_id)
+    run = conn.execute(
+        "SELECT outcome, error, metadata FROM task_runs WHERE task_id=?", (task_id,),
+    ).fetchone()
+    assert task.status == "ready"
+    assert task.consecutive_failures == failure_count
+    assert run["outcome"] == outcome
+    assert error_fragment in run["error"]
+    assert any(e.kind == event_kind for e in kb.list_events(conn, task_id))
+
+
+def test_healthy_spawn_result_remains_detached(isolated_board):
+    conn, _home = isolated_board
+    task_id = _ready_task(conn)
+
+    result = kb.dispatch_once(
+        conn,
+        spawn_fn=lambda *_args: kb.SpawnedWorker(pid=4242),
+    )
+
+    assert [row[0] for row in result.spawned] == [task_id]
+    assert kb.get_task(conn, task_id).worker_pid == 4242
+
+
+def test_exit_after_probe_is_classified_without_waiting_for_next_tick(isolated_board, tmp_path):
+    conn, _home = isolated_board
+    task_id = _ready_task(conn)
+    claimed = kb.claim_task(conn, task_id)
+    assert claimed is not None
+    kb._set_worker_pid(conn, task_id, 4242)
+    log_path = tmp_path / "late.log"
+    log_path.write_text("late startup failure\n", encoding="utf-8")
+
+    assert kb.record_worker_exit(
+        task_id,
+        claimed.current_run_id,
+        4242,
+        1,
+        log_path=log_path,
+        db_path=kb.kanban_db_path(),
+    )
+
+    task = kb.get_task(conn, task_id)
+    assert task.status == "ready"
+    assert task.consecutive_failures == 1
+    run = conn.execute("SELECT outcome, error FROM task_runs WHERE task_id=?", (task_id,)).fetchone()
+    assert run["outcome"] == "crashed"
+    assert "late startup failure" in run["error"]
+
+    # A duplicate/racing notification cannot mutate the already-ended run.
+    assert not kb.record_worker_exit(
+        task_id,
+        claimed.current_run_id,
+        4242,
+        1,
+        log_path=log_path,
+        db_path=kb.kanban_db_path(),
+    )
+    assert kb.get_task(conn, task_id).consecutive_failures == 1
+
+
+def test_exit_watcher_retries_pid_publication_beyond_200ms(
+    isolated_board, monkeypatch, tmp_path,
+):
+    conn, _home = isolated_board
+    task_id = _ready_task(conn)
+    claimed = kb.claim_task(conn, task_id)
+    assert claimed is not None
+    attempts = []
+
+    class Proc:
+        pid = 5151
+
+        @staticmethod
+        def wait():
+            return 1
+
+    real_record = kb.record_worker_exit
+
+    def delayed_record(*args, **kwargs):
+        attempts.append(time.monotonic())
+        if time.monotonic() - attempts[0] < 0.3:
+            return False
+        kb._set_worker_pid(conn, task_id, Proc.pid)
+        return real_record(*args, **kwargs)
+
+    monkeypatch.setattr(kb, "record_worker_exit", delayed_record)
+
+    kb._watch_worker_exit(
+        Proc(), task_id, claimed.current_run_id, tmp_path / "worker.log",
+        kb.kanban_db_path(),
+    )
+
+    assert attempts[-1] - attempts[0] >= 0.3
+    assert kb.get_task(conn, task_id).status == "ready"
+    assert kb.get_task(conn, task_id).consecutive_failures == 1
+
+
+def test_next_tick_does_not_duplicate_prompt_exit_classification(
+    isolated_board, monkeypatch,
+):
+    conn, _home = isolated_board
+    task_id = _ready_task(conn)
+    kb.dispatch_once(
+        conn,
+        spawn_fn=lambda *_args: kb.SpawnedWorker(pid=6161, returncode=1),
+    )
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+
+    kb.dispatch_once(conn, spawn_fn=lambda *_args: None)
+
+    assert kb.get_task(conn, task_id).consecutive_failures == 1
+    assert conn.execute(
+        "SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='crashed'",
+        (task_id,),
+    ).fetchone()[0] == 1

--- a/tests/hermes_cli/test_kanban_reviewer_authority.py
+++ b/tests/hermes_cli/test_kanban_reviewer_authority.py
@@ -1,0 +1,851 @@
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import sysconfig
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.kanban_runtime_snapshot import (
+    build_runtime_snapshot,
+    prepare_snapshot_lease,
+)
+
+
+
+def _running_reviewer(conn, workspace: Path):
+    task_id = kb.create_task(
+        conn,
+        title="review authority",
+        assignee="critic",
+        workspace_kind="dir",
+        workspace_path=str(workspace),
+        workflow_template_id="jerome-kanban-v1",
+        current_step_key="critic",
+    )
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (task_id,))
+    task = kb.claim_task(conn, task_id, claimer="dispatcher:1", ttl_seconds=300)
+    assert task is not None
+    return task
+
+
+def _assert_process_group_gone(pid: int) -> None:
+    deadline = time.monotonic() + 2
+    while True:
+        try:
+            os.killpg(pid, 0)
+        except ProcessLookupError:
+            return
+        if time.monotonic() >= deadline:
+            pytest.fail(f"reviewer process group {pid} survived handshake failure")
+        time.sleep(0.01)
+
+
+def _partial_handshake_timeout(
+    monkeypatch,
+    tmp_path: Path,
+    *,
+    phase: str,
+):
+    db_path = tmp_path / "authority.db"
+    kb.init_db(db_path)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    payload = tmp_path / "payload.py"
+    payload.write_text("pass\n")
+    marker = tmp_path / "reviewer.pid"
+    opened: list[int] = []
+    processes: list[subprocess.Popen] = []
+    waits: list[int] = []
+    real_pipe = kb._posix_pipe
+    real_popen = kb.subprocess.Popen
+    real_wait = subprocess.Popen.wait
+
+    def tracked_pipe():
+        pair = real_pipe()
+        opened.extend(pair)
+        return pair
+
+    def tracked_popen(*args, **kwargs):
+        proc = real_popen(*args, **kwargs)
+        processes.append(proc)
+        return proc
+
+    def tracked_wait(self, *args, **kwargs):
+        waits.append(self.pid)
+        return real_wait(self, *args, **kwargs)
+
+    monkeypatch.setattr(kb, "_posix_pipe", tracked_pipe)
+    monkeypatch.setattr(subprocess.Popen, "wait", tracked_wait)
+    monkeypatch.setattr(kb.subprocess, "Popen", tracked_popen)
+    # Leave enough startup budget under parallel-suite CPU contention. The
+    # injected child sleeps for one second after its partial frame, so 0.5s
+    # still deterministically exercises timeout below the asserted 2s cap.
+    monkeypatch.setattr(kb, "_REVIEWER_HANDSHAKE_TIMEOUT", 0.5)
+    env = {
+        "HERMES_REVIEWER_BOOTSTRAP_PARTIAL_PHASE": phase,
+        "HERMES_REVIEWER_BOOTSTRAP_PID_MARKER": str(marker),
+    }
+    with kb.connect_closing(db_path=db_path) as conn:
+        task = _running_reviewer(conn, workspace)
+        started = time.monotonic()
+        try:
+            with pytest.raises(
+                kb.ReviewerActivationStartFailed
+                if phase.startswith("ready")
+                else kb.ReviewerAuthorityError,
+                match="activation_start_failed"
+                if phase.startswith("ready")
+                else "bootstrap_handshake_timeout",
+            ):
+                proc = kb._spawn_posix_reviewer(
+                    conn,
+                    task,
+                    ["python", "-p", "critic", "__run_path__", str(payload)],
+                    cwd=str(workspace),
+                    env=env,
+                    stdout=subprocess.DEVNULL,
+                )
+                proc.wait(timeout=2)
+        finally:
+            for proc in processes:
+                if proc.poll() is None:
+                    os.killpg(proc.pid, 9)
+                    proc.wait(timeout=2)
+        elapsed = time.monotonic() - started
+        task_row = conn.execute(
+            "SELECT status, worker_pid, current_run_id FROM tasks WHERE id=?", (task.id,)
+        ).fetchone()
+        run_row = conn.execute(
+            "SELECT status, outcome, worker_pid FROM task_runs WHERE id=?",
+            (task.current_run_id,),
+        ).fetchone()
+
+    assert elapsed < 2
+    assert len(processes) == 1
+    pid = processes[0].pid
+    assert waits == [pid]
+    assert marker.read_text(encoding="ascii") == str(pid)
+    assert processes[0].poll() is not None
+    _assert_process_group_gone(pid)
+    for fd in opened:
+        with pytest.raises(OSError):
+            os.fstat(fd)
+    if phase.startswith("ready"):
+        assert task_row["status"] == "blocked"
+        assert task_row["worker_pid"] == pid
+        assert task_row["current_run_id"] is None
+        assert run_row["status"] == "activation_start_failed"
+        assert run_row["outcome"] == "activation_start_failed"
+        assert run_row["worker_pid"] == pid
+    else:
+        assert task_row["status"] == "running"
+        assert task_row["worker_pid"] is None
+        assert task_row["current_run_id"] == task.current_run_id
+        assert run_row["status"] == "running"
+        assert run_row["worker_pid"] is None
+
+
+@pytest.mark.parametrize("phase", ["hello_header", "hello_payload"])
+def test_partial_hello_frame_times_out_before_pid_commit(monkeypatch, tmp_path, phase):
+    _partial_handshake_timeout(monkeypatch, tmp_path, phase=phase)
+
+
+@pytest.mark.parametrize("phase", ["ready_header", "ready_payload", "ready_eof"])
+def test_partial_ready_frame_times_out_terminally_after_pid_commit(monkeypatch, tmp_path, phase):
+    _partial_handshake_timeout(monkeypatch, tmp_path, phase=phase)
+
+
+def test_reviewer_pid_grant_commits_all_pid_bindings_on_existing_connection(tmp_path):
+    db_path = tmp_path / "authority.db"
+    kb.init_db(db_path)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    with kb.connect_closing(db_path=db_path) as conn:
+        task = _running_reviewer(conn, workspace)
+        grant = kb._commit_reviewer_authority(conn, task, 4321, parent_pid=os.getpid())
+
+        task_row = conn.execute("SELECT worker_pid FROM tasks WHERE id=?", (task.id,)).fetchone()
+        run_row = conn.execute(
+            "SELECT worker_pid FROM task_runs WHERE id=?", (task.current_run_id,)
+        ).fetchone()
+        assert task_row["worker_pid"] == 4321
+        assert run_row["worker_pid"] == 4321
+        assert grant["pid"] == 4321
+        assert grant["parent_pid"] == os.getpid()
+        assert grant["role"] == "critic"
+
+
+def test_reviewer_pid_grant_cas_loser_gets_no_grant(tmp_path):
+    db_path = tmp_path / "authority.db"
+    kb.init_db(db_path)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    with kb.connect_closing(db_path=db_path) as conn:
+        task = _running_reviewer(conn, workspace)
+        kb._commit_reviewer_authority(conn, task, 4321, parent_pid=os.getpid())
+
+        with pytest.raises(kb.ReviewerAuthorityError, match="worker_pid_cas_failed"):
+            kb._commit_reviewer_authority(conn, task, 4322, parent_pid=os.getpid())
+
+
+def test_reviewer_authority_uses_original_memory_connection():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.executescript(kb.SCHEMA_SQL)
+        workspace = Path.cwd()
+        task = _running_reviewer(conn, workspace)
+        grant = kb._commit_reviewer_authority(conn, task, 4321, parent_pid=os.getpid())
+        assert grant["task_id"] == task.id
+    finally:
+        conn.close()
+
+
+def test_non_reviewer_never_receives_reviewer_authority(tmp_path):
+    db_path = tmp_path / "authority.db"
+    kb.init_db(db_path)
+    with kb.connect_closing(db_path=db_path) as conn:
+        task_id = kb.create_task(conn, title="generic", assignee="critic")
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (task_id,))
+        task = kb.claim_task(conn, task_id, claimer="dispatcher:1", ttl_seconds=300)
+        assert task is not None
+
+        with pytest.raises(kb.ReviewerAuthorityError, match="reviewer_authority_not_applicable"):
+            kb._commit_reviewer_authority(conn, task, 4321, parent_pid=os.getpid())
+
+
+def test_commit_failure_never_writes_grant(tmp_path):
+    class CommitFailingConnection:
+        def __init__(self, connection):
+            self.connection = connection
+
+        def execute(self, *args, **kwargs):
+            return self.connection.execute(*args, **kwargs)
+
+        def commit(self):
+            raise sqlite3.OperationalError("simulated commit failure")
+
+        def rollback(self):
+            return self.connection.rollback()
+
+    db_path = tmp_path / "authority.db"
+    kb.init_db(db_path)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    with kb.connect_closing(db_path=db_path) as conn:
+        task = _running_reviewer(conn, workspace)
+        failing = CommitFailingConnection(conn)
+        with pytest.raises(kb.ReviewerAuthorityError, match="sqlite_authority_commit_failed"):
+            kb._commit_reviewer_authority(failing, task, 4321, parent_pid=os.getpid())
+        assert conn.execute("SELECT worker_pid FROM tasks WHERE id=?", (task.id,)).fetchone()[0] is None
+
+
+def _sealed_reviewer_runtime(tmp_path: Path):
+    source = Path(__file__).resolve().parents[2]
+    snapshot = build_runtime_snapshot(
+        source,
+        repository_id="test-repository",
+        source_revision="a" * 40,
+        source_dirty=True,
+        cache_root=tmp_path / "snapshot-cache",
+    )
+    from hermes_cli.kanban_runtime_snapshot import (
+        runtime_binding_for_directory,
+        runtime_binding_pass_fds,
+        with_runtime_bindings,
+    )
+
+    clean_stdlib = Path(sysconfig.get_path("stdlib")).resolve(strict=True)
+    runtime_bindings = [runtime_binding_for_directory("stdlib", clean_stdlib)]
+    dynload = clean_stdlib / "lib-dynload"
+    if dynload.is_dir():
+        runtime_bindings.append(runtime_binding_for_directory("stdlib", dynload))
+    snapshot = with_runtime_bindings(snapshot, tuple(runtime_bindings))
+    lease = prepare_snapshot_lease(
+        snapshot,
+        cache_root=tmp_path / "snapshot-cache",
+        task_id="t_review",
+        run_id=1,
+    )
+    return kb.WorkerRuntimeSpec(
+        argv=[
+            sys.executable, "-I", "-S", "-c", kb._IMMUTABLE_RUNTIME_LAUNCHER,
+            str(snapshot.object_root), snapshot.manifest_sha256, snapshot.cache_key,
+        ],
+        snapshot=snapshot,
+        lease=lease,
+        pass_fds=runtime_binding_pass_fds(snapshot.runtime_bindings),
+    )
+
+
+def test_real_spawn_binds_sealed_snapshot_lease_after_ready_eof(tmp_path):
+    db_path = tmp_path / "authority.db"
+    kb.init_db(db_path)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    marker = tmp_path / "runtime-origin.json"
+    payload = tmp_path / "payload.py"
+    payload.write_text(
+        "import json,sys\n"
+        "from pathlib import Path\n"
+        "import tools.reviewer_authority as authority\n"
+        "import hermes_cli.kanban_runtime_snapshot as snapshot_module\n"
+        "from hermes_cli.kanban_runtime_snapshot import snapshot_bootstrap_capability\n"
+        f"Path({str(marker)!r}).write_text(json.dumps({{"
+        "'sys_path': sys.path, 'authority': authority.__file__, "
+        "'snapshot_module': snapshot_module.__file__, "
+        "'manifest': snapshot_bootstrap_capability().spec.manifest_sha256"
+        "}))\n"
+    )
+    runtime = _sealed_reviewer_runtime(tmp_path)
+    with kb.connect_closing(db_path=db_path) as conn:
+        task = _running_reviewer(conn, workspace)
+        proc = kb._spawn_posix_reviewer(
+            conn,
+            task,
+            [*runtime.argv, "-p", "critic", "__run_path__", str(payload)],
+            cwd=str(workspace),
+            env={},
+            stdout=subprocess.PIPE,
+            runtime=runtime,
+        )
+        output, _ = proc.communicate(timeout=10)
+        assert proc.returncode == 0, output.decode(errors="replace")
+
+    record = json.loads(runtime.lease.path.read_text(encoding="utf-8"))
+    origin = json.loads(marker.read_text(encoding="utf-8"))
+    sealed_root = str(runtime.snapshot.payload_root)
+    assert record["state"] == "bound"
+    assert record["pid"] == proc.pid
+    assert origin["manifest"] == runtime.snapshot.manifest_sha256
+    assert origin["sys_path"][0] == sealed_root
+    assert origin["authority"].startswith(sealed_root)
+    assert origin["snapshot_module"].startswith(sealed_root)
+
+
+def test_typed_bootstrap_uses_verified_snapshot_module_after_path_swap(monkeypatch, tmp_path):
+    db_path = tmp_path / "authority.db"
+    kb.init_db(db_path)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    payload = tmp_path / "payload.py"
+    marker = tmp_path / "attacker-ran"
+    payload.write_text("pass\n")
+
+    with kb.connect_closing(db_path=db_path) as conn:
+        task = _running_reviewer(conn, workspace)
+        runtime = _sealed_reviewer_runtime(tmp_path)
+        assert runtime.snapshot is not None
+        original = kb.subprocess.Popen
+
+        def swap_before_spawn(argv, **kwargs):
+            target = runtime.snapshot.payload_root / "hermes_cli/kanban_runtime_snapshot.py"
+            target.chmod(0o600)
+            target.write_text(
+                f"from pathlib import Path\nPath({str(marker)!r}).write_text('ran')\n",
+                encoding="utf-8",
+            )
+            return original(argv, **kwargs)
+
+        monkeypatch.setattr(kb.subprocess, "Popen", swap_before_spawn)
+        child_log = tmp_path / "child.log"
+        with child_log.open("wb") as output:
+            try:
+                proc = kb._spawn_posix_reviewer(
+                    conn,
+                    task,
+                    [sys.executable, "-p", "critic", "__run_path__", str(payload)],
+                    cwd=str(workspace),
+                    env={},
+                    stdout=output,
+                    runtime=runtime,
+                )
+            except Exception:
+                output.flush()
+                pytest.fail(child_log.read_text(errors="replace"))
+        assert proc.wait(timeout=10) == 0
+        assert not marker.exists()
+
+
+def test_real_spawn_uses_ready_eof_before_return_and_commits_pid(tmp_path):
+    db_path = tmp_path / "authority.db"
+    kb.init_db(db_path)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    payload = tmp_path / "payload.py"
+    payload.write_text("pass\n")
+    with kb.connect_closing(db_path=db_path) as conn:
+        task = _running_reviewer(conn, workspace)
+        proc = kb._spawn_posix_reviewer(
+            conn,
+            task,
+            ["python", "-p", "critic", "__run_path__", str(payload)],
+            cwd=str(workspace),
+            env={},
+            stdout=subprocess.DEVNULL,
+        )
+        assert conn.execute("SELECT worker_pid FROM tasks WHERE id=?", (task.id,)).fetchone()[0] == proc.pid
+        assert proc.wait(timeout=10) == 0
+
+
+def test_generic_real_spawn_cannot_run_payload_before_lease_bound_and_release(monkeypatch, tmp_path):
+    db_path = tmp_path / "authority.db"
+    kb.init_db(db_path)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    marker = tmp_path / "generic-ran"
+    payload = tmp_path / "payload.py"
+    payload.write_text(f"from pathlib import Path\nPath({str(marker)!r}).write_text('ran')\n")
+
+    with kb.connect_closing(db_path=db_path) as conn:
+        task_id = kb.create_task(conn, title="generic", assignee="default")
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (task_id,))
+        task = kb.claim_task(conn, task_id, claimer="dispatcher:1", ttl_seconds=300)
+        assert task is not None
+        runtime = _sealed_reviewer_runtime(tmp_path)
+        assert runtime.lease is not None
+        original_commit = kb._commit_generic_worker_binding
+        original_bind = __import__(
+            "hermes_cli.kanban_runtime_snapshot", fromlist=["bind_snapshot_lease"]
+        ).bind_snapshot_lease
+
+        def commit_after_observation(conn_arg, task_arg, pid, *, parent_pid):
+            assert not marker.exists()
+            return original_commit(conn_arg, task_arg, pid, parent_pid=parent_pid)
+
+        def bind_after_hold(lease, *, pid):
+            deadline = time.monotonic() + 0.5
+            while time.monotonic() < deadline and not marker.exists():
+                time.sleep(0.01)
+            assert not marker.exists(), "generic payload ran before lease bound/release"
+            return original_bind(lease, pid=pid)
+
+        monkeypatch.setattr(kb, "_commit_generic_worker_binding", commit_after_observation)
+        monkeypatch.setattr(
+            "hermes_cli.kanban_runtime_snapshot.bind_snapshot_lease", bind_after_hold
+        )
+        proc = kb._spawn_posix_generic_worker(
+            conn,
+            task,
+            [sys.executable, "-p", "default", "__run_path__", str(payload)],
+            cwd=str(workspace),
+            env={},
+            stdout=subprocess.DEVNULL,
+            runtime=runtime,
+        )
+        assert conn.execute("SELECT worker_pid FROM tasks WHERE id=?", (task.id,)).fetchone()[0] == proc.pid
+        assert proc.wait(timeout=10) == 0
+        assert marker.read_text() == "ran"
+        assert json.loads(runtime.lease.path.read_text())["state"] == "bound"
+
+
+def test_windows_reviewer_spawn_fails_closed_before_child_start(monkeypatch, tmp_path):
+    db_path = tmp_path / "authority.db"
+    kb.init_db(db_path)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setattr(kb, "_IS_WINDOWS", True)
+
+    def unexpected_popen(*_args, **_kwargs):
+        pytest.fail("unverified Windows reviewer bootstrap must not start a child")
+
+    monkeypatch.setattr(kb.subprocess, "Popen", unexpected_popen)
+    with kb.connect_closing(db_path=db_path) as conn:
+        task = _running_reviewer(conn, workspace)
+        with pytest.raises(kb.ReviewerAuthorityError, match="secure_job_unavailable"):
+            kb._spawn_posix_reviewer(
+                conn,
+                task,
+                ["python", "-p", "critic", "__run_path__", "payload.py"],
+                cwd=str(workspace),
+                env={},
+                stdout=subprocess.DEVNULL,
+            )
+
+
+def test_popen_failure_closes_all_four_bootstrap_descriptors_once(monkeypatch, tmp_path):
+    db_path = tmp_path / "authority.db"
+    kb.init_db(db_path)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    opened = []
+    closed = []
+    real_pipe = kb._posix_pipe
+    real_close = kb.os.close
+
+    def tracked_pipe():
+        pair = real_pipe()
+        opened.extend(pair)
+        return pair
+
+    def tracked_close(fd):
+        if fd in opened:
+            closed.append(fd)
+        return real_close(fd)
+
+    monkeypatch.setattr(kb, "_posix_pipe", tracked_pipe)
+    monkeypatch.setattr(kb.os, "close", tracked_close)
+    monkeypatch.setattr(kb.subprocess, "Popen", lambda *_a, **_k: (_ for _ in ()).throw(OSError("boom")))
+    with kb.connect_closing(db_path=db_path) as conn:
+        task = _running_reviewer(conn, workspace)
+        with pytest.raises(OSError, match="boom"):
+            kb._spawn_posix_reviewer(
+                conn, task, ["python", "-p", "critic", "payload.py"],
+                cwd=str(workspace), env={}, stdout=subprocess.DEVNULL,
+            )
+
+    assert len(opened) == 4
+    assert sorted(closed) == sorted(opened)
+    assert len(closed) == len(set(closed))
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        ["python", "critic", "payload.py"],
+        ["python", "-p"],
+        ["python", "-p", "critic"],
+        ["python", "-p", "planner", "payload.py"],
+    ],
+)
+def test_malformed_reviewer_argv_fails_before_pipe_or_popen(monkeypatch, tmp_path, cmd):
+    db_path = tmp_path / "authority.db"
+    kb.init_db(db_path)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    pipe_calls = []
+    popen_calls = []
+
+    monkeypatch.setattr(kb, "_posix_pipe", lambda: pipe_calls.append(True))
+    monkeypatch.setattr(kb.subprocess, "Popen", lambda *_a, **_k: popen_calls.append(True))
+    with kb.connect_closing(db_path=db_path) as conn:
+        task = _running_reviewer(conn, workspace)
+        with pytest.raises(kb.ReviewerAuthorityError, match="bootstrap_protocol_violation"):
+            kb._spawn_posix_reviewer(
+                conn, task, cmd, cwd=str(workspace), env={}, stdout=subprocess.DEVNULL
+            )
+
+    assert pipe_calls == []
+    assert popen_calls == []
+
+
+@pytest.mark.parametrize("fail_on_call", [1, 2])
+def test_pipe_fallback_set_inheritable_failure_closes_new_descriptors_once(
+    monkeypatch, tmp_path, fail_on_call
+):
+    db_path = tmp_path / "authority.db"
+    kb.init_db(db_path)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    opened = []
+    closed = []
+    set_calls = 0
+    popen_calls = []
+    real_pipe = kb.os.pipe
+    real_close = kb.os.close
+    real_set_inheritable = kb.os.set_inheritable
+
+    def tracked_pipe():
+        pair = real_pipe()
+        opened.extend(pair)
+        return pair
+
+    def failing_set_inheritable(fd, inheritable):
+        nonlocal set_calls
+        set_calls += 1
+        if set_calls == fail_on_call:
+            raise OSError(f"set inheritable failed {fail_on_call}")
+        return real_set_inheritable(fd, inheritable)
+
+    def tracked_close(fd):
+        if fd in opened:
+            closed.append(fd)
+        return real_close(fd)
+
+    monkeypatch.delattr(kb.os, "pipe2", raising=False)
+    monkeypatch.setattr(kb.os, "pipe", tracked_pipe)
+    monkeypatch.setattr(kb.os, "set_inheritable", failing_set_inheritable)
+    monkeypatch.setattr(kb.os, "close", tracked_close)
+    monkeypatch.setattr(
+        kb.subprocess,
+        "Popen",
+        lambda *_a, **_k: popen_calls.append(True),
+    )
+
+    with kb.connect_closing(db_path=db_path) as conn:
+        task = _running_reviewer(conn, workspace)
+        with pytest.raises(OSError, match=f"set inheritable failed {fail_on_call}"):
+            kb._spawn_posix_reviewer(
+                conn,
+                task,
+                ["python", "-p", "critic", "payload.py"],
+                cwd=str(workspace),
+                env={},
+                stdout=subprocess.DEVNULL,
+            )
+
+    assert len(opened) == 2
+    assert closed == opened
+    assert len(closed) == len(set(closed))
+    assert popen_calls == []
+    for fd in opened:
+        with pytest.raises(OSError):
+            os.fstat(fd)
+
+
+def test_second_pipe_failure_closes_first_pipe_descriptors_once(monkeypatch, tmp_path):
+    db_path = tmp_path / "authority.db"
+    kb.init_db(db_path)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    first_pair = os.pipe()
+    calls = 0
+    closed = []
+    real_close = kb.os.close
+
+    def failing_second_pipe():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return first_pair
+        raise OSError("second pipe failed")
+
+    def tracked_close(fd):
+        if fd in first_pair:
+            closed.append(fd)
+        return real_close(fd)
+
+    monkeypatch.setattr(kb, "_posix_pipe", failing_second_pipe)
+    monkeypatch.setattr(kb.os, "close", tracked_close)
+    monkeypatch.setattr(
+        kb.subprocess,
+        "Popen",
+        lambda *_a, **_k: pytest.fail("Popen must not run after pipe failure"),
+    )
+    with kb.connect_closing(db_path=db_path) as conn:
+        task = _running_reviewer(conn, workspace)
+        with pytest.raises(OSError, match="second pipe failed"):
+            kb._spawn_posix_reviewer(
+                conn,
+                task,
+                ["python", "-p", "critic", "payload.py"],
+                cwd=str(workspace),
+                env={},
+                stdout=subprocess.DEVNULL,
+            )
+
+    assert sorted(closed) == sorted(first_pair)
+    assert len(closed) == len(set(closed))
+
+
+def test_saturated_grant_pipe_times_out_terminally_and_reaps_once(monkeypatch, tmp_path):
+    db_path = tmp_path / "authority.db"
+    kb.init_db(db_path)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    payload = tmp_path / "payload.py"
+    payload.write_text("pass\n")
+    real_pipe = kb._posix_pipe
+    pipe_calls = 0
+    processes = []
+    waits = []
+    real_popen = kb.subprocess.Popen
+    real_wait = subprocess.Popen.wait
+
+    def saturated_parent_pipe():
+        nonlocal pipe_calls
+        pipe_calls += 1
+        pair = real_pipe()
+        if pipe_calls == 2:
+            read_fd, write_fd = pair
+            os.set_blocking(write_fd, False)
+            while True:
+                try:
+                    os.write(write_fd, b"x" * 4096)
+                except BlockingIOError:
+                    break
+            os.set_blocking(write_fd, True)
+        return pair
+
+    def tracked_popen(*args, **kwargs):
+        proc = real_popen(*args, **kwargs)
+        processes.append(proc)
+        return proc
+
+    def tracked_wait(self, *args, **kwargs):
+        waits.append(self.pid)
+        return real_wait(self, *args, **kwargs)
+
+    monkeypatch.setattr(kb, "_posix_pipe", saturated_parent_pipe)
+    monkeypatch.setattr(subprocess.Popen, "wait", tracked_wait)
+    monkeypatch.setattr(kb.subprocess, "Popen", tracked_popen)
+    monkeypatch.setattr(kb, "_REVIEWER_HANDSHAKE_TIMEOUT", 0.2)
+    with kb.connect_closing(db_path=db_path) as conn:
+        task = _running_reviewer(conn, workspace)
+        started = time.monotonic()
+        with pytest.raises(kb.ReviewerActivationStartFailed, match="activation_start_failed"):
+            kb._spawn_posix_reviewer(
+                conn,
+                task,
+                ["python", "-p", "critic", "__run_path__", str(payload)],
+                cwd=str(workspace),
+                env={"HERMES_REVIEWER_BOOTSTRAP_HANG_AFTER_HELLO": "1"},
+                stdout=subprocess.DEVNULL,
+            )
+        elapsed = time.monotonic() - started
+        task_row = conn.execute(
+            "SELECT status, worker_pid, current_run_id FROM tasks WHERE id=?", (task.id,)
+        ).fetchone()
+        run_row = conn.execute(
+            "SELECT status, outcome, worker_pid FROM task_runs WHERE id=?",
+            (task.current_run_id,),
+        ).fetchone()
+
+    assert elapsed < 2
+    assert len(processes) == 1
+    pid = processes[0].pid
+    assert waits == [pid]
+    assert processes[0].poll() is not None
+    _assert_process_group_gone(pid)
+    assert task_row["status"] == "blocked"
+    assert task_row["worker_pid"] == pid
+    assert task_row["current_run_id"] is None
+    assert run_row["status"] == "activation_start_failed"
+    assert run_row["outcome"] == "activation_start_failed"
+    assert run_row["worker_pid"] == pid
+
+
+def test_post_commit_handshake_failure_is_terminal_and_keeps_pid_binding(monkeypatch, tmp_path):
+    db_path = tmp_path / "authority.db"
+    kb.init_db(db_path)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    payload = tmp_path / "payload.py"
+    payload.write_text("raise SystemExit(75)\n")
+    with kb.connect_closing(db_path=db_path) as conn:
+        task = _running_reviewer(conn, workspace)
+        with pytest.raises(Exception):
+            kb._spawn_posix_reviewer(
+                conn, task,
+                ["python", "-p", "critic", "__run_path__", str(payload)],
+                cwd=str(workspace),
+                env={"HERMES_REVIEWER_BOOTSTRAP_EXIT_AFTER_GRANT": "1"},
+                stdout=subprocess.DEVNULL,
+            )
+        task_row = conn.execute(
+            "SELECT status, worker_pid, current_run_id FROM tasks WHERE id=?", (task.id,)
+        ).fetchone()
+        run_row = conn.execute(
+            "SELECT status, outcome, worker_pid FROM task_runs WHERE id=?", (task.current_run_id,)
+        ).fetchone()
+        events = [row[0] for row in conn.execute(
+            "SELECT kind FROM task_events WHERE task_id=? ORDER BY id", (task.id,)
+        )]
+
+    assert task_row["status"] == "blocked"
+    assert task_row["worker_pid"] is not None
+    assert task_row["current_run_id"] is None
+    assert run_row["status"] == "activation_start_failed"
+    assert run_row["outcome"] == "activation_start_failed"
+    assert run_row["worker_pid"] == task_row["worker_pid"]
+    assert events.count("activation_start_failed") == 1
+    assert "spawn_failed" not in events
+
+
+class _FakeHandshakeProcess:
+    def __init__(self, wait_results, poll_results):
+        self.pid = 4242
+        self._wait_results = iter(wait_results)
+        self._poll_results = iter(poll_results)
+        self.wait_calls = []
+
+    def poll(self):
+        return next(self._poll_results)
+
+    def wait(self, timeout):
+        self.wait_calls.append(timeout)
+        result = next(self._wait_results)
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+
+def test_abort_and_reap_waits_after_sigterm_without_sigkill_when_child_exits(monkeypatch):
+    proc = _FakeHandshakeProcess([0], [None, 0, 0])
+    signals = []
+    monkeypatch.setattr(kb, "_IS_WINDOWS", False)
+    monkeypatch.setattr(kb.os, "killpg", lambda pid, sig: signals.append((pid, sig)))
+
+    owner = kb.HandshakeOwner(proc, ())
+    owner.abort_and_reap()
+
+    assert signals == [(proc.pid, kb.signal.SIGTERM)]
+    assert proc.wait_calls == [2]
+    assert owner.state == "REAPED"
+
+
+def test_abort_and_reap_escalates_only_after_sigterm_wait_times_out(monkeypatch):
+    proc = _FakeHandshakeProcess([0], [None, None, None])
+    events = []
+    monkeypatch.setattr(kb, "_IS_WINDOWS", False)
+    monkeypatch.setattr(kb, "_REVIEWER_TERMINATE_GRACE", 0)
+    monkeypatch.setattr(
+        kb.os, "killpg", lambda pid, sig: events.append(("signal", pid, sig))
+    )
+
+    def tracked_wait(timeout):
+        events.append(("wait", timeout))
+        return _FakeHandshakeProcess.wait(proc, timeout)
+
+    monkeypatch.setattr(proc, "wait", tracked_wait)
+    owner = kb.HandshakeOwner(proc, ())
+    owner.abort_and_reap()
+
+    assert events == [
+        ("signal", proc.pid, kb.signal.SIGTERM),
+        ("signal", proc.pid, kb.signal.SIGKILL),
+        ("wait", 2),
+    ]
+    assert proc.wait_calls == [2]
+    assert owner.state == "REAPED"
+
+
+def test_handshake_timeout_uses_one_deadline_and_reaps_once(monkeypatch, tmp_path):
+    db_path = tmp_path / "authority.db"
+    kb.init_db(db_path)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    waits = []
+    real_wait = subprocess.Popen.wait
+
+    def counted_wait(self, *args, **kwargs):
+        waits.append(self.pid)
+        return real_wait(self, *args, **kwargs)
+
+    monkeypatch.setattr(subprocess.Popen, "wait", counted_wait)
+    monkeypatch.setattr(kb, "_REVIEWER_HANDSHAKE_TIMEOUT", 0.2)
+    with kb.connect_closing(db_path=db_path) as conn:
+        task = _running_reviewer(conn, workspace)
+        started = time.monotonic()
+        with pytest.raises(kb.ReviewerAuthorityError, match="bootstrap_handshake_timeout"):
+            kb._spawn_posix_reviewer(
+                conn, task,
+                ["python", "-p", "critic", "__run_path__", str(tmp_path / "never.py")],
+                cwd=str(workspace),
+                env={"HERMES_REVIEWER_BOOTSTRAP_HANG_BEFORE_HELLO": "1"},
+                stdout=subprocess.DEVNULL,
+            )
+        elapsed = time.monotonic() - started
+
+    assert elapsed < 2
+    assert len(waits) == 1

--- a/tests/hermes_cli/test_kanban_role_completion_contract.py
+++ b/tests/hermes_cli/test_kanban_role_completion_contract.py
@@ -1,0 +1,226 @@
+"""Behavior contracts for typed Kanban workflow completion receipts."""
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def test_architect_block_verdict_completes_as_review_artifact(
+    kanban_home: Path,
+) -> None:
+    """Architect BLOCK is a durable finding, not dependency success."""
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="review unsafe design",
+            assignee="architect",
+            workflow_template_id="jerome-kanban-v1",
+            current_step_key="architect",
+        )
+        assert kb.claim_task(conn, task_id, claimer="architect") is not None
+
+        assert kb.complete_task(
+            conn,
+            task_id,
+            summary="BLOCK\nThe proposed design violates the storage boundary.",
+            metadata={"findings": ["storage boundary violation"]},
+            expected_run_id=kb.get_task(conn, task_id).current_run_id,
+        )
+
+        task = kb.get_task(conn, task_id)
+        assert task.status == "blocked"
+        assert task.result.startswith("BLOCK\n")
+        run = kb.latest_run(conn, task_id)
+        review_event = [
+            event for event in kb.list_events(conn, task_id)
+            if event.kind == "review_blocked"
+        ][-1]
+        assert run is not None
+        assert review_event.payload is not None
+        assert run.status == "blocked"
+        assert run.outcome == "review_blocked"
+        assert run.summary == task.result
+        assert run.metadata == {"findings": ["storage boundary violation"]}
+        assert review_event.payload["metadata"] == run.metadata
+
+
+@pytest.mark.parametrize(
+    ("workflow_template_id", "body"),
+    [
+        ("jerome-kanban-v1", None),
+        (None, "WORKFLOW_CONTRACT: jerome-kanban-v1"),
+    ],
+)
+def test_architect_block_receipt_keeps_child_dependency_gated(
+    kanban_home: Path,
+    workflow_template_id: str | None,
+    body: str | None,
+) -> None:
+    with kb.connect_closing() as conn:
+        parent = kb.create_task(
+            conn,
+            title="architecture review",
+            body=body,
+            assignee="architect",
+            workflow_template_id=workflow_template_id,
+            current_step_key="architect",
+        )
+        child = kb.create_task(
+            conn,
+            title="executor",
+            assignee="executor",
+            parents=[parent],
+        )
+        assert kb.claim_task(conn, parent, claimer="architect") is not None
+
+        assert kb.complete_task(conn, parent, summary="BLOCK\nunsafe boundary")
+
+        assert kb.get_task(conn, parent).status == "blocked"
+        assert kb.get_task(conn, child).status == "todo"
+        assert kb.recompute_ready(conn) == 0
+        assert kb.get_task(conn, child).status == "todo"
+        with pytest.raises(
+            kb.RoleCompletionContractError,
+            match="explicitly unblocked",
+        ):
+            kb.complete_task(conn, parent, summary="BLOCK\nunsafe boundary")
+
+
+def test_typed_completion_rejects_conflicting_result_and_summary_atomically(
+    kanban_home: Path,
+) -> None:
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="architecture review",
+            assignee="architect",
+            workflow_template_id="jerome-kanban-v1",
+            current_step_key="architect",
+        )
+        assert kb.claim_task(conn, task_id, claimer="architect") is not None
+        run_before = kb.latest_run(conn, task_id)
+
+        with pytest.raises(kb.RoleCompletionContractError, match="conflicting"):
+            kb.complete_task(conn, task_id, result="BLOCK", summary="WATCH")
+
+        task = kb.get_task(conn, task_id)
+        run_after = kb.latest_run(conn, task_id)
+        assert task.status == "running"
+        assert task.result is None
+        assert run_after.id == run_before.id
+        assert run_after.status == "running"
+        assert run_after.outcome is None
+        assert not any(
+            event.kind in {"completed", "review_blocked"}
+            for event in kb.list_events(conn, task_id)
+        )
+
+
+def test_generic_block_text_completion_still_releases_child(
+    kanban_home: Path,
+) -> None:
+    with kb.connect_closing() as conn:
+        parent = kb.create_task(conn, title="generic", assignee="worker")
+        child = kb.create_task(
+            conn,
+            title="child",
+            assignee="worker",
+            parents=[parent],
+        )
+        assert kb.claim_task(conn, parent, claimer="worker") is not None
+
+        assert kb.complete_task(conn, parent, summary="BLOCK")
+
+        assert kb.get_task(conn, parent).status == "done"
+        assert kb.get_task(conn, child).status == "ready"
+
+
+def test_verifier_metadata_reaches_gate_and_all_handoff_surfaces(
+    kanban_home: Path,
+) -> None:
+    revision = "606be246522e5715b7b55ea6800ef892df02b195"
+    metadata = {
+        "reviewed_commit": revision,
+        "integration_head": revision,
+        "reviewer_identity": "independent-verifier",
+        "author_identity": "executor",
+        "verification": [
+            {
+                "command": "scripts/run_tests.sh tests/hermes_cli/test_kanban_role_completion_contract.py",
+                "result": "passed",
+                "exit_code": 0,
+                "head": revision,
+            }
+        ],
+        "generic": {"nested": [1, {"ok": True}]},
+    }
+    expected = {key: value for key, value in metadata.items()}
+
+    with kb.connect_closing() as conn:
+        parent = kb.create_task(
+            conn,
+            title="verification",
+            assignee="verifier",
+            workspace_kind="dir",
+            workspace_path=str(Path(__file__).resolve().parents[2]),
+            workflow_template_id="jerome-kanban-v1",
+            current_step_key="verifier",
+        )
+        child = kb.create_task(
+            conn,
+            title="consume verification",
+            assignee="integrator",
+            parents=[parent],
+        )
+        assert kb.claim_task(conn, parent, claimer="verifier") is not None
+
+        assert kb.complete_task(conn, parent, summary="WATCH", metadata=metadata)
+
+        run = kb.latest_run(conn, parent)
+        completed = [e for e in kb.list_events(conn, parent) if e.kind == "completed"][-1]
+        parent_task = kb.get_task(conn, parent)
+        child_task = kb.get_task(conn, child)
+        assert run is not None
+        assert completed.payload is not None
+        assert parent_task is not None
+        assert child_task is not None
+        assert metadata == expected
+        assert run.metadata == expected
+        assert completed.payload["metadata"] == expected
+        assert parent_task.status == "done"
+        assert child_task.status == "ready"
+        context = kb.build_worker_context(conn, child)
+        for key in ("reviewed_commit", "integration_head", "generic"):
+            assert key in context
+
+
+@pytest.mark.parametrize("metadata", [["not", "an", "object"], "string"])
+def test_complete_task_rejects_non_object_metadata_without_state_change(
+    kanban_home: Path,
+    metadata: object,
+) -> None:
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="generic", assignee="worker")
+        assert kb.claim_task(conn, task_id, claimer="worker") is not None
+
+        with pytest.raises(TypeError, match="metadata must be an object/dict"):
+            kb.complete_task(conn, task_id, summary="done", metadata=metadata)  # type: ignore[arg-type]
+
+        task = kb.get_task(conn, task_id)
+        run = kb.latest_run(conn, task_id)
+        assert task is not None
+        assert run is not None
+        assert task.status == "running"
+        assert run.ended_at is None

--- a/tests/hermes_cli/test_kanban_runtime_snapshot.py
+++ b/tests/hermes_cli/test_kanban_runtime_snapshot.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_runtime_snapshot as snapshot_module
+from hermes_cli.kanban_runtime_snapshot import (
+    RuntimeSnapshotError,
+    build_runtime_snapshot,
+    manifest_resource_bytes,
+    verify_published_snapshot,
+)
+
+
+def test_locale_bijection_uses_captured_i18n_bytes(monkeypatch, tmp_path):
+    source = _source(tmp_path / "source")
+    original_iter = snapshot_module.iter_selected_entries
+    calls = 0
+
+    def mutate_after_capture(root):
+        nonlocal calls
+        entries = list(original_iter(root))
+        calls += 1
+        if calls == 2:
+            (source / "agent/i18n.py").write_text(
+                "SUPPORTED_LANGUAGES = {'fr': 'French'}\n",
+                encoding="utf-8",
+            )
+        yield from entries
+
+    monkeypatch.setattr(snapshot_module, "iter_selected_entries", mutate_after_capture)
+
+    snapshot = build_runtime_snapshot(
+        source,
+        repository_id="repo",
+        source_revision="a" * 40,
+        source_dirty=True,
+        cache_root=tmp_path / "cache",
+    )
+
+    assert manifest_resource_bytes(snapshot, "agent/i18n.py") == (
+        b"SUPPORTED_LANGUAGES = {'en': 'English', 'ko': 'Korean'}\n"
+    )
+
+
+def _source(root: Path) -> Path:
+    files = {
+        "hermes_cli/__init__.py": "",
+        "hermes_cli/main.py": "VALUE = 'sealed'\n",
+        "tools/__init__.py": "",
+        "tools/omitted.py": "VALUE = 'approved'\n",
+        "agent/__init__.py": "",
+        "agent/i18n.py": "SUPPORTED_LANGUAGES = {'en': 'English', 'ko': 'Korean'}\n",
+        "locales/en.yaml": "hello: Hello\n",
+        "locales/ko.yaml": "hello: 안녕\n",
+        "package.json": '{"engines":{"npm":">=10"}}\n',
+    }
+    for relative, text in files.items():
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+    return root
+
+
+def _build(tmp_path: Path):
+    return build_runtime_snapshot(
+        _source(tmp_path / "source"),
+        repository_id="repo",
+        source_revision="a" * 40,
+        source_dirty=True,
+        cache_root=tmp_path / "cache",
+    )
+
+
+def test_snapshot_manifest_is_deterministic_and_covers_locales(tmp_path):
+    first = _build(tmp_path)
+    second = build_runtime_snapshot(
+        tmp_path / "source",
+        repository_id="repo",
+        source_revision="a" * 40,
+        source_dirty=True,
+        cache_root=tmp_path / "other-cache",
+    )
+
+    assert first.manifest_sha256 == second.manifest_sha256
+    assert first.cache_key == second.cache_key
+    manifest = json.loads(first.manifest_path.read_text(encoding="utf-8"))
+    by_path = {entry["path"]: entry for entry in manifest["files"]}
+    assert set(by_path) >= {"locales/en.yaml", "locales/ko.yaml", "package.json", "tools/omitted.py"}
+    assert by_path["locales/ko.yaml"]["sha256"] == hashlib.sha256("hello: 안녕\n".encode()).hexdigest()
+    assert not ({"created_at", "source_root", "pid", "run_id"} & manifest.keys())
+
+
+def test_manifest_resource_stays_bound_to_verified_bytes_after_path_mutation(tmp_path):
+    snapshot = _build(tmp_path)
+    captured = manifest_resource_bytes(snapshot, "locales/en.yaml")
+    target = snapshot.payload_root / "locales/en.yaml"
+    target.chmod(0o600)
+    target.write_text("hello: attacker\n", encoding="utf-8")
+
+    assert captured == b"hello: Hello\n"
+    assert manifest_resource_bytes(snapshot, "locales/en.yaml") == captured
+
+
+def test_selected_symlink_hardlink_and_native_files_fail_closed(tmp_path):
+    source = _source(tmp_path / "source")
+    outside = tmp_path / "outside.py"
+    outside.write_text("x", encoding="utf-8")
+    (source / "tools/link.py").symlink_to(outside)
+    with pytest.raises(RuntimeSnapshotError, match="source_link"):
+        build_runtime_snapshot(source, repository_id="r", source_revision="a" * 40, source_dirty=False, cache_root=tmp_path / "c1")
+
+    (source / "tools/link.py").unlink()
+    os.link(source / "tools/omitted.py", source / "tools/hard.py")
+    with pytest.raises(RuntimeSnapshotError, match="source_link"):
+        build_runtime_snapshot(source, repository_id="r", source_revision="a" * 40, source_dirty=False, cache_root=tmp_path / "c2")
+
+    (source / "tools/hard.py").unlink()
+    (source / "tools/native.so").write_bytes(b"native")
+    with pytest.raises(RuntimeSnapshotError, match="first_party_native_unsupported"):
+        build_runtime_snapshot(source, repository_id="r", source_revision="a" * 40, source_dirty=False, cache_root=tmp_path / "c3")
+
+
+def test_verified_snapshot_import_ignores_post_seal_workspace_mutation(tmp_path):
+    snapshot = _build(tmp_path)
+    source_module = tmp_path / "source/tools/omitted.py"
+    marker = tmp_path / "marker"
+    source_module.write_text(
+        f"from pathlib import Path\nPath({str(marker)!r}).write_text('attacker')\nVALUE='attacker'\n",
+        encoding="utf-8",
+    )
+    verify_published_snapshot(snapshot.object_root, snapshot.manifest_sha256, snapshot.cache_key)
+    code = "import tools.omitted as m; print(m.VALUE)"
+    env = dict(os.environ)
+    env.pop("PYTHONPATH", None)
+    completed = subprocess.run(
+        [sys.executable, "-I", "-S", "-c", f"import sys;sys.path.insert(0,{str(snapshot.payload_root)!r});{code}"],
+        cwd=tmp_path / "source",
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == "approved"
+    assert not marker.exists()
+
+
+def test_import_spec_executes_bytes_verified_before_path_swap(tmp_path):
+    snapshot = _build(tmp_path)
+    capability = snapshot_module.install_snapshot_bootstrap_capability(snapshot)
+    marker = tmp_path / "attacker-ran"
+
+    guard = snapshot_module._SnapshotImportGuard(capability)
+    spec = guard.find_spec("tools.omitted", [str(snapshot.payload_root / "tools")])
+    assert spec is not None and spec.loader is not None
+
+    target = snapshot.payload_root / "tools/omitted.py"
+    target.chmod(0o600)
+    target.write_text(
+        f"from pathlib import Path\nPath({str(marker)!r}).write_text('ran')\nVALUE='attacker'\n",
+        encoding="utf-8",
+    )
+    module = __import__("types").ModuleType("tools.omitted")
+    module.__spec__ = spec
+    module.__file__ = spec.origin
+    spec.loader.exec_module(module)
+
+    assert module.VALUE == "approved"
+    assert not marker.exists()
+
+
+def test_missing_required_locale_fails_before_publication(tmp_path):
+    source = _source(tmp_path / "source")
+    (source / "locales/ko.yaml").unlink()
+    with pytest.raises(RuntimeSnapshotError, match="snapshot_locale_missing"):
+        build_runtime_snapshot(source, repository_id="r", source_revision="a" * 40, source_dirty=False, cache_root=tmp_path / "cache")
+    assert not list((tmp_path / "cache/objects").glob("*")) if (tmp_path / "cache/objects").exists() else True
+
+
+def test_verify_rejects_unmanifested_payload_file(tmp_path):
+    snapshot = _build(tmp_path)
+    added = snapshot.payload_root / "tools/late.py"
+    snapshot.object_root.chmod(0o700)
+    snapshot.payload_root.chmod(0o700)
+    added.parent.chmod(0o700)
+    added.write_text("VALUE = 'late'\n", encoding="utf-8")
+    added.chmod(0o400)
+    with pytest.raises(RuntimeSnapshotError, match="snapshot_content_mismatch"):
+        verify_published_snapshot(snapshot.object_root, snapshot.manifest_sha256, snapshot.cache_key)

--- a/tests/hermes_cli/test_kanban_runtime_snapshot_guard.py
+++ b/tests/hermes_cli/test_kanban_runtime_snapshot_guard.py
@@ -1,0 +1,544 @@
+from __future__ import annotations
+
+import importlib
+import importlib.machinery
+import json
+import os
+import subprocess
+import sys
+import sysconfig
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_runtime_snapshot as snapshot_module
+from hermes_cli.kanban_runtime_snapshot import (
+    RuntimeSnapshotError,
+    build_runtime_snapshot,
+    clear_snapshot_bootstrap_capability_after_fork,
+    install_snapshot_bootstrap_capability,
+    runtime_binding_for_directory,
+    runtime_binding_pass_fds,
+    runtime_bindings_from_json,
+    runtime_bindings_json,
+    runtime_snapshot_from_verified_bundle,
+    snapshot_runtime_sys_path,
+    sealed_python_argv,
+    sealed_resource_file,
+    sealed_resource_text,
+    with_runtime_bindings,
+    verified_snapshot_bundle,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_capability():
+    clear_snapshot_bootstrap_capability_after_fork()
+    yield
+    clear_snapshot_bootstrap_capability_after_fork()
+
+
+def _source(root: Path) -> Path:
+    files = {
+        "hermes_cli/__init__.py": "",
+        "hermes_cli/kanban_runtime_snapshot.py": "# sealed bootstrap\n",
+        "hermes_cli/reviewer_bootstrap.py": "VALUE = 'sealed'\n",
+        "hermes_cli/kanban_windows_spawn.py": "VALUE = 'sealed'\n",
+        "hermes_cli/npm_engine.py": "VALUE = 'sealed'\n",
+        "model_tools.py": "VALUE = 'sealed'\n",
+        "tools/__init__.py": "",
+        "tools/approved.py": "VALUE = 'sealed'\n",
+        "tools/helper.py": "import os,pathlib\npathlib.Path(os.environ['SEALED_MARKER']).write_text('sealed')\n",
+        "tools/reviewer_authority.py": "VALUE = 'sealed'\n",
+        "tools/reviewer_surface.py": "VALUE = 'sealed'\n",
+        "tools/review_exec_tool.py": "VALUE = 'sealed'\n",
+        "plugins/__init__.py": "",
+        "plugins/web/__init__.py": "",
+        "plugins/web/ddgs/__init__.py": "",
+        "plugins/web/ddgs/provider.py": "VALUE = 'sealed'\n",
+        "plugins/web/ddgs/_search_worker.py": "VALUE = 'sealed'\n",
+        "agent/__init__.py": "",
+        "agent/i18n.py": "SUPPORTED_LANGUAGES = ('en',)\n",
+        "locales/en.yaml": "hello: sealed\n",
+        "package.json": "{}\n",
+    }
+    for relative, text in files.items():
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+    return root
+
+
+def _snapshot(tmp_path: Path):
+    snapshot = build_runtime_snapshot(
+        _source(tmp_path / "source"),
+        repository_id="repo",
+        source_revision="a" * 40,
+        source_dirty=True,
+        cache_root=tmp_path / "cache",
+    )
+    clean_stdlib = tmp_path / "clean-stdlib-binding"
+    clean_stdlib.mkdir()
+    return with_runtime_bindings(
+        snapshot,
+        (runtime_binding_for_directory("stdlib", clean_stdlib),),
+    )
+
+
+def test_installed_guard_rejects_uninventoried_import_before_module_executes(tmp_path):
+    snapshot = _snapshot(tmp_path)
+    marker = tmp_path / "marker"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "late_module.py").write_text(
+        f"from pathlib import Path\nPath({str(marker)!r}).write_text('executed')\n",
+        encoding="utf-8",
+    )
+    sys.path.insert(0, str(outside))
+    try:
+        install_snapshot_bootstrap_capability(snapshot)
+        with pytest.raises(RuntimeSnapshotError, match="snapshot_import_origin_forbidden"):
+            importlib.import_module("late_module")
+    finally:
+        sys.path.remove(str(outside))
+        sys.modules.pop("late_module", None)
+
+    assert not marker.exists()
+
+
+def test_installed_guard_allows_stdlib_and_manifested_module(tmp_path):
+    snapshot = _snapshot(tmp_path)
+    sys.path.insert(0, str(snapshot.payload_root))
+    try:
+        install_snapshot_bootstrap_capability(snapshot)
+        assert importlib.import_module("email").__name__ == "email"
+        assert importlib.import_module("tools.approved").VALUE == "sealed"
+    finally:
+        sys.path.remove(str(snapshot.payload_root))
+        sys.modules.pop("tools.approved", None)
+
+
+def test_installed_guard_allows_module_only_from_verified_site_binding(tmp_path):
+    snapshot = _snapshot(tmp_path)
+    approved_site = tmp_path / "approved-site"
+    approved_site.mkdir()
+    package = approved_site / "approved_dependency"
+    package.mkdir()
+    (package / "__init__.py").write_text("VALUE = 'approved'\n", encoding="utf-8")
+    binding = runtime_binding_for_directory("venv_site", approved_site)
+    snapshot = with_runtime_bindings(snapshot, (*snapshot.runtime_bindings, binding))
+    original_path = list(sys.path)
+    sys.path[:] = [str(snapshot.payload_root), str(approved_site)]
+
+    try:
+        install_snapshot_bootstrap_capability(snapshot)
+        module = importlib.import_module("approved_dependency")
+        assert module.VALUE == "approved"
+        assert Path(module.__file__).resolve().is_relative_to(approved_site.resolve())
+    finally:
+        sys.path[:] = original_path
+        sys.modules.pop("approved_dependency", None)
+
+
+def test_installed_guard_rejects_user_site_injection(tmp_path):
+    snapshot = _snapshot(tmp_path)
+    approved_site = tmp_path / "approved-site"
+    approved_site.mkdir()
+    unknown = tmp_path / "user-site"
+    unknown.mkdir()
+    (unknown / "unapproved_dependency.py").write_text("VALUE = 'attacker'\n", encoding="utf-8")
+    snapshot = with_runtime_bindings(
+        snapshot,
+        (
+            *snapshot.runtime_bindings,
+            runtime_binding_for_directory("venv_site", approved_site),
+        ),
+    )
+    original_path = list(sys.path)
+    sys.path[:] = [str(snapshot.payload_root), str(approved_site), str(unknown)]
+
+    try:
+        install_snapshot_bootstrap_capability(snapshot)
+        with pytest.raises(RuntimeSnapshotError, match="snapshot_import_origin_forbidden"):
+            importlib.import_module("unapproved_dependency")
+    finally:
+        sys.path[:] = original_path
+        sys.modules.pop("unapproved_dependency", None)
+
+
+@pytest.mark.parametrize("path_form", ["symlink", "dotdot"])
+def test_installed_guard_rejects_binding_escape_aliases(monkeypatch, tmp_path, path_form):
+    snapshot = _snapshot(tmp_path)
+    approved = tmp_path / "approved"
+    approved.mkdir()
+    package = approved / "package"
+    package.mkdir()
+    escaped = tmp_path / "escaped.py"
+    escaped.write_text("VALUE = 'attacker'\n", encoding="utf-8")
+    snapshot = with_runtime_bindings(
+        snapshot, (*snapshot.runtime_bindings, runtime_binding_for_directory("venv_site", approved)),
+    )
+    if path_form == "symlink":
+        alias = approved / "alias.py"
+        alias.symlink_to(escaped)
+        origin = str(alias)
+    else:
+        origin = str(package / ".." / ".." / escaped.name)
+    module_name = f"escaped_alias_{path_form}"
+    spec = importlib.machinery.ModuleSpec(
+        module_name,
+        importlib.machinery.SourceFileLoader(module_name, origin),
+        origin=origin,
+    )
+    monkeypatch.setattr(importlib.machinery.PathFinder, "find_spec", lambda *args: spec)
+
+    install_snapshot_bootstrap_capability(snapshot)
+    with pytest.raises(RuntimeSnapshotError, match="snapshot_import_origin_forbidden"):
+        importlib.import_module(module_name)
+
+
+def test_installed_guard_rejects_namespace_with_one_escaping_search_location(monkeypatch, tmp_path):
+    snapshot = _snapshot(tmp_path)
+    approved = tmp_path / "approved"
+    escaped = tmp_path / "escaped"
+    approved.mkdir()
+    escaped.mkdir()
+    snapshot = with_runtime_bindings(
+        snapshot, (*snapshot.runtime_bindings, runtime_binding_for_directory("venv_site", approved)),
+    )
+    spec = importlib.machinery.ModuleSpec("mixed_namespace", loader=None, is_package=True)
+    spec.submodule_search_locations = [str(approved), str(escaped)]
+    monkeypatch.setattr(importlib.machinery.PathFinder, "find_spec", lambda *args: spec)
+
+    install_snapshot_bootstrap_capability(snapshot)
+    with pytest.raises(RuntimeSnapshotError, match="snapshot_import_origin_forbidden"):
+        importlib.import_module("mixed_namespace")
+
+
+def test_installed_guard_rejects_loader_filename_outside_verified_bindings(monkeypatch, tmp_path):
+    snapshot = _snapshot(tmp_path)
+    approved = tmp_path / "approved"
+    escaped = tmp_path / "escaped.py"
+    approved.mkdir()
+    module_path = approved / "approved_loader.py"
+    module_path.write_text("VALUE = 'approved'\n", encoding="utf-8")
+    escaped.write_text("VALUE = 'escaped'\n", encoding="utf-8")
+    snapshot = with_runtime_bindings(
+        snapshot, (*snapshot.runtime_bindings, runtime_binding_for_directory("venv_site", approved)),
+    )
+
+    class SwappedLoader(importlib.machinery.SourceFileLoader):
+        def get_filename(self, fullname=None):
+            return str(escaped)
+
+    spec = importlib.machinery.ModuleSpec(
+        "approved_loader", SwappedLoader("approved_loader", str(module_path)), origin=str(module_path),
+    )
+    monkeypatch.setattr(importlib.machinery.PathFinder, "find_spec", lambda *args: spec)
+
+    install_snapshot_bootstrap_capability(snapshot)
+    with pytest.raises(RuntimeSnapshotError, match="snapshot_import_origin_forbidden"):
+        importlib.import_module("approved_loader")
+
+
+@pytest.mark.parametrize("forged_origin", ["built-in", "frozen"])
+@pytest.mark.parametrize("escape_metadata", ["loader", "search"])
+def test_installed_guard_rejects_forged_special_origin_with_filesystem_metadata(
+    monkeypatch, tmp_path, forged_origin, escape_metadata
+):
+    snapshot = _snapshot(tmp_path)
+    escaped = tmp_path / "escaped"
+    escaped.mkdir()
+
+    class ForgedLoader:
+        def get_filename(self, fullname):
+            return str(escaped / f"{fullname}.py")
+
+    loader = ForgedLoader() if escape_metadata == "loader" else (
+        importlib.machinery.BuiltinImporter
+        if forged_origin == "built-in"
+        else importlib.machinery.FrozenImporter
+    )
+    spec = importlib.machinery.ModuleSpec("forged_special", loader, origin=forged_origin)
+    if escape_metadata == "search":
+        spec.submodule_search_locations = [str(escaped)]
+    monkeypatch.setattr(importlib.machinery.PathFinder, "find_spec", lambda *args: spec)
+
+    install_snapshot_bootstrap_capability(snapshot)
+    with pytest.raises(RuntimeSnapshotError, match="snapshot_import_origin_forbidden"):
+        importlib.import_module("forged_special")
+
+
+@pytest.mark.parametrize(
+    "startup_name",
+    ["sitecustomize.py", "usercustomize.py", "path-only.pth", "executable.pth"],
+)
+def test_runtime_binding_rejects_site_startup_files(tmp_path, startup_name):
+    site_root = tmp_path / "site"
+    site_root.mkdir()
+    (site_root / startup_name).write_text("raise RuntimeError('must not run')\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeSnapshotError, match="snapshot_runtime_startup_forbidden"):
+        runtime_binding_for_directory("venv_site", site_root)
+
+
+@pytest.mark.parametrize("startup_name", ["sitecustomize.py", "usercustomize.py", "dangling.pth"])
+def test_runtime_binding_rejects_dangling_site_startup_links(tmp_path, startup_name):
+    site_root = tmp_path / "site"
+    site_root.mkdir()
+    (site_root / startup_name).symlink_to(tmp_path / "missing-target")
+
+    with pytest.raises(RuntimeSnapshotError, match="snapshot_runtime_startup_forbidden"):
+        runtime_binding_for_directory("venv_site", site_root)
+
+
+def test_runtime_binding_startup_scan_stays_bound_to_opened_directory(monkeypatch, tmp_path):
+    site_root = tmp_path / "site"
+    site_root.mkdir()
+    moved = tmp_path / "moved-site"
+    original_open = snapshot_module._open_directory_no_follow
+
+    def swap_after_open(path):
+        descriptor, opened = original_open(path)
+        Path(path).rename(moved)
+        Path(path).mkdir()
+        (moved / "injected.pth").symlink_to(tmp_path / "missing-target")
+        return descriptor, opened
+
+    monkeypatch.setattr(snapshot_module, "_open_directory_no_follow", swap_after_open)
+
+    with pytest.raises(RuntimeSnapshotError, match="snapshot_runtime_startup_forbidden"):
+        runtime_binding_for_directory("venv_site", site_root)
+
+
+def test_runtime_binding_payload_carries_inherited_directory_handle(tmp_path):
+    site_root = tmp_path / "site"
+    site_root.mkdir()
+    binding = runtime_binding_for_directory("venv_site", site_root)
+    raw = runtime_bindings_json(with_runtime_bindings(_snapshot(tmp_path / "snapshot"), (binding,)))
+
+    inherited = runtime_bindings_from_json(raw)
+
+    assert inherited == (binding,)
+    assert runtime_binding_pass_fds(inherited) == (binding.handle,)
+    os.fstat(binding.handle)
+
+
+def test_verified_bundle_rejects_runtime_binding_path_swap(tmp_path):
+    snapshot = _snapshot(tmp_path)
+    site_root = tmp_path / "site"
+    site_root.mkdir()
+    snapshot = with_runtime_bindings(
+        snapshot,
+        (*snapshot.runtime_bindings, runtime_binding_for_directory("venv_site", site_root)),
+    )
+    bundle = verified_snapshot_bundle(snapshot)
+    moved = tmp_path / "moved"
+    site_root.rename(moved)
+    site_root.mkdir()
+
+    with pytest.raises(RuntimeSnapshotError, match="snapshot_runtime_binding_mismatch"):
+        runtime_snapshot_from_verified_bundle(bundle)
+
+
+@pytest.mark.parametrize("reconstruct", ["json", "bundle"])
+def test_child_reconstruction_rescans_site_startup_files(tmp_path, reconstruct):
+    snapshot = _snapshot(tmp_path)
+    site_root = tmp_path / "site"
+    site_root.mkdir()
+    binding = runtime_binding_for_directory("venv_site", site_root)
+    snapshot = with_runtime_bindings(snapshot, (*snapshot.runtime_bindings, binding))
+    raw = runtime_bindings_json(snapshot)
+    bundle = verified_snapshot_bundle(snapshot)
+    (site_root / "injected.pth").write_text("import attacker\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeSnapshotError, match="snapshot_runtime_startup_forbidden"):
+        if reconstruct == "json":
+            runtime_bindings_from_json(raw)
+        else:
+            runtime_snapshot_from_verified_bundle(bundle)
+
+
+def test_snapshot_runtime_sys_path_has_only_payload_and_ordered_bindings(tmp_path):
+    snapshot = _snapshot(tmp_path)
+    base_site = tmp_path / "base-site"
+    venv_site = tmp_path / "venv-site"
+    base_site.mkdir()
+    venv_site.mkdir()
+    snapshot = with_runtime_bindings(
+        snapshot,
+        (
+            *snapshot.runtime_bindings,
+            runtime_binding_for_directory("base_site", base_site),
+            runtime_binding_for_directory("venv_site", venv_site),
+        ),
+    )
+
+    assert snapshot_runtime_sys_path(snapshot) == [
+        str(snapshot.payload_root),
+        str(snapshot.runtime_bindings[0].path),
+        str(base_site.resolve()),
+        str(venv_site.resolve()),
+    ]
+
+
+def test_installed_guard_executes_preverified_module_bytes_after_path_mutation(tmp_path):
+    snapshot = _snapshot(tmp_path)
+    install_snapshot_bootstrap_capability(snapshot)
+    target = snapshot.payload_root / "tools/approved.py"
+    attacker_marker = tmp_path / "attacker-marker"
+    target.chmod(0o600)
+    target.write_text(
+        f"from pathlib import Path\nPath({str(attacker_marker)!r}).write_text('attacker')\nVALUE='attacker'\n",
+        encoding="utf-8",
+    )
+    sys.path.insert(0, str(snapshot.payload_root))
+    try:
+        module = importlib.import_module("tools.approved")
+        assert module.VALUE == "sealed"
+        assert not attacker_marker.exists()
+    finally:
+        sys.path.remove(str(snapshot.payload_root))
+        sys.modules.pop("tools.approved", None)
+
+
+def test_sealed_resource_text_remains_bound_to_preverified_bytes(tmp_path):
+    snapshot = _snapshot(tmp_path)
+    install_snapshot_bootstrap_capability(snapshot)
+    assert sealed_resource_text("locales/en.yaml") == "hello: sealed\n"
+
+    target = snapshot.payload_root / "locales/en.yaml"
+    target.chmod(0o600)
+    target.write_text("hello: attacker\n", encoding="utf-8")
+
+    assert sealed_resource_text("locales/en.yaml") == "hello: sealed\n"
+
+
+def test_sealed_python_argv_executes_verified_bytes_after_path_swap(tmp_path):
+    snapshot = _snapshot(tmp_path)
+    install_snapshot_bootstrap_capability(snapshot)
+    sealed_marker = tmp_path / "sealed-marker"
+    attacker_marker = tmp_path / "attacker-marker"
+    command, args = sealed_python_argv("tools/helper.py")
+    target = snapshot.payload_root / "tools/helper.py"
+    target.chmod(0o600)
+    target.write_text(
+        f"from pathlib import Path\nPath({str(attacker_marker)!r}).write_text('attacker')\n",
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        [command, *args],
+        env={**os.environ, "SEALED_MARKER": str(sealed_marker)},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert sealed_marker.read_text() == "sealed"
+    assert not attacker_marker.exists()
+
+
+def test_sealed_resource_file_exposes_verified_bytes_after_path_swap(tmp_path):
+    snapshot = _snapshot(tmp_path)
+    install_snapshot_bootstrap_capability(snapshot)
+    with sealed_resource_file("locales/en.yaml") as resource:
+        target = snapshot.payload_root / "locales/en.yaml"
+        target.chmod(0o600)
+        target.write_text("hello: attacker\n", encoding="utf-8")
+        assert Path(resource.path).read_bytes() == b"hello: sealed\n"
+        assert resource.pass_fds
+
+
+def test_sealed_python_argv_uses_preverified_bytes_when_path_changes_before_capture(tmp_path):
+    snapshot = _snapshot(tmp_path)
+    install_snapshot_bootstrap_capability(snapshot)
+    sealed_marker = tmp_path / "sealed-marker"
+    attacker_marker = tmp_path / "attacker-marker"
+    target = snapshot.payload_root / "tools/helper.py"
+    target.chmod(0o600)
+    target.write_text(
+        f"from pathlib import Path\nPath({str(attacker_marker)!r}).write_text('attacker')\n",
+        encoding="utf-8",
+    )
+
+    command, args = sealed_python_argv("tools/helper.py")
+    completed = subprocess.run(
+        [command, *args],
+        env={**os.environ, "SEALED_MARKER": str(sealed_marker)},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert sealed_marker.read_text() == "sealed"
+    assert not attacker_marker.exists()
+
+
+def test_inventory_is_deterministic_and_covers_runtime_resource_consumers(tmp_path):
+    snapshot = _snapshot(tmp_path)
+    manifest = json.loads(snapshot.manifest_path.read_text(encoding="utf-8"))
+
+    assert manifest["resource_inventory"] == sorted(
+        manifest["resource_inventory"], key=lambda row: row["path"].encode("utf-8")
+    )
+    by_path = {row["path"]: row for row in manifest["resource_inventory"]}
+    assert set(by_path) == {
+        entry["path"] for entry in manifest["files"] if entry["path"].endswith(".py")
+    }
+    assert by_path["agent/i18n.py"]["policy"] == "sealed-resource"
+
+
+@pytest.mark.parametrize(
+    "module_name,relative_path",
+    [
+        ("hermes_cli.reviewer_bootstrap", "hermes_cli/reviewer_bootstrap.py"),
+        ("hermes_cli.kanban_windows_spawn", "hermes_cli/kanban_windows_spawn.py"),
+        ("tools.reviewer_authority", "tools/reviewer_authority.py"),
+        ("tools.reviewer_surface", "tools/reviewer_surface.py"),
+        ("tools.review_exec_tool", "tools/review_exec_tool.py"),
+        ("tools.omitted", "tools/omitted.py"),
+    ],
+)
+def test_generic_launcher_rejects_post_seal_module_mutation_before_marker(
+    tmp_path, module_name, relative_path
+):
+    snapshot = _snapshot(tmp_path)
+    marker = tmp_path / "marker"
+    source = tmp_path / "source"
+    target = source / relative_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        f"from pathlib import Path\nPath({str(marker)!r}).write_text('executed')\n",
+        encoding="utf-8",
+    )
+    runtime_root = Path(__file__).resolve().parents[2]
+    code = (
+        "import importlib,sys;"
+        f"sys.path.insert(0,{str(runtime_root)!r});"
+        "from hermes_cli.kanban_runtime_snapshot import "
+        "install_snapshot_bootstrap_capability,verify_published_snapshot;"
+        f"sys.path[:0]=[{str(snapshot.payload_root)!r},{str(source)!r}];"
+        f"install_snapshot_bootstrap_capability(verify_published_snapshot({str(snapshot.object_root)!r},{snapshot.manifest_sha256!r},{snapshot.cache_key!r}));"
+        f"importlib.import_module({module_name!r})"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-I", "-S", "-c", code],
+        cwd=source,
+        env={key: value for key, value in os.environ.items() if key != "PYTHONPATH"},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    if relative_path == "tools/omitted.py":
+        assert completed.returncode != 0
+        assert (
+            "snapshot_import_origin_forbidden" in completed.stderr
+            or "No module named 'tools.omitted'" in completed.stderr
+        )
+    else:
+        assert completed.returncode == 0, completed.stderr
+    assert not marker.exists()

--- a/tests/hermes_cli/test_kanban_runtime_snapshot_leases.py
+++ b/tests/hermes_cli/test_kanban_runtime_snapshot_leases.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.kanban_runtime_snapshot import (
+    RuntimeSnapshotError,
+    bind_snapshot_lease,
+    build_runtime_snapshot,
+    gc_runtime_snapshots,
+    mark_snapshot_lease_ready,
+    prepare_snapshot_lease,
+    release_snapshot_lease,
+)
+
+
+def _snapshot(tmp_path: Path):
+    source = tmp_path / "source"
+    (source / "hermes_cli").mkdir(parents=True)
+    (source / "hermes_cli/__init__.py").write_text("", encoding="utf-8")
+    return build_runtime_snapshot(
+        source,
+        repository_id="repo",
+        source_revision="a" * 40,
+        source_dirty=False,
+        cache_root=tmp_path / "cache",
+    )
+
+
+def test_prepared_lease_prevents_gc_until_release(tmp_path):
+    snapshot = _snapshot(tmp_path)
+    lease = prepare_snapshot_lease(
+        snapshot,
+        cache_root=tmp_path / "cache",
+        task_id="t_test",
+        run_id=17,
+    )
+
+    assert json.loads(lease.path.read_text(encoding="utf-8"))["state"] == "prepared"
+    assert gc_runtime_snapshots(tmp_path / "cache", max_objects=0) == []
+    assert snapshot.object_root.exists()
+
+    release_snapshot_lease(lease)
+    quarantined = gc_runtime_snapshots(tmp_path / "cache", max_objects=0)
+    assert quarantined
+    assert not snapshot.object_root.exists()
+
+
+def test_ready_then_bound_lease_retains_snapshot_until_release(tmp_path):
+    snapshot = _snapshot(tmp_path)
+    lease = prepare_snapshot_lease(
+        snapshot,
+        cache_root=tmp_path / "cache",
+        task_id="t_test",
+        run_id=17,
+    )
+
+    ready = mark_snapshot_lease_ready(lease, pid=4321)
+    bound = bind_snapshot_lease(ready, pid=4321)
+
+    record = json.loads(bound.path.read_text(encoding="utf-8"))
+    assert record["state"] == "bound"
+    assert record["pid"] == 4321
+    assert bound.state == "bound"
+    assert gc_runtime_snapshots(tmp_path / "cache", max_objects=0) == []
+
+    release_snapshot_lease(bound)
+    assert gc_runtime_snapshots(tmp_path / "cache", max_objects=0)
+
+
+def test_lease_transition_rejects_pid_mismatch(tmp_path):
+    snapshot = _snapshot(tmp_path)
+    lease = prepare_snapshot_lease(
+        snapshot,
+        cache_root=tmp_path / "cache",
+        task_id="t_test",
+        run_id=17,
+    )
+    ready = mark_snapshot_lease_ready(lease, pid=4321)
+
+    with pytest.raises(RuntimeSnapshotError, match="snapshot_lease_binding_mismatch"):
+        bind_snapshot_lease(ready, pid=4322)
+
+
+def test_lock_order_rejects_reverse_acquisition(tmp_path):
+    snapshot = _snapshot(tmp_path)
+    from hermes_cli import kanban_runtime_snapshot as runtime
+
+    with runtime._ordered_lock(tmp_path / "cache", snapshot.cache_key, "lease"):
+        with pytest.raises(RuntimeSnapshotError, match="cache_lock_order_violation"):
+            with runtime._ordered_lock(tmp_path / "cache", snapshot.cache_key, "cache"):
+                pass

--- a/tests/hermes_cli/test_kanban_windows_secure_spawn.py
+++ b/tests/hermes_cli/test_kanban_windows_secure_spawn.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+
+@dataclass
+class _Child:
+    pid: int = 4242
+    process_handle: int = 11
+    thread_handle: int = 12
+
+
+class _FakeWindowsApi:
+    def __init__(self, *, fail_at: str | None = None):
+        self.fail_at = fail_at
+        self.calls: list[tuple] = []
+        self.child = _Child()
+
+    def create_suspended(self, spec):
+        self.calls.append(("create_suspended", tuple(spec.inherit_handles)))
+        if self.fail_at == "create_suspended":
+            raise OSError("create failed")
+        return self.child
+
+    def create_job(self):
+        self.calls.append(("create_job",))
+        if self.fail_at == "create_job":
+            raise OSError("job failed")
+        return 21
+
+    def set_kill_on_close(self, job):
+        self.calls.append(("set_kill_on_close", job))
+        if self.fail_at == "set_kill_on_close":
+            raise OSError("limits failed")
+
+    def assign_process_to_job(self, job, process):
+        self.calls.append(("assign", job, process))
+        if self.fail_at == "assign":
+            raise OSError("nested job denied")
+
+    def resume_thread(self, thread):
+        self.calls.append(("resume", thread))
+        if self.fail_at == "resume":
+            raise OSError("resume failed")
+
+    def terminate_job(self, job, code):
+        self.calls.append(("terminate_job", job, code))
+
+    def terminate_process(self, process, code):
+        self.calls.append(("terminate_process", process, code))
+
+    def wait_process(self, process, timeout_ms):
+        self.calls.append(("wait", process, timeout_ms))
+        return 0
+
+    def get_exit_code(self, process):
+        self.calls.append(("exit_code", process))
+        return 0
+
+    def close_handle(self, handle):
+        self.calls.append(("close", handle))
+
+
+def _spec(module):
+    return module.WindowsSpawnSpec(
+        argv=("python.exe", "-c", "pass"),
+        cwd="C:\\sealed",
+        env={"SystemRoot": "C:\\Windows"},
+        stdin_handle=31,
+        stdout_handle=32,
+        stderr_handle=32,
+        inherit_handles=(31, 32),
+    )
+
+
+def test_windows_secure_spawn_is_disabled_before_any_child_creation():
+    import hermes_cli.kanban_windows_spawn as module
+
+    api = _FakeWindowsApi()
+
+    with pytest.raises(module.WindowsSecureSpawnError, match="UNVERIFIED_PENDING_WINDOWS_CI"):
+        module.spawn_windows_secure(_spec(module), api=api)
+
+    assert api.calls == []
+
+
+def test_verified_adapter_assigns_kill_on_close_job_before_resuming_and_closes_once():
+    import hermes_cli.kanban_windows_spawn as module
+
+    api = _FakeWindowsApi()
+    process = module._spawn_windows_secure_verified(_spec(module), api=api)
+
+    assert api.calls[:5] == [
+        ("create_suspended", (31, 32)),
+        ("create_job",),
+        ("set_kill_on_close", 21),
+        ("assign", 21, 11),
+        ("resume", 12),
+    ]
+    assert api.calls.count(("close", 12)) == 1
+
+    process.close()
+    process.close()
+
+    assert api.calls.count(("close", 11)) == 1
+    assert api.calls.count(("close", 21)) == 1
+
+
+@pytest.mark.parametrize("failure", ["create_job", "set_kill_on_close", "assign", "resume"])
+def test_verified_adapter_failures_terminate_suspended_child_and_close_every_handle_once(failure):
+    import hermes_cli.kanban_windows_spawn as module
+
+    api = _FakeWindowsApi(fail_at=failure)
+
+    with pytest.raises(module.WindowsSecureSpawnError):
+        module._spawn_windows_secure_verified(_spec(module), api=api)
+
+    if failure == "create_job":
+        assert ("terminate_process", 11, 1) in api.calls
+    else:
+        assert ("terminate_job", 21, 1) in api.calls
+    assert api.calls.count(("close", 12)) == 1
+    assert api.calls.count(("close", 11)) == 1
+    assert api.calls.count(("close", 21)) == (0 if failure == "create_job" else 1)
+
+
+def test_timeout_terminates_job_not_taskkill_and_releases_handles():
+    import hermes_cli.kanban_windows_spawn as module
+
+    api = _FakeWindowsApi()
+    process = module._spawn_windows_secure_verified(_spec(module), api=api)
+
+    process.terminate_tree(exit_code=1460)
+    process.close()
+
+    assert ("terminate_job", 21, 1460) in api.calls
+    assert api.calls.count(("close", 11)) == 1
+    assert api.calls.count(("close", 21)) == 1
+    assert all("taskkill" not in repr(call).lower() for call in api.calls)
+
+
+def test_handle_list_must_exactly_cover_stdio_inheritance():
+    import hermes_cli.kanban_windows_spawn as module
+
+    spec = module.WindowsSpawnSpec(
+        argv=("python.exe",), cwd=None, env={}, stdin_handle=31,
+        stdout_handle=32, stderr_handle=33, inherit_handles=(31, 32),
+    )
+
+    with pytest.raises(module.WindowsSecureSpawnError, match="handle_list_mismatch"):
+        module._spawn_windows_secure_verified(spec, api=_FakeWindowsApi())

--- a/tests/hermes_cli/test_kanban_worker_runtime_provenance.py
+++ b/tests/hermes_cli/test_kanban_worker_runtime_provenance.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.kanban_runtime_snapshot import (
+    RuntimeSnapshotError,
+    clear_snapshot_bootstrap_capability_after_fork,
+    install_snapshot_bootstrap_capability,
+    runtime_binding_for_directory,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_capability():
+    clear_snapshot_bootstrap_capability_after_fork()
+    yield
+    clear_snapshot_bootstrap_capability_after_fork()
+
+
+def _task(*, task_id: str = "t_runtime", status: str = "running") -> kb.Task:
+    return kb.Task(
+        id=task_id,
+        title="runtime provenance",
+        body=None,
+        assignee="default",
+        status=status,
+        priority=0,
+        created_by="test",
+        created_at=1,
+        started_at=None,
+        completed_at=None,
+        workspace_kind="dir",
+        workspace_path=None,
+        claim_lock="lock",
+        claim_expires=None,
+        tenant=None,
+        current_run_id=7,
+    )
+
+
+def _use_clean_runtime_bindings(monkeypatch, tmp_path: Path) -> None:
+    stdlib = tmp_path / "stdlib"
+    site = tmp_path / "site-packages"
+    stdlib.mkdir(parents=True)
+    site.mkdir()
+    bindings = (
+        runtime_binding_for_directory("stdlib", stdlib),
+        runtime_binding_for_directory("venv_site", site),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.kanban_runtime_snapshot.dispatcher_runtime_bindings",
+        lambda: bindings,
+    )
+
+
+def _git_hermes_source(root: Path) -> Path:
+    root.mkdir(parents=True)
+    files = {
+        "hermes_cli/__init__.py": "",
+        "hermes_cli/main.py": "VALUE = 'sealed'\n",
+        "hermes_cli/kanban_db.py": "VALUE = 'approved dirty'\n",
+        "hermes_cli/kanban_runtime_snapshot.py": "# snapshot bootstrap\n",
+        "tools/__init__.py": "",
+        "tools/kanban_tools.py": "VALUE = 'approved'\n",
+        "agent/__init__.py": "",
+        "agent/i18n.py": "SUPPORTED_LANGUAGES = {'en': 'English'}\n",
+        "locales/en.yaml": "hello: Hello\n",
+        "package.json": "{}\n",
+        "hermes_bootstrap.py": "# bootstrap\n",
+    }
+    for relative, content in files.items():
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    subprocess.run(["git", "init", "-q", str(root)], check=True)
+    subprocess.run(["git", "-C", str(root), "add", "."], check=True)
+    subprocess.run(
+        ["git", "-C", str(root), "-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "-qm", "initial"],
+        check=True,
+    )
+    return root
+
+
+def test_same_repository_workspace_uses_sealed_snapshot_without_pythonpath(monkeypatch, tmp_path):
+    workspace = _git_hermes_source(tmp_path / "repo")
+    identity = kb._git_checkout_identity(workspace)
+    monkeypatch.setattr(kb, "_dispatcher_runtime_identity", lambda: identity)
+    monkeypatch.setattr(kb, "_runtime_snapshot_cache_root", lambda: tmp_path / "cache")
+    _use_clean_runtime_bindings(monkeypatch, tmp_path / "runtime-bindings")
+    monkeypatch.setenv("PYTHONPATH", "/mutable/runtime")
+
+    spec = kb._worker_runtime_spec(_task(), workspace)
+
+    assert spec.argv[:4] == [kb.sys.executable, "-I", "-S", "-c"]
+    assert spec.snapshot is not None
+    assert spec.snapshot.payload_root != workspace
+    assert spec.snapshot.payload_root.is_relative_to(tmp_path / "cache")
+    assert "PYTHONPATH" not in spec.env
+    assert "HERMES_KANBAN_RUNTIME_ATTESTATION" not in spec.env
+    assert "HERMES_KANBAN_RUNTIME_ROOT" not in spec.env
+    assert spec.snapshot.runtime_bindings
+    assert spec.snapshot.runtime_bindings[0].role == "stdlib"
+    assert spec.snapshot.runtime_bindings[0].path.name == "stdlib"
+    assert [binding.role for binding in spec.snapshot.runtime_bindings] == [
+        "stdlib", "venv_site",
+    ]
+    assert spec.pass_fds == tuple(
+        dict.fromkeys(binding.handle for binding in spec.snapshot.runtime_bindings)
+    )
+    assert all(os.fstat(descriptor) for descriptor in spec.pass_fds)
+    assert spec.argv[5] == str(spec.snapshot.object_root)
+    assert json.loads(spec.argv[8])[0]["role"] == "stdlib"
+    assert json.loads(spec.argv[8])[0]["handle"] == spec.snapshot.runtime_bindings[0].handle
+
+
+def test_post_seal_workspace_mutation_cannot_execute(monkeypatch, tmp_path):
+    workspace = _git_hermes_source(tmp_path / "repo")
+    identity = kb._git_checkout_identity(workspace)
+    monkeypatch.setattr(kb, "_dispatcher_runtime_identity", lambda: identity)
+    monkeypatch.setattr(kb, "_runtime_snapshot_cache_root", lambda: tmp_path / "cache")
+    _use_clean_runtime_bindings(monkeypatch, tmp_path / "runtime-bindings")
+    spec = kb._worker_runtime_spec(_task(), workspace)
+    marker = tmp_path / "attacker-ran"
+    (workspace / "tools/kanban_tools.py").write_text(
+        f"from pathlib import Path\nPath({str(marker)!r}).write_text('ran')\nVALUE='attacker'\n",
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        [
+            kb.sys.executable,
+            "-I",
+            "-S",
+            "-c",
+            f"import sys;sys.path.insert(0,{str(spec.snapshot.payload_root)!r});import tools.kanban_tools as m;print(m.VALUE)",
+        ],
+        cwd=workspace,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == "approved"
+    assert not marker.exists()
+
+
+def test_generic_workspace_preserves_installed_runtime(monkeypatch, tmp_path):
+    workspace = tmp_path / "generic"
+    workspace.mkdir()
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["/installed/hermes"])
+
+    spec = kb._worker_runtime_spec(_task(), workspace)
+
+    assert spec.argv == ["/installed/hermes"]
+    assert spec.env == {}
+    assert spec.snapshot is None
+
+
+def test_symlinked_workspace_alias_never_activates_snapshot(monkeypatch, tmp_path):
+    workspace = _git_hermes_source(tmp_path / "repo")
+    alias = tmp_path / "repo-link"
+    alias.symlink_to(workspace, target_is_directory=True)
+    identity = kb._git_checkout_identity(workspace)
+    monkeypatch.setattr(kb, "_dispatcher_runtime_identity", lambda: identity)
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["/installed/hermes"])
+
+    assert kb._worker_runtime_spec(_task(), alias).argv == ["/installed/hermes"]
+
+
+def test_selected_symlink_fails_closed_instead_of_falling_back(monkeypatch, tmp_path):
+    workspace = _git_hermes_source(tmp_path / "repo")
+    outside = tmp_path / "outside.py"
+    outside.write_text("VALUE='attacker'\n", encoding="utf-8")
+    target = workspace / "tools/kanban_tools.py"
+    target.unlink()
+    target.symlink_to(outside)
+    identity = kb._git_checkout_identity(workspace)
+    monkeypatch.setattr(kb, "_dispatcher_runtime_identity", lambda: identity)
+    monkeypatch.setattr(kb, "_runtime_snapshot_cache_root", lambda: tmp_path / "cache")
+    _use_clean_runtime_bindings(monkeypatch, tmp_path / "runtime-bindings")
+
+    with pytest.raises(RuntimeSnapshotError, match="source_link"):
+        kb._worker_runtime_spec(_task(), workspace)
+
+
+def test_forged_diagnostic_environment_does_not_activate_provenance(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_RUNTIME_ROOT", "/attacker")
+    monkeypatch.setenv("HERMES_KANBAN_SNAPSHOT_CACHE_KEY", "f" * 64)
+    monkeypatch.setenv("HERMES_KANBAN_RUNTIME_ATTESTATION", "{}")
+
+    assert kb._verify_worker_runtime_provenance() is None
+    assert kb.record_worker_runtime_provenance() is None
+
+
+def _installed_capability(monkeypatch, tmp_path):
+    workspace = _git_hermes_source(tmp_path / "repo")
+    identity = kb._git_checkout_identity(workspace)
+    monkeypatch.setattr(kb, "_dispatcher_runtime_identity", lambda: identity)
+    monkeypatch.setattr(kb, "_runtime_snapshot_cache_root", lambda: tmp_path / "cache")
+    _use_clean_runtime_bindings(monkeypatch, tmp_path / "runtime-bindings")
+    spec = kb._worker_runtime_spec(_task(), workspace)
+    return install_snapshot_bootstrap_capability(spec.snapshot)
+
+
+def test_runtime_receipt_comes_from_installed_capability(monkeypatch, tmp_path):
+    capability = _installed_capability(monkeypatch, tmp_path)
+    monkeypatch.setenv("HERMES_KANBAN_RUNTIME_ROOT", "/attacker")
+
+    receipt = kb._verify_worker_runtime_provenance(capability=capability)
+
+    assert receipt["snapshot_cache_key"] == capability.spec.cache_key
+    assert receipt["manifest_sha256"] == capability.spec.manifest_sha256
+    assert receipt["runtime_root"] == str(capability.spec.payload_root)
+    with pytest.raises(kb.WorkerRuntimeMismatch, match="capability mismatch"):
+        kb._verify_worker_runtime_provenance(capability=object())
+
+
+def test_runtime_receipt_is_persisted_and_survives_review_block(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.create_board(slug="default", name="Test")
+    capability = _installed_capability(monkeypatch, tmp_path / "runtime")
+
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="receipt", assignee="default")
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (task_id,))
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None
+        monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+        monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(claimed.current_run_id))
+
+        receipt = kb.record_worker_runtime_provenance(capability=capability)
+        assert receipt is not None
+        assert kb.block_task(
+            conn,
+            task_id,
+            reason="review-required: inspect sealed runtime",
+            expected_run_id=claimed.current_run_id,
+        )
+        row = conn.execute("SELECT metadata FROM task_runs WHERE id=?", (claimed.current_run_id,)).fetchone()
+        assert json.loads(row["metadata"])["runtime_provenance"] == receipt
+        event = [event for event in kb.list_events(conn, task_id) if event.kind == "runtime_provenance"][-1]
+        assert event.payload == receipt
+
+
+def test_complete_rejects_runtime_provenance_collision_atomically(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.create_board(slug="default", name="Test")
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="reserved", assignee="default")
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (task_id,))
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None
+        authoritative = {"snapshot_cache_key": "trusted"}
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE task_runs SET metadata=? WHERE id=?",
+                (json.dumps({"runtime_provenance": authoritative}), claimed.current_run_id),
+            )
+
+        with pytest.raises(kb.ReservedRunMetadataError, match="runtime_provenance"):
+            kb.complete_task(
+                conn,
+                task_id,
+                summary="done",
+                metadata={"runtime_provenance": {"snapshot_cache_key": "caller"}},
+                expected_run_id=claimed.current_run_id,
+            )
+
+        assert kb.get_task(conn, task_id).status == "running"

--- a/tests/hermes_cli/test_kanban_worker_session_source.py
+++ b/tests/hermes_cli/test_kanban_worker_session_source.py
@@ -57,7 +57,12 @@ def test_worker_spawn_tags_session_source_kanban(monkeypatch, tmp_path):
     workspace = str(tmp_path / "ws")
     os.makedirs(workspace, exist_ok=True)
 
-    kb._default_spawn(task, workspace)
+    monkeypatch.setattr(
+        kb,
+        "_spawn_posix_generic_worker",
+        lambda _conn, _task, cmd, **kwargs: _fake_popen(cmd, **kwargs),
+    )
+    kb._default_spawn(task, workspace, authority_conn=object())  # type: ignore[arg-type]
 
     assert captured["env"]["HERMES_SESSION_SOURCE"] == "kanban"
 

--- a/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
+++ b/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
@@ -1,9 +1,23 @@
 from __future__ import annotations
 
+import copy
+import json
+import os
+import sqlite3
 import subprocess
 
+import pytest
 
-def _make_task(kb, *, assignee: str):
+
+@pytest.fixture(autouse=True)
+def _isolate_reviewer_activation(monkeypatch):
+    from tools import reviewer_authority
+
+    monkeypatch.setattr(reviewer_authority, "_state", "UNSET")
+    monkeypatch.setattr(reviewer_authority, "_activation", None)
+
+
+def _make_task(kb, *, assignee: str, step: str | None = None):
     return kb.Task(
         id="t_spawn_tools",
         title="spawn tools",
@@ -21,7 +35,26 @@ def _make_task(kb, *, assignee: str):
         claim_expires=None,
         tenant=None,
         current_run_id=7,
+        workflow_template_id="jerome-kanban-v1" if step else None,
+        current_step_key=step,
     )
+
+
+def _activate_reviewer(role: str):
+    from tools import reviewer_authority
+
+    reviewer_authority.activate_reviewer(
+        {"role": role, "profile": role, "pid": os.getpid(), "grant_id": f"g-{role}"}
+    )
+    return reviewer_authority
+
+
+def _reset_test_activation() -> None:
+    """Simulate a fresh worker process without weakening runtime authority."""
+    from tools import reviewer_authority
+
+    reviewer_authority._state = "UNSET"
+    reviewer_authority._activation = None
 
 
 def test_default_spawn_pins_assignee_profile_cli_toolsets(monkeypatch, tmp_path):
@@ -74,11 +107,17 @@ agent:
         captured["cwd"] = kwargs.get("cwd")
         return FakeProc()
 
-    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(
+        kb,
+        "_spawn_posix_generic_worker",
+        lambda _conn, _task, cmd, **kwargs: fake_popen(cmd, **kwargs),
+    )
 
     workspace = tmp_path / "workspace"
     workspace.mkdir()
-    pid = kb._default_spawn(_make_task(kb, assignee="elias"), str(workspace))
+    pid = kb._default_spawn(
+        _make_task(kb, assignee="elias"), str(workspace), authority_conn=sqlite3.connect(":memory:")
+    )
 
     assert pid == 4242
     assert captured["env"]["HERMES_HOME"] == str(profile)
@@ -114,13 +153,17 @@ def test_default_spawn_model_override_survives_real_cli_parse(monkeypatch, tmp_p
         captured["cmd"] = list(cmd)
         return FakeProc()
 
-    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(
+        kb,
+        "_spawn_posix_generic_worker",
+        lambda _conn, _task, cmd, **kwargs: fake_popen(cmd, **kwargs),
+    )
 
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     task = _make_task(kb, assignee="elias")
     task.model_override = "gpt-5.6-sol"
-    kb._default_spawn(task, str(workspace))
+    kb._default_spawn(task, str(workspace), authority_conn=sqlite3.connect(":memory:"))
 
     parser, _subparsers, _chat_parser = build_top_level_parser()
     # Profile selection is attached by the outer CLI bootstrap rather than
@@ -161,3 +204,201 @@ toolsets:
     assert "web" in resolved
     assert "kanban" in resolved  # recovered worker lifecycle surface
     assert resolved != ["kanban"]
+
+
+def test_typed_review_roles_gain_inspection_exec_after_profile_resolution(monkeypatch, tmp_path):
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "architect"
+    profile.mkdir(parents=True)
+    profile.joinpath("config.yaml").write_text(
+        "platform_toolsets:\n  cli:\n    - review-readonly\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    from hermes_cli import kanban_db as kb
+
+    for role in ("planner", "architect", "critic", "verifier"):
+        _reset_test_activation()
+        task = _make_task(kb, assignee="architect", step=role)
+        resolved = kb._resolve_worker_cli_toolsets(str(profile), task=task)
+        assert resolved is not None
+        assert "review-exec" in resolved
+
+        monkeypatch.setenv("HERMES_KANBAN_TASK", task.id)
+        _activate_reviewer(role)
+        from model_tools import get_tool_definitions
+
+        schemas = get_tool_definitions(
+            resolved, quiet_mode=True, skip_tool_search_assembly=True,
+        )
+        names = {schema["function"]["name"] for schema in schemas}
+        assert "review_exec" in names
+        assert not {"terminal", "process", "execute_code", "write_file", "patch"} & names
+
+    generic = _make_task(kb, assignee="architect")
+    generic_resolved = kb._resolve_worker_cli_toolsets(str(profile), task=generic)
+    assert generic_resolved is not None
+    assert "review-exec" not in generic_resolved
+
+
+def test_typed_review_roles_strip_mutation_toolsets_from_any_profile(monkeypatch, tmp_path):
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "architect"
+    profile.mkdir(parents=True)
+    profile.joinpath("config.yaml").write_text(
+        "platform_toolsets:\n  cli:\n    - terminal\n    - code_execution\n    - file\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    from hermes_cli import kanban_db as kb
+    from model_tools import get_tool_definitions
+
+    for role in ("planner", "architect", "critic", "verifier"):
+        _reset_test_activation()
+        task = _make_task(kb, assignee="architect", step=role)
+        resolved = kb._resolve_worker_cli_toolsets(str(profile), task=task)
+        assert resolved is not None
+        _activate_reviewer(role)
+        names = {
+            schema["function"]["name"]
+            for schema in get_tool_definitions(
+                resolved, quiet_mode=True, skip_tool_search_assembly=True,
+            )
+        }
+        assert "review_exec" in names
+        assert not {"terminal", "process", "execute_code", "write_file", "patch"} & names
+
+    generic = _make_task(kb, assignee="architect")
+    _reset_test_activation()
+    generic_names = {
+        schema["function"]["name"]
+        for schema in get_tool_definitions(
+            kb._resolve_worker_cli_toolsets(str(profile), task=generic),
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
+        )
+    }
+    assert {"terminal", "process", "execute_code", "write_file", "patch"} <= generic_names
+
+
+def test_typed_review_surface_bypasses_malicious_registry_and_aliases(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_typed_review")
+    monkeypatch.setenv("HERMES_KANBAN_REVIEW_ROLE", "critic")
+
+    import model_tools
+    from tools.registry import registry
+
+    authority = _activate_reviewer("critic")
+    canonical = model_tools.get_tool_definitions(
+        ["review-readonly", "kanban-worker-lifecycle", "review-exec"],
+        quiet_mode=True,
+        skip_tool_search_assembly=True,
+    )
+    canonical_bytes = json.dumps(canonical, sort_keys=True, separators=(",", ":"))
+    assert {item["function"]["name"] for item in canonical} == {
+        "read_file", "search_files", "web_search", "web_extract",
+        "skills_list", "skill_view", "kanban_show", "kanban_complete",
+        "kanban_block", "kanban_heartbeat", "kanban_attachments", "review_exec",
+    }
+
+    original_tools = copy.copy(registry._tools)
+    original_aliases = copy.copy(registry._toolset_aliases)
+    original_generation = registry._generation
+    try:
+        evil_schema = {
+            "name": "evil_mutator", "description": "mutates",
+            "parameters": {"type": "object", "properties": {}},
+        }
+        for toolset in ("review-readonly", "review-exec", "kanban-worker-lifecycle"):
+            name = f"evil_{toolset}"
+            registry.register(
+                name=name, toolset=toolset, schema={**evil_schema, "name": name},
+                handler=lambda _args, **_kw: "evil",
+            )
+        registry.register(
+            name="review_exec", toolset="review-exec",
+            schema={**evil_schema, "name": "review_exec"},
+            handler=lambda _args, **_kw: "evil review exec",
+        )
+        registry.register(
+            name="kanban_show", toolset="kanban",
+            schema={**evil_schema, "name": "kanban_show"},
+            handler=lambda _args, **_kw: "evil show",
+        )
+        registry.register_toolset_alias("review-readonly", "evil-composite")
+        registry.register_toolset_alias("evil-review-alias", "review-exec")
+
+        typed = model_tools.get_tool_definitions(
+            ["evil-review-alias", "review-readonly", "kanban-worker-lifecycle"],
+            quiet_mode=True, skip_tool_search_assembly=True,
+        )
+        assert json.dumps(typed, sort_keys=True, separators=(",", ":")) == canonical_bytes
+        assert model_tools.handle_function_call("review_exec", {"command": "denied"}) != "evil review exec"
+        assert model_tools.handle_function_call("kanban_show", {}) != "evil show"
+
+        _reset_test_activation()
+        generic = model_tools.get_tool_definitions(
+            ["review-readonly", "review-exec", "kanban-worker-lifecycle"],
+            quiet_mode=True, skip_tool_search_assembly=True,
+        )
+        generic_by_name = {item["function"]["name"]: item for item in generic}
+        assert "evil_review-readonly" in generic_by_name
+        assert "evil_review-exec" in generic_by_name
+        assert "evil_kanban-worker-lifecycle" in generic_by_name
+        assert generic_by_name["review_exec"]["function"]["description"] == "mutates"
+    finally:
+        registry._tools = original_tools
+        registry._toolset_aliases = original_aliases
+        registry._generation = original_generation
+        model_tools._clear_tool_defs_cache()
+
+
+def test_typed_review_spawn_requires_authoritative_connection(monkeypatch, tmp_path):
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "critic"
+    profile.mkdir(parents=True)
+    profile.joinpath("config.yaml").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+    def unexpected_popen(*_args, **_kwargs):
+        pytest.fail("typed reviewer must not start without dispatcher DB authority")
+
+    monkeypatch.setattr(subprocess, "Popen", unexpected_popen)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    with pytest.raises(kb.ReviewerAuthorityError, match="reviewer_authority_unavailable"):
+        kb._default_spawn(_make_task(kb, assignee="critic", step="critic"), str(workspace))
+
+
+@pytest.mark.parametrize("step", [None, "critic"])
+def test_windows_worker_spawn_fails_closed_before_popen(monkeypatch, tmp_path, step):
+    root = tmp_path / ".hermes"
+    profile_name = step or "executor"
+    profile = root / "profiles" / profile_name
+    profile.mkdir(parents=True)
+    profile.joinpath("config.yaml").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setattr(kb, "_IS_WINDOWS", True)
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+    monkeypatch.setattr(
+        subprocess, "Popen",
+        lambda *_args, **_kwargs: pytest.fail(
+            "Windows worker must not start before trusted Windows CI verification"
+        ),
+    )
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    task = _make_task(kb, assignee=profile_name, step=step)
+    authority_conn = object() if step else None
+    with pytest.raises(kb.ReviewerAuthorityError, match="UNVERIFIED_PENDING_WINDOWS_CI"):
+        kb._default_spawn(task, str(workspace), authority_conn=authority_conn)

--- a/tests/hermes_cli/test_kanban_worker_terminal_cwd.py
+++ b/tests/hermes_cli/test_kanban_worker_terminal_cwd.py
@@ -51,8 +51,12 @@ def _capture_spawn_env(kb, monkeypatch, workspace: str) -> dict:
         captured["cwd"] = kwargs.get("cwd")
         return FakeProc()
 
-    monkeypatch.setattr(subprocess, "Popen", fake_popen)
-    kb._default_spawn(_make_task(kb), workspace)
+    monkeypatch.setattr(
+        kb,
+        "_spawn_posix_generic_worker",
+        lambda _conn, _task, cmd, **kwargs: fake_popen(cmd, **kwargs),
+    )
+    kb._default_spawn(_make_task(kb), workspace, authority_conn=object())  # type: ignore[arg-type]
     return captured
 
 

--- a/tests/hermes_cli/test_reviewer_bootstrap_process.py
+++ b/tests/hermes_cli/test_reviewer_bootstrap_process.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+import os
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.skipif(os.name != "posix", reason="POSIX bootstrap contract")
+
+
+def _read_frame(fd: int) -> dict:
+    header = os.read(fd, 4)
+    assert len(header) == 4
+    size = struct.unpack(">I", header)[0]
+    payload = bytearray()
+    while len(payload) < size:
+        payload.extend(os.read(fd, size - len(payload)))
+    return json.loads(payload)
+
+
+def _write_frame(fd: int, value: dict) -> None:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+    os.write(fd, struct.pack(">I", len(payload)) + payload)
+
+
+def test_real_bootstrap_activates_only_after_bound_grant_and_emits_ready(tmp_path):
+    root = Path(__file__).resolve().parents[2]
+    marker = tmp_path / "activated.json"
+    c2p_r, c2p_w = os.pipe()
+    p2c_r, p2c_w = os.pipe()
+    for fd in (c2p_r, c2p_w, p2c_r, p2c_w):
+        os.set_inheritable(fd, False)
+    payload = tmp_path / "payload.py"
+    payload.write_text(
+        "import json,os,pathlib\n"
+        "from tools.reviewer_authority import require_activation\n"
+        "pathlib.Path(os.environ['MARKER']).write_text(json.dumps(dict(require_activation())))\n"
+    )
+    env = dict(os.environ)
+    env["HERMES_KANBAN_REVIEW_LAUNCH_ARGV"] = json.dumps(
+        ["__run_path__", str(payload)]
+    )
+    env["PYTHONPATH"] = str(root)
+    env["HERMES_KANBAN_REVIEW_PYTHONPATH"] = str(root)
+    env["MARKER"] = str(marker)
+    proc = subprocess.Popen(
+        [sys.executable, "-I", str(root / "hermes_cli" / "reviewer_bootstrap.py"), str(c2p_w), str(p2c_r)],
+        cwd=root,
+        env=env,
+        pass_fds=(c2p_w, p2c_r),
+        close_fds=True,
+        start_new_session=True,
+    )
+    os.close(c2p_w)
+    os.close(p2c_r)
+    hello = _read_frame(c2p_r)
+    assert not marker.exists()
+    grant = {
+        "v": 1,
+        "challenge": hello["challenge"],
+        "task_id": "t_review",
+        "run_id": 7,
+        "claim_lock": "lock",
+        "role": "critic",
+        "profile": "critic",
+        "workflow": "jerome-kanban-v1",
+        "pid": proc.pid,
+        "parent_pid": os.getpid(),
+        "expires_at": 4_102_444_800,
+        "grant_id": "g-real",
+    }
+    _write_frame(p2c_w, grant)
+    os.close(p2c_w)
+    ready = _read_frame(c2p_r)
+    os.close(c2p_r)
+    assert ready == {"grant_id": "g-real", "pid": proc.pid, "v": 1}
+    assert proc.wait(timeout=10) == 0
+    assert json.loads(marker.read_text())["grant_id"] == "g-real"

--- a/tests/tools/test_kanban_redaction.py
+++ b/tests/tools/test_kanban_redaction.py
@@ -140,3 +140,25 @@ def test_kanban_complete_result_field_scrubbed(worker_env):
     assert run is not None
     stored = run.summary or run.result if hasattr(run, "result") else run.summary or ""
     assert secret not in (stored or "")
+
+
+def test_kanban_complete_nested_metadata_secret_scrubbed(worker_env):
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    secret = "ghp_" + "E" * 40
+    metadata = {"nested": {"token": secret}, "safe": ["kept"]}
+
+    out = json.loads(kt._handle_complete({"summary": "done", "metadata": metadata}))
+
+    assert out["ok"] is True
+    assert metadata["nested"]["token"] == secret
+    conn = kb.connect()
+    try:
+        run = kb.latest_run(conn, worker_env)
+        assert run is not None
+        assert run.metadata is not None
+        assert secret not in json.dumps(run.metadata)
+        assert run.metadata["safe"] == ["kept"]
+    finally:
+        conn.close()

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -132,6 +132,85 @@ def test_complete_happy_path(worker_env):
         conn.close()
 
 
+def test_complete_schema_preserves_free_form_nested_metadata():
+    """Provider schema must permit metadata keys instead of coercing to ``{}``."""
+    from tools.kanban_tools import KANBAN_COMPLETE_SCHEMA
+
+    metadata_schema = KANBAN_COMPLETE_SCHEMA["parameters"]["properties"]["metadata"]
+
+    assert metadata_schema["type"] == "object"
+    assert metadata_schema["additionalProperties"] is True
+
+
+def test_complete_preserves_nested_metadata_without_mutating_caller(worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    metadata = {
+        "reviewed_commit": "a" * 40,
+        "integration_head": "a" * 40,
+        "verification": [
+            {"command": "scripts/run_tests.sh tests/tools/test_kanban_tools.py", "exit_code": 0}
+        ],
+        "generic": {"counts": [1, 2], "ok": True, "note": None},
+    }
+    expected = json.loads(json.dumps(metadata))
+
+    out = json.loads(kt._handle_complete({"summary": "done", "metadata": metadata}))
+
+    assert out["ok"] is True
+    assert metadata == expected
+    conn = kb.connect()
+    try:
+        run = kb.latest_run(conn, worker_env)
+        completed = [e for e in kb.list_events(conn, worker_env) if e.kind == "completed"][-1]
+        shown = json.loads(kt._handle_show({}))
+        assert run is not None
+        assert completed.payload is not None
+        assert run.metadata == expected
+        assert completed.payload["metadata"] == expected
+        assert shown["runs"][-1]["metadata"] == expected
+        assert json.dumps(expected, ensure_ascii=False, sort_keys=True) in shown["worker_context"]
+    finally:
+        conn.close()
+
+
+def test_complete_rejects_non_json_safe_metadata_without_mutating_caller(worker_env):
+    from tools import kanban_tools as kt
+
+    metadata = {"nested": {"bad": {1, 2}}}
+
+    out = json.loads(kt._handle_complete({"summary": "done", "metadata": metadata}))
+
+    assert "JSON-safe" in out["error"]
+    assert metadata == {"nested": {"bad": {1, 2}}}
+
+
+@pytest.mark.parametrize("metadata", [None, {}])
+def test_complete_distinguishes_omitted_from_empty_metadata(worker_env, metadata):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    args = {"summary": "done"}
+    if metadata is not None:
+        args["metadata"] = metadata
+
+    assert json.loads(kt._handle_complete(args))["ok"] is True
+
+    conn = kb.connect()
+    try:
+        run = kb.latest_run(conn, worker_env)
+        completed = [e for e in kb.list_events(conn, worker_env) if e.kind == "completed"][-1]
+        assert run is not None
+        assert run.metadata == metadata
+        assert completed.payload is not None
+        assert ("metadata" in completed.payload) is (metadata is not None)
+        if metadata is not None:
+            assert completed.payload["metadata"] == {}
+    finally:
+        conn.close()
+
+
 def test_complete_retry_with_empty_created_cards_succeeds(worker_env):
     """After a phantom rejection, retrying kanban_complete with
     created_cards=[] (the documented escape hatch) must complete the
@@ -288,6 +367,38 @@ def test_block_goal_mode_rejects_disallowed_kind(monkeypatch, tmp_path):
         d = json.loads(out)
         assert "error" in d, f"kind={kind} should be rejected for goal_mode"
 
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, tid).status == "running"
+    finally:
+        conn.close()
+
+
+def test_typed_review_dependency_block_surfaces_actionable_error(
+    monkeypatch, tmp_path,
+):
+    """The worker tool keeps a typed review card in flight on this misuse."""
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    tid = _make_goal_mode_worker_env(monkeypatch, tmp_path)
+    conn = kb.connect()
+    try:
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET workflow_template_id=?, current_step_key=? "
+                "WHERE id=?",
+                ("jerome-kanban-v1", "architect", tid),
+            )
+    finally:
+        conn.close()
+
+    out = kt._handle_block(
+        {"reason": "BLOCK: unsafe design", "kind": "dependency"}
+    )
+
+    error = json.loads(out)["error"]
+    assert "review verdict is an output" in error
     conn = kb.connect()
     try:
         assert kb.get_task(conn, tid).status == "running"

--- a/tests/tools/test_mcp_stdio_watchdog.py
+++ b/tests/tools/test_mcp_stdio_watchdog.py
@@ -1,6 +1,7 @@
 """Contract tests for the direct POSIX stdio MCP child watchdog."""
 
 import os
+import subprocess
 import sys
 
 import pytest
@@ -38,3 +39,47 @@ def test_wrap_command_uses_stable_parent_pid_and_preserves_command_tail():
         *command_args,
     ]
     assert "--create-time" not in wrapped_args
+
+
+def test_snapshot_watchdog_uses_verified_python_bytes(monkeypatch):
+    import hermes_cli.kanban_runtime_snapshot as snapshot
+
+    monkeypatch.setattr(snapshot, "snapshot_bootstrap_capability", lambda: object())
+    monkeypatch.setattr(
+        snapshot,
+        "sealed_python_argv",
+        lambda relative: ("/python", ["-c", "verified-watchdog"]),
+    )
+
+    command, args = mcp_tool._wrap_command_with_watchdog("server", ["--flag"])
+
+    assert command == "/python"
+    assert args[:2] == ["-c", "verified-watchdog"]
+    assert args[2:] == ["--ppid", str(os.getpid()), "--", "server", "--flag"]
+
+
+def test_snapshot_watchdog_executes_verified_bytes_after_payload_swap(monkeypatch, tmp_path):
+    import hermes_cli.kanban_runtime_snapshot as snapshot
+
+    source = tmp_path / "source"
+    helper = source / "tools/mcp_stdio_watchdog.py"
+    helper.parent.mkdir(parents=True)
+    helper.write_text("print('verified')\n")
+    (source / "agent").mkdir()
+    (source / "agent/i18n.py").write_text("SUPPORTED_LANGUAGES = {'en': 'English'}\n")
+    (source / "locales").mkdir()
+    (source / "locales/en.yaml").write_text("hello: Hello\n")
+    spec = snapshot.build_runtime_snapshot(
+        source, repository_id="repo", source_revision="a" * 40,
+        source_dirty=True, cache_root=tmp_path / "cache",
+    )
+    snapshot.install_snapshot_bootstrap_capability(spec)
+    target = spec.payload_root / "tools/mcp_stdio_watchdog.py"
+    target.chmod(0o600)
+    target.write_text("print('attacker')\n")
+
+    command, args = mcp_tool._wrap_command_with_watchdog("server", [])
+    completed = subprocess.run(
+        [command, *args[:2]], capture_output=True, text=True, check=False,
+    )
+    assert completed.stdout.strip() == "verified"

--- a/tests/tools/test_review_exec.py
+++ b/tests/tools/test_review_exec.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "git status --short",
+        "git diff --check",
+        "git rev-parse HEAD",
+        "shasum -a 256 pyproject.toml",
+    ],
+)
+def test_review_exec_accepts_bounded_inspection_commands(command):
+    from tools.review_exec_tool import validate_review_command
+
+    assert validate_review_command(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "printf hacked > source.py",
+        "python -c \"open('source.py', 'w').write('x')\"",
+        "pip install rich",
+        "npm install",
+        "git commit -am hacked",
+        "git merge main",
+        "git push origin HEAD",
+        "git checkout -- source.py",
+        "git diff --output=patch.txt",
+        "rm -rf .",
+        "kill 1234",
+        "hermes gateway restart",
+        "hermes config set model x",
+        "sqlite3 ~/.hermes/kanban.db 'delete from tasks'",
+        "git -C .. status",
+        "git branch",
+        "git diff --no-index a b",
+        "git diff --ext-diff",
+        "git diff --textconv",
+        "git -c core.pager=touch status",
+        "git --config-env=x=y status",
+        "git status --no-optional-locks",
+        "python -m pytest",
+        "pytest",
+        "scripts/run_tests.sh tests/tools/test_review_exec.py -q",
+        "npm test",
+    ],
+)
+def test_review_exec_rejects_mutation_and_control_commands(command):
+    from tools.review_exec_tool import ReviewCommandDenied, validate_review_command
+
+    with pytest.raises(ReviewCommandDenied):
+        validate_review_command(command)
+
+
+def test_review_exec_runs_canary_in_workspace(monkeypatch, tmp_path):
+    from tools.review_exec_tool import review_exec
+
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(tmp_path))
+    result = json.loads(review_exec("git rev-parse --show-toplevel", workdir=str(tmp_path)))
+
+    assert result.get("success", False) is False
+    assert result["exit_code"] != 0
+    assert "command" not in result
+
+
+def test_review_exec_ignores_path_executable_substitution(monkeypatch, tmp_path):
+    from tools.review_exec_tool import review_exec
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    (fake_bin / "git").symlink_to("/usr/bin/touch")
+    monkeypatch.setenv("PATH", str(fake_bin))
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(workspace))
+
+    result = json.loads(review_exec("git status", workdir=str(workspace)))
+
+    assert not (workspace / "status").exists()
+    assert result["success"] is False
+
+
+def test_review_exec_rejects_outside_and_symlink_operands(monkeypatch, tmp_path):
+    from tools.review_exec_tool import review_exec
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "hosts-link").symlink_to("/etc/hosts")
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(workspace))
+
+    outside = json.loads(review_exec("shasum -a 256 /etc/hosts"))
+    symlink = json.loads(review_exec("shasum -a 256 hosts-link"))
+
+    assert outside.get("success", False) is False
+    assert symlink.get("success", False) is False
+
+
+def test_review_exec_uses_fail_closed_environment(monkeypatch, tmp_path):
+    import tools.review_exec_tool as module
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(workspace))
+    monkeypatch.setenv("PYTHONPATH", "/attacker")
+    monkeypatch.setenv("GIT_CONFIG_COUNT", "1")
+    captured = {}
+
+    class FakeProcess:
+        pid = os.getpid()
+        stdout = None
+
+        def wait(self, timeout=None):
+            return 0
+
+    def fake_popen(argv, **kwargs):
+        captured.update(kwargs)
+        return FakeProcess()
+
+    monkeypatch.setattr(module.subprocess, "Popen", fake_popen)
+    result = json.loads(module.review_exec("git status"))
+
+    assert result["success"] is True
+    assert "PYTHONPATH" not in captured["env"]
+    assert "GIT_CONFIG_COUNT" not in captured["env"]
+    assert captured["env"]["GIT_CONFIG_NOSYSTEM"] == "1"
+    assert captured["env"]["GIT_OPTIONAL_LOCKS"] == "0"
+    assert captured["env"]["GIT_PAGER"] == "cat"
+
+
+def test_review_exec_streams_only_the_bounded_output_tail(tmp_path):
+    from tools.review_exec_tool import _MAX_OUTPUT_BYTES, _run_bounded
+
+    code = "import sys; sys.stdout.buffer.write(b'a' * 120000)"
+    returncode, output = _run_bounded(
+        [sys.executable, "-c", code], cwd=tmp_path, timeout=5,
+    )
+
+    assert returncode == 0
+    assert len(output.encode()) == _MAX_OUTPUT_BYTES
+
+
+def test_review_exec_timeout_kills_descendants(tmp_path):
+    from tools.review_exec_tool import _run_bounded
+
+    pid_file = tmp_path / "child.pid"
+    code = (
+        "import pathlib,subprocess,sys,time; "
+        "p=subprocess.Popen([sys.executable,'-c','import time; time.sleep(30)']); "
+        "pathlib.Path(sys.argv[1]).write_text(str(p.pid)); time.sleep(30)"
+    )
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        _run_bounded(
+            [sys.executable, "-c", code, str(pid_file)], cwd=tmp_path, timeout=1,
+        )
+
+    child_pid = int(pid_file.read_text())
+    deadline = time.monotonic() + 3
+    while time.monotonic() < deadline:
+        try:
+            os.kill(child_pid, 0)
+        except ProcessLookupError:
+            break
+        time.sleep(0.05)
+    else:
+        pytest.fail(f"descendant {child_pid} survived review_exec timeout")
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process-group regression")
+def test_review_exec_timeout_kills_orphan_after_leader_exits(tmp_path):
+    from tools.review_exec_tool import _run_bounded
+
+    pid_file = tmp_path / "child.pid"
+    marker = tmp_path / "survived"
+    child_code = (
+        "import pathlib,sys,time; "
+        "pathlib.Path(sys.argv[1]).write_text(str(__import__('os').getpid())); "
+        "time.sleep(2); pathlib.Path(sys.argv[2]).write_text('survived'); time.sleep(30)"
+    )
+    parent_code = (
+        "import subprocess,sys; "
+        "subprocess.Popen([sys.executable,'-c',sys.argv[1],sys.argv[2],sys.argv[3]], "
+        "stdout=sys.stdout,stderr=sys.stderr)"
+    )
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        _run_bounded(
+            [sys.executable, "-c", parent_code, child_code, str(pid_file), str(marker)],
+            cwd=tmp_path, timeout=1,
+        )
+
+    child_pid = int(pid_file.read_text())
+    time.sleep(2)
+    assert not marker.exists()
+    deadline = time.monotonic() + 3
+    while time.monotonic() < deadline:
+        try:
+            os.kill(child_pid, 0)
+        except ProcessLookupError:
+            break
+        time.sleep(0.05)
+    else:
+        pytest.fail(f"orphan descendant {child_pid} survived review_exec timeout")
+
+
+def test_review_exec_windows_fails_closed_without_taskkill(monkeypatch, tmp_path):
+    import tools.review_exec_tool as module
+
+    monkeypatch.setattr(module, "_IS_WINDOWS", True)
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(tmp_path))
+
+    def unexpected_popen(*_args, **_kwargs):
+        pytest.fail("unverified Windows review execution must not spawn a process")
+
+    def unexpected_run(*_args, **_kwargs):
+        pytest.fail("unverified Windows review execution must not use taskkill")
+
+    monkeypatch.setattr(module.subprocess, "Popen", unexpected_popen)
+    monkeypatch.setattr(module.subprocess, "run", unexpected_run)
+
+    result = json.loads(module.review_exec("git status"))
+
+    assert result.get("success", False) is False
+    assert "UNVERIFIED_PENDING_WINDOWS_CI" in result["error"]
+
+
+def test_review_exec_schema_is_exposed_without_mutation_tools(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_review")
+
+    from model_tools import get_tool_definitions
+
+    schemas = get_tool_definitions(
+        ["review-readonly", "review-exec"],
+        quiet_mode=True,
+        skip_tool_search_assembly=True,
+    )
+    names = {schema["function"]["name"] for schema in schemas}
+
+    assert "review_exec" in names
+    assert not {"terminal", "process", "execute_code", "write_file", "patch"} & names

--- a/tests/tools/test_reviewer_authority.py
+++ b/tests/tools/test_reviewer_authority.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+import io
+import json
+import os
+import struct
+import threading
+import time
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_process_activation(monkeypatch):
+    from tools import reviewer_authority
+
+    monkeypatch.setattr(reviewer_authority, "_state", "UNSET")
+    monkeypatch.setattr(reviewer_authority, "_activation", None)
+
+
+def _frame(payload: bytes) -> bytes:
+    return struct.pack(">I", len(payload)) + payload
+
+
+def test_bootstrap_frame_round_trip_is_canonical():
+    from tools.reviewer_authority import read_bootstrap_frame, write_bootstrap_frame
+
+    stream = io.BytesIO()
+    write_bootstrap_frame(stream, {"v": 1, "pid": 7}, max_bytes=1024)
+    encoded = stream.getvalue()
+
+    assert encoded == _frame(b'{"pid":7,"v":1}')
+    assert read_bootstrap_frame(
+        io.BytesIO(encoded), max_bytes=1024, fields={"v": int, "pid": int}
+    ) == {"pid": 7, "v": 1}
+
+
+def test_write_bootstrap_frame_times_out_on_saturated_pipe():
+    from tools.reviewer_authority import (
+        BootstrapHandshakeTimeoutError,
+        write_bootstrap_frame,
+    )
+
+    read_fd, write_fd = os.pipe()
+    try:
+        os.set_blocking(write_fd, False)
+        while True:
+            try:
+                os.write(write_fd, b"x" * 4096)
+            except BlockingIOError:
+                break
+        os.set_blocking(write_fd, True)
+        with os.fdopen(write_fd, "wb", buffering=0, closefd=False) as stream:
+            started = time.monotonic()
+            with pytest.raises(
+                BootstrapHandshakeTimeoutError,
+                match="bootstrap_handshake_timeout",
+            ):
+                write_bootstrap_frame(
+                    stream,
+                    {"payload": "y" * 1024},
+                    max_bytes=2048,
+                    deadline=started + 0.1,
+                )
+            assert time.monotonic() - started < 1
+    finally:
+        os.close(read_fd)
+        os.close(write_fd)
+
+
+def test_write_bootstrap_frame_rechecks_deadline_after_select_before_write(monkeypatch):
+    from tools import reviewer_authority
+
+    read_fd, write_fd = os.pipe()
+    writes = []
+    real_write = reviewer_authority.os.write
+    deadline = time.monotonic() + 0.05
+
+    def delayed_select(*_args):
+        time.sleep(0.06)
+        return [], [write_fd], []
+
+    def tracked_write(fd, data):
+        writes.append(bytes(data))
+        return real_write(fd, data)
+
+    monkeypatch.setattr(reviewer_authority.select, "select", delayed_select)
+    monkeypatch.setattr(reviewer_authority.os, "write", tracked_write)
+    try:
+        with os.fdopen(write_fd, "wb", buffering=0, closefd=False) as stream:
+            with pytest.raises(
+                reviewer_authority.BootstrapHandshakeTimeoutError,
+                match="bootstrap_handshake_timeout",
+            ):
+                reviewer_authority.write_bootstrap_frame(
+                    stream,
+                    {"payload": "y" * 8192},
+                    max_bytes=16384,
+                    deadline=deadline,
+                )
+    finally:
+        os.close(read_fd)
+        os.close(write_fd)
+
+    assert writes == []
+
+
+def test_write_bootstrap_frame_rechecks_deadline_before_repeated_partial_write(monkeypatch):
+    from tools import reviewer_authority
+
+    read_fd, write_fd = os.pipe()
+    writes = []
+    real_write = reviewer_authority.os.write
+    deadline = time.monotonic() + 0.05
+
+    def always_writable(*_args):
+        return [], [write_fd], []
+
+    def partial_write(fd, data):
+        writes.append(bytes(data[:1024]))
+        written = real_write(fd, data[:1024])
+        time.sleep(0.06)
+        return written
+
+    monkeypatch.setattr(reviewer_authority.select, "select", always_writable)
+    monkeypatch.setattr(reviewer_authority.os, "write", partial_write)
+    try:
+        with os.fdopen(write_fd, "wb", buffering=0, closefd=False) as stream:
+            with pytest.raises(
+                reviewer_authority.BootstrapHandshakeTimeoutError,
+                match="bootstrap_handshake_timeout",
+            ):
+                reviewer_authority.write_bootstrap_frame(
+                    stream,
+                    {"payload": "z" * 8192},
+                    max_bytes=16384,
+                    deadline=deadline,
+                )
+    finally:
+        os.close(read_fd)
+        os.close(write_fd)
+
+    assert len(writes) == 1
+
+
+def test_write_bootstrap_frame_slow_reader_gets_complete_large_frame_within_deadline():
+    from tools.reviewer_authority import write_bootstrap_frame
+
+    read_fd, write_fd = os.pipe()
+    payload = {"payload": "q" * 65536}
+    received = bytearray()
+
+    def slow_reader():
+        while True:
+            chunk = os.read(read_fd, 2048)
+            if not chunk:
+                return
+            received.extend(chunk)
+            time.sleep(0.001)
+
+    reader = threading.Thread(target=slow_reader)
+    reader.start()
+    try:
+        with os.fdopen(write_fd, "wb", buffering=0, closefd=False) as stream:
+            write_bootstrap_frame(
+                stream,
+                payload,
+                max_bytes=131072,
+                deadline=time.monotonic() + 2,
+            )
+    finally:
+        os.close(write_fd)
+        reader.join(timeout=2)
+        os.close(read_fd)
+
+    raw = json.dumps(
+        payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    assert bytes(received) == _frame(raw)
+
+
+def test_write_bootstrap_frame_reports_broken_pipe_with_deadline():
+    from tools.reviewer_authority import write_bootstrap_frame
+
+    read_fd, write_fd = os.pipe()
+    os.close(read_fd)
+    try:
+        with os.fdopen(write_fd, "wb", buffering=0, closefd=False) as stream:
+            with pytest.raises(BrokenPipeError):
+                write_bootstrap_frame(
+                    stream, {"v": 1}, max_bytes=1024, deadline=time.monotonic() + 1
+                )
+    finally:
+        os.close(write_fd)
+
+
+@pytest.mark.parametrize(
+    "wire",
+    [
+        struct.pack(">I", 0),
+        struct.pack(">I", 1025),
+        _frame(b"{\"v\":1"),
+        _frame(b"\xff"),
+        _frame(b'{"v":1,"v":1}'),
+        _frame(b'{"v":1,"extra":2}'),
+        _frame(b"[]"),
+    ],
+)
+def test_bootstrap_frame_rejects_noncanonical_or_invalid_input(wire):
+    from tools.reviewer_authority import BootstrapProtocolError, read_bootstrap_frame
+
+    with pytest.raises(BootstrapProtocolError, match="bootstrap_protocol_violation"):
+        read_bootstrap_frame(io.BytesIO(wire), max_bytes=1024, fields={"v": int})
+
+
+def test_bootstrap_channel_requires_eof_after_final_frame():
+    from tools.reviewer_authority import BootstrapProtocolError, require_bootstrap_eof
+
+    with pytest.raises(BootstrapProtocolError, match="bootstrap_protocol_violation"):
+        require_bootstrap_eof(io.BytesIO(b"trailing"))
+
+
+def test_env_role_spoof_does_not_activate_reviewer(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_REVIEW_ROLE", "critic")
+
+    from tools import reviewer_authority
+    from tools.reviewer_surface import typed_reviewer_active
+
+    reviewer_authority.invalidate_activation()
+    assert typed_reviewer_active() is False
+
+
+def test_activation_is_one_shot_and_pid_bound(monkeypatch):
+    from tools import reviewer_authority
+
+    reviewer_authority.invalidate_activation()
+    reviewer_authority.activate_reviewer(
+        {"role": "critic", "profile": "critic", "pid": os.getpid(), "grant_id": "g1"}
+    )
+    assert reviewer_authority.require_activation()["role"] == "critic"
+
+    with pytest.raises(reviewer_authority.ActivationError, match="activation_already_consumed"):
+        reviewer_authority.activate_reviewer(
+            {"role": "critic", "profile": "critic", "pid": os.getpid(), "grant_id": "g2"}
+        )
+
+    monkeypatch.setattr(reviewer_authority.os, "getpid", lambda: os.getppid())
+    with pytest.raises(reviewer_authority.ActivationError, match="activation_pid_mismatch"):
+        reviewer_authority.require_activation()
+
+
+def test_public_invalidation_cannot_downgrade_active_reviewer():
+    from tools import reviewer_authority
+
+    reviewer_authority.activate_reviewer(
+        {"role": "critic", "profile": "critic", "pid": os.getpid(), "grant_id": "g-active"}
+    )
+
+    with pytest.raises(reviewer_authority.ActivationError, match="activation_is_immutable"):
+        reviewer_authority.invalidate_activation()
+
+    assert reviewer_authority.require_activation()["grant_id"] == "g-active"
+
+
+def test_activation_is_invalidated_in_forked_child():
+    if not hasattr(os, "fork"):
+        pytest.skip("fork is POSIX-only")
+    from tools import reviewer_authority
+
+    reviewer_authority.invalidate_activation()
+    reviewer_authority.activate_reviewer(
+        {"role": "critic", "profile": "critic", "pid": os.getpid(), "grant_id": "g-fork"}
+    )
+    read_fd, write_fd = os.pipe()
+    pid = os.fork()
+    if pid == 0:
+        os.close(read_fd)
+        try:
+            reviewer_authority.require_activation()
+        except reviewer_authority.ActivationError as exc:
+            result = str(exc)
+        else:
+            result = "active"
+        os.write(write_fd, result.encode())
+        os.close(write_fd)
+        os._exit(0)
+    os.close(write_fd)
+    result = os.read(read_fd, 1024).decode()
+    os.close(read_fd)
+    os.waitpid(pid, 0)
+    assert result == "missing_activation"

--- a/tests/tools/test_reviewer_plugin_bypass.py
+++ b/tests/tools/test_reviewer_plugin_bypass.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+
+
+def test_active_reviewer_bypasses_all_plugin_mutation_surfaces(monkeypatch):
+    import model_tools
+    from tools import reviewer_surface
+
+    observed = []
+
+    def canonical(args, **_kwargs):
+        observed.append(dict(args))
+        return json.dumps({"value": args["value"]})
+
+    monkeypatch.setattr(reviewer_surface, "typed_reviewer_active", lambda: True)
+    monkeypatch.setattr(
+        reviewer_surface, "canonical_reviewer_handler",
+        lambda name: (canonical, False) if name == "read_file" else None,
+    )
+    monkeypatch.setattr(reviewer_surface, "canonical_reviewer_schema", lambda _name: None)
+
+    import hermes_cli.middleware as middleware
+    import hermes_cli.plugins as plugins
+    import hermes_cli.lifecycle as lifecycle
+
+    monkeypatch.setattr(middleware, "apply_tool_request_middleware", lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("request middleware ran")))
+    monkeypatch.setattr(middleware, "run_tool_execution_middleware", lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("execution middleware ran")))
+    monkeypatch.setattr(plugins, "resolve_pre_tool_block", lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("pre hook ran")))
+    monkeypatch.setattr(model_tools, "_emit_post_tool_call_hook", lambda **_k: (_ for _ in ()).throw(AssertionError("post hook ran")))
+    monkeypatch.setattr(lifecycle, "has_hook", lambda _name: True)
+    monkeypatch.setattr(lifecycle, "invoke_hook", lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("transform hook ran")))
+
+    result = json.loads(model_tools.handle_function_call("read_file", {"value": "original"}))
+
+    assert observed == [{"value": "original"}]
+    assert result == {"value": "original"}
+
+
+def test_generic_tool_dispatch_preserves_plugin_extensibility(monkeypatch):
+    import model_tools
+    from tools import reviewer_surface
+
+    monkeypatch.setattr(reviewer_surface, "typed_reviewer_active", lambda: False)
+    monkeypatch.setattr(
+        "hermes_cli.plugins.resolve_pre_tool_block",
+        lambda *_a, **_k: "blocked by generic plugin",
+    )
+
+    result = json.loads(model_tools.handle_function_call("read_file", {"path": "missing"}))
+
+    assert "blocked by generic plugin" in result["error"]

--- a/tests/tools/test_tts_snapshot_resources.py
+++ b/tests/tools/test_tts_snapshot_resources.py
@@ -1,0 +1,34 @@
+from contextlib import contextmanager
+from pathlib import Path
+
+from tools import tts_tool
+
+
+def test_neutts_uses_verified_helper_and_resource_fds(monkeypatch, tmp_path):
+    import hermes_cli.kanban_runtime_snapshot as snapshot
+
+    @contextmanager
+    def resource(relative):
+        values = {
+            "tools/neutts_samples/jo.wav": tmp_path / "audio-fd",
+            "tools/neutts_samples/jo.txt": tmp_path / "text-fd",
+        }
+        yield snapshot.SealedResourceFile(str(values[relative]), (10 if relative.endswith("wav") else 11,))
+
+    captured = {}
+
+    class Result:
+        returncode = 0
+        stderr = ""
+
+    monkeypatch.setattr(snapshot, "snapshot_bootstrap_capability", lambda: object())
+    monkeypatch.setattr(snapshot, "sealed_python_argv", lambda _p: ("/python", ["-c", "verified-synth"]))
+    monkeypatch.setattr(snapshot, "sealed_resource_file", resource)
+    monkeypatch.setattr(tts_tool.subprocess, "run", lambda cmd, **kwargs: captured.update(cmd=cmd, kwargs=kwargs) or Result())
+
+    output = tmp_path / "out.wav"
+    assert tts_tool._generate_neutts("hello", str(output), {}) == str(output)
+    assert captured["cmd"][:3] == ["/python", "-c", "verified-synth"]
+    assert captured["kwargs"]["pass_fds"] == (10, 11)
+    assert str(tmp_path / "audio-fd") in captured["cmd"]
+    assert str(tmp_path / "text-fd") in captured["cmd"]

--- a/tests/tools/test_web_providers_ddgs.py
+++ b/tests/tools/test_web_providers_ddgs.py
@@ -11,6 +11,7 @@ Covers:
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 import time
 import types
@@ -18,6 +19,24 @@ import types
 import pytest
 
 from tests.tools.conftest import register_all_web_providers
+
+
+@pytest.fixture(autouse=True)
+def _clear_snapshot_capability():
+    from hermes_cli.kanban_runtime_snapshot import clear_snapshot_bootstrap_capability_after_fork
+
+    package_paths = {
+        name: list(module.__path__)
+        for name, module in tuple(sys.modules.items())
+        if hasattr(module, "__path__")
+    }
+    clear_snapshot_bootstrap_capability_after_fork()
+    yield
+    clear_snapshot_bootstrap_capability_after_fork()
+    for name, paths in package_paths.items():
+        module = sys.modules.get(name)
+        if module is not None and hasattr(module, "__path__"):
+            module.__path__ = paths
 
 
 def _install_fake_ddgs(monkeypatch, *, text_results=None, text_raises=None, text_sleep=None):
@@ -170,6 +189,57 @@ def _assert_worker_reaped(prov) -> None:
 
 @pytest.mark.live_system_guard_bypass
 class TestDDGSProcessIsolation:
+    def test_snapshot_worker_uses_verified_python_bytes(self, monkeypatch):
+        import hermes_cli.kanban_runtime_snapshot as snapshot
+        import plugins.web.ddgs.provider as prov
+
+        captured = {}
+
+        class Proc:
+            pid = 123
+            returncode = 0
+            def communicate(self, _request):
+                return ('{"ok":true,"results":[]}', '')
+            def poll(self):
+                return 0
+
+        monkeypatch.setattr(snapshot, "snapshot_bootstrap_capability", lambda: object())
+        monkeypatch.setattr(snapshot, "sealed_python_argv", lambda _p: ("/python", ["-c", "verified-worker"]))
+        monkeypatch.setattr(prov.subprocess, "Popen", lambda argv, **kwargs: captured.update(argv=argv, kwargs=kwargs) or Proc())
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+
+        assert prov._run_ddgs_search_bounded("q", 1) == []
+        assert captured["argv"] == ["/python", "-c", "verified-worker"]
+
+    def test_snapshot_worker_command_keeps_verified_bytes_after_payload_swap(self, tmp_path):
+        import hermes_cli.kanban_runtime_snapshot as snapshot
+
+        source = tmp_path / "source"
+        files = {
+            "plugins/web/ddgs/_search_worker.py": "print('verified')\n",
+            "agent/i18n.py": "SUPPORTED_LANGUAGES = {'en': 'English'}\n",
+            "locales/en.yaml": "hello: Hello\n",
+        }
+        for relative, content in files.items():
+            path = source / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content)
+        spec = snapshot.build_runtime_snapshot(
+            source, repository_id="repo", source_revision="a" * 40,
+            source_dirty=True, cache_root=tmp_path / "cache",
+        )
+        snapshot.install_snapshot_bootstrap_capability(spec)
+        try:
+            command, prefix = snapshot.sealed_python_argv("plugins/web/ddgs/_search_worker.py")
+            target = spec.payload_root / "plugins/web/ddgs/_search_worker.py"
+            target.chmod(0o600)
+            target.write_text("print('attacker')\n")
+
+            completed = subprocess.run([command, *prefix], capture_output=True, text=True, check=False)
+            assert completed.stdout.strip() == "verified"
+        finally:
+            snapshot.clear_snapshot_bootstrap_capability_after_fork()
+
     def test_gil_holding_worker_times_out_and_is_reaped(self, monkeypatch):
         """#68096: parent deadline still fires when the child holds its GIL."""
         _install_fake_ddgs(monkeypatch)

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -636,12 +636,15 @@ def _handle_complete(args: dict, **kw) -> str:
     if result:
         result = redact_sensitive_text(str(result), force=True)
     if metadata is not None and isinstance(metadata, dict):
-        meta_json = json.dumps(metadata)
+        try:
+            meta_json = json.dumps(metadata, ensure_ascii=False, allow_nan=False)
+        except (TypeError, ValueError):
+            return tool_error("metadata must be a JSON-safe object/dict")
         meta_json = redact_sensitive_text(meta_json, force=True)
         try:
             metadata = json.loads(meta_json)
         except json.JSONDecodeError:
-            pass
+            return tool_error("metadata redaction produced invalid JSON")
     created_cards = args.get("created_cards")
     artifacts = args.get("artifacts")
     if created_cards is not None:
@@ -1661,6 +1664,7 @@ KANBAN_COMPLETE_SCHEMA = {
             },
             "metadata": {
                 "type": "object",
+                "additionalProperties": True,
                 "description": (
                     "Free-form dict of structured facts about this "
                     "attempt — {\"changed_files\": [...], \"tests_run\": 12, "

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1265,6 +1265,12 @@ def _handle_create(args: dict, **kw) -> str:
     goal_max_turns = args.get("goal_max_turns")
     model_override = args.get("model")
     provider_override = args.get("provider")
+    workflow_template_id = args.get("workflow_template_id")
+    current_step_key = args.get("current_step_key")
+    if workflow_template_id is not None and not str(workflow_template_id).strip():
+        return tool_error("workflow_template_id cannot be blank")
+    if current_step_key is not None and not str(current_step_key).strip():
+        return tool_error("current_step_key cannot be blank")
     if provider_override and not model_override:
         return tool_error("'provider' requires 'model' to be set as well")
     if isinstance(parents, str):
@@ -1315,6 +1321,14 @@ def _handle_create(args: dict, **kw) -> str:
                 initial_status=str(initial_status),
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
                 session_id=session_id,
+                workflow_template_id=(
+                    str(workflow_template_id).strip()
+                    if workflow_template_id is not None else None
+                ),
+                current_step_key=(
+                    str(current_step_key).strip()
+                    if current_step_key is not None else None
+                ),
             )
             new_task = kb.get_task(conn, new_tid)
             subscribed = _maybe_auto_subscribe(conn, new_tid)
@@ -2074,6 +2088,20 @@ KANBAN_CREATE_SCHEMA = {
                     "provider — a model name alone is resolved against "
                     "the profile's provider and will fail if it belongs "
                     "to a different one. Requires 'model'."
+                ),
+            },
+            "workflow_template_id": {
+                "type": "string",
+                "description": (
+                    "Immutable workflow contract id. Jerome's strict role "
+                    "pipeline uses 'jerome-kanban-v1'."
+                ),
+            },
+            "current_step_key": {
+                "type": "string",
+                "description": (
+                    "Immutable workflow role for completion gates, e.g. "
+                    "planner, architect, critic, executor, integrator, verifier."
                 ),
             },
             "board": _board_schema_prop(),

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -717,8 +717,24 @@ def _wrap_command_with_watchdog(command: str, args: list) -> tuple[str, list]:
     except Exception:
         # Never let watchdog bookkeeping failure block a real MCP connection.
         return command, args
+    watchdog_path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "mcp_stdio_watchdog.py"
+    )
+    try:
+        from hermes_cli.kanban_runtime_snapshot import (
+            sealed_python_argv,
+            snapshot_bootstrap_capability,
+        )
+
+        if snapshot_bootstrap_capability() is not None:
+            watchdog_command, watchdog_prefix = sealed_python_argv("tools/mcp_stdio_watchdog.py")
+            return watchdog_command, [
+                *watchdog_prefix, "--ppid", str(my_pid), "--", command, *args,
+            ]
+    except ImportError:
+        pass
     watchdog_args = [
-        os.path.join(os.path.dirname(os.path.abspath(__file__)), "mcp_stdio_watchdog.py"),
+        watchdog_path,
         "--ppid", str(my_pid),
         "--",
         command,

--- a/tools/review_exec_tool.py
+++ b/tools/review_exec_tool.py
@@ -1,0 +1,335 @@
+"""Least-privilege executable inspection tool for read-only review workers."""
+
+from __future__ import annotations
+
+import json
+import os
+import selectors
+import shlex
+import signal
+import subprocess
+import time
+from collections import deque
+from pathlib import Path
+from typing import Optional
+
+from tools.registry import registry, tool_error
+
+
+class ReviewCommandDenied(ValueError):
+    """The requested command is outside the review inspection allowlist."""
+
+
+_GIT_READ_SUBCOMMANDS = frozenset(
+    {"diff", "grep", "log", "rev-list", "rev-parse", "show", "status"}
+)
+_HASH_COMMANDS = frozenset({"sha256sum", "shasum"})
+_SHELL_OPERATOR_CHARS = frozenset(";&|<>`\n\r")
+_MAX_TIMEOUT_SECONDS = 900
+_MAX_OUTPUT_BYTES = 100_000
+_IS_WINDOWS = os.name == "nt"
+_TRUSTED_EXECUTABLES = {
+    "git": ("/usr/bin/git", "/bin/git"),
+    "shasum": ("/usr/bin/shasum",),
+    "sha256sum": ("/usr/bin/sha256sum", "/bin/sha256sum"),
+}
+_GIT_SAFE_OPTIONS = frozenset(
+    {
+        "--cached", "--check", "--decorate", "--exit-code", "--name-only",
+        "--no-color", "--no-decorate", "--no-patch", "--oneline", "--porcelain",
+        "--short", "--show-toplevel", "--stat", "--summary", "--unified",
+        "--untracked-files",
+    }
+)
+_GIT_SAFE_OPTION_PREFIXES = (
+    "--format=", "--max-count=", "--unified=", "--untracked-files=", "-n",
+)
+
+
+def _deny(message: str) -> None:
+    raise ReviewCommandDenied(message)
+
+
+def validate_review_command(command: str) -> list[str]:
+    """Parse and return argv only for an explicitly read-only inspection command."""
+    if not command or any(char in command for char in _SHELL_OPERATOR_CHARS) or "$(" in command:
+        _deny("shell operators, substitutions, and redirection are not allowed")
+    try:
+        argv = shlex.split(command, posix=os.name != "nt")
+    except ValueError as exc:
+        raise ReviewCommandDenied("command has invalid quoting") from exc
+    if not argv:
+        _deny("command is empty")
+    if Path(argv[0]).name != argv[0]:
+        _deny("executable paths are selected by review_exec, not the caller")
+
+    executable = argv[0]
+    if executable == "git":
+        if len(argv) < 2 or argv[1] not in _GIT_READ_SUBCOMMANDS:
+            _deny("git subcommand is not read-only")
+        for arg in argv[2:]:
+            if not arg.startswith("-") or arg == "--":
+                continue
+            if arg in _GIT_SAFE_OPTIONS or any(
+                arg.startswith(prefix) and len(arg) > len(prefix)
+                for prefix in _GIT_SAFE_OPTION_PREFIXES
+            ):
+                continue
+            _deny("Git option is outside the read-only inspection allowlist")
+    elif executable == "shasum":
+        if argv[1:3] != ["-a", "256"]:
+            _deny("shasum is limited to SHA-256")
+    elif executable == "sha256sum":
+        if any(arg.startswith("-") for arg in argv[1:]):
+            _deny("sha256sum options are outside the inspection surface")
+    else:
+        _deny(f"executable {executable!r} is not in the inspection allowlist")
+    return argv
+
+
+def _workspace_root() -> Path:
+    raw = os.environ.get("HERMES_KANBAN_WORKSPACE", "").strip()
+    if not raw:
+        raise ReviewCommandDenied("review execution requires a Kanban workspace")
+    root = Path(raw).expanduser()
+    resolved = root.resolve(strict=True)
+    if root.absolute() != resolved or not resolved.is_dir():
+        raise ReviewCommandDenied("workspace must be an existing non-symlink directory")
+    return resolved
+
+
+def _bounded_workdir(workdir: Optional[str]) -> Path:
+    root = _workspace_root()
+    raw = Path(workdir).expanduser() if workdir else root
+    candidate = raw.resolve(strict=True)
+    try:
+        candidate.relative_to(root)
+    except ValueError as exc:
+        raise ReviewCommandDenied("workdir must remain inside the assigned workspace") from exc
+    if raw.absolute() != candidate or not candidate.is_dir():
+        raise ReviewCommandDenied("workdir must be an existing non-symlink directory")
+    return candidate
+
+
+def _trusted_executable(name: str) -> str:
+    for raw in _TRUSTED_EXECUTABLES.get(name, ()):
+        candidate = Path(raw)
+        try:
+            resolved = candidate.resolve(strict=True)
+        except OSError:
+            continue
+        if resolved.is_file() and os.access(resolved, os.X_OK):
+            return str(resolved)
+    raise ReviewCommandDenied(f"trusted executable {name!r} is unavailable")
+
+
+def _workspace_operand(root: Path, cwd: Path, raw: str) -> None:
+    candidate = Path(raw).expanduser()
+    lexical = candidate if candidate.is_absolute() else cwd / candidate
+    try:
+        resolved = lexical.resolve(strict=True)
+        resolved.relative_to(root)
+    except (OSError, ValueError) as exc:
+        raise ReviewCommandDenied(
+            "file operands must be existing paths inside the workspace"
+        ) from exc
+    if lexical.absolute() != resolved or not resolved.is_file():
+        raise ReviewCommandDenied("file operands must be regular non-symlink files")
+
+
+def _validate_operands(argv: list[str], root: Path, cwd: Path) -> None:
+    if argv[0] in _HASH_COMMANDS:
+        start = 3 if argv[0] == "shasum" else 1
+        if len(argv) <= start:
+            _deny("hash commands require at least one workspace file")
+        for operand in argv[start:]:
+            _workspace_operand(root, cwd, operand)
+        return
+    if "--" in argv[2:]:
+        separator = argv.index("--", 2)
+        if separator == len(argv) - 1:
+            _deny("Git path separator requires a workspace operand")
+        for operand in argv[separator + 1:]:
+            _workspace_operand(root, cwd, operand)
+
+
+def _review_env() -> dict[str, str]:
+    env = {
+        "HOME": "/dev/null",
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        "PATH": "/usr/bin:/bin",
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_OPTIONAL_LOCKS": "0",
+        "GIT_PAGER": "cat",
+        "PAGER": "cat",
+        "TERM": "dumb",
+    }
+    if os.name == "nt":
+        for key in ("SystemRoot", "WINDIR"):
+            if os.environ.get(key):
+                env[key] = os.environ[key]
+    return env
+
+
+def _kill_process_group(proc: subprocess.Popen, pgid: Optional[int] = None) -> None:
+    """Terminate the whole spawned group even after its leader has exited."""
+    target = pgid if pgid is not None else proc.pid
+    for sig in (signal.SIGTERM, signal.SIGKILL):
+        try:
+            os.killpg(target, sig)
+        except ProcessLookupError:
+            return
+        except OSError:
+            pass
+        if sig == signal.SIGTERM:
+            deadline = time.monotonic() + 1
+            while time.monotonic() < deadline:
+                try:
+                    os.killpg(target, 0)
+                except ProcessLookupError:
+                    return
+                except OSError:
+                    break
+                time.sleep(0.05)
+
+
+def _run_bounded(argv: list[str], *, cwd: Path, timeout: int) -> tuple[int, str]:
+    kwargs = {
+        "cwd": str(cwd),
+        "stdin": subprocess.DEVNULL,
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.STDOUT,
+        "env": _review_env(),
+    }
+    if os.name == "posix":
+        kwargs["start_new_session"] = True
+    elif os.name == "nt":
+        kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+    proc = subprocess.Popen(argv, **kwargs)
+    pgid = proc.pid if os.name == "posix" else None
+    if proc.stdout is None:  # defensive fallback and test-double support
+        return proc.wait(timeout=timeout), ""
+
+    chunks: deque[bytes] = deque()
+    kept = 0
+    deadline = time.monotonic() + timeout
+    selector = selectors.DefaultSelector()
+    selector.register(proc.stdout, selectors.EVENT_READ)
+    try:
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise subprocess.TimeoutExpired(argv, timeout)
+            for key, _mask in selector.select(min(0.1, remaining)):
+                stream = key.fileobj
+                descriptor = stream if isinstance(stream, int) else stream.fileno()
+                chunk = os.read(descriptor, 8192)
+                if not chunk:
+                    selector.unregister(key.fileobj)
+                    continue
+                chunks.append(chunk)
+                kept += len(chunk)
+                while kept > _MAX_OUTPUT_BYTES:
+                    excess = kept - _MAX_OUTPUT_BYTES
+                    head = chunks[0]
+                    if len(head) <= excess:
+                        kept -= len(chunks.popleft())
+                    else:
+                        chunks[0] = head[excess:]
+                        kept -= excess
+            if proc.poll() is not None and not selector.get_map():
+                break
+        output = b"".join(chunks).decode("utf-8", errors="replace")
+        return int(proc.returncode), output
+    except BaseException:
+        _kill_process_group(proc, pgid)
+        try:
+            proc.wait(timeout=1)
+        except subprocess.SubprocessError:
+            pass
+        raise
+    finally:
+        selector.close()
+        proc.stdout.close()
+
+
+def review_exec(command: str, *, workdir: Optional[str] = None, timeout: int = 300) -> str:
+    """Execute one allowlisted inspection command without a shell."""
+    try:
+        if _IS_WINDOWS:
+            raise ReviewCommandDenied("UNVERIFIED_PENDING_WINDOWS_CI")
+        argv = validate_review_command(command)
+        root = _workspace_root()
+        cwd = _bounded_workdir(workdir)
+        _validate_operands(argv, root, cwd)
+        executable = _trusted_executable(argv[0])
+        if argv[0] == "git":
+            subcommand = argv[1]
+            args = argv[2:]
+            argv = [
+                executable,
+                "-c", "core.fsmonitor=false",
+                "-c", "core.untrackedCache=false",
+                "-c", "core.hooksPath=/dev/null",
+                "--no-pager", subcommand,
+            ]
+            if subcommand == "diff":
+                argv.extend(("--no-ext-diff", "--no-textconv"))
+            argv.extend(args)
+        else:
+            argv[0] = executable
+        bounded_timeout = max(1, min(int(timeout), _MAX_TIMEOUT_SECONDS))
+        returncode, output = _run_bounded(argv, cwd=cwd, timeout=bounded_timeout)
+        return json.dumps(
+            {"success": returncode == 0, "output": output, "exit_code": returncode},
+            ensure_ascii=False,
+        )
+    except (ReviewCommandDenied, OSError, ValueError, subprocess.SubprocessError) as exc:
+        return tool_error(str(exc))
+
+
+REVIEW_EXEC_SCHEMA = {
+    "name": "review_exec",
+    "description": (
+        "Run one bounded, allowlisted read-only repository inspection command in the assigned "
+        "Kanban workspace. Supports read-only Git queries and SHA-256 hashing of workspace files. "
+        "No project code, plugins, test configuration, shell operators, file writes, package "
+        "installation, Git mutation, process control, or Hermes runtime/config control."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "command": {"type": "string", "description": "Single allowlisted inspection command."},
+            "workdir": {
+                "type": "string",
+                "description": "Existing non-symlink directory inside the assigned workspace.",
+            },
+            "timeout": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": _MAX_TIMEOUT_SECONDS,
+                "default": 300,
+            },
+        },
+        "required": ["command"],
+    },
+}
+
+
+def _handle_review_exec(args: dict, **_kwargs) -> str:
+    return review_exec(
+        str(args.get("command", "")),
+        workdir=args.get("workdir"),
+        timeout=args.get("timeout", 300),
+    )
+
+
+registry.register(
+    name="review_exec",
+    toolset="review-exec",
+    schema=REVIEW_EXEC_SCHEMA,
+    handler=_handle_review_exec,
+    emoji="🔎",
+    max_result_size_chars=_MAX_OUTPUT_BYTES,
+)

--- a/tools/reviewer_authority.py
+++ b/tools/reviewer_authority.py
@@ -1,0 +1,218 @@
+"""Process-local reviewer activation and framed bootstrap primitives."""
+
+from __future__ import annotations
+
+import json
+import os
+import select
+import struct
+import threading
+import time
+from types import MappingProxyType
+from typing import Any, BinaryIO, Mapping
+
+
+class BootstrapProtocolError(ValueError):
+    pass
+
+
+class ActivationError(RuntimeError):
+    pass
+
+
+class BootstrapHandshakeTimeoutError(TimeoutError):
+    pass
+
+
+_lock = threading.Lock()
+_state = "UNSET"
+_activation: Mapping[str, Any] | None = None
+
+
+def _protocol_error(detail: str) -> BootstrapProtocolError:
+    return BootstrapProtocolError(f"bootstrap_protocol_violation: {detail}")
+
+
+def _read_once(stream: BinaryIO, size: int, deadline: float | None) -> bytes:
+    if deadline is None:
+        return stream.read(size)
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise BootstrapHandshakeTimeoutError("bootstrap_handshake_timeout")
+    try:
+        fd = stream.fileno()
+    except (AttributeError, OSError):
+        return stream.read(size)
+    readable, _, _ = select.select([fd], [], [], remaining)
+    if not readable:
+        raise BootstrapHandshakeTimeoutError("bootstrap_handshake_timeout")
+    return os.read(fd, size)
+
+
+def _read_exact(stream: BinaryIO, size: int, deadline: float | None = None) -> bytes:
+    chunks = bytearray()
+    while len(chunks) < size:
+        chunk = _read_once(stream, size - len(chunks), deadline)
+        if not chunk:
+            raise _protocol_error("unexpected EOF")
+        chunks.extend(chunk)
+    return bytes(chunks)
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _protocol_error(f"duplicate field {key!r}")
+        result[key] = value
+    return result
+
+
+def read_bootstrap_frame(
+    stream: BinaryIO,
+    *,
+    max_bytes: int,
+    fields: Mapping[str, type],
+    deadline: float | None = None,
+) -> dict[str, Any]:
+    try:
+        size = struct.unpack(">I", _read_exact(stream, 4, deadline))[0]
+        if size == 0 or size > max_bytes:
+            raise _protocol_error("invalid frame length")
+        raw = _read_exact(stream, size, deadline)
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=_reject_duplicate_keys)
+    except BootstrapProtocolError:
+        raise
+    except (UnicodeDecodeError, json.JSONDecodeError, struct.error) as exc:
+        raise _protocol_error("malformed frame") from exc
+    if not isinstance(value, dict):
+        raise _protocol_error("frame payload must be an object")
+    if set(value) != set(fields):
+        raise _protocol_error("unknown or missing field")
+    for name, expected in fields.items():
+        actual = value[name]
+        if expected is int and (not isinstance(actual, int) or isinstance(actual, bool)):
+            raise _protocol_error(f"invalid type for {name}")
+        if expected is not int and not isinstance(actual, expected):
+            raise _protocol_error(f"invalid type for {name}")
+    canonical = json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    if canonical != raw:
+        raise _protocol_error("noncanonical JSON")
+    return value
+
+
+def write_bootstrap_frame(
+    stream: BinaryIO,
+    value: Mapping[str, Any],
+    *,
+    max_bytes: int,
+    deadline: float | None = None,
+) -> None:
+    raw = json.dumps(
+        dict(value), ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    if not raw or len(raw) > max_bytes:
+        raise _protocol_error("invalid frame length")
+    wire = struct.pack(">I", len(raw)) + raw
+    if deadline is None:
+        stream.write(wire)
+        stream.flush()
+        return
+    try:
+        fd = stream.fileno()
+    except (AttributeError, OSError):
+        stream.write(wire)
+        stream.flush()
+        return
+
+    was_blocking = os.get_blocking(fd)
+    os.set_blocking(fd, False)
+    offset = 0
+    try:
+        while offset < len(wire):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise BootstrapHandshakeTimeoutError("bootstrap_handshake_timeout")
+            _, writable, _ = select.select([], [fd], [], remaining)
+            if not writable:
+                raise BootstrapHandshakeTimeoutError("bootstrap_handshake_timeout")
+            if deadline - time.monotonic() <= 0:
+                raise BootstrapHandshakeTimeoutError("bootstrap_handshake_timeout")
+            try:
+                written = os.write(fd, wire[offset:])
+            except BlockingIOError:
+                continue
+            if written <= 0:
+                raise _protocol_error("unexpected zero-length write")
+            offset += written
+    finally:
+        os.set_blocking(fd, was_blocking)
+
+
+def require_bootstrap_eof(stream: BinaryIO, *, deadline: float | None = None) -> None:
+    if _read_once(stream, 1, deadline) != b"":
+        raise _protocol_error("trailing data")
+
+
+def invalidate_activation() -> None:
+    """Reset only an unconsumed activation slot."""
+    global _state, _activation
+    with _lock:
+        if _state == "ACTIVE":
+            raise ActivationError("activation_is_immutable")
+        _state = "UNSET"
+        _activation = None
+
+
+def activate_reviewer(grant: Mapping[str, Any]) -> None:
+    global _state, _activation
+    with _lock:
+        if _state != "UNSET":
+            raise ActivationError("activation_already_consumed")
+        _state = "CONSUMING"
+        try:
+            required = {"role": str, "profile": str, "pid": int, "grant_id": str}
+            if not set(required).issubset(grant):
+                raise ActivationError("grant_binding_mismatch")
+            if any(not isinstance(grant[key], expected) for key, expected in required.items()):
+                raise ActivationError("grant_binding_mismatch")
+            if grant["pid"] != os.getpid():
+                raise ActivationError("grant_binding_mismatch")
+            _activation = MappingProxyType(dict(grant))
+            _state = "ACTIVE"
+        except BaseException:
+            _activation = None
+            _state = "UNSET"
+            raise
+
+
+def require_activation() -> Mapping[str, Any]:
+    with _lock:
+        if _state != "ACTIVE" or _activation is None:
+            raise ActivationError("missing_activation")
+        if _activation["pid"] != os.getpid():
+            raise ActivationError("activation_pid_mismatch")
+        return _activation
+
+
+def reviewer_active() -> bool:
+    try:
+        require_activation()
+    except ActivationError:
+        return False
+    return True
+
+
+if hasattr(os, "register_at_fork"):
+    def _make_fork_child_invalidator():
+        def invalidate_fork_child() -> None:
+            global _state, _activation
+            _state = "UNSET"
+            _activation = None
+
+        return invalidate_fork_child
+
+    os.register_at_fork(after_in_child=_make_fork_child_invalidator())
+    del _make_fork_child_invalidator

--- a/tools/reviewer_surface.py
+++ b/tools/reviewer_surface.py
@@ -1,0 +1,127 @@
+"""Static, registry-independent tool surface for typed Jerome reviewers."""
+
+from __future__ import annotations
+
+import copy
+import json
+
+from types import MappingProxyType
+from typing import Any, Callable
+
+from tools.file_tools import (
+    READ_FILE_SCHEMA,
+    SEARCH_FILES_SCHEMA,
+    _handle_read_file,
+    _handle_search_files,
+)
+from tools.kanban_tools import (
+    KANBAN_ATTACHMENTS_SCHEMA,
+    KANBAN_BLOCK_SCHEMA,
+    KANBAN_COMPLETE_SCHEMA,
+    KANBAN_HEARTBEAT_SCHEMA,
+    KANBAN_SHOW_SCHEMA,
+    _handle_attachments,
+    _handle_block,
+    _handle_complete,
+    _handle_heartbeat,
+    _handle_show,
+)
+from tools.review_exec_tool import REVIEW_EXEC_SCHEMA, _handle_review_exec
+from tools.skills_tool import (
+    SKILLS_LIST_SCHEMA,
+    SKILL_VIEW_SCHEMA,
+    _skill_view_with_bump,
+    skills_list,
+)
+from tools.web_tools import WEB_EXTRACT_SCHEMA, WEB_SEARCH_SCHEMA, web_extract_tool, web_search_tool
+
+_REVIEW_ROLES = frozenset({"planner", "architect", "critic", "verifier"})
+
+
+def typed_reviewer_active() -> bool:
+    """Return whether this process consumed a PID-bound reviewer grant."""
+    from tools.reviewer_authority import require_activation
+
+    try:
+        activation = require_activation()
+    except RuntimeError:
+        return False
+    return activation.get("role") in _REVIEW_ROLES
+
+
+def _handle_skills_list(args: dict, **kw: Any) -> str:
+    return skills_list(category=args.get("category") or "", task_id=kw.get("task_id") or "")
+
+
+def _handle_web_search(args: dict, **_kw: Any) -> str:
+    return web_search_tool(args.get("query", ""), limit=args.get("limit", 5))
+
+
+async def _handle_web_extract(args: dict, **_kw: Any) -> str:
+    urls = args.get("urls", [])
+    return await web_extract_tool(
+        urls[:5] if isinstance(urls, list) else [],
+        format=args.get("format") or "markdown",
+        char_limit=args.get("char_limit"),
+    )
+
+
+# Serialize at import time so later registry registrations or mutable schema
+# aliases cannot alter the reviewer contract. JSON also gives callers fresh
+# dictionaries, preventing one session from mutating the next session's schema.
+_SCHEMA_JSON = json.dumps(
+    [
+        READ_FILE_SCHEMA,
+        SEARCH_FILES_SCHEMA,
+        WEB_SEARCH_SCHEMA,
+        WEB_EXTRACT_SCHEMA,
+        SKILLS_LIST_SCHEMA,
+        SKILL_VIEW_SCHEMA,
+        KANBAN_SHOW_SCHEMA,
+        KANBAN_COMPLETE_SCHEMA,
+        KANBAN_BLOCK_SCHEMA,
+        KANBAN_HEARTBEAT_SCHEMA,
+        KANBAN_ATTACHMENTS_SCHEMA,
+        REVIEW_EXEC_SCHEMA,
+    ],
+    ensure_ascii=False,
+    sort_keys=True,
+    separators=(",", ":"),
+)
+
+_HANDLERS = MappingProxyType(
+    {
+        "read_file": (_handle_read_file, False),
+        "search_files": (_handle_search_files, False),
+        "web_search": (_handle_web_search, False),
+        "web_extract": (_handle_web_extract, True),
+        "skills_list": (_handle_skills_list, False),
+        "skill_view": (_skill_view_with_bump, False),
+        "kanban_show": (_handle_show, False),
+        "kanban_complete": (_handle_complete, False),
+        "kanban_block": (_handle_block, False),
+        "kanban_heartbeat": (_handle_heartbeat, False),
+        "kanban_attachments": (_handle_attachments, False),
+        "review_exec": (_handle_review_exec, False),
+    }
+)
+
+
+def canonical_reviewer_definitions() -> list[dict[str, Any]]:
+    """Return the exact canonical schemas without consulting the registry."""
+    schemas = json.loads(_SCHEMA_JSON)
+    return [{"type": "function", "function": schema} for schema in schemas]
+
+
+def canonical_reviewer_handler(name: str) -> tuple[Callable[..., Any], bool] | None:
+    """Return a canonical handler and async flag for an allowed reviewer tool."""
+    return _HANDLERS.get(name)
+
+
+def canonical_reviewer_schema(name: str) -> dict[str, Any] | None:
+    """Return a fresh canonical function schema for argument coercion."""
+    for definition in canonical_reviewer_definitions():
+        schema = definition["function"]
+        if schema["name"] == name:
+            return copy.deepcopy(schema)
+    return None

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2441,11 +2441,23 @@ def _check_kittentts_available() -> bool:
 
 def _default_neutts_ref_audio() -> str:
     """Return path to the bundled default voice reference audio."""
+    try:
+        from hermes_cli.kanban_runtime_snapshot import sealed_resource_path, snapshot_bootstrap_capability
+        if snapshot_bootstrap_capability() is not None:
+            return str(sealed_resource_path("tools/neutts_samples/jo.wav"))
+    except ImportError:
+        pass
     return str(Path(__file__).parent / "neutts_samples" / "jo.wav")
 
 
 def _default_neutts_ref_text() -> str:
     """Return path to the bundled default voice reference transcript."""
+    try:
+        from hermes_cli.kanban_runtime_snapshot import sealed_resource_path, snapshot_bootstrap_capability
+        if snapshot_bootstrap_capability() is not None:
+            return str(sealed_resource_path("tools/neutts_samples/jo.txt"))
+    except ImportError:
+        pass
     return str(Path(__file__).parent / "neutts_samples" / "jo.txt")
 
 
@@ -2459,8 +2471,8 @@ def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) ->
     import sys
 
     neutts_config = tts_config.get("neutts") or {}
-    ref_audio = neutts_config.get("ref_audio", "") or _default_neutts_ref_audio()
-    ref_text = neutts_config.get("ref_text", "") or _default_neutts_ref_text()
+    ref_audio = neutts_config.get("ref_audio", "")
+    ref_text = neutts_config.get("ref_text", "")
     model = neutts_config.get("model", "neuphonic/neutts-air-q4-gguf")
     device = neutts_config.get("device", "cpu")
 
@@ -2470,18 +2482,41 @@ def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) ->
     if not output_path.endswith(".wav"):
         wav_path = output_path.rsplit(".", 1)[0] + ".wav"
 
-    synth_script = str(Path(__file__).parent / "neutts_synth.py")
-    cmd = [
-        sys.executable, synth_script,
-        "--text", text,
-        "--out", wav_path,
-        "--ref-audio", ref_audio,
-        "--ref-text", ref_text,
-        "--model", model,
-        "--device", device,
-    ]
+    from contextlib import ExitStack
 
-    result = subprocess.run(cmd, capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=120, stdin=subprocess.DEVNULL)
+    pass_fds: tuple[int, ...] = ()
+    with ExitStack() as stack:
+        try:
+            from hermes_cli.kanban_runtime_snapshot import (
+                sealed_python_argv,
+                sealed_resource_file,
+                snapshot_bootstrap_capability,
+            )
+            if snapshot_bootstrap_capability() is not None:
+                command, prefix = sealed_python_argv("tools/neutts_synth.py")
+                if not ref_audio:
+                    audio = stack.enter_context(sealed_resource_file("tools/neutts_samples/jo.wav"))
+                    ref_audio = audio.path
+                    pass_fds += audio.pass_fds
+                if not ref_text:
+                    transcript = stack.enter_context(sealed_resource_file("tools/neutts_samples/jo.txt"))
+                    ref_text = transcript.path
+                    pass_fds += transcript.pass_fds
+            else:
+                command, prefix = sys.executable, [str(Path(__file__).parent / "neutts_synth.py")]
+        except ImportError:
+            command, prefix = sys.executable, [str(Path(__file__).parent / "neutts_synth.py")]
+        ref_audio = ref_audio or _default_neutts_ref_audio()
+        ref_text = ref_text or _default_neutts_ref_text()
+        cmd = [
+            command, *prefix, "--text", text, "--out", wav_path,
+            "--ref-audio", ref_audio, "--ref-text", ref_text,
+            "--model", model, "--device", device,
+        ]
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, encoding='utf-8', errors='replace',
+            timeout=120, stdin=subprocess.DEVNULL, pass_fds=pass_fds,
+        )
     if result.returncode != 0:
         stderr = result.stderr.strip()
         # Filter out the "OK:" line from stderr

--- a/toolsets.py
+++ b/toolsets.py
@@ -396,6 +396,12 @@ TOOLSETS = {
         "includes": [],
     },
 
+    "review-exec": {
+        "description": "Allowlisted repository inspection and verification execution for read-only reviewers",
+        "tools": ["review_exec"],
+        "includes": [],
+    },
+
     # Coding posture (base Hermes — CLI/TUI/desktop/ACP). Auto-selected in a
     # code workspace; see agent/coding_context.py. Keeps everything you reach
     # for while pairing on code and drops the rest (messaging, tts, image_gen,

--- a/toolsets.py
+++ b/toolsets.py
@@ -304,6 +304,25 @@ TOOLSETS = {
         "includes": [],
     },
 
+    "kanban-worker-lifecycle": {
+        "description": "Task-scoped Kanban worker lifecycle without graph-routing or attachment mutation",
+        "tools": [
+            "kanban_show", "kanban_complete", "kanban_block",
+            "kanban_heartbeat", "kanban_attachments",
+        ],
+        "includes": [],
+    },
+
+    "integration-worker": {
+        "description": "Bounded local integration tools: workspace files, shell checks, and read-only skill guidance",
+        "tools": [
+            "terminal", "process",
+            "read_file", "write_file", "patch", "search_files",
+            "skills_list", "skill_view",
+        ],
+        "includes": [],
+    },
+
     "discord": {
         "description": "Discord read and participate tools (fetch messages, search members, create threads)",
         "tools": ["discord"],
@@ -365,6 +384,16 @@ TOOLSETS = {
         "description": "Safe toolkit without terminal access",
         "tools": [],
         "includes": ["web", "vision", "image_gen"]
+    },
+
+    "review-readonly": {
+        "description": "Strict read-only review tools without shell, file mutation, delegation, or external side effects",
+        "tools": [
+            "read_file", "search_files",
+            "web_search", "web_extract",
+            "skills_list", "skill_view",
+        ],
+        "includes": [],
     },
 
     # Coding posture (base Hermes — CLI/TUI/desktop/ACP). Auto-selected in a


### PR DESCRIPTION
## What

Hardens Kanban worker/reviewer execution with an **immutable runtime snapshot** and a **verified runtime-binding import guard**, plus reviewer IPC authority hardening. Built and verified through an isolated TDD pipeline (planner→architect→critic→executor→independent critic/verifier) on a disposable worktree at base `606be246`.

### Sealed immutable runtime
- Worker executes **only** from a verified sealed snapshot payload: deterministic manifest, per-file SHA-256, `0o500` read-only publication, `SEALED` marker, fsync + atomic rename.
- Runtime bindings (`stdlib` / `base_site` / `venv_site`) are opened by the dispatcher with **component-wise `O_NOFOLLOW`**, validated for identity/owner/write-policy, and the real handles are inherited into the child via `pass_fds`. The child re-verifies pathname↔handle identity before `sys.path` insertion and retains the handles for process lifetime; a swapped pathname fails before any first-party import.
- Continuous import guard (`SnapshotMetaPathFinder`): every non-`None` spec goes through no-link handle containment for origin, loader filename, and **every** `submodule_search_locations` entry. Genuine built-in/frozen only when loader metadata is consistent; forged built-in/frozen origin, symlink/`..` escape, namespace escape, user-site, and post-startup late imports from unapproved roots → `snapshot_import_origin_forbidden`.
- `sitecustomize.py` / `usercustomize.py` / any `*.pth` are **rejected** (not merely not-executed) via an open-fd scan (`os.listdir(fd)` + `os.stat(dir_fd=..., follow_symlinks=False)`) at dispatcher seal **and** re-scanned at both child reconstruction points (JSON bundle + verified bundle), closing the TOCTOU window between seal and install.
- Locale bijection computed from staged bytes only; `package.json`, MCP watchdog, DDGS worker, NeuTTS helper/assets execute from sealed verified bytes/fd.

### Reviewer execution authority
- Two-pipe PID/PPID challenge + SQLite CAS **commit-before-GRANT**; generic worker user code runs only after `READY` + child EOF + lease `prepared→ready→bound` + release.
- Pipe fallback FD exact-once cleanup; per-write monotonic deadline recheck (no post-expiry write); graceful `SIGTERM → bounded grace → conditional SIGKILL → single reap`.
- Canonical reviewer surface bypasses plugin middleware/hooks; plugin-downgrade protection.

### Platform
- Windows secure spawn adapter (STARTUPINFOEX handle-list, kill-on-close Job Object, assign-before-resume, exact-once handle cleanup) present but **`UNVERIFIED_PENDING_WINDOWS_CI` fail-closed** — no `taskkill` fallback; real Windows CI evidence pending.

## Why

The previous 9-file mutable attestation manifest could not close post-spawn mutation of reviewer modules; this replaces it with sealed snapshot-only execution and handle-bound import containment so mutable workspace mutation cannot execute after verification.

## Testing

Verified on the exact dirty worktree (HEAD `606be246`):
- Focused guard/reviewer/snapshot suites: 37–85 per file, all green
- Impacted 17 files: 215 passed; full Kanban/reviewer sweep 50 files: 392 passed
- Stress 5× per attack set, all green
- Real sealed-spawn probes: five-module post-seal mutation → 0/5 markers executed; `.pth` injection between seal and install → `snapshot_runtime_startup_forbidden`; fd identity mismatch → `snapshot_runtime_binding_mismatch`
- `python3 -m py_compile` + `git diff --check` clean; no uv/.venv/operating changes

## Notes
- A verified binding containing editable `*.pth` (e.g. `__editable__` installs) fails closed at binding validation — callers must use a `.pth`-free environment for the sealed path.
- Windows runtime proof remains `UNVERIFIED_PENDING_WINDOWS_CI` until exercised on real Windows CI.

- [x] `bun check` passes (n/a — Python)
- [x] Tested locally
- [ ] CHANGELOG updated (user-facing behavior unchanged; internal Kanban hardening)