### PR TITLE
Preserve explicit empty toolsets

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1597,8 +1597,11 @@ def create_job(
     normalized_base_url = _normalize_job_optional_text(base_url, strip_trailing_slash=True)
     normalized_script = str(script).strip() if isinstance(script, str) else None
     normalized_script = normalized_script or None
-    normalized_toolsets = [str(t).strip() for t in enabled_toolsets if str(t).strip()] if enabled_toolsets else None
-    normalized_toolsets = normalized_toolsets or None
+    normalized_toolsets = (
+        [str(t).strip() for t in enabled_toolsets if str(t).strip()]
+        if enabled_toolsets is not None
+        else None
+    )
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -240,7 +240,9 @@ def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
     surprise $4.63 run).
     """
     per_job = job.get("enabled_toolsets")
-    if per_job:
+    if per_job is not None:
+        if not per_job:
+            return []
         return _merge_mcp_into_per_job_toolsets(list(per_job), cfg or {})
     try:
         from hermes_cli.tools_config import _get_platform_tools  # lazy: avoid heavy import at cron module load

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2250,6 +2250,14 @@ def _get_platform_tools(
     # Normalise to str so downstream sorted() never mixes types.
     toolset_names = [str(ts) for ts in toolset_names]
 
+    # An explicitly saved empty selection is an absolute deny-all policy, not
+    # a request to recover platform defaults.  Return before recently-shipped
+    # builtins, plugin toolsets, context-engine tools, and default MCP servers
+    # can widen the selection.  ``None`` remains the legacy "use defaults"
+    # sentinel; ``[]`` deliberately means "no tools" throughout runtime.
+    if explicitly_configured and not toolset_names:
+        return set()
+
     configurable_keys = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
     plugin_ts_keys = _get_plugin_toolset_keys()
     platform_default_keys = {p["default_toolset"] for p in PLATFORMS.values()}
@@ -2435,19 +2443,13 @@ def _get_platform_tools(
     # Context-engine tools are runtime-provided by the active engine, so they
     # are not part of any static platform composite. When a non-default engine
     # is selected, keep its recovery/status tools available even after a user
-    # saves an explicit platform toolset list. Preserve the explicit empty-list
-    # contract: selecting no configurable tools means no context-engine tools
-    # either unless the user adds ``context_engine`` manually later.
+    # saves an explicit platform toolset list. Explicit empty selections have
+    # already returned above, before any runtime-provided tools can be added.
     context_cfg = config.get("context") or {}
     if not isinstance(context_cfg, dict):
         context_cfg = {}
     context_engine_name = str(context_cfg.get("engine") or "compressor").strip().lower()
-    explicit_empty_selection = (
-        platform in platform_toolsets
-        and isinstance(platform_toolsets.get(platform), list)
-        and not toolset_names
-    )
-    if context_engine_name and context_engine_name != "compressor" and not explicit_empty_selection:
+    if context_engine_name and context_engine_name != "compressor":
         enabled_toolsets.add("context_engine")
 
     # Preserve any explicit non-configurable toolset entries (for example,

--- a/model_tools.py
+++ b/model_tools.py
@@ -401,16 +401,16 @@ def _compute_tool_definitions(
     if enabled_toolsets is not None:
         effective_enabled_toolsets = list(enabled_toolsets)
         if (
-            os.environ.get("HERMES_KANBAN_TASK")
+            effective_enabled_toolsets
+            and os.environ.get("HERMES_KANBAN_TASK")
             and not _is_delegated_child_context()
             and _is_dispatcher_owned_worker()
             and "kanban" not in effective_enabled_toolsets
         ):
             # Dispatcher-spawned workers are scoped by HERMES_KANBAN_TASK and
-            # must always receive the lifecycle handoff tools. Assignee
-            # profiles may intentionally restrict their normal chat toolsets
-            # (for token/cost reasons), but that should not strip the kanban
-            # worker's completion/block/heartbeat surface.
+            # normally receive the lifecycle handoff tools. Assignee profiles
+            # may restrict their normal chat toolsets, but an explicit empty
+            # selection remains the stronger absolute deny-all policy.
             effective_enabled_toolsets.append("kanban")
         for toolset_name in effective_enabled_toolsets:
             if validate_toolset(toolset_name):

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -706,6 +706,20 @@ class TestEnabledToolsets:
         job = create_job(prompt="monitor", schedule="every 1h", enabled_toolsets=["web", "terminal"])
         assert job["enabled_toolsets"] == ["web", "terminal"]
 
+    def test_explicit_empty_toolsets_survive_store_reload_and_update(self, tmp_cron_dir):
+        job = create_job(
+            prompt="monitor",
+            schedule="every 1h",
+            enabled_toolsets=[],
+        )
+        assert job["enabled_toolsets"] == []
+        assert get_job(job["id"])["enabled_toolsets"] == []
+
+        update_job(job["id"], {"enabled_toolsets": ["web"]})
+        update_job(job["id"], {"enabled_toolsets": []})
+
+        assert get_job(job["id"])["enabled_toolsets"] == []
+
 
 class TestMarkJobRunConcurrency:
     """Regression tests for concurrent parallel job state writes.

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -48,7 +48,7 @@ class TestPerJobToolsetMcpMerge:
         assert not (set(result) & self._enabled_names())
 
 
