### PR TITLE
feat: embeddable durable-execution layer + mandatory egress guardrails

### DIFF
--- a/docs/middleware/README.md
+++ b/docs/middleware/README.md
@@ -48,6 +48,16 @@ Supported middleware kinds:
 | `tool_request` | `tool_name`, `args`, `original_args` | `{"args": {...}}` | Replace effective tool args before hooks, guardrails, approvals, and execution. |
 | `llm_execution` | `request`, `original_request`, `next_call` | Any provider response | Wrap or replace the actual provider call. |
 | `tool_execution` | `tool_name`, `args`, `original_args`, `next_call` | Any tool result | Wrap or replace the actual tool call. |
+| `outbound_message` | `text`, `original_text`, `platform`, `session_key`, `category` | `{"text": "..."}` or `{"action": "block", "reason": "..."}` | Rewrite or veto an outbound message body at the egress boundary, after the built-in secret redaction pass. |
+
+`outbound_message` runs at the three outbound choke points (gateway replies,
+cron/DeliveryRouter sends, and the `send_message` tool) immediately before the
+platform adapter is invoked. The built-in egress redaction in
+`hermes_durability.egress` runs first and is fail-closed (a redaction failure
+blocks the send); plugin `outbound_message` middleware keeps the standard
+fail-open contract — only an explicit `{"action": "block"}` verdict stops
+delivery. `category` identifies the choke point (`gateway_reply`,
+`delivery_router`, `send_message_tool`).
 
 Request middleware can return optional trace fields:
 

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -78,8 +78,38 @@ class DeliveryTransport:
         content: str,
         metadata: Optional[Dict[str, Any]],
     ) -> Any:
-        """Send through this transport while preserving the logical platform."""
+        """Send through this transport while preserving the logical platform.
+
+        The native branch bottoms out in the adapter's wrapped ``send`` (see
+        ``BasePlatformAdapter.__init_subclass__``), which owns the egress
+        guardrail. The relay branch calls ``send_for_platform`` — a different
+        method that never passes through the wrapper — so it must run the
+        full guard here. A veto returns a non-retryable failure whose error
+        text is the stable ``BLOCK_ERROR`` constant: the detailed reason is
+        only logged, because free-text reasons flowing into
+        ``classify_send_error`` substring matching could mark the delivery
+        *target* dead over a one-off *content* veto.
+        """
         if self.is_relay:
