### PR TITLE
fix: replace assert with runtime guards in tools/ and plugins/ (6 sites)

### DIFF
--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -1278,7 +1278,8 @@ def recover_session_database(
         output_path=output_path,
         work_dir=work_dir,
     )
-    assert output is not None
+    if output is None:
+        raise SessionRecoverySourceError("Output path could not be resolved")
     disk_space = _disk_space_preflight(source, work_root, output.parent)
 
     temp_dir, snapshot_source, inspection = _snapshot_and_inspect(source, work_root)

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -128,7 +128,8 @@ def _load_nostr_auth():
 
         path = Path(__file__).with_name("nostr_auth.py")
         spec = importlib.util.spec_from_file_location("plugin_adapter_buzz_nostr_auth", path)
-        assert spec is not None and spec.loader is not None
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Cannot load nostr_auth module from {path}")
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
         return module

--- a/tools/computer_use/browser_route.py
+++ b/tools/computer_use/browser_route.py
@@ -478,7 +478,11 @@ class CuaTypedBrowserRoute:
         )
         if refusal is not None:
             return refusal
-        assert selected_tab is not None and self.state.target_id is not None
+        if selected_tab is None or self.state.target_id is None:
+            return _refusal(
+                "browser_no_target",
+                "Could not resolve a target tab or page for this action.",
+            )
 
         ref = call_args.get("ref")
         supports_trust_choice = tool in {"browser_click", "browser_pointer"}

--- a/tools/computer_use/doctor.py
+++ b/tools/computer_use/doctor.py
@@ -223,7 +223,8 @@ def _open_mcp(binary: str) -> subprocess.Popen:
 
 def _mcp_rpc(proc: subprocess.Popen, msg_id: int, method: str, params: Any = None) -> Dict[str, Any]:
     """Write one JSON-RPC request and read one response line."""
-    assert proc.stdin is not None and proc.stdout is not None
+    if proc.stdin is None or proc.stdout is None:
+        raise RuntimeError("MCP subprocess missing stdin/stdout pipes")
     payload: Dict[str, Any] = {"jsonrpc": "2.0", "id": msg_id, "method": method}
     if params is not None:
         payload["params"] = params

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -3594,7 +3594,8 @@ def stream_tts_to_speaker(
 
         def _playback_worker() -> None:
             """Single consumer: play audio segments from the queue in order."""
-            assert streamer is not None
+            if streamer is None:
+                return
             if output_stream is not None:
                 import numpy as _np
 
@@ -3701,7 +3702,8 @@ def stream_tts_to_speaker(
 
         def _enqueue_audio(text_to_speak: str) -> None:
             """Synthesize *text_to_speak* and start prefetching immediately."""
-            assert streamer is not None
+            if streamer is None:
+                return
             try:
                 audio_iter = streamer.stream(text_to_speak)
             except Exception as exc:


### PR DESCRIPTION
## Summary

Replace `assert` statements with explicit runtime guards in 5 files (6 sites) across `tools/` and `plugins/`. Assert statements are stripped by `python -O`, silently removing invariant checks in production.

## Changes

| File | Line | Old | New |
|------|------|-----|-----|
| `tools/tts_tool.py` | 3597 | `assert streamer is not None` | `if streamer is None: return` |
| `tools/tts_tool.py` | 3704 | `assert streamer is not None` | `if streamer is None: return` |
| `tools/computer_use/doctor.py` | 226 | `assert proc.stdin is not None and proc.stdout is not None` | `if ... raise RuntimeError(...)` |
| `tools/computer_use/browser_route.py` | 481 | `assert selected_tab is not None and self.state.target_id is not None` | `if ... return _refusal(...)` |
| `hermes_cli/session_recovery.py` | 1281 | `assert output is not None` | `if ... raise SessionRecoverySourceError(...)` |
| `plugins/platforms/buzz/adapter.py` | 131 | `assert spec is not None and spec.loader is not None` | `if ... raise ImportError(...)` |

## Guard Selection Rationale

- **tts_tool.py**: `_playback_worker` and `_enqueue_audio` are closures where `streamer` is captured from the enclosing scope. Early return is the safest guard — if streamer is somehow None, the function has nothing to do.
- **doctor.py**: `_mcp_rpc` needs both stdin and stdout pipes to communicate with the MCP subprocess. RuntimeError is appropriate since this is a precondition for the function.
- **browser_route.py**: Returns a `_refusal` response matching the existing error pattern in this file — keeps the browser action pipeline consistent.
- **session_recovery.py**: Raises `SessionRecoverySourceError` which is the existing exception type for this module's error paths.
- **buzz/adapter.py**: Raises `ImportError` since the assert guards an importlib loading operation.

## Test Plan

- [ ] `python3 -c "import ast; ast.parse(open(f).read())"` passes for all 5 files
- [ ] Existing tests pass (no behavioral change — guards only activate under `python -O` or edge-case None values)