### PR TITLE
fix(sessions): write session exports into the directory --help documents

### DIFF
--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -131,11 +131,19 @@ def _export_output_file(output: str, default_name: str) -> Path:
     and raise ``IsADirectoryError``.  Missing parents are created, matching
     the ``mkdir(parents=True, exist_ok=True)`` those two branches already do.
 
-    A plain file path is returned unchanged, so existing invocations behave
-    exactly as before.
+    A trailing path separator asks for a directory explicitly, so it is
+    honoured even when the directory does not exist yet — ``open()`` rejects
+    such a path outright today, so no working invocation changes meaning.
+
+    A path that neither exists as a directory nor ends in a separator stays
+    a file name, exactly as it is treated today: ``sessions export
+    ~/my-export --format jsonl --session-id X`` writes a file called
+    ``my-export`` and must keep doing so, which is why a bare non-existent
+    path is not guessed at.
     """
+    separators = tuple(sep for sep in (os.sep, os.altsep) if sep)
     path = Path(output).expanduser()
-    if path.is_dir():
+    if path.is_dir() or output.endswith(separators):
         path = path / default_name
     path.parent.mkdir(parents=True, exist_ok=True)
     return path

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -121,6 +121,26 @@ def _prune_never_active_keyed(db, args):
     )
 
 
+def _export_output_file(output: str, default_name: str) -> Path:
+    """Resolve the ``sessions export`` positional to a writable file path.
+
+    ``hermes sessions export --help`` documents the positional as an output
+    *directory* for md/qmd, and the bulk md/qmd branch below honours that, as
+    does the multi-session trace branch.  The single-file writers still have
+    to name a file inside such a directory rather than hand it to ``open()``
+    and raise ``IsADirectoryError``.  Missing parents are created, matching
+    the ``mkdir(parents=True, exist_ok=True)`` those two branches already do.
+
+    A plain file path is returned unchanged, so existing invocations behave
+    exactly as before.
+    """
+    path = Path(output).expanduser()
+    if path.is_dir():
+        path = path / default_name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
 def cmd_sessions(args, sessions_parser=None):
     import json as _json
 
@@ -481,11 +501,14 @@ def cmd_sessions(args, sessions_parser=None):
                 sys.stdout.write(rendered)
                 db.close()
                 return
-            with open(args.output, "w", encoding="utf-8") as f:
+            out_path = _export_output_file(
+                args.output, f"{args.only}.{args.format}"
+            )
+            with open(out_path, "w", encoding="utf-8") as f:
                 f.write(rendered)
             count, noun = export_record_count(sessions, only=args.only)
             suffix = "" if count == 1 else "s"
-            print(f"Exported {count} {noun}{suffix} to {args.output}")
+            print(f"Exported {count} {noun}{suffix} to {out_path}")
             db.close()
             return
 
@@ -508,10 +531,11 @@ def cmd_sessions(args, sessions_parser=None):
                 content = generate_html_export(sessions[0])
             else:
                 content = generate_multi_session_html_export(sessions)
-            with open(args.output, "w", encoding="utf-8") as f:
+            out_path = _export_output_file(args.output, "sessions.html")
+            with open(out_path, "w", encoding="utf-8") as f:
                 f.write(content)
             suffix = "" if len(sessions) == 1 else "s"
-            print(f"Exported {len(sessions)} session{suffix} to {args.output} (HTML)")
+            print(f"Exported {len(sessions)} session{suffix} to {out_path} (HTML)")
             db.close()
             return
 
@@ -606,9 +630,12 @@ def cmd_sessions(args, sessions_parser=None):
                     if not args.output or args.output == "-":
                         sys.stdout.write(jsonl)
                     else:
-                        with open(args.output, "w", encoding="utf-8") as f:
+                        out_path = _export_output_file(
+                            args.output, f"{ids[0]}.trace.jsonl"
+                        )
+                        with open(out_path, "w", encoding="utf-8") as f:
                             f.write(jsonl)
-                        print(f"Exported 1 session trace to {args.output}")
+                        print(f"Exported 1 session trace to {out_path}")
                 else:
                     out_dir = (
                         Path(args.output).expanduser()
@@ -649,9 +676,12 @@ def cmd_sessions(args, sessions_parser=None):
 
                     sys.stdout.write(line)
                 else:
-                    with open(args.output, "w", encoding="utf-8") as f:
+                    out_path = _export_output_file(
+                        args.output, f"{resolved_session_id}.jsonl"
+                    )
+                    with open(out_path, "w", encoding="utf-8") as f:
                         f.write(line)
-                    print(f"Exported 1 session to {args.output}")
+                    print(f"Exported 1 session to {out_path}")
             else:
                 if filters:
                     candidates = db.list_prune_candidates(**filters)
@@ -684,12 +714,13 @@ def cmd_sessions(args, sessions_parser=None):
                             _json.dumps(_redact(s), ensure_ascii=False) + "\n"
                         )
                 else:
-                    with open(args.output, "w", encoding="utf-8") as f:
+                    out_path = _export_output_file(args.output, "sessions.jsonl")
+                    with open(out_path, "w", encoding="utf-8") as f:
                         for s in sessions:
                             f.write(
                                 _json.dumps(_redact(s), ensure_ascii=False) + "\n"
                             )
-                    print(f"Exported {len(sessions)} sessions to {args.output}")
+                    print(f"Exported {len(sessions)} sessions to {out_path}")
             return
 
         # Markdown / QMD export

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -65,11 +65,19 @@ def _export_output_file(output: str, default_name: str) -> Path:
     and raise ``IsADirectoryError``.  Missing parents are created, matching
     the ``mkdir(parents=True, exist_ok=True)`` those two branches already do.
 
-    A plain file path is returned unchanged, so existing invocations behave
-    exactly as before.
+    A trailing path separator asks for a directory explicitly, so it is
+    honoured even when the directory does not exist yet — ``open()`` rejects
+    such a path outright today, so no working invocation changes meaning.
+
+    A path that neither exists as a directory nor ends in a separator stays
+    a file name, exactly as it is treated today: ``sessions export
+    ~/my-export --format jsonl --session-id X`` writes a file called
+    ``my-export`` and must keep doing so, which is why a bare non-existent
+    path is not guessed at.
     """
