### PR TITLE
fix(desktop): preserve global profile sessions across overrides

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -157,7 +157,7 @@ import { createKeepAwake } from './power-save'
 import { FirstRunSetupResetError, runPrimaryBackendStartup } from './primary-backend-startup'
 import { rehomePrimaryConnection } from './primary-connection-rehome'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
-import { fetchPrimaryProfileSessions } from './profile-session-routing'
+import { fetchPrimaryProfileSessions, resolveProfileSessionAggregateRoute } from './profile-session-routing'
 import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
 import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
 import * as remoteLifecycle from './remote-lifecycle'
@@ -1053,6 +1053,7 @@ let mainWindow = null
 const backendConnectionState = createBackendConnectionState<ReturnType<typeof spawn>, any>()
 const remoteLiveness = new RemoteLivenessTracker()
 const remoteRevalidation = new RemoteRevalidationCoordinator()
+let globalRemoteConnectionPromise: Promise<any> | null = null
 // True while connection-config:apply soft-rehomes the primary — suppresses the
 // backend-exit toast so an intentional kill doesn't look like a crash.
 let softRehomeInProgress = false
@@ -7665,6 +7666,11 @@ async function fetchJsonForProfile(profile, path) {
 // Issue an arbitrary method against a profile's resolved backend, parsed JSON.
 async function requestJsonForProfile(profile: string, path: string, method: string, body?: string) {
   const conn = await ensureBackend(profile)
+
+  return requestJsonForConnection(conn, path, method, body)
+}
+
+async function requestJsonForConnection(conn, path: string, method: string, body?: string) {
   const url = `${conn.baseUrl}${path}`
   const opts = { method, body, timeoutMs: DEFAULT_FETCH_TIMEOUT_MS }
 
@@ -7681,6 +7687,74 @@ async function requestJsonForProfile(profile: string, path: string, method: stri
   }
 
   return fetchJson(url, conn.token, opts)
+}
+
+async function ensureGlobalRemoteBackend() {
+  if (globalRemoteConnectionPromise) {
+    return globalRemoteConnectionPromise
+  }
+
+  const connectionAttempt = (async () => {
+    const remote = await resolveRemoteBackend(null)
+
+    if (!remote) {
+      throw new Error('The app-global Hermes backend is not remote.')
+    }
+
+    await waitForHermes(remote.baseUrl, remote.token, undefined, remote.authMode)
+
+    return remote
+  })()
+
+  globalRemoteConnectionPromise = connectionAttempt
+
+  try {
+    return await connectionAttempt
+  } catch (error) {
+    if (globalRemoteConnectionPromise === connectionAttempt) {
+      globalRemoteConnectionPromise = null
+    }
+
+    throw error
+  }
+}
+
+async function requestJsonForGlobalRemote(path: string, method: string, body?: string) {
+  const conn = await ensureGlobalRemoteBackend()
+  const connectionAttempt = globalRemoteConnectionPromise
+
+  try {
+    return await requestJsonForConnection(conn, path, method, body)
+  } catch (error) {
+    if (globalRemoteConnectionPromise === connectionAttempt) {
+      globalRemoteConnectionPromise = null
+    }
+
+    throw error
+  }
+}
+
+function profileSessionAggregateRoute() {
+  return resolveProfileSessionAggregateRoute({
+    globalRemote: globalRemoteActive(),
+    primaryProfileRemoteOverride: Boolean(profileHasRemoteOverride(primaryProfileKey()))
+  })
+}
+
+function profileSessionAggregateFetchOptions() {
+  return {
+    globalRemote: globalRemoteActive(),
+    primaryProfileRemoteOverride: Boolean(profileHasRemoteOverride(primaryProfileKey())),
+    fetchJsonForGlobalRemote: (_profile, path) => requestJsonForGlobalRemote(path, 'GET')
+  }
+}
+
+async function requestJsonForGlobalProfile(path: string, method: string, body?: string) {
+  if (profileSessionAggregateRoute() === 'global-remote') {
+    return requestJsonForGlobalRemote(path, method, body)
+  }
+
+  return requestJsonForProfile(null, path, method, body)
 }
 
 async function probeRemoteAuthMode(rawUrl) {
@@ -7922,6 +7996,7 @@ function stopBackendChild(child) {
 function resetHermesConnection({ soft = false } = {}) {
   backendStartFailure = null
   remoteReauthFailure = null
+  globalRemoteConnectionPromise = null
   remoteLiveness.clear()
   const hermesProcess = backendConnectionState.invalidate()
   stopBackendChild(hermesProcess)
@@ -10151,12 +10226,12 @@ async function interceptSessionRequestForRemote(request) {
       const path = `${pathname}${sep}profile=${encodeURIComponent(profile)}`
 
       if (method === 'GET') {
-        return fetchJsonForProfile(null, path)
+        return requestJsonForGlobalProfile(path, method)
       }
 
       const body = request.body && typeof request.body === 'object' ? { ...request.body, profile } : { profile }
 
-      return requestJsonForProfile(null, path, method, body)
+      return requestJsonForGlobalProfile(path, method, body)
     }
 
     return undefined
@@ -10195,7 +10270,7 @@ async function fetchProfilesSessionSlice(searchParams, remoteProfiles) {
       return remoteSessionList(requested, searchParams)
     }
 
-    return fetchPrimaryProfileSessions(searchParams, fetchJsonForProfile)
+    return fetchPrimaryProfileSessions(searchParams, fetchJsonForProfile, profileSessionAggregateFetchOptions())
   }
 
   return mergeRemoteProfileSessions(searchParams, remoteProfiles)
@@ -10210,7 +10285,11 @@ async function mergeRemoteProfileSessions(searchParams, remoteProfiles) {
   const offset = Math.max(0, Number(searchParams.get('offset')) || 0)
   const order = searchParams.get('order') === 'created' ? 'started_at' : 'last_active'
 
-  const base = (await fetchPrimaryProfileSessions(searchParams, fetchJsonForProfile)) as any
+  const base = (await fetchPrimaryProfileSessions(
+    searchParams,
+    fetchJsonForProfile,
+    profileSessionAggregateFetchOptions()
+  )) as any
 
   // Over-fetch each remote from offset 0 (limit+offset rows) so the merged window
   // is correct for this page — mirrors the primary's per-profile over-fetch.

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -302,6 +302,7 @@ import {
   findRemoteOwnerProfileForSession,
   mergeProfileSessionWindow,
   type RegistrySessionSource,
+  resolveProfileSessionAggregateRoute,
   spliceRegistrySessionRows,
   tagRegistrySessionResponse
 } from './profile-session-routing'
@@ -1385,6 +1386,7 @@ const registryDispatchRevalidation = new RemoteRevalidationCoordinator()
 // lifecycles, so concurrent dials for one (connectionId, profile) scope
 // coalesce here — the second caller awaits the first spawn's result.
 const backendDialClaims = new BackendDialClaims()
+let globalRemoteConnectionPromise: Promise<any> | null = null
 // True while connection-config:apply soft-rehomes the primary — suppresses the
 // backend-exit toast so an intentional kill doesn't look like a crash.
 let softRehomeInProgress = false
@@ -10551,6 +10553,11 @@ async function fetchJsonForProfile(profile, path) {
 // Issue an arbitrary method against a profile's resolved backend, parsed JSON.
 async function requestJsonForProfile(profile: string, path: string, method: string, body?: string) {
   const conn = await ensureBackend(profile)
+
+  return requestJsonForConnection(conn, path, method, body)
+}
+
+async function requestJsonForConnection(conn, path: string, method: string, body?: string) {
   const url = `${conn.baseUrl}${path}`
   const opts = { method, body, timeoutMs: DEFAULT_FETCH_TIMEOUT_MS }
 
@@ -10567,6 +10574,74 @@ async function requestJsonForProfile(profile: string, path: string, method: stri
   }
 
   return fetchJson(url, conn.token, { ...opts, headers: conn.headers })
+}
+
+async function ensureGlobalRemoteBackend() {
+  if (globalRemoteConnectionPromise) {
+    return globalRemoteConnectionPromise
+  }
+
+  const connectionAttempt = (async () => {
+    const remote = await resolveRemoteBackend(null)
+
+    if (!remote) {
+      throw new Error('The app-global Hermes backend is not remote.')
+    }
+
+    await waitForHermes(remote.baseUrl, remote.token, undefined, remote.authMode)
+
+    return remote
+  })()
+
+  globalRemoteConnectionPromise = connectionAttempt
+
+  try {
+    return await connectionAttempt
+  } catch (error) {
+    if (globalRemoteConnectionPromise === connectionAttempt) {
+      globalRemoteConnectionPromise = null
+    }
+
+    throw error
+  }
+}
+
+async function requestJsonForGlobalRemote(path: string, method: string, body?: string) {
+  const conn = await ensureGlobalRemoteBackend()
+  const connectionAttempt = globalRemoteConnectionPromise
+
+  try {
+    return await requestJsonForConnection(conn, path, method, body)
+  } catch (error) {
+    if (globalRemoteConnectionPromise === connectionAttempt) {
+      globalRemoteConnectionPromise = null
+    }
+
+    throw error
+  }
+}
+
+function profileSessionAggregateRoute() {
+  return resolveProfileSessionAggregateRoute({
+    globalRemote: globalRemoteActive(),
+    primaryProfileRemoteOverride: Boolean(profileHasRemoteOverride(primaryProfileKey()))
+  })
+}
+
+function profileSessionAggregateFetchOptions() {
+  return {
+    globalRemote: globalRemoteActive(),
+    primaryProfileRemoteOverride: Boolean(profileHasRemoteOverride(primaryProfileKey())),
+    fetchJsonForGlobalRemote: (_profile, path) => requestJsonForGlobalRemote(path, 'GET')
+  }
+}
+
+async function requestJsonForGlobalProfile(path: string, method: string, body?: string) {
+  if (profileSessionAggregateRoute() === 'global-remote') {
+    return requestJsonForGlobalRemote(path, method, body)
+  }
+
+  return requestJsonForProfile(null, path, method, body)
 }
 
 async function probeRemoteAuthMode(rawUrl) {
@@ -10836,6 +10911,7 @@ function stopBackendChild(child) {
 function resetHermesConnection({ soft = false } = {}) {
   backendStartFailure = null
   remoteReauthFailure = null
+  globalRemoteConnectionPromise = null
   remoteLiveness.clear()
   const hermesProcess = backendConnectionState.invalidate()
   stopBackendChild(hermesProcess)
@@ -15645,12 +15721,12 @@ async function interceptSessionRequestForRemote(request) {
       const path = `${pathname}?${passthroughParams.toString()}`
 
       if (method === 'GET') {
-        return fetchJsonForProfile(null, path)
+        return requestJsonForGlobalProfile(path, method)
       }
 
       const body = request.body && typeof request.body === 'object' ? { ...request.body, profile } : { profile }
 
-      return requestJsonForProfile(null, path, method, body)
+      return requestJsonForGlobalProfile(path, method, body)
     }
 
     return undefined
@@ -15720,7 +15796,7 @@ async function fetchProfilesSessionSlice(searchParams, remoteProfiles) {
       return remoteSessionList(requested, searchParams)
     }
 
-    return fetchPrimaryProfileSessions(searchParams, fetchJsonForProfile)
+    return fetchPrimaryProfileSessions(searchParams, fetchJsonForProfile, profileSessionAggregateFetchOptions())
   }
 
   return mergeRemoteProfileSessions(searchParams, remoteProfiles)
@@ -15737,7 +15813,11 @@ async function mergeRemoteProfileSessions(searchParams, remoteProfiles) {
   const offset = Math.max(0, Number(searchParams.get('offset')) || 0)
   const order = searchParams.get('order') === 'created' ? 'started_at' : 'last_active'
 
-  const base = (await fetchPrimaryProfileSessions(searchParams, fetchJsonForProfile)) as any
+  const base = (await fetchPrimaryProfileSessions(
+    searchParams,
+    fetchJsonForProfile,
+    profileSessionAggregateFetchOptions()
+  )) as any
 
   // Over-fetch each remote from offset 0 (limit+offset rows) so the merged window
   // is correct for this page — mirrors the primary's per-profile over-fetch.

--- a/apps/desktop/electron/profile-session-routing.test.ts
+++ b/apps/desktop/electron/profile-session-routing.test.ts
@@ -9,6 +9,7 @@ import {
   fetchRemoteProfileSessions,
   findRemoteOwnerProfileForSession,
   mergeProfileSessionWindow,
+  resolveProfileSessionAggregateRoute,
   spliceRegistrySessionRows,
   tagRegistrySessionResponse
 } from './profile-session-routing'
@@ -54,6 +55,82 @@ test('remote sidebar slices fall back to the all-profiles scope and default limi
     assert.equal(slices.cron.get('limit'), '50')
     assert.equal(slices.messaging.get('limit'), '100')
   }
+})
+
+test('mixed global remote and primary override reads the aggregate from the global backend', () => {
+  assert.equal(
+    resolveProfileSessionAggregateRoute({ globalRemote: true, primaryProfileRemoteOverride: true }),
+    'global-remote'
+  )
+})
+
+test('global remote without a primary override reuses the primary backend', () => {
+  assert.equal(
+    resolveProfileSessionAggregateRoute({ globalRemote: true, primaryProfileRemoteOverride: false }),
+    'primary'
+  )
+})
+
+test('mixed remote aggregate fetches bypass the primary profile override', async () => {
+  const expected = { sessions: [{ id: 'default-telegram' }], total: 1, profile_totals: { default: 1 } }
+  const calls: string[] = []
+
+  const result = await fetchPrimaryProfileSessions(
+    new URLSearchParams({ profile: 'all' }),
+    async () => {
+      calls.push('primary')
+      throw new Error('the active profile override does not serve default')
+    },
+    {
+      globalRemote: true,
+      primaryProfileRemoteOverride: true,
+      fetchJsonForGlobalRemote: async () => {
+        calls.push('global-remote')
+
+        return expected
+      }
+    }
+  )
+
+  assert.equal(result, expected)
+  assert.deepEqual(calls, ['global-remote'])
+})
+
+test('mixed global aggregate survives connected registry session splicing', async () => {
+  const base = await fetchPrimaryProfileSessions(
+    new URLSearchParams({ profile: 'all' }),
+    async () => {
+      throw new Error('the active profile override does not own inherited sessions')
+    },
+    {
+      globalRemote: true,
+      primaryProfileRemoteOverride: true,
+      fetchJsonForGlobalRemote: async () => ({
+        sessions: [{ id: 'default-telegram', profile: 'default' }],
+        total: 1,
+        profile_totals: { default: 1 }
+      })
+    }
+  )
+
+  const merged = [...base.sessions]
+  const profileTotals = { ...base.profile_totals }
+
+  const result = spliceRegistrySessionRows(
+    merged,
+    [
+      { id: 'registry-chat', profile: 'research', connection_id: 'gateway-1' },
+      { id: 'default-telegram', profile: 'default', connection_id: 'gateway-1' }
+    ],
+    profileTotals
+  )
+
+  assert.equal(result.added, 1)
+  assert.deepEqual(
+    merged.map(row => (row as { id: string }).id),
+    ['default-telegram', 'registry-chat']
+  )
+  assert.deepEqual(profileTotals, { default: 1, research: 1 })
 })
 
 test('primary session reads use the profile-aware request path', async () => {

--- a/apps/desktop/electron/profile-session-routing.test.ts
+++ b/apps/desktop/electron/profile-session-routing.test.ts
@@ -2,7 +2,46 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { fetchPrimaryProfileSessions } from './profile-session-routing'
+import { fetchPrimaryProfileSessions, resolveProfileSessionAggregateRoute } from './profile-session-routing'
+
+test('mixed global remote and primary override reads the aggregate from the global backend', () => {
+  assert.equal(
+    resolveProfileSessionAggregateRoute({ globalRemote: true, primaryProfileRemoteOverride: true }),
+    'global-remote'
+  )
+})
+
+test('global remote without a primary override reuses the primary backend', () => {
+  assert.equal(
+    resolveProfileSessionAggregateRoute({ globalRemote: true, primaryProfileRemoteOverride: false }),
+    'primary'
+  )
+})
+
+test('mixed remote aggregate fetches bypass the primary profile override', async () => {
+  const expected = { sessions: [{ id: 'default-telegram' }], total: 1, profile_totals: { default: 1 } }
+  const calls: string[] = []
+
+  const result = await fetchPrimaryProfileSessions(
+    new URLSearchParams({ profile: 'all' }),
+    async () => {
+      calls.push('primary')
+      throw new Error('the active profile override does not serve default')
+    },
+    {
+      globalRemote: true,
+      primaryProfileRemoteOverride: true,
+      fetchJsonForGlobalRemote: async () => {
+        calls.push('global-remote')
+
+        return expected
+      }
+    }
+  )
+
+  assert.equal(result, expected)
+  assert.deepEqual(calls, ['global-remote'])
+})
 
 test('primary session reads use the profile-aware request path', async () => {
   const calls: Array<{ profile: string | null; path: string }> = []

--- a/apps/desktop/electron/profile-session-routing.ts
+++ b/apps/desktop/electron/profile-session-routing.ts
@@ -164,13 +164,40 @@ export function buildSidebarSessionSliceParams(searchParams: URLSearchParams): S
   }
 }
 
+export type ProfileSessionAggregateRoute = 'global-remote' | 'primary'
+
+export interface ProfileSessionAggregateRouteOptions {
+  globalRemote: boolean
+  primaryProfileRemoteOverride: boolean
+}
+
+export interface ProfileSessionAggregateFetchOptions extends ProfileSessionAggregateRouteOptions {
+  fetchJsonForGlobalRemote: FetchJsonForProfile
+}
+
+// The primary backend normally owns aggregate profile reads. In mixed remote
+// mode, however, the active profile's explicit override owns that backend while
+// the app-global remote remains the authority for inherited/default profiles.
+export function resolveProfileSessionAggregateRoute({
+  globalRemote,
+  primaryProfileRemoteOverride
+}: ProfileSessionAggregateRouteOptions): ProfileSessionAggregateRoute {
+  return globalRemote && primaryProfileRemoteOverride ? 'global-remote' : 'primary'
+}
+
 /** Fetch the primary backend's profile-aware session slice, falling back to an empty result when unavailable. */
 export async function fetchPrimaryProfileSessions(
   searchParams: URLSearchParams,
-  fetchJsonForProfile: FetchJsonForProfile
+  fetchJsonForProfile: FetchJsonForProfile,
+  aggregateOptions?: ProfileSessionAggregateFetchOptions
 ): Promise<ProfileSessionsResponse> {
+  const fetchJson =
+    aggregateOptions && resolveProfileSessionAggregateRoute(aggregateOptions) === 'global-remote'
+      ? aggregateOptions.fetchJsonForGlobalRemote
+      : fetchJsonForProfile
+
   try {
-    return (await fetchJsonForProfile(null, `/api/profiles/sessions?${searchParams}`)) as ProfileSessionsResponse
+    return (await fetchJson(null, `/api/profiles/sessions?${searchParams}`)) as ProfileSessionsResponse
   } catch {
     return { sessions: [], total: 0, profile_totals: {} }
   }

--- a/apps/desktop/electron/profile-session-routing.ts
+++ b/apps/desktop/electron/profile-session-routing.ts
@@ -7,12 +7,39 @@ export interface ProfileSessionsResponse {
 
 type FetchJsonForProfile = (profile: string | null, path: string) => Promise<unknown>
 
+export type ProfileSessionAggregateRoute = 'global-remote' | 'primary'
+
+export interface ProfileSessionAggregateRouteOptions {
+  globalRemote: boolean
+  primaryProfileRemoteOverride: boolean
+}
+
+export interface ProfileSessionAggregateFetchOptions extends ProfileSessionAggregateRouteOptions {
+  fetchJsonForGlobalRemote: FetchJsonForProfile
+}
+
+// The primary backend normally owns aggregate profile reads. In mixed remote
+// mode, however, the active profile's explicit override owns that backend while
+// the app-global remote remains the authority for inherited/default profiles.
+export function resolveProfileSessionAggregateRoute({
+  globalRemote,
+  primaryProfileRemoteOverride
+}: ProfileSessionAggregateRouteOptions): ProfileSessionAggregateRoute {
+  return globalRemote && primaryProfileRemoteOverride ? 'global-remote' : 'primary'
+}
+
 export async function fetchPrimaryProfileSessions(
   searchParams: URLSearchParams,
-  fetchJsonForProfile: FetchJsonForProfile
+  fetchJsonForProfile: FetchJsonForProfile,
+  aggregateOptions?: ProfileSessionAggregateFetchOptions
 ): Promise<ProfileSessionsResponse> {
+  const fetchJson =
+    aggregateOptions && resolveProfileSessionAggregateRoute(aggregateOptions) === 'global-remote'
+      ? aggregateOptions.fetchJsonForGlobalRemote
+      : fetchJsonForProfile
+
   try {
-    return (await fetchJsonForProfile(null, `/api/profiles/sessions?${searchParams}`)) as ProfileSessionsResponse
+    return (await fetchJson(null, `/api/profiles/sessions?${searchParams}`)) as ProfileSessionsResponse
   } catch {
     return { sessions: [], total: 0, profile_totals: {} }
   }


### PR DESCRIPTION
## Summary

- distinguish the active window profile backend from the app-global remote that owns inherited/default profile sessions
- route aggregate sidebar reads and default-profile session reads/mutations to the global remote when the active profile has an explicit override
- reuse the primary connection in ordinary global-remote mode and invalidate the separate global descriptor after connection resets or request failures
- add mixed-topology routing coverage that proves the primary override is bypassed

## Root cause

`fetchPrimaryProfileSessions()` called `ensureBackend(null)`, and `null` resolves to `primaryProfileKey()`. When the active Desktop profile had its own remote override, the window's primary backend was that isolated override. The sidebar therefore used it as the `profile=all` aggregate source, so sessions inherited from the app-global remote, including the default profile's Telegram conversation, were absent. The same route was used when opening or mutating one of those default-profile sessions.

The fix keeps the active profile's explicit remote as the window backend, but resolves the app-global remote separately for inherited profile session operations. Explicit override rows are still spliced in by the existing merge logic.

## Verification

- RED on current main: the two mixed-topology route regressions failed before the aggregate route existed
- `npm --prefix apps/desktop run test:desktop:platforms -- electron/profile-session-routing.test.ts electron/connection-config.test.ts` - 80 passed
- `npm --prefix apps/desktop run typecheck` - passed
- `npm --prefix apps/desktop run lint -- --no-warn-ignored` - passed with 88 existing warnings and no errors
- `npm --prefix apps/desktop run test:ui` - 3,585 passed
- `npm --prefix apps/desktop run test:desktop:platforms` - 941 passed, 2 skipped
- `npm --prefix apps/desktop run test:desktop:all` - passed, including macOS app/DMG packaging
- `npm --prefix apps/desktop run build` - passed
- `git diff --check` - passed
- gitleaks publish-range scan - no leaks

Fixes #81198
