### PR TITLE
Inspired by Cursor: `hermes inbox` — unified view of everything in flight

### DIFF
--- a/hermes_cli/inbox.py
+++ b/hermes_cli/inbox.py
@@ -41,15 +41,10 @@ def _pid_alive(pid: Any) -> bool:
     if pid <= 0:
         return False
     try:
-        import os
+        import psutil
 
-        os.kill(pid, 0)
-        return True
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
-    except OSError:
+        return psutil.pid_exists(pid)
+    except Exception:
         return False
 
 

--- a/hermes_cli/inbox.py
+++ b/hermes_cli/inbox.py
@@ -1,0 +1,400 @@
+"""``hermes inbox`` — one view of everything in flight and needing attention.
+
+Inspired by Cursor's Inbox (changelog Jul 29 2026): a single surface showing
+"what's in progress, what needs your attention, and what finished" across
+their agents. Hermes already tracks all of that state, but scattered across
+four stores with no unified read surface:
+
+- background processes  → ``~/.hermes/processes.json`` (ProcessRegistry
+  checkpoint; PIDs re-validated here the same way recovery does)
+- async delegations     → ``state.db``'s ``async_delegations`` table
+  (running / stalled / undelivered / dropped results)
+- cron jobs             → ``cron/jobs.json`` (failures, pauses, next runs)
+- open chat surfaces    → ``runtime/active_sessions.json`` leases
+
+This module aggregates them read-only. It never mutates any store, never
+imports the agent core, and works whether or not a gateway is running.
+
+Layout follows the footprint ladder: a CLI command, not a model tool — the
+agent can run ``hermes inbox --json`` through its terminal when asked.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from hermes_constants import get_hermes_home
+
+# ---------------------------------------------------------------------------
+# Collectors — each returns a list of plain dicts and NEVER raises.
+# ---------------------------------------------------------------------------
+
+
+def _pid_alive(pid: Any) -> bool:
+    try:
+        pid = int(pid)
+    except (TypeError, ValueError):
+        return False
+    if pid <= 0:
+        return False
+    try:
+        import os
+
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+
+
+def collect_processes(home: Optional[Path] = None) -> List[Dict[str, Any]]:
+    """Background processes from the ProcessRegistry checkpoint.
+
+    The checkpoint only holds not-yet-exited sessions at write time, but the
+    owning process may have died since (or the child may have exited without
+    a checkpoint rewrite), so each host PID is re-validated.
+    """
+    home = home or get_hermes_home()
+    path = home / "processes.json"
+    out: List[Dict[str, Any]] = []
+    try:
+        entries = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return out
+    if not isinstance(entries, list):
+        return out
+    now = time.time()
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        pid = entry.get("pid")
+        scope = entry.get("pid_scope", "host")
+        alive = _pid_alive(pid) if scope == "host" else None  # None = unknown
+        started = entry.get("started_at")
+        age = None
+        if isinstance(started, (int, float)):
+            age = max(0.0, now - float(started))
+        out.append(
+            {
+                "kind": "process",
+                "id": entry.get("session_id", "?"),
+                "command": str(entry.get("command", ""))[:120],
+                "pid": pid,
+                "alive": alive,
+                "age_seconds": age,
+                "notify_on_complete": bool(entry.get("notify_on_complete")),
+                "cwd": entry.get("cwd"),
+            }
+        )
+    return out
+
+
+def collect_delegations(
+    home: Optional[Path] = None, limit: int = 20
+) -> List[Dict[str, Any]]:
+    """Async delegations from state.db — running, plus recent non-delivered.
+
+    Reads sqlite directly (read-only URI) so a missing table or a locked
+    database degrades to an empty section instead of an error.
+    """
+    home = home or get_hermes_home()
+    db = home / "state.db"
+    out: List[Dict[str, Any]] = []
+    if not db.exists():
+        return out
+    import sqlite3
+
+    # Terminal 'dropped' results older than this are historical noise, not
+    # actionable — hide them from the inbox (they remain queryable in the DB).
+    dropped_cutoff = time.time() - 7 * 86400
+
+    try:
+        conn = sqlite3.connect(f"file:{db}?mode=ro", uri=True, timeout=5)
+    except sqlite3.Error:
+        return out
+    try:
+        rows = conn.execute(
+            """SELECT delegation_id, state, dispatched_at, completed_at,
+                      delivery_state, delivery_attempts, task_json
+               FROM async_delegations
+               WHERE state IN ('running', 'finalizing', 'stalling')
+                  OR delivery_state = 'pending'
+                  OR (delivery_state = 'dropped'
+                      AND COALESCE(completed_at, dispatched_at) >= ?)
+               ORDER BY CASE WHEN state IN ('running','finalizing','stalling')
+                             THEN 0 ELSE 1 END,
+                        COALESCE(completed_at, dispatched_at) DESC
+               LIMIT ?""",
+            (dropped_cutoff, limit),
+        ).fetchall()
+    except sqlite3.Error:
+        return out
+    finally:
+        conn.close()
+    for (
+        delegation_id,
+        state,
+        dispatched_at,
+        completed_at,
+        delivery_state,
+        delivery_attempts,
+        task_json,
+    ) in rows:
+        goal = ""
+        try:
+            task = json.loads(task_json or "{}")
+            goal = str(task.get("goal") or "")[:100]
+        except ValueError:
+            pass
+        out.append(
+            {
+                "kind": "delegation",
+                "id": delegation_id,
+                "state": state,
+                "goal": goal,
+                "dispatched_at": dispatched_at,
+                "completed_at": completed_at,
+                "delivery_state": delivery_state,
+                "delivery_attempts": delivery_attempts,
+            }
+        )
+    return out
+
+
+def collect_cron(home: Optional[Path] = None) -> List[Dict[str, Any]]:
+    """Cron jobs needing attention (failed / paused) + the next few due."""
+    out: List[Dict[str, Any]] = []
+    try:
+        from cron.jobs import load_jobs
+
+        jobs = load_jobs()
+    except Exception:
+        return out
+    for job in jobs:
+        if not isinstance(job, dict):
+            continue
+        needs_attention = bool(job.get("last_error")) or (
+            job.get("last_status") not in (None, "", "success", "ok")
+        )
+        paused = job.get("state") == "paused" or not job.get("enabled", True)
+        out.append(
+            {
+                "kind": "cron",
+                "id": job.get("id", "?"),
+                "name": job.get("name", "?"),
+                "enabled": bool(job.get("enabled", True)),
+                "paused": paused,
+                "paused_reason": job.get("paused_reason"),
+                "last_status": job.get("last_status"),
+                "last_error": (str(job.get("last_error"))[:160]
+                               if job.get("last_error") else None),
+                "last_run_at": job.get("last_run_at"),
+                "next_run_at": job.get("next_run_at"),
+                "needs_attention": needs_attention,
+            }
+        )
+    return out
+
+
+def collect_active_sessions(home: Optional[Path] = None) -> List[Dict[str, Any]]:
+    """Open chat surfaces from the active-session lease file."""
+    home = home or get_hermes_home()
+    path = home / "runtime" / "active_sessions.json"
+    out: List[Dict[str, Any]] = []
+    try:
+        entries = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return out
+    if not isinstance(entries, list):
+        return out
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        if not _pid_alive(entry.get("pid")):
+            continue
+        out.append(
+            {
+                "kind": "session",
+                "surface": entry.get("surface") or entry.get("source") or "?",
+                "pid": entry.get("pid"),
+                "started_at": entry.get("started_at") or entry.get("acquired_at"),
+                "label": entry.get("label") or entry.get("session_id") or "",
+            }
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Assembly + rendering
+# ---------------------------------------------------------------------------
+
+
+def build_inbox(home: Optional[Path] = None) -> Dict[str, Any]:
+    """Assemble the full inbox snapshot as JSON-serializable data."""
+    home = home or get_hermes_home()
+    processes = collect_processes(home)
+    delegations = collect_delegations(home)
+    cron_jobs = collect_cron(home)
+    sessions = collect_active_sessions(home)
+
+    attention: List[Dict[str, Any]] = []
+    for d in delegations:
+        if d["state"] in ("stalling", "stalled", "unknown") or d[
+            "delivery_state"
+        ] == "dropped":
+            attention.append(d)
+    for j in cron_jobs:
+        if j["needs_attention"] or (j["paused"] and j.get("paused_reason")):
+            attention.append(j)
+    for p in processes:
+        # Checkpointed as running but the PID is gone and nobody rewrote the
+        # checkpoint — likely an orphaned entry from a crashed owner.
+        if p["alive"] is False:
+            attention.append(p)
+
+    in_progress: List[Dict[str, Any]] = []
+    in_progress.extend(p for p in processes if p["alive"] is not False)
+    in_progress.extend(
+        d for d in delegations if d["state"] in ("running", "finalizing")
+    )
+
+    finished: List[Dict[str, Any]] = [
+        d
+        for d in delegations
+        if d["state"] not in ("running", "finalizing", "stalling")
+        and d["delivery_state"] == "pending"
+    ]
+
+    return {
+        "generated_at": time.time(),
+        "attention": attention,
+        "in_progress": in_progress,
+        "finished_undelivered": finished,
+        "cron": cron_jobs,
+        "sessions": sessions,
+    }
+
+
+def _fmt_age(seconds: Optional[float]) -> str:
+    if not isinstance(seconds, (int, float)):
+        return "?"
+    s = int(max(0, seconds))
+    if s < 60:
+        return f"{s}s"
+    m, s = divmod(s, 60)
+    if m < 60:
+        return f"{m}m"
+    h, m = divmod(m, 60)
+    if h < 24:
+        return f"{h}h{m:02d}m"
+    d, h = divmod(h, 24)
+    return f"{d}d{h}h"
+
+
+def _describe(item: Dict[str, Any], now: float) -> str:
+    kind = item.get("kind")
+    if kind == "process":
+        age = _fmt_age(item.get("age_seconds"))
+        state = (
+            "running" if item.get("alive")
+            else "GONE (stale checkpoint)" if item.get("alive") is False
+            else "sandbox"
+        )
+        return f"process {item['id']}  [{state}, {age}]  {item['command']}"
+    if kind == "delegation":
+        when = item.get("completed_at") or item.get("dispatched_at")
+        age = _fmt_age(now - when) if isinstance(when, (int, float)) else "?"
+        bits = f"delegation {item['id']}  [{item['state']}, {age} ago]"
+        if item.get("delivery_state") == "dropped":
+            bits += "  (result DROPPED after failed deliveries)"
+        elif item.get("delivery_state") == "pending" and item["state"] not in (
+            "running",
+            "finalizing",
+        ):
+            bits += "  (result awaiting delivery)"
+        if item.get("goal"):
+            bits += f"  {item['goal']}"
+        return bits
+    if kind == "cron":
+        line = f"cron '{item['name']}'"
+        if item.get("last_error"):
+            line += f"  last run FAILED: {item['last_error']}"
+        elif item.get("paused"):
+            line += f"  paused ({item.get('paused_reason') or 'manually'})"
+        elif item.get("last_status") not in (None, "", "success", "ok"):
+            line += f"  last status: {item['last_status']}"
+        return line
+    if kind == "session":
+        return (
+            f"session [{item.get('surface')}] pid={item.get('pid')}"
+            f"  {item.get('label') or ''}".rstrip()
+        )
+    return json.dumps(item)
+
+
+def render_inbox(data: Dict[str, Any]) -> str:
+    """Human-readable inbox text."""
+    now = data.get("generated_at") or time.time()
+    lines: List[str] = [""]
+
+    attention = data.get("attention") or []
+    lines.append(f"  ◆ Needs attention ({len(attention)})")
+    if attention:
+        for item in attention:
+            lines.append(f"    ⚠ {_describe(item, now)}")
+    else:
+        lines.append("    nothing — all clear")
+    lines.append("")
+
+    in_progress = data.get("in_progress") or []
+    lines.append(f"  ◆ In progress ({len(in_progress)})")
+    if in_progress:
+        for item in in_progress:
+            lines.append(f"    ◐ {_describe(item, now)}")
+    else:
+        lines.append("    nothing running in the background")
+    lines.append("")
+
+    finished = data.get("finished_undelivered") or []
+    if finished:
+        lines.append(f"  ◆ Finished, result not yet delivered ({len(finished)})")
+        for item in finished:
+            lines.append(f"    ✔ {_describe(item, now)}")
+        lines.append("")
+
+    cron_jobs = data.get("cron") or []
+    active = [j for j in cron_jobs if j.get("enabled") and not j.get("paused")]
+    if active:
+        upcoming = sorted(
+            (j for j in active if j.get("next_run_at")),
+            key=lambda j: str(j.get("next_run_at")),
+        )[:5]
+        lines.append(f"  ◆ Scheduled ({len(active)} active job(s))")
+        for j in upcoming:
+            lines.append(f"    ⏱ {j['name']}  next: {j['next_run_at']}")
+        lines.append("")
+
+    sessions = data.get("sessions") or []
+    if sessions:
+        lines.append(f"  ◆ Open surfaces ({len(sessions)})")
+        for s in sessions:
+            lines.append(f"    ◎ {_describe(s, now)}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def cmd_inbox(args) -> int:
+    """Entry point for ``hermes inbox``."""
+    data = build_inbox()
+    if getattr(args, "json", False):
+        print(json.dumps(data, indent=2, default=str))
+        return 0
+    print(render_inbox(data))
+    return 0

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -477,6 +477,7 @@ from hermes_cli.subcommands.memory import build_memory_parser
 from hermes_cli.subcommands.acp import build_acp_parser
 from hermes_cli.subcommands.tools import build_tools_parser
 from hermes_cli.subcommands.insights import build_insights_parser
+from hermes_cli.subcommands.inbox import build_inbox_parser
 from hermes_cli.subcommands.monitoring import build_monitoring_parser
 from hermes_cli.subcommands.skills import build_skills_parser
 from hermes_cli.subcommands.pairing import build_pairing_parser
@@ -10615,7 +10616,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "acp", "approvals", "auth", "backup", "bundles", "checkpoints", "claw", "completion",
         "computer-use",
         "config", "console", "cron", "curator", "dashboard", "serve", "debug", "doctor",
-        "dump", "egress", "fallback", "gateway", "hooks", "import", "import-agent", "insights",
+        "dump", "egress", "fallback", "gateway", "hooks", "import", "import-agent", "inbox", "insights",
         "gui", "desktop", "kanban", "login", "logout", "logs", "lsp", "mcp", "memory", "migrate", "moa",
         "journey", "memory-graph", "learning",
         "model", "monitoring", "pairing", "pause", "pets", "plugins", "portal", "profile",
@@ -11093,6 +11094,13 @@ def cmd_tools(args):
         from hermes_cli.tools_config import tools_command
 
         tools_command(args)
+
+
+def cmd_inbox(args):
+    """Show everything in flight: background work, results, cron, sessions."""
+    from hermes_cli.inbox import cmd_inbox as _impl
+
+    return _impl(args)
 
 
 def cmd_insights(args):
@@ -12394,6 +12402,7 @@ def main():
     # insights command  (parser built in hermes_cli/subcommands/insights.py)
     # =========================================================================
     build_insights_parser(subparsers, cmd_insights=cmd_insights)
+    build_inbox_parser(subparsers, cmd_inbox=cmd_inbox)
     build_monitoring_parser(subparsers, cmd_monitoring=cmd_monitoring)
 
     # =========================================================================

--- a/hermes_cli/subcommands/inbox.py
+++ b/hermes_cli/subcommands/inbox.py
@@ -1,0 +1,31 @@
+"""``hermes inbox`` subcommand parser.
+
+One view of everything in flight and needing attention — background
+processes, async delegations, cron jobs, and open chat surfaces.
+Handler injected to avoid importing ``main``.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+
+def build_inbox_parser(subparsers, *, cmd_inbox: Callable) -> None:
+    """Attach the ``inbox`` subcommand to ``subparsers``."""
+    inbox_parser = subparsers.add_parser(
+        "inbox",
+        help="Show everything in flight: background work, results, cron, sessions",
+        description=(
+            "A unified, read-only view of Hermes activity: what needs your "
+            "attention (stalled delegations, failed cron runs, orphaned "
+            "processes), what is in progress (background processes, async "
+            "delegations), finished results not yet delivered, upcoming "
+            "scheduled jobs, and open chat surfaces."
+        ),
+    )
+    inbox_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the inbox snapshot as JSON",
+    )
+    inbox_parser.set_defaults(func=cmd_inbox)

