### PR TITLE
fix(agent): evict dead cached request connections

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -4331,47 +4331,153 @@ def _iter_pool_sockets(client: Any):
                 yield sock
 
 
-def cleanup_dead_connections(agent) -> bool:
-    """Detect and clean up dead TCP connections on the primary client.
+def _peek_plain_socket_is_eof(sock: Any, *, set_nonblocking: bool) -> bool:
+    """Distinguish EOF from readable data without consuming either."""
+    import socket as _socket
 
-    Inspects the httpx connection pool for sockets in unhealthy states
-    (CLOSE-WAIT, errors).  If any are found, force-closes all sockets
-    and rebuilds the primary client from scratch.
+    reset_blocking = False
+    try:
+        if set_nonblocking:
+            sock.setblocking(False)
+            reset_blocking = True
+        flags = _socket.MSG_PEEK | getattr(_socket, "MSG_DONTWAIT", 0)
+        return sock.recv(1, flags) == b""
+    except BlockingIOError:
+        return False
+    except (AttributeError, TypeError):
+        # Private stream wrappers and lightweight doubles need not implement
+        # the complete socket API. An inconclusive probe must not poison the
+        # whole pool scan or evict a connection as dead.
+        return False
+    except (OSError, ValueError):
+        return True
+    finally:
+        if reset_blocking:
+            try:
+                sock.setblocking(True)
+            except (AttributeError, TypeError, OSError, ValueError):
+                pass
+
+
+def _idle_pool_socket_is_unusable(sock: Any) -> bool:
+    """Return whether an idle HTTP socket is unsafe to reuse.
+
+    OS readiness polling works on TLS sockets without attempting
+    ``SSLSocket.recv(..., MSG_PEEK)``, which rejects non-zero flags. For plain
+    sockets, a readiness event is refined with a non-consuming peek so buffered
+    data is not mistaken for EOF. POSIX uses ``poll`` so high-numbered
+    descriptors are not misclassified by ``select``'s ``FD_SETSIZE`` limit.
+    The recv fallback preserves support for lightweight test doubles and
+    private stream wrappers without ``fileno``/``getsockopt``.
+    """
+    import select
+    import socket as _socket
+    import ssl
+    import sys
+
+    def _readable_socket_is_unusable() -> bool:
+        if isinstance(sock, _socket.socket) and not isinstance(sock, ssl.SSLSocket):
+            return _peek_plain_socket_is_eof(sock, set_nonblocking=False)
+        # TLS and unknown wrappers cannot be safely peeked. Unexpected
+        # readability between requests remains a conservative eviction signal.
+        return True
+
+    try:
+        sock_fd = sock.fileno()
+        if sock_fd < 0:
+            return True
+        if sock.getsockopt(_socket.SOL_SOCKET, _socket.SO_ERROR):
+            return True
+        if sys.platform == "win32" or getattr(select, "poll", None) is None:
+            readable, _, exceptional = select.select([sock], [], [sock], 0)
+            if exceptional:
+                return True
+            return _readable_socket_is_unusable() if readable else False
+        poller = select.poll()
+        poller.register(sock_fd, select.POLLIN)
+        events = poller.poll(0)
+        if not events:
+            return False
+        event_mask = 0
+        for _, mask in events:
+            event_mask |= mask
+        fatal_mask = (
+            getattr(select, "POLLERR", 0)
+            | getattr(select, "POLLHUP", 0)
+            | getattr(select, "POLLNVAL", 0)
+        )
+        if event_mask & fatal_mask:
+            return True
+        readable_mask = select.POLLIN | getattr(select, "POLLPRI", 0)
+        return _readable_socket_is_unusable() if event_mask & readable_mask else True
+    except (AttributeError, TypeError):
+        pass
+    except (OSError, ValueError):
+        return True
+
+    return _peek_plain_socket_is_eof(sock, set_nonblocking=True)
+
+
+def _count_dead_pool_sockets(client: Any) -> int:
+    """Return the number of sockets that are unsafe for idle-pool reuse."""
+    dead_count = 0
+    for candidate_sock in _iter_pool_sockets(client):
+        sock: Any = candidate_sock
+        if _idle_pool_socket_is_unusable(sock):
+            dead_count += 1
+    return dead_count
+
+
+def cleanup_dead_connections(agent) -> bool:
+    """Detect and clean up dead TCP connections between agent turns.
+
+    Rebuilds the primary client when its pool contains dead sockets and evicts
+    an idle cached request client when its separate pool is unhealthy.  An
+    in-flight request client is never probed or closed from the turn thread.
 
     Returns True if dead connections were found and cleaned up.
     """
-    client = getattr(agent, "client", None)
-    if client is None:
-        return False
+    cleaned = False
     try:
-        dead_count = 0
-        for sock in _iter_pool_sockets(client):
-            # Probe socket health with a non-blocking recv peek
-            import socket as _socket
-            try:
-                sock.setblocking(False)
-                data = sock.recv(1, _socket.MSG_PEEK | _socket.MSG_DONTWAIT)
-                if data == b"":
-                    dead_count += 1
-            except BlockingIOError:
-                pass  # No data available — socket is healthy
-            except OSError:
-                dead_count += 1
-            finally:
-                try:
-                    sock.setblocking(True)
-                except OSError:
-                    pass
-        if dead_count > 0:
-            _ra().logger.warning(
-                "Found %d dead connection(s) in client pool — rebuilding client",
-                dead_count,
-            )
-            agent._replace_primary_openai_client(reason="dead_connection_cleanup")
-            return True
+        primary_client = getattr(agent, "client", None)
+        if primary_client is not None:
+            primary_dead_count = _count_dead_pool_sockets(primary_client)
+            if primary_dead_count > 0:
+                _ra().logger.warning(
+                    "Found %d dead connection(s) in primary client pool — rebuilding client",
+                    primary_dead_count,
+                )
+                agent._replace_primary_openai_client(reason="dead_connection_cleanup")
+                cleaned = True
+
+        # The request client owns a separate httpx pool and remains cached
+        # between sequential calls. Hold the cache lock while checking it so a
+        # concurrent request cannot check out the client during the probe.
+        lock_factory = getattr(agent, "_openai_client_lock", None)
+        if callable(lock_factory):
+            lock: Any = lock_factory()
+            with lock:
+                cache = getattr(agent, "_request_client_cache", None)
+                request_client = (
+                    cache.get("client") if isinstance(cache, dict) else None
+                )
+                in_use = (
+                    bool(cache.get("in_use")) if isinstance(cache, dict) else False
+                )
+                if request_client is not None and not in_use:
+                    request_dead_count = _count_dead_pool_sockets(request_client)
+                    if request_dead_count > 0:
+                        _ra().logger.warning(
+                            "Found %d dead connection(s) in cached request client pool — evicting client",
+                            request_dead_count,
+                        )
+                        agent._close_cached_request_openai_client(
+                            reason="dead_connection_cleanup"
+                        )
+                        cleaned = True
     except Exception as exc:
         _ra().logger.debug("Dead connection check error: %s", exc)
-    return False
+    return cleaned
 
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -5169,6 +5169,17 @@ class AIAgent:
         return False
 
     @staticmethod
+    def _dead_request_client_socket_count(client: Any) -> int:
+        """Probe an idle request client's pool without changing shared-client semantics."""
+        from agent.agent_runtime_helpers import _count_dead_pool_sockets
+
+        try:
+            return _count_dead_pool_sockets(client)
+        except Exception as exc:
+            logger.debug("Cached request connection check error: %s", exc)
+            return 0
+
+    @staticmethod
     def _build_keepalive_http_client(base_url: str = "", *, verify: Any = True) -> Any:
         """Build an httpx.Client with proactive idle-connection reaping.
 
@@ -5477,6 +5488,7 @@ class AIAgent:
         # (a second concurrent call gets a fresh untracked client with
         # the old build-per-request behavior).
         stale = None
+        stale_dead_count = 0
         with self._openai_client_lock():
             cache = self._request_client_cache_ref()
             cached = cache["client"]
@@ -5486,16 +5498,25 @@ class AIAgent:
                     and cache["kwargs"] == request_kwargs
                     and not self._is_openai_client_closed(cached)
                 ):
-                    cache["in_use"] = True
-                    return cached
+                    stale_dead_count = self._dead_request_client_socket_count(cached)
+                    if stale_dead_count == 0:
+                        cache["in_use"] = True
+                        return cached
                 # kwargs changed (credential rotation, provider failover),
-                # poisoned by a cross-thread abort (#29507), or externally
-                # closed — never reuse; discard and rebuild below.
+                # poisoned by a cross-thread abort (#29507), externally
+                # closed, or holding a dead pooled socket — never reuse;
+                # discard and rebuild below.
                 stale = cached
                 cache["client"] = None
                 cache["kwargs"] = None
                 cache["poisoned"] = False
         if stale is not None:
+            if stale_dead_count > 0:
+                logger.warning(
+                    "Found %d dead connection(s) in cached request client pool "
+                    "before reuse — evicting client",
+                    stale_dead_count,
+                )
             # Safe to close from this thread: in_use was False, so no
             # worker thread owns the pool's FDs (#29507 concerns clients
             # with an in-flight request on another thread).

--- a/tests/agent/test_request_client_reuse.py
+++ b/tests/agent/test_request_client_reuse.py
@@ -17,8 +17,13 @@ ONE reusable wire client on the agent, keyed by the effective client kwargs:
 - MoA facade and Mock passthroughs never enter the cache.
 """
 
