### PR TITLE
feat(kanban): emit generic lifecycle events

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -210,6 +210,231 @@ def _fire_kanban_lifecycle_hook(event: str, task_id: str, **fields: Any) -> None
         _log.debug("kanban lifecycle hook %s failed: %s", event, exc)
 
 
+# ---------------------------------------------------------------------------
+# Generic per-row task_events observer (``kanban_task_event``)
+# ---------------------------------------------------------------------------
+
+#: Schema token for the generic observer's kwargs. Distinct from the plugin
+#: manager's own ``telemetry_schema_version``, which ``invoke_hook`` injects.
+KANBAN_EVENT_SCHEMA_VERSION = "hermes.kanban.event.v1"
+
+#: Upper bound for the one bounded integer the generic observer is allowed to
+#: carry out of a payload. Chosen well above DEFAULT_FAILURE_LIMIT; anything
+#: outside [0, FAILURE_COUNT_MAX] is omitted rather than clamped.
+FAILURE_COUNT_MAX = 1000
+
+#: Every ``task_events.kind`` this tree's writers emit — a CAPABILITY
+#: DECLARATION for ``kanban_task_event`` consumers, never a database
+#: constraint. ``task_events.kind`` stays an open TEXT column with no CHECK,
+#: and an undeclared kind still dispatches unchanged (a consumer must see what
+#: actually committed). Kinds must stay fixed identifiers: this is also the
+#: boundary of the hook's content-free guarantee, since an out-of-tree writer
+#: that puts prose in ``kind`` has that string delivered verbatim.
+KANBAN_EVENT_KINDS: frozenset[str] = frozenset({
+    # Literal kinds passed to _append_event.
+    "archived",
+    "assigned",
+    "attached",
+    "attachment_removed",
+    "block_loop_detected",
+    "blocked",
+    "claim_extended",
+    "claim_rejected",
+    "claimed",
+    "commented",
+    "completed",
+    "completion_blocked_hallucination",
+    "created",
+    "decomposed",
+    "dependency_wait",
+    "edited",
+    "gave_up",
+    "heartbeat",
+    "linked",
+    "model_override_set",
+    "promoted",
+    "promoted_manual",
+    "reasoning_effort_set",
+    "reclaim_deferred",
+    "reclaimed",
+    "reconciled",
+    "respawn_guarded",
+    "scheduled",
+    "spawned",
+    "specified",
+    "stale",
+    "suspected_hallucinated_references",
+    "timed_out",
+    "tip_scratch_workspace",
+    "unblocked",
+    "unlinked",
+    # detect_crashed_workers' three-way exit classifier.
+    "crashed",
+    "protocol_violation",
+    "rate_limited",
+    # _record_task_failure's dynamic outcome, gated on end_run=True. The only
+    # production callers that reach it pass 'spawn_failed' or 'timed_out'.
+    "spawn_failed",
+    # Bundled dashboard writers, routed through the same seam.
+    "reprioritized",
+    "status",
+})
+
+
+def _resolve_board_for_connection(conn: sqlite3.Connection) -> Optional[str]:
+    """Return the board slug *this connection* writes, or ``None``.
+
+    Ambient board state is deliberately not consulted. ``connect(board=...)``
+    and ``connect(db_path=...)`` both bypass the chain that
+    :func:`get_current_board` reads — and ``HERMES_KANBAN_DB`` even overrides an
+    explicit ``board=`` argument — so the dashboard and tool/CLI layers
+    routinely write a board the ambient chain does not name. The only
+    authoritative answer is the file the connection actually has open.
+
+    The slug is never parsed out of the path text. A candidate is taken from
+    the directory, then confirmed by rebuilding the canonical board path
+    through the same construction :func:`kanban_db_path` uses and comparing.
+
+    ``None`` is an honest, documented result — an in-memory or temp database, a
+    path outside the board layout, an unreadable ``PRAGMA``, or an ambiguous
+    match — and must never be back-filled from ambient state.
+
+    Attribution is best-effort and fails SAFE. This runs at frame install,
+    *after* ``BEGIN IMMEDIATE`` has already succeeded, so any failure to probe
+    the connection degrades to ``None`` rather than propagating: a cosmetic
+    attribution problem must never turn into a failed write. That deliberately
+    covers connection objects that are not real :mod:`sqlite3` connections —
+    the doubles several existing tests drive ``write_txn`` with return ``None``
+    from ``execute`` and raise :class:`AttributeError`, not ``sqlite3.Error``.
+    """
+    try:
+        listing = conn.execute("PRAGMA database_list").fetchall()
+    except Exception:
+        return None
+    if not listing:
+        return None
+
+    main_file = None
+    for row in listing:
+        try:
+            if str(row[1]) == "main":
+                main_file = row[2]
+                break
+        except (IndexError, KeyError, TypeError):
+            continue
+    if not main_file:
+        # ``:memory:`` and temporary databases report an empty file column.
+        return None
+
+    try:
+        actual = Path(str(main_file)).resolve()
+    except OSError:
+        return None
+
+    def _is(candidate: Path) -> bool:
+        try:
+            return candidate.resolve() == actual
+        except OSError:
+            return False
+
+    matches: list[str] = []
+    try:
+        # ``default`` is deliberately NOT under boards_root(): its DB stays at
+        # the back-compat ``<root>/kanban.db``.
+        if _is(kanban_home() / "kanban.db"):
+            matches.append(DEFAULT_BOARD)
+        try:
+            candidate = _normalize_board_slug(actual.parent.name)
+        except ValueError:
+            candidate = None
+        if candidate and candidate != DEFAULT_BOARD:
+            if _is(board_dir(candidate) / "kanban.db"):
+                matches.append(candidate)
+    except Exception:  # pragma: no cover - defensive; board root unresolvable
+        return None
+
+    if len(matches) != 1:
+        return None
+    return matches[0]
+
+
+@dataclass(frozen=True)
+class _TaskEventRecord:
+    """An immutable, content-free snapshot of one committed ``task_events`` row.
+
+    Every field is captured at INSERT time inside the transaction. Nothing is
+    re-read or recomputed after commit: by then another writer may have moved
+    or deleted the task. No payload object, serialized payload, or
+    payload-derived string is ever stored here.
+    """
+
+    task_id: str
+    kind: str
+    core_event_seq: int
+    created_at_epoch_s: int
+    run_id: Optional[int]
+    board: Optional[str]
+    #: The status this writer established, when it honestly established one.
+    #: ``None`` means "omit the kwarg entirely", never "unknown status".
+    status_to: Optional[str] = None
+    #: The single value extracted from a payload anywhere in C-1, and only at
+    #: the two writers that already hold it as a local integer.
+    failure_count: Optional[int] = None
+
+
+class _TaskEventFrame:
+    """The notification queue owned by one open ``write_txn``.
+
+    Bound to the exact :class:`sqlite3.Connection` identity that opened the
+    transaction, so an append against a different connection cannot land in it.
+    No state is attached to the connection object itself.
+
+    ``board`` is resolved once, at install, and carried into every record the
+    frame collects — so attribution is fixed for the transaction and cannot
+    drift if ambient state changes mid-body.
+    """
+
+    __slots__ = ("conn", "board", "records")
+
+    def __init__(self, conn: sqlite3.Connection, board: Optional[str]) -> None:
+        self.conn = conn
+        self.board = board
+        self.records: list[_TaskEventRecord] = []
+
+
+_TASK_EVENT_FRAME: ContextVar[Optional[_TaskEventFrame]] = ContextVar(
+    "_kanban_task_event_frame", default=None
+)
+
+
+def _dispatch_task_events(records: Iterable[_TaskEventRecord]) -> None:
+    """Fire ``kanban_task_event`` once per record, in insertion order.
+
+    Called only after COMMIT and the post-commit invariant have both succeeded,
+    with the frame already detached and the write lock released. Each callback
+    is isolated by the plugin manager's per-callback try/except, and the whole
+    fan-out is best-effort: an observer can neither roll back nor alter the
+    committed state it is being told about.
+    """
+    for rec in records:
+        _fire_kanban_lifecycle_hook(
+            "kanban_task_event",
+            rec.task_id,
+            kind=rec.kind,
+            core_event_seq=rec.core_event_seq,
+            created_at_epoch_s=rec.created_at_epoch_s,
+            run_id=rec.run_id,
+            board=rec.board,
+            kanban_event_schema_version=KANBAN_EVENT_SCHEMA_VERSION,
+            **({} if rec.status_to is None else {"status_to": rec.status_to}),
+            **(
+                {}
+                if rec.failure_count is None
+                else {"failure_count": rec.failure_count}
+            ),
+        )
+
+
 # A running task's claim is valid for 15 minutes by default; after that the
 # next dispatcher tick reclaims it. Workers that outlive this window should
 # call ``heartbeat_claim(task_id)`` periodically. In practice most kanban
@@ -2811,31 +3036,49 @@ def write_txn(conn: sqlite3.Connection):
     """
     _assert_not_delegated_child_mutation()
     _execute_boundary_with_retry(conn, "BEGIN IMMEDIATE")
+    # Install the generic-observer queue only once BEGIN IMMEDIATE has actually
+    # succeeded: the delegated-child guard above and a failed BEGIN must leave
+    # no frame behind, because no row can exist to notify about.
+    frame = _TaskEventFrame(conn, _resolve_board_for_connection(conn))
+    token = _TASK_EVENT_FRAME.set(frame)
+    pending: tuple[_TaskEventRecord, ...] = ()
     try:
-        yield conn
-    except Exception:
         try:
-            conn.execute("ROLLBACK")
-        except sqlite3.OperationalError:
-            # SQLite has already auto-rolled-back the transaction (typical
-            # under EIO, lock contention, or corruption). Nothing to undo;
-            # do not let this secondary failure shadow the real one.
-            pass
-        raise
-    else:
-        try:
-            _execute_boundary_with_retry(conn, "COMMIT")
+            yield conn
         except Exception:
-            # COMMIT exhausted retries with the txn still open; roll back so the
-            # connection isn't poisoned for the next BEGIN IMMEDIATE.
             try:
                 conn.execute("ROLLBACK")
             except sqlite3.OperationalError:
+                # SQLite has already auto-rolled-back the transaction (typical
+                # under EIO, lock contention, or corruption). Nothing to undo;
+                # do not let this secondary failure shadow the real one.
                 pass
             raise
-        # Post-commit file-length check: header page_count must match actual file pages.
-        # A discrepancy means a torn-extend — raise now rather than silently corrupt.
-        _check_file_length_invariant(conn)
+        else:
+            try:
+                _execute_boundary_with_retry(conn, "COMMIT")
+            except Exception:
+                # COMMIT exhausted retries with the txn still open; roll back so the
+                # connection isn't poisoned for the next BEGIN IMMEDIATE.
+                try:
+                    conn.execute("ROLLBACK")
+                except sqlite3.OperationalError:
+                    pass
+                raise
+            # Post-commit file-length check: header page_count must match actual file pages.
+            # A discrepancy means a torn-extend — raise now rather than silently corrupt.
+            _check_file_length_invariant(conn)
+            # Only a clean COMMIT *and* a clean invariant release the queue.
+            # Rollback, a terminal COMMIT failure, and an invariant failure all
+            # leave ``pending`` empty and dispatch nothing — the last of those
+            # being the deliberate committed-row-without-callback window.
+            pending = tuple(frame.records)
+    finally:
+        # Detach on every path, so a callback that writes the board below opens
+        # an independent transaction with a fresh frame and can neither append
+        # to nor re-flush this one.
+        _TASK_EVENT_FRAME.reset(token)
+    _dispatch_task_events(pending)
 
 
 # ---------------------------------------------------------------------------
@@ -3269,6 +3512,7 @@ def create_task(
                         "model_override": model_override,
                         "provider_override": provider_override,
                     },
+                    status_to=task_status,
                 )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
             return task_id
@@ -3544,14 +3788,19 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
         parent_status = conn.execute(
             "SELECT status FROM tasks WHERE id = ?", (parent_id,)
         ).fetchone()["status"]
+        demoted_rows = 0
         if parent_status != "done":
-            conn.execute(
+            demoted = conn.execute(
                 "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
                 (child_id,),
             )
+            demoted_rows = demoted.rowcount
         _append_event(
             conn, child_id, "linked",
             {"parent": parent_id, "child": child_id},
+            # Only report a transition the guarded UPDATE actually made: the
+            # child may well have already been past 'ready'.
+            status_to="todo" if demoted_rows == 1 else None,
         )
         _inherit_notify_subs(conn, child_id, (parent_id,))
 
@@ -3958,6 +4207,8 @@ def _append_event(
     payload: Optional[dict] = None,
     *,
     run_id: Optional[int] = None,
+    status_to: Optional[str] = None,
+    failure_count: Optional[int] = None,
 ) -> None:
     """Record an event row.  Called from within an already-open txn.
 
