### PR TITLE
fix(windows): quarantine Hermes venv before rebuild

### DIFF
--- a/docs/rca-windows-venv-quarantine.md
+++ b/docs/rca-windows-venv-quarantine.md
@@ -1,0 +1,56 @@
+# Windows venv replacement recovery
+
+## Symptom and reproduction
+
+On Windows, an Hermes update can leave the existing `venv` partially removed
+when a running Hermes Python process still has a native extension loaded. A
+subsequent install then reports access denied, and the console launchers may be
+missing even though a sibling `.venv` contains them.
+
+The failure is reproducible by running an Hermes process from `venv\Scripts`,
+then starting the installer's `venv` stage while the process is supervised or
+while a native extension remains open.
+
+## Root cause
+
+The old installer tried to rename the existing venv, but if that rename failed
+it fell back to recursive in-place deletion. Windows refuses deletion of a
+loaded `.pyd`/DLL, so the fallback could destroy part of the environment while
+leaving the install stage failed. A later dependency sync could also target a
+sibling `.venv` unless the project environment was pinned explicitly.
+
+## Safety behavior
+
+The venv stage now:
+
+1. disables only gateway tasks that were enabled before the stage;
+2. stops processes whose executable path is under the target venv;
+3. performs a final CIM process check and fails with structured stage output if
+   any target-venv process remains;
+4. requires `Rename-Item venv -> venv.stale.<timestamp>` to succeed;
+5. refuses all in-place recursive deletion and retains the quarantined tree;
+6. restores the original scheduled-task state in `finally`, including failure.
+
+The dependency stage continues to pin `UV_PROJECT_ENVIRONMENT` to `venv`,
+checks baseline imports, and verifies all expected console entry points before
+PATH finalization.
+
+## Rollback and operator recovery
+
+The stale tree is retained for forensics and rollback. If replacement
+validation fails, keep the failed replacement and stale tree intact, stop any
+new processes using the failed replacement, and restore the prior tree only
+after confirming that no process executes from either tree. Cleanup of
+`venv.stale.*` is an explicit operator action after acceptance; it is not part
+of the replacement stage.
+
+## Validation
+
+`scripts/tests/test-install-ps1-venv-safety.ps1` runs the real stage on native
+Windows against disposable fixtures. It covers a continuously respawned venv
+process, a failed quarantine rename caused by an open file handle, successful
+quarantine with stale-tree retention, fresh `venv\Scripts\python.exe`
+creation, and scheduled-task state preservation. The stage-protocol and Git
+Bash compatibility smoke tests also pass. The existing long-path smoke suite
+has unrelated failures on hosts where its synthetic short TEMP alias does not
+exist.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2295,50 +2295,48 @@ function Install-Venv {
                             Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue
                         }
                 } catch {
-                    Write-Warn "Could not enumerate venv processes: $($_.Exception.Message)"
-                    break
+                    throw "Could not safely enumerate processes running from the venv: $($_.Exception.Message)"
                 }
                 if ($found -eq 0) { $cleanPasses++ } else { $cleanPasses = 0 }
                 Start-Sleep -Milliseconds 400
             }
+
+            # Never begin destructive filesystem work unless the final
+            # enumeration proves that no process still executes from this
+            # venv. A failed Stop-Process, a respawner, or an unreadable
+            # process must leave the original tree intact for retry/forensics.
+            try {
+                $remaining = @(
+                    Get-CimInstance Win32_Process -ErrorAction Stop |
+                        Where-Object {
+                            $_.ProcessId -ne $myPid -and
+                            $_.ExecutablePath -and
+                            $_.ExecutablePath.StartsWith($venvPrefix, [System.StringComparison]::OrdinalIgnoreCase)
+                        }
+                )
+            } catch {
+                throw "Could not verify that the venv is quiescent: $($_.Exception.Message)"
+            }
+            if ($remaining.Count -gt 0) {
+                $details = ($remaining | ForEach-Object { "$($_.ProcessId) $($_.Name) $($_.ExecutablePath)" }) -join "; "
+                throw "Cannot safely replace venv; processes still run from it: $details"
+            }
         }
