### PR TITLE
feat(delegation): add subagent workspace visibility controls

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -546,6 +546,8 @@ def load_cli_config() -> Dict[str, Any]:
             "provider": "",    # Subagent provider override (empty = inherit parent provider)
             "base_url": "",    # Direct OpenAI-compatible endpoint for subagents
             "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
+            "workspace_visibility": "inherit",  # inherit | full_rw | full_ro | temp_rw | mapped
+            "workspace_mappings": [],  # [{source, target, read_only}] for mapped mode
         },
         "onboarding": {
             # First-touch hint flags (see agent/onboarding.py).  Each hint is

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1768,6 +1768,8 @@ DEFAULT_CONFIG = {
         # Flip to true only if you trust delegated work to run dangerous cmds
         # without human review (cron pipelines, batch automation, etc.).
         "subagent_auto_approve": False,
+        "workspace_visibility": "inherit",  # inherit | full_rw | full_ro | temp_rw | mapped
+        "workspace_mappings": [],  # [{source, target, read_only}] for mapped mode
     },
 
     # Ephemeral prefill messages file — JSON list of {role, content} dicts

--- a/run_agent.py
+++ b/run_agent.py
@@ -7702,6 +7702,9 @@ class AIAgent:
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
             background=(not _is_subagent),
+            workspace_visibility=function_args.get("workspace_visibility"),
+            workspace_mappings=function_args.get("workspace_mappings"),
+            parent_task_id=getattr(self, "_current_effective_task_id", None),
             parent_agent=self,
         )
 
@@ -7825,6 +7828,7 @@ class AIAgent:
         )
         from agent.subagent_lifecycle import bind_subagent_parent
         effective_task_id = task_id or str(uuid.uuid4())
+        self._current_effective_task_id = effective_task_id
         session_id = str(getattr(self, "session_id", None) or "")
         task_context = {
             "session_id": session_id,

--- a/tests/tools/test_docker_network_config.py
+++ b/tests/tools/test_docker_network_config.py
@@ -33,7 +33,17 @@ def test_sibling_container_config_sites_carry_docker_network():
     for module in (terminal_tool, file_tools, code_execution_tool):
         tree = ast.parse(inspect.getsource(module))
         sites = 0
+        delegates = False
         for node in ast.walk(tree):
+            # Detect delegation to _container_config_from_config — the
+            # centralized builder in terminal_tool is already checked below,
+            # so a module that delegates has no inline dict of its own.
+            if isinstance(node, ast.Call):
+                func = node.func
+                if isinstance(func, ast.Name) and func.id == "_container_config_from_config":
+                    delegates = True
+                elif isinstance(func, ast.Attribute) and func.attr == "_container_config_from_config":
+                    delegates = True
             if not isinstance(node, ast.Dict):
                 continue
             keys = {k.value for k in node.keys if isinstance(k, ast.Constant)}
@@ -44,6 +54,8 @@ def test_sibling_container_config_sites_carry_docker_network():
                     f"docker_run_as_host_user but without docker_network "
                     f"(line {node.lineno})"
                 )
+        if sites == 0 and delegates:
+            continue
         assert sites >= 1, f"expected at least one container_config site in {module.__name__}"
 
 

