### PR TITLE
fix(terminal): preserve ~user SSH cwds, not just ~ and ~/

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3233,12 +3233,19 @@ def _is_ssh_remote_tilde_cwd(backend: str, cwd: str) -> bool:
     """Return whether the remote SSH shell must expand *cwd* itself.
 
     Expanding ``~`` on the Hermes host rewrites it to the host or container
-    home before SSH sees it. Preserve ``~`` and ``~/...`` so they follow the
-    user selected by the SSH connection.
+    home before SSH sees it. Preserve every tilde form so they follow the
+    remote account: ``~`` and ``~/...`` for the connecting user, and
+    ``~other``/``~other/...`` for a named one.
+
+    The named form matters for the same reason as the bare one, and it fails
+    more quietly. ``os.path.expanduser("~alice/work")`` resolves against the
+    HOST's account database, so it silently becomes a local absolute path
+    whenever a local user shares the remote name (the common case when the
+    same login exists on both ends) and passes through untouched otherwise.
     """
     if (backend or "").strip().lower() != "ssh":
         return False
-    return cwd == "~" or cwd.startswith("~/")
+    return cwd.startswith("~")
 
 
 def apply_terminal_config_to_env(

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2087,8 +2087,11 @@ def terminal_config_env_var_for_key(key: str) -> Optional[str]:
 
 def _is_ssh_remote_tilde_cwd(backend: str, cwd: str) -> bool:
     """Whether the remote SSH shell must expand *cwd* itself: ``~`` expanded on the Hermes host
-    would name the host/container home instead of the SSH user's."""
-    return (backend or "").strip().lower() == "ssh" and (cwd == "~" or cwd.startswith("~/"))
+    would name the host/container home instead of the SSH user's. Every tilde form counts, and
+    the named one fails most quietly: ``expanduser("~alice/work")`` resolves against the HOST
+    account database, so it silently yields a local path whenever the same login exists on both
+    ends and passes through untouched otherwise."""
+    return (backend or "").strip().lower() == "ssh" and cwd.startswith("~")
 
 
 def apply_terminal_config_to_env(

--- a/tests/tools/test_quote_cwd_tilde_user.py
+++ b/tests/tools/test_quote_cwd_tilde_user.py
@@ -1,0 +1,89 @@
+"""``cd`` targets of the form ``~other`` must stay expandable by the remote shell.
+
+Preserving ``~other`` through the config bridge is only half the path. The
+bootstrap then runs it through ``_quote_cwd_for_cd``, which fell through to
+``shlex.quote`` for the named form, emitting ``cd '~other/x'``. Tilde expansion
+does not happen inside quotes, so the ``cd`` fails and the session silently
+starts in the login directory: the same quiet failure one layer down.
+
+Verified against a real shell:
+
+    cd ~grimm/'Desktop'   ->  /Users/grimm/Desktop
+    cd '~grimm'           ->  bash: cd: ~grimm: No such file or directory
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from tools.environments.base import BaseEnvironment
+
+_q = BaseEnvironment._quote_cwd_for_cd
+
+
+def test_named_tilde_is_not_swallowed_by_quotes():
+    """The bug: the whole thing was quoted, so no shell ever expanded it."""
+    out = _q("~alice/work")
+
+    assert out != "'~alice/work'", "the named tilde was quoted out of existence"
+    assert out.startswith("~alice/")
+
+
+def test_named_tilde_without_a_path():
+    assert _q("~alice") == "~alice"
+    assert _q("~alice/") == "~alice"
+
+
+def test_remainder_is_still_quoted():
+    """Only the tilde prefix may be bare; the rest keeps its quoting."""
+    assert _q("~alice/my project") == "~alice/'my project'"
+    assert _q("~alice/a;rm -rf b") == "~alice/'a;rm -rf b'"
+
+
+@pytest.mark.parametrize(
+    "cwd",
+    ["~$(id)/x", "~`id`/x", "~a b/x", "~-bad/x", "~/../etc", "~*/x"],
+)
+def test_unsafe_account_names_take_the_quoted_path(cwd):
+    """An account name outside the conservative set must never go out bare."""
+    out = _q(cwd)
+
+    assert out.startswith("'") or out.startswith("$HOME"), out
+
+
+def test_existing_forms_are_unchanged():
+    """Guards: the three cases the helper already handled keep their output."""
+    assert _q("~") == "~"
+    assert _q("~/") == "$HOME"
+    assert _q("~/work") == "$HOME/work"
+    assert _q("/abs/path") == "/abs/path"
+    assert _q("/a b") == "'/a b'"
+
+
+def test_a_real_shell_resolves_the_emitted_form():
+    """End to end: what we emit must actually expand in bash.
+
+    Uses the running account, so the home directory genuinely exists.
+    """
+    import getpass
+
+    user = getpass.getuser()
+    emitted = _q(f"~{user}")
+    assert emitted == f"~{user}"
+
+    resolved = subprocess.run(
+        ["bash", "-c", f"cd {emitted} && pwd"],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert resolved.returncode == 0, resolved.stderr
+    assert resolved.stdout.strip()
+
+    quoted = subprocess.run(
+        ["bash", "-c", f"cd '~{user}' && pwd"],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert quoted.returncode != 0, (
+        "the pre-fix form unexpectedly worked; this test no longer proves anything"
+    )

--- a/tests/tools/test_ssh_tilde_user_cwd.py
+++ b/tests/tools/test_ssh_tilde_user_cwd.py
@@ -1,0 +1,81 @@
+"""``~user`` cwds must reach the SSH shell unexpanded, like ``~`` already does.
+
+`_is_ssh_remote_tilde_cwd` preserved ``~`` and ``~/...`` but not ``~other``.
+The named form fails the same way and more quietly:
+``os.path.expanduser("~alice/work")`` resolves against the HOST's account
+database, so it silently becomes a local absolute path whenever a local user
+shares the remote name, and passes through untouched otherwise. The remote
+therefore receives a path that was resolved on the wrong machine.
+"""
+
+from __future__ import annotations
+
+import getpass
+import os
+
+import pytest
+
+from hermes_cli.config import _is_ssh_remote_tilde_cwd, apply_terminal_config_to_env
+
+
+@pytest.mark.parametrize(
+    "cwd",
+    ["~", "~/work", "~alice", "~alice/work", "~alice/deep/path"],
+)
+def test_every_tilde_form_is_left_for_the_remote_shell(cwd):
+    assert _is_ssh_remote_tilde_cwd("ssh", cwd) is True
+
+
+@pytest.mark.parametrize("cwd", ["/abs/path", "relative/path", ".", ""])
+def test_non_tilde_cwds_are_unaffected(cwd):
+    assert _is_ssh_remote_tilde_cwd("ssh", cwd) is False
+
+
+@pytest.mark.parametrize("backend", ["local", "docker", "", "SSH-ish"])
+def test_only_the_ssh_backend_defers_expansion(backend):
+    """Guard: every other backend keeps expanding on the Hermes host."""
+    assert _is_ssh_remote_tilde_cwd(backend, "~/work") is False
+
+
+def test_ssh_backend_is_matched_case_insensitively():
+    assert _is_ssh_remote_tilde_cwd("SSH", "~alice/work") is True
+    assert _is_ssh_remote_tilde_cwd("  ssh  ", "~alice/work") is True
+
+
+def test_local_account_name_does_not_rewrite_the_remote_path():
+    """The failure this fixes, using a name that really exists on this host.
+
+    Expanding here produces the HOST's home directory for that account, which
+    is then handed to the remote shell as an absolute path.
+    """
+    local_user = getpass.getuser()
+    cwd = f"~{local_user}/work"
+    assert os.path.expanduser(cwd) != cwd, (
+        "test needs a locally resolvable account name to be meaningful"
+    )
+
+    env = apply_terminal_config_to_env(
+        env={}, config={"terminal": {"backend": "ssh", "cwd": cwd}}
+    )
+
+    assert env.get("TERMINAL_CWD") == cwd, (
+        "the cwd was expanded against the local account database before SSH saw it"
+    )
+
+
+def test_plain_tilde_still_preserved_end_to_end():
+    """Guard: the case the original fix covered keeps working."""
+    env = apply_terminal_config_to_env(
+        env={}, config={"terminal": {"backend": "ssh", "cwd": "~/work"}}
+    )
+
+    assert env.get("TERMINAL_CWD") == "~/work"
+
+
+def test_non_ssh_backend_still_expands_end_to_end():
+    """Guard: a local backend must still resolve the path on this host."""
+    env = apply_terminal_config_to_env(
+        env={}, config={"terminal": {"backend": "local", "cwd": "~/work"}}
+    )
+
+    assert env.get("TERMINAL_CWD") == os.path.expanduser("~/work")

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -550,6 +550,11 @@ def _export_dump_excluding_session_vars(
 # ---------------------------------------------------------------------------
 
 
+# Account names accepted for bare ``~name`` emission in _quote_cwd_for_cd.
+# Deliberately narrower than POSIX allows: anything outside this set takes
+# the fully quoted path rather than reaching the shell unquoted.
+_TILDE_USER_RE = re.compile(r"^~([A-Za-z0-9._][A-Za-z0-9._-]*)(/.*)?$")
+
 class BaseEnvironment(ABC):
     """Common interface and unified execution flow for all Hermes backends.
 
@@ -786,13 +791,32 @@ class BaseEnvironment(ABC):
 
     @staticmethod
     def _quote_cwd_for_cd(cwd: str) -> str:
-        """Quote a ``cd`` target while preserving ``~`` expansion."""
+        """Quote a ``cd`` target while preserving ``~`` expansion.
+
+        The named form ``~other`` is preserved too, and it cannot go through
+        ``$HOME``: it names a different account's home, which only the remote
+        shell can resolve. Tilde expansion applies to the unquoted prefix up to
+        the first unquoted ``/``, so the prefix is emitted bare and only the
+        remainder is quoted. ``shlex.quote``-ing the whole thing yields
+        ``cd '~other/x'``, which no shell expands, and the session silently
+        starts in the login directory instead.
+
+        The account name is matched against a conservative pattern before it is
+        emitted unquoted, so a cwd like ``~$(cmd)/x`` still takes the fully
+        quoted path rather than reaching the shell unquoted.
+        """
         if cwd == "~":
             return cwd
         if cwd == "~/":
             return "$HOME"
         if cwd.startswith("~/"):
             return f"$HOME/{shlex.quote(cwd[2:])}"
+        named = _TILDE_USER_RE.match(cwd)
+        if named:
+            user, rest = named.group(1), named.group(2) or ""
+            if rest in ("", "/"):
+                return f"~{user}"
+            return f"~{user}/{shlex.quote(rest[1:])}"
         return shlex.quote(cwd)
 
     def _quote_shell_path(self, path: str) -> str:

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -10,6 +10,7 @@ or a temp file (local). Cohesive pieces live in sibling modules (``base_output``
 import json
 import logging
 import os
+import re
 import shlex
 import threading
 import time
@@ -137,6 +138,12 @@ def _file_mtime_key(host_path: str) -> tuple[float, int] | None:
         return (st.st_mtime, st.st_size)
     except OSError:
         return None
+
+
+# Account names accepted for bare ``~name`` emission in _quote_cwd_for_cd.
+# Deliberately narrower than POSIX allows: anything outside this set takes
+# the fully quoted path rather than reaching the shell unquoted.
+_TILDE_USER_RE = re.compile(r"^~([A-Za-z0-9._][A-Za-z0-9._-]*)(/.*)?$")
 
 
 class BaseEnvironment(ABC):
@@ -305,14 +312,32 @@ class BaseEnvironment(ABC):
     # --- Command wrapping ---
     @staticmethod
     def _quote_cwd_for_cd(cwd: str) -> str:
-        """Quote a ``cd`` target while preserving ``~`` expansion (``~/...``
-        goes through ``$HOME`` so suffixes with spaces stay one word)."""
+        """Quote a ``cd`` target while preserving ``~`` expansion.
+
+        The named form ``~other`` is preserved too, and it cannot go through
+        ``$HOME``: it names a different account's home, which only the remote
+        shell can resolve. Tilde expansion applies to the unquoted prefix up to
+        the first unquoted ``/``, so the prefix is emitted bare and only the
+        remainder is quoted. ``shlex.quote``-ing the whole thing yields
+        ``cd '~other/x'``, which no shell expands, and the session silently
+        starts in the login directory instead.
+
+        The account name is matched against a conservative pattern before it is
+        emitted unquoted, so a cwd like ``~$(cmd)/x`` still takes the fully
+        quoted path rather than reaching the shell unquoted.
+        """
         if cwd == "~":
             return cwd
         if cwd == "~/":
             return "$HOME"
         if cwd.startswith("~/"):
             return f"$HOME/{shlex.quote(cwd[2:])}"
+        named = _TILDE_USER_RE.match(cwd)
+        if named:
+            user, rest = named.group(1), named.group(2) or ""
+            if rest in ("", "/"):
+                return f"~{user}"
+            return f"~{user}/{shlex.quote(rest[1:])}"
         return shlex.quote(cwd)
 
     def _quote_shell_path(self, path: str) -> str:


### PR DESCRIPTION
## What does this PR do?

`#81414` stopped the Hermes host from expanding a `~` cwd before SSH sees it. The predicate it added covers two of the three tilde forms:

```python
return cwd == "~" or cwd.startswith("~/")
```

`~other` and `~other/...` still fall through to `os.path.expanduser()`, which resolves them against the **host's** account database rather than the remote's. That is the same defect #81414 fixed, and it fails more quietly, because what happens next depends on whether the remote login also exists locally:

```
os.path.expanduser("~grimm/work")      -> /Users/grimm/work     # local account exists
os.path.expanduser("~nosuchuser/work") -> ~nosuchuser/work      # it does not
```

The first line is the damaging one, and it is the common case: the same login existing on both ends is the usual setup for `ssh host` without an explicit user. A `terminal.cwd` of `~alice/work` then reaches the remote shell as an absolute host path such as `/Users/alice/work`, which either does not exist there or, worse, exists and is a different directory. The second line is correct only by accident: it survives because the lookup failed, not because the code intended to defer.

### The fix

Preserve every tilde form for the SSH backend:

```python
return cwd.startswith("~")
```

A remote POSIX shell expands `~`, `~/...`, `~other` and `~other/...` itself, so handing all four through unmodified is what makes the cwd mean the same thing on the far side. Nothing else about the predicate changes: a non-SSH backend still expands on the host, and a non-tilde cwd is untouched.

### Second commit: the same failure one layer down

Triage on this PR caught that the config bridge is only half the path, and it
was right. The bootstrap then runs the cwd through `_quote_cwd_for_cd`
(`tools/environments/base.py`), which handles `~`, `~/` and `~/...` but fell
through to `shlex.quote` for the named form:

```
cd '~alice/work'
```

Tilde expansion does not happen inside quotes, so the `cd` fails and the
session starts in the login directory. Preserving `~alice` through the bridge
achieved nothing on its own.

The second commit emits the tilde prefix bare and quotes only the remainder,
which is exactly where POSIX tilde expansion stops. Confirmed against a real
shell rather than reasoned about:

```
cd ~grimm/'Desktop'   ->  /Users/grimm/Desktop
cd '~grimm'           ->  bash: cd: ~grimm: No such file or directory
```

The account name is matched against a conservative pattern (`[A-Za-z0-9._-]`)
before it is emitted unquoted, so a cwd like `~$(cmd)/x` still takes the fully
quoted path. Six parametrised cases pin that.

11 further tests, and reverting only `tools/environments/base.py` fails them
with `assert "'~alice/work'" != "'~alice/work'"`. `tests/tools/` scoped to
`-k "environment or terminal or cwd or ssh"`: 16 failed / 465 passed on `main`
against 16 failed / 476 passed here, identical failing sets, zero regressions.

## Related Issue

No issue; found while reading `9c69d9886` (#81414) after it landed. Searched open and merged PRs first, per CONTRIBUTING's search-first section:

```
gh search prs --repo NousResearch/hermes-agent "tilde cwd"      --limit 15
gh search prs --repo NousResearch/hermes-agent "ssh remote home" --limit 15   # #81414, merged
gh search prs --repo NousResearch/hermes-agent "expanduser ssh"  --limit 15
```

The one neighbour is #58267 (open), which widens the same idea to the container backends (Docker, Singularity, Modal, Daytona). It is orthogonal to this change: it edits `tools/terminal_tool.py` and `tools/environments/docker.py` and widens the set of **backends**, while this widens the set of **tilde forms** in `hermes_cli/config.py`. Both can land independently. Worth noting that if #58267 lands, those backends will want the named form too, since their sandbox shells expand it the same way.

## Type of Change

Bug fix (non-breaking). Completes #81414 for the remaining tilde form.

## Changes Made

- `hermes_cli/config.py` - `_is_ssh_remote_tilde_cwd` accepts every tilde-prefixed cwd; the docstring records why the named form is the quieter failure.
- `tests/tools/test_ssh_tilde_user_cwd.py` - new, 17 tests (mostly parametrised cases).

## How to Test

```
pytest tests/tools/test_ssh_tilde_user_cwd.py -q
```

17 passed.

Reverting only `hermes_cli/config.py` and rerunning:

```
E  AssertionError: assert False is True
E   +  where False = _is_ssh_remote_tilde_cwd('ssh', '~alice/work')
...
E  AssertionError: the cwd was expanded against the local account database before SSH saw it
E  assert '/Users/grimm/work' == '~grimm/work'
```

That last one is the end-to-end probe, and it is deliberately built from `getpass.getuser()` rather than a hardcoded name, so it exercises an account that genuinely resolves on whatever machine runs it. It asserts up front that the name is locally resolvable, so it reports honestly instead of passing vacuously on a host where it is not.

Three guards pass before and after by design: a non-SSH backend still expands on the host, a non-tilde cwd is unaffected, and the plain `~/...` case #81414 fixed still works end to end.

`tests/hermes_cli/` plus `tests/tools/test_terminal_env_bridge.py`, this branch vs `main`, same environment, run serially:

```
main:   169 failed, 4327 passed, 19 skipped
branch: 169 failed, 4344 passed, 19 skipped
```

Comparing the failing sets rather than the counts: **zero regressions**, the two sets are identical. The +17 is this PR's new tests. Those 169 are pre-existing in a non-hermetic single-process run of that suite; CI's per-file isolation via `run_tests_parallel.py` is the supported path.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(terminal): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (queries above)
- [x] My PR contains only changes related to this fix
- [x] I've run the affected suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation; the docstring now explains why the named form matters and how it fails
- [x] `cli-config.yaml.example` is N/A, no new config keys; this is about how an existing `terminal.cwd` value is treated
- [x] `CONTRIBUTING.md` / `AGENTS.md` are N/A
- [x] Cross-platform impact: the change removes a host-side path rewrite, so it is if anything less platform-dependent. The end-to-end test derives its account name from the running host rather than assuming a layout
- [x] Tool descriptions/schemas are N/A

## Notes for the reviewer

I widened the predicate to any leading `~` rather than adding a second pattern for the named form. A stricter regex such as `^~[^/]*(/|$)` would accept exactly the POSIX forms, but every string starting with `~` is already ambiguous on the remote side, and there is no case where expanding one of them against the Hermes host is the right answer for an SSH cwd. If you would rather pin the exact grammar, the change is one line and the tests already cover the four shapes.

