### PR TITLE
fix(telegram): discard buffered ingress fragments at conversation boundaries

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5309,6 +5309,21 @@ class BasePlatformAdapter(ABC):
         state = self._text_debounce_store().pop(session_key, None)
         if state is not None and state.task is not None and not state.task.done():
             state.task.cancel()
+        self._discard_session_ingress(session_key)
+
+    def _discard_session_ingress(self, session_key: str) -> None:
+        """Discard adapter-specific buffered ingress fragments for a session.
+
+        Conversation boundaries (/stop, /new, /reset, auto-reset) funnel
+        through :meth:`cancel_session_processing` / :meth:`_discard_text_debounce`,
+        which clear the base-layer text-debounce and pending-message state.
+        Adapters that keep their own per-session ingress buffers (Telegram's
+        text/photo/media-group debounce slots) must override this to drop
+        them too, so fragments from a previous conversation can never merge
+        into the next unrelated user turn (#81370).  The default is a no-op
+        for adapters with no adapter-level buffers.
+        """
+        return
 
     # ------------------------------------------------------------------
     # Session task + guard ownership helpers

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5677,6 +5677,21 @@ class BasePlatformAdapter(ABC):
         state = self._text_debounce_store().pop(session_key, None)
         if state is not None and state.task is not None and not state.task.done():
             state.task.cancel()
+        self._discard_session_ingress(session_key)
+
+    def _discard_session_ingress(self, session_key: str) -> None:
+        """Discard adapter-specific buffered ingress fragments for a session.
+
+        Conversation boundaries (/stop, /new, /reset, auto-reset) funnel
+        through :meth:`cancel_session_processing` / :meth:`_discard_text_debounce`,
+        which clear the base-layer text-debounce and pending-message state.
+        Adapters that keep their own per-session ingress buffers (Telegram's
+        text/photo/media-group debounce slots) must override this to drop
+        them too, so fragments from a previous conversation can never merge
+        into the next unrelated user turn (#81370).  The default is a no-op
+        for adapters with no adapter-level buffers.
+        """
+        return
 
     # ------------------------------------------------------------------
     # Session task + guard ownership helpers

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4379,11 +4379,32 @@ class TelegramAdapter(BasePlatformAdapter):
                 if task is not None and not task.done():
                     pending_tasks.append(task)
                 self._pending_photo_batch_tasks.pop(key, None)
-        # Media-group coalescing is keyed by media_group_id; match on the
-        # buffered event's source instead.
+        # Media-group coalescing is keyed by media_group_id; the buffered
+        # ``event.source`` carries the SessionSource fields needed to
+        # rebuild the session key (SessionSource itself has no
+        # ``session_key`` attribute — that key is always *derived* via
+        # ``build_session_key``), so we compare on the recomputed key
+        # instead of reading a stale attribute (#81370).
+        from gateway.session import build_session_key
         for media_group_id, event in list(self._media_group_events.items()):
             source = getattr(event, "source", None)
-            if source is not None and getattr(source, "session_key", None) == session_key:
+            if source is None:
+                continue
+            try:
+                event_session_key = build_session_key(
+                    source,
+                    group_sessions_per_user=self.config.extra.get(
+                        "group_sessions_per_user", True
+                    ),
+                    thread_sessions_per_user=self.config.extra.get(
+                        "thread_sessions_per_user", False
+                    ),
+                    profile=getattr(source, "profile", None)
+                    or getattr(self, "_gateway_profile_name", None),
+                )
+            except Exception:
+                continue
+            if event_session_key == session_key:
                 self._media_group_events.pop(media_group_id, None)
                 task = self._media_group_tasks.pop(media_group_id, None)
                 if task is not None and not task.done():

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4349,6 +4349,48 @@ class TelegramAdapter(BasePlatformAdapter):
         )
         return False
 
