### PR TITLE
fix: persist discovered custom-provider models in the hermes model flow

### DIFF
--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -1561,11 +1561,24 @@ def _model_flow_named_custom(config, provider_info):
         fetch_kwargs = {"timeout": 8.0}
         if api_mode:
             fetch_kwargs["api_mode"] = api_mode
-        models = fetch_api_models(api_key, base_url, **fetch_kwargs)
+        live_models = fetch_api_models(api_key, base_url, **fetch_kwargs)
         # If the probe came back empty but the operator configured an explicit
         # list, fall back to it rather than forcing manual entry.
-        if not models and configured_models:
-            models = configured_models
+        models = live_models or configured_models
+        # Persist the live catalog back to the custom_providers entry so that
+        # no-probe surfaces (dashboard, desktop, ACP) show the full model list
+        # instead of collapsing to the single ``model:`` default. Mirrors the
+        # picker path in model_switch.py::_save_discovered_models_to_config; a
+        # failed save is non-fatal.
+        if live_models:
+            try:
+                from hermes_cli.model_switch import (
+                    _save_discovered_models_to_config,
+                )
+
+                _save_discovered_models_to_config(base_url, live_models)
+            except Exception:
+                pass
 
     if models:
         default_idx = 0

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -830,6 +830,74 @@ def test_save_discovered_models_preserves_dict_form(monkeypatch):
     )
 
 
+def test_model_flow_named_custom_persists_discovered_models(monkeypatch):
+    """The ``hermes model`` named-custom-provider flow persists the discovered
+    catalog back to the entry's ``models:`` list.
+
+    No-probe surfaces (dashboard, desktop, ACP) call
+    ``build_models_payload(..., probe_custom_providers=False)`` and only show
+    the configured ``models:`` list. The CLI flow probes and shows the full
+    catalog but (before this fix) never saved it, so a provider added via
+    ``hermes model`` collapsed to the single ``model:`` default everywhere but
+    the CLI. It must persist discovered models the same way the picker path in
+    ``_save_discovered_models_to_config`` does.
+    """
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_api_models",
+        lambda api_key, base_url, **kw: [
+            "discovered-a",
+            "discovered-b",
+            "discovered-c",
+        ],
+    )
+    # Non-interactive model selection.
+    monkeypatch.setattr(
+        "hermes_cli.curses_ui.curses_radiolist", lambda *a, **k: 0
+    )
+    # No-op downstream writes so the test never touches a real config.
+    monkeypatch.setattr("hermes_cli.main._save_custom_provider", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.auth._save_model_choice", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.auth.deactivate_provider", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": {}, "providers": {}, "custom_providers": []},
+    )
+    monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
+
+    save_calls = []
+    monkeypatch.setattr(
+        "hermes_cli.model_switch._save_discovered_models_to_config",
+        lambda api_url, model_ids: save_calls.append((api_url, model_ids)),
+    )
+
+    from hermes_cli.model_setup_flows import _model_flow_named_custom
+
+    _model_flow_named_custom(
+        {},
+        {
+            "name": "Dragomes",
+            "base_url": "http://example.com/v1",
+            "api_mode": "anthropic_messages",
+            "api_key": "sk-test",
+            "key_env": "",
+            "model": "MiniMax-M3",
+            "provider_key": "",
+            "discover_models": True,
+            "models": {},
+        },
+    )
+
+    assert save_calls == [
+        (
+            "http://example.com/v1",
+            ["discovered-a", "discovered-b", "discovered-c"],
+        )
+    ], (
+        "_model_flow_named_custom must persist discovered models "
+        "(base_url, model_ids) after a successful probe"
+    )
+
+
 def test_shared_url_different_display_names_are_separate_rows(monkeypatch):
     """Multiple custom_providers entries sharing base_url + api_key + api_mode
     but with *different* display-name prefixes (e.g. a proxy fronting


### PR DESCRIPTION
## Summary

The `hermes model` named custom-provider flow (`_model_flow_named_custom`) probes the endpoint and shows the full catalog, but never persists the discovered list. No-probe surfaces — the dashboard, desktop app, and ACP adapter — call `build_models_payload(..., probe_custom_providers=False, probe_current_custom_provider=False)` and only render the entry's configured `models:` list. So a provider added via `hermes model` collapses to the single `model:` default in every surface **except** the CLI.

## Root cause

There is an asymmetry in how discovered models are persisted:

- The **picker paths** (`/model` in CLI/Telegram, refresh runs) call `_save_discovered_models_to_config()` after a successful probe, writing the full catalog into the `custom_providers` entry's `models:` list. That's why a provider added via a probing picker shows its full catalog in the dashboard/desktop.
- The **`hermes model` CLI flow** (`_model_flow_named_custom`) probes identically but only calls `_save_custom_provider()`, which writes `model` + `api_mode` and never the `models:` list.

This is repo-agnostic (affects both `api_mode: chat_completions` and `api_mode: anthropic_messages` custom providers) — it surfaces most visibly for `anthropic_messages` endpoints because providers added through other flows often already carry a cached `models:` list.

## Fix

After a successful live probe in `_model_flow_named_custom`, persist the discovered catalog with the same `_save_discovered_models_to_config(base_url, live_models)` the picker path uses. A failed save is non-fatal; the configured `models:` dict-metadata guard in that helper is preserved (it never replaces a dict-form `models:` mapping).

## Test

`test_model_flow_named_custom_persists_discovered_models` asserts the CLI flow calls `_save_discovered_models_to_config(base_url, model_ids)` after a successful probe. Existing discovered-models persistence tests still pass.

## Notes

The dashboard/desktop deliberately skip live probing for responsiveness (documented in `model_switch.py` / `inventory.py`) — that behavior is unchanged. This PR only makes the CLI flow persist what it already discovers, so no-probe surfaces see the same catalog.