--- a/tests/hermes_cli/test_inbox.py
+++ b/tests/hermes_cli/test_inbox.py
@@ -1,0 +1,213 @@
+"""Tests for ``hermes inbox`` (hermes_cli/inbox.py)."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import inbox as inbox_mod
+
+
+DELEGATIONS_DDL = """CREATE TABLE async_delegations (
+    delegation_id TEXT PRIMARY KEY,
+    origin_session TEXT NOT NULL,
+    origin_ui_session_id TEXT NOT NULL DEFAULT '',
+    parent_session_id TEXT,
+    state TEXT NOT NULL,
+    dispatched_at REAL NOT NULL,
+    completed_at REAL,
+    updated_at REAL NOT NULL,
+    event_json TEXT,
+    result_json TEXT,
+    delivery_state TEXT NOT NULL DEFAULT 'pending',
+    delivery_attempts INTEGER NOT NULL DEFAULT 0,
+    delivered_at REAL,
+    owner_pid INTEGER,
+    owner_started_at INTEGER,
+    task_json TEXT,
+    delivery_claim TEXT,
+    delivery_claimed_at REAL,
+    origin_session_id TEXT NOT NULL DEFAULT ''
+)"""
+
+
+@pytest.fixture()
+def home(tmp_path: Path) -> Path:
+    (tmp_path / "runtime").mkdir()
+    (tmp_path / "cron").mkdir()
+    return tmp_path
+
+
+def _write_delegations(home: Path, rows):
+    conn = sqlite3.connect(home / "state.db")
+    conn.execute(DELEGATIONS_DDL)
+    for r in rows:
+        conn.execute(
+            """INSERT INTO async_delegations
+               (delegation_id, origin_session, state, dispatched_at,
+                completed_at, updated_at, delivery_state, delivery_attempts,
+                task_json)
+               VALUES (?, 's', ?, ?, ?, ?, ?, ?, ?)""",
+            r,
+        )
+    conn.commit()
+    conn.close()
+
+
+class TestCollectProcesses:
+    def test_missing_file_returns_empty(self, home):
+        assert inbox_mod.collect_processes(home) == []
+
+    def test_corrupt_file_returns_empty(self, home):
+        (home / "processes.json").write_text("{not json")
+        assert inbox_mod.collect_processes(home) == []
+
+    def test_live_and_dead_pids_classified(self, home):
+        now = time.time()
+        (home / "processes.json").write_text(
+            json.dumps(
+                [
+                    {
+                        "session_id": "live",
+                        "command": "sleep 5",
+                        "pid": os.getpid(),
+                        "pid_scope": "host",
+                        "started_at": now - 60,
+                    },
+                    {
+                        "session_id": "dead",
+                        "command": "gone",
+                        "pid": 2**22 + 12345,  # implausible PID
+                        "pid_scope": "host",
+                        "started_at": now - 60,
+                    },
+                    {
+                        "session_id": "sandboxed",
+                        "command": "in docker",
+                        "pid": 42,
+                        "pid_scope": "env",
+                        "started_at": now - 60,
+                    },
+                ]
+            )
+        )
+        procs = {p["id"]: p for p in inbox_mod.collect_processes(home)}
+        assert procs["live"]["alive"] is True
+        assert procs["dead"]["alive"] is False
+        # Non-host scope PIDs can't be probed — unknown, not dead.
+        assert procs["sandboxed"]["alive"] is None
+
+
+class TestCollectDelegations:
+    def test_missing_db_returns_empty(self, home):
+        assert inbox_mod.collect_delegations(home) == []
+
+    def test_running_pending_and_recent_dropped_surface(self, home):
+        now = time.time()
+        _write_delegations(
+            home,
+            [
+                ("run", "running", now - 60, None, now, "pending", 0,
+                 '{"goal": "active work"}'),
+                ("done", "completed", now - 600, now - 30, now, "pending", 0,
+                 '{"goal": "finished work"}'),
+                ("dropped_new", "stalled", now - 7200, now - 3600, now,
+                 "dropped", 5, '{"goal": "recent drop"}'),
+                # Dropped 30 days ago — must be filtered as historical noise.
+                ("dropped_old", "stalled", now - 30 * 86400,
+                 now - 30 * 86400, now, "dropped", 5, '{"goal": "old drop"}'),
+                # Already delivered — not inbox material.
+                ("delivered", "completed", now - 600, now - 500, now,
+                 "delivered", 1, '{"goal": "old news"}'),
+            ],
+        )
+        ids = {d["id"] for d in inbox_mod.collect_delegations(home)}
+        assert ids == {"run", "done", "dropped_new"}
+
+    def test_goal_extracted_from_task_json(self, home):
+        now = time.time()
+        _write_delegations(
+            home,
+            [("run", "running", now, None, now, "pending", 0,
+              '{"goal": "research pricing"}')],
+        )
+        (item,) = inbox_mod.collect_delegations(home)
+        assert item["goal"] == "research pricing"
+
+
+class TestBuildInbox:
+    def test_sections_classified(self, home, monkeypatch):
+        now = time.time()
+        (home / "processes.json").write_text(
+            json.dumps(
+                [
+                    {"session_id": "live", "command": "x", "pid": os.getpid(),
+                     "pid_scope": "host", "started_at": now},
+                    {"session_id": "dead", "command": "y",
+                     "pid": 2**22 + 12345, "pid_scope": "host",
+                     "started_at": now},
+                ]
+            )
+        )
+        _write_delegations(
+            home,
+            [
+                ("run", "running", now, None, now, "pending", 0, "{}"),
+                ("done", "completed", now - 60, now - 10, now, "pending", 0,
+                 "{}"),
+            ],
+        )
+        monkeypatch.setattr(inbox_mod, "collect_cron", lambda home=None: [
+            {"kind": "cron", "id": "j1", "name": "ok", "enabled": True,
+             "paused": False, "paused_reason": None, "last_status": "success",
+             "last_error": None, "last_run_at": None, "next_run_at": "soon",
+             "needs_attention": False},
+            {"kind": "cron", "id": "j2", "name": "bad", "enabled": True,
+             "paused": False, "paused_reason": None, "last_status": "error",
+             "last_error": "boom", "last_run_at": None, "next_run_at": None,
+             "needs_attention": True},
+        ])
+        data = inbox_mod.build_inbox(home)
+
+        attention_ids = {i.get("id") for i in data["attention"]}
+        assert "dead" in attention_ids  # orphaned checkpoint entry
+        assert "j2" in attention_ids  # failed cron job
+        in_progress_ids = {i.get("id") for i in data["in_progress"]}
+        assert {"live", "run"} <= in_progress_ids
+        assert [i["id"] for i in data["finished_undelivered"]] == ["done"]
+
+    def test_render_smoke_and_json_roundtrip(self, home):
+        data = inbox_mod.build_inbox(home)
+        text = inbox_mod.render_inbox(data)
+        assert "Needs attention" in text
+        assert "In progress" in text
+        # Must be JSON-serializable for --json.
+        json.dumps(data, default=str)
+
+    def test_empty_home_all_clear(self, home):
+        data = inbox_mod.build_inbox(home)
+        assert data["attention"] == []
+        assert data["in_progress"] == []
+        assert data["finished_undelivered"] == []
+
+
+class TestActiveSessions:
+    def test_dead_pid_leases_excluded(self, home):
+        (home / "runtime" / "active_sessions.json").write_text(
+            json.dumps(
+                [
+                    {"lease_id": "a", "session_id": "s1", "surface": "cli",
+                     "pid": os.getpid(), "started_at": time.time()},
+                    {"lease_id": "b", "session_id": "s2", "surface": "tg",
+                     "pid": 2**22 + 12345, "started_at": time.time()},
+                ]
+            )
+        )
+        sessions = inbox_mod.collect_active_sessions(home)
+        assert len(sessions) == 1
+        assert sessions[0]["surface"] == "cli"

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -88,6 +88,7 @@ hermes [global-options] <command> [subcommand/options]
 | `hermes pets` | Browse, install, and select [petdex](../user-guide/features/pets.md) animated pets shown across the CLI, TUI, and desktop app. Subcommands: `list`, `install`, `select`, `show`, `off`, `scale`, `remove`, `doctor`. |
 | `hermes sessions` | Browse, export, prune, rename, and delete sessions. |
 | `hermes insights` | Show token/cost/activity analytics. |
+| `hermes inbox` | One view of everything in flight: background processes, async delegations, failed cron runs, undelivered results, and open chat surfaces. |
 | `hermes claw` | OpenClaw migration helpers. |
 | `hermes import-agent` | Import a Claude Code (`~/.claude`) or Codex CLI (`~/.codex`) setup. |
 | `hermes dashboard` | Launch the web dashboard for managing config, API keys, and sessions. |
@@ -1478,6 +1479,27 @@ hermes insights [--days N] [--source platform]
 |--------|-------------|
 | `--days <n>` | Analyze the last `n` days (default: 30). |
 | `--source <platform>` | Filter by source such as `cli`, `telegram`, or `discord`. |
+
+## `hermes inbox`
+
+```bash
+hermes inbox [--json]
+```
+
+A unified, read-only snapshot of Hermes activity — inspired by "what's in
+progress, what needs attention, what finished" agent inboxes. Aggregates
+four stores without mutating any of them:
+
+| Section | Source | What appears |
+|---------|--------|--------------|
+| Needs attention | delegations + cron + processes | Stalled/unknown delegations, results dropped after failed deliveries (last 7 days), failed or paused cron jobs, orphaned background-process checkpoint entries whose PID is gone. |
+| In progress | `~/.hermes/processes.json` + `state.db` | Live background processes and running async delegations. |
+| Finished, not yet delivered | `state.db` | Completed delegation results still waiting to re-enter their conversation. |
+| Scheduled | `cron/jobs.json` | Active cron jobs and their next run times. |
+| Open surfaces | active-session leases | Currently open CLI/TUI/gateway chat surfaces (live PIDs only). |
+
+`--json` emits the raw snapshot for scripts and dashboards. Works whether or
+not a gateway is running, and never blocks on a locked database.
 
 ## `hermes claw`
 


### PR DESCRIPTION
`hermes inbox` gives one read-only surface for everything in flight: background processes, async delegations, cron jobs, and open chat sessions — the state Hermes already tracks across four stores, aggregated into a single glanceable view. Inspired by Cursor's Inbox (Jul 29 2026 changelog): one place showing what's in progress, what needs attention, and which agent results are waiting.

Recovered from a cursor-scout cron run that completed the implementation but was interrupted before opening the PR.

## What it does

```
$ hermes inbox
  ◆ Needs attention (2)     — failed cron runs, stalled delegations, dead-PID leases
  ◆ In progress (3)         — live background processes, running delegations
  ◆ Finished (undelivered)  — delegation results that never re-entered a conversation
  ◆ Scheduled (44)          — upcoming cron fires
  ◆ Open surfaces (1)       — active session leases (live PIDs only)
```

## Changes

- `hermes_cli/inbox.py` (new, ~400 LOC) — read-only aggregation:
  - background processes from `~/.hermes/processes.json`, PIDs re-validated via `psutil.pid_exists` before display (stale entries filtered)
  - async delegations from `state.db` (sqlite `mode=ro`): running, stalled, undelivered, recently dropped results
  - cron jobs: failed last runs, paused jobs, next fires
  - open chat surfaces: active-session leases, live PIDs only
  - every store read is individually wrapped — a missing/corrupt store degrades to an empty section, never a crash
- `hermes_cli/subcommands/inbox.py` + `hermes_cli/main.py` — parser registered like `doctor`/`verify`; `--json` for scripts and dashboards
- `tests/hermes_cli/test_inbox.py` — 10 tests against temp `HERMES_HOME` fixtures (empty stores, dead PIDs, corrupt sqlite, JSON shape)
- `website/docs/reference/cli-commands.md` — command reference entry

Footprint ladder: CLI command — zero model-tool footprint. Post-recovery fix: replaced `os.kill(pid, 0)` liveness probe with `psutil.pid_exists` (Windows footgun — CTRL_C_EVENT, bpo-14484).

## Validation

| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/hermes_cli/test_inbox.py` | ✅ 10/10 passed |
| `ruff check` on touched files | ✅ clean |
| `scripts/check-windows-footguns.py hermes_cli/inbox.py` | ✅ clean (after psutil fix) |
| E2E: `HERMES_HOME=$(mktemp -d) hermes inbox` | ✅ renders all sections empty-state |
| `scripts/audit_pr_attribution.py --fix` | ✅ all emails mapped |

## Source

Inspired by Cursor's Inbox: https://cursor.com/changelog (July 29, 2026 — "Inbox").

## Infographic

![hermes inbox infographic](https://v3b.fal.media/files/b/0aa583ec/qE502l9W2k0htQONc5Du5_MPh6Ch2x.png)
