### PR TITLE
fix(cli): run MCP bootstrap without shell

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import re
 import shutil
+import shlex
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -391,16 +392,27 @@ def _install_root() -> Path:
 def _run_bootstrap(cwd: Path, commands: List[str]) -> None:
     """Execute bootstrap commands in *cwd*. Raise CatalogError on first failure.
 
-    Each command runs through the shell (so `&&` etc. work). The output is
-    streamed to the user's terminal for visibility.
+    Commands are parsed to argv via :func:`shlex.split` and executed without a
+    shell to avoid shell metacharacter interpretation. Output is streamed to the
+    user's terminal for visibility.
     """
     for cmd in commands:
         print(color(f"  $ {cmd}", Colors.DIM))
-        proc = subprocess.run(cmd, cwd=str(cwd), shell=True)
+        try:
+            argv = shlex.split(cmd)
+        except ValueError as exc:
+            raise CatalogError(f"invalid bootstrap command syntax: {cmd}") from exc
+        if not argv:
+            raise CatalogError(f"invalid bootstrap command: {cmd}")
+        try:
+            proc = subprocess.run(argv, cwd=str(cwd), shell=False)
+        except OSError as exc:
+            raise CatalogError(f"bootstrap command could not execute: {cmd}") from exc
         if proc.returncode != 0:
             raise CatalogError(
                 f"bootstrap step failed (exit {proc.returncode}): {cmd}"
             )
+
 
 
 def _do_git_install(entry: CatalogEntry) -> Path:

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -259,12 +259,80 @@ class TestInstall:
         assert "secret-val" not in raw
 
 
+class TestBootstrap:
+    def test_run_bootstrap_uses_shlex_split_without_shell(self, monkeypatch, tmp_path):
+        from hermes_cli import mcp_catalog as mc
+
+        calls = []
+
+        class FakeProc:
+            returncode = 0
+
+        def fake_run(argv, *args, **kwargs):
+            calls.append((tuple(argv), kwargs.get("cwd"), kwargs.get("shell")))
+            return FakeProc()
+
+        monkeypatch.setattr(mc.subprocess, "run", fake_run)
+
+        mc._run_bootstrap(
+            tmp_path, ["python -c 'print(\"hello world\")'", "echo done"]
+        )
+
+        assert calls == [
+            (("python", "-c", 'print("hello world")'), str(tmp_path), False),
+            (("echo", "done"), str(tmp_path), False),
+        ]
+
+    def test_run_bootstrap_raises_catalog_error_on_failure(self, monkeypatch, tmp_path):
+        from hermes_cli import mcp_catalog as mc
+
+        class FakeProc:
+            def __init__(self, code):
+                self.returncode = code
+
+        calls = []
+
+        def fake_run(argv, *args, **kwargs):
+            calls.append((tuple(argv), kwargs.get("cwd"), kwargs.get("shell")))
+            return FakeProc(7) if "fail" in argv[0] else FakeProc(0)
+
+        monkeypatch.setattr(mc.subprocess, "run", fake_run)
+
+        with pytest.raises(mc.CatalogError, match=r"bootstrap step failed \(exit 7\): fail me"):
+            mc._run_bootstrap(tmp_path, ["echo ok", "fail me"])
+
+        # Failure should stop on the failing command and propagate CatalogError.
+        assert calls == [
+            (("echo", "ok"), str(tmp_path), False),
+            (("fail", "me"), str(tmp_path), False),
+        ]
+
+    def test_run_bootstrap_invalid_syntax_is_reported(self, tmp_path):
+        from hermes_cli import mcp_catalog as mc
+
+        with pytest.raises(mc.CatalogError, match="invalid bootstrap command syntax"):
+            mc._run_bootstrap(tmp_path, ['echo "unterminated'])
+
+    def test_run_bootstrap_empty_command_is_reported(self, tmp_path):
+        from hermes_cli import mcp_catalog as mc
+
+        with pytest.raises(mc.CatalogError, match="invalid bootstrap command"):
+            mc._run_bootstrap(tmp_path, [""])
+
+    def test_run_bootstrap_command_not_found_is_reported(self, monkeypatch, tmp_path):
+        from hermes_cli import mcp_catalog as mc
+
+        def fake_run(argv, *args, **kwargs):
+            raise FileNotFoundError("no such file")
+
+        monkeypatch.setattr(mc.subprocess, "run", fake_run)
+
+        with pytest.raises(mc.CatalogError, match="could not execute"):
+            mc._run_bootstrap(tmp_path, ["totally_missing_cmd --help"])
 
 
-# ---------------------------------------------------------------------------
 # Uninstall
 # ---------------------------------------------------------------------------
-
 
 class TestUninstall:
     def test_uninstall_removes_server_block(self, catalog_dir):


### PR DESCRIPTION
## Summary
- Executes MCP catalog bootstrap commands without `shell=True` to avoid shell metacharacter parsing/expansion.
- Uses `shlex.split` and executes command argv directly.
- Adds explicit `CatalogError` handling for malformed, empty, or non-executable bootstrap commands.
- Adds unit tests covering command parsing, failure handling, invalid syntax, empty command, and execution errors.

## Test Plan
- [x] python3 -m py_compile hermes_cli/mcp_catalog.py tests/hermes_cli/test_mcp_catalog.py
- [x] python3 -m pytest tests/hermes_cli/test_mcp_catalog.py -q
- [x] ruff check hermes_cli/mcp_catalog.py tests/hermes_cli/test_mcp_catalog.py
- [x] manual overlap check: no open PR exists for issue #81365 (closed PR #81367 observed)

Closes #81365
