### PR TITLE
fix(google-chat): keep DM sessions space-level and seed cron notification threads

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -711,6 +711,11 @@ class GoogleChatAdapter(BasePlatformAdapter):
         #       replies still land in the right visual thread without
         #       re-coupling sessions to threads.
         self._last_inbound_thread: Dict[str, str] = {}
+        # space type ("dm" | "group") per
+        # chat_id, populated from inbound envelopes. Used by cron
+        # notification seeding (_seed_cron_notification) to choose
+        # between thread-keyed (group) and space-level (DM) seeds.
+        self._space_types: Dict[str, str] = {}
         # Inbound message count per (chat_id, thread_name). Drives the
         # DM main-flow vs side-thread heuristic in _build_message_event
         # and the outbound thread routing in _resolve_thread_id.
@@ -1832,6 +1837,10 @@ class GoogleChatAdapter(BasePlatformAdapter):
             self._last_sender_by_chat[space_name] = sender_email.strip().lower()
 
         chat_type = "dm" if space_type in {"DIRECT_MESSAGE", "DM"} else "group"
+        # remember the space type for cron
+        # notification seeding at send time.
+        if space_name:
+            self._space_types[space_name] = chat_type
         text = msg.get("argumentText") or msg.get("text") or ""
         text = text.strip()
 
@@ -1894,7 +1903,19 @@ class GoogleChatAdapter(BasePlatformAdapter):
         # always reply in-thread.
         if chat_type == "dm":
             is_side_thread = prev_thread_count > 0
-            session_thread_id = thread_name if is_side_thread else None
+            # DMs keep ONE space-level
+            # session even for replies inside per-message threads. Google
+            # Chat nests every reply in the replied-to message's thread;
+            # keying the session by that thread (the old side-thread
+            # behaviour) isolated the reply from the DM's history, so the
+            # agent had no context when the user replied in a DM. Threads
+            # still drive OUTBOUND placement via _last_inbound_thread (the
+            # bot's reply nests visually in the user's thread), but the
+            # SESSION key stays the whole DM. Tradeoff: parallel threads in
+            # a DM share one rolling context (the upstream isolation existed
+            # to stop cross-thread leakage — deliberately desired here for a
+            # single-operator DM; group spaces below remain thread-isolated).
+            session_thread_id = None
             # Outbound thread cache: populated only when side-thread, so
             # _resolve_thread_id falls through to "no thread" on main
             # flow and the bot reply lands as a top-level sibling.
@@ -2145,6 +2166,23 @@ class GoogleChatAdapter(BasePlatformAdapter):
                     raise
             if last_result is None:
                 return SendResult(success=False, error="empty message")
+            # cron/automation
+            # notification context seeding. Cron deliveries carry job_id
+            # in metadata and are sent as top-level messages; Google Chat
+            # gives each its own thread, so a reply in that thread would
+            # hit a session with no record of the brief. Seed the
+            # delivered message's thread session (groups) or the DM
+            # session (DMs use space-level keys — see
+            # _build_message_event) with the brief so a reply has
+            # context. Best-effort: a delivered notification is never
+            # failed by a seeding problem.
+            if (metadata or {}).get("job_id") and not thread_id:
+                try:
+                    self._seed_cron_notification(last_result, chat_id, content)
+                except Exception:
+                    logger.debug(
+                        "[GoogleChat] cron notification seed failed", exc_info=True
+                    )
             # Mark the chat's typing slot as "consumed" so the base class's
             # _keep_typing loop (which may iterate one more time before
             # typing_task.cancel() lands) does not post a fresh marker that
@@ -2155,6 +2193,60 @@ class GoogleChatAdapter(BasePlatformAdapter):
             return last_result
         finally:
             self.resume_typing_for_chat(chat_id)
