### PR TITLE
test(tests): stabilize write_json concurrent serialization flake

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -897,24 +897,65 @@ class _BrokenStdout:
 
 
 def test_write_json_serializes_concurrent_writes(monkeypatch):
-    out = _ChunkyStdout()
-    monkeypatch.setattr(server, "_real_stdout", out)
+    """Assert StdioTransport holds _stdout_lock across the full stream.write.
 
-    threads = [
-        threading.Thread(target=server.write_json, args=({"seq": i, "text": "x" * 24},))
-        for i in range(8)
-    ]
+    The old char-by-char sleep mock made this test take long enough that
+    leftover background write_json calls from earlier cases in this file
+    could append an extra line (intermittent ``assert 9 == 8`` on CI/main).
+    Match the WS concurrent-send check: count in-flight writes, and only
+    assert on frames that carry this test's marker payload.
+    """
+    marker = "x" * 24
+    active = 0
+    max_active = 0
+    gate = threading.Lock()
+    frames: list[str] = []
 
+    class RecordingStdout:
+        def write(self, text: str) -> int:
+            nonlocal active, max_active
+            with gate:
+                active += 1
+                max_active = max(max_active, active)
+            try:
+                # Release the GIL while "in write" so a missing outer lock
+                # would let another thread bump max_active above 1.
+                time.sleep(0.01)
+                frames.append(text)
+            finally:
+                with gate:
+                    active -= 1
+            return len(text)
+
+        def flush(self) -> None:
+            return None
+
+    monkeypatch.setattr(server, "_real_stdout", RecordingStdout())
+
+    barrier = threading.Barrier(8)
+
+    def _worker(seq: int) -> None:
+        barrier.wait(timeout=5)
+        server.write_json({"seq": seq, "text": marker})
+
+    threads = [threading.Thread(target=_worker, args=(i,)) for i in range(8)]
     for t in threads:
         t.start()
-
     for t in threads:
-        t.join()
+        t.join(timeout=10)
+        assert not t.is_alive()
 
-    lines = "".join(out.parts).splitlines()
+    assert max_active == 1
 
-    assert len(lines) == 8
-    assert {json.loads(line)["seq"] for line in lines} == set(range(8))
+    ours = []
+    for frame in frames:
+        assert frame.endswith("\n"), frame
+        obj = json.loads(frame)
+        if obj.get("text") == marker and "seq" in obj:
+            ours.append(obj)
+
+    assert {obj["seq"] for obj in ours} == set(range(8))
+    assert len(ours) == 8
 
 
 def test_write_json_returns_false_on_broken_pipe(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

`test_write_json_serializes_concurrent_writes` has been intermittently failing on CI (including on main) with `assert 9 == 8`. The old char-by-char sleep mock kept the test window long enough that leftover background `write_json` calls from earlier cases in the same file could append an extra line.

Rewrite the check to match the WS concurrent-send pattern: assert at most one in-flight `stream.write`, record whole frames, and only count payloads that carry this test's marker.

## Related Issue

N/A - CI flake observed on #81415 and on main after #81321.

## Type of Change

- [x] Tests (adding or improving test coverage)

## Changes Made

- `tests/test_tui_gateway_server.py` - stabilize `test_write_json_serializes_concurrent_writes` against cross-test stdout pollution.

## How to Test

1. Run the focused write_json cases and confirm they pass.
2. Optionally stress-run the concurrent case repeatedly and confirm it stays green.

```
scripts/run_tests.sh tests/test_tui_gateway_server.py -k test_write_json_serializes_concurrent_writes -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all selected tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10 with Python 3.11

### Documentation & Housekeeping

- [x] Documentation update: N/A - test-only change
- [x] `cli-config.yaml.example` update: N/A - no configuration keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no contributor workflow changed
- [x] Cross-platform impact considered: threading assertions are platform-independent
- [x] Tool descriptions/schemas update: N/A - no tool behavior changed

## Screenshots / Logs

N/A - local stress run of the write_json cases passed 20/20.
