### PR TITLE
feat(gateway): add one-shot self-nudge tool

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -765,6 +765,7 @@ def init_agent(
     agent.thinking_callback = thinking_callback
     agent.reasoning_callback = reasoning_callback
     agent.clarify_callback = clarify_callback
+    agent.self_nudge_callback = None
     agent.read_terminal_callback = read_terminal_callback
     agent.read_preview_callback = read_preview_callback
     agent.step_callback = step_callback
@@ -827,6 +828,7 @@ def init_agent(
     agent._delegate_depth = 0        # 0 = top-level agent, incremented for children
     agent._active_children = []      # Running child AIAgents (for interrupt propagation)
     agent._active_children_lock = threading.Lock()
+    agent._self_nudge_armed_this_turn = False
     
     # Store OpenRouter provider preferences
     agent.providers_allowed = providers_allowed
@@ -1441,6 +1443,7 @@ def init_agent(
         enabled_toolsets=enabled_toolsets,
         disabled_toolsets=disabled_toolsets,
         quiet_mode=agent.quiet_mode,
+        platform=agent.platform,
     )
     
     # Show tool configuration and store valid tool names for validation

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2978,6 +2978,15 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 ),
                 next_args,
             )
+    elif function_name == "self_nudge":
+        def _execute(next_args: dict) -> Any:
+            return _finish_agent_tool(
+                agent._emit_self_nudge(
+                    next_args.get("delay_seconds", 0),
+                    next_args.get("note", ""),
+                ),
+                next_args,
+            )
     elif function_name == "read_terminal":
         def _execute(next_args: dict) -> Any:
             from tools.read_terminal_tool import read_terminal_tool as _read_terminal_tool

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1807,7 +1807,10 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
                 "type": tool_call.type,
                 "function": {
                     "name": tool_call.function.name,
-                    "arguments": tool_call.function.arguments
+                    "arguments": agent._sanitize_private_tool_arguments(
+                        tool_call.function.name,
+                        tool_call.function.arguments,
+                    ),
                 },
             }
             # Tool-call arguments are intentionally NOT redacted here. This

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 
 # Tools that must never run concurrently (interactive / user-facing).
 # When any of these appear in a batch, we fall back to sequential execution.
