### PR TITLE
fix(desktop): stop workspace edits from reloading external preview tabs

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
@@ -110,6 +110,50 @@ describe('PreviewPane console state', () => {
     forgetPreviewStripTools(tabId)
   })
 
+  it('does not workspace-reload an external browser page', async () => {
+    const target = {
+      kind: 'url' as const,
+      label: 'X',
+      source: 'https://x.com',
+      url: 'https://x.com'
+    }
+
+    const rendered = render(<PreviewPane reloadRequest={0} target={target} />)
+
+    const reloadIgnoringCache = vi.fn()
+
+    Object.defineProperty(rendered.container.querySelector('webview'), 'reloadIgnoringCache', {
+      configurable: true,
+      value: reloadIgnoringCache
+    })
+
+    await act(async () => rendered.rerender(<PreviewPane reloadRequest={1} target={target} />))
+
+    expect(reloadIgnoringCache).not.toHaveBeenCalled()
+  })
+
+  it('keeps workspace reload for a local development page', async () => {
+    const target = {
+      kind: 'url' as const,
+      label: 'Preview',
+      source: 'http://localhost:5174',
+      url: 'http://localhost:5174'
+    }
+
+    const rendered = render(<PreviewPane reloadRequest={0} target={target} />)
+
+    const reloadIgnoringCache = vi.fn()
+
+    Object.defineProperty(rendered.container.querySelector('webview'), 'reloadIgnoringCache', {
+      configurable: true,
+      value: reloadIgnoringCache
+    })
+
+    await act(async () => rendered.rerender(<PreviewPane reloadRequest={1} target={target} />))
+
+    expect(reloadIgnoringCache).toHaveBeenCalledOnce()
+  })
+
   it('renders authenticated remote HTML safely and honors source mode', async () => {
     const dataUrl = `data:text/html;base64,${btoa('<h1>remote</h1>')}`
 

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Tip } from '@/components/ui/tooltip'
 import { type Translations, useI18n } from '@/i18n'
 import { isDesktopFsRemoteMode } from '@/lib/desktop-fs'
-import { openPreviewTargetInBrowser, remoteHtmlPreviewDocument } from '@/lib/local-preview'
+import { isWorkspaceLiveReloadUrl, openPreviewTargetInBrowser, remoteHtmlPreviewDocument } from '@/lib/local-preview'
 import { rafCoalesce } from '@/lib/raf-coalesce'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
@@ -429,7 +429,7 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
 
     lastReloadRequestRef.current = reloadRequest
 
-    if (target.kind !== 'url') {
+    if (target.kind !== 'url' || !isWorkspaceLiveReloadUrl(currentUrl)) {
       return
     }
 
@@ -438,7 +438,7 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
       message: copy.workspaceReloading
     })
     reloadPreview()