--- a/tests/tools/test_subagent_workspace.py
+++ b/tests/tools/test_subagent_workspace.py
@@ -1,0 +1,194 @@
+from pathlib import Path
+
+import pytest
+
+from tools.subagent_workspace import (
+    _split_workspace_volume,
+    build_workspace_overrides,
+    resolve_parent_workspace_root,
+)
+
+
+def test_full_ro_mounts_parent_workspace_read_only(tmp_path):
+    plan = build_workspace_overrides(
+        visibility="full_ro",
+        mappings=None,
+        workspace_root=tmp_path,
+        child_token="child-1",
+        backend="docker",
+    )
+
+    assert plan["task_env_overrides"]["cwd"] == "/workspace"
+    assert plan["task_env_overrides"]["docker_volumes"] == [f"{tmp_path.resolve()}:/workspace:ro"]
+    assert "read-only" in plan["prompt_note"]
+
+
+def test_temp_rw_creates_isolated_subworkspace(tmp_path):
+    plan = build_workspace_overrides(
+        visibility="temp_rw",
+        mappings=None,
+        workspace_root=tmp_path,
+        child_token="child-2",
+        backend="docker",
+    )
+
+    mount = plan["task_env_overrides"]["docker_volumes"][0]
+    host_path = Path(mount.split(":", 1)[0])
+    assert host_path.is_dir()
+    assert host_path.parent == tmp_path / ".hermes-subagents"
+    assert mount.endswith(":/workspace")
+    assert "isolated writable subworkspace" in plan["prompt_note"]
+
+
+def test_mapped_rejects_workspace_escape(tmp_path):
+    outside = tmp_path.parent / "outside"
+    outside.mkdir(exist_ok=True)
+
+    with pytest.raises(ValueError, match="escapes the parent workspace"):
+        build_workspace_overrides(
+            visibility="mapped",
+            mappings=[{"source": str(outside), "target": "shared"}],
+            workspace_root=tmp_path,
+            child_token="child-3",
+            backend="docker",
+        )
+
+
+def test_mapped_supports_multiple_targets_and_read_only(tmp_path):
+    (tmp_path / "pkg-a").mkdir()
+    (tmp_path / "pkg-b").mkdir()
+
+    plan = build_workspace_overrides(
+        visibility="mapped",
+        mappings=[
+            {"source": "pkg-a", "target": "work/a"},
+            {"source": "pkg-b", "target": "/workspace/work/b", "read_only": True},
+        ],
+        workspace_root=tmp_path,
+        child_token="child-4",
+        backend="docker",
+    )
+
+    assert plan["task_env_overrides"]["cwd"] == "/workspace"
+    assert plan["task_env_overrides"]["docker_volumes"] == [
+        f"{(tmp_path / 'pkg-a').resolve()}:/workspace/work/a",
+        f"{(tmp_path / 'pkg-b').resolve()}:/workspace/work/b:ro",
+    ]
+    assert "/workspace/work/a" in plan["prompt_note"]
+    assert "/workspace/work/b" in plan["prompt_note"]
+
+
+def test_mapped_rejects_container_targets_outside_workspace(tmp_path):
+    (tmp_path / "pkg-a").mkdir()
+
+    with pytest.raises(ValueError, match="within /workspace"):
+        build_workspace_overrides(
+            visibility="mapped",
+            mappings=[{"source": "pkg-a", "target": "/workspace2"}],
+            workspace_root=tmp_path,
+            child_token="child-6",
+            backend="docker",
+        )
+
+
+def test_restricted_modes_require_docker_backend(tmp_path):
+    with pytest.raises(ValueError, match="requires the docker terminal backend"):
+        build_workspace_overrides(
+            visibility="full_ro",
+            mappings=None,
+            workspace_root=tmp_path,
+            child_token="child-5",
+            backend="local",
+        )
+
+
+def test_resolve_parent_workspace_root_prefers_task_overrides(monkeypatch, tmp_path):
+    host_root = tmp_path / "workspace-root"
+    host_root.mkdir()
+
+    import tools.terminal_tool as terminal_tool
+
+    monkeypatch.setattr(
+        terminal_tool,
+        "_task_env_overrides",
+        {"task-1": {"host_cwd": str(host_root)}},
+    )
+
+    assert resolve_parent_workspace_root("task-1") == host_root.resolve()
+
+
+def test_resolve_parent_workspace_root_uses_runtime_config(monkeypatch, tmp_path):
+    import tools.terminal_tool as terminal_tool
+
+    monkeypatch.setattr(
+        terminal_tool,
+        "_get_env_config",
+        lambda: {"cwd": str(tmp_path), "host_cwd": None, "docker_volumes": []},
+    )
+
+    assert resolve_parent_workspace_root() == tmp_path.resolve()
+
+
+def test_resolve_parent_workspace_root_rejects_docker_container_cwd_fallback(monkeypatch):
+    import tools.terminal_tool as terminal_tool
+
+    monkeypatch.setattr(
+        terminal_tool,
+        "_get_env_config",
+        lambda: {
+            "env_type": "docker",
+            "cwd": "/workspace",
+            "host_cwd": None,
+            "docker_volumes": [],
+        },
+    )
+
+    with pytest.raises(ValueError, match="unable to prove the parent host workspace root"):
+        resolve_parent_workspace_root()
+
+
+def test_resolve_parent_workspace_root_uses_single_nested_workspace_mount(monkeypatch, tmp_path):
+    host_root = tmp_path / "pkg"
+    host_root.mkdir()
+
+    import tools.terminal_tool as terminal_tool
+
+    monkeypatch.setattr(
+        terminal_tool,
+        "_task_env_overrides",
+        {"task-2": {"docker_volumes": [f"{host_root.resolve()}:/workspace/pkg:ro"]}},
+    )
+
+    assert resolve_parent_workspace_root("task-2") == host_root.resolve()
+
+
+def test_resolve_parent_workspace_root_rejects_ambiguous_nested_workspace_mounts(monkeypatch, tmp_path):
+    pkg_a = tmp_path / "pkg-a"
+    pkg_b = tmp_path / "pkg-b"
+    pkg_a.mkdir()
+    pkg_b.mkdir()
+
+    import tools.terminal_tool as terminal_tool
+
+    monkeypatch.setattr(
+        terminal_tool,
+        "_task_env_overrides",
+        {
+            "task-3": {
+                "docker_volumes": [
+                    f"{pkg_a.resolve()}:/workspace/a",
+                    f"{pkg_b.resolve()}:/workspace/b:ro",
+                ]
+            }
+        },
+    )
+
+    with pytest.raises(ValueError, match="no single host workspace root"):
+        resolve_parent_workspace_root("task-3")
+
+
+def test_split_workspace_volume_supports_windows_style_host_paths():
+    host, container = _split_workspace_volume(r"C:/repo:/workspace/pkg:ro")
+
+    assert host == "C:/repo"
+    assert container == "/workspace/pkg"

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -853,6 +853,7 @@ _HEARTBEAT_INTERVAL = 30  # seconds between parent activity heartbeats during de
 _HEARTBEAT_STALE_CYCLES_IDLE = 15  # 15 * 30s = 450s idle between turns → stale
 _HEARTBEAT_STALE_CYCLES_IN_TOOL = 40  # 40 * 30s = 1200s stuck on same tool → stale
 DEFAULT_TOOLSETS = ["terminal", "file", "web"]
