### PR TITLE
fix: harden session recovery and gateway state

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1209,27 +1209,67 @@ def _adopt_live_compression_child(
     session_db: Any,
     parent_session_id: str,
 ) -> Optional[List[Dict[str, Any]]]:
-    """Move a stale compression contender onto the unique durable child.
+    """Move a stale compression contender onto the durable live lineage tip.
 
-    Resolve and load first, then mutate the live agent. This ordering keeps the
-    stale contender fail-closed when lineage is ambiguous or the compacted
-    handoff cannot be read.
+    A cached agent or late async-completion turn can remain pinned to a parent
+    while the same logical conversation compresses more than once. In that
+    case the direct child is already ended, so ``find_live_compression_child``
+    correctly returns nothing even though a unique live descendant exists.
+    Prefer the DB's fail-closed full-lineage resolver when it exists, while
+    retaining the direct-child fallback for older/custom implementations.
+
+    Resolve and load first, then mutate the live agent. Re-resolving the tip
+    after the load keeps the stale contender fail-closed if another rotation
+    races this adoption or the compacted handoff cannot be read.
     """
     finder = getattr(type(session_db), "find_live_compression_child", None)
+    tip_finder = getattr(type(session_db), "find_live_compression_tip", None)
     loader = getattr(type(session_db), "get_messages_as_conversation", None)
-    if not callable(finder) or not callable(loader):
+    if not callable(loader):
         return None
-    child = finder(session_db, parent_session_id)
+
+    # Claim the chosen live tip in the SAME write transaction as full-lineage
+    # resolution. The holder is passed to the first transcript append, fencing
+    # a third compression rotation out of the resolve/load/adopt/write window.
+    recovery_holder = _compression_lock_holder(agent)
+    claimed_session_id = ""
+
+    def _resolve_target() -> Optional[Dict[str, Any]]:
+        if callable(tip_finder):
+            try:
+                live_tip = tip_finder(
+                    session_db,
+                    parent_session_id,
+                    acquire_lease_holder=recovery_holder,
+                    lease_ttl_seconds=60.0,
+                )
+            except TypeError:
+                # Older/custom stores may expose a read-only full-tip resolver
+                # without lease-claim kwargs. Use it, then rely on the guarded
+                # persistence retry if the tip rotates before the write.
+                live_tip = tip_finder(session_db, parent_session_id)
+            if isinstance(live_tip, dict):
+                return live_tip
+        if callable(finder):
+            direct_child = finder(session_db, parent_session_id)
+            return direct_child if isinstance(direct_child, dict) else None
+        return None
+
+    child = _resolve_target()
     if not child or not child.get("id"):
         return None
     child_session_id = str(child["id"])
+    claimed_session_id = child_session_id
+    holder_getter = getattr(session_db, "get_compression_lock_holder", None)
+    lease_claimed = bool(
+        callable(holder_getter)
+        and holder_getter(child_session_id) == recovery_holder
+    )
     recovered = loader(session_db, child_session_id)
     if not isinstance(recovered, list) or not recovered:
-        return None
-    # Revalidate after loading: the child may have rotated or a competing
-    # continuation may have appeared between the two DB reads.
-    confirmed = finder(session_db, parent_session_id)
-    if not confirmed or str(confirmed.get("id") or "") != child_session_id:
+        release = getattr(session_db, "release_compression_lock", None)
+        if callable(release):
+            release(child_session_id, recovery_holder)
         return None
 
     agent.session_id = child_session_id
@@ -1254,27 +1294,19 @@ def _adopt_live_compression_child(
     agent._flushed_db_message_ids = {
         id(message) for message in recovered if isinstance(message, dict)
     }
+    if lease_claimed:
+        agent._active_compression_lock_holder = recovery_holder
+        agent._compression_recovery_lock_session_id = claimed_session_id
 
-    on_session_start = getattr(agent.context_compressor, "on_session_start", None)
-    if callable(on_session_start):
+    # This is adoption of an already-authoritative tip, not publication of a
+    # fresh compression boundary. Bind the tip's own durable guard state; do not
+    # carry stale ancestor counters forward via old_session_id.
+    bind_state = getattr(agent.context_compressor, "bind_session_state", None)
+    if callable(bind_state):
         try:
-            on_session_start(
-                child_session_id,
-                boundary_reason="compression",
-                old_session_id=parent_session_id,
-                session_db=session_db,
-                platform=getattr(agent, "platform", None) or "cli",
-                conversation_id=getattr(agent, "_gateway_session_key", None),
-            )
+            bind_state(session_db=session_db, session_id=child_session_id)
         except Exception as exc:
             logger.debug("context engine compression-child adoption failed: %s", exc)
-    else:
-        bind_state = getattr(agent.context_compressor, "bind_session_state", None)
-        if callable(bind_state):
-            try:
-                bind_state(session_db=session_db, session_id=child_session_id)
-            except Exception:
-                pass
     try:
         if agent._memory_manager:
             agent._memory_manager.on_session_switch(
@@ -1342,6 +1374,19 @@ def recover_rotated_compression_session(
             exc,
         )
         return None
+
+
+def recover_rotated_compression_session_for_write(
+    agent: Any,
+) -> Optional[List[Dict[str, Any]]]:
+    """Recover a tip that rotated after turn setup but before persistence."""
+    session_db = getattr(agent, "_session_db", None)
+    session_id = getattr(agent, "session_id", None) or ""
+    if session_db is None or not session_id:
+        return None
+    if not _session_was_rotated_by_compression(session_db, session_id):
+        return None
+    return _adopt_live_compression_child(agent, session_db, session_id)
 
 
 def _compression_lock_holder(agent: Any) -> str:

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -497,48 +497,62 @@ def _external_dirs_cache_clear() -> None:
 
 
 def get_external_skills_dirs() -> List[Path]:
-    """Read ``skills.external_dirs`` from config.yaml and return validated paths.
+    """Return configured external skill directories.
 
-    Each entry is expanded (``~`` and ``${VAR}``) and resolved to an absolute
-    path.  Only directories that actually exist are returned.  Duplicates and
-    paths that resolve to the local ``~/.hermes/skills/`` are silently skipped.
+    Reads the fully resolved Hermes config so administrator-managed
+    ``skills.external_dirs`` values apply to every Profile, including a newly
+    created Profile with no user ``config.yaml``. Each path is expanded and
+    resolved; missing directories and the Profile-local skill root are skipped.
 
-    Cached in-process, keyed on ``config.yaml`` mtime — the function is
-    called once per skill during banner / tool-registry scans, and YAML
-    parsing a non-trivial config dominates ``hermes`` cold-start time
-    when the cache is absent.
+    The resolved config loader already caches both user and managed config by
+    mtime+size. This function keeps a tiny directory-list cache keyed by those
+    same signatures because banner/tool scans call it once per skill.
     """
     config_path = get_config_path()