+    separators = tuple(sep for sep in (os.sep, os.altsep) if sep)
     path = Path(output).expanduser()
-    if path.is_dir():
+    if path.is_dir() or output.endswith(separators):
         path = path / default_name
     path.parent.mkdir(parents=True, exist_ok=True)
     return path

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -55,6 +55,26 @@ def _confirm_prompt(prompt: str) -> bool:
         return False
 
 
+def _export_output_file(output: str, default_name: str) -> Path:
+    """Resolve the ``sessions export`` positional to a writable file path.
+
+    ``hermes sessions export --help`` documents the positional as an output
+    *directory* for md/qmd, and the bulk md/qmd branch below honours that, as
+    does the multi-session trace branch.  The single-file writers still have
+    to name a file inside such a directory rather than hand it to ``open()``
+    and raise ``IsADirectoryError``.  Missing parents are created, matching
+    the ``mkdir(parents=True, exist_ok=True)`` those two branches already do.
+
+    A plain file path is returned unchanged, so existing invocations behave
+    exactly as before.
+    """
+    path = Path(output).expanduser()
+    if path.is_dir():
+        path = path / default_name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
 def cmd_sessions(args, sessions_parser=None):
     import json as _json
 
@@ -403,11 +423,14 @@ def cmd_sessions(args, sessions_parser=None):
                 sys.stdout.write(rendered)
                 db.close()
                 return
-            with open(args.output, "w", encoding="utf-8") as f:
+            out_path = _export_output_file(
+                args.output, f"{args.only}.{args.format}"
+            )
+            with open(out_path, "w", encoding="utf-8") as f:
                 f.write(rendered)
             count, noun = export_record_count(sessions, only=args.only)
             suffix = "" if count == 1 else "s"
-            print(f"Exported {count} {noun}{suffix} to {args.output}")
+            print(f"Exported {count} {noun}{suffix} to {out_path}")
             db.close()
             return
 
@@ -430,10 +453,11 @@ def cmd_sessions(args, sessions_parser=None):
                 content = generate_html_export(sessions[0])
             else:
                 content = generate_multi_session_html_export(sessions)
-            with open(args.output, "w", encoding="utf-8") as f:
+            out_path = _export_output_file(args.output, "sessions.html")
+            with open(out_path, "w", encoding="utf-8") as f:
                 f.write(content)
             suffix = "" if len(sessions) == 1 else "s"
