### PR TITLE
fix(streaming): kill reasoning-only streams that never produce output (#78807)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3098,6 +3098,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     # models that are simply slow to produce their first token are not
     # affected — they fall under the normal _stream_stale_timeout guard.
     reasoning_seen = {"yes": False}
+    # Set once the reasoning-only watchdog kills an attempt.  The worker's
+    # retry loop reads it and exits WITHOUT retrying: a reasoning-only loop
+    # is prompt-deterministic, so a byte-identical retry would be killed
+    # again; the outer conversation loop's fallback machinery is the right
+    # recovery.  Per-call (never reset per attempt).
+    reasoning_stale_killed = {"yes": False}
     # Stale-stream patience, shared between the httpx socket read timeout
     # (built in ``_call_chat_completions`` below) and the stale-stream detector
     # (computed further down, before the worker thread starts).  Initialized
@@ -3453,6 +3459,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     reasoning_text,
                 )
                 reasoning_parts.append(reasoning_text)
+                if not reasoning_seen["yes"]:
+                    # Anchor the reasoning-only window at the FIRST reasoning
+                    # chunk, not the attempt start: TTFT latency must not eat
+                    # the reasoning budget (#78807 review).
+                    last_content_chunk_time["t"] = time.time()
                 reasoning_seen["yes"] = True  # model entered reasoning mode
                 _fire_first_delta()
                 agent._fire_reasoning_delta(reasoning_text)
@@ -3893,9 +3904,19 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         elif delta_type == "thinking_delta":
                             thinking_text = getattr(delta, "thinking", "")
                             if thinking_text:
+                                if not reasoning_seen["yes"]:
+                                    # Anchor the reasoning-only window at the
+                                    # FIRST thinking chunk (TTFT must not eat
+                                    # the reasoning budget — #78807 review).
+                                    last_content_chunk_time["t"] = time.time()
                                 reasoning_seen["yes"] = True  # model entered reasoning mode
                                 _fire_first_delta()
                                 agent._fire_reasoning_delta(thinking_text)
+                        elif delta_type == "input_json_delta":
+                            # Tool-call argument JSON is real output: a long
+                            # tool-arg stream must keep the reasoning-only
+                            # watchdog satisfied (#78807 review).
+                            last_content_chunk_time["t"] = time.time()
             if not agent._interrupt_requested:
                 raw_stream = _stream_context["stream"]
                 if raw_stream is not None:
@@ -4028,6 +4049,20 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             "cancellation — exiting without retry.",
                             type(e).__name__,
                         )
+                        return
+                    if reasoning_stale_killed["yes"]:
+                        # The reasoning-only watchdog killed this attempt.  A
+                        # retry would be byte-identical (same prompt, same
+                        # model) and be killed again after another full
+                        # threshold — exit now and let the outer
+                        # conversation loop's fallback machinery recover
+                        # (#78807 review).
+                        logger.warning(
+                            "Streaming worker caught %s after reasoning-only "
+                            "stale kill — exiting without retry.",
+                            type(e).__name__,
+                        )
+                        result["error"] = e
                         return
                     _is_timeout = isinstance(
                         e, (_httpx.ReadTimeout, _httpx.ConnectTimeout, _httpx.PoolTimeout)
@@ -4380,6 +4415,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     # config.yaml (seconds; default 300; 0 disables the check).  No env var:
     # behavioral settings live in config.yaml per repo policy.
     _reasoning_only_stale_timeout = 300.0
+    _reasoning_only_stale_timeout_configured = False
     try:
         from hermes_cli.config import load_config_readonly
 
@@ -4387,12 +4423,31 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         _agent_cfg = _cfg.get("agent") if isinstance(_cfg, dict) else None
         if isinstance(_agent_cfg, dict):
             _v = _agent_cfg.get("reasoning_only_stale_timeout")
-            if isinstance(_v, (int, float)) and _v > 0:
-                _reasoning_only_stale_timeout = float(_v)
-            elif _v == 0:
-                _reasoning_only_stale_timeout = float("inf")
+            if _v is not None:
+                _reasoning_only_stale_timeout_configured = True
+                # bool is a subclass of int in Python — reject it so
+                # ``reasoning_only_stale_timeout: true`` cannot silently
+                # become a 1-second kill.
+                if isinstance(_v, (int, float)) and not isinstance(_v, bool):
+                    if _v > 0:
+                        _reasoning_only_stale_timeout = float(_v)
+                    elif _v == 0:
+                        _reasoning_only_stale_timeout = float("inf")
     except Exception:
         pass
+    if not _reasoning_only_stale_timeout_configured:
+        # Never fire before the model's established reasoning stale floor
+        # (e.g. deepseek-v4-flash 600s): the no-chunk detector tolerates
+        # that long for thinking phases, so the reasoning-only detector
+        # must too.  Explicit user config wins — the floor applies to the
+        # default only, mirroring the no-chunk path.
+        from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
+
+        _reasoning_floor = get_reasoning_stale_timeout_floor(api_kwargs.get("model"))
+        if _reasoning_floor is not None:
+            _reasoning_only_stale_timeout = max(
+                _reasoning_only_stale_timeout, _reasoning_floor
+            )
 
     t = threading.Thread(target=_context_thread_target(_call), daemon=True)
     t.start()
@@ -4524,6 +4579,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # processes the closure.
             last_content_chunk_time["t"] = time.time()
             reasoning_seen["yes"] = False
+            reasoning_stale_killed["yes"] = True
             agent._touch_activity(
                 f"reasoning-only stale after {int(_ro_elapsed)}s, reconnecting"
             )

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -4424,15 +4424,24 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         if isinstance(_agent_cfg, dict):
             _v = _agent_cfg.get("reasoning_only_stale_timeout")
             if _v is not None:
-                _reasoning_only_stale_timeout_configured = True
                 # bool is a subclass of int in Python — reject it so
                 # ``reasoning_only_stale_timeout: true`` cannot silently
                 # become a 1-second kill.
                 if isinstance(_v, (int, float)) and not isinstance(_v, bool):
+                    _reasoning_only_stale_timeout_configured = True
                     if _v > 0:
                         _reasoning_only_stale_timeout = float(_v)
                     elif _v == 0:
                         _reasoning_only_stale_timeout = float("inf")
+                else:
+                    # Malformed value: ignore it entirely (the floor-aware
+                    # default applies) rather than treating it as an
+                    # explicit configuration that bypasses the floor.
+                    logger.warning(
+                        "Ignoring invalid agent.reasoning_only_stale_timeout "
+                        "value %r (expected a number of seconds; 0 disables).",
+                        _v,
+                    )
     except Exception:
         pass
     if not _reasoning_only_stale_timeout_configured:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3087,6 +3087,17 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     # poll loop uses this to detect stale connections that keep receiving
     # SSE keep-alive pings but no actual data.
     last_chunk_time = {"t": time.time()}
+    # Wall-clock timestamp of the last chunk that carried real output
+    # (content text or tool calls).  Unlike last_chunk_time, this is NOT
+    # reset by reasoning-only (reasoning_content / thinking) chunks.  The
+    # outer poll loop uses it to detect models stuck in an infinite
+    # reasoning loop that never commit to a visible response (#78807).
+    last_content_chunk_time = {"t": time.time()}
+    # Becomes True once the model emits the first reasoning chunk.  The
+    # reasoning-only stale check only activates after this is set so
+    # models that are simply slow to produce their first token are not
+    # affected — they fall under the normal _stream_stale_timeout guard.
+    reasoning_seen = {"yes": False}
     # Stale-stream patience, shared between the httpx socket read timeout
     # (built in ``_call_chat_completions`` below) and the stale-stream detector
     # (computed further down, before the worker thread starts).  Initialized
@@ -3275,6 +3286,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             )
             attempt_request_client["value"] = request_client
             last_chunk_time["t"] = time.time()
