### PR TITLE
fix(gateway): self-reacquire scoped lock regardless of start_time

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -1391,7 +1391,21 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
         except (KeyError, TypeError, ValueError):
             existing_pid = None
 
-        if existing_pid == os.getpid() and existing.get("start_time") == record.get("start_time"):
+        if existing_pid == os.getpid():
+            # Same PID as the live process: this record is always ours to
+            # refresh, regardless of start_time. start_time only guards PID
+            # reuse by a *different* process, which cannot happen for our
+            # own PID -- if the disk record isn't from this call, it is from
+            # a now-dead process that used to have this PID, and taking over
+            # its abandoned lock is correct too. Requiring start_time to
+            # match here broke self-reacquisition whenever the two writes
+            # disagreed (e.g. start_time: null on disk from a platform
+            # without /proc, once psutil failed at the first write), which
+            # made a gateway reconnecting (e.g. after a Discord 503 burst)
+            # report its own live PID as a foreign squatter of its own lock
+            # forever (#81468). This matches the same "compare only when
+            # both are known" idiom already used for *other* PIDs below and
+            # by runtime_status_pid_is_live.
             _write_json_file(lock_path, record)
             return True, existing
 
@@ -1503,8 +1517,10 @@ def release_scoped_lock(scope: str, identity: str) -> None:
         return
     if existing.get("pid") != os.getpid():
         return
-    if existing.get("start_time") != _get_process_start_time(os.getpid()):
-        return
+    # Same PID as the live process means we own this lock -- see the matching
+    # comment in acquire_scoped_lock (#81468). Requiring start_time equality
+    # here left the lock stuck across reconnects whenever the disk and live
+    # values disagreed (e.g. start_time: null from a platform without /proc).
     try:
         lock_path.unlink(missing_ok=True)
     except OSError:

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -418,6 +418,102 @@ class TestScopedLocks:
         assert payload["pid"] == os.getpid()
         assert payload["metadata"]["platform"] == "telegram"
 
