### PR TITLE
fix(gateway): let a process reacquire the scoped lock it already holds

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -1391,7 +1391,15 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
         except (KeyError, TypeError, ValueError):
             existing_pid = None
 
-        if existing_pid == os.getpid() and existing.get("start_time") == record.get("start_time"):
+        # Self-reacquisition: the record names THIS pid, so it is ours to
+        # refresh. Deliberately not conjoined with a start_time match. That
+        # guard exists to catch pid reuse by a *different* process, which
+        # cannot apply to a live process's own pid. Requiring it meant that
+        # whenever the two writes disagreed about start_time (None on macOS /
+        # Windows, where there is no /proc and psutil may fail), a gateway
+        # reacquiring its own lock after a reconnect fell through to the
+        # staleness path and reported itself as a foreign squatter.
+        if existing_pid == os.getpid():
             _write_json_file(lock_path, record)
             return True, existing
 

--- a/tests/gateway/test_scoped_lock_self_reacquire.py
+++ b/tests/gateway/test_scoped_lock_self_reacquire.py
@@ -1,0 +1,128 @@
+"""A process must be able to reacquire a scoped lock it already owns.
+
+``acquire_scoped_lock`` gated self-reacquisition on ``pid`` AND ``start_time``
+both matching. ``start_time`` is ``None`` whenever the platform cannot report
+it (macOS and Windows have no ``/proc``, and psutil can fail), so the two
+writes can disagree. When they did, a gateway reacquiring its own lock after a
+reconnect fell through to the staleness path and reported its own live pid as
+a foreign holder of its own token.
+
+The ``start_time`` guard exists to catch pid reuse by a *different* process.
+That cannot happen for a live process's own pid, so it never belonged in the
+self-ownership test.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from gateway import status as gw_status
+
+
+@pytest.fixture(autouse=True)
+def _isolated_lock_dir(tmp_path, monkeypatch):
+    """Never touch the machine-global lock dir from a test."""
+    monkeypatch.setattr(gw_status, "_get_lock_dir", lambda: tmp_path)
+    return tmp_path
+
+
+def _lock_path(lock_dir, scope):
+    existing = list(lock_dir.glob("*"))
+    assert existing, "expected the acquire call to have written a lock file"
+    return existing[0]
+
+
+def _rewrite(path, **changes):
+    record = json.loads(path.read_text(encoding="utf-8"))
+    record.update(changes)
+    path.write_text(json.dumps(record), encoding="utf-8")
+    return record
+
+
+def _as_live_gateway(monkeypatch, *, start_time):
+    """Make this process look to the lock code like a real running gateway.
+
+    Production gateways satisfy ``_looks_like_gateway_process``; a pytest
+    process does not, which is why an unpatched run would otherwise mark its
+    own record stale and take the lock through the staleness path instead of
+    failing the way the report describes.
+    """
+    monkeypatch.setattr(gw_status, "_pid_exists", lambda pid: True)
+    monkeypatch.setattr(gw_status, "_looks_like_gateway_process", lambda pid: True)
+    monkeypatch.setattr(gw_status, "_get_process_start_time", lambda pid: start_time)
+
+
+def test_reacquires_when_the_stored_start_time_is_null(_isolated_lock_dir, monkeypatch):
+    """The reported shape: our stored record has start_time=None.
+
+    The platform can now report a start_time, so the two disagree and the
+    conjoined self-ownership test fails on a lock this very process holds.
+    """
+    gw_status.acquire_scoped_lock("discord-bot-token", "tok-1")
+    path = _lock_path(_isolated_lock_dir, "discord-bot-token")
+    _rewrite(path, start_time=None)
+    _as_live_gateway(monkeypatch, start_time=123.0)
+
+    ok, existing = gw_status.acquire_scoped_lock("discord-bot-token", "tok-1")
+
+    assert ok is True, (
+        "the gateway could not reacquire its own lock; it reported its own live "
+        f"pid ({os.getpid()}) as a foreign holder of its own token"
+    )
+
+
+def test_reacquires_when_the_platform_cannot_report_start_time(
+    _isolated_lock_dir, monkeypatch
+):
+    """The mirror case: the stored value exists, the live probe returns None."""
+    gw_status.acquire_scoped_lock("discord-bot-token", "tok-1")
+    path = _lock_path(_isolated_lock_dir, "discord-bot-token")
+    _rewrite(path, start_time=1.0)
+    _as_live_gateway(monkeypatch, start_time=None)
+
+    ok, _ = gw_status.acquire_scoped_lock("discord-bot-token", "tok-1")
+
+    assert ok is True
+
+
+def test_plain_reacquire_still_works(_isolated_lock_dir):
+    """Guard: the untouched happy path is unchanged."""
+    assert gw_status.acquire_scoped_lock("discord-bot-token", "tok-1")[0] is True
+    assert gw_status.acquire_scoped_lock("discord-bot-token", "tok-1")[0] is True
+
+
+def test_reacquire_refreshes_the_record_on_disk(_isolated_lock_dir):
+    """Self-reacquisition must rewrite the record, not just report success."""
+    gw_status.acquire_scoped_lock("discord-bot-token", "tok-1")
+    path = _lock_path(_isolated_lock_dir, "discord-bot-token")
+    # The lock file is keyed by scope+identity, so the reacquire must reuse
+    # the same identity to land on the same file.
+    _rewrite(path, start_time=None, scope="bogus-scope")
+
+    gw_status.acquire_scoped_lock("discord-bot-token", "tok-1")
+
+    written = json.loads(path.read_text(encoding="utf-8"))
+    assert written["pid"] == os.getpid()
+    assert written["scope"] == "discord-bot-token", "the stale record was not refreshed"
+
+
+def test_a_live_foreign_gateway_still_holds_its_lock(_isolated_lock_dir, monkeypatch):
+    """Guard: this must not turn into 'always steal the lock'.
+
+    A record naming a different, live, gateway-looking pid stays held.
+    """
+    gw_status.acquire_scoped_lock("discord-bot-token", "tok-1")
+    path = _lock_path(_isolated_lock_dir, "discord-bot-token")
+    foreign_pid = os.getpid() + 1
+    _rewrite(path, pid=foreign_pid, start_time=None)
+
+    monkeypatch.setattr(gw_status, "_pid_exists", lambda pid: True)
+    monkeypatch.setattr(gw_status, "_looks_like_gateway_process", lambda pid: True)
+
+    ok, existing = gw_status.acquire_scoped_lock("discord-bot-token", "tok-1")
+
+    assert ok is False, "a live foreign gateway's lock must not be taken"
+    assert existing is not None and existing.get("pid") == foreign_pid


### PR DESCRIPTION
## What does this PR do?

After a Discord 503 burst forces a reconnect, the gateway cannot reacquire the scoped lock it is already holding. It reports its own live pid as a foreign holder of its own bot token, and the platform stays down.

The self-ownership test conjoins two conditions:

```python
if existing_pid == os.getpid() and existing.get("start_time") == record.get("start_time"):
    _write_json_file(lock_path, record)
    return True, existing
```

`start_time` comes from `_get_process_start_time()`, which returns `None` whenever the platform cannot report it. macOS and Windows have no `/proc`, and psutil can fail. So the value stored when the lock was first written and the value computed on reacquisition can disagree, most commonly `None` on one side and a real timestamp on the other.

When they disagree the self-ownership branch is skipped and control falls into the staleness check, which is written to reason about *other* processes. It finds the pid alive, finds it looks like a gateway (it is: it is us), concludes "not stale", and refuses the acquisition.

### Why the guard does not belong here

`start_time` disambiguates pid reuse: a recycled pid can name a different process than the one that wrote the record. That cannot happen for a live process's own pid. If `existing_pid == os.getpid()`, the record names this very process.

The degenerate reading gives the same answer: if the record is a leftover from a dead process that happened to hold this pid, then that process is gone and the lock is free, so acquiring it is still correct. Either way, self-reacquisition is the right outcome, which is why the conjunct is removed rather than replaced with a different comparison.

The staleness path below is untouched, so a lock held by a live foreign gateway is still refused.

## Related Issue

Fixes #81468 (P1, `comp/gateway`, `platform/discord`). Searched open and merged PRs first, per CONTRIBUTING's search-first section:

```
gh search prs --repo NousResearch/hermes-agent "start_time lock"        --limit 25
gh search prs --repo NousResearch/hermes-agent "platform lock"          --limit 25
gh search prs --repo NousResearch/hermes-agent "_acquire_platform_lock" --limit 25
gh search prs --repo NousResearch/hermes-agent "lock in:title"          --limit 25
```

Two closed PRs touched the null-`start_time` case from the opposite direction: #16966 and #23953 both proposed treating a null-`start_time` record as *stale* so a different process could take it. This PR is about the holder recognising itself, and it does not change staleness for foreign records at all. #40204 (open) is adjacent but concerns when the identity is written relative to acquisition, not the ownership comparison.

## Type of Change

Bug fix (non-breaking). One conjunct removed from a self-ownership test; no change to the staleness rules, the lock file format, or the acquisition contract.

## Changes Made

- `gateway/status.py` - `acquire_scoped_lock` treats a record naming the current pid as self-owned, with a comment recording why the `start_time` conjunct cannot apply to one's own pid.
- `tests/gateway/test_scoped_lock_self_reacquire.py` - new, 5 tests.

## How to Test

```
pytest tests/gateway/test_scoped_lock_self_reacquire.py -q
```

5 passed.

Reverting only `gateway/status.py` and rerunning:

```
FAILED test_reacquires_when_the_stored_start_time_is_null
FAILED test_reacquires_when_the_platform_cannot_report_start_time
2 failed, 3 passed
```

with the reported symptom:

```
E  AssertionError: the gateway could not reacquire its own lock; it reported its
E                  own live pid (42890) as a foreign holder of its own token
E  assert False is True
```

Reproducing this needed two conditions, and it is worth naming them because a naive test passes on unpatched code. The stored and live `start_time` must actually disagree, and the process must satisfy `_looks_like_gateway_process`. A pytest process does not look like a gateway, so without that second condition an unpatched run marks its own record stale and takes the lock through the staleness path, returning the same `True` for the wrong reason. `_as_live_gateway()` sets both.

Three tests pass before and after by design, and are guards rather than probes: an ordinary repeat acquisition still works, self-reacquisition still refreshes the record on disk rather than only reporting success, and, most importantly, a live foreign gateway still keeps its lock. That last one is what stops this change from degrading into "always take the lock".

Full `tests/gateway/` suite, this branch vs `main`, same environment, run serially:

```
main:   7 failed, 4983 passed, 30 skipped, 1 xfailed
branch: 7 failed, 4988 passed, 30 skipped, 1 xfailed
```

Comparing the failing sets rather than the counts: **zero regressions**, the two sets are identical. The +5 is this PR's new tests. Those 7 are pre-existing in a non-hermetic single-process run; CI's per-file isolation via `run_tests_parallel.py` is the supported path.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(gateway): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (queries above)
- [x] My PR contains only changes related to this fix
- [x] I've run the affected suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation; the branch carries a comment explaining why pid reuse cannot apply to one's own pid
- [x] `cli-config.yaml.example` is N/A, no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` are N/A
- [x] Cross-platform impact: this is the fix for a platform difference. macOS and Windows lack `/proc`, which is where the two `start_time` values diverge; the tests drive both directions of the mismatch rather than depending on the host
- [x] Tool descriptions/schemas are N/A

## Notes for the reviewer

The report is a Discord 503 reconnect on macOS with four launchd profiles, but nothing here is Discord-specific or macOS-specific. Any scoped-lock holder that reacquires after the two `start_time` reads diverge hits the same branch, and the fix is in the shared `acquire_scoped_lock`.

I removed the conjunct rather than making `start_time` comparison tolerant of `None` on one side. Tolerating `None` would still leave the case where both sides report a value and they differ for an unrelated reason, and it would keep implying that a process needs to prove its identity against its own pid. If you would rather keep an explicit `start_time` check with a `None`-tolerant comparison, I will follow that shape instead.
