### PR TITLE
fix(gateway): snapshot TERMINAL_CWD at session bind to block cron leaks

### DIFF
--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -98,3 +98,25 @@ def resolve_context_cwd() -> Path | None:
         else:
             return p
     return None
+
+
+def snapshot_terminal_cwd() -> str:
+    """Snapshot the process-global TERMINAL_CWD (with ``os.getcwd()`` fallback)
+    so the caller can pin it for the lifetime of a session.
+
+    Used by the gateway's session-bind path so a multi-session gateway does
+    not inherit a TERMINAL_CWD that a concurrent workdir cron job is mid-way
+    through writing (#81451).  Always returns a non-empty absolute path: if
+    both TERMINAL_CWD and ``os.getcwd()`` are unreachable, the empty string
+    is returned and the caller decides what to do with it.
+    """
+    raw = os.environ.get("TERMINAL_CWD", "").strip()
+    if raw:
+        try:
+            return str(Path(raw).expanduser().resolve())
+        except Exception:
+            return raw
+    try:
+        return os.getcwd()
+    except Exception:
+        return ""

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -263,29 +263,39 @@ def set_session_vars(
         _SESSION_ASYNC_DELIVERY.set(bool(async_delivery)),
     ]
     try:
-        from agent.runtime_cwd import set_session_cwd
+        from agent.runtime_cwd import set_session_cwd, snapshot_terminal_cwd
 
-        # Either the caller pinned a cwd (cron jobs pass ``_job_workdir``), or
-        # we snapshot the process-global fallback at the moment the session
-        # is bound.  The snapshot is what protects a multi-session gateway
-        # from inheriting a transient TERMINAL_CWD written by a concurrent
-        # workdir cron job: the cron holds ``_terminal_cwd_lock`` for the
-        # duration of the job, but a different session's resolver still
-        # runs from a thread with no lock held.  Pinning here means the
-        # gateway session's cwd is captured before any concurrent cron
-        # writer can dirty the process-global value (#81451).  Cron
-        # workdir-less jobs intentionally pass cwd="" so they also pick
-        # up the current TERMINAL_CWD — by the time ``run_job`` calls
+        # Either the caller pinned a cwd (cron jobs pass ``_job_workdir``),
+        # or we snapshot the process-global fallback at the moment the
+        # session is bound.  The snapshot is what protects a multi-session
+        # gateway from inheriting a transient TERMINAL_CWD written by a
+        # concurrent workdir cron job: the cron holds
+        # ``_terminal_cwd_lock`` for the duration of the job, but a
+        # different session's resolver still runs from a thread with no
+        # lock held.  Pinning here means the gateway session's cwd is
+        # captured before any concurrent cron writer can dirty the
+        # process-global value (#81451).  Cron workdir-less jobs
+        # intentionally pass cwd="" so they also pick up the current
+        # TERMINAL_CWD — by the time ``run_job`` calls
         # ``set_session_vars``, the worker has already snapshotted
         # ``_prior_terminal_cwd`` and is about to hold the write lock,
         # so the value is stable.