-            print(f"Exported {len(sessions)} session{suffix} to {args.output} (HTML)")
+            print(f"Exported {len(sessions)} session{suffix} to {out_path} (HTML)")
             db.close()
             return
 
@@ -528,9 +552,12 @@ def cmd_sessions(args, sessions_parser=None):
                     if not args.output or args.output == "-":
                         sys.stdout.write(jsonl)
                     else:
-                        with open(args.output, "w", encoding="utf-8") as f:
+                        out_path = _export_output_file(
+                            args.output, f"{ids[0]}.trace.jsonl"
+                        )
+                        with open(out_path, "w", encoding="utf-8") as f:
                             f.write(jsonl)
-                        print(f"Exported 1 session trace to {args.output}")
+                        print(f"Exported 1 session trace to {out_path}")
                 else:
                     out_dir = (
                         Path(args.output).expanduser()
@@ -571,9 +598,12 @@ def cmd_sessions(args, sessions_parser=None):
 
                     sys.stdout.write(line)
                 else:
-                    with open(args.output, "w", encoding="utf-8") as f:
+                    out_path = _export_output_file(
+                        args.output, f"{resolved_session_id}.jsonl"
+                    )
+                    with open(out_path, "w", encoding="utf-8") as f:
                         f.write(line)
-                    print(f"Exported 1 session to {args.output}")
+                    print(f"Exported 1 session to {out_path}")
             else:
                 if filters:
                     candidates = db.list_prune_candidates(**filters)
@@ -606,12 +636,13 @@ def cmd_sessions(args, sessions_parser=None):
                             _json.dumps(_redact(s), ensure_ascii=False) + "\n"
                         )
                 else:
-                    with open(args.output, "w", encoding="utf-8") as f:
+                    out_path = _export_output_file(args.output, "sessions.jsonl")
+                    with open(out_path, "w", encoding="utf-8") as f:
                         for s in sessions:
                             f.write(
                                 _json.dumps(_redact(s), ensure_ascii=False) + "\n"
                             )
-                    print(f"Exported {len(sessions)} sessions to {args.output}")
+                    print(f"Exported {len(sessions)} sessions to {out_path}")
             return
 
         # Markdown / QMD export

--- a/tests/hermes_cli/test_session_export.py
+++ b/tests/hermes_cli/test_session_export.py
@@ -135,3 +135,213 @@ def test_sessions_export_cli_prompt_only_stdout(monkeypatch, capsys):
     }
 
 
