### PR TITLE
fix(cron): clarify RuntimeError when config.yaml is unreadable (#81420)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3667,6 +3667,7 @@ def run_job(
         # Load config.yaml for model, reasoning, prefill, toolsets, provider routing
         _cfg = {}
         _model_cfg = {}
+        _config_load_error: Optional[str] = None
         try:
             from hermes_cli.config import read_user_config_raw
             _cfg_path = str(_get_hermes_home() / "config.yaml")
@@ -3707,16 +3708,23 @@ def run_job(
                         if _default:
                             model = _default
         except Exception as e:
+            _config_load_error = str(e)
             logger.warning("Job '%s': failed to load config.yaml, using defaults: %s", job_id, e)
 
         # Fail fast if no model resolved from job / env / config.yaml: an empty
         # model otherwise reaches the provider as an opaque 400 (#23979).
         if not (isinstance(model, str) and model.strip()):
+            _config_hint = (
+                f"config.yaml could not be loaded: {_config_load_error}. "
+                "Check file permissions and syntax."
+                if _config_load_error
+                else "config.yaml model.default missing or empty"
+            )
             raise RuntimeError(
                 f"Cron job '{job_name}' has no model configured "
                 f"(job.model={job.get('model')!r}, "
                 f"HERMES_MODEL={os.getenv('HERMES_MODEL', '')!r}, "
-                "config.yaml model.default missing or empty). "
+                f"{_config_hint}). "
                 f"Set a per-job model via "
                 f"`cronjob action=update job_id={job_id} model=<name>` or set a "
                 "default with `hermes model <name>`."


### PR DESCRIPTION
fix(cron): clarify RuntimeError when config.yaml is unreadable

## Problem

When a cron job cannot resolve a model because `config.yaml` failed to load (permission denied, file missing, parse error), the `RuntimeError` raised uses a static template that claims `model.default` is "missing or empty" — even when the field is in fact correctly populated in the unreadable file.

The preceding `WARNING` log line correctly identifies the real cause (e.g. `[Errno 13] Permission denied`), but the `RuntimeError` text sends operators down the wrong path (inspecting config fields, verifying model swap history) instead of checking file ownership/perms.

## Real-world impact

Observed in production on a Linux systemd deployment. A `sudo`'d installer rewrote `config.yaml` as root, leaving it unreadable by the service user. The error message said "model.default missing or empty" — the operator spent 20 minutes verifying the model config before checking file permissions.

## Fix

Track whether `config.yaml` loading failed (`_config_load_error` flag) and include that context in the `RuntimeError` message:

- **When config load failed**: `"config.yaml could not be loaded: [Errno 13] Permission denied. Check file permissions and syntax."`
- **When config loaded but model is empty**: `"config.yaml model.default missing or empty"` (existing behavior, unchanged)

Fixes #81420
