### PR TITLE
fix(gateway): refuse handoff that would hijack a live gateway session

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12022,24 +12022,47 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # reset. The check FAILS CLOSED: if the bound session's state
         # cannot be verified (DB unavailable / read error), the handoff is
         # refused rather than risking a live-session hijack.
+        #
+        # The check runs on the entry get_or_create_session resolves for
+        # the destination key — the same entry switch_session would end —
+        # so an inbound message that created a live session during the
+        # earlier awaits is seen here, not skipped.
         await self.async_session_store._ensure_loaded()
-        existing_entry = self.session_store._entries.get(session_key)  # noqa: SLF001
-        if existing_entry is not None:
-            bound_session_id = existing_entry.session_id
-            if bound_session_id == cli_session_id:
-                raise RuntimeError(
-                    f"session {cli_session_id} is already the gateway session "
-                    f"for {session_key}; nothing to hand off"
-                )
-            bound_row: Optional[Dict[str, Any]] = None
+        dest_entry = await self.async_session_store.get_or_create_session(dest_source)
+        if dest_entry.session_id == cli_session_id:
+            # The CLI session is already the gateway session for this key
+            # (the user resumed the gateway session in the CLI/desktop).
+            # Handing it off again is a no-op — refuse instead of running
+            # the switch + synthetic turn on a live channel.
+            raise RuntimeError(
+                f"session {cli_session_id} is already the gateway session "
+                f"for {session_key}; nothing to hand off"
+            )
+        bound_session_id = dest_entry.session_id
+
+        # In-flight agent work on the destination key must never be
+        # hijacked, regardless of what the DB row says (a session can
+        # be mid-first-turn before any message is persisted).
+        if self.session_store._has_active_processes_safe(
+            session_key, context="handoff"
+        ):
+            raise RuntimeError(
+                f"destination {session_key} has active agent work; "
+                f"refusing handoff"
+            )
+
+        # Verify the bound session's state when the DB is available.
+        # Fail closed: an unreadable DB row means we cannot prove the
+        # session is closed, so refuse rather than risk a hijack.
+        bound_row: Optional[Dict[str, Any]] = None
+        if self._session_db is not None:
             verified = False
             try:
-                if self._session_db is not None:
-                    bound_row = cast(
-                        Optional[Dict[str, Any]],
-                        await self._session_db.get_session(bound_session_id),
-                    )
-                    verified = True
+                bound_row = cast(
+                    Optional[Dict[str, Any]],
+                    await self._session_db.get_session(bound_session_id),
+                )
+                verified = True
             except Exception:
                 verified = False
             if not verified:
@@ -12047,30 +12070,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     f"cannot verify session state for destination {session_key} "
                     f"(bound to {bound_session_id}); refusing handoff"
                 )
-            # Live = session row not ended AND (has conversation content OR
-            # the gateway has active agent work on the key). An empty fresh
-            # /new session (0 messages, no active work) is safe to replace.
-            has_active_work = self.session_store._has_active_processes_safe(
-                session_key, context="handoff"
-            )
-            if (
-                bound_row is not None
-                and bound_row.get("ended_at") is None
-                and (
-                    (bound_row.get("message_count") or 0) > 0
-                    or has_active_work
-                )
-            ):
-                raise RuntimeError(
-                    f"destination {session_key} is already bound to live gateway "
-                    f"session {bound_session_id}; end that conversation first "
-                    f"(e.g. /new on the platform) before handing off"
-                )
 
-        # Make sure there's an entry in the session_store for this key. If
-        # the home channel has never been used, get_or_create_session
-        # creates one; switch_session then re-points it.
-        await self.async_session_store.get_or_create_session(dest_source)
+        # Live = session row exists, not ended, and has conversation
+        # content. An empty fresh /new session (0 messages, no active
+        # work) is safe to replace; a missing row (in-memory/JSONL
+        # fallback session) is likewise replaceable.
+        if (
+            bound_row is not None
+            and bound_row.get("ended_at") is None
+            and (bound_row.get("message_count") or 0) > 0
+        ):
+            raise RuntimeError(
+                f"destination {session_key} is already bound to live gateway "
+                f"session {bound_session_id}; end that conversation first "
+                f"(e.g. /new on the platform) before handing off"
+            )
 
         # Re-bind the destination key to the CLI session_id. switch_session
         # ends the prior session in SQLite and reopens the CLI session under

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12018,7 +12018,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # conversation with the CLI's, making the old history unreachable
         # from the platform. Only proceed when the destination is unbound,
         # bound to the CLI session itself (Case B — already gateway-owned),
