### PR TITLE
fix(tests): isolate terminal runtime state between tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1080,6 +1080,41 @@ def pytest_collection_modifyitems(config, items):  # noqa: D401 — pytest hook
 
 
 @pytest.fixture(autouse=True)
+def _reset_terminal_runtime_state():
+    """Isolate process-global terminal state between tests.
+
+    Terminal/code-execution/file tools cache environments and interrupt state at
+    module scope. Full-suite runs can otherwise reuse a sandbox created by an
+    earlier test with a different backend (for example Modal), which makes later
+    tests nondeterministically inherit the wrong environment.
+    """
+    from tools.interrupt import _interrupted_threads, _lock, set_interrupt
+    from tools.file_tools import clear_file_ops_cache
+    from tools import terminal_tool as _terminal_tool
+
+    def _reset():
+        # Clear interrupt state for ALL threads, not just the current one.
+        # set_interrupt(False) only clears the calling thread's flag; worker
+        # thread flags survive and can bleed into later tests.
+        with _lock:
+            _interrupted_threads.clear()
+        set_interrupt(False)
+        clear_file_ops_cache()
+        _terminal_tool._stop_cleanup_thread()
+        for task_id in list(_terminal_tool._active_environments.keys()):
+            _terminal_tool.cleanup_vm(task_id)
+        _terminal_tool._creation_locks.clear()
+        _terminal_tool._task_env_overrides.clear()
+
+    _reset()
+
+    try:
+        yield
+    finally:
+        _reset()
+
+
+@pytest.fixture(autouse=True)
 def _live_system_guard(request, monkeypatch):
     """Block real os.kill / systemctl / gateway-pid scans during tests.
 


### PR DESCRIPTION
## Summary

Retargeted fix for terminal runtime state isolation between tests (supersedes #5329).

Adds an `autouse` pytest fixture that resets process-global terminal/code-execution/file state before and after each test to prevent full-suite contamination.

### What it resets
- **Interrupt state**: clears `_interrupted_threads` set under its lock (ALL threads, not just current) + `set_interrupt(False)` for the current thread
- **File ops cache**: `clear_file_ops_cache()`
- **Terminal tool state**: stops cleanup thread, clears active environments, creation locks, and per-task env overrides

### Addresses @teknium1's review on #5329

1. **`set_interrupt(False)` thread scope** — the original PR only cleared the current thread's interrupt flag; worker thread flags survived. Fix: clear `_interrupted_threads` set under its lock before calling `set_interrupt(False)`.

2. **`_last_known_cwd`** — not applicable on current main (this variable does not exist). The PR branch had an older version of `file_tools.py` where it existed; main has moved on.

## Validation

- `python -m pytest tests/tools/test_terminal_tool.py tests/tools/test_code_execution.py tests/tools/test_file_tools.py tests/test_mcp_serve.py -q` → **142 passed, 40 skipped**

## Changes

| File | Change |
|------|--------|
| `tests/conftest.py` | +35 lines (new `_reset_terminal_runtime_state` autouse fixture) |

Total: +35/−0 across 1 file.