### PR TITLE
fix(desktop): count pinned rows toward sidebar window truncation

### DIFF
--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -166,6 +166,47 @@ describe('Hermes REST helpers', () => {
     expect(paths).toContainEqual(expect.stringContaining('exclude_sources=cron%2Ctool'))
   })
 
+  it('reports truncated in the legacy path when pinned rows occupy in-window slots', async () => {
+    // Regression: 50 rows back against a cap-50 window, 3 of them pinned.
+    // Pinned conversations consume LIMIT slots like any other recent row, so
+    // the window is full and older sessions exist beyond it — the legacy path
+    // must report truncated or the load-more row never renders.
+    const row = (id: string, pinned: boolean) => ({ id, title: id, profile: 'default', pinned })
+
+    const recents = [
+      ...Array.from({ length: 47 }, (_, i) => row(`recent-${i}`, false)),
+      ...Array.from({ length: 3 }, (_, i) => row(`pinned-${i}`, true))
+    ]
+
+    api.mockImplementation(({ path }: { path: string }) => {
+      if (path.startsWith('/api/profiles/sessions/sidebar')) {
+        return Promise.reject(new Error('404: {"detail":"No such API endpoint: /api/profiles/sessions/sidebar"}'))
+      }
+
+      if (path.includes('source=cron')) {
+        return Promise.resolve({ ...emptySessionsResponse, sessions: [], total: 0 })
+      }
+
+      if (path.includes('exclude_sources=cron%2Cdesktop')) {
+        return Promise.resolve({ ...emptySessionsResponse, sessions: [], total: 0 })
+      }
+
+      return Promise.resolve({ ...emptySessionsResponse, sessions: recents, total: recents.length })
+    })
+
+    const result = await listSidebarSessions({
+      recentsProfile: 'default',
+      recentsLimit: 50,
+      recentsExclude: ['cron'],
+      cronLimit: 50,
+      messagingLimit: 100,
+      messagingExclude: []
+    })
+
+    expect(result.recents.sessions).toHaveLength(50)
+    expect(result.recents.profiles_truncated).toEqual({ default: true })
+  })
+
   it('remembers endpoint-missing and skips re-probing the batched route on later refreshes', async () => {
     api.mockImplementation(({ path }: { path: string }) =>
       path.startsWith('/api/profiles/sessions/sidebar')

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -465,16 +465,19 @@ export interface SidebarSessionSlice {
 
 /** Which profiles filled their per-profile window in a returned page. The
  *  legacy per-slice endpoint doesn't report this, so derive it from the rows:
- *  a profile at (or over) the cap still has more on disk. Pinned rows are
- *  discounted — they're back-filled past the LIMIT, so counting them fakes a
- *  full page and leaves a "Load more" that can never resolve. */
+ *  a profile at (or over) the cap still has more on disk. Pinned rows count
+ *  toward the window like any other row — they occupy in-window LIMIT slots
+ *  on the backend, so discounting them would under-report a full page (e.g.
+ *  47 unpinned + 3 pinned in a cap-50 page) and hide the load-more row,
+ *  stranding older sessions behind an unreachable page. Back-filled pins past
+ *  the LIMIT only cost an extra click that resolves to an empty page. */
 function profilesTruncatedFrom(sessions: SessionInfo[], cap: number): Record<string, boolean> {
   const counts = new Map<string, number>()
 
   for (const session of sessions) {
     const key = session.profile || 'default'
 
-    counts.set(key, (counts.get(key) ?? 0) + (session.pinned ? 0 : 1))
+    counts.set(key, (counts.get(key) ?? 0) + 1)
   }
 
   return Object.fromEntries([...counts].map(([name, count]) => [name, count >= cap]))

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -329,10 +329,15 @@ def get_profiles_sessions_sidebar(
                 # A full window means more rows remain on disk. That is all the
                 # sidebar's "load more" needs, and unlike an exact COUNT(*) per
                 # profile per refresh it costs nothing beyond the rows already
-                # read. Discount pinned back-fills — they arrive past the LIMIT
-                # and would otherwise fake a full page on a short list.
-                unpinned_count = sum(1 for s in profile_rows if not s.get("pinned"))
-                recents_truncated[name] = unpinned_count >= recents_cap
+                # read. Count ALL rows in the window, pinned included: pinned
+                # conversations occupy in-window LIMIT slots like any other
+                # recent row, so discounting them would under-report a full
+                # window (e.g. 47 unpinned + 3 pinned in a cap-50 page) and
+                # silently hide the load-more affordance — stranding every
+                # older session behind an unreachable page. (Back-filled pins
+                # past the LIMIT inflate the count slightly; the only cost is
+                # an extra click that resolves to an empty page.)
+                recents_truncated[name] = len(profile_rows) >= recents_cap
                 recents_rows.extend(_tag(profile_rows, name))
             cron_rows.extend(_tag(_slice(db, source="cron", cap=cron_cap), name))
             messaging_rows.extend(

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -476,6 +476,44 @@ class TestWebServerEndpoints:
             "sidebar-stale"
         ]
 
+    def test_profiles_sidebar_truncated_when_pinned_rows_fill_window(self):
+        """Pinned sessions occupying in-window LIMIT slots must still mark the
+        sidebar window truncated (#81484).
+
+        Regression: recents_truncated discounted pinned rows
+        (``unpinned_count >= cap``). With 47 unpinned + 3 pinned rows in a
+        cap-50 page, that computed False — the desktop hid its load-more
+        affordance and every older session became unreachable from the list,
+        even though the window was genuinely full.
+        """
+        from hermes_constants import get_hermes_home
+        from hermes_state import SessionDB
+
+        db_path = get_hermes_home() / "state.db"
+        seed = SessionDB(db_path=db_path)
+        try:
+            for i in range(47):
+                seed.create_session(f"unpinned-{i:02d}", source="cli")
+                seed.append_message(
+                    session_id=f"unpinned-{i:02d}", role="user", content=f"hi {i}"
+                )
+            for i in range(3):
+                seed.create_session(f"pinned-{i:02d}", source="cli")
+                seed.append_message(
+                    session_id=f"pinned-{i:02d}", role="user", content=f"pinned {i}"
+                )
+                seed.set_session_pinned(f"pinned-{i:02d}", True)
+        finally:
+            seed.close()
+
+        response = self.client.get("/api/profiles/sessions/sidebar?recents_limit=50")
+
+        assert response.status_code == 200
+        payload = response.json()
+        recents = payload["recents"]
+        assert len(recents["sessions"]) == 50
+        assert recents["profiles_truncated"] == {"default": True}
+
     def test_heal_gives_up_when_reconcile_cannot_fix_the_store(self, monkeypatch):
         """A probe failure reconciliation can't cure must not retry forever.
 


### PR DESCRIPTION
## What does this PR do?

Fixes **#81484**: the sidebar "Load more" (⋯) row never appears when pinned sessions occupy the most-recent recency window, stranding every older session behind an unreachable page.

## Root cause

Two places computed sidebar truncation from **unpinned rows only**:

1. **Backend** — `hermes_cli/web_routers/profiles.py` (batched `/api/profiles/sessions/sidebar`):
   ```python
   unpinned_count = sum(1 for s in profile_rows if not s.get("pinned"))
   recents_truncated[name] = unpinned_count >= recents_cap
   ```
   Pinned conversations consume in-window LIMIT slots like any other recent row. With 47 unpinned + 3 pinned in a cap-50 page, this evaluates `False` even though the window is genuinely full — the frontend renders no load-more row, and 92 older sessions in the affected store became unreachable from the list (FTS search still finds them).

2. **Frontend legacy fallback** — `apps/desktop/src/hermes.ts` `profilesTruncatedFrom()` had the same `pinned ? 0 : 1` discount.

## The fix

Count **all** returned rows against the cap in both places. Back-filled pins past the LIMIT only inflate the count; the sole cost is an extra click that resolves to an empty page (frontend already hides the button when no new rows arrive). Under-reporting a full window, by contrast, hides real history with no recovery path.

## Tests

- Backend: `test_profiles_sidebar_truncated_when_pinned_rows_fill_window` — 47 unpinned + 3 pinned, cap 50 → `profiles_truncated == {default: True}`
- Frontend: legacy path with 50 rows (47 unpinned + 3 pinned) → `profiles_truncated == {default: true}`
- Verified against a live 139-session state.db: old logic `False`, new logic `True`

## Related

- #44009 / #44015 (closed, unmerged): the opposite failure of the same discount logic ("Load N more" never disappears) — still reproducible at current main
- #72492 / #72494 (open): multi-profile legacy-path truncation miscount — related but distinct (batched endpoint, single profile)