-  }, [appendConsoleEntry, copy.workspaceReloading, reloadPreview, reloadRequest, target.kind])
+  }, [appendConsoleEntry, copy.workspaceReloading, currentUrl, reloadPreview, reloadRequest, target.kind])
 
   useEffect(() => {
     if (

--- a/apps/desktop/src/lib/local-preview.test.ts
+++ b/apps/desktop/src/lib/local-preview.test.ts
@@ -9,12 +9,32 @@ vi.mock('@/lib/desktop-fs', () => ({
 }))
 
 import {
+  isWorkspaceLiveReloadUrl,
   localPreviewTarget,
   normalizeOrLocalPreviewTarget,
   openPreviewTargetInBrowser,
   remoteHtmlPreviewDocument,
   validatedRemoteHtmlDataUrl
 } from './local-preview'
+
+describe('workspace live reload URLs', () => {
+  it.each([
+    'http://localhost:5173',
+    'https://127.0.0.1:8443/app',
+    'http://0.0.0.0:3000',
+    'http://[::1]:4173',
+    'http://demo.local:8080'
+  ])('accepts local development origin %s', url => {
+    expect(isWorkspaceLiveReloadUrl(url)).toBe(true)
+  })
+
+  it.each(['https://x.com', 'https://localhost.example.com', 'https://demo.local.example.com', 'not a URL'])(
+    'rejects external or malformed origin %s',
+    url => {
+      expect(isWorkspaceLiveReloadUrl(url)).toBe(false)
+    }
+  )
+})
 
 const remoteTarget = {
   kind: 'file' as const,

--- a/apps/desktop/src/lib/local-preview.ts
+++ b/apps/desktop/src/lib/local-preview.ts
@@ -9,6 +9,7 @@ const PDF_EXTENSIONS = new Set(['.pdf'])
 // Mirrors `_FS_DATA_URL_MAX_BYTES` in the backend filesystem endpoint.
 const REMOTE_HTML_PREVIEW_MAX_BYTES = 16 * 1024 * 1024
 const REMOTE_HTML_PREVIEW_MAX_BASE64_BYTES = Math.ceil(REMOTE_HTML_PREVIEW_MAX_BYTES / 3) * 4
+const WORKSPACE_RELOAD_HOSTS = new Set(['localhost', '127.0.0.1', '0.0.0.0', '::1'])
 
 const LANGUAGE_BY_EXT: Record<string, string> = {
   '.c': 'c',
@@ -78,6 +79,22 @@ function pathToFileUrl(path: string) {
   }
 
   return `file://${encoded.startsWith('/') ? encoded : `/${encoded}`}`
+}
+
+export function isWorkspaceLiveReloadUrl(value: string): boolean {
+  try {
+    const url = new URL(value)
+
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return false
+    }
+
+    const hostname = url.hostname.toLowerCase().replace(/^\[|\]$/g, '').replace(/\.$/, '')
+
+    return WORKSPACE_RELOAD_HOSTS.has(hostname) || hostname.endsWith('.local')
+  } catch {
+    return false
+  }
 }
 
 export function validatedRemoteHtmlDataUrl(value: string): string | null {


### PR DESCRIPTION
## What does this PR do?

Workspace file edits no longer reload unrelated external pages in the Desktop preview pane. This preserves scroll position, feed state, and in-progress reading on general web tabs while retaining automatic reloads for local development previews.

### Symptom

Completing any workspace file edit increments the shared preview reload request. A URL preview such as `https://x.com` consumed that request unconditionally and reloaded even though the page was unrelated to the changed file.

### Impact

Desktop users browsing an external site in the preview pane can lose transient page state, including their scroll position and current feed state, whenever an agent edits a workspace file.

### Bug Cause

**Trigger:** `apps/desktop/src/app/chat/right-rail/preview-pane.tsx` workspace reload effect

**Causal chain:**
1. A completed file diff increments the shared workspace reload request.
2. Every URL-kind preview consumes the new request without checking the current webview origin.
3. The active external page reloads and loses transient browsing state.

**Why it is wrong:** The reload consumer classified only the preview target kind, conflating local development servers with general-purpose web tabs.

**Working sibling / contrast:** File previews use a file watcher scoped by watch id, and explicit preview-server restarts match the restarted server URL before reloading.

**Ruled out:** The explicit preview-server restart path is not responsible because its reload is gated by a match between the restart URL and the current URL.

### Fix

Classify workspace-live-reload URLs by their current webview hostname. Loopback hosts and `.local` development hosts continue to reload, while external, malformed, deceptive, and non-HTTP(S) URLs ignore workspace reload requests. The consumer checks the current URL so a local tab that navigates to an external page is also protected.

## Related Issue

Fixes #81487

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/lib/local-preview.ts` - add the local development URL classifier.
- `apps/desktop/src/lib/local-preview.test.ts` - cover loopback, `.local`, malformed, deceptive, and external URL cases.
- `apps/desktop/src/app/chat/right-rail/preview-pane.tsx` - gate workspace-triggered reloads on the current webview URL.
- `apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx` - verify external tabs stay untouched while local previews still reload.

## How to Test

1. Run the focused Desktop preview tests:

```bash
npx vitest run src/lib/local-preview.test.ts src/app/chat/right-rail/preview-pane.test.tsx
```

2. Run Desktop static checks:

```bash
npm run typecheck --if-present
npx eslint src/lib/local-preview.ts src/lib/local-preview.test.ts src/app/chat/right-rail/preview-pane.tsx src/app/chat/right-rail/preview-pane.test.tsx
```

3. Confirm all 37 focused tests and both static checks pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant Desktop test entry and all focused tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - N/A, renderer-only URL classification
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A