+import socket
+import ssl
+import threading
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from agent.agent_runtime_helpers import _idle_pool_socket_is_unusable
 from run_agent import AIAgent
 
 
@@ -30,6 +35,57 @@ class _StubClient:
 
     def close(self):
         self.is_closed = True
+
+
+class _PoolSocket:
+    """Minimal socket probe target for the cached request-client pool."""
+
+    def __init__(self, *, dead=False):
+        self.dead = dead
+        self.blocking = True
+        self.recv_calls = 0
+
+    def setblocking(self, value):
+        self.blocking = value
+
+    def recv(self, *_args):
+        self.recv_calls += 1
+        if self.dead:
+            return b""
+        raise BlockingIOError
+
+
+def _client_for_pool_socket(pool_socket):
+    client = _StubClient()
+    stream = SimpleNamespace(_sock=pool_socket)
+    connection = SimpleNamespace(_network_stream=stream)
+    pool_entry = SimpleNamespace(_connection=connection)
+    pool = SimpleNamespace(_connections=[pool_entry])
+    setattr(
+        client,
+        "_client",
+        SimpleNamespace(
+            _transport=SimpleNamespace(_pool=pool),
+            is_closed=False,
+        ),
+    )
+    setattr(client, "_pool_socket", pool_socket)
+    return client
+
+
+def _client_with_pool_socket(*, dead=False):
+    return _client_for_pool_socket(_PoolSocket(dead=dead))
+
+
+def _set_cached_request_client(agent, client, *, in_use=False):
+    request_kwargs = dict(agent._client_kwargs)
+    request_kwargs["max_retries"] = 0
+    agent._request_client_cache = {
+        "client": client,
+        "kwargs": request_kwargs,
+        "poisoned": False,
+        "in_use": in_use,
+    }
 
 
 def _make_agent(provider="openai", base_url="https://api.openai.com/v1", model="gpt-5.4"):