+DEFAULT_WORKSPACE_VISIBILITY = "inherit"
 
 
 # ---------------------------------------------------------------------------
@@ -902,6 +903,7 @@ def _build_child_system_prompt(
     context: Optional[str] = None,
     *,
     workspace_path: Optional[str] = None,
+    workspace_note: Optional[str] = None,
     role: str = "leaf",
     max_spawn_depth: int = 2,
     child_depth: int = 1,
@@ -927,6 +929,8 @@ def _build_child_system_prompt(
             f"{workspace_path}\n"
             "Use this exact path for local repository/workdir operations unless the task explicitly says otherwise."
         )
+    if workspace_note and workspace_note.strip():
+        parts.append(f"\n{workspace_note.strip()}")
     parts.append(
         "\nComplete this task using the tools available to you. "
         "When finished, provide a clear, concise summary of:\n"
@@ -1000,6 +1004,59 @@ def _resolve_workspace_hint(parent_agent) -> Optional[str]:
         if os.path.isabs(text) and os.path.isdir(text):
             return text
     return None
+
+
+def _configure_child_workspace(child, task_index: int, task_cfg: Dict[str, Any], delegation_cfg: Dict[str, Any]):
+    """Resolve workspace visibility for a delegated child and attach task overrides."""
+    from tools.subagent_workspace import (
+        build_workspace_overrides,
+        resolve_parent_workspace_root,
+        resolve_terminal_backend,
+    )
+
+    visibility = task_cfg.get("workspace_visibility")
+    mappings = task_cfg.get("workspace_mappings")
+    if mappings is None:
+        mappings = delegation_cfg.get("workspace_mappings")
+    if visibility is None:
+        visibility = delegation_cfg.get("workspace_visibility", DEFAULT_WORKSPACE_VISIBILITY)
+    if (visibility in (None, "", "inherit")) and mappings:
+        visibility = "mapped"
+
+    backend = resolve_terminal_backend()
+    workspace_root = None
+    if visibility not in (None, "", "inherit") or mappings:
+        workspace_root = resolve_parent_workspace_root(task_cfg.get("_parent_task_id"))
+
+    plan = build_workspace_overrides(
+        visibility=visibility,
+        mappings=mappings,
+        workspace_root=workspace_root,
+        child_token=f"subagent-{task_index}-{getattr(child, 'session_id', '') or task_index}",
+        backend=backend,
+    )
+
+    child._delegate_task_id = getattr(child, "session_id", None)
+    child._delegate_task_env_overrides = plan.get("task_env_overrides")
+    child._delegate_workspace_cleanup_paths = plan.get("cleanup_paths", [])
+    prompt_note = plan.get("prompt_note", "").strip()
+    if prompt_note:
+        child.ephemeral_system_prompt = _build_child_system_prompt(
+            task_cfg["goal"],
+            task_cfg.get("context"),
+            workspace_note=prompt_note,
+        )
+
+
+def _cleanup_child_workspace(child) -> None:
+    paths = getattr(child, "_delegate_workspace_cleanup_paths", None) or []
+    if not paths:
+        return
+    try:
+        from tools.subagent_workspace import cleanup_workspace_paths
+        cleanup_workspace_paths(paths)
+    except Exception:
+        logger.debug("Failed to cleanup delegated temp workspace paths", exc_info=True)
 
 
 def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
@@ -3124,6 +3181,9 @@ def delegate_task(
     role: Optional[str] = None,
     background: Optional[bool] = None,
     output_schema: Optional[Dict[str, Any]] = None,
+    workspace_visibility: Optional[str] = None,
+    workspace_mappings: Optional[List[Dict[str, Any]]] = None,
+    parent_task_id: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -3222,7 +3282,14 @@ def delegate_task(
             )
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
-        single_task: Dict[str, Any] = {"goal": goal, "context": context, "role": top_role}
+        single_task: Dict[str, Any] = {
+            "goal": goal,
+            "context": context,
+            "role": top_role,
+            "workspace_visibility": workspace_visibility,
+            "workspace_mappings": workspace_mappings,
+            "_parent_task_id": parent_task_id,
+        }
         if output_schema is not None:
             single_task["output_schema"] = output_schema
         task_list = [single_task]
@@ -3240,6 +3307,7 @@ def delegate_task(
             )
         if not task.get("goal", "").strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
+        task.setdefault("_parent_task_id", parent_task_id)
 
     # Batch-only quality gate: catch malformed fan-outs (duplicate goals,
     # placeholder goals, 1-task batches) before any child is spawned.  The
@@ -4273,6 +4341,45 @@ DELEGATE_TASK_SCHEMA = {
                     "backward compatibility."
                 ),
             },
+            "workspace_visibility": {
+                "type": "string",
+                "enum": ["inherit", "full_rw", "full_ro", "temp_rw", "mapped"],
+                "description": (
+                    "Filesystem visibility for the child sandbox (Docker backend only). "
+                    "'inherit' (default) keeps the current backend behavior. "
+                    "'full_rw' mounts the full parent workspace at /workspace read-write. "
+                    "'full_ro' mounts it read-only. "
+                    "'temp_rw' creates a fresh writable subdirectory inside the parent "
+                    "workspace and mounts only that at /workspace. "
+                    "'mapped' exposes only the paths listed in workspace_mappings."
+                ),
+            },
+            "workspace_mappings": {
+                "type": "array",
+                "description": (
+                    "Used only with workspace_visibility='mapped'. "
+                    "Each mapping source must stay inside the parent workspace. "
+                    "target defaults under /workspace and read_only defaults to false."
+                ),
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "source": {
+                            "type": "string",
+                            "description": "Workspace-relative or absolute path inside the parent workspace.",
+                        },
+                        "target": {
+                            "type": "string",
+                            "description": "Path inside the child sandbox under /workspace.",
+                        },
+                        "read_only": {
+                            "type": "boolean",
+                            "description": "Mount this mapping read-only.",
+                        },
+                    },
+                    "required": ["source"],
+                },
+            },
         },
         "required": [],
     },