+
+    def _seed_cron_notification(
+        self, send_result: SendResult, chat_id: str, content: str
+    ) -> None:
+        """Seed session context for a cron-delivered notification.
+
+        Groups: the delivered
+        message's own thread session (``spaces/X/threads/Y`` from the
+        send response — Google Chat gives every top-level message its own
+        thread) gets the brief as a labelled user turn, so a reply in
+        that thread continues with the brief in context. DMs: sessions
+        are space-level (see _build_message_event), so the brief is
+        mirrored into the DM session instead. Mirrors the scheduler's
+        ``_seed_cron_thread_session`` pattern: create the session row,
+        then append via ``gateway.mirror.mirror_to_session``. Best-effort.
+        """
+        resp = getattr(send_result, "raw_response", None) or {}
+        resp_thread = (resp.get("thread") or {}).get("name")
+        space_kind = self._space_types.get(chat_id, "group")
+        seed_thread = None if space_kind == "dm" else resp_thread
+        session_store = getattr(self, "_session_store", None)
+        if session_store is None:
+            return
+        try:
+            from gateway.config import Platform
+            from gateway.session import SessionSource
+
+            dest_source = SessionSource(
+                platform=Platform("google_chat"),
+                chat_id=chat_id,
+                chat_name="",
+                chat_type="dm" if space_kind == "dm" else "group",
+                thread_id=seed_thread,
+                user_id="system:cron",
+                user_name="Cron",
+            )
+            session_store.get_or_create_session(dest_source)
+        except Exception:
+            logger.debug("[GoogleChat] cron seed session create failed", exc_info=True)
+            return
+        try:
+            from gateway.mirror import mirror_to_session
+
+            mirror_to_session(
+                "google_chat",
+                chat_id,
+                f"[Cron delivery]\n{content}",
+                source_label="cron",
+                thread_id=seed_thread,
+                user_id="system:cron",
+                role="user",
+            )
+        except Exception:
+            logger.debug("[GoogleChat] cron seed mirror failed", exc_info=True)
 
     async def send_card(
         self,
@@ -2622,7 +2714,12 @@ class GoogleChatAdapter(BasePlatformAdapter):
                     "[GoogleChat] outbound thread-count incr failed",
                     exc_info=True,
                 )
