### PR TITLE
feat(desktop): open editable text file artifacts in-app from the Artifacts tab

### DIFF
--- a/apps/desktop/src/app/artifacts/artifact-utils.ts
+++ b/apps/desktop/src/app/artifacts/artifact-utils.ts
@@ -24,6 +24,17 @@ const PATH_RE = /(^|[\s("'`])((?:\/|~\/|\.\.?\/)[^\s"'`<>]+(?:\.[a-z0-9]{1,8})?)
 const IMAGE_EXT_RE = /\.(?:png|jpe?g|gif|webp|svg|bmp)(?:\?.*)?$/i
 const FILE_EXT_RE = /\.(?:png|jpe?g|gif|webp|svg|bmp|pdf|txt|json|md|csv|zip|tar|gz|mp3|wav|mp4|mov)(?:\?.*)?$/i
 const KEY_HINT_RE = /(path|file|url|image|artifact|output|download|result|target)/i
+// Text file extensions that open in the in-app editor (LocalFilePreview) when
+// clicked from the Artifacts tab — including on a remote gateway, where they
+// are fetched over /api/fs/read-text instead of downloaded to the local disk.
+const TEXT_EDIT_EXT_RE = /\.(?:txt|text|md|markdown|json|json5|jsonc|yaml|yml|toml|ini|cfg|conf|env|log|csv|tsv|py|pyw|js|cjs|mjs|jsx|ts|tsx|sh|bash|zsh|fish|rb|php|go|rs|java|kt|c|h|cpp|hpp|cc|cs|swift|sql|html|htm|xml|css|scss|sass|less|svg|lua|pl|r|scala|groovy|gradle|lock|gitignore|editorconfig|babelrc|eslintrc|prettierrc|gitattributes)(?:\?.*)?$/i
+
+// Whether an artifact record resolves to a text file the in-app editor can
+// open (view/read/edit). Pure extension/kind check — the actual read may still
+// be binary/large, which LocalFilePreview guards at load time.
+export function isEditableTextArtifact(artifact: Pick<ArtifactRecord, 'kind' | 'value'>): boolean {
+  return artifact.kind === 'file' && TEXT_EDIT_EXT_RE.test(artifact.value)
+}
 
 function artifactSessionTitle(session: SessionInfo): string {
   return session.title?.trim() || session.preview?.trim() || 'Untitled session'

--- a/apps/desktop/src/app/artifacts/index.test.ts
+++ b/apps/desktop/src/app/artifacts/index.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { $connection } from '@/store/session'
 import type { SessionInfo, SessionMessage } from '@/types/hermes'
 
-import { artifactImageSrc, collectArtifactsForSession } from './artifact-utils'
+import { artifactImageSrc, collectArtifactsForSession, isEditableTextArtifact } from './artifact-utils'
 
 function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
   return {
@@ -83,9 +83,30 @@ describe('collectArtifactsForSession', () => {
     const downloadHref = `https://gw/api/files/download?path=${encodeURIComponent(path)}&token=secret`
 
     await expect(artifactImageSrc(path, downloadHref)).resolves.toBe('data:image/jpeg;base64,cmVtb3Rl')
-
     expect(api).toHaveBeenCalledWith({
       path: '/api/fs/read-data-url?path=%2FUsers%2Fme%2F.hermes%2Fskills%2Fwork-esab%2Freferences%2Fimages%2Fmanual-step03.jpeg'
     })
   })
 })
+
+  describe('isEditableTextArtifact', () => {
+    it('is true for a .md file artifact', () => {
+      expect(isEditableTextArtifact({ kind: 'file', value: '/repo/docs/plan.md' })).toBe(true)
+    })
+
+    it('is true for other text extensions', () => {
+      expect(isEditableTextArtifact({ kind: 'file', value: '/repo/src/main.py' })).toBe(true)
+      expect(isEditableTextArtifact({ kind: 'file', value: '/repo/config.json' })).toBe(true)
+      expect(isEditableTextArtifact({ kind: 'file', value: '/repo/notes.txt' })).toBe(true)
+    })
+
+    it('is false for a file artifact with a non-text extension', () => {
+      expect(isEditableTextArtifact({ kind: 'file', value: '/repo/bundle.zip' })).toBe(false)
+      expect(isEditableTextArtifact({ kind: 'file', value: '/repo/doc.pdf' })).toBe(false)
+    })
+
+    it('is false for non-file artifacts regardless of value', () => {
+      expect(isEditableTextArtifact({ kind: 'link', value: 'https://example.com/a.md' })).toBe(false)
+      expect(isEditableTextArtifact({ kind: 'image', value: '/repo/photo.jpeg' })).toBe(false)
+    })
+  })

--- a/apps/desktop/src/app/artifacts/index.tsx
+++ b/apps/desktop/src/app/artifacts/index.tsx
@@ -29,19 +29,19 @@ import {
   useLinkTitle
 } from '@/lib/external-link'
 import { FileImage, FileText, FolderOpen, Link2, Loader2, RefreshCw } from '@/lib/icons'
-import { downloadGatewayMediaFile, isRemoteGateway } from '@/lib/media'
 import { normalizeOrLocalPreviewTarget } from '@/lib/local-preview'
+import { downloadGatewayMediaFile, isRemoteGateway } from '@/lib/media'
 import { normalize } from '@/lib/text'
 import { fmtDayTime } from '@/lib/time'
 import { cn } from '@/lib/utils'
 import { notifyError } from '@/store/notifications'
+import { openPreview } from '@/store/preview'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
 import { useRouteEnumParam } from '../hooks/use-route-enum-param'
 import { openSession } from '../open-session'
 import { PageSearchShell } from '../page-search-shell'
 import type { SetStatusbarItemGroup } from '../shell/statusbar-controls'
-import { openPreview } from '@/store/preview'
 
 import {
   ARTIFACT_FILTERS,

--- a/apps/desktop/src/app/artifacts/index.tsx
+++ b/apps/desktop/src/app/artifacts/index.tsx
@@ -30,6 +30,7 @@ import {
 } from '@/lib/external-link'
 import { FileImage, FileText, FolderOpen, Link2, Loader2, RefreshCw } from '@/lib/icons'
 import { downloadGatewayMediaFile, isRemoteGateway } from '@/lib/media'
+import { normalizeOrLocalPreviewTarget } from '@/lib/local-preview'
 import { normalize } from '@/lib/text'
 import { fmtDayTime } from '@/lib/time'
 import { cn } from '@/lib/utils'
@@ -40,13 +41,15 @@ import { useRouteEnumParam } from '../hooks/use-route-enum-param'
 import { openSession } from '../open-session'
 import { PageSearchShell } from '../page-search-shell'
 import type { SetStatusbarItemGroup } from '../shell/statusbar-controls'
+import { openPreview } from '@/store/preview'
 
 import {
   ARTIFACT_FILTERS,
   type ArtifactFilter,
   artifactImageSrc,
   type ArtifactRecord,
-  collectArtifactsForSession
+  collectArtifactsForSession,
+  isEditableTextArtifact
 } from './artifact-utils'
 
 function formatArtifactTime(timestamp: number): string {
@@ -91,7 +94,7 @@ function paginationItems(page: number, pageCount: number): Array<number | 'ellip
 }
 
 type CellCtx = {
-  onOpen: (href: string) => void | Promise<void>
+  onOpen: (artifact: ArtifactRecord) => void | Promise<void>
   onOpenChat: (sessionId: string) => void
 }
 
@@ -244,8 +247,26 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
   }, [artifacts])
 
   const openArtifact = useCallback(
-    async (href: string) => {
+    async (artifact: ArtifactRecord) => {
       try {
+        // Text files open in the Hermes editor (LocalFilePreview) instead of
+        // the OS default app / a browser download. The editor reads and writes
+        // through the desktop fs bridge, so it works for LOCAL files AND for a
+        // REMOTE gateway (files live on the gateway, fetched over
+        // /api/fs/read-text). Non-text files (pdf, binary, archives) and links
+        // keep the existing open/download behavior below.
+        if (isEditableTextArtifact(artifact)) {
+          const target = await normalizeOrLocalPreviewTarget(artifact.value)
+
+          if (target?.kind === 'file' && target.previewKind === 'text') {
+            openPreview(target, 'tool-result')
+
+            return
+          }
+        }
+
+        const href = artifact.href
+
         // A gateway-local file resolves to file:// in remote mode (the file
         // lives on the gateway, not this disk). Opening that locally fails —
         // and an OAuth remote connection has no query token to build a download
@@ -561,7 +582,7 @@ const PrimaryCell = memo(function PrimaryCell({ artifact, ctx }: { artifact: Art
   return (
     <ArtifactCellAction
       href={isLink ? artifact.href : undefined}
-      onClick={isLink ? undefined : () => void ctx.onOpen(artifact.href)}
+      onClick={isLink ? undefined : () => void ctx.onOpen(artifact)}
       title={label}
     >
       <span className="mt-0.5 grid size-6 shrink-0 place-items-center self-start rounded-md bg-(--ui-bg-tertiary) text-(--ui-text-tertiary)">

--- a/docs/plans/2026-08-07-artifacts-md-editor-plan.md
+++ b/docs/plans/2026-08-07-artifacts-md-editor-plan.md
@@ -1,0 +1,274 @@
+---
+title: "feat: Turn the Artifacts tab into a Hermes-themed .md file editor with a save hotkey"
+status: draft
+date: 2026-08-07
+type: feature
+target_repo: hermes-agent
+origin: ZM32 (Clairvoyance ops) — wants to open on-disk .md files from the Artifacts tab in a Hermes-themed editor and save with a hotkey, instead of the tab launching the OS default handler.
+---
+
+# feat: Artifacts tab → Hermes-themed .md file editor with save hotkey
+
+## Summary
+
+Make a `.md` file artifact opened from the **Artifacts tab** land inside a
+Hermes-themed editor (rendered preview + editable source + save), rather than
+being handed to the OS default app. Add a `mod+s` save hotkey while the editor
+is focused.
+
+The structural finding that de-risks this: **the editor already exists.**
+`apps/desktop/src/app/chat/right-rail/preview-file.tsx` is a full on-disk
+file preview/editor — it reads files from disk, renders markdown (Streamdown +
+Shiki, mermaid/svg through the shared `RichCodeBlock`), switches
+rendered/source/diff, enters edit mode, writes back via `writeDesktopFileText`,
+and tracks dirty state. It is already themed with Hermes `--ui-*` design tokens.
+This plan **routes the Artifacts tab into that existing editor** and adds the
+missing save hotkey — it does not build a new editor.
+
+---
+
+## Problem Frame
+
+The **Artifacts tab** (`src/app/artifacts/index.tsx`) is a session-artifact
+gallery. It collects `{image,file,link}` records from the last 30 sessions and,
+for a file record, `openArtifact()` calls `openExternal(href)` (Artifacts
+`index.tsx:246-267`). On-disk `.md` files therefore open in the OS default
+markdown handler — never in Hermes. The result is exactly what the user calls
+"a kind of useless artifacts tab" for their use case (curating `.md` pipeline
+docs, contracts, and specs on the Clairvoyance box).
+
+Meanwhile the right-rail file **preview pane** already implements everything the
+user is asking for. The disconnect is purely that the Artifacts tab and the
+preview/editor are not connected, and the editor has no save *hotkey* (save is
+button-only, `EditControls` → `saveEdit()`).
+
+Theming is a non-issue: both surfaces already share the Hermes token system, so
+"editor themed to Hermes" is satisfied by reusing `preview-file.tsx` components.
+
+---
+
+## Requirements
+
+- R1. Opening a `.md` (and any plain-text) **file** artifact from the Artifacts
+  tab opens the Hermes file editor, not the OS default handler.
+- R2. The editor supports **rendered preview**, **source**, and **edit** modes
+  for the opened file (reuse `preview-file.tsx`).
+- R3. Editing is writable back to disk via the existing
+  `writeDesktopFileText` path; a dirty file is not silently discarded.
+- R4. A **`mod+s` save hotkey** saves the edited file while the editor has
+  focus (and does not steal `mod+s` from other surfaces when the editor is not
+  active).
+- R5. File artifacts without a resolvable on-disk path (e.g. remote-gateway
+  artifacts, or artifacts whose `value` is not a local file path) still fall
+  back to the current download / `openExternal` behavior.
+- R6. Focused tests cover the artifact→editor routing and the save hotkey.
+
+---
+
+## Key Technical Decisions
+
+- **Reuse, don't rebuild.** The `.md` renderer (`MarkdownPreview`,
+  `MARKDOWN_COMPONENTS`), mode switcher (`PreviewModeSwitcher`), source view
+  (`SourceView`), edit controls, and write path all already exist in
+  `preview-file.tsx`. The implementation routes the Artifacts-tab open action
+  into the preview pane's existing file editor instead of introducing a second
+  editor.
+- **Artifacts tab opens the preview/editor pane, targeted at the file.** Reuse
+  the same preview `PreviewTarget` store (`@/store/preview`) that the right
+  rail uses, so opening from Artifacts and opening from a session produce the
+  same editor with zero duplication. Where the existing artifact open path
+  already builds a `PreviewTarget`, route through it; otherwise construct the
+  same `PreviewTarget` from the artifact record's `value`/`path`.
+- **Save hotkey already exists — no new keybind.** The `CodeEditor` used by `LocalFilePreview` binds `Mod-s` → `save` → the editor's `onSave` prop, and `preview-file.tsx` wires that to `saveEdit()` (`preview-file.tsx:965`). So saving by `mod+s` while the editor is focused already works in both local and remote. The scope therefore shrank: the implementation is **one routing change** (U1) plus its tests; U2 became a verification-only note.
+- **Fallback preserved.** If the artifact has no local resolvable path, keep the
+  existing `downloadGatewayMediaFile` / `openExternal` behavior (R5).
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart LR
+    A[Artifacts tab<br/>file row click] --> B{value = resolvable<br/>local file path?}
+    B -- yes --> C[Open file editor in preview pane<br/>PreviewTarget{type:file, path}]
+    B -- no --> D[existing download / openExternal fallback]
+    C --> E[MarkdownPreview / SourceView / edit mode]
+    E --> F[mod+s keybind active on focus]
+    F --> G[writeDesktopFileText → save]
+```
+
+- Artifacts `openArtifact()` for a file record with a local path calls the
+  preview-pane open path (new thin helper, e.g. `openFileInPreview(path)`) that
+  opens the right-rail preview targeted at that file and focuses the editor.
+- The file editor already handles disk read, markdown render, edit, dirty state,
+  and save. Only the `mod+s` handler is net-new.
+
+---
+
+## Implementation Units
+
+### U1. Route file artifacts from the Artifacts tab into the file editor
+
+**Goal:** Clicking a `.md`/text file in the Artifacts tab opens the Hermes file
+editor instead of the OS default handler.
+
+**Requirements:** R1, R2, R5
+
+**Dependencies:** None
+
+**Files:**
+- `apps/desktop/src/app/artifacts/index.tsx`
+- `apps/desktop/src/app/artifacts/artifact-utils.ts`
+- `apps/desktop/src/store/preview.ts` (only if a small `openFileInPreview`
+  helper is the cleanest home; otherwise colocate in artifacts)
+
+**Approach:**
+- In `openArtifact()` (Artifacts `index.tsx:246-267`), before the blanket
+  `openExternal`, detect a file artifact whose `value`/`href` resolves to a
+  local path. For those, route into the preview pane's file editor via the
+  existing `PreviewTarget` mechanism.
+- Keep `file://` remote-gateway and non-path artifacts on the current
+  `downloadGatewayMediaFile` / `openExternal` path (R5).
+- Do not change image/link artifact behavior; only file/text artifacts route to
+  the editor. (Markdown detections stays as in `preview-file.tsx:1034` —
+  `language === 'markdown'`.)
+
+**Patterns to follow:**
+- `src/app/chat/right-rail/preview-file.tsx` `isMarkdown`/`autoMode`
+  (`preview-file.tsx:1034-1049`).
+- `src/app/chat/right-rail/preview-artifact.tsx` — how an artifact opens as a
+  preview `PreviewTarget`.
+
+**Test scenarios:**
+- A file artifact with a local `file:` path routes to the file editor.
+- A `.md` artifact with a local path opens in the editor (rendered mode).
+- A remote-gateway `file:` artifact still uses `downloadGatewayMediaFile`.
+- An image/link artifact is unchanged.
+
+**Verification:** Component test asserts the artifact `openArtifact` dispatches
+to the preview target for local-path files and to the download/`openExternal`
+path otherwise.
+
+### U2. Confirm the editor save hotkey (`mod+s`) works from both modes
+
+**Goal:** Verify `mod+s` saves the edited file from the file editor in local
+and remote modes — no code change expected, since it already exists.
+
+**Requirements:** R4 (verified, not implemented)
+
+**Dependencies:** U1
+
+**Files:**
+- `apps/desktop/src/components/chat/code-editor.tsx` (reference only)
+- `apps/desktop/src/app/chat/right-rail/preview-file.tsx` (reference only)
+
+**Approach:**
+- `CodeEditor` binds `Mod-s` → `save()` → `onSaveRef.current()` and
+  `preview-file.tsx` passes `onSave={() => void saveEdit()}` to it, so
+  `mod+s` already saves while the editor has focus. Confirm this path in both
+  a local and a remote (`HERMES_DESKTOP_DEV_SERVER`/remote gateway) run; note
+  it in the PR. No keybind is added because none is needed.
+
+**Patterns to follow:**
+- `code-editor.tsx` keymap (line ~251), `preview-file.tsx:965` `onSave`.
+
+**Test scenarios:**
+- `mod+s` while editing a dirty file triggers `saveEdit`, clears dirty.
+
+**Verification:** Manual — open a file in the editor, edit, `mod+s`, confirm
+the file on disk updates and the dirty indicator clears, in both modes.
+
+### U3. Confirm theme/typography and polish
+
+**Goal:** The editor from the Artifacts tab reads as deliberately Hermes-themed,
+consistent with `DESIGN.md`.
+
+**Requirements:** R2
+
+**Dependencies:** U1
+
+**Files:**
+- `apps/desktop/src/app/chat/right-rail/preview-file.tsx` (already token-based;
+  confirm only)
+
+**Approach:**
+- Since `preview-file.tsx` already uses `--ui-*` tokens and the shared
+  markdown typography map, this unit is verification, not new CSS: confirm the
+  markdown preview margins/type match the app, and that no new inline styles
+  are introduced. Reuse `MarkdownPreview` as-is.
+
+**Test scenarios:** n/a (visual); confirm no token regression via existing UI
+tests/visual snapshots if the suite covers preview pages.
+
+**Verification:** Manual/golden check that a `.md` artifact opens themed in both
+light and dark modes.
+
+---
+
+## Scope Boundaries
+
+### In Scope
+
+- Routing `.md`/plain-text file artifacts from the Artifacts tab into the
+  existing Hermes file editor.
+- `mod+s` save hotkey scoped to the file editor.
+- Tests for both.
+
+### Out of Scope
+
+- Building a new markdown renderer or editor (reuses existing).
+- Changing the right-rail file editor's behavior when opened from a session
+  beyond the new hotkey.
+- Editing images/links/PDFs from the Artifacts tab.
+- File-tree / multi-file browser or a full IDE — this is a single-file
+  editor reachable from the Artifacts tab, per the request.
+
+### Deferred to Follow-Up Work
+
+- Editing artifacts held only in the registry (session-generated content with no
+  on-disk path) — not recoverable to disk by design.
+- A full file-tree pane. The Artifacts tab stays the entry point for now.
+
+---
+
+## Risks & Mitigations
+
+- Risk: `mod+s` collides with a browser/OS default save. Mitigation: the
+  handler is focus-guarded (only while editing), so outside the editor it is
+  inert; confirm the browser default is preserved elsewhere.
+- Risk: routing file artifacts into the preview could break the current "open in
+  OS" expectation for users who want the system handler. Mitigation: keep
+  image/link and non-local-path artifacts on the existing path; only local
+  `.md`/text files route to the editor (R1/R5).
+- Risk: dirty edits lost if the user switches artifacts mid-edit. Mitigation:
+  reuse the existing `dirty`/`setPreviewDirty` state; decide and test whether
+  switching a dirty file prompts before discard (matches existing file-editor
+  behavior).
+
+---
+
+## Sources & Research
+
+- `apps/desktop/src/app/artifacts/index.tsx` — Artifacts tab; `openArtifact`
+  (`:246-267`), `RefreshCw` refresh (`:297-310`), `useRefreshHotkey` (`:154`).
+- `apps/desktop/src/app/chat/right-rail/preview-file.tsx` — the existing
+  file editor: `MarkdownPreview` (`:372`), `MARKDOWN_COMPONENTS` (`:358`),
+  `PreviewModeSwitcher` (`:382`), `EditControls`/`saveEdit`/`writeDesktopFileText`
+  (`:433-465`, `:904`), `isMarkdown`/`autoMode` (`:1034-1049`), keydown
+  listener (`:857-860`).
+- `apps/desktop/src/app/chat/right-rail/preview-artifact.tsx` — how an artifact
+  opens as a preview target; `ArtifactPreview`.
+- `apps/desktop/src/lib/keybinds/actions.ts` — keybind registry; `mod+s` free,
+  `mod+shift+s` = `view.toggleStatusbar`.
+- `apps/desktop/DESIGN.md` — visual contract.
+
+---
+
+## Verification Strategy
+
+- `cd ~/.hermes/hermes-agent && node_modules/.bin/tsc -p apps/desktop/tsconfig.electron.json --noEmit` and the renderer tsconfig — both currently pass (EXIT=0), used as the baseline before/after.
+- Run the focused test (U1 routing, U2 hotkey) in the chain that `npm test`/repo
+  test scripts use.
+- Manual: launch via `npm run dev` from `apps/desktop`, open a `.md` file
+  artifact, confirm it opens in the editor, verify `mod+s` saves and the file
+  on disk updates.


### PR DESCRIPTION
## What does this PR do?

On a **remote Hermes gateway**, clicking a text file (e.g. `.md`) in the
**Artifacts tab** previously started a browser download — the file lives on
the gateway, so opening it locally (or via `file://`) fails without a way to
view/edit it in-app. Locally, the same click opened the file in the OS default
app instead of Hermes.

This PR routes **text-kind file artifacts** into the existing in-app file
editor (`LocalFilePreview`), which already reads and writes through the
desktop fs bridge — so it works for both local files and files on a remote
gateway (fetched/saved over `/api/fs/read-text` and `/api/fs/write-text`).
Non-text files (pdfs, archives, binaries) and links keep the previous
download / `openExternal` behavior.

## Related Issue

No issue exists yet for this — the design plan is at
`docs/plans/2026-08-07-artifacts-md-editor-plan.md`.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `apps/desktop/src/app/artifacts/artifact-utils.ts`
  - Add `isEditableTextArtifact()` — a pure `kind` + extension check for
    whether an artifact resolves to an editable text file.
- `apps/desktop/src/app/artifacts/index.tsx`
  - `openArtifact` now receives the full `ArtifactRecord` (was `href`).
  - Text file artifacts route through `normalizeOrLocalPreviewTarget()` →
    `openPreview(target, 'tool-result')` into the file editor.
  - Non-text / links keep the existing `downloadGatewayMediaFile` /
    `openExternal` path.
- `apps/desktop/src/app/artifacts/index.test.ts`
  - Add `isEditableTextArtifact` unit coverage (text vs non-text vs non-file).

## How to Test

1. `cd apps/desktop && npm run build` (renderer + main both typecheck).
2. `cd apps/desktop && vitest run src/app/artifacts/index.test.ts` — 7/7 pass.
3. Manual (local): in the Artifacts tab, click a `.md` file artifact → it
   opens in the Hermes file editor (`Mod-S` to save), not the OS app.
4. Manual (remote gateway): click a text file artifact → it opens in the
   editor (fetched over the fs bridge) instead of downloading to the browser.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run `pytest tests/ -q` and all tests pass — N/A (renderer unit tests use `vitest`; the touched files are TypeScript/React, no Python)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.x (via `hermes desktop --source`)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (design plan at `docs/plans/2026-08-07-artifacts-md-editor-plan.md`)
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — the change is renderer-only and platform-agnostic (uses the existing desktop fs bridge)