+            from hermes_durability.egress import (BLOCK_ERROR, EgressBlocked,
+                                                  guard_outbound_text)
+
+            try:
+                content = guard_outbound_text(
+                    content,
+                    platform=getattr(logical_platform, "value",
+                                     str(logical_platform)),
+                    category="delivery_relay",
+                )
+            except EgressBlocked as exc:
+                from gateway.platforms.base import SendResult
+
+                logger.warning(
+                    "[delivery] Egress guardrail blocked %s relay send: %s",
+                    logical_platform, exc.reason,
+                )
+                return SendResult(success=False, error=BLOCK_ERROR,
+                                  retryable=False)
             return await self.adapter.send_for_platform(
                 logical_platform,
                 chat_id,
@@ -429,7 +459,12 @@ class DeliveryRouter:
         lines.append("")
         lines.append(content)
         
-        output_path.write_text("\n".join(lines), encoding="utf-8")
+        # Atomic (tmp + fsync + rename): a crash mid-write must not leave a
+        # torn markdown file that looks like a complete cron delivery.
+        from utils import atomic_write_text
+
+        atomic_write_text(output_path, "\n".join(lines), encoding="utf-8",
+                          create_mode=0o644)
         
         return {
             "path": str(output_path),
@@ -442,7 +477,9 @@ class DeliveryRouter:
         out_dir = get_hermes_home() / "cron" / "output"
         out_dir.mkdir(parents=True, exist_ok=True)
         path = out_dir / f"{job_id}_{timestamp}.txt"
-        path.write_text(content, encoding="utf-8")
+        from utils import atomic_write_text
+
+        atomic_write_text(path, content, encoding="utf-8", create_mode=0o644)
         return path
 
     def _filter_silence_narration_enabled(self) -> bool:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2635,6 +2635,47 @@ def _strip_media_directives(text: str) -> str:
     return _strip_media_tag_directives(text)
 
 
+def _wrap_with_egress_guard(fn, method_name: str):
+    """Return ``fn`` wrapped so its ``content`` argument passes the egress
+    guardrail before the platform API is called. See
+    ``BasePlatformAdapter.__init_subclass__`` for why the boundary lives here.
+    """
+    import functools
+
+    sig = inspect.signature(fn)
+
+    @functools.wraps(fn)
+    async def guarded(self, *args, **kwargs):
+        from hermes_durability.egress import (BLOCK_ERROR, EgressBlocked,
+                                              guard_outbound_text)
+
+        try:
+            bound = sig.bind(self, *args, **kwargs)
+        except TypeError:
+            # Let the real method raise the natural signature error.
+            return await fn(self, *args, **kwargs)
+        content = bound.arguments.get("content")
+        if isinstance(content, str) and content:
+            try:
+                bound.arguments["content"] = guard_outbound_text(
+                    content,
+                    platform=getattr(self, "name", "") or "",
+                    category=f"adapter_{method_name}",
+                )
+            except EgressBlocked as exc:
+                logger.warning(
+                    "[%s] Egress guardrail blocked %s: %s",
+                    getattr(self, "name", "?"), method_name, exc.reason,
+                )
+                return SendResult(success=False, error=BLOCK_ERROR,
+                                  retryable=False)
+        bound_args = bound.args[1:]
+        return await fn(self, *bound_args, **bound.kwargs)
+
+    guarded._egress_guarded = True
+    return guarded
+
+
 class BasePlatformAdapter(ABC):
     """
     Base class for platform adapters.
@@ -2655,6 +2696,30 @@ class BasePlatformAdapter(ABC):
     # first code line).  Plain-text platforms fall back to the short truncated
     # preview (see gateway/run.py progress_callback).
     supports_code_blocks: bool = False
+
+    def __init_subclass__(cls, **kwargs):
+        """Wrap concrete ``send``/``edit_message`` with the egress guardrail.
+
+        The guardrail must hold for EVERY caller that reaches a platform
+        adapter — not just ``_send_with_retry``. The stream consumer edits
+        model text into chats via ``edit_message``/``send`` directly, media
+        captions and clarify/private notices call ``self.send()``, and the
+        delivery-ledger redelivery path calls raw ``adapter.send`` at boot.
+        Guarding each call site individually is unwinnable (and was the bug:
+        streaming replies bypassed the boundary entirely), so the boundary
+        lives on the adapter methods themselves. Wrapping happens at subclass
+        creation; already-wrapped methods are skipped so diamond/child
+        adapters don't double-guard, and plugin ``outbound_message``
+        middleware therefore runs exactly once per delivered body.
+        """
+        super().__init_subclass__(**kwargs)
+        for method_name in ("send", "edit_message"):
+            fn = cls.__dict__.get(method_name)
+            if fn is None or getattr(fn, "_egress_guarded", False):
+                continue
+            if not asyncio.iscoroutinefunction(fn):
+                continue
+            setattr(cls, method_name, _wrap_with_egress_guard(fn, method_name))
 
     # Whether this adapter's typing indicator renders TEXT (a status line
     # next to the bot name) rather than a native textless bubble. When True,
@@ -5064,6 +5129,11 @@ class BasePlatformAdapter(ABC):
         to a plain-text version before giving up. If all attempts fail due to
         network errors, sends the user a brief delivery-failure notice so they
         know to retry rather than waiting indefinitely.
+
+        The egress guardrail runs inside ``self.send`` itself (wrapped at
+        subclass creation, see ``__init_subclass__``), so every attempt —
+        including the plain-text fallback — is guarded, and a veto surfaces
+        as a non-retryable failure.
         """
 
         result = await self.send(
@@ -6055,6 +6125,27 @@ class BasePlatformAdapter(ABC):
                         event.source.chat_id,
                     )
                     _reply_anchor = _reply_anchor_for_event(event)
+                    # Redact BEFORE the ledger records the body: without this,
+                    # a secret sits unredacted in delivery_obligations.content
+                    # and the boot-time redelivery sweep would hand it to
+                    # adapter.send verbatim. Redaction only (idempotent) —
+                    # plugin outbound_message middleware runs exactly once, at
+                    # the adapter send wrapper. If redaction itself fails the
+                    # boundary is fail-closed: skip recording and let the
+                    # guarded send veto the delivery.
+                    _egress_recordable = True
+                    try:
+                        from hermes_durability.egress import (EgressBlocked,
+                                                              guard_outbound_text)
+
+                        text_content = guard_outbound_text(
+                            text_content,
+                            platform=delivery_adapter.name,
+                            category="final_response",
+                            apply_middleware=False,
+                        )
+                    except EgressBlocked:
+                        _egress_recordable = False
                     # Delivery-obligation ledger: durably record the final
                     # response BEFORE the send attempt so a gateway crash
                     # between finalize and platform ACK can redeliver it on
@@ -6064,7 +6155,7 @@ class BasePlatformAdapter(ABC):
                     # Slash-command and ephemeral replies are cheap to
                     # regenerate and are not recorded.
                     _obligation_id = None
-                    if not is_ephemeral_response and not str(
+                    if _egress_recordable and not is_ephemeral_response and not str(
                         event.text or ""
                     ).lstrip().startswith(("/", self.typed_command_prefix or "!")):
                         try:

--- a/hermes_cli/middleware.py
+++ b/hermes_cli/middleware.py
@@ -21,6 +21,7 @@ TOOL_REQUEST_MIDDLEWARE = "tool_request"
 TOOL_EXECUTION_MIDDLEWARE = "tool_execution"
 LLM_REQUEST_MIDDLEWARE = "llm_request"
 LLM_EXECUTION_MIDDLEWARE = "llm_execution"
+OUTBOUND_MESSAGE_MIDDLEWARE = "outbound_message"
 
 # Back-compat aliases for older PoC branches that used API terminology.
 API_REQUEST_MIDDLEWARE = LLM_REQUEST_MIDDLEWARE
@@ -31,6 +32,7 @@ VALID_MIDDLEWARE: set[str] = {
     TOOL_EXECUTION_MIDDLEWARE,
     LLM_REQUEST_MIDDLEWARE,
     LLM_EXECUTION_MIDDLEWARE,
+    OUTBOUND_MESSAGE_MIDDLEWARE,
 }
 
 
@@ -172,6 +174,91 @@ def apply_tool_request_middleware(
         payload=current_args,
         original_payload=original_args,
         changed=bool(trace),
+        trace=trace,
+    )
+
+
+@dataclass
+class OutboundMessageResult:
+    """Result of applying ``outbound_message`` middleware to a message body."""
+
+    text: str
+    original_text: str
+    changed: bool = False
+    blocked: bool = False
+    block_reason: str = ""
+    trace: List[Dict[str, Any]] = field(default_factory=list)
+
+
+def apply_outbound_message_middleware(
+    text: str,
+    **context: Any,
+) -> OutboundMessageResult:
+    """Apply registered ``outbound_message`` middleware to an egress body.
+
+    This is the plugin-extensible half of the egress boundary; the built-in
+    fail-closed secret redaction lives in ``hermes_durability.egress`` and
+    runs before plugin middleware is consulted. Callbacks receive the current
+    ``text``, the ``original_text``, and the delivery ``context`` (platform,
+    session_key, category) and may return:
+
+      * ``{"text": "..."}`` — replace the outgoing body, or
+      * ``{"action": "block", "reason": "..."}`` — veto the send entirely.
+
+    Per the existing middleware contract, a *raising* callback is logged and
+    skipped (fail-open); only an explicit block verdict stops delivery.
+
+    Callbacks run as a sequential chain: each one receives the previous
+    callback's rewritten ``text`` (unlike the eager fan-out of
+    ``invoke_middleware``, where every callback would see the original body
+    and the last writer would silently win — unacceptable at a boundary
+    documented as a security choke point).
+    """
+    if not _has_middleware(OUTBOUND_MESSAGE_MIDDLEWARE):
+        return OutboundMessageResult(text=text, original_text=text)
+
+    original_text = text
+    current_text = text
+    trace: List[Dict[str, Any]] = []
+
+    for callback in _get_middleware_callbacks(OUTBOUND_MESSAGE_MIDDLEWARE):
+        try:
+            result = callback(**middleware_payload(
+                text=current_text,
+                original_text=original_text,
+                **context,
+            ))
+        except Exception as exc:
+            logger.warning(
+                "Middleware '%s' callback %s raised: %s",
+                OUTBOUND_MESSAGE_MIDDLEWARE,
+                getattr(callback, "__name__", repr(callback)),
+                exc,
+            )
+            continue
+        if not isinstance(result, dict):
+            continue
+        if result.get("action") == "block":
+            reason = str(result.get("reason") or "blocked by outbound_message middleware")
+            trace.append(_trace_entry(result))
+            return OutboundMessageResult(
+                text=current_text,
+                original_text=original_text,
+                changed=current_text != original_text,
+                blocked=True,
+                block_reason=reason,
+                trace=trace,
+            )
+        next_text = result.get("text")
+        if not isinstance(next_text, str):
+            continue
+        current_text = next_text
+        trace.append(_trace_entry(result))
+
+    return OutboundMessageResult(
+        text=current_text,
+        original_text=original_text,
+        changed=current_text != original_text,
         trace=trace,
     )
 

--- a/hermes_durability/__init__.py
+++ b/hermes_durability/__init__.py
@@ -1,0 +1,42 @@
+"""hermes_durability — embeddable durable-execution layer for Hermes.
+
+Three guarantees, stdlib-``sqlite3`` only (per the pyproject scope rule that
+core deps must be universal):
+
+  * crash-safe sessions   — fsynced append-only journal (hash chain, torn-tail
+                            detection) + replay recovery (``journal``/``runtime``)
+  * exactly-once outbound — transactional outbox committed atomically with the
+                            journal, idempotency-keyed delivery, retry/DLQ
+                            (``outbox``)
+  * egress guardrails     — mandatory redaction at the outbound platform
+                            boundary, wired at the gateway/cron/tool send choke
+                            points (``egress``), extensible via the
+                            ``outbound_message`` middleware kind
+
+The journal/outbox engine is deliberately framework-agnostic so other agent
+runtimes can embed it; the Hermes-specific wiring lives in ``egress`` and the
+call sites it names.
+"""
+
+from hermes_durability.egress import EgressBlocked, guard_outbound_text
+from hermes_durability.guardrail import Envelope, Guardrail, Rule, Verdict
+from hermes_durability.journal import (ASSISTANT_MESSAGE, COMPACTION_COMPLETE,
+                                       COMPACTION_SNAPSHOT, GUARDRAIL_AUDIT,
+                                       Journal, JournalTransaction,
+                                       OUTBOX_DELIVERED, OUTBOX_ENQUEUED,
+                                       Record, SESSION_START,
+                                       TOOL_CALL_INVOKED, TOOL_CALL_RESULT,
+                                       TXN_COMMIT, USER_MESSAGE)
+from hermes_durability.outbox import Adapter, OutboxWorker, RetryPolicy
+from hermes_durability.runtime import DurableRuntime
+
+__all__ = [
+    "DurableRuntime", "Journal", "JournalTransaction", "Record",
+    "OutboxWorker", "RetryPolicy", "Adapter",
+    "Guardrail", "Rule", "Envelope", "Verdict",
+    "EgressBlocked", "guard_outbound_text",
+    "SESSION_START", "USER_MESSAGE", "ASSISTANT_MESSAGE",
+    "TOOL_CALL_INVOKED", "TOOL_CALL_RESULT", "OUTBOX_ENQUEUED",
+    "OUTBOX_DELIVERED", "TXN_COMMIT", "COMPACTION_SNAPSHOT",
+    "COMPACTION_COMPLETE", "GUARDRAIL_AUDIT",
+]

--- a/hermes_durability/egress.py
+++ b/hermes_durability/egress.py
@@ -1,0 +1,153 @@
+"""Mandatory egress guardrail for outbound platform message bodies.
+
+Hermes applies ``agent.redact`` on ingress (tool results into the model) and
+on display/persistence — but historically never on the bytes actually sent to
+Telegram/Slack/Discord/Matrix. A secret that reaches the assistant's final
+response was delivered verbatim. This module closes that gap at the three
+outbound choke points:
+
+  * ``gateway/platforms/base.py`` ``_send_with_retry`` (gateway replies)
+  * ``gateway/delivery.py`` ``DeliveryTransport.send`` (cron / DeliveryRouter)
+  * ``tools/send_message_tool.py`` ``_send_via_adapter`` (agent-initiated)
+
+Behavior:
+
+  1. Redact the body with ``agent.redact.redact_sensitive_text(force=True)``.
+     ``force=True`` because this is a safety boundary: the user-facing
+     *display* redaction preference must not disable *egress* redaction.
+  2. Re-check a normalized form of the body (ANSI escapes and zero-width
+     characters stripped, NFKC-folded). This defeats obfuscation bypasses
+     where a secret is split by styling sequences, zero-width joiners, or
+     written in full-width forms. If the normalized form reveals a secret
+     that the raw form hid, the *normalized redacted* body is sent instead —
+     losing cosmetic styling is acceptable when it was hiding a credential.
+  3. Consult plugin ``outbound_message`` middleware (fail-open per the
+     middleware contract), which may further rewrite or block the send.
+
+Steps 1–2 are fail-closed: if redaction itself raises, the send is blocked
+(``EgressBlocked``) rather than delivered unexamined.
+
+Opt-out: ``HERMES_EGRESS_GUARDRAIL=false`` disables the whole boundary,
+mirroring the ``HERMES_REDACT_SECRETS`` env convention in ``agent/redact.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import unicodedata
+
+logger = logging.getLogger(__name__)
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)")
+# ZWSP, ZWNJ, ZWJ, word joiner, BOM/zero-width no-break space
+_ZERO_WIDTH_RE = re.compile("[​‌‍⁠﻿]")
+
+
+def _enabled() -> bool:
+    return os.getenv("HERMES_EGRESS_GUARDRAIL", "true").lower() in {
+        "1", "true", "yes", "on",
+    }
+
+
+class EgressBlocked(Exception):
+    """Raised when the egress boundary vetoes an outbound send."""
+
+    def __init__(self, reason: str):
+        super().__init__(reason)
+        self.reason = reason
+
+
+def normalize_for_detection(text: str) -> str:
+    """Strip ANSI/zero-width characters and NFKC-fold for secret detection."""
+    stripped = _ANSI_RE.sub("", text)
+    stripped = _ZERO_WIDTH_RE.sub("", stripped)
+    return unicodedata.normalize("NFKC", stripped)
+
+
+BLOCK_ERROR = "message vetoed by egress guardrail"
+"""Stable error text for blocked sends.
+
+Deliberately free of transport-error vocabulary ("forbidden", "not found",
+"unauthorized"...): SendResult errors flow into ``classify_send_error`` /
+``DeadTargetRegistry`` substring matching, and a *content* veto must never
+mark a delivery *target* dead. Callers should log the detailed reason but
+put only this constant in error strings.
+"""
+
+
+def guard_outbound_text(
+    text: str,
+    *,
+    platform: str = "",
+    session_key: str = "",
+    category: str = "message",
+    apply_middleware: bool = True,
+) -> str:
+    """Redact/inspect an outbound message body immediately before send.
+
+    Returns the (possibly redacted or middleware-rewritten) body to deliver.
+    Raises ``EgressBlocked`` when the send must not happen.
+
+    The built-in redaction pass is idempotent, so layered choke points may
+    repeat it safely. Plugin ``outbound_message`` middleware is NOT assumed
+    idempotent (a footer-appending plugin must not run twice on one body):
+    exactly one boundary per delivery path runs with ``apply_middleware=True``
+    — the platform-adapter ``send``/``edit_message`` wrapper for in-process
+    deliveries, and the relay branch of ``DeliveryTransport.send`` (which
+    never reaches a wrapped adapter method). Pre-chunking or defense-in-depth
+    call sites pass ``apply_middleware=False`` for redaction only.
+    """
+    if not text or not isinstance(text, str) or not _enabled():
+        return text
+
+    try:
+        from agent.redact import redact_sensitive_text
+
+        guarded = redact_sensitive_text(text, force=True)
+        normalized = normalize_for_detection(guarded)
+        if normalized != guarded:
+            # Body contains styling/zero-width/compat characters that could be
+            # hiding a split secret. Detect on the normalized form; if that
+            # reveals anything new, prefer the de-obfuscated redacted body.
+            renormalized = redact_sensitive_text(normalized, force=True)
+            if renormalized != normalized:
+                logger.warning(
+                    "[egress] obfuscated secret detected in outbound %s for %s; "
+                    "sending normalized redacted body",
+                    category, platform or "unknown platform",
+                )
+                guarded = renormalized
+    except EgressBlocked:
+        raise
+    except Exception as exc:
+        # Fail closed: never deliver a body the redactor could not examine.
+        logger.error(
+            "[egress] redaction failed for outbound %s on %s; blocking send",
+            category, platform or "unknown platform", exc_info=True,
+        )
+        raise EgressBlocked(f"egress redaction failed: {exc}") from exc
+
+    if not apply_middleware:
+        return guarded
+
+    try:
+        from hermes_cli.middleware import apply_outbound_message_middleware
+
+        result = apply_outbound_message_middleware(
+            guarded,
+            platform=platform,
+            session_key=session_key,
+            category=category,
+        )
+    except Exception:
+        # Plugin middleware is fail-open by contract; a broken dispatch layer
+        # must not turn the built-in redaction pass into a delivery outage.
+        logger.warning("[egress] outbound_message middleware dispatch failed",
+                       exc_info=True)
+        return guarded
+
+    if result.blocked:
+        raise EgressBlocked(result.block_reason)
+    return result.text

--- a/hermes_durability/guardrail.py
+++ b/hermes_durability/guardrail.py
@@ -1,0 +1,184 @@
+"""Structural egress guardrails (library engine).
+
+NOTE: this engine and its ``DEFAULT_RULES`` serve *standalone* embeddings of
+the durability layer (the ``OutboxWorker`` guardrail hook). Hermes's own
+outbound platform boundary intentionally does NOT use these rules — it runs
+``agent.redact.redact_sensitive_text`` via ``hermes_durability.egress`` so
+there is exactly one authoritative secret-pattern set in the repo.
+
+A mandatory middleware chain evaluated on every outbound envelope before any
+network send: parse -> normalize -> detect -> redact/block/drop -> audit.
+
+Normalization defeats the classic bypasses:
+  * ANSI escape "glue" hiding secrets across styling sequences
+  * zero-width characters splitting tokens
+  * Unicode full-width / CJK-compatibility forms (NFKC folding)
+Detection runs on the normalized text but redaction is applied to the
+original string via span mapping, so legitimate formatting survives.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import time
+import unicodedata
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)")
+ZERO_WIDTH_RE = re.compile("[​‌‍⁠﻿]")
+
+DEFAULT_RULES = [
+    # (policy_id, pattern, action)
+    ("secret.openai-key", r"sk-[A-Za-z0-9_-]{20,}", "redact"),
+    ("secret.anthropic-key", r"sk-ant-[A-Za-z0-9_-]{20,}", "redact"),
+    ("secret.aws-access-key", r"\bAKIA[0-9A-Z]{16}\b", "redact"),
+    ("secret.github-token", r"\bgh[pousr]_[A-Za-z0-9]{20,}\b", "redact"),
+    ("secret.slack-token", r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b", "redact"),
+    ("secret.private-key-block", r"-----BEGIN [A-Z ]*PRIVATE KEY-----", "block"),
+    ("secret.jwt", r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b", "redact"),
+    ("secret.cookie-header", r"(?im)^(?:set-)?cookie\s*:\s*\S+", "redact"),
+    ("secret.env-assignment",
+     r"(?im)\b(?:[A-Z][A-Z0-9_]*_)?(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIALS?)\s*=\s*['\"]?[^\s'\"]{8,}", "redact"),
+    ("secret.bearer", r"(?i)\bbearer\s+[A-Za-z0-9._~+/-]{16,}=*", "redact"),
+]
+
+REDACTION = "[REDACTED:{policy}]"
+
+
+@dataclass
+class Envelope:
+    session_id: str
+    channel: str
+    payload: dict          # must contain "text" (str) for text channels
+    outbox_id: str = ""
+    meta: dict = field(default_factory=dict)
+
+
+@dataclass
+class Verdict:
+    action: str            # "allow" | "redact" | "block" | "drop"
+    envelope: Optional[Envelope]
+    matched_policies: list[str] = field(default_factory=list)
+
+
+class Rule:
+    def __init__(self, policy_id: str, pattern: str, action: str):
+        assert action in ("redact", "block", "drop")
+        self.policy_id = policy_id
+        self.pattern = re.compile(pattern)
+        self.action = action
+
+
+class Guardrail:
+    """Pure evaluation engine plus durable audit hook.
+
+    audit_sink(payload_id, session_id, action, policy_id, envelope_hash)
+    is called (and must persist) BEFORE the verdict is returned, so the
+    audit trail exists before any send is attempted.
+    """
+
+    def __init__(self, rules: Optional[list[Rule]] = None,
+                 audit_sink: Optional[Callable[..., None]] = None):
+        self.rules = rules if rules is not None else [Rule(*r) for r in DEFAULT_RULES]
+        self.audit_sink = audit_sink
+
+    def load_policy_dicts(self, dicts: list[dict]) -> None:
+        """Hot-reload: replace the rule set atomically."""
+        self.rules = [Rule(d["id"], d["pattern"], d["action"]) for d in dicts]
+
+    # -- normalization -----------------------------------------------------
+    @staticmethod
+    def normalize(text: str) -> tuple[str, list[int]]:
+        """Strip ANSI + zero-width chars and NFKC-fold, returning the
+        normalized text and a map: normalized index -> original index."""
+        kept: list[tuple[str, int]] = []
+        i = 0
+        while i < len(text):
+            m = ANSI_RE.match(text, i) or ZERO_WIDTH_RE.match(text, i)
+            if m:
+                i = m.end()
+                continue
+            kept.append((text[i], i))
+            i += 1
+        norm_chars: list[str] = []
+        idx_map: list[int] = []
+        for ch, orig_i in kept:
+            folded = unicodedata.normalize("NFKC", ch)
+            for fch in folded:
+                norm_chars.append(fch)
+                idx_map.append(orig_i)
+        return "".join(norm_chars), idx_map
+
+    # -- evaluation --------------------------------------------------------
+    def evaluate(self, envelope: Envelope) -> Verdict:
+        text = envelope.payload.get("text")
+        if not isinstance(text, str):
+            text = json.dumps(envelope.payload, ensure_ascii=False)
+            structured = True
+        else:
+            structured = False
+
+        norm, idx_map = self.normalize(text)
+        matches: list[tuple[Rule, int, int]] = []
+        for rule in self.rules:
+            for m in rule.pattern.finditer(norm):
+                matches.append((rule, m.start(), m.end()))
+
+        matched_ids = sorted({r.policy_id for r, _, _ in matches})
+        envelope_hash = hashlib.sha256(text.encode()).digest()
+
+        def audit(action: str, policy_id: str) -> None:
+            if self.audit_sink:
+                self.audit_sink(envelope.outbox_id or "-", envelope.session_id,
+                                action, policy_id, envelope_hash)
+
+        for rule, _, _ in matches:
+            if rule.action == "block":
+                audit("block", rule.policy_id)
+                return Verdict("block", None, matched_ids)
+        for rule, _, _ in matches:
+            if rule.action == "drop":
+                audit("drop", rule.policy_id)
+                return Verdict("drop", None, matched_ids)
+
+        if not matches:
+            return Verdict("allow", envelope, [])
+
+        # Redact: map normalized spans back to original offsets.
+        spans: list[tuple[int, int, str]] = []
+        for rule, s, e in matches:
+            if rule.action != "redact":
+                continue
+            orig_s = idx_map[s] if s < len(idx_map) else len(text)
+            orig_e = (idx_map[e - 1] + 1) if e - 1 < len(idx_map) else len(text)
+            spans.append((orig_s, orig_e, rule.policy_id))
+        spans.sort()
+        merged: list[tuple[int, int, str]] = []
+        for s, e, pid in spans:
+            if merged and s <= merged[-1][1]:
+                ps, pe, ppid = merged[-1]
+                merged[-1] = (ps, max(pe, e), ppid)
+            else:
+                merged.append((s, e, pid))
+        out: list[str] = []
+        cursor = 0
+        for s, e, pid in merged:
+            out.append(text[cursor:s])
+            out.append(REDACTION.format(policy=pid))
+            audit("redact", pid)
+            cursor = e
+        out.append(text[cursor:])
+        redacted_text = "".join(out)
+
+        new_payload = dict(envelope.payload)
+        if structured:
+            new_payload = {"text": redacted_text}
+        else:
+            new_payload["text"] = redacted_text
+        return Verdict("redact",
+                       Envelope(envelope.session_id, envelope.channel,
+                                new_payload, envelope.outbox_id, envelope.meta),
+                       matched_ids)

--- a/hermes_durability/journal.py
+++ b/hermes_durability/journal.py
@@ -1,0 +1,427 @@
+"""Append-only SQLite journal with hash chain, transactions, snapshots.
+
+Durability model:
+  * SQLite in WAL mode with synchronous=FULL — every commit is fsynced.
+    (On macOS additionally ``checkpoint_fullfsync=1``: Apple's plain
+    ``fsync`` does not guarantee data-on-platter, mirroring the guard in
+    ``hermes_state.py``.)
+  * Records produced inside a runtime transaction are buffered in memory and
+    written together with the TransactionCommit record in ONE SQLite
+    transaction, so a crash at any point either persists the whole
+    transaction or none of it (no partial-transaction replay needed).
+  * Each record carries a sha256 checksum of its payload and a prev_hash
+    linking it to the previous record (hash chain).  `verify_chain` detects
+    torn tails / corruption and truncates back to the last valid prefix.
+  * Every multi-statement write goes through the ``_txn`` context manager:
+    a failed statement ROLLs BACK instead of wedging the shared connection
+    inside an open transaction (isolation_level=None autocommit mode means
+    an unhandled error would otherwise leave the transaction open and every
+    later BEGIN would fail).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import sys
+import threading
+import time
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any, Iterator, Optional
+
+GENESIS_HASH = b"\x00" * 32
+
+# Record types
+SESSION_START = "SessionStart"
+USER_MESSAGE = "UserMessage"
+ASSISTANT_MESSAGE = "AssistantMessage"
+TOOL_CALL_INVOKED = "ToolCallInvoked"
+TOOL_CALL_RESULT = "ToolCallResult"
+OUTBOX_ENQUEUED = "OutboxEnqueued"
+OUTBOX_DELIVERED = "OutboxDelivered"
+TXN_COMMIT = "TransactionCommit"
+COMPACTION_SNAPSHOT = "CompactionSnapshot"
+COMPACTION_COMPLETE = "CompactionComplete"
+GUARDRAIL_AUDIT = "GuardrailAudit"
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS journal (
+    seq            INTEGER PRIMARY KEY AUTOINCREMENT,
+    record_type    TEXT NOT NULL,
+    session_id     TEXT NOT NULL,
+    transaction_id TEXT,
+    payload        BLOB NOT NULL,
+    checksum       BLOB NOT NULL,
+    prev_hash      BLOB NOT NULL,
+    created_at     REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_journal_session ON journal(session_id, seq);
+
+CREATE TABLE IF NOT EXISTS outbox (
+    outbox_id     TEXT PRIMARY KEY,
+    session_id    TEXT NOT NULL,
+    seq_hint      INTEGER NOT NULL,
+    channel       TEXT NOT NULL,
+    payload       BLOB NOT NULL,
+    status        TEXT NOT NULL DEFAULT 'pending',
+    attempts      INTEGER NOT NULL DEFAULT 0,
+    next_retry_at REAL NOT NULL DEFAULT 0,
+    last_error    TEXT,
+    created_at    REAL NOT NULL,
+    delivered_at  REAL
+);
+CREATE INDEX IF NOT EXISTS idx_outbox_pending ON outbox(session_id, status, seq_hint);
+
+CREATE TABLE IF NOT EXISTS dlq (
+    outbox_id  TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    channel    TEXT NOT NULL,
+    payload    BLOB NOT NULL,
+    error      TEXT,
+    attempts   INTEGER NOT NULL,
+    moved_at   REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS snapshot (
+    snapshot_id TEXT PRIMARY KEY,
+    session_id  TEXT NOT NULL,
+    base_seq    INTEGER NOT NULL,
+    state       BLOB NOT NULL,
+    checksum    BLOB NOT NULL,
+    complete    INTEGER NOT NULL DEFAULT 0,
+    created_at  REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS audit_log (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    payload_id    TEXT NOT NULL,
+    session_id    TEXT NOT NULL,
+    action        TEXT NOT NULL,
+    policy_id     TEXT NOT NULL,
+    envelope_hash BLOB NOT NULL,
+    created_at    REAL NOT NULL
+);
+"""
+
+
+@contextmanager
+def _txn(conn: sqlite3.Connection):
+    """BEGIN IMMEDIATE ... COMMIT with ROLLBACK on any error.
+
+    Never let an exception escape between BEGIN and COMMIT without rolling
+    back — with isolation_level=None the connection would stay inside the
+    open transaction and every subsequent BEGIN would raise "cannot start a
+    transaction within a transaction" until process restart.
+    """
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        yield conn
+    except BaseException:
+        conn.execute("ROLLBACK")
+        raise
+    conn.execute("COMMIT")
+
+
+@dataclass
+class Record:
+    seq: int
+    record_type: str
+    session_id: str
+    transaction_id: Optional[str]
+    payload: dict
+    checksum: bytes
+    prev_hash: bytes
+    created_at: float
+
+
+def _canonical(payload: dict) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+
+
+def _checksum(record_type: str, session_id: str, transaction_id: Optional[str],
+              payload_bytes: bytes, prev_hash: bytes) -> bytes:
+    h = hashlib.sha256()
+    h.update(prev_hash)
+    h.update(record_type.encode())
+    h.update(session_id.encode())
+    h.update((transaction_id or "").encode())
+    h.update(payload_bytes)
+    return h.digest()
+
+
+class Journal:
+    """Owns the SQLite database. Thread-safe; one writer at a time."""
+
+    def __init__(self, db_path: str):
+        self.db_path = db_path
+        self._lock = threading.RLock()
+        self._conn = sqlite3.connect(db_path, check_same_thread=False,
+                                     isolation_level=None)
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA synchronous=FULL")
+        self._conn.execute("PRAGMA foreign_keys=ON")
+        if sys.platform == "darwin":
+            try:
+                self._conn.execute("PRAGMA checkpoint_fullfsync=1")
+            except sqlite3.OperationalError:
+                pass
+        with self._lock:
+            self._conn.executescript(_SCHEMA)
+        self._tip_hash = self._load_tip_hash()
+
+    # -- chain helpers -----------------------------------------------------
+    def _load_tip_hash(self) -> bytes:
+        row = self._conn.execute(
+            "SELECT checksum FROM journal ORDER BY seq DESC LIMIT 1").fetchone()
+        return row[0] if row else GENESIS_HASH
+
+    def verify_chain(self, repair: bool = False) -> tuple[bool, int]:
+        """Walk the chain; return (ok, first_bad_seq or -1).
+
+        With repair=True, truncate the journal at the first corrupt record
+        (torn-tail recovery) and roll back any dependent state.
+        """
+        with self._lock:
+            prev = GENESIS_HASH
+            cur = self._conn.execute(
+                "SELECT seq, record_type, session_id, transaction_id, payload,"
+                " checksum, prev_hash FROM journal ORDER BY seq")
+            for seq, rtype, sid, txid, payload, cksum, prev_hash in cur:
+                expected = _checksum(rtype, sid, txid, payload, prev)
+                if prev_hash != prev or cksum != expected:
+                    if repair:
+                        with _txn(self._conn):
+                            self._conn.execute(
+                                "DELETE FROM journal WHERE seq >= ?", (seq,))
+                        self._tip_hash = self._load_tip_hash()
+                    return False, seq
+                prev = cksum
+            return True, -1
+
+    # -- transactions ------------------------------------------------------
+    def begin(self, session_id: str) -> "JournalTransaction":
+        return JournalTransaction(self, session_id)
+
+    def _commit_records(self, session_id: str, transaction_id: str,
+                        records: list[tuple[str, dict]],
+                        outbox_rows: list[tuple[str, str, dict]],
+                        extra_sql: Optional[list[tuple[str, tuple]]] = None,
+                        ) -> list[int]:
+        """Atomically append `records` + TransactionCommit, insert outbox
+        rows, and run `extra_sql` statements in one fsynced SQLite
+        transaction. Returns assigned seqs.
+
+        `extra_sql` lets callers (e.g. the outbox worker's delivered-mark)
+        make a journal append and a table update atomic — a crash can never
+        observe one without the other.
+        """
+        now = time.time()
+        with self._lock:
+            prev = self._tip_hash
+            with _txn(self._conn):
+                seqs = []
+                all_records = records + [(TXN_COMMIT, {"txn": transaction_id})]
+                for rtype, payload in all_records:
+                    pb = _canonical(payload)
+                    cksum = _checksum(rtype, session_id, transaction_id, pb, prev)
+                    cur = self._conn.execute(
+                        "INSERT INTO journal (record_type, session_id,"
+                        " transaction_id, payload, checksum, prev_hash,"
+                        " created_at) VALUES (?,?,?,?,?,?,?)",
+                        (rtype, session_id, transaction_id, pb, cksum, prev, now))
+                    seqs.append(cur.lastrowid)
+                    prev = cksum
+                for outbox_id, channel, payload in outbox_rows:
+                    self._conn.execute(
+                        "INSERT INTO outbox (outbox_id, session_id, seq_hint,"
+                        " channel, payload, status, created_at)"
+                        " VALUES (?,?,?,?,?,'pending',?)",
+                        (outbox_id, session_id, seqs[-1], channel,
+                         _canonical(payload), now))
+                for sql, params in (extra_sql or []):
+                    self._conn.execute(sql, params)
+            self._tip_hash = prev
+            return seqs
+
+    def append(self, session_id: str, record_type: str, payload: dict,
+               transaction_id: Optional[str] = None,
+               extra_sql: Optional[list[tuple[str, tuple]]] = None) -> int:
+        """Append a single standalone (auto-committed) record, optionally
+        with extra SQL statements in the same atomic transaction."""
+        return self._commit_records(
+            session_id, transaction_id or str(uuid.uuid4()),
+            [(record_type, payload)], [], extra_sql=extra_sql)[0]
+
+    # -- reads -------------------------------------------------------------
+    def records(self, session_id: Optional[str] = None,
+                after_seq: int = 0) -> Iterator[Record]:
+        q = ("SELECT seq, record_type, session_id, transaction_id, payload,"
+             " checksum, prev_hash, created_at FROM journal WHERE seq > ?")
+        args: list[Any] = [after_seq]
+        if session_id:
+            q += " AND session_id = ?"
+            args.append(session_id)
+        q += " ORDER BY seq"
+        with self._lock:
+            rows = self._conn.execute(q, args).fetchall()
+        for r in rows:
+            yield Record(r[0], r[1], r[2], r[3], json.loads(r[4]), r[5], r[6], r[7])
+
+    def committed_transactions(self, session_id: str) -> set[str]:
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT DISTINCT transaction_id FROM journal"
+                " WHERE session_id = ? AND record_type = ?",
+                (session_id, TXN_COMMIT)).fetchall()
+        return {r[0] for r in rows}
+
+    def enqueued_outbox_ids(self) -> set[str]:
+        """outbox_ids with a surviving OutboxEnqueued journal record.
+
+        Exact-match by parsing the canonical JSON payloads — no SQL LIKE
+        (an id containing a wildcard would false-positive, and substring
+        matches are not identity checks).
+        """
+        ids: set[str] = set()
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT payload FROM journal WHERE record_type = ?",
+                (OUTBOX_ENQUEUED,)).fetchall()
+        for (payload,) in rows:
+            try:
+                oid = json.loads(payload).get("outbox_id")
+            except (ValueError, TypeError):
+                continue
+            if isinstance(oid, str):
+                ids.add(oid)
+        return ids
+
+    # -- snapshots / compaction -------------------------------------------
+    def write_snapshot(self, session_id: str, base_seq: int, state: dict) -> str:
+        """Two-phase snapshot: write row (complete=0), fsync, mark complete.
+        Recovery ignores snapshots with complete=0."""
+        snapshot_id = str(uuid.uuid4())
+        sb = _canonical(state)
+        cksum = hashlib.sha256(sb).digest()
+        with self._lock:
+            with _txn(self._conn):
+                self._conn.execute(
+                    "INSERT INTO snapshot (snapshot_id, session_id, base_seq,"
+                    " state, checksum, complete, created_at)"
+                    " VALUES (?,?,?,?,?,0,?)",
+                    (snapshot_id, session_id, base_seq, sb, cksum, time.time()))
+            self.append(session_id, COMPACTION_SNAPSHOT,
+                        {"snapshot_id": snapshot_id, "base_seq": base_seq})
+            self.append(session_id, COMPACTION_COMPLETE,
+                        {"snapshot_id": snapshot_id, "base_seq": base_seq},
+                        extra_sql=[(
+                            "UPDATE snapshot SET complete = 1"
+                            " WHERE snapshot_id = ?", (snapshot_id,))])
+        return snapshot_id
+
+    def latest_snapshot(self, session_id: str) -> Optional[tuple[int, dict]]:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT base_seq, state, checksum FROM snapshot"
+                " WHERE session_id = ? AND complete = 1"
+                " ORDER BY base_seq DESC LIMIT 1", (session_id,)).fetchone()
+        if not row:
+            return None
+        base_seq, state, cksum = row
+        if hashlib.sha256(state).digest() != cksum:
+            return None
+        return base_seq, json.loads(state)
+
+    def compact(self, session_id: str, state: dict,
+                keep_after_seq: Optional[int] = None) -> str:
+        """Snapshot current state, then delete journal records the snapshot
+        covers (except outbox-relevant records still pending).
+
+        The DELETE and the hash-chain re-root happen in ONE SQLite
+        transaction: a crash between them would otherwise leave surviving
+        records whose prev_hash points at deleted rows, and the next
+        verify_chain(repair=True) would truncate the entire surviving
+        journal — silently dropping fsync-durable state.
+        """
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT MAX(seq) FROM journal WHERE session_id = ?",
+                (session_id,)).fetchone()
+            base_seq = row[0] or 0
+            sid = self.write_snapshot(session_id, base_seq, state)
+            cutoff = keep_after_seq if keep_after_seq is not None else base_seq
+            with _txn(self._conn):
+                self._conn.execute(
+                    "DELETE FROM journal WHERE session_id = ? AND seq <= ?"
+                    " AND record_type NOT IN (?,?,?,?)",
+                    (session_id, cutoff, COMPACTION_SNAPSHOT,
+                     COMPACTION_COMPLETE, OUTBOX_ENQUEUED, OUTBOX_DELIVERED))
+                # Chain is intentionally re-rooted after compaction (same
+                # transaction as the DELETE): the snapshot checksum vouches
+                # for the deleted prefix.
+                prev = GENESIS_HASH
+                rows = self._conn.execute(
+                    "SELECT seq, record_type, session_id, transaction_id,"
+                    " payload FROM journal ORDER BY seq").fetchall()
+                for seq, rtype, rsid, txid, payload in rows:
+                    cksum = _checksum(rtype, rsid, txid, payload, prev)
+                    self._conn.execute(
+                        "UPDATE journal SET checksum = ?, prev_hash = ?"
+                        " WHERE seq = ?", (cksum, prev, seq))
+                    prev = cksum
+            self._tip_hash = prev
+        return sid
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()
+
+
+class JournalTransaction:
+    """Buffers records in memory; nothing is durable until commit()."""
+
+    def __init__(self, journal: Journal, session_id: str):
+        self.journal = journal
+        self.session_id = session_id
+        self.transaction_id = str(uuid.uuid4())
+        self._records: list[tuple[str, dict]] = []
+        self._outbox: list[tuple[str, str, dict]] = []
+        self._done = False
+
+    def record(self, record_type: str, payload: dict) -> None:
+        assert not self._done, "transaction already finished"
+        self._records.append((record_type, payload))
+
+    def enqueue_outbound(self, channel: str, payload: dict,
+                         outbox_id: Optional[str] = None) -> str:
+        assert not self._done, "transaction already finished"
+        outbox_id = outbox_id or str(uuid.uuid4())
+        self._records.append((OUTBOX_ENQUEUED, {
+            "outbox_id": outbox_id, "channel": channel, "payload": payload}))
+        self._outbox.append((outbox_id, channel, payload))
+        return outbox_id
+
+    def commit(self) -> list[int]:
+        assert not self._done, "transaction already finished"
+        self._done = True
+        return self.journal._commit_records(
+            self.session_id, self.transaction_id, self._records, self._outbox)
+
+    def rollback(self) -> None:
+        self._done = True
+        self._records.clear()
+        self._outbox.clear()
+
+    def __enter__(self) -> "JournalTransaction":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self._done:
+            return
+        if exc_type is None:
+            self.commit()
+        else:
+            self.rollback()