-    def test_resolver_empty_per_job_falls_through_to_platform(self):
+    def test_resolver_omitted_per_job_falls_through_to_platform(self):
         # No per-job list -> must delegate to _get_platform_tools (the platform
         # fallback), NOT the per-job merge. Stub the platform resolver and assert
         # it is the path taken and its result is returned.
@@ -61,6 +61,18 @@ class TestPerJobToolsetMcpMerge:
         # _get_platform_tools args: (cfg, "cron")
         assert m_platform.call_args[0][1] == "cron"
         assert set(result) == set(sentinel)
+
+    def test_resolver_explicit_empty_per_job_stays_empty_without_mcp(self):
+        with patch(
+            "cron.scheduler._merge_mcp_into_per_job_toolsets",
+            side_effect=AssertionError("MCP must not widen explicit []"),
+        ), patch(
+            "hermes_cli.tools_config._get_platform_tools",
+            side_effect=AssertionError("platform defaults must not widen explicit []"),
+        ):
+            assert _resolve_cron_enabled_toolsets(
+                {"enabled_toolsets": []}, self.CFG
+            ) == []
 
 
 class TestResolveOrigin:
@@ -576,6 +588,18 @@ class TestRunJobSessionPersistence:
         assert kwargs["enabled_toolsets"] == ["memory", "file"]
         assert "memory" in kwargs["disabled_toolsets"]
 
+    def test_run_job_preserves_explicit_empty_toolsets(self, tmp_path):
+        job = {
+            "id": "zero-tool-job",
+            "name": "test",
+            "prompt": "hello",
+            "enabled_toolsets": [],
+        }
+        with self._run_job_patches(tmp_path) as (_fake_db, mock_agent_cls):
+            run_job(job)
+
+        assert mock_agent_cls.call_args.kwargs["enabled_toolsets"] == []
+
     def test_tick_skips_due_jobs_while_dispatch_is_paused(self, tmp_path):
         """The drain gate runs before advancing a due job's schedule."""
         from cron.scheduler import tick
@@ -594,6 +618,18 @@ class TestRunJobSessionPersistence:
 
         advance.assert_not_called()
         run_one.assert_not_called()
