### PR TITLE
fix(checkpoints): distinguish protected unreachable workdirs

### DIFF
--- a/hermes_cli/checkpoints.py
+++ b/hermes_cli/checkpoints.py
@@ -86,8 +86,9 @@ def cmd_status(args: argparse.Namespace) -> int:
             wd = p.get("workdir") or "(unknown)"
             if len(wd) > 60:
                 wd = "…" + wd[-59:]
-            exists = p.get("exists")
-            state = "live" if exists else "orphan"
+            state = p.get("state") or (
+                "live" if p.get("exists") else "unreachable"
+            )
             commits = p.get("commits", 0)
             last = _fmt_age(p.get("last_touch"))
             print(f"  {wd:<60}  {commits:>7}  {last:>12}  {state}")
@@ -125,11 +126,11 @@ def cmd_prune(args: argparse.Namespace) -> int:
         info = store_status()
         orphans = [
             p for p in info.get("projects", [])
-            if not p.get("exists")
+            if p.get("state") == "orphan"
         ]
         pre_v2_orphans = [
             p for p in info.get("pre_v2_projects", [])
-            if not p.get("exists")
+            if p.get("state") == "orphan"
         ]
         if orphans or pre_v2_orphans:
             print(f"This will permanently delete {len(orphans) + len(pre_v2_orphans)} "
@@ -173,6 +174,7 @@ def cmd_prune(args: argparse.Namespace) -> int:
     print(f"Scanned:         {result['scanned']}")
     print(f"Deleted orphan:  {result['deleted_orphan']}")
     print(f"Deleted stale:   {result['deleted_stale']}")
+    print(f"Protected unreachable: {result.get('protected_unreachable', 0)}")
     print(f"Errors:          {result['errors']}")
     print(f"Bytes reclaimed: {_fmt_bytes(result['bytes_freed'])}")
     return 0

--- a/tests/hermes_cli/test_checkpoints_prune.py
+++ b/tests/hermes_cli/test_checkpoints_prune.py
@@ -21,7 +21,7 @@ def _ns(**kwargs) -> argparse.Namespace:
 
 
 def _prune_result(**kwargs) -> dict:
-    result = {"scanned": 0, "deleted_orphan": 0, "deleted_stale": 0, "errors": 0, "bytes_freed": 0}
+    result = {"scanned": 0, "deleted_orphan": 0, "deleted_stale": 0, "protected_unreachable": 0, "errors": 0, "bytes_freed": 0}
     result.update(kwargs)
     return result
 
@@ -34,17 +34,37 @@ _V2_ORPHAN_ONLY_STATUS = {
 _PRE_V2_ONLY_STATUS = {
     "projects": [],
     "pre_v2_projects": [
-        {"path": "/home/user/.hermes/checkpoints/deadbeefcafebabe", "workdir": None, "exists": False},
+        {"path": "/home/user/.hermes/checkpoints/deadbeefcafebabe", "workdir": None, "exists": False, "state": "orphan"},
     ],
 }
 
 _MIXED_STATUS = {
     "projects": [
-        {"hash": "abc123", "workdir": "/gone/v2-project", "exists": False, "commits": 4},
+        {"hash": "abc123", "workdir": "/gone/v2-project", "exists": False, "state": "orphan", "commits": 4},
     ],
     "pre_v2_projects": [
-        {"path": "/home/user/.hermes/checkpoints/deadbeefcafebabe", "workdir": "/gone/pre-v2-project", "exists": False},
+        {"path": "/home/user/.hermes/checkpoints/deadbeefcafebabe", "workdir": "/gone/pre-v2-project", "exists": False, "state": "orphan"},
     ],
+}
+
+_ORPHAN_AND_UNREACHABLE_STATUS = {
+    "projects": [
+        {
+            "hash": "deletable",
+            "workdir": "/gone/deletable",
+            "exists": False,
+            "state": "orphan",
+            "commits": 2,
+        },
+        {
+            "hash": "protected",
+            "workdir": "/offline/protected",
+            "exists": False,
+            "state": "unreachable",
+            "commits": 3,
+        },
+    ],
+    "pre_v2_projects": [],
 }
 
 
@@ -56,7 +76,14 @@ def _patch_checkpoint_manager(monkeypatch, status: dict, prune_calls: list):
     def _fake_prune(**kwargs):
         prune_calls.append(kwargs)
         return _prune_result(
-            deleted_orphan=len(status["projects"]) + len(status["pre_v2_projects"]),
+            deleted_orphan=sum(
+                p.get("state") == "orphan"
+                for p in status["projects"] + status["pre_v2_projects"]
+            ),
+            protected_unreachable=sum(
+                p.get("state") == "unreachable"
+                for p in status["projects"] + status["pre_v2_projects"]
+            ),
         )
 
     monkeypatch.setattr(ckpt_mgr, "prune_checkpoints", _fake_prune)
@@ -97,7 +124,67 @@ def test_keep_orphans_skips_prompt(monkeypatch, capsys, status):
 # ─── no orphans present: never prompts even without --force ───────────────
 
 
+def test_status_labels_protected_missing_workdir_as_unreachable(
+    monkeypatch, capsys,
+):
+    import hermes_cli.checkpoints as checkpoints_cli
+    import tools.checkpoint_manager as ckpt_mgr
+
+    status = {
+        **_ORPHAN_AND_UNREACHABLE_STATUS,
+        "base": "/tmp/checkpoints",
+        "total_size_bytes": 0,
+        "store_size_bytes": 0,
+        "legacy_size_bytes": 0,
+        "project_count": 2,
+        "legacy_archives": [],
+    }
+    monkeypatch.setattr(ckpt_mgr, "store_status", lambda: status)
+
+    rc = checkpoints_cli.cmd_status(argparse.Namespace(limit=20))
+
+    assert rc == 0
+    output = capsys.readouterr().out
+    assert "/offline/protected" in output
+    assert "unreachable" in output
+
+
+def test_force_reports_unreachable_projects_retained_for_safety(
+    monkeypatch, capsys,
+):
+    import hermes_cli.checkpoints as checkpoints_cli
+
+    prune_calls: list = []
+    _patch_checkpoint_manager(
+        monkeypatch, _ORPHAN_AND_UNREACHABLE_STATUS, prune_calls,
+    )
+
+    rc = checkpoints_cli.cmd_prune(_ns(force=True))
+
+    assert rc == 0
+    assert "Protected unreachable: 1" in capsys.readouterr().out
+
+
 # ─── allowlist binding: preview set == deletion set, even when empty ───────
+
+
+def test_preview_only_authorizes_deletable_orphans(monkeypatch, capsys):
+    import hermes_cli.checkpoints as checkpoints_cli
+
+    prune_calls: list = []
+    _patch_checkpoint_manager(
+        monkeypatch, _ORPHAN_AND_UNREACHABLE_STATUS, prune_calls,
+    )
+    monkeypatch.setattr("builtins.input", lambda _prompt: "y")
+
+    rc = checkpoints_cli.cmd_prune(_ns())
+
+    assert rc == 0
+    output = capsys.readouterr().out
+    assert "permanently delete 1 orphan checkpoint project(s)" in output
+    assert "/gone/deletable" in output
+    assert "/offline/protected" not in output
+    assert prune_calls[0]["orphan_allowlist"] == {"deletable"}
 
 
 def test_empty_preview_binds_empty_allowlist(monkeypatch, capsys):

--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -647,6 +647,29 @@ class TestPruneCheckpointsV2:
         gone_hash = _project_hash(str(gone))
         assert not (base / "store" / "projects" / f"{gone_hash}.json").exists()
 
+    def test_reports_unreachable_project_retained_by_orphan_safety(
+        self, tmp_path, monkeypatch,
+    ):
+        base = tmp_path / "checkpoints"
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", base)
+
+        parent = tmp_path / "volume"
+        project = parent / "project"
+        project.mkdir(parents=True)
+        (project / "f").write_text("checkpointed")
+
+        m = CheckpointManager(enabled=True)
+        assert m.ensure_checkpoint(str(project), "initial") is True
+        project_hash = _project_hash(str(project))
+        shutil.rmtree(project)
+        assert not any(parent.iterdir())
+
+        result = prune_checkpoints(retention_days=0, checkpoint_base=base)
+
+        assert result["deleted_orphan"] == 0
+        assert result["protected_unreachable"] == 1
+        assert (base / "store" / "projects" / f"{project_hash}.json").exists()
+
     def test_retention_prunes_stale_projects_and_legacy_archives(
         self, tmp_path, monkeypatch,
     ):
@@ -783,6 +806,39 @@ class TestPruneCheckpointsOrphanAllowlist:
         # The one that only went orphan mid-confirmation must survive.
         assert second_repo.exists()
 
+    def test_previewed_v2_orphan_that_becomes_live_is_not_deleted(
+        self, tmp_path, monkeypatch,
+    ):
+        import hermes_cli.checkpoints as checkpoints_cli
+
+        base = tmp_path / "checkpoints"
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", base)
+
+        parent = tmp_path / "projects"
+        workdir = parent / "previewed"
+        workdir.mkdir(parents=True)
+        (parent / "sibling").mkdir()
+        (workdir / "f").write_text("checkpointed")
+
+        m = CheckpointManager(enabled=True)
+        assert m.ensure_checkpoint(str(workdir), "initial") is True
+        project_hash = _project_hash(str(workdir))
+        shutil.rmtree(workdir)
+
+        def _confirm_after_workdir_returns(_prompt):
+            workdir.mkdir()
+            return "y"
+
+        monkeypatch.setattr("builtins.input", _confirm_after_workdir_returns)
+        args = argparse.Namespace(
+            retention_days=0, max_size_mb=0, keep_orphans=False, force=False,
+        )
+
+        rc = checkpoints_cli.cmd_prune(args)
+
+        assert rc == 0
+        assert (base / "store" / "projects" / f"{project_hash}.json").exists()
+
 
 class TestMaybeAutoPruneCheckpoints:
     def test_prunes_once_then_skips_within_interval(self, tmp_path):
@@ -812,6 +868,43 @@ class TestMaybeAutoPruneCheckpoints:
 # =========================================================================
 
 class TestStoreStatus:
+    def test_pre_v2_status_uses_pruner_state_classification(self, tmp_path):
+        base = tmp_path / "checkpoints"
+        alive = tmp_path / "alive"
+        alive.mkdir()
+        _seed_legacy_repo(base, "aaaa" * 4, alive)
+        _seed_legacy_repo(base, "bbbb" * 4, tmp_path / "gone")
+
+        info = store_status(base)
+
+        states = {
+            project["workdir"]: project["state"]
+            for project in info["pre_v2_projects"]
+        }
+        assert states[str(alive)] == "live"
+        assert states[str(tmp_path / "gone")] == "orphan"
+
+    def test_reports_missing_workdir_without_deletion_evidence_as_unreachable(
+        self, tmp_path, monkeypatch,
+    ):
+        base = tmp_path / "checkpoints"
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", base)
+
+        parent = tmp_path / "volume"
+        project = parent / "project"
+        project.mkdir(parents=True)
+        (project / "f").write_text("checkpointed")
+
+        m = CheckpointManager(enabled=True)
+        assert m.ensure_checkpoint(str(project), "initial") is True
+        shutil.rmtree(project)
+        assert not any(parent.iterdir())
+
+        info = store_status(base)
+
+        assert info["projects"][0]["exists"] is False
+        assert info["projects"][0]["state"] == "unreachable"
+
     def test_reports_projects_and_legacy(self, tmp_path, monkeypatch, work_dir):
         base = tmp_path / "checkpoints"
         monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", base)

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -1480,6 +1480,55 @@ def _dir_has_any_entry(directory: Path) -> bool:
     return False
 
 
+def _workdir_state(
+    workdir: str,
+    parent_dev: Optional[int] = None,
+    parent_ino: Optional[int] = None,
+    require_parent_identity: bool = True,
+) -> str:
+    """Classify a checkpoint workdir using the orphan-pruner safety rules."""
+    if not workdir:
+        return "orphan"
+    try:
+        if Path(workdir).exists():
+            return "live"
+    except OSError:
+        return "unreachable"
+    if _workdir_is_observably_gone(
+        workdir,
+        parent_dev=parent_dev,
+        parent_ino=parent_ino,
+        require_parent_identity=require_parent_identity,
+    ):
+        return "orphan"
+    return "unreachable"
+
+
+def _metadata_workdir_state(meta: Dict) -> str:
+    """Classify a v2 project from its persisted workdir evidence."""
+    parent_dev = meta.get("workdir_parent_dev")
+    parent_ino = meta.get("workdir_parent_ino")
+    if not isinstance(parent_dev, int) or isinstance(parent_dev, bool):
+        parent_dev = None
+    if not isinstance(parent_ino, int) or isinstance(parent_ino, bool):
+        parent_ino = None
+    return _workdir_state(
+        meta.get("workdir") or "",
+        parent_dev=parent_dev,
+        parent_ino=parent_ino,
+    )
+
+
+def _pre_v2_workdir_state(repo: Dict) -> str:
+    """Classify a pre-v2 project without overstating unreadable metadata."""
+    if repo.get("marker_unreadable"):
+        return "unreachable"
+    return _workdir_state(
+        repo.get("workdir") or "",
+        require_parent_identity=False,
+    )
+
+
 def prune_checkpoints(
     retention_days: int = 7,
     delete_orphans: bool = True,
@@ -1514,7 +1563,7 @@ def prune_checkpoints(
     also deleted.
 
     Returns a dict with counts ``{"scanned", "deleted_orphan",
-    "deleted_stale", "errors", "bytes_freed"}``.
+    "deleted_stale", "protected_unreachable", "errors", "bytes_freed"}``.
 
     Never raises — maintenance must never block interactive startup.
     """
@@ -1523,6 +1572,7 @@ def prune_checkpoints(
         "scanned": 0,
         "deleted_orphan": 0,
         "deleted_stale": 0,
+        "protected_unreachable": 0,
         "errors": 0,
         "bytes_freed": 0,
     }
@@ -1570,18 +1620,10 @@ def prune_checkpoints(
         child = repo["path"]
         result["scanned"] += 1
         reason: Optional[str] = None
+        state = _pre_v2_workdir_state(repo)
         if (
             delete_orphans
-            and not repo["marker_unreadable"]
-            and (
-                repo["workdir"] is None
-                # The frozen pre-v2 layout has no metadata channel to carry a
-                # recorded parent identity, so only the structural checks
-                # (parent present + populated / live mount point) apply here.
-                or _workdir_is_observably_gone(
-                    repo["workdir"], require_parent_identity=False,
-                )
-            )
+            and state == "orphan"
             and (orphan_allowlist is None or str(child) in orphan_allowlist)
         ):
             reason = "orphan"
@@ -1599,6 +1641,8 @@ def prune_checkpoints(
             if newest > 0 and newest < cutoff:
                 reason = "stale"
         if reason is None:
+            if delete_orphans and state == "unreachable":
+                result["protected_unreachable"] += 1
             continue
         try:
             size = _dir_size_bytes(child)
@@ -1622,22 +1666,10 @@ def prune_checkpoints(
                 continue
             result["scanned"] += 1
             reason = None
-            parent_dev = meta.get("workdir_parent_dev")
-            parent_ino = meta.get("workdir_parent_ino")
-            if not isinstance(parent_dev, int) or isinstance(parent_dev, bool):
-                parent_dev = None
-            if not isinstance(parent_ino, int) or isinstance(parent_ino, bool):
-                parent_ino = None
+            state = _metadata_workdir_state(meta)
             if (
                 delete_orphans
-                and (
-                    not workdir
-                    or _workdir_is_observably_gone(
-                        workdir,
-                        parent_dev=parent_dev,
-                        parent_ino=parent_ino,
-                    )
-                )
+                and state == "orphan"
                 and (orphan_allowlist is None or dir_hash in orphan_allowlist)
             ):
                 reason = "orphan"
@@ -1646,6 +1678,8 @@ def prune_checkpoints(
                 if last_touch > 0 and last_touch < cutoff:
                     reason = "stale"
             if reason is None:
+                if delete_orphans and state == "unreachable":
+                    result["protected_unreachable"] += 1
                 continue
             ref = _ref_name(dir_hash)
             _delete_ref(store, ref)
@@ -1779,7 +1813,7 @@ def maybe_auto_prune_checkpoints(
         if not base.exists():
             out["result"] = {
                 "scanned": 0, "deleted_orphan": 0, "deleted_stale": 0,
-                "errors": 0, "bytes_freed": 0,
+                "protected_unreachable": 0, "errors": 0, "bytes_freed": 0,
             }
             return out
 
@@ -1837,10 +1871,12 @@ def store_status(checkpoint_base: Optional[Path] = None) -> Dict:
 
     ``pre_v2_projects`` covers shadow repos still on the pre-v2 per-project
     layout (``base/<hash>/HEAD``) — distinct from ``legacy_archives``, which
-    are already-migrated ``legacy-<ts>/`` dirs. Callers that preview an
-    orphan-deletion sweep must include both ``projects`` and
-    ``pre_v2_projects``, since ``prune_checkpoints`` deletes orphans from
-    both layouts.
+    are already-migrated ``legacy-<ts>/`` dirs. Each project reports a
+    ``state`` of ``live``, ``orphan`` (safe to prune), or ``unreachable``
+    (retained because deletion cannot be distinguished from unavailable
+    storage). Callers that preview an orphan-deletion sweep must include both
+    ``projects`` and ``pre_v2_projects``, since ``prune_checkpoints`` deletes
+    orphans from both layouts.
     """
     base = checkpoint_base or CHECKPOINT_BASE
     out: Dict = {
@@ -1863,6 +1899,7 @@ def store_status(checkpoint_base: Optional[Path] = None) -> Dict:
             for meta in _list_projects(store):
                 dir_hash = meta.get("_hash") or ""
                 workdir = meta.get("workdir") or ""
+                state = _metadata_workdir_state(meta)
                 ref = _ref_name(dir_hash)
                 ok, count_out, _ = _run_git(
                     ["rev-list", "--count", ref], store, str(base),
@@ -1875,21 +1912,22 @@ def store_status(checkpoint_base: Optional[Path] = None) -> Dict:
                 out["projects"].append({
                     "hash": dir_hash,
                     "workdir": workdir,
-                    "exists": bool(workdir) and Path(workdir).exists(),
+                    "exists": state == "live",
+                    "state": state,
                     "created_at": meta.get("created_at"),
                     "last_touch": meta.get("last_touch"),
                     "commits": commits,
                 })
     out["project_count"] = len(out["projects"])
 
-    out["pre_v2_projects"] = [
-        {
-            "path": str(r["path"]),
-            "workdir": r["workdir"],
-            "exists": r["exists"],
-        }
-        for r in _pre_v2_shadow_repos(base)
-    ]
+    for repo in _pre_v2_shadow_repos(base):
+        state = _pre_v2_workdir_state(repo)
+        out["pre_v2_projects"].append({
+            "path": str(repo["path"]),
+            "workdir": repo["workdir"],
+            "exists": state == "live",
+            "state": state,
+        })
 
     for child in base.iterdir():
         if child.is_dir() and child.name.startswith(_LEGACY_PREFIX):


### PR DESCRIPTION
## Summary

- classify checkpoint workdirs as `live`, deletable `orphan`, or protected `unreachable` using the same volume-safety evidence as the pruner
- limit the interactive deletion preview and allowlist to projects the pruner can actually delete
- report how many unreachable projects were retained by the safety guard, including for `--force`

## Root cause

`hermes checkpoints list` and the prune confirmation preview treated every missing workdir (`Path.exists() == False`) as an orphan. `prune_checkpoints()` deliberately applies stricter checks: recorded parent device/inode identity, a populated parent or live mount point, and conservative handling of old metadata without identity evidence.

That mismatch produced output such as “permanently delete 2 orphan projects” followed by a successful prune with `Deleted orphan: 0`, even with `--force`. (`--force` correctly skips only the confirmation prompt; it must not bypass volume-detachment safeguards.)

## Safety

- preserves the existing external-volume/network-share/bind-mount protections
- keeps `--force` semantics unchanged
- preserves confirmation allowlist binding, so a project that becomes orphaned after the preview is not implicitly authorized
- uses the same classifier in status and pruning paths to prevent future drift
- retains pre-v2 conservative behavior when metadata is unreadable

## Test plan

- [x] RED/GREEN: missing workdir under an empty parent is reported as `unreachable`
- [x] RED/GREEN: prune reports protected unreachable projects without deleting their metadata
- [x] RED/GREEN: preview includes only deletable orphans and binds the same allowlist
- [x] `checkpoints list` labels protected missing workdirs as `unreachable`
- [x] `--force` output reports the protected unreachable count
- [x] a previewed v2 orphan that becomes live during confirmation is retained
- [x] pre-v2 status uses the same live/orphan classification as pruning
- [x] `scripts/run_tests.sh tests/tools/test_checkpoint_manager.py tests/hermes_cli/test_checkpoints_prune.py tests/hermes_cli/test_console_engine.py -q` — 56 passed
- [x] Ruff and static security scans passed
