### PR TITLE
fix(gateway): fall back when native update prompt delivery fails

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21206,6 +21206,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             from tools.ansi_strip import strip_ansi
             return strip_ansi(text)
 
+        def _format_adapter_error(error: object) -> str:
+            """Keep adapter errors safe and bounded in watcher logs."""
+            text = str(error or "").replace("\r", " ").replace("\n", " ").strip()
+            return text[:300] or "unknown error"
+
         bytes_sent = 0
         last_stream_time = loop.time()
         buffer = ""
@@ -21328,22 +21333,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 # but an explicit SendResult failure must use the text fallback.
                                 native_send_succeeded = (
                                     result is None
-                                    or getattr(result, "success", True)
+                                    or getattr(result, "success", True) is not False
                                 )
                                 if not native_send_succeeded:
                                     logger.warning(
                                         "Native update prompt send reported failure for %s; "
                                         "falling back to text: %s",
                                         session_key,
-                                        getattr(result, "error", None) or "unknown error",
+                                        _format_adapter_error(getattr(result, "error", None)),
                                     )
                                 sent_buttons = native_send_succeeded
                             except Exception as btn_err:
-                                logger.debug("Button-based update prompt failed: %s", btn_err)
+                                logger.debug(
+                                    "Button-based update prompt failed: %s",
+                                    _format_adapter_error(btn_err),
+                                )
+                        prompt_delivered = sent_buttons
                         if not sent_buttons:
                             default_hint = f" (default: {default})" if default else ""
                             _p = getattr(adapter, "typed_command_prefix", "/")
-                            await adapter.send(
+                            fallback_result = await adapter.send(
                                 chat_id,
                                 f"⚕ **Update needs your input:**\n\n"
                                 f"{prompt_text}{default_hint}\n\n"
@@ -21351,6 +21360,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 f"or type your answer directly.",
                                 metadata=_non_conversational_metadata(metadata, platform=platform),
                             )
+                            prompt_delivered = (
+                                fallback_result is None
+                                or getattr(fallback_result, "success", True) is not False
+                            )
+                            if not prompt_delivered:
+                                logger.warning(
+                                    "Text update prompt send reported failure for %s: %s",
+                                    session_key,
+                                    _format_adapter_error(
+                                        getattr(fallback_result, "error", None)
+                                    ),
+                                )
                         # Keep the prompt marker on disk until the user
                         # answers. If the gateway restarts mid-prompt, the
                         # next watcher can recover by re-forwarding it from
@@ -21360,7 +21381,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             session_key
                         ).persistent.update_prompt_pending = True
                         # .update_response to continue — it doesn't re-check
-                        logger.info("Forwarded update prompt to %s: %s", session_key, prompt_text[:80])
+                        if prompt_delivered:
+                            logger.info(
+                                "Forwarded update prompt to %s: %s",
+                                session_key,
+                                prompt_text[:80],
+                            )
                 except (json.JSONDecodeError, OSError) as e:
                     logger.debug("Failed to read update prompt: %s", e)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21313,18 +21313,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         # Flush any buffered output first so the user sees
                         # context before the prompt
                         await _flush_buffer()
-                        # Try platform-native buttons first (Discord, Telegram)
+                        # Try platform-native prompt controls first.
                         sent_buttons = False
                         if getattr(type(adapter), "send_update_prompt", None) is not None:
                             try:
-                                await adapter.send_update_prompt(
+                                result = await adapter.send_update_prompt(
                                     chat_id=chat_id,
                                     prompt=prompt_text,
                                     default=default,
                                     session_key=session_key,
                                     metadata=_non_conversational_metadata(metadata, platform=platform),
                                 )
-                                sent_buttons = True
+                                # Native hooks may return None for a successful send,
+                                # but an explicit SendResult failure must use the text fallback.
+                                native_send_succeeded = (
+                                    result is None
+                                    or getattr(result, "success", True)
+                                )
+                                if not native_send_succeeded:
+                                    logger.warning(
+                                        "Native update prompt send reported failure for %s; "
+                                        "falling back to text: %s",
+                                        session_key,
+                                        getattr(result, "error", None) or "unknown error",
+                                    )
+                                sent_buttons = native_send_succeeded
                             except Exception as btn_err:
                                 logger.debug("Button-based update prompt failed: %s", btn_err)
                         if not sent_buttons:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21206,10 +21206,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             from tools.ansi_strip import strip_ansi
             return strip_ansi(text)
 
+        def _format_watcher_log_value(
+            value: object,
+            *,
+            max_length: int = 300,
+            fallback: str = "unknown",
+        ) -> str:
+            """Keep untrusted watcher values single-line, safe, and bounded."""
+            text = _strip_ansi(str(value or ""))
+            text = re.sub(r"[\x00-\x1f\x7f-\x9f]", " ", text).strip()
+            return text[:max_length] or fallback
+
         def _format_adapter_error(error: object) -> str:
             """Keep adapter errors safe and bounded in watcher logs."""
-            text = str(error or "").replace("\r", " ").replace("\n", " ").strip()
-            return text[:300] or "unknown error"
+            return _format_watcher_log_value(error, fallback="unknown error")
 
         bytes_sent = 0
         last_stream_time = loop.time()
@@ -21339,7 +21349,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                     logger.warning(
                                         "Native update prompt send reported failure for %s; "
                                         "falling back to text: %s",
-                                        session_key,
+                                        _format_watcher_log_value(session_key),
                                         _format_adapter_error(getattr(result, "error", None)),
                                     )
                                 sent_buttons = native_send_succeeded
@@ -21352,26 +21362,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         if not sent_buttons:
                             default_hint = f" (default: {default})" if default else ""
                             _p = getattr(adapter, "typed_command_prefix", "/")
-                            fallback_result = await adapter.send(
-                                chat_id,
-                                f"⚕ **Update needs your input:**\n\n"
-                                f"{prompt_text}{default_hint}\n\n"
-                                f"Reply `{_p}approve` (yes) or `{_p}deny` (no), "
-                                f"or type your answer directly.",
-                                metadata=_non_conversational_metadata(metadata, platform=platform),
-                            )
-                            prompt_delivered = (
-                                fallback_result is None
-                                or getattr(fallback_result, "success", True) is not False
-                            )
-                            if not prompt_delivered:
-                                logger.warning(
-                                    "Text update prompt send reported failure for %s: %s",
-                                    session_key,
-                                    _format_adapter_error(
-                                        getattr(fallback_result, "error", None)
-                                    ),
+                            try:
+                                fallback_result = await adapter.send(
+                                    chat_id,
+                                    f"⚕ **Update needs your input:**\n\n"
+                                    f"{prompt_text}{default_hint}\n\n"
+                                    f"Reply `{_p}approve` (yes) or `{_p}deny` (no), "
+                                    f"or type your answer directly.",
+                                    metadata=_non_conversational_metadata(metadata, platform=platform),
                                 )
+                            except Exception as fallback_err:
+                                prompt_delivered = False
+                                logger.warning(
+                                    "Text update prompt send failed for %s: %s",
+                                    _format_watcher_log_value(session_key),
+                                    _format_adapter_error(fallback_err),
+                                )
+                            else:
+                                prompt_delivered = (
+                                    fallback_result is None
+                                    or getattr(fallback_result, "success", True) is not False
+                                )
+                                if not prompt_delivered:
+                                    logger.warning(
+                                        "Text update prompt send reported failure for %s: %s",
+                                        _format_watcher_log_value(session_key),
+                                        _format_adapter_error(
+                                            getattr(fallback_result, "error", None)
+                                        ),
+                                    )
                         # Keep the prompt marker on disk until the user
                         # answers. If the gateway restarts mid-prompt, the
                         # next watcher can recover by re-forwarding it from
@@ -21384,8 +21403,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         if prompt_delivered:
                             logger.info(
                                 "Forwarded update prompt to %s: %s",
-                                session_key,
-                                prompt_text[:80],
+                                _format_watcher_log_value(session_key, max_length=120),
+                                _format_watcher_log_value(prompt_text, max_length=80),
                             )
                 except (json.JSONDecodeError, OSError) as e:
                     logger.debug("Failed to read update prompt: %s", e)

--- a/tests/gateway/test_update_streaming.py
+++ b/tests/gateway/test_update_streaming.py
@@ -16,7 +16,7 @@ from unittest.mock import patch, MagicMock, AsyncMock
 import pytest
 
 from gateway.config import Platform
-from gateway.platforms.base import MessageEvent
+from gateway.platforms.base import MessageEvent, SendResult
 from gateway.session import SessionSource
 
 
@@ -250,6 +250,79 @@ class TestWatchUpdateProgress:
         # Check session was marked as having pending prompt
         # (may be cleared by the time we check since update finished)
 
+    @pytest.mark.parametrize(
+        ("native_result", "uses_text_fallback"),
+        [
+            pytest.param(None, False, id="legacy-none"),
+            pytest.param(SendResult(success=True), False, id="success"),
+            pytest.param(
+                SendResult(success=False, error="native delivery failed"),
+                True,
+                id="failure",
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_native_prompt_send_uses_text_fallback_only_on_failure(
+        self, tmp_path, caplog, native_result, uses_text_fallback
+    ):
+        """Only an explicit native SendResult failure uses the text prompt."""
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+
+        pending = {
+            "platform": "telegram",
+            "chat_id": "111",
+            "user_id": "222",
+            "session_key": "agent:main:telegram:dm:111",
+        }
+        (hermes_home / ".update_pending.json").write_text(json.dumps(pending))
+        (hermes_home / ".update_prompt.json").write_text(json.dumps({
+            "prompt": "Restore local changes? [Y/n]",
+            "default": "y",
+        }))
+
+        class NativePromptAdapter:
+            def __init__(self):
+                self.native_prompt_calls = []
+                self.sent = []
+
+            async def send_update_prompt(self, **kwargs):
+                self.native_prompt_calls.append(kwargs)
+                return native_result
+
+            async def send(self, chat_id, content, metadata=None):
+                self.sent.append((chat_id, content, metadata))
+                return SendResult(success=True)
+
+        adapter = NativePromptAdapter()
+        runner.adapters = {Platform.TELEGRAM: adapter}
+
+        async def finish_update():
+            await asyncio.sleep(0.2)
+            (hermes_home / ".update_exit_code").write_text("0")
+
+        with caplog.at_level("DEBUG", logger="gateway.run"):
+            with patch("gateway.run._hermes_home", hermes_home):
+                task = asyncio.create_task(finish_update())
+                await runner._watch_update_progress(
+                    poll_interval=0.05,
+                    stream_interval=0.1,
+                    timeout=10.0,
+                )
+                await task
+
+        assert len(adapter.native_prompt_calls) == 1
+        prompt_sends = [
+            content for _, content, _ in adapter.sent
+            if "Restore local changes" in content
+        ]
+        assert len(prompt_sends) == int(uses_text_fallback)
+        if uses_text_fallback:
+            assert "native delivery failed" in caplog.text
+        else:
+            assert "Native update prompt send reported failure" not in caplog.text
 
     @pytest.mark.asyncio
     async def test_prompt_is_recovered_after_watcher_restart(self, tmp_path):

--- a/tests/gateway/test_update_streaming.py
+++ b/tests/gateway/test_update_streaming.py
@@ -332,6 +332,11 @@ class TestWatchUpdateProgress:
                 "native delivery failed  " + "x" * 276,
                 id="sanitized-and-capped",
             ),
+            pytest.param(
+                "\x1b[31mnative delivery failed\x1b[0m\x00\x07\r\n" + "x" * 400,
+                "native delivery failed    " + "x" * 274,
+                id="ansi-and-c0-controls-removed",
+            ),
             pytest.param(None, "unknown error", id="unknown-error"),
         ],
     )
@@ -441,6 +446,134 @@ class TestWatchUpdateProgress:
                     "text delivery failed" in record.message
                     for record in caplog.records
                 )
+                (hermes_home / ".update_exit_code").write_text("0")
+                await watcher
+
+    @pytest.mark.asyncio
+    async def test_text_prompt_exception_warns_without_false_forward_log_and_keeps_pending(
+        self, tmp_path, caplog
+    ):
+        """A text fallback exception cannot kill the watcher or claim delivery."""
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        session_key = "agent:main:telegram:dm:111"
+        (hermes_home / ".update_pending.json").write_text(json.dumps({
+            "platform": "telegram",
+            "chat_id": "111",
+            "user_id": "222",
+            "session_key": session_key,
+        }))
+        (hermes_home / ".update_prompt.json").write_text(json.dumps({
+            "prompt": "Restore local changes? [Y/n]",
+            "default": "y",
+        }))
+
+        prompt_attempted = asyncio.Event()
+        fallback_error = "\x1b[31mtext transport failed\x1b[0m\x00\r\n" + "x" * 400
+
+        class TextFallbackExceptionAdapter:
+            async def send_update_prompt(self, **kwargs):
+                return SendResult(success=False, error="native delivery failed")
+
+            async def send(self, chat_id, content, metadata=None):
+                if "Update needs your input" in content:
+                    prompt_attempted.set()
+                    raise RuntimeError(fallback_error)
+                return SendResult(success=True)
+
+        runner.adapters = {Platform.TELEGRAM: TextFallbackExceptionAdapter()}
+
+        with caplog.at_level("DEBUG", logger="gateway.run"):
+            with patch("gateway.run._hermes_home", hermes_home):
+                watcher = asyncio.create_task(runner._watch_update_progress(
+                    poll_interval=0.05,
+                    stream_interval=0.1,
+                    timeout=10.0,
+                ))
+                await asyncio.wait_for(prompt_attempted.wait(), timeout=2.0)
+
+                state = runner._peek_session_state(session_key)
+                assert state is not None
+                assert state.persistent.update_prompt_pending is True
+
+                failure_records = [
+                    record.message
+                    for record in caplog.records
+                    if "Text update prompt send failed" in record.message
+                ]
+                assert len(failure_records) == 1
+                failure = failure_records[0]
+                assert "text transport failed" in failure
+                assert "\x1b" not in failure
+                assert not any(
+                    0 <= ord(char) < 0x20 or 0x7F <= ord(char) <= 0x9F
+                    for char in failure
+                )
+                assert len(failure.rsplit(": ", 1)[-1]) <= 300
+                assert not any(
+                    "Forwarded update prompt" in record.message
+                    for record in caplog.records
+                )
+
+                (hermes_home / ".update_exit_code").write_text("0")
+                await watcher
+
+    @pytest.mark.asyncio
+    async def test_forwarded_prompt_log_sanitizes_bounded_values(self, tmp_path, caplog):
+        """Forwarded-prompt logs keep hostile session and prompt values safe."""
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        session_key = "agent:main:telegram:dm:\x1b[31m" + "s" * 200 + "\n"
+        prompt_text = "\x1b]0;spoofed title\x07Restore\x00\n" + "p" * 200
+        (hermes_home / ".update_pending.json").write_text(json.dumps({
+            "platform": "telegram",
+            "chat_id": "111",
+            "user_id": "222",
+            "session_key": session_key,
+        }))
+        (hermes_home / ".update_prompt.json").write_text(json.dumps({
+            "prompt": prompt_text,
+            "default": "y",
+        }))
+
+        prompt_forwarded = asyncio.Event()
+
+        class PromptLoggingAdapter:
+            async def send(self, chat_id, content, metadata=None):
+                if "Update needs your input" in content:
+                    prompt_forwarded.set()
+                return SendResult(success=True)
+
+        runner.adapters = {Platform.TELEGRAM: PromptLoggingAdapter()}
+
+        with caplog.at_level("INFO", logger="gateway.run"):
+            with patch("gateway.run._hermes_home", hermes_home):
+                watcher = asyncio.create_task(runner._watch_update_progress(
+                    poll_interval=0.05,
+                    stream_interval=0.1,
+                    timeout=10.0,
+                ))
+                await asyncio.wait_for(prompt_forwarded.wait(), timeout=2.0)
+
+                forwarded_records = [
+                    record.message
+                    for record in caplog.records
+                    if "Forwarded update prompt" in record.message
+                ]
+                assert len(forwarded_records) == 1
+                forwarded = forwarded_records[0]
+                assert "Restore" in forwarded
+                assert "\x1b" not in forwarded
+                assert not any(
+                    0 <= ord(char) < 0x20 or 0x7F <= ord(char) <= 0x9F
+                    for char in forwarded
+                )
+                assert len(forwarded) < 350
+                assert "s" * 150 not in forwarded
+                assert "p" * 100 not in forwarded
+
                 (hermes_home / ".update_exit_code").write_text("0")
                 await watcher
 

--- a/tests/gateway/test_update_streaming.py
+++ b/tests/gateway/test_update_streaming.py
@@ -324,6 +324,182 @@ class TestWatchUpdateProgress:
         else:
             assert "Native update prompt send reported failure" not in caplog.text
 
+    @pytest.mark.parametrize(
+        ("native_error", "expected_error"),
+        [
+            pytest.param(
+                " \r\nnative delivery failed\r\n" + "x" * 400 + " \n",
+                "native delivery failed  " + "x" * 276,
+                id="sanitized-and-capped",
+            ),
+            pytest.param(None, "unknown error", id="unknown-error"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_native_prompt_failure_logs_safe_error_text(
+        self, tmp_path, caplog, native_error, expected_error
+    ):
+        """Native prompt failures log a bounded, single-line error."""
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        session_key = "agent:main:telegram:dm:111"
+        (hermes_home / ".update_pending.json").write_text(json.dumps({
+            "platform": "telegram",
+            "chat_id": "111",
+            "user_id": "222",
+            "session_key": session_key,
+        }))
+        (hermes_home / ".update_prompt.json").write_text(json.dumps({
+            "prompt": "Restore local changes? [Y/n]",
+            "default": "y",
+        }))
+
+        prompt_sent = asyncio.Event()
+
+        class NativePromptAdapter:
+            async def send_update_prompt(self, **kwargs):
+                return SendResult(success=False, error=native_error)
+
+            async def send(self, chat_id, content, metadata=None):
+                if "Update needs your input" in content:
+                    prompt_sent.set()
+                return SendResult(success=True)
+
+        runner.adapters = {Platform.TELEGRAM: NativePromptAdapter()}
+
+        with caplog.at_level("DEBUG", logger="gateway.run"):
+            with patch("gateway.run._hermes_home", hermes_home):
+                watcher = asyncio.create_task(runner._watch_update_progress(
+                    poll_interval=0.05,
+                    stream_interval=0.1,
+                    timeout=10.0,
+                ))
+                await asyncio.wait_for(prompt_sent.wait(), timeout=2.0)
+                failure_records = [
+                    record.message
+                    for record in caplog.records
+                    if "Native update prompt send reported failure" in record.message
+                ]
+                assert len(failure_records) == 1
+                assert failure_records[0].endswith(expected_error)
+                assert "\r" not in failure_records[0]
+                assert "\n" not in failure_records[0]
+                (hermes_home / ".update_exit_code").write_text("0")
+                await watcher
+
+    @pytest.mark.asyncio
+    async def test_text_prompt_failure_warns_without_false_forward_log_and_keeps_pending(
+        self, tmp_path, caplog
+    ):
+        """A failed text fallback remains answerable without claiming delivery."""
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        session_key = "agent:main:telegram:dm:111"
+        (hermes_home / ".update_pending.json").write_text(json.dumps({
+            "platform": "telegram",
+            "chat_id": "111",
+            "user_id": "222",
+            "session_key": session_key,
+        }))
+        (hermes_home / ".update_prompt.json").write_text(json.dumps({
+            "prompt": "Restore local changes? [Y/n]",
+            "default": "y",
+        }))
+
+        prompt_sent = asyncio.Event()
+
+        class TextFallbackFailureAdapter:
+            async def send_update_prompt(self, **kwargs):
+                return SendResult(success=False, error="native delivery failed")
+
+            async def send(self, chat_id, content, metadata=None):
+                if "Update needs your input" in content:
+                    prompt_sent.set()
+                    return SendResult(success=False, error="text delivery failed")
+                return SendResult(success=True)
+
+        runner.adapters = {Platform.TELEGRAM: TextFallbackFailureAdapter()}
+
+        with caplog.at_level("INFO", logger="gateway.run"):
+            with patch("gateway.run._hermes_home", hermes_home):
+                watcher = asyncio.create_task(runner._watch_update_progress(
+                    poll_interval=0.05,
+                    stream_interval=0.1,
+                    timeout=10.0,
+                ))
+                await asyncio.wait_for(prompt_sent.wait(), timeout=2.0)
+                state = runner._peek_session_state(session_key)
+                assert state is not None
+                assert state.persistent.update_prompt_pending is True
+                assert not any(
+                    "Forwarded update prompt" in record.message
+                    for record in caplog.records
+                )
+                assert any(
+                    "text delivery failed" in record.message
+                    for record in caplog.records
+                )
+                (hermes_home / ".update_exit_code").write_text("0")
+                await watcher
+
+    @pytest.mark.asyncio
+    async def test_native_prompt_exception_logs_safely_and_uses_text_fallback(
+        self, tmp_path, caplog
+    ):
+        """Native prompt exceptions still reach the actionable text fallback."""
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        session_key = "agent:main:telegram:dm:111"
+        (hermes_home / ".update_pending.json").write_text(json.dumps({
+            "platform": "telegram",
+            "chat_id": "111",
+            "user_id": "222",
+            "session_key": session_key,
+        }))
+        (hermes_home / ".update_prompt.json").write_text(json.dumps({
+            "prompt": "Restore local changes? [Y/n]",
+            "default": "y",
+        }))
+
+        prompt_sent = asyncio.Event()
+        native_error = " \r\nbutton transport failed\r\n" + "x" * 400 + " \n"
+
+        class NativePromptExceptionAdapter:
+            async def send_update_prompt(self, **kwargs):
+                raise RuntimeError(native_error)
+
+            async def send(self, chat_id, content, metadata=None):
+                if "Update needs your input" in content:
+                    prompt_sent.set()
+                return SendResult(success=True)
+
+        runner.adapters = {Platform.TELEGRAM: NativePromptExceptionAdapter()}
+
+        with caplog.at_level("DEBUG", logger="gateway.run"):
+            with patch("gateway.run._hermes_home", hermes_home):
+                watcher = asyncio.create_task(runner._watch_update_progress(
+                    poll_interval=0.05,
+                    stream_interval=0.1,
+                    timeout=10.0,
+                ))
+                await asyncio.wait_for(prompt_sent.wait(), timeout=2.0)
+                prompt_sends = [
+                    record
+                    for record in caplog.records
+                    if "Button-based update prompt failed" in record.message
+                ]
+                assert len(prompt_sends) == 1
+                assert prompt_sends[0].message.endswith(
+                    "button transport failed  " + "x" * 275
+                )
+                assert "\r" not in prompt_sends[0].message
+                assert "\n" not in prompt_sends[0].message
+                (hermes_home / ".update_exit_code").write_text("0")
+                await watcher
+
     @pytest.mark.asyncio
     async def test_prompt_is_recovered_after_watcher_restart(self, tmp_path):
         """A forwarded prompt stays on disk until answered so a new watcher can recover it."""


### PR DESCRIPTION
## Bug Description

Fixes #81482.

Gateway `/update` can wait for the full five-minute input timeout after reaching an interactive question such as `Restore local changes now? [Y/n]`. The updater is not stuck in Git; it is waiting for `.update_response`, but the user did not receive an actionable Yes/No prompt.

A verified Discord reproduction on 2026-08-08 showed:

- `08:35:44` — `/update` invoked
- `08:35:51` — gateway logged the prompt as forwarded
- No separate buttons or text `/approve` / `/deny` instructions appeared
- `08:41:14` — update finished, about 323 seconds later, matching the 300-second prompt timeout plus remaining work

## Root Cause

`GatewayRunner._watch_update_progress()` treated every non-raising `send_update_prompt()` call as a successful native delivery. Native adapters return `SendResult(success=False)` for many delivery errors rather than raising, so the watcher skipped its existing text fallback, logged the prompt as forwarded, and left `_gateway_prompt()` waiting for 300 seconds.

## Platform Scope

This is a shared gateway bug. Native update-prompt hooks currently exist for Discord, Telegram, Feishu, and QQBot, and all can return `SendResult(success=False)`. Platforms without a native hook already use the text fallback.

Discord is the verified live reproduction; the fix applies uniformly at the shared watcher boundary.

The live gateway was running pre-update commit `87fd0ed252` until restart. That commit already had both the watcher call to `adapter.send_update_prompt(...)` and Discord's native implementation. The adapter catches delivery exceptions and returns `SendResult(success=False)`; the watcher then unconditionally marked buttons as sent. Thus, zero Discord components plus no logged exception is consistent with this exact soft-failure contract mismatch.

## Fix

- Treat explicit native `SendResult(success=False)` as failed delivery.
- Sanitize and cap adapter error text before logging.
- Log the native error before falling back.
- Use the existing actionable text `/approve` / `/deny` prompt on failure.
- Inspect the text fallback's result and avoid falsely logging a failed fallback as forwarded.
- Keep the prompt pending after delivery failure so a direct answer can still unblock the updater.
- Preserve compatibility with successful hooks returning `None`.
- Cover `None`, `SendResult(success=True)`, `SendResult(success=False)`, raised native exceptions, safe error logging, and failed text fallback behavior.

## How to Verify

1. Have a native update-prompt adapter return `SendResult(success=False)`.
2. Confirm the gateway logs the native failure and sends the text prompt.
3. Confirm `None` and `SendResult(success=True)` do not send a duplicate text fallback.
4. Reply through the fallback and confirm the detached updater receives `.update_response` without waiting for its 300-second default.

## Test Plan

- [x] Final-SHA combined update suites — 50 passed
- [x] Final-SHA update streaming suite — 18 passed
- [x] RED check on unpatched parent with the final result-contract test — failure case fails because no text fallback is sent; legacy `None` and success cases pass
- [x] Native adapter suites (Discord, Telegram, Feishu, QQBot) — 102 passed; one pre-existing QQBot coroutine warning
- [x] Full gateway suite at exact final SHA — 602 files, 4,999 passed, 0 failed in 192.3 seconds
- [x] `uv run --extra dev ruff check gateway/run.py tests/gateway/test_update_streaming.py`
- [x] `git diff --check`

## Risk Assessment

Low — the change is limited to interpreting the existing native prompt result contract. Successful native sends and legacy `None` returns retain current behavior. Only explicit soft failures now take the existing text fallback.

Related but distinct: #73937 concerns Discord interactive-view lifetime after successful delivery. This PR concerns failure to deliver the actionable prompt in the first place.