-        # or bound to a session that is closed or an empty fresh reset.
+        # or bound to a session that is confirmed closed or an empty fresh
+        # reset. The check FAILS CLOSED: if the bound session's state
+        # cannot be verified (DB unavailable / read error), the handoff is
+        # refused rather than risking a live-session hijack.
         await self.async_session_store._ensure_loaded()
         existing_entry = self.session_store._entries.get(session_key)  # noqa: SLF001
         if existing_entry is not None:
@@ -12028,18 +12031,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     f"session {cli_session_id} is already the gateway session "
                     f"for {session_key}; nothing to hand off"
                 )
+            bound_row: Optional[Dict[str, Any]] = None
+            verified = False
             try:
-                bound_row = (
-                    None
-                    if self._session_db is None
-                    else await self._session_db.get_session(bound_session_id)
-                )
+                if self._session_db is not None:
+                    bound_row = cast(
+                        Optional[Dict[str, Any]],
+                        await self._session_db.get_session(bound_session_id),
+                    )
+                    verified = True
             except Exception:
-                bound_row = None
+                verified = False
+            if not verified:
+                raise RuntimeError(
+                    f"cannot verify session state for destination {session_key} "
+                    f"(bound to {bound_session_id}); refusing handoff"
+                )
+            # Live = session row not ended AND (has conversation content OR
+            # the gateway has active agent work on the key). An empty fresh
+            # /new session (0 messages, no active work) is safe to replace.
+            has_active_work = self.session_store._has_active_processes_safe(
+                session_key, context="handoff"
+            )
             if (
                 bound_row is not None
                 and bound_row.get("ended_at") is None
-                and (bound_row.get("message_count") or 0) > 0
+                and (
+                    (bound_row.get("message_count") or 0) > 0
+                    or has_active_work
+                )
             ):
                 raise RuntimeError(
                     f"destination {session_key} is already bound to live gateway "

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12010,6 +12010,43 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             thread_sessions_per_user=extra.get("thread_sessions_per_user", False),
         )
 
+        # Source/ownership check (#81513): never hijack a live gateway
+        # session. The destination key may already be bound to a session
+        # the gateway is actively serving (e.g. an ongoing QQ conversation
+        # on the home channel). switch_session would END that session and
+        # rebind the key to the CLI session — silently replacing a live
+        # conversation with the CLI's, making the old history unreachable
+        # from the platform. Only proceed when the destination is unbound,
+        # bound to the CLI session itself (Case B — already gateway-owned),
+        # or bound to a session that is closed or an empty fresh reset.
+        await self.async_session_store._ensure_loaded()
+        existing_entry = self.session_store._entries.get(session_key)  # noqa: SLF001
+        if existing_entry is not None:
+            bound_session_id = existing_entry.session_id
+            if bound_session_id == cli_session_id:
+                raise RuntimeError(
+                    f"session {cli_session_id} is already the gateway session "
+                    f"for {session_key}; nothing to hand off"
+                )
+            try:
+                bound_row = (
+                    None
+                    if self._session_db is None
+                    else await self._session_db.get_session(bound_session_id)
+                )
+            except Exception:
+                bound_row = None
+            if (
+                bound_row is not None
+                and bound_row.get("ended_at") is None
+                and (bound_row.get("message_count") or 0) > 0
+            ):
+                raise RuntimeError(
+                    f"destination {session_key} is already bound to live gateway "
+                    f"session {bound_session_id}; end that conversation first "
+                    f"(e.g. /new on the platform) before handing off"
+                )
+
         # Make sure there's an entry in the session_store for this key. If
         # the home channel has never been used, get_or_create_session
         # creates one; switch_session then re-points it.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12043,7 +12043,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # In-flight agent work on the destination key must never be
         # hijacked, regardless of what the DB row says (a session can
         # be mid-first-turn before any message is persisted).