+    def _discard_session_ingress(self, session_key: str) -> None:
+        """Drop Telegram ingress fragments buffered for a session.
+
+        Overrides the base-adapter hook called at every conversation
+        boundary (/stop, /new, /reset, auto-reset, expiry finalization).
+        Telegram keeps per-session debounce slots — text batching,
+        photo bursts/albums, and media-group coalescing — that only
+        ``disconnect()`` used to clear.  A forward/media download that
+        finishes after the conversation was reset kept its fragments in
+        those slots and could merge into the next unrelated user message
+        (#81370).  Cancelling the flush tasks and dropping the buffered
+        events at the boundary invalidates every in-flight fragment.
+        """
+        # Text batches are keyed by the bare session key.
+        pending_tasks: list[asyncio.Task] = []
+        for key, task in list(self._pending_text_batch_tasks.items()):
+            if key == session_key:
+                self._pending_text_batches.pop(key, None)
+                if task is not None and not task.done():
+                    pending_tasks.append(task)
+                self._pending_text_batch_tasks.pop(key, None)
+        # Photo batches key as f"{session_key}:album:{media_group_id}" and
+        # f"{session_key}:photo-burst".
+        prefix = f"{session_key}:"
+        for key, task in list(self._pending_photo_batch_tasks.items()):
+            if key.startswith(prefix):
+                self._pending_photo_batches.pop(key, None)
+                if task is not None and not task.done():
+                    pending_tasks.append(task)
+                self._pending_photo_batch_tasks.pop(key, None)
+        # Media-group coalescing is keyed by media_group_id; match on the
+        # buffered event's source instead.
+        for media_group_id, event in list(self._media_group_events.items()):
+            source = getattr(event, "source", None)
+            if source is not None and getattr(source, "session_key", None) == session_key:
+                self._media_group_events.pop(media_group_id, None)
+                task = self._media_group_tasks.pop(media_group_id, None)
+                if task is not None and not task.done():
+                    pending_tasks.append(task)
+        for task in pending_tasks:
+            task.cancel()
+
     async def disconnect(self) -> None:
         """Stop polling/webhook, cancel pending delayed deliveries, and disconnect."""
         # Mark disconnected first so the drop guard short-circuits any flush

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4352,6 +4352,48 @@ class TelegramAdapter(BasePlatformAdapter):
         )
         return False
 
+    def _discard_session_ingress(self, session_key: str) -> None:
+        """Drop Telegram ingress fragments buffered for a session.
+
+        Overrides the base-adapter hook called at every conversation
+        boundary (/stop, /new, /reset, auto-reset, expiry finalization).
+        Telegram keeps per-session debounce slots — text batching,
+        photo bursts/albums, and media-group coalescing — that only
+        ``disconnect()`` used to clear.  A forward/media download that
+        finishes after the conversation was reset kept its fragments in
+        those slots and could merge into the next unrelated user message
+        (#81370).  Cancelling the flush tasks and dropping the buffered
+        events at the boundary invalidates every in-flight fragment.
+        """
+        # Text batches are keyed by the bare session key.
+        pending_tasks: list[asyncio.Task] = []
+        for key, task in list(self._pending_text_batch_tasks.items()):
+            if key == session_key:
+                self._pending_text_batches.pop(key, None)
+                if task is not None and not task.done():
+                    pending_tasks.append(task)
+                self._pending_text_batch_tasks.pop(key, None)
+        # Photo batches key as f"{session_key}:album:{media_group_id}" and
+        # f"{session_key}:photo-burst".
+        prefix = f"{session_key}:"
+        for key, task in list(self._pending_photo_batch_tasks.items()):
+            if key.startswith(prefix):
+                self._pending_photo_batches.pop(key, None)
+                if task is not None and not task.done():
+                    pending_tasks.append(task)
+                self._pending_photo_batch_tasks.pop(key, None)
+        # Media-group coalescing is keyed by media_group_id; match on the
+        # buffered event's source instead.
+        for media_group_id, event in list(self._media_group_events.items()):
+            source = getattr(event, "source", None)
+            if source is not None and getattr(source, "session_key", None) == session_key:
+                self._media_group_events.pop(media_group_id, None)
+                task = self._media_group_tasks.pop(media_group_id, None)
+                if task is not None and not task.done():
+                    pending_tasks.append(task)
+        for task in pending_tasks:
+            task.cancel()
+
     async def disconnect(self) -> None:
         """Stop polling/webhook, cancel pending delayed deliveries, and disconnect."""
         # Mark disconnected first so the drop guard short-circuits any flush

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4382,11 +4382,32 @@ class TelegramAdapter(BasePlatformAdapter):
                 if task is not None and not task.done():
                     pending_tasks.append(task)
                 self._pending_photo_batch_tasks.pop(key, None)