+# ─── `sessions export <directory>` ────────────────────────────────────────
+#
+# `hermes sessions export --help` documents the positional as an output
+# *directory* for md/qmd, and the bulk md/qmd branch honours that. Every
+# single-file writer in `cmd_sessions` instead called `open(args.output, "w")`
+# on the raw positional, so handing it a directory raised an uncaught
+# `IsADirectoryError` — for `--only` and `--format html` only after the whole
+# export had already been rendered. A missing parent directory raised an
+# equally uncaught `FileNotFoundError` at the same lines.
+
+
+class _FakeSessionDB:
+    """Minimal ``SessionDB`` stand-in covering the export command's reads."""
+
+    def __init__(self):
+        self.closed = False
+
+    def resolve_session_id(self, session_id):
+        return "sess-123"
+
+    def export_session(self, session_id):
+        return _sample_session()
+
+    def export_all(self, source=None):
+        return [_sample_session()]
+
+    def get_session(self, session_id):
+        return {"id": session_id, "model": "test/model"}
+
+    def get_messages_as_conversation(self, session_id):
+        return [
+            {"role": "user", "content": "Why is login broken?"},
+            {"role": "assistant", "content": "I will inspect the auth middleware."},
+        ]
+
+    def close(self):
+        self.closed = True
+
+
+def _run_sessions_export(monkeypatch, argv):
+    """Drive ``hermes sessions export`` end-to-end against a stub database."""
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    db = _FakeSessionDB()
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: db)
+    monkeypatch.setattr(sys, "argv", ["hermes", "sessions", "export"] + argv)
+    main_mod.main()
+    return db
+
+
+def test_prompt_only_md_export_into_directory(monkeypatch, capsys, tmp_path):
+    """``--format md --only user-prompts <dir>`` is the documented invocation.
+
+    The positional is documented as a directory for md and ``--only`` is
+    documented as supported for md, yet the same command line only worked
+    once ``--only`` was dropped.
+    """
+    _run_sessions_export(
+        monkeypatch,
+        [
+            str(tmp_path),
+            "--format",
+            "md",
+            "--only",
+            "user-prompts",
+            "--session-id",
+            "sess",
+        ],
+    )
+
+    written = tmp_path / "user-prompts.md"
+    assert written.is_file()
+    assert "Why is login broken?" in written.read_text(encoding="utf-8")
+    assert str(written) in capsys.readouterr().out
+
+
+def test_prompt_only_jsonl_export_into_directory(monkeypatch, capsys, tmp_path):
+    _run_sessions_export(
+        monkeypatch,
+        [
+            str(tmp_path),
+            "--format",
+            "jsonl",
+            "--only",
+            "user-prompts",
+            "--session-id",
+            "sess",
+        ],
+    )
+
+    written = tmp_path / "user-prompts.jsonl"
+    assert written.is_file()
+    records = [
+        json.loads(line) for line in written.read_text(encoding="utf-8").splitlines()
+    ]
+    assert [record["text"] for record in records] == [
+        "Why is login broken?",
+        "Only show me the prompts.",
+    ]
+    assert str(written) in capsys.readouterr().out
+
+
+def test_html_export_into_directory(monkeypatch, capsys, tmp_path):
+    _run_sessions_export(
+        monkeypatch,
+        [str(tmp_path), "--format", "html", "--session-id", "sess"],
+    )
+
+    written = tmp_path / "sessions.html"
+    assert written.is_file()
+    assert "<html" in written.read_text(encoding="utf-8").lower()
+    assert str(written) in capsys.readouterr().out
+
+
+def test_trace_single_session_export_into_directory(monkeypatch, capsys, tmp_path):
+    """``--format trace`` accepted a directory for many sessions but not one.
+
+    Five lines apart in the same function, the multi-session trace branch
+    does ``Path(args.output)`` + ``mkdir(parents=True, exist_ok=True)`` while
+    the single-session branch opened the same positional as a file.
+    """
+    _run_sessions_export(
+        monkeypatch,
+        [str(tmp_path), "--format", "trace", "--session-id", "sess"],
+    )
+
+    written = tmp_path / "sess-123.trace.jsonl"
+    assert written.is_file()
+    assert written.read_text(encoding="utf-8").strip()
+    assert str(written) in capsys.readouterr().out
+
+
+def test_jsonl_session_export_into_directory(monkeypatch, capsys, tmp_path):
+    _run_sessions_export(
+        monkeypatch,
+        [str(tmp_path), "--format", "jsonl", "--session-id", "sess"],
+    )
+
+    written = tmp_path / "sess-123.jsonl"
+    assert written.is_file()
+    assert json.loads(written.read_text(encoding="utf-8"))["id"] == "sess-123"
+    assert str(written) in capsys.readouterr().out
+
+
+def test_jsonl_bulk_export_into_directory(monkeypatch, capsys, tmp_path):
+    _run_sessions_export(monkeypatch, [str(tmp_path), "--format", "jsonl"])
+
+    written = tmp_path / "sessions.jsonl"
+    assert written.is_file()
+    assert json.loads(written.read_text(encoding="utf-8"))["id"] == "sess-123"
+    assert str(written) in capsys.readouterr().out
+
+
+def test_export_creates_missing_parent_directory(monkeypatch, tmp_path):
+    """A not-yet-existing parent raised a bare ``FileNotFoundError``."""
+    target = tmp_path / "nested" / "deep" / "prompts.md"
+
+    _run_sessions_export(
+        monkeypatch,
+        [
+            str(target),
+            "--format",
+            "md",
+            "--only",
+            "user-prompts",
+            "--session-id",
+            "sess",
+        ],
+    )
+
+    assert target.is_file()
+    assert "Why is login broken?" in target.read_text(encoding="utf-8")
+
+
+def test_prompt_only_md_stdout_dash_unchanged(monkeypatch, capsys):
+    """Behaviour-preservation guard: ``-`` still streams to stdout."""
+    _run_sessions_export(
+        monkeypatch,
+        ["-", "--format", "md", "--only", "user-prompts", "--session-id", "sess"],
+    )
+
+    out = capsys.readouterr().out
+    assert "Why is login broken?" in out
+    assert "Exported" not in out
+
+
+def test_prompt_only_md_plain_file_path_unchanged(monkeypatch, capsys, tmp_path):
+    """Behaviour-preservation guard: a file path still writes that exact file."""
+    target = tmp_path / "prompts.md"
+
+    _run_sessions_export(
+        monkeypatch,
+        [
+            str(target),
+            "--format",
+            "md",
+            "--only",
+            "user-prompts",
+            "--session-id",
+            "sess",
+        ],
+    )
+
+    assert target.is_file()
+    assert "Why is login broken?" in target.read_text(encoding="utf-8")
+    assert not (tmp_path / "user-prompts.md").exists()
+    assert str(target) in capsys.readouterr().out
+
+