--- a/hermes_durability/outbox.py
+++ b/hermes_durability/outbox.py
@@ -1,0 +1,237 @@
+"""Outbox worker: exactly-once outbound delivery.
+
+Rows are enqueued atomically with the journal transaction that produced
+them (see JournalTransaction.enqueue_outbound).  The worker drains rows
+per-session in enqueue order, passes each envelope through the guardrail,
+sends via an adapter using outbox_id as the idempotency key, and records
+OutboxDelivered in the journal in the SAME SQLite transaction that flips
+the row to its terminal status — a crash can never observe one without
+the other.
+
+Concurrency/crash model:
+  * A row is CLAIMED (status 'pending' -> 'inflight') before its send is
+    attempted, so a background worker tick and a synchronous drain (e.g.
+    recovery) can never both deliver the same row.  ``drain_once`` is
+    additionally serialized by a lock.
+  * A crash while a row is 'inflight' means the send outcome is unknown;
+    startup resets 'inflight' -> 'pending' and retries.  The adapter-level
+    idempotency key (outbox_id) makes that retry safe.
+
+Exactly-once therefore reduces to: at-least-once delivery attempts +
+adapter-level idempotency keyed on outbox_id.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from typing import Callable, Optional, Protocol
+
+from hermes_durability.guardrail import Envelope, Guardrail
+from hermes_durability.journal import Journal, OUTBOX_DELIVERED, _canonical, _txn
+
+
+class Adapter(Protocol):
+    """Transport adapter. send() MUST be idempotent on idempotency_key
+    (map it to Slack client_msg_id, Discord nonce, email Message-ID,
+    webhook Idempotency-Key header...). Raise on failure."""
+
+    def send(self, envelope: Envelope, idempotency_key: str) -> dict: ...
+
+
+class RetryPolicy:
+    def __init__(self, base_delay: float = 0.5, max_delay: float = 60.0,
+                 max_attempts: int = 8):
+        self.base_delay = base_delay
+        self.max_delay = max_delay
+        self.max_attempts = max_attempts
+
+    def next_delay(self, attempts: int) -> float:
+        return min(self.max_delay, self.base_delay * (2 ** max(0, attempts - 1)))
+
+
+class OutboxWorker:
+    def __init__(self, journal: Journal, adapters: dict[str, Adapter],
+                 guardrail: Optional[Guardrail] = None,
+                 retry: Optional[RetryPolicy] = None,
+                 on_dead_letter: Optional[Callable[[str, str], None]] = None):
+        self.journal = journal
+        self.adapters = adapters
+        self.guardrail = guardrail
+        self.retry = retry or RetryPolicy()
+        self.on_dead_letter = on_dead_letter
+        self._drain_lock = threading.Lock()
+        self._wake = threading.Event()
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+
+    # -- lifecycle ---------------------------------------------------------
+    def start(self) -> None:
+        self._thread = threading.Thread(target=self._run, daemon=True,
+                                        name="hermes-durable-outbox")
+        self._thread.start()
+
+    def stop(self, timeout: float = 5.0) -> None:
+        self._stop.set()
+        self._wake.set()
+        if self._thread:
+            self._thread.join(timeout)
+
+    def signal(self) -> None:
+        """Called by the runtime after every commit that enqueued rows."""
+        self._wake.set()
+
+    def reset_inflight(self) -> int:
+        """Startup: rows claimed by a crashed process go back to pending."""
+        conn = self.journal._conn
+        with self.journal._lock:
+            with _txn(conn):
+                cur = conn.execute(
+                    "UPDATE outbox SET status = 'pending'"
+                    " WHERE status = 'inflight'")
+            return cur.rowcount
+
+    # -- draining ----------------------------------------------------------
+    def drain_once(self, now: Optional[float] = None) -> int:
+        """Process all currently-eligible rows once. Returns rows delivered.
+        Safe to call synchronously (used by recovery and tests); serialized
+        against the background worker by ``_drain_lock`` and per-row claims.
+        """
+        with self._drain_lock:
+            return self._drain_locked(now)
+
+    def _drain_locked(self, now: Optional[float]) -> int:
+        now = now if now is not None else time.time()
+        conn = self.journal._conn
+        with self.journal._lock:
+            rows = conn.execute(
+                "SELECT outbox_id, session_id, channel, payload, attempts"
+                " FROM outbox WHERE status = 'pending' AND next_retry_at <= ?"
+                " ORDER BY session_id, seq_hint", (now,)).fetchall()
+        delivered = 0
+        # Strict per-session ordering: once a session's row fails, skip the
+        # rest of that session's rows this pass.
+        blocked_sessions: set[str] = set()
+        for outbox_id, session_id, channel, payload, attempts in rows:
+            if session_id in blocked_sessions:
+                continue
+            if not self._claim(outbox_id):
+                continue  # another drainer got it between SELECT and claim
+            envelope = Envelope(session_id=session_id, channel=channel,
+                                payload=json.loads(payload),
+                                outbox_id=outbox_id)
+            if not self._deliver(envelope, attempts):
+                blocked_sessions.add(session_id)
+            else:
+                delivered += 1
+        return delivered
+
+    def _claim(self, outbox_id: str) -> bool:
+        conn = self.journal._conn
+        with self.journal._lock:
+            with _txn(conn):
+                cur = conn.execute(
+                    "UPDATE outbox SET status = 'inflight'"
+                    " WHERE outbox_id = ? AND status = 'pending'",
+                    (outbox_id,))
+            return cur.rowcount == 1
+
+    def _deliver(self, envelope: Envelope, attempts: int) -> bool:
+        outbox_id = envelope.outbox_id
+        session_id = envelope.session_id
+
+        if self.guardrail is not None:
+            verdict = self.guardrail.evaluate(envelope)
+            if verdict.action in ("block", "drop"):
+                self._finalize(outbox_id, session_id,
+                               status="blocked",
+                               detail={"guardrail": verdict.action,
+                                       "policies": verdict.matched_policies})
+                return True
+            envelope = verdict.envelope or envelope
+
+        adapter = self.adapters.get(envelope.channel)
+        if adapter is None:
+            self._fail(outbox_id, session_id, envelope, attempts,
+                       f"no adapter for channel {envelope.channel!r}")
+            return False
+        try:
+            receipt = adapter.send(envelope, idempotency_key=outbox_id)
+        except Exception as exc:  # noqa: BLE001 - transport errors are data
+            self._fail(outbox_id, session_id, envelope, attempts, repr(exc))
+            return False
+        self._finalize(outbox_id, session_id, status="delivered",
+                       detail={"receipt": receipt})
+        return True
+
+    def _finalize(self, outbox_id: str, session_id: str, status: str,
+                  detail: dict) -> None:
+        """Journal OutboxDelivered and mark the row terminal in ONE
+        transaction (via Journal.append extra_sql) — a crash between the
+        two would otherwise leave a journaled delivery with a still-pending
+        row, and the retry would append a duplicate OutboxDelivered."""
+        self.journal.append(
+            session_id, OUTBOX_DELIVERED,
+            {"outbox_id": outbox_id, "status": status, **detail},
+            extra_sql=[(
+                "UPDATE outbox SET status = ?, delivered_at = ?"
+                " WHERE outbox_id = ?",
+                (status, time.time(), outbox_id))])
+
+    def _fail(self, outbox_id: str, session_id: str, envelope: Envelope,
+              attempts: int, error: str) -> None:
+        attempts += 1
+        conn = self.journal._conn
+        with self.journal._lock:
+            if attempts >= self.retry.max_attempts:
+                with _txn(conn):
+                    conn.execute(
+                        "INSERT OR REPLACE INTO dlq (outbox_id, session_id,"
+                        " channel, payload, error, attempts, moved_at)"
+                        " VALUES (?,?,?,?,?,?,?)",
+                        (outbox_id, session_id, envelope.channel,
+                         _canonical(envelope.payload), error, attempts,
+                         time.time()))
+                    conn.execute(
+                        "UPDATE outbox SET status = 'deadletter', attempts = ?,"
+                        " last_error = ? WHERE outbox_id = ?",
+                        (attempts, error, outbox_id))
+                if self.on_dead_letter:
+                    self.on_dead_letter(outbox_id, error)
+            else:
+                delay = self.retry.next_delay(attempts)
+                with _txn(conn):
+                    conn.execute(
+                        "UPDATE outbox SET status = 'pending', attempts = ?,"
+                        " last_error = ?, next_retry_at = ?"
+                        " WHERE outbox_id = ?",
+                        (attempts, error, time.time() + delay, outbox_id))
+
+    def replay_dead_letter(self, outbox_id: str) -> bool:
+        conn = self.journal._conn
+        with self.journal._lock:
+            row = conn.execute(
+                "SELECT outbox_id FROM dlq WHERE outbox_id = ?",
+                (outbox_id,)).fetchone()
+            if not row:
+                return False
+            with _txn(conn):
+                conn.execute(
+                    "UPDATE outbox SET status = 'pending', attempts = 0,"
+                    " next_retry_at = 0, last_error = NULL WHERE outbox_id = ?",
+                    (outbox_id,))
+                conn.execute("DELETE FROM dlq WHERE outbox_id = ?", (outbox_id,))
+        self.signal()
+        return True
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            self._wake.wait(timeout=0.25)
+            self._wake.clear()
+            if self._stop.is_set():
+                break
+            try:
+                self.drain_once()
+            except Exception:  # pragma: no cover - worker must not die
+                time.sleep(0.5)

--- a/hermes_durability/runtime.py
+++ b/hermes_durability/runtime.py
@@ -1,0 +1,143 @@
+"""DurableRuntime: the embeddable facade.
+
+    rt = DurableRuntime("agent.db", adapters={"slack": SlackAdapter(...)})
+    rt.recover()                      # crash-safe resume + drain pending sends
+    with rt.transaction(session_id) as txn:
+        txn.record(USER_MESSAGE, {...})
+        txn.record(TOOL_CALL_INVOKED, {...})
+        txn.enqueue_outbound("slack", {"text": reply})
+    # commit fsyncs journal + outbox atomically; worker delivers with
+    # guardrails + idempotency keys.
+
+Startup integrity runs in __init__ BEFORE the background worker starts:
+chain verification (torn-tail repair), orphaned-outbox cleanup, and
+inflight-claim reset all complete before any thread can pick up a row, so
+the worker can never deliver a row whose journal context is about to be
+truncated. ``recover()`` then only drains and reports.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Optional
+
+from hermes_durability.guardrail import Guardrail
+from hermes_durability.journal import (Journal, JournalTransaction,
+                                       OUTBOX_DELIVERED, TXN_COMMIT, _txn)
+from hermes_durability.outbox import Adapter, OutboxWorker, RetryPolicy
+
+
+class DurableRuntime:
+    def __init__(self, db_path: str, adapters: Optional[dict[str, Adapter]] = None,
+                 guardrail: Optional[Guardrail] = None,
+                 retry: Optional[RetryPolicy] = None,
+                 start_worker: bool = True):
+        self.journal = Journal(db_path)
+        self.guardrail = guardrail or Guardrail(audit_sink=self._audit_sink)
+        if self.guardrail.audit_sink is None:
+            self.guardrail.audit_sink = self._audit_sink
+        self.worker = OutboxWorker(self.journal, adapters or {},
+                                   guardrail=self.guardrail, retry=retry)
+        self._startup_report = self._verify_and_clean()
+        self._worker_started = False
+        if start_worker:
+            self.worker.start()
+            self._worker_started = True
+
+    # -- audit -------------------------------------------------------------
+    def _audit_sink(self, payload_id: str, session_id: str, action: str,
+                    policy_id: str, envelope_hash: bytes) -> None:
+        conn = self.journal._conn
+        with self.journal._lock:
+            with _txn(conn):
+                conn.execute(
+                    "INSERT INTO audit_log (payload_id, session_id, action,"
+                    " policy_id, envelope_hash, created_at)"
+                    " VALUES (?,?,?,?,?,?)",
+                    (payload_id, session_id, action, policy_id, envelope_hash,
+                     time.time()))
+
+    # -- API ---------------------------------------------------------------
+    def transaction(self, session_id: str) -> JournalTransaction:
+        txn = self.journal.begin(session_id)
+        original_commit = txn.commit
+
+        def commit_and_signal() -> list[int]:
+            seqs = original_commit()
+            self.worker.signal()
+            return seqs
+
+        txn.commit = commit_and_signal  # type: ignore[method-assign]
+        return txn
+
+    def _verify_and_clean(self) -> dict:
+        """Chain verify/repair + outbox consistency, BEFORE any delivery.
+
+        Orphan cleanup compares outbox rows against surviving OutboxEnqueued
+        journal records by exact id (enqueue and journal are one SQLite
+        transaction, so an orphan can only exist after a torn-tail
+        truncation removed its journal context — delivering it would be a
+        ghost send of a transaction that officially never committed).
+        """
+        ok, bad_seq = self.journal.verify_chain(repair=True)
+        conn = self.journal._conn
+        with self.journal._lock:
+            orphaned = []
+            if not ok:
+                enqueued = self.journal.enqueued_outbox_ids()
+                rows = conn.execute(
+                    "SELECT outbox_id FROM outbox"
+                    " WHERE status IN ('pending', 'inflight')").fetchall()
+                orphaned = [oid for (oid,) in rows if oid not in enqueued]
+                if orphaned:
+                    with _txn(conn):
+                        for oid in orphaned:
+                            conn.execute(
+                                "DELETE FROM outbox WHERE outbox_id = ?",
+                                (oid,))
+        reset = self.worker.reset_inflight()
+        return {"chain_ok": ok, "truncated_at": bad_seq if not ok else None,
+                "orphaned_outbox_discarded": len(orphaned),
+                "inflight_reset": reset}
+
+    def recover(self) -> dict:
+        """Drain committed-but-undelivered sends and report startup state.
+
+        Integrity repair already ran in __init__; idempotency keys make the
+        redelivery of possibly-already-sent rows safe.
+        """
+        conn = self.journal._conn
+        with self.journal._lock:
+            pending = conn.execute(
+                "SELECT COUNT(*) FROM outbox WHERE status = 'pending'"
+            ).fetchone()[0]
+        delivered = self.worker.drain_once() if pending else 0
+        report = dict(self._startup_report)
+        report.update({"pending_outbox": pending,
+                       "delivered_on_recovery": delivered})
+        return report
+
+    def replay_state(self, session_id: str) -> dict:
+        """Rebuild session state: latest complete snapshot + committed
+        transactions after it. Uncommitted transactions are discarded."""
+        snap = self.journal.latest_snapshot(session_id)
+        state: dict = snap[1] if snap else {"messages": [], "delivered": []}
+        base_seq = snap[0] if snap else 0
+        committed = self.journal.committed_transactions(session_id)
+        for rec in self.journal.records(session_id, after_seq=base_seq):
+            if rec.record_type == TXN_COMMIT:
+                continue
+            if rec.transaction_id not in committed:
+                continue  # uncommitted -> discard
+            if rec.record_type == OUTBOX_DELIVERED:
+                state.setdefault("delivered", []).append(rec.payload)
+            elif rec.record_type not in ("CompactionSnapshot",
+                                         "CompactionComplete"):
+                state.setdefault("messages", []).append(
+                    {"type": rec.record_type, **rec.payload})
+        return state
+
+    def close(self) -> None:
+        if self._worker_started:
+            self.worker.stop()
+        self.journal.close()

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -677,8 +677,8 @@ def _apply_macos_checkpoint_barrier(conn: sqlite3.Connection) -> None:
         pass
 
 