-    if not config_path.exists():
-        return []
-
-    # Cache key: (absolute path, mtime_ns).  stat() is ~2us vs ~85ms for
-    # the full YAML parse, so the fast path is nearly free.
     try:
-        stat = config_path.stat()
-        cache_key: Tuple[str, int] = (str(config_path), stat.st_mtime_ns)
+        user_stat = config_path.stat() if config_path.exists() else None
     except OSError:
-        cache_key = None  # type: ignore[assignment]
+        user_stat = None
 
-    if cache_key is not None:
-        cached = _EXTERNAL_DIRS_CACHE.get(cache_key)
-        if cached is not None:
-            # Return a copy so callers can't mutate the cached list.
-            return list(cached)
+    managed_path: Optional[Path] = None
+    managed_sig = (0, 0)
+    try:
+        from hermes_cli import managed_scope
 
-    parsed = _load_raw_config()
-    if not parsed:
-        return []
+        managed_dir = managed_scope.get_managed_dir()
+        managed_path = (managed_dir / "config.yaml") if managed_dir else None
+        managed_stat = managed_path.stat() if managed_path else None
+        if managed_stat:
+            managed_sig = (managed_stat.st_mtime_ns, managed_stat.st_size)
+    except OSError:
+        pass
 
-    skills_cfg = parsed.get("skills")
-    if not isinstance(skills_cfg, dict):
-        return []
+    user_sig = (
+        user_stat.st_mtime_ns if user_stat else 0,
+        user_stat.st_size if user_stat else 0,
+    )
+    cache_key: Tuple[str, int] = (
+        str(config_path),
+        hash((user_sig, managed_sig)),
+    )
+    cached = _EXTERNAL_DIRS_CACHE.get(cache_key)
+    if cached is not None:
+        return list(cached)
 
-    raw_dirs = skills_cfg.get("external_dirs")
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        parsed = load_config_readonly()
+    except Exception as exc:
+        logger.debug("Could not load resolved skill config: %s", exc)
+        parsed = _load_raw_config()
+
+    skills_cfg = parsed.get("skills") if isinstance(parsed, dict) else None
+    raw_dirs = skills_cfg.get("external_dirs") if isinstance(skills_cfg, dict) else None
     if not raw_dirs:
         result: List[Path] = []
-        if cache_key is not None:
-            _EXTERNAL_DIRS_CACHE[cache_key] = list(result)
+        _EXTERNAL_DIRS_CACHE.clear()
+        _EXTERNAL_DIRS_CACHE[cache_key] = list(result)
         return result
     if isinstance(raw_dirs, str):
         raw_dirs = [raw_dirs]
@@ -551,22 +565,13 @@ def get_external_skills_dirs() -> List[Path]:
     local_skills = get_skills_dir().resolve()
     seen: Set[Path] = set()
     result = []
-
     for entry in raw_dirs:
         entry = str(entry).strip()
         if not entry:
             continue
-        # Expand ~ and environment variables
-        expanded = os.path.expanduser(os.path.expandvars(entry))
-        p = Path(expanded)
-        # Resolve relative paths against HERMES_HOME, not cwd
-        if not p.is_absolute():
-            p = (hermes_home / p).resolve()
-        else:
-            p = p.resolve()
-        if p == local_skills:
-            continue
-        if p in seen:
+        p = Path(os.path.expanduser(os.path.expandvars(entry)))
+        p = (hermes_home / p).resolve() if not p.is_absolute() else p.resolve()
+        if p == local_skills or p in seen:
             continue
         if p.is_dir():
             seen.add(p)
@@ -574,8 +579,8 @@ def get_external_skills_dirs() -> List[Path]:
         else:
             logger.debug("External skills dir does not exist, skipping: %s", p)
 
-    if cache_key is not None:
-        _EXTERNAL_DIRS_CACHE[cache_key] = list(result)
+    _EXTERNAL_DIRS_CACHE.clear()
+    _EXTERNAL_DIRS_CACHE[cache_key] = list(result)
     return result
 
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1273,22 +1273,25 @@ def load_gateway_config() -> GatewayConfig:
         except Exception as e:
             logger.warning("Failed to load %s: %s", gateway_json_path, e)
 
-    # Primary source: config.yaml
+    # Primary source: config.yaml + administrator-managed overlay.
     try:
         import yaml
         config_yaml_path = _home / "config.yaml"
+        yaml_cfg: dict = {}
         if config_yaml_path.exists():
             with open(config_yaml_path, encoding="utf-8") as f:
