### PR TITLE
fix(desktop): normalize artifact timestamps (#81016)

### DIFF
--- a/apps/desktop/src/app/artifacts/index.tsx
+++ b/apps/desktop/src/app/artifacts/index.tsx
@@ -50,7 +50,12 @@ import {
 } from './artifact-utils'
 
 function formatArtifactTime(timestamp: number): string {
-  return fmtDayTime.format(new Date(timestamp))
+  // Session and message timestamps are epoch seconds, while Date expects
+  // epoch milliseconds. Keep accepting millisecond values for compatibility
+  // with any newer backend that may already normalize them.
+  const milliseconds = timestamp < 1_000_000_000_000 ? timestamp * 1000 : timestamp
+
+  return fmtDayTime.format(new Date(milliseconds))
 }
 
 function pageRangeLabel(total: number, page: number, pageSize: number, a: Translations['artifacts']): string {


### PR DESCRIPTION
Fixes #81016.

Desktop artifact timestamps are epoch seconds from session/message records, but the Artifacts view passed them directly to Date, which interprets values as milliseconds and rendered dates in 1970. Normalize seconds to milliseconds while retaining compatibility with millisecond timestamps.