+
+    def test_tick_with_no_jobs_never_constructs_agent(self, tmp_path):
+        from cron.scheduler import tick
+
+        with patch("cron.scheduler._get_lock_paths", return_value=(tmp_path, tmp_path / "tick.lock")), patch(
+            "cron.scheduler.get_due_jobs", return_value=[]
+        ), patch("tools.mcp_tool._kill_orphaned_mcp_children"), patch(
+            "run_agent.AIAgent"
+        ) as agent_cls:
+            assert tick(verbose=False, sync=True) == 0
+
+        agent_cls.assert_not_called()
 
 
 class TestRunJobConfigLogging:
@@ -1974,5 +2010,3 @@ class TestSetCronSessionTitle:
         out = _set_cron_session_title(db, "sess-1", "Nightly Synthesis")
         assert out == "Nightly Synthesis #2"
         db.get_next_title_in_lineage.assert_called_once_with("Nightly Synthesis")
-
-

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -31,6 +31,24 @@ from hermes_cli.tools_config import (
 )
 
 
+def test_explicit_empty_platform_toolsets_is_absolute_deny_all():
+    """Defaults, plugins, context tools, and MCP must not widen []."""
+    config = {
+        "platform_toolsets": {"cli": []},
+        "context": {"engine": "lcm"},
+        "mcp_servers": {"demo": {"enabled": True}},
+    }
+
+    with patch(
+        "hermes_cli.tools_config._get_plugin_toolset_keys",
+        side_effect=AssertionError("plugin discovery must not run"),
+    ), patch(
+        "hermes_cli.tools_config.enabled_mcp_server_names",
+        side_effect=AssertionError("MCP defaults must not be added"),
+    ):
+        assert _get_platform_tools(config, "cli") == set()
+
+
 
 
 def test_all_invalid_platform_toolsets_logs_runtime_warning(caplog):

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -306,6 +306,51 @@ def test_build_api_kwargs_codex(monkeypatch):
     assert "extra_body" not in kwargs
 
 
+def test_zero_tool_codex_request_omits_all_tool_fields(monkeypatch):
+    """Capture the final OpenAI-Codex request for an actual [] tool scope."""
+    monkeypatch.setattr(run_agent, "check_toolset_requirements", lambda: {})
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "must-not-widen-zero-tools")
+
+    agent = run_agent.AIAgent(
+        model="gpt-5.6-terra",
+        provider="openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="test-token",
+        enabled_toolsets=[],
+        quiet_mode=True,
+        max_iterations=1,
+        skip_context_files=True,
+        skip_memory=True,
+        skip_background_review=True,
+    )
+    # The worker env is only needed to exercise model_tools' force-add path at
+    # construction.  Clear it before the turn so the unrelated kanban
+    # completion nudge does not turn this transport assertion into a worker
+    # lifecycle test.
+    monkeypatch.delenv("HERMES_KANBAN_TASK")
+    agent._cleanup_task_resources = lambda task_id: None
+    agent._persist_session = lambda messages, history=None: None
+    agent._save_trajectory = lambda messages, user_message, completed: None
+    agent._disable_streaming = True
+    captured = {}
+
+    def _capture_api_call(api_kwargs):
+        captured.update(api_kwargs)
+        return _codex_message_response("OK")
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _capture_api_call)
+
+    result = agent.run_conversation("Connectivity test only; no legal content.")
+
+    assert result["completed"] is True
+    assert agent.enabled_toolsets == []
+    assert agent.tools == []
+    assert agent.valid_tool_names == set()
+    assert "tools" not in captured
+    assert "tool_choice" not in captured
+    assert "parallel_tool_calls" not in captured
+
+
 def test_build_api_kwargs_mantle_sets_extended_prompt_cache_retention(monkeypatch):
     _patch_agent_bootstrap(monkeypatch)
     agent = run_agent.AIAgent(

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -680,6 +680,7 @@ def test_profile_scoped_agent_build_starts_mcp_discovery_in_profile_home(
     try:
         server._start_agent_build(sid, session)
         assert built.wait(timeout=2)
+        assert ready.wait(timeout=2)
     finally:
         server._sessions.pop(sid, None)
 
@@ -735,6 +736,7 @@ def test_profile_scoped_agent_build_installs_secret_scope(monkeypatch, tmp_path)
     try:
         server._start_agent_build(sid, session)
         assert built.wait(timeout=2)
+        assert ready.wait(timeout=2)
     finally:
         server._sessions.pop(sid, None)
 
@@ -3533,6 +3535,26 @@ def test_background_agent_kwargs_preserves_empty_fallback_chain(monkeypatch):
     kwargs = server._background_agent_kwargs(agent, "task-id")
 
     assert kwargs["fallback_model"] == []
+
+
+def test_background_agent_kwargs_preserves_empty_toolsets(monkeypatch):
+    agent = types.SimpleNamespace(
+        model="gpt-5.6-terra",
+        provider="openai-codex",
+        enabled_toolsets=[],
+    )
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"max_turns": 25})
+    monkeypatch.setattr(
+        server,
+        "_load_enabled_toolsets",
+        lambda *_a, **_kw: pytest.fail(
+            "background task must not re-resolve an explicit empty selection"
+        ),
+    )
+
+    kwargs = server._background_agent_kwargs(agent, "task-id")
+
+    assert kwargs["enabled_toolsets"] == []
 
 
 def test_startup_runtime_resolves_short_alias_without_network(monkeypatch):