-                yaml_cfg = yaml.safe_load(f) or {}
+                loaded_yaml = yaml.safe_load(f) or {}
+            if isinstance(loaded_yaml, dict):
+                yaml_cfg = loaded_yaml
 
-            # Managed scope: overlay administrator-pinned values so the gateway
-            # honors them too. This loader builds its own dict instead of going
-            # through hermes_cli.config.load_config, so without this a managed
-            # session_reset / quick_commands / stt / model would be ignored by
-            # the messaging gateway. Fail-open via the shared helper.
-            from hermes_cli import managed_scope
-            yaml_cfg = managed_scope.apply_managed_overlay(yaml_cfg)
+        # Managed scope applies even when this is a brand-new profile with no
+        # config.yaml yet. Otherwise administrator-pinned gateway defaults such
+        # as a Slack home channel disappear until the profile writes a local
+        # config file, defeating the purpose of a global managed scope.
+        from hermes_cli import managed_scope
+        yaml_cfg = managed_scope.apply_managed_overlay(yaml_cfg)
 
+        if yaml_cfg:
             # Shared nested-fallback source: settings meant to be top-level
             # keys are also accepted when a user nests them under `gateway:`
             # (e.g. via `hermes config set gateway.<key> ...`, which naturally

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3709,6 +3709,105 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             ).fetchall()
         return self._session_row_dict(rows[0]) if len(rows) == 1 else None
 
+    def find_live_compression_tip(
+        self,
+        ancestor_session_id: str,
+        *,
+        acquire_lease_holder: Optional[str] = None,
+        lease_ttl_seconds: float = 60.0,
+    ) -> Optional[Dict[str, Any]]:
+        """Return the unique live descendant of a compression lineage.
+
+        Unlike :meth:`get_compression_tip`, which is a best-effort UI/resume
+        projection and may choose among stale siblings, this recovery helper
+        fails closed whenever a compression hop has more than one canonical
+        continuation. A stale writer may adopt a descendant only when every
+        durable edge from the closed ancestor to the live tip is unambiguous.
+
+        When ``acquire_lease_holder`` is supplied, resolution and lease claim
+        run in one ``BEGIN IMMEDIATE`` transaction. The returned live tip then
+        cannot rotate before that holder performs the first transcript append
+        and releases the holder-qualified lease.
+        """
+        if not ancestor_session_id:
+            return None
+        def _resolve(conn):
+            current = ancestor_session_id
+            seen = {current}
+            for _ in range(100):
+                parent = conn.execute(
+                    "SELECT ended_at, end_reason FROM sessions WHERE id = ?",
+                    (current,),
+                ).fetchone()
+                if parent is None:
+                    return None
+                if parent["ended_at"] is None:
+                    if current == ancestor_session_id:
+                        return None
+                    row = conn.execute(
+                        """
+                        SELECT s.*,
+                               COALESCE(sp.prompt, s.system_prompt)
+                                   AS _system_prompt_resolved
+                        FROM sessions s
+                        LEFT JOIN system_prompts sp ON sp.hash = s.system_prompt_hash
+                        WHERE s.id = ?
+                        """,
+                        (current,),
+                    ).fetchone()
+                    if row is None:
+                        return None
+                    if acquire_lease_holder:
+                        now = time.time()
+                        conn.execute(
+                            "DELETE FROM compression_locks "
+                            "WHERE session_id = ? AND expires_at <= ?",
+                            (current, now),
+                        )
+                        try:
+                            conn.execute(
+                                "INSERT INTO compression_locks "
+                                "(session_id, holder, acquired_at, expires_at) "
+                                "VALUES (?, ?, ?, ?)",
+                                (
+                                    current,
+                                    acquire_lease_holder,
+                                    now,
+                                    now + max(1.0, float(lease_ttl_seconds)),
+                                ),
+                            )
+                        except sqlite3.IntegrityError:
+                            return None
+                    return self._session_row_dict(row) if row else None
+                if parent["end_reason"] != "compression":
+                    return None
+                rows = conn.execute(
+                    """
+                    SELECT s.id
+                    FROM sessions s
+                    WHERE s.parent_session_id = ?
+                    """
+                    + self._NON_CONTINUATION_CHILD_FILTER_SQL.format(alias="s.")
+                    + """
+                    ORDER BY s.started_at ASC, s.id ASC
+                    LIMIT 2
+                    """,
+                    (current, current, current),
+                ).fetchall()
+                if len(rows) != 1:
+                    return None
+                child_id = str(rows[0]["id"] or "")
+                if not child_id or child_id in seen:
+                    return None
+                seen.add(child_id)
+                current = child_id
+            return None
+
+        if acquire_lease_holder:
+            return self._execute_write(_resolve)
+        with self._lock:
+            return _resolve(self._conn)
+
     def reopen_orphaned_compression_session(self, session_id: str) -> bool:
         """Reopen a compression parent only when no continuation was published.
 

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2292,6 +2292,13 @@ class SlackAdapter(BasePlatformAdapter):
                     "[Slack] Watchdog task raised during disconnect", exc_info=True
                 )
 
+        # Slack Assistant status is server-persistent: closing Socket Mode or
+        # the Web API clients does not dismiss an outstanding "is thinking..."
+        # line. Clear every status we still own while workspace clients are
+        # usable; otherwise a gateway restart loses the in-memory routing map
+        # and can leave Slack showing "still working..." indefinitely.
+        await self._clear_active_status_threads_on_disconnect()
+
         await self._stop_socket_mode_handler()
         await self._close_workspace_clients()
         self._app = None
@@ -2405,22 +2412,27 @@ class SlackAdapter(BasePlatformAdapter):
     async def _clear_thread_status_quietly(
         self, chat_id: str, metadata: Optional[Dict[str, Any]] = None
     ) -> None:
-        """Best-effort assistant-status clear for send() paths that bypass
-        the normal post-delivery clear.
+        """Best-effort assistant-status clear for message-delivery paths.
 
         Issue #24117: the assistant thread can stay stuck "is thinking..."
-        when a turn ends through a path that never reaches the regular
-        ``if thread_ts: stop_typing`` clear — an empty final response, a
-        slash-command ephemeral reply, or an exception raised before
-        ``thread_ts`` was resolved. ``stop_typing`` is already idempotent
-        (clearing an unset status is a no-op on Slack's side), so this just
-        guarantees it runs without letting a cleanup error mask the caller's
-        SendResult.
+        when a turn ends through a path that never reaches the regular clear —
+        an empty final response, a slash-command ephemeral reply, or an
+        exception raised before ``thread_ts`` was resolved. A status-clear
+        failure must never reclassify an already-posted response as failed or
+        trigger a duplicate gateway retry, so cleanup errors are logged here
+        and deliberately do not escape.
         """
         try:
             await self.stop_typing(chat_id, metadata=metadata)
         except Exception as e:  # pragma: no cover - defensive cleanup