@@ -4334,6 +4441,8 @@ registry.register(
         role=args.get("role"),
         background=_model_background_value(args, kw.get("parent_agent")),
         output_schema=args.get("output_schema"),
+        workspace_visibility=args.get("workspace_visibility"),
+        workspace_mappings=args.get("workspace_mappings"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1449,18 +1449,8 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
 
             container_config = None
             if env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}:
-                container_config = {
-                    "container_cpu": config.get("container_cpu", 1),
-                    "container_memory": config.get("container_memory", 5120),
-                    "container_disk": config.get("container_disk", 51200),
-                    "container_persistent": config.get("container_persistent", True),
-                    "vercel_runtime": config.get("vercel_runtime", ""),
-                    "docker_volumes": config.get("docker_volumes", []),
-                    "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
-                    "docker_forward_env": config.get("docker_forward_env", []),
-                    "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
-                    "docker_network": config.get("docker_network", True),
-                }
+                from tools.terminal_tool import _container_config_from_config
+                container_config = _container_config_from_config(config, overrides)
 
             ssh_config = None
             if env_type == "ssh":
@@ -1487,7 +1477,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                 container_config=container_config,
                 local_config=local_config,
                 task_id=task_id,
-                host_cwd=config.get("host_cwd"),
+                host_cwd=overrides.get("host_cwd", config.get("host_cwd")),
             )
 
             with _env_lock:

--- a/tools/subagent_workspace.py
+++ b/tools/subagent_workspace.py
@@ -1,0 +1,367 @@
+"""Workspace visibility policies for delegated subagents.
+
+This module turns high-level child workspace requests into task-specific
+terminal overrides that the Docker backend can honor safely.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import posixpath
+import tempfile
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+
+ALLOWED_WORKSPACE_VISIBILITY = frozenset({
+    "inherit",
+    "full_rw",
+    "full_ro",
+    "temp_rw",
+    "mapped",
+})
+
+MAX_WORKSPACE_MAPPINGS = 8
+
+
+def resolve_parent_workspace_root(parent_task_id: Optional[str] = None) -> Path:
+    """Return the parent workspace root on the host filesystem.
+
+    Prefer task-specific sandbox overrides when the parent already has an
+    environment mapping. Fall back to the same config/env resolution used by
+    the terminal backend.
+    """
+    root = _resolve_workspace_root_from_task(parent_task_id)
+    if root is None:
+        root = _resolve_workspace_root_from_runtime()
+    if root is None:
+        raise ValueError(
+            "Cannot use delegated workspace visibility: unable to prove the parent host workspace root "
+            "from the current sandbox mapping."
+        )
+    if not root.exists() or not root.is_dir():
+        raise ValueError(
+            f"Cannot use delegated workspace visibility: parent workspace root is not a directory: {root}"
+        )
+    return root
+
+
+def resolve_terminal_backend() -> str:
+    """Resolve the configured terminal backend without importing large surfaces eagerly."""
+    try:
+        from tools.terminal_tool import _get_env_config
+
+        return str(_get_env_config().get("env_type") or "local").strip() or "local"
+    except Exception:
+        return (os.getenv("TERMINAL_ENV") or "local").strip() or "local"
+
+
+def build_workspace_overrides(
+    visibility: Optional[str],
+    mappings: Optional[List[Dict[str, Any]]],
+    workspace_root: Optional[Path],
+    child_token: str,
+    backend: str,
+) -> Dict[str, Any]:
+    """Build terminal overrides and prompt text for a delegated child."""
+    mode = str(visibility or "inherit").strip() or "inherit"
+    if mode not in ALLOWED_WORKSPACE_VISIBILITY:
+        allowed = ", ".join(sorted(ALLOWED_WORKSPACE_VISIBILITY))
+        raise ValueError(f"Invalid workspace_visibility '{mode}'. Expected one of: {allowed}.")
+
+    if mode != "mapped" and mappings:
+        raise ValueError("workspace_mappings may only be used when workspace_visibility='mapped'.")
+
+    if mode == "inherit":
+        return {"prompt_note": "", "task_env_overrides": None, "cleanup_paths": []}
+
+    if backend != "docker":
+        raise ValueError(
+            f"workspace_visibility='{mode}' requires the docker terminal backend; current backend is '{backend}'."
+        )
+    if workspace_root is None:
+        raise ValueError("Cannot use delegated workspace visibility without a resolved parent workspace root.")
+
+    workspace_root = workspace_root.resolve()
+    if mode == "full_rw":
+        return _build_mount_override(
+            host_path=workspace_root,
+            container_path="/workspace",
+            read_only=False,
+            prompt_note=(
+                "WORKSPACE VISIBILITY:\n"
+                f"- You can access the parent workspace at /workspace (host root: {workspace_root}).\n"
+                "- The mount is read-write."
+            ),
+        )
+
+    if mode == "full_ro":
+        return _build_mount_override(
+            host_path=workspace_root,
+            container_path="/workspace",
+            read_only=True,
+            prompt_note=(
+                "WORKSPACE VISIBILITY:\n"
+                f"- You can access the parent workspace at /workspace (host root: {workspace_root}).\n"
+                "- The mount is read-only. Copy files elsewhere before editing."
+            ),
+        )
+
+    if mode == "temp_rw":
+        base_dir = workspace_root / ".hermes-subagents"
+        base_dir.mkdir(parents=True, exist_ok=True)
+        temp_dir = Path(
+            tempfile.mkdtemp(
+                prefix=f"{child_token[:24]}-",
+                dir=str(base_dir),
+            )
+        ).resolve()
+        rel_path = temp_dir.relative_to(workspace_root)
+        return _build_mount_override(
+            host_path=temp_dir,
+            container_path="/workspace",
+            read_only=False,
+            cleanup_paths=[temp_dir],
+            prompt_note=(
+                "WORKSPACE VISIBILITY:\n"
+                f"- You only see an isolated writable subworkspace at /workspace.\n"
+                f"- Host path: {rel_path}.\n"
+                "- You cannot see the rest of the parent workspace."
+            ),
+        )
+
+    normalized_mappings = _normalize_mappings(mappings or [], workspace_root)
+    if not normalized_mappings:
+        raise ValueError("workspace_visibility='mapped' requires at least one workspace_mappings entry.")
+
+    volume_specs = []
+    visible_paths = []
+    for item in normalized_mappings:
+        suffix = ":ro" if item["read_only"] else ""
+        volume_specs.append(f"{item['host_path']}:{item['container_path']}{suffix}")
+        visible_paths.append(
+            f"- {item['container_path']} -> {item['host_path'].relative_to(workspace_root)}"
+            + (" (read-only)" if item["read_only"] else "")
+        )
+
+    return {
+        "prompt_note": "WORKSPACE VISIBILITY:\n- You only see these mapped paths:\n" + "\n".join(visible_paths),
+        "task_env_overrides": {
+            "cwd": "/workspace",
+            "host_cwd": None,
+            "docker_mount_cwd_to_workspace": False,
+            "docker_volumes": volume_specs,
+            "workspace_isolation": True,
+        },
+        "cleanup_paths": [],
+    }
+
+
+def _build_mount_override(
+    *,
+    host_path: Path,
+    container_path: str,
+    read_only: bool,
+    cleanup_paths: Optional[List[Path]] = None,
+    prompt_note: str,
+) -> Dict[str, Any]:
+    suffix = ":ro" if read_only else ""
+    return {
+        "prompt_note": prompt_note,
+        "task_env_overrides": {
+            "cwd": container_path,
+            "host_cwd": None,
+            "docker_mount_cwd_to_workspace": False,
+            "docker_volumes": [f"{host_path}:{container_path}{suffix}"],
+            "workspace_isolation": True,
+        },
+        "cleanup_paths": list(cleanup_paths or []),
+    }
+
+
+def _normalize_mappings(
+    mappings: List[Dict[str, Any]],
+    workspace_root: Path,
+) -> List[Dict[str, Any]]:
+    if len(mappings) > MAX_WORKSPACE_MAPPINGS:
+        raise ValueError(
+            f"Too many workspace_mappings entries ({len(mappings)}). Maximum is {MAX_WORKSPACE_MAPPINGS}."
+        )
+
+    normalized = []
+    for index, item in enumerate(mappings):
+        if not isinstance(item, dict):
+            raise ValueError(f"workspace_mappings[{index}] must be an object.")
+
+        source = str(item.get("source") or item.get("host_path") or "").strip()
+        if not source:
+            raise ValueError(f"workspace_mappings[{index}] is missing 'source'.")
+
+        host_path = _resolve_workspace_child_path(source, workspace_root)
+        if not host_path.exists():
+            raise ValueError(
+                f"workspace_mappings[{index}] source does not exist within the workspace: {host_path}"
+            )
+
+        target = str(item.get("target") or item.get("container_path") or "").strip()
+        container_path = _normalize_container_path(target, host_path.name)
+        normalized.append(
+            {
+                "host_path": host_path,
+                "container_path": container_path,
+                "read_only": bool(item.get("read_only", False)),
+            }
+        )
+
+    return normalized
+
+
+def _resolve_workspace_child_path(raw_path: str, workspace_root: Path) -> Path:
+    candidate = Path(raw_path).expanduser()
+    if candidate.is_absolute():
+        resolved = candidate.resolve()
+    else:
+        resolved = (workspace_root / candidate).resolve()
+
+    try:
+        resolved.relative_to(workspace_root)
+    except ValueError as exc:
+        raise ValueError(
+            f"Workspace path escapes the parent workspace: {raw_path}"
+        ) from exc
+
+    return resolved
+
+
+def _normalize_container_path(raw_path: str, fallback_name: str) -> str:
+    target = raw_path or fallback_name
+    if not target:
+        target = f"mapped-{uuid.uuid4().hex[:8]}"
+
+    if target.startswith("/"):
+        normalized = posixpath.normpath(target)
+    else:
+        normalized = posixpath.normpath(posixpath.join("/workspace", target))
+
+    if normalized != "/workspace" and not normalized.startswith("/workspace/"):
+        raise ValueError(
+            f"Mapped container path must stay within /workspace, got '{raw_path}'."
+        )
+    return normalized
+
+
+def cleanup_workspace_paths(paths: List[Path]) -> None:
+    """Best-effort cleanup for delegated temporary workspace directories."""
+    for path in paths or []:
+        try:
+            shutil.rmtree(path, ignore_errors=True)
+        except Exception:
+            pass
+
+
+def _resolve_workspace_root_from_task(parent_task_id: Optional[str]) -> Optional[Path]:
+    if not parent_task_id:
+        return None
+
+    try:
+        from tools.terminal_tool import _task_env_overrides
+    except Exception:
+        return None
+
+    overrides = _task_env_overrides.get(parent_task_id)
+    if overrides is None:
+        return None
+    overrides = overrides or {}
+    host_cwd = overrides.get("host_cwd")
+    if isinstance(host_cwd, str) and host_cwd.strip():
+        return Path(host_cwd).expanduser().resolve()
+
+    volume_root = _resolve_workspace_root_from_volumes(overrides.get("docker_volumes", []) or [])
+    if volume_root is not None:
+        return volume_root
+
+    if overrides.get("docker_volumes"):
+        raise ValueError(
+            "Cannot use delegated workspace visibility: parent task has workspace mappings but no single "
+            "host workspace root can be derived from them."
+        )
+
+    return None
+
+
+def _resolve_workspace_root_from_runtime() -> Optional[Path]:
+    try:
+        from tools.terminal_tool import _get_env_config
+
+        config = _get_env_config()
+        env_type = str(config.get("env_type") or "local").strip() or "local"
+        host_cwd = config.get("host_cwd")
+        if isinstance(host_cwd, str) and host_cwd.strip():
+            return Path(host_cwd).expanduser().resolve()
+
+        volume_root = _resolve_workspace_root_from_volumes(config.get("docker_volumes", []) or [])
+        if volume_root is not None:
+            return volume_root
+
+        if env_type == "docker":
+            return None
+
+        raw = config.get("cwd") or os.getenv("TERMINAL_CWD") or os.getcwd()
+    except Exception:
+        raw = os.getenv("TERMINAL_CWD") or os.getcwd()
+
+    return Path(raw).expanduser().resolve()
+
+
+def _resolve_workspace_root_from_volumes(volumes: List[str]) -> Optional[Path]:
+    exact_match: Optional[Path] = None
+    subpath_matches: List[Path] = []
+
+    for raw_volume in volumes:
+        host_path, container_path = _parse_workspace_volume(str(raw_volume))
+        if host_path is None or container_path is None:
+            continue
+        if container_path == "/workspace":
+            exact_match = host_path
+            break
+        if container_path.startswith("/workspace/"):
+            subpath_matches.append(host_path)
+
+    if exact_match is not None:
+        return exact_match
+    if len(subpath_matches) == 1:
+        return subpath_matches[0]
+    return None
+
+
+def _parse_workspace_volume(volume: str) -> Tuple[Optional[Path], Optional[str]]:
+    host, container_path = _split_workspace_volume(volume)
+    if host is None or container_path is None:
+        return None, None
+    return Path(host).expanduser().resolve(), container_path
+
+
+def _split_workspace_volume(volume: str) -> Tuple[Optional[str], Optional[str]]:
+    volume = volume.strip()
+    if not volume:
+        return None, None
+
+    readonly_suffix = ":ro"
+    if volume.endswith(readonly_suffix):
+        volume = volume[: -len(readonly_suffix)]
+
+    marker = ":/workspace"
+    index = volume.rfind(marker)
+    if index < 0:
+        return None, None
+
+    host = volume[:index].strip()
+    container_path = volume[index + 1 :].strip()
+    if container_path != "/workspace" and not container_path.startswith("/workspace/"):
+        return None, None
+
+    if not host:
+        return None, None
+    return host, container_path

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1233,6 +1233,12 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
         - modal_image: str -- Path to Dockerfile or Docker Hub image name
         - docker_image: str -- Docker image name
         - cwd: str -- Working directory inside the sandbox
+        - host_cwd: str -- Host workspace root for Docker bind mounting
+        - docker_mount_cwd_to_workspace: bool -- Mount host_cwd at /workspace
+        - docker_volumes: list[str] -- Explicit Docker bind mounts for this task
+        - docker_forward_env: list[str] -- Additional env vars to forward
+        - docker_network: str -- Docker network override
+        - workspace_isolation: bool -- Trigger per-child container isolation
 
     Args:
         task_id: The rollout's unique task identifier
@@ -1298,7 +1304,7 @@ def _resolve_container_task_id(task_id: Optional[str]) -> str:
     """
     _ISOLATION_KEYS = frozenset({
         "docker_image", "modal_image", "singularity_image",
-        "daytona_image", "env_type",
+        "daytona_image", "env_type", "workspace_isolation",
     })
     if task_id and task_id in _task_env_overrides:
         overrides = _task_env_overrides[task_id]