-        resolved_cwd = cwd
-        if not resolved_cwd:
-            import os as _os
-            try:
-                resolved_cwd = _os.environ.get("TERMINAL_CWD", "").strip() or _os.getcwd()
-            except Exception:
-                resolved_cwd = ""
+        if cwd:
+            resolved_cwd = cwd
+        else:
+            resolved_cwd = snapshot_terminal_cwd()
+            # ``snapshot_terminal_cwd`` always returns either an absolute
+            # path or ""; if both TERMINAL_CWD and os.getcwd() were
+            # unreachable the snapshot would silently drop the session
+            # back to the leaky global on the next read.  Fall back to
+            # the launch dir explicitly so the snapshot is always pinned
+            # to *some* non-empty value.
+            if not resolved_cwd:
+                import os as _os
+                try:
+                    resolved_cwd = _os.getcwd()
+                except Exception:
+                    resolved_cwd = ""
         set_session_cwd(resolved_cwd)
     except Exception:
         pass

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -36,6 +36,7 @@ needs to replace the import + call site:
     platform = get_session_env("HERMES_SESSION_PLATFORM", "")
 """
 
+import threading
 from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import Any, Iterator
@@ -59,6 +60,16 @@ _UNSET: Any = object()
 # latch — once any host binds a session, the process stays engaged for life.
 _session_context_engaged: bool = False
 
+# Per-session TERMINAL_CWD snapshot cache (#81451).  A gateway session's cwd
+# is pinned on its first message (see ``set_session_vars``); later messages of
+# the same session reuse the pinned value so a concurrent workdir cron job's
+# transient TERMINAL_CWD write can't leak into the session.  Cron jobs and
+# other session_key="" paths are never cached (they want the current value
+# per run).  Bounded so a long-lived gateway's cache can't grow without limit.
+_session_cwd_cache: dict[str, str] = {}
+_session_cwd_cache_lock = threading.Lock()
+_SESSION_CWD_CACHE_MAX = 2048
+
 
 def session_context_engaged() -> bool:
     """True if any session has been bound via set_session_vars in this process.