-            logger.debug("[Slack] status cleanup failed: %s", e)
+            logger.warning(
+                "[Slack] status cleanup raised unexpectedly "
+                "(team_id=%s channel_id=%s thread_ts=%s): %s",
+                self._metadata_team_id(metadata) or "<unknown>",
+                chat_id,
+                str((metadata or {}).get("thread_id") or (metadata or {}).get("thread_ts") or "<unknown>"),
+                e,
+            )
 
     def _slack_ignored_channels(self) -> set[str]:
         """Configured Slack channels the generic gateway must never touch."""
@@ -2581,9 +2593,13 @@ class SlackAdapter(BasePlatformAdapter):
                     else:
                         raise
 
-            # Clear Slack Assistant status as soon as the final message is posted.
+            # Clear Slack Assistant status as soon as the final message is
+            # posted. Do not let a failed status API call look like a failed
+            # message delivery: the post already succeeded and gateway retry
+            # would duplicate the visible reply. stop_typing remains directly
+            # callable for lifecycle code that wants strict exception behavior.
             if thread_ts:
-                await self.stop_typing(chat_id, metadata=metadata)
+                await self._clear_thread_status_quietly(chat_id, metadata)
 
             # Track the sent message ts so we can auto-respond to thread
             # replies without requiring @mention.
@@ -3031,7 +3047,50 @@ class SlackAdapter(BasePlatformAdapter):
                 status="",
             )
         except Exception as e:
