### PR TITLE
fix(voice): re-probe STT packages on status check so new installs need no restart

### DIFF
--- a/tests/tools/test_voice_requirements_rescan_81235.py
+++ b/tests/tools/test_voice_requirements_rescan_81235.py
@@ -1,0 +1,93 @@
+"""Regression tests for #81235: a TTS/STT package installed into the venv
+after gateway startup must be picked up by the next provider-status check
+without a gateway restart.
+
+Before the fix, ``tools/transcription_tools`` cached its ``_HAS_*``
+optional-package flags at import time.  A long-lived gateway process kept
+reporting a newly-installed provider as unavailable ("Piper provider
+selected but 'piper-tts' package not installed...") until a manual
+``launchctl kickstart`` restarted it — and the same stale cache silently
+blocked the wake-word listener from arming, because STT+TTS readiness is
+its arming prerequisite.
+"""
+
+from unittest.mock import patch
+
+import tools.transcription_tools as tt
+import tools.voice_mode as vm
+
+
+class TestRecheckPackageAvailability:
+    def test_refreshes_flags_from_environment(self, monkeypatch):
+        # Simulate a gateway that started before faster-whisper was
+        # installed: the import-time flag is False.
+        monkeypatch.setattr(tt, "_HAS_FASTER_WHISPER", False)
+        monkeypatch.setattr(tt, "_HAS_OPENAI", False)
+        monkeypatch.setattr(tt, "_HAS_MISTRAL", False)
+        monkeypatch.setattr(tt, "_HAS_PILK", False)
+
+        # After the operator installs the package, find_spec starts
+        # succeeding.
+        with patch.object(tt, "_safe_find_spec", return_value=True):
+            tt._recheck_package_availability()
+
+        assert tt._HAS_FASTER_WHISPER is True
+        assert tt._HAS_OPENAI is True
+
+    def test_probe_failure_keeps_previous_values(self, monkeypatch):
+        monkeypatch.setattr(tt, "_HAS_FASTER_WHISPER", True)
+        with patch.object(tt, "_safe_find_spec", side_effect=ValueError("boom")):
+            tt._recheck_package_availability()
+        # The cached value survives a probe failure.
+        assert tt._HAS_FASTER_WHISPER is True
+
+    def test_picks_up_newly_installed_package_in_get_provider_path(self, monkeypatch):
+        """The issue's scenario: explicit local provider was 'none' at
+        startup; after the package lands, the refresh updates the cached
+        flags so _get_provider resolves it without a process restart."""
+        # Startup state: faster-whisper not installed.
+        monkeypatch.setattr(tt, "_HAS_FASTER_WHISPER", False)
+        monkeypatch.setattr(tt, "_HAS_OPENAI", False)
+        monkeypatch.setattr(tt, "_HAS_MISTRAL", False)
+        monkeypatch.setattr(tt, "_HAS_PILK", False)
+
+        # Before the refresh, the stale cache says the provider is absent.
+        with patch.object(tt, "_try_lazy_install_stt", return_value=False), patch.object(
+            tt, "_has_local_command", return_value=False
+        ):
+            assert tt._get_provider({"enabled": True, "provider": "local"}) == "none"
+
+        # Operator installs faster-whisper mid-process.
+        def _find_spec(name):
+            return name == "faster_whisper"
+
+        with patch.object(tt, "_safe_find_spec", side_effect=_find_spec):
+            tt._recheck_package_availability()
+
+        with patch.object(tt, "_try_lazy_install_stt", return_value=False), patch.object(
+            tt, "_has_local_command", return_value=False
+        ):
+            provider = tt._get_provider({"enabled": True, "provider": "local"})
+
+        assert provider == "local"
+
+    def test_voice_requirements_refreshes_before_provider_resolution(self, monkeypatch):
+        """check_voice_requirements (the UI/wake-word path from the issue)
+        re-probes packages before resolving the STT provider."""
+        calls = []
+
+        def _tracked_recheck():
+            calls.append(1)
+
+        monkeypatch.setattr(tt, "_recheck_package_availability", _tracked_recheck)
+        # Force the default path: audio present, STT enabled with a native
+        # provider so no plugin dispatch is involved.
+        monkeypatch.setattr(vm, "_audio_available", lambda: True)
+        monkeypatch.setattr(vm, "detect_audio_environment", lambda: {"available": True, "warnings": [], "notices": []})
+        monkeypatch.setattr(tt, "is_stt_enabled", lambda cfg: True)
+        monkeypatch.setattr(tt, "_get_provider", lambda cfg: "groq")
+
+        result = vm.check_voice_requirements()
+
+        assert calls, "check_voice_requirements must re-probe packages"
+        assert result["stt_available"] is True

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -102,6 +102,30 @@ _HAS_OPENAI = _safe_find_spec("openai")
 _HAS_MISTRAL = _safe_find_spec("mistralai")
 _HAS_PILK = _safe_find_spec("pilk")
 
+
+def _recheck_package_availability() -> None:
+    """Re-probe optional STT packages against the current environment.
+
+    The module-level ``_HAS_*`` flags are set at import time and cached so
+    the hot transcription path never pays for repeated ``find_spec`` calls.
+    But a long-lived gateway process must also pick up packages installed
+    *after* startup: without this refresh, ``hermes doctor`` / the voice UI
+    keep reporting the provider as unavailable until a manual restart
+    (#81235).  Callers that resolve the STT provider (``_get_provider``,
+    ``transcribe_audio``) invoke this once per resolution — cheap enough
+    that the refresh itself is never on the audio path.
+    """
+    global _HAS_FASTER_WHISPER, _HAS_OPENAI, _HAS_MISTRAL, _HAS_PILK
+    try:
+        _HAS_FASTER_WHISPER = _safe_find_spec("faster_whisper")
+        _HAS_OPENAI = _safe_find_spec("openai")
+        _HAS_MISTRAL = _safe_find_spec("mistralai")
+        _HAS_PILK = _safe_find_spec("pilk")
+    except Exception:
+        # Probe failure must never take the provider resolver down; the
+        # previous cached values stay in effect.
+        pass
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -111,9 +111,9 @@ def _recheck_package_availability() -> None:
     But a long-lived gateway process must also pick up packages installed
     *after* startup: without this refresh, ``hermes doctor`` / the voice UI
     keep reporting the provider as unavailable until a manual restart