-        # Rename-then-delete: on Windows a directory RENAME succeeds even while
-        # files inside it are mapped as DLLs (only in-place delete/replace of
-        # the mapped file is denied, and only same-volume renames are atomic
-        # moves). Moving the old venv aside means `uv venv` can create a fresh
-        # one immediately even if some straggler still holds a .pyd from the
-        # old tree; the renamed dir is deleted best-effort (now, and by the
-        # cleanup pass below on the NEXT install if a handle outlives this one).
+        # Quarantine first: on Windows a directory RENAME is atomic within the
+        # same volume and does not replace mapped DLLs in place. The old tree
+        # stays available for forensics and rollback until the replacement has
+        # passed dependency, launcher, and runtime validation.
         $staleName = "venv.stale.{0}" -f (Get-Date -Format "yyyyMMddHHmmss")
-        $renamed = $false
         try {
             Rename-Item -Path "venv" -NewName $staleName -ErrorAction Stop
-            $renamed = $true
         } catch {
-            Write-Warn "Could not rename venv aside ($($_.Exception.Message)); falling back to in-place delete"
-        }
-        if ($renamed) {
-            Remove-Item -Recurse -Force $staleName -ErrorAction SilentlyContinue
-            if (Test-Path $staleName) {
-                Write-Warn "Old venv parked at $staleName (a process still holds files in it); it will be cleaned up on the next install"
-            }
-        } else {
-            Remove-Item -Recurse -Force "venv" -ErrorAction SilentlyContinue
-            # A killed process can take a moment to release its file handles, so a
-            # first Remove-Item may still hit a locked .pyd. Retry once after a short
-            # pause before giving up and letting the stage fail loudly.
-            if (Test-Path "venv") {
-                Start-Sleep -Seconds 2
-                Remove-Item -Recurse -Force "venv"
-            }
+            throw "Could not quarantine the existing venv ($($_.Exception.Message)); refusing in-place deletion"
         }
     }
 
-    # Clean up parked venvs from previous installs whose handles have since
-    # been released. Best-effort -- a still-held tree just stays for next time.
-    Get-ChildItem -Directory -Filter "venv.stale.*" -ErrorAction SilentlyContinue | ForEach-Object {
-        Remove-Item -Recurse -Force $_.FullName -ErrorAction SilentlyContinue
-    }
+    # Do not clean up venv.stale.* here. Retain quarantined trees until the
+    # replacement has passed all post-install validation and an operator has
+    # explicitly accepted cleanup.
     
     # uv creates the venv and pins the Python version in one step.  uv emits
     # normal progress such as "Using CPython ..." on stderr; under Windows