-        return SendResult(success=True, message_id=resp.get("name"))
+        # expose the raw response (carries the
+        # created message's thread name) so send() can seed cron
+        # notification sessions with the delivered brief.
+        return SendResult(
+            success=True, message_id=resp.get("name"), raw_response=resp
+        )
 
     async def send_typing(self, chat_id: str, metadata: Any = None) -> None:
         """Post a visible 'Hermes is thinking…' marker message.

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -632,16 +632,14 @@ class TestBuildMessageEvent:
         ) == 1
 
     @pytest.mark.asyncio
-    async def test_dm_second_message_in_same_thread_is_side_thread(self, adapter):
-        """If we've SEEN a thread before (count > 0), the user explicitly
-        re-engaged it (clicked 'Reply in thread' on a prior message).
-        Isolate to its own session so old top-level chatter doesn't
-        leak in.
-
-        Without this isolation the bug Ramón reported reappears: he
-        opens a new thread, says 'Hola!', asks 'dime los mensajes
-        anteriores' and the bot answers with messages from OTHER
-        threads — because all DM threads were sharing one session."""
+    async def test_dm_second_message_in_same_thread_keeps_space_session(self, adapter):
+        """replying inside a DM
+        thread must NOT isolate the session — the reply continues the
+        DM's space-level session so the agent has the conversation's
+        context (previously a 'side thread' got its own session and the
+        reply arrived with no history). The thread is still cached for
+        OUTBOUND placement so the bot's reply nests in the user's
+        thread visually."""
         env1 = _make_chat_envelope(text="primera vez", thread_name="spaces/S/threads/T1")
         msg1 = env1["chat"]["messagePayload"]["message"]
         event1 = await adapter._build_message_event(msg1, env1)
@@ -650,8 +648,11 @@ class TestBuildMessageEvent:
         env2 = _make_chat_envelope(text="segunda vez", thread_name="spaces/S/threads/T1")
         msg2 = env2["chat"]["messagePayload"]["message"]
         event2 = await adapter._build_message_event(msg2, env2)
-        # Second time same thread = user re-engaged → isolated session.
-        assert event2.source.thread_id == "spaces/S/threads/T1"
+        # Reply in an engaged thread: session stays space-level (context!),
+        # but the thread is cached so the bot replies inside it visually.
+        assert event2.source.thread_id is None
+        assert event2.source.chat_id == "spaces/S"
+        assert adapter._last_inbound_thread.get("spaces/S") == "spaces/S/threads/T1"
 
 
     @pytest.mark.asyncio
@@ -684,6 +685,74 @@ class TestSend:
         result = await adapter.send("spaces/S", "hola")
         adapter._create_message.assert_called()
         assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_plain_send_does_not_seed(self, adapter):
+        """non-cron sends never seed sessions."""
+        adapter._session_store = MagicMock()
+        adapter._space_types["spaces/S"] = "dm"
+        resp = type("R", (), {"success": True, "message_id": "m/1",
+                              "raw_response": {"thread": {"name": "spaces/S/threads/TN"}}})()
+        adapter._create_message = AsyncMock(return_value=resp)
+        with patch("gateway.mirror.mirror_to_session") as mirror:
+            result = await adapter.send("spaces/S", "hola")
+        assert result.success is True
+        mirror.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cron_send_seeds_thread_session_for_group(self, adapter):
+        """a cron notification delivered to a
+        group space seeds the delivered message's thread session with the
+        brief, so a reply in that thread has context."""
+        adapter._session_store = MagicMock()
+        captured = {}
+
+        def _fake_mirror(platform, chat_id, text, **kw):
+            captured.update(kw)
+            captured["text"] = text
+            return True
+
+        adapter._space_types["spaces/G"] = "group"
+        resp = type("R", (), {"success": True, "message_id": "m/1",
+                              "raw_response": {"thread": {"name": "spaces/G/threads/TN"}}})()
+        adapter._create_message = AsyncMock(return_value=resp)
+        with patch("gateway.mirror.mirror_to_session", _fake_mirror):
+            result = await adapter.send(
+                "spaces/G", "the brief", metadata={"job_id": "j1"}
+            )
+        assert result.success is True
+        assert captured["thread_id"] == "spaces/G/threads/TN"
+        assert captured["role"] == "user"
+        assert "the brief" in captured["text"]
+        # Session row created for the thread key.
+        adapter._session_store.get_or_create_session.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cron_send_seeds_dm_session_flat(self, adapter):
+        """a cron notification delivered to a DM
+        seeds the space-level DM session (thread_id=None) — replies in the
+        DM resolve there (DMs key sessions at space level)."""
+        adapter._session_store = MagicMock()
+        captured = {}
+
+        def _fake_mirror(platform, chat_id, text, **kw):
+            captured["chat_id"] = chat_id
+            captured["text"] = text
+            captured.update(kw)
+            return True
+
+        adapter._space_types["spaces/S"] = "dm"
+        resp = type("R", (), {"success": True, "message_id": "m/1",
+                              "raw_response": {"thread": {"name": "spaces/S/threads/TN"}}})()
+        adapter._create_message = AsyncMock(return_value=resp)
+        with patch("gateway.mirror.mirror_to_session", _fake_mirror):
+            result = await adapter.send(
+                "spaces/S", "brief dm", metadata={"job_id": "j2"}
+            )
+        assert result.success is True
+        assert captured["thread_id"] is None
+        assert captured["chat_id"] == "spaces/S"
+        assert "brief dm" in captured["text"]
 
     @pytest.mark.asyncio
     async def test_create_message_passes_messageReplyOption_when_thread_set(self, adapter):


### PR DESCRIPTION
## Problem

On Google Chat, replying to a message loses conversation context:

- **DMs**: Google Chat nests every reply in the replied-to message's thread. The adapter's side-thread heuristic (`prev_count >= 1` → isolate session by thread) keyed those replies to fresh thread-scoped sessions, so the agent saw only the user's reply with no history from the DM — "Alfred has no context when I reply, especially in DMs".
- **Notifications**: cron/automation deliveries are fire-and-forget — the delivered brief never enters any session. Even with correct session keying, a reply to a notification had no record of what was sent.

## Fix

1. **DM sessions keyed at space level.** `_build_message_event` no longer propagates `thread_id` to the session source for DMs. The thread still drives *outbound* placement (`_last_inbound_thread`), so the bot's reply nests visually in the user's thread — only the session key stays the whole DM.

2. **Cron notification thread seeding.** When `send()` sees cron route metadata (`job_id`) on a top-level delivery, it seeds the delivered message's own thread session (groups) or the DM session (DMs) with the brief as a labelled user turn (`[Cron delivery]` + content, role=user), using the same create-then-mirror pattern as `_seed_cron_thread_session` in the scheduler. `_create_message` now returns the raw response so the created message's thread name is available.

Group-space thread isolation is **unchanged** — parallel task threads in shared spaces keep separate sessions (only DMs collapse to one session, which is the intended single-operator UX; the prior isolation existed to stop cross-thread leakage, and the tradeoff is documented in the code).

## Tests

`tests/gateway/test_google_chat.py`: 66 passed, including:
- updated `test_dm_second_message_in_same_thread_keeps_space_session` (session stays space-level, outbound thread cache still set)
- `test_cron_send_seeds_thread_session_for_group` / `test_cron_send_seeds_dm_session_flat` (seeding paths)
- `test_plain_send_does_not_seed` (no seeding without cron metadata)