-def _enforce_macos_synchronous_full(conn: sqlite3.Connection) -> None:
-    """Enforce ``PRAGMA synchronous=FULL`` on macOS to prevent btree corruption.
+def _enforce_synchronous_full(conn: sqlite3.Connection) -> None:
+    """Enforce ``PRAGMA synchronous=FULL`` (all platforms; overridable) on state.db.
 
     On Darwin, the default ``synchronous=NORMAL`` only calls ``fsync()``,
     which Apple's fsync(2) man page explicitly states does *not* guarantee
@@ -697,12 +697,27 @@ def _enforce_macos_synchronous_full(conn: sqlite3.Connection) -> None:
     an existing WAL mode). It ensures macOS connections always use FULL
     synchronous mode, even if a prior connection set ``synchronous=NORMAL``.
 
+    Non-macOS platforms now also get ``synchronous=FULL`` by default: the
+    WAL default of ``NORMAL`` means a committed transcript turn can be lost
+    on power loss / kernel panic (fine for a cache, not for the canonical
+    session store — ``hermes_cli/kanban_db.py`` and ``cron/executions.py``
+    already use FULL unconditionally; ``state.db`` was the outlier).
+    Operators on non-macOS platforms who prefer the old throughput
+    trade-off can set ``HERMES_DB_SYNCHRONOUS=normal`` (or ``off``) to
+    override. On Darwin the override is floored at FULL (``extra`` is still
+    allowed): weakening below FULL there re-opens the exact btree-corruption
+    window (#30636) this guard exists to close, so it must not be reachable
+    via an env var framed as a throughput knob.
+
     Best-effort: never raises.
     """
-    if sys.platform != "darwin":
-        return
+    level = os.getenv("HERMES_DB_SYNCHRONOUS", "full").strip().lower()
+    if level not in {"full", "normal", "off", "extra"}:
+        level = "full"
+    if sys.platform == "darwin" and level in {"normal", "off"}:
+        level = "full"
     try:
-        conn.execute("PRAGMA synchronous=FULL")
+        conn.execute(f"PRAGMA synchronous={level.upper()}")
     except sqlite3.OperationalError:
         pass
 
@@ -849,7 +864,7 @@ def apply_wal_with_fallback(
     current_mode = _on_disk_journal_mode(conn)
     if current_mode == "wal":
         _apply_macos_checkpoint_barrier(conn)
-        _enforce_macos_synchronous_full(conn)
+        _enforce_synchronous_full(conn)
         return "wal"
 
     # #68545: honor the canonical database.journal_mode setting. Existing
@@ -889,7 +904,7 @@ def apply_wal_with_fallback(
         mode = str(row[0]).strip().lower() if row and row[0] is not None else ""
         if mode == "wal":
             _apply_macos_checkpoint_barrier(conn)
-            _enforce_macos_synchronous_full(conn)
+            _enforce_synchronous_full(conn)
             return "wal"
         # Silent refusal (macOS NFS / SMB / AgentFS overlay): WAL was not
         # honored, but nothing raised.
@@ -937,7 +952,7 @@ def apply_wal_with_fallback(
                 )
                 if mode == "wal":
                     _apply_macos_checkpoint_barrier(conn)
-                    _enforce_macos_synchronous_full(conn)
+                    _enforce_synchronous_full(conn)
                     return "wal"
                 break
         # Don't downgrade if another process already set WAL on disk, or if
@@ -1016,7 +1031,7 @@ def _apply_delete_for_wal_reset_bug(
         # still hold this WAL DB open — same safety rule as the NFS path.
         _log_wal_reset_bug_once(db_label, kept_wal=True)
         _apply_macos_checkpoint_barrier(conn)
-        _enforce_macos_synchronous_full(conn)
+        _enforce_synchronous_full(conn)
         return "wal"
 
     if current is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -396,7 +396,7 @@ py-modules = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "cron.*", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]
+include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "cron.*", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*", "hermes_durability", "hermes_durability.*"]
 
 [tool.setuptools.package-data]
 hermes_cli = ["observability/schemas/*.json"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -249,6 +249,11 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     # into the next test. See ``_audio_playback_guard`` for the second layer.
     "HERMES_VOICE",
     "HERMES_VOICE_TTS",
+    # Egress/durability knobs: a developer shell exporting
+    # HERMES_EGRESS_GUARDRAIL=false (or a weakened HERMES_DB_SYNCHRONOUS)
+    # must not silently disable the boundary the egress tests assert on.
+    "HERMES_EGRESS_GUARDRAIL",
+    "HERMES_DB_SYNCHRONOUS",
     "HERMES_YOLO_MODE",
     "HERMES_INTERACTIVE",
     "HERMES_QUIET",

--- a/tests/hermes_durability/crash_child.py
+++ b/tests/hermes_durability/crash_child.py
@@ -1,0 +1,66 @@
+"""Workload child for crash-injection tests.
+
+Runs agent-like turns forever: journal a user message + tool call, enqueue
+an outbound message, commit, deliver via a file-based idempotent receiver.
+The parent kill -9s this process at a random moment.
+
+Usage: python crash_child.py <db_path> <receiver_dir>
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from hermes_durability import (DurableRuntime, TOOL_CALL_INVOKED, USER_MESSAGE)
+from hermes_durability.guardrail import Envelope
+
+
+class FileReceiver:
+    """External service simulated on disk; idempotent on key.
+
+    Writes are atomic (tmp + rename) so the receiver itself can't be torn.
+    """
+
+    def __init__(self, root: str):
+        self.root = root
+
+    def send(self, envelope: Envelope, idempotency_key: str) -> dict:
+        path = os.path.join(self.root, idempotency_key + ".json")
+        if not os.path.exists(path):
+            tmp = path + ".tmp"
+            with open(tmp, "w") as f:
+                json.dump(envelope.payload, f)
+                f.flush()
+                os.fsync(f.fileno())
+            os.rename(tmp, path)
+        return {"id": idempotency_key}
+
+
+def main() -> None:
+    db_path, receiver_dir = sys.argv[1], sys.argv[2]
+    rt = DurableRuntime(db_path, adapters={"file": FileReceiver(receiver_dir)},
+                        start_worker=False)
+    report = rt.recover()
+    print("RECOVERED", json.dumps(report), flush=True)
+
+    state = rt.replay_state("s1")
+    n = sum(1 for m in state.get("messages", [])
+            if m.get("type") == USER_MESSAGE)
+    while True:
+        with rt.transaction("s1") as txn:
+            txn.record(USER_MESSAGE, {"text": f"user turn {n}", "n": n})
+            txn.record(TOOL_CALL_INVOKED, {"tool": "search", "n": n})
+            txn.enqueue_outbound("file", {"text": f"reply {n}", "n": n},
+                                 outbox_id=f"turn-{n}")
+        rt.worker.drain_once()
+        print(f"TURN {n}", flush=True)
+        n += 1
+        if n % 25 == 0:  # exercise compaction under crashes too
+            rt.journal.compact("s1", rt.replay_state("s1"))
+            print(f"COMPACTED {n}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/hermes_durability/test_crash_injection.py
+++ b/tests/hermes_durability/test_crash_injection.py
@@ -1,0 +1,111 @@
+"""Conformance: kill -9 the workload at random points; verify on restart:
+
+  I1  hash chain valid (possibly after torn-tail repair)
+  I2  replay state contains only committed transactions, contiguous turns
+  I3  every delivered receipt exists exactly once (idempotency)
+  I4  every receipt on the receiver corresponds to a committed enqueue
+  I5  recovery drains any send that committed but hadn't delivered
+"""
+
+import json
+import os
+import random
+import signal
+import subprocess
+import sys
+import time
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from hermes_durability import DurableRuntime, USER_MESSAGE
+
+CHILD = os.path.join(os.path.dirname(__file__), "crash_child.py")
+ROUNDS = int(os.environ.get("CRASH_ROUNDS", "12"))
+
+
+def run_and_kill(db, recv_dir, delay: float) -> None:
+    proc = subprocess.Popen([sys.executable, CHILD, db, recv_dir],
+                            stdout=subprocess.DEVNULL,
+                            stderr=subprocess.DEVNULL)
+    time.sleep(delay)
+    os.kill(proc.pid, signal.SIGKILL)
+    proc.wait()
+
+
+def verify_invariants(db, recv_dir) -> dict:
+    rt = DurableRuntime(db, start_worker=False)
+    ok, bad = rt.journal.verify_chain(repair=True)
+    ok2, _ = rt.journal.verify_chain()
+    assert ok2, "chain must be valid after repair"
+
+    state = rt.replay_state("s1")
+    turns = sorted(m["n"] for m in state.get("messages", [])
+                   if m.get("type") == USER_MESSAGE)
+    # I2: committed turns are contiguous from the last compaction point
+    if turns:
+        assert turns == list(range(turns[0], turns[0] + len(turns))), \
+            f"non-contiguous committed turns: {turns}"
+
+    receipts = sorted(os.listdir(recv_dir))
+    # I3: receiver files are keyed by outbox_id -> inherently unique
+    payload_ns = set()
+    for r in receipts:
+        if r.endswith(".tmp"):
+            continue
+        with open(os.path.join(recv_dir, r)) as f:
+            payload_ns.add(json.load(f)["n"])
+    assert len(payload_ns) == len([r for r in receipts if r.endswith(".json")])
+
+    # I4: every receipt corresponds to a committed enqueue in the journal
+    enqueued = set()
+    for rec in rt.journal.records("s1"):
+        if rec.record_type == "OutboxEnqueued":
+            enqueued.add(rec.payload["outbox_id"])
+    committed_outbox = {
+        row[0] for row in rt.journal._conn.execute(
+            "SELECT outbox_id FROM outbox").fetchall()}
+    for r in receipts:
+        if r.endswith(".json"):
+            key = r[:-5]
+            assert key in committed_outbox or key in enqueued, \
+                f"receiver has receipt {key} with no committed enqueue (ghost send)"
+    n_msgs = len(state.get("messages", []))
+    rt.close()
+    return {"turns": len(turns), "receipts": len(receipts), "chain_ok": ok,
+            "messages": n_msgs}
+
+
+@pytest.mark.live_system_guard_bypass
+@pytest.mark.parametrize("seed", range(ROUNDS))
+def test_kill9_at_random_points(tmp_path, seed):
+    random.seed(seed)
+    db = str(tmp_path / "crash.db")
+    recv_dir = str(tmp_path / "recv")
+    os.makedirs(recv_dir, exist_ok=True)
+    # several crash/restart cycles per scenario
+    for cycle in range(3):
+        delay = random.uniform(0.05, 1.2)
+        run_and_kill(db, recv_dir, delay)
+        verify_invariants(db, recv_dir)
+    # final full recovery: pending sends must drain (I5)
+    rt = DurableRuntime(db, start_worker=False)
+
+    class Recv:
+        def __init__(self, root):
+            self.root = root
+
+        def send(self, envelope, idempotency_key):
+            path = os.path.join(self.root, idempotency_key + ".json")
+            if not os.path.exists(path):
+                with open(path, "w") as f:
+                    json.dump(envelope.payload, f)
+            return {"id": idempotency_key}
+
+    rt.worker.adapters["file"] = Recv(recv_dir)
+    rt.recover()
+    pending = rt.journal._conn.execute(
+        "SELECT COUNT(*) FROM outbox WHERE status='pending'").fetchone()[0]
+    assert pending == 0, "recovery must drain all committed pending sends"
+    rt.close()

--- a/tests/hermes_durability/test_egress.py
+++ b/tests/hermes_durability/test_egress.py
@@ -1,0 +1,134 @@
+"""Egress guardrail boundary: redaction, obfuscation bypasses, middleware."""
+
+import pytest
+
+from hermes_durability.egress import (EgressBlocked, guard_outbound_text,
+                                      normalize_for_detection)
+
+GHP = "ghp_AbCdEfGhIjKlMnOpQrStUvWxYz0123456789"
+
+
+def test_plain_text_passes_through():
+    assert guard_outbound_text("hello world", platform="telegram") == "hello world"
+
+
+def test_secret_redacted_at_egress():
+    out = guard_outbound_text(f"your token is {GHP}", platform="telegram")
+    assert GHP not in out
+    assert "your token is" in out
+
+
+def test_ansi_glue_bypass_defeated():
+    # secret body split by ANSI styling sequences hides it from a raw regex
+    glued = f"ghp_AbCdEfGh\x1b[31mIjKlMnOpQrStUvWxYz\x1b[0m0123456789"
+    out = guard_outbound_text(f"token {glued}", platform="telegram")
+    assert "IjKlMnOpQrStUvWxYz" not in out
+
+
+def test_zero_width_split_defeated():
+    glued = "ghp_AbCdEfGh​IjKlMnOpQrStUvWxYz‍0123456789"
+    out = guard_outbound_text(f"token {glued}", platform="telegram")
+    assert "IjKlMnOpQrStUvWxYz" not in out
+
+
+def test_fullwidth_forms_defeated():
+    # full-width latin NFKC-folds back to ascii before detection
+    fullwidth = "ｇｈｐ＿" + "ＡｂＣｄＥｆＧｈＩｊＫｌＭｎＯｐＱｒＳｔ" + "０１２３４５６７８９"
+    out = guard_outbound_text(f"token {fullwidth}", platform="telegram")
+    assert "ＡｂＣｄＥｆＧｈ" not in out
+
+
+def test_normalize_for_detection():
+    assert normalize_for_detection("a\x1b[1mb​c") == "abc"
+    assert normalize_for_detection("ＡＢＣ") == "ABC"
+
+
+def test_disabled_via_env(monkeypatch):
+    monkeypatch.setenv("HERMES_EGRESS_GUARDRAIL", "false")
+    text = f"token {GHP}"
+    assert guard_outbound_text(text, platform="telegram") == text
+
+
+def test_fail_closed_when_redactor_raises(monkeypatch):
+    import agent.redact as redact_mod
+
+    def boom(*a, **k):
+        raise RuntimeError("redactor broke")
+
+    monkeypatch.setattr(redact_mod, "redact_sensitive_text", boom)
+    with pytest.raises(EgressBlocked):
+        guard_outbound_text("anything", platform="telegram")
+
+
+def _install_callbacks(monkeypatch, callbacks):
+    import hermes_cli.middleware as mw
+    import hermes_cli.plugins as plugins_mod
+
+    monkeypatch.setattr(plugins_mod, "has_middleware",
+                        lambda kind: kind == "outbound_message")
+    monkeypatch.setattr(mw, "_get_middleware_callbacks",
+                        lambda kind: list(callbacks))
+
+
+def test_middleware_can_rewrite(monkeypatch):
+    _install_callbacks(monkeypatch,
+                       [lambda **kw: {"text": kw["text"] + " [checked]",
+                                      "source": "test-plugin"}])
+    out = guard_outbound_text("hello", platform="telegram")
+    assert out == "hello [checked]"
+
+
+def test_middleware_can_block(monkeypatch):
+    _install_callbacks(monkeypatch,
+                       [lambda **kw: {"action": "block",
+                                      "reason": "policy says no"}])
+    with pytest.raises(EgressBlocked, match="policy says no"):
+        guard_outbound_text("hello", platform="telegram")
+
+
+def test_middleware_chains_sequentially(monkeypatch):
+    # Each callback must see the PREVIOUS callback's rewrite — last-writer-
+    # wins over the original body would silently drop a security rewrite.
+    _install_callbacks(monkeypatch, [
+        lambda **kw: {"text": kw["text"].replace("PII", "[scrubbed]")},
+        lambda **kw: {"text": kw["text"] + " -- footer"},
+    ])
+    out = guard_outbound_text("has PII inside", platform="telegram")
+    assert out == "has [scrubbed] inside -- footer"
+
+
+def test_middleware_raising_callback_skipped_fail_open(monkeypatch):
+    def boom(**kw):
+        raise RuntimeError("plugin bug")
+
+    _install_callbacks(monkeypatch, [
+        boom,
+        lambda **kw: {"text": kw["text"] + " [ok]"},
+    ])
+    assert guard_outbound_text("hello", platform="telegram") == "hello [ok]"
+
+
+def test_apply_middleware_false_skips_plugins(monkeypatch):
+    _install_callbacks(monkeypatch,
+                       [lambda **kw: {"text": kw["text"] + " [footer]"}])
+    out = guard_outbound_text("hello", platform="telegram",
+                              apply_middleware=False)
+    assert out == "hello"
+
+
+def test_outbound_message_is_valid_middleware_kind():
+    from hermes_cli.middleware import (OUTBOUND_MESSAGE_MIDDLEWARE,
+                                       VALID_MIDDLEWARE)
+
+    assert OUTBOUND_MESSAGE_MIDDLEWARE in VALID_MIDDLEWARE
+
+
+def test_apply_outbound_message_middleware_no_callbacks(monkeypatch):
+    import hermes_cli.plugins as plugins_mod
+
+    monkeypatch.setattr(plugins_mod, "has_middleware", lambda kind: False)
+    from hermes_cli.middleware import apply_outbound_message_middleware
+
+    result = apply_outbound_message_middleware("body", platform="slack")
+    assert result.text == "body"
+    assert not result.changed and not result.blocked

--- a/tests/hermes_durability/test_egress_wiring.py
+++ b/tests/hermes_durability/test_egress_wiring.py
@@ -1,0 +1,101 @@
+"""The egress guardrail must hold at the adapter methods themselves.
+
+Regression tests for the review finding that guarding individual call sites
+(_send_with_retry) left the streaming path, media captions, and ledger
+redelivery unguarded: every concrete adapter's ``send``/``edit_message`` is
+wrapped at subclass creation, so ANY caller is covered.
+"""
+
+import asyncio
+
+import pytest
+
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from hermes_durability.egress import BLOCK_ERROR
+
+GHP = "ghp_AbCdEfGhIjKlMnOpQrStUvWxYz0123456789"
+
+
+class RecordingAdapter(BasePlatformAdapter):
+    """Minimal concrete adapter capturing what the platform would receive."""
+
+    def __init__(self):
+        self.sent = []
+        self.edited = []
+
+    @property
+    def name(self):
+        return "recording"
+
+    @property
+    def platform(self):
+        return "recording"
+
+    async def connect(self, *, is_reconnect=False):  # pragma: no cover
+        return True
+
+    async def disconnect(self):  # pragma: no cover - not exercised
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent.append(content)
+        return SendResult(success=True, message_id="1")
+
+    async def edit_message(self, chat_id, message_id, content, *,
+                           finalize=False):
+        self.edited.append(content)
+        return SendResult(success=True, message_id=message_id)
+
+    async def get_chat_info(self, chat_id):  # pragma: no cover
+        return {}
+
+
+@pytest.fixture
+def adapter():
+    return RecordingAdapter()
+
+
+def test_send_is_wrapped(adapter):
+    result = asyncio.run(adapter.send("chat", f"token {GHP} end"))
+    assert result.success
+    assert len(adapter.sent) == 1
+    assert GHP not in adapter.sent[0]
+    assert "end" in adapter.sent[0]
+
+
+def test_edit_message_is_wrapped(adapter):
+    # The streaming path delivers model text via edit_message, not send.
+    result = asyncio.run(
+        adapter.edit_message("chat", "42", f"stream {GHP} tail"))
+    assert result.success
+    assert GHP not in adapter.edited[0]
+
+
+def test_blocked_send_returns_stable_error(adapter, monkeypatch):
+    import agent.redact as redact_mod
+
+    def boom(*a, **k):
+        raise RuntimeError("redactor broke")
+
+    monkeypatch.setattr(redact_mod, "redact_sensitive_text", boom)
+    result = asyncio.run(adapter.send("chat", "anything"))
+    assert not result.success
+    assert result.error == BLOCK_ERROR
+    assert not result.retryable
+    assert adapter.sent == []
+
+
+def test_wrapping_not_doubled_in_subclasses():
+    class Child(RecordingAdapter):
+        pass
+
+    # Child doesn't define its own send: it inherits the already-wrapped
+    # method, and __init_subclass__ must not wrap it again (plugin
+    # middleware would run twice per body).
+    assert Child.send is RecordingAdapter.send
+    assert getattr(RecordingAdapter.__dict__["send"], "_egress_guarded", False)
+
+
+def test_clean_content_passes_unchanged(adapter):
+    asyncio.run(adapter.send("chat", "hello world"))
+    assert adapter.sent == ["hello world"]

--- a/tests/hermes_durability/test_guardrail.py
+++ b/tests/hermes_durability/test_guardrail.py
@@ -1,0 +1,121 @@
+
+import pytest
+
+
+from hermes_durability import DurableRuntime, Guardrail
+from hermes_durability.guardrail import Envelope
+
+
+def ev(text: str) -> Envelope:
+    return Envelope("s1", "mem", {"text": text}, "oid-1")
+
+
+@pytest.fixture
+def g():
+    return Guardrail()
+
+
+def test_clean_text_allowed(g):
+    v = g.evaluate(ev("just a normal message"))
+    assert v.action == "allow"
+
+
+def test_api_key_redacted(g):
+    v = g.evaluate(ev("my key is sk-abc123def456ghi789jkl012 ok"))
+    assert v.action == "redact"
+    assert "sk-abc" not in v.envelope.payload["text"]
+    assert "[REDACTED:" in v.envelope.payload["text"]
+    assert "ok" in v.envelope.payload["text"]
+
+
+def test_private_key_blocked(g):
+    v = g.evaluate(ev("-----BEGIN RSA PRIVATE KEY-----\nMIIE..."))
+    assert v.action == "block"
+    assert v.envelope is None
+
+
+def test_ansi_glue_bypass_defeated(g):
+    # secret split by ANSI styling sequences
+    text = "sk-\x1b[31mabc123def456\x1b[0mghi789jkl012mno"
+    v = g.evaluate(ev(text))
+    assert v.action in ("redact", "block")
+    assert "abc123def456" not in (v.envelope.payload["text"] if v.envelope else "")
+
+
+def test_zero_width_split_defeated(g):
+    text = "sk-abc​123def456ghi‍789jkl012mno"
+    v = g.evaluate(ev(text))
+    assert v.action == "redact"
+
+
+def test_fullwidth_cjk_form_defeated(g):
+    # full-width latin (NFKC folds to ascii)
+    text = "ＡＫＩＡＩＯＳＦＯＤＮＮ７ＥＸＡＭＰＬＥ"
+    v = g.evaluate(ev(text))
+    assert v.action == "redact"
+
+
+def test_cookie_header_redacted(g):
+    v = g.evaluate(ev("Set-Cookie: session=8f2a9b1c7d3e4f5a; HttpOnly"))
+    assert v.action == "redact"
+
+
+def test_env_assignment_redacted(g):
+    v = g.evaluate(ev("export STRIPE_SECRET_KEY='sk_live_abcdef123456'"))
+    assert v.action == "redact"
+    assert "sk_live" not in v.envelope.payload["text"]
+
+
+def test_jwt_redacted(g):
+    jwt = ("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0."
+           "dQw4w9WgXcQdQw4w9WgXcQ")
+    v = g.evaluate(ev(f"token: {jwt}"))
+    assert v.action == "redact"
+    assert jwt not in v.envelope.payload["text"]
+
+
+def test_hot_reload_policies(g):
+    g.load_policy_dicts([{"id": "custom.word", "pattern": r"\bxyzzy\b",
+                          "action": "drop"}])
+    assert g.evaluate(ev("say xyzzy")).action == "drop"
+    # old rules replaced
+    assert g.evaluate(ev("sk-abc123def456ghi789jkl012")).action == "allow"
+
+
+def test_audit_written_before_send(tmp_path):
+    db = str(tmp_path / "a.db")
+
+    class NeverSend:
+        def send(self, envelope, idempotency_key):
+            raise AssertionError("must not be called for blocked envelope")
+
+    rt = DurableRuntime(db, adapters={"mem": NeverSend()}, start_worker=False)
+    with rt.transaction("s1") as txn:
+        txn.enqueue_outbound("mem", {"text": "-----BEGIN PRIVATE KEY-----"})
+    rt.worker.drain_once()
+    rows = rt.journal._conn.execute(
+        "SELECT action, policy_id FROM audit_log").fetchall()
+    assert ("block", "secret.private-key-block") in rows
+    # blocked row is terminal, never retried
+    status = rt.journal._conn.execute(
+        "SELECT status FROM outbox").fetchone()[0]
+    assert status == "blocked"
+    rt.close()
+
+
+def test_guardrail_runs_on_delivery_path(tmp_path):
+    db = str(tmp_path / "b.db")
+    sent = {}
+
+    class Recv:
+        def send(self, envelope, idempotency_key):
+            sent[idempotency_key] = envelope.payload["text"]
+            return {}
+
+    rt = DurableRuntime(db, adapters={"mem": Recv()}, start_worker=False)
+    with rt.transaction("s1") as txn:
+        oid = txn.enqueue_outbound(
+            "mem", {"text": "key=sk-abc123def456ghi789jkl012"})
+    rt.worker.drain_once()
+    assert "sk-abc" not in sent[oid]
+    rt.close()

--- a/tests/hermes_durability/test_journal.py
+++ b/tests/hermes_durability/test_journal.py
@@ -1,0 +1,108 @@
+import sqlite3
+
+import pytest
+
+
+from hermes_durability import (Journal, TXN_COMMIT, USER_MESSAGE,
+                            ASSISTANT_MESSAGE, DurableRuntime)
+
+
+@pytest.fixture
+def db(tmp_path):
+    return str(tmp_path / "j.db")
+
+
+def test_commit_is_atomic_and_chained(db):
+    j = Journal(db)
+    with j.begin("s1") as txn:
+        txn.record(USER_MESSAGE, {"text": "hi"})
+        txn.record(ASSISTANT_MESSAGE, {"text": "hello"})
+    recs = list(j.records("s1"))
+    assert [r.record_type for r in recs] == [USER_MESSAGE, ASSISTANT_MESSAGE,
+                                             TXN_COMMIT]
+    ok, bad = j.verify_chain()
+    assert ok and bad == -1
+    j.close()
+
+
+def test_rollback_writes_nothing(db):
+    j = Journal(db)
+    with pytest.raises(RuntimeError):
+        with j.begin("s1") as txn:
+            txn.record(USER_MESSAGE, {"text": "hi"})
+            raise RuntimeError("boom")
+    assert list(j.records("s1")) == []
+    j.close()
+
+
+def test_uncommitted_buffer_never_touches_disk(db):
+    j = Journal(db)
+    txn = j.begin("s1")
+    txn.record(USER_MESSAGE, {"text": "hi"})
+    # simulate crash: just drop the txn, reopen db
+    j.close()
+    j2 = Journal(db)
+    assert list(j2.records("s1")) == []
+    j2.close()
+
+
+def test_torn_tail_detected_and_repaired(db):
+    j = Journal(db)
+    with j.begin("s1") as txn:
+        txn.record(USER_MESSAGE, {"text": "one"})
+    with j.begin("s1") as txn:
+        txn.record(USER_MESSAGE, {"text": "two"})
+    j.close()
+    # corrupt the last record's payload directly
+    conn = sqlite3.connect(db)
+    conn.execute("UPDATE journal SET payload = ? WHERE seq ="
+                 " (SELECT MAX(seq) FROM journal)", (b'{"text":"EVIL"}',))
+    conn.commit()
+    conn.close()
+    j2 = Journal(db)
+    ok, bad = j2.verify_chain(repair=True)
+    assert not ok
+    ok2, _ = j2.verify_chain()
+    assert ok2
+    # "two"'s TransactionCommit was the corrupted record: after truncation
+    # its records survive raw but the transaction is uncommitted, so replay
+    # must discard it.
+    committed = j2.committed_transactions("s1")
+    texts = [r.payload.get("text") for r in j2.records("s1")
+             if r.record_type == USER_MESSAGE
+             and r.transaction_id in committed]
+    assert texts == ["one"]
+    j2.close()
+
+
+def test_snapshot_and_replay(db):
+    rt = DurableRuntime(db, start_worker=False)
+    for i in range(5):
+        with rt.transaction("s1") as txn:
+            txn.record(USER_MESSAGE, {"text": f"m{i}"})
+    state = rt.replay_state("s1")
+    assert len(state["messages"]) == 5
+    rt.journal.compact("s1", state)
+    state2 = rt.replay_state("s1")
+    assert state2 == state  # snapshot equivalent to full replay
+    with rt.transaction("s1") as txn:
+        txn.record(USER_MESSAGE, {"text": "after-compact"})
+    state3 = rt.replay_state("s1")
+    assert state3["messages"][-1]["text"] == "after-compact"
+    assert len(state3["messages"]) == 6
+    rt.close()
+
+
+def test_incomplete_snapshot_ignored(db):
+    rt = DurableRuntime(db, start_worker=False)
+    with rt.transaction("s1") as txn:
+        txn.record(USER_MESSAGE, {"text": "m"})
+    # write snapshot row but leave complete=0 (simulate crash mid-compaction)
+    conn = rt.journal._conn
+    conn.execute("INSERT INTO snapshot (snapshot_id, session_id, base_seq,"
+                 " state, checksum, complete, created_at)"
+                 " VALUES ('x','s1',999,'{}',x'00',0,0)")
+    assert rt.journal.latest_snapshot("s1") is None
+    state = rt.replay_state("s1")
+    assert len(state["messages"]) == 1
+    rt.close()

--- a/tests/hermes_durability/test_outbox.py
+++ b/tests/hermes_durability/test_outbox.py
@@ -1,0 +1,125 @@
+
+import pytest
+
+
+from hermes_durability import DurableRuntime, RetryPolicy
+from hermes_durability.guardrail import Envelope
+
+
+class MemoryReceiver:
+    """Simulates an external service that honours idempotency keys."""
+
+    def __init__(self, fail_first_n: int = 0):
+        self.by_key: dict[str, dict] = {}
+        self.send_calls = 0
+        self.fail_first_n = fail_first_n
+
+    def send(self, envelope: Envelope, idempotency_key: str) -> dict:
+        self.send_calls += 1
+        if self.send_calls <= self.fail_first_n:
+            raise ConnectionError("transient")
+        # idempotent: duplicate keys do not create duplicate messages
+        if idempotency_key not in self.by_key:
+            self.by_key[idempotency_key] = dict(envelope.payload)
+        return {"id": idempotency_key}
+
+
+@pytest.fixture
+def db(tmp_path):
+    return str(tmp_path / "o.db")
+
+
+def test_enqueue_commit_deliver(db):
+    recv = MemoryReceiver()
+    rt = DurableRuntime(db, adapters={"mem": recv}, start_worker=False)
+    with rt.transaction("s1") as txn:
+        oid = txn.enqueue_outbound("mem", {"text": "hello world"})
+    assert rt.worker.drain_once() == 1
+    assert list(recv.by_key) == [oid]
+    rt.close()
+
+
+def test_rollback_never_sends(db):
+    recv = MemoryReceiver()
+    rt = DurableRuntime(db, adapters={"mem": recv}, start_worker=False)
+    txn = rt.transaction("s1")
+    txn.enqueue_outbound("mem", {"text": "should not go"})
+    txn.rollback()
+    assert rt.worker.drain_once() == 0
+    assert recv.by_key == {}
+    rt.close()
+
+
+def test_retry_then_success_exactly_once(db):
+    recv = MemoryReceiver(fail_first_n=2)
+    rt = DurableRuntime(db, adapters={"mem": recv},
+                        retry=RetryPolicy(base_delay=0, max_attempts=5),
+                        start_worker=False)
+    with rt.transaction("s1") as txn:
+        txn.enqueue_outbound("mem", {"text": "retry me"})
+    total = 0
+    for _ in range(5):
+        total += rt.worker.drain_once()
+    assert total == 1
+    assert recv.send_calls == 3
+    assert len(recv.by_key) == 1
+    rt.close()
+
+
+def test_dead_letter_and_replay(db):
+    recv = MemoryReceiver(fail_first_n=100)
+    rt = DurableRuntime(db, adapters={"mem": recv},
+                        retry=RetryPolicy(base_delay=0, max_attempts=3),
+                        start_worker=False)
+    with rt.transaction("s1") as txn:
+        oid = txn.enqueue_outbound("mem", {"text": "doomed"})
+    for _ in range(5):
+        rt.worker.drain_once()
+    row = rt.journal._conn.execute(
+        "SELECT status FROM outbox WHERE outbox_id = ?", (oid,)).fetchone()
+    assert row[0] == "deadletter"
+    assert rt.journal._conn.execute(
+        "SELECT COUNT(*) FROM dlq").fetchone()[0] == 1
+    # manual replay after the receiver recovers
+    recv.fail_first_n = 0
+    assert rt.worker.replay_dead_letter(oid)
+    assert rt.worker.drain_once() == 1
+    assert oid in recv.by_key
+    rt.close()
+
+
+def test_per_session_ordering(db):
+    order = []
+
+    class OrderedRecv(MemoryReceiver):
+        def send(self, envelope, idempotency_key):
+            order.append(envelope.payload["n"])
+            return super().send(envelope, idempotency_key)
+
+    recv = OrderedRecv()
+    rt = DurableRuntime(db, adapters={"mem": recv}, start_worker=False)
+    for n in range(10):
+        with rt.transaction("s1") as txn:
+            txn.enqueue_outbound("mem", {"text": f"msg {n}", "n": n})
+    rt.worker.drain_once()
+    assert order == list(range(10))
+    rt.close()
+
+
+def test_crash_after_send_before_mark_is_deduped_by_key(db):
+    """Simulate: send succeeded, process died before OutboxDelivered."""
+    recv = MemoryReceiver()
+    rt = DurableRuntime(db, adapters={"mem": recv}, start_worker=False)
+    with rt.transaction("s1") as txn:
+        oid = txn.enqueue_outbound("mem", {"text": "once only"})
+    # send manually, but do NOT finalize (crash window)
+    recv.send(Envelope("s1", "mem", {"text": "once only"}, oid), oid)
+    rt.close()
+    # restart: recovery finds the row still pending and retries
+    rt2 = DurableRuntime(db, adapters={"mem": recv}, start_worker=False)
+    report = rt2.recover()
+    assert report["pending_outbox"] == 1
+    assert report["delivered_on_recovery"] == 1
+    assert recv.send_calls == 2          # at-least-once attempts...
+    assert len(recv.by_key) == 1         # ...exactly-once effect
+    rt2.close()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -705,8 +705,14 @@ async def _send_via_adapter(
          ``PlatformEntry`` (used when the gateway is not in this process, so
          the runner weakref is ``None``).
       3. A descriptive error explaining both options.
+
+    Egress redaction already ran on the whole pre-chunk body in
+    ``_send_to_platform``; the live-adapter attempt below additionally passes
+    the wrapped ``adapter.send`` (redaction + plugin outbound_message
+    middleware).
     """
     platform_name = platform.value if hasattr(platform, "value") else str(platform)
+
     runner = None
     try:
         from gateway.run import _gateway_runner_ref
@@ -790,6 +796,26 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     from gateway.config import Platform
 
     media_files = media_files or []
+
+    # Egress guardrail on the WHOLE body, BEFORE chunking and BEFORE the
+    # platform branches below. Both orderings matter:
+    #   * chunking first would split a secret across a chunk boundary into
+    #     fragments too short to match the redaction patterns' length gates;
+    #   * most branches (_send_telegram, _send_signal, _send_matrix, ...)
+    #     talk to platform APIs directly and never pass a wrapped adapter
+    #     ``send``, so this is their only redaction boundary.
+    # Redaction only (idempotent): plugin outbound_message middleware runs at
+    # the adapter wrapper on the live-adapter path.
+    from hermes_durability.egress import EgressBlocked, guard_outbound_text
+
+    platform_label = platform.value if hasattr(platform, "value") else str(platform)
+    try:
+        message = guard_outbound_text(
+            message, platform=platform_label, category="send_message_tool",
+            apply_middleware=False,
+        )
+    except EgressBlocked as exc:
+        return {"error": f"Egress guardrail blocked send: {exc.reason}"}
 
     # Weixin handles text/media delivery inside its native helper and does not
     # need the optional platform adapter imports below. Keep this branch early


### PR DESCRIPTION
# feat: embeddable durable-execution layer (journal/outbox) + mandatory egress guardrails

Branch: `feat/durable-execution-runtime` (4 commits, each one logical change)

## Problem

Hermes has strong pieces of durability, but they don't compose into durable-execution guarantees:

1. **Outbound delivery is durable on only one of four send paths.** `gateway/delivery_ledger.py` (idempotency keys, owner-liveness claims, attempt caps) is wired only into the gateway final-response path. Cron/`DeliveryRouter`, the `send_message` tool, and outbound webhooks have zero delivery durability.
2. **No egress guardrail exists.** `agent/redact.py` runs on ingress/display/snapshots — never on the bytes sent to Telegram/Slack/Discord. A secret in a reply is delivered verbatim on every path: streaming edits, captions, cron, `send_message`, ledger redelivery.
3. **Mid-tool crashes degrade to "effect UNKNOWN".** `agent/replay_cleanup.py` infers state from a torn transcript instead of replaying recorded intent; there is no journal.
4. **`synchronous=FULL` was macOS-only** — on Linux, committed transcript turns can be lost on power loss.
5. **No crash-injection tests** anywhere in the tree.

## The fix, in two diagrams

**Where the egress boundary sits.** Every in-process send path bottoms out in the wrapped adapter methods (`BasePlatformAdapter.__init_subclass__` wraps `send`/`edit_message` on all 22 platform adapters + Relay), so no caller can bypass it. The two paths that never reach a wrapped method get their own guard:

```mermaid
flowchart TD
    SC["stream consumer<br/>(8 direct send/edit sites)"] --> W
    SWR["_send_with_retry<br/>(final replies + plain-text fallback)"] --> W
    CAP["captions / clarify / voice /<br/>private notices (base.py self.send)"] --> W
    LED["delivery-ledger boot redelivery<br/>(gateway/run.py adapter.send)"] --> W
    DR["cron / DeliveryRouter"] -->|"native adapter"| W
    DR -->|"relay: send_for_platform"| G2["guard_outbound_text<br/>(full guard)"]
    SMT["send_message tool"] -->|"guard whole body pre-chunk,<br/>then live adapter"| W
    SMT -->|"standalone raw senders<br/>(telegram/signal/matrix/...)"| G3["pre-chunk redaction<br/>(only boundary for this path)"]
    W[["wrapped adapter.send / edit_message<br/>redact(force) → normalize (ANSI/zero-width/NFKC) → recheck<br/>fail-closed · plugin outbound_message middleware (once)"]]
    W --> P[("platform API")]
    G2 --> P
    G3 --> P2[("raw platform APIs")]
```

**The outbox exactly-once flow** (the durability half — `hermes_durability`):

```mermaid
sequenceDiagram
    participant A as Agent turn
    participant J as Journal (SQLite, fsynced)
    participant O as Outbox worker
    participant X as Platform (idempotent on outbox_id)
    A->>J: records + OutboxEnqueued + TxnCommit — ONE transaction
    Note over J: crash before commit → nothing replayed, nothing sent
    O->>J: claim row (pending → inflight)
    O->>X: send(envelope, idempotency_key=outbox_id)
    Note over O,X: crash here → startup resets inflight,<br/>retry deduped by idempotency key
    O->>J: OutboxDelivered + row terminal — ONE transaction
```

## What this PR adds

### Mandatory egress guardrail at the platform-adapter boundary
`BasePlatformAdapter.__init_subclass__` wraps every concrete `send`/`edit_message` with `hermes_durability.egress.guard_outbound_text()`, so **any** caller is covered — the stream consumer's direct `adapter.send`/`edit_message` calls, media captions, clarify/private notices, `_send_with_retry` (including its plain-text fallback), and the delivery-ledger boot redelivery sweep. Double-wrapping is impossible (subclasses inherit the wrapped method).

Two paths never reach a wrapped adapter method and get their own guard:
- `tools/send_message_tool.py::_send_to_platform` guards the **whole body before chunking** (a secret straddling a chunk boundary would split into fragments too short for the patterns' length gates) and before the platform branches (Telegram/Signal/Matrix/… raw API senders).
- `gateway/delivery.py` guards the relay `send_for_platform` branch.

Behavior: `redact_sensitive_text(force=True)` + a second pass on a normalized body (ANSI/zero-width stripped, NFKC-folded) against obfuscation bypasses; fail-closed if redaction raises; veto surfaces as a non-retryable `SendResult` with a **stable error constant** (free-text reasons must not substring-match `classify_send_error` and dead-mark a target). The gateway reply path redacts **before** the delivery ledger records the body, so secrets are never durably persisted in `delivery_obligations.content`. Opt-out: `HERMES_EGRESS_GUARDRAIL=false`.

### New `outbound_message` middleware kind
Plugin-extensible egress: rewrite (`{"text": ...}`) or veto (`{"action": "block"}`). Callbacks run as a **sequential chain** (each sees the previous rewrite — no last-writer-wins), raising callbacks are skipped per the fail-open middleware contract, and exactly one boundary per delivery path runs plugin middleware so non-idempotent rewrites (footers) can't double-apply. Documented in `docs/middleware/README.md`.

### `hermes_durability/` — embeddable library (stdlib `sqlite3` only, per the core-deps scope rule)
- Append-only journal, WAL + `synchronous=FULL` (+ `checkpoint_fullfsync` on macOS), sha256 checksums + prev-hash chain, torn-tail detection/repair.
- Buffered transactions: a turn's records + `TransactionCommit` land in one fsynced SQLite transaction. Compaction re-roots the hash chain **in the same transaction** as its DELETE. Every multi-statement write rolls back on error (no wedged connections).
- Transactional outbox committed atomically with the journal; rows are **claimed** (`pending → inflight`) before sending so a worker tick and a recovery drain can never double-deliver; the delivered-mark is atomic with the `OutboxDelivered` journal record; per-session ordered delivery with `outbox_id` idempotency keys; backoff retries; DLQ with manual replay.
- Two-phase snapshots (incomplete ignored on recovery). Startup integrity (chain repair, exact-match orphan cleanup, inflight reset) runs **before** the worker thread starts.

### Independent fixes (separate commits)
- `fix(state)`: `synchronous=FULL` on all platforms; `HERMES_DB_SYNCHRONOUS` override floored at FULL on Darwin (never re-opens #30636).
- `fix(gateway)`: relay egress guard; `_deliver_local`/`_save_full_output` use `atomic_write_text` with `create_mode=0o644`.

## Tests

`tests/hermes_durability/` — 56 tests:
- Journal: atomic commit, rollback, torn-tail repair, snapshot equivalence, incomplete-snapshot handling.
- Outbox: exactly-once across retries, rollback-never-sends, DLQ + replay, per-session ordering, crash-between-send-and-mark deduped by idempotency key.
- Egress: redaction at boundary, ANSI-glue / zero-width / full-width bypasses defeated, fail-closed on redactor failure, middleware chain/skip/block semantics, env opt-out.
- Adapter wiring: `send` and `edit_message` (streaming path) wrapped; blocked sends return the stable non-retryable error; subclasses not double-wrapped.
- **Crash-injection conformance**: child process runs journaled turns + outbox sends + compaction while the parent SIGKILLs it at random points (validated up to 30 seeds × 3 crash/restart cycles); invariants: valid hash chain, only committed transactions replayed, contiguous turns, exactly-once external effects, pending sends drained on recovery. Uses the established `live_system_guard_bypass` marker.

An adversarial multi-agent code review was run on the branch; all 18 confirmed findings (streaming bypass, chunk-straddle, ledger pre-guard storage, compaction atomicity, transaction wedging, delivery races, dead-target misclassification, macOS override weakening, middleware last-writer-wins, etc.) were fixed and are covered by the tests above.

Regression: full `scripts/run_tests.sh` (~24,300 tests) passes with only failures already present on the base commit (external-service/credential-dependent suites, verified identical on base).

## Related issues

- **#70694** — "Gateway drops semantic turn finality and logical delivery identity at the platform-adapter boundary": this PR introduces exactly that identity (`outbox_id` as the stable idempotency key spanning retries/fallbacks) and the adapter-boundary interception point; full closure lands with the ledger-migration follow-up below.
- **#79576** — Telegram/Linux `state.db` corruption → infinite context-loss loop: the `fix(state)` commit closes the Linux `synchronous=NORMAL` corruption entry point that seeds this loop.
- **Duplicate-delivery family** — #81052 (Slack streaming fallback re-send), #78183 / #14061 (timeout → plain-text fallback duplicates), #51463 (Signal regression), #72131, #46731: all share one root cause — transport retries/fallbacks with no logical delivery identity. The outbox pattern in this PR fixes the class; the follow-up that threads `outbox_id` through `_send_with_retry`, the streaming-fallback path, and per-platform dedup keys (Slack `client_msg_id`, Discord nonce) closes them concretely.
- **#62860** — inbound dedup marks messages seen before processing (silent message loss): the mirror image of this PR's claim/ack (`inflight`) pattern, applicable as a small separate PR.

## Design notes / future work
- The library intentionally does not yet replace `delivery_ledger.py`; a follow-up can migrate the ledger onto the shared outbox so all four send paths converge (the ledger's `INSERT OR REPLACE` + 500-row LRU eviction can drop undelivered obligations under load).
- A further follow-up can journal per-tool-call intent with idempotency keys (the `effect_disposition` column and `IDEMPOTENT_TOOL_NAMES` already exist), converting today's "[Orphan recovery: effect UNKNOWN]" into deterministic replay.