--- a/scripts/tests/test-install-ps1-venv-safety.ps1
+++ b/scripts/tests/test-install-ps1-venv-safety.ps1
@@ -1,0 +1,298 @@
+# Native Windows behavior tests for the venv replacement boundary.
+#
+# These tests invoke the real venv stage against disposable directories. They
+# never use the live Hermes install directory and clean up only their own
+# fixtures. UV_CACHE_DIR is redirected because some hermetic Windows runners
+# expose the user's default uv cache as a junction or a stale file.
+
+$ErrorActionPreference = "Stop"
+$scriptPath = Join-Path (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)) "install.ps1"
+$pwshPath = (Get-Command pwsh -ErrorAction Stop).Source
+$uvPath = (Get-Command uv -ErrorAction Stop).Source
+$uvCacheRoot = Join-Path $env:TEMP ("hermes-venv-safety-uv-cache-" + [guid]::NewGuid().ToString("N"))
+$testRoot = Join-Path $env:TEMP ("hermes-venv-safety-" + [guid]::NewGuid().ToString("N"))
+$previousUvCache = $env:UV_CACHE_DIR
+$previousOs = $env:OS
+$failures = 0
+
+function Assert-True {
+    param([Parameter(Mandatory=$true)][bool]$Condition,
+          [Parameter(Mandatory=$true)][string]$Label)
+    if ($Condition) {
+        Write-Host "OK: $Label" -ForegroundColor Green
+    } else {
+        Write-Host "FAIL: $Label" -ForegroundColor Red
+        $script:failures++
+    }
+}
+
+function New-Fixture {
+    $path = Join-Path $testRoot ([guid]::NewGuid().ToString("N"))
+    New-Item -ItemType Directory -Path $path -Force | Out-Null
+    return $path
+}
+
+function Write-FixtureFile {
+    param([Parameter(Mandatory=$true)][string]$Path,
+          [AllowEmptyString()][string]$Content)
+    $parent = Split-Path -Parent $Path
+    New-Item -ItemType Directory -Path $parent -Force | Out-Null
+    Set-Content -LiteralPath $Path -Value $Content -NoNewline
+}
+
+function Get-GatewayTaskState {
+    $rows = @(schtasks /Query /FO CSV 2>$null | ConvertFrom-Csv |
+        Where-Object { $_.TaskName -like '*Hermes_Gateway*' } |
+        ForEach-Object { "$($_.TaskName)=$($_.Status)" })
+    return ($rows -join "|")
+}
+
+function Invoke-VenvStage {
+    param([Parameter(Mandatory=$true)][string]$InstallDir)
+    $output = @(& $pwshPath -NoProfile -ExecutionPolicy Bypass -File $scriptPath `
+        -Stage venv -InstallDir $InstallDir -NonInteractive 2>&1)
+    [pscustomobject]@{
+        ExitCode = $LASTEXITCODE
+        Output   = ($output -join "`n")
+    }
+}
+
+function Stop-TestProcess {
+    param([System.Diagnostics.Process]$Process)
+    if ($null -ne $Process) {
+        try {
+            if (-not $Process.HasExited) {
+                Stop-Process -Id $Process.Id -Force -ErrorAction SilentlyContinue
+            }
+        } catch {
+        }
+    }
+}
+
+function Get-StageJson {
+    param([Parameter(Mandatory=$true)][string]$Output)
+    $jsonLine = ($Output -split "`r?`n" |
+        Where-Object { $_.TrimStart().StartsWith('{') -and $_.TrimEnd().EndsWith('}') } |
+        Select-Object -Last 1)
+    if (-not $jsonLine) { return $null }
+    return ($jsonLine | ConvertFrom-Json)
+}
+
+New-Item -ItemType Directory -Path $testRoot, $uvCacheRoot -Force | Out-Null
+$env:UV_CACHE_DIR = $uvCacheRoot
+$env:OS = 'Windows_NT'
+
+try {
+    Write-Host "-- native Windows venv replacement behavior --"
+
+    # A disposable venv process is continually respawned by a supervisor that
+    # runs outside the target venv. The real installer must stop retrying and
+    # return a structured failure before attempting Rename-Item.
+    $respawnDir = New-Fixture
+    $respawnVenv = Join-Path $respawnDir "venv"
+    $respawnScripts = Join-Path $respawnVenv "Scripts"
+    & $uvPath venv $respawnVenv --python 3.11 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "Could not create the respawn fixture venv" }
+    $runtimeHome = ((Get-Content (Join-Path $respawnVenv 'pyvenv.cfg') |
+        Where-Object { $_ -like 'home = *' }) -replace '^home = ', '').Trim()
+    Copy-Item -LiteralPath (Join-Path $runtimeHome 'python.exe') -Destination (Join-Path $respawnScripts 'python.exe') -Force
+    Get-ChildItem -LiteralPath $runtimeHome -Filter '*.dll' -File |
+        ForEach-Object { Copy-Item -LiteralPath $_.FullName -Destination $respawnScripts -Force }
+    $respawnExe = Join-Path $respawnScripts "python.exe"
+    $respawnStop = Join-Path $respawnDir "stop-supervisor"
+    $supervisor = Start-Job -ScriptBlock {
+        param($target, $stop)
+        while (-not (Test-Path -LiteralPath $stop)) {
+            Start-Process -FilePath $target -ArgumentList @('-c', '"import time; time.sleep(60)"') | Out-Null
+            Start-Sleep -Milliseconds 75
+        }
+    } -ArgumentList $respawnExe, $respawnStop
+    try {
+        Start-Sleep -Milliseconds 500
+        $initialChildren = @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |
+            Where-Object { $_.ExecutablePath -eq $respawnExe })
+        Assert-True ($initialChildren.Count -gt 0) "respawn fixture starts a venv process"
+        $beforeTasks = Get-GatewayTaskState
+        $result = Invoke-VenvStage -InstallDir $respawnDir
+        $afterTasks = Get-GatewayTaskState
+        $stage = Get-StageJson -Output $result.Output
+        Assert-True ($result.ExitCode -ne 0) "remaining venv process fails the stage"
+        Assert-True ($null -ne $stage -and $stage.ok -eq $false) "remaining process returns structured failure"
+        Assert-True (Test-Path -LiteralPath $respawnVenv) "remaining process leaves the original venv intact"
+        Assert-True (-not (Get-ChildItem -LiteralPath $respawnDir -Directory -Filter 'venv.stale.*' -ErrorAction SilentlyContinue)) `
+            "remaining process does not quarantine a live venv"
+        Assert-True ($beforeTasks -eq $afterTasks) "scheduled-task state is preserved after process-lock failure"
+    } finally {
+        New-Item -ItemType File -Path $respawnStop -Force | Out-Null
+        Stop-Job $supervisor -ErrorAction SilentlyContinue
+        Remove-Job $supervisor -Force -ErrorAction SilentlyContinue
+        Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |
+            Where-Object { $_.ExecutablePath -eq $respawnExe } |
+            ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+    }
+
+    # A non-Hermes process holds a file without FILE_SHARE_DELETE. Quarantine
+    # must fail closed and preserve the original tree; it must never fall back
+    # to recursive in-place deletion.
+    $lockedDir = New-Fixture
+    $lockedVenv = Join-Path $lockedDir "venv"
+    New-Item -ItemType Directory -Path $lockedVenv -Force | Out-Null
+    $lockedFile = Join-Path $lockedVenv "held-by-test.bin"
+    [IO.File]::WriteAllText($lockedFile, "rollback-marker")
+    $lockStop = Join-Path $lockedDir "stop-locker"
+    $lockedEscaped = $lockedFile.Replace("'", "''")
+    $lockStopEscaped = $lockStop.Replace("'", "''")
+    $lockerCode = @"
+`$stream = [IO.File]::Open('$lockedEscaped', [IO.FileMode]::Open, [IO.FileAccess]::ReadWrite, [IO.FileShare]::Read)
+try {
+    while (-not (Test-Path -LiteralPath '$lockStopEscaped')) { Start-Sleep -Milliseconds 100 }
+} finally {
+    `$stream.Dispose()
+}
+"@
+    $locker = Start-Process -FilePath $pwshPath -WindowStyle Hidden -PassThru `
+        -ArgumentList @('-NoProfile', '-Command', $lockerCode)
+    try {
+        Start-Sleep -Milliseconds 500
+        $beforeTasks = Get-GatewayTaskState
+        $result = Invoke-VenvStage -InstallDir $lockedDir
+        $afterTasks = Get-GatewayTaskState
+        $stage = Get-StageJson -Output $result.Output
+        Assert-True ($result.ExitCode -ne 0) "failed quarantine rename fails the stage"
+        Assert-True ($null -ne $stage -and $stage.ok -eq $false) "failed quarantine returns structured failure"
+        Assert-True (Test-Path -LiteralPath $lockedFile) "failed quarantine retains the stale tree"
+        Assert-True (-not (Get-ChildItem -LiteralPath $lockedDir -Directory -Filter 'venv.stale.*' -ErrorAction SilentlyContinue)) `
+            "failed quarantine does not create a partial stale tree"
+        Assert-True ($beforeTasks -eq $afterTasks) "scheduled-task state is preserved after quarantine failure"
+    } finally {
+        New-Item -ItemType File -Path $lockStop -Force | Out-Null
+        Stop-TestProcess $locker
+    }
+
+    # A clean replacement must quarantine the old tree and retain its marker
+    # after uv creates the replacement.
+    $successDir = New-Fixture
+    $successVenv = Join-Path $successDir "venv"
+    $marker = Join-Path $successVenv "rollback-marker.txt"
+    New-Item -ItemType Directory -Path $successVenv -Force | Out-Null
+    [IO.File]::WriteAllText($marker, "retain-until-accepted")
+    $beforeTasks = Get-GatewayTaskState
+    $result = Invoke-VenvStage -InstallDir $successDir
+    $afterTasks = Get-GatewayTaskState
+    $stage = Get-StageJson -Output $result.Output
+    $staleTrees = @(Get-ChildItem -LiteralPath $successDir -Directory -Filter 'venv.stale.*')
+    Assert-True ($result.ExitCode -eq 0 -and $null -ne $stage -and $stage.ok -eq $true) `
+        "clean replacement succeeds"
+    Assert-True (Test-Path -LiteralPath (Join-Path $successVenv 'Scripts\python.exe')) `
+        "replacement is created at venv, never .venv"
+    Assert-True ($staleTrees.Count -eq 1 -and (Test-Path -LiteralPath (Join-Path $staleTrees[0].FullName 'rollback-marker.txt'))) `
+        "successful replacement retains the quarantined stale tree"
+    Assert-True ($beforeTasks -eq $afterTasks) "scheduled-task state is preserved across success"
+
+    # A failed stage must also restore the same task state.
+    $failureTasks = Get-GatewayTaskState
+    Assert-True ($failureTasks -eq $afterTasks) "scheduled-task state remains stable after failure"
+
+    # Exercise the real dependency stage with a tiny local project. A watcher
+    # removes one generated launcher exactly once; the supported repair path
+    # must reinstall it, keep the dependency target at venv, and finish with a
+    # runnable launcher set without touching the user's PATH.
+    $dependencyDir = New-Fixture
+    $packageSource = @'
+def main():
+    return 0
+'@
+    $pyproject = @'
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "hermes-agent"
+version = "0.0.0"
+requires-python = ">=3.11,<3.14"
+dependencies = []
+
+[project.optional-dependencies]
+all = []
+
+[project.scripts]
+hermes = "hermes_cli.main:main"
+hermes-agent = "hermes_cli.main:main"
+hermes-acp = "hermes_cli.main:main"
+
+[tool.setuptools.packages.find]
+include = ["hermes_cli*", "dotenv*", "openai*", "rich*", "prompt_toolkit*", "fastapi*", "uvicorn*"]
+'@
+    Write-FixtureFile (Join-Path $dependencyDir 'pyproject.toml') $pyproject
+    Write-FixtureFile (Join-Path $dependencyDir 'hermes_cli\__init__.py') ''
+    Write-FixtureFile (Join-Path $dependencyDir 'hermes_cli\main.py') $packageSource
+    Write-FixtureFile (Join-Path $dependencyDir 'hermes_cli\web_server.py') 'app = None'
+    foreach ($module in @('dotenv', 'openai', 'rich', 'prompt_toolkit', 'fastapi', 'uvicorn')) {
+        Write-FixtureFile (Join-Path $dependencyDir "$module\__init__.py") ''
+    }
+    & $uvPath venv (Join-Path $dependencyDir 'venv') --python 3.11 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "Could not create the dependency fixture venv" }
+    & $uvPath lock --directory $dependencyDir 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "Could not lock the dependency fixture project" }
+    $launcherStop = Join-Path $dependencyDir 'stop-launcher-watcher'
+    $launcherScripts = Join-Path $dependencyDir 'venv\Scripts'
+    $launcherWatcher = Start-Job -ScriptBlock {
+        param($scripts, $stop)
+        $target = Join-Path $scripts 'hermes.exe'
+        while (-not (Test-Path -LiteralPath $stop)) {
+            if (Test-Path -LiteralPath $target) {
+                Remove-Item -LiteralPath $target -Force
+                New-Item -ItemType File -Path $stop -Force | Out-Null
+                break
+            }
+            Start-Sleep -Milliseconds 100
+        }
+    } -ArgumentList $launcherScripts, $launcherStop
+    try {
+        $result = @(& $pwshPath -NoProfile -ExecutionPolicy Bypass -File $scriptPath `
+            -Stage dependencies -InstallDir $dependencyDir -NonInteractive 2>&1)
+        $dependencyExit = $LASTEXITCODE
+        $dependencyOutput = $result -join "`n"
+        $dependencyStage = Get-StageJson -Output $dependencyOutput
+        if ($dependencyExit -ne 0) { Write-Host $dependencyOutput }
+        Assert-True ($dependencyExit -eq 0 -and $null -ne $dependencyStage -and $dependencyStage.ok -eq $true) `
+            "dependency rebuild succeeds after launcher loss"
+        Assert-True (Test-Path -LiteralPath (Join-Path $launcherScripts 'hermes.exe')) `
+            "missing hermes launcher is repaired"
+        Assert-True (-not (Test-Path -LiteralPath (Join-Path $dependencyDir '.venv'))) `
+            ".venv is not silently used as the dependency target"
+        Assert-True ($dependencyOutput -like '*Console entry point(s) missing*' -and
+            $dependencyOutput -like '*Console entry points restored*') `
+            "launcher repair path is reported"
+        $directSmoke = & (Join-Path $launcherScripts 'python.exe') -c 'import dotenv, openai, rich, prompt_toolkit; print("runtime-ok")' 2>&1
+        Assert-True ($LASTEXITCODE -eq 0 -and ($directSmoke -join "`n") -like '*runtime-ok*') `
+            "rebuilt venv passes direct runtime smoke check"
+    } finally {
+        New-Item -ItemType File -Path $launcherStop -Force | Out-Null
+        Stop-Job $launcherWatcher -ErrorAction SilentlyContinue
+        Remove-Job $launcherWatcher -Force -ErrorAction SilentlyContinue
+    }
+} catch {
+    Write-Host "FAIL: unexpected test harness error: $($_.Exception.Message)" -ForegroundColor Red
+    $failures++
+} finally {
+    if ($previousUvCache) { $env:UV_CACHE_DIR = $previousUvCache }
+    else { Remove-Item Env:UV_CACHE_DIR -ErrorAction SilentlyContinue }
+    $env:OS = $previousOs
+    if (Test-Path -LiteralPath $testRoot) {
+        Remove-Item -LiteralPath $testRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    if (Test-Path -LiteralPath $uvCacheRoot) {
+        Remove-Item -LiteralPath $uvCacheRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Write-Host ""
+if ($failures -gt 0) {
+    Write-Host "FAILED: $failures assertion(s) failed" -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "All native Windows venv safety tests passed." -ForegroundColor Green
+exit 0


### PR DESCRIPTION
## What changed

- Make Windows venv replacement quarantine-first.
- Stop only processes whose executable path is inside the target venv and perform a final quiescence check.
- Fail safely when a process remains or quarantine rename fails; never fall back to in-place recursive deletion.
- Retain `venv.stale.<timestamp>` trees for rollback and forensics.
- Preserve the pre-existing enabled/disabled state of Hermes gateway scheduled tasks on both success and failure.
- Keep the existing dependency target, import gate, console-entry-point repair, stage protocol, and JSON result shape.

## Root cause

Hermes processes can hold Windows native-extension DLLs open. The previous installer fell back to recursive deletion when renaming the existing venv failed. That could partially destroy the environment while the stage was already failing, leaving missing launchers and an unusable runtime. A sibling `.venv` could also hide a misdirected dependency sync without the explicit `UV_PROJECT_ENVIRONMENT` guard.

## Before / after

Before: a failed venv rename could trigger in-place deletion, and stale venv trees were removed automatically.

After: process locks or a failed quarantine rename produce a structured stage failure before destructive filesystem work. A successful quarantine leaves the old tree available until post-install acceptance and explicit operator cleanup.

## Rollback

The stale tree is retained for inspection and rollback. If replacement validation fails, keep both trees intact, stop processes from either tree, and restore the stale tree only after the replacement is quiescent. Cleanup is intentionally outside the installer stage.

## Validation

- Native Windows `scripts/tests/test-install-ps1-venv-safety.ps1`: respawning process failure, failed rename with an open file handle, stale-tree retention, scheduled-task restoration, fresh `venv` target, launcher repair, and direct runtime smoke.
- `scripts/tests/test-install-ps1-stage-protocol.ps1`: pass.
- `scripts/tests/test-install-ps1-gitbash-compatibility.ps1`: pass.
- `scripts/install.ps1` PowerShell parser: pass.
- Existing long-path smoke test was run; its synthetic short TEMP alias cases remain environment-dependent on hosts where that alias does not exist.

This branch is independent of `fork-integration`, the integration manifest, and fork-only source changes.