--- a/tests/hermes_cli/test_session_export.py
+++ b/tests/hermes_cli/test_session_export.py
@@ -1,4 +1,5 @@
 import json
+import os
 import sys
 
 from hermes_cli.session_export import export_record_count, render_sessions_export
@@ -308,6 +309,46 @@ def test_export_creates_missing_parent_directory(monkeypatch, tmp_path):
 
     assert target.is_file()
     assert "Why is login broken?" in target.read_text(encoding="utf-8")
+
+
+def test_export_trailing_separator_creates_new_directory(monkeypatch, capsys, tmp_path):
+    """A trailing separator asks for a directory that need not exist yet.
+
+    The multi-session trace and bulk md/qmd branches ``mkdir`` a
+    not-yet-existing output directory, so the single-session writers need a
+    way to say "directory" about a path that is not one on disk. ``open()``
+    rejects a trailing-separator path outright, so honouring it here cannot
+    change the meaning of any invocation that works today.
+    """
+    target_dir = tmp_path / "new-exports"
+
+    _run_sessions_export(
+        monkeypatch,
+        [str(target_dir) + os.sep, "--format", "trace", "--session-id", "sess"],
+    )
+
+    written = target_dir / "sess-123.trace.jsonl"
+    assert target_dir.is_dir()
+    assert written.is_file()
+    assert str(written) in capsys.readouterr().out
+
+
+def test_export_bare_nonexistent_path_stays_a_file(monkeypatch, tmp_path):
+    """Boundary guard: a bare non-existent path is still a file name.
+
+    ``sessions export ~/my-export --format jsonl --session-id X`` writes a
+    file called ``my-export`` today, so a path that is neither an existing
+    directory nor separator-terminated must not be silently reinterpreted.
+    """
+    target = tmp_path / "my-export"
+
+    _run_sessions_export(
+        monkeypatch,
+        [str(target), "--format", "jsonl", "--session-id", "sess"],
+    )
+
+    assert target.is_file()
+    assert json.loads(target.read_text(encoding="utf-8"))["id"] == "sess-123"
 
 
 def test_prompt_only_md_stdout_dash_unchanged(monkeypatch, capsys):


### PR DESCRIPTION
## What does this PR do?

`hermes sessions export` disagrees with itself about what its output positional means. Two of those disagreements need no help text at all to see — they are self-contradictions inside a single format, in a single function:

**1. `--format trace` accepts a directory for many sessions and rejects it for one.** Five lines apart in `cmd_sessions`:

```py
# hermes_cli/sessions_cmd.py:531 — single session
with open(args.output, "w", encoding="utf-8") as f:      # IsADirectoryError

# hermes_cli/sessions_cmd.py:535-540 — several sessions
out_dir = Path(args.output).expanduser() if args.output and args.output != "-" else ...
out_dir.mkdir(parents=True, exist_ok=True)               # fine
```

Whether `hermes sessions export ~/exports --format trace` works depends on how many sessions the filter happened to match.

**2. `--format md` accepts a directory in bulk and rejects it with `--only`.** `sessions_cmd.py:624-628` resolves the positional as `output_dir`; `sessions_cmd.py:406` opens it as a file. The same command line starts working the moment you drop `--only`.

**The help text then settles the md/qmd case.** `hermes_cli/main.py:12100-12106` documents the positional as:

```
Output path. JSONL: file path (use - for stdout, required).
md/qmd: output directory (default: <hermes home>/session-exports)
```