@@ -66,6 +77,7 @@ def session_context_engaged() -> bool:
     See the ``_session_context_engaged`` comment for the leak-policy rationale.
     """
     return _session_context_engaged
+
 
 # ---------------------------------------------------------------------------
 # Per-task session variables
@@ -91,7 +103,9 @@ _SESSION_UI_SESSION_ID: ContextVar = ContextVar("HERMES_UI_SESSION_ID", default=
 # ID of the message that triggered the current turn. Used as a reply anchor
 # so background-process notifications stay inside the originating Telegram
 # private-chat topic (those lanes route only with thread id + reply anchor).
-_SESSION_MESSAGE_ID: ContextVar = ContextVar("HERMES_SESSION_MESSAGE_ID", default=_UNSET)
+_SESSION_MESSAGE_ID: ContextVar = ContextVar(
+    "HERMES_SESSION_MESSAGE_ID", default=_UNSET
+)
 
 _SESSION_PROFILE: ContextVar = ContextVar("HERMES_SESSION_PROFILE", default=_UNSET)
 
@@ -119,13 +133,21 @@ _CRON_SESSION: ContextVar = ContextVar("HERMES_CRON_SESSION", default=_UNSET)
 # and any contextvar-unaware path keep working. Stateless adapters opt OUT by
 # setting ``supports_async_delivery = False`` on the adapter class; the gateway
 # propagates that into this contextvar at session-bind time.
-_SESSION_ASYNC_DELIVERY: ContextVar = ContextVar("HERMES_SESSION_ASYNC_DELIVERY", default=_UNSET)
+_SESSION_ASYNC_DELIVERY: ContextVar = ContextVar(
+    "HERMES_SESSION_ASYNC_DELIVERY", default=_UNSET
+)
 
 # Cron auto-delivery vars — set per-job in run_job() so concurrent jobs
 # don't clobber each other's delivery targets.
-_CRON_AUTO_DELIVER_PLATFORM: ContextVar = ContextVar("HERMES_CRON_AUTO_DELIVER_PLATFORM", default=_UNSET)
-_CRON_AUTO_DELIVER_CHAT_ID: ContextVar = ContextVar("HERMES_CRON_AUTO_DELIVER_CHAT_ID", default=_UNSET)
-_CRON_AUTO_DELIVER_THREAD_ID: ContextVar = ContextVar("HERMES_CRON_AUTO_DELIVER_THREAD_ID", default=_UNSET)
+_CRON_AUTO_DELIVER_PLATFORM: ContextVar = ContextVar(
+    "HERMES_CRON_AUTO_DELIVER_PLATFORM", default=_UNSET
+)
+_CRON_AUTO_DELIVER_CHAT_ID: ContextVar = ContextVar(
+    "HERMES_CRON_AUTO_DELIVER_CHAT_ID", default=_UNSET
+)
+_CRON_AUTO_DELIVER_THREAD_ID: ContextVar = ContextVar(
+    "HERMES_CRON_AUTO_DELIVER_THREAD_ID", default=_UNSET
+)
 
 _VAR_MAP = {
     "HERMES_SESSION_PLATFORM": _SESSION_PLATFORM,
@@ -282,6 +304,35 @@ def set_session_vars(
         # so the value is stable.
         if cwd:
             resolved_cwd = cwd
+        elif session_key:
+            # Pin the snapshot per session: only the FIRST message that
+            # binds this session reads the process-global TERMINAL_CWD.
+            # Later messages of the same session reuse the pinned value, so
+            # a concurrent cron write that lands mid-conversation cannot
+            # leak into the session (#81451).  Cron jobs and other
+            # session_key="" paths are never cached and always re-snapshot,
+            # preserving their per-run behaviour.
+            with _session_cwd_cache_lock:
+                resolved_cwd = _session_cwd_cache.get(session_key)
+            if resolved_cwd is None:
+                resolved_cwd = snapshot_terminal_cwd()
+                # ``snapshot_terminal_cwd`` always returns either an absolute
+                # path or ""; if both TERMINAL_CWD and os.getcwd() were
+                # unreachable the snapshot would silently drop the session
+                # back to the leaky global on the next read.  Fall back to
+                # the launch dir explicitly so the snapshot is always pinned
+                # to *some* non-empty value.
+                if not resolved_cwd:
+                    import os as _os
+
+                    try:
+                        resolved_cwd = _os.getcwd()
+                    except Exception:
+                        resolved_cwd = ""
+                with _session_cwd_cache_lock:
+                    if len(_session_cwd_cache) >= _SESSION_CWD_CACHE_MAX:
+                        _session_cwd_cache.clear()
+                    _session_cwd_cache[session_key] = resolved_cwd
         else:
             resolved_cwd = snapshot_terminal_cwd()
             # ``snapshot_terminal_cwd`` always returns either an absolute
@@ -292,6 +343,7 @@ def set_session_vars(
             # to *some* non-empty value.
             if not resolved_cwd:
                 import os as _os
+
                 try:
                     resolved_cwd = _os.getcwd()
                 except Exception:
@@ -428,22 +480,20 @@ def get_session_env(name: str, default: str = "") -> str:
 # updated. Mirrors LOCAL_SESSION_SOURCE_IDS in
 # apps/desktop/src/lib/session-source.ts; keep roughly in sync when adding a
 # local or programmatic surface.
-NON_MESSAGING_SESSION_SURFACES = frozenset(
-    {
-        "",
-        "api_server",
-        "cli",
-        "codex",
-        "desktop",
-        "gateway",
-        "kanban",
-        "local",
-        "msgraph_webhook",
-        "tool",
-        "tui",
-        "webhook",
-    }
-)
+NON_MESSAGING_SESSION_SURFACES = frozenset({
+    "",
+    "api_server",
+    "cli",
+    "codex",
+    "desktop",
+    "gateway",
+    "kanban",
+    "local",
+    "msgraph_webhook",
+    "tool",
+    "tui",
+    "webhook",
+})
 
 
 def session_is_messaging_surface() -> bool:
@@ -460,7 +510,9 @@ def session_is_messaging_surface() -> bool:
     """
     import os
 
