### PR TITLE
fix(gateway): route /update to the Docker message inside containers

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -5564,7 +5564,12 @@ class GatewaySlashCommandsMixin:
         import shutil
         import subprocess
         from datetime import datetime
-        from hermes_cli.config import is_managed, format_managed_message
+        from hermes_cli.config import (
+            format_docker_update_message,
+            format_managed_message,
+            is_managed,
+        )
+        from gateway.restart import is_container_restart_context
 
         # Block non-messaging platforms (API server, webhooks, ACP)
         platform = event.source.platform
@@ -5586,6 +5591,12 @@ class GatewaySlashCommandsMixin:
         git_dir = project_root / '.git'
 
         if not git_dir.exists():
+            # A containerized deployment has no working tree to pull into, so the
+            # generic "not a git repository" text is a dead end.  The CLI and web
+            # paths already surface container-specific instructions via
+            # format_docker_update_message(); route the gateway there too.
+            if is_container_restart_context():
+                return format_docker_update_message()
             return t("gateway.update.not_git_repo")
 
         hermes_cmd = _resolve_hermes_bin()

--- a/tests/gateway/test_update_docker_message.py
+++ b/tests/gateway/test_update_docker_message.py
@@ -1,0 +1,77 @@
+"""``/update`` must give container users the container instructions.
+
+A containerized deployment has no working tree, so ``/update`` fell through to
+``gateway.update.not_git_repo`` — "not a git repository". That is technically
+true and practically a dead end: it tells the user nothing about how to update.
+
+The container-specific message already exists
+(``hermes_cli.config.format_docker_update_message``) and is already used by the
+CLI and web paths; these tests pin that the gateway slash-command path routes
+there too.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_event():
+    return MessageEvent(
+        text="/update",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="1",
+            chat_id="2",
+            user_name="tester",
+        ),
+    )
+
+
+def _make_runner():
+    """Bare GatewayRunner — the handler only needs the mixin."""
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = None
+    return runner
+
+
+@pytest.fixture
+def worktree_less_root(tmp_path):
+    """A project root with no ``.git``, wired in via the module's ``__file__``."""
+    fake_root = tmp_path / "app"
+    (fake_root / "gateway").mkdir(parents=True)
+    fake_file = str(fake_root / "gateway" / "slash_commands.py")
+    with patch("gateway.slash_commands.__file__", fake_file):
+        yield fake_root
+
+
+@pytest.mark.asyncio
+async def test_container_gets_docker_update_message(worktree_less_root):
+    """Inside a container, /update returns the container instructions."""
+    from hermes_cli.config import format_docker_update_message
+
+    with patch("gateway.restart.is_container_restart_context", lambda: True), \
+         patch("hermes_cli.config.is_managed", lambda: False):
+        result = await _make_runner()._handle_update_command(_make_event())
+
+    assert result == format_docker_update_message()
+
+
+@pytest.mark.asyncio
+async def test_non_container_keeps_the_git_message(worktree_less_root):
+    """Outside a container the existing message is unchanged."""
+    from hermes_cli.config import format_docker_update_message
+
+    with patch("gateway.restart.is_container_restart_context", lambda: False), \
+         patch("hermes_cli.config.is_managed", lambda: False):
+        result = await _make_runner()._handle_update_command(_make_event())
+
+    assert result != format_docker_update_message()
+    assert "docker pull" not in result


### PR DESCRIPTION
Running /update from a messaging platform while the gateway is in a container
returns "not a git repository" (gateway.update.not_git_repo). That is
technically true and practically a dead end — a containerized deployment has no
working tree, and the message says nothing about how to actually update.

All three pieces to fix this already exist and were simply not wired together:

- hermes_cli.config.format_docker_update_message() — the container-specific
  instructions, already used by hermes_cli/web_server.py and
  hermes_cli/update_cmd.py
- gateway.restart.is_container_restart_context() — container detection, already
  living inside gateway/
- the gateway /update handler, which returned the generic git message

The handler now checks the container probe before falling back to the git
message. Imports follow the handler's existing deferred-import style.

Note on wording: _DOCKER_UPDATE_MESSAGE tells the user to run
"docker pull nousresearch/hermes-agent:latest". That is right for the published
image but wrong for deployments that build their own image from this repo — a
pull would silently replace their build. I kept this change to the routing only
so it can land independently; happy to follow up with a wording branch (or add a
line covering self-built images) if you'd like that too.

Tests: two cases pinning both branches. The container case fails without this
change. Existing tests/gateway/test_update_streaming.py still passes.
