### PR TITLE
fix(memory): default action to "add" when omitted with content, give actionable error otherwise

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -307,6 +307,42 @@ class TestMemoryToolDispatcher:
         assert "current_entries" not in result
 
 
+    def test_none_action_with_content_defaults_to_add(self, store):
+        """Regression for issue #81542: a strict provider filling the
+        optional 'action' field with JSON null (or a model simply
+        forgetting it on a single-op call) must not fail with the
+        confusing "Unknown action 'None'" message when content is
+        clearly present with no old_text -- the natural single-op shape
+        for adding an entry. Mirrors the existing null-target handling."""
+        result = json.loads(memory_tool(action=None, content="a new fact", store=store))
+        assert result["success"] is True
+        assert "a new fact" in store._entries_for("memory")
+
+    def test_none_action_without_content_gives_actionable_error(self, store):
+        """When there's truly nothing to dispatch on (no action, no
+        operations, no content to imply 'add'), the error must guide the
+        model toward the fix instead of the confusing "Unknown action
+        'None'" message."""
+        result = json.loads(memory_tool(action=None, store=store))
+        assert result["success"] is False
+        assert "Unknown action" not in result["error"]
+        assert "action" in result["error"].lower()
+
+    def test_none_action_is_not_defaulted_in_batch_mode(self, store):
+        """action=None alongside operations= must not trigger the
+        single-op default-to-add path -- the batch path handles its own
+        per-operation action values independently."""
+        result = json.loads(
+            memory_tool(
+                action=None,
+                operations=[{"action": "add", "content": "batched fact"}],
+                store=store,
+            )
+        )
+        assert result["success"] is True
+        assert "batched fact" in store._entries_for("memory")
+
+
 class TestMemoryBatch:
     """The 'operations' batch shape: atomic, all-or-nothing, final-budget."""
 

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -1074,6 +1074,24 @@ def memory_tool(
     if target not in {"memory", "user"}:
         return tool_error(f"Invalid target '{target}'. Use 'memory' or 'user'.", success=False)
 
+    # Same strict-provider null-filling issue as target above: action is
+    # documented as optional (omit when using 'operations'), but a model
+    # can pass action: null explicitly, or simply forget it on a single-op
+    # call. Default to "add" when content is supplied without old_text --
+    # the natural reading of a single-op call with only content set -- so
+    # the write succeeds instead of failing with the confusing "Unknown
+    # action 'None'" message (issue #81542). Batch calls (operations set)
+    # are unaffected: this only applies to the single-op path below.
+    if action is None and not operations:
+        if content and not old_text:
+            action = "add"
+        else:
+            return tool_error(
+                "Missing 'action'. Provide action ('add', 'replace', or 'remove') for a "
+                "single-op call, or 'operations' for a batch call.",
+                success=False,
+            )
+
     # --- Batch path -------------------------------------------------------
     if operations:
         if not isinstance(operations, list):


### PR DESCRIPTION
Fixes #81542 (part 1 -- the "Unknown action 'None'" dispatch bug).

## Problem

`action` is documented as optional (omit when using `operations`), but a strict provider can fill it with JSON null explicitly, or a model can simply forget it on a single-op call. Either way it fell through to `"Unknown action 'None'. Use: add, replace, remove"` -- a confusing error that rejects a call that clearly intended to add an entry.

## Fix

Mirrors the EXISTING null-target handling immediately above (the same strict-provider-fills-optional-fields-with-null issue, already solved for `target`): default `action` to `"add"` when `content` is supplied without `old_text`. When there's truly nothing to dispatch on, return a clear, actionable error instead. Batch calls are unaffected.

## About part 2 of the issue

The "auto-eviction thrashing" part did not reproduce: there is no eviction mechanism in this file at all. `MemoryStore.add()` already REJECTS a write that would exceed the char limit with a clear consolidation-guidance error, rather than silently auto-evicting -- which is what the reporter's own proposed fix asked for. Left unchanged.

## Verification

Added 3 regression tests. Verified as genuine by reverting the fix and confirming 2 of 3 fail with the exact reported "Unknown action 'None'" message.

39/39 pass across the two memory tool test files (no regression).