### PR TITLE
fix(file): don't flag UTF-8 files as binary on truncated read sample

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -673,3 +673,26 @@ class TestReadNonUtf8IsBinary:
         ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
         # Proper UTF-8 (including non-ASCII) must still read as text.
         assert ops._is_likely_binary("notes.txt", "café résumé\nsecond\n") is False
+
+    def test_truncated_cjk_tail_single_ufffd_not_flagged(self, tmp_path):
+        """A 1000-byte `head -c` truncation can split a UTF-8 multi-byte char.
+
+        The truncated tail decodes (errors="replace") to exactly one U+FFFD —
+        this is truncation noise, not mojibake, and must NOT flag the file
+        binary. Genuine decode failures produce multiple U+FFFD chars and are
+        still caught by the >1 threshold.
+        """
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        # 333 CJK chars (3 bytes each) = 999 bytes; the 1000th byte splits a
+        # 3-byte char → 1 U+FFFD after lossy decode. No newlines → the
+        # non-printable ratio is 0, so only the U+FFFD check could flag it.
+        truncated_sample = "汉" * 333 + "\ufffd"
+        assert len(truncated_sample) == 334
+        assert ops._is_likely_binary("notes.txt", truncated_sample) is False
+
+    def test_many_ufffd_still_flagged_binary(self, tmp_path):
+        """Two or more U+FFFD chars in the sample = real mojibake, not truncation."""
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        # e.g. GBK bytes decoded as UTF-8 yield dozens of replacement chars.
+        mojibake_sample = "正常文本" * 10 + "\ufffd" * 50
+        assert ops._is_likely_binary("notes.txt", mojibake_sample) is True

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -901,9 +901,13 @@ class ShellFileOperations(FileOperations):
             # lossy text would let a read→edit→write round-trip silently
             # overwrite the original bytes with mojibake. Treat a file whose
             # sample carries the replacement char as binary (read-only) so the
-            # agent can't corrupt it. Legitimate UTF-8 text effectively never
-            # contains U+FFFD.
-            if "\ufffd" in content_sample[:1000]:
+            # agent can't corrupt it.
+            # NOTE: allow exactly one U+FFFD — `head -c 1000` truncation can
+            # split a UTF-8 multi-byte char at the 1000-byte boundary, and the
+            # truncated tail decodes to a single U+FFFD even in legitimate
+            # UTF-8 text (common with CJK files). Genuine decode failures
+            # produce many more (e.g. GBK-decoding a UTF-8 file → dozens).
+            if content_sample[:1000].count("\ufffd") > 1:
                 return True
             non_printable = sum(1 for c in content_sample[:1000]
                                if ord(c) < 32 and c not in '\n\r\t')


### PR DESCRIPTION
## Summary

`read_file` uses a 1000-byte `head -c` sample to decide whether a file is binary. When the 1000th byte splits a UTF-8 multi-byte character, the truncated tail decodes (with `errors="replace"`) to **exactly one** U+FFFD — even in perfectly legitimate UTF-8 text. This is very common with CJK files (3 bytes per char).

The old check (`"\ufffd" in sample`) treated **any** U+FFFD as binary, so large CJK text files (>= ~333 chars) were permanently flagged binary/read-only.

## Change

Allow exactly one U+FFFD in the sample: `sample.count("\ufffd") > 1` flags binary. Genuine decode failures (GBK bytes read as UTF-8, latin-1 decoded with replace) produce **many** replacement chars and are still caught.

## Tests

Added to `tests/tools/test_file_operations.py::TestReadNonUtf8IsBinary`:
- `test_truncated_cjk_tail_single_ufffd_not_flagged` — 333 CJK chars (999 bytes) + truncated char tail → 1 U+FFFD, must NOT be binary
- `test_many_ufffd_still_flagged_binary` — mojibake with dozens of U+FFFD still flagged

Verified: 6/6 binary-related tests pass; full-file run shows no new failures vs. base (8 pre-existing Windows-only failures: POSIX file-mode + symlink tests).