-        # Media-group coalescing is keyed by media_group_id; match on the
-        # buffered event's source instead.
+        # Media-group coalescing is keyed by media_group_id; the buffered
+        # ``event.source`` carries the SessionSource fields needed to
+        # rebuild the session key (SessionSource itself has no
+        # ``session_key`` attribute — that key is always *derived* via
+        # ``build_session_key``), so we compare on the recomputed key
+        # instead of reading a stale attribute (#81370).
+        from gateway.session import build_session_key
         for media_group_id, event in list(self._media_group_events.items()):
             source = getattr(event, "source", None)
-            if source is not None and getattr(source, "session_key", None) == session_key:
+            if source is None:
+                continue
+            try:
+                event_session_key = build_session_key(
+                    source,
+                    group_sessions_per_user=self.config.extra.get(
+                        "group_sessions_per_user", True
+                    ),
+                    thread_sessions_per_user=self.config.extra.get(
+                        "thread_sessions_per_user", False
+                    ),
+                    profile=getattr(source, "profile", None)
+                    or getattr(self, "_gateway_profile_name", None),
+                )
+            except Exception:
+                continue
+            if event_session_key == session_key:
                 self._media_group_events.pop(media_group_id, None)
                 task = self._media_group_tasks.pop(media_group_id, None)
                 if task is not None and not task.done():

--- a/tests/gateway/test_telegram_ingress_boundary_81370.py
+++ b/tests/gateway/test_telegram_ingress_boundary_81370.py
@@ -35,6 +35,17 @@ def _make_adapter():
     adapter._text_debounce = {}
     adapter._active_sessions = {}
     adapter._session_tasks = {}
+    # ``build_session_key`` reads ``self.config.extra`` to derive the
+    # ``group_sessions_per_user`` / ``thread_sessions_per_user`` flags.
+    # Default both to True (matches the gateway default and is enough for
+    # DM key derivation).
+    class _Cfg:
+        extra = {
+            "group_sessions_per_user": True,
+            "thread_sessions_per_user": True,
+        }
+    adapter.config = _Cfg()
+    adapter._gateway_profile_name = None
     return adapter
 
 
@@ -99,17 +110,32 @@ class TestDiscardSessionIngress:
 
     def test_media_group_slots_for_session_are_dropped(self):
         adapter = _make_adapter()
-        session_key = "telegram:chat:123"
+        # Build real SessionSource objects so the adapter's media-group
+        # branch has to call ``build_session_key``.  The earlier fixture
+        # used a fabricated ``source.session_key`` attribute that masked
+        # the dead-code defect — SessionSource has no such attribute, so
+        # the cleanup branch never matched in production (#81370).
+        from gateway.config import Platform
+        from gateway.session import SessionSource, build_session_key
+        source_a = SessionSource(platform=Platform.TELEGRAM, chat_id="123")
+        source_b = SessionSource(platform=Platform.TELEGRAM, chat_id="456")
 
         class _Event:
-            def __init__(self, key):
-                self.source = type("Source", (), {"session_key": key})()
+            def __init__(self, source):
+                self.source = source
 
-        adapter._media_group_events["grp_a"] = _Event(session_key)
-        adapter._media_group_events["grp_b"] = _Event("telegram:chat:456")
+        adapter._media_group_events["grp_a"] = _Event(source_a)
+        adapter._media_group_events["grp_b"] = _Event(source_b)
         adapter._media_group_tasks["grp_a"] = None
         adapter._media_group_tasks["grp_b"] = None
 
+        # Compute the key the same way the gateway does so the test
+        # mirrors the production flow end-to-end.
+        session_key = build_session_key(
+            source_a,
+            group_sessions_per_user=True,
+            thread_sessions_per_user=True,
+        )
         adapter._discard_session_ingress(session_key)
 
         assert "grp_a" not in adapter._media_group_events