-            logger.debug("[Slack] assistant.threads.setStatus clear failed: %s", e)
+            logger.warning(
+                "[Slack] assistant.threads.setStatus clear failed "
+                "(team_id=%s channel_id=%s thread_ts=%s): %s",
+                team_id or "<unknown>",
+                chat_id,
+                thread_ts,
+                e,
+            )
+
+    async def _clear_active_status_threads_on_disconnect(self) -> None:
+        """Best-effort clear of server-persistent Assistant statuses.
+
+        Entries are removed only after Slack accepts the clear. Failed entries
+        remain tracked until adapter teardown, and the warning preserves the
+        exact workspace/channel/thread identity for diagnosis.
+        """
+        for status_key, active in list(self._active_status_threads.items()):
+            team_id, channel_id, key_thread_ts = status_key
+            thread_ts = (
+                str(active.get("thread_ts") or key_thread_ts)
+                if isinstance(active, dict)
+                else str(active or key_thread_ts)
+            )
+            if not thread_ts:
+                continue
+            try:
+                await self._get_client(
+                    channel_id, team_id=team_id
+                ).assistant_threads_setStatus(
+                    channel_id=channel_id,
+                    thread_ts=thread_ts,
+                    status="",
+                )
+            except Exception as e:
+                logger.warning(
+                    "[Slack] Assistant status cleanup during disconnect failed "
+                    "(team_id=%s channel_id=%s thread_ts=%s): %s",
+                    team_id or "<unknown>",
+                    channel_id,
+                    thread_ts,
+                    e,
+                )
+                continue
+            self._active_status_threads.pop(status_key, None)
 
     def _dm_top_level_threads_as_sessions(self) -> bool:
         """Whether top-level Slack DMs get per-message session threads.

--- a/run_agent.py
+++ b/run_agent.py
@@ -2278,13 +2278,36 @@ class AIAgent:
             # re-writes the whole tail (same recovery contract as before,
             # minus the partial-prefix case that could double-pay counters).
             if _batch_rows:
-                self._session_db.append_messages_batch(
-                    session_id=self.session_id,
-                    messages=_batch_rows,
-                    compression_lock_holder=getattr(
-                        self, "_active_compression_lock_holder", None
-                    ),
-                )
+                try:
+                    self._session_db.append_messages_batch(
+                        session_id=self.session_id,
+                        messages=_batch_rows,
+                        compression_lock_holder=getattr(
+                            self, "_active_compression_lock_holder", None
+                        ),
+                    )
+                except Exception as _append_exc:
+                    from hermes_state import CompressionSessionClosedError
+
+                    if not isinstance(_append_exc, CompressionSessionClosedError):
+                        raise
+                    # The adopted tip can rotate after turn setup if its recovery
+                    # lease expired or an older/custom store could not provide a
+                    # lease. Re-resolve once at the persistence chokepoint, then
+                    # retry the SAME unstamped batch against the new live tip.
+                    from agent.conversation_compression import (
+                        recover_rotated_compression_session_for_write,
+                    )
+
+                    if recover_rotated_compression_session_for_write(self) is None:
+                        raise
+                    self._session_db.append_messages_batch(
+                        session_id=self.session_id,
+                        messages=_batch_rows,
+                        compression_lock_holder=getattr(
+                            self, "_active_compression_lock_holder", None
+                        ),
+                    )
                 for _written in _batch_msgs:
                     _written[_DB_PERSISTED_MARKER] = True
             # The intrinsic markers are now the sole source of truth. Reset the
@@ -2295,6 +2318,20 @@ class AIAgent:
             # Snapshot for the bounded scan above — only on full success, so
             # a partially-processed list can never be treated as settled.
             self._db_flush_scan_prefix = messages[:]
+            _recovery_lock_session_id = getattr(
+                self, "_compression_recovery_lock_session_id", ""
+            )
+            _recovery_lock_holder = getattr(
+                self, "_active_compression_lock_holder", None
+            )
+            if _recovery_lock_session_id and _recovery_lock_holder:
+                try:
+                    self._session_db.release_compression_lock(
+                        _recovery_lock_session_id, _recovery_lock_holder
+                    )
+                finally:
+                    self._compression_recovery_lock_session_id = ""
+                    self._active_compression_lock_holder = None
             return True
         except Exception as e:
             # Force a full re-scan on the next flush: an exception mid-loop

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -755,11 +755,9 @@ def test_delayed_contender_adopts_unique_rotated_child(tmp_path: Path) -> None:
     assert agent._flushed_db_message_session_id == child_sid
     assert agent._last_flushed_db_idx == len(recovered)
     agent.context_compressor.compress.assert_not_called()
-    lifecycle_args, lifecycle_kwargs = agent.context_compressor.on_session_start.call_args
-    assert lifecycle_args == (child_sid,)
-    assert lifecycle_kwargs["boundary_reason"] == "compression"
-    assert lifecycle_kwargs["old_session_id"] == parent_sid
-    assert lifecycle_kwargs["session_db"] is db
+    agent.context_compressor.bind_session_state.assert_called_once_with(
+        session_db=db, session_id=child_sid
+    )
 
 
 

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import os
 import time
 from pathlib import Path
+import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -155,6 +156,220 @@ class TestOrphanRollbackOnCreateFailure:
         assert parent_row is not None
         assert parent_row["ended_at"] is None
         assert db.find_live_compression_child(parent) is None
+
+
+class TestStaleAgentAdoptsFullCompressionTip:
+    def test_recovery_keeps_single_hop_live_child_behavior(self, tmp_path: Path):
+        """The full-tip resolver must preserve ordinary one-hop adoption."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        root = "ROOT_SINGLE_HOP"
+        child = "CHILD_SINGLE_HOP"
+        db.create_session(root, source="slack")
+        db.append_message(root, "user", "root message")
+        db.end_session(root, "compression")
+        db.create_session(child, source="slack", parent_session_id=root)
+        db.append_message(child, "user", "child message")
+
+        agent = _build_agent_with_db(db, root, platform="slack")
+        direct_child = db.find_live_compression_child(root)
+        assert direct_child is not None
+        assert direct_child["id"] == child
+        assert db.get_compression_tip(root) == child
+
+        from agent.conversation_compression import recover_rotated_compression_session
+
+        recovered = recover_rotated_compression_session(agent)
+
+        assert recovered is not None
+        assert agent.session_id == child
+        assert [m["content"] for m in recovered] == ["child message"]
+
+    def test_recovery_walks_multiple_rotations_before_next_turn(self, tmp_path: Path):
+        """A late async completion can wake an agent pinned two rotations back.
+
+        The direct child is already compression-ended, so recovery must walk to
+        the unique live tip rather than retrying a durable write on the root.
+        """
+        db = SessionDB(db_path=tmp_path / "state.db")
+        root = "ROOT_MULTI_HOP"
+        middle = "MIDDLE_MULTI_HOP"
+        tip = "TIP_MULTI_HOP"
+        db.create_session(root, source="slack")
+        db.append_message(root, "user", "root message")
+        db.end_session(root, "compression")
+        db.create_session(middle, source="slack", parent_session_id=root)
+        db.append_message(middle, "user", "middle message")
+        db.end_session(middle, "compression")
+        db.create_session(tip, source="slack", parent_session_id=middle)
+        db.append_message(tip, "user", "tip message")
+
+        agent = _build_agent_with_db(db, root, platform="slack")
+        assert db.find_live_compression_child(root) is None
+        assert db.get_compression_tip(root) == tip
+
+        from agent.conversation_compression import recover_rotated_compression_session
+
+        recovered = recover_rotated_compression_session(agent)
+
+        assert recovered is not None
+        assert agent.session_id == tip
+        assert [m["content"] for m in recovered] == ["tip message"]
+        assert agent._flushed_db_message_session_id == tip
+        agent.context_compressor.bind_session_state.assert_called_once_with(
+            session_db=db, session_id=tip
+        )
+
+    def test_recovery_fails_closed_when_lineage_forks(self, tmp_path: Path):
+        """A stale writer must not guess between two canonical continuations."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        root = "ROOT_AMBIGUOUS"
+        db.create_session(root, source="slack")
+        db.append_message(root, "user", "root message")
+        db.end_session(root, "compression")
+        for child in ("CHILD_A", "CHILD_B"):
+            db.create_session(child, source="slack", parent_session_id=root)
+            db.append_message(child, "user", child)
+
+        agent = _build_agent_with_db(db, root, platform="slack")
+
+        from agent.conversation_compression import recover_rotated_compression_session
+
+        assert db.find_live_compression_tip(root) is None
+        assert recover_rotated_compression_session(agent) is None
+        assert agent.session_id == root
+
+    def test_recovery_holds_tip_lease_through_first_append(self, tmp_path: Path):
+        """The adopted tip cannot rotate before the first durable turn write."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        root = "ROOT_WRITE_FENCE"
+        tip = "TIP_WRITE_FENCE"
+        db.create_session(root, source="slack")
+        db.append_message(root, "user", "root message")
+        db.end_session(root, "compression")
+        db.create_session(tip, source="slack", parent_session_id=root)
+        db.append_message(tip, "user", "tip message")
+        agent = _build_agent_with_db(db, root, platform="slack")
+
+        from agent.conversation_compression import recover_rotated_compression_session
+
+        recovered = recover_rotated_compression_session(agent)
+        assert recovered is not None
+        holder = agent._active_compression_lock_holder
+        assert holder
+
+        contender_result = []
+
+        def _contend():
+            contender_result.append(
+                db.try_acquire_compression_lock(tip, "contender", ttl_seconds=60)
+            )
+
+        contender = threading.Thread(target=_contend)
+        contender.start()
+        contender.join(timeout=5)
+        assert contender_result == [False]
+
+        db.append_messages_batch(
+            tip,
+            [{"role": "user", "content": "first adopted write"}],
+            compression_lock_holder=holder,
+        )
+        db.release_compression_lock(tip, holder)
+        agent._active_compression_lock_holder = None
+        agent._compression_recovery_lock_session_id = ""
+        assert [m["content"] for m in db.get_messages(tip)][-1] == "first adopted write"
+
+    def test_recovery_preserves_authoritative_tip_guard_state(self, tmp_path: Path):
+        """Recovery binds the tip without carrying stale root counters forward."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        root = "ROOT_GUARD_STATE"
+        tip = "TIP_GUARD_STATE"
+        db.create_session(root, source="slack")
+        db.append_message(root, "user", "root message")
+        db.set_compression_fallback_streak(root, 1)
+        db.set_compression_ineffective_count(root, 2)
+        db.end_session(root, "compression")
+        db.create_session(tip, source="slack", parent_session_id=root)
+        db.append_message(tip, "user", "tip message")
+        db.set_compression_fallback_streak(tip, 7)
+        db.set_compression_ineffective_count(tip, 8)
+        agent = _build_agent_with_db(db, root, platform="slack")
+        with patch(
+            "agent.context_compressor.get_model_context_length",
+            return_value=100_000,
+        ):
+            agent.context_compressor = ContextCompressor(
+                model="test/model",
+                threshold_percent=0.85,
+                protect_first_n=2,
+                protect_last_n=2,
+                quiet_mode=True,
+            )
+        agent.context_compressor.bind_session_state(db, root)
+
+        from agent.conversation_compression import recover_rotated_compression_session
+
+        recovered = recover_rotated_compression_session(agent)
+
+        assert recovered is not None
+        holder = agent._active_compression_lock_holder
+        db.release_compression_lock(tip, holder)
+        agent._active_compression_lock_holder = None
+        assert agent.context_compressor._fallback_compression_streak == 7
+        assert agent.context_compressor._ineffective_compression_count == 8
+        assert db.get_compression_fallback_streak(tip) == 7
+        assert db.get_compression_ineffective_count(tip) == 8
+
+    def test_recovery_accepts_foreign_inherited_delegate_marker(self, tmp_path: Path):
+        """A marker for another parent does not disqualify a continuation."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        marker = {"_delegate_from": "OUTER_PARENT"}
+        root = "ROOT_FOREIGN_MARKER"
+        middle = "MIDDLE_FOREIGN_MARKER"
+        tip = "TIP_FOREIGN_MARKER"
+        db.create_session(root, source="slack", model_config=marker)
+        db.append_message(root, "user", "root message")
+        db.end_session(root, "compression")
+        db.create_session(
+            middle, source="slack", parent_session_id=root, model_config=marker
+        )
+        db.append_message(middle, "user", "middle message")
+        db.end_session(middle, "compression")
+        db.create_session(
+            tip, source="slack", parent_session_id=middle, model_config=marker
+        )
+        db.append_message(tip, "user", "tip message")
+        agent = _build_agent_with_db(db, root, platform="slack")
+
+        from agent.conversation_compression import recover_rotated_compression_session
+
+        recovered = recover_rotated_compression_session(agent)
+
+        assert recovered is not None
+        assert agent.session_id == tip
+
+    def test_recovery_legacy_direct_child_fallback_without_full_tip_api(
+        self, tmp_path: Path
+    ):
+        """Older/custom stores retain the unique direct-child recovery path."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        root = "ROOT_LEGACY_FALLBACK"
+        child = "CHILD_LEGACY_FALLBACK"
+        db.create_session(root, source="slack")
+        db.append_message(root, "user", "root message")
+        db.end_session(root, "compression")
+        db.create_session(child, source="slack", parent_session_id=root)
+        db.append_message(child, "user", "child message")
+        agent = _build_agent_with_db(db, root, platform="slack")
+
+        from agent.conversation_compression import _adopt_live_compression_child
+
+        with patch.object(SessionDB, "find_live_compression_tip", new=None):
+            recovered = _adopt_live_compression_child(agent, db, root)
+
+        assert recovered is not None
+        assert agent.session_id == child
+        assert [m["content"] for m in recovered] == ["child message"]
 
 
 class TestWorkspaceMetadataFollowsRotation:

--- a/tests/agent/test_external_skills_dirs_cache.py
+++ b/tests/agent/test_external_skills_dirs_cache.py
@@ -110,3 +110,29 @@ def test_cache_key_is_per_config_path(tmp_path, monkeypatch):
     # And switching back still works — both entries coexist in the cache.
     monkeypatch.setenv("HERMES_HOME", str(home_a))
     assert get_external_skills_dirs() == [ext_a.resolve()]
+
+
+def test_managed_external_dir_applies_without_user_config(tmp_path, monkeypatch):
+    """Managed external_dirs reaches a fresh Profile with no config.yaml."""
+    home = tmp_path / "profiles" / "fresh"
+    home.mkdir(parents=True)
+    shared = tmp_path / "shared-skills"
+    shared.mkdir()
+    managed = tmp_path / "managed"
+    managed.mkdir()
+    (managed / "config.yaml").write_text(
+        f"skills:\n  external_dirs:\n    - {shared}\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed))
+    from hermes_cli import managed_scope
+    from hermes_cli.config import _LOAD_CONFIG_CACHE
+
+    managed_scope.invalidate_managed_cache()
+    _LOAD_CONFIG_CACHE.clear()
+    _external_dirs_cache_clear()
+
+    assert not (home / "config.yaml").exists()
+    assert get_external_skills_dirs() == [shared.resolve()]

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -45,6 +45,35 @@ class TestHomeChannelRoundtrip:
         assert restored.user_id == "user-123"
         assert restored.scope_id == "guild-456"
 
+    def test_managed_home_channel_loads_without_profile_config(self, tmp_path, monkeypatch):
+        """A brand-new profile must still receive an administrator-pinned home."""
+        profile_home = tmp_path / "profile"
+        profile_home.mkdir()
+        managed_home = tmp_path / "managed"
+        managed_home.mkdir()
+        (managed_home / "config.yaml").write_text(
+            "platforms:\n"
+            "  slack:\n"
+            "    home_channel:\n"
+            "      platform: slack\n"
+            "      chat_id: C0HOME\n"
+            "      name: hermes-home\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed_home))
+
+        from hermes_cli import managed_scope
+        managed_scope.invalidate_managed_cache()
+        try:
+            config = load_gateway_config()
+            home = config.get_home_channel(Platform.SLACK)
+            assert home is not None
+            assert home.chat_id == "C0HOME"
+            assert home.name == "hermes-home"
+        finally:
+            managed_scope.invalidate_managed_cache()
+
 
 class TestPlatformConfigRoundtrip:
     def test_to_dict_from_dict(self):

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2104,6 +2104,22 @@ class TestSendTyping:
         )
 
     @pytest.mark.asyncio
+    async def test_stop_typing_clear_failure_logs_identity(self, adapter, caplog):
+        """A failed server-side clear must not be hidden at DEBUG level."""
+        adapter._app.client.assistant_threads_setStatus = AsyncMock(
+            side_effect=RuntimeError("clear unavailable")
+        )
+
+        with caplog.at_level("WARNING"):
+            await adapter.stop_typing(
+                "D123",
+                metadata={"thread_id": "171.000", "slack_team_id": "T_ONE"},
+            )
+
+        assert "assistant.threads.setStatus clear failed" in caplog.text
+        assert "team_id=T_ONE channel_id=D123 thread_ts=171.000" in caplog.text
+
+    @pytest.mark.asyncio
     async def test_stop_typing_untracked_fallback_respects_ambiguous_workspaces(
         self, adapter
     ):
@@ -2146,6 +2162,25 @@ class TestSendTyping:
         )
         assert ("", "C123", "parent_ts") not in adapter._active_status_threads
 
+    @pytest.mark.asyncio
+    async def test_status_clear_failure_does_not_reclassify_successful_post(
+        self, adapter, caplog
+    ):
+        """A clear failure after chat.postMessage must not duplicate the reply."""
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "reply_ts"})
+        adapter._app.client.assistant_threads_setStatus = AsyncMock(
+            side_effect=RuntimeError("clear unavailable")
+        )
+
+        with caplog.at_level("WARNING"):
+            result = await adapter.send(
+                "C123", "done", metadata={"thread_id": "parent_ts"}
+            )
+
+        assert result.success
+        assert result.message_id == "reply_ts"
+        adapter._app.client.chat_postMessage.assert_awaited_once()
+        assert "assistant.threads.setStatus clear failed" in caplog.text
 
     @pytest.mark.asyncio
     async def test_status_tracking_is_per_thread(self, adapter):

--- a/tests/gateway/test_slack_socket_reconnect_heal.py
+++ b/tests/gateway/test_slack_socket_reconnect_heal.py
@@ -270,6 +270,67 @@ class TestSocketModeTeardown:
             f"{session.ws_connect_after_close} time(s)"
         )
 
+    @pytest.mark.asyncio
+    async def test_disconnect_clears_tracked_assistant_statuses_before_clients_close(
+        self, adapter
+    ):
+        """A restart must dismiss server-persistent statuses before teardown."""
+        team_client = MagicMock()
+        team_client.closed = False
+
+        async def _set_status(**kwargs):
+            assert not team_client.closed
+            return {"ok": True}
+
+        async def _close():
+            team_client.closed = True
+
+        team_client.assistant_threads_setStatus = AsyncMock(side_effect=_set_status)
+        team_client.close = AsyncMock(side_effect=_close)
+        adapter._team_clients = {"T_ONE": team_client}
+        adapter._active_status_threads[("T_ONE", "D123", "171.000")] = {
+            "thread_ts": "171.000",
+            "team_id": "T_ONE",
+        }
+        adapter._socket_watchdog_task = None
+        adapter._handler = None
+        adapter._socket_mode_task = None
+
+        await adapter.disconnect()
+
+        team_client.assistant_threads_setStatus.assert_awaited_once_with(
+            channel_id="D123", thread_ts="171.000", status=""
+        )
+        assert adapter._active_status_threads == {}
+        assert team_client.closed
+
+    @pytest.mark.asyncio
+    async def test_disconnect_status_clear_failure_is_visible_and_does_not_block_teardown(
+        self, adapter, caplog
+    ):
+        """A failed clear is warning-visible while disconnect still completes."""
+        team_client = MagicMock()
+        team_client.assistant_threads_setStatus = AsyncMock(
+            side_effect=RuntimeError("clear unavailable")
+        )
+        team_client.close = AsyncMock()
+        adapter._team_clients = {"T_ONE": team_client}
+        status_key = ("T_ONE", "D123", "171.000")
+        adapter._active_status_threads[status_key] = {
+            "thread_ts": "171.000",
+            "team_id": "T_ONE",
+        }
+        adapter._socket_watchdog_task = None
+        adapter._handler = None
+        adapter._socket_mode_task = None
+
+        with caplog.at_level("WARNING"):
+            await adapter.disconnect()
+
+        assert "Assistant status cleanup during disconnect failed" in caplog.text
+        assert "team_id=T_ONE channel_id=D123 thread_ts=171.000" in caplog.text
+        team_client.close.assert_awaited_once()
+
 
 class TestSocketModeRestart:
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -179,6 +179,50 @@ def test_direct_session_db_flushes_share_marker_claim(agent):
     assert db.rows == ["exactly once"]
 
 
+def test_flush_retries_once_after_adopted_tip_rotates(agent, tmp_path):
+    """A closed adopted tip is re-resolved before reporting persistence failure."""
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    root = "ROOT_FLUSH_RETRY"
+    tip = "TIP_FLUSH_RETRY"
+    next_tip = "NEXT_TIP_FLUSH_RETRY"
+    db.create_session(root, source="slack")
+    db.append_message(root, "user", "root message")
+    db.end_session(root, "compression")
+    db.create_session(tip, source="slack", parent_session_id=root)
+    db.append_message(tip, "user", "tip message")
+    agent._session_db = db
+    agent._session_db_created = True
+    agent.session_id = root
+    agent._last_flushed_db_idx = 0
+    agent._flushed_db_message_ids = set()
+    agent._flushed_db_message_session_id = None
+    agent._persist_user_message_idx = None
+    agent._persist_user_message_override = None
+    agent._persist_user_message_timestamp = None
+    agent._persist_disabled = False
+    agent._session_persist_lock = threading.RLock()
+    agent._session_json_enabled = False
+
+    from agent.conversation_compression import recover_rotated_compression_session
+
+    recovered = recover_rotated_compression_session(agent)
+    assert recovered is not None
+    holder = agent._active_compression_lock_holder
+    db.release_compression_lock(tip, holder)
+    agent._active_compression_lock_holder = None
+    db.end_session(tip, "compression")
+    db.create_session(next_tip, source="slack", parent_session_id=tip)
+    db.append_message(next_tip, "user", "next tip message")
+    new_message = {"role": "assistant", "content": "late completion"}
+
+    assert agent._flush_messages_to_session_db(recovered + [new_message], recovered)
+    assert agent.session_id == next_tip
+    assert [m["content"] for m in db.get_messages(next_tip)][-1] == "late completion"
+    db.close()
+
+
 @pytest.fixture()
 def agent_with_memory_tool():
     """Agent whose valid_tool_names includes 'memory'."""

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1938,7 +1938,12 @@ class TestCompressionChainProjection:
         db.append_message("root1", "user", "help me refactor auth")
 
         # Delegate subagent spawned while root1 was live (before it ended)
-        db.create_session("delegate1", "cli", parent_session_id="root1")
+        db.create_session(
+            "delegate1",
+            "cli",
+            parent_session_id="root1",
+            model_config={"_delegate_from": "root1"},
+        )
         db._conn.execute(
             "UPDATE sessions SET started_at=?, ended_at=? WHERE id=?",
             (t0 + 600, t0 + 650, "delegate1"),
@@ -1984,6 +1989,39 @@ class TestCompressionChainProjection:
         assert db.get_compression_tip("root1") == "tip1"
         assert db.get_compression_tip("mid1") == "tip1"
         assert db.get_compression_tip("tip1") == "tip1"
+
+    def test_find_live_compression_tip_requires_unique_chain(self, db):
+        import time as _time
+        self._build_compression_chain(db, _time.time() - 3600)
+        row = db.find_live_compression_tip("root1")
+        assert row is not None
+        assert row["id"] == "tip1"
+
+        db._conn.execute(
+            "INSERT INTO sessions (id, source, parent_session_id, started_at) "
+            "VALUES (?, ?, ?, ?)",
+            ("ambiguous_sibling", "cli", "root1", _time.time()),
+        )
+        db._conn.commit()
+
+        # UI projection still picks a best tip, but writer recovery fails closed.
+        assert db.get_compression_tip("root1") in {"tip1", "ambiguous_sibling"}
+        assert db.find_live_compression_tip("root1") is None
+
+    def test_find_live_compression_tip_claims_tip_lease_atomically(self, db):
+        import time as _time
+        self._build_compression_chain(db, _time.time() - 3600)
+
+        row = db.find_live_compression_tip(
+            "root1", acquire_lease_holder="recovery-holder", lease_ttl_seconds=60
+        )
+
+        assert row is not None
+        assert row["id"] == "tip1"
+        assert db.get_compression_lock_holder("tip1") == "recovery-holder"
+        assert db.try_acquire_compression_lock(
+            "tip1", "competing-holder", ttl_seconds=60
+        ) is False
 
 
 


### PR DESCRIPTION
## Summary
- Harden compression recovery across live descendant lineage.
- Apply managed gateway overlay on new profiles.
- Clear Slack Assistant status during delivery cleanup and disconnect.
- Add regression coverage.

## Validation
- `git diff --check` passed.
- Focused suite: 726 passed.
- 1 test failed because the environment lacks optional `anthropic` package: `ImportError: The 'anthropic' package is required for the Anthropic provider.`\n\nLocal branch is based on an older upstream commit and may need rebase before merge.