### PR TITLE
Log memory-provider toolset gate decisions

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -119,11 +119,21 @@ def inject_memory_provider_tools(agent: Any) -> int:
         for tool in tools
         if isinstance(tool, dict)
     }
+    enabled_toolsets = getattr(agent, "enabled_toolsets", None)
+    disabled_toolsets = getattr(agent, "disabled_toolsets", None)
+    memory_tool_present = "memory" in existing_tool_names
     if not memory_provider_tools_enabled(
-        getattr(agent, "enabled_toolsets", None),
-        getattr(agent, "disabled_toolsets", None),
-        memory_tool_present="memory" in existing_tool_names,
+        enabled_toolsets,
+        disabled_toolsets,
+        memory_tool_present=memory_tool_present,
     ):
+        logger.debug(
+            "Memory provider tools not injected: toolset gate disabled "
+            "(enabled_toolsets=%r, disabled_toolsets=%r, memory_tool_present=%s)",
+            enabled_toolsets,
+            disabled_toolsets,
+            memory_tool_present,
+        )
         return 0
 
     get_schemas = getattr(memory_manager, "get_all_tool_schemas", None)

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -112,6 +112,12 @@ def inject_memory_provider_tools(agent: Any) -> int:
     memory_manager = getattr(agent, "_memory_manager", None)
     tools = getattr(agent, "tools", None)
     if not memory_manager or tools is None:
+        logger.debug(
+            "Memory provider tools not injected: prerequisites unavailable "
+            "(memory_manager_present=%s, tools_present=%s)",
+            bool(memory_manager),
+            tools is not None,
+        )
         return 0
 
     existing_tool_names = {
@@ -138,6 +144,11 @@ def inject_memory_provider_tools(agent: Any) -> int:
 
     get_schemas = getattr(memory_manager, "get_all_tool_schemas", None)
     if not callable(get_schemas):
+        logger.debug(
+            "Memory provider tools not injected: schema API unavailable "
+            "(memory_manager_type=%s)",
+            type(memory_manager).__name__,
+        )
         return 0
 
     valid_tool_names = getattr(agent, "valid_tool_names", None)

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -942,6 +942,27 @@ class TestMemoryToolToolsetGate:
         assert tools == []
         assert names == set()
 
+    def test_blocked_toolsets_log_the_effective_gate_inputs(self, caplog):
+        """A silent zero-tool result must expose enough state to diagnose it."""
+        mgr = self._mgr_with_tools("fact_store")
+        agent = SimpleNamespace(
+            _memory_manager=mgr,
+            enabled_toolsets=["terminal", "web"],
+            disabled_toolsets=[],
+            tools=[],
+            valid_tool_names=set(),
+        )
+
+        with caplog.at_level("DEBUG", logger="agent.memory_manager"):
+            assert inject_memory_provider_tools(agent) == 0
+
+        assert (
+            "Memory provider tools not injected: toolset gate disabled" in caplog.text
+        )
+        assert "enabled_toolsets=['terminal', 'web']" in caplog.text
+        assert "disabled_toolsets=[]" in caplog.text
+        assert "memory_tool_present=False" in caplog.text
+
     def test_toolsets_without_memory_blocks_injection(self):
         """Toolsets that don't include memory must suppress injection."""
         mgr = self._mgr_with_tools("fact_store")

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -963,6 +963,43 @@ class TestMemoryToolToolsetGate:
         assert "disabled_toolsets=[]" in caplog.text
         assert "memory_tool_present=False" in caplog.text
 
+    @pytest.mark.parametrize(
+        ("memory_manager", "tools", "expected_state"),
+        [
+            (None, [], "memory_manager_present=False, tools_present=True"),
+            (SimpleNamespace(), None, "memory_manager_present=True, tools_present=False"),
+        ],
+    )
+    def test_missing_injection_prerequisites_log_state(
+        self,
+        caplog,
+        memory_manager,
+        tools,
+        expected_state,
+    ):
+        """Missing injection prerequisites must identify the absent boundary."""
+        agent = SimpleNamespace(_memory_manager=memory_manager, tools=tools)
+
+        with caplog.at_level("DEBUG", logger="agent.memory_manager"):
+            assert inject_memory_provider_tools(agent) == 0
+
+        assert "Memory provider tools not injected: prerequisites unavailable" in caplog.text
+        assert expected_state in caplog.text
+
+    def test_missing_schema_api_logs_reason(self, caplog):
+        """A manager without the schema API must not fail silently."""
+        agent = SimpleNamespace(
+            _memory_manager=SimpleNamespace(),
+            enabled_toolsets=None,
+            disabled_toolsets=None,
+            tools=[],
+        )
+
+        with caplog.at_level("DEBUG", logger="agent.memory_manager"):
+            assert inject_memory_provider_tools(agent) == 0
+
+        assert "Memory provider tools not injected: schema API unavailable" in caplog.text
+
     def test_toolsets_without_memory_blocks_injection(self):
         """Toolsets that don't include memory must suppress injection."""
         mgr = self._mgr_with_tools("fact_store")


### PR DESCRIPTION
## Summary

- log the effective enabled and disabled toolsets when the external memory-provider tool gate withholds schemas
- log which prerequisite is absent when the memory manager or agent tool surface is unavailable
- log when the memory manager does not expose a callable schema API
- add focused regression coverage for every explicit early `return 0` stage

## Why

#81427 reports that a provider registers in Desktop but `inject_memory_provider_tools()` returns zero, while the caller discards that result. The issue infers an empty `enabled_toolsets` list, but the Desktop/TUI config fallback converts an empty resolved set to `None`, and empty-list blocking is an intentional contract covered by #5544. Changing the gate without runtime evidence risks regressing explicit tool suppression.

The first PR revision logged only the toolset-gate branch. This revision also distinguishes missing injection prerequisites and a missing schema API, so each explicit early zero-return stage is observable at DEBUG level. Injection behavior is unchanged.

## Verification

- rebased both commits onto current `upstream/main` at `9829746df`
- red first: the new prerequisite and schema-API log assertions failed against the previous implementation
- `HERMES_PYTHON=/opt/homebrew/bin/python3.14 HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/agent/test_memory_provider.py -k 'TestMemoryToolToolsetGate' -q` — 16 passed
- `uvx ruff check agent/memory_manager.py tests/agent/test_memory_provider.py` — passed
- `git diff --check upstream/main...HEAD` — passed

The complete test file on local Python 3.14 reports 61 passed and two `DaemonThreadPoolExecutor._initializer` failures. The same two failures reproduce unchanged on `upstream/main@9829746df`, so they are not introduced by this PR.