--- a/tests/gateway/test_telegram_ingress_boundary_81370.py
+++ b/tests/gateway/test_telegram_ingress_boundary_81370.py
@@ -1,0 +1,133 @@
+"""Regression tests for #81370: Telegram ingress fragments buffered in the
+adapter's text/photo/media-group debounce slots must be invalidated at
+every conversation boundary (/stop, /new, /reset, auto-reset) so they
+can never merge into the next unrelated user turn.
+
+Before the fix, only ``disconnect()`` cleared these slots. A forward or
+media download that finished after a conversation reset kept its
+fragments in the debounce slots, and the next unrelated user message
+merged them (production log: "Merged 1 Telegram startup attachment(s)"
+two minutes after a /stop).
+"""
+
+import asyncio
+
+import pytest
+
+from gateway.platforms.base import BasePlatformAdapter
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+def _make_adapter():
+    """Build a TelegramAdapter without running its full constructor side
+    effects (config, network stack).  The buffers under test are plain
+    dicts initialized in __init__, so a minimal object via __new__ plus
+    manual init of the relevant attrs is enough for the unit-level
+    regression tests below."""
+    adapter = object.__new__(TelegramAdapter)
+    adapter._pending_text_batches = {}
+    adapter._pending_text_batch_tasks = {}
+    adapter._pending_photo_batches = {}
+    adapter._pending_photo_batch_tasks = {}
+    adapter._media_group_events = {}
+    adapter._media_group_tasks = {}
+    adapter._pending_messages = {}
+    adapter._text_debounce = {}
+    adapter._active_sessions = {}
+    adapter._session_tasks = {}
+    return adapter
+
+
+class TestDiscardSessionIngress:
+    def test_text_batch_for_session_is_dropped(self):
+        adapter = _make_adapter()
+        key = "telegram:chat:123"
+        adapter._pending_text_batches[key] = "pending text"
+        # A completed task must not be cancelled (no error); a pending one
+        # would be cancelled by the flush. Use a sentinel completed task.
+        adapter._pending_text_batch_tasks[key] = asyncio.Task(
+            asyncio.sleep(0)
+        )
+        adapter._pending_text_batch_tasks[key].cancel()
+        try:
+            asyncio.get_running_loop().run_until_complete(
+                asyncio.sleep(0)
+            )
+        except RuntimeError:
+            pass  # no running loop in this context
+
+        adapter._discard_session_ingress(key)
+
+        assert key not in adapter._pending_text_batches
+        assert key not in adapter._pending_text_batch_tasks
+
+    def test_other_sessions_batches_survive(self):
+        adapter = _make_adapter()
+        mine = "telegram:chat:123"
+        other = "telegram:chat:456"
+        adapter._pending_text_batches[mine] = "mine"
+        adapter._pending_text_batches[other] = "other"
+        adapter._pending_text_batch_tasks[mine] = None
+        adapter._pending_text_batch_tasks[other] = None
+
+        adapter._discard_session_ingress(mine)
+
+        # My batch is gone; the unrelated session's is untouched.
+        assert mine not in adapter._pending_text_batches
+        assert other in adapter._pending_text_batches
+        assert adapter._pending_text_batches[other] == "other"
+
+    def test_photo_burst_and_album_slots_for_session_are_dropped(self):
+        adapter = _make_adapter()
+        session_key = "telegram:chat:123"
+        burst_key = f"{session_key}:photo-burst"
+        album_key = f"{session_key}:album:media_grp_9"
+        other_key = "telegram:chat:456:photo-burst"
+        adapter._pending_photo_batches[burst_key] = "burst"
+        adapter._pending_photo_batches[album_key] = "album"
+        adapter._pending_photo_batches[other_key] = "other"
+        adapter._pending_photo_batch_tasks[burst_key] = None
+        adapter._pending_photo_batch_tasks[album_key] = None
+        adapter._pending_photo_batch_tasks[other_key] = None
+
+        adapter._discard_session_ingress(session_key)
+
+        assert burst_key not in adapter._pending_photo_batches
+        assert album_key not in adapter._pending_photo_batches
+        # Other session's burst survives.
+        assert other_key in adapter._pending_photo_batches
+
+    def test_media_group_slots_for_session_are_dropped(self):
+        adapter = _make_adapter()
+        session_key = "telegram:chat:123"
+
+        class _Event:
+            def __init__(self, key):
+                self.source = type("Source", (), {"session_key": key})()
+
+        adapter._media_group_events["grp_a"] = _Event(session_key)
+        adapter._media_group_events["grp_b"] = _Event("telegram:chat:456")
+        adapter._media_group_tasks["grp_a"] = None
+        adapter._media_group_tasks["grp_b"] = None
+
+        adapter._discard_session_ingress(session_key)
+
+        assert "grp_a" not in adapter._media_group_events
+        # Unrelated session's media group survives.
+        assert "grp_b" in adapter._media_group_events
+
+
+class TestBaseHookFunnel:
+    def test_base_discard_calls_adapter_override(self):
+        """_discard_text_debounce must funnel into the adapter override so
+        every boundary that clears the base debounce also clears Telegram's
+        own slots."""
+        adapter = _make_adapter()
+        session_key = "telegram:chat:123"
+        adapter._pending_text_batches[session_key] = "fragment"
+        adapter._pending_text_batch_tasks[session_key] = None
+
+        # _discard_text_debounce -> _discard_session_ingress (override)
+        BasePlatformAdapter._discard_text_debounce(adapter, session_key)
+
+        assert session_key not in adapter._pending_text_batches