@@ -3965,13 +4216,55 @@ def _append_event(
     events by attempt. For events that aren't scoped to a single run
     (task created/edited/archived, dependency promotion) leave it None
     and the row carries NULL.
+
+    ``failure_count`` is likewise notification-only, and is accepted only from
+    a writer that already holds a bounded local integer — never parsed out of
+    ``payload``. Acceptance is strict: a real ``int`` (``bool`` rejected) in
+    ``[0, FAILURE_COUNT_MAX]``. Anything else is omitted, never coerced.
+
+    ``status_to`` is notification metadata only — it is never written to the
+    row. Pass the status this writer just established, taken from the local
+    transition scalar and only when the guarded UPDATE actually matched, so the
+    generic observer never has to reconstruct it from ``payload`` or re-read
+    ``tasks.status`` after commit. Anything outside :data:`VALID_STATUSES` is
+    omitted rather than guessed at.
     """
+    frame = _TASK_EVENT_FRAME.get()
+    if frame is None or frame.conn is not conn:
+        # Fail closed *before* the INSERT: a durable new-event row must never
+        # escape instrumentation. The test is "is a frame active for this
+        # connection", not "did this function open one" — helpers like
+        # _insert_completion_attachment legitimately run inside a caller's frame.
+        raise RuntimeError(
+            "_append_event requires an active write_txn frame for this "
+            f"connection (task_id={task_id!r}, kind={kind!r})"
+        )
     now = int(time.time())
     pl = json.dumps(payload, ensure_ascii=False) if payload else None
-    conn.execute(
+    cur = conn.execute(
         "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) "
         "VALUES (?, ?, ?, ?, ?)",
         (task_id, run_id, kind, pl, now),
+    )
+    frame.records.append(
+        _TaskEventRecord(
+            task_id=task_id,
+            kind=kind,
+            core_event_seq=int(cur.lastrowid),
+            created_at_epoch_s=now,
+            run_id=run_id,
+            board=frame.board,
+            status_to=status_to if status_to in VALID_STATUSES else None,
+            failure_count=(
+                failure_count
+                if (
+                    isinstance(failure_count, int)
+                    and not isinstance(failure_count, bool)
+                    and 0 <= failure_count <= FAILURE_COUNT_MAX
+                )
+                else None
+            ),
+        )
     )
 
 
@@ -4204,17 +4497,20 @@ def recompute_ready(
                     )
                     if failures >= effective_limit:
                         continue
-                    conn.execute(
+                    promoted_cur = conn.execute(
                         "UPDATE tasks SET status = 'ready' "
                         "WHERE id = ? AND status = 'blocked'",
                         (task_id,),
                     )
                 else:
-                    conn.execute(
+                    promoted_cur = conn.execute(
                         "UPDATE tasks SET status = 'ready' WHERE id = ? AND status = 'todo'",
                         (task_id,),
                     )
-                _append_event(conn, task_id, "promoted", None)
+                _append_event(
+                    conn, task_id, "promoted", None,
+                    status_to="ready" if promoted_cur.rowcount == 1 else None,
+                )
                 promoted += 1
     return promoted
 
@@ -4254,7 +4550,7 @@ def claim_task(
             (task_id,),
         ).fetchone()
         if undone:
-            conn.execute(
+            demoted = conn.execute(
                 "UPDATE tasks SET status = 'todo' "
                 "WHERE id = ? AND status = 'ready'",
                 (task_id,),
@@ -4262,6 +4558,7 @@ def claim_task(
             _append_event(
                 conn, task_id, "claim_rejected",
                 {"reason": "parents_not_done"},
+                status_to="todo" if demoted.rowcount == 1 else None,
             )
             return None
         # Defensive: if a prior run somehow leaked (invariant violation from
@@ -4333,6 +4630,7 @@ def claim_task(
             conn, task_id, "claimed",
             {"lock": lock, "expires": expires, "run_id": run_id},
             run_id=run_id,
+            status_to="running",
         )
         claimed = get_task(conn, task_id)
     _fire_kanban_lifecycle_hook(
@@ -4416,6 +4714,7 @@ def claim_review_task(
             {"lock": lock, "expires": expires, "run_id": run_id,
              "source_status": "review"},
             run_id=run_id,
+            status_to="running",
         )
         return get_task(conn, task_id)
 
@@ -4592,6 +4891,7 @@ def release_stale_claims(
                 conn, row["id"], "reclaimed",
                 payload,
                 run_id=run_id,
+                status_to="ready",
             )
             reclaimed += 1
     return reclaimed
@@ -4657,6 +4957,7 @@ def reclaim_task(
             conn, task_id, "reclaimed",
             payload,
             run_id=run_id,
+            status_to="ready",
         )
     # Operator intervention — they've looked at the task, so the
     # consecutive-failures counter is now stale. Give the next retry
@@ -5000,6 +5301,7 @@ def complete_task(
             conn, task_id, "completed",
             completed_payload,
             run_id=run_id,
+            status_to="done",
         )
     # Prose-scan the summary + result for t_<hex> references that do
     # not resolve. Advisory — does not block the completion. Runs in
@@ -5703,6 +6005,7 @@ def block_task(
             _append_event(
                 conn, task_id, "dependency_wait",
                 {"reason": reason, "kind": kind}, run_id=run_id,
+                status_to="todo",
             )
             _blocked_task = get_task(conn, task_id)
             _fire_kanban_lifecycle_hook(
@@ -5761,6 +6064,7 @@ def block_task(
                     "recurrences": recurrences,
                     "limit": BLOCK_RECURRENCE_LIMIT,
                 },
+                status_to="triage",
                 run_id=run_id,
             )
         else:
@@ -5814,6 +6118,7 @@ def block_task(
                 conn, task_id, "blocked",
                 {"reason": reason, "kind": kind, "recurrences": recurrences},
                 run_id=run_id,
+                status_to="blocked",
             )
         _blocked_task = get_task(conn, task_id)
     _fire_kanban_lifecycle_hook(
@@ -5893,6 +6198,7 @@ def promote_task(
             task_id,
             "promoted_manual",
             {"actor": actor, "reason": reason, "forced": force},
+            status_to="ready",
         )
 
     return True, None
@@ -5960,6 +6266,7 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         _append_event(
             conn, task_id, "unblocked",
             {"status": new_status} if new_status != "ready" else None,
+            status_to=new_status,
         )
         return True
 
@@ -6045,6 +6352,7 @@ def specify_triage_task(
             task_id,
             "specified",
             {"changed_fields": changed_fields} if changed_fields else None,
+            status_to="todo",
         )
     # Outside the write_txn above, so we don't nest BEGIN IMMEDIATE — the
     # ready-promotion pass opens its own IMMEDIATE txn. This runs the same
@@ -6214,6 +6522,7 @@ def decompose_triage_task(
             _append_event(
                 conn, new_id, "created",
                 {"by": author or "decomposer", "from_decompose_of": task_id},
+                status_to="todo",
             )
             _inherit_notify_subs(conn, new_id, (task_id,), created_at=now)
             child_ids.append(new_id)
@@ -6276,6 +6585,7 @@ def decompose_triage_task(
                 "child_ids": child_ids,
                 "root_assignee": root_assignee,
             },
+            status_to="todo",
         )
 
     # Outside the write_txn: promote parent-free children to 'ready'
@@ -6306,7 +6616,10 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
             outcome="reclaimed", status="reclaimed",
             summary="task archived with run still active",
         )
-        _append_event(conn, task_id, "archived", None, run_id=run_id)
+        _append_event(
+            conn, task_id, "archived", None, run_id=run_id,
+            status_to="archived",
+        )
     # ``archived`` parents no longer block children, same as ``done``.
     # Promote newly-unblocked dependents immediately instead of waiting
     # for a later dispatcher tick.
@@ -6728,7 +7041,10 @@ def schedule_task(
                 outcome="scheduled",
                 summary=reason,
             )
-        _append_event(conn, task_id, "scheduled", {"reason": reason}, run_id=run_id)
+        _append_event(
+            conn, task_id, "scheduled", {"reason": reason}, run_id=run_id,
+            status_to="scheduled",
+        )
         return True
 
 
@@ -7283,6 +7599,7 @@ def enforce_max_runtime(
                 )
                 _append_event(
                     conn, tid, "timed_out", payload, run_id=run_id,
+                    status_to="ready",
                 )
                 timed_out.append(tid)
         # Increment the unified failure counter. Outside the write_txn
@@ -7421,6 +7738,7 @@ def detect_stale_running(
             )
             _append_event(
                 conn, tid, "stale", payload, run_id=run_id,
+                status_to="ready",
             )
             reclaimed.append(tid)
 
@@ -7518,7 +7836,10 @@ def reconcile_orphaned_running(
                     now,
                 ),
             )
-            _append_event(conn, tid, "reconciled", payload, run_id=run_id)
+            _append_event(
+                conn, tid, "reconciled", payload, run_id=run_id,
+                status_to="ready",
+            )
             reconciled.append(tid)
         _log.info(
             "kanban reconcile: requeued orphaned running task %s "
@@ -7755,6 +8076,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     conn, row["id"], event_kind,
                     event_payload,
                     run_id=run_id,
+                    status_to="ready",
                 )
                 if rate_limited_exit:
                     # Stamp the failure-error column so ``check_respawn_guard``
@@ -7962,7 +8284,7 @@ def _record_task_failure(
             # Trip the breaker.
             if release_claim:
                 # Spawn path: still running, also clear claim state.
-                conn.execute(
+                blocked_cur = conn.execute(
                     "UPDATE tasks SET status = 'blocked', claim_lock = NULL, "
                     "claim_expires = NULL, worker_pid = NULL, "
                     "consecutive_failures = ?, last_failure_error = ? "
@@ -7973,7 +8295,7 @@ def _record_task_failure(
                 # Timeout/crash path: task is already at ``ready``
                 # with claim cleared; just flip to blocked + update
                 # counter fields.
-                conn.execute(
+                blocked_cur = conn.execute(
                     "UPDATE tasks SET status = 'blocked', "
                     "consecutive_failures = ?, last_failure_error = ? "
                     "WHERE id = ? AND status IN ('ready', 'running')",
@@ -8004,19 +8326,25 @@ def _record_task_failure(
                 payload.update(event_payload_extra)
             _append_event(
                 conn, task_id, "gave_up", payload, run_id=run_id,
+                # Both guarded branches can match zero rows if the task moved;
+                # never claim 'blocked' from the SQL literal alone.
+                status_to="blocked" if blocked_cur.rowcount == 1 else None,
+                failure_count=failures,
             )
             blocked = True
         else:
             # Below threshold.
+            requeued_rows = 0
             if release_claim:
                 # Spawn path: transition running → ready + clear claim.
-                conn.execute(
+                requeued = conn.execute(
                     "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
                     "claim_expires = NULL, worker_pid = NULL, "
                     "consecutive_failures = ?, last_failure_error = ? "
                     "WHERE id = ? AND status = 'running'",
                     (failures, error[:500], task_id),
                 )
+                requeued_rows = requeued.rowcount
             else:
                 # Timeout/crash path: task is already at ``ready`` via
                 # its own UPDATE. Just bookkeep the counter + last error.
@@ -8037,6 +8365,10 @@ def _record_task_failure(
                     conn, task_id, outcome,
                     {"error": error[:500], "failures": failures},
                     run_id=run_id,
+                    # Only the release_claim branch establishes a status, and
+                    # only when its guarded UPDATE matched.
+                    status_to="ready" if requeued_rows == 1 else None,
+                    failure_count=failures,
                 )
             # Timeout/crash path's caller already emitted its own event.
     return blocked

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -214,9 +214,12 @@ def _kanban_observer_consumed(event: str) -> bool:
     """Return whether any first-party observer or plugin consumes *event*.
 
     Hot-path short-circuit for the worker-lifecycle / task-mutation /
-    dispatch-tick observers (RFC #58548): those fire on every dispatcher
-    tick and every task write, so call sites skip payload assembly entirely
-    when nothing subscribes. Best-effort — if inspection fails the event is
+    dispatch-tick observers (RFC #58548) and for the generic per-row
+    ``kanban_task_event`` observer (C-1): those fire on every dispatcher
+    tick, every task write, and every ``write_txn`` respectively, so call
+    sites skip payload assembly entirely when nothing subscribes — for
+    ``kanban_task_event`` that also means skipping the per-transaction
+    board resolution. Best-effort — if inspection fails the event is
     treated as unconsumed (the invoke path would fail the same way, and
     these are observers, so dropping is always safe).
     """
@@ -270,9 +273,12 @@ def notify_task_updated(
 
     Task-mutation boundary primitive from RFC #58548: a surface that mutates
     a task row outside the claim/complete/block lifecycle calls this AFTER
-    its write txn has committed — including surfaces that write with direct
-    SQL and bypass every ``kanban_db`` mutator (the dashboard plugin API's
-    priority/title/body editors). ``changed_fields`` carries field NAMES
+    its write txn has committed — including surfaces whose task-row write is
+    direct SQL and so goes through no ``kanban_db`` mutator (the dashboard
+    plugin API's priority/title/body editors, single and bulk). Those
+    surfaces still append their ``task_events`` row via ``_append_event``,
+    so only the task-row mutation needs reporting here; the event row
+    reaches ``kanban_task_event`` on its own. ``changed_fields`` carries NAMES
     only, never values. Observer-only and fully best-effort: it can never
     fail a task mutation, and it costs one ``has_hook`` probe when nothing
     subscribes.
@@ -356,6 +362,263 @@ def _fire_dispatch_tick_hook(
         )
     except Exception as exc:  # pragma: no cover - defensive
         _log.debug("kanban dispatch tick hook failed: %s", exc)
+# ---------------------------------------------------------------------------
+# Generic per-row task_events observer (``kanban_task_event``)
+# ---------------------------------------------------------------------------
+
+#: Schema token for the generic observer's kwargs. Distinct from the plugin
+#: manager's own ``telemetry_schema_version``, which ``invoke_hook`` injects.
+KANBAN_EVENT_SCHEMA_VERSION = "hermes.kanban.event.v1"
+
+#: Upper bound for the one bounded integer the generic observer is allowed to
+#: carry out of a payload. Chosen well above DEFAULT_FAILURE_LIMIT; anything
+#: outside [0, FAILURE_COUNT_MAX] is omitted rather than clamped.
+FAILURE_COUNT_MAX = 1000
+
+#: Every ``task_events.kind`` this tree's writers emit — a CAPABILITY
+#: DECLARATION for ``kanban_task_event`` consumers, never a database
+#: constraint. ``task_events.kind`` stays an open TEXT column with no CHECK,
+#: and an undeclared kind still dispatches unchanged (a consumer must see what
+#: actually committed). Kinds must stay fixed identifiers: this is also the
+#: boundary of the hook's content-free guarantee, since an out-of-tree writer
+#: that puts prose in ``kind`` has that string delivered verbatim.
+KANBAN_EVENT_KINDS: frozenset[str] = frozenset({
+    # Literal kinds passed to _append_event.
+    "archived",
+    "assigned",
+    "attached",
+    "attachment_removed",
+    "block_loop_detected",
+    "blocked",
+    "changes_requested",
+    "claim_extended",
+    "claim_rejected",
+    "claimed",
+    "commented",
+    "completed",
+    "completion_blocked_hallucination",
+    "created",
+    "decomposed",
+    "dependency_wait",
+    "descendant_invalidated",
+    "edited",
+    "gave_up",
+    "heartbeat",
+    "linked",
+    "model_override_set",
+    "promoted",
+    "promoted_manual",
+    "reasoning_effort_set",
+    "reclaim_deferred",
+    "reclaimed",
+    "reconciled",
+    "respawn_guarded",
+    "review_reopened",
+    "review_requested",
+    "scheduled",
+    "spawned",
+    "specified",
+    "stale",
+    "suspected_hallucinated_references",
+    "timed_out",
+    "tip_scratch_workspace",
+    "unblocked",
+    "unlinked",
+    # detect_crashed_workers' three-way exit classifier.
+    "crashed",
+    "protocol_violation",
+    "rate_limited",
+    # _record_task_failure's dynamic outcome, gated on end_run=True. The only
+    # production callers that reach it pass 'spawn_failed' or 'timed_out'.
+    "spawn_failed",
+    # Bundled dashboard writers, routed through the same seam.
+    "reprioritized",
+    "status",
+})
+
+
+def _resolve_board_for_connection(conn: sqlite3.Connection) -> Optional[str]:
+    """Return the board slug *this connection* writes, or ``None``.
+
+    Ambient board state is deliberately not consulted. ``connect(board=...)``
+    and ``connect(db_path=...)`` both bypass the chain that
+    :func:`get_current_board` reads — and ``HERMES_KANBAN_DB`` even overrides an
+    explicit ``board=`` argument — so the dashboard and tool/CLI layers
+    routinely write a board the ambient chain does not name. The only
+    authoritative answer is the file the connection actually has open.
+
+    The slug is never parsed out of the path text. A candidate is taken from
+    the directory, then confirmed by rebuilding the canonical board path
+    through the same construction :func:`kanban_db_path` uses and comparing.
+
+    ``None`` is an honest, documented result — an in-memory or temp database, a
+    path outside the board layout, an unreadable ``PRAGMA``, or an ambiguous
+    match — and must never be back-filled from ambient state.
+
+    Attribution is best-effort and fails SAFE. This runs at frame install,
+    *after* ``BEGIN IMMEDIATE`` has already succeeded, so any failure to probe
+    the connection degrades to ``None`` rather than propagating: a cosmetic
+    attribution problem must never turn into a failed write. That deliberately
+    covers connection objects that are not real :mod:`sqlite3` connections —
+    the doubles several existing tests drive ``write_txn`` with return ``None``
+    from ``execute`` and raise :class:`AttributeError`, not ``sqlite3.Error``.
+    """
+    try:
+        listing = conn.execute("PRAGMA database_list").fetchall()
+    except Exception:
+        return None
+    if not listing:
+        return None
+
+    main_file = None
+    for row in listing:
+        try:
+            if str(row[1]) == "main":
+                main_file = row[2]
+                break
+        except (IndexError, KeyError, TypeError):
+            continue
+    if not main_file:
+        # ``:memory:`` and temporary databases report an empty file column.
+        return None
+
+    try:
+        actual = Path(str(main_file)).resolve()
+    except OSError:
+        return None
+
+    def _is(candidate: Path) -> bool:
+        try:
+            return candidate.resolve() == actual
+        except OSError:
+            return False
+
+    matches: list[str] = []
+    try:
+        # ``default`` is deliberately NOT under boards_root(): its DB stays at
+        # the back-compat ``<root>/kanban.db``.
+        if _is(kanban_home() / "kanban.db"):
+            matches.append(DEFAULT_BOARD)
+        try:
+            candidate = _normalize_board_slug(actual.parent.name)
+        except ValueError:
+            candidate = None
+        if candidate and candidate != DEFAULT_BOARD:
+            if _is(board_dir(candidate) / "kanban.db"):
+                matches.append(candidate)
+    except Exception:  # pragma: no cover - defensive; board root unresolvable
+        return None
+
+    if len(matches) != 1:
+        return None
+    return matches[0]
+
+
+@dataclass(frozen=True)
+class _TaskEventRecord:
+    """An immutable, content-free snapshot of one committed ``task_events`` row.
+
+    Every field is captured at INSERT time inside the transaction. Nothing is
+    re-read or recomputed after commit: by then another writer may have moved
+    or deleted the task. No payload object, serialized payload, or
+    payload-derived string is ever stored here.
+    """
+
+    task_id: str
+    kind: str
+    core_event_seq: int
+    created_at_epoch_s: int
+    run_id: Optional[int]
+    board: Optional[str]
+    #: The status this writer established, when it honestly established one.
+    #: ``None`` means "omit the kwarg entirely", never "unknown status".
+    status_to: Optional[str] = None
+    #: The single value extracted from a payload anywhere in C-1, and only at
+    #: the two writers that already hold it as a local integer.
+    failure_count: Optional[int] = None
+
+
+class _TaskEventFrame:
+    """The notification queue owned by one open ``write_txn``.
+
+    Bound to the exact :class:`sqlite3.Connection` identity that opened the
+    transaction, so an append against a different connection cannot land in it.
+    No state is attached to the connection object itself.
+
+    ``board`` is resolved once, at install, and carried into every record the
+    frame collects — so attribution is fixed for the transaction and cannot
+    drift if ambient state changes mid-body.
+
+    ``consumed`` is the zero-subscriber fast path, decided once at install by
+    the same ``_kanban_observer_consumed`` probe the RFC #58548 observers use.
+    When it is ``False`` the frame is a pure fail-closed sentinel: it still
+    proves to ``_append_event`` that a transaction is open, but no board is
+    resolved, no record is built, and nothing is dispatched. The probe is
+    deliberately taken at install rather than at flush, because the cost this
+    avoids (``_resolve_board_for_connection``) is paid at install. A plugin
+    that subscribes mid-transaction therefore misses that transaction's
+    events, which is within the hook's documented at-most-once, best-effort
+    delivery contract.
+    """
+
+    __slots__ = ("conn", "board", "records", "consumed")
+
+    def __init__(
+        self,
+        conn: sqlite3.Connection,
+        board: Optional[str],
+        *,
+        consumed: bool = True,
+    ) -> None:
+        self.conn = conn
+        self.board = board
+        self.consumed = consumed
+        self.records: list[_TaskEventRecord] = []
+
+
+_TASK_EVENT_FRAME: ContextVar[Optional[_TaskEventFrame]] = ContextVar(
+    "_kanban_task_event_frame", default=None
+)
+
+
+def _dispatch_task_events(records: Iterable[_TaskEventRecord]) -> None:
+    """Fire ``kanban_task_event`` once per record, in insertion order.
+
+    Called only after COMMIT and the post-commit invariant have both succeeded,
+    with the frame already detached and the SQLite write lock released. Each
+    callback is isolated by the plugin manager's per-callback try/except, and
+    the whole fan-out is best-effort: an observer can neither roll back nor
+    alter the committed state it is being told about.
+
+    The released lock is the SQLite write lock, NOT the board's outer dispatch
+    lock. For an event produced inside a dispatcher tick this runs while
+    :func:`_dispatch_tick_lock` is still held — that lock spans the entire
+    tick, and a tick commits many transactions, each flushing here at its own
+    commit. Hoisting these flushes past the outer lock would mean buffering
+    every row for the whole tick, which trades this hook's per-row,
+    flush-at-commit contract (and its at-most-once window) for a per-tick
+    batch, and would still not cover the same mutators when a worker process
+    calls them under no dispatch lock at all. So the contract is stated rather
+    than engineered around: callbacks must be fast, and a slow one can make a
+    sibling dispatcher skip a tick (the lock is non-blocking by design).
+    """
+    for rec in records:
+        _fire_kanban_lifecycle_hook(
+            "kanban_task_event",
+            rec.task_id,
+            kind=rec.kind,
+            core_event_seq=rec.core_event_seq,
+            created_at_epoch_s=rec.created_at_epoch_s,
+            run_id=rec.run_id,
+            board=rec.board,
+            kanban_event_schema_version=KANBAN_EVENT_SCHEMA_VERSION,
+            **({} if rec.status_to is None else {"status_to": rec.status_to}),
+            **(
+                {}
+                if rec.failure_count is None
+                else {"failure_count": rec.failure_count}
+            ),
+        )
 
 
 # A running task's claim is valid for 15 minutes by default; after that the
@@ -3073,10 +3336,24 @@ def write_txn(conn: sqlite3.Connection, *, allow_nested: bool = False):
                 "the outer transaction commits)."
             )
         savepoint = f"hermes_nested_{secrets.token_hex(8)}"
+        # A nested block never owns a frame: its rows belong to the OUTER
+        # transaction and must flush only when that transaction commits. All we
+        # take is a high-water mark, so a ``ROLLBACK TO`` can discard exactly
+        # the notifications whose rows it just undid. Without this, a caller
+        # that swallows a nested failure and commits the outer transaction
+        # would dispatch events for rows that never committed.
+        outer = _TASK_EVENT_FRAME.get()
+        mark = len(outer.records) if outer is not None and outer.conn is conn else None
         conn.execute(f"SAVEPOINT {savepoint}")
         try:
             yield conn
         except Exception:
+            # Truncate before (and independently of) the ROLLBACK TO: if the
+            # rollback itself fails the database state is unknown, and dropping
+            # a notification is a documented outcome while announcing an
+            # uncommitted row is not.
+            if mark is not None:
+                del outer.records[mark:]
             try:
                 conn.execute(f"ROLLBACK TO {savepoint}")
                 conn.execute(f"RELEASE {savepoint}")
@@ -3084,35 +3361,65 @@ def write_txn(conn: sqlite3.Connection, *, allow_nested: bool = False):
                 pass
             raise
         else:
+            # RELEASE only folds the savepoint into the outer transaction; the
+            # records stay queued on the outer frame and are still pending.
             conn.execute(f"RELEASE {savepoint}")
         return
 
     _execute_boundary_with_retry(conn, "BEGIN IMMEDIATE")
+    # Install the generic-observer queue only once BEGIN IMMEDIATE has actually
+    # succeeded: the delegated-child guard above and a failed BEGIN must leave
+    # no frame behind, because no row can exist to notify about.
+    # Zero-subscriber fast path (same convention as the RFC #58548 observers):
+    # with nothing consuming the generic hook, every kanban write in the
+    # process pays exactly one has_hook dict probe and no board resolution,
+    # no record construction, and no post-commit fan-out. A frame is still
+    # installed — it is what keeps _append_event fail-closed.
+    consumed = _kanban_observer_consumed("kanban_task_event")
+    frame = _TaskEventFrame(
+        conn,
+        _resolve_board_for_connection(conn) if consumed else None,
+        consumed=consumed,
+    )
+    token = _TASK_EVENT_FRAME.set(frame)
+    pending: tuple[_TaskEventRecord, ...] = ()
     try:
-        yield conn
-    except Exception:
         try:
-            conn.execute("ROLLBACK")
-        except sqlite3.OperationalError:
-            # SQLite has already auto-rolled-back the transaction (typical
-            # under EIO, lock contention, or corruption). Nothing to undo;
-            # do not let this secondary failure shadow the real one.
-            pass
-        raise
-    else:
-        try:
-            _execute_boundary_with_retry(conn, "COMMIT")
+            yield conn
         except Exception:
-            # COMMIT exhausted retries with the txn still open; roll back so the
-            # connection isn't poisoned for the next BEGIN IMMEDIATE.
             try:
                 conn.execute("ROLLBACK")
             except sqlite3.OperationalError:
+                # SQLite has already auto-rolled-back the transaction (typical
+                # under EIO, lock contention, or corruption). Nothing to undo;
+                # do not let this secondary failure shadow the real one.
                 pass
             raise
-        # Post-commit file-length check: header page_count must match actual file pages.
-        # A discrepancy means a torn-extend — raise now rather than silently corrupt.
-        _check_file_length_invariant(conn)
+        else:
+            try:
+                _execute_boundary_with_retry(conn, "COMMIT")
+            except Exception:
+                # COMMIT exhausted retries with the txn still open; roll back so the
+                # connection isn't poisoned for the next BEGIN IMMEDIATE.
+                try:
+                    conn.execute("ROLLBACK")
+                except sqlite3.OperationalError:
+                    pass
+                raise
+            # Post-commit file-length check: header page_count must match actual file pages.
+            # A discrepancy means a torn-extend — raise now rather than silently corrupt.
+            _check_file_length_invariant(conn)
+            # Only a clean COMMIT *and* a clean invariant release the queue.
+            # Rollback, a terminal COMMIT failure, and an invariant failure all
+            # leave ``pending`` empty and dispatch nothing — the last of those
+            # being the deliberate committed-row-without-callback window.
+            pending = tuple(frame.records)
+    finally:
+        # Detach on every path, so a callback that writes the board below opens
+        # an independent transaction with a fresh frame and can neither append
+        # to nor re-flush this one.
+        _TASK_EVENT_FRAME.reset(token)
+    _dispatch_task_events(pending)
 
 
 # ---------------------------------------------------------------------------
@@ -3553,6 +3860,7 @@ def create_task(
                         "model_override": model_override,
                         "provider_override": provider_override,
                     },
+                    status_to=task_status,
                 )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
             return task_id
@@ -3845,14 +4153,19 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
         parent_status = conn.execute(
             "SELECT status FROM tasks WHERE id = ?", (parent_id,)
         ).fetchone()["status"]
+        demoted_rows = 0
         if parent_status != "done":
-            conn.execute(
+            demoted = conn.execute(
                 "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
                 (child_id,),
             )
+            demoted_rows = demoted.rowcount
         _append_event(
             conn, child_id, "linked",
             {"parent": parent_id, "child": child_id},
+            # Only report a transition the guarded UPDATE actually made: the
+            # child may well have already been past 'ready'.
+            status_to="todo" if demoted_rows == 1 else None,
         )
         _inherit_notify_subs(conn, child_id, (parent_id,))
 
@@ -4304,6 +4617,8 @@ def _append_event(
     payload: Optional[dict] = None,
     *,
     run_id: Optional[int] = None,
+    status_to: Optional[str] = None,
+    failure_count: Optional[int] = None,
 ) -> None:
     """Record an event row.  Called from within an already-open txn.
 
@@ -4311,13 +4626,60 @@ def _append_event(
     events by attempt. For events that aren't scoped to a single run
     (task created/edited/archived, dependency promotion) leave it None
     and the row carries NULL.
+
+    ``failure_count`` is likewise notification-only, and is accepted only from
+    a writer that already holds a bounded local integer — never parsed out of
+    ``payload``. Acceptance is strict: a real ``int`` (``bool`` rejected) in
+    ``[0, FAILURE_COUNT_MAX]``. Anything else is omitted, never coerced.
+
+    ``status_to`` is notification metadata only — it is never written to the
+    row. Pass the status this writer just established, taken from the local
+    transition scalar and only when the guarded UPDATE actually matched, so the
+    generic observer never has to reconstruct it from ``payload`` or re-read
+    ``tasks.status`` after commit. Anything outside :data:`VALID_STATUSES` is
+    omitted rather than guessed at.
     """
+    frame = _TASK_EVENT_FRAME.get()
+    if frame is None or frame.conn is not conn:
+        # Fail closed *before* the INSERT: a durable new-event row must never
+        # escape instrumentation. The test is "is a frame active for this
+        # connection", not "did this function open one" — helpers like
+        # _insert_completion_attachment legitimately run inside a caller's frame.
+        raise RuntimeError(
+            "_append_event requires an active write_txn frame for this "
+            f"connection (task_id={task_id!r}, kind={kind!r})"
+        )
     now = int(time.time())
     pl = json.dumps(payload, ensure_ascii=False) if payload else None
-    conn.execute(
+    cur = conn.execute(
         "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) "
         "VALUES (?, ?, ?, ?, ?)",
         (task_id, run_id, kind, pl, now),
+    )
+    if not frame.consumed:
+        # Zero-subscriber fast path: the row is durable, but nobody is
+        # listening, so build no envelope. The fail-closed check above still
+        # ran — this shortcut skips notification work, never the guard.
+        return
+    frame.records.append(
+        _TaskEventRecord(
+            task_id=task_id,
+            kind=kind,
+            core_event_seq=int(cur.lastrowid),
+            created_at_epoch_s=now,
+            run_id=run_id,
+            board=frame.board,
+            status_to=status_to if status_to in VALID_STATUSES else None,
+            failure_count=(
+                failure_count
+                if (
+                    isinstance(failure_count, int)
+                    and not isinstance(failure_count, bool)
+                    and 0 <= failure_count <= FAILURE_COUNT_MAX
+                )
+                else None
+            ),
+        )
     )
 
 
@@ -4581,19 +4943,23 @@ def recompute_ready(
                     )
                     if failures >= effective_limit:
                         continue
-                    conn.execute(
+                    promoted_cur = conn.execute(
                         "UPDATE tasks SET status = ? "
                         "WHERE id = ? AND status = 'blocked'",
                         (resume_status, task_id),
                     )
                 else:
-                    conn.execute(
+                    promoted_cur = conn.execute(
                         "UPDATE tasks SET status = ? WHERE id = ? AND status = 'todo'",
                         (resume_status, task_id),
                     )
                 _append_event(
                     conn, task_id, "promoted",
                     {"status": resume_status} if resume_status != "ready" else None,
+                    # The resume lane decides the destination, so report what
+                    # this writer actually established — and only when the
+                    # guarded UPDATE matched.
+                    status_to=resume_status if promoted_cur.rowcount == 1 else None,
                 )
                 promoted += 1
     return promoted
@@ -4645,7 +5011,7 @@ def claim_task(
             (task_id,),
         ).fetchone()
         if undone:
-            conn.execute(
+            demoted = conn.execute(
                 "UPDATE tasks SET status = 'todo' "
                 "WHERE id = ? AND status = 'ready'",
                 (task_id,),
@@ -4653,6 +5019,7 @@ def claim_task(
             _append_event(
                 conn, task_id, "claim_rejected",
                 {"reason": "parents_not_done"},
+                status_to="todo" if demoted.rowcount == 1 else None,
             )
             return None
         # Defensive: if a prior run somehow leaked (invariant violation from
@@ -4724,6 +5091,7 @@ def claim_task(
             conn, task_id, "claimed",
             {"lock": lock, "expires": expires, "run_id": run_id},
             run_id=run_id,
+            status_to="running",
         )
         claimed = get_task(conn, task_id)
     _fire_kanban_lifecycle_hook(
@@ -4773,6 +5141,8 @@ def claim_review_task(
                         "reason": "parent_reopened",
                         "source_status": "review",
                     },
+                    # Only reached when the guarded demotion matched a row.
+                    status_to="todo",
                 )
             return None
         cur = conn.execute(
@@ -4823,6 +5193,7 @@ def claim_review_task(
             {"lock": lock, "expires": expires, "run_id": run_id,
              "source_status": "review"},
             run_id=run_id,
+            status_to="running",
         )
         return get_task(conn, task_id)
 
@@ -5088,6 +5459,9 @@ def release_stale_claims(
                 conn, row["id"], "reclaimed",
                 payload,
                 run_id=run_id,
+                # The reclaim restores the claimed source phase, which is
+                # ``review`` for a review-lane run — not an assumed 'ready'.
+                status_to=retry_status,
             )
             reclaimed += 1
         # Worker-lifecycle observer (RFC #58548): the reclaim txn above has
@@ -5173,6 +5547,8 @@ def reclaim_task(
             conn, task_id, "reclaimed",
             payload,
             run_id=run_id,
+            # Restores the claimed source phase, not an assumed 'ready'.
+            status_to=retry_status,
         )
     # Operator intervention — they've looked at the task, so the
     # consecutive-failures counter is now stale. Give the next retry
@@ -5548,6 +5924,7 @@ def complete_task(
             conn, task_id, "completed",
             completed_payload,
             run_id=run_id,
+            status_to="done",
         )
     # Prose-scan the summary + result for t_<hex> references that do
     # not resolve. Advisory — does not block the completion. Runs in
@@ -6260,6 +6637,7 @@ def block_task(
                     "source_status": source_status,
                 },
                 run_id=run_id,
+                status_to="todo",
             )
             _blocked_task = get_task(conn, task_id)
             _fire_kanban_lifecycle_hook(
@@ -6319,6 +6697,7 @@ def block_task(
                     "limit": BLOCK_RECURRENCE_LIMIT,
                     "source_status": source_status,
                 },
+                status_to="triage",
                 run_id=run_id,
             )
         else:
@@ -6377,6 +6756,7 @@ def block_task(
                     "source_status": source_status,
                 },
                 run_id=run_id,
+                status_to="blocked",
             )
         _blocked_task = get_task(conn, task_id)
     _fire_kanban_lifecycle_hook(
@@ -6564,6 +6944,8 @@ def request_review(
                 "reviewer": reviewer,
             },
             run_id=run_id,
+            # The guarded UPDATE above returned early unless it matched.
+            status_to="review",
         )
     return _ret(True)
 
@@ -6683,6 +7065,8 @@ def request_changes(
                 "status": new_status,
             },
             run_id=run_id,
+            # The guarded UPDATE above returned early unless it matched.
+            status_to=new_status,
         )
     return True, implementer
 
@@ -6752,6 +7136,7 @@ def promote_task(
             task_id,
             "promoted_manual",
             {"actor": actor, "reason": reason, "forced": force},
+            status_to="ready",
         )
 
     return True, None
@@ -6863,6 +7248,7 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
                 if new_status != "ready" or resume_status != "ready"
                 else None
             ),
+            status_to=new_status,
         )
         return True
 
@@ -6931,6 +7317,8 @@ def reopen_review_task(conn: sqlite3.Connection, task_id: str) -> bool:
             task_id,
             "review_reopened",
             payload if payload != {"status": "ready"} else None,
+            # The guarded UPDATE above returned early unless it matched.
+            status_to=new_status,
         )
         return True
 
@@ -7039,12 +7427,16 @@ def invalidate_descendants_for_parent_reopen(
                 )
             # consecutive_failures = 0: deliberate operator reset — see
             # docstring for why this diverges from reopen_review_task.
-            conn.execute(
+            demoted = conn.execute(
                 "UPDATE tasks SET status = 'todo', completed_at = NULL, "
                 "claim_lock = NULL, claim_expires = NULL, worker_pid = NULL, "
                 "current_run_id = NULL, consecutive_failures = 0 WHERE id = ?",
                 (row["id"],),
             )
+            # Both events below are emitted by THIS writer for the same
+            # transition, so both carry the status it actually established —
+            # and only when the UPDATE really matched the row.
+            demoted_to = "todo" if demoted.rowcount == 1 else None
             _append_event(
                 conn,
                 row["id"],
@@ -7056,6 +7448,7 @@ def invalidate_descendants_for_parent_reopen(
                     "resume_status": resume_status,
                 },
                 run_id=run_id,
+                status_to=demoted_to,
             )
             # Legacy 'status' event kept so existing live-feed consumers
             # still see the move without learning the new event kind.
@@ -7071,6 +7464,7 @@ def invalidate_descendants_for_parent_reopen(
                     "resume_status": resume_status,
                 },
                 run_id=run_id,
+                status_to=demoted_to,
             )
             # Inline comment insert (not add_comment: no txn-opening helper
             # calls inside a txn per file convention).
@@ -7186,6 +7580,7 @@ def specify_triage_task(
             task_id,
             "specified",
             {"changed_fields": changed_fields} if changed_fields else None,
+            status_to="todo",
         )
     # Outside the write_txn above, so we don't nest BEGIN IMMEDIATE — the
     # ready-promotion pass opens its own IMMEDIATE txn. This runs the same
@@ -7355,6 +7750,7 @@ def decompose_triage_task(
             _append_event(
                 conn, new_id, "created",
                 {"by": author or "decomposer", "from_decompose_of": task_id},
+                status_to="todo",
             )
             _inherit_notify_subs(conn, new_id, (task_id,), created_at=now)
             child_ids.append(new_id)
@@ -7417,6 +7813,7 @@ def decompose_triage_task(
                 "child_ids": child_ids,
                 "root_assignee": root_assignee,
             },
+            status_to="todo",
         )
 
     # Outside the write_txn: promote parent-free children to 'ready'
@@ -7447,7 +7844,10 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
             outcome="reclaimed", status="reclaimed",
             summary="task archived with run still active",
         )
-        _append_event(conn, task_id, "archived", None, run_id=run_id)
+        _append_event(
+            conn, task_id, "archived", None, run_id=run_id,
+            status_to="archived",
+        )
     # ``archived`` parents no longer block children, same as ``done``.
     # Promote newly-unblocked dependents immediately instead of waiting
     # for a later dispatcher tick.
@@ -7869,7 +8269,10 @@ def schedule_task(
                 outcome="scheduled",
                 summary=reason,
             )
-        _append_event(conn, task_id, "scheduled", {"reason": reason}, run_id=run_id)
+        _append_event(
+            conn, task_id, "scheduled", {"reason": reason}, run_id=run_id,
+            status_to="scheduled",
+        )
         return True
 
 
@@ -8426,6 +8829,8 @@ def enforce_max_runtime(
                 )
                 _append_event(
                     conn, tid, "timed_out", payload, run_id=run_id,
+                    # Restores the claimed source phase, not an assumed 'ready'.
+                    status_to=retry_status,
                 )
                 timed_out.append(tid)
         # Increment the unified failure counter. Outside the write_txn
@@ -8570,6 +8975,8 @@ def detect_stale_running(
             )
             _append_event(
                 conn, tid, "stale", payload, run_id=run_id,
+                # Restores the claimed source phase, not an assumed 'ready'.
+                status_to=retry_status,
             )
             reclaimed.append(tid)
 
@@ -8667,7 +9074,10 @@ def reconcile_orphaned_running(
                     now,
                 ),
             )
-            _append_event(conn, tid, "reconciled", payload, run_id=run_id)
+            _append_event(
+                conn, tid, "reconciled", payload, run_id=run_id,
+                status_to="ready",
+            )
             reconciled.append(tid)
         _log.info(
             "kanban reconcile: requeued orphaned running task %s "
@@ -8910,6 +9320,8 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     conn, row["id"], event_kind,
                     event_payload,
                     run_id=run_id,
+                    # Restores the claimed source phase, not an assumed 'ready'.
+                    status_to=retry_status,
                 )
                 exited_hook_payloads.append({
                     "task_id": row["id"],
@@ -9146,7 +9558,7 @@ def _record_task_failure(
             # Trip the breaker.
             if release_claim:
                 # Spawn path: still running, also clear claim state.
-                conn.execute(
+                blocked_cur = conn.execute(
                     "UPDATE tasks SET status = 'blocked', claim_lock = NULL, "
                     "claim_expires = NULL, worker_pid = NULL, "
                     "consecutive_failures = ?, last_failure_error = ? "
@@ -9157,7 +9569,7 @@ def _record_task_failure(
                 # Timeout/crash path: source phase already restored with claim
                 # cleared; just flip to blocked + update
                 # counter fields.
-                conn.execute(
+                blocked_cur = conn.execute(
                     "UPDATE tasks SET status = 'blocked', "
                     "consecutive_failures = ?, last_failure_error = ? "
                     "WHERE id = ? AND status IN ('ready', 'review', 'running')",
@@ -9190,19 +9602,25 @@ def _record_task_failure(
                 payload.update(event_payload_extra)
             _append_event(
                 conn, task_id, "gave_up", payload, run_id=run_id,
+                # Both guarded branches can match zero rows if the task moved;
+                # never claim 'blocked' from the SQL literal alone.
+                status_to="blocked" if blocked_cur.rowcount == 1 else None,
+                failure_count=failures,
             )
             blocked = True
         else:
             # Below threshold.
+            requeued_rows = 0
             if release_claim:
                 # Spawn path: restore the claimed source phase + clear claim.
-                conn.execute(
+                requeued = conn.execute(
                     "UPDATE tasks SET status = ?, claim_lock = NULL, "
                     "claim_expires = NULL, worker_pid = NULL, "
                     "consecutive_failures = ?, last_failure_error = ? "
                     "WHERE id = ? AND status = 'running'",
                     (retry_status, failures, error[:500], task_id),
                 )
+                requeued_rows = requeued.rowcount
             else:
                 # Timeout/crash path: caller already restored the source phase.
                 conn.execute(
@@ -9229,6 +9647,12 @@ def _record_task_failure(
                         "retry_status": retry_status,
                     },
                     run_id=run_id,
+                    # Only the release_claim branch establishes a status, and
+                    # only when its guarded UPDATE matched. The restored phase
+                    # is ``retry_status`` (``review`` for a review-lane retry),
+                    # never an assumed 'ready'.
+                    status_to=retry_status if requeued_rows == 1 else None,
+                    failure_count=failures,
                 )
             # Timeout/crash path's caller already emitted its own event.
     return blocked

--- a/hermes_cli/kanban_swarm.py
+++ b/hermes_cli/kanban_swarm.py
@@ -121,6 +121,10 @@ def _activate_root_inline(
         "completed",
         {"result_len": 0, "summary": summary[:400] or None},
         run_id=run_id,
+        # The guarded CAS above matched exactly one row (rowcount != 1 returned
+        # early), so 'done' was honestly established here — report it rather
+        # than leaving the generic observer to reconstruct it after commit.
+        status_to="done",
     )
     return True
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -216,6 +216,77 @@ VALID_HOOKS: Set[str] = {
     "kanban_task_claimed",
     "kanban_task_completed",
     "kanban_task_blocked",
+    # Generic per-row Kanban observer. Fired once for every row committed to
+    # the board's `task_events` table, in whichever process performed the
+    # write (dispatcher, worker/manual CLI, or the web server for
+    # dashboard-origin edits). Observer only: return values are ignored.
+    #
+    # TIMING. Notifications are queued inside the write transaction and
+    # flushed only after COMMIT succeeds AND the post-commit file-length
+    # invariant passes, with the transaction frame already detached — so a
+    # callback never runs while the SQLite write lock is held and always sees
+    # durable state. Rollback, a terminal COMMIT failure, and an invariant
+    # failure each discard the whole queue. Delivery is AT MOST ONCE, best
+    # effort: there is no outbox, no retry, and no acknowledgement, so a
+    # committed row with zero callbacks is a real and documented outcome
+    # (invariant failure happens after the data is durable). A gap in
+    # `core_event_seq` therefore never proves hook loss, and a repeat never
+    # proves duplicate delivery.
+    #
+    # LATENCY is off-lock but on-path: callbacks run synchronously on the
+    # originating call's return path, so a slow observer delays the caller
+    # (including a dashboard HTTP response) after the commit.
+    #
+    # Kwargs (all content-free; no payload, reason, summary, title, body,
+    # message, note, filename, author, actor, or PID is ever passed):
+    #   task_id: str                     -- the task the event belongs to
+    #   kind: str                        -- the exact committed task_events.kind
+    #   core_event_seq: int              -- the committed task_events.id
+    #   created_at_epoch_s: int          -- the exact committed created_at
+    #   run_id: int | None               -- the exact committed run_id
+    #   board: str | None                -- the board THIS CONNECTION writes,
+    #                                       resolved from the connection's own
+    #                                       main DB file; None when that file
+    #                                       maps to no board (in-memory/temp DB,
+    #                                       a path outside the board layout).
+    #                                       Never guessed from ambient state.
+    #   profile_name: str
+    #   kanban_event_schema_version: "hermes.kanban.event.v1"
+    #   status_to: str                   -- ONLY when the writer established a
+    #                                       status and its guarded UPDATE
+    #                                       actually matched a row; omitted
+    #                                       otherwise. Never reconstructed and
+    #                                       never re-read after commit.
+    #   failure_count: int               -- ONLY at the two failure writers that
+    #                                       already hold a bounded integer.
+    #
+    # `core_event_seq` is the board-local rowid: monotonic within one board
+    # GENERATION only, not globally unique, not gap-free (task deletion and
+    # event retention GC leave holes), not stable across a schema rebuild
+    # (which reassigns ids), and reset to 1 by `remove_board` + a same-slug
+    # reconnect. The `(core_event_seq, kind)` pair is likewise not stable
+    # across migration, which rewrites some legacy kinds in place.
+    #
+    # VOCABULARY. `kanban_db.KANBAN_EVENT_KINDS` declares the kinds core emits.
+    # It is a capability declaration, not a DB constraint: `task_events.kind`
+    # is an open TEXT column, and an undeclared kind (a future core kind, or an
+    # out-of-tree writer's) is dispatched UNCHANGED — never dropped, coerced,
+    # or rewritten, because a consumer must see what actually committed. That
+    # pass-through is also the exact limit of the content-free guarantee: core
+    # introduces no content channel of its own and copies no payload into one,
+    # but an out-of-tree writer that puts arbitrary prose in `kind` will have
+    # that string delivered verbatim. Writers must keep kinds fixed
+    # identifiers.
+    #
+    # Registration is NOT capability detection: `register_hook` warns but still
+    # stores an unknown name, so a plugin can register this hook on a runtime
+    # that will never fire it. Detect support by reading VALID_HOOKS (and
+    # KANBAN_EVENT_KINDS), never by registering and assuming delivery.
+    #
+    # This hook is purely additive: it neither replaces nor retimes the three
+    # legacy hooks above, and core does not deduplicate between them. A row
+    # that fires a legacy hook also fires one generic notification.
+    "kanban_task_event",
 }
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -345,6 +345,109 @@ VALID_HOOKS: Set[str] = {
     #     skipped_nonspawnable, skipped_locked).
     #   Privacy: result carries task ids, assignees, and workspace paths.
     "on_kanban_dispatch_tick",
+    # NAMING. This hook stays `kanban_task_event`, NOT `on_kanban_task_event`,
+    # even though the RFC #58548 observers directly above all carry the `on_`
+    # prefix. Two reasons, in order of weight:
+    #   1. Compatibility. The name is already the published API of an open PR
+    #      and is what out-of-tree subscribers register today. Renaming would
+    #      silently stop delivery for them — `register_hook` warns on unknown
+    #      names but still stores them, so a stale `kanban_task_event`
+    #      registration would look healthy and simply never fire.
+    #   2. Taxonomy. This is the per-row generalization of the three
+    #      `kanban_task_claimed` / `_completed` / `_blocked` hooks listed
+    #      above, which are unprefixed; it belongs to that family, not to the
+    #      RFC #58548 worker/tick family. `on_kanban_task_updated` is a
+    #      different thing (a *field-mutation* boundary, names-only), so the
+    #      two names do not collide in meaning.
+    # Both prefixes therefore coexist deliberately; the prefix marks which
+    # family a hook came from, not a quality tier.
+    #
+    # Generic per-row Kanban observer. Fired once for every row committed to
+    # the board's `task_events` table, in whichever process performed the
+    # write (dispatcher, worker/manual CLI, or the web server for
+    # dashboard-origin edits). Observer only: return values are ignored.
+    #
+    # TIMING. Notifications are queued inside the write transaction and
+    # flushed only after COMMIT succeeds AND the post-commit file-length
+    # invariant passes, with the transaction frame already detached — so a
+    # callback never runs while the SQLite write lock is held and always sees
+    # durable state. Rollback, a terminal COMMIT failure, and an invariant
+    # failure each discard the whole queue. Delivery is AT MOST ONCE, best
+    # effort: there is no outbox, no retry, and no acknowledgement, so a
+    # committed row with zero callbacks is a real and documented outcome
+    # (invariant failure happens after the data is durable). A gap in
+    # `core_event_seq` therefore never proves hook loss, and a repeat never
+    # proves duplicate delivery.
+    #
+    # LATENCY is off-SQLite-lock but on-path: callbacks run synchronously on
+    # the originating call's return path, so a slow observer delays the caller
+    # (including a dashboard HTTP response) after the commit.
+    #
+    # WHICH LOCK. "Off-lock" above means the SQLite write lock ONLY, and the
+    # distinction is load-bearing. When the write happened inside a dispatcher
+    # tick, the flush runs while the board's outer single-writer dispatch lock
+    # (``kanban_db._dispatch_tick_lock``) is still held — that lock wraps the
+    # whole tick, and a tick performs many independent transactions, each
+    # flushing at its own commit. So a slow callback on a dispatcher-origin
+    # event DOES extend the dispatch critical section, and because the lock is
+    # non-blocking, a sibling dispatcher on the same board will skip its tick
+    # rather than wait. Contrast ``on_kanban_dispatch_tick`` above, which is
+    # deliberately fired after that lock is released; this hook cannot be,
+    # because its contract is a flush per committed row, not per tick.
+    # Practical rule: state callbacks must be fast and must not block. Anything
+    # slow (network, disk, subprocess) belongs on a queue the callback hands
+    # off to, never inline.
+    #
+    # Kwargs (all content-free; no payload, reason, summary, title, body,
+    # message, note, filename, author, actor, or PID is ever passed):
+    #   task_id: str                     -- the task the event belongs to
+    #   kind: str                        -- the exact committed task_events.kind
+    #   core_event_seq: int              -- the committed task_events.id
+    #   created_at_epoch_s: int          -- the exact committed created_at
+    #   run_id: int | None               -- the exact committed run_id
+    #   board: str | None                -- the board THIS CONNECTION writes,
+    #                                       resolved from the connection's own
+    #                                       main DB file; None when that file
+    #                                       maps to no board (in-memory/temp DB,
+    #                                       a path outside the board layout).
+    #                                       Never guessed from ambient state.
+    #   profile_name: str
+    #   kanban_event_schema_version: "hermes.kanban.event.v1"
+    #   status_to: str                   -- ONLY when the writer established a
+    #                                       status and its guarded UPDATE
+    #                                       actually matched a row; omitted
+    #                                       otherwise. Never reconstructed and
+    #                                       never re-read after commit.
+    #   failure_count: int               -- ONLY at the two failure writers that
+    #                                       already hold a bounded integer.
+    #
+    # `core_event_seq` is the board-local rowid: monotonic within one board
+    # GENERATION only, not globally unique, not gap-free (task deletion and
+    # event retention GC leave holes), not stable across a schema rebuild
+    # (which reassigns ids), and reset to 1 by `remove_board` + a same-slug
+    # reconnect. The `(core_event_seq, kind)` pair is likewise not stable
+    # across migration, which rewrites some legacy kinds in place.
+    #
+    # VOCABULARY. `kanban_db.KANBAN_EVENT_KINDS` declares the kinds core emits.
+    # It is a capability declaration, not a DB constraint: `task_events.kind`
+    # is an open TEXT column, and an undeclared kind (a future core kind, or an
+    # out-of-tree writer's) is dispatched UNCHANGED — never dropped, coerced,
+    # or rewritten, because a consumer must see what actually committed. That
+    # pass-through is also the exact limit of the content-free guarantee: core
+    # introduces no content channel of its own and copies no payload into one,
+    # but an out-of-tree writer that puts arbitrary prose in `kind` will have
+    # that string delivered verbatim. Writers must keep kinds fixed
+    # identifiers.
+    #
+    # Registration is NOT capability detection: `register_hook` warns but still
+    # stores an unknown name, so a plugin can register this hook on a runtime
+    # that will never fire it. Detect support by reading VALID_HOOKS (and
+    # KANBAN_EVENT_KINDS), never by registering and assuming delivery.
+    #
+    # This hook is purely additive: it neither replaces nor retimes the three
+    # legacy hooks above, and core does not deduplicate between them. A row
+    # that fires a legacy hook also fires one generic notification.
+    "kanban_task_event",
     # Gateway platform-boundary observer hooks (#64176). Observer-only; each
     # callback isolated by invoke_hook. Payloads are normalized envelopes only,
     # never raw platform SDK objects (per #64176 / #64182 ground rule). This

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1007,15 +1007,16 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                     "UPDATE tasks SET priority = ? WHERE id = ?",
                     (int(payload.priority), task_id),
                 )
-                conn.execute(
-                    "INSERT INTO task_events (task_id, kind, payload, created_at) "
-                    "VALUES (?, 'reprioritized', ?, ?)",
-                    (task_id, json.dumps({"priority": int(payload.priority)}),
-                     int(time.time())),
+                kanban_db._append_event(
+                    conn, task_id, "reprioritized",
+                    {"priority": int(payload.priority)},
                 )
-            # Mutation-boundary observer (RFC #58548): this direct-SQL write
-            # bypasses every kanban_db mutator, so report it here — after
-            # the txn commits.
+            # Mutation-boundary observer (RFC #58548). The *task-row* UPDATE
+            # here is direct SQL and goes through no kanban_db mutator, so
+            # no mutator reports it for us — hence this explicit call, after
+            # the txn commits. (The task_events row is a different story: it
+            # is appended via kanban_db._append_event, so the generic per-row
+            # observer already sees it without any help from here.)
             kanban_db.notify_task_updated(
                 conn, task_id, ("priority",), board=board,
             )
@@ -1036,11 +1037,7 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                 conn.execute(
                     f"UPDATE tasks SET {', '.join(sets)} WHERE id = ?", vals,
                 )
-                conn.execute(
-                    "INSERT INTO task_events (task_id, kind, payload, created_at) "
-                    "VALUES (?, 'edited', NULL, ?)",
-                    (task_id, int(time.time())),
-                )
+                kanban_db._append_event(conn, task_id, "edited")
             # Mutation-boundary observer (RFC #58548), post-commit. Field
             # names only — values never leave the DB via this payload.
             kanban_db.notify_task_updated(
@@ -1198,20 +1195,19 @@ def _set_status_direct(
                 summary=f"status changed to {effective_status} (dashboard/direct)",
             )
             terminations.append((prev["worker_pid"], prev["claim_lock"]))
-        conn.execute(
-            "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) "
-            "VALUES (?, ?, 'status', ?, ?)",
-            (
-                task_id,
-                run_id,
-                json.dumps(
-                    {
-                        "status": effective_status,
-                        "requested_status": new_status,
-                    }
-                ),
-                int(time.time()),
-            ),
+        kanban_db._append_event(
+            conn,
+            task_id,
+            "status",
+            {
+                "status": effective_status,
+                "requested_status": new_status,
+            },
+            run_id=run_id,
+            # The guarded UPDATE above already returned early unless it matched
+            # exactly one row, so ``effective_status`` is the status this writer
+            # actually established — never the requested one.
+            status_to=effective_status,
         )
         if reopening_satisfied_parent:
             _invalidate_descendants_for_parent_reopen(
@@ -1409,15 +1405,15 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                             "UPDATE tasks SET priority = ? WHERE id = ?",
                             (int(payload.priority), tid),
                         )
-                        conn.execute(
-                            "INSERT INTO task_events (task_id, kind, payload, created_at) "
-                            "VALUES (?, 'reprioritized', ?, ?)",
-                            (tid, json.dumps({"priority": int(payload.priority)}),
-                             int(time.time())),
+                        kanban_db._append_event(
+                            conn, tid, "reprioritized",
+                            {"priority": int(payload.priority)},
                         )
                     # Mutation-boundary observer (RFC #58548): the bulk
-                    # editor writes with direct SQL too — report each task's
-                    # committed write.
+                    # editor's task-row UPDATE is direct SQL too, so report
+                    # each task's committed write here (its task_events row,
+                    # like the single-task editor's, reaches the generic
+                    # observer through _append_event).
                     kanban_db.notify_task_updated(
                         conn, tid, ("priority",), board=board,
                     )

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -964,11 +964,9 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                     "UPDATE tasks SET priority = ? WHERE id = ?",
                     (int(payload.priority), task_id),
                 )
-                conn.execute(
-                    "INSERT INTO task_events (task_id, kind, payload, created_at) "
-                    "VALUES (?, 'reprioritized', ?, ?)",
-                    (task_id, json.dumps({"priority": int(payload.priority)}),
-                     int(time.time())),
+                kanban_db._append_event(
+                    conn, task_id, "reprioritized",
+                    {"priority": int(payload.priority)},
                 )
 
         # --- title / body -------------------------------------------------
@@ -987,11 +985,7 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                 conn.execute(
                     f"UPDATE tasks SET {', '.join(sets)} WHERE id = ?", vals,
                 )
-                conn.execute(
-                    "INSERT INTO task_events (task_id, kind, payload, created_at) "
-                    "VALUES (?, 'edited', NULL, ?)",
-                    (task_id, int(time.time())),
-                )
+                kanban_db._append_event(conn, task_id, "edited")
 
         updated = kanban_db.get_task(conn, task_id)
         return {"task": _task_dict(updated) if updated else None}
@@ -1099,10 +1093,9 @@ def _set_status_direct(
                 outcome="reclaimed", status="reclaimed",
                 summary=f"status changed to {new_status} (dashboard/direct)",
             )
-        conn.execute(
-            "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) "
-            "VALUES (?, ?, 'status', ?, ?)",
-            (task_id, run_id, json.dumps({"status": new_status}), int(time.time())),
+        kanban_db._append_event(
+            conn, task_id, "status", {"status": new_status},
+            run_id=run_id, status_to=new_status,
         )
         if reopening_satisfied_parent:
             # A parent leaving done/archived invalidates any direct child that
@@ -1120,20 +1113,16 @@ def _set_status_direct(
                     (child_id,),
                 )
                 if demoted.rowcount == 1:
-                    conn.execute(
-                        "INSERT INTO task_events (task_id, kind, payload, created_at) "
-                        "VALUES (?, 'status', ?, ?)",
-                        (
-                            child_id,
-                            json.dumps(
-                                {
-                                    "status": "todo",
-                                    "reason": "parent_reopened",
-                                    "parent": task_id,
-                                }
-                            ),
-                            int(time.time()),
-                        ),
+                    kanban_db._append_event(
+                        conn,
+                        child_id,
+                        "status",
+                        {
+                            "status": "todo",
+                            "reason": "parent_reopened",
+                            "parent": task_id,
+                        },
+                        status_to="todo",
                     )
     # If we re-opened something, children may have gone stale.
     if new_status in {"done", "ready"}:
@@ -1310,11 +1299,9 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                             "UPDATE tasks SET priority = ? WHERE id = ?",
                             (int(payload.priority), tid),
                         )
-                        conn.execute(
-                            "INSERT INTO task_events (task_id, kind, payload, created_at) "
-                            "VALUES (?, 'reprioritized', ?, ?)",
-                            (tid, json.dumps({"priority": int(payload.priority)}),
-                             int(time.time())),
+                        kanban_db._append_event(
+                            conn, tid, "reprioritized",
+                            {"priority": int(payload.priority)},
                         )
                 if payload.clear_model_override or payload.model_override is not None:
                     new_model = (

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -313,7 +313,10 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
         tid = kb.create_task(conn, title="cycle test", assignee="worker")
         kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
         # First crash — fired by the dispatcher when the worker PID dies.
-        kb._append_event(conn, tid, kind="crashed")
+        # The seam is transaction-local and fails closed without an open
+        # write_txn, exactly as the dispatcher calls it.
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, kind="crashed")
     finally:
         conn.close()
 
@@ -338,7 +341,8 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
         # Second crash — same task, same dispatcher (or a respawn). Append
         # another event to simulate the dispatcher firing crashed a second
         # time during retry.
-        kb._append_event(conn, tid, kind="crashed")
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, kind="crashed")
     finally:
         conn.close()
 
@@ -594,11 +598,12 @@ def test_notifier_delivers_block_loop_detected_triage_ping(tmp_path, monkeypatch
     try:
         tid = kb.create_task(conn, title="loops forever", assignee="worker")
         kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
-        kb._append_event(
-            conn, tid, "block_loop_detected",
-            {"reason": "needs credentials", "kind": "needs_input",
-             "recurrences": 2, "limit": kb.BLOCK_RECURRENCE_LIMIT},
-        )
+        with kb.write_txn(conn):
+            kb._append_event(
+                conn, tid, "block_loop_detected",
+                {"reason": "needs credentials", "kind": "needs_input",
+                 "recurrences": 2, "limit": kb.BLOCK_RECURRENCE_LIMIT},
+            )
     finally:
         conn.close()
 

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -312,7 +312,10 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
         tid = kb.create_task(conn, title="cycle test", assignee="worker")
         kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
         # First crash — fired by the dispatcher when the worker PID dies.
-        kb._append_event(conn, tid, kind="crashed")
+        # The seam is transaction-local and fails closed without an open
+        # write_txn, exactly as the dispatcher calls it.
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, kind="crashed")
     finally:
         conn.close()
 
@@ -337,7 +340,8 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
         # Second crash — same task, same dispatcher (or a respawn). Append
         # another event to simulate the dispatcher firing crashed a second
         # time during retry.
-        kb._append_event(conn, tid, kind="crashed")
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, kind="crashed")
     finally:
         conn.close()
 
@@ -488,11 +492,12 @@ def test_notifier_delivers_block_loop_detected_triage_ping(tmp_path, monkeypatch
     try:
         tid = kb.create_task(conn, title="loops forever", assignee="worker")
         kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
-        kb._append_event(
-            conn, tid, "block_loop_detected",
-            {"reason": "needs credentials", "kind": "needs_input",
-             "recurrences": 2, "limit": kb.BLOCK_RECURRENCE_LIMIT},
-        )
+        with kb.write_txn(conn):
+            kb._append_event(
+                conn, tid, "block_loop_detected",
+                {"reason": "needs credentials", "kind": "needs_input",
+                 "recurrences": 2, "limit": kb.BLOCK_RECURRENCE_LIMIT},
+            )
     finally:
         conn.close()
 

--- a/tests/hermes_cli/test_kanban_event_closure.py
+++ b/tests/hermes_cli/test_kanban_event_closure.py
@@ -1,0 +1,790 @@
+"""C1N-T15 — executable source/AST closure guards for the ``task_events`` writers.
+
+These guards assert *relationships*, never magnitudes. They deliberately do not
+freeze the number of ``_append_event`` call sites, the size of
+``KANBAN_EVENT_KINDS``, or the number of writers in any module: those are
+exact-base evidence and would turn an incidental count into API.
+
+The scan is not literal-only. ``_rebuild_drifted_tables`` builds its
+``INSERT INTO {table} ... SELECT ... FROM {table}_legacy`` by f-string
+interpolation over ``_REBUILD_SPECS``, so a scan matching only the literal
+string ``INSERT INTO task_events`` under-reports the writer closure. Every hit
+is then classified as a *semantic new event* (must be instrumented) or a
+*non-semantic copy/mutation* (must emit nothing).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from hermes_cli import kanban_db as kb
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+KANBAN_DB = REPO_ROOT / "hermes_cli" / "kanban_db.py"
+
+SEAM = "_append_event"
+
+#: The functions allowed to touch ``task_events`` without emitting anything,
+#: because they create no semantically new event. Membership here is the claim
+#: under test, not a waiver: each is asserted to emit nothing below.
+NON_SEMANTIC_WRITERS = {
+    # Copies already-existing rows into a rebuilt table during migration.
+    "_rebuild_drifted_tables",
+    # Rewrites the ``kind`` of existing rows in place during migration
+    # (the one-shot legacy-kind rename pass).
+    "_migrate_add_optional_columns",
+    # Row loss surfaces — deletion is not an event.
+    "delete_archived_task",
+    "delete_task",
+    "gc_events",
+}
+
+
+def production_python_files():
+    """Every production ``.py`` file — paths with a ``tests`` component excluded."""
+    out = []
+    for path in REPO_ROOT.rglob("*.py"):
+        rel = path.relative_to(REPO_ROOT)
+        parts = set(rel.parts)
+        if "tests" in parts or "tests-js" in parts:
+            continue
+        if any(p in parts for p in (".git", "node_modules", "venv", ".venv", "build")):
+            continue
+        out.append(path)
+    return out
+
+
+def parse(path):
+    try:
+        return ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+    except (SyntaxError, ValueError):
+        return None
+
+
+def enclosing_functions(tree):
+    """Return ``(start, end, name)`` for every function in *tree*."""
+    spans = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            spans.append((node.lineno, node.end_lineno, node.name))
+    return spans
+
+
+def owner_of(spans, lineno):
+    best = None
+    for start, end, name in spans:
+        if start <= lineno <= end and (best is None or start > best[0]):
+            best = (start, name)
+    return best[1] if best else None
+
+
+def rebuild_spec_functions(tree):
+    """Functions that range over ``_REBUILD_SPECS``.
+
+    Only inside these is it meaningful to resolve an interpolated table name
+    against the spec — rendering every f-string in the tree against every spec
+    table would manufacture matches that the source cannot produce.
+    """
+    out = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        names = {
+            child.id for child in ast.walk(node) if isinstance(child, ast.Name)
+        }
+        if "_REBUILD_SPECS" in names:
+            out.add(node.name)
+    return out
+
+
+def sql_strings(tree, spec_functions=frozenset(), spans=()):
+    """Yield ``(lineno, sql_text, is_dynamic)`` for every SQL-ish string.
+
+    Three passes, because a literal-only scan under-reports the closure:
+
+    1. every plain string constant (this also covers the literal fragments of
+       an f-string);
+    2. each f-string's literal parts joined with a placeholder, so a phrase
+       that is *not* split by interpolation is still seen;
+    3. inside functions that range over ``_REBUILD_SPECS`` only, each f-string
+       rendered once per spec table — which is what makes
+       ``INSERT INTO {table} ... FROM {table}_legacy`` visible.
+    """
+    tables = sorted(kb._REBUILD_SPECS)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            yield node.lineno, node.value, False
+        elif isinstance(node, ast.JoinedStr):
+            parts = [
+                v.value if isinstance(v, ast.Constant) and isinstance(v.value, str)
+                else "\x00"
+                for v in node.values
+            ]
+            yield node.lineno, "".join(parts), False
+            if owner_of(spans, node.lineno) in spec_functions:
+                for table in tables:
+                    yield node.lineno, "".join(
+                        table if p == "\x00" else p for p in parts
+                    ), True
+
+
+# --------------------------------------------------------------------------
+# The seam is the only semantic new-event writer
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t15_only_the_seam_inserts_new_task_event_rows():
+    """Every semantic new-event INSERT lives in ``_append_event``.
+
+    The five bundled-dashboard direct inserts were routed through the seam, so
+    no production module outside it constructs one any more.
+    """
+    offenders = []
+    dynamic_hits = []
+    for path in production_python_files():
+        tree = parse(path)
+        if tree is None:
+            continue
+        spans = enclosing_functions(tree)
+        specs = rebuild_spec_functions(tree)
+        for lineno, sql, is_dynamic in sql_strings(tree, specs, spans):
+            upper = " ".join(sql.upper().split())
+            if "INSERT INTO TASK_EVENTS" not in upper:
+                continue
+            owner = owner_of(spans, lineno)
+            rel = path.relative_to(REPO_ROOT)
+            if is_dynamic:
+                dynamic_hits.append((str(rel), lineno, owner))
+                continue
+            if not (path == KANBAN_DB and owner == SEAM):
+                offenders.append((str(rel), lineno, owner))
+
+    assert offenders == [], (
+        "semantic new-event INSERTs must route through _append_event: "
+        f"{offenders}"
+    )
+    # The scan must actually be able to see the interpolated rebuild INSERT —
+    # otherwise this whole guard would silently under-report.
+    assert dynamic_hits, "dynamic INSERT INTO {table} was not resolved by the scan"
+    for _rel, _lineno, owner in dynamic_hits:
+        assert owner in NON_SEMANTIC_WRITERS, (
+            f"dynamically-built task_events INSERT in {owner!r} is unclassified"
+        )
+
+
+def test_c1n_t15_task_event_mutations_and_deletions_are_classified():
+    """``UPDATE`` / ``DELETE`` on ``task_events`` create no event and emit nothing."""
+    unclassified = []
+    for path in production_python_files():
+        tree = parse(path)
+        if tree is None:
+            continue
+        spans = enclosing_functions(tree)
+        specs = rebuild_spec_functions(tree)
+        for lineno, sql, _dyn in sql_strings(tree, specs, spans):
+            upper = " ".join(sql.upper().split())
+            if not (
+                "UPDATE TASK_EVENTS" in upper
+                or "DELETE FROM TASK_EVENTS" in upper
+            ):
+                continue
+            owner = owner_of(spans, lineno)
+            if owner not in NON_SEMANTIC_WRITERS:
+                unclassified.append((str(path.relative_to(REPO_ROOT)), lineno, owner))
+    assert unclassified == [], (
+        "every task_events mutation/deletion must be a classified non-semantic "
+        f"writer: {unclassified}"
+    )
+
+
+def test_c1n_t15_non_semantic_writers_never_call_the_seam():
+    """A migration copy or an in-place rewrite must install no frame and emit nothing."""
+    tree = ast.parse(KANBAN_DB.read_text())
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if node.name not in NON_SEMANTIC_WRITERS:
+            continue
+        # ``init_db`` legitimately calls other helpers; only the rebuild/rename
+        # migration writers must be free of the seam, and none of these five
+        # may reach it directly.
+        calls = {
+            child.func.id
+            for child in ast.walk(node)
+            if isinstance(child, ast.Call) and isinstance(child.func, ast.Name)
+        }
+        assert SEAM not in calls, f"{node.name} must not emit task events"
+
+
+def test_c1n_t15_rebuild_runs_outside_write_txn():
+    """The rebuild owns a raw ``BEGIN IMMEDIATE``; it never enters ``write_txn``."""
+    tree = ast.parse(KANBAN_DB.read_text())
+    fn = next(
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.FunctionDef) and n.name == "_rebuild_drifted_tables"
+    )
+    with_calls = [
+        item.context_expr for node in ast.walk(fn)
+        if isinstance(node, ast.With) for item in node.items
+    ]
+    for expr in with_calls:
+        if isinstance(expr, ast.Call) and isinstance(expr.func, ast.Name):
+            assert expr.func.id != "write_txn"
+    raw = [
+        s for _l, s, _d in sql_strings(fn)
+        if "BEGIN IMMEDIATE" in s.upper()
+    ]
+    assert raw, "expected the rebuild's raw BEGIN IMMEDIATE"
+
+
+# --------------------------------------------------------------------------
+# Every emitted kind is classified and declared
+# --------------------------------------------------------------------------
+
+
+def append_event_sites():
+    """``(path, lineno, owner, kind_node)`` for every production seam call.
+
+    Matches BOTH call forms — bare ``_append_event(...)`` (``ast.Name``, how
+    ``kanban_db`` calls itself) and ``<mod>._append_event(...)``
+    (``ast.Attribute``, how ``kanban_swarm`` and the bundled dashboard call
+    it). A ``ast.Name``-only match makes an importing writer invisible to
+    every guard built on this helper; see the C1N-T41 section.
+    """
+    sites = []
+    for path in production_python_files():
+        tree = parse(path)
+        if tree is None:
+            continue
+        spans = enclosing_functions(tree)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = (
+                func.attr if isinstance(func, ast.Attribute)
+                else func.id if isinstance(func, ast.Name) else None
+            )
+            if name != SEAM:
+                continue
+            kind = node.args[2] if len(node.args) >= 3 else None
+            sites.append((path, node.lineno, owner_of(spans, node.lineno), kind))
+    return sites
+
+
+def test_c1n_t15_every_seam_call_is_classified_and_declared():
+    """Literal kinds must be declared; dynamic kinds must have a resolved domain.
+
+    No assertion on how many call sites there are — that count is evidence, not
+    API, and adding a writer must not break this guard.
+    """
+    sites = append_event_sites()
+    assert sites, "the AST scan found no _append_event call sites at all"
+
+    dynamic = []
+    for path, lineno, owner, kind in sites:
+        rel = path.relative_to(REPO_ROOT)
+        assert kind is not None, f"{rel}:{lineno} passes no positional kind"
+        if isinstance(kind, ast.Constant) and isinstance(kind.value, str):
+            assert kind.value in kb.KANBAN_EVENT_KINDS, (
+                f"{rel}:{lineno} emits undeclared kind {kind.value!r}"
+            )
+        else:
+            dynamic.append((rel, lineno, owner, ast.unparse(kind)))
+
+    # Each dynamic site's domain is resolved from its own function, not assumed.
+    resolved = {owner for _r, _l, owner, _e in dynamic}
+    assert resolved <= {"detect_crashed_workers", "_record_task_failure"}, (
+        f"unclassified dynamic kind expression: {dynamic}"
+    )
+
+
+def test_c1n_t15_crash_classifier_domain_is_declared():
+    """Every string ``detect_crashed_workers`` assigns to ``event_kind`` is declared."""
+    tree = ast.parse(KANBAN_DB.read_text())
+    fn = next(
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.FunctionDef) and n.name == "detect_crashed_workers"
+    )
+    values = set()
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "event_kind":
+                    assert isinstance(node.value, ast.Constant), (
+                        "event_kind must stay a fixed identifier"
+                    )
+                    values.add(node.value.value)
+    assert values, "crash classifier assigned no event_kind"
+    for value in values:
+        assert value in kb.KANBAN_EVENT_KINDS, f"{value!r} is emitted but undeclared"
+
+
+def test_c1n_t15_dynamic_outcome_domain_is_declared():
+    """Every production caller that can reach the dynamic append is declared.
+
+    ``_record_task_failure``'s dynamic append is gated on ``end_run=True``, and
+    the writer closure reaches beyond ``kanban_db.py``: ``agent/turn_finalizer``
+    calls it too (D-4/D-5).
+    """
+    reaching = set()
+    for path in production_python_files():
+        tree = parse(path)
+        if tree is None:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            name = getattr(node.func, "attr", None) or getattr(node.func, "id", None)
+            if name not in ("_record_task_failure", "_record_spawn_failure"):
+                continue
+            kwargs = {
+                kw.arg: kw.value for kw in node.keywords if kw.arg is not None
+            }
+            outcome = kwargs.get("outcome")
+            end_run = kwargs.get("end_run")
+            # _record_spawn_failure is the end_run=True alias.
+            reaches = name == "_record_spawn_failure" or (
+                isinstance(end_run, ast.Constant) and end_run.value is True
+            )
+            if reaches and isinstance(outcome, ast.Constant):
+                reaching.add(outcome.value)
+    assert reaching, "no production caller reaching the dynamic append was found"
+    for value in reaching:
+        assert value in kb.KANBAN_EVENT_KINDS, f"{value!r} is emitted but undeclared"
+
+
+def test_c1n_t15_writer_closure_includes_modules_outside_kanban_db():
+    """The closure is not confined to ``kanban_db.py`` (D-5)."""
+    finalizer = REPO_ROOT / "agent" / "turn_finalizer.py"
+    tree = parse(finalizer)
+    assert tree is not None
+    names = {
+        getattr(n.func, "attr", None) or getattr(n.func, "id", None)
+        for n in ast.walk(tree) if isinstance(n, ast.Call)
+    }
+    assert "_record_task_failure" in names or "_record_spawn_failure" in names
+
+
+def test_c1n_t15_declaration_covers_the_dashboard_writers():
+    """The bundled dashboard's kinds are declared, and it adds no second notifier."""
+    dash = REPO_ROOT / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
+    tree = parse(dash)
+    assert tree is not None
+    kinds = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        target = getattr(node.func, "attr", None)
+        if target != SEAM:
+            continue
+        kind = node.args[2] if len(node.args) >= 3 else None
+        assert isinstance(kind, ast.Constant), "dashboard kinds must be literals"
+        kinds.add(kind.value)
+    assert kinds, "the dashboard no longer reaches the shared seam"
+    for value in kinds:
+        assert value in kb.KANBAN_EVENT_KINDS
+    # No dashboard-local observer logic: it must not invoke the hook itself.
+    source = dash.read_text()
+    assert "kanban_task_event" not in source
+    assert "invoke_hook" not in source
+
+
+def test_c1n_t15_capture_path_never_consults_ambient_board():
+    """``get_current_board()`` is forbidden anywhere in the C-1 capture path (D-17)."""
+    tree = ast.parse(KANBAN_DB.read_text())
+    capture_path = {
+        "_append_event",
+        "write_txn",
+        "_resolve_board_for_connection",
+        "_dispatch_task_events",
+    }
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if node.name not in capture_path:
+            continue
+        names = {
+            child.func.id
+            for child in ast.walk(node)
+            if isinstance(child, ast.Call) and isinstance(child.func, ast.Name)
+        }
+        assert "get_current_board" not in names, (
+            f"{node.name} must resolve board from the connection, not ambient state"
+        )
+
+
+# --------------------------------------------------------------------------
+# C1N-T26 / C1N-T15 — every seam call site carries its §6.6 classification
+# --------------------------------------------------------------------------
+
+PLUGIN_API = REPO_ROOT / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
+
+#: The packet's §6.6 matrix, transcribed as a CLASSIFICATION map — never a
+#: count. Each entry is ``(function, kind) -> how status_to is supplied``:
+#:
+#:   ``literal:<status>``  a fixed VALID_STATUSES member from the writer
+#:   ``local:<name>``      the writer's own local transition scalar
+#:   ``conditional``       gated on a captured rowcount (the D-9 writers)
+#:   ``omitted``           the writer establishes no status
+#:
+#: Behavioural tests in ``test_kanban_generic_event_hook.py`` drive these rows;
+#: this guard is what makes the matrix *exhaustive*. A new writer, or a writer
+#: whose status source changes, must be classified here rather than silently
+#: joining the seam — which is the failure mode a per-writer behavioural test
+#: cannot catch on its own. It freezes no magnitude: not the site count, not
+#: the vocabulary size, not a line number.
+STATUS_TO_MATRIX = {
+    ("kanban_db.py", "create_task", "created"): "local:task_status",
+    ("kanban_db.py", "assign_task", "assigned"): "omitted",
+    ("kanban_db.py", "set_model_override", "model_override_set"): "omitted",
+    ("kanban_db.py", "set_reasoning_effort", "reasoning_effort_set"): "omitted",
+    ("kanban_db.py", "link_tasks", "linked"): "conditional",
+    ("kanban_db.py", "unlink_tasks", "unlinked"): "omitted",
+    ("kanban_db.py", "add_comment", "commented"): "omitted",
+    ("kanban_db.py", "add_attachment", "attached"): "omitted",
+    ("kanban_db.py", "delete_attachment", "attachment_removed"): "omitted",
+    ("kanban_db.py", "recompute_ready", "promoted"): "conditional",
+    ("kanban_db.py", "claim_task", "claim_rejected"): "conditional",
+    ("kanban_db.py", "claim_task", "claimed"): "literal:running",
+    ("kanban_db.py", "claim_review_task", "claimed"): "literal:running",
+    # Review-lane gating: a review card whose parents were reopened is demoted
+    # back to todo, and the event is only emitted when that UPDATE matched.
+    ("kanban_db.py", "claim_review_task", "dependency_wait"): "literal:todo",
+    ("kanban_db.py", "release_stale_claims", "claim_extended"): "omitted",
+    # The reclaim/timeout/crash writers restore the claimed SOURCE phase
+    # (``review`` for a review-lane run), so they report the local
+    # ``retry_status`` rather than an assumed 'ready'.
+    ("kanban_db.py", "release_stale_claims", "reclaimed"): "local:retry_status",
+    ("kanban_db.py", "reclaim_task", "reclaimed"): "local:retry_status",
+    ("kanban_db.py", "complete_task", "completion_blocked_hallucination"): "omitted",
+    ("kanban_db.py", "complete_task", "completed"): "literal:done",
+    ("kanban_db.py", "complete_task", "suspected_hallucinated_references"): "omitted",
+    ("kanban_db.py", "_insert_completion_attachment", "attached"): "omitted",
+    ("kanban_db.py", "_maybe_emit_scratch_tip", "tip_scratch_workspace"): "omitted",
+    ("kanban_db.py", "edit_completed_task_result", "edited"): "omitted",
+    ("kanban_db.py", "block_task", "dependency_wait"): "literal:todo",
+    ("kanban_db.py", "block_task", "block_loop_detected"): "literal:triage",
+    ("kanban_db.py", "block_task", "blocked"): "literal:blocked",
+    ("kanban_db.py", "promote_task", "promoted_manual"): "literal:ready",
+    ("kanban_db.py", "unblock_task", "unblocked"): "local:new_status",
+    # Review-lane transitions. Each sits behind a guarded UPDATE that returns
+    # early unless it matched exactly one row.
+    ("kanban_db.py", "request_review", "review_requested"): "literal:review",
+    ("kanban_db.py", "request_changes", "changes_requested"): "local:new_status",
+    ("kanban_db.py", "reopen_review_task", "review_reopened"): "local:new_status",
+    # Done-reopen descendant retraction. Both events come from the same writer
+    # and the same UPDATE, so both carry the status it established.
+    (
+        "kanban_db.py", "invalidate_descendants_for_parent_reopen",
+        "descendant_invalidated",
+    ): "local:demoted_to",
+    (
+        "kanban_db.py", "invalidate_descendants_for_parent_reopen", "status",
+    ): "local:demoted_to",
+    ("kanban_db.py", "specify_triage_task", "specified"): "literal:todo",
+    ("kanban_db.py", "decompose_triage_task", "created"): "literal:todo",
+    ("kanban_db.py", "decompose_triage_task", "linked"): "omitted",
+    ("kanban_db.py", "decompose_triage_task", "decomposed"): "literal:todo",
+    ("kanban_db.py", "archive_task", "archived"): "literal:archived",
+    ("kanban_db.py", "schedule_task", "scheduled"): "literal:scheduled",
+    ("kanban_db.py", "_defer_reclaim_for_live_worker", "reclaim_deferred"): "omitted",
+    ("kanban_db.py", "heartbeat_worker", "heartbeat"): "omitted",
+    ("kanban_db.py", "enforce_max_runtime", "timed_out"): "local:retry_status",
+    ("kanban_db.py", "detect_stale_running", "stale"): "local:retry_status",
+    # Still a literal: reconcile's UPDATE hard-codes 'ready'.
+    ("kanban_db.py", "reconcile_orphaned_running", "reconciled"): "literal:ready",
+    # The two dynamic-kind writers. Their kinds are bounded domains, asserted
+    # separately by the declaration guards above.
+    ("kanban_db.py", "detect_crashed_workers", "<dynamic>"): "local:retry_status",
+    ("kanban_db.py", "_record_task_failure", "gave_up"): "conditional",
+    ("kanban_db.py", "_record_task_failure", "<dynamic>"): "conditional",
+    ("kanban_db.py", "_set_worker_pid", "spawned"): "omitted",
+    ("kanban_db.py", "_dispatch_once_locked", "assigned"): "omitted",
+    ("kanban_db.py", "_dispatch_once_locked", "respawn_guarded"): "omitted",
+    # Review-lane respawn guard. Like its implementer-lane twin it only notes
+    # why a spawn was withheld; it establishes no status.
+    ("kanban_db.py", "_dispatch_once_locked", "respawn_guarded#2"): "omitted",
+    # The four bundled-dashboard writers, now on the shared seam. The former
+    # ``status#2`` (reopened-parent child demotion) moved into the domain
+    # layer's ``invalidate_descendants_for_parent_reopen``.
+    ("plugin_api.py", "update_task", "reprioritized"): "omitted",
+    ("plugin_api.py", "update_task", "edited"): "omitted",
+    # ``effective_status`` is what the guarded UPDATE wrote — the requested
+    # status may have been re-gated to something else.
+    ("plugin_api.py", "_set_status_direct", "status"): "local:effective_status",
+    ("plugin_api.py", "bulk_update", "reprioritized"): "omitted",
+}
+
+
+def _classify_status_to(call):
+    """Describe how one seam call supplies ``status_to``."""
+    for kw in call.keywords:
+        if kw.arg != "status_to":
+            continue
+        value = kw.value
+        if isinstance(value, ast.Constant) and isinstance(value.value, str):
+            return f"literal:{value.value}"
+        if isinstance(value, ast.IfExp):
+            return "conditional"
+        if isinstance(value, ast.Name):
+            return f"local:{value.id}"
+        return f"other:{ast.unparse(value)}"
+    return "omitted"
+
+
+def _seam_calls(path):
+    """Yield ``((file, function, kind), classification, call_node)`` per site.
+
+    A second call in the same function emitting the same kind is disambiguated
+    with a ``#2`` suffix so both remain individually classified.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    spans = enclosing_functions(tree)
+    seen = {}
+    calls = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = (
+            func.attr if isinstance(func, ast.Attribute)
+            else func.id if isinstance(func, ast.Name) else None
+        )
+        if name != SEAM:
+            continue
+        calls.append(node)
+    for node in sorted(calls, key=lambda n: n.lineno):
+        kind_node = node.args[2] if len(node.args) > 2 else None
+        if isinstance(kind_node, ast.Constant) and isinstance(kind_node.value, str):
+            kind = kind_node.value
+        else:
+            kind = "<dynamic>"
+        key = (path.name, owner_of(spans, node.lineno), kind)
+        seen[key] = seen.get(key, 0) + 1
+        if seen[key] > 1:
+            key = (key[0], key[1], f"{key[2]}#{seen[key]}")
+        yield key, _classify_status_to(node), node
+
+
+def test_c1n_t26_every_seam_call_site_is_classified_by_the_status_matrix():
+    """Exhaustive §6.6 coverage: no writer reaches the seam unclassified.
+
+    Asserts a relationship (which writer supplies ``status_to`` and how), not a
+    magnitude. Adding a writer without a matrix row — or changing where an
+    existing one gets its status from — fails here, which is precisely the
+    regression a per-writer behavioural test cannot see.
+    """
+    observed = {}
+    for path in (KANBAN_DB, PLUGIN_API):
+        for key, classification, _node in _seam_calls(path):
+            assert key not in observed, f"ambiguous seam key {key}"
+            observed[key] = classification
+
+    missing = sorted(set(STATUS_TO_MATRIX) - set(observed))
+    extra = sorted(set(observed) - set(STATUS_TO_MATRIX))
+    assert not extra, f"unclassified seam writer(s): {extra}"
+    assert not missing, f"matrix row(s) with no seam call site: {missing}"
+
+    wrong = {
+        k: (STATUS_TO_MATRIX[k], observed[k])
+        for k in STATUS_TO_MATRIX
+        if STATUS_TO_MATRIX[k] != observed[k]
+    }
+    assert not wrong, f"status_to source changed: {wrong}"
+
+
+def test_c1n_t26_literal_status_to_values_are_valid_statuses():
+    """A literal ``status_to`` is always a closed ``VALID_STATUSES`` member.
+
+    ``_append_event`` drops anything else, so a typo would silently become an
+    omission rather than a visible failure.
+    """
+    literals = {
+        v.split(":", 1)[1]
+        for v in STATUS_TO_MATRIX.values() if v.startswith("literal:")
+    }
+    assert literals, "expected at least one literal status writer"
+    for status in literals:
+        assert status in kb.VALID_STATUSES, f"{status} is not a valid status"
+
+
+def test_c1n_t27_every_conditional_status_to_is_gated_on_a_rowcount():
+    """D-9: a conditional ``status_to`` is gated on a *captured rowcount*.
+
+    The four unchecked writers the packet names each ran a ``WHERE``-guarded
+    ``UPDATE`` and appended without inspecting ``cur.rowcount`` — several
+    without even binding the cursor. This asserts the gate is the rowcount
+    itself, not some other predicate that merely looks conditional.
+    """
+    conditional = 0
+    for path in (KANBAN_DB, PLUGIN_API):
+        for key, classification, node in _seam_calls(path):
+            if classification != "conditional":
+                continue
+            conditional += 1
+            expr = next(
+                ast.unparse(kw.value)
+                for kw in node.keywords if kw.arg == "status_to"
+            )
+            test = ast.unparse(
+                next(
+                    kw.value for kw in node.keywords if kw.arg == "status_to"
+                ).test
+            )
+            assert "rowcount" in test or test.endswith("_rows == 1"), (
+                f"{key} gates status_to on {test!r}, not on a captured rowcount"
+            )
+            assert expr.endswith("else None"), (
+                f"{key} must omit status_to on a zero-row match, got {expr!r}"
+            )
+    # A relationship, not a count: at minimum the D-9 writers must be here.
+    assert conditional >= 4
+
+
+def test_c1n_t26_failure_count_is_extracted_at_exactly_the_two_failure_writers():
+    """§6.7: the single payload-derived value is confined to the two writers
+    that already hold it as a bounded local integer."""
+    holders = set()
+    for path in (KANBAN_DB, PLUGIN_API):
+        for key, _classification, node in _seam_calls(path):
+            if any(kw.arg == "failure_count" for kw in node.keywords):
+                holders.add(key)
+    assert holders == {
+        ("kanban_db.py", "_record_task_failure", "gave_up"),
+        ("kanban_db.py", "_record_task_failure", "<dynamic>"),
+    }, f"failure_count escaped its two writers: {sorted(holders)}"
+
+
+# --------------------------------------------------------------------------
+# C1N-T41 — the seam scan must see BOTH call forms
+#
+# ``append_event_sites`` above matches only bare ``_append_event(...)``
+# (``ast.Name``). A writer that imports the module and calls
+# ``kb._append_event(...)`` is an ``ast.Attribute`` and was invisible to every
+# guard built on it. These tests close that hole and keep it closed.
+#
+# No test in this section asserts a frozen number of call sites: adding a
+# legitimate writer must never break the guard, it must only be classified.
+# --------------------------------------------------------------------------
+
+#: Production modules that are allowed to reach the seam. This is a
+#: CLASSIFICATION, not a budget — a new module here is a deliberate review
+#: decision, and its call sites still have to satisfy every other guard.
+SEAM_CALLER_MODULES = {
+    "hermes_cli/kanban_db.py",
+    "hermes_cli/kanban_swarm.py",
+    "plugins/kanban/dashboard/plugin_api.py",
+}
+
+
+def all_seam_call_sites():
+    """``(rel, lineno, owner, call_node)`` for EVERY production seam call.
+
+    Recognizes both ``_append_event(...)`` (``ast.Name``) and
+    ``<mod>._append_event(...)`` (``ast.Attribute``).
+    """
+    sites = []
+    for path in production_python_files():
+        tree = parse(path)
+        if tree is None:
+            continue
+        spans = enclosing_functions(tree)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = (
+                func.attr if isinstance(func, ast.Attribute)
+                else func.id if isinstance(func, ast.Name) else None
+            )
+            if name != SEAM:
+                continue
+            rel = str(path.relative_to(REPO_ROOT))
+            sites.append((rel, node.lineno, owner_of(spans, node.lineno), node))
+    return sites
+
+
+def test_c1n_t41_attribute_style_seam_calls_are_visible_to_the_scan():
+    """The attribute-aware scan sees the swarm writer, and every module is known."""
+    sites = all_seam_call_sites()
+    assert sites, "the attribute-aware scan found no seam call sites at all"
+
+    modules = {rel for rel, _l, _o, _n in sites}
+    assert "hermes_cli/kanban_swarm.py" in modules, (
+        "the swarm writer calls kb._append_event and must be scanned"
+    )
+    unclassified = modules - SEAM_CALLER_MODULES
+    assert unclassified == set(), (
+        f"unclassified production module reaches the seam: {sorted(unclassified)}"
+    )
+
+
+def test_c1n_t41_classification_is_exhaustive_over_both_call_forms():
+    """No seam call may escape the kind-declaration guard by its call form.
+
+    Every site the attribute-aware scan finds must pass a literal declared
+    kind, or be one of the two already-classified dynamic-kind writers.
+    """
+    dynamic_owners = set()
+    for rel, lineno, owner, node in all_seam_call_sites():
+        kind = node.args[2] if len(node.args) >= 3 else None
+        assert kind is not None, f"{rel}:{lineno} passes no positional kind"
+        if isinstance(kind, ast.Constant) and isinstance(kind.value, str):
+            assert kind.value in kb.KANBAN_EVENT_KINDS, (
+                f"{rel}:{lineno} emits undeclared kind {kind.value!r}"
+            )
+        else:
+            dynamic_owners.add(owner)
+    assert dynamic_owners <= {"detect_crashed_workers", "_record_task_failure"}, (
+        f"unclassified dynamic kind expression in {sorted(dynamic_owners)}"
+    )
+
+
+def test_c1n_t41_swarm_root_completion_declares_its_status():
+    """The swarm's inline root completion must pass ``status_to='done'``.
+
+    ``_activate_root_inline`` performs a guarded ``blocked -> done`` CAS and
+    returns False unless it matched exactly one row, so by the time it appends
+    its event it has honestly established ``done`` — exactly the condition
+    ``status_to`` exists to report. Being invisible to the scan is why this
+    writer alone never carried it.
+    """
+    tree = ast.parse((REPO_ROOT / "hermes_cli" / "kanban_swarm.py").read_text())
+    fn = next(
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.FunctionDef) and n.name == "_activate_root_inline"
+    )
+    calls = [
+        n for n in ast.walk(fn)
+        if isinstance(n, ast.Call)
+        and (getattr(n.func, "attr", None) or getattr(n.func, "id", None)) == SEAM
+    ]
+    assert len(calls) == 1, "expected exactly one seam call in _activate_root_inline"
+    kwargs = {kw.arg: kw.value for kw in calls[0].keywords if kw.arg is not None}
+    status_to = kwargs.get("status_to")
+    assert isinstance(status_to, ast.Constant) and status_to.value == "done", (
+        "the swarm root completion establishes 'done' and must report it"
+    )
+
+
+def test_c1n_t41_the_kind_declaration_guard_sees_every_seam_module():
+    """``append_event_sites`` must not under-report by call form.
+
+    Every other kind/declaration guard in this file is built on
+    ``append_event_sites``. If that helper matches only ``ast.Name`` calls,
+    a module that does ``import kanban_db as kb; kb._append_event(...)``
+    silently satisfies all of them by being invisible — which is exactly how
+    the swarm writer's missing ``status_to`` survived review.
+    """
+    scanned = {rel for rel, _l, _o, _n in all_seam_call_sites()}
+    guarded = {
+        str(path.relative_to(REPO_ROOT))
+        for path, _l, _o, _k in append_event_sites()
+    }
+    missed = scanned - guarded
+    assert missed == set(), (
+        "these modules reach the seam but escape the declaration guard: "
+        f"{sorted(missed)}"
+    )

--- a/tests/hermes_cli/test_kanban_event_closure.py
+++ b/tests/hermes_cli/test_kanban_event_closure.py
@@ -1,0 +1,618 @@
+"""C1N-T15 — executable source/AST closure guards for the ``task_events`` writers.
+
+These guards assert *relationships*, never magnitudes. They deliberately do not
+freeze the number of ``_append_event`` call sites, the size of
+``KANBAN_EVENT_KINDS``, or the number of writers in any module: those are
+exact-base evidence and would turn an incidental count into API.
+
+The scan is not literal-only. ``_rebuild_drifted_tables`` builds its
+``INSERT INTO {table} ... SELECT ... FROM {table}_legacy`` by f-string
+interpolation over ``_REBUILD_SPECS``, so a scan matching only the literal
+string ``INSERT INTO task_events`` under-reports the writer closure. Every hit
+is then classified as a *semantic new event* (must be instrumented) or a
+*non-semantic copy/mutation* (must emit nothing).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from hermes_cli import kanban_db as kb
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+KANBAN_DB = REPO_ROOT / "hermes_cli" / "kanban_db.py"
+
+SEAM = "_append_event"
+
+#: The functions allowed to touch ``task_events`` without emitting anything,
+#: because they create no semantically new event. Membership here is the claim
+#: under test, not a waiver: each is asserted to emit nothing below.
+NON_SEMANTIC_WRITERS = {
+    # Copies already-existing rows into a rebuilt table during migration.
+    "_rebuild_drifted_tables",
+    # Rewrites the ``kind`` of existing rows in place during migration
+    # (the one-shot legacy-kind rename pass).
+    "_migrate_add_optional_columns",
+    # Row loss surfaces — deletion is not an event.
+    "delete_archived_task",
+    "delete_task",
+    "gc_events",
+}
+
+
+def production_python_files():
+    """Every production ``.py`` file — paths with a ``tests`` component excluded."""
+    out = []
+    for path in REPO_ROOT.rglob("*.py"):
+        rel = path.relative_to(REPO_ROOT)
+        parts = set(rel.parts)
+        if "tests" in parts or "tests-js" in parts:
+            continue
+        if any(p in parts for p in (".git", "node_modules", "venv", ".venv", "build")):
+            continue
+        out.append(path)
+    return out
+
+
+def parse(path):
+    try:
+        return ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+    except (SyntaxError, ValueError):
+        return None
+
+
+def enclosing_functions(tree):
+    """Return ``(start, end, name)`` for every function in *tree*."""
+    spans = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            spans.append((node.lineno, node.end_lineno, node.name))
+    return spans
+
+
+def owner_of(spans, lineno):
+    best = None
+    for start, end, name in spans:
+        if start <= lineno <= end and (best is None or start > best[0]):
+            best = (start, name)
+    return best[1] if best else None
+
+
+def rebuild_spec_functions(tree):
+    """Functions that range over ``_REBUILD_SPECS``.
+
+    Only inside these is it meaningful to resolve an interpolated table name
+    against the spec — rendering every f-string in the tree against every spec
+    table would manufacture matches that the source cannot produce.
+    """
+    out = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        names = {
+            child.id for child in ast.walk(node) if isinstance(child, ast.Name)
+        }
+        if "_REBUILD_SPECS" in names:
+            out.add(node.name)
+    return out
+
+
+def sql_strings(tree, spec_functions=frozenset(), spans=()):
+    """Yield ``(lineno, sql_text, is_dynamic)`` for every SQL-ish string.
+
+    Three passes, because a literal-only scan under-reports the closure:
+
+    1. every plain string constant (this also covers the literal fragments of
+       an f-string);
+    2. each f-string's literal parts joined with a placeholder, so a phrase
+       that is *not* split by interpolation is still seen;
+    3. inside functions that range over ``_REBUILD_SPECS`` only, each f-string
+       rendered once per spec table — which is what makes
+       ``INSERT INTO {table} ... FROM {table}_legacy`` visible.
+    """
+    tables = sorted(kb._REBUILD_SPECS)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            yield node.lineno, node.value, False
+        elif isinstance(node, ast.JoinedStr):
+            parts = [
+                v.value if isinstance(v, ast.Constant) and isinstance(v.value, str)
+                else "\x00"
+                for v in node.values
+            ]
+            yield node.lineno, "".join(parts), False
+            if owner_of(spans, node.lineno) in spec_functions:
+                for table in tables:
+                    yield node.lineno, "".join(
+                        table if p == "\x00" else p for p in parts
+                    ), True
+
+
+# --------------------------------------------------------------------------
+# The seam is the only semantic new-event writer
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t15_only_the_seam_inserts_new_task_event_rows():
+    """Every semantic new-event INSERT lives in ``_append_event``.
+
+    The five bundled-dashboard direct inserts were routed through the seam, so
+    no production module outside it constructs one any more.
+    """
+    offenders = []
+    dynamic_hits = []
+    for path in production_python_files():
+        tree = parse(path)
+        if tree is None:
+            continue
+        spans = enclosing_functions(tree)
+        specs = rebuild_spec_functions(tree)
+        for lineno, sql, is_dynamic in sql_strings(tree, specs, spans):
+            upper = " ".join(sql.upper().split())
+            if "INSERT INTO TASK_EVENTS" not in upper:
+                continue
+            owner = owner_of(spans, lineno)
+            rel = path.relative_to(REPO_ROOT)
+            if is_dynamic:
+                dynamic_hits.append((str(rel), lineno, owner))
+                continue
+            if not (path == KANBAN_DB and owner == SEAM):
+                offenders.append((str(rel), lineno, owner))
+
+    assert offenders == [], (
+        "semantic new-event INSERTs must route through _append_event: "
+        f"{offenders}"
+    )
+    # The scan must actually be able to see the interpolated rebuild INSERT —
+    # otherwise this whole guard would silently under-report.
+    assert dynamic_hits, "dynamic INSERT INTO {table} was not resolved by the scan"
+    for _rel, _lineno, owner in dynamic_hits:
+        assert owner in NON_SEMANTIC_WRITERS, (
+            f"dynamically-built task_events INSERT in {owner!r} is unclassified"
+        )
+
+
+def test_c1n_t15_task_event_mutations_and_deletions_are_classified():
+    """``UPDATE`` / ``DELETE`` on ``task_events`` create no event and emit nothing."""
+    unclassified = []
+    for path in production_python_files():
+        tree = parse(path)
+        if tree is None:
+            continue
+        spans = enclosing_functions(tree)
+        specs = rebuild_spec_functions(tree)
+        for lineno, sql, _dyn in sql_strings(tree, specs, spans):
+            upper = " ".join(sql.upper().split())
+            if not (
+                "UPDATE TASK_EVENTS" in upper
+                or "DELETE FROM TASK_EVENTS" in upper
+            ):
+                continue
+            owner = owner_of(spans, lineno)
+            if owner not in NON_SEMANTIC_WRITERS:
+                unclassified.append((str(path.relative_to(REPO_ROOT)), lineno, owner))
+    assert unclassified == [], (
+        "every task_events mutation/deletion must be a classified non-semantic "
+        f"writer: {unclassified}"
+    )
+
+
+def test_c1n_t15_non_semantic_writers_never_call_the_seam():
+    """A migration copy or an in-place rewrite must install no frame and emit nothing."""
+    tree = ast.parse(KANBAN_DB.read_text())
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if node.name not in NON_SEMANTIC_WRITERS:
+            continue
+        # ``init_db`` legitimately calls other helpers; only the rebuild/rename
+        # migration writers must be free of the seam, and none of these five
+        # may reach it directly.
+        calls = {
+            child.func.id
+            for child in ast.walk(node)
+            if isinstance(child, ast.Call) and isinstance(child.func, ast.Name)
+        }
+        assert SEAM not in calls, f"{node.name} must not emit task events"
+
+
+def test_c1n_t15_rebuild_runs_outside_write_txn():
+    """The rebuild owns a raw ``BEGIN IMMEDIATE``; it never enters ``write_txn``."""
+    tree = ast.parse(KANBAN_DB.read_text())
+    fn = next(
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.FunctionDef) and n.name == "_rebuild_drifted_tables"
+    )
+    with_calls = [
+        item.context_expr for node in ast.walk(fn)
+        if isinstance(node, ast.With) for item in node.items
+    ]
+    for expr in with_calls:
+        if isinstance(expr, ast.Call) and isinstance(expr.func, ast.Name):
+            assert expr.func.id != "write_txn"
+    raw = [
+        s for _l, s, _d in sql_strings(fn)
+        if "BEGIN IMMEDIATE" in s.upper()
+    ]
+    assert raw, "expected the rebuild's raw BEGIN IMMEDIATE"
+
+
+# --------------------------------------------------------------------------
+# Every emitted kind is classified and declared
+# --------------------------------------------------------------------------
+
+
+def append_event_sites():
+    """``(path, lineno, owner, kind_node)`` for every production seam call."""
+    sites = []
+    for path in production_python_files():
+        tree = parse(path)
+        if tree is None:
+            continue
+        spans = enclosing_functions(tree)
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)):
+                continue
+            if node.func.id != SEAM:
+                continue
+            kind = node.args[2] if len(node.args) >= 3 else None
+            sites.append((path, node.lineno, owner_of(spans, node.lineno), kind))
+    return sites
+
+
+def test_c1n_t15_every_seam_call_is_classified_and_declared():
+    """Literal kinds must be declared; dynamic kinds must have a resolved domain.
+
+    No assertion on how many call sites there are — that count is evidence, not
+    API, and adding a writer must not break this guard.
+    """
+    sites = append_event_sites()
+    assert sites, "the AST scan found no _append_event call sites at all"
+
+    dynamic = []
+    for path, lineno, owner, kind in sites:
+        rel = path.relative_to(REPO_ROOT)
+        assert kind is not None, f"{rel}:{lineno} passes no positional kind"
+        if isinstance(kind, ast.Constant) and isinstance(kind.value, str):
+            assert kind.value in kb.KANBAN_EVENT_KINDS, (
+                f"{rel}:{lineno} emits undeclared kind {kind.value!r}"
+            )
+        else:
+            dynamic.append((rel, lineno, owner, ast.unparse(kind)))
+
+    # Each dynamic site's domain is resolved from its own function, not assumed.
+    resolved = {owner for _r, _l, owner, _e in dynamic}
+    assert resolved <= {"detect_crashed_workers", "_record_task_failure"}, (
+        f"unclassified dynamic kind expression: {dynamic}"
+    )
+
+
+def test_c1n_t15_crash_classifier_domain_is_declared():
+    """Every string ``detect_crashed_workers`` assigns to ``event_kind`` is declared."""
+    tree = ast.parse(KANBAN_DB.read_text())
+    fn = next(
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.FunctionDef) and n.name == "detect_crashed_workers"
+    )
+    values = set()
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "event_kind":
+                    assert isinstance(node.value, ast.Constant), (
+                        "event_kind must stay a fixed identifier"
+                    )
+                    values.add(node.value.value)
+    assert values, "crash classifier assigned no event_kind"
+    for value in values:
+        assert value in kb.KANBAN_EVENT_KINDS, f"{value!r} is emitted but undeclared"
+
+
+def test_c1n_t15_dynamic_outcome_domain_is_declared():
+    """Every production caller that can reach the dynamic append is declared.
+
+    ``_record_task_failure``'s dynamic append is gated on ``end_run=True``, and
+    the writer closure reaches beyond ``kanban_db.py``: ``agent/turn_finalizer``
+    calls it too (D-4/D-5).
+    """
+    reaching = set()
+    for path in production_python_files():
+        tree = parse(path)
+        if tree is None:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            name = getattr(node.func, "attr", None) or getattr(node.func, "id", None)
+            if name not in ("_record_task_failure", "_record_spawn_failure"):
+                continue
+            kwargs = {
+                kw.arg: kw.value for kw in node.keywords if kw.arg is not None
+            }
+            outcome = kwargs.get("outcome")
+            end_run = kwargs.get("end_run")
+            # _record_spawn_failure is the end_run=True alias.
+            reaches = name == "_record_spawn_failure" or (
+                isinstance(end_run, ast.Constant) and end_run.value is True
+            )
+            if reaches and isinstance(outcome, ast.Constant):
+                reaching.add(outcome.value)
+    assert reaching, "no production caller reaching the dynamic append was found"
+    for value in reaching:
+        assert value in kb.KANBAN_EVENT_KINDS, f"{value!r} is emitted but undeclared"
+
+
+def test_c1n_t15_writer_closure_includes_modules_outside_kanban_db():
+    """The closure is not confined to ``kanban_db.py`` (D-5)."""
+    finalizer = REPO_ROOT / "agent" / "turn_finalizer.py"
+    tree = parse(finalizer)
+    assert tree is not None
+    names = {
+        getattr(n.func, "attr", None) or getattr(n.func, "id", None)
+        for n in ast.walk(tree) if isinstance(n, ast.Call)
+    }
+    assert "_record_task_failure" in names or "_record_spawn_failure" in names
+
+
+def test_c1n_t15_declaration_covers_the_dashboard_writers():
+    """The bundled dashboard's kinds are declared, and it adds no second notifier."""
+    dash = REPO_ROOT / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
+    tree = parse(dash)
+    assert tree is not None
+    kinds = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        target = getattr(node.func, "attr", None)
+        if target != SEAM:
+            continue
+        kind = node.args[2] if len(node.args) >= 3 else None
+        assert isinstance(kind, ast.Constant), "dashboard kinds must be literals"
+        kinds.add(kind.value)
+    assert kinds, "the dashboard no longer reaches the shared seam"
+    for value in kinds:
+        assert value in kb.KANBAN_EVENT_KINDS
+    # No dashboard-local observer logic: it must not invoke the hook itself.
+    source = dash.read_text()
+    assert "kanban_task_event" not in source
+    assert "invoke_hook" not in source
+
+
+def test_c1n_t15_capture_path_never_consults_ambient_board():
+    """``get_current_board()`` is forbidden anywhere in the C-1 capture path (D-17)."""
+    tree = ast.parse(KANBAN_DB.read_text())
+    capture_path = {
+        "_append_event",
+        "write_txn",
+        "_resolve_board_for_connection",
+        "_dispatch_task_events",
+    }
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if node.name not in capture_path:
+            continue
+        names = {
+            child.func.id
+            for child in ast.walk(node)
+            if isinstance(child, ast.Call) and isinstance(child.func, ast.Name)
+        }
+        assert "get_current_board" not in names, (
+            f"{node.name} must resolve board from the connection, not ambient state"
+        )
+
+
+# --------------------------------------------------------------------------
+# C1N-T26 / C1N-T15 — every seam call site carries its §6.6 classification
+# --------------------------------------------------------------------------
+
+PLUGIN_API = REPO_ROOT / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
+
+#: The packet's §6.6 matrix, transcribed as a CLASSIFICATION map — never a
+#: count. Each entry is ``(function, kind) -> how status_to is supplied``:
+#:
+#:   ``literal:<status>``  a fixed VALID_STATUSES member from the writer
+#:   ``local:<name>``      the writer's own local transition scalar
+#:   ``conditional``       gated on a captured rowcount (the D-9 writers)
+#:   ``omitted``           the writer establishes no status
+#:
+#: Behavioural tests in ``test_kanban_generic_event_hook.py`` drive these rows;
+#: this guard is what makes the matrix *exhaustive*. A new writer, or a writer
+#: whose status source changes, must be classified here rather than silently
+#: joining the seam — which is the failure mode a per-writer behavioural test
+#: cannot catch on its own. It freezes no magnitude: not the site count, not
+#: the vocabulary size, not a line number.
+STATUS_TO_MATRIX = {
+    ("kanban_db.py", "create_task", "created"): "local:task_status",
+    ("kanban_db.py", "assign_task", "assigned"): "omitted",
+    ("kanban_db.py", "set_model_override", "model_override_set"): "omitted",
+    ("kanban_db.py", "set_reasoning_effort", "reasoning_effort_set"): "omitted",
+    ("kanban_db.py", "link_tasks", "linked"): "conditional",
+    ("kanban_db.py", "unlink_tasks", "unlinked"): "omitted",
+    ("kanban_db.py", "add_comment", "commented"): "omitted",
+    ("kanban_db.py", "add_attachment", "attached"): "omitted",
+    ("kanban_db.py", "delete_attachment", "attachment_removed"): "omitted",
+    ("kanban_db.py", "recompute_ready", "promoted"): "conditional",
+    ("kanban_db.py", "claim_task", "claim_rejected"): "conditional",
+    ("kanban_db.py", "claim_task", "claimed"): "literal:running",
+    ("kanban_db.py", "claim_review_task", "claimed"): "literal:running",
+    ("kanban_db.py", "release_stale_claims", "claim_extended"): "omitted",
+    ("kanban_db.py", "release_stale_claims", "reclaimed"): "literal:ready",
+    ("kanban_db.py", "reclaim_task", "reclaimed"): "literal:ready",
+    ("kanban_db.py", "complete_task", "completion_blocked_hallucination"): "omitted",
+    ("kanban_db.py", "complete_task", "completed"): "literal:done",
+    ("kanban_db.py", "complete_task", "suspected_hallucinated_references"): "omitted",
+    ("kanban_db.py", "_insert_completion_attachment", "attached"): "omitted",
+    ("kanban_db.py", "_maybe_emit_scratch_tip", "tip_scratch_workspace"): "omitted",
+    ("kanban_db.py", "edit_completed_task_result", "edited"): "omitted",
+    ("kanban_db.py", "block_task", "dependency_wait"): "literal:todo",
+    ("kanban_db.py", "block_task", "block_loop_detected"): "literal:triage",
+    ("kanban_db.py", "block_task", "blocked"): "literal:blocked",
+    ("kanban_db.py", "promote_task", "promoted_manual"): "literal:ready",
+    ("kanban_db.py", "unblock_task", "unblocked"): "local:new_status",
+    ("kanban_db.py", "specify_triage_task", "specified"): "literal:todo",
+    ("kanban_db.py", "decompose_triage_task", "created"): "literal:todo",
+    ("kanban_db.py", "decompose_triage_task", "linked"): "omitted",
+    ("kanban_db.py", "decompose_triage_task", "decomposed"): "literal:todo",
+    ("kanban_db.py", "archive_task", "archived"): "literal:archived",
+    ("kanban_db.py", "schedule_task", "scheduled"): "literal:scheduled",
+    ("kanban_db.py", "_defer_reclaim_for_live_worker", "reclaim_deferred"): "omitted",
+    ("kanban_db.py", "heartbeat_worker", "heartbeat"): "omitted",
+    ("kanban_db.py", "enforce_max_runtime", "timed_out"): "literal:ready",
+    ("kanban_db.py", "detect_stale_running", "stale"): "literal:ready",
+    ("kanban_db.py", "reconcile_orphaned_running", "reconciled"): "literal:ready",
+    # The two dynamic-kind writers. Their kinds are bounded domains, asserted
+    # separately by the declaration guards above.
+    ("kanban_db.py", "detect_crashed_workers", "<dynamic>"): "literal:ready",
+    ("kanban_db.py", "_record_task_failure", "gave_up"): "conditional",
+    ("kanban_db.py", "_record_task_failure", "<dynamic>"): "conditional",
+    ("kanban_db.py", "_set_worker_pid", "spawned"): "omitted",
+    ("kanban_db.py", "_dispatch_once_locked", "assigned"): "omitted",
+    ("kanban_db.py", "_dispatch_once_locked", "respawn_guarded"): "omitted",
+    # The five bundled-dashboard writers, now on the shared seam.
+    ("plugin_api.py", "update_task", "reprioritized"): "omitted",
+    ("plugin_api.py", "update_task", "edited"): "omitted",
+    ("plugin_api.py", "_set_status_direct", "status"): "local:new_status",
+    ("plugin_api.py", "_set_status_direct", "status#2"): "literal:todo",
+    ("plugin_api.py", "bulk_update", "reprioritized"): "omitted",
+}
+
+
+def _classify_status_to(call):
+    """Describe how one seam call supplies ``status_to``."""
+    for kw in call.keywords:
+        if kw.arg != "status_to":
+            continue
+        value = kw.value
+        if isinstance(value, ast.Constant) and isinstance(value.value, str):
+            return f"literal:{value.value}"
+        if isinstance(value, ast.IfExp):
+            return "conditional"
+        if isinstance(value, ast.Name):
+            return f"local:{value.id}"
+        return f"other:{ast.unparse(value)}"
+    return "omitted"
+
+
+def _seam_calls(path):
+    """Yield ``((file, function, kind), classification, call_node)`` per site.
+
+    A second call in the same function emitting the same kind is disambiguated
+    with a ``#2`` suffix so both remain individually classified.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    spans = enclosing_functions(tree)
+    seen = {}
+    calls = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = (
+            func.attr if isinstance(func, ast.Attribute)
+            else func.id if isinstance(func, ast.Name) else None
+        )
+        if name != SEAM:
+            continue
+        calls.append(node)
+    for node in sorted(calls, key=lambda n: n.lineno):
+        kind_node = node.args[2] if len(node.args) > 2 else None
+        if isinstance(kind_node, ast.Constant) and isinstance(kind_node.value, str):
+            kind = kind_node.value
+        else:
+            kind = "<dynamic>"
+        key = (path.name, owner_of(spans, node.lineno), kind)
+        seen[key] = seen.get(key, 0) + 1
+        if seen[key] > 1:
+            key = (key[0], key[1], f"{key[2]}#{seen[key]}")
+        yield key, _classify_status_to(node), node
+
+
+def test_c1n_t26_every_seam_call_site_is_classified_by_the_status_matrix():
+    """Exhaustive §6.6 coverage: no writer reaches the seam unclassified.
+
+    Asserts a relationship (which writer supplies ``status_to`` and how), not a
+    magnitude. Adding a writer without a matrix row — or changing where an
+    existing one gets its status from — fails here, which is precisely the
+    regression a per-writer behavioural test cannot see.
+    """
+    observed = {}
+    for path in (KANBAN_DB, PLUGIN_API):
+        for key, classification, _node in _seam_calls(path):
+            assert key not in observed, f"ambiguous seam key {key}"
+            observed[key] = classification
+
+    missing = sorted(set(STATUS_TO_MATRIX) - set(observed))
+    extra = sorted(set(observed) - set(STATUS_TO_MATRIX))
+    assert not extra, f"unclassified seam writer(s): {extra}"
+    assert not missing, f"matrix row(s) with no seam call site: {missing}"
+
+    wrong = {
+        k: (STATUS_TO_MATRIX[k], observed[k])
+        for k in STATUS_TO_MATRIX
+        if STATUS_TO_MATRIX[k] != observed[k]
+    }
+    assert not wrong, f"status_to source changed: {wrong}"
+
+
+def test_c1n_t26_literal_status_to_values_are_valid_statuses():
+    """A literal ``status_to`` is always a closed ``VALID_STATUSES`` member.
+
+    ``_append_event`` drops anything else, so a typo would silently become an
+    omission rather than a visible failure.
+    """
+    literals = {
+        v.split(":", 1)[1]
+        for v in STATUS_TO_MATRIX.values() if v.startswith("literal:")
+    }
+    assert literals, "expected at least one literal status writer"
+    for status in literals:
+        assert status in kb.VALID_STATUSES, f"{status} is not a valid status"
+
+
+def test_c1n_t27_every_conditional_status_to_is_gated_on_a_rowcount():
+    """D-9: a conditional ``status_to`` is gated on a *captured rowcount*.
+
+    The four unchecked writers the packet names each ran a ``WHERE``-guarded
+    ``UPDATE`` and appended without inspecting ``cur.rowcount`` — several
+    without even binding the cursor. This asserts the gate is the rowcount
+    itself, not some other predicate that merely looks conditional.
+    """
+    conditional = 0
+    for path in (KANBAN_DB, PLUGIN_API):
+        for key, classification, node in _seam_calls(path):
+            if classification != "conditional":
+                continue
+            conditional += 1
+            expr = next(
+                ast.unparse(kw.value)
+                for kw in node.keywords if kw.arg == "status_to"
+            )
+            test = ast.unparse(
+                next(
+                    kw.value for kw in node.keywords if kw.arg == "status_to"
+                ).test
+            )
+            assert "rowcount" in test or test.endswith("_rows == 1"), (
+                f"{key} gates status_to on {test!r}, not on a captured rowcount"
+            )
+            assert expr.endswith("else None"), (
+                f"{key} must omit status_to on a zero-row match, got {expr!r}"
+            )
+    # A relationship, not a count: at minimum the D-9 writers must be here.
+    assert conditional >= 4
+
+
+def test_c1n_t26_failure_count_is_extracted_at_exactly_the_two_failure_writers():
+    """§6.7: the single payload-derived value is confined to the two writers
+    that already hold it as a bounded local integer."""
+    holders = set()
+    for path in (KANBAN_DB, PLUGIN_API):
+        for key, _classification, node in _seam_calls(path):
+            if any(kw.arg == "failure_count" for kw in node.keywords):
+                holders.add(key)
+    assert holders == {
+        ("kanban_db.py", "_record_task_failure", "gave_up"),
+        ("kanban_db.py", "_record_task_failure", "<dynamic>"),
+    }, f"failure_count escaped its two writers: {sorted(holders)}"

--- a/tests/hermes_cli/test_kanban_generic_event_hook.py
+++ b/tests/hermes_cli/test_kanban_generic_event_hook.py
@@ -1,0 +1,2548 @@
+"""C-1: generic ``kanban_task_event`` observer surface.
+
+Tests are named ``C1N-*`` after the implementation packet's matrix. They assert
+relationships and transaction behavior only — never line numbers, hook totals,
+the production ``_append_event`` call-site count, or a frozen vocabulary size.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+from sqlite3 import OperationalError as sqlite3_OperationalError
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.plugins import VALID_HOOKS, get_plugin_manager
+
+GENERIC_HOOK = "kanban_task_event"
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """A private board root, with every ambient board override cleared.
+
+    ``HERMES_KANBAN_DB`` in particular must be unset: ``kanban_db_path``
+    consults it *ahead of* an explicit board slug, so a leaked value would
+    silently redirect every ``connect(board=...)`` in this module.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def pinned_manager(monkeypatch):
+    """The plugin-manager singleton, pinned for the duration of one test.
+
+    ``get_plugin_manager`` is a lazily-created module singleton and the
+    repo-wide autouse ``_hermetic_environment`` fixture resets it to ``None``
+    (``tests/conftest.py``). Resolving the manager once at fixture setup is
+    therefore not enough: if anything re-resolves it mid-test, a *different*
+    manager answers the dispatch and the callback this fixture registered is
+    simply not there.
+
+    That is a pre-existing, C-1-independent hazard — on the unmodified base,
+    ``test_kanban_lifecycle_hooks.py::test_claim_fires_hook`` fails for exactly
+    this reason when ``test_kanban_cli_dispatch_passthrough.py`` runs before it
+    in the same process. Pinning the module attribute makes these tests
+    order-independent instead of inheriting it.
+    """
+    from hermes_cli import plugins as plugins_mod
+
+    mgr = get_plugin_manager()
+    monkeypatch.setattr(plugins_mod, "_plugin_manager", mgr)
+    return mgr
+
+
+@pytest.fixture
+def events(pinned_manager):
+    """Capture every ``kanban_task_event`` callback kwargs dict, in order."""
+    mgr = pinned_manager
+    seen: list[dict] = []
+    saved = {k: list(v) for k, v in mgr._hooks.items()}
+    mgr._hooks.setdefault(GENERIC_HOOK, []).append(lambda **kw: seen.append(kw))
+    try:
+        yield seen
+    finally:
+        mgr._hooks = saved
+
+
+@pytest.fixture
+def hooks(pinned_manager):
+    """Register arbitrary callbacks against the shared plugin manager.
+
+    Yields a ``register(hook_name, callback)`` helper; the registry is restored
+    afterwards so tests never leak callbacks into each other.
+    """
+    mgr = pinned_manager
+    saved = {k: list(v) for k, v in mgr._hooks.items()}
+
+    def register(hook_name, callback):
+        mgr._hooks.setdefault(hook_name, []).append(callback)
+
+    try:
+        yield register
+    finally:
+        mgr._hooks = saved
+
+
+def rows(conn, task_id=None):
+    """Read committed ``task_events`` rows, oldest first."""
+    sql = "SELECT id, task_id, run_id, kind, created_at FROM task_events"
+    args: tuple = ()
+    if task_id is not None:
+        sql += " WHERE task_id = ?"
+        args = (task_id,)
+    return [dict(r) for r in conn.execute(sql + " ORDER BY id", args).fetchall()]
+
+
+# --------------------------------------------------------------------------
+# C1N-T01 — registration surface
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t01_generic_hook_is_declared():
+    """The generic observer hook is declared as a valid hook name."""
+    assert "kanban_task_event" in VALID_HOOKS
+
+
+def test_c1n_t01_legacy_hooks_unchanged():
+    """The three legacy kanban hooks survive C-1 untouched.
+
+    No assertion on ``len(VALID_HOOKS)`` — the total is exact-base evidence,
+    never API.
+    """
+    for name in (
+        "kanban_task_claimed",
+        "kanban_task_completed",
+        "kanban_task_blocked",
+    ):
+        assert name in VALID_HOOKS
+
+
+# --------------------------------------------------------------------------
+# C1N-T02 — one committed row -> exactly one callback, with the committed scalars
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t02_committed_row_produces_one_matching_callback(kanban_home, events):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        committed = rows(conn, tid)
+    finally:
+        conn.close()
+
+    assert len(committed) == 1
+    assert len(events) == 1
+    kw = events[0]
+    row = committed[0]
+    assert kw["task_id"] == row["task_id"] == tid
+    assert kw["kind"] == row["kind"] == "created"
+    assert kw["core_event_seq"] == row["id"]
+    assert kw["created_at_epoch_s"] == row["created_at"]
+    assert kw["run_id"] == row["run_id"]
+    assert kw["kanban_event_schema_version"] == "hermes.kanban.event.v1"
+    assert "profile_name" in kw
+
+
+# --------------------------------------------------------------------------
+# C1N-T16 — the append seam fails closed
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t16_append_event_without_a_frame_raises_before_inserting(kanban_home):
+    """A durable new-event insert must never escape instrumentation."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        before = len(rows(conn))
+        with pytest.raises(RuntimeError):
+            kb._append_event(conn, tid, "created")
+        assert len(rows(conn)) == before
+    finally:
+        conn.close()
+
+
+def test_c1n_t16_append_event_works_under_a_callers_frame(kanban_home, events):
+    """The guard tests for an *active* frame, not a locally-opened one.
+
+    ``_insert_completion_attachment`` never opens its own ``write_txn``; it runs
+    inside ``complete_task``'s. Reproduce that shape directly.
+    """
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        events.clear()
+        with kb.write_txn(conn):
+            kb._insert_completion_attachment(
+                conn,
+                tid,
+                filename="a.txt",
+                stored_path="/tmp/a.txt",
+                size=3,
+                created_at=1,
+            )
+        committed = [r for r in rows(conn, tid) if r["kind"] == "attached"]
+    finally:
+        conn.close()
+
+    assert len(committed) == 1
+    assert [e["kind"] for e in events] == ["attached"]
+    assert events[0]["core_event_seq"] == committed[0]["id"]
+
+
+# --------------------------------------------------------------------------
+# C1N-T03 / C1N-T05 — insertion ordering, including epoch-second ties
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t03_multi_row_transaction_dispatches_in_insertion_order(
+    kanban_home, events
+):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        events.clear()
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, "commented")
+            kb._append_event(conn, tid, "edited")
+            kb._append_event(conn, tid, "heartbeat")
+            # Nothing may be dispatched while the transaction is still open.
+            assert events == []
+        committed = [r for r in rows(conn, tid) if r["kind"] != "created"]
+    finally:
+        conn.close()
+
+    assert [e["kind"] for e in events] == ["commented", "edited", "heartbeat"]
+    assert [e["core_event_seq"] for e in events] == [r["id"] for r in committed]
+
+
+def test_c1n_t05_epoch_second_ties_still_order_by_core_event_seq(kanban_home, events):
+    """Rows in one transaction routinely share ``created_at``; ids still order."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        events.clear()
+        with kb.write_txn(conn):
+            for _ in range(5):
+                kb._append_event(conn, tid, "heartbeat")
+    finally:
+        conn.close()
+
+    stamps = {e["created_at_epoch_s"] for e in events}
+    assert len(stamps) == 1, "fixture did not produce an epoch-second tie"
+    seqs = [e["core_event_seq"] for e in events]
+    assert seqs == sorted(seqs)
+    assert len(set(seqs)) == len(seqs)
+
+
+# --------------------------------------------------------------------------
+# C1N-T06 / C1N-T07 — callbacks run outside the transaction and on-path
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t06_callback_runs_outside_the_transaction_and_write_lock(
+    kanban_home, hooks
+):
+    observed: list[bool] = []
+    other = kb.connect()
+
+    def _cb(**kw):
+        observed.append(other.in_transaction)
+        # The write lock must already be released: a competing connection can
+        # take BEGIN IMMEDIATE while this observer is still running.
+        other.execute("BEGIN IMMEDIATE")
+        other.execute("ROLLBACK")
+
+    hooks(GENERIC_HOOK, _cb)
+    conn = kb.connect()
+    try:
+        conn.execute("PRAGMA busy_timeout=2000")
+        kb.create_task(conn, title="t")
+    finally:
+        conn.close()
+        other.close()
+
+    assert observed == [False]
+
+
+def test_c1n_t07_callback_latency_is_off_lock_but_on_path(kanban_home, hooks):
+    """A sleeping observer measurably delays the originating call, after commit."""
+    import time as _time
+
+    marks: list[tuple[str, float]] = []
+
+    def _cb(**kw):
+        marks.append(("cb_enter", _time.monotonic()))
+        _time.sleep(0.25)
+        marks.append(("cb_exit", _time.monotonic()))
+
+    hooks(GENERIC_HOOK, _cb)
+    conn = kb.connect()
+    try:
+        start = _time.monotonic()
+        kb.create_task(conn, title="t")
+        elapsed = _time.monotonic() - start
+    finally:
+        conn.close()
+
+    assert [m[0] for m in marks] == ["cb_enter", "cb_exit"]
+    assert elapsed >= 0.25
+
+
+# --------------------------------------------------------------------------
+# C1N-T08 / T09 / T10 / T11 — every suppression path
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t08_body_rollback_suppresses_and_clears(kanban_home, events):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        events.clear()
+        with pytest.raises(RuntimeError):
+            with kb.write_txn(conn):
+                kb._append_event(conn, tid, "commented")
+                raise RuntimeError("body blew up")
+        assert events == []
+        assert [r["kind"] for r in rows(conn, tid)] == ["created"]
+        assert kb._TASK_EVENT_FRAME.get() is None
+        assert conn.in_transaction is False
+    finally:
+        conn.close()
+
+
+def test_c1n_t08_nested_savepoint_rollback_discards_only_its_own_records(
+    kanban_home, events
+):
+    """A swallowed nested failure must not announce rows it rolled back.
+
+    ``write_txn(allow_nested=True)`` composes via a SQLite savepoint, so a
+    ``ROLLBACK TO`` undoes the inner rows while the OUTER transaction goes on
+    to commit. The queue has to be truncated to its pre-savepoint mark or the
+    outer commit would dispatch events for rows that never became durable —
+    the same "no callbacks on rollback" rule the top-level path enforces.
+    """
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        events.clear()
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, "commented")
+            # Swallowed on purpose: this is the whole point of a savepoint.
+            with pytest.raises(RuntimeError):
+                with kb.write_txn(conn, allow_nested=True):
+                    kb._append_event(conn, tid, "attached")
+                    raise RuntimeError("nested blew up")
+            kb._append_event(conn, tid, "edited")
+        durable = [r["kind"] for r in rows(conn, tid)]
+        assert kb._TASK_EVENT_FRAME.get() is None
+        assert conn.in_transaction is False
+    finally:
+        conn.close()
+
+    # The rolled-back row is gone from the table, and from the fan-out.
+    assert durable == ["created", "commented", "edited"]
+    assert [e["kind"] for e in events] == ["commented", "edited"]
+    assert "attached" not in {e["kind"] for e in events}
+
+
+def test_c1n_t08_nested_savepoint_success_flushes_once_with_the_outer_commit(
+    kanban_home, events
+):
+    """A released savepoint stays pending until the OUTER transaction commits."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        events.clear()
+        with kb.write_txn(conn):
+            with kb.write_txn(conn, allow_nested=True):
+                kb._append_event(conn, tid, "commented")
+            # RELEASE only folds the savepoint in — nothing is durable, so
+            # nothing may have been dispatched yet.
+            assert events == []
+        assert [e["kind"] for e in events] == ["commented"]
+        assert [r["kind"] for r in rows(conn, tid)] == ["created", "commented"]
+    finally:
+        conn.close()
+
+
+def test_c1n_t08_outer_rollback_still_discards_released_nested_records(
+    kanban_home, events
+):
+    """A successful savepoint is not durable on its own.
+
+    If the outer transaction later rolls back, the released inner rows go with
+    it and must not be announced.
+    """
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        events.clear()
+        with pytest.raises(RuntimeError):
+            with kb.write_txn(conn):
+                with kb.write_txn(conn, allow_nested=True):
+                    kb._append_event(conn, tid, "commented")
+                raise RuntimeError("outer blew up")
+        assert events == []
+        assert [r["kind"] for r in rows(conn, tid)] == ["created"]
+        assert kb._TASK_EVENT_FRAME.get() is None
+    finally:
+        conn.close()
+
+
+def test_c1n_t09_terminal_commit_failure_suppresses_and_clears(
+    kanban_home, events, monkeypatch
+):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        events.clear()
+
+        real = kb._execute_boundary_with_retry
+
+        def _fail_commit(c, stmt, *a, **kw):
+            if stmt.strip().upper().startswith("COMMIT"):
+                raise sqlite3_OperationalError("commit exhausted retries")
+            return real(c, stmt, *a, **kw)
+
+        monkeypatch.setattr(kb, "_execute_boundary_with_retry", _fail_commit)
+        with pytest.raises(Exception):
+            with kb.write_txn(conn):
+                kb._append_event(conn, tid, "commented")
+        monkeypatch.undo()
+
+        assert events == []
+        assert kb._TASK_EVENT_FRAME.get() is None
+        assert conn.in_transaction is False
+        assert [r["kind"] for r in rows(conn, tid)] == ["created"]
+    finally:
+        conn.close()
+
+
+def test_c1n_t10_post_commit_invariant_failure_suppresses(
+    kanban_home, events, monkeypatch
+):
+    """The deliberate committed-row-without-callback window.
+
+    Asserts the CALLBACK COUNT ONLY and explicitly tolerates a durable row: the
+    invariant runs after COMMIT, so the data may well be on disk. The
+    connection is put in rollback-journal mode first, because the invariant
+    deliberately skips under WAL.
+    """
+    import hermes_cli.sqlite_safe_read as ssr
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        conn.execute("PRAGMA journal_mode=DELETE")
+        events.clear()
+        monkeypatch.setattr(ssr, "file_length_matches_header", lambda _c: False)
+        with pytest.raises(Exception):
+            with kb.write_txn(conn):
+                kb._append_event(conn, tid, "commented")
+        monkeypatch.undo()
+
+        assert events == []
+        assert kb._TASK_EVENT_FRAME.get() is None
+        # Deliberately NOT asserting the row is absent — it may be durable.
+    finally:
+        conn.close()
+
+
+def test_c1n_t10_invariant_is_skipped_under_wal(kanban_home, events, monkeypatch):
+    """D-11 control: the same forced mismatch is a no-op under WAL."""
+    import hermes_cli.sqlite_safe_read as ssr
+
+    conn = kb.connect()
+    try:
+        assert str(conn.execute("PRAGMA journal_mode").fetchone()[0]).lower() == "wal"
+        tid = kb.create_task(conn, title="t")
+        events.clear()
+        monkeypatch.setattr(ssr, "file_length_matches_header", lambda _c: False)
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, "commented")
+        monkeypatch.undo()
+        assert [e["kind"] for e in events] == ["commented"]
+    finally:
+        conn.close()
+
+
+def test_c1n_t11_pre_begin_guard_installs_no_frame(kanban_home, events, monkeypatch):
+    conn = kb.connect()
+    try:
+        events.clear()
+        monkeypatch.setenv("HERMES_DELEGATED_CHILD_CONTEXT", "1")
+        with pytest.raises(PermissionError):
+            with kb.write_txn(conn):  # pragma: no cover - body never runs
+                raise AssertionError("body must not run")
+        monkeypatch.undo()
+        assert events == []
+        assert kb._TASK_EVENT_FRAME.get() is None
+        assert conn.in_transaction is False
+    finally:
+        conn.close()
+
+
+# --------------------------------------------------------------------------
+# C1N-T12 / T13 / T14 — observer isolation, fan-out order, reentrancy
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t12_raising_observer_is_isolated(kanban_home, hooks):
+    seen: list[str] = []
+
+    def _boom(**kw):
+        seen.append("boom")
+        raise RuntimeError("observer exploded")
+
+    hooks(GENERIC_HOOK, _boom)
+    hooks(GENERIC_HOOK, lambda **kw: seen.append("after"))
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        committed = rows(conn, tid)
+    finally:
+        conn.close()
+
+    assert seen == ["boom", "after"]
+    assert [r["kind"] for r in committed] == ["created"]
+
+
+def test_c1n_t13_fanout_follows_registration_order(kanban_home, hooks):
+    order: list[str] = []
+    for name in ("a", "b", "c"):
+        hooks(GENERIC_HOOK, lambda _n=name, **kw: order.append(f"{_n}:{kw['kind']}"))
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, "commented")
+    finally:
+        conn.close()
+
+    assert order == [
+        "a:created", "b:created", "c:created",
+        "a:commented", "b:commented", "c:commented",
+    ]
+
+
+def test_c1n_t14_observer_that_writes_the_board_uses_a_fresh_frame(kanban_home, hooks):
+    depth: list[int] = []
+    seen: list[str] = []
+
+    def _cb(**kw):
+        seen.append(kw["kind"])
+        # The completed frame is already detached, so this write cannot append
+        # to it or re-flush it.
+        assert kb._TASK_EVENT_FRAME.get() is None
+        if kw["kind"] == "created" and len(depth) < 3:
+            depth.append(1)
+            inner = kb.connect()
+            try:
+                with kb.write_txn(inner):
+                    kb._append_event(inner, kw["task_id"], "commented")
+            finally:
+                inner.close()
+
+    hooks(GENERIC_HOOK, _cb)
+    conn = kb.connect()
+    try:
+        kb.create_task(conn, title="t")
+    finally:
+        conn.close()
+
+    # One nested write, no unbounded recursion: 'commented' does not re-trigger.
+    assert seen == ["created", "commented"]
+    assert kb._TASK_EVENT_FRAME.get() is None
+
+
+# --------------------------------------------------------------------------
+# C1N-T35 — board comes from the CONNECTION, never from ambient state
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t35a_explicit_board_beats_ambient_board(kanban_home, events, monkeypatch):
+    """``HERMES_KANBAN_DB`` must stay cleared here.
+
+    ``kanban_db_path`` consults that variable *ahead of* the explicit slug, so
+    a set value would open the env-named file and this assertion would say
+    nothing about ``board="B"``.
+    """
+    kb.create_board("board-b")
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "board-a")
+    kb.create_board("board-a")
+    assert kb.get_current_board() == "board-a"
+
+    conn = kb.connect(board="board-b")
+    try:
+        events.clear()
+        kb.create_task(conn, title="t")
+    finally:
+        conn.close()
+
+    assert [e["board"] for e in events] == ["board-b"]
+
+
+def test_c1n_t35a_explicit_db_path_beats_ambient_board(kanban_home, events, monkeypatch):
+    kb.create_board("board-b")
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "board-a")
+    kb.create_board("board-a")
+
+    conn = kb.connect(db_path=kb.kanban_db_path(board="board-b"))
+    try:
+        events.clear()
+        kb.create_task(conn, title="t")
+    finally:
+        conn.close()
+
+    assert [e["board"] for e in events] == ["board-b"]
+
+
+def test_c1n_t35a_default_board_legacy_path_resolves(kanban_home, events):
+    conn = kb.connect(board="default")
+    try:
+        events.clear()
+        kb.create_task(conn, title="t")
+    finally:
+        conn.close()
+
+    assert [e["board"] for e in events] == ["default"]
+
+
+def test_c1n_t35b_env_db_override_outside_layout_yields_none(
+    kanban_home, events, tmp_path, monkeypatch
+):
+    """The resolver reports the connection's ACTUAL file.
+
+    ``HERMES_KANBAN_DB`` overrode the explicit ``board="B"`` argument, so the
+    connection is not writing board B at all. Reporting ``"board-b"`` here
+    would be a lie; ``None`` is the honest answer.
+    """
+    kb.create_board("board-b")
+    outside = tmp_path / "elsewhere" / "kanban.db"
+    outside.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(outside))
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "board-a")
+
+    conn = kb.connect(board="board-b")
+    try:
+        events.clear()
+        kb.create_task(conn, title="t")
+    finally:
+        conn.close()
+
+    assert [e["board"] for e in events] == [None]
+
+
+def test_c1n_t35b_db_path_outside_layout_yields_none(
+    kanban_home, events, tmp_path, monkeypatch
+):
+    outside = tmp_path / "elsewhere2" / "kanban.db"
+    outside.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "board-a")
+
+    conn = kb.connect(db_path=outside)
+    try:
+        events.clear()
+        kb.create_task(conn, title="t")
+    finally:
+        conn.close()
+
+    assert [e["board"] for e in events] == [None]
+
+
+def test_c1n_t35_board_is_fixed_at_frame_install(kanban_home, events, monkeypatch):
+    """Ambient state changing mid-transaction cannot re-attribute the board."""
+    kb.create_board("board-b")
+    conn = kb.connect(board="board-b")
+    try:
+        tid = kb.create_task(conn, title="t")
+        events.clear()
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, "commented")
+            monkeypatch.setenv("HERMES_KANBAN_BOARD", "board-a")
+            kb._append_event(conn, tid, "edited")
+    finally:
+        conn.close()
+
+    assert [e["board"] for e in events] == ["board-b", "board-b"]
+
+
+# --------------------------------------------------------------------------
+# C1N-T21 — capability declaration
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t21_declaration_is_an_immutable_module_constant():
+    assert isinstance(kb.KANBAN_EVENT_KINDS, frozenset)
+    assert all(isinstance(k, str) for k in kb.KANBAN_EVENT_KINDS)
+
+
+def test_c1n_t21_driven_writers_emit_declared_kinds(kanban_home, events):
+    """Per-writer assertion. No assertion on the size of the declaration."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t", assignee="w")
+        kb.assign_task(conn, tid, "w2")
+        kb.add_comment(conn, tid, "me", "hello")
+        claimed = kb.claim_task(conn, tid, claimer="w:1")
+        assert claimed is not None
+        kb.complete_task(conn, tid, result="done")
+    finally:
+        conn.close()
+
+    emitted = [e["kind"] for e in events]
+    assert "created" in emitted and "claimed" in emitted and "completed" in emitted
+    for kind in emitted:
+        assert kind in kb.KANBAN_EVENT_KINDS, f"{kind} is emitted but undeclared"
+
+
+# --------------------------------------------------------------------------
+# C1N-T17 / T18 / T34 — the five bundled-dashboard writers
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def dash():
+    """The bundled dashboard plugin API module (a third writing process)."""
+    return pytest.importorskip("plugins.kanban.dashboard.plugin_api")
+
+
+def test_c1n_t17_dashboard_reprioritized_and_edited_use_the_shared_seam(
+    kanban_home, events, dash
+):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+    finally:
+        conn.close()
+    events.clear()
+
+    dash.update_task(tid, dash.UpdateTaskBody(priority=7), board=None)
+    dash.update_task(tid, dash.UpdateTaskBody(title="new title"), board=None)
+
+    conn = kb.connect()
+    try:
+        committed = [r for r in rows(conn, tid) if r["kind"] != "created"]
+    finally:
+        conn.close()
+
+    assert [e["kind"] for e in events] == ["reprioritized", "edited"]
+    for kw, row in zip(events, committed):
+        assert kw["core_event_seq"] == row["id"]
+        assert kw["created_at_epoch_s"] == row["created_at"]
+        assert kw["run_id"] == row["run_id"] is None
+        assert kw["task_id"] == tid
+        assert kw["kanban_event_schema_version"] == "hermes.kanban.event.v1"
+        assert kw["kind"] in kb.KANBAN_EVENT_KINDS
+    # A dashboard edit carries no title/body content.
+    assert "title" not in events[1] and "body" not in events[1]
+
+
+def test_c1n_t17_dashboard_status_writer_uses_the_shared_seam(
+    kanban_home, events, dash
+):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+    finally:
+        conn.close()
+    events.clear()
+
+    conn = kb.connect()
+    try:
+        assert dash._set_status_direct(conn, tid, "todo") is True
+        committed = [r for r in rows(conn, tid) if r["kind"] == "status"]
+    finally:
+        conn.close()
+
+    assert [e["kind"] for e in events] == ["status"]
+    assert events[0]["core_event_seq"] == committed[0]["id"]
+    assert events[0]["status_to"] == "todo"
+
+
+def test_c1n_t17_dashboard_bulk_reprioritized_uses_the_shared_seam(
+    kanban_home, events, dash
+):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+    finally:
+        conn.close()
+    events.clear()
+
+    dash.bulk_update(dash.BulkTaskBody(ids=[tid], priority=3), board=None)
+
+    assert [e["kind"] for e in events] == ["reprioritized"]
+    assert "priority" not in events[0]
+    assert "status_to" not in events[0]
+
+
+def test_c1n_t18_reopened_parent_demotion_carries_status_to_todo(
+    kanban_home, events, dash
+):
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child")
+        kb.link_tasks(conn, parent, child)
+        # Drive the parent to done so the child can sit in ready.
+        assert dash._set_status_direct(conn, parent, "done") is True
+        assert dash._set_status_direct(conn, child, "ready") is True
+        events.clear()
+        # Reopening the parent must demote the ready child back to todo.
+        assert dash._set_status_direct(conn, parent, "todo") is True
+        child_rows = [r for r in rows(conn, child) if r["kind"] == "status"]
+    finally:
+        conn.close()
+
+    demotions = [e for e in events if e["task_id"] == child and e["kind"] == "status"]
+    assert len(demotions) == 1
+    assert demotions[0]["status_to"] == "todo"
+    assert demotions[0]["core_event_seq"] == child_rows[-1]["id"]
+    # No payload parsing and no post-commit read: nothing from the payload
+    # ('reason', 'parent') leaks into the kwargs.
+    assert "reason" not in demotions[0] and "parent" not in demotions[0]
+
+
+def test_c1n_t34_dashboard_board_is_the_connection_not_ambient(
+    kanban_home, events, dash, monkeypatch
+):
+    kb.create_board("board-b")
+    kb.create_board("board-a")
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "board-a")
+    assert kb.get_current_board() == "board-a"
+
+    conn = kb.connect(board="board-b")
+    try:
+        tid = kb.create_task(conn, title="t")
+    finally:
+        conn.close()
+    events.clear()
+
+    dash.update_task(tid, dash.UpdateTaskBody(priority=9), board="board-b")
+
+    assert [e["kind"] for e in events] == ["reprioritized"]
+    assert events[0]["board"] == "board-b"
+
+
+# --------------------------------------------------------------------------
+# C1N-T26 / C1N-T27 — the exact status_to matrix and conditional-transition honesty
+# --------------------------------------------------------------------------
+
+
+def only(events, kind, task_id=None):
+    """Return the single callback for ``kind`` (optionally scoped to a task)."""
+    hits = [
+        e for e in events
+        if e["kind"] == kind and (task_id is None or e["task_id"] == task_id)
+    ]
+    assert len(hits) == 1, f"expected exactly one {kind!r} callback, got {len(hits)}"
+    return hits[0]
+
+
+def test_c1n_t26_created_status_domain(kanban_home, events):
+    """``created``'s domain is {ready, todo, triage, blocked} — never running."""
+    conn = kb.connect()
+    try:
+        plain = kb.create_task(conn, title="plain")
+        assert only(events, "created", plain)["status_to"] == "ready"
+
+        events.clear()
+        triage = kb.create_task(conn, title="triage", triage=True)
+        assert only(events, "created", triage)["status_to"] == "triage"
+
+        events.clear()
+        blocked = kb.create_task(conn, title="b", initial_status="blocked")
+        assert only(events, "created", blocked)["status_to"] == "blocked"
+
+        events.clear()
+        child = kb.create_task(conn, title="child", parents=[plain])
+        assert only(events, "created", child)["status_to"] == "todo"
+    finally:
+        conn.close()
+
+
+def test_c1n_t26_claim_complete_and_block_transitions(kanban_home, events):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        events.clear()
+        assert kb.claim_task(conn, tid, claimer="w:1") is not None
+        assert only(events, "claimed")["status_to"] == "running"
+
+        events.clear()
+        assert kb.block_task(conn, tid, reason="need input", kind="needs_input")
+        assert only(events, "blocked")["status_to"] == "blocked"
+
+        events.clear()
+        assert kb.unblock_task(conn, tid)
+        assert only(events, "unblocked")["status_to"] == "ready"
+
+        events.clear()
+        assert kb.claim_task(conn, tid, claimer="w:2") is not None
+        kb.complete_task(conn, tid, result="ok")
+        assert only(events, "completed")["status_to"] == "done"
+    finally:
+        conn.close()
+
+
+def test_c1n_t26_unblocked_reports_the_exact_local_new_status(kanban_home, events):
+    """``unblocked`` reports ``todo`` when parents are still undone."""
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", parents=[parent])
+        # The child sits in 'todo' behind its parent; force it ready so
+        # block_task's guarded UPDATE can match, then block it.
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (child,))
+        conn.commit()
+        assert kb.block_task(conn, child, reason="r")
+        events.clear()
+        assert kb.unblock_task(conn, child)
+        assert only(events, "unblocked")["status_to"] == "todo"
+    finally:
+        conn.close()
+
+
+def test_c1n_t26_dependency_wait_reports_todo(kanban_home, events):
+    """A dependency block routes to ``todo``, never to ``blocked``."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        events.clear()
+        assert kb.block_task(conn, tid, reason="dep", kind="dependency") is True
+        assert only(events, "dependency_wait")["status_to"] == "todo"
+        assert kb.get_task(conn, tid).status == "todo"
+    finally:
+        conn.close()
+
+
+def test_c1n_t26_block_loop_detected_reports_triage(kanban_home, events):
+    """At BLOCK_RECURRENCE_LIMIT the block routes to ``triage``."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        # First block for this cause records recurrence 1 and lands in
+        # 'blocked'; the re-block after an unblock reaches the limit.
+        assert kb.block_task(conn, tid, reason="same", kind="needs_input")
+        assert kb.unblock_task(conn, tid)
+        events.clear()
+        assert kb.block_task(conn, tid, reason="same", kind="needs_input")
+        assert only(events, "block_loop_detected")["status_to"] == "triage"
+        assert kb.get_task(conn, tid).status == "triage"
+    finally:
+        conn.close()
+
+
+def test_c1n_t26_promote_schedule_archive_specify_decompose(kanban_home, events):
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", parents=[parent])
+        events.clear()
+        ok, _ = kb.promote_task(conn, child, actor="op", force=True)
+        assert ok
+        assert only(events, "promoted_manual")["status_to"] == "ready"
+
+        events.clear()
+        assert kb.schedule_task(conn, child, reason="later")
+        assert only(events, "scheduled")["status_to"] == "scheduled"
+
+        events.clear()
+        assert kb.archive_task(conn, child)
+        assert only(events, "archived")["status_to"] == "archived"
+
+        tri = kb.create_task(conn, title="tri", triage=True)
+        events.clear()
+        assert kb.specify_triage_task(conn, tri, title="spec", body="b")
+        assert only(events, "specified")["status_to"] == "todo"
+
+        tri2 = kb.create_task(conn, title="tri2", triage=True)
+        events.clear()
+        kids = kb.decompose_triage_task(
+            conn, tri2, root_assignee=None,
+            children=[{"title": "k1"}, {"title": "k2"}],
+        )
+        assert kids
+        assert only(events, "decomposed")["status_to"] == "todo"
+        created = [e for e in events if e["kind"] == "created"]
+        assert created and all(e["status_to"] == "todo" for e in created)
+        # decompose's own `linked` writes establish no status.
+        for e in events:
+            if e["kind"] == "linked":
+                assert "status_to" not in e
+    finally:
+        conn.close()
+
+
+def test_c1n_t26_reclaim_and_recovery_writers_report_ready(kanban_home, events):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        assert kb.claim_task(conn, tid, claimer="w:1") is not None
+        events.clear()
+        assert kb.reclaim_task(conn, tid, reason="operator")
+        assert only(events, "reclaimed")["status_to"] == "ready"
+
+        # reconcile_orphaned_running: running with broken claim bookkeeping.
+        conn.execute(
+            "UPDATE tasks SET status='running', claim_lock=NULL, "
+            "claim_expires=NULL WHERE id=?", (tid,),
+        )
+        conn.commit()
+        events.clear()
+        assert kb.reconcile_orphaned_running(conn) == [tid]
+        assert only(events, "reconciled")["status_to"] == "ready"
+    finally:
+        conn.close()
+
+
+def test_c1n_t26_non_transition_writers_omit_status_to(kanban_home, events):
+    conn = kb.connect()
+    try:
+        a = kb.create_task(conn, title="a")
+        b = kb.create_task(conn, title="b")
+        events.clear()
+        kb.assign_task(conn, a, "worker")
+        kb.set_model_override(conn, a, "gpt-x")
+        kb.set_reasoning_effort(conn, a, "high")
+        kb.add_comment(conn, a, "me", "hi")
+        kb.link_tasks(conn, a, b)
+        kb.unlink_tasks(conn, a, b)
+        assert kb.claim_task(conn, a, claimer="w:1") is not None
+        kb.heartbeat_worker(conn, a, note="tick")
+    finally:
+        conn.close()
+
+    expected_omitted = {
+        "assigned", "model_override_set", "reasoning_effort_set",
+        "commented", "unlinked", "heartbeat",
+    }
+    seen = {e["kind"] for e in events}
+    assert expected_omitted <= seen
+    for e in events:
+        if e["kind"] in expected_omitted:
+            assert "status_to" not in e, f"{e['kind']} must omit status_to"
+
+
+def test_c1n_t27_promoted_omits_status_to_when_the_update_matched_nothing(
+    kanban_home, events, monkeypatch
+):
+    """D-9: ``recompute_ready`` appends without binding its UPDATE's rowcount.
+
+    Move the row out of the guarded status between the SELECT and the UPDATE so
+    the guarded UPDATE matches zero rows; ``status_to`` must be omitted rather
+    than asserted from the SQL literal.
+    """
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", parents=[parent])
+        assert kb.claim_task(conn, parent, claimer="w:1") is not None
+        kb.complete_task(conn, parent, result="ok")
+        # complete_task already ran its own recompute_ready pass; push the
+        # child back to 'todo' so this test drives the promotion itself.
+        conn.execute("UPDATE tasks SET status='todo' WHERE id=?", (child,))
+        conn.commit()
+        events.clear()
+        real_execute = conn.execute
+        state = {"sabotaged": False}
+
+        def _sabotage(sql, *a, **kw):
+            # The promotion target is now bound (the review lane resumes to
+            # its source phase), so match the guarded 'todo' predicate plus
+            # the parameterised SET rather than a 'ready' literal.
+            if (
+                not state["sabotaged"]
+                and "SET status = ?" in sql
+                and "status = 'todo'" in sql
+            ):
+                state["sabotaged"] = True
+                real_execute(
+                    "UPDATE tasks SET status = 'blocked' WHERE id = ?", (child,)
+                )
+            return real_execute(sql, *a, **kw)
+
+        monkeypatch.setattr(conn, "execute", _sabotage)
+        kb.recompute_ready(conn)
+        monkeypatch.undo()
+        assert state["sabotaged"]
+
+        promoted = [e for e in events if e["kind"] == "promoted"]
+        assert len(promoted) == 1
+        assert "status_to" not in promoted[0]
+    finally:
+        conn.close()
+
+
+def test_c1n_t27_promoted_reports_ready_when_the_update_matched(kanban_home, events):
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", parents=[parent])
+        assert kb.claim_task(conn, parent, claimer="w:1") is not None
+        kb.complete_task(conn, parent, result="ok")
+        conn.execute("UPDATE tasks SET status='todo' WHERE id=?", (child,))
+        conn.commit()
+        events.clear()
+        kb.recompute_ready(conn)
+        assert only(events, "promoted", child)["status_to"] == "ready"
+    finally:
+        conn.close()
+
+
+def test_c1n_t27_linked_status_to_is_rowcount_gated(kanban_home, events):
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent")
+        ready_child = kb.create_task(conn, title="ready-child")
+        events.clear()
+        kb.link_tasks(conn, parent, ready_child)
+        # The child WAS ready, so the guarded demotion matched: honest 'todo'.
+        assert only(events, "linked", ready_child)["status_to"] == "todo"
+
+        # A second link from another parent: the child is already 'todo', so
+        # the guarded UPDATE matches nothing and status_to must be omitted.
+        other_parent = kb.create_task(conn, title="parent2")
+        events.clear()
+        kb.link_tasks(conn, other_parent, ready_child)
+        assert "status_to" not in only(events, "linked", ready_child)
+    finally:
+        conn.close()
+
+
+def test_c1n_t27_claim_rejected_status_to_is_rowcount_gated(kanban_home, events):
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child")
+        # Force the child ready even though its parent is not done, so
+        # claim_task takes the parents_not_done branch and demotes it.
+        kb.link_tasks(conn, parent, child)
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (child,))
+        conn.commit()
+        events.clear()
+        assert kb.claim_task(conn, child, claimer="w:1") is None
+        assert only(events, "claim_rejected", child)["status_to"] == "todo"
+
+        # Now the child is already 'todo': the guarded demotion matches nothing.
+        events.clear()
+        assert kb.claim_task(conn, child, claimer="w:1") is None
+        assert "status_to" not in only(events, "claim_rejected", child)
+    finally:
+        conn.close()
+
+
+# --------------------------------------------------------------------------
+# C1N-T28 / C1N-T24 — strict failure_count, and the dynamic outcome domain
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t28_failure_count_acceptance_is_strict(kanban_home, events):
+    """No parsing, coercion, rounding, clamping, or defaulting."""
+    assert kb.FAILURE_COUNT_MAX == 1000
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        events.clear()
+        accepted = [0, 1, 7, kb.FAILURE_COUNT_MAX]
+        rejected = [True, False, "3", 3.0, -1, kb.FAILURE_COUNT_MAX + 1, None]
+        with kb.write_txn(conn):
+            for value in accepted + rejected:
+                kb._append_event(conn, tid, "heartbeat", failure_count=value)
+    finally:
+        conn.close()
+
+    got = events[: len(accepted)]
+    assert [e["failure_count"] for e in got] == accepted
+    for e in events[len(accepted):]:
+        assert "failure_count" not in e
+
+
+def test_c1n_t28_failure_count_absent_by_default(kanban_home, events):
+    conn = kb.connect()
+    try:
+        kb.create_task(conn, title="t")
+    finally:
+        conn.close()
+    assert all("failure_count" not in e for e in events)
+
+
+def test_c1n_t28_gave_up_carries_the_bounded_local_integer(kanban_home, events):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        assert kb.claim_task(conn, tid, claimer="w:1") is not None
+        events.clear()
+        # force_trip drives the gave_up branch on the first failure.
+        assert kb._record_task_failure(
+            conn, tid, "boom", outcome="spawn_failed",
+            force_trip=True, release_claim=True, end_run=True,
+        ) is True
+        gave_up = only(events, "gave_up")
+        assert gave_up["failure_count"] == 1
+        assert gave_up["status_to"] == "blocked"
+        # No payload-derived content rides along.
+        for banned in ("error", "payload", "trigger_outcome", "reason"):
+            assert banned not in gave_up
+    finally:
+        conn.close()
+
+
+def test_c1n_t24_dynamic_outcome_domain_reaches_the_seam(kanban_home, events):
+    """``spawn_failed`` and ``timed_out`` reach the dynamic append; ``crashed``
+    with ``end_run=False`` correctly does not (D-4)."""
+    conn = kb.connect()
+    try:
+        for outcome in ("spawn_failed", "timed_out"):
+            tid = kb.create_task(conn, title=outcome)
+            assert kb.claim_task(conn, tid, claimer="w:1") is not None
+            events.clear()
+            assert kb._record_task_failure(
+                conn, tid, "boom", outcome=outcome,
+                failure_limit=99, release_claim=True, end_run=True,
+            ) is False
+            kw = only(events, outcome)
+            assert kw["kind"] in kb.KANBAN_EVENT_KINDS
+            assert kw["status_to"] == "ready"
+            assert kw["failure_count"] == 1
+
+        # end_run=False never reaches the dynamic append.
+        tid = kb.create_task(conn, title="crashed")
+        assert kb.claim_task(conn, tid, claimer="w:1") is not None
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+        conn.commit()
+        events.clear()
+        kb._record_task_failure(
+            conn, tid, "boom", outcome="crashed",
+            failure_limit=99, release_claim=False, end_run=False,
+        )
+        assert [e["kind"] for e in events] == []
+    finally:
+        conn.close()
+
+
+# --------------------------------------------------------------------------
+# C1N-T04 — capture happens at INSERT time, never by post-commit re-read
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t04_later_mutation_cannot_change_an_earlier_events_scalars(
+    kanban_home, hooks
+):
+    """A competing post-commit mutation/deletion must not rewrite what was
+    already captured — because nothing is re-read after commit."""
+    captured: list[dict] = []
+
+    def _cb(**kw):
+        captured.append(dict(kw))
+        # Mutate and then delete the very row/task this callback describes.
+        other = kb.connect()
+        try:
+            other.execute("UPDATE tasks SET status='archived' WHERE id=?",
+                          (kw["task_id"],))
+            other.execute("UPDATE task_events SET kind='rewritten' WHERE id=?",
+                          (kw["core_event_seq"],))
+            other.execute("DELETE FROM task_events WHERE id=?",
+                          (kw["core_event_seq"],))
+            other.commit()
+        finally:
+            other.close()
+
+    hooks(GENERIC_HOOK, _cb)
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        assert rows(conn, tid) == []  # the callback deleted the row
+    finally:
+        conn.close()
+
+    assert len(captured) == 1
+    assert captured[0]["kind"] == "created"
+    assert captured[0]["status_to"] == "ready"
+    assert isinstance(captured[0]["core_event_seq"], int)
+    assert captured[0]["task_id"] == tid
+
+
+# --------------------------------------------------------------------------
+# C1N-T19 — a writer outside kanban_db.py reaches the same seam
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t19_out_of_module_iteration_budget_path(kanban_home, events):
+    """``agent/turn_finalizer``'s iteration-budget path, reproduced exactly.
+
+    The finalizer opens its own connection and relies on
+    ``_record_task_failure`` to open ``write_txn``; it needs no C-1 edit but is
+    inside the writer closure. This test drives that exact call shape rather
+    than a whole agent turn; that the finalizer really is this caller is
+    asserted statically in ``test_kanban_event_closure.py``.
+    """
+    setup = kb.connect()
+    try:
+        tid = kb.create_task(setup, title="t")
+        assert kb.claim_task(setup, tid, claimer="w:1") is not None
+    finally:
+        setup.close()
+    events.clear()
+
+    conn = kb.connect()  # a fresh connection, as the finalizer does
+    try:
+        kb._record_task_failure(
+            conn,
+            tid,
+            error="Iteration budget exhausted (40/40)",
+            outcome="timed_out",
+            failure_limit=99,
+            release_claim=True,
+            end_run=True,
+            event_payload_extra={"budget_used": 40, "budget_max": 40},
+        )
+    finally:
+        conn.close()
+
+    kw = only(events, "timed_out")
+    assert kw["status_to"] == "ready"
+    assert kw["failure_count"] == 1
+    assert "error" not in kw and "budget_used" not in kw
+
+
+# --------------------------------------------------------------------------
+# C1N-T20 — three process surfaces, each asserting LOCAL delivery only
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t20_each_process_surface_delivers_locally(kanban_home, events, dash):
+    """Dispatcher-, worker/manual- and web-server-side writers each deliver in
+    the process that performed the write.
+
+    Deliberately makes no claim about arrival order ACROSS surfaces — there is
+    no cross-process broker, and none is requested.
+    """
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+
+        # Dispatcher-side surface: recovery/claim bookkeeping.
+        events.clear()
+        assert kb.claim_task(conn, tid, claimer="w:1") is not None
+        assert {e["kind"] for e in events} == {"claimed"}
+
+        # Worker/manual surface: the terminal verb.
+        events.clear()
+        kb.complete_task(conn, tid, result="ok")
+        assert "completed" in {e["kind"] for e in events}
+    finally:
+        conn.close()
+
+    # Web-server surface: the bundled dashboard's plugin API.
+    events.clear()
+    conn = kb.connect()
+    try:
+        other = kb.create_task(conn, title="dash")
+    finally:
+        conn.close()
+    events.clear()
+    dash.update_task(other, dash.UpdateTaskBody(priority=2), board=None)
+    assert [e["kind"] for e in events] == ["reprioritized"]
+
+
+# --------------------------------------------------------------------------
+# C1N-T22 / C1N-T23 — reconciled, and the dynamic crash domain
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t22_reconciled_is_declared_and_reports_ready(kanban_home, events):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        conn.execute(
+            "UPDATE tasks SET status='running', claim_lock=NULL, "
+            "claim_expires=NULL WHERE id=?", (tid,),
+        )
+        conn.commit()
+        events.clear()
+        assert kb.reconcile_orphaned_running(conn) == [tid]
+    finally:
+        conn.close()
+
+    kw = only(events, "reconciled")
+    assert kw["kind"] in kb.KANBAN_EVENT_KINDS
+    assert kw["status_to"] == "ready"
+
+
+@pytest.mark.parametrize(
+    "exit_code, expected_kind",
+    [
+        (0, "protocol_violation"),
+        (None, "rate_limited"),   # replaced with the quota sentinel below
+        (3, "crashed"),
+    ],
+)
+def test_c1n_t23_crash_classifier_kinds_dispatch_as_declared(
+    kanban_home, events, monkeypatch, exit_code, expected_kind
+):
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    if expected_kind == "rate_limited":
+        exit_code = kb.KANBAN_RATE_LIMIT_EXIT_CODE
+
+    conn = kb.connect()
+    try:
+        host = kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="c")
+        assert kb.claim_task(conn, tid, claimer=f"{host}:w") is not None
+        pid = 90001
+        conn.execute("UPDATE tasks SET worker_pid=? WHERE id=?", (pid, tid))
+        conn.commit()
+        kb._record_worker_exit(pid, exit_code << 8)
+        events.clear()
+        kb.detect_crashed_workers(conn)
+    finally:
+        conn.close()
+
+    kw = only(events, expected_kind)
+    assert kw["kind"] in kb.KANBAN_EVENT_KINDS
+    assert kw["status_to"] == "ready"
+
+
+# --------------------------------------------------------------------------
+# C1N-T25 / C1N-T39 — unknown kinds pass through, and what that costs
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t25_unknown_future_kind_dispatches_unchanged(kanban_home, events):
+    """Core never drops, rewrites, or coerces an undeclared kind."""
+    kind = "some_future_kind_from_a_later_release"
+    assert kind not in kb.KANBAN_EVENT_KINDS
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        events.clear()
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, kind)
+        committed = [r for r in rows(conn, tid) if r["kind"] == kind]
+    finally:
+        conn.close()
+
+    assert [e["kind"] for e in events] == [kind]
+    assert committed and committed[0]["kind"] == kind
+
+
+def test_c1n_t39_unknown_kind_privacy_is_convention_bounded_not_enforced(
+    kanban_home, events
+):
+    """DOCUMENTED LIMITATION, not a promise — do not "fix" this by coercing kinds.
+
+    ``task_events.kind`` is an open TEXT column and undeclared kinds are
+    dispatched unchanged. Those two facts compose: an out-of-tree writer that
+    puts arbitrary prose in ``kind`` has that string delivered VERBATIM to every
+    observer. C-1 cannot prevent this without dropping or rewriting kinds,
+    which the contract forbids. The guarantee C-1 actually makes is narrower:
+    it introduces no content channel of its own and copies no payload into one.
+    """
+    prose = "user said: my password is hunter2 /home/someone/secret.txt"
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        events.clear()
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, prose, {"reason": "not delivered"})
+    finally:
+        conn.close()
+
+    assert [e["kind"] for e in events] == [prose]
+    # The payload channel stays closed even here.
+    assert "reason" not in events[0] and "payload" not in events[0]
+
+
+# --------------------------------------------------------------------------
+# C1N-T29 — content exclusion, against the real prose-bearing writers
+# --------------------------------------------------------------------------
+
+
+BANNED_KWARGS = {
+    "payload", "reason", "error", "summary", "summary_preview", "title",
+    "body", "message", "note", "filename", "author", "claimer", "pid",
+    "actor", "assignee", "by", "priority", "parent", "child_ids",
+}
+
+
+def test_c1n_t29_no_payload_content_reaches_the_callback(kanban_home, events):
+    secret_reason = "SECRET-REASON-cbd41"
+    secret_summary = "SECRET-SUMMARY-9f2aa"
+    secret_comment = "SECRET-COMMENT-77bcd"
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="SECRET-TITLE", body="SECRET-BODY")
+        kb.add_comment(conn, tid, "SECRET-AUTHOR", secret_comment)
+        assert kb.claim_task(conn, tid, claimer="SECRET-CLAIMER:1") is not None
+        assert kb.block_task(conn, tid, reason=secret_reason, kind="needs_input")
+        assert kb.unblock_task(conn, tid)
+        assert kb.claim_task(conn, tid, claimer="SECRET-CLAIMER:2") is not None
+        kb.complete_task(conn, tid, result="SECRET-RESULT", summary=secret_summary)
+    finally:
+        conn.close()
+
+    assert len(events) >= 5
+    allowed = {
+        "task_id", "kind", "core_event_seq", "created_at_epoch_s", "run_id",
+        "board", "profile_name", "status_to", "failure_count",
+        "kanban_event_schema_version", "telemetry_schema_version",
+    }
+    haystack = " ".join(
+        str(v) for e in events for v in e.values()
+    )
+    for e in events:
+        assert set(e) <= allowed, f"unexpected kwargs: {set(e) - allowed}"
+        assert not (set(e) & BANNED_KWARGS)
+    for secret in (
+        "SECRET-TITLE", "SECRET-BODY", "SECRET-AUTHOR", "SECRET-CLAIMER",
+        "SECRET-RESULT", secret_reason, secret_summary, secret_comment,
+    ):
+        assert secret not in haystack
+
+
+# --------------------------------------------------------------------------
+# C1N-T30 / C1N-T33 — legacy coexistence and R-1 independence
+# --------------------------------------------------------------------------
+
+
+def dependency_branch_is_precommit():
+    """Probe THIS base: does the dependency branch dispatch inside write_txn?
+
+    Parameterizing on the base is the whole point — hard-coding the frozen
+    base's asymmetry would fail the moment R-1 lands independently, and
+    hard-coding harmonized timing fails here. Either way the failure would be
+    the test's, not C-1's.
+    """
+    import ast
+    import inspect
+
+    src = inspect.getsource(kb.block_task)
+    tree = ast.parse(src.lstrip() if src.startswith(" ") else src)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.With):
+            continue
+        opens_txn = any(
+            isinstance(item.context_expr, ast.Call)
+            and getattr(item.context_expr.func, "id", None) == "write_txn"
+            for item in node.items
+        )
+        if not opens_txn:
+            continue
+        for child in ast.walk(node):
+            if (
+                isinstance(child, ast.Call)
+                and getattr(child.func, "id", None) == "_fire_kanban_lifecycle_hook"
+                and child.args
+                and isinstance(child.args[0], ast.Constant)
+                and child.args[0].value == "kanban_task_blocked"
+            ):
+                return True
+    return False
+
+
+def test_c1n_t30_legacy_timing_is_preserved_exactly_as_the_base_has_it(
+    kanban_home, hooks
+):
+    """C-1 changes NO legacy timing — asserted parameterized on the base."""
+    timeline: list[tuple[str, bool]] = []
+    probe = kb.connect()
+
+    def _in_txn():
+        # The generic hook is post-commit on every path, so a competing
+        # BEGIN IMMEDIATE succeeding proves the write lock is gone.
+        try:
+            probe.execute("BEGIN IMMEDIATE")
+            probe.execute("ROLLBACK")
+            return False
+        except Exception:
+            return True
+
+    hooks("kanban_task_blocked", lambda **kw: timeline.append(("legacy", _in_txn())))
+    hooks(GENERIC_HOOK, lambda **kw: timeline.append((f"generic:{kw['kind']}", _in_txn())))
+
+    conn = kb.connect()
+    try:
+        conn.execute("PRAGMA busy_timeout=500")
+        probe.execute("PRAGMA busy_timeout=500")
+        tid = kb.create_task(conn, title="t")
+        timeline.clear()
+        assert kb.block_task(conn, tid, reason="dep", kind="dependency") is True
+    finally:
+        conn.close()
+        probe.close()
+
+    legacy = [t for t in timeline if t[0] == "legacy"]
+    generic = [t for t in timeline if t[0].startswith("generic:")]
+    assert len(legacy) == 1, "the legacy hook must keep firing exactly once"
+    assert [t[0] for t in generic] == ["generic:dependency_wait"]
+
+    # The generic hook is post-commit unconditionally, on every base.
+    assert generic[0][1] is False
+
+    if dependency_branch_is_precommit():
+        # Frozen base, R-1 not applied: legacy fires while the lock is held.
+        assert legacy[0][1] is True
+        assert timeline.index(legacy[0]) < timeline.index(generic[0])
+    else:
+        # A base or fixture with R-1 applied: both are post-commit.
+        assert legacy[0][1] is False
+
+
+def test_c1n_t33_c1_contains_no_r1_change(kanban_home):
+    """C-1 must stay droppable without disturbing R-1's published PR.
+
+    It neither moves the dependency branch's dispatch site nor retimes any
+    legacy hook — so this candidate's suite is valid on a base with or without
+    R-1, which is exactly why C1N-T30 probes instead of hard-coding.
+    """
+    import inspect
+
+    src = inspect.getsource(kb.block_task)
+    # The dependency branch's legacy dispatch is untouched: still exactly one
+    # legacy blocked-hook call per block path, and C-1 added none.
+    assert src.count('_fire_kanban_lifecycle_hook(') == 2
+    assert 'kanban_task_event' not in src
+    # The generic hook is never dispatched from a legacy call site.
+    for fn in (kb.claim_task, kb.complete_task, kb.block_task):
+        assert 'kanban_task_event' not in inspect.getsource(fn)
+
+
+def test_c1n_t30_legacy_hooks_keep_names_kwargs_and_cardinality(
+    kanban_home, hooks, events
+):
+    seen: list[tuple[str, dict]] = []
+    for name in ("kanban_task_claimed", "kanban_task_completed", "kanban_task_blocked"):
+        hooks(name, lambda _n=name, **kw: seen.append((_n, kw)))
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        assert kb.claim_task(conn, tid, claimer="w:1") is not None
+        assert kb.block_task(conn, tid, reason="r", kind="needs_input")
+        assert kb.unblock_task(conn, tid)
+        assert kb.claim_task(conn, tid, claimer="w:2") is not None
+        kb.complete_task(conn, tid, result="ok")
+    finally:
+        conn.close()
+
+    fired = [n for n, _ in seen]
+    assert fired.count("kanban_task_claimed") == 2
+    assert fired.count("kanban_task_blocked") == 1
+    assert fired.count("kanban_task_completed") == 1
+    for name, kw in seen:
+        for key in ("task_id", "board", "assignee", "run_id", "profile_name"):
+            assert key in kw, f"{name} lost kwarg {key}"
+        if name == "kanban_task_completed":
+            assert "summary" in kw
+        if name == "kanban_task_blocked":
+            assert "reason" in kw
+    # A row that fires a legacy hook also fires one generic notification; core
+    # does not deduplicate. That exclusivity is the consumer's job.
+    assert any(e["kind"] == "completed" for e in events)
+
+
+# --------------------------------------------------------------------------
+# C1N-T31 / T32 / T38 — sequence honesty
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t31_gaps_after_deletion_and_gc_are_not_hook_loss(kanban_home, events):
+    conn = kb.connect()
+    try:
+        keep = kb.create_task(conn, title="keep")
+        doomed = kb.create_task(conn, title="doomed")
+        with kb.write_txn(conn):
+            kb._append_event(conn, doomed, "commented")
+            kb._append_event(conn, keep, "commented")
+            kb._append_event(conn, doomed, "edited")
+        delivered = [e["core_event_seq"] for e in events]
+        assert delivered == sorted(delivered)
+        assert kb.archive_task(conn, doomed)
+        assert kb.delete_archived_task(conn, doomed) is True
+        surviving = [r["id"] for r in rows(conn)]
+    finally:
+        conn.close()
+
+    # Every surviving row was delivered, but not every delivered row survived.
+    assert set(surviving) < set(delivered)
+    # Non-contiguous survivors: a gap is a deletion, never evidence of loss.
+    assert surviving != list(range(surviving[0], surviving[0] + len(surviving)))
+
+
+def test_c1n_t32_core_event_seq_is_not_stable_across_a_rebuild(
+    kanban_home, events, tmp_path
+):
+    """``_rebuild_drifted_tables`` excludes the legacy id, so AUTOINCREMENT
+    reassigns fresh values. No test may treat the seq as stable."""
+    db = tmp_path / "drifted" / "kanban.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    import sqlite3
+
+    raw = sqlite3.connect(db)
+    raw.execute(
+        "CREATE TABLE task_events (id TEXT PRIMARY KEY, task_id TEXT NOT NULL, "
+        "run_id INTEGER, kind TEXT NOT NULL, payload TEXT, "
+        "created_at INTEGER NOT NULL)"
+    )
+    raw.execute(
+        "INSERT INTO task_events VALUES ('legacy-1','t1',NULL,'created',NULL,10)"
+    )
+    raw.commit()
+    raw.close()
+
+    events.clear()
+    conn = kb.connect(db_path=db)
+    try:
+        after = [dict(r) for r in conn.execute(
+            "SELECT id, kind FROM task_events"
+        ).fetchall()]
+    finally:
+        conn.close()
+
+    assert after == [{"id": 1, "kind": "created"}]  # id reassigned, not 'legacy-1'
+    assert events == [], "a migration copy must emit nothing"
+
+
+def test_c1n_t38_board_generation_resets_and_repeats_the_sequence(
+    kanban_home, events
+):
+    """A repeat is a NEW BOARD GENERATION, not duplicate delivery or hook loss."""
+    for archive in (True, False):
+        slug = f"gen-{int(archive)}"
+        kb.create_board(slug)
+        conn = kb.connect(board=slug)
+        try:
+            events.clear()
+            kb.create_task(conn, title="first")
+            first = [e["core_event_seq"] for e in events]
+        finally:
+            conn.close()
+        assert first == [1]
+
+        kb.remove_board(slug, archive=archive)
+        kb.create_board(slug)
+        conn = kb.connect(board=slug)
+        try:
+            events.clear()
+            kb.create_task(conn, title="second")
+            second = [e["core_event_seq"] for e in events]
+        finally:
+            conn.close()
+        assert second == [1], "a same-slug board is a new generation from 1"
+
+
+# --------------------------------------------------------------------------
+# C1N-T36 / C1N-T37 — migration writers are invisible to C-1
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t36_rebuild_of_a_drifted_table_emits_nothing(
+    kanban_home, events, tmp_path
+):
+    import sqlite3
+
+    db = tmp_path / "rebuild" / "kanban.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    raw = sqlite3.connect(db)
+    raw.execute(
+        "CREATE TABLE task_events (id TEXT PRIMARY KEY, task_id TEXT NOT NULL, "
+        "run_id INTEGER, kind TEXT NOT NULL, payload TEXT, "
+        "created_at INTEGER NOT NULL)"
+    )
+    for i in range(5):
+        raw.execute(
+            "INSERT INTO task_events VALUES (?,?,NULL,'created',NULL,?)",
+            (f"legacy-{i}", f"t{i}", 100 + i),
+        )
+    raw.commit()
+    raw.close()
+
+    events.clear()
+    conn = kb.connect(db_path=db)
+    try:
+        moved = conn.execute("SELECT COUNT(*) FROM task_events").fetchone()[0]
+        assert moved == 5, "the rebuild must have copied every row"
+        assert kb._TASK_EVENT_FRAME.get() is None, "no frame may survive migration"
+    finally:
+        conn.close()
+
+    assert events == []
+
+
+def test_c1n_t37_event_kind_rename_emits_nothing_and_breaks_seq_kind_stability(
+    kanban_home, events, tmp_path
+):
+    """``(core_event_seq, kind)`` is NOT stable across migration (D-18).
+
+    The rename mutates existing rows in place, so the id is unchanged while the
+    kind a consumer already observed reads back differently.
+    """
+    import sqlite3
+
+    db = tmp_path / "renames" / "kanban.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+
+    # First open creates the current schema.
+    conn = kb.connect(db_path=db)
+    try:
+        tid = kb.create_task(conn, title="t")
+        events.clear()
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, "gave_up")
+        seq = events[0]["core_event_seq"]
+        # Put the row back into its legacy shape, as an old board would have it.
+        conn.execute(
+            "UPDATE task_events SET kind='spawn_auto_blocked' WHERE id=?", (seq,)
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    # Force the one-shot migration pass to run again on this path.
+    kb._INITIALIZED_PATHS.discard(str(db.resolve()))
+    events.clear()
+    conn = kb.connect(db_path=db)
+    try:
+        after = conn.execute(
+            "SELECT kind FROM task_events WHERE id=?", (seq,)
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert events == [], "an in-place kind rewrite must emit nothing"
+    assert after["kind"] == "gave_up"
+    # Same id, different kind than the row a consumer may have stored.
+
+
+# --------------------------------------------------------------------------
+# C1N-T27 (continued) — the two D-9 writers inside ``_record_task_failure``
+#
+# The packet names FOUR unchecked writers plus the dynamic-outcome UPDATE.
+# ``promoted``, ``linked`` and ``claim_rejected`` are driven above; the two
+# remaining ones both live in ``_record_task_failure`` and each has two
+# guarded branches (``release_claim=True`` and the else branch), so all four
+# combinations are driven here.
+# --------------------------------------------------------------------------
+
+
+def _park(conn, task_id, status):
+    """Move a task out of a guarded UPDATE's ``WHERE`` status, out of band."""
+    conn.execute("UPDATE tasks SET status=? WHERE id=?", (status, task_id))
+    conn.commit()
+
+
+def test_c1n_t27_gave_up_release_claim_branch_is_rowcount_gated(
+    kanban_home, events
+):
+    """D-9: ``gave_up``'s ``release_claim=True`` UPDATE is guarded
+    ``WHERE id = ? AND status IN ('running', 'ready')``.
+
+    Positive and zero-match are driven through the *same* branch so the
+    difference is the rowcount and nothing else.
+    """
+    conn = kb.connect()
+    try:
+        # Matched: the task really is 'running'.
+        hit = kb.create_task(conn, title="hit")
+        assert kb.claim_task(conn, hit, claimer="w:1") is not None
+        events.clear()
+        assert kb._record_task_failure(
+            conn, hit, "boom", outcome="spawn_failed",
+            force_trip=True, release_claim=True, end_run=True,
+        ) is True
+        assert only(events, "gave_up", hit)["status_to"] == "blocked"
+        assert kb.get_task(conn, hit).status == "blocked"
+
+        # Zero match: the task moved out of ('running', 'ready') first. The
+        # append still happens — only the status claim must disappear.
+        miss = kb.create_task(conn, title="miss")
+        _park(conn, miss, "triage")
+        events.clear()
+        assert kb._record_task_failure(
+            conn, miss, "boom", outcome="spawn_failed",
+            force_trip=True, release_claim=True, end_run=True,
+        ) is True
+        gave_up = only(events, "gave_up", miss)
+        assert "status_to" not in gave_up
+        # The row genuinely did not move, which is exactly why the claim
+        # would have been a lie.
+        assert kb.get_task(conn, miss).status == "triage"
+        # The bounded integer is unaffected by the rowcount gate.
+        assert gave_up["failure_count"] == 1
+    finally:
+        conn.close()
+
+
+def test_c1n_t27_gave_up_else_branch_is_rowcount_gated(kanban_home, events):
+    """D-9: the ``release_claim=False`` branch is guarded
+    ``WHERE id = ? AND status IN ('ready', 'running')`` — the timeout/crash
+    path, where the caller has already parked the task at ``ready``.
+    """
+    conn = kb.connect()
+    try:
+        hit = kb.create_task(conn, title="hit")   # created 'ready'
+        assert kb.get_task(conn, hit).status == "ready"
+        events.clear()
+        assert kb._record_task_failure(
+            conn, hit, "boom", outcome="timed_out",
+            force_trip=True, release_claim=False, end_run=False,
+        ) is True
+        assert only(events, "gave_up", hit)["status_to"] == "blocked"
+
+        miss = kb.create_task(conn, title="miss")
+        _park(conn, miss, "todo")
+        events.clear()
+        assert kb._record_task_failure(
+            conn, miss, "boom", outcome="timed_out",
+            force_trip=True, release_claim=False, end_run=False,
+        ) is True
+        assert "status_to" not in only(events, "gave_up", miss)
+        assert kb.get_task(conn, miss).status == "todo"
+    finally:
+        conn.close()
+
+
+def test_c1n_t27_dynamic_outcome_requeue_is_rowcount_gated(kanban_home, events):
+    """D-9: the below-threshold dynamic-outcome append reports ``ready`` only
+    when the ``WHERE id = ? AND status = 'running'`` requeue actually matched.
+    """
+    conn = kb.connect()
+    try:
+        miss = kb.create_task(conn, title="miss")
+        assert kb.claim_task(conn, miss, claimer="w:1") is not None
+        # Move it out of 'running' so the guarded requeue matches nothing,
+        # while end_run=True still drives the dynamic append.
+        _park(conn, miss, "review")
+        events.clear()
+        assert kb._record_task_failure(
+            conn, miss, "boom", outcome="spawn_failed",
+            failure_limit=99, release_claim=True, end_run=True,
+        ) is False
+        kw = only(events, "spawn_failed", miss)
+        assert "status_to" not in kw
+        assert kw["failure_count"] == 1
+        assert kb.get_task(conn, miss).status == "review"
+    finally:
+        conn.close()
+
+
+def test_c1n_t27_dynamic_outcome_non_release_branch_omits_status_to(
+    kanban_home, events
+):
+    """The else branch bookkeeps the counter only — it establishes no status,
+    so ``status_to`` is omitted even though the task is sitting at ``ready``.
+
+    Asserting the writer's *own* honesty, not the row's current value: a
+    status the writer did not establish is never reported.
+    """
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        assert kb.get_task(conn, tid).status == "ready"
+        events.clear()
+        assert kb._record_task_failure(
+            conn, tid, "boom", outcome="timed_out",
+            failure_limit=99, release_claim=False, end_run=True,
+        ) is False
+        kw = only(events, "timed_out", tid)
+        assert "status_to" not in kw
+        assert kw["failure_count"] == 1
+        assert kb.get_task(conn, tid).status == "ready"
+    finally:
+        conn.close()
+
+
+# --------------------------------------------------------------------------
+# C1N-T26 (continued) — the §6.6 rows whose writers the matrix above does not
+# reach: claim_review_task, release_stale_claims, enforce_max_runtime and
+# detect_stale_running.
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t26_claim_review_task_reports_running(kanban_home, events):
+    """The second ``claimed`` writer (review → running) reports ``running``."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        assert kb.claim_task(conn, tid, claimer="w:1") is not None
+        _park(conn, tid, "review")
+        conn.execute(
+            "UPDATE tasks SET claim_lock=NULL, claim_expires=NULL WHERE id=?",
+            (tid,),
+        )
+        conn.commit()
+        events.clear()
+        assert kb.claim_review_task(conn, tid, claimer="reviewer:1") is not None
+        kw = only(events, "claimed", tid)
+        assert kw["status_to"] == "running"
+        assert kw["kind"] in kb.KANBAN_EVENT_KINDS
+        # source_status rides only on the payload, never on the kwargs.
+        assert "source_status" not in kw and "lock" not in kw
+    finally:
+        conn.close()
+
+
+def test_c1n_t26_release_stale_claims_reports_ready(kanban_home, events):
+    """The ``reclaimed`` writer inside ``release_stale_claims`` (:4591 in the
+    packet's inventory) reports ``ready``; its ``claim_extended`` sibling in
+    the same function establishes no status and must omit it."""
+    conn = kb.connect()
+    try:
+        host = kb._claimer_id().split(":", 1)[0]
+
+        # (a) expired claim, no live worker -> reclaimed
+        dead = kb.create_task(conn, title="dead")
+        assert kb.claim_task(conn, dead, claimer=f"{host}:w1") is not None
+        conn.execute(
+            "UPDATE tasks SET claim_expires=?, worker_pid=NULL WHERE id=?",
+            (1, dead),
+        )
+        conn.commit()
+        events.clear()
+        assert kb.release_stale_claims(conn) == 1
+        assert only(events, "reclaimed", dead)["status_to"] == "ready"
+        assert kb.get_task(conn, dead).status == "ready"
+    finally:
+        conn.close()
+
+
+def test_c1n_t26_claim_extended_omits_status_to(kanban_home, events, monkeypatch):
+    """A live host-local worker gets its claim extended — no status changes."""
+    conn = kb.connect()
+    try:
+        host = kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="live")
+        assert kb.claim_task(conn, tid, claimer=f"{host}:w1") is not None
+        conn.execute(
+            "UPDATE tasks SET claim_expires=?, worker_pid=?, "
+            "last_heartbeat_at=? WHERE id=?",
+            (1, 4242, int(time.time()), tid),
+        )
+        conn.commit()
+        monkeypatch.setattr(kb, "_pid_alive", lambda _pid: True)
+        events.clear()
+        assert kb.release_stale_claims(conn) == 0
+        kw = only(events, "claim_extended", tid)
+        assert "status_to" not in kw
+        assert kb.get_task(conn, tid).status == "running"
+        for banned in ("reason", "claim_lock", "worker_pid"):
+            assert banned not in kw
+    finally:
+        conn.close()
+
+
+def test_c1n_t26_enforce_max_runtime_reports_ready(kanban_home, events, monkeypatch):
+    """``timed_out`` (:7284 in the inventory) reports ``ready``."""
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    conn = kb.connect()
+    try:
+        host = kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="slow")
+        assert kb.claim_task(conn, tid, claimer=f"{host}:w1") is not None
+        conn.execute(
+            "UPDATE tasks SET worker_pid=?, max_runtime_seconds=1, "
+            "started_at=? WHERE id=?",
+            (4242, 1, tid),
+        )
+        conn.execute("UPDATE task_runs SET started_at=? WHERE task_id=?", (1, tid))
+        conn.commit()
+        events.clear()
+        assert kb.enforce_max_runtime(conn, signal_fn=lambda *_a: None) == [tid]
+        kw = only(events, "timed_out", tid)
+        assert kw["status_to"] == "ready"
+        assert kw["kind"] in kb.KANBAN_EVENT_KINDS
+        for banned in ("pid", "elapsed_seconds", "sigkill"):
+            assert banned not in kw
+    finally:
+        conn.close()
+
+
+def test_c1n_t26_detect_stale_running_reports_ready(kanban_home, events, monkeypatch):
+    """``stale`` (:7422 in the inventory) reports ``ready``."""
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    conn = kb.connect()
+    try:
+        host = kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="wedged")
+        assert kb.claim_task(conn, tid, claimer=f"{host}:w1") is not None
+        conn.execute(
+            "UPDATE tasks SET started_at=?, last_heartbeat_at=NULL, "
+            "worker_pid=NULL WHERE id=?", (1, tid),
+        )
+        conn.execute("UPDATE task_runs SET started_at=? WHERE task_id=?", (1, tid))
+        conn.commit()
+        events.clear()
+        assert kb.detect_stale_running(
+            conn, stale_timeout_seconds=60, signal_fn=lambda *_a: None,
+        ) == [tid]
+        assert only(events, "stale", tid)["status_to"] == "ready"
+        assert kb.get_task(conn, tid).status == "ready"
+    finally:
+        conn.close()
+
+
+def test_c1n_t26_reclaim_deferred_omits_status_to(kanban_home, events, monkeypatch):
+    """A deferred reclaim holds the claim — the task stays ``running`` and the
+    writer establishes nothing."""
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: True)
+    conn = kb.connect()
+    try:
+        host = kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="survivor")
+        assert kb.claim_task(conn, tid, claimer=f"{host}:w1") is not None
+        conn.execute(
+            "UPDATE tasks SET started_at=?, last_heartbeat_at=NULL, "
+            "worker_pid=? WHERE id=?", (1, 4242, tid),
+        )
+        conn.execute("UPDATE task_runs SET started_at=? WHERE task_id=?", (1, tid))
+        conn.commit()
+        events.clear()
+        assert kb.detect_stale_running(
+            conn, stale_timeout_seconds=60, signal_fn=lambda *_a: None,
+        ) == []
+        kw = only(events, "reclaim_deferred", tid)
+        assert "status_to" not in kw
+        assert kb.get_task(conn, tid).status == "running"
+    finally:
+        conn.close()
+
+
+# --------------------------------------------------------------------------
+# C1N-T26 (continued) — the remaining §6.6 "omitted" writers, driven for real
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t26_attachment_writers_omit_status_to(kanban_home, events):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        events.clear()
+        att = kb.add_attachment(
+            conn, tid, filename="secret-notes.txt",
+            stored_path=str(kanban_home / "secret-notes.txt"),
+            size=11, uploaded_by="SECRET-UPLOADER",
+        )
+        assert kb.delete_attachment(conn, att) is not None
+    finally:
+        conn.close()
+
+    assert [e["kind"] for e in events] == ["attached", "attachment_removed"]
+    for e in events:
+        assert "status_to" not in e
+        assert "filename" not in e and "by" not in e
+    assert "secret-notes.txt" not in " ".join(
+        str(v) for e in events for v in e.values()
+    )
+
+
+def test_c1n_t26_edit_completed_result_omits_status_to(kanban_home, events):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        assert kb.claim_task(conn, tid, claimer="w:1") is not None
+        kb.complete_task(conn, tid, result="first")
+        events.clear()
+        assert kb.edit_completed_task_result(
+            conn, tid, result="revised", summary="SECRET-EDIT-SUMMARY",
+        ) is True
+    finally:
+        conn.close()
+
+    kw = only(events, "edited", tid)
+    assert "status_to" not in kw
+    assert "summary" not in kw and "fields" not in kw
+    assert "SECRET-EDIT-SUMMARY" not in " ".join(str(v) for v in kw.values())
+
+
+def test_c1n_t26_spawn_and_scratch_tip_writers_omit_status_to(
+    kanban_home, events, monkeypatch
+):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        assert kb.claim_task(conn, tid, claimer="w:1") is not None
+        events.clear()
+        kb._set_worker_pid(conn, tid, 4242)
+        monkeypatch.setattr(kb, "_scratch_tip_shown", lambda: False)
+        monkeypatch.setattr(kb, "_mark_scratch_tip_shown", lambda: None)
+        kb._maybe_emit_scratch_tip(conn, tid, "scratch")
+    finally:
+        conn.close()
+
+    kinds = [e["kind"] for e in events]
+    assert "spawned" in kinds and "tip_scratch_workspace" in kinds
+    for e in events:
+        assert "status_to" not in e
+        assert "pid" not in e and "message" not in e
+
+
+def test_c1n_t26_hallucination_advisory_writers_omit_status_to(kanban_home, events):
+    """Both completion-advisory writers establish no status of their own."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        assert kb.claim_task(conn, tid, claimer="w:1") is not None
+        events.clear()
+        with pytest.raises(kb.HallucinatedCardsError):
+            kb.complete_task(
+                conn, tid, result="ok", created_cards=["t_deadbeefcafe"],
+            )
+        blocked = only(events, "completion_blocked_hallucination", tid)
+        assert "status_to" not in blocked
+        assert "phantom_cards" not in blocked and "summary_preview" not in blocked
+        assert kb.get_task(conn, tid).status == "running"
+
+        events.clear()
+        kb.complete_task(
+            conn, tid, result="see t_deadbeefcafe for the rest", summary="done",
+        )
+        suspected = only(events, "suspected_hallucinated_references", tid)
+        assert "status_to" not in suspected
+        assert "refs" not in suspected
+        # The sibling 'completed' row in the same transaction still reports its
+        # own honest destination.
+        assert only(events, "completed", tid)["status_to"] == "done"
+    finally:
+        conn.close()
+
+
+def test_c1n_t26_dashboard_reprioritized_and_edited_omit_status_to(
+    kanban_home, events, dash
+):
+    """The two dashboard writers that change no status omit ``status_to``,
+    unlike the dashboard ``status`` writer covered by C1N-T17/T18."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+    finally:
+        conn.close()
+    events.clear()
+
+    dash.update_task(tid, dash.UpdateTaskBody(priority=5), board=None)
+    dash.update_task(tid, dash.UpdateTaskBody(body="new body"), board=None)
+
+    assert [e["kind"] for e in events] == ["reprioritized", "edited"]
+    for e in events:
+        assert "status_to" not in e
+
+
+# --------------------------------------------------------------------------
+# C1N-T35 (continued) — the resolver fails SAFE, never fails the transaction
+# --------------------------------------------------------------------------
+
+
+class _NotASqliteConnection:
+    """A connection double, as several existing kanban tests already use.
+
+    ``execute`` returns ``None`` for anything it does not model, so a
+    ``PRAGMA database_list`` probe gets an object with no ``fetchall``. The
+    resolver must treat that as "this connection maps to no board", exactly
+    like an erroring PRAGMA — it must not raise out of ``write_txn`` and take
+    an unrelated write down with it.
+    """
+
+    def __init__(self):
+        self.calls = []
+        self.in_transaction = False
+
+    def execute(self, sql, *args):
+        self.calls.append(sql)
+        return None
+
+
+def test_c1n_t35_resolver_returns_none_when_the_pragma_probe_is_unusable():
+    """§6.2a: ``None`` on ANY failure, not only on ``sqlite3.Error``.
+
+    The resolver is best-effort board *attribution*. It runs at frame install,
+    after BEGIN IMMEDIATE has already succeeded, so a failure to attribute must
+    degrade to an honest ``None`` and never propagate — otherwise C-1 would
+    convert a cosmetic attribution problem into a failed write.
+    """
+    conn = _NotASqliteConnection()
+    assert kb._resolve_board_for_connection(conn) is None
+
+
+def test_c1n_t35_resolver_returns_none_when_the_pragma_raises_any_exception():
+    class _Boom:
+        def execute(self, sql, *args):
+            raise RuntimeError("connection wrapper blew up")
+
+    assert kb._resolve_board_for_connection(_Boom()) is None
+
+
+def test_c1n_t35_frame_install_survives_an_unattributable_connection(
+    kanban_home, monkeypatch
+):
+    """A write_txn over a connection double still opens, commits, and clears.
+
+    This is the shape several pre-existing kanban tests use to exercise
+    ``write_txn``'s busy-retry boundary; C-1 must leave them working. The
+    post-commit invariant is stubbed exactly as those tests already stub it —
+    it reads its own PRAGMAs and is not what this test is about.
+    """
+    monkeypatch.setattr(kb, "_check_file_length_invariant", lambda conn: None)
+    conn = _NotASqliteConnection()
+    with kb.write_txn(conn):
+        pass
+    assert conn.calls[0] == "BEGIN IMMEDIATE"
+    assert "COMMIT" in conn.calls
+    assert kb._TASK_EVENT_FRAME.get() is None
+
+
+# --------------------------------------------------------------------------
+# C1N-T40 — zero-subscriber fast path
+#
+# Cost assertions here are DETERMINISTIC: they count calls to the expensive
+# collaborators (board resolution, profile resolution, hook fan-out), never
+# wall-clock time. Nothing in this section may assert a duration, a rate, or
+# a frozen absolute call total for a production writer.
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def no_generic_subscriber(pinned_manager):
+    """Guarantee zero ``kanban_task_event`` subscribers for one test."""
+    mgr = pinned_manager
+    saved = {k: list(v) for k, v in mgr._hooks.items()}
+    mgr._hooks.pop(GENERIC_HOOK, None)
+    try:
+        yield mgr
+    finally:
+        mgr._hooks = saved
+
+
+def _count_resolver(monkeypatch):
+    """Count ``_resolve_board_for_connection`` calls, preserving behavior."""
+    calls: list[object] = []
+    real = kb._resolve_board_for_connection
+
+    def counting(conn):
+        calls.append(conn)
+        return real(conn)
+
+    monkeypatch.setattr(kb, "_resolve_board_for_connection", counting)
+    return calls
+
+
+def _count_profile_resolution(monkeypatch):
+    """Count ``get_active_profile_name`` calls made by the hook fan-out."""
+    from hermes_cli import profiles as profiles_mod
+
+    calls: list[int] = []
+    real = profiles_mod.get_active_profile_name
+
+    def counting(*a, **kw):
+        calls.append(1)
+        return real(*a, **kw)
+
+    monkeypatch.setattr(profiles_mod, "get_active_profile_name", counting)
+    return calls
+
+
+def test_c1n_t40_no_subscriber_skips_board_resolution(
+    kanban_home, no_generic_subscriber, monkeypatch
+):
+    """With nothing subscribed, write_txn must not resolve the board.
+
+    Board resolution runs ``PRAGMA database_list`` and several ``Path``
+    resolutions per transaction. It exists only to attribute a generic
+    notification, so with no subscriber it is pure waste on every kanban
+    write in the process.
+    """
+    resolver_calls = _count_resolver(monkeypatch)
+    conn = kb.connect()
+    try:
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET priority = priority WHERE 1 = 0")
+    finally:
+        conn.close()
+
+    assert resolver_calls == []
+
+
+def test_c1n_t40_no_subscriber_skips_dispatch_and_profile_work(
+    kanban_home, no_generic_subscriber, monkeypatch
+):
+    """With nothing subscribed, an appended event does no envelope work.
+
+    ``_append_event`` must still enforce its transaction requirement, but it
+    must not build a record, and the post-commit path must not resolve a
+    profile or fan out.
+    """
+    resolver_calls = _count_resolver(monkeypatch)
+    profile_calls = _count_profile_resolution(monkeypatch)
+    fired: list[tuple] = []
+    monkeypatch.setattr(
+        kb,
+        "_fire_kanban_lifecycle_hook",
+        lambda *a, **kw: fired.append((a, kw)),
+    )
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="unobserved")
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, "status", {"status": "ready"})
+        committed = rows(conn, tid)
+    finally:
+        conn.close()
+
+    # The row still commits — the fast path skips NOTIFICATION work only.
+    assert any(r["kind"] == "status" for r in committed)
+    assert resolver_calls == []
+    assert profile_calls == []
+    assert [f for f in fired if f[0][:1] == ("kanban_task_event",)] == []
+
+
+def test_c1n_t40_no_subscriber_still_fails_closed_outside_a_txn(
+    kanban_home, no_generic_subscriber
+):
+    """The fail-closed seam survives the fast path.
+
+    The zero-subscriber shortcut must not become a back door that lets an
+    out-of-transaction ``_append_event`` through.
+    """
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="unobserved")
+        with pytest.raises(RuntimeError, match="requires an active write_txn"):
+            kb._append_event(conn, tid, "status", {"status": "ready"})
+    finally:
+        conn.close()
+
+
+def test_c1n_t40_subscriber_still_gets_board_resolution_and_delivery(
+    kanban_home, events, monkeypatch
+):
+    """The fast path must not damage the subscribed case.
+
+    Same transaction as the skip tests, but with a subscriber registered:
+    the resolver runs and the event is delivered with its attribution.
+    """
+    resolver_calls = _count_resolver(monkeypatch)
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="observed")
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, "status", {"status": "ready"})
+    finally:
+        conn.close()
+
+    assert resolver_calls, "board resolution must run when someone subscribes"
+    delivered = [e for e in events if e.get("kind") == "status"]
+    assert len(delivered) == 1
+    assert delivered[0]["task_id"] == tid
+    assert delivered[0]["board"] == "default"
+    assert delivered[0]["kanban_event_schema_version"] == (
+        kb.KANBAN_EVENT_SCHEMA_VERSION
+    )
+
+
+def test_c1n_t41_swarm_root_completion_delivers_status_to_done(
+    kanban_home, events
+):
+    """End-to-end: the swarm root's ``completed`` event carries status_to='done'.
+
+    The AST guard in test_kanban_event_closure asserts the call site passes it;
+    this asserts a real subscriber actually receives it, through the swarm's
+    attribute-style seam call and its outer write_txn.
+    """
+    from hermes_cli.kanban_swarm import SwarmWorkerSpec, create_swarm
+
+    conn = kb.connect()
+    try:
+        created = create_swarm(
+            conn,
+            goal="observe the root completion",
+            workers=[SwarmWorkerSpec(profile="worker-a", title="A", body="A")],
+            verifier_assignee="reviewer",
+            synthesizer_assignee="writer",
+        )
+        root_id = created.root_id
+    finally:
+        conn.close()
+
+    completed = [
+        e for e in events
+        if e.get("kind") == "completed" and e.get("task_id") == root_id
+    ]
+    assert len(completed) == 1, "the swarm root must emit exactly one completion"
+    assert completed[0]["status_to"] == "done"
+
+
+# --------------------------------------------------------------------------
+# C1N-T42 — shell-hook interaction
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t42_generic_hook_is_not_shell_excluded():
+    """``kanban_task_event`` stays available to shell hooks, deliberately.
+
+    ``SHELL_UNSUPPORTED_HOOKS`` is a RETURN-VALUE-CHANNEL exclusion, not a
+    cost control: ``agent/shell_hooks._parse_hooks_block`` refuses those
+    events because ``_parse_response`` has no channel for the directive they
+    return, so registering would silently drop the hook's output. This hook
+    is an observer whose return value is ignored by contract, so there is no
+    directive to drop and nothing to refuse.
+
+    Excluding it here to save a fork would also be inconsistent: the RFC
+    #58548 observers fire just as often (every tick, every task write) and
+    are not excluded either. A shell subscriber costs a fork per event only
+    because a user explicitly registered one, and with none registered the
+    zero-subscriber fast path means no work at all.
+    """
+    from hermes_cli.plugins import SHELL_UNSUPPORTED_HOOKS
+
+    assert GENERIC_HOOK not in SHELL_UNSUPPORTED_HOOKS
+    for peer in (
+        "on_kanban_task_updated",
+        "on_kanban_dispatch_tick",
+        "kanban_task_completed",
+    ):
+        assert peer not in SHELL_UNSUPPORTED_HOOKS, (
+            "peer kanban observers are not shell-excluded either — if that "
+            "changes, revisit this hook's exclusion too"
+        )
+
+
+def test_c1n_t42_a_shell_style_subscriber_defeats_the_fast_path(
+    kanban_home, hooks, monkeypatch
+):
+    """The fast path must not silently drop shell-hook subscribers.
+
+    ``agent.shell_hooks.register_from_config`` wires its callbacks straight
+    into ``manager._hooks[event]`` — the same dict ``has_hook`` reads. A
+    subscriber registered that way must therefore make the event consumed and
+    receive delivery, exactly like a Python plugin's.
+    """
+    delivered: list[dict] = []
+    hooks(GENERIC_HOOK, lambda **kw: delivered.append(kw))
+
+    resolver_calls = _count_resolver(monkeypatch)
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="shell-observed")
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, "status", {"status": "ready"})
+    finally:
+        conn.close()
+
+    assert resolver_calls, "a registered shell hook must defeat the fast path"
+    assert [e for e in delivered if e.get("kind") == "status"]

--- a/tests/hermes_cli/test_kanban_generic_event_hook.py
+++ b/tests/hermes_cli/test_kanban_generic_event_hook.py
@@ -1,0 +1,2224 @@
+"""C-1: generic ``kanban_task_event`` observer surface.
+
+Tests are named ``C1N-*`` after the implementation packet's matrix. They assert
+relationships and transaction behavior only — never line numbers, hook totals,
+the production ``_append_event`` call-site count, or a frozen vocabulary size.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+from sqlite3 import OperationalError as sqlite3_OperationalError
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.plugins import VALID_HOOKS, get_plugin_manager
+
+GENERIC_HOOK = "kanban_task_event"
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """A private board root, with every ambient board override cleared.
+
+    ``HERMES_KANBAN_DB`` in particular must be unset: ``kanban_db_path``
+    consults it *ahead of* an explicit board slug, so a leaked value would
+    silently redirect every ``connect(board=...)`` in this module.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def pinned_manager(monkeypatch):
+    """The plugin-manager singleton, pinned for the duration of one test.
+
+    ``get_plugin_manager`` is a lazily-created module singleton and the
+    repo-wide autouse ``_hermetic_environment`` fixture resets it to ``None``
+    (``tests/conftest.py``). Resolving the manager once at fixture setup is
+    therefore not enough: if anything re-resolves it mid-test, a *different*
+    manager answers the dispatch and the callback this fixture registered is
+    simply not there.
+
+    That is a pre-existing, C-1-independent hazard — on the unmodified base,
+    ``test_kanban_lifecycle_hooks.py::test_claim_fires_hook`` fails for exactly
+    this reason when ``test_kanban_cli_dispatch_passthrough.py`` runs before it
+    in the same process. Pinning the module attribute makes these tests
+    order-independent instead of inheriting it.
+    """
+    from hermes_cli import plugins as plugins_mod
+
+    mgr = get_plugin_manager()
+    monkeypatch.setattr(plugins_mod, "_plugin_manager", mgr)
+    return mgr
+
+
+@pytest.fixture
+def events(pinned_manager):
+    """Capture every ``kanban_task_event`` callback kwargs dict, in order."""
+    mgr = pinned_manager
+    seen: list[dict] = []
+    saved = {k: list(v) for k, v in mgr._hooks.items()}
+    mgr._hooks.setdefault(GENERIC_HOOK, []).append(lambda **kw: seen.append(kw))
+    try:
+        yield seen
+    finally:
+        mgr._hooks = saved
+
+
+@pytest.fixture
+def hooks(pinned_manager):
+    """Register arbitrary callbacks against the shared plugin manager.
+
+    Yields a ``register(hook_name, callback)`` helper; the registry is restored
+    afterwards so tests never leak callbacks into each other.
+    """
+    mgr = pinned_manager
+    saved = {k: list(v) for k, v in mgr._hooks.items()}
+
+    def register(hook_name, callback):
+        mgr._hooks.setdefault(hook_name, []).append(callback)
+
+    try:
+        yield register
+    finally:
+        mgr._hooks = saved
+
+
+def rows(conn, task_id=None):
+    """Read committed ``task_events`` rows, oldest first."""
+    sql = "SELECT id, task_id, run_id, kind, created_at FROM task_events"
+    args: tuple = ()
+    if task_id is not None:
+        sql += " WHERE task_id = ?"
+        args = (task_id,)
+    return [dict(r) for r in conn.execute(sql + " ORDER BY id", args).fetchall()]
+
+
+# --------------------------------------------------------------------------
+# C1N-T01 — registration surface
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t01_generic_hook_is_declared():
+    """The generic observer hook is declared as a valid hook name."""
+    assert "kanban_task_event" in VALID_HOOKS
+
+
+def test_c1n_t01_legacy_hooks_unchanged():
+    """The three legacy kanban hooks survive C-1 untouched.
+
+    No assertion on ``len(VALID_HOOKS)`` — the total is exact-base evidence,
+    never API.
+    """
+    for name in (
+        "kanban_task_claimed",
+        "kanban_task_completed",
+        "kanban_task_blocked",
+    ):
+        assert name in VALID_HOOKS
+
+
+# --------------------------------------------------------------------------
+# C1N-T02 — one committed row -> exactly one callback, with the committed scalars
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t02_committed_row_produces_one_matching_callback(kanban_home, events):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        committed = rows(conn, tid)
+    finally:
+        conn.close()
+
+    assert len(committed) == 1
+    assert len(events) == 1
+    kw = events[0]
+    row = committed[0]
+    assert kw["task_id"] == row["task_id"] == tid
+    assert kw["kind"] == row["kind"] == "created"
+    assert kw["core_event_seq"] == row["id"]
+    assert kw["created_at_epoch_s"] == row["created_at"]
+    assert kw["run_id"] == row["run_id"]
+    assert kw["kanban_event_schema_version"] == "hermes.kanban.event.v1"
+    assert "profile_name" in kw
+
+
+# --------------------------------------------------------------------------
+# C1N-T16 — the append seam fails closed
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t16_append_event_without_a_frame_raises_before_inserting(kanban_home):
+    """A durable new-event insert must never escape instrumentation."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        before = len(rows(conn))
+        with pytest.raises(RuntimeError):
+            kb._append_event(conn, tid, "created")
+        assert len(rows(conn)) == before
+    finally:
+        conn.close()
+
+
+def test_c1n_t16_append_event_works_under_a_callers_frame(kanban_home, events):
+    """The guard tests for an *active* frame, not a locally-opened one.
+
+    ``_insert_completion_attachment`` never opens its own ``write_txn``; it runs
+    inside ``complete_task``'s. Reproduce that shape directly.
+    """
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        events.clear()
+        with kb.write_txn(conn):
+            kb._insert_completion_attachment(
+                conn,
+                tid,
+                filename="a.txt",
+                stored_path="/tmp/a.txt",
+                size=3,
+                created_at=1,
+            )
+        committed = [r for r in rows(conn, tid) if r["kind"] == "attached"]
+    finally:
+        conn.close()
+
+    assert len(committed) == 1
+    assert [e["kind"] for e in events] == ["attached"]
+    assert events[0]["core_event_seq"] == committed[0]["id"]
+
+
+# --------------------------------------------------------------------------
+# C1N-T03 / C1N-T05 — insertion ordering, including epoch-second ties
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t03_multi_row_transaction_dispatches_in_insertion_order(
+    kanban_home, events
+):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        events.clear()
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, "commented")
+            kb._append_event(conn, tid, "edited")
+            kb._append_event(conn, tid, "heartbeat")
+            # Nothing may be dispatched while the transaction is still open.
+            assert events == []
+        committed = [r for r in rows(conn, tid) if r["kind"] != "created"]
+    finally:
+        conn.close()
+
+    assert [e["kind"] for e in events] == ["commented", "edited", "heartbeat"]
+    assert [e["core_event_seq"] for e in events] == [r["id"] for r in committed]
+
+
+def test_c1n_t05_epoch_second_ties_still_order_by_core_event_seq(kanban_home, events):
+    """Rows in one transaction routinely share ``created_at``; ids still order."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        events.clear()
+        with kb.write_txn(conn):
+            for _ in range(5):
+                kb._append_event(conn, tid, "heartbeat")
+    finally:
+        conn.close()
+
+    stamps = {e["created_at_epoch_s"] for e in events}
+    assert len(stamps) == 1, "fixture did not produce an epoch-second tie"
+    seqs = [e["core_event_seq"] for e in events]
+    assert seqs == sorted(seqs)
+    assert len(set(seqs)) == len(seqs)
+
+
+# --------------------------------------------------------------------------
+# C1N-T06 / C1N-T07 — callbacks run outside the transaction and on-path
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t06_callback_runs_outside_the_transaction_and_write_lock(
+    kanban_home, hooks
+):
+    observed: list[bool] = []
+    other = kb.connect()
+
+    def _cb(**kw):
+        observed.append(other.in_transaction)
+        # The write lock must already be released: a competing connection can
+        # take BEGIN IMMEDIATE while this observer is still running.
+        other.execute("BEGIN IMMEDIATE")
+        other.execute("ROLLBACK")
+
+    hooks(GENERIC_HOOK, _cb)
+    conn = kb.connect()
+    try:
+        conn.execute("PRAGMA busy_timeout=2000")
+        kb.create_task(conn, title="t")
+    finally:
+        conn.close()
+        other.close()
+
+    assert observed == [False]
+
+
+def test_c1n_t07_callback_latency_is_off_lock_but_on_path(kanban_home, hooks):
+    """A sleeping observer measurably delays the originating call, after commit."""
+    import time as _time
+
+    marks: list[tuple[str, float]] = []
+
+    def _cb(**kw):
+        marks.append(("cb_enter", _time.monotonic()))
+        _time.sleep(0.25)
+        marks.append(("cb_exit", _time.monotonic()))
+
+    hooks(GENERIC_HOOK, _cb)
+    conn = kb.connect()
+    try:
+        start = _time.monotonic()
+        kb.create_task(conn, title="t")
+        elapsed = _time.monotonic() - start
+    finally:
+        conn.close()
+
+    assert [m[0] for m in marks] == ["cb_enter", "cb_exit"]
+    assert elapsed >= 0.25
+
+
+# --------------------------------------------------------------------------
+# C1N-T08 / T09 / T10 / T11 — every suppression path
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t08_body_rollback_suppresses_and_clears(kanban_home, events):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        events.clear()
+        with pytest.raises(RuntimeError):
+            with kb.write_txn(conn):
+                kb._append_event(conn, tid, "commented")
+                raise RuntimeError("body blew up")
+        assert events == []
+        assert [r["kind"] for r in rows(conn, tid)] == ["created"]
+        assert kb._TASK_EVENT_FRAME.get() is None
+        assert conn.in_transaction is False
+    finally:
+        conn.close()
+
+
+def test_c1n_t09_terminal_commit_failure_suppresses_and_clears(
+    kanban_home, events, monkeypatch
+):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        events.clear()
+
+        real = kb._execute_boundary_with_retry
+
+        def _fail_commit(c, stmt, *a, **kw):
+            if stmt.strip().upper().startswith("COMMIT"):
+                raise sqlite3_OperationalError("commit exhausted retries")
+            return real(c, stmt, *a, **kw)
+
+        monkeypatch.setattr(kb, "_execute_boundary_with_retry", _fail_commit)
+        with pytest.raises(Exception):
+            with kb.write_txn(conn):
+                kb._append_event(conn, tid, "commented")
+        monkeypatch.undo()
+
+        assert events == []
+        assert kb._TASK_EVENT_FRAME.get() is None
+        assert conn.in_transaction is False
+        assert [r["kind"] for r in rows(conn, tid)] == ["created"]
+    finally:
+        conn.close()
+
+
+def test_c1n_t10_post_commit_invariant_failure_suppresses(
+    kanban_home, events, monkeypatch
+):
+    """The deliberate committed-row-without-callback window.
+
+    Asserts the CALLBACK COUNT ONLY and explicitly tolerates a durable row: the
+    invariant runs after COMMIT, so the data may well be on disk. The
+    connection is put in rollback-journal mode first, because the invariant
+    deliberately skips under WAL.
+    """
+    import hermes_cli.sqlite_safe_read as ssr
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        conn.execute("PRAGMA journal_mode=DELETE")
+        events.clear()
+        monkeypatch.setattr(ssr, "file_length_matches_header", lambda _c: False)
+        with pytest.raises(Exception):
+            with kb.write_txn(conn):
+                kb._append_event(conn, tid, "commented")
+        monkeypatch.undo()
+
+        assert events == []
+        assert kb._TASK_EVENT_FRAME.get() is None
+        # Deliberately NOT asserting the row is absent — it may be durable.
+    finally:
+        conn.close()
+
+
+def test_c1n_t10_invariant_is_skipped_under_wal(kanban_home, events, monkeypatch):
+    """D-11 control: the same forced mismatch is a no-op under WAL."""
+    import hermes_cli.sqlite_safe_read as ssr
+
+    conn = kb.connect()
+    try:
+        assert str(conn.execute("PRAGMA journal_mode").fetchone()[0]).lower() == "wal"
+        tid = kb.create_task(conn, title="t")
+        events.clear()
+        monkeypatch.setattr(ssr, "file_length_matches_header", lambda _c: False)
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, "commented")
+        monkeypatch.undo()
+        assert [e["kind"] for e in events] == ["commented"]
+    finally:
+        conn.close()
+
+
+def test_c1n_t11_pre_begin_guard_installs_no_frame(kanban_home, events, monkeypatch):
+    conn = kb.connect()
+    try:
+        events.clear()
+        monkeypatch.setenv("HERMES_DELEGATED_CHILD_CONTEXT", "1")
+        with pytest.raises(PermissionError):
+            with kb.write_txn(conn):  # pragma: no cover - body never runs
+                raise AssertionError("body must not run")
+        monkeypatch.undo()
+        assert events == []
+        assert kb._TASK_EVENT_FRAME.get() is None
+        assert conn.in_transaction is False
+    finally:
+        conn.close()
+
+
+# --------------------------------------------------------------------------
+# C1N-T12 / T13 / T14 — observer isolation, fan-out order, reentrancy
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t12_raising_observer_is_isolated(kanban_home, hooks):
+    seen: list[str] = []
+
+    def _boom(**kw):
+        seen.append("boom")
+        raise RuntimeError("observer exploded")
+
+    hooks(GENERIC_HOOK, _boom)
+    hooks(GENERIC_HOOK, lambda **kw: seen.append("after"))
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        committed = rows(conn, tid)
+    finally:
+        conn.close()
+
+    assert seen == ["boom", "after"]
+    assert [r["kind"] for r in committed] == ["created"]
+
+
+def test_c1n_t13_fanout_follows_registration_order(kanban_home, hooks):
+    order: list[str] = []
+    for name in ("a", "b", "c"):
+        hooks(GENERIC_HOOK, lambda _n=name, **kw: order.append(f"{_n}:{kw['kind']}"))
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, "commented")
+    finally:
+        conn.close()
+
+    assert order == [
+        "a:created", "b:created", "c:created",
+        "a:commented", "b:commented", "c:commented",
+    ]
+
+
+def test_c1n_t14_observer_that_writes_the_board_uses_a_fresh_frame(kanban_home, hooks):
+    depth: list[int] = []
+    seen: list[str] = []
+
+    def _cb(**kw):
+        seen.append(kw["kind"])
+        # The completed frame is already detached, so this write cannot append
+        # to it or re-flush it.
+        assert kb._TASK_EVENT_FRAME.get() is None
+        if kw["kind"] == "created" and len(depth) < 3:
+            depth.append(1)
+            inner = kb.connect()
+            try:
+                with kb.write_txn(inner):
+                    kb._append_event(inner, kw["task_id"], "commented")
+            finally:
+                inner.close()
+
+    hooks(GENERIC_HOOK, _cb)
+    conn = kb.connect()
+    try:
+        kb.create_task(conn, title="t")
+    finally:
+        conn.close()
+
+    # One nested write, no unbounded recursion: 'commented' does not re-trigger.
+    assert seen == ["created", "commented"]
+    assert kb._TASK_EVENT_FRAME.get() is None
+
+
+# --------------------------------------------------------------------------
+# C1N-T35 — board comes from the CONNECTION, never from ambient state
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t35a_explicit_board_beats_ambient_board(kanban_home, events, monkeypatch):
+    """``HERMES_KANBAN_DB`` must stay cleared here.
+
+    ``kanban_db_path`` consults that variable *ahead of* the explicit slug, so
+    a set value would open the env-named file and this assertion would say
+    nothing about ``board="B"``.
+    """
+    kb.create_board("board-b")
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "board-a")
+    kb.create_board("board-a")
+    assert kb.get_current_board() == "board-a"
+
+    conn = kb.connect(board="board-b")
+    try:
+        events.clear()
+        kb.create_task(conn, title="t")
+    finally:
+        conn.close()
+
+    assert [e["board"] for e in events] == ["board-b"]
+
+
+def test_c1n_t35a_explicit_db_path_beats_ambient_board(kanban_home, events, monkeypatch):
+    kb.create_board("board-b")
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "board-a")
+    kb.create_board("board-a")
+
+    conn = kb.connect(db_path=kb.kanban_db_path(board="board-b"))
+    try:
+        events.clear()
+        kb.create_task(conn, title="t")
+    finally:
+        conn.close()
+
+    assert [e["board"] for e in events] == ["board-b"]
+
+
+def test_c1n_t35a_default_board_legacy_path_resolves(kanban_home, events):
+    conn = kb.connect(board="default")
+    try:
+        events.clear()
+        kb.create_task(conn, title="t")
+    finally:
+        conn.close()
+
+    assert [e["board"] for e in events] == ["default"]
+
+
+def test_c1n_t35b_env_db_override_outside_layout_yields_none(
+    kanban_home, events, tmp_path, monkeypatch
+):
+    """The resolver reports the connection's ACTUAL file.
+
+    ``HERMES_KANBAN_DB`` overrode the explicit ``board="B"`` argument, so the
+    connection is not writing board B at all. Reporting ``"board-b"`` here
+    would be a lie; ``None`` is the honest answer.
+    """
+    kb.create_board("board-b")
+    outside = tmp_path / "elsewhere" / "kanban.db"
+    outside.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(outside))
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "board-a")
+
+    conn = kb.connect(board="board-b")
+    try:
+        events.clear()
+        kb.create_task(conn, title="t")
+    finally:
+        conn.close()
+
+    assert [e["board"] for e in events] == [None]
+
+
+def test_c1n_t35b_db_path_outside_layout_yields_none(
+    kanban_home, events, tmp_path, monkeypatch
+):
+    outside = tmp_path / "elsewhere2" / "kanban.db"
+    outside.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "board-a")
+
+    conn = kb.connect(db_path=outside)
+    try:
+        events.clear()
+        kb.create_task(conn, title="t")
+    finally:
+        conn.close()
+
+    assert [e["board"] for e in events] == [None]
+
+
+def test_c1n_t35_board_is_fixed_at_frame_install(kanban_home, events, monkeypatch):
+    """Ambient state changing mid-transaction cannot re-attribute the board."""
+    kb.create_board("board-b")
+    conn = kb.connect(board="board-b")
+    try:
+        tid = kb.create_task(conn, title="t")
+        events.clear()
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, "commented")
+            monkeypatch.setenv("HERMES_KANBAN_BOARD", "board-a")
+            kb._append_event(conn, tid, "edited")
+    finally:
+        conn.close()
+
+    assert [e["board"] for e in events] == ["board-b", "board-b"]
+
+
+# --------------------------------------------------------------------------
+# C1N-T21 — capability declaration
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t21_declaration_is_an_immutable_module_constant():
+    assert isinstance(kb.KANBAN_EVENT_KINDS, frozenset)
+    assert all(isinstance(k, str) for k in kb.KANBAN_EVENT_KINDS)
+
+
+def test_c1n_t21_driven_writers_emit_declared_kinds(kanban_home, events):
+    """Per-writer assertion. No assertion on the size of the declaration."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t", assignee="w")
+        kb.assign_task(conn, tid, "w2")
+        kb.add_comment(conn, tid, "me", "hello")
+        claimed = kb.claim_task(conn, tid, claimer="w:1")
+        assert claimed is not None
+        kb.complete_task(conn, tid, result="done")
+    finally:
+        conn.close()
+
+    emitted = [e["kind"] for e in events]
+    assert "created" in emitted and "claimed" in emitted and "completed" in emitted
+    for kind in emitted:
+        assert kind in kb.KANBAN_EVENT_KINDS, f"{kind} is emitted but undeclared"
+
+
+# --------------------------------------------------------------------------
+# C1N-T17 / T18 / T34 — the five bundled-dashboard writers
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def dash():
+    """The bundled dashboard plugin API module (a third writing process)."""
+    return pytest.importorskip("plugins.kanban.dashboard.plugin_api")
+
+
+def test_c1n_t17_dashboard_reprioritized_and_edited_use_the_shared_seam(
+    kanban_home, events, dash
+):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+    finally:
+        conn.close()
+    events.clear()
+
+    dash.update_task(tid, dash.UpdateTaskBody(priority=7), board=None)
+    dash.update_task(tid, dash.UpdateTaskBody(title="new title"), board=None)
+
+    conn = kb.connect()
+    try:
+        committed = [r for r in rows(conn, tid) if r["kind"] != "created"]
+    finally:
+        conn.close()
+
+    assert [e["kind"] for e in events] == ["reprioritized", "edited"]
+    for kw, row in zip(events, committed):
+        assert kw["core_event_seq"] == row["id"]
+        assert kw["created_at_epoch_s"] == row["created_at"]
+        assert kw["run_id"] == row["run_id"] is None
+        assert kw["task_id"] == tid
+        assert kw["kanban_event_schema_version"] == "hermes.kanban.event.v1"
+        assert kw["kind"] in kb.KANBAN_EVENT_KINDS
+    # A dashboard edit carries no title/body content.
+    assert "title" not in events[1] and "body" not in events[1]
+
+
+def test_c1n_t17_dashboard_status_writer_uses_the_shared_seam(
+    kanban_home, events, dash
+):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+    finally:
+        conn.close()
+    events.clear()
+
+    conn = kb.connect()
+    try:
+        assert dash._set_status_direct(conn, tid, "todo") is True
+        committed = [r for r in rows(conn, tid) if r["kind"] == "status"]
+    finally:
+        conn.close()
+
+    assert [e["kind"] for e in events] == ["status"]
+    assert events[0]["core_event_seq"] == committed[0]["id"]
+    assert events[0]["status_to"] == "todo"
+
+
+def test_c1n_t17_dashboard_bulk_reprioritized_uses_the_shared_seam(
+    kanban_home, events, dash
+):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+    finally:
+        conn.close()
+    events.clear()
+
+    dash.bulk_update(dash.BulkTaskBody(ids=[tid], priority=3), board=None)
+
+    assert [e["kind"] for e in events] == ["reprioritized"]
+    assert "priority" not in events[0]
+    assert "status_to" not in events[0]
+
+
+def test_c1n_t18_reopened_parent_demotion_carries_status_to_todo(
+    kanban_home, events, dash
+):
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child")
+        kb.link_tasks(conn, parent, child)
+        # Drive the parent to done so the child can sit in ready.
+        assert dash._set_status_direct(conn, parent, "done") is True
+        assert dash._set_status_direct(conn, child, "ready") is True
+        events.clear()
+        # Reopening the parent must demote the ready child back to todo.
+        assert dash._set_status_direct(conn, parent, "todo") is True
+        child_rows = [r for r in rows(conn, child) if r["kind"] == "status"]
+    finally:
+        conn.close()
+
+    demotions = [e for e in events if e["task_id"] == child and e["kind"] == "status"]
+    assert len(demotions) == 1
+    assert demotions[0]["status_to"] == "todo"
+    assert demotions[0]["core_event_seq"] == child_rows[-1]["id"]
+    # No payload parsing and no post-commit read: nothing from the payload
+    # ('reason', 'parent') leaks into the kwargs.
+    assert "reason" not in demotions[0] and "parent" not in demotions[0]
+
+
+def test_c1n_t34_dashboard_board_is_the_connection_not_ambient(
+    kanban_home, events, dash, monkeypatch
+):
+    kb.create_board("board-b")
+    kb.create_board("board-a")
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "board-a")
+    assert kb.get_current_board() == "board-a"
+
+    conn = kb.connect(board="board-b")
+    try:
+        tid = kb.create_task(conn, title="t")
+    finally:
+        conn.close()
+    events.clear()
+
+    dash.update_task(tid, dash.UpdateTaskBody(priority=9), board="board-b")
+
+    assert [e["kind"] for e in events] == ["reprioritized"]
+    assert events[0]["board"] == "board-b"
+
+
+# --------------------------------------------------------------------------
+# C1N-T26 / C1N-T27 — the exact status_to matrix and conditional-transition honesty
+# --------------------------------------------------------------------------
+
+
+def only(events, kind, task_id=None):
+    """Return the single callback for ``kind`` (optionally scoped to a task)."""
+    hits = [
+        e for e in events
+        if e["kind"] == kind and (task_id is None or e["task_id"] == task_id)
+    ]
+    assert len(hits) == 1, f"expected exactly one {kind!r} callback, got {len(hits)}"
+    return hits[0]
+
+
+def test_c1n_t26_created_status_domain(kanban_home, events):
+    """``created``'s domain is {ready, todo, triage, blocked} — never running."""
+    conn = kb.connect()
+    try:
+        plain = kb.create_task(conn, title="plain")
+        assert only(events, "created", plain)["status_to"] == "ready"
+
+        events.clear()
+        triage = kb.create_task(conn, title="triage", triage=True)
+        assert only(events, "created", triage)["status_to"] == "triage"
+
+        events.clear()
+        blocked = kb.create_task(conn, title="b", initial_status="blocked")
+        assert only(events, "created", blocked)["status_to"] == "blocked"
+
+        events.clear()
+        child = kb.create_task(conn, title="child", parents=[plain])
+        assert only(events, "created", child)["status_to"] == "todo"
+    finally:
+        conn.close()
+
+
+def test_c1n_t26_claim_complete_and_block_transitions(kanban_home, events):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        events.clear()
+        assert kb.claim_task(conn, tid, claimer="w:1") is not None
+        assert only(events, "claimed")["status_to"] == "running"
+
+        events.clear()
+        assert kb.block_task(conn, tid, reason="need input", kind="needs_input")
+        assert only(events, "blocked")["status_to"] == "blocked"
+
+        events.clear()
+        assert kb.unblock_task(conn, tid)
+        assert only(events, "unblocked")["status_to"] == "ready"
+
+        events.clear()
+        assert kb.claim_task(conn, tid, claimer="w:2") is not None
+        kb.complete_task(conn, tid, result="ok")
+        assert only(events, "completed")["status_to"] == "done"
+    finally:
+        conn.close()
+
+
+def test_c1n_t26_unblocked_reports_the_exact_local_new_status(kanban_home, events):
+    """``unblocked`` reports ``todo`` when parents are still undone."""
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", parents=[parent])
+        # The child sits in 'todo' behind its parent; force it ready so
+        # block_task's guarded UPDATE can match, then block it.
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (child,))
+        conn.commit()
+        assert kb.block_task(conn, child, reason="r")
+        events.clear()
+        assert kb.unblock_task(conn, child)
+        assert only(events, "unblocked")["status_to"] == "todo"
+    finally:
+        conn.close()
+
+
+def test_c1n_t26_dependency_wait_reports_todo(kanban_home, events):
+    """A dependency block routes to ``todo``, never to ``blocked``."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        events.clear()
+        assert kb.block_task(conn, tid, reason="dep", kind="dependency") is True
+        assert only(events, "dependency_wait")["status_to"] == "todo"
+        assert kb.get_task(conn, tid).status == "todo"
+    finally:
+        conn.close()
+
+
+def test_c1n_t26_block_loop_detected_reports_triage(kanban_home, events):
+    """At BLOCK_RECURRENCE_LIMIT the block routes to ``triage``."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        # First block for this cause records recurrence 1 and lands in
+        # 'blocked'; the re-block after an unblock reaches the limit.
+        assert kb.block_task(conn, tid, reason="same", kind="needs_input")
+        assert kb.unblock_task(conn, tid)
+        events.clear()
+        assert kb.block_task(conn, tid, reason="same", kind="needs_input")
+        assert only(events, "block_loop_detected")["status_to"] == "triage"
+        assert kb.get_task(conn, tid).status == "triage"
+    finally:
+        conn.close()
+
+
+def test_c1n_t26_promote_schedule_archive_specify_decompose(kanban_home, events):
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", parents=[parent])
+        events.clear()
+        ok, _ = kb.promote_task(conn, child, actor="op", force=True)
+        assert ok
+        assert only(events, "promoted_manual")["status_to"] == "ready"
+
+        events.clear()
+        assert kb.schedule_task(conn, child, reason="later")
+        assert only(events, "scheduled")["status_to"] == "scheduled"
+
+        events.clear()
+        assert kb.archive_task(conn, child)
+        assert only(events, "archived")["status_to"] == "archived"
+
+        tri = kb.create_task(conn, title="tri", triage=True)
+        events.clear()
+        assert kb.specify_triage_task(conn, tri, title="spec", body="b")
+        assert only(events, "specified")["status_to"] == "todo"
+
+        tri2 = kb.create_task(conn, title="tri2", triage=True)
+        events.clear()
+        kids = kb.decompose_triage_task(
+            conn, tri2, root_assignee=None,
+            children=[{"title": "k1"}, {"title": "k2"}],
+        )
+        assert kids
+        assert only(events, "decomposed")["status_to"] == "todo"
+        created = [e for e in events if e["kind"] == "created"]
+        assert created and all(e["status_to"] == "todo" for e in created)
+        # decompose's own `linked` writes establish no status.
+        for e in events:
+            if e["kind"] == "linked":
+                assert "status_to" not in e
+    finally:
+        conn.close()
+
+
+def test_c1n_t26_reclaim_and_recovery_writers_report_ready(kanban_home, events):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        assert kb.claim_task(conn, tid, claimer="w:1") is not None
+        events.clear()
+        assert kb.reclaim_task(conn, tid, reason="operator")
+        assert only(events, "reclaimed")["status_to"] == "ready"
+
+        # reconcile_orphaned_running: running with broken claim bookkeeping.
+        conn.execute(
+            "UPDATE tasks SET status='running', claim_lock=NULL, "
+            "claim_expires=NULL WHERE id=?", (tid,),
+        )
+        conn.commit()
+        events.clear()
+        assert kb.reconcile_orphaned_running(conn) == [tid]
+        assert only(events, "reconciled")["status_to"] == "ready"
+    finally:
+        conn.close()
+
+
+def test_c1n_t26_non_transition_writers_omit_status_to(kanban_home, events):
+    conn = kb.connect()
+    try:
+        a = kb.create_task(conn, title="a")
+        b = kb.create_task(conn, title="b")
+        events.clear()
+        kb.assign_task(conn, a, "worker")
+        kb.set_model_override(conn, a, "gpt-x")
+        kb.set_reasoning_effort(conn, a, "high")
+        kb.add_comment(conn, a, "me", "hi")
+        kb.link_tasks(conn, a, b)
+        kb.unlink_tasks(conn, a, b)
+        assert kb.claim_task(conn, a, claimer="w:1") is not None
+        kb.heartbeat_worker(conn, a, note="tick")
+    finally:
+        conn.close()
+
+    expected_omitted = {
+        "assigned", "model_override_set", "reasoning_effort_set",
+        "commented", "unlinked", "heartbeat",
+    }
+    seen = {e["kind"] for e in events}
+    assert expected_omitted <= seen
+    for e in events:
+        if e["kind"] in expected_omitted:
+            assert "status_to" not in e, f"{e['kind']} must omit status_to"
+
+
+def test_c1n_t27_promoted_omits_status_to_when_the_update_matched_nothing(
+    kanban_home, events, monkeypatch
+):
+    """D-9: ``recompute_ready`` appends without binding its UPDATE's rowcount.
+
+    Move the row out of the guarded status between the SELECT and the UPDATE so
+    the guarded UPDATE matches zero rows; ``status_to`` must be omitted rather
+    than asserted from the SQL literal.
+    """
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", parents=[parent])
+        assert kb.claim_task(conn, parent, claimer="w:1") is not None
+        kb.complete_task(conn, parent, result="ok")
+        # complete_task already ran its own recompute_ready pass; push the
+        # child back to 'todo' so this test drives the promotion itself.
+        conn.execute("UPDATE tasks SET status='todo' WHERE id=?", (child,))
+        conn.commit()
+        events.clear()
+        real_execute = conn.execute
+        state = {"sabotaged": False}
+
+        def _sabotage(sql, *a, **kw):
+            if (
+                not state["sabotaged"]
+                and "SET status = 'ready'" in sql
+                and "status = 'todo'" in sql
+            ):
+                state["sabotaged"] = True
+                real_execute(
+                    "UPDATE tasks SET status = 'blocked' WHERE id = ?", (child,)
+                )
+            return real_execute(sql, *a, **kw)
+
+        monkeypatch.setattr(conn, "execute", _sabotage)
+        kb.recompute_ready(conn)
+        monkeypatch.undo()
+        assert state["sabotaged"]
+
+        promoted = [e for e in events if e["kind"] == "promoted"]
+        assert len(promoted) == 1
+        assert "status_to" not in promoted[0]
+    finally:
+        conn.close()
+
+
+def test_c1n_t27_promoted_reports_ready_when_the_update_matched(kanban_home, events):
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", parents=[parent])
+        assert kb.claim_task(conn, parent, claimer="w:1") is not None
+        kb.complete_task(conn, parent, result="ok")
+        conn.execute("UPDATE tasks SET status='todo' WHERE id=?", (child,))
+        conn.commit()
+        events.clear()
+        kb.recompute_ready(conn)
+        assert only(events, "promoted", child)["status_to"] == "ready"
+    finally:
+        conn.close()
+
+
+def test_c1n_t27_linked_status_to_is_rowcount_gated(kanban_home, events):
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent")
+        ready_child = kb.create_task(conn, title="ready-child")
+        events.clear()
+        kb.link_tasks(conn, parent, ready_child)
+        # The child WAS ready, so the guarded demotion matched: honest 'todo'.
+        assert only(events, "linked", ready_child)["status_to"] == "todo"
+
+        # A second link from another parent: the child is already 'todo', so
+        # the guarded UPDATE matches nothing and status_to must be omitted.
+        other_parent = kb.create_task(conn, title="parent2")
+        events.clear()
+        kb.link_tasks(conn, other_parent, ready_child)
+        assert "status_to" not in only(events, "linked", ready_child)
+    finally:
+        conn.close()
+
+
+def test_c1n_t27_claim_rejected_status_to_is_rowcount_gated(kanban_home, events):
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child")
+        # Force the child ready even though its parent is not done, so
+        # claim_task takes the parents_not_done branch and demotes it.
+        kb.link_tasks(conn, parent, child)
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (child,))
+        conn.commit()
+        events.clear()
+        assert kb.claim_task(conn, child, claimer="w:1") is None
+        assert only(events, "claim_rejected", child)["status_to"] == "todo"
+
+        # Now the child is already 'todo': the guarded demotion matches nothing.
+        events.clear()
+        assert kb.claim_task(conn, child, claimer="w:1") is None
+        assert "status_to" not in only(events, "claim_rejected", child)
+    finally:
+        conn.close()
+
+
+# --------------------------------------------------------------------------
+# C1N-T28 / C1N-T24 — strict failure_count, and the dynamic outcome domain
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t28_failure_count_acceptance_is_strict(kanban_home, events):
+    """No parsing, coercion, rounding, clamping, or defaulting."""
+    assert kb.FAILURE_COUNT_MAX == 1000
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        events.clear()
+        accepted = [0, 1, 7, kb.FAILURE_COUNT_MAX]
+        rejected = [True, False, "3", 3.0, -1, kb.FAILURE_COUNT_MAX + 1, None]
+        with kb.write_txn(conn):
+            for value in accepted + rejected:
+                kb._append_event(conn, tid, "heartbeat", failure_count=value)
+    finally:
+        conn.close()
+
+    got = events[: len(accepted)]
+    assert [e["failure_count"] for e in got] == accepted
+    for e in events[len(accepted):]:
+        assert "failure_count" not in e
+
+
+def test_c1n_t28_failure_count_absent_by_default(kanban_home, events):
+    conn = kb.connect()
+    try:
+        kb.create_task(conn, title="t")
+    finally:
+        conn.close()
+    assert all("failure_count" not in e for e in events)
+
+
+def test_c1n_t28_gave_up_carries_the_bounded_local_integer(kanban_home, events):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        assert kb.claim_task(conn, tid, claimer="w:1") is not None
+        events.clear()
+        # force_trip drives the gave_up branch on the first failure.
+        assert kb._record_task_failure(
+            conn, tid, "boom", outcome="spawn_failed",
+            force_trip=True, release_claim=True, end_run=True,
+        ) is True
+        gave_up = only(events, "gave_up")
+        assert gave_up["failure_count"] == 1
+        assert gave_up["status_to"] == "blocked"
+        # No payload-derived content rides along.
+        for banned in ("error", "payload", "trigger_outcome", "reason"):
+            assert banned not in gave_up
+    finally:
+        conn.close()
+
+
+def test_c1n_t24_dynamic_outcome_domain_reaches_the_seam(kanban_home, events):
+    """``spawn_failed`` and ``timed_out`` reach the dynamic append; ``crashed``
+    with ``end_run=False`` correctly does not (D-4)."""
+    conn = kb.connect()
+    try:
+        for outcome in ("spawn_failed", "timed_out"):
+            tid = kb.create_task(conn, title=outcome)
+            assert kb.claim_task(conn, tid, claimer="w:1") is not None
+            events.clear()
+            assert kb._record_task_failure(
+                conn, tid, "boom", outcome=outcome,
+                failure_limit=99, release_claim=True, end_run=True,
+            ) is False
+            kw = only(events, outcome)
+            assert kw["kind"] in kb.KANBAN_EVENT_KINDS
+            assert kw["status_to"] == "ready"
+            assert kw["failure_count"] == 1
+
+        # end_run=False never reaches the dynamic append.
+        tid = kb.create_task(conn, title="crashed")
+        assert kb.claim_task(conn, tid, claimer="w:1") is not None
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+        conn.commit()
+        events.clear()
+        kb._record_task_failure(
+            conn, tid, "boom", outcome="crashed",
+            failure_limit=99, release_claim=False, end_run=False,
+        )
+        assert [e["kind"] for e in events] == []
+    finally:
+        conn.close()
+
+
+# --------------------------------------------------------------------------
+# C1N-T04 — capture happens at INSERT time, never by post-commit re-read
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t04_later_mutation_cannot_change_an_earlier_events_scalars(
+    kanban_home, hooks
+):
+    """A competing post-commit mutation/deletion must not rewrite what was
+    already captured — because nothing is re-read after commit."""
+    captured: list[dict] = []
+
+    def _cb(**kw):
+        captured.append(dict(kw))
+        # Mutate and then delete the very row/task this callback describes.
+        other = kb.connect()
+        try:
+            other.execute("UPDATE tasks SET status='archived' WHERE id=?",
+                          (kw["task_id"],))
+            other.execute("UPDATE task_events SET kind='rewritten' WHERE id=?",
+                          (kw["core_event_seq"],))
+            other.execute("DELETE FROM task_events WHERE id=?",
+                          (kw["core_event_seq"],))
+            other.commit()
+        finally:
+            other.close()
+
+    hooks(GENERIC_HOOK, _cb)
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        assert rows(conn, tid) == []  # the callback deleted the row
+    finally:
+        conn.close()
+
+    assert len(captured) == 1
+    assert captured[0]["kind"] == "created"
+    assert captured[0]["status_to"] == "ready"
+    assert isinstance(captured[0]["core_event_seq"], int)
+    assert captured[0]["task_id"] == tid
+
+
+# --------------------------------------------------------------------------
+# C1N-T19 — a writer outside kanban_db.py reaches the same seam
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t19_out_of_module_iteration_budget_path(kanban_home, events):
+    """``agent/turn_finalizer``'s iteration-budget path, reproduced exactly.
+
+    The finalizer opens its own connection and relies on
+    ``_record_task_failure`` to open ``write_txn``; it needs no C-1 edit but is
+    inside the writer closure. This test drives that exact call shape rather
+    than a whole agent turn; that the finalizer really is this caller is
+    asserted statically in ``test_kanban_event_closure.py``.
+    """
+    setup = kb.connect()
+    try:
+        tid = kb.create_task(setup, title="t")
+        assert kb.claim_task(setup, tid, claimer="w:1") is not None
+    finally:
+        setup.close()
+    events.clear()
+
+    conn = kb.connect()  # a fresh connection, as the finalizer does
+    try:
+        kb._record_task_failure(
+            conn,
+            tid,
+            error="Iteration budget exhausted (40/40)",
+            outcome="timed_out",
+            failure_limit=99,
+            release_claim=True,
+            end_run=True,
+            event_payload_extra={"budget_used": 40, "budget_max": 40},
+        )
+    finally:
+        conn.close()
+
+    kw = only(events, "timed_out")
+    assert kw["status_to"] == "ready"
+    assert kw["failure_count"] == 1
+    assert "error" not in kw and "budget_used" not in kw
+
+
+# --------------------------------------------------------------------------
+# C1N-T20 — three process surfaces, each asserting LOCAL delivery only
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t20_each_process_surface_delivers_locally(kanban_home, events, dash):
+    """Dispatcher-, worker/manual- and web-server-side writers each deliver in
+    the process that performed the write.
+
+    Deliberately makes no claim about arrival order ACROSS surfaces — there is
+    no cross-process broker, and none is requested.
+    """
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+
+        # Dispatcher-side surface: recovery/claim bookkeeping.
+        events.clear()
+        assert kb.claim_task(conn, tid, claimer="w:1") is not None
+        assert {e["kind"] for e in events} == {"claimed"}
+
+        # Worker/manual surface: the terminal verb.
+        events.clear()
+        kb.complete_task(conn, tid, result="ok")
+        assert "completed" in {e["kind"] for e in events}
+    finally:
+        conn.close()
+
+    # Web-server surface: the bundled dashboard's plugin API.
+    events.clear()
+    conn = kb.connect()
+    try:
+        other = kb.create_task(conn, title="dash")
+    finally:
+        conn.close()
+    events.clear()
+    dash.update_task(other, dash.UpdateTaskBody(priority=2), board=None)
+    assert [e["kind"] for e in events] == ["reprioritized"]
+
+
+# --------------------------------------------------------------------------
+# C1N-T22 / C1N-T23 — reconciled, and the dynamic crash domain
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t22_reconciled_is_declared_and_reports_ready(kanban_home, events):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        conn.execute(
+            "UPDATE tasks SET status='running', claim_lock=NULL, "
+            "claim_expires=NULL WHERE id=?", (tid,),
+        )
+        conn.commit()
+        events.clear()
+        assert kb.reconcile_orphaned_running(conn) == [tid]
+    finally:
+        conn.close()
+
+    kw = only(events, "reconciled")
+    assert kw["kind"] in kb.KANBAN_EVENT_KINDS
+    assert kw["status_to"] == "ready"
+
+
+@pytest.mark.parametrize(
+    "exit_code, expected_kind",
+    [
+        (0, "protocol_violation"),
+        (None, "rate_limited"),   # replaced with the quota sentinel below
+        (3, "crashed"),
+    ],
+)
+def test_c1n_t23_crash_classifier_kinds_dispatch_as_declared(
+    kanban_home, events, monkeypatch, exit_code, expected_kind
+):
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    if expected_kind == "rate_limited":
+        exit_code = kb.KANBAN_RATE_LIMIT_EXIT_CODE
+
+    conn = kb.connect()
+    try:
+        host = kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="c")
+        assert kb.claim_task(conn, tid, claimer=f"{host}:w") is not None
+        pid = 90001
+        conn.execute("UPDATE tasks SET worker_pid=? WHERE id=?", (pid, tid))
+        conn.commit()
+        kb._record_worker_exit(pid, exit_code << 8)
+        events.clear()
+        kb.detect_crashed_workers(conn)
+    finally:
+        conn.close()
+
+    kw = only(events, expected_kind)
+    assert kw["kind"] in kb.KANBAN_EVENT_KINDS
+    assert kw["status_to"] == "ready"
+
+
+# --------------------------------------------------------------------------
+# C1N-T25 / C1N-T39 — unknown kinds pass through, and what that costs
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t25_unknown_future_kind_dispatches_unchanged(kanban_home, events):
+    """Core never drops, rewrites, or coerces an undeclared kind."""
+    kind = "some_future_kind_from_a_later_release"
+    assert kind not in kb.KANBAN_EVENT_KINDS
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        events.clear()
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, kind)
+        committed = [r for r in rows(conn, tid) if r["kind"] == kind]
+    finally:
+        conn.close()
+
+    assert [e["kind"] for e in events] == [kind]
+    assert committed and committed[0]["kind"] == kind
+
+
+def test_c1n_t39_unknown_kind_privacy_is_convention_bounded_not_enforced(
+    kanban_home, events
+):
+    """DOCUMENTED LIMITATION, not a promise — do not "fix" this by coercing kinds.
+
+    ``task_events.kind`` is an open TEXT column and undeclared kinds are
+    dispatched unchanged. Those two facts compose: an out-of-tree writer that
+    puts arbitrary prose in ``kind`` has that string delivered VERBATIM to every
+    observer. C-1 cannot prevent this without dropping or rewriting kinds,
+    which the contract forbids. The guarantee C-1 actually makes is narrower:
+    it introduces no content channel of its own and copies no payload into one.
+    """
+    prose = "user said: my password is hunter2 /home/someone/secret.txt"
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        events.clear()
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, prose, {"reason": "not delivered"})
+    finally:
+        conn.close()
+
+    assert [e["kind"] for e in events] == [prose]
+    # The payload channel stays closed even here.
+    assert "reason" not in events[0] and "payload" not in events[0]
+
+
+# --------------------------------------------------------------------------
+# C1N-T29 — content exclusion, against the real prose-bearing writers
+# --------------------------------------------------------------------------
+
+
+BANNED_KWARGS = {
+    "payload", "reason", "error", "summary", "summary_preview", "title",
+    "body", "message", "note", "filename", "author", "claimer", "pid",
+    "actor", "assignee", "by", "priority", "parent", "child_ids",
+}
+
+
+def test_c1n_t29_no_payload_content_reaches_the_callback(kanban_home, events):
+    secret_reason = "SECRET-REASON-cbd41"
+    secret_summary = "SECRET-SUMMARY-9f2aa"
+    secret_comment = "SECRET-COMMENT-77bcd"
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="SECRET-TITLE", body="SECRET-BODY")
+        kb.add_comment(conn, tid, "SECRET-AUTHOR", secret_comment)
+        assert kb.claim_task(conn, tid, claimer="SECRET-CLAIMER:1") is not None
+        assert kb.block_task(conn, tid, reason=secret_reason, kind="needs_input")
+        assert kb.unblock_task(conn, tid)
+        assert kb.claim_task(conn, tid, claimer="SECRET-CLAIMER:2") is not None
+        kb.complete_task(conn, tid, result="SECRET-RESULT", summary=secret_summary)
+    finally:
+        conn.close()
+
+    assert len(events) >= 5
+    allowed = {
+        "task_id", "kind", "core_event_seq", "created_at_epoch_s", "run_id",
+        "board", "profile_name", "status_to", "failure_count",
+        "kanban_event_schema_version", "telemetry_schema_version",
+    }
+    haystack = " ".join(
+        str(v) for e in events for v in e.values()
+    )
+    for e in events:
+        assert set(e) <= allowed, f"unexpected kwargs: {set(e) - allowed}"
+        assert not (set(e) & BANNED_KWARGS)
+    for secret in (
+        "SECRET-TITLE", "SECRET-BODY", "SECRET-AUTHOR", "SECRET-CLAIMER",
+        "SECRET-RESULT", secret_reason, secret_summary, secret_comment,
+    ):
+        assert secret not in haystack
+
+
+# --------------------------------------------------------------------------
+# C1N-T30 / C1N-T33 — legacy coexistence and R-1 independence
+# --------------------------------------------------------------------------
+
+
+def dependency_branch_is_precommit():
+    """Probe THIS base: does the dependency branch dispatch inside write_txn?
+
+    Parameterizing on the base is the whole point — hard-coding the frozen
+    base's asymmetry would fail the moment R-1 lands independently, and
+    hard-coding harmonized timing fails here. Either way the failure would be
+    the test's, not C-1's.
+    """
+    import ast
+    import inspect
+
+    src = inspect.getsource(kb.block_task)
+    tree = ast.parse(src.lstrip() if src.startswith(" ") else src)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.With):
+            continue
+        opens_txn = any(
+            isinstance(item.context_expr, ast.Call)
+            and getattr(item.context_expr.func, "id", None) == "write_txn"
+            for item in node.items
+        )
+        if not opens_txn:
+            continue
+        for child in ast.walk(node):
+            if (
+                isinstance(child, ast.Call)
+                and getattr(child.func, "id", None) == "_fire_kanban_lifecycle_hook"
+                and child.args
+                and isinstance(child.args[0], ast.Constant)
+                and child.args[0].value == "kanban_task_blocked"
+            ):
+                return True
+    return False
+
+
+def test_c1n_t30_legacy_timing_is_preserved_exactly_as_the_base_has_it(
+    kanban_home, hooks
+):
+    """C-1 changes NO legacy timing — asserted parameterized on the base."""
+    timeline: list[tuple[str, bool]] = []
+    probe = kb.connect()
+
+    def _in_txn():
+        # The generic hook is post-commit on every path, so a competing
+        # BEGIN IMMEDIATE succeeding proves the write lock is gone.
+        try:
+            probe.execute("BEGIN IMMEDIATE")
+            probe.execute("ROLLBACK")
+            return False
+        except Exception:
+            return True
+
+    hooks("kanban_task_blocked", lambda **kw: timeline.append(("legacy", _in_txn())))
+    hooks(GENERIC_HOOK, lambda **kw: timeline.append((f"generic:{kw['kind']}", _in_txn())))
+
+    conn = kb.connect()
+    try:
+        conn.execute("PRAGMA busy_timeout=500")
+        probe.execute("PRAGMA busy_timeout=500")
+        tid = kb.create_task(conn, title="t")
+        timeline.clear()
+        assert kb.block_task(conn, tid, reason="dep", kind="dependency") is True
+    finally:
+        conn.close()
+        probe.close()
+
+    legacy = [t for t in timeline if t[0] == "legacy"]
+    generic = [t for t in timeline if t[0].startswith("generic:")]
+    assert len(legacy) == 1, "the legacy hook must keep firing exactly once"
+    assert [t[0] for t in generic] == ["generic:dependency_wait"]
+
+    # The generic hook is post-commit unconditionally, on every base.
+    assert generic[0][1] is False
+
+    if dependency_branch_is_precommit():
+        # Frozen base, R-1 not applied: legacy fires while the lock is held.
+        assert legacy[0][1] is True
+        assert timeline.index(legacy[0]) < timeline.index(generic[0])
+    else:
+        # A base or fixture with R-1 applied: both are post-commit.
+        assert legacy[0][1] is False
+
+
+def test_c1n_t33_c1_contains_no_r1_change(kanban_home):
+    """C-1 must stay droppable without disturbing R-1's published PR.
+
+    It neither moves the dependency branch's dispatch site nor retimes any
+    legacy hook — so this candidate's suite is valid on a base with or without
+    R-1, which is exactly why C1N-T30 probes instead of hard-coding.
+    """
+    import inspect
+
+    src = inspect.getsource(kb.block_task)
+    # The dependency branch's legacy dispatch is untouched: still exactly one
+    # legacy blocked-hook call per block path, and C-1 added none.
+    assert src.count('_fire_kanban_lifecycle_hook(') == 2
+    assert 'kanban_task_event' not in src
+    # The generic hook is never dispatched from a legacy call site.
+    for fn in (kb.claim_task, kb.complete_task, kb.block_task):
+        assert 'kanban_task_event' not in inspect.getsource(fn)
+
+
+def test_c1n_t30_legacy_hooks_keep_names_kwargs_and_cardinality(
+    kanban_home, hooks, events
+):
+    seen: list[tuple[str, dict]] = []
+    for name in ("kanban_task_claimed", "kanban_task_completed", "kanban_task_blocked"):
+        hooks(name, lambda _n=name, **kw: seen.append((_n, kw)))
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        assert kb.claim_task(conn, tid, claimer="w:1") is not None
+        assert kb.block_task(conn, tid, reason="r", kind="needs_input")
+        assert kb.unblock_task(conn, tid)
+        assert kb.claim_task(conn, tid, claimer="w:2") is not None
+        kb.complete_task(conn, tid, result="ok")
+    finally:
+        conn.close()
+
+    fired = [n for n, _ in seen]
+    assert fired.count("kanban_task_claimed") == 2
+    assert fired.count("kanban_task_blocked") == 1
+    assert fired.count("kanban_task_completed") == 1
+    for name, kw in seen:
+        for key in ("task_id", "board", "assignee", "run_id", "profile_name"):
+            assert key in kw, f"{name} lost kwarg {key}"
+        if name == "kanban_task_completed":
+            assert "summary" in kw
+        if name == "kanban_task_blocked":
+            assert "reason" in kw
+    # A row that fires a legacy hook also fires one generic notification; core
+    # does not deduplicate. That exclusivity is the consumer's job.
+    assert any(e["kind"] == "completed" for e in events)
+
+
+# --------------------------------------------------------------------------
+# C1N-T31 / T32 / T38 — sequence honesty
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t31_gaps_after_deletion_and_gc_are_not_hook_loss(kanban_home, events):
+    conn = kb.connect()
+    try:
+        keep = kb.create_task(conn, title="keep")
+        doomed = kb.create_task(conn, title="doomed")
+        with kb.write_txn(conn):
+            kb._append_event(conn, doomed, "commented")
+            kb._append_event(conn, keep, "commented")
+            kb._append_event(conn, doomed, "edited")
+        delivered = [e["core_event_seq"] for e in events]
+        assert delivered == sorted(delivered)
+        assert kb.archive_task(conn, doomed)
+        assert kb.delete_archived_task(conn, doomed) is True
+        surviving = [r["id"] for r in rows(conn)]
+    finally:
+        conn.close()
+
+    # Every surviving row was delivered, but not every delivered row survived.
+    assert set(surviving) < set(delivered)
+    # Non-contiguous survivors: a gap is a deletion, never evidence of loss.
+    assert surviving != list(range(surviving[0], surviving[0] + len(surviving)))
+
+
+def test_c1n_t32_core_event_seq_is_not_stable_across_a_rebuild(
+    kanban_home, events, tmp_path
+):
+    """``_rebuild_drifted_tables`` excludes the legacy id, so AUTOINCREMENT
+    reassigns fresh values. No test may treat the seq as stable."""
+    db = tmp_path / "drifted" / "kanban.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    import sqlite3
+
+    raw = sqlite3.connect(db)
+    raw.execute(
+        "CREATE TABLE task_events (id TEXT PRIMARY KEY, task_id TEXT NOT NULL, "
+        "run_id INTEGER, kind TEXT NOT NULL, payload TEXT, "
+        "created_at INTEGER NOT NULL)"
+    )
+    raw.execute(
+        "INSERT INTO task_events VALUES ('legacy-1','t1',NULL,'created',NULL,10)"
+    )
+    raw.commit()
+    raw.close()
+
+    events.clear()
+    conn = kb.connect(db_path=db)
+    try:
+        after = [dict(r) for r in conn.execute(
+            "SELECT id, kind FROM task_events"
+        ).fetchall()]
+    finally:
+        conn.close()
+
+    assert after == [{"id": 1, "kind": "created"}]  # id reassigned, not 'legacy-1'
+    assert events == [], "a migration copy must emit nothing"
+
+
+def test_c1n_t38_board_generation_resets_and_repeats_the_sequence(
+    kanban_home, events
+):
+    """A repeat is a NEW BOARD GENERATION, not duplicate delivery or hook loss."""
+    for archive in (True, False):
+        slug = f"gen-{int(archive)}"
+        kb.create_board(slug)
+        conn = kb.connect(board=slug)
+        try:
+            events.clear()
+            kb.create_task(conn, title="first")
+            first = [e["core_event_seq"] for e in events]
+        finally:
+            conn.close()
+        assert first == [1]
+
+        kb.remove_board(slug, archive=archive)
+        kb.create_board(slug)
+        conn = kb.connect(board=slug)
+        try:
+            events.clear()
+            kb.create_task(conn, title="second")
+            second = [e["core_event_seq"] for e in events]
+        finally:
+            conn.close()
+        assert second == [1], "a same-slug board is a new generation from 1"
+
+
+# --------------------------------------------------------------------------
+# C1N-T36 / C1N-T37 — migration writers are invisible to C-1
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t36_rebuild_of_a_drifted_table_emits_nothing(
+    kanban_home, events, tmp_path
+):
+    import sqlite3
+
+    db = tmp_path / "rebuild" / "kanban.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    raw = sqlite3.connect(db)
+    raw.execute(
+        "CREATE TABLE task_events (id TEXT PRIMARY KEY, task_id TEXT NOT NULL, "
+        "run_id INTEGER, kind TEXT NOT NULL, payload TEXT, "
+        "created_at INTEGER NOT NULL)"
+    )
+    for i in range(5):
+        raw.execute(
+            "INSERT INTO task_events VALUES (?,?,NULL,'created',NULL,?)",
+            (f"legacy-{i}", f"t{i}", 100 + i),
+        )
+    raw.commit()
+    raw.close()
+
+    events.clear()
+    conn = kb.connect(db_path=db)
+    try:
+        moved = conn.execute("SELECT COUNT(*) FROM task_events").fetchone()[0]
+        assert moved == 5, "the rebuild must have copied every row"
+        assert kb._TASK_EVENT_FRAME.get() is None, "no frame may survive migration"
+    finally:
+        conn.close()
+
+    assert events == []
+
+
+def test_c1n_t37_event_kind_rename_emits_nothing_and_breaks_seq_kind_stability(
+    kanban_home, events, tmp_path
+):
+    """``(core_event_seq, kind)`` is NOT stable across migration (D-18).
+
+    The rename mutates existing rows in place, so the id is unchanged while the
+    kind a consumer already observed reads back differently.
+    """
+    import sqlite3
+
+    db = tmp_path / "renames" / "kanban.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+
+    # First open creates the current schema.
+    conn = kb.connect(db_path=db)
+    try:
+        tid = kb.create_task(conn, title="t")
+        events.clear()
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, "gave_up")
+        seq = events[0]["core_event_seq"]
+        # Put the row back into its legacy shape, as an old board would have it.
+        conn.execute(
+            "UPDATE task_events SET kind='spawn_auto_blocked' WHERE id=?", (seq,)
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    # Force the one-shot migration pass to run again on this path.
+    kb._INITIALIZED_PATHS.discard(str(db.resolve()))
+    events.clear()
+    conn = kb.connect(db_path=db)
+    try:
+        after = conn.execute(
+            "SELECT kind FROM task_events WHERE id=?", (seq,)
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert events == [], "an in-place kind rewrite must emit nothing"
+    assert after["kind"] == "gave_up"
+    # Same id, different kind than the row a consumer may have stored.
+
+
+# --------------------------------------------------------------------------
+# C1N-T27 (continued) — the two D-9 writers inside ``_record_task_failure``
+#
+# The packet names FOUR unchecked writers plus the dynamic-outcome UPDATE.
+# ``promoted``, ``linked`` and ``claim_rejected`` are driven above; the two
+# remaining ones both live in ``_record_task_failure`` and each has two
+# guarded branches (``release_claim=True`` and the else branch), so all four
+# combinations are driven here.
+# --------------------------------------------------------------------------
+
+
+def _park(conn, task_id, status):
+    """Move a task out of a guarded UPDATE's ``WHERE`` status, out of band."""
+    conn.execute("UPDATE tasks SET status=? WHERE id=?", (status, task_id))
+    conn.commit()
+
+
+def test_c1n_t27_gave_up_release_claim_branch_is_rowcount_gated(
+    kanban_home, events
+):
+    """D-9: ``gave_up``'s ``release_claim=True`` UPDATE is guarded
+    ``WHERE id = ? AND status IN ('running', 'ready')``.
+
+    Positive and zero-match are driven through the *same* branch so the
+    difference is the rowcount and nothing else.
+    """
+    conn = kb.connect()
+    try:
+        # Matched: the task really is 'running'.
+        hit = kb.create_task(conn, title="hit")
+        assert kb.claim_task(conn, hit, claimer="w:1") is not None
+        events.clear()
+        assert kb._record_task_failure(
+            conn, hit, "boom", outcome="spawn_failed",
+            force_trip=True, release_claim=True, end_run=True,
+        ) is True
+        assert only(events, "gave_up", hit)["status_to"] == "blocked"
+        assert kb.get_task(conn, hit).status == "blocked"
+
+        # Zero match: the task moved out of ('running', 'ready') first. The
+        # append still happens — only the status claim must disappear.
+        miss = kb.create_task(conn, title="miss")
+        _park(conn, miss, "triage")
+        events.clear()
+        assert kb._record_task_failure(
+            conn, miss, "boom", outcome="spawn_failed",
+            force_trip=True, release_claim=True, end_run=True,
+        ) is True
+        gave_up = only(events, "gave_up", miss)
+        assert "status_to" not in gave_up
+        # The row genuinely did not move, which is exactly why the claim
+        # would have been a lie.
+        assert kb.get_task(conn, miss).status == "triage"
+        # The bounded integer is unaffected by the rowcount gate.
+        assert gave_up["failure_count"] == 1
+    finally:
+        conn.close()
+
+
+def test_c1n_t27_gave_up_else_branch_is_rowcount_gated(kanban_home, events):
+    """D-9: the ``release_claim=False`` branch is guarded
+    ``WHERE id = ? AND status IN ('ready', 'running')`` — the timeout/crash
+    path, where the caller has already parked the task at ``ready``.
+    """
+    conn = kb.connect()
+    try:
+        hit = kb.create_task(conn, title="hit")   # created 'ready'
+        assert kb.get_task(conn, hit).status == "ready"
+        events.clear()
+        assert kb._record_task_failure(
+            conn, hit, "boom", outcome="timed_out",
+            force_trip=True, release_claim=False, end_run=False,
+        ) is True
+        assert only(events, "gave_up", hit)["status_to"] == "blocked"
+
+        miss = kb.create_task(conn, title="miss")
+        _park(conn, miss, "todo")
+        events.clear()
+        assert kb._record_task_failure(
+            conn, miss, "boom", outcome="timed_out",
+            force_trip=True, release_claim=False, end_run=False,
+        ) is True
+        assert "status_to" not in only(events, "gave_up", miss)
+        assert kb.get_task(conn, miss).status == "todo"
+    finally:
+        conn.close()
+
+
+def test_c1n_t27_dynamic_outcome_requeue_is_rowcount_gated(kanban_home, events):
+    """D-9: the below-threshold dynamic-outcome append reports ``ready`` only
+    when the ``WHERE id = ? AND status = 'running'`` requeue actually matched.
+    """
+    conn = kb.connect()
+    try:
+        miss = kb.create_task(conn, title="miss")
+        assert kb.claim_task(conn, miss, claimer="w:1") is not None
+        # Move it out of 'running' so the guarded requeue matches nothing,
+        # while end_run=True still drives the dynamic append.
+        _park(conn, miss, "review")
+        events.clear()
+        assert kb._record_task_failure(
+            conn, miss, "boom", outcome="spawn_failed",
+            failure_limit=99, release_claim=True, end_run=True,
+        ) is False
+        kw = only(events, "spawn_failed", miss)
+        assert "status_to" not in kw
+        assert kw["failure_count"] == 1
+        assert kb.get_task(conn, miss).status == "review"
+    finally:
+        conn.close()
+
+
+def test_c1n_t27_dynamic_outcome_non_release_branch_omits_status_to(
+    kanban_home, events
+):
+    """The else branch bookkeeps the counter only — it establishes no status,
+    so ``status_to`` is omitted even though the task is sitting at ``ready``.
+
+    Asserting the writer's *own* honesty, not the row's current value: a
+    status the writer did not establish is never reported.
+    """
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        assert kb.get_task(conn, tid).status == "ready"
+        events.clear()
+        assert kb._record_task_failure(
+            conn, tid, "boom", outcome="timed_out",
+            failure_limit=99, release_claim=False, end_run=True,
+        ) is False
+        kw = only(events, "timed_out", tid)
+        assert "status_to" not in kw
+        assert kw["failure_count"] == 1
+        assert kb.get_task(conn, tid).status == "ready"
+    finally:
+        conn.close()
+
+
+# --------------------------------------------------------------------------
+# C1N-T26 (continued) — the §6.6 rows whose writers the matrix above does not
+# reach: claim_review_task, release_stale_claims, enforce_max_runtime and
+# detect_stale_running.
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t26_claim_review_task_reports_running(kanban_home, events):
+    """The second ``claimed`` writer (review → running) reports ``running``."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        assert kb.claim_task(conn, tid, claimer="w:1") is not None
+        _park(conn, tid, "review")
+        conn.execute(
+            "UPDATE tasks SET claim_lock=NULL, claim_expires=NULL WHERE id=?",
+            (tid,),
+        )
+        conn.commit()
+        events.clear()
+        assert kb.claim_review_task(conn, tid, claimer="reviewer:1") is not None
+        kw = only(events, "claimed", tid)
+        assert kw["status_to"] == "running"
+        assert kw["kind"] in kb.KANBAN_EVENT_KINDS
+        # source_status rides only on the payload, never on the kwargs.
+        assert "source_status" not in kw and "lock" not in kw
+    finally:
+        conn.close()
+
+
+def test_c1n_t26_release_stale_claims_reports_ready(kanban_home, events):
+    """The ``reclaimed`` writer inside ``release_stale_claims`` (:4591 in the
+    packet's inventory) reports ``ready``; its ``claim_extended`` sibling in
+    the same function establishes no status and must omit it."""
+    conn = kb.connect()
+    try:
+        host = kb._claimer_id().split(":", 1)[0]
+
+        # (a) expired claim, no live worker -> reclaimed
+        dead = kb.create_task(conn, title="dead")
+        assert kb.claim_task(conn, dead, claimer=f"{host}:w1") is not None
+        conn.execute(
+            "UPDATE tasks SET claim_expires=?, worker_pid=NULL WHERE id=?",
+            (1, dead),
+        )
+        conn.commit()
+        events.clear()
+        assert kb.release_stale_claims(conn) == 1
+        assert only(events, "reclaimed", dead)["status_to"] == "ready"
+        assert kb.get_task(conn, dead).status == "ready"
+    finally:
+        conn.close()
+
+
+def test_c1n_t26_claim_extended_omits_status_to(kanban_home, events, monkeypatch):
+    """A live host-local worker gets its claim extended — no status changes."""
+    conn = kb.connect()
+    try:
+        host = kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="live")
+        assert kb.claim_task(conn, tid, claimer=f"{host}:w1") is not None
+        conn.execute(
+            "UPDATE tasks SET claim_expires=?, worker_pid=?, "
+            "last_heartbeat_at=? WHERE id=?",
+            (1, 4242, int(time.time()), tid),
+        )
+        conn.commit()
+        monkeypatch.setattr(kb, "_pid_alive", lambda _pid: True)
+        events.clear()
+        assert kb.release_stale_claims(conn) == 0
+        kw = only(events, "claim_extended", tid)
+        assert "status_to" not in kw
+        assert kb.get_task(conn, tid).status == "running"
+        for banned in ("reason", "claim_lock", "worker_pid"):
+            assert banned not in kw
+    finally:
+        conn.close()
+
+
+def test_c1n_t26_enforce_max_runtime_reports_ready(kanban_home, events, monkeypatch):
+    """``timed_out`` (:7284 in the inventory) reports ``ready``."""
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    conn = kb.connect()
+    try:
+        host = kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="slow")
+        assert kb.claim_task(conn, tid, claimer=f"{host}:w1") is not None
+        conn.execute(
+            "UPDATE tasks SET worker_pid=?, max_runtime_seconds=1, "
+            "started_at=? WHERE id=?",
+            (4242, 1, tid),
+        )
+        conn.execute("UPDATE task_runs SET started_at=? WHERE task_id=?", (1, tid))
+        conn.commit()
+        events.clear()
+        assert kb.enforce_max_runtime(conn, signal_fn=lambda *_a: None) == [tid]
+        kw = only(events, "timed_out", tid)
+        assert kw["status_to"] == "ready"
+        assert kw["kind"] in kb.KANBAN_EVENT_KINDS
+        for banned in ("pid", "elapsed_seconds", "sigkill"):
+            assert banned not in kw
+    finally:
+        conn.close()
+
+
+def test_c1n_t26_detect_stale_running_reports_ready(kanban_home, events, monkeypatch):
+    """``stale`` (:7422 in the inventory) reports ``ready``."""
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    conn = kb.connect()
+    try:
+        host = kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="wedged")
+        assert kb.claim_task(conn, tid, claimer=f"{host}:w1") is not None
+        conn.execute(
+            "UPDATE tasks SET started_at=?, last_heartbeat_at=NULL, "
+            "worker_pid=NULL WHERE id=?", (1, tid),
+        )
+        conn.execute("UPDATE task_runs SET started_at=? WHERE task_id=?", (1, tid))
+        conn.commit()
+        events.clear()
+        assert kb.detect_stale_running(
+            conn, stale_timeout_seconds=60, signal_fn=lambda *_a: None,
+        ) == [tid]
+        assert only(events, "stale", tid)["status_to"] == "ready"
+        assert kb.get_task(conn, tid).status == "ready"
+    finally:
+        conn.close()
+
+
+def test_c1n_t26_reclaim_deferred_omits_status_to(kanban_home, events, monkeypatch):
+    """A deferred reclaim holds the claim — the task stays ``running`` and the
+    writer establishes nothing."""
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: True)
+    conn = kb.connect()
+    try:
+        host = kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="survivor")
+        assert kb.claim_task(conn, tid, claimer=f"{host}:w1") is not None
+        conn.execute(
+            "UPDATE tasks SET started_at=?, last_heartbeat_at=NULL, "
+            "worker_pid=? WHERE id=?", (1, 4242, tid),
+        )
+        conn.execute("UPDATE task_runs SET started_at=? WHERE task_id=?", (1, tid))
+        conn.commit()
+        events.clear()
+        assert kb.detect_stale_running(
+            conn, stale_timeout_seconds=60, signal_fn=lambda *_a: None,
+        ) == []
+        kw = only(events, "reclaim_deferred", tid)
+        assert "status_to" not in kw
+        assert kb.get_task(conn, tid).status == "running"
+    finally:
+        conn.close()
+
+
+# --------------------------------------------------------------------------
+# C1N-T26 (continued) — the remaining §6.6 "omitted" writers, driven for real
+# --------------------------------------------------------------------------
+
+
+def test_c1n_t26_attachment_writers_omit_status_to(kanban_home, events):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        events.clear()
+        att = kb.add_attachment(
+            conn, tid, filename="secret-notes.txt",
+            stored_path=str(kanban_home / "secret-notes.txt"),
+            size=11, uploaded_by="SECRET-UPLOADER",
+        )
+        assert kb.delete_attachment(conn, att) is not None
+    finally:
+        conn.close()
+
+    assert [e["kind"] for e in events] == ["attached", "attachment_removed"]
+    for e in events:
+        assert "status_to" not in e
+        assert "filename" not in e and "by" not in e
+    assert "secret-notes.txt" not in " ".join(
+        str(v) for e in events for v in e.values()
+    )
+
+
+def test_c1n_t26_edit_completed_result_omits_status_to(kanban_home, events):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        assert kb.claim_task(conn, tid, claimer="w:1") is not None
+        kb.complete_task(conn, tid, result="first")
+        events.clear()
+        assert kb.edit_completed_task_result(
+            conn, tid, result="revised", summary="SECRET-EDIT-SUMMARY",
+        ) is True
+    finally:
+        conn.close()
+
+    kw = only(events, "edited", tid)
+    assert "status_to" not in kw
+    assert "summary" not in kw and "fields" not in kw
+    assert "SECRET-EDIT-SUMMARY" not in " ".join(str(v) for v in kw.values())
+
+
+def test_c1n_t26_spawn_and_scratch_tip_writers_omit_status_to(
+    kanban_home, events, monkeypatch
+):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        assert kb.claim_task(conn, tid, claimer="w:1") is not None
+        events.clear()
+        kb._set_worker_pid(conn, tid, 4242)
+        monkeypatch.setattr(kb, "_scratch_tip_shown", lambda: False)
+        monkeypatch.setattr(kb, "_mark_scratch_tip_shown", lambda: None)
+        kb._maybe_emit_scratch_tip(conn, tid, "scratch")
+    finally:
+        conn.close()
+
+    kinds = [e["kind"] for e in events]
+    assert "spawned" in kinds and "tip_scratch_workspace" in kinds
+    for e in events:
+        assert "status_to" not in e
+        assert "pid" not in e and "message" not in e
+
+
+def test_c1n_t26_hallucination_advisory_writers_omit_status_to(kanban_home, events):
+    """Both completion-advisory writers establish no status of their own."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+        assert kb.claim_task(conn, tid, claimer="w:1") is not None
+        events.clear()
+        with pytest.raises(kb.HallucinatedCardsError):
+            kb.complete_task(
+                conn, tid, result="ok", created_cards=["t_deadbeefcafe"],
+            )
+        blocked = only(events, "completion_blocked_hallucination", tid)
+        assert "status_to" not in blocked
+        assert "phantom_cards" not in blocked and "summary_preview" not in blocked
+        assert kb.get_task(conn, tid).status == "running"
+
+        events.clear()
+        kb.complete_task(
+            conn, tid, result="see t_deadbeefcafe for the rest", summary="done",
+        )
+        suspected = only(events, "suspected_hallucinated_references", tid)
+        assert "status_to" not in suspected
+        assert "refs" not in suspected
+        # The sibling 'completed' row in the same transaction still reports its
+        # own honest destination.
+        assert only(events, "completed", tid)["status_to"] == "done"
+    finally:
+        conn.close()
+
+
+def test_c1n_t26_dashboard_reprioritized_and_edited_omit_status_to(
+    kanban_home, events, dash
+):
+    """The two dashboard writers that change no status omit ``status_to``,
+    unlike the dashboard ``status`` writer covered by C1N-T17/T18."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t")
+    finally:
+        conn.close()
+    events.clear()
+
+    dash.update_task(tid, dash.UpdateTaskBody(priority=5), board=None)
+    dash.update_task(tid, dash.UpdateTaskBody(body="new body"), board=None)
+
+    assert [e["kind"] for e in events] == ["reprioritized", "edited"]
+    for e in events:
+        assert "status_to" not in e
+
+
+# --------------------------------------------------------------------------
+# C1N-T35 (continued) — the resolver fails SAFE, never fails the transaction
+# --------------------------------------------------------------------------
+
+
+class _NotASqliteConnection:
+    """A connection double, as several existing kanban tests already use.
+
+    ``execute`` returns ``None`` for anything it does not model, so a
+    ``PRAGMA database_list`` probe gets an object with no ``fetchall``. The
+    resolver must treat that as "this connection maps to no board", exactly
+    like an erroring PRAGMA — it must not raise out of ``write_txn`` and take
+    an unrelated write down with it.
+    """
+
+    def __init__(self):
+        self.calls = []
+        self.in_transaction = False
+
+    def execute(self, sql, *args):
+        self.calls.append(sql)
+        return None
+
+
+def test_c1n_t35_resolver_returns_none_when_the_pragma_probe_is_unusable():
+    """§6.2a: ``None`` on ANY failure, not only on ``sqlite3.Error``.
+
+    The resolver is best-effort board *attribution*. It runs at frame install,
+    after BEGIN IMMEDIATE has already succeeded, so a failure to attribute must
+    degrade to an honest ``None`` and never propagate — otherwise C-1 would
+    convert a cosmetic attribution problem into a failed write.
+    """
+    conn = _NotASqliteConnection()
+    assert kb._resolve_board_for_connection(conn) is None
+
+
+def test_c1n_t35_resolver_returns_none_when_the_pragma_raises_any_exception():
+    class _Boom:
+        def execute(self, sql, *args):
+            raise RuntimeError("connection wrapper blew up")
+
+    assert kb._resolve_board_for_connection(_Boom()) is None
+
+
+def test_c1n_t35_frame_install_survives_an_unattributable_connection(
+    kanban_home, monkeypatch
+):
+    """A write_txn over a connection double still opens, commits, and clears.
+
+    This is the shape several pre-existing kanban tests use to exercise
+    ``write_txn``'s busy-retry boundary; C-1 must leave them working. The
+    post-commit invariant is stubbed exactly as those tests already stub it —
+    it reads its own PRAGMAs and is not what this test is about.
+    """
+    monkeypatch.setattr(kb, "_check_file_length_invariant", lambda conn: None)
+    conn = _NotASqliteConnection()
+    with kb.write_txn(conn):
+        pass
+    assert conn.calls[0] == "BEGIN IMMEDIATE"
+    assert "COMMIT" in conn.calls
+    assert kb._TASK_EVENT_FRAME.get() is None

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -333,7 +333,8 @@ async def test_notifier_notify_wake_does_not_wake_on_status_event(kanban_home):
             conn, task_id=tid, platform="telegram", chat_id="chat1",
             delivery_mode="notify+wake",
         )
-        kb._append_event(conn, tid, kind="status", payload={"status": "review"})
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, kind="status", payload={"status": "review"})
     finally:
         conn.close()
 
@@ -508,7 +509,8 @@ async def test_notifier_unsubs_after_abnormal_events(kind, kanban_home):
     try:
         tid = kb.create_task(conn, title=f"test {kind} task", assignee="worker1")
         kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat1")
-        kb._append_event(conn, tid, kind=kind)
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, kind=kind)
     finally:
         conn.close()
 

--- a/tests/hermes_cli/test_kanban_swarm.py
+++ b/tests/hermes_cli/test_kanban_swarm.py
@@ -109,6 +109,18 @@ def test_create_swarm_graph_is_atomic_and_rolls_back_partial_build(
 
         hooks: list[tuple[str, bool]] = []
         monkeypatch.setattr(ks, "_activate_root_inline", original_activate)
+        # A real subscriber must exist for the generic observer to do any work:
+        # write_txn takes the zero-subscriber fast path on a has_hook probe, so
+        # patching _fire_kanban_lifecycle_hook alone only observes dispatches,
+        # it does not cause them. The patched fire function below still stands
+        # in for delivery — this registration only makes the hook *consumed*.
+        from hermes_cli.plugins import get_plugin_manager
+
+        mgr = get_plugin_manager()
+        monkeypatch.setitem(mgr._hooks, "kanban_task_event", [lambda **_kw: None])
+        monkeypatch.setattr(
+            "hermes_cli.plugins._plugin_manager", mgr, raising=False
+        )
         monkeypatch.setattr(
             kb,
             "_fire_kanban_lifecycle_hook",
@@ -123,7 +135,16 @@ def test_create_swarm_graph_is_atomic_and_rolls_back_partial_build(
             verifier_assignee="reviewer",
             synthesizer_assignee="writer",
         )
-        assert hooks == [("kanban_task_completed", False)]
+        # The generic ``kanban_task_event`` dispatches are additive; the legacy
+        # completion hook must still fire exactly once, last, and every hook --
+        # legacy or additive -- only after the outer transaction has closed.
+        events = [event for event, _ in hooks]
+        assert events.count("kanban_task_completed") == 1
+        assert hooks[-1] == ("kanban_task_completed", False)
+        additive = [entry for entry in hooks if entry[0] == "kanban_task_event"]
+        assert additive, "expected generic kanban_task_event dispatches"
+        assert all(in_transaction is False for _event, in_transaction in additive)
+        assert set(events) == {"kanban_task_event", "kanban_task_completed"}
     finally:
         reader.close()
         writer.close()


### PR DESCRIPTION
## Summary

Add a generic, observer-only `kanban_task_event` plugin hook for committed Kanban lifecycle-event rows.

- Queue notifications in the owning `write_txn` frame and flush them synchronously, in insertion order, only after commit, frame detachment, file-invariant validation, and SQLite write-lock release.
- Emit no notification for rollback, failed commit, pre-BEGIN failure, or post-commit invariant failure.
- Route semantic `task_events` writers, including bundled dashboard and swarm writes, through the shared fail-closed `_append_event()` seam.
- Expose a content-free scalar envelope containing `task_id`, `kind`, `core_event_seq`, `created_at_epoch_s`, and `schema_version`, with `board`, `run_id`, `status_to`, `retry_count`, and `failure_count` only when known.
- Preserve legacy Kanban lifecycle hooks and notifier polling behavior without duplicate event rows.
- Keep unknown database event kinds observable while maintaining a tested closure matrix for known producer kinds.

## Compatibility and semantics

The hook is process-local, synchronous, ordered per transaction, observer-only, and at-most-once. It provides no replay guarantee. Observer failures are isolated from the already-committed Kanban mutation. Callbacks run after the SQLite write lock is released, though callers may still hold an outer dispatcher lock.

The zero-subscriber path avoids board resolution, envelope construction, and dispatch while retaining the transaction frame and fail-closed write guard. Subscriber lookup failure is treated as a best-effort observer drop and cannot fail the Kanban write.

This PR contains C-1 only. The dependency-block post-commit correction remains isolated in #81339. It supersedes the C-1 portion of the older combined proposal in #78077.

No persisted schema migration, plugin activation, profile configuration, deployment, or service restart is included.

## Verification

- Focused ten-file C-1, closure, compatibility, notifier, and swarm suite: **178 passed**
- Broad 66-file Kanban candidate sweep: **527 passed, 18 failed, 1 skipped**
- Identical clean-current-main baseline command/order: **417 passed, 18 failed, 1 skipped**
- Broad comparison: **zero candidate-only failures**; all 18 failure names matched the current-main baseline
- Candidate adds **110 passing tests** to the broad sweep
- Ruff: passed on all nine changed paths
- AST parse: **9/9 files**
- Added-line security scan: clean
- `git diff --check`: passed
- Independent exact-index review: **PASS**, with no security concerns, logic errors, or blocking test/contract gaps
- Reviewed and committed binary patch SHA-256: `1a1dace865a188c28cc026a5937866bf8aa1388a8fae953093487ec64d987d2d`

## Base and candidate identity

- Upstream base: `86b2057a1b3365b93cedf1ea9b1962dfc6b08170`
- Candidate commit: `135374c8e197a0284ff0e6862b5d3e7852f213a8`
- Commit tree: `716043f7027ae113cdd3bb7655c79515252818de`