### PR TITLE
fix(transport): stringify non-string tool content on the wire (#19814)

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -555,6 +555,21 @@ def _coerce_args(args: Mapping[str, Any] | None) -> Mapping[str, Any]:
 
 
 def _result_hash(result: str | None) -> str:
+    # #19814 — the raw tool result can arrive as a dict/list rather than a JSON
+    # string.  safe_json_loads() returns None for a non-str, so ``canonical``
+    # would fall through to the container itself and _sha256()'s
+    # .encode("utf-8") would raise AttributeError.  Normalize first.
+    if result is not None and not isinstance(result, str):
+        try:
+            result = json.dumps(
+                result,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+                default=str,
+            )
+        except TypeError:
+            result = str(result)
     parsed = safe_json_loads(result or "")
     if parsed is not None:
         try:

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -520,6 +520,21 @@ def _coerce_args(args: Mapping[str, Any] | None) -> Mapping[str, Any]:
 
 
 def _result_hash(result: str | None) -> str:
+    # #19814 — the raw tool result can arrive as a dict/list rather than a JSON
+    # string.  safe_json_loads() returns None for a non-str, so ``canonical``
+    # would fall through to the container itself and _sha256()'s
+    # .encode("utf-8") would raise AttributeError.  Normalize first.
+    if result is not None and not isinstance(result, str):
+        try:
+            result = json.dumps(
+                result,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+                default=str,
+            )
+        except TypeError:
+            result = str(result)
     parsed = safe_json_loads(result or "")
     return _sha256(_canonical_json(parsed) if parsed is not None else (result or ""))
 

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -19,6 +19,37 @@ from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall, Usage
 
 
+def _is_multimodal_envelope(value: Any) -> bool:
+    """True for the ``{"_multimodal": True, "content": [...]}`` tool-result envelope.
+
+    Mirrors ``agent.tool_dispatch_helpers._is_multimodal_tool_result`` deliberately
+    rather than importing it: a transport should not pull in the tool-dispatch layer
+    (which reaches into ``tools.*``).  Keep the two in sync if the envelope changes.
+    """
+    return (
+        isinstance(value, dict)
+        and value.get("_multimodal") is True
+        and isinstance(value.get("content"), list)
+    )
+
+
+def _tool_content_needs_stringify(msg: dict[str, Any]) -> bool:
+    """True for a ``role: "tool"`` message whose content cannot go on the wire.
+
+    Chat Completions requires ``content`` to be a string on tool messages.  Plugin
+    tools (e.g. the ``custom-tools`` plugin) may return a ``dict``; passing it
+    through makes strict providers reject the whole request with
+    ``messages.N.content: Invalid input``.  Recognized multimodal envelopes are
+    left alone so the multimodal path can still handle them.  See #19814.
+    """
+    if msg.get("role") != "tool":
+        return False
+    content = msg.get("content")
+    if content is None or isinstance(content, str):
+        return False
+    return not _is_multimodal_envelope(content)
+
+
 def _static_prompt_instructions(messages: list[dict[str, Any]]) -> str:
     """Return the stable system/developer prefix used for cache routing.
 
@@ -270,6 +301,9 @@ class ChatCompletionsTransport(ProviderTransport):
             if any(isinstance(k, str) and k.startswith("_") for k in msg):
                 needs_sanitize = True
                 break
+            if _tool_content_needs_stringify(msg):
+                needs_sanitize = True
+                break
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):
                 for tc in tool_calls:
@@ -325,6 +359,12 @@ class ChatCompletionsTransport(ProviderTransport):
                 out_msg = mutable_msg()
                 for key in internal_keys:
                     out_msg.pop(key, None)
+
+            if _tool_content_needs_stringify(msg):
+                # #19814 — stringify non-str tool content before it hits the wire.
+                mutable_msg()["content"] = json.dumps(
+                    msg["content"], ensure_ascii=False, default=str
+                )
 
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -53,6 +53,37 @@ def _rename_tool_search_bridge_for_xai(tools: list[dict[str, Any]]) -> tuple[lis
     )
 
 
+def _is_multimodal_envelope(value: Any) -> bool:
+    """True for the ``{"_multimodal": True, "content": [...]}`` tool-result envelope.
+
+    Mirrors ``agent.tool_dispatch_helpers._is_multimodal_tool_result`` deliberately
+    rather than importing it: a transport should not pull in the tool-dispatch layer
+    (which reaches into ``tools.*``).  Keep the two in sync if the envelope changes.
+    """
+    return (
+        isinstance(value, dict)
+        and value.get("_multimodal") is True
+        and isinstance(value.get("content"), list)
+    )
+
+
+def _tool_content_needs_stringify(msg: dict[str, Any]) -> bool:
+    """True for a ``role: "tool"`` message whose content cannot go on the wire.
+
+    Chat Completions requires ``content`` to be a string on tool messages.  Plugin
+    tools (e.g. the ``custom-tools`` plugin) may return a ``dict``; passing it
+    through makes strict providers reject the whole request with
+    ``messages.N.content: Invalid input``.  Recognized multimodal envelopes are
+    left alone so the multimodal path can still handle them.  See #19814.
+    """
+    if msg.get("role") != "tool":
+        return False
+    content = msg.get("content")
+    if content is None or isinstance(content, str):
+        return False
+    return not _is_multimodal_envelope(content)
+
+
 def _static_prompt_instructions(messages: list[dict[str, Any]]) -> str:
     """Stable leading system/developer prefix used for cache routing (later messages are conversation state)."""
     first = messages[0] if messages and isinstance(messages[0], dict) else {}
@@ -311,6 +342,13 @@ def _sanitize_message(msg: Any, strip_extra_content: bool) -> dict | None:
     if msg.get("role") == "tool" and "name" in msg:
         strip_keys.append("name")
     out_msg = {k: v for k, v in msg.items() if k not in strip_keys}
+    # #19814 — stringify non-str tool content before it hits the wire.  Chat
+    # Completions requires ``content`` to be a string on tool messages; a plugin
+    # tool returning a dict otherwise makes strict providers reject the whole
+    # request with ``messages.N.content: Invalid input``.
+    stringified_content = _tool_content_needs_stringify(msg)
+    if stringified_content:
+        out_msg["content"] = json.dumps(msg["content"], ensure_ascii=False, default=str)
     tool_calls = msg.get("tool_calls")
     copied_tool_calls = None
     if msg.get("role") == "assistant" and "tool_calls" in msg and (tool_calls is None or (isinstance(tool_calls, list) and not tool_calls)):
@@ -329,7 +367,7 @@ def _sanitize_message(msg: Any, strip_extra_content: bool) -> dict | None:
                 copied_tool_calls[tc_idx] = {k: v for k, v in tc.items() if k not in keys}
         if copied_tool_calls is not None:
             out_msg["tool_calls"] = copied_tool_calls
-    return out_msg if strip_keys or copied_tool_calls is not None else None
+    return out_msg if strip_keys or copied_tool_calls is not None or stringified_content else None
 
 
 class ChatCompletionsTransport(ProviderTransport):

--- a/tests/agent/test_issue_19814_non_string_tool_results.py
+++ b/tests/agent/test_issue_19814_non_string_tool_results.py
@@ -1,0 +1,137 @@
+"""Regression tests for #19814 — non-string tool results must not break the wire.
+
+Plugin tools (e.g. the ``custom-tools`` plugin) may return a ``dict`` rather than
+a string.  Chat Completions requires ``content`` to be a string on ``role: "tool"``
+messages, so an unconverted dict makes strict OpenAI-compatible providers
+(OpenRouter, DeepSeek, Ollama) reject the *entire* request with
+``messages.N.content: Invalid input`` — every turn, until the session is reset.
+
+The same root cause reaches ``tool_guardrails._result_hash()``, which assumes a
+string and raises ``AttributeError`` inside ``_sha256()`` when handed a dict.
+
+Recognized multimodal envelopes (``{"_multimodal": True, "content": [...]}``) must
+survive untouched — flattening those would break the multimodal path.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agent.transports.chat_completions import ChatCompletionsTransport
+from agent.tool_guardrails import _result_hash
+
+
+@pytest.fixture
+def transport():
+    return ChatCompletionsTransport()
+
+
+def _tool_msg(content):
+    return {"role": "tool", "tool_call_id": "call_1", "content": content}
+
+
+def test_dict_tool_content_is_stringified(transport):
+    """A dict tool result is serialized to a JSON string."""
+    messages = [_tool_msg({"unread": 3, "subjects": ["a", "b"]})]
+
+    out = transport.convert_messages(messages, model="deepseek-chat")
+
+    assert isinstance(out[0]["content"], str), out[0]
+    assert json.loads(out[0]["content"]) == {"unread": 3, "subjects": ["a", "b"]}
+
+
+def test_list_tool_content_is_stringified(transport):
+    """A bare list is also not a valid Chat Completions tool content."""
+    messages = [_tool_msg([{"id": 1}, {"id": 2}])]
+
+    out = transport.convert_messages(messages, model="deepseek-chat")
+
+    assert isinstance(out[0]["content"], str), out[0]
+    assert json.loads(out[0]["content"]) == [{"id": 1}, {"id": 2}]
+
+
+def test_stringify_happens_without_any_other_sanitize_trigger(transport):
+    """The early ``needs_sanitize`` return must not skip the conversion.
+
+    ``convert_messages`` returns ``messages`` unchanged when nothing needs
+    sanitizing.  A message carrying *only* a non-string content has none of the
+    other markers, so the detection pass has to recognize it too — otherwise the
+    dict flows straight to the provider.
+    """
+    messages = [_tool_msg({"only": "trigger"})]
+
+    out = transport.convert_messages(messages, model="deepseek-chat")
+
+    assert isinstance(out[0]["content"], str), out[0]
+
+
+def test_multimodal_envelope_is_preserved(transport):
+    """Recognized ``_multimodal`` envelopes must not be flattened."""
+    envelope = {
+        "_multimodal": True,
+        "content": [{"type": "text", "text": "hi"}],
+        "text_summary": "hi",
+    }
+    messages = [_tool_msg(envelope)]
+
+    out = transport.convert_messages(messages, model="deepseek-chat")
+
+    assert out[0]["content"] == envelope
+
+
+def test_string_and_none_content_are_untouched(transport):
+    """Valid content is passed through byte-for-byte."""
+    messages = [_tool_msg("already a string"), _tool_msg(None)]
+
+    out = transport.convert_messages(messages, model="deepseek-chat")
+
+    assert out[0]["content"] == "already a string"
+    assert out[1]["content"] is None
+
+
+def test_non_tool_roles_are_untouched(transport):
+    """Only ``role: "tool"`` messages are normalized here.
+
+    Assistant/user content parts are lists by design in the OpenAI schema.
+    """
+    parts = [{"type": "text", "text": "hello"}]
+    messages = [{"role": "user", "content": parts}]
+
+    out = transport.convert_messages(messages, model="deepseek-chat")
+
+    assert out[0]["content"] == parts
+
+
+def test_original_messages_are_not_mutated(transport):
+    """Sanitizing copies; the caller's history must stay intact."""
+    original = {"unread": 3}
+    messages = [_tool_msg(original)]
+
+    transport.convert_messages(messages, model="deepseek-chat")
+
+    assert messages[0]["content"] is original
+
+
+def test_result_hash_accepts_dict():
+    """``_result_hash`` no longer raises AttributeError on a dict result."""
+    assert _result_hash({"a": 1}) == _result_hash('{"a":1}')
+
+
+def test_result_hash_accepts_list():
+    assert isinstance(_result_hash([1, 2, 3]), str)
+
+
+def test_result_hash_still_accepts_str_and_none():
+    assert isinstance(_result_hash('{"a": 1}'), str)
+    assert isinstance(_result_hash(None), str)
+
+
+def test_result_hash_survives_unserializable_object():
+    """A non-JSON-serializable result degrades to ``str()`` instead of crashing."""
+
+    class Opaque:
+        pass
+
+    assert isinstance(_result_hash({"obj": Opaque()}), str)


### PR DESCRIPTION
Plugin tools (e.g. the custom-tools plugin) can return a dict rather than a
string. Chat Completions requires content to be a string on role: "tool"
messages, so an unconverted dict makes strict OpenAI-compatible providers
(OpenRouter, DeepSeek, Ollama) reject the entire request with
"messages.N.content: Invalid input" on every turn until the session is reset.

This was reported in #19814 as the most critical of the three sites in that
issue. The other two (agent/display.py::_detect_tool_failure and the delegate
error preview) are already fixed on main; this one is not, and #19877 — the
only PR that carried it — is now closed.

Changes:
- ChatCompletionsTransport.convert_messages() serializes non-string content on
  tool messages. Recognized multimodal envelopes
  ({"_multimodal": True, "content": [...]}) are left untouched so the
  multimodal path keeps working.
- The detection pass recognizes the same condition. convert_messages() returns
  messages unchanged when needs_sanitize is False, so a message carrying only a
  non-string content would otherwise bypass the conversion entirely.
- tool_guardrails._result_hash() normalizes a dict/list result before hashing.
  safe_json_loads() returns None for a non-str, so canonical fell through to the
  container itself and _sha256()'s .encode("utf-8") raised AttributeError. Same
  root cause, host-side crash rather than a provider rejection.

_is_multimodal_envelope() intentionally mirrors
agent.tool_dispatch_helpers._is_multimodal_tool_result rather than importing it:
a transport should not pull in the tool-dispatch layer, which reaches into
tools.*.

Tests: 11 new regression tests. Six of them fail on main without this change,
including the original AttributeError; the other five pin the behaviour that
must not change (multimodal envelopes preserved, strings and None untouched,
non-tool roles untouched, caller's messages not mutated).
