### PR TITLE
fix(gateway): clean up stale .tmp files in Windows Startup folder

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -538,6 +538,24 @@ def _build_startup_launcher(script_path: Path) -> str:
     return "\r\n".join(lines) + "\r\n"
 
 
+def _write_tmp_then_replace(tmp: Path, target: Path, content: str) -> None:
+    """Atomically write ``content`` to ``target`` via a sibling ``.tmp`` file.
+
+    Writes to ``tmp`` first, then renames it over ``target``. The temporary
+    file is always cleaned up afterwards — even if the rename fails — so a
+    stale ``*.tmp`` never lingers in the Startup folder, where Windows would
+    otherwise pop the "How do you want to open this file?" dialog on login.
+    """
+    try:
+        tmp.write_text(content, encoding="utf-8", newline="")
+        tmp.replace(target)
+    finally:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
 def _write_task_script() -> Path:
     """Generate and write the gateway.cmd wrapper. Return its absolute path."""
     _assert_windows()
@@ -556,18 +574,14 @@ def _write_task_script() -> Path:
 
     content = _build_gateway_cmd_script(python_path, working_dir, hermes_home, profile_arg)
     script_path = get_task_script_path()
-    tmp = script_path.with_suffix(".tmp")
-    tmp.write_text(content, encoding="utf-8", newline="")
-    tmp.replace(script_path)
+    _write_tmp_then_replace(script_path.with_suffix(".tmp"), script_path, content)
 
     # Also render the console-less .vbs launcher used by Scheduled Task and the
     # Startup-folder fallback via wscript.exe (issue #45599 fix A). The .cmd
     # wrapper stays as a generated helper/compatibility artifact.
     vbs_content = _build_gateway_vbs_script(python_path, working_dir, hermes_home, profile_arg)
     vbs_path = script_path.with_suffix(".vbs")
-    vbs_tmp = vbs_path.with_name(vbs_path.name + ".tmp")
-    vbs_tmp.write_text(vbs_content, encoding="utf-8", newline="")
-    vbs_tmp.replace(vbs_path)
+    _write_tmp_then_replace(vbs_path.with_name(vbs_path.name + ".tmp"), vbs_path, vbs_content)
     return script_path
 
 
@@ -702,9 +716,7 @@ def _install_startup_entry(script_path: Path) -> Path:
     """Write the Startup-folder fallback launcher. Returns its path."""
     entry = get_startup_entry_path()
     entry.parent.mkdir(parents=True, exist_ok=True)
-    tmp = entry.with_suffix(".tmp")
-    tmp.write_text(_build_startup_launcher(script_path), encoding="utf-8", newline="")
-    tmp.replace(entry)
+    _write_tmp_then_replace(entry.with_suffix(".tmp"), entry, _build_startup_launcher(script_path))
     legacy_entry = _legacy_startup_entry_path()
     try:
         if legacy_entry.exists():

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -223,6 +223,54 @@ def test_gateway_vbs_script_is_console_less(monkeypatch):
     assert content.endswith("\r\n")
 
 
+def test_write_tmp_then_replace_succeeds_cleanly(tmp_path):
+    """Successful write+rename must leave no .tmp behind and populate target."""
+    target = tmp_path / "Hermes_Gateway.vbs"
+    tmp = target.with_name(target.name + ".tmp")
+
+    gateway_windows._write_tmp_then_replace(tmp, target, "content\r\n")
+
+    assert open(target, encoding="utf-8", newline="").read() == "content\r\n"
+    assert not tmp.exists()
+
+
+def test_write_tmp_then_replace_cleans_up_on_rename_failure(tmp_path, monkeypatch):
+    """A failed rename must not leave a stale .tmp behind (Windows pops the
+    \"How do you want to open this file?\" dialog for Startup-folder files)."""
+    target = tmp_path / "Hermes_Gateway.vbs"
+    tmp = target.with_name(target.name + ".tmp")
+
+    def _boom(self, *args):
+        raise PermissionError("simulated rename failure")
+
+    monkeypatch.setattr(Path, "replace", _boom)
+
+    with pytest.raises(PermissionError):
+        gateway_windows._write_tmp_then_replace(tmp, target, "content\r\n")
+
+    assert not tmp.exists()
+    assert not target.exists()
+
+
+def test_write_tmp_then_replace_ignores_cleanup_error(tmp_path, monkeypatch):
+    """If even the cleanup unlink fails, the error must not mask the original
+    rename failure — the caller should still see the root cause."""
+    target = tmp_path / "Hermes_Gateway.vbs"
+    tmp = target.with_name(target.name + ".tmp")
+
+    def _boom(self, *args):
+        raise PermissionError("simulated rename failure")
+
+    def _unlink_boom(self, *args, **kwargs):
+        raise OSError("simulated cleanup failure")
+
+    monkeypatch.setattr(Path, "replace", _boom)
+    monkeypatch.setattr(Path, "unlink", _unlink_boom)
+
+    with pytest.raises(PermissionError):
+        gateway_windows._write_tmp_then_replace(tmp, target, "content\r\n")
+
+
 
 
 


### PR DESCRIPTION
## Problem

The gateway install path writes its launcher via a temp file that is renamed into place. If the rename fails (e.g. a concurrent `wscript.exe` holding the target, antivirus interference, or a crashed install), the `.tmp` file is left behind. A leftover `.tmp` in the Startup folder makes Windows pop the "How do you want to open this file?" dialog on every login, because `.tmp` has no file association.

## Fix

Extract a `_write_tmp_then_replace` helper that writes, renames, and **always** cleans up the temp file (even on failure) without masking the original error, and use it in `_write_task_script` and `_install_startup_entry` (covers both the `.cmd` wrapper and the `.vbs` launcher).

## Test plan

Added regression tests in `tests/hermes_cli/test_gateway_windows.py` covering:
- success path — tmp written, renamed into place, tmp cleaned up
- rename failure — tmp still cleaned up, original error not masked
- cleanup-failure — `unlink` OSError swallowed, original result intact

```bash
python -m pytest tests/hermes_cli/test_gateway_windows.py -q
# 10 passed
```