--- a/tests/tools/test_blueprints.py
+++ b/tests/tools/test_blueprints.py
@@ -82,6 +82,18 @@ class TestParseBlueprint:
         assert spec is not None
         assert spec.deliver == "origin"
 
+    def test_explicit_empty_toolsets_survive_blueprint_parse(self):
+        skill = (
+            "---\nname: zero-tools\ndescription: d\nmetadata:\n  hermes:\n"
+            "    blueprint:\n      schedule: every 1h\n"
+            "      enabled_toolsets: []\n---\n\nbody"
+        )
+
+        spec = parse_blueprint(skill)
+
+        assert spec is not None
+        assert spec.enabled_toolsets == []
+
 
 class TestBlueprintSpecForInstalled:
     def test_finds_and_parses_installed_blueprint(self, tmp_path):

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -246,6 +246,33 @@ class TestUnifiedCronjobTool:
         assert listing["jobs"][0]["name"] == "Server Check"
         assert listing["jobs"][0]["state"] == "scheduled"
 
+    def test_create_update_and_list_preserve_explicit_empty_toolsets(self):
+        from cron.jobs import get_job
+
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check",
+                schedule="every 1h",
+                enabled_toolsets=[],
+            )
+        )
+        job_id = created["job_id"]
+        assert created["job"]["enabled_toolsets"] == []
+        assert get_job(job_id)["enabled_toolsets"] == []
+
+        updated = json.loads(
+            cronjob(
+                action="update",
+                job_id=job_id,
+                enabled_toolsets=[],
+            )
+        )
+        assert updated["job"]["enabled_toolsets"] == []
+
+        listing = json.loads(cronjob(action="list"))
+        assert listing["jobs"][0]["enabled_toolsets"] == []
+
     def test_list_handles_partial_legacy_job_records(self):
         from cron.jobs import save_jobs
 

--- a/tests/tools/test_refresh_agent_mcp_tools.py
+++ b/tests/tools/test_refresh_agent_mcp_tools.py
@@ -134,6 +134,51 @@ def test_refresh_respects_context_engine_toolset_gate(monkeypatch):
     assert "lcm_grep" not in agent.valid_tool_names   # gated out (#5544)
 
 