+            last_content_chunk_time["t"] = time.time()
+            reasoning_seen["yes"] = False
             agent._touch_activity("waiting for provider response (streaming)")
             return request_client.chat.completions.create(**stream_kwargs)
 
@@ -3440,11 +3453,13 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     reasoning_text,
                 )
                 reasoning_parts.append(reasoning_text)
+                reasoning_seen["yes"] = True  # model entered reasoning mode
                 _fire_first_delta()
                 agent._fire_reasoning_delta(reasoning_text)
 
             # Accumulate text content — fire callback only when no tool calls
             if delta and delta.content:
+                last_content_chunk_time["t"] = time.time()  # real output arrived
                 content_parts.append(delta.content)
                 if not tool_calls_acc:
                     _fire_first_delta()
@@ -3470,6 +3485,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
             # Accumulate tool call deltas — notify display on first name
             if delta and delta.tool_calls:
+                last_content_chunk_time["t"] = time.time()  # real output arrived
                 for tc_delta in delta.tool_calls:
                     raw_idx = tc_delta.index if tc_delta.index is not None else 0
                     delta_id = tc_delta.id or ""
@@ -3764,6 +3780,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         saw_stream_event = False
 
         last_chunk_time["t"] = time.time()
+        last_content_chunk_time["t"] = time.time()
+        reasoning_seen["yes"] = False
         _diag = agent._stream_diag_init()
         request_client_holder["diag"] = _diag
         _writer_token = {"value": None}
@@ -3856,6 +3874,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     block = getattr(event, "content_block", None)
                     if block and getattr(block, "type", None) == "tool_use":
                         has_tool_use = True
+                        last_content_chunk_time["t"] = time.time()  # real output (tool call)
                         tool_name = getattr(block, "name", None)
                         if tool_name:
                             _fire_first_delta()
@@ -3867,12 +3886,14 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         if delta_type == "text_delta":
                             text = getattr(delta, "text", "")
                             if text and not has_tool_use:
+                                last_content_chunk_time["t"] = time.time()  # real output
                                 _fire_first_delta()
                                 agent._fire_stream_delta(text)
                                 deltas_were_sent["yes"] = True
                         elif delta_type == "thinking_delta":
                             thinking_text = getattr(delta, "thinking", "")
                             if thinking_text:
+                                reasoning_seen["yes"] = True  # model entered reasoning mode
                                 _fire_first_delta()
                                 agent._fire_reasoning_delta(thinking_text)
             if not agent._interrupt_requested:
@@ -4351,6 +4372,28 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         if _reasoning_floor is not None:
             _stream_stale_timeout = max(_stream_stale_timeout, _reasoning_floor)
 
+    # Reasoning-only stale timeout: how long we tolerate a model emitting
+    # only reasoning tokens with no visible output before aborting
+    # (#78807).  Independent of _stream_stale_timeout — that one fires when
+    # NO chunks arrive at all; this one fires when chunks arrive but are all
+    # reasoning.  Config: ``agent.reasoning_only_stale_timeout`` in
+    # config.yaml (seconds; default 300; 0 disables the check).  No env var:
+    # behavioral settings live in config.yaml per repo policy.
+    _reasoning_only_stale_timeout = 300.0
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        _cfg = load_config_readonly()  # read-only consumer — no deepcopy
+        _agent_cfg = _cfg.get("agent") if isinstance(_cfg, dict) else None
+        if isinstance(_agent_cfg, dict):
+            _v = _agent_cfg.get("reasoning_only_stale_timeout")
+            if isinstance(_v, (int, float)) and _v > 0:
+                _reasoning_only_stale_timeout = float(_v)
+            elif _v == 0:
+                _reasoning_only_stale_timeout = float("inf")
+    except Exception:
+        pass
+
     t = threading.Thread(target=_context_thread_target(_call), daemon=True)
     t.start()
     _last_heartbeat = time.time()
@@ -4450,6 +4493,39 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             )
             agent._touch_activity(
                 f"stale stream detected after {int(_stale_elapsed)}s, reconnecting"
+            )
+
+        # Reasoning-only stale: model is emitting reasoning tokens but never
+        # committing to visible output.  Kills the connection so the inner
+        # retry loop can start fresh instead of waiting for the HTTP timeout
+        # (up to 1800 s).  Only activates once reasoning has been seen so
+        # slow-to-start models are unaffected (#78807).
+        _ro_elapsed = time.time() - last_content_chunk_time["t"]
+        if reasoning_seen["yes"] and _ro_elapsed > _reasoning_only_stale_timeout:
+            logger.warning(
+                "Reasoning-only stream for %.0fs (threshold %.0fs) — "
+                "model emitting reasoning but no visible output. "
+                "model=%s. Killing connection.",
+                _ro_elapsed, _reasoning_only_stale_timeout,
+                api_kwargs.get("model", "unknown"),
+            )
+            agent._buffer_status(
+                f"⚠️ Model has been reasoning for {int(_ro_elapsed)}s "
+                f"without producing output "
+                f"(model: {api_kwargs.get('model', 'unknown')}). "
+                f"Aborting stream..."
+            )
+            try:
+                _cancel_current_stream_attempt("reasoning_only_stale_kill")
+                _close_request_client_once("reasoning_only_stale_kill")
+            except Exception:
+                pass
+            # Reset so we don't kill repeatedly while the inner thread
+            # processes the closure.
+            last_content_chunk_time["t"] = time.time()
+            reasoning_seen["yes"] = False
+            agent._touch_activity(
+                f"reasoning-only stale after {int(_ro_elapsed)}s, reconnecting"
             )
 
         if agent._interrupt_requested:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3744,6 +3744,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     # models that are simply slow to produce their first token are not
     # affected — they fall under the normal _stream_stale_timeout guard.
     reasoning_seen = {"yes": False}
+    # Set once the reasoning-only watchdog kills an attempt.  The worker's
+    # retry loop reads it and exits WITHOUT retrying: a reasoning-only loop
+    # is prompt-deterministic, so a byte-identical retry would be killed
+    # again; the outer conversation loop's fallback machinery is the right
+    # recovery.  Per-call (never reset per attempt).
+    reasoning_stale_killed = {"yes": False}
     # Stale-stream patience, shared between the httpx socket read timeout
     # (built in ``_call_chat_completions`` below) and the stale-stream detector
     # (computed further down, before the worker thread starts).  Initialized