@@ -122,14 +178,216 @@ def test_rebuild_on_client_kwargs_change():
         assert c is b
 
 
+def test_pre_turn_cleanup_rebuilds_dead_primary_client():
+    agent = _make_agent()
+    agent.client = _client_with_pool_socket(dead=True)
+
+    with patch.object(
+        agent, "_replace_primary_openai_client", return_value=True
+    ) as replace_primary:
+        cleaned = agent._cleanup_dead_connections()
+
+    assert cleaned is True
+    replace_primary.assert_called_once_with(reason="dead_connection_cleanup")
 
 
+def test_request_creation_evicts_dead_idle_cached_client_before_reuse():
+    agent = _make_agent()
+    cached = _client_with_pool_socket(dead=True)
+    _set_cached_request_client(agent, cached)
+
+    with _Harness(agent) as h:
+        replacement = agent._create_request_openai_client(reason="next_request")
+
+    assert replacement is not cached
+    assert (cached, "reuse_evict:next_request") in h.closed
+    assert len(h.built) == 1
 
 
+def test_concurrent_request_creation_does_not_probe_in_flight_cached_client():
+    agent = _make_agent()
+    cached = _client_with_pool_socket(dead=False)
+    _set_cached_request_client(agent, cached)
+    checked_out = threading.Event()
+    release_owner = threading.Event()
+    owner_errors = []
+
+    def _own_cached_client():
+        try:
+            client = agent._create_request_openai_client(reason="active_request")
+            assert client is cached
+            # The peer can become unreadable while the request owns the socket.
+            # A concurrent acquisition must trust ``in_use`` and never probe it.
+            getattr(cached, "_pool_socket").dead = True
+            checked_out.set()
+            assert release_owner.wait(timeout=2)
+            agent._close_request_openai_client(client, reason="request_complete")
+        except BaseException as exc:
+            owner_errors.append(exc)
+            checked_out.set()
+
+    with _Harness(agent) as h:
+        owner = threading.Thread(target=_own_cached_client)
+        owner.start()
+        assert checked_out.wait(timeout=2)
+        probe_calls_before = getattr(cached, "_pool_socket").recv_calls
+
+        concurrent = agent._create_request_openai_client(reason="concurrent_request")
+        agent._close_request_openai_client(concurrent, reason="request_complete")
+
+        release_owner.set()
+        owner.join(timeout=2)
+
+    assert not owner.is_alive()
+    assert owner_errors == []
+    assert concurrent is not cached
+    assert cached not in h.closed_clients()
+    assert len(h.built) == 1
+    assert agent._request_client_cache["client"] is cached
+    assert agent._request_client_cache["in_use"] is False
+    assert getattr(cached, "_pool_socket").recv_calls == probe_calls_before
 
 
+def test_openai_client_lock_is_stable_and_reentrant():
+    agent = AIAgent.__new__(AIAgent)
+
+    lock = agent._openai_client_lock()
+
+    assert agent._openai_client_lock() is lock
+    with lock:
+        assert lock.acquire(blocking=False) is True
+        lock.release()
 
 
+def test_dead_socket_probe_handles_tls_wrapped_connections():
+    raw_socket, peer_socket = socket.socketpair()
+    context = ssl.create_default_context()
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
+    tls_socket = context.wrap_socket(
+        raw_socket,
+        server_hostname="localhost",
+        do_handshake_on_connect=False,
+    )
+    client = _client_for_pool_socket(tls_socket)
+
+    try:
+        assert AIAgent._dead_request_client_socket_count(client) == 0
+        peer_socket.close()
+        assert AIAgent._dead_request_client_socket_count(client) == 1
+    finally:
+        peer_socket.close()
+        tls_socket.close()
+
+
+def test_idle_plain_socket_probe_distinguishes_buffered_data_from_eof():
+    local_socket, peer_socket = socket.socketpair()
+
+    try:
+        peer_socket.sendall(b"x")
+        assert _idle_pool_socket_is_unusable(local_socket) is False
+        assert local_socket.recv(1, socket.MSG_PEEK) == b"x"
+
+        local_socket.recv(1)
+        peer_socket.close()
+        assert _idle_pool_socket_is_unusable(local_socket) is True
+    finally:
+        peer_socket.close()
+        local_socket.close()
+
+
+def test_socket_probe_fallback_skips_incomplete_double_and_continues_pool_scan():
+    incomplete_socket = SimpleNamespace()
+    dead_socket = _PoolSocket(dead=True)
+
+    with patch(
+        "agent.agent_runtime_helpers._iter_pool_sockets",
+        return_value=iter([incomplete_socket, dead_socket]),
+    ):
+        assert AIAgent._dead_request_client_socket_count(_StubClient()) == 1
+
+    assert dead_socket.recv_calls == 1
+
+
+def test_idle_socket_probe_uses_poll_for_high_posix_fds():
+    sock = MagicMock()
+    sock.fileno.return_value = 2048
+    sock.getsockopt.return_value = 0
+    poller = MagicMock()
+    poller.poll.return_value = []
+
+    with (
+        patch("sys.platform", "linux"),
+        patch("select.poll", return_value=poller, create=True),
+        patch("select.POLLIN", 1, create=True),
+        patch("select.select", side_effect=AssertionError("select must not run")),
+    ):
+        assert _idle_pool_socket_is_unusable(sock) is False
+
+    poller.register.assert_called_once_with(2048, 1)
+
+
+def test_idle_socket_probe_uses_select_on_windows():
+    sock = MagicMock()
+    sock.fileno.return_value = 2048
+    sock.getsockopt.return_value = 0
+
+    with (
+        patch("sys.platform", "win32"),
+        patch("select.poll", side_effect=AssertionError("poll must not run"), create=True),
+        patch("select.select", return_value=([], [], [])) as select_mock,
+    ):
+        assert _idle_pool_socket_is_unusable(sock) is False
+
+    select_mock.assert_called_once_with([sock], [], [sock], 0)
+
+
+def test_pre_turn_cleanup_evicts_dead_idle_cached_request_client():
+    agent = _make_agent()
+    cached = _client_with_pool_socket(dead=True)
+    _set_cached_request_client(agent, cached)
+
+    with (
+        _Harness(agent) as h,
+        patch.object(agent, "_replace_primary_openai_client") as replace_primary,
+    ):
+        cleaned = agent._cleanup_dead_connections()
+        replacement = agent._create_request_openai_client(reason="next_request")
+
+    assert cleaned is True
+    assert (cached, "dead_connection_cleanup") in h.closed
+    assert replacement is not cached
+    assert len(h.built) == 1
+    replace_primary.assert_not_called()
+
+
+def test_pre_turn_cleanup_keeps_healthy_idle_cached_request_client():
+    agent = _make_agent()
+    cached = _client_with_pool_socket(dead=False)
+    _set_cached_request_client(agent, cached)
+
+    with _Harness(agent) as h:
+        cleaned = agent._cleanup_dead_connections()
+        reused = agent._create_request_openai_client(reason="next_request")
+
+    assert cleaned is False
+    assert h.closed == []
+    assert reused is cached
+    assert h.built == []
+
+
+def test_pre_turn_cleanup_does_not_close_in_flight_request_client():
+    agent = _make_agent()
+    cached = _client_with_pool_socket(dead=True)
+    _set_cached_request_client(agent, cached, in_use=True)
+
+    with _Harness(agent) as h:
+        cleaned = agent._cleanup_dead_connections()
+
+    assert cleaned is False
+    assert h.closed == []
+    assert agent._request_client_cache["client"] is cached
+    assert getattr(cached, "_pool_socket").recv_calls == 0
 
 
 def test_agent_close_closes_cached_request_client():