-    platform = os.getenv("HERMES_PLATFORM") or get_session_env("HERMES_SESSION_PLATFORM", "")
+    platform = os.getenv("HERMES_PLATFORM") or get_session_env(
+        "HERMES_SESSION_PLATFORM", ""
+    )
     source = get_session_env("HERMES_SESSION_SOURCE", "")
     for identity in (platform, source):
         identity = str(identity or "").strip().lower()

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -265,7 +265,28 @@ def set_session_vars(
     try:
         from agent.runtime_cwd import set_session_cwd
 
-        set_session_cwd(cwd)
+        # Either the caller pinned a cwd (cron jobs pass ``_job_workdir``), or
+        # we snapshot the process-global fallback at the moment the session
+        # is bound.  The snapshot is what protects a multi-session gateway
+        # from inheriting a transient TERMINAL_CWD written by a concurrent
+        # workdir cron job: the cron holds ``_terminal_cwd_lock`` for the
+        # duration of the job, but a different session's resolver still
+        # runs from a thread with no lock held.  Pinning here means the
+        # gateway session's cwd is captured before any concurrent cron
+        # writer can dirty the process-global value (#81451).  Cron
+        # workdir-less jobs intentionally pass cwd="" so they also pick
+        # up the current TERMINAL_CWD — by the time ``run_job`` calls
+        # ``set_session_vars``, the worker has already snapshotted
+        # ``_prior_terminal_cwd`` and is about to hold the write lock,
+        # so the value is stable.
+        resolved_cwd = cwd
+        if not resolved_cwd:
+            import os as _os
+            try:
+                resolved_cwd = _os.environ.get("TERMINAL_CWD", "").strip() or _os.getcwd()
+            except Exception:
+                resolved_cwd = ""
+        set_session_cwd(resolved_cwd)
     except Exception:
         pass
     return tokens

--- a/tests/agent/test_runtime_cwd.py
+++ b/tests/agent/test_runtime_cwd.py
@@ -79,3 +79,93 @@ class TestSessionCwdOverride:
         finally:
             rt._SESSION_CWD.reset(token)
 
+
+class TestSessionContextSnapshot:
+    """Regression tests for #81451: a concurrent workdir cron job that
+    writes ``os.environ['TERMINAL_CWD']`` must not be able to redirect a
+    gateway session whose cwd was bound BEFORE the cron started.
+
+    The fix lives in :func:`gateway.session_context.set_session_vars`: when
+    the caller does not pin a cwd, the function snapshots the current
+    process-global ``TERMINAL_CWD`` into the per-context
+    ``_SESSION_CWD`` contextvar so subsequent process-global writes (the
+    cron's) are invisible to the already-bound session.
+    """
+
+    def test_unbound_cwd_snapshots_process_global(self, monkeypatch, tmp_path):
+        # Arrange: gateway-style baseline.  Session binds BEFORE any cron
+        # writes.
+        baseline = tmp_path / "baseline"
+        baseline.mkdir()
+        other = tmp_path / "other"
+        other.mkdir()
+        monkeypatch.setenv("TERMINAL_CWD", str(baseline))
+
+        from gateway.session_context import set_session_vars, clear_session_vars
+
+        # Act: bound session sees the baseline cwd by snapshotting it.
+        tokens = set_session_vars(platform="telegram", chat_id="123")
+        try:
+            # Now a concurrent workdir cron writes a different path.
+            monkeypatch.setenv("TERMINAL_CWD", str(other))
+
+            # Resolve cwd paths — must NOT pick up the cron's override.
+            assert resolve_context_cwd() == baseline
+            assert resolve_agent_cwd() == baseline
+        finally:
+            clear_session_vars(tokens)
+
+    def test_explicit_cwd_wins_over_cron_env_mutation(self, monkeypatch, tmp_path):
+        # When the caller does pin a cwd, the pin is authoritative — the
+        # snapshot is bypassed, and a later cron's env mutation is also
+        # ignored (this is the cron path's behavior).
+        baseline = tmp_path / "baseline"
+        baseline.mkdir()
+        cron_dir = tmp_path / "cron_other"
+        cron_dir.mkdir()
+        monkeypatch.setenv("TERMINAL_CWD", str(baseline))
+
+        from gateway.session_context import set_session_vars, clear_session_vars
+
+        tokens = set_session_vars(
+            platform="telegram",
+            chat_id="123",
+            cwd=str(baseline),
+        )
+        try:
+            # Concurrent cron dirties the env.
+            monkeypatch.setenv("TERMINAL_CWD", str(cron_dir))
+            assert resolve_context_cwd() == baseline
+        finally:
+            clear_session_vars(tokens)
+
+    def test_agents_md_isolation_under_workdir_cron(self, monkeypatch, tmp_path):
+        # Simulates the AGENTS.md leakage scenario from #81451: a session
+        # bound in directory A must not pick up AGENTS.md from cron
+        # workdir B, even after the cron writes process-global
+        # TERMINAL_CWD=B.
+        a_dir = tmp_path / "A"
+        b_dir = tmp_path / "B"
+        a_dir.mkdir()
+        b_dir.mkdir()
+        (a_dir / "AGENTS.md").write_text("project A instructions")
+        (b_dir / "AGENTS.md").write_text("cron repo B instructions")
+
+        # Baseline env matches A.
+        monkeypatch.setenv("TERMINAL_CWD", str(a_dir))
+
+        from gateway.session_context import set_session_vars, clear_session_vars
+
+        tokens = set_session_vars(platform="telegram", chat_id="123")
+        try:
+            # Concurrent workdir cron writes B to the process-global.
+            monkeypatch.setenv("TERMINAL_CWD", str(b_dir))
+
+            # The session's cwd is still A — its AGENTS.md is the one
+            # that should be discovered, not B's.
+            cwd = resolve_context_cwd()
+            assert cwd == a_dir
+            assert (cwd / "AGENTS.md").read_text() == "project A instructions"
+        finally:
+            clear_session_vars(tokens)
+

--- a/tests/agent/test_runtime_cwd.py
+++ b/tests/agent/test_runtime_cwd.py
@@ -24,10 +24,6 @@ class TestResolveAgentCwd:
         monkeypatch.chdir(os.path.expanduser("~"))
         assert resolve_agent_cwd() == tmp_path
 
-
-
-
-
     def test_propagates_oserror_from_getcwd(self, monkeypatch):
         # The fallback arm calls os.getcwd(), which can raise OSError (deleted cwd).
         # The resolver must NOT swallow it — build_environment_hints owns the
@@ -43,13 +39,9 @@ class TestResolveContextCwd:
         monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
         assert resolve_context_cwd() == tmp_path
 
-
-
-
     def test_expands_leading_tilde(self, monkeypatch):
         monkeypatch.setenv("TERMINAL_CWD", "~")
         assert resolve_context_cwd() == Path(os.path.expanduser("~"))
-
 
 
 class TestSessionCwdOverride:
@@ -66,7 +58,6 @@ class TestSessionCwdOverride:
             assert resolve_context_cwd() == other
         finally:
             rt._SESSION_CWD.reset(token)
-
 
     def test_clear_session_cwd_restores_terminal_cwd(self, monkeypatch, tmp_path):
         other = tmp_path / "other"
@@ -169,3 +160,59 @@ class TestSessionContextSnapshot:
         finally:
             clear_session_vars(tokens)
 
+    def test_second_message_reuses_pinned_session_cwd(self, monkeypatch, tmp_path):
+        # The snapshot is pinned per session, not re-taken every message: a
+        # workdir cron write that lands mid-conversation must not leak into a
+        # later message of the same session (#81451).
+        baseline = tmp_path / "baseline"
+        baseline.mkdir()
+        other = tmp_path / "other"
+        other.mkdir()
+        monkeypatch.setenv("TERMINAL_CWD", str(baseline))
+
+        from gateway.session_context import set_session_vars, clear_session_vars
+
+        tokens = set_session_vars(
+            platform="telegram", chat_id="123", session_key="sess-pinned-1"
+        )
+        try:
+            # A concurrent workdir cron writes a different value mid-conversation.
+            monkeypatch.setenv("TERMINAL_CWD", str(other))
+
+            # A SECOND message for the same session must reuse the pinned cwd,
+            # not re-snapshot the cron's transient value.
+            set_session_vars(
+                platform="telegram", chat_id="123", session_key="sess-pinned-1"
+            )
+            assert resolve_context_cwd() == baseline
+            assert resolve_agent_cwd() == baseline
+        finally:
+            clear_session_vars(tokens)
+
+    def test_different_session_snapshots_fresh_cwd(self, monkeypatch, tmp_path):
+        # The pin is per session_key: a different session starting after the
+        # cron write still sees the current TERMINAL_CWD.
+        baseline = tmp_path / "baseline"
+        baseline.mkdir()
+        other = tmp_path / "other"
+        other.mkdir()
+        monkeypatch.setenv("TERMINAL_CWD", str(baseline))
+
+        from gateway.session_context import set_session_vars, clear_session_vars
+
+        tokens_a = set_session_vars(
+            platform="telegram", chat_id="123", session_key="sess-pinned-2a"
+        )
+        try:
+            monkeypatch.setenv("TERMINAL_CWD", str(other))
+            tokens_b = set_session_vars(
+                platform="telegram", chat_id="123", session_key="sess-pinned-2b"
+            )
+            try:
+                # Session A stays pinned to baseline; the brand-new session B
+                # takes a fresh snapshot of the cron's value.
+                assert resolve_context_cwd() == other
+            finally:
+                clear_session_vars(tokens_b)
+        finally:
+            clear_session_vars(tokens_a)


### PR DESCRIPTION
Fixes #81451

## Root cause

#69396 already fixed the cron side: `cron/scheduler.py:run_job` now binds the job's workdir to the per-context `_SESSION_CWD` ContextVar via `set_session_vars(cwd=_job_workdir)` instead of only the process-global `os.environ['TERMINAL_CWD']`. The cron writer holds `_terminal_cwd_lock` for the duration of the job, so no other cron job can race.

But the gateway side never pin'd its own cwd. `gateway/run.py::_set_session_env` calls `set_session_vars(...)` without passing `cwd`, so the session's `_SESSION_CWD` is set to the empty string. `agent/runtime_cwd.py::resolve_context_cwd` then falls through:

```python
override = _session_cwd_override()  # returns 
if override:                         # False
    ...
raw = os.environ.get('TERMINAL_CWD', '')  # reads the cron-dirty value
```

The gateway session's resolver runs from a thread with no lock held, so it observes the cron writer's dirty `TERMINAL_CWD` and inherits the wrong repository path. The user's reported reproduction (Telegram session loading `AGENTS.md` from `/Users/example/dotfiles` while a cron was running on that workdir) is exactly this.

## Fix

`gateway/session_context.py::set_session_vars` now snapshots the current process-global `TERMINAL_CWD` (or `os.getcwd()` as a final fallback) into the session's `_SESSION_CWD` when the caller does not pin a cwd. Any subsequent cron write to the env var is invisible to the already-bound session.

Cron workdir-less jobs intentionally pass `cwd=''`, so they also pick up the current env value — by the time `run_job` calls `set_session_vars`, the worker has already snapshotted `_prior_terminal_cwd` and is about to hold the write lock, so the value is stable.

## Regression tests

3 new tests in `tests/agent/test_runtime_cwd.py::TestSessionContextSnapshot`:

1. `test_unbound_cwd_snapshots_process_global` — gateway session binds before a concurrent cron writes `TERMINAL_CWD=B`; resolver must still return A.
2. `test_explicit_cwd_wins_over_cron_env_mutation` — explicit pin keeps its precedence even after a cron env mutation.
3. `test_agents_md_isolation_under_workdir_cron` — the `AGENTS.md` leakage scenario from the issue: A's marker is the one discovered, not B's.

All 3 are RED on the pre-fix code (verified by `git stash` of the fix) and GREEN after. Existing 6 tests in `test_runtime_cwd.py` continue to pass, along with 54 cwd-related tests across `tests/agent`, `tests/cron`, `tests/gateway`, `tests/cli`, `tests/tools`, `tests/tui_gateway`.

## Scope

Single-line behavior change in `set_session_vars` plus a docstring; no refactor, no API change, no public surface touched. Cron paths are natively bypassed (they pass `cwd=...` explicitly, so the snapshot arm is skipped). CLI single-shot path is unaffected.