### PR TITLE
fix(installer): don't adopt the Node tarball's uids on root installs

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -933,10 +933,13 @@ install_node() {
     fi
 
     log_info "Extracting to ~/.hermes/node/..."
+    # --no-same-owner: as root, tar restores the uids recorded in the archive,
+    # and nodejs.org builds theirs as uid 1001, which collides with the first
+    # local account created after the installing user.
     if [[ "$tarball_name" == *.tar.xz ]]; then
-        tar xf "$tmp_dir/$tarball_name" -C "$tmp_dir"
+        tar --no-same-owner -xf "$tmp_dir/$tarball_name" -C "$tmp_dir"
     else
-        tar xzf "$tmp_dir/$tarball_name" -C "$tmp_dir"
+        tar --no-same-owner -xzf "$tmp_dir/$tarball_name" -C "$tmp_dir"
     fi
 
     local extracted_dir

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -933,13 +933,14 @@ install_node() {
     fi
 
     log_info "Extracting to ~/.hermes/node/..."
-    # --no-same-owner: as root, tar restores the uids recorded in the archive,
-    # and nodejs.org builds theirs as uid 1001, which collides with the first
-    # local account created after the installing user.
+    # nodejs.org records uid 1001 in the archive, and a root extraction adopts
+    # it, handing the runtime to the next local account created on the host.
+    # -o rather than --no-same-owner: a busybox tar built without long options
+    # accepts only the short spelling.
     if [[ "$tarball_name" == *.tar.xz ]]; then
-        tar --no-same-owner -xf "$tmp_dir/$tarball_name" -C "$tmp_dir"
+        tar -o -xf "$tmp_dir/$tarball_name" -C "$tmp_dir"
     else
-        tar --no-same-owner -xzf "$tmp_dir/$tarball_name" -C "$tmp_dir"
+        tar -o -xzf "$tmp_dir/$tarball_name" -C "$tmp_dir"
     fi
 
     local extracted_dir

--- a/scripts/lib/node-bootstrap.sh
+++ b/scripts/lib/node-bootstrap.sh
@@ -281,10 +281,13 @@ _nb_install_bundled_node() {
     }
 
     _nb_log "Extracting to $HERMES_HOME/node/..."
+    # --no-same-owner: as root, tar restores the uids recorded in the archive,
+    # and nodejs.org builds theirs as uid 1001, which collides with the first
+    # local account created after the installing user.
     if [[ "$tarball" == *.tar.xz ]]; then
-        tar xf  "$tmp/$tarball" -C "$tmp" || { rm -rf "$tmp"; return 1; }
+        tar --no-same-owner -xf  "$tmp/$tarball" -C "$tmp" || { rm -rf "$tmp"; return 1; }
     else
-        tar xzf "$tmp/$tarball" -C "$tmp" || { rm -rf "$tmp"; return 1; }
+        tar --no-same-owner -xzf "$tmp/$tarball" -C "$tmp" || { rm -rf "$tmp"; return 1; }
     fi
 
     local extracted

--- a/scripts/lib/node-bootstrap.sh
+++ b/scripts/lib/node-bootstrap.sh
@@ -281,13 +281,14 @@ _nb_install_bundled_node() {
     }
 
     _nb_log "Extracting to $HERMES_HOME/node/..."
-    # --no-same-owner: as root, tar restores the uids recorded in the archive,
-    # and nodejs.org builds theirs as uid 1001, which collides with the first
-    # local account created after the installing user.
+    # nodejs.org records uid 1001 in the archive, and a root extraction adopts
+    # it, handing the runtime to the next local account created on the host.
+    # -o rather than --no-same-owner: a busybox tar built without long options
+    # accepts only the short spelling.
     if [[ "$tarball" == *.tar.xz ]]; then
-        tar --no-same-owner -xf  "$tmp/$tarball" -C "$tmp" || { rm -rf "$tmp"; return 1; }
+        tar -o -xf  "$tmp/$tarball" -C "$tmp" || { rm -rf "$tmp"; return 1; }
     else
-        tar --no-same-owner -xzf "$tmp/$tarball" -C "$tmp" || { rm -rf "$tmp"; return 1; }
+        tar -o -xzf "$tmp/$tarball" -C "$tmp" || { rm -rf "$tmp"; return 1; }
     fi
 
     local extracted

--- a/tests/test_install_sh_node_tarball_ownership.py
+++ b/tests/test_install_sh_node_tarball_ownership.py
@@ -1,0 +1,47 @@
+"""Regression tests for Node tarball ownership on root installs.
+
+``tar`` restores the uid/gid recorded inside an archive when it runs as root,
+and the official nodejs.org tarballs are built as ``iojs``, uid/gid 1001. A root
+install therefore left ``$HERMES_HOME/node`` owned by 1001 rather than root.
+
+That matters because uid 1001 is the first id most distributions hand out after
+the initial human account: the next account created on the host silently took
+ownership of the Node runtime root executes for browser tools, at mode 0755.
+
+Both Node install paths extract a downloaded tarball, so both must pass
+``--no-same-owner``. It is already tar's default for non-root, and is accepted
+by GNU tar and bsdtar alike, so the shared macOS path is unaffected.
+
+See https://github.com/NousResearch/hermes-agent/issues/81525.
+"""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+NODE_BOOTSTRAP = REPO_ROOT / "scripts" / "lib" / "node-bootstrap.sh"
+
+# A tar extraction call site, in either the `tar xf` or the `tar -xf` form.
+# Matched by shape rather than by exact line so a future third call site cannot
+# be added without the flag.
+EXTRACTION = re.compile(r"^\s*tar\b.*\s-?x[a-z]*f\b")
+
+
+def _extraction_lines(path: Path) -> list[str]:
+    return [line.strip() for line in path.read_text().splitlines() if EXTRACTION.match(line)]
+
+
+def test_install_sh_extracts_node_without_adopting_archive_ownership() -> None:
+    lines = _extraction_lines(INSTALL_SH)
+    assert lines, "no tar extraction found in install.sh"
+    for line in lines:
+        assert "--no-same-owner" in line, line
+
+
+def test_node_bootstrap_extracts_node_without_adopting_archive_ownership() -> None:
+    """The lazy runtime path installs Node too, and runs as whoever runs hermes."""
+    lines = _extraction_lines(NODE_BOOTSTRAP)
+    assert lines, "no tar extraction found in node-bootstrap.sh"
+    for line in lines:
+        assert "--no-same-owner" in line, line

--- a/tests/test_install_sh_node_tarball_ownership.py
+++ b/tests/test_install_sh_node_tarball_ownership.py
@@ -8,9 +8,9 @@ That matters because uid 1001 is the first id most distributions hand out after
 the initial human account: the next account created on the host silently took
 ownership of the Node runtime root executes for browser tools, at mode 0755.
 
-Both Node install paths extract a downloaded tarball, so both must pass
-``--no-same-owner``. It is already tar's default for non-root, and is accepted
-by GNU tar and bsdtar alike, so the shared macOS path is unaffected.
+Both Node install paths extract a downloaded tarball, so both must suppress
+owner restoration. Either spelling satisfies that: ``-o`` is the extract-mode
+synonym of ``--no-same-owner`` in GNU tar, busybox and bsdtar.
 
 See https://github.com/NousResearch/hermes-agent/issues/81525.
 """
@@ -27,6 +27,10 @@ NODE_BOOTSTRAP = REPO_ROOT / "scripts" / "lib" / "node-bootstrap.sh"
 # be added without the flag.
 EXTRACTION = re.compile(r"^\s*tar\b.*\s-?x[a-z]*f\b")
 
+# A folded `-oxzf` suppresses ownership too; requiring the standalone form
+# keeps the flag visible at the call site.
+NO_SAME_OWNER = re.compile(r"\s(?:-o|--no-same-owner)(?=\s)")
+
 
 def _extraction_lines(path: Path) -> list[str]:
     return [line.strip() for line in path.read_text().splitlines() if EXTRACTION.match(line)]
@@ -36,7 +40,7 @@ def test_install_sh_extracts_node_without_adopting_archive_ownership() -> None:
     lines = _extraction_lines(INSTALL_SH)
     assert lines, "no tar extraction found in install.sh"
     for line in lines:
-        assert "--no-same-owner" in line, line
+        assert NO_SAME_OWNER.search(line), line
 
 
 def test_node_bootstrap_extracts_node_without_adopting_archive_ownership() -> None:
@@ -44,4 +48,4 @@ def test_node_bootstrap_extracts_node_without_adopting_archive_ownership() -> No
     lines = _extraction_lines(NODE_BOOTSTRAP)
     assert lines, "no tar extraction found in node-bootstrap.sh"
     for line in lines:
-        assert "--no-same-owner" in line, line
+        assert NO_SAME_OWNER.search(line), line


### PR DESCRIPTION
## What does this PR do?

`tar` restores the uid/gid recorded inside an archive when it runs as root, and the official
nodejs.org tarballs are built as `iojs`, uid/gid 1001. A root install therefore leaves
`$HERMES_HOME/node` owned by 1001 rather than root.

uid 1001 is the first id most distributions hand out after the initial human account, so the next
account created on the host silently takes ownership of the 204 MB Node runtime that root's Hermes
executes for browser tools, at mode 0755. `/root` being 0700 is the only thing preventing reach in
the default layout, and that is a property of the distribution default rather than a control Hermes
applies.

The fix is `-o`, which is the extract-mode synonym of `--no-same-owner` in GNU tar, bsdtar and
busybox alike, and the only spelling a busybox compiled without `FEATURE_TAR_LONG_OPTIONS` accepts.
Suppressing owner restoration is already tar's default for non-root, so this only changes behaviour
in the case where the behaviour was wrong.

**Both** Node install paths extract a downloaded tarball, so both get the flag: `scripts/install.sh`
and the lazy runtime path in `scripts/lib/node-bootstrap.sh` (reached from
`hermes_cli/main.py` when node/npm are missing, and running as whoever runs hermes).

`scripts/dev-sandbox.sh` also pipes through `tar -xf`, but its archive is created locally by the
same user in the same command, so it carries local ownership by design. Left alone.

## Related Issue

Fixes #81525

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

<!-- Not ticking "security fix": this is a local privilege-boundary defect, not remotely
exploitable, and I would rather understate it than trigger a disclosure process it does not need. -->

## Changes Made

- `scripts/install.sh` — `-o` on both Node tarball extractions
- `scripts/lib/node-bootstrap.sh` — same, for the lazy runtime install path
- `tests/test_install_sh_node_tarball_ownership.py` — new. Asserts every `tar` extraction call site
  in both scripts suppresses owner restoration, accepting either `-o` or `--no-same-owner` so it
  pins the behaviour rather than the wording. Matched by shape rather than by exact line, so a
  future third call site cannot be added without it

## How to Test

1. Root-install on a Linux host where uid 1001 is not yet allocated (fresh Ubuntu, one human
   account at uid 1000)
2. `stat -c '%u:%g %a %n' /root/.hermes/node`
   - before: `1001:1001 755 /root/.hermes/node`
   - after: `0:0 755 /root/.hermes/node`
3. `useradd svc`, then re-stat
   - before: `svc:svc 755` — the new account now owns root's Node runtime
   - after: still `root:root 755`

The ownership comes straight out of the archive, so it reproduces on any host:

```console
$ curl -sL https://nodejs.org/dist/v22.23.2/node-v22.23.2-linux-x64.tar.xz \
    | tar -tvJf - --numeric-owner | head -3
drwxr-xr-x 1001/1001         0 2026-07-29 08:23 node-v22.23.2-linux-x64/
drwxr-xr-x 1001/1001         0 2026-07-29 08:23 node-v22.23.2-linux-x64/bin/
-rwxr-xr-x 1001/1001 124836408 2026-07-29 08:23 node-v22.23.2-linux-x64/bin/node
```

Found on a real install: provisioning one unprivileged service account on Ubuntu 26.04 handed it
`/root/.hermes/node`, reported as `svc:svc-work 755`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — see the note below for exactly what ran
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 26.04 LTS, x86_64

**On the test run, precisely:** `tests/test_install*.py` passes at 74 passed / 1 skipped, including
the two new cases, with the real `conftest.py` active. I did not run the full 26k-test suite: a
clean checkout of `main` already hits collection errors in `tests/gateway/` and
`tests/integration/` on my machine because I installed only `--extra dev` and not every optional
extra. Those errors are present without my change, so I left the full run to CI rather than report
a green I had not actually seen.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, behaviour-only fix
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

**On cross-platform:** `install_node` is shared with macOS, so the flag has to be portable even
though the root/FHS install that triggers the bug is Linux-only. `bsdtar.1` documents `-o` in x mode
as "use the user and group of the user running the program rather than those specified in the
archive", so the macOS path gets the same behaviour and is otherwise unaffected. busybox tar accepts
`-o` as well, including builds without `FEATURE_TAR_LONG_OPTIONS`. Windows does not use these
scripts.

## Note on #19806

#19806 rewrites these same two lines in `scripts/install.sh`, for the unrelated reason of checking
`xz` availability before extracting. I opened this separately because it is a different bug and
folding it in would park it behind that review, but the two are complementary: if #19806 lands
first, this becomes the same one-flag change on its two `tar` invocations. Happy to rebase onto it,
fold it in, or hold, whichever you prefer.