+def test_refresh_cannot_widen_explicit_empty_toolsets(monkeypatch):
+    """Late MCP, memory, and context schemas remain unreachable under []."""
+    from tools.registry import registry
+
+    registry.register(
+        name="mcp_zero_tool_late_arrival",
+        handler=lambda args, **kwargs: "{}",
+        schema=_tool("mcp_zero_tool_late_arrival")["function"],
+        toolset="mcp-zero-tool-late",
+    )
+    agent = _agent([], enabled=[])
+    agent._memory_manager = types.SimpleNamespace(
+        get_all_tool_schemas=lambda: [
+            {"name": "memory_search", "description": "", "parameters": {}}
+        ]
+    )
+    agent.context_compressor = types.SimpleNamespace(
+        get_tool_schemas=lambda: [
+            {"name": "lcm_grep", "description": "", "parameters": {}}
+        ]
+    )
+    agent._context_engine_tool_names = set()
+
+    import model_tools
+
+    original = model_tools.get_tool_definitions
+
+    def _late_registry(**kwargs):
+        assert kwargs["enabled_toolsets"] == []
+        assert original(
+            enabled_toolsets=[],
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
+        ) == []
+        return []
+
+    monkeypatch.setattr(model_tools, "get_tool_definitions", _late_registry)
+
+    added = mcp_tool.refresh_agent_mcp_tools(agent)
+
+    assert added == set()
+    assert agent.tools == []
+    assert agent.valid_tool_names == set()
+
+
 def test_refreshed_tool_is_callable_through_valid_tool_names_guard(monkeypatch):
     """The whole point: a late tool, once refreshed, passes the name guard the
     run loop uses to accept/reject tool calls (agent.valid_tool_names)."""

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -179,6 +179,27 @@ class TestRetrieval:
 
 
 class TestAssembly:
+    def test_explicit_empty_has_no_bridge_or_deferred_catalog(self):
+        import model_tools
+        from tools.tool_search import assemble_tool_defs, ToolSearchConfig
+
+        defs = model_tools.get_tool_definitions(
+            enabled_toolsets=[],
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
+        )
+        result = assemble_tool_defs(
+            defs,
+            context_length=200_000,
+            config=ToolSearchConfig.from_raw({"enabled": "on"}),
+        )
+
+        assert defs == []
+        assert result.tool_defs == []
+        assert result.activated is False
+        assert result.deferred_count == 0
+        assert result.tier == 0
+
     def test_no_deferrable_returns_unchanged(self):
         """Pure-core toolset: pass-through, no bridge tools added."""
         from tools.tool_search import assemble_tool_defs, ToolSearchConfig
@@ -443,6 +464,33 @@ class TestRegression_ToolsetScoping:
         )
         hit_names = {m["name"] for m in parsed["matches"]}
         assert "scoped_oos_plugin" not in hit_names
+
+    def test_empty_scope_has_zero_search_and_call_reachability(self):
+        import model_tools
+
+        self._register("mcp_zero_scope_secret", "mcp-zero-scope")
+
+        searched = json.loads(
+            model_tools.handle_function_call(
+                function_name="tool_search",
+                function_args={"query": "zero scope"},
+                enabled_toolsets=[],
+            )
+        )
+        called = json.loads(
+            model_tools.handle_function_call(
+                function_name="tool_call",
+                function_args={
+                    "name": "mcp_zero_scope_secret",
+                    "arguments": {},
+                },
+                enabled_toolsets=[],
+            )
+        )
+
+        assert searched["total_available"] == 0
+        assert searched["matches"] == []
+        assert "not available in this session" in called["error"]
 
 
     def test_scoped_deferrable_names_helper(self):

--- a/tests/tui_gateway/test_gui_surface_toolsets.py
+++ b/tests/tui_gateway/test_gui_surface_toolsets.py
@@ -77,6 +77,27 @@ class TestSurfaceResolution:
 
 
 class TestResolverPlumbing:
