### PR TITLE
fix(feishu): retry post messages without thread routing on 99992402

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1982,16 +1982,38 @@ class FeishuAdapter(BasePlatformAdapter):
                         metadata=metadata,
                     )
                 except Exception as exc:
-                    if msg_type != "post" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
+                    if (
+                        msg_type == "post"
+                        and (metadata or {}).get("thread_id")
+                        and "99992402" in str(exc)
+                    ):
+                        # Feishu rejects the receive_id_type=thread_id create
+                        # path for post payloads. Strip thread routing and
+                        # retry so the message lands in the main chat instead
+                        # of being dropped (audio got the same fix in
+                        # _send_uploaded_file_message).
+                        logger.warning(
+                            "[Feishu] Post+thread_id rejected by API (%s); retrying without thread routing",
+                            exc,
+                        )
+                        response = await self._feishu_send_with_retry(
+                            chat_id=chat_id,
+                            msg_type=msg_type,
+                            payload=payload,
+                            reply_to=None,
+                            metadata={k: v for k, v in (metadata or {}).items() if k != "thread_id"},
+                        )
+                    elif msg_type != "post" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
                         raise
-                    logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
-                    response = await self._feishu_send_with_retry(
-                        chat_id=chat_id,
-                        msg_type="text",
-                        payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
-                        reply_to=reply_to,
-                        metadata=metadata,
-                    )
+                    else:
+                        logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
+                        response = await self._feishu_send_with_retry(
+                            chat_id=chat_id,
+                            msg_type="text",
+                            payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                            reply_to=reply_to,
+                            metadata=metadata,
+                        )
                 if (
                     msg_type == "post"
                     and not self._response_succeeded(response)
@@ -2004,6 +2026,22 @@ class FeishuAdapter(BasePlatformAdapter):
                         payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
                         reply_to=reply_to,
                         metadata=metadata,
+                    )
+                # Post + thread_id → 99992402 response path (create with
+                # receive_id_type=thread_id). Retry without thread routing.
+                if (
+                    msg_type == "post"
+                    and not self._response_succeeded(response)
+                    and getattr(response, "code", None) == 99992402
+                    and (metadata or {}).get("thread_id")
+                ):
+                    logger.warning("[Feishu] Post+thread_id rejected by API response; retrying without thread routing")
+                    response = await self._feishu_send_with_retry(
+                        chat_id=chat_id,
+                        msg_type=msg_type,
+                        payload=payload,
+                        reply_to=None,
+                        metadata={k: v for k, v in (metadata or {}).items() if k != "thread_id"},
                     )
                 last_response = response
 