-        if self.session_store._has_active_processes_safe(
+        if await self.async_session_store._has_active_processes_safe(
             session_key, context="handoff"
         ):
             raise RuntimeError(

--- a/tests/gateway/test_handoff_ownership_check.py
+++ b/tests/gateway/test_handoff_ownership_check.py
@@ -258,7 +258,7 @@ async def test_handoff_rejects_when_dest_has_active_agent_work(tmp_path):
         active_processes=True,
     )
 
-    with pytest.raises(RuntimeError, match="already bound to live gateway session"):
+    with pytest.raises(RuntimeError, match="has active agent work"):
         await runner._process_handoff({
             "id": "cli-session",
             "title": "CLI work",
@@ -292,3 +292,22 @@ async def test_handoff_fails_closed_when_bound_session_state_unverifiable(tmp_pa
 
     assert runner.session_store.switch_calls == []
     runner._handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handoff_proceeds_when_no_session_db(tmp_path):
+    """Without a SessionDB the guard falls back to routing-entry + active-work
+    signals only, and does NOT fail closed on the absent DB (JSONL fallback /
+    memory-only store must still be able to hand off)."""
+    key = _dest_key()
+    runner = _make_qq_runner(None, prebound_entries={key: "in-memory-session"})
+    runner._session_db = None
+
+    await runner._process_handoff({
+        "id": "cli-session",
+        "title": "CLI work",
+        "handoff_platform": "qqbot",
+    })
+
+    assert runner.session_store.switch_calls == [(key, "cli-session")]
+    runner._handle_message.assert_awaited_once()

--- a/tests/gateway/test_handoff_ownership_check.py
+++ b/tests/gateway/test_handoff_ownership_check.py
@@ -1,0 +1,240 @@
+"""Regression tests for #81513: CLI→gateway handoff must not hijack a live
+gateway session.
+
+Bug: ``_process_handoff`` blindly called ``switch_session`` on the
+destination session key. When that key was already bound to a gateway
+session the gateway was actively serving (e.g. an ongoing QQ conversation
+on the home channel), ``switch_session`` ENDED the live session and
+rebound the key to the CLI session — silently replacing the active
+conversation and making its history unreachable from the platform.
+
+The fix adds a source/ownership check before the switch: the handoff is
+rejected when the destination key is already bound to a live gateway
+session (different session id, not ended, with messages). It remains a
+no-op rejection when the destination key is already bound to the CLI
+session itself (the CLI resumed the gateway session). Rebind is allowed
+when the bound session is ended or an empty fresh reset, and when the
+destination key is unbound (the normal first-handoff path).
+"""
+
+import asyncio
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from hermes_state import AsyncSessionDB, SessionDB
+from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+def _make_qq_runner(session_db, *, prebound_entries=None):
+    """Build a GatewayRunner stand-in wired for qqbot handoff.
+
+    ``prebound_entries`` maps session_key → session_id and is seeded into
+    the fake session store's routing index so the ownership check sees an
+    existing binding (as the real gateway would after a QQ conversation).
+    """
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.QQBOT: PlatformConfig(enabled=True, token="***")}
+    )
+    runner.config.platforms[Platform.QQBOT].home_channel = HomeChannel(
+        platform=Platform.QQBOT,
+        chat_id="OPENID123",
+        name="QQ DM",
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock(return_value=SimpleNamespace(success=True))
+    adapter.create_handoff_thread = AsyncMock(return_value=None)
+    adapter._bot = None
+    runner.adapters = {Platform.QQBOT: adapter}
+    runner.hooks = SimpleNamespace(
+        emit=AsyncMock(),
+        emit_collect=AsyncMock(return_value=[]),
+        loaded_hooks=False,
+    )
+
+    class _FakeSessionStore:
+        def __init__(self):
+            self._entries = {}
+            for key, session_id in (prebound_entries or {}).items():
+                self._entries[key] = SessionEntry(
+                    session_key=key,
+                    session_id=session_id,
+                    created_at=datetime.now(),
+                    updated_at=datetime.now(),
+                    platform=Platform.QQBOT,
+                    chat_type="dm",
+                )
+            self.switch_calls = []
+            self.create_calls = []
+
+        def _ensure_loaded(self):
+            return None
+
+        def _generate_session_key(self, source):
+            return build_session_key(
+                source,
+                group_sessions_per_user=True,
+                thread_sessions_per_user=False,
+            )
+
+        def get_or_create_session(self, source, force_new=False):
+            key = self._generate_session_key(source)
+            self.create_calls.append(key)
+            if key not in self._entries:
+                self._entries[key] = SessionEntry(
+                    session_key=key,
+                    session_id="fresh-session",
+                    created_at=datetime.now(),
+                    updated_at=datetime.now(),
+                    platform=source.platform,
+                    chat_type=source.chat_type,
+                    origin=source,
+                )
+            return self._entries[key]
+
+        def switch_session(self, session_key, target_session_id):
+            self.switch_calls.append((session_key, target_session_id))
+            return SessionEntry(
+                session_key=session_key,
+                session_id=target_session_id,
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+                platform=Platform.QQBOT,
+                chat_type="dm",
+            )
+
+    runner.session_store = _FakeSessionStore()
+    runner._session_db = AsyncSessionDB(session_db)
+    runner._evict_cached_agent = MagicMock()
+    runner._release_running_agent_state = MagicMock()
+    runner._handle_message = AsyncMock(return_value="handoff ok")
+    return runner
+
+
+def _dest_key() -> str:
+    """The session key a qqbot handoff produces for home chat OPENID123."""
+    source = SessionSource(
+        platform=Platform.QQBOT,
+        chat_id="OPENID123",
+        chat_name="QQ DM",
+        chat_type="dm",
+        user_id="system:handoff",
+        user_name="Handoff",
+        thread_id=None,
+    )
+    return build_session_key(
+        source,
+        group_sessions_per_user=True,
+        thread_sessions_per_user=False,
+    )
+
+
+def _seed_live_session(db, session_id, *, message_count=5, ended=False):
+    """Create a real gateway-session row in state.db for the bound entry."""
+    db.create_session(session_id, source="qqbot", chat_id="OPENID123", chat_type="dm")
+    if message_count:
+        db._conn.execute(
+            "UPDATE sessions SET message_count = ? WHERE id = ?",
+            (message_count, session_id),
+        )
+        db._conn.commit()
+    if ended:
+        db.end_session(session_id, "user")
+
+
+@pytest.mark.asyncio
+async def test_handoff_rejects_when_dest_key_bound_to_live_gateway_session(tmp_path):
+    """A handoff must NOT end a live gateway conversation on the destination key."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    key = _dest_key()
+    _seed_live_session(db, "gw-live-session", message_count=7)
+    runner = _make_qq_runner(db, prebound_entries={key: "gw-live-session"})
+
+    with pytest.raises(RuntimeError, match="already bound to live gateway session"):
+        await runner._process_handoff({
+            "id": "cli-session",
+            "title": "CLI work",
+            "handoff_platform": "qqbot",
+        })
+
+    # The live session must not be switched away, and no synthetic turn runs.
+    assert runner.session_store.switch_calls == []
+    runner._handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handoff_rejects_when_session_already_gateway_owned(tmp_path):
+    """Handing off the gateway session itself is a no-op, not a re-switch."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    key = _dest_key()
+    _seed_live_session(db, "cli-session", message_count=3)
+    runner = _make_qq_runner(db, prebound_entries={key: "cli-session"})
+
+    with pytest.raises(RuntimeError, match="already the gateway session"):
+        await runner._process_handoff({
+            "id": "cli-session",
+            "title": "CLI work",
+            "handoff_platform": "qqbot",
+        })
+
+    assert runner.session_store.switch_calls == []
+    runner._handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handoff_allows_when_bound_session_ended(tmp_path):
+    """An ended destination session is safe to rebind (normal re-handoff)."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    key = _dest_key()
+    _seed_live_session(db, "old-qq-session", message_count=9, ended=True)
+    runner = _make_qq_runner(db, prebound_entries={key: "old-qq-session"})
+
+    await runner._process_handoff({
+        "id": "cli-session",
+        "title": "CLI work",
+        "handoff_platform": "qqbot",
+    })
+
+    assert runner.session_store.switch_calls == [(key, "cli-session")]
+    runner._handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_handoff_allows_when_bound_session_is_empty_fresh_reset(tmp_path):
+    """A fresh /new session (zero messages) is safe to replace."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    key = _dest_key()
+    _seed_live_session(db, "fresh-empty", message_count=0)
+    runner = _make_qq_runner(db, prebound_entries={key: "fresh-empty"})
+
+    await runner._process_handoff({
+        "id": "cli-session",
+        "title": "CLI work",
+        "handoff_platform": "qqbot",
+    })
+
+    assert runner.session_store.switch_calls == [(key, "cli-session")]
+    runner._handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_handoff_allows_unbound_destination(tmp_path):
+    """First handoff to a never-used home channel still works."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    key = _dest_key()
+    runner = _make_qq_runner(db, prebound_entries={})
+
+    await runner._process_handoff({
+        "id": "cli-session",
+        "title": "CLI work",
+        "handoff_platform": "qqbot",
+    })
+
+    assert runner.session_store.switch_calls == [(key, "cli-session")]
+    runner._handle_message.assert_awaited_once()

--- a/tests/gateway/test_handoff_ownership_check.py
+++ b/tests/gateway/test_handoff_ownership_check.py
@@ -29,12 +29,14 @@ from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
 from gateway.session import SessionEntry, SessionSource, build_session_key
 
 
-def _make_qq_runner(session_db, *, prebound_entries=None):
+def _make_qq_runner(session_db, *, prebound_entries=None, active_processes=False):
     """Build a GatewayRunner stand-in wired for qqbot handoff.
 
     ``prebound_entries`` maps session_key → session_id and is seeded into
     the fake session store's routing index so the ownership check sees an
     existing binding (as the real gateway would after a QQ conversation).
+    ``active_processes`` makes the store report in-flight agent work on
+    every key (mirrors process_registry.has_active_for_session).
     """
     from gateway.run import GatewayRunner
 
@@ -75,6 +77,9 @@ def _make_qq_runner(session_db, *, prebound_entries=None):
 
         def _ensure_loaded(self):
             return None
+
+        def _has_active_processes_safe(self, session_key, *, context):
+            return active_processes
 
         def _generate_session_key(self, source):
             return build_session_key(
@@ -238,3 +243,52 @@ async def test_handoff_allows_unbound_destination(tmp_path):
 
     assert runner.session_store.switch_calls == [(key, "cli-session")]
     runner._handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_handoff_rejects_when_dest_has_active_agent_work(tmp_path):
+    """In-flight agent work on the destination key counts as live, even with
+    zero persisted messages (first turn still running)."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    key = _dest_key()
+    _seed_live_session(db, "gw-busy", message_count=0)
+    runner = _make_qq_runner(
+        db,
+        prebound_entries={key: "gw-busy"},
+        active_processes=True,
+    )
+
+    with pytest.raises(RuntimeError, match="already bound to live gateway session"):
+        await runner._process_handoff({
+            "id": "cli-session",
+            "title": "CLI work",
+            "handoff_platform": "qqbot",
+        })
+
+    assert runner.session_store.switch_calls == []
+    runner._handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handoff_fails_closed_when_bound_session_state_unverifiable(tmp_path):
+    """If the bound session's state cannot be read, refuse the handoff rather
+    than risk hijacking a live conversation (fail-closed)."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    key = _dest_key()
+    _seed_live_session(db, "gw-unknown", message_count=1)
+    runner = _make_qq_runner(db, prebound_entries={key: "gw-unknown"})
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("db exploded")
+
+    runner._session_db.get_session = _boom
+
+    with pytest.raises(RuntimeError, match="cannot verify session state"):
+        await runner._process_handoff({
+            "id": "cli-session",
+            "title": "CLI work",
+            "handoff_platform": "qqbot",
+        })
+
+    assert runner.session_store.switch_calls == []
+    runner._handle_message.assert_not_called()

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -78,8 +78,10 @@ def _make_runner(session_db=None):
     runner.session_store = MagicMock()
     # The ownership check (#81513) reads the routing index directly; an
     # empty dict accurately models a fresh destination with no pre-bound
-    # gateway session (a bare MagicMock would make .get() truthy).
+    # gateway session (a bare MagicMock would make .get() truthy). No
+    # in-flight agent work either.
     runner.session_store._entries = {}
+    runner.session_store._has_active_processes_safe = MagicMock(return_value=False)
     runner.session_store._generate_session_key.side_effect = lambda source: build_session_key(
         source,
         group_sessions_per_user=getattr(runner.config, "group_sessions_per_user", True),

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -76,6 +76,10 @@ def _make_runner(session_db=None):
     )
 
     runner.session_store = MagicMock()
+    # The ownership check (#81513) reads the routing index directly; an
+    # empty dict accurately models a fresh destination with no pre-bound
+    # gateway session (a bare MagicMock would make .get() truthy).
+    runner.session_store._entries = {}
     runner.session_store._generate_session_key.side_effect = lambda source: build_session_key(
         source,
         group_sessions_per_user=getattr(runner.config, "group_sessions_per_user", True),


### PR DESCRIPTION
## Summary

Refs #81513 — the CLI→gateway handoff path could **end a live gateway session** and rebind the destination key to the CLI session, silently replacing an active conversation (e.g. an ongoing QQ chat on the home channel) and making its history unreachable from the platform.

`_process_handoff` (`gateway/run.py`) blindly called `switch_session(session_key, cli_session_id)`. When that key was already bound to a session the gateway was actively serving, `switch_session` ENDs the bound session (`promote_to_session_reset`) and re-points the key at the CLI session. The next real message on the platform continued the CLI transcript instead of the conversation the user was actually having.

This affected any platform whose home channel already had a live gateway session — not just QQ. The QQ report was the trigger, but the bug class is the missing ownership check.

## Change

Add a source/ownership check in `_process_handoff`, on the entry `get_or_create_session` resolves for the destination key (the same entry `switch_session` would end):

- **Destination key already bound to the CLI session being handed off** (user resumed the gateway session in CLI/desktop) → reject with a clear "already the gateway session; nothing to hand off" error instead of running the switch + synthetic turn on a live channel.
- **In-flight agent work on the destination key** (`_has_active_processes_safe`) → refuse. A session mid-first-turn has no persisted messages yet, so message count alone can't protect it.
- **Bound session row not ended AND has messages** → refuse with an actionable error ("end that conversation first, e.g. /new on the platform"). The CLI failure path keeps the user's CLI session intact and prints the reason.
- **Fail-closed**: if the bound session's state cannot be read from the DB, refuse rather than risk a hijack.
- **Still allowed**: unbound destination (first handoff), bound to an ended session (re-handoff after the conversation closed), and empty fresh `/new` sessions (0 messages, no active work).

## Tests

`tests/gateway/test_handoff_ownership_check.py` — 8 regression tests:

- reject when dest key bound to a live gateway session (switch never called, no synthetic turn)
- reject when the CLI session is already the gateway session
- allow when bound session is ended
- allow when bound session is an empty fresh reset
- allow unbound destination (normal first handoff)
- reject when destination has active agent work (0 messages, first turn running)
- fail closed when bound session state is unreadable
- proceed without a SessionDB (JSONL/memory-only store)

Existing coverage: handoff watcher async, Discord thread-key, Telegram DM-topic, CLI session handoff, qqbot — 95 tests total pass. The Telegram handoff harness now seeds an empty routing index + no active work so the ownership check sees a fresh destination.

## Notes

- Scope: this PR carries the ownership/source check only. The issue's second expected-behavior item (destination key shape) was partially verified incorrect — the QQ adapter builds C2C sources with `chat_type="dm"`, so organic and handoff keys already match for a C2C home. The real remaining key-shape defect (QQ **group** home: handoff binds `agent:main:qqbot:dm:{group_openid}` vs organic `agent:main:qqbot:group:{group_openid}:{member_openid}`) is tracked as follow-up #81860.
- The check runs on the entry `get_or_create_session` resolves, not a pre-read snapshot, so an inbound message that created a live session during the earlier awaits is seen by the check rather than skipped. A sub-millisecond check-then-act window remains between the last check and `switch_session` (an inbound message arriving in exactly that gap); the original code had no protection at all, so this is a strict improvement and consistent with single-async-read practices elsewhere in the gateway.
- **Open question:** should the CLI's `/handoff` command also pre-check and warn earlier (before marking the row pending), or is the gateway-side rejection + CLI failure message sufficient? The current fix keeps the authoritative check in the gateway where the session store and DB state live.