-_NEVER_PARALLEL_TOOLS = frozenset({"clarify"})
+_NEVER_PARALLEL_TOOLS = frozenset({"clarify", "self_nudge"})
 
 # Read-only tools with no shared mutable session state.
 _PARALLEL_SAFE_TOOLS = frozenset({

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1838,6 +1838,25 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             tool_duration = time.time() - tool_start_time
             if agent._should_emit_quiet_tool_messages():
                 agent._vprint(f"  {_get_cute_tool_message_impl('clarify', function_args, tool_duration, result=function_result)}")
+        elif function_name == "self_nudge":
+            def _execute(next_args: dict) -> Any:
+                return agent._emit_self_nudge(
+                    next_args.get("delay_seconds", 0),
+                    next_args.get("note", ""),
+                )
+            function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_agent_tool_execution_middleware(
+                agent,
+                function_name=function_name,
+                function_args=function_args,
+                effective_task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", "") or "",
+                execute=_execute,
+                scope_block=_ts_scope_block,
+                display_index=i,
+            ))
+            tool_duration = time.time() - tool_start_time
+            if agent._should_emit_quiet_tool_messages():
+                agent._vprint(f"  {_get_cute_tool_message_impl('self_nudge', function_args, tool_duration, result=function_result)}")
         elif function_name == "read_terminal":
             def _execute(next_args: dict) -> Any:
                 from tools.read_terminal_tool import read_terminal_tool as _read_terminal_tool

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -450,6 +450,7 @@ def build_turn_context(
     agent._persist_user_message_idx = None
     agent._persist_user_message_override = persist_user_message
     agent._persist_user_message_timestamp = persist_user_timestamp
+    agent._self_nudge_armed_this_turn = False
     # Generate unique task_id if not provided to isolate VMs between tasks.
     effective_task_id = task_id or str(uuid.uuid4())
     agent._current_task_id = effective_task_id

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2124,6 +2124,9 @@ class MessageEvent:
     # Discord channel_skill_bindings).  A single name or ordered list.
     auto_skill: Optional[str | list[str]] = None
 
+    # Optional transcript-safe substitute for internal/hidden user turns.
+    persist_user_message: Optional[str] = None
+
     # Per-channel ephemeral system prompt (e.g. Discord channel_prompts).
     # Applied at API call time and never persisted to transcript history.
     channel_prompt: Optional[str] = None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -33,6 +33,7 @@ import json
 import logging
 import os
 import queue
+import uuid
 import re
 import shlex
 import site
@@ -43,7 +44,7 @@ import time
 from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Awaitable, Callable, Dict, Optional, Any, List, Tuple, Union, cast
 
 from agent.async_utils import consume_detached_task_result, safe_schedule_threadsafe
@@ -2486,6 +2487,8 @@ def _own_policy_open_startup_violation(config) -> Optional[str]:
 # session from bypassing the "already running" guard during the async gap
 # between the guard check and actual agent creation.
 _AGENT_PENDING_SENTINEL = object()
+_SELF_NUDGE_NO_REPLY = "NO_REPLY"
+_SELF_NUDGE_MAX_DELAY_SECONDS = 86400
 
 # Conversation-scoped per-session state registry (legacy contract).
 # The state itself now lives in ``SessionState.conversation`` (see
@@ -5859,6 +5862,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     _queued_events = legacy_dict_property("_queued_events")
     _pending_turn_sidecar_notes = legacy_dict_property("_pending_turn_sidecar_notes")
     _pending_messages = legacy_dict_property("_pending_messages")
+    _self_nudge_tasks = legacy_dict_property("_self_nudge_tasks")
+    _self_nudge_entries = legacy_dict_property("_self_nudge_entries")
+    _pending_hidden_turns = legacy_dict_property("_pending_hidden_turns")
     _pending_native_image_paths_by_session = legacy_dict_property(
         "_pending_native_image_paths_by_session"
     )
@@ -7492,6 +7498,116 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._exit_cleanly = True
         self._exit_reason = reason
         self._shutdown_event.set()
+
+    def _build_self_nudge_text(self, entry: Dict[str, Any]) -> str:
+        """Build the hidden prompt text for a fired self-nudge."""
+        hidden_prefix = (
+            "[System note: A self-nudge timer you armed earlier has fired. "
+            "Resume from the last persisted context and continue the follow-up task below.]"
+        )
+        note = str(entry.get("note") or "").strip()
+        if note:
+            return f"{hidden_prefix}\n\nReminder:\n{note}"
+        return hidden_prefix
+
+    async def _cancel_self_nudge(self, session_key: str, reason: str = "") -> bool:
+        """Cancel the active self-nudge for a session, if any."""
+        task = self._self_nudge_tasks.pop(session_key, None)
+        self._self_nudge_entries.pop(session_key, None)
+        self._pending_hidden_turns.pop(session_key, None)
+        if task:
+            task.cancel()
+        entry_was = task is not None
+        if entry_was and reason:
+            logger.debug("Cancelled self-nudge for %s (%s)", session_key[:20], reason)
+        return entry_was
+
+    async def _arm_self_nudge(
+        self,
+        session_key: str,
+        source: SessionSource,
+        delay_seconds: int,
+        note: str = "",
+    ) -> Dict[str, Any]:
+        """Arm or replace a one-shot self-nudge for a session."""
+        seconds = int(delay_seconds)
+        if seconds <= 0:
+            return {"armed": False, "error": "delay_seconds must be greater than zero."}
+        if seconds > _SELF_NUDGE_MAX_DELAY_SECONDS:
+            return {
+                "armed": False,
+                "error": (
+                    f"delay_seconds exceeds the maximum of "
+                    f"{_SELF_NUDGE_MAX_DELAY_SECONDS} seconds."
+                ),
+            }
+
+        replaced = await self._cancel_self_nudge(session_key, reason="replaced")
+        due_at = datetime.now() + timedelta(seconds=seconds)
+        entry = {
+            "session_key": session_key,
+            "source": source.to_dict(),
+            "delay_seconds": seconds,
+            "note": str(note or "").strip(),
+            "due_at": due_at.isoformat(),
+        }
+        self._self_nudge_entries[session_key] = entry
+
+        task = asyncio.create_task(self._fire_self_nudge(entry))
+        self._self_nudge_tasks[session_key] = task
+
+        def _cleanup(done_task, key=session_key):
+            current = self._self_nudge_tasks.get(key)
+            if current is done_task:
+                self._self_nudge_tasks.pop(key, None)
+
+        task.add_done_callback(_cleanup)
+        return {
+            "armed": True,
+            "delay_seconds": seconds,
+            "due_at": due_at.isoformat(),
+            "replaced_existing": replaced,
+        }
+
+    async def _fire_self_nudge(self, entry: Dict[str, Any]) -> None:
+        """Wait for a self-nudge timer, then enqueue or run its hidden turn."""
+        session_key = entry.get("session_key") or ""
+        delay = max(int(entry.get("delay_seconds") or 0), 0)
+        if not session_key or delay <= 0:
+            return
+
+        try:
+            await asyncio.sleep(delay)
+        except asyncio.CancelledError:
+            raise
+
+        current = self._self_nudge_entries.get(session_key)
+        if current is not entry:
+            return
+        self._self_nudge_entries.pop(session_key, None)
+        if session_key in self._running_agents:
+            self._pending_hidden_turns[session_key] = entry
+            return
+        await self._run_self_nudge_entry(entry)
+
+    async def _run_self_nudge_entry(self, entry: Dict[str, Any]) -> None:
+        """Inject a hidden follow-up turn for a fired self-nudge."""
+        session_key = entry.get("session_key") or ""
+        if not session_key or session_key in self._running_agents:
+            return
+        try:
+            source = SessionSource.from_dict(entry.get("source") or {})
+        except Exception as e:
+            logger.warning("Skipping invalid self-nudge entry: %s", e)
+            return
+
+        event = MessageEvent(
+            text=self._build_self_nudge_text(entry),
+            source=source,
+            message_id=f"self-nudge-{uuid.uuid4().hex[:8]}",
+            persist_user_message="[System note: a self-nudge timer fired.]",
+        )
+        await self._handle_message_with_agent(event, source, session_key)
 
     def _running_agent_count(self) -> int:
         return len(self._running_agents)

--- a/gateway/session_state.py
+++ b/gateway/session_state.py
@@ -109,6 +109,12 @@ class ConversationState:
     ephemeral_pin: Optional[Tuple[Any, ...]] = None
     # Last voice-channel context delivered (None = never delivered).
     vc_last: Optional[str] = None
+    # Self-nudge timer task (asyncio.Task or None) — one per session.
+    self_nudge_task: Optional[Any] = None
+    # Self-nudge entry metadata (dict or None) — one per session.
+    self_nudge_entry: Optional[Dict[str, Any]] = None
+    # Pending hidden turn queued while session was busy (dict or None).
+    pending_hidden_turn: Optional[Dict[str, Any]] = None
 
     def clear(self) -> None:
         """Reset every conversation-scoped field to its default.
@@ -126,6 +132,9 @@ class ConversationState:
         self.sidecar_notes = []
         self.ephemeral_pin = None
         self.vc_last = None
+        self.self_nudge_task = None
+        self.self_nudge_entry = None
+        self.pending_hidden_turn = None
 
 
 @dataclass
@@ -397,6 +406,15 @@ LEGACY_FIELD_SPECS: Dict[str, _FieldSpec] = {
     ),
     "_session_vc_last": _FieldSpec(
         "conversation", "vc_last", lambda: None, _present_not_none
+    ),
+    "_self_nudge_tasks": _FieldSpec(
+        "conversation", "self_nudge_task", lambda: None, _present_not_none
+    ),
+    "_self_nudge_entries": _FieldSpec(
+        "conversation", "self_nudge_entry", lambda: None, _present_not_none
+    ),
+    "_pending_hidden_turns": _FieldSpec(
+        "conversation", "pending_hidden_turn", lambda: None, _present_not_none
     ),
     "_pending_approvals": _FieldSpec(
         "persistent", "approvals", lambda: None, _present_not_none

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2182,7 +2182,7 @@ def _exempt_explicit_platform_native(
 #: schemas to a user with no Nous credential — the same split Home Assistant
 #: uses. Probing the portal from this path would put a network call on every
 #: CLI start, gateway session and cron tick.
-_RECENTLY_SHIPPED_TOOLSETS = frozenset({"bfl"})
+_RECENTLY_SHIPPED_TOOLSETS = frozenset({"bfl", "user_updates"})
 
 
 def _enable_recently_shipped_toolsets(

--- a/model_tools.py
+++ b/model_tools.py
@@ -307,6 +307,7 @@ def get_tool_definitions(
     disabled_toolsets: Optional[List[str]] = None,
     quiet_mode: bool = False,
     skip_tool_search_assembly: bool = False,
+    platform: str | None = None,
 ) -> List[Dict[str, Any]]:
     """
     Get tool definitions for model API calls with toolset-based filtering.
@@ -355,6 +356,7 @@ def get_tool_definitions(
                 _is_delegated_child_context(),
                 _is_dispatcher_owned_worker(),
                 profile_scope,
+                platform,
             )
         cached = _tool_defs_cache.get(cache_key) if cache_key is not None else None
         if cached is not None:
@@ -367,7 +369,8 @@ def get_tool_definitions(
             return list(cached)
 
     result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode,
-                                       skip_tool_search_assembly=skip_tool_search_assembly)
+                                       skip_tool_search_assembly=skip_tool_search_assembly,
+                                       platform=platform)
     if quiet_mode and cache_key is not None:
         # Cache the freshly-computed list, but hand callers a shallow copy so
         # downstream mutations (e.g. run_agent appending memory/LCM tool
@@ -393,6 +396,7 @@ def _compute_tool_definitions(
     disabled_toolsets: Optional[List[str]] = None,
     quiet_mode: bool = False,
     skip_tool_search_assembly: bool = False,
+    platform: str | None = None,
 ) -> List[Dict[str, Any]]:
     """Uncached implementation of :func:`get_tool_definitions`."""
     # Determine which tool names the caller wants
@@ -482,6 +486,17 @@ def _compute_tool_definitions(
 
     # Ask the registry for schemas (only returns tools whose check_fn passes)
     filtered_tools = registry.get_definitions(tools_to_include, quiet=quiet_mode)
+
+    # Platform-based filtering for self_nudge: use a deny-list of non-chat
+    # platforms so every current and future chat platform gets the tool by
+    # default.  Addresses teknium1's review on #5251 — an allowlist would
+    # silently omit new platforms added to the Platform enum.
+    _SELF_NUDGE_DENY_PLATFORMS = {"local", "api_server", "webhook", "msgraph_webhook", "sms", "relay"}
+    if platform in _SELF_NUDGE_DENY_PLATFORMS:
+        filtered_tools = [
+            td for td in filtered_tools
+            if td.get("function", {}).get("name") != "self_nudge"
+        ]
 
     # The set of tool names that actually passed check_fn filtering.
     # Use this (not tools_to_include) for any downstream schema that references
@@ -677,7 +692,7 @@ def _resolve_active_context_length() -> int:
 # because they need agent-level state (TodoStore, MemoryStore, etc.).
 # The registry still holds their schemas; dispatch just returns a stub error
 # so if something slips through, the LLM sees a sensible message.
-_AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task"}
+_AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task", "self_nudge"}
 _READ_SEARCH_TOOLS = {"read_file", "search_files"}
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -994,6 +994,60 @@ class AIAgent:
             except Exception:
                 logger.debug("status_callback error in _emit_warning", exc_info=True)
 
+    def _emit_self_nudge(self, delay_seconds: int, note: str = "") -> str:
+        """Arm a one-shot hidden follow-up timer for the current session."""
+        try:
+            seconds = int(delay_seconds)
+        except (TypeError, ValueError):
+            return json.dumps(
+                {"error": "delay_seconds must be an integer number of seconds."},
+                ensure_ascii=False,
+            )
+
+        if seconds <= 0:
+            return json.dumps(
+                {"error": "delay_seconds must be greater than zero."},
+                ensure_ascii=False,
+            )
+
+        callback = getattr(self, "self_nudge_callback", None)
+        if not callback:
+            return json.dumps(
+                {"error": "self_nudge is not available in this execution context."},
+                ensure_ascii=False,
+            )
+
+        try:
+            payload = callback(seconds, str(note or ""))
+        except Exception as exc:
+            return json.dumps(
+                {"error": f"Failed to arm self-nudge: {exc}"},
+                ensure_ascii=False,
+            )
+
+        if isinstance(payload, dict) and payload.get("armed"):
+            self._self_nudge_armed_this_turn = True
+            return json.dumps(payload, ensure_ascii=False)
+
+        if isinstance(payload, dict):
+            return json.dumps(payload, ensure_ascii=False)
+        return json.dumps({"error": "Failed to arm self-nudge."}, ensure_ascii=False)
+
+    @staticmethod
+    def _sanitize_private_tool_arguments(function_name: str, raw_arguments: Any) -> Any:
+        """Redact private tool-call fields before persisting/replaying history."""
+        if function_name != "self_nudge" or not isinstance(raw_arguments, str):
+            return raw_arguments
+        try:
+            parsed = json.loads(raw_arguments)
+        except Exception:
+            return raw_arguments
+        if not isinstance(parsed, dict) or "note" not in parsed:
+            return raw_arguments
+        parsed = dict(parsed)
+        parsed.pop("note", None)
+        return json.dumps(parsed, ensure_ascii=False)
+
     def _warn_context_overflow_blocked(
         self, reason: str, preflight_tokens: int, threshold_tokens: int
     ) -> None:

--- a/tests/agent/test_tool_call_arg_no_redaction.py
+++ b/tests/agent/test_tool_call_arg_no_redaction.py
@@ -64,6 +64,10 @@ class _FakeAgent:
     def _deterministic_call_id(self, _name, _args, idx):
         return f"det_{idx}"
 
+    @staticmethod
+    def _sanitize_private_tool_arguments(_function_name, raw_arguments):
+        return raw_arguments
+
 
 def _build(arguments):
     tc = _FakeToolCall("call_1", "terminal", arguments)

--- a/tests/gateway/test_self_nudge.py
+++ b/tests/gateway/test_self_nudge.py
@@ -1,0 +1,144 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, SendResult
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, build_session_key
+
+
+class StubAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="***"), Platform.TELEGRAM)
+
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return SendResult(success=True, message_id="1")
+
+    async def send_typing(self, chat_id, metadata=None):
+        return None
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+
+def _source(chat_id="123456"):
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=chat_id,
+        chat_type="dm",
+    )
+
+
+@pytest.mark.asyncio
+async def test_arm_self_nudge_replaces_existing_timer():
+    runner = object.__new__(GatewayRunner)
+    runner._self_nudge_tasks = {}
+    runner._self_nudge_entries = {}
+    runner._pending_hidden_turns = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+
+    source = _source()
+    session_key = build_session_key(source)
+
+    first = await runner._arm_self_nudge(session_key, source, 300, "First note")
+    second = await runner._arm_self_nudge(session_key, source, 120, "Second note")
+
+    assert first["armed"] is True
+    assert second["armed"] is True
+    assert second["replaced_existing"] is True
+    assert runner._self_nudge_entries[session_key]["note"] == "Second note"
+
+    await runner._cancel_self_nudge(session_key, reason="test_cleanup")
+
+
+@pytest.mark.asyncio
+async def test_fire_self_nudge_queues_hidden_turn_when_session_busy(monkeypatch):
+    runner = object.__new__(GatewayRunner)
+    runner._self_nudge_tasks = {}
+    runner._self_nudge_entries = {}
+    runner._pending_hidden_turns = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+
+    source = _source()
+    session_key = build_session_key(source)
+    entry = {
+        "session_key": session_key,
+        "source": source.to_dict(),
+        "delay_seconds": 5,
+        "note": "Check the deploy result.",
+    }
+    runner._self_nudge_entries[session_key] = entry
+    runner._running_agents[session_key] = object()
+
+    async def _no_sleep(_seconds):
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    await runner._fire_self_nudge(entry)
+
+    assert session_key not in runner._self_nudge_entries
+    assert runner._pending_hidden_turns[session_key]["note"] == "Check the deploy result."
+
+
+@pytest.mark.asyncio
+async def test_run_self_nudge_entry_injects_hidden_turn():
+    runner = object.__new__(GatewayRunner)
+    runner._self_nudge_tasks = {}
+    runner._self_nudge_entries = {}
+    runner._pending_hidden_turns = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._handle_message_with_agent = AsyncMock(return_value=None)
+
+    source = _source()
+    session_key = build_session_key(source)
+    entry = {
+        "session_key": session_key,
+        "source": source.to_dict(),
+        "delay_seconds": 300,
+        "note": "Check whether the background task finished.",
+    }
+
+    await runner._run_self_nudge_entry(entry)
+
+    runner._handle_message_with_agent.assert_awaited_once()
+    event, call_source, call_session_key = runner._handle_message_with_agent.call_args.args
+    assert call_source.chat_id == source.chat_id
+    assert call_session_key == session_key
+    assert "self-nudge timer" in event.text.lower()
+    assert "background task finished" in event.text.lower()
+    assert event.persist_user_message == "[System note: a self-nudge timer fired.]"
+
+
+@pytest.mark.asyncio
+async def test_cancel_self_nudge_clears_pending_hidden_turn():
+    runner = object.__new__(GatewayRunner)
+    runner._self_nudge_tasks = {}
+    runner._self_nudge_entries = {}
+    runner._pending_hidden_turns = {}
+
+    source = _source()
+    session_key = build_session_key(source)
+    task = asyncio.create_task(asyncio.sleep(60))
+    runner._self_nudge_tasks[session_key] = task
+    runner._self_nudge_entries[session_key] = {"session_key": session_key, "source": source.to_dict()}
+    runner._pending_hidden_turns[session_key] = {"session_key": session_key}
+
+    cancelled = await runner._cancel_self_nudge(session_key, reason="user_message")
+
+    assert cancelled is True
+    assert session_key not in runner._self_nudge_tasks
+    assert session_key not in runner._self_nudge_entries
+    assert session_key not in runner._pending_hidden_turns
+    task.cancel()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1446,6 +1446,17 @@ class TestBuildAssistantMessage:
             "google": {"thought_signature": "abc123"}
         }
 