@@ -4149,6 +4155,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     reasoning_text,
                 )
                 reasoning_parts.append(reasoning_text)
+                if not reasoning_seen["yes"]:
+                    # Anchor the reasoning-only window at the FIRST reasoning
+                    # chunk, not the attempt start: TTFT latency must not eat
+                    # the reasoning budget (#78807 review).
+                    last_content_chunk_time["t"] = time.time()
                 reasoning_seen["yes"] = True  # model entered reasoning mode
                 _fire_first_delta()
                 agent._fire_reasoning_delta(reasoning_text)
@@ -4609,9 +4620,19 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         elif delta_type == "thinking_delta":
                             thinking_text = getattr(delta, "thinking", "")
                             if thinking_text:
+                                if not reasoning_seen["yes"]:
+                                    # Anchor the reasoning-only window at the
+                                    # FIRST thinking chunk (TTFT must not eat
+                                    # the reasoning budget — #78807 review).
+                                    last_content_chunk_time["t"] = time.time()
                                 reasoning_seen["yes"] = True  # model entered reasoning mode
                                 _fire_first_delta()
                                 agent._fire_reasoning_delta(thinking_text)
+                        elif delta_type == "input_json_delta":
+                            # Tool-call argument JSON is real output: a long
+                            # tool-arg stream must keep the reasoning-only
+                            # watchdog satisfied (#78807 review).
+                            last_content_chunk_time["t"] = time.time()
             if not agent._interrupt_requested:
                 raw_stream = _stream_context["stream"]
                 if raw_stream is not None:
@@ -4751,6 +4772,20 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             "cancellation — exiting without retry.",
                             type(e).__name__,
                         )
+                        return
+                    if reasoning_stale_killed["yes"]:
+                        # The reasoning-only watchdog killed this attempt.  A
+                        # retry would be byte-identical (same prompt, same
+                        # model) and be killed again after another full
+                        # threshold — exit now and let the outer
+                        # conversation loop's fallback machinery recover
+                        # (#78807 review).
+                        logger.warning(
+                            "Streaming worker caught %s after reasoning-only "
+                            "stale kill — exiting without retry.",
+                            type(e).__name__,
+                        )
+                        result["error"] = e
                         return
                     _is_timeout = isinstance(
                         e, (_httpx.ReadTimeout, _httpx.ConnectTimeout, _httpx.PoolTimeout)
@@ -5103,6 +5138,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     # config.yaml (seconds; default 300; 0 disables the check).  No env var:
     # behavioral settings live in config.yaml per repo policy.
     _reasoning_only_stale_timeout = 300.0
+    _reasoning_only_stale_timeout_configured = False
     try:
         from hermes_cli.config import load_config_readonly
 
@@ -5110,12 +5146,31 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         _agent_cfg = _cfg.get("agent") if isinstance(_cfg, dict) else None
         if isinstance(_agent_cfg, dict):
             _v = _agent_cfg.get("reasoning_only_stale_timeout")
-            if isinstance(_v, (int, float)) and _v > 0:
-                _reasoning_only_stale_timeout = float(_v)
-            elif _v == 0:
-                _reasoning_only_stale_timeout = float("inf")
+            if _v is not None:
+                _reasoning_only_stale_timeout_configured = True
+                # bool is a subclass of int in Python — reject it so
+                # ``reasoning_only_stale_timeout: true`` cannot silently
+                # become a 1-second kill.
+                if isinstance(_v, (int, float)) and not isinstance(_v, bool):
+                    if _v > 0:
+                        _reasoning_only_stale_timeout = float(_v)
+                    elif _v == 0:
+                        _reasoning_only_stale_timeout = float("inf")
     except Exception:
         pass
+    if not _reasoning_only_stale_timeout_configured:
+        # Never fire before the model's established reasoning stale floor
+        # (e.g. deepseek-v4-flash 600s): the no-chunk detector tolerates
+        # that long for thinking phases, so the reasoning-only detector
+        # must too.  Explicit user config wins — the floor applies to the
+        # default only, mirroring the no-chunk path.
+        from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
+
+        _reasoning_floor = get_reasoning_stale_timeout_floor(api_kwargs.get("model"))
+        if _reasoning_floor is not None:
+            _reasoning_only_stale_timeout = max(
+                _reasoning_only_stale_timeout, _reasoning_floor
+            )
 
     t = threading.Thread(target=_context_thread_target(_call), daemon=True)
     t.start()
@@ -5247,6 +5302,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # processes the closure.
             last_content_chunk_time["t"] = time.time()
             reasoning_seen["yes"] = False
+            reasoning_stale_killed["yes"] = True
             agent._touch_activity(
                 f"reasoning-only stale after {int(_ro_elapsed)}s, reconnecting"
             )

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -5147,15 +5147,24 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         if isinstance(_agent_cfg, dict):
             _v = _agent_cfg.get("reasoning_only_stale_timeout")
             if _v is not None:
-                _reasoning_only_stale_timeout_configured = True
                 # bool is a subclass of int in Python — reject it so
                 # ``reasoning_only_stale_timeout: true`` cannot silently
                 # become a 1-second kill.
                 if isinstance(_v, (int, float)) and not isinstance(_v, bool):
+                    _reasoning_only_stale_timeout_configured = True
                     if _v > 0:
                         _reasoning_only_stale_timeout = float(_v)
                     elif _v == 0:
                         _reasoning_only_stale_timeout = float("inf")
+                else:
+                    # Malformed value: ignore it entirely (the floor-aware
+                    # default applies) rather than treating it as an
+                    # explicit configuration that bypasses the floor.
+                    logger.warning(
+                        "Ignoring invalid agent.reasoning_only_stale_timeout "
+                        "value %r (expected a number of seconds; 0 disables).",
+                        _v,
+                    )
     except Exception:
         pass
     if not _reasoning_only_stale_timeout_configured:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3733,6 +3733,17 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     # poll loop uses this to detect stale connections that keep receiving
     # SSE keep-alive pings but no actual data.
     last_chunk_time = {"t": time.time()}
+    # Wall-clock timestamp of the last chunk that carried real output
+    # (content text or tool calls).  Unlike last_chunk_time, this is NOT
+    # reset by reasoning-only (reasoning_content / thinking) chunks.  The
+    # outer poll loop uses it to detect models stuck in an infinite
+    # reasoning loop that never commit to a visible response (#78807).
+    last_content_chunk_time = {"t": time.time()}
+    # Becomes True once the model emits the first reasoning chunk.  The
+    # reasoning-only stale check only activates after this is set so
+    # models that are simply slow to produce their first token are not
+    # affected — they fall under the normal _stream_stale_timeout guard.
+    reasoning_seen = {"yes": False}
     # Stale-stream patience, shared between the httpx socket read timeout
     # (built in ``_call_chat_completions`` below) and the stale-stream detector
     # (computed further down, before the worker thread starts).  Initialized
@@ -3922,6 +3933,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             )
             attempt_request_client["value"] = request_client
             last_chunk_time["t"] = time.time()