### PR DESCRIPTION
## What does this PR do?

Hermes keeps a separate OpenAI request client cached between sequential LLM calls. That cache previously reused a client when `is_closed` was false even if its underlying TLS socket had become unusable. The pre-turn cleanup also inspected only the primary client, allowing half-dead request-client connections to cause long TTFB stalls behind proxies.

This change probes **idle** pool sockets without consuming application data, evicts unhealthy cached request clients before reuse, and includes idle request clients in pre-turn cleanup. A request client checked out by another thread is neither probed nor closed.

The current candidate was semantically replayed onto `origin/main` `057dcdf236f8a6a26721c10fcc6ccb72726e272a` as one atomic commit:

- candidate: `30c1fa278df12f0aeb4d4f85004a4ea9629d7fff`
- tree: `74e7d00c4c47ac784f35b7ce0a14223d212fe091`
- exact-SHA Spec review: **PASS**, no findings
- exact-SHA Standards review: **PASS**, no findings

## Related Issue

Fixes #81518

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add an idle-socket liveness probe using `SO_ERROR` and zero-timeout OS readiness polling (`poll` on POSIX, `select` on Windows).
- Preserve unread application data on plain sockets via `MSG_PEEK`; conservatively classify readable TLS sockets for idle-pool eviction.
- Check cached request-client pools before reuse and evict/rebuild clients with unusable sockets.
- Extend pre-turn cleanup to idle cached request clients while holding the shared reentrant client lock.
- Skip probing and teardown whenever the cached request client is `in_use`.
- Continue scanning pool entries when wrappers or incomplete test doubles do not expose a probeable socket.
- Add deterministic concurrency, TLS, plain-socket, high-FD POSIX, and Windows-path regression coverage.