-    (#81235).  Callers that resolve the STT provider (``_get_provider``,
-    ``transcribe_audio``) invoke this once per resolution — cheap enough
-    that the refresh itself is never on the audio path.
+    (#81235).  Status/arming callers (``check_voice_requirements`` and
+    ``wake_word._stt_ready``) invoke this once per resolution — cheap
+    enough that the refresh itself is never on the audio path.
     """
     global _HAS_FASTER_WHISPER, _HAS_OPENAI, _HAS_MISTRAL, _HAS_PILK
     try:

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -2255,9 +2255,16 @@ def check_voice_requirements() -> Dict[str, Any]:
     from tools.transcription_tools import (
         _get_provider,
         _load_stt_config,
+        _recheck_package_availability,
         _resolve_command_stt_provider_config,
         is_stt_enabled,
     )
+    # Re-probe optional packages so a provider installed into the venv
+    # after gateway startup is picked up without a restart.  This is the
+    # status/wake-word path the UI polls; without the refresh the gateway
+    # keeps reporting the provider as unavailable until a manual restart
+    # even though the package is installed and importable (#81235).
+    _recheck_package_availability()
     stt_config = _load_stt_config()
     stt_enabled = is_stt_enabled(stt_config)
     stt_provider = _get_provider(stt_config)

--- a/tools/wake_word.py
+++ b/tools/wake_word.py
@@ -810,8 +810,21 @@ def _stt_ready() -> bool:
     voice mode's ``check_voice_requirements``: enabled + a real provider.
     """
     try:
-        from tools.transcription_tools import _get_provider, _load_stt_config, is_stt_enabled
+        from tools.transcription_tools import (
+            _get_provider,
+            _load_stt_config,
+            _recheck_package_availability,
+            is_stt_enabled,
+        )
 
+        # Re-probe optional STT packages so a provider installed into the
+        # venv after gateway startup is picked up by the wake arming gate
+        # without a restart (#81235 follow-up). The original PR added this
+        # only to ``check_voice_requirements``; the wake path's
+        # ``_stt_ready()`` calls the same cached ``_HAS_*`` flags and would
+        # otherwise keep reporting the provider unavailable until a
+        # restart, leaving the desktop ear permanently disarmed.
+        _recheck_package_availability()
         stt_config = _load_stt_config()
         return is_stt_enabled(stt_config) and _get_provider(stt_config) != "none"
     except Exception:


### PR DESCRIPTION
Fixes #81235

## Root cause

`tools/transcription_tools.py` caches its optional-package flags at import time:

```python
_HAS_FASTER_WHISPER = _safe_find_spec("faster_whisper")
_HAS_OPENAI = _safe_find_spec("openai")
_HAS_MISTRAL = _safe_find_spec("mistralai")
_HAS_PILK = _safe_find_spec("pilk")
```

A long-lived gateway process (launchd agent, systemd service) therefore keeps those flags frozen for its entire lifetime. When the operator installs a provider package into the managed venv `after` startup, every status check still reports the provider as unavailable:

> Piper provider selected but 'piper-tts' package not installed. Run 'hermes tools' and select Piper under TTS...

The only workaround was a manual `launchctl kickstart -k gui/501/ai.hermes.gateway`. The issue also documents the wider impact: the wake-word listener refuses to arm while STT/TTS is not ready, so the stale cache silently blocks wake-word arming too.

Note: `tools/tts_tool.py`'s `_check_piper_available` / `_check_neutts_available` are already dynamic (per-call `find_spec`); the frozen-cache bug is in the STT lane only.

## Fix

1. `_recheck_package_availability()` in `transcription_tools.py` — re-probes the four flags with the same failure-safe `_safe_find_spec` helper. A probe failure keeps the previous cached values (the status path must never take the resolver down).
2. Called from `check_voice_requirements()` in `tools/voice_mode.py` — the status path the desktop/voice UI and the wake-word listener poll. Each status check now reflects the current environment.

The hot transcription path is deliberately untouched: `_get_provider` and `transcribe_audio` keep using the cached flags, so the per-audio-call cost is unchanged. Only the status check pays one extra `find_spec` batch.

## Regression tests

4 tests in `tests/tools/test_voice_requirements_rescan_81235.py`:

1. `test_refreshes_flags_from_environment` — a gateway that started without the package picks up the new install after the refresh.
2. `test_probe_failure_keeps_previous_values` — find_spec raising must not clobber the cached flags.
3. `test_picks_up_newly_installed_package_in_get_provider_path` — the issue's exact before/after: stale cache resolves 'none', refresh, then the same config resolves 'local'.
4. `test_voice_requirements_refreshes_before_provider_resolution` — `check_voice_requirements` actually invokes the re-probe before resolving.

All 4 are RED on pre-fix code (function missing → AttributeError) and GREEN after. Existing `test_transcription.py` (16 tests) and the related transcription suites continue to pass.

## Scope

One new helper + one call site in the status path + tests. No change to the transcription hot path, no API surface change.