and `--only` is documented as supported for md (`main.py:12139-12145`, *"headed sections for md"*). So `hermes sessions export <dir> --format md --only user-prompts` is a documented, supported invocation that dies with an uncaught `IsADirectoryError` traceback — and it dies *after* `render_sessions_export()` has already rendered the entire export (`sessions_cmd.py:397-406`), so the work is thrown away.

**Root cause: one construct, repeated five times.** `open(args.output, "w")` on the raw positional, with nothing asking whether it is a directory. A non-existent parent directory raised an equally uncaught `FileNotFoundError` at the same five lines.

`_export_output_file()` resolves the positional once — a directory gets a default file name inside it, a plain file path is returned unchanged, missing parents are created. Neither half is a new idea in this codebase:

- **"a directory means name a file inside it"** is already how a sibling `hermes_cli` command reads its `--output`. `hermes_cli/backup.py:606-611`:
  ```py
  out_path = Path(args.output).expanduser().resolve()
  # If user gave a directory, put the zip inside it
  if out_path.is_dir():
      stamp = datetime.now().strftime("%Y-%m-%d-%H%M%S")
      out_path = out_path / f"hermes-backup-{stamp}.zip"
  ```
- **`mkdir(parents=True, exist_ok=True)`** is what the two already-correct export branches do: `hermes_cli/session_export_md.py:255` (in `write_session_markdown`) and `:265` (in `append_manifest_entry`) — both called by the bulk md/qmd branch via `_export_one` — and `hermes_cli/sessions_cmd.py:540` (the multi-session trace branch).

**Honest scope note.** Only md/qmd is documented as a directory. The **jsonl** sites and the **html** site are covered for *consistency*, not as contract fixes — jsonl's help documents a file path, and html is not described in that string at all, so accepting a directory there is an additive convenience. They share the identical construct, the identical crash and the identical one-line fix, and covering them means the command's output positional has one meaning instead of five.

A **trailing path separator** is honoured as an explicit "directory" even when it does not exist yet, so `sessions export ~/exports/ --format trace --session-id X` creates `~/exports` and writes `<id>.trace.jsonl` inside it — matching what the multi-session trace branch does with the same argument. That is safe to add because `open()` already rejects a trailing-separator path outright (`FileNotFoundError`), so no working invocation changes meaning.

A **bare non-existent path stays a file name**, deliberately: `sessions export ~/my-export --format jsonl --session-id X` writes a file called `my-export` today, and every rule that would reinterpret it (always-a-directory, no-suffix-means-directory, directory-only-for-md) breaks that or turns `~/prompts.md` into a directory. That is a decision about what the positional should mean rather than a bug, so it is left to the maintainers and pinned by `test_export_bare_nonexistent_path_stays_a_file` so the boundary is explicit instead of accidental.

This is additive throughout. `-` still streams to stdout, an omitted positional still behaves exactly as before per format, and a plain file path still writes that exact file — all pinned by tests that are green before *and* after. Only the invocations that raised now succeed.

## Related Issue

None — self-found while auditing the `sessions export` output-path contract against `sessions export --help`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

**`hermes_cli/sessions_cmd.py`**

- New module-level `_export_output_file(output, default_name) -> Path`, placed immediately above `cmd_sessions`. Expands `~`, appends `default_name` when the positional is an existing directory **or ends in a path separator**, `mkdir(parents=True, exist_ok=True)` on the parent, and returns the path unchanged otherwise.
- All five single-file writers routed through it, and each now prints the file it actually wrote instead of echoing the positional it was handed:

  | line | branch | file name used inside a directory |
  |---|---|---|
  | 406 | `--only user-prompts` (md and jsonl) | `user-prompts.md` / `user-prompts.jsonl` |
  | 433 | `--format html` | `sessions.html` |
  | 531 | `--format trace`, single session | `<session_id>.trace.jsonl` — same name the multi-session branch writes at line 546 |
  | 574 | `--format jsonl --session-id` | `<session_id>.jsonl` |
  | 609 | `--format jsonl`, bulk | `sessions.jsonl` |

**Sites examined and deliberately excluded** (they do not share the root cause):

- `sessions_cmd.py:624-628` (bulk md/qmd) and `sessions_cmd.py:536-540` (multi-session trace) — already directory-correct. These are the behaviour being mirrored, not changed.
- `hermes_cli/backup.py:606-611` — already resolves a directory to a file inside it (quoted above); nothing to fix, it is the precedent.
- `hermes_cli/main.py:9674` (`profile export`) and `hermes_cli/skills_hub.py:1778` (`skills snapshot export`) — different commands, their own `--output` semantics and their own help text. Widening there would be scope creep, not the same root cause.