+    def test_acquire_scoped_lock_self_reacquire_heals_null_start_time(self, tmp_path, monkeypatch):
+        """Regression for #81468: gateway must self-reacquire its own lock
+        even when the on-disk record's start_time is null.
+
+        On macOS, psutil can transiently fail to read create_time() at the
+        moment the lock is first written, leaving start_time: null on disk
+        forever (only a successful self-reacquire ever refreshes it). A
+        live reconnect (e.g. after a Discord 503 burst) then calls
+        acquire_scoped_lock() again from the *same* PID, but this time
+        _get_process_start_time() succeeds and returns a real value. The
+        None/number mismatch must not make the gateway see itself as a
+        foreign squatter of its own token lock.
+        """
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "discord-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": os.getpid(),
+            "start_time": None,
+            "kind": "hermes-gateway",
+            "argv": list(sys.argv),
+        }))
+
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 999)
+
+        acquired, existing = status.acquire_scoped_lock(
+            "discord-bot-token", "secret", metadata={"platform": "discord"}
+        )
+
+        assert acquired is True
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+        assert payload["start_time"] == 999
+        assert payload["metadata"]["platform"] == "discord"
+
+    def test_acquire_scoped_lock_same_pid_different_start_time_still_self_reacquires(
+        self, tmp_path, monkeypatch
+    ):
+        """A PID match with two *known, differing* start_times is still
+        treated as self-reacquisition, not routed through the staleness
+        check.
+
+        There can only ever be one live process holding this PID right now
+        (this call). If the on-disk record names the same PID with a
+        different start_time, its writer is necessarily dead already (PID
+        reuse), so taking over is always correct -- start_time cannot
+        distinguish "us" from "an unrelated live process" the way it does
+        for *other* PIDs, because no other live process can share our PID.
+        """
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "discord-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": os.getpid(),
+            "start_time": 111,
+            "kind": "hermes-gateway",
+            "argv": list(sys.argv),
+        }))
+
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 999)
+
+        acquired, existing = status.acquire_scoped_lock(
+            "discord-bot-token", "secret", metadata={"platform": "discord"}
+        )
+
+        assert acquired is True
+        payload = json.loads(lock_path.read_text())
+        assert payload["start_time"] == 999
+        assert payload["metadata"]["platform"] == "discord"
+
+    def test_release_scoped_lock_heals_null_start_time(self, tmp_path, monkeypatch):
+        """Regression for #81468: release must not no-op on its own lock
+        just because the on-disk start_time disagrees with the live one.
+
+        Mirrors the acquire-side bug: release_scoped_lock() required
+        start_time equality to confirm ownership, so a lock with
+        start_time: null on disk (platform without /proc, psutil miss at
+        first write) could never be released by the very process that owns
+        it -- leaving the lock file stuck until an unrelated staleness
+        check cleaned it up.
+        """
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "discord-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": os.getpid(),
+            "start_time": None,
+            "kind": "hermes-gateway",
+            "argv": list(sys.argv),
+        }))
+
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 999)
+
+        status.release_scoped_lock("discord-bot-token", "secret")
+
+        assert not lock_path.exists()
 
     def test_acquire_scoped_lock_race_second_acquirer_loses(self, tmp_path, monkeypatch):
         """Two racing starters both observe the same stale lock. The loser's


### PR DESCRIPTION
## What does this PR do?

After a Discord 503 reconnect burst, the gateway can no longer reacquire the scoped lock it already holds for its own bot token. It reports its own live PID as a foreign holder of its own lock, and the platform connection stays down.

Both `acquire_scoped_lock` and `release_scoped_lock` in `gateway/status.py` required `start_time` equality to recognize a lock record as belonging to the calling process:

```python
if existing_pid == os.getpid() and existing.get("start_time") == record.get("start_time"):
    ...  # acquire: self-reacquire shortcut
if existing.get("start_time") != _get_process_start_time(os.getpid()):
    return  # release: refuse to release our own lock
```

`start_time` comes from `_get_process_start_time()`, which returns `None` whenever the platform cannot report it. macOS and Windows have no `/proc`, so `psutil` can transiently fail at the exact moment the lock is first written. Once a lock record is written with `start_time: null`, only the self-reacquire branch above ever refreshes it — and that branch is gated on equality, so a `None`-vs-real-value disagreement makes it fall through to the general staleness check. That check finds the PID alive and gateway-shaped (it's us) and correctly concludes "not stale" — so acquisition is refused. On the release side, the same disagreement means the process that legitimately owns the lock can never remove it.

### Why the `start_time` guard doesn't belong in the self-ownership test

`start_time` exists to disambiguate PID reuse: a recycled PID can name a *different* process than the one that originally wrote the record. That scenario is structurally impossible when `existing_pid == os.getpid()` — only one live process can hold a given PID at any moment, so if the on-disk record names our own PID, it is either literally this call (self) or a stale leftover from a now-dead process that used to have this PID (also safe to take over). Either way, self-reacquisition is the correct outcome, which is why the conjunct is removed rather than replaced with a different comparison — not weakened elsewhere: the staleness path for *other* PIDs is untouched, so a lock genuinely held by a live foreign gateway is still refused.

This also brings both functions in line with the "compare `start_time` only when both sides are known" idiom already used elsewhere in this same file (e.g. `runtime_status_pid_is_live`), which never treated a `None` on either side as an automatic mismatch.

## Prior art / avoiding duplication

I searched before writing this (`gh search prs --repo NousResearch/hermes-agent "start_time lock"`, `"scoped_lock"`, `"81468"`) and found two other open PRs already targeting the same root cause:

- **#81475** — removes the `start_time` conjunct from `acquire_scoped_lock` **and** applies the matching fix to `release_scoped_lock`.
- **#81477** — removes the `start_time` conjunct from `acquire_scoped_lock` only. Already flagged by a maintainer as a duplicate of #81475, since #81475 additionally covers `release_scoped_lock`.

This PR converges on the same core fix as #81475 (confirmed independently while investigating #81468, before re-checking for prior art) and is functionally equivalent in scope: both `acquire_scoped_lock` and `release_scoped_lock` are fixed. The concrete differences, in case they're useful to cherry-pick regardless of which PR lands:

- An explicit regression test asserting that a same-PID record with two *known, differing* `start_time` values still self-reacquires (`test_acquire_scoped_lock_same_pid_different_start_time_still_self_reacquires`) — documents that this is an intentional design decision, not just the null-value case.
- Comments cross-reference the existing `runtime_status_pid_is_live` idiom as precedent for the "compare only when both known" pattern, for reviewers checking internal consistency.

Given the overlap, maintainers may prefer to merge #81475 (opened first) and close this one — happy to have this closed in favor of it. 
## Investigation for related bottlenecks

- Confirmed `_acquire_platform_lock` / `_release_platform_lock` in `gateway/platforms/base.py` are the only call sites for these two functions, shared by every platform adapter (Discord, Telegram, Feishu, Slack, WhatsApp, Signal, Buzz) — the bug and the fix are not Discord-specific.
- Checked `release_all_scoped_locks` for the same pattern: it already guards with `owner_start_time is not None`, so it was not affected.
- Checked `release_scoped_lock`'s PID comparison (`existing.get("pid") != os.getpid()`) for a missing `int()` cast like the one `acquire_scoped_lock` has — found a minor, unrelated edge case (a manually-corrupted lock file with `pid` stored as a string would never be released) but left it untouched, out of scope for #81468.

## Type of change

Bug fix (non-breaking). Only the self-ownership test in `acquire_scoped_lock` and the ownership check in `release_scoped_lock` change; staleness rules for foreign PIDs, the lock file format, and the acquisition contract are untouched.

## Testing

```
python -m pytest tests/gateway/test_status.py -q                                  # 54 passed
python -m pytest tests/gateway/test_discord_connect.py tests/gateway/test_discord_liveness.py \
  tests/gateway/test_telegram_conflict.py tests/gateway/test_slack.py \
  tests/gateway/test_whatsapp_connect.py tests/gateway/test_signal.py \
  tests/gateway/test_buzz_adapter.py -q                                           # 274 passed
python -m py_compile gateway/status.py                                            # OK
```

`tests/gateway/test_feishu.py` has 11 pre-existing, unrelated failures (`get_hermes_home` environment issue in `plugins/platforms/feishu/adapter.py`) — confirmed present on `main` without this diff (`git stash` + rerun), so they are not a regression from this change.

## Flow

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A[🔥 Discord 503 Burst] --> B[⚔️ Reconnect Triggered]
    B --> C[🩸 acquire_scoped_lock Same PID]
    C --> D{Start Time Match?}
    D -->|"Before: No (null vs real)"| E[💀 Falls Through To Staleness Check]
    E --> F[⚰️ Reports Self As Foreign Squatter]
    F --> G[🚫 Platform Stays Down]
    D -->|"After: PID Match Is Enough"| H[🔥 Self Reacquire Shortcut]
    H --> I[⚡ Lock Refreshed Instantly]
    I --> J[🚀 Platform Reconnects]
    K[🩸 release_scoped_lock Same PID] --> L{Start Time Match?}
    L -->|"Before: No"| M[⛓️ Refuses To Release Own Lock]
    L -->|"After: PID Match Is Enough"| N[✅ Lock Released Cleanly]
```

Fixes #81468 (P1, `comp/gateway`, `platform/discord`).
