### PR TITLE
feat(providers): Cursor subscription support via the official SDK bridge

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -717,8 +717,10 @@ def init_agent(
         api_mode is None
         and agent.api_mode == "chat_completions"
         and agent.provider != "copilot-acp"
+        and agent.provider != "cursor"
         and not str(agent.base_url or "").lower().startswith("acp://copilot")
         and not str(agent.base_url or "").lower().startswith("acp+tcp://")
+        and not str(agent.base_url or "").lower().startswith("sdkbridge://")
         and not agent._is_azure_openai_url()
         and (
             agent._is_direct_openai_url()

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2266,6 +2266,17 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
             agent._client_log_context(),
         )
         return client
+    if agent.provider == "cursor" or str(client_kwargs.get("base_url", "")).startswith("sdkbridge://"):
+        from agent.cursor_bridge_client import CursorBridgeClient
+
+        client = CursorBridgeClient(**client_kwargs)
+        _ra().logger.info(
+            "Cursor SDK bridge client created (%s, shared=%s) %s",
+            reason,
+            shared,
+            agent._client_log_context(),
+        )
+        return client
     if agent.provider == "gemini":
         from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2036,6 +2036,12 @@ def _maybe_wrap_anthropic(
             return client_obj
     except ImportError:
         pass
+    try:
+        from agent.cursor_bridge_client import CursorBridgeClient
+        if _safe_isinstance(client_obj, CursorBridgeClient):
+            return client_obj
+    except ImportError:
+        pass
 
     # Explicit non-anthropic api_mode wins over URL heuristics.
     if api_mode and api_mode != "anthropic_messages":
@@ -3231,7 +3237,7 @@ def _validate_base_url(base_url: str) -> None:
     from urllib.parse import urlparse
 
     candidate = str(base_url or "").strip()
-    if not candidate or candidate.startswith("acp://"):
+    if not candidate or candidate.startswith(("acp://", "sdkbridge://")):
         return
     try:
         parsed = urlparse(candidate)
@@ -5609,6 +5615,12 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
             return sync_client, model
     except ImportError:
         pass
+    try:
+        from agent.cursor_bridge_client import CursorBridgeClient
+        if isinstance(sync_client, CursorBridgeClient):
+            return sync_client, model
+    except ImportError:
+        pass
 
     async_kwargs = {
         "api_key": sync_client.api_key,
@@ -6258,6 +6270,19 @@ def resolve_provider_client(
 
         default_model = _get_aux_model_for_provider(provider)
         final_model = _normalize_resolved_model(model or default_model, provider)
+
+        if provider == "cursor" or raw_base_url.startswith("sdkbridge://"):
+            # The Cursor SDK bridge is a local subprocess, not an HTTP
+            # endpoint — a plain OpenAI client on the marker URL can never
+            # connect ("Connection error" on every aux task). Mirror the
+            # copilot-acp arm: hand auxiliary tasks the OpenAI-compatible
+            # bridge client instead.
+            from agent.cursor_bridge_client import CursorBridgeClient
+
+            client = CursorBridgeClient(api_key=api_key, base_url=raw_base_url)
+            logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
+            return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                    else (client, final_model))
 
         if provider == "gemini":
             from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2356,9 +2356,10 @@ def run_conversation(
                 # stream.  Mirror the ACP exclusion used for Responses
                 # API upgrade (lines ~1083-1085).
                 elif (
-                    agent.provider in {"copilot-acp"}
+                    agent.provider in {"copilot-acp", "cursor"}
                     or str(agent.base_url or "").lower().startswith("acp://copilot")
                     or str(agent.base_url or "").lower().startswith("acp+tcp://")
+                    or str(agent.base_url or "").lower().startswith("sdkbridge://")
                 ):
                     _use_streaming = False
                 # MoA streams only when a display/TTS consumer is present to

--- a/agent/cursor_bridge_client.py
+++ b/agent/cursor_bridge_client.py
@@ -1,0 +1,796 @@
+"""OpenAI-compatible client that runs Hermes turns through the Cursor SDK bridge.
+
+This adapter lets Hermes treat a user's Cursor subscription as a chat backend
+(``model.provider: cursor``).  Each request spawns/reuses a local
+``cursor-sdk-bridge`` process (the official `sdk.v1` contract from
+https://github.com/cursor/sdk-bridge), creates a short-lived Cursor agent,
+sends the formatted conversation as one prompt, and converts the result back
+into the minimal OpenAI-response shape Hermes expects.
+
+Tool handling — the part that keeps Hermes's harness intact — supports two
+modes (config.yaml ``cursor_bridge.tool_mode``):
+
+* ``loop`` (default): Cursor's built-in tools are disabled and Hermes tools
+  are declared as SDK *custom tools*.  When the Cursor agent invokes one, the
+  bridge round-trips to the loopback callback server below; Hermes captures
+  the call, cancels the run, and returns it to ``run_conversation()`` as a
+  normal OpenAI ``tool_call``.  Every Hermes mechanism (approvals, budget,
+  interrupts, agent-level todo/memory interception) keeps working because the
+  tool executes inside Hermes's own loop, exactly like any other provider.
+
+* ``harness``: the callback executes the tool inline (via
+  ``model_tools.handle_function_call``) and returns the result to the bridge,
+  so Cursor's agent loop drives the whole turn.  Cursor's built-in tools stay
+  available unless ``cursor_bridge.builtin_tools`` is false.
+
+Billing goes to the user's own ``CURSOR_API_KEY`` — Hermes never proxies or
+resells Cursor inference.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import secrets
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Callable
+
+from openai.types.chat.chat_completion_message_tool_call import (
+    ChatCompletionMessageToolCall,
+    Function,
+)
+
+from agent.cursor_bridge_transport import (
+    ConnectJsonTransport,
+    CursorBridgeError,
+    CursorBridgeProcess,
+    resolve_bridge_command,
+)
+from agent.cursor_bridge_wire import (
+    decode_call_custom_tool_request,
+    encode_call_custom_tool_response,
+)
+
+logger = logging.getLogger(__name__)
+
+BRIDGE_MARKER_BASE_URL = "sdkbridge://cursor"
+_DEFAULT_TIMEOUT_SECONDS = 900.0
+_CALLBACK_PATH = "/sdk.v1.SdkCustomToolCallbackService/CallCustomTool"
+_TERMINAL_STATUSES = {
+    "RUN_LIFECYCLE_STATUS_FINISHED",
+    "RUN_LIFECYCLE_STATUS_ERROR",
+    "RUN_LIFECYCLE_STATUS_CANCELLED",
+    "RUN_LIFECYCLE_STATUS_EXPIRED",
+}
+
+_DEFERRED_TOOL_RESULT = {
+    "status": "deferred",
+    "detail": "Hermes executes this tool and will continue the conversation.",
+}
+
+
+def load_bridge_settings() -> dict[str, Any]:
+    """Read the ``cursor_bridge`` config section with safe defaults."""
+    settings: dict[str, Any] = {
+        "command": "",
+        "tool_mode": "loop",
+        "builtin_tools": False,
+        "download_version": "",
+    }
+    try:
+        # Lazy import: hermes_cli.config imports provider plugins which may
+        # import agent modules — importing it at module load would cycle.
+        from hermes_cli.config import load_config
+
+        section = load_config().get("cursor_bridge")
+        if isinstance(section, dict):
+            for key in settings:
+                if key in section and section[key] is not None:
+                    settings[key] = section[key]
+    except Exception as exc:  # config errors must never break the client
+        logger.debug("cursor_bridge config load failed: %s", exc)
+    mode = str(settings.get("tool_mode") or "loop").strip().lower()
+    settings["tool_mode"] = mode if mode in {"loop", "harness"} else "loop"
+    settings["builtin_tools"] = bool(settings.get("builtin_tools"))
+    return settings
+
+
+# ── Prompt formatting ─────────────────────────────────────────────────────
+
+
+def _render_message_content(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, dict):
+        if isinstance(content.get("text"), str):
+            return content["text"].strip()
+        return json.dumps(content, ensure_ascii=True)
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict) and isinstance(item.get("text"), str):
+                parts.append(item["text"].strip())
+        return "\n".join(p for p in parts if p).strip()
+    return str(content).strip()
+
+
+def format_messages_as_prompt(messages: list[dict[str, Any]]) -> str:
+    """Flatten an OpenAI-shaped conversation into one Cursor prompt.
+
+    The Cursor SDK does not allow customizing the system prompt, so the
+    Hermes system message and history travel as user-message text.  Tool
+    calls/results from earlier Hermes loop iterations are rendered inline so
+    the model has the full working context each turn.
+    """
+    transcript: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = str(message.get("role") or "unknown").strip().lower()
+        label = {
+            "system": "System",
+            "user": "User",
+            "assistant": "Assistant",
+            "tool": "Tool result",
+        }.get(role, role.title() or "Context")
+
+        rendered = _render_message_content(message.get("content"))
+        tool_calls = message.get("tool_calls")
+        if isinstance(tool_calls, list) and tool_calls:
+            call_lines = []
+            for call in tool_calls:
+                fn = call.get("function") if isinstance(call, dict) else None
+                if isinstance(fn, dict):
+                    call_lines.append(
+                        f"[tool call] {fn.get('name')}({fn.get('arguments', '{}')})"
+                    )
+            if call_lines:
+                rendered = "\n".join(filter(None, [rendered, *call_lines]))
+        if not rendered:
+            continue
+        transcript.append(f"{label}:\n{rendered}")
+
+    sections = [
+        "You are the model backend for the Hermes agent. The transcript below "
+        "is the full conversation so far, including earlier tool activity.",
+        "When you need a tool, call one of your available tools directly — "
+        "do not describe or simulate tool calls in text.",
+    ]
+    if transcript:
+        sections.append("Conversation transcript:\n\n" + "\n\n".join(transcript))
+    sections.append("Continue the conversation from the latest user request.")
+    return "\n\n".join(sections)
+
+
+def convert_openai_tools_to_custom_tools(
+    tools: list[dict[str, Any]] | None,
+) -> dict[str, dict[str, Any]]:
+    """OpenAI function schemas → sdk.v1 ``custom_tools`` map."""
+    custom: dict[str, dict[str, Any]] = {}
+    for tool in tools or []:
+        if not isinstance(tool, dict):
+            continue
+        fn = tool.get("function") or {}
+        if not isinstance(fn, dict):
+            continue
+        name = str(fn.get("name") or "").strip()
+        if not name:
+            continue
+        parameters = fn.get("parameters")
+        if not isinstance(parameters, dict) or not parameters:
+            parameters = {"type": "object", "properties": {}}
+        entry: dict[str, Any] = {"inputSchema": parameters}
+        description = fn.get("description")
+        if isinstance(description, str) and description.strip():
+            entry["description"] = description.strip()
+        custom[name] = entry
+    return custom
+
+
+# ── Tool callback server ──────────────────────────────────────────────────
+
+
+class _CallbackHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    server_version = "hermes-cursor-callback"
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        logger.debug("cursor tool callback: " + fmt, *args)
+
+    def handle_one_request(self) -> None:
+        # Loop mode cancels the Cursor run after capturing a tool call, so the
+        # bridge routinely resets in-flight/idle keep-alive callback
+        # connections. Swallow the resulting reset instead of letting
+        # socketserver dump a ConnectionResetError traceback to stderr.
+        try:
+            super().handle_one_request()
+        except (ConnectionResetError, BrokenPipeError, ConnectionAbortedError):
+            self.close_connection = True
+        except OSError as exc:
+            logger.debug("cursor tool callback connection closed: %s", exc)
+            self.close_connection = True
+
+    def _read_body(self) -> bytes:
+        transfer_encoding = (self.headers.get("Transfer-Encoding") or "").lower()
+        if "chunked" in transfer_encoding:
+            # Minimal chunked decoder — http.server does not decode chunked
+            # request bodies, and the bridge may send them (see sdk-bridge
+            # docs/services.md).
+            body = b""
+            while True:
+                size_line = self.rfile.readline(65536).strip()
+                if b";" in size_line:
+                    size_line = size_line.split(b";", 1)[0]
+                size = int(size_line or b"0", 16)
+                if size == 0:
+                    self.rfile.readline(65536)  # trailing CRLF (or trailers)
+                    return body
+                body += self.rfile.read(size)
+                self.rfile.readline(65536)  # chunk-terminating CRLF
+        length = int(self.headers.get("Content-Length") or 0)
+        return self.rfile.read(length) if length else b""
+
+    def _respond(self, status: int, content_type: str, body: bytes) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _respond_connect_error(self, http_status: int, code: str, message: str) -> None:
+        payload = json.dumps({"code": code, "message": message}).encode("utf-8")
+        self._respond(http_status, "application/json", payload)
+
+    def do_POST(self) -> None:  # noqa: N802 — http.server API
+        server: _ToolCallbackServer = self.server  # type: ignore[assignment]
+        auth = self.headers.get("Authorization") or ""
+        token = auth[len("Bearer "):].strip() if auth.startswith("Bearer ") else ""
+        if not token or not secrets.compare_digest(token, server.auth_token):
+            self._respond_connect_error(401, "unauthenticated", "invalid callback token")
+            return
+        if self.path.rstrip("/") != _CALLBACK_PATH:
+            self._respond_connect_error(404, "unimplemented", f"unknown RPC {self.path}")
+            return
+
+        try:
+            raw = self._read_body()
+        except (OSError, ValueError) as exc:
+            self._respond_connect_error(400, "invalid_argument", f"unreadable body: {exc}")
+            return
+
+        content_type = (self.headers.get("Content-Type") or "").split(";")[0].strip().lower()
+        is_proto = content_type == "application/proto"
+        try:
+            if is_proto:
+                request = decode_call_custom_tool_request(raw)
+            else:
+                request = json.loads(raw.decode("utf-8")) if raw else {}
+                if not isinstance(request, dict):
+                    raise ValueError("request body is not a JSON object")
+        except (ValueError, UnicodeDecodeError) as exc:
+            self._respond_connect_error(400, "invalid_argument", f"bad request body: {exc}")
+            return
+
+        try:
+            result = server.handler(request)
+        except Exception as exc:  # tool failures must not kill the stream
+            logger.warning("cursor tool callback handler failed: %s", exc)
+            result = {"error": str(exc)}
+        if not isinstance(result, dict):
+            result = {"value": str(result)}
+
+        if is_proto:
+            self._respond(200, "application/proto", encode_call_custom_tool_response(result))
+        else:
+            body = json.dumps({"result": result}).encode("utf-8")
+            self._respond(200, "application/json", body)
+
+
+class _ToolCallbackServer(ThreadingHTTPServer):
+    """Loopback Connect server implementing SdkCustomToolCallbackService."""
+
+    daemon_threads = True
+
+    def __init__(self, handler: Callable[[dict[str, Any]], dict[str, Any]]):
+        super().__init__(("127.0.0.1", 0), _CallbackHandler)
+        self.handler = handler
+        self.auth_token = secrets.token_urlsafe(32)
+        self._thread = threading.Thread(
+            target=self.serve_forever, daemon=True, name="cursor-tool-callback"
+        )
+
+    @property
+    def url(self) -> str:
+        host, port = self.server_address[0], self.server_address[1]
+        return f"http://{host}:{port}"
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def stop(self) -> None:
+        try:
+            self.shutdown()
+            self.server_close()
+        except OSError:
+            pass
+
+    def handle_error(self, request: Any, client_address: Any) -> None:
+        # Backstop for the whole request lifecycle (read, dispatch, response
+        # flush): a bridge that resets a callback connection — which loop mode
+        # provokes on every CancelRun — must not print a traceback to stderr.
+        import sys
+
+        exc = sys.exc_info()[1]
+        if isinstance(exc, (ConnectionResetError, BrokenPipeError, ConnectionAbortedError)):
+            return
+        logger.debug("cursor tool callback server error from %s", client_address, exc_info=True)
+
+
+# ── Active-run bookkeeping ────────────────────────────────────────────────
+
+
+class _ActiveRun:
+    """Per-request state shared between the stream loop and tool callbacks."""
+
+    def __init__(self, agent_id: str, tool_names: set[str]):
+        self.agent_id = agent_id
+        self.tool_names = tool_names
+        self.lock = threading.Lock()
+        self.captured_calls: list[dict[str, Any]] = []
+        self.cancel_requested = False
+
+    def capture(self, request: dict[str, Any]) -> None:
+        with self.lock:
+            self.captured_calls.append(request)
+
+
+# ── OpenAI-compatible facade ──────────────────────────────────────────────
+
+
+class _BridgeChatCompletions:
+    def __init__(self, client: "CursorBridgeClient"):
+        self._client = client
+
+    def create(self, **kwargs: Any) -> Any:
+        return self._client._create_chat_completion(**kwargs)
+
+
+class _BridgeChatNamespace:
+    def __init__(self, client: "CursorBridgeClient"):
+        self.completions = _BridgeChatCompletions(client)
+
+
+class CursorBridgeClient:
+    """Minimal OpenAI-client-compatible facade for the Cursor SDK bridge."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        default_headers: dict[str, str] | None = None,
+        workspace: str | None = None,
+        bridge_command: str | None = None,
+        tool_mode: str | None = None,
+        builtin_tools: bool | None = None,
+        tool_dispatcher: Callable[[str, dict[str, Any], str | None], Any] | None = None,
+        **_: Any,
+    ):
+        settings = load_bridge_settings()
+        self.api_key = (api_key or os.getenv("CURSOR_API_KEY", "")).strip()
+        self.base_url = base_url or BRIDGE_MARKER_BASE_URL
+        self._default_headers = dict(default_headers or {})
+        self._workspace = str(Path(workspace or os.getcwd()).resolve())
+        self._bridge_command = bridge_command or str(settings.get("command") or "")
+        self._tool_mode = (tool_mode or settings["tool_mode"]).strip().lower()
+        if self._tool_mode not in {"loop", "harness"}:
+            self._tool_mode = "loop"
+        self._builtin_tools = (
+            bool(builtin_tools)
+            if builtin_tools is not None
+            else bool(settings["builtin_tools"])
+        )
+        self._tool_dispatcher = tool_dispatcher
+
+        self.chat = _BridgeChatNamespace(self)
+        self.is_closed = False
+        self._lock = threading.Lock()
+        self._process: CursorBridgeProcess | None = None
+        self._transport: ConnectJsonTransport | None = None
+        self._callback_server: _ToolCallbackServer | None = None
+        self._active_runs: dict[str, _ActiveRun] = {}
+        self._call_counter = 0
+
+    # ── lifecycle ────────────────────────────────────────────────────────
+
+    def _ensure_bridge(self) -> ConnectJsonTransport:
+        with self._lock:
+            if self._transport is not None and self._process is not None and self._process.is_alive():
+                return self._transport
+
+            if not self.api_key or self.api_key == "cursor":
+                # Fall back to the SDK's shared credential store, filled by
+                # `hermes cursor login` (or any Cursor SDK login).
+                from agent.cursor_sdk_auth import read_sdk_credentials
+
+                stored = read_sdk_credentials()
+                if stored:
+                    self.api_key = str(stored["apiKey"])
+                else:
+                    raise CursorBridgeError(
+                        "No Cursor credential available. Run `hermes cursor login` "
+                        "(browser login on your Cursor account), or add "
+                        "CURSOR_API_KEY to ~/.hermes/.env "
+                        "(cursor.com/dashboard → API Keys)."
+                    )
+
+            command = resolve_bridge_command(self._bridge_command)
+            if not command:
+                raise CursorBridgeError(
+                    "Cursor SDK bridge not found. Run `hermes model` and pick Cursor "
+                    "to install it, `pip install cursor-sdk`, or set "
+                    "cursor_bridge.command in config.yaml."
+                )
+
+            if self._callback_server is None:
+                self._callback_server = _ToolCallbackServer(self._handle_tool_callback)
+                self._callback_server.start()
+
+            process = CursorBridgeProcess(
+                command=command,
+                api_key=self.api_key,
+                workspace=self._workspace,
+                tool_callback_url=self._callback_server.url,
+                tool_callback_auth_token=self._callback_server.auth_token,
+            )
+            endpoint = process.start()
+            self._process = process
+            self._transport = ConnectJsonTransport(endpoint.url, endpoint.auth_token)
+            self.is_closed = False
+            return self._transport
+
+    def close(self) -> None:
+        with self._lock:
+            self.is_closed = True
+            transport, self._transport = self._transport, None
+            process, self._process = self._process, None
+            callback_server, self._callback_server = self._callback_server, None
+        if transport is not None:
+            try:
+                transport.unary(
+                    "SdkBridgeControlService",
+                    "Shutdown",
+                    {"graceSeconds": 0},
+                    timeout=3.0,
+                )
+            except CursorBridgeError:
+                pass
+        if process is not None:
+            process.stop()
+        if callback_server is not None:
+            callback_server.stop()
+
+    # ── tool callbacks ───────────────────────────────────────────────────
+
+    def _handle_tool_callback(self, request: dict[str, Any]) -> dict[str, Any]:
+        tool_name = str(request.get("toolName") or "").strip()
+        agent_id = str(request.get("agentId") or "").strip()
+        args = request.get("args")
+        if not isinstance(args, dict):
+            args = {}
+
+        run = self._active_runs.get(agent_id)
+        if run is None:
+            return {"error": f"no active Hermes run for agent {agent_id!r}"}
+
+        if self._tool_mode == "harness":
+            return self._execute_tool_inline(tool_name, args, request.get("toolCallId"))
+
+        # Loop mode: capture the call, hand it back to Hermes's loop, and
+        # cancel the Cursor run so the model does not keep iterating on the
+        # placeholder result below.
+        run.capture(
+            {
+                "toolName": tool_name,
+                "args": args,
+                "toolCallId": request.get("toolCallId"),
+            }
+        )
+        self._request_cancel(run)
+        return dict(_DEFERRED_TOOL_RESULT)
+
+    def _execute_tool_inline(
+        self, tool_name: str, args: dict[str, Any], tool_call_id: Any
+    ) -> dict[str, Any]:
+        dispatcher = self._tool_dispatcher
+        if dispatcher is None:
+            # Default: the shared Hermes tool dispatcher.  Agent-level tools
+            # (todo/memory) are intercepted by run_agent before this layer,
+            # so harness mode covers registry tools only.
+            from model_tools import handle_function_call
+
+            def dispatcher(name: str, call_args: dict[str, Any], call_id: str | None) -> Any:
+                return handle_function_call(name, call_args, tool_call_id=call_id)
+
+        result = dispatcher(tool_name, args, tool_call_id if isinstance(tool_call_id, str) else None)
+        if isinstance(result, dict):
+            return result
+        text = result if isinstance(result, str) else json.dumps(result, ensure_ascii=False)
+        try:
+            parsed = json.loads(text)
+            if isinstance(parsed, dict):
+                return parsed
+        except (ValueError, TypeError):
+            pass
+        return {"value": text}
+
+    def _request_cancel(self, run: _ActiveRun) -> None:
+        with run.lock:
+            if run.cancel_requested:
+                return
+            run.cancel_requested = True
+
+        def cancel() -> None:
+            try:
+                transport = self._transport
+                if transport is None:
+                    return
+                listing = transport.unary(
+                    "SdkAgentService",
+                    "ListRuns",
+                    {"agentId": run.agent_id, "options": {"limit": 5}},
+                    timeout=15.0,
+                )
+                for item in listing.get("items") or []:
+                    if not isinstance(item, dict):
+                        continue
+                    status = str(item.get("status") or "")
+                    run_id = str(item.get("runId") or "")
+                    if run_id and status not in _TERMINAL_STATUSES:
+                        transport.unary(
+                            "SdkAgentService",
+                            "CancelRun",
+                            {"runId": run_id, "agentId": run.agent_id},
+                            timeout=15.0,
+                        )
+                        return
+            except CursorBridgeError as exc:
+                logger.debug("cursor run cancel failed (continuing): %s", exc)
+
+        threading.Thread(target=cancel, daemon=True, name="cursor-run-cancel").start()
+
+    # ── request execution ────────────────────────────────────────────────
+
+    def _next_call_id(self) -> str:
+        self._call_counter += 1
+        return f"cursor_call_{self._call_counter}"
+
+    @staticmethod
+    def _normalize_timeout(timeout: Any) -> float:
+        if timeout is None:
+            return _DEFAULT_TIMEOUT_SECONDS
+        if isinstance(timeout, (int, float)):
+            return float(timeout)
+        candidates = [
+            getattr(timeout, attr, None)
+            for attr in ("read", "write", "connect", "pool", "timeout")
+        ]
+        numeric = [float(v) for v in candidates if isinstance(v, (int, float))]
+        return max(numeric) if numeric else _DEFAULT_TIMEOUT_SECONDS
+
+    def _create_chat_completion(
+        self,
+        *,
+        model: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        timeout: Any = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: Any = None,
+        stream: bool = False,
+        **_: Any,
+    ) -> Any:
+        del tool_choice  # the Cursor harness decides tool use on its own
+        transport = self._ensure_bridge()
+        effective_timeout = self._normalize_timeout(timeout)
+        deadline = time.monotonic() + effective_timeout
+
+        model_id = (model or "").strip()
+        if not model_id or model_id.lower() == "cursor":
+            model_id = "auto"
+
+        custom_tools = convert_openai_tools_to_custom_tools(tools)
+        options: dict[str, Any] = {
+            "model": {"id": model_id},
+            "name": "hermes",
+            "local": {"cwd": [self._workspace]},
+            "mode": "AGENT_MODE_OPTION_AGENT",
+        }
+        if custom_tools:
+            options["local"]["customTools"] = custom_tools
+        if self._tool_mode == "loop" and not self._builtin_tools:
+            # Restrict Cursor's built-in tools so the harness cannot bypass
+            # Hermes approvals with its own shell/file tools.  Custom tools
+            # are surfaced to the model THROUGH the harness's `mcp`
+            # meta-tools (verified live against bridge 1.0.27: with an empty
+            # ToolList the model sees the custom-user-tools server but has
+            # no way to call it), so `mcp` must stay allow-listed whenever
+            # Hermes declares tools.  With no tools at all, empty = pure
+            # text generation.
+            options["tools"] = {"names": ["mcp"] if custom_tools else []}
+
+        created = transport.unary(
+            "SdkAgentService", "CreateAgent", {"options": options}, timeout=60.0
+        )
+        agent_id = str(created.get("agentId") or "")
+        if not agent_id:
+            raise CursorBridgeError("CreateAgent returned no agentId")
+
+        run = _ActiveRun(agent_id, set(custom_tools))
+        self._active_runs[agent_id] = run
+        prompt_text = format_messages_as_prompt(messages or [])
+
+        final_text = ""
+        usage_payload: dict[str, Any] = {}
+        status = ""
+        error_code = None
+        try:
+            stream_iter = transport.server_stream(
+                "SdkAgentService",
+                "Send",
+                {
+                    "agentId": agent_id,
+                    "message": {"text": prompt_text},
+                    "options": {},
+                },
+                deadline=deadline,
+            )
+            for message in stream_iter:
+                result_env = message.get("result")
+                if isinstance(result_env, dict):
+                    status = str(result_env.get("status") or "")
+                    error_code = result_env.get("errorCode")
+                    run_result = result_env.get("result")
+                    if isinstance(run_result, dict):
+                        final_text = str(run_result.get("result") or "")
+                        maybe_usage = run_result.get("usage")
+                        if isinstance(maybe_usage, dict):
+                            usage_payload = maybe_usage
+                    continue
+                if "done" in message:
+                    break
+                # sdk_message / interaction_update / keepalives: ignored.
+        finally:
+            self._active_runs.pop(agent_id, None)
+            self._cleanup_agent(transport, agent_id)
+
+        captured = list(run.captured_calls)
+        if not captured and status and status not in {
+            "RUN_LIFECYCLE_STATUS_FINISHED",
+        }:
+            code_note = f" (code={error_code})" if error_code else ""
+            raise CursorBridgeError(
+                f"Cursor run ended with status {status}{code_note}: "
+                f"{final_text or 'no result text'}",
+                code=str(error_code) if error_code else None,
+            )
+
+        tool_calls = [
+            ChatCompletionMessageToolCall(
+                id=str(call.get("toolCallId") or self._next_call_id()),
+                call_id=str(call.get("toolCallId") or self._next_call_id()),
+                response_item_id=None,
+                type="function",
+                function=Function(
+                    name=str(call.get("toolName") or ""),
+                    arguments=json.dumps(call.get("args") or {}, ensure_ascii=False),
+                ),
+            )
+            for call in captured
+        ]
+
+        usage = self._usage_namespace(usage_payload)
+        assistant_message = SimpleNamespace(
+            content=(final_text or None) if not tool_calls else None,
+            tool_calls=tool_calls,
+            reasoning=None,
+            reasoning_content=None,
+            reasoning_details=None,
+        )
+        finish_reason = "tool_calls" if tool_calls else "stop"
+        completion = SimpleNamespace(
+            choices=[SimpleNamespace(message=assistant_message, finish_reason=finish_reason)],
+            usage=usage,
+            model=model_id,
+        )
+        if stream:
+            return _completion_to_stream_chunks(completion)
+        return completion
+
+    def _cleanup_agent(self, transport: ConnectJsonTransport, agent_id: str) -> None:
+        """Delete the per-request agent so bridge-store state does not pile up."""
+        try:
+            transport.unary(
+                "SdkAgentService",
+                "DeleteAgent",
+                {"agentId": agent_id, "options": {"cwd": self._workspace}},
+                timeout=15.0,
+            )
+        except CursorBridgeError as exc:
+            logger.debug("cursor agent cleanup failed for %s: %s", agent_id, exc)
+
+    @staticmethod
+    def _usage_namespace(usage_payload: dict[str, Any]) -> SimpleNamespace:
+        def as_int(key: str) -> int:
+            value = usage_payload.get(key)
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                return 0
+
+        input_tokens = as_int("inputTokens")
+        output_tokens = as_int("outputTokens")
+        total = as_int("totalTokens") or (input_tokens + output_tokens)
+        return SimpleNamespace(
+            prompt_tokens=input_tokens,
+            completion_tokens=output_tokens,
+            total_tokens=total,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=as_int("cacheReadTokens")),
+        )
+
+    # ── catalog ──────────────────────────────────────────────────────────
+
+    def list_models(self) -> list[dict[str, Any]]:
+        """Return the account's model catalog (SdkModel dicts)."""
+        transport = self._ensure_bridge()
+        response = transport.unary(
+            "SdkCursorService",
+            "ListModels",
+            {"options": {"apiKey": self.api_key}},
+            timeout=30.0,
+        )
+        items = response.get("items")
+        return [item for item in items or [] if isinstance(item, dict)]
+
+
+def _completion_to_stream_chunks(completion: SimpleNamespace) -> list[SimpleNamespace]:
+    """Convert a one-shot bridge response into OpenAI-style stream chunks."""
+    choice = completion.choices[0]
+    message = choice.message
+    tool_call_deltas = None
+    if message.tool_calls:
+        tool_call_deltas = [
+            SimpleNamespace(
+                index=index,
+                id=getattr(tool_call, "id", None),
+                type=getattr(tool_call, "type", "function"),
+                function=SimpleNamespace(
+                    name=getattr(tool_call.function, "name", None),
+                    arguments=getattr(tool_call.function, "arguments", None),
+                ),
+            )
+            for index, tool_call in enumerate(message.tool_calls)
+        ]
+
+    delta = SimpleNamespace(
+        role="assistant",
+        content=message.content or None,
+        tool_calls=tool_call_deltas,
+        reasoning_content=None,
+        reasoning=None,
+    )
+    data_chunk = SimpleNamespace(
+        choices=[SimpleNamespace(index=0, delta=delta, finish_reason=choice.finish_reason)],
+        model=completion.model,
+        usage=None,
+    )
+    usage_chunk = SimpleNamespace(choices=[], model=completion.model, usage=completion.usage)
+    return [data_chunk, usage_chunk]

--- a/agent/cursor_bridge_transport.py
+++ b/agent/cursor_bridge_transport.py
@@ -1,0 +1,648 @@
+"""Cursor SDK bridge process management + Connect JSON transport.
+
+Implements the `sdk.v1` bridge protocol from https://github.com/cursor/sdk-bridge:
+
+* locate or install the ``cursor-sdk-bridge`` launcher,
+* spawn it with ``CURSOR_API_KEY`` and parse the ``cursor-sdk-bridge ready``
+  stderr discovery line,
+* speak Connect over HTTP/1.1 with JSON encoding — unary RPCs are plain JSON
+  POSTs, server streams use enveloped ``application/connect+json`` frames
+  (1 flags byte + 4-byte big-endian length + payload).
+
+The bridge is HTTP/1.1 only; classic gRPC clients do not work.  JSON encoding
+is used so Hermes does not need generated protobuf stubs (proto3 has a
+canonical JSON mapping and Connect servers accept it natively).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import struct
+import subprocess
+import threading
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+READY_LINE_PREFIX = "cursor-sdk-bridge ready "
+_STARTUP_TIMEOUT_SECONDS = 45.0
+_SHUTDOWN_TIMEOUT_SECONDS = 5.0
+
+# Default bridge version installed by `hermes model` when no bridge is found.
+# Matches a released @cursor/sdk / cursor-sdk version that includes the
+# custom-tools callback surface (landed in SDK 1.0.2x, Aug 2026).  Users can
+# override via config.yaml `cursor_bridge.download_version`.
+DEFAULT_BRIDGE_VERSION = "1.0.27"
+# Primary distribution: GitHub release assets (ship with SHA256SUMS.txt so
+# the install can be integrity-checked).  The downloads.cursor.com mirror
+# documented in the sdk-bridge README is the fallback.
+_GITHUB_RELEASE_URL_TEMPLATE = (
+    "https://github.com/cursor/sdk-bridge/releases/download/v{version}/"
+    "cursor-sdk-bridge-standalone-{os}-{arch}.tar.gz"
+)
+_GITHUB_SHASUMS_URL_TEMPLATE = (
+    "https://github.com/cursor/sdk-bridge/releases/download/v{version}/SHA256SUMS.txt"
+)
+_MIRROR_URL_TEMPLATE = (
+    "https://downloads.cursor.com/sdk-bridge/{version}/{os}/{arch}/"
+    "cursor-sdk-bridge-package.tar.gz"
+)
+
+
+class CursorBridgeError(RuntimeError):
+    """Raised for bridge process, transport, or Connect-level failures."""
+
+    def __init__(self, message: str, *, code: str | None = None):
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass
+class BridgeEndpoint:
+    """Where a running bridge listens and how to authenticate to it."""
+
+    url: str
+    auth_token: str
+    server_version: str = ""
+    pid: int | None = None
+    workspace_ref: str = ""
+    state_root: str = ""
+
+
+def parse_ready_line(line: str) -> dict[str, Any] | None:
+    """Parse one stderr line; return the discovery payload or None.
+
+    Never log the returned payload verbatim — older bridges inline the auth
+    token in the discovery JSON.
+    """
+    if not line.startswith(READY_LINE_PREFIX):
+        return None
+    raw = line[len(READY_LINE_PREFIX):].strip()
+    try:
+        payload = json.loads(raw)
+    except ValueError as exc:
+        raise CursorBridgeError(f"invalid bridge discovery JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise CursorBridgeError("bridge discovery payload is not a JSON object")
+    return payload
+
+
+def validate_discovery(payload: dict[str, Any]) -> None:
+    if payload.get("schemaVersion") != 1:
+        raise CursorBridgeError(
+            f"unsupported bridge discovery schemaVersion={payload.get('schemaVersion')!r}"
+        )
+    if payload.get("transport") != "tcp":
+        raise CursorBridgeError(
+            f"unsupported bridge transport={payload.get('transport')!r}"
+        )
+    if payload.get("protocol") != "connect":
+        raise CursorBridgeError(
+            f"unsupported bridge protocol={payload.get('protocol')!r}"
+        )
+
+
+def endpoint_from_discovery(payload: dict[str, Any]) -> BridgeEndpoint:
+    validate_discovery(payload)
+    url = str(payload.get("url") or "").strip()
+    if not url:
+        host = str(payload.get("host") or "").strip()
+        port = payload.get("port")
+        if not host or not isinstance(port, int):
+            raise CursorBridgeError("bridge discovery has no url/host/port")
+        if ":" in host and not host.startswith("["):
+            host = f"[{host}]"
+        url = f"http://{host}:{port}"
+
+    token = str(payload.get("authToken") or "").strip()
+    if not token:
+        token_file = str(payload.get("authTokenFile") or "").strip()
+        if not token_file:
+            raise CursorBridgeError("bridge discovery has no authTokenFile")
+        try:
+            token = Path(token_file).read_text(encoding="utf-8").strip()
+        except OSError as exc:
+            raise CursorBridgeError(f"could not read bridge auth token file: {exc}") from exc
+    if not token:
+        raise CursorBridgeError("bridge auth token is empty")
+
+    return BridgeEndpoint(
+        url=url,
+        auth_token=token,
+        server_version=str(payload.get("serverVersion") or ""),
+        pid=payload.get("pid") if isinstance(payload.get("pid"), int) else None,
+        workspace_ref=str(payload.get("workspaceRef") or ""),
+        state_root=str(payload.get("stateRoot") or ""),
+    )
+
+
+# ── Bridge binary resolution ──────────────────────────────────────────────
+
+
+def bridge_install_dir() -> Path:
+    """Hermes-managed bridge install location (profile-aware)."""
+    return get_hermes_home() / "cursor-sdk-bridge"
+
+
+def _launcher_name() -> str:
+    return "cursor-sdk-bridge.cmd" if os.name == "nt" else "cursor-sdk-bridge"
+
+
+def _bridge_from_cursor_sdk_wheel() -> str | None:
+    """Locate the bridge bundled inside an installed ``cursor-sdk`` wheel."""
+    try:
+        import importlib.util
+
+        spec = importlib.util.find_spec("cursor_sdk")
+    except (ImportError, ValueError):
+        return None
+    if spec is None or not spec.submodule_search_locations:
+        return None
+    for root in spec.submodule_search_locations:
+        base = Path(root)
+        for candidate in (
+            base / "cursor-sdk-bridge" / "bin" / _launcher_name(),
+            base / "_bridge" / "bin" / _launcher_name(),
+            base / "bridge" / "bin" / _launcher_name(),
+        ):
+            if candidate.exists():
+                return str(candidate)
+        # Fall back to a shallow scan — wheel layout is not contractual.
+        try:
+            for candidate in base.glob(f"**/bin/{_launcher_name()}"):
+                return str(candidate)
+        except OSError:
+            continue
+    return None
+
+
+def resolve_bridge_command(configured_command: str = "") -> str | None:
+    """Resolve the bridge launcher path, or None when not installed.
+
+    Resolution order:
+      1. ``cursor_bridge.command`` from config.yaml (caller passes it in)
+      2. the bridge embedded in an installed ``cursor-sdk`` PyPI wheel
+      3. ``CURSOR_SDK_BRIDGE_BIN`` (the upstream adapter convention)
+      4. ``cursor-sdk-bridge`` on PATH
+      5. the Hermes-managed install under ``$HERMES_HOME/cursor-sdk-bridge/``
+    """
+    configured = (configured_command or "").strip()
+    if configured:
+        expanded = os.path.expanduser(configured)
+        if shutil.which(expanded) or Path(expanded).exists():
+            return expanded
+        logger.warning("Configured cursor_bridge.command %r not found", configured)
+
+    wheel_bridge = _bridge_from_cursor_sdk_wheel()
+    if wheel_bridge:
+        return wheel_bridge
+
+    env_bin = os.getenv("CURSOR_SDK_BRIDGE_BIN", "").strip()
+    if env_bin and Path(os.path.expanduser(env_bin)).exists():
+        return os.path.expanduser(env_bin)
+
+    on_path = shutil.which("cursor-sdk-bridge")
+    if on_path:
+        return on_path
+
+    for managed in (
+        bridge_install_dir() / "bin" / _launcher_name(),
+        bridge_install_dir() / "cursor-sdk-bridge" / "bin" / _launcher_name(),
+    ):
+        if managed.exists():
+            return str(managed)
+    return None
+
+
+def bridge_platform() -> tuple[str, str]:
+    """Return the (os, arch) pair used by the bridge download URL."""
+    import platform as _platform
+    import sys
+
+    if sys.platform == "win32":
+        os_name = "win32"
+    elif sys.platform == "darwin":
+        os_name = "darwin"
+    else:
+        os_name = "linux"
+    machine = _platform.machine().lower()
+    arch = "arm64" if machine in {"arm64", "aarch64"} else "x64"
+    if os_name == "win32":
+        arch = "x64"  # win32 archives are x64-only
+    return os_name, arch
+
+
+def _fetch_url(url: str, timeout: float = 120) -> bytes:
+    request = urllib.request.Request(url, headers={"User-Agent": "hermes-cli"})
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return response.read()
+
+
+def _expected_archive_sha256(version: str, archive_name: str) -> str | None:
+    """Fetch the release SHA256SUMS.txt and return the archive's digest."""
+    try:
+        sums = _fetch_url(
+            _GITHUB_SHASUMS_URL_TEMPLATE.format(version=version), timeout=30
+        ).decode("utf-8", "replace")
+    except (urllib.error.URLError, OSError):
+        return None
+    for line in sums.splitlines():
+        parts = line.split()
+        if len(parts) >= 2 and parts[-1].lstrip("*") == archive_name:
+            return parts[0].lower()
+    return None
+
+
+def download_bridge(version: str = "", *, progress: bool = True) -> str:
+    """Download and unpack the bridge archive into the Hermes-managed dir.
+
+    Prefers the GitHub release asset (integrity-checked against the
+    release's SHA256SUMS.txt) and falls back to the downloads.cursor.com
+    mirror.  Returns the launcher path.  Called from setup flows
+    (`hermes model`) — the runtime client never downloads implicitly.
+    """
+    import hashlib
+    import tarfile
+    import tempfile
+
+    version = (version or DEFAULT_BRIDGE_VERSION).strip().lstrip("v")
+    os_name, arch = bridge_platform()
+    archive_name = f"cursor-sdk-bridge-standalone-{os_name}-{arch}.tar.gz"
+    dest_root = bridge_install_dir()
+    dest_root.mkdir(parents=True, exist_ok=True)
+
+    if progress:
+        print(f"  Downloading Cursor SDK bridge {version} ({os_name}/{arch})...")
+
+    data: bytes | None = None
+    errors: list[str] = []
+    github_url = _GITHUB_RELEASE_URL_TEMPLATE.format(
+        version=version, os=os_name, arch=arch
+    )
+    try:
+        data = _fetch_url(github_url)
+        expected = _expected_archive_sha256(version, archive_name)
+        if expected:
+            actual = hashlib.sha256(data).hexdigest()
+            if actual != expected:
+                raise CursorBridgeError(
+                    f"bridge archive checksum mismatch: expected {expected}, got {actual}"
+                )
+            if progress:
+                print("  ✓ SHA256 verified against the release manifest")
+    except CursorBridgeError:
+        raise
+    except (urllib.error.URLError, OSError) as exc:
+        errors.append(f"{github_url}: {exc}")
+        data = None
+
+    if data is None:
+        mirror_url = _MIRROR_URL_TEMPLATE.format(version=version, os=os_name, arch=arch)
+        try:
+            data = _fetch_url(mirror_url)
+        except (urllib.error.URLError, OSError) as exc:
+            errors.append(f"{mirror_url}: {exc}")
+            raise CursorBridgeError(
+                "bridge download failed: " + "; ".join(errors)
+            ) from exc
+
+    with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as tmp:
+        tmp.write(data)
+        archive_path = tmp.name
+
+    try:
+        with tarfile.open(archive_path, "r:gz") as tar:
+            # The archive unpacks to a single `cursor-sdk-bridge/` directory.
+            tar.extractall(dest_root, filter="data")
+    except (tarfile.TarError, OSError) as exc:
+        raise CursorBridgeError(f"bridge archive extraction failed: {exc}") from exc
+    finally:
+        try:
+            os.unlink(archive_path)
+        except OSError:
+            pass
+
+    # The GitHub standalone archive is flat (bin/, manifest.json, proto/);
+    # the packaged mirror archive nests everything under cursor-sdk-bridge/.
+    bridge_root = None
+    for candidate in (dest_root, dest_root / "cursor-sdk-bridge"):
+        if (candidate / "manifest.json").exists():
+            bridge_root = candidate
+            break
+    if bridge_root is None:
+        raise CursorBridgeError(
+            f"bridge manifest not found under {dest_root} after install"
+        )
+    try:
+        manifest = json.loads((bridge_root / "manifest.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise CursorBridgeError(f"bridge manifest unreadable after install: {exc}") from exc
+    if manifest.get("protocol") != "sdk.v1":
+        raise CursorBridgeError(
+            f"installed bridge speaks protocol {manifest.get('protocol')!r}, expected 'sdk.v1'"
+        )
+
+    launcher = bridge_root / "bin" / _launcher_name()
+    if not launcher.exists():
+        raise CursorBridgeError(f"bridge launcher missing after install: {launcher}")
+    if os.name != "nt":
+        launcher.chmod(launcher.stat().st_mode | 0o755)
+    if progress:
+        print(f"  ✓ Installed Cursor SDK bridge → {launcher}")
+    return str(launcher)
+
+
+# ── Bridge process ────────────────────────────────────────────────────────
+
+
+def _build_subprocess_env(api_key: str) -> dict[str, str]:
+    # The bridge is a model-driving executor: it needs the Cursor credential
+    # but must not inherit Tier-1 Hermes secrets (gateway bot tokens, etc.).
+    from tools.environments.local import hermes_subprocess_env
+
+    env = hermes_subprocess_env(inherit_credentials=True)
+    env["CURSOR_API_KEY"] = api_key
+    env["CURSOR_SDK_CLIENT_LANGUAGE"] = "python"
+    return env
+
+
+class CursorBridgeProcess:
+    """Owns one ``cursor-sdk-bridge`` child process."""
+
+    def __init__(
+        self,
+        *,
+        command: str,
+        api_key: str,
+        workspace: str,
+        tool_callback_url: str = "",
+        tool_callback_auth_token: str = "",
+    ):
+        self._command = command
+        self._api_key = api_key
+        self._workspace = str(Path(workspace).resolve())
+        self._tool_callback_url = tool_callback_url
+        self._tool_callback_auth_token = tool_callback_auth_token
+        self._process: subprocess.Popen[str] | None = None
+        self.endpoint: BridgeEndpoint | None = None
+
+    @property
+    def workspace(self) -> str:
+        return self._workspace
+
+    def is_alive(self) -> bool:
+        return self._process is not None and self._process.poll() is None
+
+    def start(self) -> BridgeEndpoint:
+        argv = [self._command, "--workspace", self._workspace]
+        if self._tool_callback_url:
+            argv += ["--tool-callback-url", self._tool_callback_url]
+            if self._tool_callback_auth_token:
+                argv += ["--tool-callback-auth-token", self._tool_callback_auth_token]
+        try:
+            from hermes_cli._subprocess_compat import windows_hide_flags
+
+            self._process = subprocess.Popen(
+                argv,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                stdin=subprocess.DEVNULL,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                env=_build_subprocess_env(self._api_key),
+                creationflags=windows_hide_flags(),
+            )
+        except OSError as exc:
+            raise CursorBridgeError(
+                f"could not launch Cursor SDK bridge {self._command!r}: {exc}"
+            ) from exc
+
+        discovery = self._await_ready_line(self._process)
+        endpoint = endpoint_from_discovery(discovery)
+        self.endpoint = endpoint
+        logger.info(
+            "Cursor SDK bridge ready (pid=%s, version=%s)",
+            endpoint.pid,
+            endpoint.server_version,
+        )
+        return endpoint
+
+    def _await_ready_line(self, process: subprocess.Popen[str]) -> dict[str, Any]:
+        """Scan stderr for the discovery line; keep draining forever after.
+
+        A full stderr pipe blocks the bridge, so the scanner thread never
+        stops reading.
+        """
+        import queue as _queue
+
+        found: _queue.Queue[dict[str, Any] | Exception] = _queue.Queue(maxsize=1)
+
+        def scan() -> None:
+            if process.stderr is None:
+                found.put(CursorBridgeError("bridge process exposed no stderr pipe"))
+                return
+            diagnostics: list[str] = []
+            for line in process.stderr:
+                line = line.rstrip("\n")
+                try:
+                    payload = parse_ready_line(line)
+                except CursorBridgeError as exc:
+                    found.put(exc)
+                    payload = None
+                if payload is None:
+                    if len(diagnostics) < 60:
+                        diagnostics.append(line)
+                    continue
+                found.put(payload)
+                for _ in process.stderr:  # drain so the bridge never blocks
+                    pass
+                return
+            found.put(
+                CursorBridgeError(
+                    "Cursor SDK bridge exited before emitting its ready line. "
+                    "Stderr tail:\n" + "\n".join(diagnostics[-20:])
+                )
+            )
+
+        threading.Thread(target=scan, daemon=True, name="cursor-bridge-stderr").start()
+        import queue as _queue
+
+        try:
+            result = found.get(timeout=_STARTUP_TIMEOUT_SECONDS)
+        except _queue.Empty:
+            self.stop()
+            raise CursorBridgeError(
+                f"timed out after {_STARTUP_TIMEOUT_SECONDS:.0f}s waiting for the "
+                "Cursor SDK bridge ready line"
+            ) from None
+        if isinstance(result, Exception):
+            self.stop()
+            raise result
+        return result
+
+    def stop(self) -> None:
+        process, self._process = self._process, None
+        self.endpoint = None
+        if process is None:
+            return
+        if process.poll() is None:
+            try:
+                process.terminate()
+                process.wait(timeout=_SHUTDOWN_TIMEOUT_SECONDS)
+            except subprocess.TimeoutExpired:
+                try:
+                    process.kill()
+                except OSError:
+                    pass
+            except OSError:
+                pass
+        try:
+            process.wait(timeout=1)
+        except (subprocess.TimeoutExpired, OSError):
+            pass
+
+
+# ── Connect JSON transport ────────────────────────────────────────────────
+
+
+class ConnectJsonTransport:
+    """Connect-over-HTTP/1.1 client with JSON message encoding.
+
+    Unary RPCs: ``POST {base}/sdk.v1.<Service>/<Method>`` with
+    ``application/json``; errors arrive as non-200 with a Connect error JSON
+    body (``{"code": ..., "message": ...}``).
+
+    Server streams: ``application/connect+json`` enveloped frames.  Each frame
+    is 1 flags byte + 4-byte big-endian payload length + payload.  A frame
+    with flags bit ``0x02`` is the JSON EndStreamResponse (holds ``error``
+    when the stream failed).
+    """
+
+    def __init__(self, base_url: str, auth_token: str):
+        self.base_url = base_url.rstrip("/")
+        self._token = auth_token
+
+    def _request(self, path: str, content_type: str, body: bytes) -> urllib.request.Request:
+        return urllib.request.Request(
+            f"{self.base_url}{path}",
+            data=body,
+            method="POST",
+            headers={
+                "Content-Type": content_type,
+                "Authorization": f"Bearer {self._token}",
+                "Connect-Protocol-Version": "1",
+            },
+        )
+
+    @staticmethod
+    def _raise_connect_error(raw: bytes, http_status: int | None = None) -> None:
+        code = None
+        message = raw.decode("utf-8", "replace")[:2000]
+        try:
+            payload = json.loads(raw.decode("utf-8"))
+            if isinstance(payload, dict):
+                code = payload.get("code")
+                message = str(payload.get("message") or message)
+        except ValueError:
+            pass
+        prefix = f"HTTP {http_status} " if http_status else ""
+        raise CursorBridgeError(f"{prefix}connect error [{code}]: {message}", code=code)
+
+    def unary(
+        self,
+        service: str,
+        method: str,
+        request: dict[str, Any],
+        *,
+        timeout: float = 60.0,
+    ) -> dict[str, Any]:
+        body = json.dumps(request).encode("utf-8")
+        req = self._request(f"/sdk.v1.{service}/{method}", "application/json", body)
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as reply:
+                raw = reply.read()
+        except urllib.error.HTTPError as err:
+            self._raise_connect_error(err.read(), http_status=err.code)
+        except (urllib.error.URLError, OSError) as err:
+            raise CursorBridgeError(f"{service}/{method}: {err}") from None
+        if not raw:
+            return {}
+        try:
+            payload = json.loads(raw.decode("utf-8"))
+        except ValueError as exc:
+            raise CursorBridgeError(f"{service}/{method}: invalid JSON response: {exc}") from exc
+        return payload if isinstance(payload, dict) else {}
+
+    def server_stream(
+        self,
+        service: str,
+        method: str,
+        request: dict[str, Any],
+        *,
+        read_timeout: float = 90.0,
+        deadline: float | None = None,
+    ) -> Iterator[dict[str, Any]]:
+        """Yield stream messages as dicts until the EndStreamResponse frame.
+
+        ``read_timeout`` bounds a single socket read; the bridge emits
+        keepalives every ~15s so a quiet-but-alive stream never trips it.
+        ``deadline`` (monotonic timestamp) bounds the whole stream.
+        """
+        payload = json.dumps(request).encode("utf-8")
+        body = struct.pack(">BI", 0, len(payload)) + payload
+        req = self._request(f"/sdk.v1.{service}/{method}", "application/connect+json", body)
+        try:
+            reply = urllib.request.urlopen(req, timeout=read_timeout)
+        except urllib.error.HTTPError as err:
+            self._raise_connect_error(err.read(), http_status=err.code)
+            return  # unreachable; keeps type-checkers happy
+        except (urllib.error.URLError, OSError) as err:
+            raise CursorBridgeError(f"{service}/{method}: {err}") from None
+
+        with reply:
+            while True:
+                if deadline is not None and time.monotonic() > deadline:
+                    raise CursorBridgeError(f"{service}/{method}: stream deadline exceeded")
+                header = _read_exact(reply, 5, what=f"{service}/{method} frame header")
+                flags, length = struct.unpack(">BI", header)
+                frame = _read_exact(reply, length, what=f"{service}/{method} frame body")
+                if flags & 0x02:
+                    end = json.loads(frame) if frame else {}
+                    error = end.get("error") if isinstance(end, dict) else None
+                    if error:
+                        self._raise_connect_error(json.dumps(error).encode("utf-8"))
+                    return
+                if not frame:
+                    continue
+                try:
+                    message = json.loads(frame.decode("utf-8"))
+                except ValueError as exc:
+                    raise CursorBridgeError(
+                        f"{service}/{method}: invalid JSON stream frame: {exc}"
+                    ) from exc
+                if isinstance(message, dict):
+                    yield message
+
+
+def _read_exact(stream: Any, count: int, *, what: str) -> bytes:
+    chunks = b""
+    while len(chunks) < count:
+        try:
+            chunk = stream.read(count - len(chunks))
+        except OSError as exc:
+            raise CursorBridgeError(f"{what}: stream read failed: {exc}") from None
+        if not chunk:
+            raise CursorBridgeError(f"{what}: stream ended before EndStreamResponse")
+        chunks += chunk
+    return chunks

--- a/agent/cursor_bridge_wire.py
+++ b/agent/cursor_bridge_wire.py
@@ -1,0 +1,256 @@
+"""Minimal protobuf wire codec for the Cursor SDK bridge callback messages.
+
+The bridge (`cursor-sdk-bridge`, see https://github.com/cursor/sdk-bridge)
+calls back into Hermes over Connect unary POSTs when a custom tool executes
+(`sdk.v1.SdkCustomToolCallbackService/CallCustomTool`).  Connect clients may
+encode those requests as JSON (`application/json`) or binary protobuf
+(`application/proto`).  Hermes speaks JSON for everything it initiates, but
+the callback server must accept whichever encoding the bridge uses.
+
+Rather than pulling in generated protobuf stubs (and a codegen pipeline) for
+two small messages, this module hand-rolls the proto3 wire format for exactly
+the types the callback needs:
+
+    message CallCustomToolRequest {
+      string tool_name = 1;
+      google.protobuf.Struct args = 2;
+      optional string tool_call_id = 3;
+      string agent_id = 4;
+    }
+
+    message CallCustomToolResponse {
+      google.protobuf.Struct result = 1;
+    }
+
+plus ``google.protobuf.Struct`` / ``Value`` / ``ListValue`` which map 1:1 to
+JSON objects / values / arrays.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# ── varint ────────────────────────────────────────────────────────────────
+
+
+def _encode_varint(value: int) -> bytes:
+    if value < 0:
+        raise ValueError("varint must be non-negative")
+    out = bytearray()
+    while True:
+        bits = value & 0x7F
+        value >>= 7
+        if value:
+            out.append(bits | 0x80)
+        else:
+            out.append(bits)
+            return bytes(out)
+
+
+def _decode_varint(data: bytes, pos: int) -> tuple[int, int]:
+    result = 0
+    shift = 0
+    while True:
+        if pos >= len(data):
+            raise ValueError("truncated varint")
+        byte = data[pos]
+        pos += 1
+        result |= (byte & 0x7F) << shift
+        if not byte & 0x80:
+            return result, pos
+        shift += 7
+        if shift > 63:
+            raise ValueError("varint too long")
+
+
+def _tag(field_number: int, wire_type: int) -> bytes:
+    return _encode_varint((field_number << 3) | wire_type)
+
+
+def _len_delimited(field_number: int, payload: bytes) -> bytes:
+    return _tag(field_number, 2) + _encode_varint(len(payload)) + payload
+
+
+# ── google.protobuf.Struct <-> Python ─────────────────────────────────────
+#
+# Struct   { map<string, Value> fields = 1; }   (map entry: key=1, value=2)
+# Value    { oneof kind { NullValue null_value = 1; double number_value = 2;
+#            string string_value = 3; bool bool_value = 4;
+#            Struct struct_value = 5; ListValue list_value = 6; } }
+# ListValue{ repeated Value values = 1; }
+
+
+def encode_struct(obj: dict[str, Any]) -> bytes:
+    if not isinstance(obj, dict):
+        raise TypeError("Struct payload must be a dict")
+    out = bytearray()
+    for key, value in obj.items():
+        entry = _len_delimited(1, str(key).encode("utf-8")) + _len_delimited(
+            2, _encode_value(value)
+        )
+        out += _len_delimited(1, entry)
+    return bytes(out)
+
+
+def _encode_value(value: Any) -> bytes:
+    if value is None:
+        return _tag(1, 0) + _encode_varint(0)  # NULL_VALUE
+    if isinstance(value, bool):
+        return _tag(4, 0) + _encode_varint(1 if value else 0)
+    if isinstance(value, (int, float)):
+        import struct as _struct
+
+        return _tag(2, 1) + _struct.pack("<d", float(value))
+    if isinstance(value, str):
+        return _len_delimited(3, value.encode("utf-8"))
+    if isinstance(value, dict):
+        return _len_delimited(5, encode_struct(value))
+    if isinstance(value, (list, tuple)):
+        payload = bytearray()
+        for item in value:
+            payload += _len_delimited(1, _encode_value(item))
+        return _len_delimited(6, bytes(payload))
+    raise TypeError(f"Struct cannot encode value of type {type(value).__name__}")
+
+
+def decode_struct(data: bytes) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    pos = 0
+    while pos < len(data):
+        tag, pos = _decode_varint(data, pos)
+        field_number, wire_type = tag >> 3, tag & 0x07
+        if field_number == 1 and wire_type == 2:
+            length, pos = _decode_varint(data, pos)
+            entry = data[pos : pos + length]
+            pos += length
+            key, value = _decode_map_entry(entry)
+            result[key] = value
+        else:
+            pos = _skip_field(data, pos, wire_type)
+    return result
+
+
+def _decode_map_entry(entry: bytes) -> tuple[str, Any]:
+    key = ""
+    value: Any = None
+    pos = 0
+    while pos < len(entry):
+        tag, pos = _decode_varint(entry, pos)
+        field_number, wire_type = tag >> 3, tag & 0x07
+        if field_number == 1 and wire_type == 2:
+            length, pos = _decode_varint(entry, pos)
+            key = entry[pos : pos + length].decode("utf-8")
+            pos += length
+        elif field_number == 2 and wire_type == 2:
+            length, pos = _decode_varint(entry, pos)
+            value = _decode_value(entry[pos : pos + length])
+            pos += length
+        else:
+            pos = _skip_field(entry, pos, wire_type)
+    return key, value
+
+
+def _decode_value(data: bytes) -> Any:
+    import struct as _struct
+
+    value: Any = None
+    pos = 0
+    while pos < len(data):
+        tag, pos = _decode_varint(data, pos)
+        field_number, wire_type = tag >> 3, tag & 0x07
+        if field_number == 1 and wire_type == 0:  # null_value
+            _, pos = _decode_varint(data, pos)
+            value = None
+        elif field_number == 2 and wire_type == 1:  # number_value
+            value = _struct.unpack("<d", data[pos : pos + 8])[0]
+            # Render integral doubles as ints for friendlier tool args.
+            if isinstance(value, float) and value.is_integer() and abs(value) < 2**53:
+                value = int(value)
+            pos += 8
+        elif field_number == 3 and wire_type == 2:  # string_value
+            length, pos = _decode_varint(data, pos)
+            value = data[pos : pos + length].decode("utf-8")
+            pos += length
+        elif field_number == 4 and wire_type == 0:  # bool_value
+            raw, pos = _decode_varint(data, pos)
+            value = bool(raw)
+        elif field_number == 5 and wire_type == 2:  # struct_value
+            length, pos = _decode_varint(data, pos)
+            value = decode_struct(data[pos : pos + length])
+            pos += length
+        elif field_number == 6 and wire_type == 2:  # list_value
+            length, pos = _decode_varint(data, pos)
+            value = _decode_list(data[pos : pos + length])
+            pos += length
+        else:
+            pos = _skip_field(data, pos, wire_type)
+    return value
+
+
+def _decode_list(data: bytes) -> list[Any]:
+    items: list[Any] = []
+    pos = 0
+    while pos < len(data):
+        tag, pos = _decode_varint(data, pos)
+        field_number, wire_type = tag >> 3, tag & 0x07
+        if field_number == 1 and wire_type == 2:
+            length, pos = _decode_varint(data, pos)
+            items.append(_decode_value(data[pos : pos + length]))
+            pos += length
+        else:
+            pos = _skip_field(data, pos, wire_type)
+    return items
+
+
+def _skip_field(data: bytes, pos: int, wire_type: int) -> int:
+    if wire_type == 0:  # varint
+        _, pos = _decode_varint(data, pos)
+        return pos
+    if wire_type == 1:  # 64-bit
+        return pos + 8
+    if wire_type == 2:  # length-delimited
+        length, pos = _decode_varint(data, pos)
+        return pos + length
+    if wire_type == 5:  # 32-bit
+        return pos + 4
+    raise ValueError(f"unsupported wire type {wire_type}")
+
+
+# ── CallCustomTool messages ───────────────────────────────────────────────
+
+
+def decode_call_custom_tool_request(data: bytes) -> dict[str, Any]:
+    """Decode a binary ``CallCustomToolRequest`` into a plain dict.
+
+    Returns ``{"toolName", "args", "toolCallId", "agentId"}`` using the same
+    camelCase keys the JSON encoding produces, so callers handle one shape.
+    """
+    result: dict[str, Any] = {"toolName": "", "args": {}, "toolCallId": None, "agentId": ""}
+    pos = 0
+    while pos < len(data):
+        tag, pos = _decode_varint(data, pos)
+        field_number, wire_type = tag >> 3, tag & 0x07
+        if field_number == 1 and wire_type == 2:
+            length, pos = _decode_varint(data, pos)
+            result["toolName"] = data[pos : pos + length].decode("utf-8")
+            pos += length
+        elif field_number == 2 and wire_type == 2:
+            length, pos = _decode_varint(data, pos)
+            result["args"] = decode_struct(data[pos : pos + length])
+            pos += length
+        elif field_number == 3 and wire_type == 2:
+            length, pos = _decode_varint(data, pos)
+            result["toolCallId"] = data[pos : pos + length].decode("utf-8")
+            pos += length
+        elif field_number == 4 and wire_type == 2:
+            length, pos = _decode_varint(data, pos)
+            result["agentId"] = data[pos : pos + length].decode("utf-8")
+            pos += length
+        else:
+            pos = _skip_field(data, pos, wire_type)
+    return result
+
+
+def encode_call_custom_tool_response(result: dict[str, Any]) -> bytes:
+    """Encode ``CallCustomToolResponse{result: Struct}`` to binary protobuf."""
+    return _len_delimited(1, encode_struct(result))

--- a/agent/cursor_sdk_auth.py
+++ b/agent/cursor_sdk_auth.py
@@ -1,0 +1,415 @@
+"""Interactive Cursor SDK login for Hermes (`hermes cursor login`).
+
+Implements the same browser PKCE flow the Cursor SDK's ``Cursor.auth.login()``
+ships (sdk 1.0.27+): generate a one-time ``verifier``, send the user's browser
+to ``cursor.com/loginDeepControl`` with ``challenge = sha256(verifier)``, poll
+``api2.cursor.sh/auth/poll`` until the browser completes, then use the session
+token **once** to mint a named, expiring user API key via
+``aiserver.v1.DashboardService/CreateUserApiKey`` — and drop the session
+tokens.  The minted key is the only credential persisted.
+
+Credentials are stored in the SDK's own store (``~/.cursor/sdk/auth.json``,
+0600) so a login done through Hermes, the Cursor SDK, or any other adapter is
+shared — this path is deliberately NOT ``HERMES_HOME``-scoped; it belongs to
+the user's Cursor identity, not to a Hermes profile.
+
+The login URL can be opened on ANY device logged into cursor.com (it is a
+device-code-style flow): only the process holding the verifier can redeem it.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import logging
+import os
+import secrets
+import socket
+import time
+import urllib.error
+import urllib.request
+import uuid as uuid_module
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_WEBSITE_URL = "https://cursor.com"
+DEFAULT_BACKEND_URL = "https://api2.cursor.sh"
+# Matches the SDK's DEFAULT_LOGIN_API_KEY_TTL_MS: 90 days.
+DEFAULT_API_KEY_TTL_MS = 90 * 24 * 60 * 60 * 1000
+
+_POLL_MAX_ATTEMPTS = 150
+_POLL_BASE_DELAY_S = 1.0
+_POLL_MAX_DELAY_S = 10.0
+_POLL_BACKOFF = 1.2
+_MAX_CONSECUTIVE_ERRORS = 3
+
+
+class CursorAuthError(RuntimeError):
+    pass
+
+
+def resolve_website_url(url: str = "") -> str:
+    return (url or os.getenv("CURSOR_WEBSITE_URL", "") or DEFAULT_WEBSITE_URL).rstrip("/")
+
+
+def resolve_backend_url(url: str = "") -> str:
+    return (url or os.getenv("CURSOR_BACKEND_URL", "") or DEFAULT_BACKEND_URL).rstrip("/")
+
+
+# ── Handshake ─────────────────────────────────────────────────────────────
+
+
+@dataclass
+class LoginHandshake:
+    uuid: str
+    verifier: str
+    login_url: str
+
+
+def create_login_handshake(website_url: str = "") -> LoginHandshake:
+    website_url = resolve_website_url(website_url)
+    verifier = base64.urlsafe_b64encode(secrets.token_bytes(32)).decode().rstrip("=")
+    challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+        .decode()
+        .rstrip("=")
+    )
+    login_uuid = str(uuid_module.uuid4())
+    login_url = (
+        f"{website_url}/loginDeepControl?challenge={challenge}"
+        f"&uuid={login_uuid}&mode=login&redirectTarget=sdk"
+    )
+    return LoginHandshake(uuid=login_uuid, verifier=verifier, login_url=login_url)
+
+
+# ── Poll ──────────────────────────────────────────────────────────────────
+
+
+def _is_route_not_found_body(body: bytes) -> bool:
+    text = body.decode("utf-8", "replace").strip()
+    if not text.startswith("{"):
+        return False
+    try:
+        parsed = json.loads(text)
+    except ValueError:
+        return False
+    message = parsed.get("message")
+    return (
+        isinstance(message, str)
+        and message.startswith("Route ")
+        and "not found" in message
+    )
+
+
+def poll_for_login_tokens(
+    *,
+    api_url: str,
+    uuid: str,
+    verifier: str,
+    on_status: Callable[[str], None] | None = None,
+    max_attempts: int = _POLL_MAX_ATTEMPTS,
+    sleep: Callable[[float], None] = time.sleep,
+) -> dict[str, str] | None:
+    """Poll ``/auth/poll`` until the browser completes the login.
+
+    POST with the verifier in the JSON body (it is redeemable — it must not
+    reach a URL or access log).  Backends predating the POST route answer
+    with route-not-found; those get one sticky fallback to GET.  A 404 with
+    any other body means the login is still pending.
+
+    Returns ``{"accessToken", "refreshToken"}`` or None on timeout/errors.
+    """
+    use_get = False
+    consecutive_errors = 0
+    for attempt in range(max_attempts):
+        delay = min(_POLL_BASE_DELAY_S * (_POLL_BACKOFF ** attempt), _POLL_MAX_DELAY_S)
+        try:
+            if use_get:
+                request = urllib.request.Request(
+                    f"{api_url}/auth/poll?uuid={uuid}&verifier={verifier}",
+                    method="GET",
+                    headers={"Accept": "application/json"},
+                )
+            else:
+                request = urllib.request.Request(
+                    f"{api_url}/auth/poll",
+                    method="POST",
+                    data=json.dumps({"uuid": uuid, "verifier": verifier}).encode(),
+                    headers={
+                        "Accept": "application/json",
+                        "Content-Type": "application/json",
+                    },
+                )
+            try:
+                with urllib.request.urlopen(request, timeout=15) as response:
+                    raw = response.read()
+            except urllib.error.HTTPError as err:
+                if err.code == 404:
+                    body = err.read()
+                    if not use_get and _is_route_not_found_body(body):
+                        use_get = True
+                        if on_status:
+                            on_status(
+                                "backend has no POST /auth/poll — falling back to GET"
+                            )
+                        continue
+                    consecutive_errors = 0
+                    sleep(delay)
+                    continue
+                raise
+            consecutive_errors = 0
+            result = json.loads(raw.decode("utf-8"))
+            if (
+                isinstance(result, dict)
+                and isinstance(result.get("accessToken"), str)
+                and isinstance(result.get("refreshToken"), str)
+            ):
+                return {
+                    "accessToken": result["accessToken"],
+                    "refreshToken": result["refreshToken"],
+                }
+            return None
+        except Exception as exc:
+            consecutive_errors += 1
+            logger.debug("auth/poll attempt %d failed: %s", attempt, exc)
+            if consecutive_errors >= _MAX_CONSECUTIVE_ERRORS:
+                return None
+            sleep(delay)
+    return None
+
+
+# ── Mint ──────────────────────────────────────────────────────────────────
+
+
+def _dashboard_rpc(
+    backend_url: str, method: str, payload: dict[str, Any], access_token: str
+) -> dict[str, Any]:
+    """Connect unary POST to aiserver.v1.DashboardService with JSON encoding."""
+    request = urllib.request.Request(
+        f"{backend_url}/aiserver.v1.DashboardService/{method}",
+        method="POST",
+        data=json.dumps(payload).encode(),
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {access_token}",
+            "Connect-Protocol-Version": "1",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            raw = response.read()
+    except urllib.error.HTTPError as err:
+        body = err.read().decode("utf-8", "replace")[:500]
+        raise CursorAuthError(
+            f"DashboardService/{method} failed (HTTP {err.code}): {body}"
+        ) from err
+    try:
+        parsed = json.loads(raw.decode("utf-8"))
+    except ValueError as exc:
+        raise CursorAuthError(f"DashboardService/{method}: invalid JSON response") from exc
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def mint_user_api_key(
+    *,
+    backend_url: str,
+    access_token: str,
+    name: str,
+    expires_at_ms: int | None = None,
+) -> str:
+    """Mint a named user API key; the session token is used once and dropped."""
+    payload: dict[str, Any] = {"name": name}
+    if expires_at_ms is not None:
+        # proto3 JSON encodes int64 as a string.
+        payload["expiresAt"] = str(int(expires_at_ms))
+    response = _dashboard_rpc(backend_url, "CreateUserApiKey", payload, access_token)
+    api_key = response.get("apiKey")
+    if not isinstance(api_key, str) or not api_key:
+        raise CursorAuthError(
+            "Login succeeded but CreateUserApiKey returned no key — your team's "
+            "settings may restrict user API keys; ask a team admin, or add an "
+            "existing CURSOR_API_KEY to ~/.hermes/.env instead."
+        )
+    return api_key
+
+
+def get_login_email(backend_url: str, access_token: str) -> str:
+    """Best-effort GetMe for a friendly status line."""
+    try:
+        response = _dashboard_rpc(backend_url, "GetMe", {}, access_token)
+        email = response.get("email")
+        return email if isinstance(email, str) else ""
+    except Exception:
+        return ""
+
+
+# ── Credential store (shared with the Cursor SDK) ─────────────────────────
+
+
+def sdk_auth_path() -> Path:
+    """The SDK's credential store: ``~/.cursor/sdk/auth.json``.
+
+    Intentionally HOME-anchored, not HERMES_HOME-anchored: this is Cursor's
+    own credential store, shared with `@cursor/sdk` / `cursor-sdk`, so one
+    login covers every SDK consumer on the machine.
+    """
+    return Path.home() / ".cursor" / "sdk" / "auth.json"
+
+
+def read_sdk_credentials() -> dict[str, Any] | None:
+    """Return valid stored credentials, or None (missing/foreign/expired)."""
+    try:
+        parsed = json.loads(sdk_auth_path().read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(parsed, dict) or parsed.get("version") != 1:
+        return None
+    api_key = parsed.get("apiKey")
+    if not isinstance(api_key, str) or not api_key:
+        return None
+    expires = parsed.get("apiKeyExpiresAtMs")
+    if isinstance(expires, (int, float)) and expires <= time.time() * 1000:
+        return None
+    return parsed
+
+
+def save_sdk_credentials(
+    *,
+    backend_url: str,
+    api_key: str,
+    api_key_expires_at_ms: int | None = None,
+    email: str = "",
+) -> Path:
+    path = sdk_auth_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        path.parent.chmod(0o700)
+    except OSError:
+        pass
+    payload: dict[str, Any] = {
+        "version": 1,
+        "backendUrl": backend_url,
+        "apiKey": api_key,
+        "createdAtMs": int(time.time() * 1000),
+    }
+    if api_key_expires_at_ms is not None:
+        payload["apiKeyExpiresAtMs"] = int(api_key_expires_at_ms)
+    if email:
+        payload["email"] = email
+    tmp_path = path.with_suffix(".json.tmp")
+    tmp_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    tmp_path.chmod(0o600)
+    tmp_path.replace(path)
+    try:
+        path.chmod(0o600)
+    except OSError:
+        pass
+    return path
+
+
+def clear_sdk_credentials() -> bool:
+    try:
+        sdk_auth_path().unlink()
+        return True
+    except OSError:
+        return False
+
+
+# ── Top-level login ───────────────────────────────────────────────────────
+
+
+def _default_api_key_name() -> str:
+    try:
+        host = socket.gethostname() or "unknown-host"
+    except OSError:
+        host = "unknown-host"
+    return f"Hermes Agent ({host})"
+
+
+def login(
+    *,
+    on_login_url: Callable[[str], None],
+    on_status: Callable[[str], None] | None = None,
+    api_key_name: str = "",
+    api_key_ttl_ms: int = DEFAULT_API_KEY_TTL_MS,
+    backend_url: str = "",
+    website_url: str = "",
+    open_browser: bool = True,
+) -> dict[str, Any]:
+    """Run the full interactive login; returns the stored credential payload.
+
+    The caller receives the login URL via ``on_login_url`` and may show it
+    anywhere — the user can complete it on another device.
+    """
+    backend_url = resolve_backend_url(backend_url)
+    handshake = create_login_handshake(website_url)
+    on_login_url(handshake.login_url)
+    if open_browser and not os.getenv("NO_OPEN_BROWSER") and not os.getenv("SSH_CONNECTION"):
+        try:
+            import webbrowser
+
+            webbrowser.open(handshake.login_url)
+        except Exception:
+            pass
+
+    if on_status:
+        on_status("Waiting for the browser login to complete...")
+    tokens = poll_for_login_tokens(
+        api_url=backend_url,
+        uuid=handshake.uuid,
+        verifier=handshake.verifier,
+        on_status=on_status,
+    )
+    if tokens is None:
+        raise CursorAuthError(
+            "Login did not complete (timed out or was cancelled). Run "
+            "`hermes cursor login` to try again."
+        )
+
+    expires_at_ms = int(time.time() * 1000) + int(api_key_ttl_ms)
+    api_key = mint_user_api_key(
+        backend_url=backend_url,
+        access_token=tokens["accessToken"],
+        name=api_key_name or _default_api_key_name(),
+        expires_at_ms=expires_at_ms,
+    )
+    email = get_login_email(backend_url, tokens["accessToken"])
+    save_sdk_credentials(
+        backend_url=backend_url,
+        api_key=api_key,
+        api_key_expires_at_ms=expires_at_ms,
+        email=email,
+    )
+    return {
+        "apiKey": api_key,
+        "email": email,
+        "apiKeyExpiresAtMs": expires_at_ms,
+        "path": str(sdk_auth_path()),
+    }
+
+
+def resolve_cursor_api_key() -> tuple[str, str]:
+    """Resolve the Cursor credential: explicit env/.env key, else SDK login.
+
+    Returns ``(api_key, source)`` where source is ``"env"``,
+    ``"sdk_login"``, or ``("", "")`` when nothing usable exists.
+    """
+    env_key = os.getenv("CURSOR_API_KEY", "").strip()
+    if env_key:
+        return env_key, "env"
+    try:
+        from hermes_cli.config import get_env_value
+
+        dotenv_key = (get_env_value("CURSOR_API_KEY") or "").strip()
+        if dotenv_key:
+            return dotenv_key, "env"
+    except Exception:
+        pass
+    stored = read_sdk_credentials()
+    if stored:
+        return str(stored["apiKey"]), "sdk_login"
+    return "", ""

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1305,6 +1305,26 @@ delegation:
   #                                           # Supported: openrouter, nous, zai, kimi-coding, minimax
 
 # =============================================================================
+# Cursor SDK Bridge (model.provider: cursor)
+# =============================================================================
+# Run Hermes turns through your own Cursor subscription via the official
+# cursor-sdk-bridge subprocess (https://github.com/cursor/sdk-bridge).
+# Auth: `hermes cursor login` (browser) or CURSOR_API_KEY in ~/.hermes/.env.
+#
+# cursor_bridge:
+#   command: ""              # Explicit bridge launcher path. Empty = auto-resolve
+#                            # (installed cursor-sdk wheel → PATH → ~/.hermes/cursor-sdk-bridge/).
+#   tool_mode: "loop"        # "loop" (default): Cursor's built-in tools stay off and
+#                            #   Hermes tools run inside Hermes's own loop (approvals,
+#                            #   budgets, interrupts all apply).
+#                            # "harness": Cursor's agent drives the whole turn and
+#                            #   executes Hermes tools inline via the callback service.
+#   builtin_tools: false     # Expose Cursor's built-in tools (file edit, shell, search)
+#                            # to the model. They bypass Hermes approvals — use with care.
+#   download_version: ""     # Bridge version for `hermes model` auto-install.
+#                            # Empty = the pinned default.
+
+# =============================================================================
 # Honcho Integration (Cross-Session User Modeling)
 # =============================================================================
 # AI-native persistent memory via Honcho (https://honcho.dev/).

--- a/cli.py
+++ b/cli.py
@@ -10094,6 +10094,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             self._handle_curator_command(cmd_original)
         elif canonical == "kanban":
             self._handle_kanban_command(cmd_original)
+        elif canonical == "cursor":
+            self._handle_cursor_command(cmd_original)
         elif canonical == "skills":
             with self._busy_command(self._slow_command_status(cmd_original)):
                 self._handle_skills_command(cmd_original)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14143,6 +14143,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "agents": self._handle_agents_command,
                 "background": self._handle_background_command,
                 "kanban": self._handle_kanban_command,
+                "cursor": self._handle_cursor_command,
                 "subgoal": self._handle_subgoal_command,
                 "heartbeat": self._handle_heartbeat_command,
                 "yolo": self._handle_yolo_command,
@@ -15207,6 +15208,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if canonical == "kanban":
             return await self._handle_kanban_command(event)
+
+        if canonical == "cursor":
+            return await self._handle_cursor_command(event)
 
         if canonical == "suggestions":
             return await self._handle_suggestions_command(event)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -429,6 +429,59 @@ class GatewaySlashCommandsMixin:
             f"Slash commands you can run: {runnable_str}"
         )
 
+    async def _handle_cursor_command(self, event: MessageEvent) -> str:
+        """Handle /cursor — Cursor cloud-agent handoff on the user's own sub.
+
+        Runs the bridge/network work in a thread pool so the gateway event
+        loop stays responsive.  Safe while an agent is running: the cloud
+        agent is external state (Cursor's cloud), it never touches the
+        running agent's session.  Streaming verbs (watch, --wait) are not
+        offered here — messaging surfaces get the detached forms and can
+        poll with /cursor status; live mirroring goes through the existing
+        ``terminal(background=true, notify_on_complete=true)`` machinery.
+        """
+        import asyncio
+
+        from hermes_cli.cursor_cloud import run_slash
+
+        text = (event.text or "").strip()
+        if text.startswith("/"):
+            text = text.lstrip("/")
+        if text.startswith("cursor"):
+            text = text[len("cursor"):].lstrip()
+
+        verb = text.split()[0].lower() if text.split() else ""
+        if verb == "watch":
+            return (
+                "`/cursor watch` streams and is CLI-only. Use `/cursor status` "
+                "or `/cursor pull` here, or ask me to run "
+                "`hermes cursor watch` as a background terminal command with "
+                "notify_on_complete so the result lands back in this chat."
+            )
+        if verb == "login":
+            # The login URL must reach the user BEFORE polling starts, but
+            # this handler returns output only when the command completes —
+            # so interactive login stays on the CLI.
+            return (
+                "`/cursor login` is interactive and CLI-only — run "
+                "`hermes cursor login` in a terminal (the URL it prints can "
+                "be opened from any device signed in to cursor.com), or add "
+                "CURSOR_API_KEY to ~/.hermes/.env."
+            )
+
+        def _run() -> str:
+            collected: list[str] = []
+            result = run_slash(text, emit=collected.append)
+            if collected and result not in collected:
+                return "\n".join([*collected, result])
+            return result
+
+        try:
+            output = await asyncio.to_thread(_run)
+        except Exception as exc:
+            output = f"cursor cloud error: {exc}"
+        return output or "(no output)"
+
     async def _handle_kanban_command(self, event: MessageEvent) -> str:
         """Handle /kanban — delegate to the shared kanban CLI.
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -668,6 +668,20 @@ def _resolve_api_key_provider_secret(
     except Exception:
         pass
 
+    # Cursor: fall back to the SDK's shared login store
+    # (~/.cursor/sdk/auth.json, filled by `hermes cursor login` or any Cursor
+    # SDK login). Shared resolver so the runtime gate, auth status, and
+    # doctor all see the login credential.
+    if provider_id == "cursor":
+        try:
+            from agent.cursor_sdk_auth import read_sdk_credentials
+
+            stored = read_sdk_credentials()
+            if stored:
+                return str(stored["apiKey"]), "cursor_sdk_login"
+        except Exception:
+            pass
+
     return "", ""
 
 

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1838,6 +1838,27 @@ class CLICommandsMixin:
         if output:
             print(output)
 
+    def _handle_cursor_command(self, cmd: str):
+        """Handle /cursor — delegate to the shared Cursor cloud-agent CLI.
+
+        Same shape as /kanban: strip the leading ``/cursor`` and hand the
+        remainder to ``cursor_cloud.run_slash`` which returns one formatted
+        string.
+        """
+        from hermes_cli.cursor_cloud import run_slash
+
+        rest = cmd.strip()
+        if rest.startswith("/"):
+            rest = rest.lstrip("/")
+        if rest.startswith("cursor"):
+            rest = rest[len("cursor"):].lstrip()
+        try:
+            output = run_slash(rest)
+        except Exception as exc:  # pragma: no cover - defensive
+            output = f"(._.) cursor cloud error: {exc}"
+        if output:
+            print(output)
+
     def _handle_skills_command(self, cmd: str):
         """Handle /skills slash command — delegates to hermes_cli.skills_hub."""
         from cli import ChatConsole

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -292,6 +292,11 @@ COMMAND_REGISTRY: list[CommandDef] = [
                             "notify-list", "notify-unsubscribe", "log", "runs",
                             "heartbeat", "assignees", "context", "specify", "gc"),
                busy_policy="dispatch"),
+    CommandDef("cursor", "Hand tasks to a Cursor cloud agent on your Cursor subscription",
+               "Tools & Skills", args_hint="[subcommand]",
+               subcommands=("login", "logout", "handoff", "send", "status", "runs",
+                            "pull", "watch", "list", "open"),
+               busy_policy="dispatch"),
     CommandDef("reload", "Reload .env variables into the running session", "Tools & Skills",
                cli_only=True),
     CommandDef("reload-mcp", "Reload MCP servers from config", "Tools & Skills",
@@ -1272,7 +1277,10 @@ _SLACK_PRIORITY_ALIASES = ("btw", "bg")
 #   - refine: on-demand memory/skill review; reached via /hermes refine on
 #     Slack. Added at the 50-cap — a native slot would clamp an existing
 #     native slash.
-_SLACK_VIA_HERMES_ONLY = frozenset({"topup", "moa", "debug", "egress", "init", "version", "diff", "update", "heartbeat", "refine"})
+#   - cursor: Cursor cloud-agent handoff; reached via /hermes cursor on
+#     Slack. Added at the 50-cap — a native slot would clamp an existing
+#     native slash and break Telegram parity.
+_SLACK_VIA_HERMES_ONLY = frozenset({"topup", "moa", "debug", "egress", "init", "version", "diff", "update", "heartbeat", "refine", "cursor"})
 
 
 def _sanitize_slack_name(raw: str) -> str:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1884,6 +1884,27 @@ DEFAULT_CONFIG = {
     # (apiKey, workspace, peerName, sessions, enabled) comes from the global config.
     "honcho": {},
 
+    # Cursor SDK bridge (model.provider: cursor) — runs Hermes turns through
+    # the user's own Cursor subscription via the official cursor-sdk-bridge
+    # subprocess. Auth (CURSOR_API_KEY) lives in .env; these are behavior knobs.
+    "cursor_bridge": {
+        # Explicit bridge launcher path. Empty = auto-resolve (installed
+        # cursor-sdk wheel → PATH → $HERMES_HOME/cursor-sdk-bridge/).
+        "command": "",
+        # "loop" (default): Cursor's built-in tools are disabled and Hermes
+        #   tools run inside Hermes's own loop (approvals, budget, interrupts
+        #   all apply). "harness": Cursor's agent drives the whole turn and
+        #   executes Hermes tools inline via the callback service.
+        "tool_mode": "loop",
+        # Expose Cursor's built-in tools (file edit, shell, codebase search)
+        # to the model. Only meaningful in harness mode; loop mode keeps them
+        # off so the Cursor harness cannot bypass Hermes approvals.
+        "builtin_tools": False,
+        # Bridge version for `hermes model` auto-install. Empty = the pinned
+        # default in agent/cursor_bridge_transport.py.
+        "download_version": "",
+    },
+
     # IANA timezone (e.g. "Asia/Kolkata", "America/New_York").
     # Empty string means use server-local time.
     "timezone": "",

--- a/hermes_cli/cursor_cloud.py
+++ b/hermes_cli/cursor_cloud.py
@@ -1,0 +1,703 @@
+"""Cursor Cloud Agent handoff — `hermes cursor <verb>` and the /cursor command.
+
+Phase 2 of the Cursor subscription integration: hand a task to a **durable
+Cursor cloud agent** running on Cursor-managed infrastructure.  The agent is
+visible (and can be taken over) at cursor.com/agents, in the Cursor IDE's
+Agents window, and on mobile, while Hermes can keep watching or prompting the
+same agent.
+
+Everything goes through the same official sdk.v1 bridge as the `cursor`
+model provider (github.com/cursor/sdk-bridge) using the user's own
+``CURSOR_API_KEY`` — billing lands on their Cursor plan.
+
+Verbs:
+
+    hermes cursor handoff "<prompt>" [--repo URL] [--ref REF] [--model M] [--pr] [--wait]
+    hermes cursor send <agent-id> "<prompt>" [--wait]
+    hermes cursor status [agent-id]
+    hermes cursor runs [agent-id]
+    hermes cursor pull [agent-id]
+    hermes cursor watch [agent-id]
+    hermes cursor open [agent-id]
+    hermes cursor list
+
+Mirroring runs into a live Hermes session reuses the existing
+background-process machinery rather than a bespoke watcher: run
+``hermes cursor watch <id>`` via ``terminal(background=true,
+notify_on_complete=true)`` and the gateway's completion notification frames
+the result into the conversation (cron-style header/footer, alternation-safe).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+from hermes_constants import get_hermes_home
+
+AGENTS_DASHBOARD_URL = "https://cursor.com/agents"
+
+_TERMINAL_STATUSES = {
+    "RUN_LIFECYCLE_STATUS_FINISHED",
+    "RUN_LIFECYCLE_STATUS_ERROR",
+    "RUN_LIFECYCLE_STATUS_CANCELLED",
+    "RUN_LIFECYCLE_STATUS_EXPIRED",
+}
+
+_STATUS_LABELS = {
+    "RUN_LIFECYCLE_STATUS_CREATING": "creating",
+    "RUN_LIFECYCLE_STATUS_RUNNING": "running",
+    "RUN_LIFECYCLE_STATUS_FINISHED": "finished",
+    "RUN_LIFECYCLE_STATUS_ERROR": "error",
+    "RUN_LIFECYCLE_STATUS_CANCELLED": "cancelled",
+    "RUN_LIFECYCLE_STATUS_EXPIRED": "expired",
+}
+
+
+def agent_url(agent_id: str) -> str:
+    return f"{AGENTS_DASHBOARD_URL}?id={agent_id}"
+
+
+def _status_label(status: str) -> str:
+    return _STATUS_LABELS.get(status, status or "unknown")
+
+
+# ── Handoff state sidecar ─────────────────────────────────────────────────
+
+
+def _state_path() -> Path:
+    return get_hermes_home() / "cursor_cloud_agents.json"
+
+
+def _load_state() -> list[dict[str, Any]]:
+    try:
+        data = json.loads(_state_path().read_text(encoding="utf-8"))
+        return data if isinstance(data, list) else []
+    except (OSError, ValueError):
+        return []
+
+
+def _remember_agent(agent_id: str, repo: str, prompt: str) -> None:
+    entries = [e for e in _load_state() if e.get("agent_id") != agent_id]
+    entries.append(
+        {
+            "agent_id": agent_id,
+            "repo": repo,
+            "prompt": prompt[:200],
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        }
+    )
+    entries = entries[-50:]
+    path = _state_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(entries, indent=2), encoding="utf-8")
+    except OSError:
+        pass
+
+
+def _default_agent_id() -> str:
+    entries = _load_state()
+    return str(entries[-1]["agent_id"]) if entries else ""
+
+
+# ── Bridge session ────────────────────────────────────────────────────────
+
+
+def _resolve_api_key() -> str:
+    from agent.cursor_sdk_auth import resolve_cursor_api_key
+
+    key, _source = resolve_cursor_api_key()
+    if not key:
+        raise RuntimeError(
+            "No Cursor credential found. Run `hermes cursor login` (browser "
+            "login on your Cursor account), or add CURSOR_API_KEY to "
+            "~/.hermes/.env (cursor.com/dashboard → API Keys)."
+        )
+    return key
+
+
+class CursorCloudSession:
+    """One bridge process + transport for a batch of cloud-agent operations."""
+
+    def __init__(self, api_key: str | None = None, workspace: str | None = None):
+        import os
+
+        self._api_key = api_key or _resolve_api_key()
+        self._workspace = workspace or os.getcwd()
+        self._process = None
+        self._transport = None
+
+    def __enter__(self) -> "CursorCloudSession":
+        from hermes_cli.config import load_config
+        from agent.cursor_bridge_transport import (
+            ConnectJsonTransport,
+            CursorBridgeError,
+            CursorBridgeProcess,
+            resolve_bridge_command,
+        )
+
+        settings = load_config().get("cursor_bridge") or {}
+        command = resolve_bridge_command(str(settings.get("command") or ""))
+        if not command:
+            raise CursorBridgeError(
+                "Cursor SDK bridge not found. Run `hermes model` and pick Cursor "
+                "to install it, or `pip install cursor-sdk`."
+            )
+        self._process = CursorBridgeProcess(
+            command=command, api_key=self._api_key, workspace=self._workspace
+        )
+        endpoint = self._process.start()
+        self._transport = ConnectJsonTransport(endpoint.url, endpoint.auth_token)
+        return self
+
+    def __exit__(self, *exc_info: Any) -> None:
+        if self._process is not None:
+            self._process.stop()
+            self._process = None
+        self._transport = None
+
+    @property
+    def transport(self):
+        if self._transport is None:
+            raise RuntimeError("CursorCloudSession is not started")
+        return self._transport
+
+    # ── operations ───────────────────────────────────────────────────────
+
+    def create_cloud_agent(
+        self,
+        *,
+        repo: str,
+        ref: str = "",
+        model: str = "",
+        auto_create_pr: bool = False,
+    ) -> str:
+        repo_entry: dict[str, Any] = {"url": repo}
+        if ref:
+            repo_entry["startingRef"] = ref
+        options: dict[str, Any] = {
+            "name": "hermes-handoff",
+            "cloud": {
+                "env": {"type": "CLOUD_ENVIRONMENT_TYPE_CLOUD"},
+                "repos": [repo_entry],
+                "metadata": {"created_by": "hermes-agent"},
+            },
+        }
+        if auto_create_pr:
+            options["cloud"]["autoCreatePr"] = True
+        if model:
+            options["model"] = {"id": model}
+        created = self.transport.unary(
+            "SdkAgentService", "CreateAgent", {"options": options}, timeout=120.0
+        )
+        agent_id = str(created.get("agentId") or "")
+        if not agent_id:
+            raise RuntimeError("CreateAgent returned no agentId")
+        return agent_id
+
+    def send_detached(self, agent_id: str, prompt: str) -> None:
+        """Start a run and return once it is accepted; do not wait for it.
+
+        Dropping a Send stream does NOT cancel the run (sdk-bridge
+        docs/streaming.md) — the cloud agent keeps executing and remains
+        visible at cursor.com/agents.
+        """
+        started = threading.Event()
+        failure: list[BaseException] = []
+
+        def drain() -> None:
+            try:
+                stream = self.transport.server_stream(
+                    "SdkAgentService",
+                    "Send",
+                    {"agentId": agent_id, "message": {"text": prompt}, "options": {}},
+                )
+                started.set()
+                for _ in stream:
+                    pass
+            except BaseException as exc:  # surfaced via `failure` below
+                failure.append(exc)
+                started.set()
+
+        thread = threading.Thread(target=drain, daemon=True, name="cursor-cloud-send")
+        thread.start()
+        started.wait(timeout=30.0)
+        if failure:
+            raise RuntimeError(f"cloud send failed: {failure[0]}")
+        # Give the request a moment to register server-side before the
+        # process (and with it the bridge) exits.
+        deadline = time.monotonic() + 20.0
+        while time.monotonic() < deadline:
+            runs = self.list_runs(agent_id, limit=1)
+            if runs:
+                return
+            time.sleep(1.0)
+
+    def send_and_stream(
+        self, agent_id: str, prompt: str, *, emit: Callable[[str], None]
+    ) -> str:
+        final = ""
+        for message in self.transport.server_stream(
+            "SdkAgentService",
+            "Send",
+            {"agentId": agent_id, "message": {"text": prompt}, "options": {}},
+        ):
+            final = _handle_stream_message(message, emit) or final
+            if "done" in message:
+                break
+        return final
+
+    def list_runs(self, agent_id: str, limit: int = 10) -> list[dict[str, Any]]:
+        response = self.transport.unary(
+            "SdkAgentService",
+            "ListRuns",
+            {"agentId": agent_id, "options": {"limit": limit}},
+            timeout=60.0,
+        )
+        return [r for r in response.get("items") or [] if isinstance(r, dict)]
+
+    def get_agent(self, agent_id: str) -> dict[str, Any]:
+        response = self.transport.unary(
+            "SdkAgentService",
+            "GetAgent",
+            {"agentId": agent_id, "options": {}},
+            timeout=60.0,
+        )
+        agent = response.get("agent")
+        return agent if isinstance(agent, dict) else {}
+
+    def list_agents(self, limit: int = 20) -> list[dict[str, Any]]:
+        response = self.transport.unary(
+            "SdkAgentService",
+            "ListAgents",
+            {"options": {"limit": limit, "runtime": "RUNTIME_CLOUD"}},
+            timeout=60.0,
+        )
+        return [a for a in response.get("items") or [] if isinstance(a, dict)]
+
+    def observe_run(
+        self, run_id: str, *, emit: Callable[[str], None], after_offset: str = ""
+    ) -> str:
+        request: dict[str, Any] = {"runId": run_id}
+        if after_offset:
+            request["afterOffset"] = after_offset
+        final = ""
+        for message in self.transport.server_stream(
+            "SdkAgentService", "ObserveRun", request
+        ):
+            final = _handle_stream_message(message, emit) or final
+            if "done" in message:
+                break
+        return final
+
+
+def _handle_stream_message(message: dict[str, Any], emit: Callable[[str], None]) -> str:
+    """Render one RunStreamMessage; return final text when terminal."""
+    result_env = message.get("result")
+    if isinstance(result_env, dict):
+        status = _status_label(str(result_env.get("status") or ""))
+        run_result = result_env.get("result")
+        text = ""
+        if isinstance(run_result, dict):
+            text = str(run_result.get("result") or "")
+        emit(f"── run {status} ──")
+        if text:
+            emit(text)
+        return text or f"(run {status}, no result text)"
+
+    sdk_message = message.get("sdkMessage")
+    if isinstance(sdk_message, dict):
+        # Best-effort progress rendering; payload shapes follow the public
+        # SDK message types and may evolve — unknown shapes are skipped.
+        payload = sdk_message.get("message")
+        if isinstance(payload, dict):
+            text = payload.get("text")
+            if isinstance(text, str) and text.strip():
+                emit(text.strip())
+    return ""
+
+
+# ── Repo resolution ───────────────────────────────────────────────────────
+
+
+def _git_output(args: list[str]) -> str:
+    try:
+        return subprocess.run(
+            ["git", *args], capture_output=True, text=True, timeout=10, check=False
+        ).stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        return ""
+
+
+def _strip_url_credentials(repo: str) -> str:
+    """Remove userinfo (tokens!) from a git remote URL before it leaves Hermes.
+
+    CI checkouts and credential-helper remotes often embed an access token
+    (``https://x-access-token:TOKEN@github.com/...``). That token must never
+    be sent to the cloud API or written to the handoff state file — cloud
+    agents authenticate to the repo through the user's Cursor GitHub
+    connection, not through this URL.
+    """
+    from urllib.parse import urlsplit, urlunsplit
+
+    if "@" not in repo:
+        return repo
+    try:
+        parts = urlsplit(repo)
+    except ValueError:
+        return repo
+    if not parts.scheme or "@" not in parts.netloc:
+        return repo  # scp-style git@host:path remotes carry no secret
+    host = parts.netloc.rsplit("@", 1)[1]
+    return urlunsplit((parts.scheme, host, parts.path, parts.query, parts.fragment))
+
+
+def resolve_repo_and_ref(repo: str = "", ref: str = "") -> tuple[str, str]:
+    """Fill repo/ref from the current git checkout when omitted."""
+    if not repo:
+        repo = _git_output(["remote", "get-url", "origin"])
+    if not ref:
+        branch = _git_output(["rev-parse", "--abbrev-ref", "HEAD"])
+        if branch and branch != "HEAD":
+            ref = branch
+    return _strip_url_credentials(repo), ref
+
+
+# ── Verb implementations (return display strings) ─────────────────────────
+
+
+def do_handoff(
+    prompt: str,
+    *,
+    repo: str = "",
+    ref: str = "",
+    model: str = "",
+    auto_pr: bool = False,
+    wait: bool = False,
+    emit: Callable[[str], None] = print,
+) -> str:
+    if not prompt.strip():
+        return "Usage: hermes cursor handoff \"<task prompt>\" [--repo URL] [--ref REF]"
+    repo, ref = resolve_repo_and_ref(repo, ref)
+    if not repo:
+        return (
+            "No repository detected. Pass --repo <git-url> or run from a git "
+            "checkout with an 'origin' remote (cloud agents work on a repo clone)."
+        )
+
+    with CursorCloudSession() as session:
+        agent_id = session.create_cloud_agent(
+            repo=repo, ref=ref, model=model, auto_create_pr=auto_pr
+        )
+        _remember_agent(agent_id, repo, prompt)
+        header = (
+            f"Cloud agent created: {agent_id}\n"
+            f"  repo: {repo}" + (f" @ {ref}" if ref else "") + "\n"
+            f"  take over anytime: {agent_url(agent_id)}"
+        )
+        if wait:
+            emit(header)
+            emit("── streaming run (Ctrl+C detaches; the run keeps going) ──")
+            final = session.send_and_stream(agent_id, prompt, emit=emit)
+            return f"{header}\n\nFinal result:\n{final}"
+        session.send_detached(agent_id, prompt)
+        return (
+            f"{header}\n"
+            f"  run started — it keeps going even after this command exits.\n"
+            f"  check on it: hermes cursor status {agent_id}\n"
+            f"  follow it:   hermes cursor watch {agent_id}"
+        )
+
+
+def do_send(agent_id: str, prompt: str, *, wait: bool = False,
+            emit: Callable[[str], None] = print) -> str:
+    agent_id = agent_id or _default_agent_id()
+    if not agent_id:
+        return "No agent id given and no previous handoff found."
+    if not prompt.strip():
+        return "Usage: hermes cursor send <agent-id> \"<follow-up prompt>\""
+    with CursorCloudSession() as session:
+        if wait:
+            final = session.send_and_stream(agent_id, prompt, emit=emit)
+            return f"Final result:\n{final}"
+        session.send_detached(agent_id, prompt)
+        return (
+            f"Follow-up run started on {agent_id}.\n"
+            f"  take over anytime: {agent_url(agent_id)}"
+        )
+
+
+def do_status(agent_id: str = "") -> str:
+    agent_id = agent_id or _default_agent_id()
+    if not agent_id:
+        return "No agent id given and no previous handoff found."
+    with CursorCloudSession() as session:
+        agent = session.get_agent(agent_id)
+        runs = session.list_runs(agent_id, limit=3)
+
+    lines = [f"Cursor cloud agent {agent_id}"]
+    if agent:
+        name = agent.get("name") or ""
+        summary = agent.get("summary") or ""
+        if name:
+            lines.append(f"  name: {name}")
+        if summary:
+            lines.append(f"  summary: {summary}")
+    lines.append(f"  dashboard: {agent_url(agent_id)}")
+    if runs:
+        lines.append("  recent runs:")
+        for run in runs:
+            status = _status_label(str(run.get("status") or ""))
+            run_id = run.get("runId") or "?"
+            lines.append(f"    {run_id}: {status}")
+    else:
+        lines.append("  no runs recorded yet")
+    return "\n".join(lines)
+
+
+def do_runs(agent_id: str = "") -> str:
+    agent_id = agent_id or _default_agent_id()
+    if not agent_id:
+        return "No agent id given and no previous handoff found."
+    with CursorCloudSession() as session:
+        runs = session.list_runs(agent_id, limit=20)
+    if not runs:
+        return f"No runs recorded for {agent_id}."
+    lines = [f"Runs for {agent_id}:"]
+    for run in runs:
+        status = _status_label(str(run.get("status") or ""))
+        preview = str(run.get("result") or "").strip().replace("\n", " ")[:80]
+        lines.append(f"  {run.get('runId', '?')}: {status}" + (f" — {preview}" if preview else ""))
+    return "\n".join(lines)
+
+
+def do_pull(agent_id: str = "") -> str:
+    agent_id = agent_id or _default_agent_id()
+    if not agent_id:
+        return "No agent id given and no previous handoff found."
+    with CursorCloudSession() as session:
+        runs = session.list_runs(agent_id, limit=1)
+    if not runs:
+        return f"No runs recorded for {agent_id}."
+    run = runs[0]
+    status = _status_label(str(run.get("status") or ""))
+    text = str(run.get("result") or "").strip()
+    header = f"Latest run on {agent_id} ({run.get('runId', '?')}): {status}"
+    return f"{header}\n\n{text}" if text else f"{header}\n(no result text yet)"
+
+
+def do_watch(agent_id: str = "", *, emit: Callable[[str], None] = print) -> str:
+    """Follow the latest run to completion (the mirroring primitive).
+
+    From a live Hermes session, run this via ``terminal(background=true,
+    notify_on_complete=true)`` — the existing background-process
+    notification machinery frames the completed output back into the
+    conversation without breaking message-role alternation.
+    """
+    agent_id = agent_id or _default_agent_id()
+    if not agent_id:
+        return "No agent id given and no previous handoff found."
+    with CursorCloudSession() as session:
+        runs = session.list_runs(agent_id, limit=1)
+        if not runs:
+            return f"No runs recorded for {agent_id}."
+        run = runs[0]
+        run_id = str(run.get("runId") or "")
+        status = str(run.get("status") or "")
+        emit(f"── Cursor cloud run {run_id} on {agent_id} ──")
+        if status in _TERMINAL_STATUSES:
+            text = str(run.get("result") or "").strip()
+            emit(f"── run {_status_label(status)} (already terminal) ──")
+            return text or f"(run {_status_label(status)}, no result text)"
+        final = session.observe_run(run_id, emit=emit)
+        return final
+
+
+def do_list() -> str:
+    with CursorCloudSession() as session:
+        agents = session.list_agents(limit=20)
+    if not agents:
+        return "No cloud agents found for this account."
+    lines = ["Cursor cloud agents (newest first):"]
+    for agent in agents:
+        agent_id = agent.get("agentId") or "?"
+        name = agent.get("name") or ""
+        summary = str(agent.get("summary") or "").replace("\n", " ")[:60]
+        lines.append(f"  {agent_id}  {name}" + (f" — {summary}" if summary else ""))
+    return "\n".join(lines)
+
+
+def do_open(agent_id: str = "") -> str:
+    agent_id = agent_id or _default_agent_id()
+    url = agent_url(agent_id) if agent_id else AGENTS_DASHBOARD_URL
+    try:
+        import webbrowser
+
+        webbrowser.open(url)
+    except Exception:
+        pass
+    return f"Cursor Agents dashboard: {url}"
+
+
+def do_login(*, emit: Callable[[str], None] = print) -> str:
+    """Interactive browser login — mints a Cursor user API key for Hermes.
+
+    The URL can be opened on any device that is signed in to cursor.com;
+    only this process can redeem it (device-code-style PKCE).
+    """
+    from agent.cursor_sdk_auth import CursorAuthError, login, read_sdk_credentials
+
+    existing = read_sdk_credentials()
+    if existing:
+        who = existing.get("email") or "your Cursor account"
+        emit(f"Already logged in as {who} (re-running will mint a fresh key).")
+
+    def show_url(url: str) -> None:
+        emit("Open this URL in a browser signed in to cursor.com:")
+        emit(f"  {url}")
+
+    try:
+        result = login(on_login_url=show_url, on_status=emit)
+    except CursorAuthError as exc:
+        return str(exc)
+    who = result.get("email") or "your Cursor account"
+    expires_days = max(
+        0, int((result["apiKeyExpiresAtMs"] / 1000 - time.time()) / 86400)
+    )
+    return (
+        f"✓ Logged in as {who}. Minted a user API key (visible and revocable "
+        f"in the Cursor dashboard, expires in ~{expires_days} days), stored "
+        f"at {result['path']}.\n"
+        f"Hermes now uses it automatically — try `hermes chat --provider cursor`."
+    )
+
+
+def do_logout() -> str:
+    from agent.cursor_sdk_auth import clear_sdk_credentials, sdk_auth_path
+
+    if clear_sdk_credentials():
+        return (
+            f"Removed {sdk_auth_path()}. The minted key stays valid until it "
+            "expires — revoke it in the Cursor dashboard's API-keys list if needed."
+        )
+    return "No stored Cursor SDK login found."
+
+
+# ── Slash command + argparse surfaces ─────────────────────────────────────
+
+_HELP = """/cursor — hand tasks to a durable Cursor cloud agent (your Cursor sub)
+
+  /cursor login                  browser login (mints a Cursor user API key)
+  /cursor logout                 forget the stored SDK login
+  /cursor handoff <prompt>       start a cloud agent on this repo
+  /cursor send [id] <prompt>     follow-up prompt to an agent
+  /cursor status [id]            agent + recent run status
+  /cursor runs [id]              list runs
+  /cursor pull [id]              fetch the latest run's result
+  /cursor watch [id]             follow the active run to completion
+  /cursor list                   list your cloud agents
+  /cursor open [id]              open cursor.com/agents
+
+The agent stays visible (and can be taken over) at cursor.com/agents, in the
+Cursor IDE Agents window, and on mobile. Usage bills to your Cursor plan."""
+
+
+def run_slash(rest: str, *, emit: Callable[[str], None] = print) -> str:
+    """Shared /cursor dispatcher for CLI and gateway. Returns display text."""
+    import shlex
+
+    rest = (rest or "").strip()
+    if not rest or rest in {"help", "--help", "-h"}:
+        return _HELP
+    try:
+        tokens = shlex.split(rest)
+    except ValueError:
+        tokens = rest.split()
+    verb, args = tokens[0].lower(), tokens[1:]
+
+    def _id_and_text(items: list[str]) -> tuple[str, str]:
+        if items and (items[0].startswith("bc-") or items[0].startswith("agent-")):
+            return items[0], " ".join(items[1:])
+        return "", " ".join(items)
+
+    try:
+        if verb == "login":
+            return do_login(emit=emit)
+        if verb == "logout":
+            return do_logout()
+        if verb == "handoff":
+            return do_handoff(" ".join(args), emit=emit)
+        if verb == "send":
+            agent_id, text = _id_and_text(args)
+            return do_send(agent_id, text, emit=emit)
+        if verb == "status":
+            return do_status(args[0] if args else "")
+        if verb == "runs":
+            return do_runs(args[0] if args else "")
+        if verb == "pull":
+            return do_pull(args[0] if args else "")
+        if verb == "watch":
+            return do_watch(args[0] if args else "", emit=emit)
+        if verb == "list":
+            return do_list()
+        if verb == "open":
+            return do_open(args[0] if args else "")
+    except KeyboardInterrupt:
+        return "(detached — the cloud run keeps going; check cursor.com/agents)"
+    except Exception as exc:
+        return f"cursor cloud error: {exc}"
+    return f"Unknown /cursor subcommand: {verb}\n\n{_HELP}"
+
+
+def cmd_cursor(args) -> int:
+    """``hermes cursor <verb>`` argparse handler."""
+    verb = getattr(args, "cursor_command", None) or "help"
+    try:
+        if verb == "login":
+            output = do_login()
+        elif verb == "logout":
+            output = do_logout()
+        elif verb == "handoff":
+            output = do_handoff(
+                " ".join(args.prompt or []),
+                repo=getattr(args, "repo", "") or "",
+                ref=getattr(args, "ref", "") or "",
+                model=getattr(args, "model", "") or "",
+                auto_pr=bool(getattr(args, "pr", False)),
+                wait=bool(getattr(args, "wait", False)),
+            )
+        elif verb == "send":
+            output = do_send(
+                getattr(args, "agent_id", "") or "",
+                " ".join(args.prompt or []),
+                wait=bool(getattr(args, "wait", False)),
+            )
+        elif verb == "status":
+            output = do_status(getattr(args, "agent_id", "") or "")
+        elif verb == "runs":
+            output = do_runs(getattr(args, "agent_id", "") or "")
+        elif verb == "pull":
+            output = do_pull(getattr(args, "agent_id", "") or "")
+        elif verb == "watch":
+            output = do_watch(getattr(args, "agent_id", "") or "")
+        elif verb == "list":
+            output = do_list()
+        elif verb == "open":
+            output = do_open(getattr(args, "agent_id", "") or "")
+        else:
+            output = _HELP
+    except KeyboardInterrupt:
+        print("(detached — the cloud run keeps going; check cursor.com/agents)")
+        return 130
+    except Exception as exc:
+        print(f"cursor cloud error: {exc}")
+        return 1
+    if output:
+        print(output)
+    return 0

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -473,6 +473,7 @@ from hermes_cli.subcommands.logs import build_logs_parser
 from hermes_cli.subcommands.prompt_size import build_prompt_size_parser
 from hermes_cli.subcommands.memory import build_memory_parser
 from hermes_cli.subcommands.acp import build_acp_parser
+from hermes_cli.subcommands.cursor_agent import build_cursor_parser
 from hermes_cli.subcommands.tools import build_tools_parser
 from hermes_cli.subcommands.insights import build_insights_parser
 from hermes_cli.subcommands.monitoring import build_monitoring_parser
@@ -792,6 +793,7 @@ from hermes_cli.model_setup_flows import (
     _model_flow_named_custom,
     _model_flow_copilot,
     _model_flow_copilot_acp,
+    _model_flow_cursor,
     _model_flow_kimi,
     _model_flow_stepfun,
     _model_flow_bedrock_api_key,
@@ -3430,6 +3432,8 @@ def select_provider_and_model(args=None):
         _model_flow_minimax_oauth(config, current_model, args=args)
     elif selected_provider == "copilot-acp":
         _model_flow_copilot_acp(config, current_model)
+    elif selected_provider == "cursor":
+        _model_flow_cursor(config, current_model)
     elif selected_provider == "copilot":
         _model_flow_copilot(config, current_model)
     elif selected_provider == "custom":
@@ -12399,6 +12403,15 @@ def main():
     # acp command  (parser built in hermes_cli/subcommands/acp.py)
     # =========================================================================
     build_acp_parser(subparsers, cmd_acp=cmd_acp)
+
+    # =========================================================================
+    # cursor command  (parser built in hermes_cli/subcommands/cursor_agent.py)
+    # =========================================================================
+    # Lazy handler import: hermes_cli.cursor_cloud pulls in the agent bridge
+    # modules, which must not load during bare `hermes --help` startup.
+    from hermes_cli.cursor_cloud import cmd_cursor
+
+    build_cursor_parser(subparsers, cmd_cursor=cmd_cursor)
 
     # =========================================================================
     # profile command  (parser built in hermes_cli/subcommands/profile.py)

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -2010,6 +2010,136 @@ def _model_flow_copilot_acp(config, current_model=""):
 
     print(f"Default model set to: {selected} (via {pconfig.name})")
 
+
+def _model_flow_cursor(config, current_model=""):
+    """Cursor subscription flow via the official Cursor SDK bridge.
+
+    Uses the user's own CURSOR_API_KEY (cursor.com/dashboard → API Keys);
+    usage bills to their Cursor plan. Offers to install the sdk.v1 bridge
+    when none is found, then fetches the live account model catalog through
+    it (SdkCursorService.ListModels).
+    """
+    from hermes_cli.main import _prompt_api_key
+    from hermes_cli.auth import (
+        PROVIDER_REGISTRY,
+        _prompt_model_selection,
+        _save_model_choice,
+        deactivate_provider,
+    )
+    from hermes_cli.config import load_config, save_config
+    from hermes_cli.models import _PROVIDER_MODELS
+
+    del config
+
+    provider_id = "cursor"
+    pconfig = PROVIDER_REGISTRY[provider_id]
+    effective_base = pconfig.inference_base_url  # sdkbridge://cursor marker
+
+    print("  Cursor runs Hermes turns through the official Cursor SDK bridge.")
+    print("  You need your own Cursor account and API key — usage bills to")
+    print("  your Cursor plan. Hermes never proxies or resells Cursor inference.")
+    print()
+
+    # Step 1: API key
+    existing_key, existing_source = _existing_api_key_for_model_flow(provider_id, pconfig)
+    existing_key, abort = _prompt_api_key(
+        pconfig,
+        existing_key,
+        provider_id=provider_id,
+        existing_source=existing_source,
+    )
+    if abort:
+        return
+
+    # Step 2: bridge binary (offer install when missing)
+    from agent.cursor_bridge_transport import (
+        CursorBridgeError,
+        download_bridge,
+        resolve_bridge_command,
+    )
+
+    bridge_settings = load_config().get("cursor_bridge") or {}
+    configured_command = str(bridge_settings.get("command") or "")
+    bridge_command = resolve_bridge_command(configured_command)
+    if not bridge_command:
+        print("  The Cursor SDK bridge (cursor-sdk-bridge) is not installed.")
+        try:
+            answer = input("  Download it now? [Y/n]: ").strip().lower()
+        except (KeyboardInterrupt, EOFError):
+            print()
+            answer = "n"
+        if answer in {"", "y", "yes"}:
+            try:
+                bridge_command = download_bridge(
+                    str(bridge_settings.get("download_version") or "")
+                )
+            except CursorBridgeError as exc:
+                print(f"  ⚠ {exc}")
+        if not bridge_command:
+            print("  Continuing without the bridge — install later with")
+            print("  `pip install cursor-sdk` or set cursor_bridge.command in config.yaml.")
+
+    # Step 3: model catalog through the bridge (best-effort)
+    model_list: list = []
+    if bridge_command and existing_key:
+        try:
+            from agent.cursor_bridge_client import CursorBridgeClient
+
+            print("  Fetching your Cursor model catalog...")
+            client = CursorBridgeClient(api_key=existing_key)
+            try:
+                catalog = client.list_models()
+            finally:
+                client.close()
+            model_list = [str(m.get("id") or "").strip() for m in catalog]
+            model_list = [m for m in model_list if m]
+            if model_list:
+                print(f"  Found {len(model_list)} model(s) on your Cursor account")
+        except Exception as exc:
+            print(f"  ⚠ Could not fetch the live catalog: {exc}")
+
+    if not model_list:
+        model_list = _PROVIDER_MODELS.get(provider_id, [])
+        if model_list:
+            print("  Showing default models — use \"Enter custom model name\" if")
+            print("  you do not see the model you want.")
+
+    if model_list:
+        selected = _prompt_model_selection(
+            model_list,
+            current_model=current_model,
+            confirm_provider=provider_id,
+            confirm_base_url=effective_base,
+            confirm_api_key=existing_key,
+        )
+    else:
+        try:
+            selected = input("Model name: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            selected = None
+
+    if not selected:
+        print("No change.")
+        return
+
+    _save_model_choice(selected)
+
+    cfg = load_config()
+    model = cfg.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        cfg["model"] = model
+    model["provider"] = provider_id
+    model["base_url"] = effective_base
+    model["api_mode"] = "chat_completions"
+    clear_model_endpoint_credentials(model, clear_api_mode=False)
+    save_config(cfg)
+    deactivate_provider()
+
+    print(f"Default model set to: {selected} (via {pconfig.name})")
+    print("  Usage is billed to your own Cursor subscription.")
+
+
 def _model_flow_kimi(config, current_model=""):
     """Kimi / Moonshot model selection with automatic endpoint routing.
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2320,6 +2320,17 @@ def list_authenticated_providers(
                     if any(os.environ.get(ev) for ev in pcfg.api_key_env_vars):
                         has_creds = True
                         break
+        # Cursor: `hermes cursor login` stores the credential in the SDK's
+        # shared store (~/.cursor/sdk/auth.json), not env vars, the Hermes
+        # auth store, or the credential pool — mirror the vertex gate above
+        # so the provider is not hidden from the /model picker when it is
+        # fully configured (and possibly the ACTIVE provider).
+        if not has_creds and hermes_slug == "cursor":
+            try:
+                from agent.cursor_sdk_auth import read_sdk_credentials
+                has_creds = read_sdk_credentials() is not None
+            except Exception as exc:
+                logger.debug("Cursor SDK login check failed: %s", exc)
         # Check auth store and credential pool for non-env-var credentials.
         # This applies to OAuth providers AND api_key providers that also
         # support OAuth (e.g. anthropic supports both API key and Claude Code

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -298,6 +298,12 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    # Cursor subscription (sdk.v1 bridge). Offline insurance only — the setup
+    # flow fetches the live account catalog through the bridge's ListModels.
+    "cursor": [
+        "auto",
+        "composer-2.5",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",
@@ -1127,6 +1133,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("nvidia",         "NVIDIA NIM",               "NVIDIA NIM (Nemotron models via build.nvidia.com or local NIM)"),
     ProviderEntry("copilot",        "GitHub Copilot",           "GitHub Copilot (Uses GITHUB_TOKEN or gh auth token)"),
     ProviderEntry("copilot-acp",    "GitHub Copilot ACP",       "GitHub Copilot ACP (Spawns copilot --acp --stdio)"),
+    ProviderEntry("cursor",         "Cursor",                   "Cursor (Your Cursor subscription via the Cursor SDK bridge)"),
     ProviderEntry("huggingface",    "Hugging Face",             "Hugging Face Inference Providers"),
     ProviderEntry("gemini",         "Google AI Studio",         "Google AI Studio (Native Gemini API)"),
     ProviderEntry("vertex",         "Google Vertex AI",         "Google Vertex AI (Gemini via GCP; OAuth2 service account or ADC, GCP billing/quotas)"),

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -94,6 +94,15 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="acp://copilot",
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    # Cursor subscription — local sdk.v1 bridge subprocess, not a REST
+    # endpoint. The marker base URL routes client construction to
+    # agent/cursor_bridge_client.py.
+    "cursor": HermesOverlay(
+        transport="openai_chat",
+        auth_type="api_key",
+        extra_env_vars=("CURSOR_API_KEY",),
+        base_url_override="sdkbridge://cursor",
+    ),
     "github-copilot": HermesOverlay(
         transport="openai_chat",
         extra_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN"),
@@ -319,6 +328,10 @@ ALIASES: Dict[str, str] = {
     "github": "github-copilot",
     "github-copilot-acp": "copilot-acp",
 
+    # cursor (subscription via the Cursor SDK bridge)
+    "cursor-sdk": "cursor",
+    "cursor-agent": "cursor",
+
     # vercel (models.dev ID for AI Gateway)
     "ai-gateway": "vercel",
     "aigateway": "vercel",
@@ -415,6 +428,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "nous": "Nous Portal",
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
+    "cursor": "Cursor",
     "stepfun": "StepFun Step Plan",
     "xiaomi": "Xiaomi MiMo",
     "gmi": "GMI Cloud",

--- a/hermes_cli/subcommands/cursor_agent.py
+++ b/hermes_cli/subcommands/cursor_agent.py
@@ -1,0 +1,66 @@
+"""``hermes cursor`` subcommand parser.
+
+Cloud-agent handoff on the user's own Cursor subscription — see
+``hermes_cli/cursor_cloud.py`` for the implementation.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+
+def build_cursor_parser(subparsers, *, cmd_cursor: Callable) -> None:
+    """Attach the ``cursor`` subcommand to ``subparsers``."""
+    cursor_parser = subparsers.add_parser(
+        "cursor",
+        help="Hand tasks to a Cursor cloud agent (your own Cursor subscription)",
+        description=(
+            "Create and follow durable Cursor cloud agents through the official "
+            "Cursor SDK bridge. Agents are visible and can be taken over at "
+            "cursor.com/agents, in the Cursor IDE Agents window, and on mobile. "
+            "Requires CURSOR_API_KEY in ~/.hermes/.env; usage bills to your "
+            "Cursor plan."
+        ),
+    )
+    cursor_sub = cursor_parser.add_subparsers(dest="cursor_command")
+
+    cursor_sub.add_parser(
+        "login",
+        help="Browser login to your Cursor account (mints a user API key)",
+    )
+    cursor_sub.add_parser(
+        "logout", help="Forget the stored Cursor SDK login on this machine"
+    )
+
+    handoff = cursor_sub.add_parser(
+        "handoff", help="Start a cloud agent on a repository with a task prompt"
+    )
+    handoff.add_argument("prompt", nargs="+", help="Task prompt for the cloud agent")
+    handoff.add_argument("--repo", default="", help="Git repo URL (default: origin remote)")
+    handoff.add_argument("--ref", default="", help="Starting ref (default: current branch)")
+    handoff.add_argument("--model", default="", help="Model id (default: server-resolved)")
+    handoff.add_argument("--pr", action="store_true", help="Auto-create a PR when done")
+    handoff.add_argument(
+        "--wait", action="store_true", help="Stream the run instead of detaching"
+    )
+
+    send = cursor_sub.add_parser("send", help="Send a follow-up prompt to an agent")
+    send.add_argument("agent_id", help="Cloud agent id (bc-...)")
+    send.add_argument("prompt", nargs="+", help="Follow-up prompt")
+    send.add_argument("--wait", action="store_true", help="Stream the run instead of detaching")
+
+    for verb, help_text in (
+        ("status", "Show agent + recent run status"),
+        ("runs", "List runs for an agent"),
+        ("pull", "Print the latest run's result"),
+        ("watch", "Follow the active run to completion"),
+        ("open", "Open the cursor.com/agents dashboard"),
+    ):
+        sub = cursor_sub.add_parser(verb, help=help_text)
+        sub.add_argument(
+            "agent_id", nargs="?", default="", help="Cloud agent id (default: last handoff)"
+        )
+
+    cursor_sub.add_parser("list", help="List your Cursor cloud agents")
+
+    cursor_parser.set_defaults(func=cmd_cursor)

--- a/plugins/model-providers/cursor/__init__.py
+++ b/plugins/model-providers/cursor/__init__.py
@@ -1,0 +1,72 @@
+"""Cursor (subscription) provider profile.
+
+Runs Hermes turns through the user's own Cursor subscription via the official
+Cursor SDK bridge (https://github.com/cursor/sdk-bridge).  There is no REST
+chat-completions endpoint — ``base_url`` is an internal marker scheme and the
+transport is a local ``cursor-sdk-bridge`` subprocess driven by
+``agent/cursor_bridge_client.py``.
+
+Auth is the user's own ``CURSOR_API_KEY`` (cursor.com/dashboard → API Keys).
+Usage bills to the user's Cursor plan; Hermes never proxies or resells
+Cursor inference.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class CursorProfile(ProviderProfile):
+    """Cursor subscription — local sdk.v1 bridge subprocess, no REST catalog."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Fetch the account catalog through the bridge when it is installed.
+
+        Spawning the bridge takes a few seconds of Node startup, so this only
+        runs when a bridge binary is already resolvable AND an API key is
+        available; otherwise it returns None immediately and callers fall
+        back to the static list.
+        """
+        del base_url, timeout
+        if not api_key:
+            return None
+        try:
+            from agent.cursor_bridge_client import CursorBridgeClient
+            from agent.cursor_bridge_transport import resolve_bridge_command
+
+            if not resolve_bridge_command():
+                return None
+            client = CursorBridgeClient(api_key=api_key)
+            try:
+                models = client.list_models()
+            finally:
+                client.close()
+            ids = [str(m.get("id") or "").strip() for m in models]
+            return [m for m in ids if m] or None
+        except Exception:
+            return None
+
+
+cursor = CursorProfile(
+    name="cursor",
+    aliases=("cursor-sdk", "cursor-agent"),
+    display_name="Cursor",
+    description="Cursor subscription (Composer + catalog via the Cursor SDK bridge)",
+    signup_url="https://cursor.com/dashboard",
+    api_mode="chat_completions",  # bridge subprocess uses chat_completions routing
+    env_vars=("CURSOR_API_KEY",),
+    base_url="sdkbridge://cursor",  # internal marker scheme, not a REST endpoint
+    auth_type="api_key",
+    supports_health_check=False,  # no /models REST probe — doctor skips it
+    fallback_models=(
+        "auto",
+        "composer-2.5",
+    ),
+)
+
+register_provider(cursor)

--- a/plugins/model-providers/cursor/plugin.yaml
+++ b/plugins/model-providers/cursor/plugin.yaml
@@ -1,0 +1,5 @@
+name: cursor
+kind: model-provider
+version: 1.0.0
+description: Cursor subscription — runs Hermes turns through the official Cursor SDK bridge (sdk.v1), billed to the user's own Cursor account
+author: Hermes Agent

--- a/tests/agent/test_cursor_bridge_client.py
+++ b/tests/agent/test_cursor_bridge_client.py
@@ -1,0 +1,495 @@
+"""Tests for the OpenAI-compatible Cursor bridge client.
+
+The bridge itself is stubbed — these tests exercise the prompt/tool
+conversion, the loopback callback server (JSON, binary proto, chunked
+bodies, auth), and the loop-mode capture flow end to end against a fake
+transport.
+"""
+
+import json
+import threading
+import urllib.error
+import urllib.request
+
+import pytest
+
+from agent.cursor_bridge_client import (
+    CursorBridgeClient,
+    _ToolCallbackServer,
+    convert_openai_tools_to_custom_tools,
+    format_messages_as_prompt,
+)
+from agent.cursor_bridge_wire import (
+    _encode_varint,
+    decode_struct,
+    encode_struct,
+)
+
+
+class TestPromptFormatting:
+    def test_transcript_includes_roles_and_tool_results(self):
+        messages = [
+            {"role": "system", "content": "You are Hermes."},
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"function": {"name": "terminal", "arguments": '{"command": "ls"}'}}
+                ],
+            },
+            {"role": "tool", "content": "file.txt"},
+        ]
+        prompt = format_messages_as_prompt(messages)
+        assert "System:\nYou are Hermes." in prompt
+        assert "User:\nhi" in prompt
+        assert '[tool call] terminal({"command": "ls"})' in prompt
+        assert "Tool result:\nfile.txt" in prompt
+        assert prompt.index("System:") < prompt.index("User:")
+
+    def test_multipart_content_flattened(self):
+        messages = [{"role": "user", "content": [{"type": "text", "text": "part one"}, "part two"]}]
+        prompt = format_messages_as_prompt(messages)
+        assert "part one" in prompt
+        assert "part two" in prompt
+
+
+class TestToolConversion:
+    def test_openai_schema_maps_to_custom_tools(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "web_search",
+                    "description": "Search the web.",
+                    "parameters": {"type": "object", "properties": {"q": {"type": "string"}}},
+                },
+            },
+            {"type": "function", "function": {"name": "no_params"}},
+            {"not": "a tool"},
+        ]
+        custom = convert_openai_tools_to_custom_tools(tools)
+        assert set(custom) == {"web_search", "no_params"}
+        assert custom["web_search"]["description"] == "Search the web."
+        assert custom["web_search"]["inputSchema"]["properties"]["q"]["type"] == "string"
+        # Tools without parameters still get a valid empty JSON Schema object.
+        assert custom["no_params"]["inputSchema"] == {"type": "object", "properties": {}}
+
+    def test_none_and_empty(self):
+        assert convert_openai_tools_to_custom_tools(None) == {}
+        assert convert_openai_tools_to_custom_tools([]) == {}
+
+
+# ── Callback server ───────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def callback_server():
+    received = []
+
+    def handler(request):
+        received.append(request)
+        return {"value": "handled"}
+
+    server = _ToolCallbackServer(handler)
+    server.start()
+    yield server, received
+    server.stop()
+
+
+def _post(url, path, body, *, token, content_type="application/json", chunked=False):
+    headers = {"Content-Type": content_type, "Authorization": f"Bearer {token}"}
+    if chunked:
+        # urllib sends Transfer-Encoding: chunked when data is an iterable
+        # without a length.
+        def gen():
+            yield body
+
+        request = urllib.request.Request(url + path, data=gen(), method="POST", headers=headers)
+    else:
+        request = urllib.request.Request(url + path, data=body, method="POST", headers=headers)
+    return urllib.request.urlopen(request, timeout=10)
+
+
+CALLBACK_PATH = "/sdk.v1.SdkCustomToolCallbackService/CallCustomTool"
+
+
+class TestCallbackServer:
+    def test_json_request_dispatches_and_wraps_result(self, callback_server):
+        server, received = callback_server
+        body = json.dumps(
+            {"toolName": "memory", "args": {"action": "save"}, "agentId": "agent-1"}
+        ).encode()
+        with _post(server.url, CALLBACK_PATH, body, token=server.auth_token) as reply:
+            payload = json.loads(reply.read())
+        assert payload == {"result": {"value": "handled"}}
+        assert received[0]["toolName"] == "memory"
+        assert received[0]["args"] == {"action": "save"}
+
+    def test_chunked_json_request_decodes(self, callback_server):
+        server, received = callback_server
+        body = json.dumps({"toolName": "t", "args": {}, "agentId": "a"}).encode()
+        with _post(server.url, CALLBACK_PATH, body, token=server.auth_token, chunked=True) as reply:
+            payload = json.loads(reply.read())
+        assert payload["result"] == {"value": "handled"}
+        assert received[0]["toolName"] == "t"
+
+    def test_proto_request_decodes_and_responds_proto(self, callback_server):
+        server, received = callback_server
+        name = b"proto_tool"
+        agent = b"agent-2"
+        args = encode_struct({"k": "v"})
+        raw = (
+            _encode_varint((1 << 3) | 2) + _encode_varint(len(name)) + name
+            + _encode_varint((2 << 3) | 2) + _encode_varint(len(args)) + args
+            + _encode_varint((4 << 3) | 2) + _encode_varint(len(agent)) + agent
+        )
+        with _post(
+            server.url, CALLBACK_PATH, raw,
+            token=server.auth_token, content_type="application/proto",
+        ) as reply:
+            assert reply.headers["Content-Type"] == "application/proto"
+            encoded = reply.read()
+        # response = field 1 (Struct)
+        length = encoded[1]
+        assert decode_struct(encoded[2 : 2 + length]) == {"value": "handled"}
+        assert received[0]["toolName"] == "proto_tool"
+        assert received[0]["args"] == {"k": "v"}
+
+    def test_bad_token_rejected(self, callback_server):
+        server, _ = callback_server
+        with pytest.raises(urllib.error.HTTPError) as excinfo:
+            _post(server.url, CALLBACK_PATH, b"{}", token="wrong-token")
+        assert excinfo.value.code == 401
+
+    def test_unknown_path_rejected(self, callback_server):
+        server, _ = callback_server
+        with pytest.raises(urllib.error.HTTPError) as excinfo:
+            _post(server.url, "/sdk.v1.Other/Rpc", b"{}", token=server.auth_token)
+        assert excinfo.value.code == 404
+
+    def test_connection_reset_is_swallowed(self, callback_server, capfd):
+        """Loop mode resets callback connections on CancelRun; the server must
+        not dump a ConnectionResetError traceback to stderr."""
+        import socket
+        import struct
+        import time
+
+        server, _ = callback_server
+        host, port = server.server_address
+        for _ in range(3):
+            sock = socket.create_connection((host, port))
+            sock.sendall(
+                b"POST " + CALLBACK_PATH.encode() + b" HTTP/1.1\r\nHost: x\r\n"
+            )
+            # SO_LINGER 0 => abortive close => RST => ConnectionResetError
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0))
+            sock.close()
+            time.sleep(0.1)
+        time.sleep(0.2)
+        err = capfd.readouterr().err
+        assert "ConnectionResetError" not in err
+        assert "Traceback" not in err
+        # The server is still serving after the resets.
+        body = json.dumps({"toolName": "t", "agentId": "a"}).encode()
+        with _post(server.url, CALLBACK_PATH, body, token=server.auth_token) as reply:
+            assert reply.status == 200
+
+    def test_handler_exception_returns_error_result(self):
+        def handler(request):
+            raise RuntimeError("tool blew up")
+
+        server = _ToolCallbackServer(handler)
+        server.start()
+        try:
+            body = json.dumps({"toolName": "t", "agentId": "a"}).encode()
+            with _post(server.url, CALLBACK_PATH, body, token=server.auth_token) as reply:
+                payload = json.loads(reply.read())
+            assert "tool blew up" in payload["result"]["error"]
+        finally:
+            server.stop()
+
+
+# ── Loop-mode end-to-end against a fake transport ─────────────────────────
+
+
+class _FakeTransport:
+    """Programmable stand-in for ConnectJsonTransport."""
+
+    def __init__(self):
+        self.calls = []
+        self.stream_events = []
+        self.on_stream_start = None
+        self.list_runs_items = []
+
+    def unary(self, service, method, request, timeout=60.0):
+        self.calls.append((service, method, request))
+        if method == "CreateAgent":
+            return {"agentId": "agent-test", "model": {"id": request["options"]["model"]["id"]}}
+        if method == "ListRuns":
+            return {"items": self.list_runs_items}
+        return {}
+
+    def server_stream(self, service, method, request, deadline=None, read_timeout=90.0):
+        self.calls.append((service, method, request))
+        if self.on_stream_start:
+            self.on_stream_start()
+        yield from self.stream_events
+
+
+def _make_client(fake, tool_mode="loop"):
+    client = CursorBridgeClient(api_key="key-1", tool_mode=tool_mode)
+    client._transport = fake
+
+    def fake_ensure():
+        return fake
+
+    client._ensure_bridge = fake_ensure
+    return client
+
+
+def _finished_event(text, usage=None):
+    run_result = {"result": text}
+    if usage:
+        run_result["usage"] = usage
+    return {
+        "result": {
+            "agentId": "agent-test",
+            "runId": "run-1",
+            "status": "RUN_LIFECYCLE_STATUS_FINISHED",
+            "result": run_result,
+        }
+    }
+
+
+class TestLoopModeCompletion:
+    def test_plain_text_completion_with_usage(self):
+        fake = _FakeTransport()
+        fake.stream_events = [
+            {"sdkMessage": {"type": "assistant", "message": {"text": "thinking..."}}},
+            _finished_event(
+                "The answer is 4.",
+                usage={"inputTokens": "120", "outputTokens": "8", "totalTokens": "128",
+                       "cacheReadTokens": "50"},
+            ),
+            {"done": {"agentId": "agent-test", "runId": "run-1"}},
+        ]
+        client = _make_client(fake)
+        completion = client.chat.completions.create(
+            model="composer-2.5",
+            messages=[{"role": "user", "content": "what is 2+2"}],
+        )
+        message = completion.choices[0].message
+        assert message.content == "The answer is 4."
+        assert message.tool_calls == []
+        assert completion.choices[0].finish_reason == "stop"
+        assert completion.usage.prompt_tokens == 120
+        assert completion.usage.completion_tokens == 8
+        assert completion.usage.total_tokens == 128
+        assert completion.usage.prompt_tokens_details.cached_tokens == 50
+
+    def test_builtin_tools_restricted_to_mcp_when_tools_declared(self):
+        fake = _FakeTransport()
+        fake.stream_events = [_finished_event("done"), {"done": {}}]
+        client = _make_client(fake)
+        client.chat.completions.create(
+            model="composer-2.5",
+            messages=[{"role": "user", "content": "go"}],
+            tools=[{"type": "function", "function": {"name": "terminal", "parameters": {"type": "object"}}}],
+        )
+        create_request = next(r for s, m, r in fake.calls if m == "CreateAgent")
+        options = create_request["options"]
+        # Loop mode with tools: only the harness's `mcp` meta-tools stay
+        # enabled — that is the channel custom tools ride on (verified live
+        # against bridge 1.0.27). Shell/file built-ins stay off so the
+        # Cursor harness cannot bypass Hermes approvals.
+        assert options["tools"] == {"names": ["mcp"]}
+        assert "terminal" in options["local"]["customTools"]
+
+    def test_no_tools_means_pure_text_generation(self):
+        fake = _FakeTransport()
+        fake.stream_events = [_finished_event("done"), {"done": {}}]
+        client = _make_client(fake)
+        client.chat.completions.create(
+            model="composer-2.5",
+            messages=[{"role": "user", "content": "go"}],
+        )
+        create_request = next(r for s, m, r in fake.calls if m == "CreateAgent")
+        assert create_request["options"]["tools"] == {"names": []}
+
+    def test_agent_deleted_after_run(self):
+        fake = _FakeTransport()
+        fake.stream_events = [_finished_event("ok"), {"done": {}}]
+        client = _make_client(fake)
+        client.chat.completions.create(model="m", messages=[{"role": "user", "content": "x"}])
+        assert any(m == "DeleteAgent" for _, m, _ in fake.calls)
+
+    def test_error_status_raises(self):
+        fake = _FakeTransport()
+        fake.stream_events = [
+            {
+                "result": {
+                    "status": "RUN_LIFECYCLE_STATUS_ERROR",
+                    "errorCode": "quota_exceeded",
+                    "result": {"result": ""},
+                }
+            },
+            {"done": {}},
+        ]
+        client = _make_client(fake)
+        with pytest.raises(Exception) as excinfo:
+            client.chat.completions.create(model="m", messages=[{"role": "user", "content": "x"}])
+        assert "quota_exceeded" in str(excinfo.value)
+
+    def test_stream_kwarg_returns_chunks(self):
+        fake = _FakeTransport()
+        fake.stream_events = [_finished_event("streamed text"), {"done": {}}]
+        client = _make_client(fake)
+        chunks = client.chat.completions.create(
+            model="m", messages=[{"role": "user", "content": "x"}], stream=True
+        )
+        assert chunks[0].choices[0].delta.content == "streamed text"
+        assert chunks[1].usage is not None
+
+    def test_default_model_placeholder_maps_to_auto(self):
+        fake = _FakeTransport()
+        fake.stream_events = [_finished_event("ok"), {"done": {}}]
+        client = _make_client(fake)
+        client.chat.completions.create(model="cursor", messages=[{"role": "user", "content": "x"}])
+        create_request = next(r for s, m, r in fake.calls if m == "CreateAgent")
+        assert create_request["options"]["model"]["id"] == "auto"
+
+
+class TestLoopModeToolCapture:
+    def test_tool_callback_mid_run_becomes_openai_tool_call(self):
+        fake = _FakeTransport()
+        fake.list_runs_items = [
+            {"runId": "run-1", "status": "RUN_LIFECYCLE_STATUS_RUNNING"}
+        ]
+        client = _make_client(fake)
+
+        cancelled = threading.Event()
+        original_unary = fake.unary
+
+        def tracking_unary(service, method, request, timeout=60.0):
+            if method == "CancelRun":
+                cancelled.set()
+            return original_unary(service, method, request, timeout=timeout)
+
+        fake.unary = tracking_unary
+
+        def simulate_bridge_tool_call():
+            # The bridge invokes the callback while the Send stream is live.
+            response = client._handle_tool_callback(
+                {
+                    "toolName": "send_message",
+                    "args": {"text": "hello"},
+                    "toolCallId": "call-7",
+                    "agentId": "agent-test",
+                }
+            )
+            assert response["status"] == "deferred"
+
+        fake.on_stream_start = simulate_bridge_tool_call
+        fake.stream_events = [
+            {
+                "result": {
+                    "status": "RUN_LIFECYCLE_STATUS_CANCELLED",
+                    "result": {"result": ""},
+                }
+            },
+            {"done": {}},
+        ]
+
+        completion = client.chat.completions.create(
+            model="composer-2.5",
+            messages=[{"role": "user", "content": "message me"}],
+            tools=[{"type": "function", "function": {"name": "send_message", "parameters": {"type": "object"}}}],
+        )
+        message = completion.choices[0].message
+        assert completion.choices[0].finish_reason == "tool_calls"
+        assert len(message.tool_calls) == 1
+        call = message.tool_calls[0]
+        assert call.id == "call-7"
+        assert call.function.name == "send_message"
+        assert json.loads(call.function.arguments) == {"text": "hello"}
+        assert cancelled.wait(timeout=5), "CancelRun was never issued"
+
+    def test_callback_for_unknown_agent_returns_error(self):
+        fake = _FakeTransport()
+        client = _make_client(fake)
+        response = client._handle_tool_callback(
+            {"toolName": "t", "args": {}, "agentId": "agent-unknown"}
+        )
+        assert "error" in response
+
+
+class TestHarnessMode:
+    def test_dispatcher_executes_inline_and_returns_result(self):
+        fake = _FakeTransport()
+        executed = []
+
+        def dispatcher(name, args, call_id):
+            executed.append((name, args, call_id))
+            return json.dumps({"success": True, "data": 42})
+
+        client = CursorBridgeClient(
+            api_key="k", tool_mode="harness", tool_dispatcher=dispatcher
+        )
+        client._transport = fake
+        client._ensure_bridge = lambda: fake
+        client._active_runs["agent-test"] = __import__(
+            "agent.cursor_bridge_client", fromlist=["_ActiveRun"]
+        )._ActiveRun("agent-test", {"my_tool"})
+
+        response = client._handle_tool_callback(
+            {"toolName": "my_tool", "args": {"a": 1}, "toolCallId": "c1", "agentId": "agent-test"}
+        )
+        assert response == {"success": True, "data": 42}
+        assert executed == [("my_tool", {"a": 1}, "c1")]
+
+    def test_harness_mode_keeps_builtin_tools_configurable(self):
+        fake = _FakeTransport()
+        fake.stream_events = [_finished_event("ok"), {"done": {}}]
+        client = CursorBridgeClient(api_key="k", tool_mode="harness", builtin_tools=True)
+        client._transport = fake
+        client._ensure_bridge = lambda: fake
+        client.chat.completions.create(model="m", messages=[{"role": "user", "content": "x"}])
+        create_request = next(r for s, m, r in fake.calls if m == "CreateAgent")
+        assert "tools" not in create_request["options"]
+
+
+class TestMissingCredentials:
+    def test_no_credentials_raise_actionable_error(self, tmp_path, monkeypatch):
+        from pathlib import Path
+
+        # Isolate the SDK credential store: a developer's real
+        # ~/.cursor/sdk/auth.json must not satisfy the fallback here.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("CURSOR_API_KEY", raising=False)
+        client = CursorBridgeClient(api_key="")
+        with pytest.raises(Exception) as excinfo:
+            client.chat.completions.create(model="m", messages=[{"role": "user", "content": "x"}])
+        message = str(excinfo.value)
+        assert "hermes cursor login" in message
+        assert "CURSOR_API_KEY" in message
+
+    def test_sdk_login_store_satisfies_credential_check(self, tmp_path, monkeypatch):
+        from pathlib import Path
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        monkeypatch.delenv("CURSOR_API_KEY", raising=False)
+        from agent.cursor_sdk_auth import save_sdk_credentials
+
+        save_sdk_credentials(backend_url="https://api2.cursor.sh", api_key="key_from_login")
+        client = CursorBridgeClient(api_key="")
+        # Force bridge resolution to fail AFTER the credential check so the
+        # test proves which credential was picked up without spawning.
+        monkeypatch.setattr(
+            "agent.cursor_bridge_client.resolve_bridge_command", lambda *_a, **_k: None
+        )
+        with pytest.raises(Exception) as excinfo:
+            client.chat.completions.create(model="m", messages=[{"role": "user", "content": "x"}])
+        assert "bridge not found" in str(excinfo.value)
+        assert client.api_key == "key_from_login"

--- a/tests/agent/test_cursor_bridge_transport.py
+++ b/tests/agent/test_cursor_bridge_transport.py
@@ -1,0 +1,260 @@
+"""Tests for bridge discovery parsing and the Connect JSON transport."""
+
+import json
+import struct
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from agent.cursor_bridge_transport import (
+    ConnectJsonTransport,
+    CursorBridgeError,
+    READY_LINE_PREFIX,
+    endpoint_from_discovery,
+    parse_ready_line,
+    resolve_bridge_command,
+)
+
+
+def _discovery(tmp_path, **overrides):
+    token_file = tmp_path / "auth-token"
+    token_file.write_text("secret-token\n", encoding="utf-8")
+    payload = {
+        "schemaVersion": 1,
+        "serverVersion": "1.0.0",
+        "pid": 4242,
+        "transport": "tcp",
+        "protocol": "connect",
+        "host": "127.0.0.1",
+        "port": 49152,
+        "url": "http://127.0.0.1:49152",
+        "authTokenFile": str(token_file),
+        "workspaceRef": "/repo",
+        "stateRoot": "/state",
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestReadyLine:
+    def test_non_ready_lines_return_none(self):
+        assert parse_ready_line("some diagnostic output") is None
+        assert parse_ready_line("") is None
+
+    def test_ready_line_parses_json(self, tmp_path):
+        payload = _discovery(tmp_path)
+        line = READY_LINE_PREFIX + json.dumps(payload)
+        assert parse_ready_line(line) == payload
+
+    def test_invalid_json_raises(self):
+        with pytest.raises(CursorBridgeError):
+            parse_ready_line(READY_LINE_PREFIX + "{not json")
+
+    def test_endpoint_reads_token_file(self, tmp_path):
+        endpoint = endpoint_from_discovery(_discovery(tmp_path))
+        assert endpoint.url == "http://127.0.0.1:49152"
+        assert endpoint.auth_token == "secret-token"
+        assert endpoint.pid == 4242
+        assert endpoint.workspace_ref == "/repo"
+
+    def test_inline_auth_token_preferred(self, tmp_path):
+        endpoint = endpoint_from_discovery(_discovery(tmp_path, authToken="inline-tok"))
+        assert endpoint.auth_token == "inline-tok"
+
+    def test_host_port_fallback_when_url_missing(self, tmp_path):
+        endpoint = endpoint_from_discovery(_discovery(tmp_path, url=""))
+        assert endpoint.url == "http://127.0.0.1:49152"
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"schemaVersion": 2},
+            {"transport": "unix"},
+            {"protocol": "grpc"},
+        ],
+    )
+    def test_unsupported_discovery_rejected(self, tmp_path, overrides):
+        with pytest.raises(CursorBridgeError):
+            endpoint_from_discovery(_discovery(tmp_path, **overrides))
+
+    def test_missing_token_file_raises(self, tmp_path):
+        payload = _discovery(tmp_path, authTokenFile=str(tmp_path / "missing"))
+        with pytest.raises(CursorBridgeError):
+            endpoint_from_discovery(payload)
+
+
+class TestResolveBridgeCommand:
+    def test_configured_command_wins(self, tmp_path):
+        binary = tmp_path / "my-bridge"
+        binary.write_text("#!/bin/sh\n")
+        assert resolve_bridge_command(str(binary)) == str(binary)
+
+    def test_managed_install_found_via_hermes_home(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("CURSOR_SDK_BRIDGE_BIN", raising=False)
+        monkeypatch.setenv("PATH", str(tmp_path / "empty-path"))
+        launcher = tmp_path / "cursor-sdk-bridge" / "cursor-sdk-bridge" / "bin" / "cursor-sdk-bridge"
+        launcher.parent.mkdir(parents=True)
+        launcher.write_text("#!/bin/sh\n")
+        assert resolve_bridge_command() == str(launcher)
+
+    def test_returns_none_when_nothing_installed(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("CURSOR_SDK_BRIDGE_BIN", raising=False)
+        monkeypatch.setenv("PATH", str(tmp_path / "empty-path"))
+        assert resolve_bridge_command() is None
+
+    def test_env_var_respected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("PATH", str(tmp_path / "empty-path"))
+        binary = tmp_path / "env-bridge"
+        binary.write_text("#!/bin/sh\n")
+        monkeypatch.setenv("CURSOR_SDK_BRIDGE_BIN", str(binary))
+        assert resolve_bridge_command() == str(binary)
+
+
+# ── Connect transport against a stub server ───────────────────────────────
+
+
+class _StubHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *args):
+        pass
+
+    def _body(self) -> bytes:
+        return self.rfile.read(int(self.headers.get("Content-Length") or 0))
+
+    def do_POST(self):
+        server = self.server
+        server.requests.append(
+            {
+                "path": self.path,
+                "headers": dict(self.headers),
+                "body": self._body(),
+            }
+        )
+        route = server.routes.get(self.path)
+        if route is None:
+            payload = json.dumps({"code": "unimplemented", "message": "no route"}).encode()
+            self.send_response(404)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+            return
+        status, content_type, body = route
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+class _StubServer(ThreadingHTTPServer):
+    def __init__(self):
+        super().__init__(("127.0.0.1", 0), _StubHandler)
+        self.routes = {}
+        self.requests = []
+
+    @property
+    def url(self):
+        return f"http://127.0.0.1:{self.server_address[1]}"
+
+
+def _frame(payload: bytes, flags: int = 0) -> bytes:
+    return struct.pack(">BI", flags, len(payload)) + payload
+
+
+@pytest.fixture()
+def stub_server():
+    server = _StubServer()
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield server
+    server.shutdown()
+    server.server_close()
+
+
+class TestConnectJsonTransport:
+    def test_unary_success_sends_bearer_and_parses_json(self, stub_server):
+        stub_server.routes["/sdk.v1.SdkAgentService/CreateAgent"] = (
+            200,
+            "application/json",
+            json.dumps({"agentId": "agent-1"}).encode(),
+        )
+        transport = ConnectJsonTransport(stub_server.url, "tok-123")
+        response = transport.unary(
+            "SdkAgentService", "CreateAgent", {"options": {"name": "x"}}
+        )
+        assert response == {"agentId": "agent-1"}
+        request = stub_server.requests[0]
+        assert request["headers"]["Authorization"] == "Bearer tok-123"
+        assert request["headers"]["Connect-Protocol-Version"] == "1"
+        assert json.loads(request["body"]) == {"options": {"name": "x"}}
+
+    def test_unary_connect_error_raises_with_code(self, stub_server):
+        stub_server.routes["/sdk.v1.SdkAgentService/GetRun"] = (
+            401,
+            "application/json",
+            json.dumps({"code": "unauthenticated", "message": "bad key"}).encode(),
+        )
+        transport = ConnectJsonTransport(stub_server.url, "tok")
+        with pytest.raises(CursorBridgeError) as excinfo:
+            transport.unary("SdkAgentService", "GetRun", {"runId": "r"})
+        assert excinfo.value.code == "unauthenticated"
+        assert "bad key" in str(excinfo.value)
+
+    def test_server_stream_yields_frames_until_end(self, stub_server):
+        body = (
+            _frame(json.dumps({"sdkMessage": {"type": "assistant"}}).encode())
+            + _frame(b"")  # keepalive-style empty frame is skipped
+            + _frame(json.dumps({"result": {"status": "RUN_LIFECYCLE_STATUS_FINISHED"}}).encode())
+            + _frame(json.dumps({"done": {}}).encode())
+            + _frame(json.dumps({}).encode(), flags=0x02)
+        )
+        stub_server.routes["/sdk.v1.SdkAgentService/Send"] = (
+            200,
+            "application/connect+json",
+            body,
+        )
+        transport = ConnectJsonTransport(stub_server.url, "tok")
+        messages = list(
+            transport.server_stream("SdkAgentService", "Send", {"agentId": "a"})
+        )
+        assert [set(m) for m in messages] == [
+            {"sdkMessage"},
+            {"result"},
+            {"done"},
+        ]
+        # The request itself must be a single enveloped JSON frame.
+        raw = stub_server.requests[0]["body"]
+        flags, length = struct.unpack(">BI", raw[:5])
+        assert flags == 0
+        assert json.loads(raw[5 : 5 + length]) == {"agentId": "a"}
+
+    def test_server_stream_end_frame_error_raises(self, stub_server):
+        body = _frame(
+            json.dumps({"error": {"code": "internal", "message": "boom"}}).encode(),
+            flags=0x02,
+        )
+        stub_server.routes["/sdk.v1.SdkAgentService/Send"] = (
+            200,
+            "application/connect+json",
+            body,
+        )
+        transport = ConnectJsonTransport(stub_server.url, "tok")
+        with pytest.raises(CursorBridgeError) as excinfo:
+            list(transport.server_stream("SdkAgentService", "Send", {"agentId": "a"}))
+        assert excinfo.value.code == "internal"
+
+    def test_server_stream_truncated_raises(self, stub_server):
+        stub_server.routes["/sdk.v1.SdkAgentService/Send"] = (
+            200,
+            "application/connect+json",
+            _frame(json.dumps({"done": {}}).encode()),  # no end-stream frame
+        )
+        transport = ConnectJsonTransport(stub_server.url, "tok")
+        with pytest.raises(CursorBridgeError):
+            list(transport.server_stream("SdkAgentService", "Send", {"agentId": "a"}))

--- a/tests/agent/test_cursor_bridge_wire.py
+++ b/tests/agent/test_cursor_bridge_wire.py
@@ -1,0 +1,121 @@
+"""Tests for the hand-rolled protobuf wire codec used by Cursor tool callbacks."""
+
+import struct
+
+import pytest
+
+from agent.cursor_bridge_wire import (
+    _encode_varint,
+    decode_call_custom_tool_request,
+    decode_struct,
+    encode_call_custom_tool_response,
+    encode_struct,
+)
+
+
+class TestStructRoundTrip:
+    def test_empty(self):
+        assert decode_struct(encode_struct({})) == {}
+
+    def test_scalars(self):
+        obj = {"s": "hello", "i": 42, "f": 2.5, "t": True, "x": False, "n": None}
+        assert decode_struct(encode_struct(obj)) == obj
+
+    def test_nested_and_lists(self):
+        obj = {
+            "list": [1, "two", None, True, {"deep": [3.5]}],
+            "obj": {"inner": {"leaf": "v"}},
+        }
+        assert decode_struct(encode_struct(obj)) == obj
+
+    def test_unicode_keys_and_values(self):
+        obj = {"héllo": "wörld ∆", "emoji": "🎉"}
+        assert decode_struct(encode_struct(obj)) == obj
+
+    def test_integral_doubles_come_back_as_ints(self):
+        decoded = decode_struct(encode_struct({"count": 7}))
+        assert decoded["count"] == 7
+        assert isinstance(decoded["count"], int)
+
+    def test_non_integral_doubles_stay_floats(self):
+        decoded = decode_struct(encode_struct({"ratio": 0.25}))
+        assert decoded["ratio"] == 0.25
+        assert isinstance(decoded["ratio"], float)
+
+    def test_rejects_non_dict(self):
+        with pytest.raises(TypeError):
+            encode_struct(["not", "a", "dict"])  # type: ignore[arg-type]
+
+    def test_rejects_unencodable_value(self):
+        with pytest.raises(TypeError):
+            encode_struct({"bad": object()})
+
+
+class TestCallCustomToolMessages:
+    def _encode_request(
+        self,
+        tool_name: str = "",
+        args: dict | None = None,
+        tool_call_id: str | None = None,
+        agent_id: str = "",
+    ) -> bytes:
+        out = b""
+        if tool_name:
+            payload = tool_name.encode()
+            out += _encode_varint((1 << 3) | 2) + _encode_varint(len(payload)) + payload
+        if args is not None:
+            payload = encode_struct(args)
+            out += _encode_varint((2 << 3) | 2) + _encode_varint(len(payload)) + payload
+        if tool_call_id is not None:
+            payload = tool_call_id.encode()
+            out += _encode_varint((3 << 3) | 2) + _encode_varint(len(payload)) + payload
+        if agent_id:
+            payload = agent_id.encode()
+            out += _encode_varint((4 << 3) | 2) + _encode_varint(len(payload)) + payload
+        return out
+
+    def test_full_request_decodes(self):
+        raw = self._encode_request(
+            tool_name="send_message",
+            args={"text": "hi", "count": 2},
+            tool_call_id="call-9",
+            agent_id="agent-abc",
+        )
+        decoded = decode_call_custom_tool_request(raw)
+        assert decoded == {
+            "toolName": "send_message",
+            "args": {"text": "hi", "count": 2},
+            "toolCallId": "call-9",
+            "agentId": "agent-abc",
+        }
+
+    def test_empty_request_yields_defaults(self):
+        decoded = decode_call_custom_tool_request(b"")
+        assert decoded["toolName"] == ""
+        assert decoded["args"] == {}
+        assert decoded["toolCallId"] is None
+        assert decoded["agentId"] == ""
+
+    def test_unknown_fields_are_skipped(self):
+        raw = self._encode_request(tool_name="t", agent_id="a")
+        # Append an unknown varint field (field 15) and a fixed64 field (16).
+        raw += _encode_varint((15 << 3) | 0) + _encode_varint(12345)
+        raw += _encode_varint((16 << 3) | 1) + struct.pack("<d", 1.0)
+        decoded = decode_call_custom_tool_request(raw)
+        assert decoded["toolName"] == "t"
+        assert decoded["agentId"] == "a"
+
+    def test_response_round_trips_through_request_struct_decoder(self):
+        # The response is field 1 = Struct; reuse the request decoder's
+        # Struct path by crafting a request whose field-2 payload matches.
+        result = {"value": "ok", "meta": {"n": 1}}
+        encoded = encode_call_custom_tool_response(result)
+        # field 1, wiretype 2, then the struct payload
+        tag = encoded[0]
+        assert tag >> 3 == 1 and tag & 0x07 == 2
+        length = encoded[1]
+        assert decode_struct(encoded[2 : 2 + length]) == result
+
+    def test_truncated_varint_raises(self):
+        with pytest.raises(ValueError):
+            decode_call_custom_tool_request(b"\xff")

--- a/tests/agent/test_cursor_sdk_auth.py
+++ b/tests/agent/test_cursor_sdk_auth.py
@@ -1,0 +1,242 @@
+"""Tests for the Cursor SDK browser-login flow (`hermes cursor login`)."""
+
+import base64
+import hashlib
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from agent.cursor_sdk_auth import (
+    CursorAuthError,
+    create_login_handshake,
+    login,
+    mint_user_api_key,
+    poll_for_login_tokens,
+    read_sdk_credentials,
+    resolve_cursor_api_key,
+    save_sdk_credentials,
+    sdk_auth_path,
+)
+
+
+class TestHandshake:
+    def test_challenge_is_sha256_of_verifier(self):
+        handshake = create_login_handshake("https://cursor.com")
+        query = parse_qs(urlparse(handshake.login_url).query)
+        expected = (
+            base64.urlsafe_b64encode(
+                hashlib.sha256(handshake.verifier.encode()).digest()
+            )
+            .decode()
+            .rstrip("=")
+        )
+        assert query["challenge"] == [expected]
+        assert query["uuid"] == [handshake.uuid]
+        assert query["mode"] == ["login"]
+        assert query["redirectTarget"] == ["sdk"]
+
+    def test_verifier_not_in_login_url(self):
+        handshake = create_login_handshake("https://cursor.com")
+        assert handshake.verifier not in handshake.login_url
+
+    def test_each_handshake_is_unique(self):
+        first = create_login_handshake("https://cursor.com")
+        second = create_login_handshake("https://cursor.com")
+        assert first.verifier != second.verifier
+        assert first.uuid != second.uuid
+
+
+# ── Stub backend ──────────────────────────────────────────────────────────
+
+
+class _AuthStubHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *args):
+        pass
+
+    def _reply(self, status, payload):
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self):
+        server = self.server
+        length = int(self.headers.get("Content-Length") or 0)
+        body = json.loads(self.rfile.read(length)) if length else {}
+        server.requests.append(("POST", self.path, dict(self.headers), body))
+        if self.path == "/auth/poll":
+            if server.poll_route_missing:
+                self._reply(404, {"message": "Route POST:/auth/poll not found"})
+                return
+            server.poll_count += 1
+            if server.poll_count < server.succeed_on_poll:
+                self._reply(404, {"error": "pending"})
+                return
+            self._reply(200, {"accessToken": "sess-token", "refreshToken": "refresh"})
+            return
+        if self.path == "/aiserver.v1.DashboardService/CreateUserApiKey":
+            if self.headers.get("Authorization") != "Bearer sess-token":
+                self._reply(401, {"code": "unauthenticated", "message": "bad token"})
+                return
+            server.minted.append(body)
+            self._reply(200, {"apiKey": "key_minted_123"})
+            return
+        if self.path == "/aiserver.v1.DashboardService/GetMe":
+            self._reply(200, {"email": "user@example.com"})
+            return
+        self._reply(404, {"message": f"Route POST:{self.path} not found"})
+
+    def do_GET(self):
+        server = self.server
+        server.requests.append(("GET", self.path, dict(self.headers), None))
+        if self.path.startswith("/auth/poll"):
+            self._reply(200, {"accessToken": "sess-token-get", "refreshToken": "r"})
+            return
+        self._reply(404, {})
+
+
+class _AuthStub(ThreadingHTTPServer):
+    def __init__(self):
+        super().__init__(("127.0.0.1", 0), _AuthStubHandler)
+        self.requests = []
+        self.poll_count = 0
+        self.succeed_on_poll = 1
+        self.poll_route_missing = False
+        self.minted = []
+
+    @property
+    def url(self):
+        return f"http://127.0.0.1:{self.server_address[1]}"
+
+
+@pytest.fixture()
+def auth_stub():
+    server = _AuthStub()
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield server
+    server.shutdown()
+    server.server_close()
+
+
+class TestPoll:
+    def test_pending_then_success_via_post(self, auth_stub):
+        auth_stub.succeed_on_poll = 3
+        tokens = poll_for_login_tokens(
+            api_url=auth_stub.url, uuid="u1", verifier="v1", sleep=lambda _s: None
+        )
+        assert tokens == {"accessToken": "sess-token", "refreshToken": "refresh"}
+        # Verifier travels in the POST body, never in a URL.
+        post_polls = [r for r in auth_stub.requests if r[0] == "POST" and r[1] == "/auth/poll"]
+        assert post_polls and all(r[3] == {"uuid": "u1", "verifier": "v1"} for r in post_polls)
+
+    def test_route_not_found_falls_back_to_get(self, auth_stub):
+        auth_stub.poll_route_missing = True
+        tokens = poll_for_login_tokens(
+            api_url=auth_stub.url, uuid="u2", verifier="v2", sleep=lambda _s: None
+        )
+        assert tokens == {"accessToken": "sess-token-get", "refreshToken": "r"}
+        assert any(r[0] == "GET" for r in auth_stub.requests)
+
+    def test_timeout_returns_none(self, auth_stub):
+        auth_stub.succeed_on_poll = 10**9
+        tokens = poll_for_login_tokens(
+            api_url=auth_stub.url,
+            uuid="u3",
+            verifier="v3",
+            max_attempts=3,
+            sleep=lambda _s: None,
+        )
+        assert tokens is None
+
+
+class TestMint:
+    def test_mint_sends_name_and_expiry_with_bearer(self, auth_stub):
+        key = mint_user_api_key(
+            backend_url=auth_stub.url,
+            access_token="sess-token",
+            name="Hermes Agent (test)",
+            expires_at_ms=1234567890123,
+        )
+        assert key == "key_minted_123"
+        minted = auth_stub.minted[0]
+        assert minted["name"] == "Hermes Agent (test)"
+        assert minted["expiresAt"] == "1234567890123"  # proto3 JSON int64 = string
+
+    def test_mint_auth_failure_is_actionable(self, auth_stub):
+        with pytest.raises(CursorAuthError):
+            mint_user_api_key(
+                backend_url=auth_stub.url, access_token="wrong", name="n"
+            )
+
+
+class TestCredentialStore:
+    @pytest.fixture(autouse=True)
+    def _home(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        monkeypatch.delenv("CURSOR_API_KEY", raising=False)
+        return tmp_path
+
+    def test_store_lives_in_cursor_sdk_dir_not_hermes_home(self, _home):
+        assert sdk_auth_path() == _home / ".cursor" / "sdk" / "auth.json"
+
+    def test_round_trip_and_permissions(self):
+        path = save_sdk_credentials(
+            backend_url="https://api2.cursor.sh",
+            api_key="key_abc",
+            api_key_expires_at_ms=int(time.time() * 1000) + 60_000,
+            email="me@example.com",
+        )
+        assert oct(path.stat().st_mode & 0o777) == "0o600"
+        stored = read_sdk_credentials()
+        assert stored["apiKey"] == "key_abc"
+        assert stored["email"] == "me@example.com"
+
+    def test_expired_credentials_read_as_none(self):
+        save_sdk_credentials(
+            backend_url="https://api2.cursor.sh",
+            api_key="key_old",
+            api_key_expires_at_ms=int(time.time() * 1000) - 1,
+        )
+        assert read_sdk_credentials() is None
+
+    def test_foreign_shaped_file_reads_as_none(self):
+        path = sdk_auth_path()
+        path.parent.mkdir(parents=True)
+        path.write_text('{"something": "else"}', encoding="utf-8")
+        assert read_sdk_credentials() is None
+
+    def test_resolve_prefers_env_then_sdk_login(self, monkeypatch):
+        save_sdk_credentials(backend_url="https://api2.cursor.sh", api_key="key_store")
+        key, source = resolve_cursor_api_key()
+        assert (key, source) == ("key_store", "sdk_login")
+        monkeypatch.setenv("CURSOR_API_KEY", "key_env")
+        key, source = resolve_cursor_api_key()
+        assert (key, source) == ("key_env", "env")
+
+
+class TestFullLogin:
+    def test_end_to_end_against_stub(self, auth_stub, tmp_path, monkeypatch):
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        urls = []
+        result = login(
+            on_login_url=urls.append,
+            backend_url=auth_stub.url,
+            website_url="https://cursor.example",
+            open_browser=False,
+        )
+        assert result["apiKey"] == "key_minted_123"
+        assert result["email"] == "user@example.com"
+        assert urls and urls[0].startswith("https://cursor.example/loginDeepControl?")
+        stored = read_sdk_credentials()
+        assert stored["apiKey"] == "key_minted_123"

--- a/tests/hermes_cli/test_cursor_provider.py
+++ b/tests/hermes_cli/test_cursor_provider.py
@@ -1,0 +1,138 @@
+"""Integration invariants for the Cursor subscription provider.
+
+These assert how the provider's surfaces must relate to each other (profile
+↔ registry ↔ overlay ↔ picker ↔ client marker), not snapshots of catalog
+data that is expected to change.
+"""
+
+from agent.cursor_bridge_client import BRIDGE_MARKER_BASE_URL
+from hermes_cli.cursor_cloud import (
+    _strip_url_credentials,
+    agent_url,
+    run_slash,
+)
+
+
+class TestProviderRegistration:
+    def test_profile_registered_with_marker_base_url(self):
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("cursor")
+        assert profile is not None
+        assert profile.base_url == BRIDGE_MARKER_BASE_URL
+        assert profile.auth_type == "api_key"
+        assert "CURSOR_API_KEY" in profile.env_vars
+        # No REST /models endpoint exists — doctor must skip the probe.
+        assert profile.supports_health_check is False
+        assert len(profile.fallback_models) >= 1
+
+    def test_auth_registry_auto_wired_from_profile(self):
+        from hermes_cli.auth import PROVIDER_REGISTRY
+
+        pconfig = PROVIDER_REGISTRY.get("cursor")
+        assert pconfig is not None
+        assert pconfig.auth_type == "api_key"
+        assert pconfig.inference_base_url == BRIDGE_MARKER_BASE_URL
+        assert "CURSOR_API_KEY" in pconfig.api_key_env_vars
+
+    def test_env_var_exposed_in_optional_env_vars(self):
+        from hermes_cli.config import OPTIONAL_ENV_VARS
+
+        entry = OPTIONAL_ENV_VARS.get("CURSOR_API_KEY")
+        assert entry is not None
+        assert entry.get("password") is True
+        assert entry.get("category") == "provider"
+
+    def test_identity_overlay_matches_marker(self):
+        from hermes_cli.providers import get_provider, normalize_provider
+
+        pdef = get_provider("cursor", allow_network=False)
+        assert pdef is not None
+        assert pdef.base_url == BRIDGE_MARKER_BASE_URL
+        assert pdef.transport == "openai_chat"
+        # Aliases resolve to the canonical id.
+        assert normalize_provider("cursor-sdk") == "cursor"
+        assert normalize_provider("cursor-agent") == "cursor"
+
+    def test_model_picker_lists_cursor(self):
+        from hermes_cli.models import CANONICAL_PROVIDERS, _PROVIDER_MODELS
+
+        assert any(p.slug == "cursor" for p in CANONICAL_PROVIDERS)
+        assert len(_PROVIDER_MODELS.get("cursor", [])) >= 1
+
+    def test_default_config_has_cursor_bridge_section(self):
+        from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+        section = DEFAULT_CONFIG.get("cursor_bridge")
+        assert isinstance(section, dict)
+        assert section.get("tool_mode") in {"loop", "harness"}
+        # Loop mode must be the shipped default: it keeps Hermes approvals
+        # and budget in charge of every tool call.
+        assert section.get("tool_mode") == "loop"
+        assert section.get("builtin_tools") is False
+
+    def test_runtime_client_routes_on_marker(self):
+        # The runtime routes to CursorBridgeClient on provider name OR the
+        # marker scheme — both must stay in sync with the profile.
+        from agent.cursor_bridge_client import CursorBridgeClient
+
+        client = CursorBridgeClient(api_key="k")
+        assert client.base_url == BRIDGE_MARKER_BASE_URL
+        assert BRIDGE_MARKER_BASE_URL.startswith("sdkbridge://")
+
+
+class TestSlashCommand:
+    def test_registered_in_command_registry(self):
+        from hermes_cli.commands import resolve_command
+
+        command = resolve_command("cursor")
+        assert command is not None
+        assert command.name == "cursor"
+        assert "handoff" in command.subcommands
+        assert not command.cli_only  # available from messaging platforms
+
+    def test_help_and_unknown_verbs(self):
+        help_text = run_slash("")
+        assert "/cursor handoff" in help_text
+        unknown = run_slash("frobnicate")
+        assert "Unknown /cursor subcommand" in unknown
+
+    def test_agent_url_shape(self):
+        assert agent_url("bc-abc") == "https://cursor.com/agents?id=bc-abc"
+
+
+class TestSdkLoginRuntimeResolution:
+    def test_runtime_credentials_fall_back_to_sdk_login_store(self, tmp_path, monkeypatch):
+        """`hermes chat --provider cursor` must work after `hermes cursor login`.
+
+        The runtime gate in runtime_provider.py fails resolution when the
+        shared secret resolver returns empty — so the resolver itself must
+        consult the SDK login store, not just the bridge client.
+        """
+        from pathlib import Path
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        monkeypatch.delenv("CURSOR_API_KEY", raising=False)
+
+        from agent.cursor_sdk_auth import save_sdk_credentials
+        from hermes_cli.auth import resolve_api_key_provider_credentials
+
+        save_sdk_credentials(backend_url="https://api2.cursor.sh", api_key="key_login")
+        creds = resolve_api_key_provider_credentials("cursor")
+        assert creds["api_key"] == "key_login"
+        assert creds["source"] == "cursor_sdk_login"
+
+
+class TestRepoCredentialStripping:
+    def test_token_stripped_from_https_remote(self):
+        url = "https://x-access-token:ghs_secret123@github.com/org/repo"
+        assert _strip_url_credentials(url) == "https://github.com/org/repo"
+
+    def test_plain_https_unchanged(self):
+        url = "https://github.com/org/repo.git"
+        assert _strip_url_credentials(url) == url
+
+    def test_scp_style_remote_unchanged(self):
+        url = "git@github.com:org/repo.git"
+        assert _strip_url_credentials(url) == url

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -18,6 +18,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **OpenAI Codex** | `hermes model` (ChatGPT OAuth, uses Codex models) |
 | **GitHub Copilot** | `hermes model` (OAuth device code flow, `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `gh auth token`) |
 | **GitHub Copilot ACP** | `hermes model` (spawns local `copilot --acp --stdio`) |
+| **Cursor** | `hermes model` (your Cursor subscription via the official Cursor SDK bridge; `CURSOR_API_KEY`) |
 | **Anthropic** | `hermes model` (Claude Max + extra usage credits via OAuth; also supports Anthropic API key or manual setup-token — see note below) |
 | **OpenRouter** | `OPENROUTER_API_KEY` in `~/.hermes/.env` |
 | **Fireworks AI** | `FIREWORKS_API_KEY` in `~/.hermes/.env` (provider: `fireworks`; aliases: `fireworks-ai`, `fw`) |
@@ -237,6 +238,98 @@ model:
 | `COPILOT_GITHUB_TOKEN` | GitHub token for Copilot API (first priority) |
 | `HERMES_COPILOT_ACP_COMMAND` | Override the Copilot CLI binary path (default: `copilot`) |
 | `HERMES_COPILOT_ACP_ARGS` | Override ACP args (default: `--acp --stdio`) |
+
+### Cursor (Subscription)
+
+Run Hermes on your own [Cursor](https://cursor.com) subscription. Hermes talks
+to Cursor through the official [Cursor SDK bridge](https://github.com/cursor/sdk-bridge)
+(`sdk.v1` protocol) — the same runtime that powers Cursor's IDE, CLI, and SDK.
+
+```bash
+hermes cursor login     # browser login — mints a user API key on your account
+hermes model            # pick "Cursor" — offers to install the bridge and
+                        # fetches the model catalog from your account
+hermes chat --provider cursor --model composer-2.5
+```
+
+Auth, in priority order: `CURSOR_API_KEY` in `~/.hermes/.env`
+(cursor.com/dashboard → API Keys), else the SDK login store
+(`~/.cursor/sdk/auth.json`) filled by `hermes cursor login`. The login is the
+same PKCE flow the Cursor SDK ships: it mints a **named, expiring user API
+key** (~90 days, visible and revocable in the dashboard) and never persists
+your session tokens. The login URL can be opened from any device signed in to
+cursor.com, so it works on headless boxes too. `hermes cursor logout` forgets
+the stored login.
+
+**Billing and terms:** you bring your own Cursor account and API key. Usage
+bills to *your* Cursor plan; Hermes never proxies, pools, or resells Cursor
+inference. Model availability follows your plan.
+
+**How it works:** each turn, Hermes spawns a local `cursor-sdk-bridge`
+subprocess, creates a short-lived Cursor agent, and streams the run. Hermes
+tools are declared as SDK *custom tools* and execute back inside Hermes
+through a loopback callback service.
+
+Two tool modes (`cursor_bridge.tool_mode` in config.yaml):
+
+- **`loop`** (default) — Cursor's built-in tools are disabled; when the model
+  calls a Hermes tool the call returns into Hermes's own loop, so approvals,
+  budgets, interrupts, and agent-level tools (todo, memory) all behave exactly
+  like any other provider.
+- **`harness`** — Cursor's agent drives the whole turn and executes Hermes
+  tools inline via the callback service. Set `cursor_bridge.builtin_tools: true`
+  to also give the model Cursor's native file/shell/search tools (they bypass
+  Hermes approvals — use with care).
+
+```yaml
+model:
+  provider: "cursor"
+  default: "composer-2.5"   # or "auto" for server-side routing
+
+cursor_bridge:
+  command: ""               # explicit bridge path; empty = auto-resolve
+  tool_mode: "loop"
+  builtin_tools: false
+```
+
+The bridge binary resolves from (in order): `cursor_bridge.command`, an
+installed [`cursor-sdk`](https://pypi.org/project/cursor-sdk/) Python wheel,
+`CURSOR_SDK_BRIDGE_BIN`, `cursor-sdk-bridge` on PATH, then the Hermes-managed
+install under `~/.hermes/cursor-sdk-bridge/` (installed by `hermes model`).
+
+**Known limits:** the Cursor SDK does not allow custom system prompts, so
+Hermes context (system message, memory, skills) travels as prompt text;
+responses arrive complete rather than token-streamed.
+
+**Auxiliary tasks bill to your plan too.** Hermes does auxiliary tasks, for
+example title generation, compression, and vision. With `auxiliary.*.provider:
+"auto"` (the default), these tasks use your main provider. On Cursor, each
+auxiliary task starts a short agent run through the bridge, and Cursor bills
+those tokens to your subscription — the same as a chat turn. If you do not
+want auxiliary tasks on Cursor, turn the task off or send it to a different
+provider in `~/.hermes/config.yaml`:
+
+```yaml
+auxiliary:
+  title_generation:
+    enabled: false          # turn the task off entirely
+  # — or —
+  vision:
+    provider: "openrouter"  # keep chat on Cursor, move this task elsewhere
+    model: "google/gemini-3-flash-preview"
+```
+
+Each auxiliary task has its own configuration section — see
+[Auxiliary Models](/user-guide/configuration#auxiliary-models).
+
+**Cloud agents:** `hermes cursor handoff "<task>"` (or `/cursor handoff` in
+chat) hands a task to a durable **Cursor cloud agent** on the same
+subscription — visible and take-over-able at
+[cursor.com/agents](https://cursor.com/agents), in the Cursor IDE Agents
+window, and on mobile. `hermes cursor status|runs|pull|watch|send|list|open`
+manage it afterwards. To hear back in a live chat session, ask Hermes to run
+`hermes cursor watch <id>` as a background terminal command with
+`notify_on_complete=true`.
 
 ### First-Class API-Key Providers
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -80,6 +80,7 @@ hermes [global-options] <command> [subcommand/options]
 | `hermes journey` (aliases `learning`, `memory-graph`) | Timeline of learned skills + memories over time. |
 | `hermes memory` | Configure external memory provider. Plugin-specific subcommands (e.g. `hermes honcho`) register automatically when their provider is active. |
 | `hermes acp` | Run Hermes as an ACP server for editor integration. |
+| `hermes cursor` | Hand tasks to a Cursor cloud agent on your own Cursor subscription (`handoff`, `send`, `status`, `runs`, `pull`, `watch`, `list`, `open`). |
 | `hermes mcp` | Manage MCP server configurations and run Hermes as an MCP server. |
 | `hermes plugins` | Manage Hermes Agent plugins (install, enable, disable, remove). |
 | `hermes portal` | Nous Portal status, subscription link, and Tool Gateway routing. See [Tool Gateway](../user-guide/features/tool-gateway.md). |


### PR DESCRIPTION
Run Hermes on the user's own Cursor subscription.

- `hermes cursor login`: browser PKCE login. Mints a named, expiring user API key (revocable in the Cursor dashboard) and stores it in the SDK's shared credential store. `CURSOR_API_KEY` in `.env` takes priority.
- `cursor` model provider: runs each turn through the official [cursor-sdk-bridge](https://github.com/cursor/sdk-bridge) (`sdk.v1`, Connect over HTTP with JSON messages). Hermes tools are declared as SDK custom tools and execute inside Hermes through a loopback callback server. Default `tool_mode: loop` keeps Cursor's built-in tools off and returns each tool call to the Hermes loop, so approvals, budgets, and interrupts apply as usual. Optional `tool_mode: harness` lets the Cursor agent drive the turn.
- `hermes cursor handoff` and `/cursor`: create and manage durable Cursor cloud agents, visible and controllable at cursor.com/agents, in the Cursor IDE Agents window, and on mobile.

`hermes model` installs the bridge (SHA256-verified release asset) and lists the account model catalog. Billing goes to the user's own Cursor plan. Verified live end to end: login, ListModels, text turn on composer-2.5, and a full tool loop through the callback service.

## What does this PR do?

Adds Cursor as a first-class subscription provider, the same shape as `openai-codex` (ChatGPT sub) and `copilot`. Users run Hermes on their own Cursor plan while Hermes stays the harness.

The provider talks to the published `sdk.v1` bridge contract directly — plain HTTP + JSON, no `cursor-sdk` pip dependency, no protobuf codegen — and uses the SDK's native custom-tools callback service instead of `<tool_call>` text extraction. Tool calls are therefore structured end to end, and in the default `loop` mode every Hermes control keeps working unchanged: approvals, budgets, interrupts, agent-level todo/memory interception, and plugin hooks. This was verified at runtime — a registered plugin's `pre_tool_call` / `post_tool_call` / `pre_llm_call` / `on_session_start` hooks all fired during a live Cursor session.

The one SDK constraint: Cursor does not allow a custom system prompt, so Hermes context (system message, memory, skills) travels as prompt text rather than a cached system prompt.

Related open PRs with overlapping intent, not duplicated by this one: #68994 adds a Cursor fallback client via the `cursor-sdk` package with `<tool_call>` text-scraping, and #73617 patches provider validation for it. This PR is an independent, fuller implementation (native tool callbacks, browser login, cloud-agent handoff); happy to coordinate or converge with those authors.

## Related Issue

No existing issue.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/cursor_bridge_transport.py` — bridge resolve/spawn/ready-line handshake, Connect-over-HTTP JSON transport (unary + enveloped server streams), SHA256-verified bridge installer
- `agent/cursor_bridge_client.py` — OpenAI-compatible client; loopback `SdkCustomToolCallbackService` server; `loop` and `harness` tool modes
- `agent/cursor_bridge_wire.py` — minimal proto wire codec for binary callback payloads (no generated stubs)
- `agent/cursor_sdk_auth.py` — browser PKCE login, key minting via `DashboardService/CreateUserApiKey`, shared credential store at `~/.cursor/sdk/auth.json`
- `plugins/model-providers/cursor/` — provider profile (auto-wires registry, env vars, model picker, doctor)
- `hermes_cli/cursor_cloud.py`, `hermes_cli/subcommands/cursor_agent.py` — `hermes cursor login|logout|handoff|send|status|runs|pull|watch|list|open`
- `hermes_cli/commands.py`, `cli.py`, `hermes_cli/cli_commands_mixin.py`, `gateway/run.py`, `gateway/slash_commands.py` — `/cursor` slash command (CLI + gateway; via `/hermes cursor` on Slack to respect the 50-slash cap)
- `hermes_cli/model_setup_flows.py`, `hermes_cli/main.py`, `hermes_cli/models.py`, `hermes_cli/providers.py`, `hermes_cli/model_switch.py`, `hermes_cli/auth.py` — `hermes model` flow, picker entry (SDK-login aware), identity overlay, aliases, credential resolution
- `agent/agent_init.py`, `agent/agent_runtime_helpers.py`, `agent/conversation_loop.py`, `agent/auxiliary_client.py` — client routing on the `sdkbridge://cursor` marker, streaming/Responses-upgrade gates, auxiliary-task routing
- `hermes_cli/config_defaults.py`, `cli-config.yaml.example` — `cursor_bridge` config section
- `website/docs/integrations/providers.md`, `website/docs/reference/cli-commands.md` — docs
- `tests/agent/test_cursor_bridge_{wire,transport,client}.py`, `tests/agent/test_cursor_sdk_auth.py`, `tests/hermes_cli/test_cursor_provider.py` — tests

## How to Test

1. `hermes cursor login` — complete the browser login (the URL works from any device signed in to cursor.com), or put `CURSOR_API_KEY` in `~/.hermes/.env`.
2. `hermes model` → pick "Cursor" — accept the bridge install; the picker lists your account's model catalog.
3. `hermes chat --provider cursor --model composer-2.5` — ask something that forces a tool call (e.g. "use the terminal tool to check the OS version"): the tool executes through Hermes's own loop and the answer uses the result.
4. Optional cloud handoff: `hermes cursor handoff "summarize this repo" --repo <git-url>`, then take over the agent at cursor.com/agents.
5. Tests (no network or credentials needed — bridge and backend are stubbed): `scripts/run_tests.sh tests/agent/test_cursor_bridge_wire.py tests/agent/test_cursor_bridge_transport.py tests/agent/test_cursor_bridge_client.py tests/agent/test_cursor_sdk_auth.py tests/hermes_cli/test_cursor_provider.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (related but distinct: #68994, #73617 — noted above)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the tests and they pass (via `scripts/run_tests.sh`, the repo's CI-parity wrapper per `AGENTS.md`, rather than bare `pytest`)
- [x] I've added tests for my changes (adding or improving test coverage)
- [x] I've tested on my platform: Ubuntu 24.04 (also verified live against a real Cursor account: login, catalog, chat turn, full tool loop, plugin hooks)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/integrations/providers.md`, `website/docs/reference/cli-commands.md`)
- [x] I've updated `cli-config.yaml.example` (new `cursor_bridge` section)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture or workflow change)
- [x] I've considered cross-platform impact (Windows `.cmd` launcher + hidden-console spawn, per-OS bridge archive selection, no POSIX-only primitives in the new modules)
- [x] Tool descriptions/schemas — N/A (no model-tool behavior changed; zero new core tools)

## Screenshots / Logs

Real session on the `cursor` provider after `hermes cursor login` (no `CURSOR_API_KEY` set). Composer 2.5 drove Hermes's own `terminal` tool and answered from the actual output:

​```
$ hermes chat -q "Use the terminal tool to run: uname -sr && df -h / | tail -1.
  Report the OS and free disk in one sentence." --provider cursor -m composer-2.5

  ┊ 💻 $         uname -sr + 1 command
 ─  ⚕ Hermes  ─────────────────────────────────────────────
 The host runs Linux 6.12.94+ and the root filesystem has about 228G free.
 ──────────────────────────────────────────────────────────
Session: 20260807_193928 — Messages: 11 (1 user, 9 tool calls)
​```