### PR DESCRIPTION
Fixes #81370

## Root cause

Telegram keeps per-session debounce slots for inbound text batching, photo bursts/albums, and media-group coalescing (implemented for #46100 / #46101 in `plugins/platforms/telegram/adapter.py`):

- `_pending_text_batches` / `_pending_text_batch_tasks` — `_enqueue_text_event`
- `_pending_photo_batches` / `_pending_photo_batch_tasks` — `_flush_photo_batch`
- `_media_group_events` / `_media_group_tasks` — `_queue_media_group_event`

Only `disconnect()` (`_cancel_pending_delayed_deliveries`) cleared them. A conversation boundary (/stop, /new, /reset, auto-reset, expiry finalization) never triggers `disconnect()`, so a forward or media download that finished after the reset kept its fragments in those slots — and the next unrelated user message merged them.

The production evidence from the issue: forwarded video `411357` was still in the startup/photo slot after /stop (`411367`); 2+ minutes later, ordinary copied text `411376` merged it and the gateway logged `Merged 1 Telegram startup attachment(s)` for a turn where the user sent no media.

## Fix

1. New hook `BasePlatformAdapter._discard_session_ingress(session_key)` in `gateway/platforms/base.py` (default no-op), funneled through `_discard_text_debounce`, which every conversation boundary already calls via `cancel_session_processing` and the /stop,/new,/reset bypass-dispatch path.
2. `TelegramAdapter._discard_session_ingress` overrides it: drops the session's text-batch, photo-burst/album, and media-group slots and cancels their flush tasks. Unrelated sessions' buffers are keyed differently and survive untouched.

The fix is session-scoped — one conversation's reset cannot affect a concurrent session's in-flight batch.

## Regression tests

5 tests in `tests/gateway/test_telegram_ingress_boundary_81370.py`:

1. `test_text_batch_for_session_is_dropped` — the issue's scenario: a stale text-batch fragment is gone after the boundary.
2. `test_other_sessions_batches_survive` — session scoping: another session's batch is untouched.
3. `test_photo_burst_and_album_slots_for_session_are_dropped` — photo burst (`session:photo-burst`) and album (`session:album:<id>`) slots both cleared.
4. `test_media_group_slots_for_session_are_dropped` — media-group coalescing keyed by `media_group_id` is matched via the buffered event's source.
5. `test_base_hook_funnel` — `_discard_text_debounce` funnels into the adapter override, so every existing boundary that clears the base debounce also clears Telegram's slots.

All 5 are RED on pre-fix code (hook missing → AttributeError) and GREEN after. Existing Telegram tests (`test_telegram_caption_merge.py`, `test_telegram_auth_check.py`, `test_telegram_audio_vs_voice.py`, `test_telegram_approval_buttons.py` — 27 tests) continue to pass.

## Scope

One new base hook (no-op default) + one adapter override + tests. No refactor of the debounce machinery itself; the existing boundary funnel is reused rather than adding a parallel cleanup path.