### PR TITLE
fix(mcp): suppress benign asyncio subprocess-transport teardown noise (#81175)

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -120,6 +120,33 @@ from tools.registry import tool_error
 
 logger = logging.getLogger(__name__)
 
+# ---------------------------------------------------------------------------
+# Suppress benign asyncio subprocess-transport teardown noise (#81175)
+# ---------------------------------------------------------------------------
+# When an MCP stdio server's subprocess transport is GC'd after the event
+# loop closes, BaseSubprocessTransport.__del__ raises RuntimeError("Event
+# loop is closed") via sys.unraisablehook (not via the loop's exception
+# handler). This is cosmetic — the transport already completed — but noisy
+# in the TUI. Install a filter that swallows ONLY this specific pattern.
+_original_unraisablehook = sys.unraisablehook
+
+
+def _quiet_asyncio_del_hook(unraisable):
+    """Swallow benign asyncio transport __del__ noise."""
+    if (
+        unraisable.exc_type is RuntimeError
+        and unraisable.exc_value is not None
+        and "Event loop is closed" in str(unraisable.exc_value)
+    ):
+        return  # benign shutdown race — suppress
+    _original_unraisablehook(unraisable)
+
+
+try:
+    sys.unraisablehook = _quiet_asyncio_del_hook
+except AttributeError:
+    pass  # Python < 3.8 — no unraisablehook, skip silently
+
 # Upper bound for the OSV malware preflight during stdio MCP startup. The
 # check makes a blocking urllib HTTPS call whose own timeout can fail to
 # interrupt a stalled SSL handshake, which froze the asyncio event loop and


### PR DESCRIPTION
fix(mcp): suppress benign asyncio subprocess-transport teardown noise

## Problem

When an MCP stdio server's subprocess transport is garbage-collected after the event loop closes, `BaseSubprocessTransport.__del__` raises `RuntimeError: Event loop is closed` via `sys.unraisablehook`. This is cosmetic — the transport already completed — but the traceback pollutes the TUI display:

```
Exception ignored in: <function BaseSubprocessTransport.__del__ at 0x...>
Traceback (most recent call last):
  .../asyncio/base_subprocess.py, line 126, in __del__ -> self.close()
  .../asyncio/unix_events.py, line 566, in close -> ...
RuntimeError: Event loop is closed
```

## Fix

Install a `sys.unraisablehook` filter at module load time in `tools/mcp_tool.py` that swallows ONLY the benign asyncio-transport teardown pattern (`RuntimeError` with "Event loop is closed" message). All other unraisable exceptions are forwarded to the original hook unchanged.

The existing `_mcp_loop_exception_handler` (line ~4604) handles the same error when routed through asyncio's loop exception handler; this new hook catches the `__del__` path that bypasses the loop handler entirely.

Fixes #81175