@@ -1616,12 +1622,21 @@ def _ssh_config_from_config(config: Dict[str, Any]) -> dict:
     }
 
 
-def _container_config_from_config(config: Dict[str, Any]) -> dict:
+def _container_config_from_config(
+    config: Dict[str, Any], overrides: Optional[Dict[str, Any]] = None,
+) -> dict:
     """Build the ``container_config`` dict passed to :func:`_create_environment`.
 
     Shared by the terminal tool's own get-or-create path and the lazy
     :func:`ensure_task_env` bring-up (see :func:`_ssh_config_from_config`).
+
+    When *overrides* is provided (per-task env overrides registered via
+    :func:`register_task_env_overrides`), Docker-specific keys are read from
+    the overrides first, falling back to the global config. This lets
+    delegated subagents request custom workspace mounts without changing the
+    parent's container.
     """
+    ov = overrides or {}
     return {
         "container_cpu": config.get("container_cpu", 1),
         "container_memory": config.get("container_memory", 5120),
@@ -1629,14 +1644,20 @@ def _container_config_from_config(config: Dict[str, Any]) -> dict:
         "container_persistent": config.get("container_persistent", True),
         "modal_mode": config.get("modal_mode", "auto"),
         "vercel_runtime": config.get("vercel_runtime", ""),
-        "docker_volumes": config.get("docker_volumes", []),
-        "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
-        "docker_forward_env": config.get("docker_forward_env", []),
+        "docker_volumes": ov.get("docker_volumes", config.get("docker_volumes", [])),
+        "docker_mount_cwd_to_workspace": ov.get(
+            "docker_mount_cwd_to_workspace",
+            config.get("docker_mount_cwd_to_workspace", False),
+        ),
+        "docker_forward_env": ov.get(
+            "docker_forward_env",
+            config.get("docker_forward_env", []),
+        ),
         "docker_env": config.get("docker_env", {}),
         "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
         "docker_extra_args": config.get("docker_extra_args", []),
         "docker_shm_size": config.get("docker_shm_size", "1g"),
-        "docker_network": config.get("docker_network", True),
+        "docker_network": ov.get("docker_network", config.get("docker_network", True)),
         "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
         "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
     }