No argparse or help-string changes: the help text already describes the intended behaviour; it was the implementation that diverged from it.

**`tests/hermes_cli/test_session_export.py`** — eleven tests added after `test_sessions_export_cli_prompt_only_stdout`, driving the real CLI (`main_mod.main()` with a patched `hermes_state.SessionDB` and `sys.argv`): one per site, the missing-parent case, the trailing-separator case, and three behaviour-preservation guards (`-` to stdout, a plain file path, and a bare non-existent path staying a file).

## How to Test

```bash
mkdir -p /tmp/hx
hermes sessions export /tmp/hx --format md    --only user-prompts   # was Errno 21, after a full render
hermes sessions export /tmp/hx --format jsonl --only user-prompts   # was Errno 21, after a full render
hermes sessions export /tmp/hx --format html  --session-id <sid>    # was Errno 21
hermes sessions export /tmp/hx --format trace --session-id <sid>    # was Errno 21 (single session only)
hermes sessions export /tmp/hx --format jsonl --session-id <sid>    # was Errno 21
hermes sessions export /tmp/hx/does/not/exist/out.md --format md --only user-prompts   # was Errno 2
hermes sessions export /tmp/hx/new-dir/ --format trace --session-id <sid>              # was Errno 2
```

Automated, verified in both directions:

```
uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest \
  tests/hermes_cli/test_session_export.py -q
```

**Production hunk reverted** (tests as shipped, `sessions_cmd.py` at `origin/main`) — `7 failed, 5 passed`, each failing at its own site:

| test | fails at | with |
|---|---|---|
| `test_prompt_only_md_export_into_directory` | `sessions_cmd.py:406` | `IsADirectoryError: [Errno 21]` |
| `test_prompt_only_jsonl_export_into_directory` | `sessions_cmd.py:406` | `IsADirectoryError: [Errno 21]` |
| `test_html_export_into_directory` | `sessions_cmd.py:433` | `IsADirectoryError: [Errno 21]` |
| `test_trace_single_session_export_into_directory` | `sessions_cmd.py:531` | `IsADirectoryError: [Errno 21]` |
| `test_jsonl_session_export_into_directory` | `sessions_cmd.py:574` | `IsADirectoryError: [Errno 21]` |
| `test_jsonl_bulk_export_into_directory` | `sessions_cmd.py:609` | `IsADirectoryError: [Errno 21]` |
| `test_export_creates_missing_parent_directory` | `sessions_cmd.py:406` | `FileNotFoundError: [Errno 2]` |

**Production hunk restored** — `12 passed`.

The behaviour-preservation guards `test_prompt_only_md_stdout_dash_unchanged` and `test_prompt_only_md_plain_file_path_unchanged` are among the 5 that pass in *both* states: `-` still streams to stdout with no "Exported" line, and a plain file path still writes that exact file with no `user-prompts.md` appearing beside it.

The trailing-separator follow-up (commit `e99430d6442`) was checked the same way: with its production hunk reverted, `test_export_trailing_separator_creates_new_directory` is the only failure, and `test_export_bare_nonexistent_path_stays_a_file` passes in both states. Full file after both commits: `14 passed`.

Adjacent suites, all green after the change (56 passed):

```
tests/hermes_cli/test_sessions_export_md_cli.py  tests/hermes_cli/test_session_export_html.py
tests/hermes_cli/test_session_export_html_escape.py  tests/hermes_cli/test_session_export_md.py
tests/hermes_cli/test_sessions_delete.py  tests/hermes_cli/test_session_browse.py
tests/hermes_cli/test_session_filters.py  tests/hermes_cli/test_session_listing.py
tests/hermes_cli/test_resolve_last_session.py  tests/hermes_cli/test_coalesce_session_args.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the focused and adjacent suites listed above, not the full tree
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the new helper is documented; no user-facing docs needed, since the change makes the code match the existing `--help` text rather than changing it
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `pathlib` only (`Path.expanduser`, `Path.is_dir`, `Path.mkdir`); no separators or errno values are hardcoded, and the `IsADirectoryError`/`FileNotFoundError` this replaces are raised by `open()` on every platform
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
