### PR TITLE
fix(desktop): seed Kanban event cursor

### DIFF
--- a/apps/desktop/src/plugins/kanban/api.test.ts
+++ b/apps/desktop/src/plugins/kanban/api.test.ts
@@ -1,0 +1,47 @@
+import { type PluginRestOptions, type PluginStorage, queryClient } from '@hermes/plugin-sdk'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { bindApi } from './api'
+
+const BOARD = { assignees: [], columns: [], latest_event_id: 14_386, now: 0, tenants: [] }
+
+afterEach(() => {
+  queryClient.clear()
+  vi.clearAllMocks()
+})
+
+describe('kanban event stream', () => {
+  it('starts after the board snapshot instead of replaying event history', async () => {
+    let resolveBoard: (board: typeof BOARD) => void = () => undefined
+
+    const board = new Promise<typeof BOARD>(resolve => {
+      resolveBoard = resolve
+    })
+
+    const rest = async <T>(path: string, _opts?: PluginRestOptions): Promise<T> => {
+      if (path === '/board') {
+        return board as Promise<T>
+      }
+
+      throw new Error(`unexpected REST path: ${path}`)
+    }
+
+    const storage: PluginStorage = {
+      get: (_key, fallback) => fallback,
+      remove: vi.fn(),
+      set: vi.fn()
+    }
+
+    const socket = vi.fn(() => vi.fn())
+    const dispose = bindApi(rest, storage, socket)
+
+    expect(socket).not.toHaveBeenCalled()
+    resolveBoard(BOARD)
+
+    await vi.waitFor(() => {
+      expect(socket).toHaveBeenCalledWith('/events?since=14386', expect.any(Function))
+    })
+
+    dispose()
+  })
+})

--- a/apps/desktop/src/plugins/kanban/api.ts
+++ b/apps/desktop/src/plugins/kanban/api.ts
@@ -95,16 +95,41 @@ export function bindApi(r: Rest, storage: PluginStorage, socket: Socket): () => 
   persist($collapsedLanes, COLLAPSED_KEY, {})
 
   let close: (() => void) | null = null
+  let socketGeneration = 0
 
   const open = (slug: string) => {
+    const generation = ++socketGeneration
     close?.()
-    close = socket(slug ? `/events?board=${encodeURIComponent(slug)}` : '/events', data => onEventsFrame(slug, data))
+    close = null
+
+    const boardPath = slug ? `/board?board=${encodeURIComponent(slug)}` : '/board'
+
+    void queryClient
+      .fetchQuery({
+        queryFn: () => r<KanbanBoard>(boardPath),
+        queryKey: boardKey(slug, false)
+      })
+      .then(board => {
+        if (generation !== socketGeneration) {
+          return
+        }
+
+        const params = new URLSearchParams({ since: String(board.latest_event_id) })
+
+        if (slug) {
+          params.set('board', slug)
+        }
+
+        close = socket(`/events?${params}`, data => onEventsFrame(slug, data))
+      })
+      .catch(() => undefined)
   }
 
   open($boardSlug.get())
   unsubs.push($boardSlug.listen(open))
 
   return () => {
+    socketGeneration += 1
     unsubs.forEach(unsub => unsub())
     close?.()
     rest = null


### PR DESCRIPTION
## Summary

- fetch the selected Kanban board snapshot before opening its event WebSocket
- seed the socket with `since=<latest_event_id>` and preserve the selected `board` parameter
- prevent stale snapshots from opening sockets after board switches or plugin disposal
- add a focused regression test for snapshot-before-socket ordering and cursor propagation

## Why

Without a cursor, Desktop replays the board's complete event history on every load. Every historical frame invalidates the board query, causing repeated large snapshots and severe backend CPU load on mature boards.

Closes #81537

## Test plan

- `npx eslint src/plugins/kanban/api.ts src/plugins/kanban/api.test.ts`
- `npx tsc -p . --noEmit`
- `npx vitest run --project ui src/plugins/kanban/api.test.ts src/plugins/kanban/model-override.test.tsx` (10 tests passed)
- `npm run build`
- packaged Desktop diagnostic with the same patch opened `/api/plugins/kanban/events?since=14386`; a real message round trip rendered in 14.053 seconds