@@ -1976,12 +1997,12 @@ def ensure_task_env(task_id: Optional[str] = None):
                 timeout=config["timeout"],
                 ssh_config=_ssh_config_from_config(config) if env_type == "ssh" else None,
                 container_config=(
-                    _container_config_from_config(config)
+                    _container_config_from_config(config, overrides)
                     if env_type in _CONTAINER_BACKENDS else None
                 ),
                 local_config=None,
                 task_id=effective_task_id,
-                host_cwd=config.get("host_cwd"),
+                host_cwd=overrides.get("host_cwd", config.get("host_cwd")),
             )
         except Exception as exc:  # noqa: BLE001 — best-effort bring-up
             logger.warning(
@@ -2551,7 +2572,7 @@ def terminal_tool(
                     try:
                         ssh_config = _ssh_config_from_config(config) if env_type == "ssh" else None
                         container_config = (
-                            _container_config_from_config(config)
+                            _container_config_from_config(config, overrides)
                             if env_type in _CONTAINER_BACKENDS else None
                         )
 
@@ -2570,7 +2591,7 @@ def terminal_tool(
                             container_config=container_config,
                             local_config=local_config,
                             task_id=effective_task_id,
-                            host_cwd=config.get("host_cwd"),
+                            host_cwd=overrides.get("host_cwd", config.get("host_cwd")),
                         )
                     except ImportError as e:
                         return json.dumps({


### PR DESCRIPTION
## Summary

Adds workspace visibility controls to `delegate_task` for Docker-backed subagents, with strict path validation against the parent workspace root.

New child sandbox modes:
- `inherit` (default — unchanged behavior)
- `full_rw` — full parent workspace at `/workspace` read-write
- `full_ro` — full parent workspace at `/workspace` read-only
- `temp_rw` — fresh writable subdirectory inside `/.hermes-subagents/` mounted at `/workspace`
- `mapped` — only the paths listed in `workspace_mappings` are exposed

This reuses the existing Docker mount primitives but adds the missing delegation-layer policy and validation.

Closes #5029. Replaces #5030 (rebased onto current main + architectural fix for the container-isolation blocker).

## Architectural fix for teknium1's review

teknium1's review on #5030 identified that volume-only task overrides do not create a child-specific Docker environment: `_resolve_container_task_id()` only treats `docker_image`/`modal_image`/`singularity_image`/`daytona_image`/`env_type` as isolation signals, so children collapse to the shared `default` container and mount selection never takes effect when that container already exists.

**Fix:** Add `"workspace_isolation"` to `_ISOLATION_KEYS` in `tools/terminal_tool.py`. The `build_workspace_overrides()` function sets `"workspace_isolation": True` in the task env overrides for all non-`inherit` modes. This ensures each child with workspace visibility gets its own freshly-created Docker container with the correct mounts.

## What changed

- **`tools/subagent_workspace.py`** (new, 365 lines): workspace policy resolver, path validation (rejects workspace escape, enforces targets within `/workspace`), temp directory creation + cleanup, parent workspace root inference from task overrides or runtime config
- **`tools/terminal_tool.py`**: add `workspace_isolation` to `_ISOLATION_KEYS`; extend `_container_config_from_config()` to accept `overrides` and apply Docker volume/mount/network/forward-env overrides; pass overrides at both call sites (`terminal_tool()` + `ensure_task_env()`) and use `overrides.get("host_cwd", ...)`
- **`tools/file_tools.py`**: replace inline `container_config` dict with `_container_config_from_config(config, overrides)`; use `overrides.get("host_cwd", ...)`
- **`tools/delegate_tool.py`**: add `workspace_visibility`/`workspace_mappings`/`parent_task_id` params to `delegate_task()`; add `_configure_child_workspace()` and `_cleanup_child_workspace()` helpers; wire into child-building loop with error cleanup; add `workspace_note` param to `_build_child_system_prompt()`; add schema entries for `workspace_visibility` and `workspace_mappings`
- **`run_agent.py`**: pass `workspace_visibility`, `workspace_mappings`, and `parent_task_id` to `delegate_task()` in `_dispatch_delegate_task()`; track `_current_effective_task_id` on the agent
- **`cli.py`** + **`hermes_cli/config_defaults.py`**: add `delegation.workspace_visibility` and `delegation.workspace_mappings` config defaults

## Validation

- `python -m pytest tests/tools/test_subagent_workspace.py tests/tools/test_delegate.py tests/tools/test_parse_env_var.py tests/tools/test_docker_environment.py -q`
  - `131 passed`
- Schema verification: `workspace_visibility` and `workspace_mappings` present in `DELEGATE_TASK_SCHEMA` properties

## Notes for reviewers

- The `workspace_isolation` key in `_ISOLATION_KEYS` is the critical fix — without it, children with workspace visibility modes collapse to the shared `default` container and mounts never take effect.
- `workspace_visibility` defaults to `"inherit"` so existing behavior is unchanged unless the model or config explicitly opts in.
- The `mapped` mode enforces that source paths stay inside the parent workspace (rejects `../` escapes) and target paths stay within `/workspace` in the child sandbox.
- `temp_rw` creates subdirectories under `<workspace>/.hermes-subagents/` and cleans them up when the child finishes.