### PR TITLE
fix(env): don't cache a failed .env read as empty; log resolution failures

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3655,18 +3655,26 @@ def load_env() -> Dict[str, str]:
     same file on every call was burning ~300ms of CPU per `hermes tools`
     menu paint on top of the OAuth-refresh slowness. The mtime check
     invalidates the cache when the user edits .env mid-process.
+
+    A failed stat/read never becomes the new cached truth: a transient
+    unreadable window (e.g. mid-rewrite of .env) falls back to the last
+    successful load with a warning, because a long-running gateway
+    silently losing its keys is worse than briefly serving stale ones.
+    Writers that intentionally change .env via this module still call
+    ``invalidate_env_cache()``, which also drops the fallback copy.
     """
-    global _env_cache
+    global _env_cache, _env_load_failing
     env_path = get_env_path()
 
+    cache_key = None
+    failure = None
     try:
-        mtime = env_path.stat().st_mtime
-        size = env_path.stat().st_size
-        cache_key = (str(env_path), mtime, size)
+        st = env_path.stat()
+        cache_key = (str(env_path), st.st_mtime, st.st_size)
     except FileNotFoundError:
-        cache_key = (str(env_path), None, None)
-    except Exception:
-        cache_key = None
+        failure = "file not found"
+    except Exception as exc:
+        failure = f"stat failed: {exc!r}"
 
     if cache_key is not None and _env_cache is not None:
         cached_key, cached_vars = _env_cache
@@ -3675,38 +3683,68 @@ def load_env() -> Dict[str, str]:
 
     env_vars: Dict[str, str] = {}
 
-    if env_path.exists():
+    if failure is None:
         # On Windows, open() defaults to the system locale (cp1252) which can
         # fail on UTF-8 .env files. Always use explicit UTF-8; tolerate BOM
         # via utf-8-sig since users may edit .env in Notepad which adds one.
         open_kw = {"encoding": "utf-8-sig", "errors": "replace"}
-        with open(env_path, **open_kw) as f:
-            raw_lines = f.readlines()
-        # Normalize line endings without interpreting value contents as syntax.
-        lines = _sanitize_env_lines(raw_lines)
-        for line in lines:
-            line = line.strip()
-            if line and not line.startswith('#') and '=' in line:
-                # Strip the bash-compatible ``export `` prefix so lines like
-                # ``export API_KEY=...`` parse as ``API_KEY`` rather than being
-                # stored under the wrong key ``"export API_KEY"`` (#6659).
-                if line.startswith('export '):
-                    line = line[7:]
-                key, _, value = line.partition('=')
-                env_vars[key.strip()] = _parse_env_value(value)
+        try:
+            with open(env_path, **open_kw) as f:
+                raw_lines = f.readlines()
+        except FileNotFoundError:
+            failure = "file not found"  # disappeared between stat and open
+        except Exception as exc:
+            failure = f"read failed: {exc!r}"
+        else:
+            # Normalize line endings without interpreting value contents as syntax.
+            lines = _sanitize_env_lines(raw_lines)
+            for line in lines:
+                line = line.strip()
+                if line and not line.startswith('#') and '=' in line:
+                    # Strip the bash-compatible ``export `` prefix so lines like
+                    # ``export API_KEY=...`` parse as ``API_KEY`` rather than being
+                    # stored under the wrong key ``"export API_KEY"`` (#6659).
+                    if line.startswith('export '):
+                        line = line[7:]
+                    key, _, value = line.partition('=')
+                    env_vars[key.strip()] = _parse_env_value(value)
 
-    if cache_key is not None:
+    if failure is None:
         _env_cache = (cache_key, dict(env_vars))
+        _env_load_failing = False
+        return env_vars
 
-    return env_vars
+    # Unreadable .env: keep the last good values instead of caching "empty"
+    # as the new truth, and log the first failure of each streak so the
+    # incident is observable from the journal.
+    if _env_cache is not None:
+        cached_key, cached_vars = _env_cache
+        if not _env_load_failing:
+            logger.warning(
+                "Could not read %s (%s); keeping %d value(s) from the last successful load",
+                env_path, failure, len(cached_vars),
+            )
+        _env_load_failing = True
+        return dict(cached_vars)
+    if failure != "file not found" and not _env_load_failing:
+        # A missing .env with nothing to fall back to is a legitimate state
+        # (fresh install); any other failure with no fallback is worth a line.
+        logger.warning("Could not read %s (%s); no previous load to fall back to", env_path, failure)
+        _env_load_failing = True
+    return {}
 
 
 # Module-level memo for load_env(), keyed on (path, mtime, size).
 # Editing .env bumps mtime → next load_env() rebuilds. invalidate_env_cache()
 # is the explicit knob for writers that update .env via this module
 # (set_env_value, save_env, etc.) without relying on filesystem mtime
-# resolution.
+# resolution. Holds the last *successful* load only; failed loads never
+# overwrite it (load_env falls back to it instead).
 _env_cache: Optional[Tuple[Tuple[str, Optional[float], Optional[int]], Dict[str, str]]] = None
+
+# True while load_env() is inside a failure streak (unreadable .env);
+# used to log each streak once instead of once per call.
+_env_load_failing: bool = False
 
 
 def invalidate_env_cache() -> None:

--- a/tests/hermes_cli/test_load_env_failure_fallback.py
+++ b/tests/hermes_cli/test_load_env_failure_fallback.py
@@ -1,0 +1,79 @@
+"""load_env() must not cache a failed read as the new truth.
+
+Regression: when ``stat`` on ``~/.hermes/.env`` raised ``FileNotFoundError``
+(e.g. the file is momentarily absent during an atomic rewrite), ``load_env``
+stored an *empty* result under the failure cache key and returned it — and the
+whole resolve path (``load_env`` → ``_load_hermes_env_vars`` → docker env
+forwarding) logged nothing. A long-running gateway could silently lose
+forwarded credentials for entire sessions (observed as ``GH_TOKEN`` vanishing
+from ``docker exec -e`` injection with zero log lines).
+
+The fix: failures never overwrite the memo; callers get the last successful
+values back (with one warning per failure streak), a fresh install with no
+.env stays silent, and the writer path (``invalidate_env_cache``) still
+forgets everything so intentional edits behave as before.
+"""
+
+import logging
+
+import pytest
+
+import hermes_cli.config as cfg
+
+
+@pytest.fixture()
+def env_file(monkeypatch, tmp_path):
+    env = tmp_path / ".env"
+    monkeypatch.setattr(cfg, "get_env_path", lambda: env)
+    monkeypatch.setattr(cfg, "_env_cache", None)
+    monkeypatch.setattr(cfg, "_env_load_failing", False)
+    return env
+
+
+def _warnings(caplog):
+    return [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+def test_missing_env_with_no_history_is_empty_and_quiet(env_file, caplog):
+    caplog.set_level(logging.WARNING, logger=cfg.__name__)
+    assert cfg.load_env() == {}
+    assert _warnings(caplog) == []  # fresh install is a legitimate state
+
+
+def test_transient_removal_falls_back_to_last_good_and_warns_once(env_file, caplog):
+    caplog.set_level(logging.WARNING, logger=cfg.__name__)
+    env_file.write_text("GH_TOKEN=abc\n", encoding="utf-8")
+    assert cfg.load_env() == {"GH_TOKEN": "abc"}
+
+    env_file.unlink()
+    assert cfg.load_env() == {"GH_TOKEN": "abc"}  # last good, not empty
+    assert cfg.load_env() == {"GH_TOKEN": "abc"}  # still cached, still quiet
+    assert len(_warnings(caplog)) == 1  # one warning per streak, not per call
+
+
+def test_recovery_and_second_streak_warns_again(env_file, caplog):
+    caplog.set_level(logging.WARNING, logger=cfg.__name__)
+    env_file.write_text("GH_TOKEN=abc\n", encoding="utf-8")
+    cfg.load_env()
+    env_file.unlink()
+    cfg.load_env()
+    assert len(_warnings(caplog)) == 1
+
+    # File comes back with different content (different size => new cache key).
+    env_file.write_text("GH_TOKEN=xyz-longer\n", encoding="utf-8")
+    assert cfg.load_env() == {"GH_TOKEN": "xyz-longer"}
+
+    env_file.unlink()
+    assert cfg.load_env() == {"GH_TOKEN": "xyz-longer"}
+    assert len(_warnings(caplog)) == 2  # new streak logs once more
+
+
+def test_writer_invalidation_still_forgets_the_fallback(env_file, caplog):
+    caplog.set_level(logging.WARNING, logger=cfg.__name__)
+    env_file.write_text("GH_TOKEN=abc\n", encoding="utf-8")
+    cfg.load_env()
+    env_file.unlink()
+
+    cfg.invalidate_env_cache()
+    # Intentional writer-path edits must not resurrect stale values.
+    assert cfg.load_env() == {}

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -107,7 +107,17 @@ def _load_hermes_env_vars() -> dict[str, str]:
 
         return load_env() or {}
     except Exception:
+        logger.warning(
+            "Could not load ~/.hermes/.env for docker env forwarding; "
+            "forwarded keys may be missing from this command", exc_info=True,
+        )
         return {}
+
+
+# Explicit docker_forward_env keys that resolved to no value and were warned
+# about already. A key is removed when it resolves again, so each failure
+# streak logs exactly once instead of once per command.
+_unresolved_forward_warned: set = set()
 
 
 # Docker label values must match [a-zA-Z0-9_.-] and stay ≤63 chars to round-trip
@@ -1577,7 +1587,16 @@ class DockerEnvironment(BaseEnvironment):
                 value = resolve_passthrough_value(key, value)
             if value is not None:
                 exec_env[key] = value
-            elif multiplex_active and not is_global_env(key) and _ENV_VAR_NAME_RE.fullmatch(key):
+                _unresolved_forward_warned.discard(key)
+                continue
+            if key in explicit_forward_keys and key not in _unresolved_forward_warned:
+                _unresolved_forward_warned.add(key)
+                logger.warning(
+                    "docker_forward_env key %s resolved to no value (not in the "
+                    "process environment nor ~/.hermes/.env); it will be missing "
+                    "in the container", key,
+                )
+            if multiplex_active and not is_global_env(key) and _ENV_VAR_NAME_RE.fullmatch(key):
                 unset_names.add(key)
         return exec_env, unset_names
 


### PR DESCRIPTION
## Problem

`load_env()` (hermes_cli/config.py) memoises on `(path, mtime, size)`. When `stat` raises `FileNotFoundError` — e.g. the file is momentarily absent during an atomic rewrite of `~/.hermes/.env` — the cache key becomes `(path, None, None)` and an **empty result is stored and returned as the new truth**. On top of that, the whole resolve path is silent: `_load_hermes_env_vars()` (tools/environments/docker.py) swallows every exception, and forwarded keys that resolve to no value are skipped without a log line.

Net effect: a long-running gateway can silently lose forwarded credentials. Observed in production: 13 hourly-cron sessions over 3 days ran with `GH_TOKEN` missing from `docker exec -e` injection — indistinguishable from "nothing to do", zero log lines anywhere. Each affected session failed all-or-nothing (the cached empty result persisted until the next mtime/size change).

## Fix

- `load_env()`: never cache a failed stat/read. Fall back to the last successful values with **one warning per failure streak** (a stale key is safer than a silently missing one for a long-running gateway). A missing `.env` with nothing cached (fresh install) stays quiet as before. The writer path (`invalidate_env_cache`) still drops the fallback, so intentional edits via the CLI behave exactly as before.
- `_load_hermes_env_vars()`: log the swallowed exception (warning, `exc_info`).
- `_resolve_passthrough_env()`: warn once per streak when an explicit `docker_forward_env` key resolves to no value (cleared when it resolves again).

No behavior change on the happy path; the memo/perf rationale in the docstring is preserved.

## Tests

`tests/hermes_cli/test_load_env_failure_fallback.py` (4 tests, passing): fresh-install quiet / fallback + warn-once per streak / recovery + second streak warns again / writer invalidation still forgets.

## Duplicate check

Searched open+merged PRs and issues for `load_env cache`, `env forwarding docker`, `GH_TOKEN missing container`, `.env silent empty` — no existing work found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)