### PR TITLE
fix(compression): stop Kimi histories from triggering premature compression

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -809,19 +809,24 @@ def _serialized_length_for_budget(value: Any) -> int:
         return len(str(value))
 
 
-# Provider replay/metadata fields that ride the wire on every request but are
-# invisible to ``msg["content"]``/``msg["tool_calls"]`` accounting.  Codex
-# Responses sessions in particular carry ``codex_reasoning_items`` blobs of
-# ``encrypted_content`` that can dominate the serialized session (a measured
-# 214-turn session held ~115K tokens / 27% of its payload there — #55572).
+# Provider replay/metadata fields invisible to
+# ``msg["content"]``/``msg["tool_calls"]`` accounting. ``reasoning`` and
+# ``reasoning_content`` are aliases: chat-completions replay removes the
+# internal ``reasoning`` key and sends at most one ``reasoning_content`` value.
+# Count the larger persisted alias once so provider-specific echo-back remains
+# conservatively covered without double-charging duplicate history rows.
+_REASONING_REPLAY_KEYS = ("reasoning", "reasoning_content")
+
+# Codex Responses sessions carry these blobs on every request. In particular,
+# ``codex_reasoning_items`` encrypted content can dominate the serialized
+# session (a measured 214-turn session held ~115K tokens / 27% of its payload
+# there — #55572).
 #
 # ``reasoning_details`` is handled separately (see
 # ``_reasoning_details_text_chars``): its signed/base64 envelope is excluded
 # from the budget, mirroring the preflight estimator's exclusion in
 # ``model_metadata._estimate_message_tokens_without_images`` (#73298).
 _REPLAY_BUDGET_KEYS = (
-    "reasoning",
-    "reasoning_content",
     "codex_reasoning_items",
     "codex_message_items",
 )
@@ -889,6 +894,10 @@ def _estimate_msg_budget_tokens(msg: dict) -> int:
     for tc in msg.get("tool_calls") or []:
         if isinstance(tc, dict):
             tokens += estimate_tokens_rough(str(tc))
+    tokens += max(
+        _serialized_length_for_budget(msg.get(key))
+        for key in _REASONING_REPLAY_KEYS
+    ) // _CHARS_PER_TOKEN
     for key in _REPLAY_BUDGET_KEYS:
         tokens += _serialized_length_for_budget(msg.get(key)) // _CHARS_PER_TOKEN
     # reasoning_details: charge only the thinking TEXT, never the signed /

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -3216,9 +3216,24 @@ def _wire_message_shadow(msg: Dict[str, Any]) -> Dict[str, Any]:
         and bool(sidecar)
         and msg.get("role") in ("user", "assistant")
     )
+    reasoning_aliases = ("reasoning", "reasoning_content")
+    has_both_reasoning_aliases = all(key in msg for key in reasoning_aliases)
+    reasoning_replay = None
+    if has_both_reasoning_aliases:
+        # ``reasoning`` is an internal normalized alias. Chat-completions
+        # replay always removes it after optionally copying one value to
+        # ``reasoning_content``. Keep the larger alias as a conservative
+        # provider-agnostic estimate, but never charge both persisted copies.
+        reasoning_replay = max(
+            (msg[key] for key in reasoning_aliases),
+            key=lambda value: len(str(value)),
+        )
+
     shadow: Dict[str, Any] = {}
     for k, v in msg.items():
         if k in ("_anthropic_content_blocks", "reasoning_details"):
+            continue
+        if has_both_reasoning_aliases and k in reasoning_aliases:
             continue
         if k == "api_content":
             # Always popped before the request is built; only counted when it
@@ -3248,6 +3263,8 @@ def _wire_message_shadow(msg: Dict[str, Any]) -> Dict[str, Any]:
                 shadow[k] = v
         else:
             shadow[k] = v
+    if has_both_reasoning_aliases:
+        shadow["reasoning_content"] = reasoning_replay
     return shadow
 
 

--- a/tests/agent/test_budget_reasoning_details_exclusion.py
+++ b/tests/agent/test_budget_reasoning_details_exclusion.py
@@ -23,6 +23,17 @@ def _signed_thinking_block(thinking_chars: int, sig_chars: int) -> dict:
 
 
 class TestBudgetExcludesReasoningDetailsEnvelope:
+    def test_reasoning_aliases_charge_the_larger_value_once(self):
+        """reasoning is internal; chat completions replays at most one alias."""
+        short = "s" * 4_000
+        long = "l" * 12_000
+        base = {"role": "assistant", "content": "hi"}
+        both = dict(base, reasoning=short, reasoning_content=long)
+        longer_only = dict(base, reasoning_content=long)
+
+        assert _estimate_msg_budget_tokens(both) == \
+            _estimate_msg_budget_tokens(longer_only)
+
     def test_signature_blob_not_charged(self):
         base = {"role": "assistant", "content": "hello there"}
         with_envelope = dict(

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -93,6 +93,19 @@ class TestEstimateMessagesTokensRough:
         assert estimate_messages_tokens_rough([persisted_shape]) == \
             estimate_messages_tokens_rough([wire_shape])
 
+    def test_duplicate_reasoning_aliases_are_charged_once(self):
+        """Only one reasoning alias can survive chat-completions replay."""
+        prose = "reasoning token pressure " * 2_000
+        wire_shape = {
+            "role": "assistant",
+            "content": "done",
+            "reasoning_content": prose,
+        }
+        persisted_shape = dict(wire_shape, reasoning=prose)
+
+        assert estimate_messages_tokens_rough([persisted_shape]) == \
+            estimate_messages_tokens_rough([wire_shape])
+
     def test_api_content_is_counted_when_it_differs_from_content(self):
         """The sidecar is what's sent, so its size is the one that matters."""
         big_sidecar = "cached prompt bytes " * 2000

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5967,6 +5967,40 @@ class TestReasoningReplayForStrictProviders:
         sent_messages = agent.client.chat.completions.create.call_args.kwargs["messages"]
         replayed_assistant = next(msg for msg in sent_messages if msg.get("role") == "assistant")
         assert replayed_assistant["reasoning_content"] == "provider-native scratchpad"
+        assert "reasoning" not in replayed_assistant
+
+    def test_duplicate_reasoning_aliases_replay_once_on_kimi_chat_completions(self, agent):
+        self._setup_agent(agent)
+        agent.base_url = "https://api.kimi.com/coding/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.provider = "kimi-coding"
+        prose = "same provider reasoning"
+        prior_assistant = {
+            "role": "assistant",
+            "content": "answer",
+            "reasoning": prose,
+            "reasoning_content": prose,
+        }
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="done", finish_reason="stop"
+        )
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation(
+                "next step", conversation_history=[prior_assistant]
+            )
+
+        assert result["completed"] is True
+        sent_messages = agent.client.chat.completions.create.call_args.kwargs["messages"]
+        replayed_assistant = next(
+            msg for msg in sent_messages if msg.get("role") == "assistant"
+        )
+        assert replayed_assistant["reasoning_content"] == prose
+        assert "reasoning" not in replayed_assistant
 
 
 


### PR DESCRIPTION
## What does this PR do?

Kimi chat-completions histories can store the same reasoning text under both `reasoning` and `reasoning_content`. Compression estimates charged both aliases even though the outbound request replays at most one, inflating prompt estimates and triggering compression substantially earlier than the provider's actual token usage requires.

This change charges the larger reasoning alias once in both the preflight and tail-budget estimators. It preserves conservative accounting when the aliases differ, keeps Codex replay and `reasoning_details` accounting unchanged, and verifies that Kimi sends only `reasoning_content`.

## Related Issue

Fixes #81481

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/model_metadata.py` - deduplicate persisted reasoning aliases in the preflight wire-shadow estimate while retaining the larger value.
- `agent/context_compressor.py` - apply the same single-charge invariant to tail-budget estimation without changing other replay carriers.
- `tests/agent/test_model_metadata.py` - cover duplicate-alias preflight accounting.
- `tests/agent/test_budget_reasoning_details_exclusion.py` - cover tail-budget accounting when aliases differ.
- `tests/run_agent/test_run_agent.py` - verify Kimi chat-completions replays one reasoning alias on the actual request path.

## How to Test

1. Build a persisted assistant message containing duplicate `reasoning` and `reasoning_content` values.
2. Confirm both estimators match the equivalent message containing only the wire-visible alias.
3. Run the focused regression suites:

```bash
scripts/run_tests.sh tests/agent/test_budget_reasoning_details_exclusion.py tests/agent/test_model_metadata.py tests/run_agent/test_run_agent.py
scripts/run_tests.sh tests/agent/test_context_compressor.py -k TailBudgetCodexReplayFields
```

The commands pass 321 tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant suites and all 321 tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A - internal token-estimation behavior only
- [x] `cli-config.yaml.example` update: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow change
- [x] Cross-platform impact considered: the estimator uses platform-independent message dictionaries
- [x] Tool descriptions/schemas update: N/A - no tool behavior changed