## How to Test

```bash
python -m pytest -q tests/agent/test_request_client_reuse.py
python -m pytest -q \
  tests/agent/test_turn_context.py \
  tests/run_agent/test_request_client_reuse_abort_races.py \
  tests/run_agent/test_openai_client_lifecycle.py
python -m ruff check \
  agent/agent_runtime_helpers.py \
  run_agent.py \
  tests/agent/test_request_client_reuse.py
```

Verified on the exact candidate:

- request-client suite: **16 passed** (repeated three times during Standards review)
- related lifecycle/abort/turn-context suites: **35 passed**
- Ruff: **passed**
- compileall: **passed**
- `git diff --check`: **passed**
- real TLS probe: healthy connection `0` dead sockets; peer-closed connection `1`
- high-numbered POSIX FD probe: peer-closed connection detected

Native Windows execution was not available locally; the Windows branch is covered by deterministic unit tests and remains subject to repository Windows CI.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs
- [x] My PR contains only changes related to this fix
- [ ] I've run the entire repository test suite — focused and adjacent acceptance suites are documented above; CI runs the repository gates
- [x] I've added tests for the bug and concurrency regression
- [x] I've tested on Linux

### Documentation & Housekeeping

- [x] Runtime behavior is documented in code; no user-facing docs are required
- [x] No configuration keys were added or changed
- [x] No contribution or architecture documentation changes are required
- [x] Cross-platform socket behavior was considered and tested where locally possible
- [x] No tool schemas or descriptions changed

## Screenshots / Logs

Not applicable; this is an internal connection-lifecycle fix with deterministic regression tests.