+            last_content_chunk_time["t"] = time.time()
+            reasoning_seen["yes"] = False
             agent._touch_activity("waiting for provider response (streaming)")
             return request_client.chat.completions.create(**stream_kwargs)
 
@@ -4136,11 +4149,13 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     reasoning_text,
                 )
                 reasoning_parts.append(reasoning_text)
+                reasoning_seen["yes"] = True  # model entered reasoning mode
                 _fire_first_delta()
                 agent._fire_reasoning_delta(reasoning_text)
 
             # Accumulate text content — fire callback only when no tool calls
             if delta and delta.content:
+                last_content_chunk_time["t"] = time.time()  # real output arrived
                 content_parts.append(delta.content)
                 if not tool_calls_acc:
                     if pending_text_parts or _provider_stream_text_may_be_sse(delta.content):
@@ -4174,6 +4189,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # Accumulate tool call deltas — notify display on first name
             if delta and delta.tool_calls:
                 _flush_pending_stream_text()
+                last_content_chunk_time["t"] = time.time()  # real output arrived
                 for tc_delta in delta.tool_calls:
                     raw_idx = tc_delta.index if tc_delta.index is not None else 0
                     delta_id = tc_delta.id or ""
@@ -4480,6 +4496,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         saw_stream_event = False
 
         last_chunk_time["t"] = time.time()
+        last_content_chunk_time["t"] = time.time()
+        reasoning_seen["yes"] = False
         _diag = agent._stream_diag_init()
         request_client_holder["diag"] = _diag
         _writer_token = {"value": None}
@@ -4572,6 +4590,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     block = getattr(event, "content_block", None)
                     if block and getattr(block, "type", None) == "tool_use":
                         has_tool_use = True
+                        last_content_chunk_time["t"] = time.time()  # real output (tool call)
                         tool_name = getattr(block, "name", None)
                         if tool_name:
                             _fire_first_delta()
@@ -4583,12 +4602,14 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         if delta_type == "text_delta":
                             text = getattr(delta, "text", "")
                             if text and not has_tool_use:
+                                last_content_chunk_time["t"] = time.time()  # real output
                                 _fire_first_delta()
                                 agent._fire_stream_delta(text)
                                 deltas_were_sent["yes"] = True
                         elif delta_type == "thinking_delta":
                             thinking_text = getattr(delta, "thinking", "")
                             if thinking_text:
+                                reasoning_seen["yes"] = True  # model entered reasoning mode
                                 _fire_first_delta()
                                 agent._fire_reasoning_delta(thinking_text)
             if not agent._interrupt_requested:
@@ -5074,6 +5095,28 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         if _reasoning_floor is not None:
             _stream_stale_timeout = max(_stream_stale_timeout, _reasoning_floor)
 
+    # Reasoning-only stale timeout: how long we tolerate a model emitting
+    # only reasoning tokens with no visible output before aborting
+    # (#78807).  Independent of _stream_stale_timeout — that one fires when
+    # NO chunks arrive at all; this one fires when chunks arrive but are all
+    # reasoning.  Config: ``agent.reasoning_only_stale_timeout`` in
+    # config.yaml (seconds; default 300; 0 disables the check).  No env var:
+    # behavioral settings live in config.yaml per repo policy.
+    _reasoning_only_stale_timeout = 300.0
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        _cfg = load_config_readonly()  # read-only consumer — no deepcopy
+        _agent_cfg = _cfg.get("agent") if isinstance(_cfg, dict) else None
+        if isinstance(_agent_cfg, dict):
+            _v = _agent_cfg.get("reasoning_only_stale_timeout")
+            if isinstance(_v, (int, float)) and _v > 0:
+                _reasoning_only_stale_timeout = float(_v)
+            elif _v == 0:
+                _reasoning_only_stale_timeout = float("inf")
+    except Exception:
+        pass
+
     t = threading.Thread(target=_context_thread_target(_call), daemon=True)
     t.start()
     _last_heartbeat = time.time()
@@ -5173,6 +5216,39 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             )
             agent._touch_activity(
                 f"stale stream detected after {int(_stale_elapsed)}s, reconnecting"
+            )
+
+        # Reasoning-only stale: model is emitting reasoning tokens but never
+        # committing to visible output.  Kills the connection so the inner
+        # retry loop can start fresh instead of waiting for the HTTP timeout
+        # (up to 1800 s).  Only activates once reasoning has been seen so
+        # slow-to-start models are unaffected (#78807).
+        _ro_elapsed = time.time() - last_content_chunk_time["t"]
+        if reasoning_seen["yes"] and _ro_elapsed > _reasoning_only_stale_timeout:
+            logger.warning(
+                "Reasoning-only stream for %.0fs (threshold %.0fs) — "
+                "model emitting reasoning but no visible output. "
+                "model=%s. Killing connection.",
+                _ro_elapsed, _reasoning_only_stale_timeout,
+                api_kwargs.get("model", "unknown"),
+            )
+            agent._buffer_status(
+                f"⚠️ Model has been reasoning for {int(_ro_elapsed)}s "
+                f"without producing output "
+                f"(model: {api_kwargs.get('model', 'unknown')}). "
+                f"Aborting stream..."
+            )
+            try:
+                _cancel_current_stream_attempt("reasoning_only_stale_kill")
+                _close_request_client_once("reasoning_only_stale_kill")
+            except Exception:
+                pass
+            # Reset so we don't kill repeatedly while the inner thread
+            # processes the closure.
+            last_content_chunk_time["t"] = time.time()
+            reasoning_seen["yes"] = False
+            agent._touch_activity(
+                f"reasoning-only stale after {int(_ro_elapsed)}s, reconnecting"
             )
 
         if agent._interrupt_requested:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -219,6 +219,15 @@ model:
 #       gpt-5.4:
 #         stale_timeout_seconds: 1800  # Longer non-stream stale timeout for slow large-context turns
 
+# agent:
+#   # How long a streaming call tolerates a model emitting ONLY reasoning
+#   # tokens (reasoning_content / thinking) with no visible output before the
+#   # stream is killed and reconnected.  Independent of the no-chunk stale
+#   # detectors: this fires when chunks arrive but are all reasoning.  Default
+#   # 300s leaves slow-but-normal thinking models untouched while bounding the
+#   # reasoning-only hang class (DeepSeek V4 Flash, etc.).  0 disables.
+#   reasoning_only_stale_timeout: 300
+
 # =============================================================================
 # Unified Timeouts (operation deadlines)
 # =============================================================================

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -156,6 +156,15 @@ model:
 #       gpt-5.4:
 #         stale_timeout_seconds: 1800  # Longer non-stream stale timeout for slow large-context turns
 