+    def test_self_nudge_tool_call_redacts_private_note(self, agent):
+        tc = _mock_tool_call(
+            name="self_nudge",
+            arguments='{"delay_seconds":300,"note":"Check prod credentials."}',
+            call_id="call-1",
+        )
+        msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        result = agent._build_assistant_message(msg, "tool_calls")
+        persisted_args = result["tool_calls"][0]["function"]["arguments"]
+        assert json.loads(persisted_args) == {"delay_seconds": 300}
+
 
 
 

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -7,6 +7,7 @@ from unittest.mock import ANY, call, patch
 from model_tools import (
     handle_function_call,
     get_all_tool_names,
+    get_tool_definitions,
     get_toolset_for_tool,
     _AGENT_LOOP_TOOLS,
     _LEGACY_TOOLSET_MAP,
@@ -231,6 +232,7 @@ class TestAgentLoopTools:
         assert "memory" in _AGENT_LOOP_TOOLS
         assert "session_search" in _AGENT_LOOP_TOOLS
         assert "delegate_task" in _AGENT_LOOP_TOOLS
+        assert "self_nudge" in _AGENT_LOOP_TOOLS
 
     def test_no_regular_tools_in_set(self):
         assert "web_search" not in _AGENT_LOOP_TOOLS

--- a/tools/self_nudge_tool.py
+++ b/tools/self_nudge_tool.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""One-shot self-nudge tool for gateway sessions.
+
+Lets the agent arm a single in-memory timer that will later inject a hidden
+continuation turn back into the same session. This is lighter and safer than
+creating a cron job for short-lived follow-up work.
+"""
+
+import json
+
+from tools.registry import registry
+
+
+SELF_NUDGE_SCHEMA = {
+    "name": "self_nudge",
+    "description": (
+        "Arm a one-time self-nudge timer for the current session. When the "
+        "timer fires, Hermes injects a hidden follow-up turn back into this "
+        "same session. Use this instead of cron for short-lived reminders or "
+        "follow-up checks. Only one self-nudge is kept per session; arming a "
+        "new one replaces the previous timer."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "delay_seconds": {
+                "type": "integer",
+                "minimum": 1,
+                "description": (
+                    "How many seconds to wait before firing the one-time "
+                    "hidden follow-up turn."
+                ),
+            },
+            "note": {
+                "type": "string",
+                "description": (
+                    "Optional private reminder to inject into the hidden turn. "
+                    "Example: 'Check whether the deploy finished and report "
+                    "back if it failed.'"
+                ),
+            },
+        },
+        "required": ["delay_seconds"],
+    },
+}
+
+
+def check_self_nudge_requirements() -> bool:
+    """Tool availability is filtered by platform in model_tools."""
+    return True
+
+
+def self_nudge_tool(args, **kwargs):
+    """Stub dispatcher for the registry.
+
+    Real handling happens in run_agent.py because it needs the live session's
+    gateway callback.
+    """
+    return json.dumps(
+        {"error": "self_nudge must be handled by the agent loop"},
+        ensure_ascii=False,
+    )
+
+
+registry.register(
+    name="self_nudge",
+    toolset="user_updates",
+    schema=SELF_NUDGE_SCHEMA,
+    handler=self_nudge_tool,
+    check_fn=check_self_nudge_requirements,
+    description="Arm a one-shot hidden self-reminder for the current gateway session.",
+    emoji="⏰",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -68,6 +68,9 @@ _HERMES_CORE_TOOLS = [
     "session_search",
     # Clarifying questions
     "clarify",
+    # One-shot hidden follow-up timer for gateway sessions.
+    # Platform-gated in model_tools.py: hidden from local/api_server/webhook/sms/relay.
+    "self_nudge",
     # Code execution + delegation
     "execute_code", "delegate_task",
     # Cronjob management
@@ -281,6 +284,12 @@ TOOLSETS = {
     "clarify": {
         "description": "Ask the user clarifying questions (multiple-choice or open-ended)",
         "tools": ["clarify"],
+        "includes": []
+    },
+    
+    "user_updates": {
+        "description": "Arm one-shot hidden follow-up nudges for the current gateway session",
+        "tools": ["self_nudge"],
         "includes": []
     },
     


### PR DESCRIPTION
## Summary

Retargeted self-nudge tool onto current main HEAD (supersedes #5251). Addresses all 3 of @teknium1's review comments.

### What it does
Adds a gateway-only `self_nudge` tool for arming one-shot hidden follow-up timers. When the timer fires, Hermes injects a hidden continuation turn back into the same session.

### teknium1's review fixes

1. **Cache key includes platform** (`model_tools.py`): `platform` added to `_tool_defs_cache` cache_key tuple to prevent cross-platform tool leakage.

2. **Deny-list instead of allowlist** (`model_tools.py`): Replaced the PR's platform allowlist with a deny-list of non-chat platforms: `{local, api_server, webhook, msgraph_webhook, sms, relay}`. All other platforms (including weixin, bluebubbles, qqbot, yuanbao, wecom_callback, whatsapp_cloud) get `self_nudge`.

3. **Core tools placement** (`toolsets.py`): `self_nudge` is in `_HERMES_CORE_TOOLS` with a comment documenting that it's platform-gated in `model_tools.py`. The platform filter removes it before the model sees it on non-gateway surfaces. A `user_updates` toolset is also defined for explicit toolset-level gating.

### Validation
- `python -m pytest tests/gateway/test_self_nudge.py tests/test_model_tools.py tests/gateway/test_api_server_toolset.py -q` → **33 passed**

Closes #5250.