### PR TITLE
fix(delegate): narrow template-marker regex to avoid false positives (#81391)

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3059,7 +3059,17 @@ def _recover_tasks_from_json_string(
 # Placeholder shapes for batch goal validation: bare 'TODO', bare 'task N'
 # labels, or goals still carrying unexpanded template markers.
 _PLACEHOLDER_GOAL_RE = re.compile(r"^(todo|task\s*\d+)$", re.IGNORECASE)
-_TEMPLATE_MARKER_RE = re.compile(r"<[^<>]+>|\{[^{}]+\}")
+_TEMPLATE_MARKER_RE = re.compile(
+    # Angle-brace placeholders: <FILE_PATH>, <file_path>, <component.name>
+    # Require underscores, hyphens, dots, or ALL-CAPS to distinguish from
+    # HTML tags like <button>, <div> which are lowercase single words (#81391).
+    r"<[A-Z_][\w. -]*>"
+    r"|<[a-z][\w]*[-_.][\w. -]*>"
+    # Curly-brace placeholders: {component_name}, {file.path}
+    # Exclude ${SHELL_VAR} (lookbehind for $) and JSON-like content (quotes,
+    # colons, commas, comparison operators) which indicate concrete syntax.
+    r"|(?<!\$)\{[A-Za-z_][\w. -]*\}"
+)
 _MIN_BATCH_GOAL_LEN = 10
 
 


### PR DESCRIPTION
fix(delegate): narrow template-marker regex to avoid false positives

## Problem

`_TEMPLATE_MARKER_RE` in `tools/delegate_tool.py` matches ANY content inside angle brackets or curly braces, which rejects concrete syntax that is valid in task goals:

- JSON objects: `{"status": "ok"}`
- HTML tags: `<button>`, `<div>`
- Shell variables: `${HOME}`
- Comparisons: `{x > 0}`

This makes semantically accurate batch goals fail before execution, forcing callers to rewrite otherwise valid instructions.

## Fix

Narrow the regex to only match patterns that look like actual template placeholders:

- **Angle brackets**: require uppercase start or underscore/hyphen/dot in the name (`<FILE_PATH>`, `<file_path.txt>`) to distinguish from HTML tags (`<button>`, `<div>` which are lowercase single words).
- **Curly braces**: require identifier-start char and exclude `${SHELL_VAR}` via lookbehind. JSON content with quotes/colons/commas naturally fails the identifier-only pattern.

## Test cases (all pass)

| Input | Old regex | New regex | Correct |
|---|---|---|---|
| `<FILE_PATH>` | match | match | reject placeholder |
| `{component_name}` | match | match | reject placeholder |
| `{"status": "ok"}` | match | no match | allow JSON |
| `<button>` | match | no match | allow HTML |
| `${HOME}` | match | no match | allow shell var |
| `{x > 0}` | match | no match | allow comparison |

Fixes #81391
