### PR TITLE
fix(tui_gateway): profile-scope the projects.* RPC surface

### DIFF
--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -379,6 +379,18 @@ export async function followActiveSessionCwd(cwd: string): Promise<void> {
   }
 }
 
+// Projects are per-profile (each profile owns a projects.db), and in app-global
+// remote mode ONE backend serves every profile — so, exactly like session.*,
+// every projects RPC must carry the profile the sidebar is showing or the
+// backend answers from its launch profile. Omitted for 'default' (the backend
+// treats a missing profile as its launch profile). Callers race-guard against
+// profile switches, so tagging with the active profile at send time is correct.
+function activeProfileParam(): { profile?: string } {
+  const profile = $activeGatewayProfile.get() || 'default'
+
+  return profile !== 'default' ? { profile } : {}
+}
+
 // Issue a request on whichever gateway is currently active, reconnecting once
 // if the socket dropped. Projects are per-profile, so they intentionally follow
 // the active gateway just like the session list does.
@@ -393,7 +405,7 @@ async function gatewayRequest<T>(method: string, params: Record<string, unknown>
     throw new Error('Hermes gateway is not connected')
   }
 
-  return gateway.request<T>(method, params)
+  return gateway.request<T>(method, { ...activeProfileParam(), ...params })
 }
 
 async function gatewayRequestOn<T>(
@@ -401,7 +413,7 @@ async function gatewayRequestOn<T>(
   method: string,
   params: Record<string, unknown> = {}
 ): Promise<T> {
-  return gateway.request<T>(method, params)
+  return gateway.request<T>(method, { ...activeProfileParam(), ...params })
 }
 
 interface ActiveProjectsContext {

--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -17,31 +17,33 @@ _profile_scoped = _registry.profile_scoped
 
 
 @method("projects.discover_repos")
+@_profile_scoped
 def _(rid, params: dict) -> dict:
     """Repos for the desktop overview: scanned-from-disk (cached) ∪ session-derived."""
     try:
-        db = _get_db()
-        if db is None:
-            return _ok(rid, {"repos": []})
         from hermes_cli import projects_db as pdb
 
         policy = _repo_discovery_policy()
         policy_key = _repo_discovery_policy_key(policy)
-        with pdb.connect_closing() as conn:
-            pdb.reconcile_discovered_repos_policy(
-                conn,
-                policy_key,
-                preserve_unversioned=_repo_discovery_policy_is_default(policy),
-            )
-            repos = _discover_repos_payload(
-                db, conn=conn, include_cached=policy["enabled"]
-            )
+        with _profile_db(params) as db:
+            if db is None:
+                return _ok(rid, {"repos": []})
+            with pdb.connect_closing() as conn:
+                pdb.reconcile_discovered_repos_policy(
+                    conn,
+                    policy_key,
+                    preserve_unversioned=_repo_discovery_policy_is_default(policy),
+                )
+                repos = _discover_repos_payload(
+                    db, conn=conn, include_cached=policy["enabled"]
+                )
         return _ok(rid, {"repos": repos, "discovery_policy": policy})
     except Exception as e:
         return _err(rid, 5061, str(e))
 
 
 @method("projects.record_repos")
+@_profile_scoped
 def _(rid, params: dict) -> dict:
     """Persist git repo roots found by the client's filesystem scan, then return
     the merged repo list. The native crawl runs on the desktop (local fs); this
@@ -88,15 +90,16 @@ def _(rid, params: dict) -> dict:
             elif not policy["enabled"]:
                 pdb.clear_discovered_repos(conn, policy_key=policy_key)
 
-        db = _get_db()
+        with _profile_db(params) as db:
+            repos_payload = (
+                _discover_repos_payload(db, include_cached=policy["enabled"])
+                if db is not None
+                else []
+            )
         return _ok(
             rid,
             {
-                "repos": _discover_repos_payload(
-                    db, include_cached=policy["enabled"]
-                )
-                if db is not None
-                else [],
+                "repos": repos_payload,
                 "accepted": accepted,
                 "discovery_policy": policy,
             },
@@ -106,6 +109,7 @@ def _(rid, params: dict) -> dict:
 
 
 @method("projects.tree")
+@_profile_scoped
 def _(rid, params: dict) -> dict:
     """Authoritative project overview: project -> repo -> lane structure with
     counts + a few preview sessions per project, plus the flat set of session
@@ -113,17 +117,17 @@ def _(rid, params: dict) -> dict:
     Lanes carry no session rows here; drill-in uses ``projects.project_sessions``.
     """
     try:
-        db = _get_db()
-        if db is None:
-            return _ok(rid, {"projects": [], "active_id": None, "scoped_session_ids": []})
+        with _profile_db(params) as db:
+            if db is None:
+                return _ok(rid, {"projects": [], "active_id": None, "scoped_session_ids": []})
 
-        tree, active_id = _build_project_tree(
-            db,
-            preview_limit=int(params.get("preview_limit") or 3),
-            hydrate=False,
-            session_limit=int(params.get("session_limit") or 2000),
-            include_discovered=True,
-        )
+            tree, active_id = _build_project_tree(
+                db,
+                preview_limit=int(params.get("preview_limit") or 3),
+                hydrate=False,
+                session_limit=int(params.get("session_limit") or 2000),
+                include_discovered=True,
+            )
         return _ok(
             rid,
             {"projects": tree["projects"], "active_id": active_id, "scoped_session_ids": tree["scoped_session_ids"]},
@@ -133,6 +137,7 @@ def _(rid, params: dict) -> dict:
 
 
 @method("projects.project_sessions")
+@_profile_scoped
 def _(rid, params: dict) -> dict:
     """Fully hydrated lanes (repo -> lane -> session rows) for one project,
     built from the same authoritative grouping as ``projects.tree`` so ids and
@@ -142,16 +147,16 @@ def _(rid, params: dict) -> dict:
         if not project_id:
             return _err(rid, 5063, "project_id required")
 
-        db = _get_db()
-        if db is None:
-            return _ok(rid, {"project": None})
+        with _profile_db(params) as db:
+            if db is None:
+                return _ok(rid, {"project": None})
 
-        # Drill-in only needs the entered project (which has sessions), so skip
-        # the zero-session discovery tier entirely.
-        tree, _active = _build_project_tree(
-            db, preview_limit=0, hydrate=True, session_limit=int(params.get("session_limit") or 5000),
-            include_discovered=False,
-        )
+            # Drill-in only needs the entered project (which has sessions), so
+            # skip the zero-session discovery tier entirely.
+            tree, _active = _build_project_tree(
+                db, preview_limit=0, hydrate=True, session_limit=int(params.get("session_limit") or 5000),
+                include_discovered=False,
+            )
         proj = next((p for p in tree["projects"] if p["id"] == project_id), None)
         return _ok(rid, {"project": proj})
     except Exception as e:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11348,7 +11348,11 @@ def _projects_method(name: str):
     """
 
     def decorator(fn):
+        # Profile-scoped like session.*: in app-global remote mode the desktop
+        # sends ``profile`` so the ContextVar override makes connect_closing()
+        # resolve THAT profile's projects.db instead of the launch profile's.
         @method(name)
+        @_profile_scoped
         def handler(rid, params: dict) -> dict:
             try:
                 from hermes_cli import projects_db as pdb


### PR DESCRIPTION
### Problem

In the desktop's app-global remote mode, one backend serves every local
profile. `session.*` RPCs handle this: the desktop sends a `profile` param
and the handlers rebind `HERMES_HOME` (ContextVar) plus open that profile's
`state.db` for the duration of the call.

The `projects.*` surface never got the same treatment, on either end:

- Backend: `projects.tree` / `projects.project_sessions` /
  `projects.discover_repos` / `projects.record_repos` read sessions from the
  module-global launch-profile `_get_db()` handle, and the `_projects_method`
  CRUD family resolves `projects.db` via `connect_closing()` without any
  profile binding — so both always hit the **launch** profile's databases.
- Renderer: the projects store sends no `profile` field on any projects
  request (`apps/desktop/src/store/projects.ts`), even though the file's own
  comment says "Projects are per-profile, so they intentionally follow the
  active gateway just like the session list does."

**Repro**: create a second profile, add a project to it, switch the desktop
to that profile. The session lanes rescope correctly; the projects sidebar
still shows the launch profile's tree, and the second profile's projects are
unreachable from the UI.

### Fix

Mirrors the existing `session.*` pattern exactly:

- The four tree/discovery handlers in `tui_gateway/methods_config.py` take
  `@_profile_scoped` and read sessions via `with _profile_db(params) as db:`
  instead of `_get_db()`.
- `_projects_method` in `tui_gateway/server.py` applies `@_profile_scoped`
  once for the whole CRUD family — `projects_db_path()` already resolves
  through `get_hermes_home()`, so the ContextVar rebind is sufficient there.
- The renderer's projects store merges the active gateway profile into every
  projects request (`activeProfileParam()` in both request helpers). The
  param is omitted for `default`, so single-profile installs send
  byte-identical requests and the backend path for them is unchanged. Callers
  already race-guard profile switches (generation counter + active-gateway
  check), so tagging with the active profile at send time is safe.

### Compatibility

- Single-profile installs: no behavior change (no `profile` sent; backend
  treats a missing param as the launch profile, as before).
- Old renderer + new backend, or new renderer + old backend: degrade to
  today's behavior (launch-profile tree) rather than erroring.

### Testing

- Manually verified on a macOS install with two profiles served by one
  remote-mode backend: the projects sidebar now switches with the profile
  rail (each profile shows its own `projects.db` tree + session grouping);
  the launch profile's view is unchanged.
- `python -m py_compile` on both backend files against this branch;
  desktop `npm run build` + packaged app verified interactively.
