### PR TITLE
fix(google_meet): keep realtime PCM pump alive and unmute mic after admission

### DIFF
--- a/plugins/google_meet/meet_bot.py
+++ b/plugins/google_meet/meet_bot.py
@@ -107,6 +107,8 @@ class _BotState:
         self.last_audio_out_at: Optional[float] = None
         self.last_barge_in_at: Optional[float] = None
         self.leave_reason: Optional[str] = None
+        # Result of the post-admission mic check (see _ensure_mic_on).
+        self.mic_state: Optional[str] = None
         # Scraped captions, in order, deduped. Each entry is a dict of
         # {"ts": <epoch>, "speaker": str, "text": str}.
         self._seen: set = set()
@@ -162,6 +164,7 @@ class _BotState:
             "lastAudioOutAt": self.last_audio_out_at,
             "lastBargeInAt": self.last_barge_in_at,
             "leaveReason": self.leave_reason,
+            "micState": self.mic_state,
         }
         tmp = self.status_path.with_suffix(".json.tmp")
         tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
@@ -278,10 +281,11 @@ def _start_realtime_speaker(
 
     The speaker thread reads text lines from ``say_queue.jsonl``, sends each
     to OpenAI Realtime, and writes PCM audio into ``speaker.pcm``. A
-    separate *pump* thread forwards that PCM into the OS audio sink so
-    Chrome's fake mic picks it up. On Linux we pipe to ``paplay`` against
-    the null-sink; on macOS the caller is expected to have the BlackHole
-    device selected as default input.
+    *pump* process forwards that PCM into the OS audio sink so Chrome's
+    fake mic picks it up: on Linux ``paplay`` against the null-sink, on
+    macOS ``ffmpeg`` into the BlackHole device. The pump reads raw PCM
+    from stdin, fed by a tail thread that follows ``speaker.pcm`` as it
+    grows, so audio appended after startup is still played.
     """
     try:
         from plugins.google_meet.realtime.openai_client import (
@@ -340,75 +344,139 @@ def _start_realtime_speaker(
 
     # PCM pump: feeds speaker.pcm (24kHz s16le mono) into the OS audio
     # device that Chrome's fake mic reads from. Different tools per
-    # platform, but the contract is the same — block-read the growing
-    # PCM file and stream it to the device in near-real-time.
+    # platform, but the contract is the same — stream the growing PCM
+    # file to the device in near-real-time. The pump process reads raw
+    # PCM from stdin; a tail thread forwards appended bytes, so audio
+    # arriving after startup (the whole point of this mode) is played
+    # instead of the pump exiting on an empty file.
     platform_tag = (bridge_info or {}).get("platform")
+    pump_argv = None
     if platform_tag == "linux":
-        import subprocess as _sp
-
         sink = (bridge_info or {}).get("write_target") or "hermes_meet_sink"
+        pump_argv = [
+            "paplay",
+            "--raw",
+            "--rate=24000",
+            "--format=s16le",
+            "--channels=1",
+            f"--device={sink}",
+            "-",  # read raw PCM from stdin
+        ]
+    elif platform_tag == "darwin":
+        import shutil as _shutil
+
+        device_name = (bridge_info or {}).get("write_target") or "BlackHole 2ch"
+        if _shutil.which("ffmpeg"):
+            pump_argv = [
+                "ffmpeg",
+                "-hide_banner", "-loglevel", "error",
+                "-f", "s16le", "-ar", "24000", "-ac", "1",
+                "-i", "-",  # read raw PCM from stdin
+                "-f", "audiotoolbox",
+                "-audio_device_index", _mac_audio_device_index(device_name),
+                "-",  # positional output arg — ffmpeg rejects the command without one
+            ]
+        else:
+            state.set(error="ffmpeg not found — install via `brew install ffmpeg` for realtime on macOS")
+
+    if pump_argv:
         try:
+            import subprocess as _sp
+
             proc = _sp.Popen(
-                [
-                    "paplay",
-                    "--raw",
-                    "--rate=24000",
-                    "--format=s16le",
-                    "--channels=1",
-                    f"--device={sink}",
-                    str(pcm_path),
-                ],
-                stdin=_sp.DEVNULL,
+                pump_argv,
+                stdin=_sp.PIPE,
                 stdout=_sp.DEVNULL,
                 stderr=_sp.DEVNULL,
             )
             rt["pcm_pump"] = proc
+            t_pump = threading.Thread(
+                target=_pcm_tail_loop,
+                args=(proc, pcm_path, stop_flag),
+                name="meet-pcm-tail",
+                daemon=True,
+            )
+            t_pump.start()
+            rt["pcm_tail_thread"] = t_pump
         except FileNotFoundError:
-            state.set(error="paplay not found — install pulseaudio-utils for realtime on Linux")
-    elif platform_tag == "darwin":
-        # macOS: use ffmpeg to tail-read speaker.pcm and write it to the
-        # BlackHole output device. The user must have BlackHole selected
-        # as the default input in System Settings → Sound for Chrome to
-        # pick it up. We prefer ffmpeg because it's scriptable and can
-        # target AVFoundation devices by name; fall back to afplay-ing
-        # the file in a tight loop if ffmpeg is absent.
-        import shutil as _shutil
-        import subprocess as _sp
-
-        device_name = (bridge_info or {}).get("write_target") or "BlackHole 2ch"
-        if _shutil.which("ffmpeg"):
-            try:
-                # -re: read input at native frame rate.
-                # -f avfoundation -i: speaker path as raw PCM.
-                # -f s16le -ar 24000 -ac 1 -i <pcm>: interpret the file.
-                # -f audiotoolbox -audio_device_index: write to BlackHole.
-                # Simpler: output as raw via coreaudio using "-f audiotoolbox".
-                # ffmpeg's audiotoolbox output picks the current default
-                # output device, which isn't what we want. Instead we use
-                # -f avfoundation with the named device as OUTPUT via
-                # -vn and the device name.
-                proc = _sp.Popen(
-                    [
-                        "ffmpeg",
-                        "-nostdin", "-hide_banner", "-loglevel", "error",
-                        "-re",
-                        "-f", "s16le", "-ar", "24000", "-ac", "1",
-                        "-i", str(pcm_path),
-                        "-f", "audiotoolbox",
-                        "-audio_device_index", _mac_audio_device_index(device_name),
-                        "-",
-                    ],
-                    stdin=_sp.DEVNULL,
-                    stdout=_sp.DEVNULL,
-                    stderr=_sp.DEVNULL,
-                )
-                rt["pcm_pump"] = proc
-            except FileNotFoundError:
+            if platform_tag == "linux":
+                state.set(error="paplay not found — install pulseaudio-utils for realtime on Linux")
+            else:
                 state.set(error="ffmpeg not found — install via `brew install ffmpeg` for realtime on macOS")
-            except Exception as e:
-                state.set(error=f"macOS pcm pump failed to start: {e}")
-        else:
-            state.set(error="ffmpeg not found — install via `brew install ffmpeg` for realtime on macOS")
+        except Exception as e:
+            state.set(error=f"PCM pump failed to start: {e}")
+
+
+def _pcm_tail_loop(
+    proc,
+    pcm_path: Path,
+    stop_flag: dict,
+    poll_interval: float = 0.05,
+) -> None:
+    """Stream bytes appended to *pcm_path* into ``proc.stdin``.
+
+    Reads the PCM sink file from its end and forwards appended chunks to
+    the audio pump's stdin. Unlike a plain ``paplay <file>`` invocation,
+    this never exits when the file is empty or momentarily at EOF — it
+    keeps polling until ``stop_flag`` is set or the pump process dies, so
+    audio appended after startup still reaches the virtual microphone.
+
+    Returns when the pump's stdin is gone (process died) or the loop is
+    told to stop.
+    """
+    closed = False
+
+    def _close_stdin() -> None:
+        nonlocal closed
+        if closed:
+            return
+        closed = True
+        try:
+            proc.stdin.close()
+        except Exception:
+            pass
+
+    try:
+        try:
+            f = open(pcm_path, "rb")
+        except FileNotFoundError:
+            # The sink file is truncated just before the pump starts; if it
+            # is not visible yet, wait briefly instead of dying silently.
+            deadline = time.monotonic() + 2.0
+            while True:
+                if stop_flag.get("stop", False) or proc.poll() is not None:
+                    return
+                time.sleep(poll_interval)
+                try:
+                    f = open(pcm_path, "rb")
+                    break
+                except FileNotFoundError:
+                    if time.monotonic() > deadline:
+                        return
+        with f:
+            # Start at the end: the sink file is truncated before the
+            # pump starts, and we only forward bytes appended after that.
+            f.seek(0, os.SEEK_END)
+            while not stop_flag.get("stop", False):
+                if proc.poll() is not None:
+                    # Pump process exited on its own (device gone, crash);
+                    # nothing left to stream to.
+                    return
+                chunk = f.read(65536)
+                if chunk:
+                    try:
+                        proc.stdin.write(chunk)
+                        proc.stdin.flush()
+                    except Exception:
+                        # Pump process exited or its pipe closed; nothing
+                        # left to stream to.
+                        return
+                else:
+                    time.sleep(poll_interval)
+    except Exception:
+        return
+    finally:
+        _close_stdin()
 
 
 def _mac_audio_device_index(device_name: str) -> str:
@@ -498,6 +566,7 @@ def run_bot() -> int:  # noqa: C901 — orchestration, explicit branches
         "session": None,           # RealtimeSession | None
         "speaker_thread": None,    # threading.Thread | None
         "speaker_stop": None,      # callable | None
+        "pcm_tail_thread": None,   # threading.Thread | None
     }
     if rt["enabled"]:
         if not realtime_api_key:
@@ -638,6 +707,7 @@ def run_bot() -> int:  # noqa: C901 — orchestration, explicit branches
                             in_call=True,
                             lobby_waiting=False,
                             joined_at=now,
+                            mic_state=_ensure_mic_on(page),
                         )
                     elif now > lobby_deadline:
                         state.set(
@@ -703,11 +773,25 @@ def run_bot() -> int:  # noqa: C901 — orchestration, explicit branches
 
             context.close()
             browser.close()
-            # v2: teardown PCM pump, speaker thread, and audio bridge.
+            # The session is ending — make background loops see the stop
+            # flag regardless of why we left (SIGTERM sets it, but
+            # duration expiry and lobby timeout break the loop without
+            # setting it). Without this the tail thread would keep
+            # polling until its join timeout below.
+            stop_flag["stop"] = True
+            # v2: teardown PCM pump, tail thread, speaker thread, and
+            # audio bridge. The pump is terminated first so the tail
+            # thread's blocked stdin write fails fast and the join below
+            # returns promptly.
             if rt.get("pcm_pump"):
                 try:
                     rt["pcm_pump"].terminate()
                     rt["pcm_pump"].wait(timeout=3)
+                except Exception:
+                    pass
+            if rt.get("pcm_tail_thread"):
+                try:
+                    rt["pcm_tail_thread"].join(timeout=1.0)
                 except Exception:
                     pass
             if rt["speaker_stop"]:
@@ -747,6 +831,31 @@ def _try_guest_name(page, guest_name: str) -> None:
             locator.fill(guest_name, timeout=2_000)
     except Exception:
         pass
+
+
+def _ensure_mic_on(page) -> str:
+    """Make sure the bot's microphone is unmuted once admitted.
+
+    Meet's in-call mic toggle exposes its state via ``aria-label``:
+    "Turn on microphone" when muted, "Turn off microphone" when
+    unmuted. We only act when the muted label is present, so an
+    already-unmuted call is never touched.
+
+    Returns one of ``"unmuted"`` (already on), ``"unmuted_clicked"``
+    (we clicked the toggle), or ``"unknown"`` (button not found —
+    Meet variant changed, or the label is localized).
+    """
+    try:
+        muted = page.locator('button[aria-label*="Turn on microphone" i]').first
+        if muted.count() and muted.is_visible():
+            muted.click(timeout=3_000)
+            return "unmuted_clicked"
+        on = page.locator('button[aria-label*="Turn off microphone" i]').first
+        if on.count() and on.is_visible():
+            return "unmuted"
+    except Exception:
+        pass
+    return "unknown"
 
 
 def _detect_admission(page) -> bool:

--- a/tests/plugins/test_google_meet_plugin.py
+++ b/tests/plugins/test_google_meet_plugin.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import json
 import os
 import signal
+import threading
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -268,6 +270,384 @@ def test_detect_admission_returns_false_on_error():
         def evaluate(self, _js): raise RuntimeError("boom")
 
     assert _detect_admission(_FakePage()) is False
+
+
+# ---------------------------------------------------------------------------
+# Post-admission microphone unmute (_ensure_mic_on)
+# ---------------------------------------------------------------------------
+
+class _Locator:
+    """Fake Playwright locator whose ``.first`` is one of the fake buttons."""
+
+    def __init__(self, btn):
+        self._btn = btn
+
+    @property
+    def first(self):
+        return self._btn
+
+
+class _PresentBtn:
+    def __init__(self):
+        self.clicks = 0
+
+    def count(self):
+        return 1
+
+    def is_visible(self):
+        return True
+
+    def click(self, timeout=0):
+        self.clicks += 1
+
+
+class _AbsentBtn:
+    def __init__(self):
+        self.clicks = 0  # never incremented; keeps the fake's interface uniform
+
+    def count(self):
+        return 0
+
+    def is_visible(self):
+        return False
+
+
+class _MicPage:
+    """Fake page: ``muted=True`` means the "Turn on microphone" toggle exists."""
+
+    def __init__(self, muted):
+        self._muted = muted
+        self.muted_btn = _PresentBtn() if muted else _AbsentBtn()
+        self.unmuted_btn = _AbsentBtn() if muted else _PresentBtn()
+
+    def locator(self, sel):
+        if "Turn on microphone" in sel:
+            return _Locator(self.muted_btn)
+        return _Locator(self.unmuted_btn)
+
+
+def test_ensure_mic_on_clicks_toggle_when_muted():
+    from plugins.google_meet.meet_bot import _ensure_mic_on
+
+    page = _MicPage(muted=True)
+    assert _ensure_mic_on(page) == "unmuted_clicked"
+    assert page.muted_btn.clicks == 1
+
+
+def test_ensure_mic_on_leaves_already_unmuted_alone():
+    from plugins.google_meet.meet_bot import _ensure_mic_on
+
+    page = _MicPage(muted=False)
+    assert _ensure_mic_on(page) == "unmuted"
+    assert page.unmuted_btn.clicks == 0
+
+
+def test_ensure_mic_on_unknown_when_no_toggle_found():
+    from plugins.google_meet.meet_bot import _ensure_mic_on
+
+    class _Page:
+        def locator(self, _sel):
+            return _Locator(_AbsentBtn())
+
+    assert _ensure_mic_on(_Page()) == "unknown"
+
+
+def test_ensure_mic_on_survives_locator_errors():
+    from plugins.google_meet.meet_bot import _ensure_mic_on
+
+    class _Page:
+        def locator(self, _sel):
+            raise RuntimeError("boom")
+
+    assert _ensure_mic_on(_Page()) == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Streaming PCM pump tail loop (_pcm_tail_loop)
+# ---------------------------------------------------------------------------
+
+class _FakeStdin:
+    def __init__(self):
+        self.received = bytearray()
+        self.closed = False
+
+    def write(self, b):
+        self.received.extend(b)
+
+    def flush(self):
+        pass
+
+    def close(self):
+        self.closed = True
+
+
+class _FakePump:
+    def __init__(self, stdin, poll_result=None):
+        self.stdin = stdin
+        self._poll_result = poll_result
+
+    def poll(self):
+        return self._poll_result
+
+
+def _append_pcm(path: Path, data: bytes) -> None:
+    # Mirrors RealtimeSession.speak(): open 'ab', write, close.
+    with open(path, "ab") as f:
+        f.write(data)
+
+
+def test_pcm_tail_loop_survives_empty_file_and_streams_appended_bytes(tmp_path):
+    from plugins.google_meet.meet_bot import _pcm_tail_loop
+
+    pcm = tmp_path / "speaker.pcm"
+    pcm.write_bytes(b"")  # production truncates the sink before pump start
+    stdin = _FakeStdin()
+    stop = {"stop": False}
+
+    t = threading.Thread(target=_pcm_tail_loop, args=(_FakePump(stdin), pcm, stop, 0.01))
+    t.start()
+    try:
+        # The pump must NOT exit just because the file is empty at start.
+        time.sleep(0.1)
+        assert t.is_alive(), "tail loop exited on an empty sink file"
+
+        # Bytes appended after startup must reach the pump's stdin.
+        chunk = b"\x00\x01" * 10
+        _append_pcm(pcm, chunk)
+        deadline = time.time() + 2.0
+        while len(stdin.received) < len(chunk) and time.time() < deadline:
+            time.sleep(0.01)
+        assert bytes(stdin.received) == chunk
+
+        # Later appends keep flowing.
+        chunk2 = b"\xff" * 25
+        _append_pcm(pcm, chunk2)
+        deadline = time.time() + 2.0
+        while len(stdin.received) < len(chunk) + len(chunk2) and time.time() < deadline:
+            time.sleep(0.01)
+        assert bytes(stdin.received) == chunk + chunk2
+    finally:
+        stop["stop"] = True
+        t.join(timeout=1.0)
+    assert stdin.closed
+
+
+def test_pcm_tail_loop_stops_when_told(tmp_path):
+    from plugins.google_meet.meet_bot import _pcm_tail_loop
+
+    pcm = tmp_path / "speaker.pcm"
+    pcm.write_bytes(b"")
+    stdin = _FakeStdin()
+    stop = {"stop": False}
+
+    t = threading.Thread(target=_pcm_tail_loop, args=(_FakePump(stdin), pcm, stop, 0.01))
+    t.start()
+    time.sleep(0.05)
+    stop["stop"] = True
+    t.join(timeout=1.0)
+    assert not t.is_alive()
+    assert stdin.closed
+
+
+def test_pcm_tail_loop_exits_when_pump_dies(tmp_path):
+    from plugins.google_meet.meet_bot import _pcm_tail_loop
+
+    class _DeadStdin:
+        def write(self, _b):
+            raise BrokenPipeError("pump gone")
+
+        def flush(self):
+            pass
+
+        def close(self):
+            pass
+
+    pcm = tmp_path / "speaker.pcm"
+    pcm.write_bytes(b"")
+    stop = {"stop": False}
+
+    t = threading.Thread(
+        target=_pcm_tail_loop,
+        args=(_FakePump(_DeadStdin()), pcm, stop, 0.01),
+    )
+    t.start()
+    _append_pcm(pcm, b"\x00" * 100)  # triggers a write that fails
+    t.join(timeout=1.0)
+    assert not t.is_alive()
+
+
+def test_pcm_tail_loop_exits_when_pump_process_gone_while_idle(tmp_path):
+    from plugins.google_meet.meet_bot import _pcm_tail_loop
+
+    pcm = tmp_path / "speaker.pcm"
+    pcm.write_bytes(b"")
+    stdin = _FakeStdin()
+    stop = {"stop": False}
+
+    # poll() != None means the pump process has exited; the loop must
+    # notice even while the sink file is idle (no pending writes).
+    t = threading.Thread(
+        target=_pcm_tail_loop,
+        args=(_FakePump(stdin, poll_result=1), pcm, stop, 0.01),
+    )
+    t.start()
+    t.join(timeout=1.0)
+    assert not t.is_alive()
+    assert len(stdin.received) == 0
+
+
+def test_pcm_tail_loop_waits_for_late_sink_file(tmp_path):
+    from plugins.google_meet.meet_bot import _pcm_tail_loop
+
+    pcm = tmp_path / "speaker.pcm"  # deliberately NOT created yet
+    stdin = _FakeStdin()
+    stop = {"stop": False}
+
+    t = threading.Thread(target=_pcm_tail_loop, args=(_FakePump(stdin), pcm, stop, 0.01))
+    t.start()
+    try:
+        time.sleep(0.05)
+        assert t.is_alive(), "tail loop gave up before the sink file appeared"
+        # The file appears empty (as in production); let the loop open it
+        # at EOF, then grow it and confirm appended bytes still flow.
+        pcm.write_bytes(b"")
+        time.sleep(0.05)
+        _append_pcm(pcm, b"\x00" * 10)
+        deadline = time.time() + 2.0
+        while len(stdin.received) < 10 and time.time() < deadline:
+            time.sleep(0.01)
+        assert bytes(stdin.received) == b"\x00" * 10
+    finally:
+        stop["stop"] = True
+        t.join(timeout=1.0)
+
+
+def test_realtime_speaker_reports_missing_pump_binary(monkeypatch, tmp_path):
+    import plugins.google_meet.meet_bot as mb
+    from plugins.google_meet.meet_bot import _start_realtime_speaker
+
+    class _FakeSession:
+        def __init__(self, **kwargs):
+            self.audio_bytes_out = 0
+
+        def connect(self):
+            pass
+
+    class _FakeSpeaker:
+        def __init__(self, **kwargs):
+            pass
+
+        def run_until_stopped(self, stop_fn):
+            return None
+
+    monkeypatch.setattr(
+        "plugins.google_meet.realtime.openai_client.RealtimeSession", _FakeSession
+    )
+    monkeypatch.setattr(
+        "plugins.google_meet.realtime.openai_client.RealtimeSpeaker", _FakeSpeaker
+    )
+
+    def _missing_pump(*args, **kwargs):
+        raise FileNotFoundError("paplay")
+
+    monkeypatch.setattr("subprocess.Popen", _missing_pump)
+
+    out = tmp_path / "meet"
+    state = mb._BotState(out_dir=out, meeting_id="abc", url="https://meet.google.com/abc-defg-hij")
+    rt = {
+        "session": None,
+        "speaker_thread": None,
+        "speaker_stop": None,
+        "pcm_pump": None,
+        "pcm_tail_thread": None,
+    }
+    _start_realtime_speaker(
+        rt=rt,
+        out_dir=out,
+        bridge_info={"platform": "linux", "write_target": "hermes_meet_sink"},
+        api_key="sk-test",
+        model="gpt-realtime",
+        voice="alloy",
+        instructions="",
+        stop_flag={"stop": False},
+        state=state,
+    )
+    assert "paplay not found" in (state.error or "")
+    assert rt["pcm_pump"] is None
+    assert rt["pcm_tail_thread"] is None
+
+
+def test_realtime_speaker_builds_macos_ffmpeg_pump_argv(monkeypatch, tmp_path):
+    import plugins.google_meet.meet_bot as mb
+    from plugins.google_meet.meet_bot import _start_realtime_speaker
+
+    class _FakeSession:
+        def __init__(self, **kwargs):
+            self.audio_bytes_out = 0
+
+        def connect(self):
+            pass
+
+    class _FakeSpeaker:
+        def __init__(self, **kwargs):
+            pass
+
+        def run_until_stopped(self, stop_fn):
+            return None
+
+    monkeypatch.setattr(
+        "plugins.google_meet.realtime.openai_client.RealtimeSession", _FakeSession
+    )
+    monkeypatch.setattr(
+        "plugins.google_meet.realtime.openai_client.RealtimeSpeaker", _FakeSpeaker
+    )
+    monkeypatch.setattr(
+        "shutil.which", lambda name: "/usr/bin/ffmpeg" if name == "ffmpeg" else None
+    )
+    monkeypatch.setattr(mb, "_mac_audio_device_index", lambda device_name: "3")
+
+    captured = {}
+
+    def _fake_popen(argv, **kwargs):
+        captured["argv"] = argv
+        captured["kwargs"] = kwargs
+        return _FakePump(_FakeStdin())
+
+    monkeypatch.setattr("subprocess.Popen", _fake_popen)
+
+    out = tmp_path / "meet"
+    state = mb._BotState(out_dir=out, meeting_id="abc", url="https://meet.google.com/abc-defg-hij")
+    stop = {"stop": False}
+    rt = {
+        "session": None,
+        "speaker_thread": None,
+        "speaker_stop": None,
+        "pcm_pump": None,
+        "pcm_tail_thread": None,
+    }
+    _start_realtime_speaker(
+        rt=rt,
+        out_dir=out,
+        bridge_info={"platform": "darwin", "write_target": "BlackHole 2ch"},
+        api_key="sk-test",
+        model="gpt-realtime",
+        voice="alloy",
+        instructions="",
+        stop_flag=stop,
+        state=state,
+    )
+    argv = captured["argv"]
+    assert argv[0] == "ffmpeg"
+    assert argv[argv.index("-i") + 1] == "-"  # raw PCM from stdin
+    # The output-side "-f" (after the "-i -" input) selects audiotoolbox.
+    assert argv[argv.index("-f", argv.index("-i")) + 1] == "audiotoolbox"
+    # ffmpeg rejects the command without a positional output arg.
+    assert argv[-1] == "-"
+    assert captured["kwargs"]["stdin"] is not None  # PIPE
+    assert rt["pcm_pump"] is not None
+    assert rt["pcm_tail_thread"] is not None
+    stop["stop"] = True
+    rt["pcm_tail_thread"].join(timeout=1.0)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes two of the four issues reported in #80875 for the bundled Google Meet plugin's `--mode realtime` path: the bot could join a meeting but emit no audible speech.

**1. PCM pump exits before audio arrives (issue 3).** The pump started `paplay` (Linux) / `ffmpeg` (macOS) against `speaker.pcm` while the file was empty. Both read the file to EOF and exited immediately, so audio appended by the Realtime session after startup never reached the virtual microphone — `audioBytesOut` grew while participants heard nothing. The pump now reads raw PCM from **stdin**, fed by a tail thread (`_pcm_tail_loop`) that follows `speaker.pcm` as it grows and keeps polling at EOF until the session stops. It also exits promptly if the pump process dies mid-session, and surfaces the platform-appropriate install hint if `paplay`/`ffmpeg` is missing.

**2. Bot joins muted (issue 2).** Meet can place an authenticated bot in-call with the microphone muted; nothing in the plugin checked. After admission is detected, `_ensure_mic_on(page)` looks for the mic toggle's `aria-label` and clicks "Turn on microphone" only when the muted label is present (an already-unmuted call is never touched). The result is surfaced in `hermes meet status` as `micState` (`unmuted` / `unmuted_clicked` / `unknown`).

Scope is deliberately limited: the join-button race (issue 1) is already covered by open PRs (#37945, #48958), and bidirectional meeting-audio ingestion (issue 4) is a feature-scale change deferred to the RealtimeVoiceProvider convergence in #77111.

## Related Issue

Refs #80875 (does not close — issues 1 and 4 remain open)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/google_meet/meet_bot.py` — streaming PCM pump (stdin-fed tail thread), post-admission mic unmute, `micState` status field; docstrings updated
- `tests/plugins/test_google_meet_plugin.py` — 11 new tests: tail-loop liveness on empty/late sink files, appended-byte streaming, stop flag, pump-death detection (via write failure and via `poll()` while idle), missing-binary error path, macOS ffmpeg argv shape, mic toggle muted/unmuted/missing/error branches

## How to Test

1. `pytest tests/plugins/test_google_meet_plugin.py tests/plugins/test_google_meet_realtime.py tests/plugins/test_google_meet_audio.py tests/plugins/test_google_meet_node.py -q` → 41 passed
2. `ruff check plugins/google_meet/meet_bot.py tests/plugins/test_google_meet_plugin.py` → clean
3. Live (needs Google Meet auth + `HERMES_MEET_REALTIME_KEY`): join a meeting with `--mode realtime`, run `hermes meet say "Hello"`, confirm participants hear audio and `micState` shows `unmuted`/`unmuted_clicked` in `hermes meet status`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (join-race and GA-protocol PRs already exist and are intentionally not duplicated here)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (ran the google_meet suite: 41 passed; full `tests/plugins/` shows 7 pre-existing failures unrelated to this change — hindsight-provider env ImportError and a2a batch-order interference, reproduced on untouched main)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (test suite + empirical ffmpeg stdin/argv check); Linux paplay path covered by unit tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstrings updated in `meet_bot.py`; `micState` is additive to the existing status JSON)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — both Linux and macOS pump paths updated; Windows has no realtime pump path (unchanged)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Notes

**Open question:** the pump change makes realtime mode depend on `paplay` (Linux) / `ffmpeg` (macOS) being present; the old macOS path already required ffmpeg, and Linux already required paplay — this PR only changes *how* they are invoked (stdin vs. file argument), not the dependency set. If the maintainers would prefer the pump to also stream through a pure-Python fallback (e.g. `sndfile`/`sounddevice`), that can be a follow-up.

## Screenshots / Logs

```
$ pytest tests/plugins/test_google_meet_plugin.py tests/plugins/test_google_meet_realtime.py tests/plugins/test_google_meet_audio.py tests/plugins/test_google_meet_node.py -q
.........................................                                 [100%]
41 passed in 1.01s

$ ruff check plugins/google_meet/meet_bot.py tests/plugins/test_google_meet_plugin.py
All checks passed!
```