+    def test_explicit_empty_config_beats_posture_and_desktop_surface(
+        self, tmp_path, no_desktop_env
+    ):
+        """Exercise the real config loader from an isolated HERMES_HOME."""
+        tmp_path.joinpath("config.yaml").write_text(
+            "platform_toolsets:\n  cli: []\n",
+            encoding="utf-8",
+        )
+        no_desktop_env.setenv("HERMES_HOME", str(tmp_path))
+
+        import agent.coding_context as cc
+
+        no_desktop_env.setattr(
+            cc,
+            "coding_selection",
+            lambda **_: pytest.fail("coding posture must not widen explicit []"),
+        )
+
+        assert server._load_enabled_toolsets("desktop") == []
+        assert server._load_enabled_toolsets("tui") == []
+
     def test_posture_path_folds_in_the_session_surface(self, no_desktop_env):
         """Focus-mode returns early — the surface toolsets must survive it."""
         import agent.coding_context as cc
@@ -111,3 +132,16 @@ class TestResolverPlumbing:
         no_desktop_env.setenv("HERMES_TUI_TOOLSETS", "web,memory")
 
         assert server._load_enabled_toolsets("desktop") == ["web", "memory"]
+
+    def test_explicit_env_pin_can_override_empty_config(self, no_desktop_env):
+        """The existing operator-only env override retains its precedence."""
+        import hermes_cli.config as config_mod
+
+        no_desktop_env.setenv("HERMES_TUI_TOOLSETS", "web")
+        no_desktop_env.setattr(
+            config_mod,
+            "load_config",
+            lambda: {"platform_toolsets": {"cli": []}},
+        )
+
+        assert server._load_enabled_toolsets("desktop") == ["web"]

--- a/tools/blueprints.py
+++ b/tools/blueprints.py
@@ -136,7 +136,9 @@ def parse_blueprint(skill_md_text: str) -> Optional[BlueprintSpec]:
         no_agent=no_agent,
         model=str(model).strip() if model else None,
         provider=str(provider).strip() if provider else None,
-        enabled_toolsets=[str(t) for t in toolsets] if toolsets else None,
+        enabled_toolsets=(
+            [str(t) for t in toolsets] if toolsets is not None else None
+        ),
         raw=blueprint,
     )
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -587,7 +587,7 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["monitor_state"] = job["monitor_state"]
     if job.get("no_agent"):
         result["no_agent"] = True