--- a/tests/gateway/test_feishu_post_thread_fallback.py
+++ b/tests/gateway/test_feishu_post_thread_fallback.py
@@ -1,0 +1,134 @@
+"""Post + thread_id messages rejected with 99992402 retry without thread routing.
+
+Feishu rejects the ``receive_id_type=thread_id`` create path for post
+payloads (error 99992402). The adapter must strip thread routing and retry
+so the message lands in the main chat instead of being dropped. Mirrors the
+existing audio fallback in ``_send_uploaded_file_message``.
+"""
+
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from gateway.config import PlatformConfig
+from plugins.platforms.feishu.adapter import FeishuAdapter
+
+
+def _make_adapter() -> FeishuAdapter:
+    config = PlatformConfig(enabled=True)
+    adapter = FeishuAdapter(config)
+    adapter._client = MagicMock()
+    return adapter
+
+
+def _ok_response(message_id: str = "msg_001") -> SimpleNamespace:
+    return SimpleNamespace(
+        success=lambda: True,
+        data=SimpleNamespace(message_id=message_id),
+        msg="",
+        code=0,
+    )
+
+
+class TestSendMessagePostThreadFallback:
+    """send_message strips thread routing on 99992402 for post messages."""
+
+    @pytest.mark.asyncio
+    async def test_exception_path_strips_thread_id_and_retries(self):
+        adapter = _make_adapter()
+        api_error = Exception("Feishu API error: 99992402")
+        ok = _ok_response("msg_ok")
+
+        with patch.object(
+            adapter,
+            "_feishu_send_with_retry",
+            new_callable=AsyncMock,
+            side_effect=[api_error, ok],
+        ) as mock_send:
+            result = await adapter.send(
+                "oc_1", "**bold** content", metadata={"thread_id": "om_thread"}
+            )
+
+        assert result.success is True
+        assert result.message_id == "msg_ok"
+        assert mock_send.await_count == 2
+
+        first, second = mock_send.await_args_list
+        # First attempt kept thread routing; retry dropped it.
+        assert first.kwargs["metadata"].get("thread_id") == "om_thread"
+        assert second.kwargs["metadata"] == {}
+        assert second.kwargs["msg_type"] == "post"
+        assert second.kwargs["reply_to"] is None
+
+    @pytest.mark.asyncio
+    async def test_response_path_strips_thread_id_and_retries(self):
+        adapter = _make_adapter()
+        rejected = SimpleNamespace(
+            success=lambda: False,
+            msg="create message fail",
+            code=99992402,
+            data=None,
+        )
+        ok = _ok_response("msg_ok2")
+
+        with patch.object(
+            adapter,
+            "_feishu_send_with_retry",
+            new_callable=AsyncMock,
+            side_effect=[rejected, ok],
+        ) as mock_send:
+            result = await adapter.send(
+                "oc_1", "**bold** content", metadata={"thread_id": "om_thread"}
+            )
+
+        assert result.success is True
+        assert result.message_id == "msg_ok2"
+        assert mock_send.await_count == 2
+
+        first, second = mock_send.await_args_list
+        assert first.kwargs["metadata"].get("thread_id") == "om_thread"
+        assert second.kwargs["metadata"] == {}
+        assert second.kwargs["msg_type"] == "post"
+        assert second.kwargs["reply_to"] is None
+
+    @pytest.mark.asyncio
+    async def test_non_thread_post_error_still_raises(self):
+        """Unrelated post errors propagate unchanged (no fallback).
+
+        ``send()`` catches exceptions and returns ``SendResult(success=False,
+        error=...)``; assert the error surfaces and only one attempt was made
+        (no thread-stripping retry).
+        """
+        adapter = _make_adapter()
+        api_error = Exception("Feishu API error: 99992402")
+        with patch.object(
+            adapter,
+            "_feishu_send_with_retry",
+            new_callable=AsyncMock,
+            side_effect=[api_error],
+        ) as mock_send:
+            result = await adapter.send("oc_1", "**bold** content")
+
+        assert result.success is False
+        assert "99992402" in result.error
+        assert mock_send.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_plain_text_with_thread_id_unaffected(self):
+        """Text messages keep thread routing (only post payloads are rejected)."""
+        adapter = _make_adapter()
+        ok = _ok_response("msg_txt")
+        with patch.object(
+            adapter,
+            "_feishu_send_with_retry",
+            new_callable=AsyncMock,
+            return_value=ok,
+        ) as mock_send:
+            result = await adapter.send(
+                "oc_1", "plain text", metadata={"thread_id": "om_thread"}
+            )
+
+        assert result.success is True
+        assert mock_send.await_count == 1
+        assert mock_send.await_args.kwargs["msg_type"] == "text"
+        assert mock_send.await_args.kwargs["metadata"].get("thread_id") == "om_thread"


### PR DESCRIPTION
Fixes #78975 (and duplicate #81169).

## Summary

Feishu rejects the `receive_id_type=thread_id` create path for **post** payloads with error **99992402**. Any post message routed via a topic thread (e.g. cron origin deliveries into Feishu topic chats) was dropped — the exception path only knew the "invalid post content" fallback, and the response path never looked at `code == 99992402`.

## Change

In `FeishuAdapter.send()`, when a post message routed via `metadata["thread_id"]` is rejected with 99992402 (both the raised-exception path and the API-response path), strip the thread routing and retry so the message lands in the main chat instead of being dropped. This mirrors the existing audio fallback in `_send_uploaded_file_message` (#78975 context).

- Exception path: new branch before the `raise` — detects `msg_type == "post"`, `thread_id` present, `"99992402"` in the error.
- Response path: new branch after the content-invalid fallback — detects `code == 99992402` + `thread_id`.
- Both retries use `reply_to=None` and drop only the `thread_id` key from metadata.

## Tests

New `tests/gateway/test_feishu_post_thread_fallback.py` (4 tests, all pass):
- exception path strips thread_id and retries into the main chat
- response path strips thread_id and retries
- unrelated post errors surface unchanged (single attempt, no fallback)
- text messages keep thread routing untouched

Existing feishu gateway tests show no new failures vs. base (pre-existing env-dependent failures unchanged).