### PR TITLE
fix(gateway): queue secondary-profile reconnect before disconnect await (#81335)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13771,9 +13771,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             return
         profile_map.pop(platform, None)
-        await self._safe_adapter_disconnect(adapter, platform)
         if not self._running:
             return
+        # #81335: queue the reconnect BEFORE the disconnect await, mirroring the
+        # primary-adapter fix (#80598). A wedged/slow disconnect() must not delay
+        # (or, on cancellation, lose) the reconnect scheduling for this profile.
         self._schedule_secondary_profile_reconnect(profile_name, platform, adapter)
         logger.error(
             "Fatal %s adapter error for multiplexed profile %s (%s)",
@@ -13783,6 +13785,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
         # Reconnect is scoped to the profile's own config and secret mapping;
         # never rebuild a secondary adapter with the default profile's credentials.
+        await self._safe_adapter_disconnect(adapter, platform)
 
     def _make_profile_message_handler(self, profile_name: str):
         """Return a message handler that stamps source.profile then delegates.

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4369,6 +4369,19 @@ class TelegramAdapter(BasePlatformAdapter):
         # Recovery can be suspended in stop/drain/start while disconnect begins.
         # Cancel and await both polling lifecycle owners immediately after the
         # fence, before any other teardown await lets them start a new generation.
+        #
+        # NOTE (#81335): the `task is current_task` check below does NOT protect
+        # against the fatal-error self-cancellation race. The gateway invokes
+        # disconnect() through `_safe_adapter_disconnect`, which wraps this
+        # coroutine in its own `asyncio.ensure_future` task
+        # (gateway/run.py:_await_adapter_cleanup_with_timeout) — so
+        # `current_task()` here is always that wrapper, never the real carrier
+        # (`_polling_error_task`) that transitively awaited its way down into
+        # this call. `_polling_error_task` still gets cancelled below, killing
+        # the fatal-error handler chain if it's awaiting this call. That race
+        # is guarded at the base-class level instead (see
+        # `BasePlatformAdapter._notify_fatal_error`'s shielded detached-task
+        # handler, PR #81337) — do not assume this guard already covers it.
         current_task = asyncio.current_task()
         lifecycle_tasks: list[asyncio.Task] = []
         lifecycle_seen: set[int] = set()

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -237,6 +237,61 @@ class TestSecondaryProfileFatalRecovery:
         assert replacement.disconnected is True
         assert runner._profile_failed_platforms == {}
 
+    @pytest.mark.asyncio
+    async def test_secondary_fatal_queues_reconnect_before_disconnect_returns(
+        self, monkeypatch
+    ):
+        """#81335: a wedged secondary disconnect() must not delay reconnect
+        scheduling — mirrors the primary-adapter fix from #80598."""
+        runner = _secondary_recovery_runner()
+        stale = _SecondaryRecoveryAdapter()
+        replacement = _SecondaryRecoveryAdapter()
+        runner._profile_adapters["reviewer"] = {Platform.DISCORD: stale}
+        _install_secondary_reconnect_context(monkeypatch, runner, replacement)
+
+        connect_started = asyncio.Event()
+        release_connect = asyncio.Event()
+
+        async def connect(adapter, platform, *, is_reconnect=False):
+            # Keep the reconnect task alive so it can't pop the queued entry
+            # before we assert on it below.
+            connect_started.set()
+            await release_connect.wait()
+            replacement.connected = True
+            return True
+
+        monkeypatch.setattr(runner, "_connect_adapter_with_timeout", connect)
+
+        disconnect_entered = asyncio.Event()
+        release_disconnect = asyncio.Event()
+
+        async def blocking_disconnect():
+            # Disconnect has started — the reconnect must already be queued.
+            assert Platform.DISCORD in runner._profile_failed_platforms.get(
+                "reviewer", {}
+            )
+            disconnect_entered.set()
+            await release_disconnect.wait()
+            stale.disconnected = True
+
+        monkeypatch.setattr(stale, "disconnect", blocking_disconnect)
+        operation = asyncio.create_task(
+            runner._handle_profile_adapter_fatal_error(
+                "reviewer", Platform.DISCORD, stale
+            )
+        )
+        await asyncio.wait_for(disconnect_entered.wait(), timeout=0.5)
+        try:
+            assert Platform.DISCORD in runner._profile_failed_platforms["reviewer"]
+            assert Platform.DISCORD not in runner._profile_adapters["reviewer"]
+        finally:
+            release_disconnect.set()
+            await asyncio.wait_for(operation, timeout=0.5)
+            await asyncio.wait_for(connect_started.wait(), timeout=0.5)
+            release_connect.set()
+            for task in list(runner._background_tasks):
+                await asyncio.wait_for(task, timeout=0.5)
+
 
 class TestSecondaryProfileConfigHandling:
     """Secondary config errors degrade only when the profile is safe to skip."""


### PR DESCRIPTION
## Summary

Fixes a sibling instance of the ordering bug described in **#81335** ("Telegram adapter zombie: fatal-error handler cancels itself via `disconnect()`, platform never queued for reconnection"), but in the **secondary/multiplex-profile** fatal-error path (`GatewayRunner._handle_profile_adapter_fatal_error`) rather than the primary-adapter path.

The primary-adapter path was already hardened for this exact class of bug in **#80598**: queue the reconnect *before* awaiting `disconnect()`, so a wedged/slow/cancelled disconnect can never strand the platform. The secondary/profile path never received that same fix — it still disconnected first and scheduled the reconnect only afterward.

- No handler for `disconnect()` finishing (or being cancelled) — the reconnect scheduling code sat *after* the `await`.
- On a half-dead transport, `disconnect()` can wedge for the full adapter-disconnect timeout, or be cancelled outright, silently losing the reconnect scheduling for that profile+platform.
- Net effect: a multiplexed secondary platform (e.g. a secondary Discord/Telegram bot under a non-default profile) can go permanently deaf after a fatal error, even after the underlying network issue clears — because nothing ever queued it for reconnection.

## Fix

Reorder `_handle_profile_adapter_fatal_error` (`gateway/run.py`) to call `_schedule_secondary_profile_reconnect(...)` **before** `await self._safe_adapter_disconnect(...)`. Disconnect is now best-effort teardown that happens *after* the platform is already queued for recovery — mirroring the primary-path fix from #80598.

## Relation to PR #81337 (no duplication)

I compared this against the currently open **#81337** (`fix/notify-fatal-error-cancellation-race`), which wraps `BasePlatformAdapter._notify_fatal_error` (`gateway/platforms/base.py`) in a detached task + `asyncio.shield`, protecting **every** fatal-error handler (primary, secondary/profile, relay) from being cancelled by its own carrier task generically at the base-class level.

This PR is complementary, not overlapping:
- **Different file** (`gateway/run.py` here vs `gateway/platforms/base.py` there) — no merge conflict.
- **Different failure mode addressed.** #81337 protects the handler *task* from carrier-cancellation. This PR fixes an *ordering* bug inside the handler itself: even with the handler fully shielded from cancellation, if it still disconnects before scheduling, a merely slow/wedged (non-cancelled) `disconnect()` still delays reconnection unnecessarily — the same latency gap #80598 already closed for the primary path.

## Additional finding: a dead self-cancel guard in Telegram `disconnect()`

While comparing the two fixes I traced *why* the fatal-error carrier task gets cancelled at all, given `plugins/platforms/telegram/adapter.py` already has a guard that looks like it should prevent exactly this:

```python
current_task = asyncio.current_task()
for task in (self._polling_error_task, self._polling_progress_verifier_task):
    if not task or task.done() or task is current_task:
        continue   # <- looks like self-cancel protection
    task.cancel()
```

This guard is **dead in the exact call path #81335 describes**. `_safe_adapter_disconnect` (`gateway/run.py`) never calls `adapter.disconnect()` directly — it routes through `_await_adapter_cleanup_with_timeout`, which wraps the coroutine in its own `asyncio.ensure_future` task:

```python
task = asyncio.ensure_future(awaitable)   # gateway/run.py:_await_adapter_cleanup_with_timeout
...
await asyncio.wait({task}, timeout=timeout)
```

So `asyncio.current_task()` inside `disconnect()` is always that anonymous wrapper task — **never** `_polling_error_task`, even when `_polling_error_task` is the real carrier transitively awaiting its way down into this call (`_polling_error_task` → `_notify_fatal_error` → fatal handler → `_safe_adapter_disconnect` → wrapper task → `disconnect()`). The `is current_task` check therefore never matches, and `_polling_error_task` gets cancelled anyway — which is the actual mechanism #81337 fixes with the shield.

This isn't a functional bug in itself (the shield in #81337 covers the real race regardless), but the guard gives a false sense of existing protection. Left a documentation-only comment at that guard (`plugins/platforms/telegram/adapter.py`) pointing future readers at #81337's shield as the real fix, so nobody assumes this guard already handles the race and, e.g., removes the shield later as "redundant."

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[⚡ _polling_error_task detects fatal error] --> B[🔒 await _notify_fatal_error]
    B --> C[⚡ await fatal handler]
    C --> D[🔒 await _safe_adapter_disconnect]
    D --> E[⚡ asyncio.ensure_future wraps disconnect in NEW wrapper task]
    E --> F[🚀 current_task inside disconnect == wrapper task]
    F --> G{is current_task check vs _polling_error_task}
    G -->|Never matches, wrong task compared| H[💀 _polling_error_task.cancel called anyway]
    H --> I[🔒 CancelledError propagates up into fatal handler]
    I -->|Fixed by shield| J[✅ PR #81337: asyncio.shield keeps handler alive]
```

## Test plan

- [x] New regression test: `test_secondary_fatal_queues_reconnect_before_disconnect_returns` (`tests/gateway/test_multiplex_adapter_registry.py`) — blocks `disconnect()` and asserts the reconnect is already queued before it returns.
- [x] Verified the new test fails against the pre-fix code (reverted `gateway/run.py` locally, confirmed the assertion inside `disconnect()` fails) and passes with the fix.
- [x] Full suite: `pytest tests/gateway/test_multiplex_adapter_registry.py tests/gateway/test_runner_fatal_adapter.py` — 19 passed.
- [x] Comment-only change to `plugins/platforms/telegram/adapter.py` verified with `ast.parse` (no behavior change).