-    if job.get("enabled_toolsets"):
+    if job.get("enabled_toolsets") is not None:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
@@ -1131,7 +1131,9 @@ def cronjob(
                     base_url=_normalize_optional_job_value(base_url, strip_trailing_slash=True),
                     script=_normalize_optional_job_value(script),
                     context_from=context_from,
-                    enabled_toolsets=enabled_toolsets or None,
+                    enabled_toolsets=(
+                        enabled_toolsets if enabled_toolsets is not None else None
+                    ),
                     workdir=_normalize_optional_job_value(workdir),
                     no_agent=_no_agent,
                     attach_to_session=attach_to_session,
@@ -1389,7 +1391,7 @@ def cronjob(
                             )
                 updates["context_from"] = refs or None
             if enabled_toolsets is not None:
-                updates["enabled_toolsets"] = enabled_toolsets or None
+                updates["enabled_toolsets"] = enabled_toolsets
             if attach_to_session is not None:
                 updates["attach_to_session"] = bool(attach_to_session)
             if workdir is not None:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4164,6 +4164,25 @@ def _load_enabled_toolsets(platform: str | None = None) -> list[str] | None:
     cfg = None
     fallback_notice = None
 
+    # Load the supported per-platform selection before coding posture or
+    # client-surface defaults.  ``platform_toolsets.cli: []`` is an explicit
+    # deny-all policy and must survive as [] all the way into AIAgent; returning
+    # None here would mean "all/default tools" and re-open the entire surface.
+    if not explicit:
+        try:
+            from hermes_cli.config import load_config
+
+            cfg = load_config()
+            platform_toolsets = cfg.get("platform_toolsets")
+            if (
+                isinstance(platform_toolsets, dict)
+                and isinstance(platform_toolsets.get("cli"), list)
+                and not platform_toolsets["cli"]
+            ):
+                return []
+        except Exception:
+            cfg = None
+
     # Coding posture (base Hermes): with no explicit pin, collapse to the
     # coding toolset (+ enabled MCP servers) when sitting in a code workspace.
     # The desktop app and `hermes --tui` both land here. See
@@ -4279,6 +4298,16 @@ def _load_enabled_toolsets(platform: str | None = None) -> list[str] | None:
         from hermes_cli.tools_config import _get_platform_tools
 
         cfg = cfg if cfg is not None else load_config()
+
+        platform_toolsets = cfg.get("platform_toolsets")
+        if (
+            isinstance(platform_toolsets, dict)
+            and isinstance(platform_toolsets.get("cli"), list)
+            and not platform_toolsets["cli"]
+        ):
+            if fallback_notice is not None:
+                print(fallback_notice, file=sys.stderr, flush=True)
+            return []
 
         # Runtime toolset resolution must include default MCP servers so the
         # agent can actually call them. Passing ``False`` here is the
@@ -6048,6 +6077,7 @@ def _agent_fallback_model(agent):
 
 def _background_agent_kwargs(agent, task_id: str) -> dict:
     cfg = _load_cfg()
+    enabled_toolsets = getattr(agent, "enabled_toolsets", None)
 
     return {
         "base_url": getattr(agent, "base_url", None) or None,
@@ -6058,12 +6088,13 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
         "acp_args": getattr(agent, "acp_args", None) or None,
         "model": getattr(agent, "model", None) or _resolve_model(),
         "max_iterations": _cfg_max_turns(cfg, 25),
-        "enabled_toolsets": getattr(agent, "enabled_toolsets", None)
+        "enabled_toolsets": enabled_toolsets
         # Detached background tasks declare platform="tui" below: they have no
         # UI session id, so a renderer-routed event has nowhere to land. Resolve
         # their toolsets against that same platform rather than the gateway
         # process's, so they never carry GUI schema they cannot use.
-        or _load_enabled_toolsets("tui"),
+        if enabled_toolsets is not None
+        else _load_enabled_toolsets("tui"),
         "quiet_mode": True,
         "verbose_logging": False,
         "ephemeral_system_prompt": getattr(agent, "ephemeral_system_prompt", None)


### PR DESCRIPTION
## What changed

- preserve `platform_toolsets.cli: []` as an explicit deny-all selection through CLI, Desktop/Gateway, agent construction, background agents, cron jobs, and blueprints
- prevent kanban defaults, plugin/default toolsets, MCP refresh, context tools, and deferred Tool Search from widening an explicit empty selection
- omit OpenAI-Codex `tools`, `tool_choice`, and `parallel_tool_calls` fields when the effective tool selection is empty
- harden two existing gateway tests so their daemon agent-build thread cannot leak a late `session.info` frame into the concurrent JSON writer test

## Root cause

Several call sites used truthiness (`value or None`, `if value`, or `value or defaults`) for toolset selection. That collapsed explicit `[]` into the legacy `None` sentinel, which means use defaults/all tools. Gateway and cron paths could therefore widen a deliberate empty selection through platform defaults, Desktop/project injection, plugins, MCP, background agents, or persisted jobs.

## Validation

- full relevant regression suite, retries disabled: 109 files, 1,884 passed, 0 failed
- focused race stress: 30/30 repetitions passed after teardown synchronization
- canonical two-worker concurrency pair: 764 passed, 0 failed
- Ruff, Python byte compilation, and `git diff --check`: passed
- captured OpenAI-Codex request keys: `extra_headers`, `include`, `input`, `instructions`, `model`, `prompt_cache_key`, `reasoning`, `store`, `timeout`; forbidden fields present: none

## Operational boundary

This PR does not modify or deploy the live Legal Assistant service or configuration. Deployment remains blocked pending exact-head CI and separate persistent-service Remote Gateway transport proof.
