### PR TITLE
fix(dashboard): clipboard copy, chat scroll, settings/profiles merge

### DIFF
--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -14,7 +14,7 @@ import type {
   SessionUndoResponse,
   SystemBatteryResponse
 } from '../../../gatewayTypes.js'
-import { writeClipboardText } from '../../../lib/clipboard.js'
+import { normalizeClipboardText, writeClipboardText } from '../../../lib/clipboard.js'
 import { writeOsc52Clipboard } from '../../../lib/osc52.js'
 import {
   configureDetectedTerminalKeybindings,
@@ -407,15 +407,20 @@ export const coreCommands: SlashCommand[] = [
         return sys('nothing to copy — start a conversation first')
       }
 
+      const clipboardText = normalizeClipboardText(target.text)
+      if (!clipboardText) {
+        return sys('nothing textual to copy')
+      }
+
       const shouldUseTerminalClipboard = isRemoteShellSession(process.env)
 
       if (shouldUseTerminalClipboard) {
-        writeOsc52Clipboard(target.text)
+        writeOsc52Clipboard(clipboardText)
 
         return sys('sent OSC52 copy sequence (terminal support required)')
       }
 
-      void writeClipboardText(target.text)
+      void writeClipboardText(clipboardText)
         .then(nativeOk => {
           if (ctx.stale()) {
             return
@@ -424,7 +429,7 @@ export const coreCommands: SlashCommand[] = [
           if (nativeOk) {
             sys('copied to clipboard')
           } else {
-            writeOsc52Clipboard(target.text)
+            writeOsc52Clipboard(clipboardText)
             sys('sent OSC52 copy sequence (terminal support required)')
           }
         })

--- a/ui-tui/src/lib/clipboard.test.ts
+++ b/ui-tui/src/lib/clipboard.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { normalizeClipboardText } from "./clipboard";
+
+describe("normalizeClipboardText", () => {
+  it("copies the textual payload when a message wrapper is passed", () => {
+    expect(
+      normalizeClipboardText({
+        text: "```ts\nconst answer = 42;\n```",
+        metadata: { source: "assistant" },
+      }),
+    ).toBe("```ts\nconst answer = 42;\n```");
+  });
+
+  it("never stringifies an internal object as [object Object]", () => {
+    expect(normalizeClipboardText({ metadata: { source: "assistant" } })).toBe("");
+    expect(normalizeClipboardText({ value: { text: "nested" } })).toBe("nested");
+  });
+});

--- a/ui-tui/src/lib/clipboard.ts
+++ b/ui-tui/src/lib/clipboard.ts
@@ -142,6 +142,27 @@ function writeClipboardCommands(platform: NodeJS.Platform, env: NodeJS.ProcessEn
  * Returns true if at least one backend succeeded, false otherwise
  * (callers should fall back to OSC52 on false).
  */
+function textFromUnknown(value: unknown, depth = 0): string {
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined || depth > 4) return "";
+  if (Array.isArray(value)) {
+    return value.map((item) => textFromUnknown(item, depth + 1)).filter(Boolean).join("\n");
+  }
+  if (typeof value !== "object") return "";
+
+  const record = value as Record<string, unknown>;
+  for (const key of ["text", "content", "value", "message"]) {
+    const text = textFromUnknown(record[key], depth + 1);
+    if (text) return text;
+  }
+  return "";
+}
+
+/** Extract only user-visible text before sending it to OSC52/system clipboard. */
+export function normalizeClipboardText(value: unknown): string {
+  return textFromUnknown(value);
+}
+
 export async function writeClipboardText(
   text: string,
   platform: NodeJS.Platform = process.platform,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -19,6 +19,7 @@ import {
   Navigate,
   useLocation,
   useNavigate,
+  useSearchParams,
 } from "react-router";
 import {
   Activity,
@@ -104,6 +105,7 @@ import type { PluginManifest } from "@/plugins";
 import { useTheme } from "@/themes";
 import { isDashboardEmbeddedChatEnabled } from "@/lib/dashboard-flags";
 import { latchChatActivation } from "@/lib/chat-activation";
+import { managementTabFromSearch } from "@/lib/chat-navigation";
 import { api } from "@/lib/api";
 import type { StatusResponse, UpdateCheckResponse } from "@/lib/api";
 
@@ -132,6 +134,60 @@ function UnknownRouteFallback({ pluginsLoading }: { pluginsLoading: boolean }) {
     return null;
   }
   return <Navigate to="/sessions" replace />;
+}
+
+function ManagePage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeTab = managementTabFromSearch(
+    searchParams.toString() ? `?${searchParams.toString()}` : "",
+  );
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-auto p-4 sm:p-6">
+      <div
+        aria-label="Manage"
+        className="flex w-fit items-center gap-1 rounded-lg border border-current/20 p-1"
+        role="tablist"
+      >
+        <Button
+          aria-selected={activeTab === "profiles"}
+          className={cn(
+            "px-3 py-1.5",
+            activeTab === "profiles" && "bg-current/10",
+          )}
+          ghost
+          onClick={() => setSearchParams({ tab: "profiles" })}
+          role="tab"
+          type="button"
+        >
+          Profiles
+        </Button>
+        <Button
+          aria-selected={activeTab === "settings"}
+          className={cn(
+            "px-3 py-1.5",
+            activeTab === "settings" && "bg-current/10",
+          )}
+          ghost
+          onClick={() => setSearchParams({ tab: "settings" })}
+          role="tab"
+          type="button"
+        >
+          Settings
+        </Button>
+      </div>
+
+      {activeTab === "profiles" ? <ProfilesPage /> : <ConfigPage />}
+    </div>
+  );
+}
+
+function ProfilesRedirect() {
+  return <Navigate replace to="/manage?tab=profiles" />;
+}
+
+function ConfigRedirect() {
+  return <Navigate replace to="/manage?tab=settings" />;
 }
 
 const CHAT_NAV_ITEM: NavItem = {
@@ -167,9 +223,10 @@ const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/channels": ChannelsPage,
   "/webhooks": WebhooksPage,
   "/system": SystemPage,
-  "/profiles": ProfilesPage,
+  "/manage": ManagePage,
+  "/profiles": ProfilesRedirect,
   "/profiles/new": ProfileBuilderPage,
-  "/config": ConfigPage,
+  "/config": ConfigRedirect,
   "/env": EnvPage,
   "/docs": DocsPage,
 };
@@ -210,8 +267,7 @@ const BUILTIN_NAV_REST: NavItem[] = [
   { path: "/channels", label: "Channels", icon: Radio },
   { path: "/webhooks", label: "Webhooks", icon: Webhook },
   { path: "/pairing", label: "Pairing", icon: ShieldCheck },
-  { path: "/profiles", labelKey: "profiles", label: "Profiles", icon: Users },
-  { path: "/config", labelKey: "config", label: "Config", icon: Settings },
+  { path: "/manage", labelKey: "manage", label: "Manage", icon: Settings },
   { path: "/env", labelKey: "keys", label: "Keys", icon: KeyRound },
   { path: "/system", label: "System", icon: Wrench },
   {

--- a/web/src/lib/chat-navigation.test.ts
+++ b/web/src/lib/chat-navigation.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import {
+  MANAGEMENT_PATH,
+  managementTabFromSearch,
+  shouldScrollToBottomOnChatActivation,
+} from "./chat-navigation";
+
+describe("chat navigation", () => {
+  it("recognizes only an inactive-to-active chat transition as a bottom-scroll", () => {
+    expect(shouldScrollToBottomOnChatActivation(false, true)).toBe(true);
+    expect(shouldScrollToBottomOnChatActivation(true, true)).toBe(false);
+    expect(shouldScrollToBottomOnChatActivation(false, false)).toBe(false);
+  });
+
+  it("provides one management entry point with stable profile/settings tabs", () => {
+    expect(MANAGEMENT_PATH).toBe("/manage");
+    expect(managementTabFromSearch("")).toBe("profiles");
+    expect(managementTabFromSearch("?tab=settings")).toBe("settings");
+    expect(managementTabFromSearch("?tab=unknown")).toBe("profiles");
+  });
+});

--- a/web/src/lib/chat-navigation.ts
+++ b/web/src/lib/chat-navigation.ts
@@ -1,0 +1,15 @@
+export const MANAGEMENT_PATH = "/manage";
+
+type ManagementTab = "profiles" | "settings";
+
+export function managementTabFromSearch(search: string): ManagementTab {
+  const tab = new URLSearchParams(search).get("tab");
+  return tab === "settings" ? "settings" : "profiles";
+}
+
+export function shouldScrollToBottomOnChatActivation(
+  wasActive: boolean,
+  isActive: boolean,
+): boolean {
+  return !wasActive && isActive;
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -36,6 +36,7 @@ import { usePageHeader } from "@/contexts/usePageHeader";
 import { useI18n } from "@/i18n";
 import { api } from "@/lib/api";
 import { latchChatActivation } from "@/lib/chat-activation";
+import { shouldScrollToBottomOnChatActivation } from "@/lib/chat-navigation";
 import { normalizeSessionTitle } from "@/lib/chat-title";
 import { PtyResumeSanitizer } from "@/lib/pty-resume-sanitizer";
 import {
@@ -164,6 +165,7 @@ function terminalLineHeightForWidth(layoutWidthPx: number): number {
 export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<Terminal | null>(null);
+  const prevActiveRef = useRef(isActive);
   const fitRef = useRef<FitAddon | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
   // Exposed to the main metrics-sync effect so it can refit the terminal
@@ -333,6 +335,14 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     (title: string | null) => setSessionTitleState({ scope: titleScope, title }),
     [titleScope],
   );
+
+  useEffect(() => {
+    const wasActive = prevActiveRef.current;
+    prevActiveRef.current = isActive;
+    if (shouldScrollToBottomOnChatActivation(wasActive, isActive)) {
+      termRef.current?.scrollToBottom();
+    }
+  }, [isActive]);
 
   useEffect(() => {
     if (!isActive) {


### PR DESCRIPTION
## 변경 내용

### 🐛 버그 수정
1. **코드 블록 복사 시 `[object Object]` 포함 제거** — `normalizeClipboardText()`를 추가해 OSC52와 브라우저 복사 양쪽에서 non-string payload를 문자열로 직렬화
2. **채팅 재진입 시 맨 아래 스크롤** — 다른 페이지 갔다가 채팅으로 돌아올 때 `inactive→active` 전환에서 1회만 `scrollToBottom()` 호출 (매 렌더 강제 아님)

### ✨ UX 개선
3. **프로필+설정 사이드바 통합** — `/profiles`와 `/config`를 단일 `/manage` 페이지로 통합 (Profiles/Settings 탭). 기존 URL은 리다이렉트 유지
4. **설정/프로필에서 채팅 복귀** — 통합된 관리 페이지에서 사이드바의 Chat NavLink로 항상 돌아갈 수 있음

### 테스트
- `web/src/lib/chat-navigation.test.ts` — 스크롤 활성화 조건 + 탭 파싱 (2 tests ✅)
- `ui-tui/src/lib/clipboard.test.ts` — 클립보드 정규화 (2 tests ✅)

### 검증
- `npx vitest run` ✅ 4/4 테스트 통과
- `npx tsc --noEmit` ✅ 타입 에러 없음