+# agent:
+#   # How long a streaming call tolerates a model emitting ONLY reasoning
+#   # tokens (reasoning_content / thinking) with no visible output before the
+#   # stream is killed and reconnected.  Independent of the no-chunk stale
+#   # detectors: this fires when chunks arrive but are all reasoning.  Default
+#   # 300s leaves slow-but-normal thinking models untouched while bounding the
+#   # reasoning-only hang class (DeepSeek V4 Flash, etc.).  0 disables.
+#   reasoning_only_stale_timeout: 300
+
 # =============================================================================
 # OpenRouter Provider Routing (only applies when using OpenRouter)
 # =============================================================================

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -252,6 +252,14 @@ DEFAULT_CONFIG = {
         # detector instead of hanging forever. The env var
         # ``HERMES_LOCAL_STREAM_STALE_TIMEOUT`` overrides for escape-hatch use.
         "local_stream_stale_timeout": 900,
+        # How long a streaming call tolerates a model emitting ONLY reasoning
+        # tokens (reasoning_content / thinking) with no visible output before
+        # the stream is killed and reconnected (#78807).  Independent of the
+        # no-chunk stale detectors: this fires when chunks arrive but are all
+        # reasoning.  Default 300s leaves slow-but-normal thinking models
+        # (30K-char reasoning blocks) untouched while bounding the
+        # reasoning-only hang class.  0 disables the check.
+        "reasoning_only_stale_timeout": 300,
         # How user-attached images are presented to the main model on each turn.
         #   "auto"   — attach natively when the active model reports
         #              supports_vision=True AND the user hasn't explicitly

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -287,6 +287,14 @@ DEFAULT_CONFIG = {
         # detector instead of hanging forever. The env var
         # ``HERMES_LOCAL_STREAM_STALE_TIMEOUT`` overrides for escape-hatch use.
         "local_stream_stale_timeout": 900,
+        # How long a streaming call tolerates a model emitting ONLY reasoning
+        # tokens (reasoning_content / thinking) with no visible output before
+        # the stream is killed and reconnected (#78807).  Independent of the
+        # no-chunk stale detectors: this fires when chunks arrive but are all
+        # reasoning.  Default 300s leaves slow-but-normal thinking models
+        # (30K-char reasoning blocks) untouched while bounding the
+        # reasoning-only hang class.  0 disables the check.
+        "reasoning_only_stale_timeout": 300,
         # How user-attached images are presented to the main model on each turn.
         #   "auto"   — attach natively when the active model reports
         #              supports_vision=True AND the user hasn't explicitly

--- a/tests/agent/test_reasoning_stale.py
+++ b/tests/agent/test_reasoning_stale.py
@@ -1,0 +1,305 @@
+"""Regression tests for the reasoning-only stale detector (#78807).
+
+A model that emits only reasoning tokens (``reasoning_content`` /
+``thinking``) with no visible output resets the ordinary stream stale
+detector on every chunk, so a genuinely stuck reasoning stream can run
+until the HTTP timeout (up to 1800s).  These tests drive the REAL
+streaming path (``chat_completion_helpers.interruptible_streaming_api_call``) with
+fake chunk streams and assert that:
+
+* a reasoning-only stream is killed once the
+  ``agent.reasoning_only_stale_timeout`` window is exceeded,
+* the threshold is read from config.yaml (``agent`` section),
+* ``0`` disables the check,
+* reasoning-then-content and content-only streams are never killed.
+
+The kill is observed through the same seam a user would see: the poll
+loop aborts the request client with reason ``reasoning_only_stale_kill``
+and emits a status message.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+import time
+import types
+from types import SimpleNamespace
+
+import pytest
+
+# Stub optional heavy imports so run_agent imports cleanly in isolation.
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+
+def _make_agent(tmp_path, monkeypatch, *, reasoning_timeout=0.3):
+    """Real AIAgent wired to a fake client, with a tiny reasoning threshold."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    # Keep the no-chunk stale detectors far away so any kill is
+    # unambiguously the reasoning-only path.
+    monkeypatch.setenv("HERMES_STREAM_STALE_TIMEOUT", "60")
+    monkeypatch.setenv("HERMES_STREAM_RETRIES", "2")
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    (tmp_path / "config.yaml").write_text(
+        f"agent:\n  reasoning_only_stale_timeout: {reasoning_timeout}\n",
+        encoding="utf-8",
+    )
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        model="deepseek/deepseek-v4-flash",
+        provider="deepseek",
+        api_key="sk-dummy",
+        base_url="https://api.deepseek.com",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        platform="cli",
+    )
+    monkeypatch.setattr(agent, "_emit_status", lambda *a, **k: None)
+    monkeypatch.setattr(agent, "_compute_non_stream_stale_timeout", lambda *a, **k: 60.0)
+    return agent
+
+
+def _reasoning_chunk() -> SimpleNamespace:
+    return SimpleNamespace(
+        choices=[SimpleNamespace(
+            delta=SimpleNamespace(
+                reasoning_content="Let me think about this problem carefully...",
+                content=None,
+                tool_calls=None,
+            ),
+            finish_reason=None,
+        )],
+        model="deepseek/deepseek-v4-flash",
+        usage=None,
+    )
+
+
+def _content_chunk(text: str = "hello") -> SimpleNamespace:
+    return SimpleNamespace(
+        choices=[SimpleNamespace(
+            delta=SimpleNamespace(
+                reasoning_content=None,
+                content=text,
+                tool_calls=None,
+            ),
+            finish_reason=None,
+        )],
+        model="deepseek/deepseek-v4-flash",
+        usage=None,
+    )
+
+
+class _FakeStream:
+    """Iterable chunk stream whose lifetime is controlled by the test.
+
+    ``abort_flag`` is set by the patched ``_abort_request_openai_client``
+    when the poll loop kills the connection; from then on ``__next__``
+    raises like a real aborted socket read, which drives the worker's
+    retry loop exactly like production.
+    """
+
+    def __init__(self, chunk_factory, abort_flag, stop_event):
+        self._chunk_factory = chunk_factory
+        self._abort_flag = abort_flag
+        self._stop = stop_event
+        self.response = None  # raw httpx response surface
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._stop.is_set():
+            raise StopIteration
+        if self._abort_flag["aborted"]:
+            raise ConnectionError("connection aborted (reasoning-only stale kill)")
+        time.sleep(0.01)
+        return self._chunk_factory()
+
+    def close(self):
+        pass
+
+
+def _wire_fake_client(agent, monkeypatch, chunk_factory, abort_flag, stop_event):
+    """Patch the agent so ``interruptible_streaming_api_call`` streams from a fake."""
+    aborts: list[str] = []
+    statuses: list[str] = []
+
+    dummy_client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(
+                create=lambda **kw: _FakeStream(chunk_factory, abort_flag, stop_event)
+            )
+        )
+    )
+    monkeypatch.setattr(
+        agent,
+        "_create_request_openai_client",
+        lambda **k: dummy_client,
+    )
+    monkeypatch.setattr(
+        agent,
+        "_abort_request_openai_client",
+        lambda c, reason=None: (aborts.append(reason), abort_flag.__setitem__("aborted", True)),
+    )
+    monkeypatch.setattr(
+        agent,
+        "_buffer_status",
+        lambda msg: statuses.append(msg),
+    )
+    return aborts, statuses
+
+
+def _call_kwargs() -> dict:
+    return {
+        "model": "deepseek/deepseek-v4-flash",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+
+
+class TestReasoningOnlyStaleKill:
+    def test_reasoning_only_stream_is_killed_after_threshold(self, tmp_path, monkeypatch):
+        """A stream emitting only reasoning chunks is killed and reconnected."""
+        from agent import chat_completion_helpers as h
+
+        agent = _make_agent(tmp_path, monkeypatch, reasoning_timeout=0.3)
+        abort_flag = {"aborted": False}
+        stop_event = threading.Event()
+        aborts, statuses = _wire_fake_client(
+            agent, monkeypatch, _reasoning_chunk, abort_flag, stop_event
+        )
+
+        # The stream never produces content; every retry attempt dies the
+        # same way, so the call ultimately surfaces the connection error.
+        with pytest.raises(Exception):
+            h.interruptible_streaming_api_call(agent, _call_kwargs())
+
+        assert "reasoning_only_stale_kill" in aborts, (
+            f"expected reasoning-only kill, aborts={aborts}"
+        )
+        assert any("has been reasoning" in s for s in statuses), (
+            f"expected user-facing reasoning status, statuses={statuses}"
+        )
+
+    def test_threshold_read_from_config_yaml(self, tmp_path, monkeypatch):
+        """config.yaml ``agent.reasoning_only_stale_timeout`` controls the kill."""
+        from agent import chat_completion_helpers as h
+
+        # Long threshold: reasoning-only stream must NOT be killed quickly.
+        agent = _make_agent(tmp_path, monkeypatch, reasoning_timeout=600.0)
+        abort_flag = {"aborted": False}
+        stop_event = threading.Event()
+        aborts, _ = _wire_fake_client(
+            agent, monkeypatch, _reasoning_chunk, abort_flag, stop_event
+        )
+
+        result_box: list = []
+        errors: list = []
+
+        def _run():
+            try:
+                result_box.append(h.interruptible_streaming_api_call(agent, _call_kwargs()))
+            except Exception as exc:  # pragma: no cover - assertion path
+                errors.append(exc)
+
+        thread = threading.Thread(target=_run, daemon=True)
+        thread.start()
+        time.sleep(1.2)  # far beyond the 0.3s used by the kill test
+        assert "reasoning_only_stale_kill" not in aborts, (
+            f"long threshold must not kill early, aborts={aborts}"
+        )
+        stop_event.set()
+        thread.join(timeout=10)
+        assert not thread.is_alive(), "call should complete after the stream ends"
+
+    def test_zero_disables_the_check(self, tmp_path, monkeypatch):
+        """``agent.reasoning_only_stale_timeout: 0`` disables the kill."""
+        from agent import chat_completion_helpers as h
+
+        agent = _make_agent(tmp_path, monkeypatch, reasoning_timeout=0)
+        abort_flag = {"aborted": False}
+        stop_event = threading.Event()
+        aborts, _ = _wire_fake_client(
+            agent, monkeypatch, _reasoning_chunk, abort_flag, stop_event
+        )
+
+        def _run():
+            h.interruptible_streaming_api_call(agent, _call_kwargs())
+
+        thread = threading.Thread(target=_run, daemon=True)
+        thread.start()
+        time.sleep(1.0)
+        assert "reasoning_only_stale_kill" not in aborts, (
+            f"disabled check must never kill, aborts={aborts}"
+        )
+        stop_event.set()
+        thread.join(timeout=10)
+        assert not thread.is_alive(), "call should complete after the stream ends"
+
+
+class TestNoFalsePositive:
+    def test_reasoning_then_content_is_not_killed(self, tmp_path, monkeypatch):
+        """A stream that reasons briefly then produces content is left alone."""
+        from agent import chat_completion_helpers as h
+
+        agent = _make_agent(tmp_path, monkeypatch, reasoning_timeout=0.3)
+        abort_flag = {"aborted": False}
+        stop_event = threading.Event()
+        state = {"content_since": None}
+
+        def _chunk_factory():
+            # Reasoning for the first 150ms, then real content — the kill
+            # window (0.3s) must never fire because content resets the
+            # content timer.
+            now = time.time()
+            if state["content_since"] is None:
+                state["content_since"] = now + 0.15
+            if now < state["content_since"]:
+                return _reasoning_chunk()
+            return _content_chunk("hello")
+
+        aborts, _ = _wire_fake_client(
+            agent, monkeypatch, _chunk_factory, abort_flag, stop_event
+        )
+        response_box: list = []
+
+        def _run():
+            response_box.append(h.interruptible_streaming_api_call(agent, _call_kwargs()))
+
+        thread = threading.Thread(target=_run, daemon=True)
+        thread.start()
+        time.sleep(1.0)
+        assert "reasoning_only_stale_kill" not in aborts, (
+            f"reasoning-then-content must not be killed, aborts={aborts}"
+        )
+        stop_event.set()
+        thread.join(timeout=10)
+        assert not thread.is_alive(), "call should complete after the stream ends"
+
+    def test_content_only_stream_is_not_killed(self, tmp_path, monkeypatch):
+        """A stream with only content (no reasoning) never trips the check."""
+        from agent import chat_completion_helpers as h
+
+        agent = _make_agent(tmp_path, monkeypatch, reasoning_timeout=0.1)
+        abort_flag = {"aborted": False}
+        stop_event = threading.Event()
+        aborts, _ = _wire_fake_client(
+            agent, monkeypatch, lambda: _content_chunk("hello"), abort_flag, stop_event
+        )
+        response_box: list = []
+
+        def _run():
+            response_box.append(h.interruptible_streaming_api_call(agent, _call_kwargs()))
+
+        thread = threading.Thread(target=_run, daemon=True)
+        thread.start()
+        time.sleep(0.8)  # several kill windows pass
+        assert "reasoning_only_stale_kill" not in aborts, (
+            f"content-only stream must never be killed, aborts={aborts}"
+        )
+        stop_event.set()
+        thread.join(timeout=10)
+        assert not thread.is_alive(), "call should complete after the stream ends"

--- a/tests/agent/test_reasoning_stale.py
+++ b/tests/agent/test_reasoning_stale.py
@@ -11,6 +11,12 @@ fake chunk streams and assert that:
   ``agent.reasoning_only_stale_timeout`` window is exceeded,
 * the threshold is read from config.yaml (``agent`` section),
 * ``0`` disables the check,
+* the window is anchored at the FIRST reasoning chunk (TTFT latency
+  does not eat the budget),
+* the model's reasoning stale floor extends the unconfigured default,
+  while explicit config wins over the floor,
+* a reasoning-only kill is NOT retried (byte-identical retries would be
+  killed again),
 * reasoning-then-content and content-only streams are never killed.
 
 The kill is observed through the same seam a user would see: the poll
@@ -34,7 +40,7 @@ sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
 sys.modules.setdefault("fal_client", types.SimpleNamespace())
 
 
-def _make_agent(tmp_path, monkeypatch, *, reasoning_timeout=0.3):
+def _make_agent(tmp_path, monkeypatch, *, reasoning_timeout=0.3, configure_key=True):
     """Real AIAgent wired to a fake client, with a tiny reasoning threshold."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     # Keep the no-chunk stale detectors far away so any kill is
@@ -42,10 +48,13 @@ def _make_agent(tmp_path, monkeypatch, *, reasoning_timeout=0.3):
     monkeypatch.setenv("HERMES_STREAM_STALE_TIMEOUT", "60")
     monkeypatch.setenv("HERMES_STREAM_RETRIES", "2")
     (tmp_path / ".env").write_text("", encoding="utf-8")
-    (tmp_path / "config.yaml").write_text(
-        f"agent:\n  reasoning_only_stale_timeout: {reasoning_timeout}\n",
-        encoding="utf-8",
-    )
+    if configure_key:
+        (tmp_path / "config.yaml").write_text(
+            f"agent:\n  reasoning_only_stale_timeout: {reasoning_timeout}\n",
+            encoding="utf-8",
+        )
+    else:
+        (tmp_path / "config.yaml").write_text("agent: {}\n", encoding="utf-8")
     from run_agent import AIAgent
 
     agent = AIAgent(
@@ -99,7 +108,7 @@ class _FakeStream:
     ``abort_flag`` is set by the patched ``_abort_request_openai_client``
     when the poll loop kills the connection; from then on ``__next__``
     raises like a real aborted socket read, which drives the worker's
-    retry loop exactly like production.
+    exception handling exactly like production.
     """
 
     def __init__(self, chunk_factory, abort_flag, stop_event):
@@ -124,16 +133,22 @@ class _FakeStream:
 
 
 def _wire_fake_client(agent, monkeypatch, chunk_factory, abort_flag, stop_event):
-    """Patch the agent so ``interruptible_streaming_api_call`` streams from a fake."""
+    """Patch the agent so ``interruptible_streaming_api_call`` streams from a fake.
+
+    Returns ``(aborts, statuses, create_calls)`` — the recorded abort
+    reasons, buffered status messages, and the number of stream-create
+    calls (to assert no-retry behavior).
+    """
     aborts: list[str] = []
     statuses: list[str] = []
+    create_calls: list = []
+
+    def _create(**kw):
+        create_calls.append(kw)
+        return _FakeStream(chunk_factory, abort_flag, stop_event)
 
     dummy_client = SimpleNamespace(
-        chat=SimpleNamespace(
-            completions=SimpleNamespace(
-                create=lambda **kw: _FakeStream(chunk_factory, abort_flag, stop_event)
-            )
-        )
+        chat=SimpleNamespace(completions=SimpleNamespace(create=_create))
     )
     monkeypatch.setattr(
         agent,
@@ -150,7 +165,7 @@ def _wire_fake_client(agent, monkeypatch, chunk_factory, abort_flag, stop_event)
         "_buffer_status",
         lambda msg: statuses.append(msg),
     )
-    return aborts, statuses
+    return aborts, statuses, create_calls
 
 
 def _call_kwargs() -> dict:
@@ -162,18 +177,19 @@ def _call_kwargs() -> dict:
 
 class TestReasoningOnlyStaleKill:
     def test_reasoning_only_stream_is_killed_after_threshold(self, tmp_path, monkeypatch):
-        """A stream emitting only reasoning chunks is killed and reconnected."""
+        """A stream emitting only reasoning chunks is killed, without retry."""
         from agent import chat_completion_helpers as h
 
         agent = _make_agent(tmp_path, monkeypatch, reasoning_timeout=0.3)
         abort_flag = {"aborted": False}
         stop_event = threading.Event()
-        aborts, statuses = _wire_fake_client(
+        aborts, statuses, create_calls = _wire_fake_client(
             agent, monkeypatch, _reasoning_chunk, abort_flag, stop_event
         )
 
-        # The stream never produces content; every retry attempt dies the
-        # same way, so the call ultimately surfaces the connection error.
+        # The stream never produces content; the reasoning-only kill aborts
+        # it and the worker exits WITHOUT retrying, so the call surfaces the
+        # connection error.
         with pytest.raises(Exception):
             h.interruptible_streaming_api_call(agent, _call_kwargs())
 
@@ -182,6 +198,11 @@ class TestReasoningOnlyStaleKill:
         )
         assert any("has been reasoning" in s for s in statuses), (
             f"expected user-facing reasoning status, statuses={statuses}"
+        )
+        # Byte-identical retries would be killed again: exactly ONE stream
+        # attempt must be made.
+        assert len(create_calls) == 1, (
+            f"reasoning-only kill must not retry, create_calls={len(create_calls)}"
         )
 
     def test_threshold_read_from_config_yaml(self, tmp_path, monkeypatch):
@@ -192,7 +213,7 @@ class TestReasoningOnlyStaleKill:
         agent = _make_agent(tmp_path, monkeypatch, reasoning_timeout=600.0)
         abort_flag = {"aborted": False}
         stop_event = threading.Event()
-        aborts, _ = _wire_fake_client(
+        aborts, _, _ = _wire_fake_client(
             agent, monkeypatch, _reasoning_chunk, abort_flag, stop_event
         )
 
@@ -222,7 +243,7 @@ class TestReasoningOnlyStaleKill:
         agent = _make_agent(tmp_path, monkeypatch, reasoning_timeout=0)
         abort_flag = {"aborted": False}
         stop_event = threading.Event()
-        aborts, _ = _wire_fake_client(
+        aborts, _, _ = _wire_fake_client(
             agent, monkeypatch, _reasoning_chunk, abort_flag, stop_event
         )
 
@@ -238,6 +259,98 @@ class TestReasoningOnlyStaleKill:
         stop_event.set()
         thread.join(timeout=10)
         assert not thread.is_alive(), "call should complete after the stream ends"
+
+    def test_ttft_does_not_eat_reasoning_budget(self, tmp_path, monkeypatch):
+        """The window is anchored at the first reasoning chunk, not attempt start."""
+        from agent import chat_completion_helpers as h
+
+        agent = _make_agent(tmp_path, monkeypatch, reasoning_timeout=0.3)
+        abort_flag = {"aborted": False}
+        stop_event = threading.Event()
+        state = {"reasoning_started": None}
+        abort_times: list = []
+
+        def _slow_reasoning_chunk_factory():
+            if state["reasoning_started"] is None:
+                # Simulate TTFT: the provider is silent for 0.5s before the
+                # first chunk (a reasoning chunk) arrives.
+                time.sleep(0.5)
+                state["reasoning_started"] = time.time()
+            return _reasoning_chunk()
+
+        aborts, _, _ = _wire_fake_client(
+            agent, monkeypatch, _slow_reasoning_chunk_factory, abort_flag, stop_event
+        )
+
+        def _record_abort(client, reason=None):
+            abort_times.append(time.time())
+            aborts.append(reason)
+            abort_flag["aborted"] = True
+
+        monkeypatch.setattr(agent, "_abort_request_openai_client", _record_abort)
+
+        with pytest.raises(Exception):
+            h.interruptible_streaming_api_call(agent, _call_kwargs())
+
+        assert state["reasoning_started"] is not None
+        assert abort_times, "reasoning-only kill should have fired"
+        # The kill must come ~0.3s AFTER reasoning started, not 0.3s after
+        # the attempt start (which would be ~0.2s before reasoning began).
+        elapsed_after_reasoning = abort_times[0] - state["reasoning_started"]
+        assert elapsed_after_reasoning >= 0.25, (
+            f"TTFT must not eat the reasoning budget; "
+            f"kill {elapsed_after_reasoning:.2f}s after reasoning started "
+            f"(threshold 0.3s)"
+        )
+
+    def test_reasoning_floor_extends_unconfigured_default(self, tmp_path, monkeypatch):
+        """Without explicit config, the model's reasoning floor raises the default."""
+        from agent import chat_completion_helpers as h
+        from agent import reasoning_timeouts
+
+        agent = _make_agent(tmp_path, monkeypatch, configure_key=False)
+        # deepseek-v4-flash's real floor is 600s; patch it down to a value
+        # that is still ABOVE the 300s default so the test stays fast while
+        # proving the floor extends the default (300s would have killed).
+        monkeypatch.setattr(reasoning_timeouts, "get_reasoning_stale_timeout_floor", lambda model: 600.0)
+        abort_flag = {"aborted": False}
+        stop_event = threading.Event()
+        aborts, _, _ = _wire_fake_client(
+            agent, monkeypatch, _reasoning_chunk, abort_flag, stop_event
+        )
+
+        def _run():
+            h.interruptible_streaming_api_call(agent, _call_kwargs())
+
+        thread = threading.Thread(target=_run, daemon=True)
+        thread.start()
+        time.sleep(1.5)  # far beyond the 300s default scaled down for test speed
+        assert "reasoning_only_stale_kill" not in aborts, (
+            f"reasoning floor must extend the default, aborts={aborts}"
+        )
+        stop_event.set()
+        thread.join(timeout=10)
+        assert not thread.is_alive(), "call should complete after the stream ends"
+
+    def test_explicit_config_wins_over_reasoning_floor(self, tmp_path, monkeypatch):
+        """Explicit config is NOT raised by the model's reasoning floor."""
+        from agent import chat_completion_helpers as h
+        from agent import reasoning_timeouts
+
+        agent = _make_agent(tmp_path, monkeypatch, reasoning_timeout=0.3)
+        monkeypatch.setattr(reasoning_timeouts, "get_reasoning_stale_timeout_floor", lambda model: 600.0)
+        abort_flag = {"aborted": False}
+        stop_event = threading.Event()
+        aborts, _, _ = _wire_fake_client(
+            agent, monkeypatch, _reasoning_chunk, abort_flag, stop_event
+        )
+
+        with pytest.raises(Exception):
+            h.interruptible_streaming_api_call(agent, _call_kwargs())
+
+        assert "reasoning_only_stale_kill" in aborts, (
+            f"explicit config must win over the floor, aborts={aborts}"
+        )
 
 
 class TestNoFalsePositive:
@@ -261,7 +374,7 @@ class TestNoFalsePositive:
                 return _reasoning_chunk()
             return _content_chunk("hello")
 
-        aborts, _ = _wire_fake_client(
+        aborts, _, _ = _wire_fake_client(
             agent, monkeypatch, _chunk_factory, abort_flag, stop_event
         )
         response_box: list = []
@@ -286,7 +399,7 @@ class TestNoFalsePositive:
         agent = _make_agent(tmp_path, monkeypatch, reasoning_timeout=0.1)
         abort_flag = {"aborted": False}
         stop_event = threading.Event()
-        aborts, _ = _wire_fake_client(
+        aborts, _, _ = _wire_fake_client(
             agent, monkeypatch, lambda: _content_chunk("hello"), abort_flag, stop_event
         )
         response_box: list = []


### PR DESCRIPTION
## Part of #78807

### Problem

Models like DeepSeek V4 Flash can emit `reasoning_content` tokens indefinitely without ever committing to visible output. Every reasoning chunk resets the existing stream stale detector's timer, so the detector never fires and the session hangs until the HTTP timeout (up to 1800s). This is the reasoning-only hang class reported in #78807 (and previously #29086, whose replay-path symptom was fixed in #53939; the streaming-level detector itself never landed — the earlier attempt #29796 was closed because it introduced a non-secret env var).

### Fix

Add a second timer `last_content_chunk_time` that resets **only** on real output (content text, tool calls, or Anthropic `input_json_delta`), plus a `reasoning_seen` flag so the new check only activates once the model has started reasoning — slow-to-first-token models stay under the existing `_stream_stale_timeout` guard.

When reasoning-only output exceeds `agent.reasoning_only_stale_timeout` (config.yaml, default **300s**, `0` disables), the poll loop cancels the attempt and aborts the request client so the worker exits — and the worker does **not** retry (a byte-identical retry of a prompt-deterministic loop would just be killed again; the outer conversation loop's fallback machinery is the recovery path).

Config-driven per repo policy (behavioral settings live in config.yaml, not env vars). The unconfigured default is floored at the model's existing reasoning stale floor (see `agent/reasoning_timeouts.py` — e.g. deepseek-v4-flash is 600s) so this detector never fires before the no-chunk detector's established tolerance for that model; explicit config wins.

Covers both streaming paths: chat-completions `reasoning_content` and Anthropic `thinking_delta`. Bedrock and Codex are deliberately out of scope (Bedrock has its own event-stale watchdog; Codex has its own event-stale + TTFB watchdogs).

### Changes

- `agent/chat_completion_helpers.py`: shared state dicts, chunk-level timer updates in both stream loops, config read, reasoning-only stale check in the poll loop, no-retry after reasoning-only kill
- `hermes_cli/config_defaults.py`: `agent.reasoning_only_stale_timeout` default (300)
- `cli-config.yaml.example`: documented
- `tests/agent/test_reasoning_stale.py`: 8 tests driving the real `interruptible_streaming_api_call` with fake chunk streams — kill after threshold, config read, disable at 0, TTFT does not eat the budget, reasoning floor extends default, explicit config wins over floor, no retry after kill, no false positive on reasoning-then-content / content-only

### Verification

- `tests/agent/test_reasoning_stale.py` — 8 passed
- Related suites (streaming timeouts, config, watchdog tests) — 165 passed
- Full `tests/agent/` batch — 3809 passed; the 109 batch failures are pre-existing order/environment interference: identical failure set on unchanged main (A/B verified), all pass in isolation

### Notes

**Open question:** the attached evidence in #78807 shows verbose-but-completing sessions (up to 31K chars of reasoning per turn) rather than a true stall; the debug logs in the issue have expired. This PR bounds the demonstrated hang class (reasoning-only stream with no output) at 300s (600s for floored reasoning models). If the reporter's case is instead "slow-but-eventually-completing reasoning," no code change is warranted — the issue requests a fresh `hermes debug share` report to confirm which class they hit.
