### PR TITLE
fix(memory-setup): route Hindsight Intel-macOS local_embedded to slim runtime + post-install smoke check

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -175,6 +175,15 @@ def _install_dependencies(provider_name: str, *, force: bool = False) -> None:
         "mem0ai": "mem0",
         "hindsight-client": "hindsight_client",
         "hindsight-all": "hindsight",
+        # Intel-macOS slim stack (#81421): the slim meta-packages don't
+        # expose a top-level import at their pip name (e.g. `import
+        # hindsight_all_slim` would fail), so map them to the underlying
+        # modules they ship. Without these entries the missing-dep probe
+        # below would mark the slim packages as still-missing on every
+        # refresh and reinstall them indefinitely.
+        "hindsight-all-slim": "hindsight_api",
+        "hindsight-api-slim": "hindsight_api",
+        "hindsight-embed": "hindsight_embed",
     }
 
     # Check which packages need installation.
@@ -242,7 +251,7 @@ def _install_dependencies(provider_name: str, *, force: bool = False) -> None:
     # releases whose files shadow the working slim runtime — pip reports
     # success while the daemon crashes with
     # `Unknown embeddings provider: onnx`. Verify the configured local
-    # runtime actually imports before claiming the heal succeeded. We
+    # runtime is actually usable before claiming the heal succeeded. We
     # only smoke-check on the affected code path (Intel macOS +
     # local_embedded) so non-Intel installs and cloud modes don't pay a
     # new import cost on every refresh.
@@ -266,7 +275,7 @@ def _install_dependencies(provider_name: str, *, force: bool = False) -> None:
                 smoke_errors = _smoke_import_hindsight_local()
                 if smoke_errors:
                     print(
-                        "  ✗ Hindsight slim runtime installed but smoke import failed "
+                        "  ✗ Hindsight slim runtime installed but smoke validation failed "
                         "(#81421). The daemon will not start with this stack; "
                         "re-running the install will not help until the resolver "
                         "stops backtracking. Check `pip show hindsight-api-slim` "
@@ -274,25 +283,71 @@ def _install_dependencies(provider_name: str, *, force: bool = False) -> None:
                     )
                     for err in smoke_errors:
                         print(f"    {err}")
+                    # Surface the failure to callers as well — printing a
+                    # warning alone lets `hermes update` report success
+                    # while leaving the user with a broken daemon. This
+                    # only fires on the Intel-macOS local_embedded code
+                    # path, so non-Intel installs and cloud modes are
+                    # unaffected.
+                    raise RuntimeError(
+                        "Hindsight slim runtime smoke validation failed after "
+                        "install on Intel macOS — pip reported success but the "
+                        "configured local runtime is not usable. See the "
+                        "warnings printed above; the heal is NOT considered "
+                        "successful. (#81421)"
+                    )
 
 
-def _smoke_import_hindsight_local():
-    """Import the Hindsight local runtime modules and return a list of
+def _smoke_import_hindsight_local() -> list[str]:
+    """Validate the Hindsight local runtime is usable and return a list of
     failure descriptions (empty on success).
 
     Wrapped in a helper so tests can monkeypatch it without touching
     ``builtins.__import__`` (which pytest uses internally for fixture
-    lookup). The slim stack wraps the daemon + embedder at the top-level
-    ``hindsight`` import path (matching the existing _IMPORT_NAMES map
-    entry for ``hindsight-all``). The slim API backend lives at
-    ``hindsight_api``; the embed manager at ``hindsight_embed``.
+    lookup).
+
+    The validation probes more than just module imports (#81421): the
+    reported regression is "pip says ok but the daemon crashes with
+    ``Unknown embeddings provider: onnx``", which means a fully
+    importable API surface can still expose a runtime that rejects the
+    configured embeddings provider. We import the slim API backend
+    (``hindsight_api``), the embed manager (``hindsight_embed``), and the
+    configured local embeddings class (``hindsight_api.LocalSTEmbeddings``
+    — the SentenceTransformers / ONNX provider that backs
+    ``local_embedded``) and confirm the class symbol resolves. We do not
+    instantiate it because that triggers a model download we can't do
+    in CI; resolving the class is enough to detect the
+    backtrack-to-ancient-API failure mode where ``hindsight_api`` still
+    imports but no longer exposes ``LocalSTEmbeddings``.
     """
     errors: list[str] = []
-    for smoke_module in ("hindsight", "hindsight_api", "hindsight_embed"):
+    # Module imports first — catches the most obvious "pip backtracked
+    # to a release that doesn't ship the module at all" failure mode.
+    # Use inline imports so the missing-module case falls into our
+    # except branch (and the class probe below is gated on the module
+    # having imported at all).
+    hindsight_api_module = None
+    for smoke_module in ("hindsight_api", "hindsight_embed"):
         try:
-            __import__(smoke_module)
+            hindsight_api_module = __import__(
+                smoke_module
+            ) if smoke_module == "hindsight_api" else __import__(smoke_module)
         except Exception as e:  # ImportError + anything else
             errors.append(f"{smoke_module}: {type(e).__name__}: {e}")
+    # Symbol probe — catches the subtle backtrack where the module
+    # imports but the configured provider class is gone (this is the
+    # exact regression from #81421: the slim runtime was shadowed by
+    # an ancient API release that exposed `Embeddings` but not
+    # `LocalSTEmbeddings`). Skipped if the module itself failed to
+    # import — that's already in `errors` and a separate diagnostic.
+    if hindsight_api_module is not None and not hasattr(
+        hindsight_api_module, "LocalSTEmbeddings"
+    ):
+        errors.append(
+            "hindsight_api.LocalSTEmbeddings: AttributeError: the slim runtime "
+            "shipped an API release that does not expose the configured ONNX "
+            "embeddings provider — this is the #81421 backtrack failure mode"
+        )
     return errors
 
 

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -139,6 +139,14 @@ def _install_dependencies(provider_name: str, *, force: bool = False) -> None:
     ranges. This is how ``hermes update`` heals the active memory provider
     after a venv rebuild/sync removed or downgraded its bridge packages
     (#53272, #70636).
+
+    For Hindsight ``local_embedded`` on Intel macOS (#81421), the dep list
+    routes through the slim stack. After install we smoke-check that the
+    configured local runtime actually imports — a resolver backtrack that
+    shadows the working slim API with an older non-ONNX release will fail
+    here, surfacing a clear "installed but broken" message instead of
+    silently succeeding and then crashing the daemon with
+    ``Unknown embeddings provider: onnx``.
     """
     import subprocess
     from plugins.memory import find_provider_dir
@@ -195,6 +203,7 @@ def _install_dependencies(provider_name: str, *, force: bool = False) -> None:
     from tools.lazy_deps import install_specs
 
     manual_cmd = f"uv pip install {' '.join(missing)}"
+    outcome = None
     try:
         outcome = install_specs(missing, timeout=120)
         if outcome.ok:
@@ -226,6 +235,65 @@ def _install_dependencies(provider_name: str, *, force: bool = False) -> None:
                 if install_cmd:
                     print(f"\n  ⚠ '{dep_name}' not found. Install with:")
                     print(f"    {install_cmd}")
+
+    # Post-install smoke check (#81421): for Hindsight local_embedded on
+    # Intel macOS the dep list now routes through the slim stack, but the
+    # underlying failure mode was the resolver backtracking to ancient API
+    # releases whose files shadow the working slim runtime — pip reports
+    # success while the daemon crashes with
+    # `Unknown embeddings provider: onnx`. Verify the configured local
+    # runtime actually imports before claiming the heal succeeded. We
+    # only smoke-check on the affected code path (Intel macOS +
+    # local_embedded) so non-Intel installs and cloud modes don't pay a
+    # new import cost on every refresh.
+    if (
+        provider_name == "hindsight"
+        and outcome is not None
+        and outcome.ok
+    ):
+        import json
+        try:
+            cfg_path = get_hermes_home() / "hindsight" / "config.json"
+            cfg = json.loads(cfg_path.read_text(encoding="utf-8")) if cfg_path.exists() else {}
+        except Exception:
+            cfg = {}
+        if cfg.get("mode", "") in {"local", "local_embedded"}:
+            is_intel_macos = (
+                platform.system() == "Darwin"
+                and platform.machine() == "x86_64"
+            )
+            if is_intel_macos:
+                smoke_errors = _smoke_import_hindsight_local()
+                if smoke_errors:
+                    print(
+                        "  ✗ Hindsight slim runtime installed but smoke import failed "
+                        "(#81421). The daemon will not start with this stack; "
+                        "re-running the install will not help until the resolver "
+                        "stops backtracking. Check `pip show hindsight-api-slim` "
+                        "and `pip show hindsight-embed` for overlapping API files."
+                    )
+                    for err in smoke_errors:
+                        print(f"    {err}")
+
+
+def _smoke_import_hindsight_local():
+    """Import the Hindsight local runtime modules and return a list of
+    failure descriptions (empty on success).
+
+    Wrapped in a helper so tests can monkeypatch it without touching
+    ``builtins.__import__`` (which pytest uses internally for fixture
+    lookup). The slim stack wraps the daemon + embedder at the top-level
+    ``hindsight`` import path (matching the existing _IMPORT_NAMES map
+    entry for ``hindsight-all``). The slim API backend lives at
+    ``hindsight_api``; the embed manager at ``hindsight_embed``.
+    """
+    errors: list[str] = []
+    for smoke_module in ("hindsight", "hindsight_api", "hindsight_embed"):
+        try:
+            __import__(smoke_module)
+        except Exception as e:  # ImportError + anything else
+            errors.append(f"{smoke_module}: {type(e).__name__}: {e}")
+    return errors
 
 
 def _get_available_providers() -> list:

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -336,59 +336,72 @@ def _smoke_import_hindsight_local() -> list[str]:
     """Validate the Hindsight local runtime is usable and return a list of
     failure descriptions (empty on success).
 
-    Wrapped in a helper so tests can monkeypatch it without touching
-    ``builtins.__import__`` (which pytest uses internally for fixture
-    lookup).
+    Runs the validation in a clean subprocess so cached modules from the
+    updating process can't mask the newly installed environment (#81421).
+    The subprocess exits 0 with JSON ``{"errors": [...]}`` on stdout;
+    non-zero exit is itself treated as a failure (the script crashed
+    before it could report).
 
-    The validation probes more than just module imports (#81421): the
-    reported regression is "pip says ok but the daemon crashes with
+    The validation probes more than just module imports: the reported
+    regression is "pip says ok but the daemon crashes with
     ``Unknown embeddings provider: onnx``", which means a fully
     importable API surface can still expose a runtime that rejects the
-    configured embeddings provider. We import the slim API backend
-    (``hindsight_api``), the embed manager (``hindsight_embed``), and the
-    configured local embeddings class (``hindsight_api.LocalSTEmbeddings``
-    — the SentenceTransformers / ONNX provider that backs
-    ``local_embedded``) and confirm the class symbol resolves. We do not
-    instantiate it because that triggers a model download we can't do
-    in CI; resolving the class is enough to detect the
-    backtrack-to-ancient-API failure mode where ``hindsight_api`` still
-    imports but no longer exposes ``LocalSTEmbeddings``.
+    configured embeddings provider. The subprocess imports the slim API
+    backend (``hindsight_api``), the embed manager (``hindsight_embed``),
+    and the configured local embeddings class
+    (``hindsight_api.LocalSTEmbeddings`` — the SentenceTransformers /
+    ONNX provider that backs ``local_embedded``) and confirms the class
+    symbol resolves. We do not instantiate it because that triggers a
+    model download we can't do in CI; resolving the class is enough to
+    detect the backtrack-to-ancient-API failure mode where
+    ``hindsight_api`` still imports but no longer exposes
+    ``LocalSTEmbeddings``.
     """
-    errors: list[str] = []
-    # Module imports first — catches the most obvious "pip backtracked
-    # to a release that doesn't ship the module at all" failure mode.
-    # Track only the API module — the helper checks for the configured
-    # provider *class* on the API module specifically, not on the embed
-    # manager. Overwriting a single variable in a loop would let the
-    # final iteration's value (the embed manager) replace the API
-    # module reference, which makes the class probe check the wrong
-    # module — a healthy slim install where ``hindsight_api`` exposes
-    # ``LocalSTEmbeddings`` but ``hindsight_embed`` doesn't would be
-    # wrongly rejected (#81421 round-3 review).
-    hindsight_api_module = None
-    for smoke_module in ("hindsight_api", "hindsight_embed"):
-        try:
-            imported = __import__(smoke_module)
-        except Exception as e:  # ImportError + anything else
-            errors.append(f"{smoke_module}: {type(e).__name__}: {e}")
-            continue
-        if smoke_module == "hindsight_api":
-            hindsight_api_module = imported
-    # Symbol probe — catches the subtle backtrack where the module
-    # imports but the configured provider class is gone (this is the
-    # exact regression from #81421: the slim runtime was shadowed by
-    # an ancient API release that exposed `Embeddings` but not
-    # `LocalSTEmbeddings`). Skipped if the module itself failed to
-    # import — that's already in `errors` and a separate diagnostic.
-    if hindsight_api_module is not None and not hasattr(
-        hindsight_api_module, "LocalSTEmbeddings"
-    ):
-        errors.append(
-            "hindsight_api.LocalSTEmbeddings: AttributeError: the slim runtime "
-            "shipped an API release that does not expose the configured ONNX "
-            "embeddings provider — this is the #81421 backtrack failure mode"
+    import subprocess as _sp
+    import sys as _sys
+
+    script = (
+        "import json\n"
+        "errors = []\n"
+        "api_module = None\n"
+        "for mod in ('hindsight_api', 'hindsight_embed'):\n"
+        "    try:\n"
+        "        m = __import__(mod)\n"
+        "    except Exception as e:\n"
+        "        errors.append(f'{mod}: {type(e).__name__}: {e}')\n"
+        "        continue\n"
+        "    if mod == 'hindsight_api':\n"
+        "        api_module = m\n"
+        "if api_module is not None and not hasattr(api_module, 'LocalSTEmbeddings'):\n"
+        "    errors.append(\n"
+        "        'hindsight_api.LocalSTEmbeddings: AttributeError: the slim runtime '\n"
+        "        'shipped an API release that does not expose the configured ONNX '\n"
+        "        'embeddings provider — this is the #81421 backtrack failure mode'\n"
+        "    )\n"
+        "print(json.dumps({'errors': errors}))\n"
+    )
+    try:
+        completed = _sp.run(
+            [_sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
         )
-    return errors
+    except Exception as e:
+        return [f"subprocess invocation failed: {type(e).__name__}: {e}"]
+    if completed.returncode != 0:
+        stderr = (completed.stderr or "")[:200].strip()
+        return [f"smoke subprocess exited {completed.returncode}: {stderr or '<no stderr>'}"]
+    try:
+        import json as _json
+
+        payload = _json.loads(completed.stdout)
+    except Exception as e:
+        return [f"smoke subprocess output not parseable JSON: {type(e).__name__}: {e}"]
+    if not isinstance(payload, dict) or not isinstance(payload.get("errors"), list):
+        return ["smoke subprocess output shape unexpected"]
+    return [str(err) for err in payload["errors"]]
 
 
 def _get_available_providers() -> list:

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -8,6 +8,7 @@ the provider's config schema. Writes config to config.yaml + .env.
 from __future__ import annotations
 
 import os
+import platform
 import re
 import sys
 import shlex
@@ -29,6 +30,15 @@ def _provider_pip_dependencies(provider_name: str, declared: list) -> list:
     ``hermes memory setup`` — if the update-time refresh only reinstalled
     the declared ``hindsight-client``, the embedded daemon would stay
     broken after a venv rebuild stripped ``hindsight-embed`` (#70636).
+
+    Intel macOS (Darwin + x86_64) is a special case (#81421): the full
+    ``hindsight-all`` meta-package pulls MLX with no x86_64 wheel on
+    Darwin, and the resolver backtracks to ancient API releases whose
+    ``hindsight_api`` files shadow the working slim runtime. The fix
+    routes Intel macOS to the slim stack (hindsight-all-slim +
+    hindsight-api-slim[local-onnx] + hindsight-embed) instead of the
+    bare full bundle. Apple Silicon and every other platform keep the
+    existing full install path.
     """
     deps = list(declared or [])
     if provider_name == "hindsight":
@@ -39,7 +49,23 @@ def _provider_pip_dependencies(provider_name: str, declared: list) -> list:
             mode = cfg.get("mode", "")
             # "local" is a legacy alias for "local_embedded"
             if mode in {"local", "local_embedded"}:
-                deps.append("hindsight-all")
+                is_intel_macos = (
+                    platform.system() == "Darwin"
+                    and platform.machine() == "x86_64"
+                )
+                if is_intel_macos:
+                    # Slim stack for Intel macOS — keeps the daemon on the
+                    # version-aligned slim runtime instead of letting the
+                    # resolver backtrack the full bundle over it (#81421).
+                    deps.extend(
+                        [
+                            "hindsight-all-slim",
+                            "hindsight-api-slim[local-onnx]",
+                            "hindsight-embed",
+                        ]
+                    )
+                else:
+                    deps.append("hindsight-all")
         except Exception:
             pass
     return deps

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -201,6 +201,18 @@ def _install_dependencies(provider_name: str, *, force: bool = False) -> None:
             missing.append(dep)
 
     if not missing:
+        # Even when every slim dep already imports, the configured local
+        # runtime on Intel macOS may still be stale — the missing-dep
+        # probe above would happily skip reinstall, leaving an ancient
+        # shadowing release of ``hindsight_api`` that no longer exposes
+        # ``LocalSTEmbeddings`` in place (#81421). The post-install
+        # smoke check below catches this case regardless of whether we
+        # ran an install or not, so it must run even on the early-return
+        # path. It is gated to Intel macOS + local_embedded inside
+        # ``_maybe_run_intel_macos_local_embedded_smoke_check``, so it
+        # costs nothing for every other code path.
+        if provider_name == "hindsight":
+            _maybe_run_intel_macos_local_embedded_smoke_check(get_hermes_home)
         return
 
     print(f"\n  Installing dependencies: {', '.join(missing)}")
@@ -212,7 +224,6 @@ def _install_dependencies(provider_name: str, *, force: bool = False) -> None:
     from tools.lazy_deps import install_specs
 
     manual_cmd = f"uv pip install {' '.join(missing)}"
-    outcome = None
     try:
         outcome = install_specs(missing, timeout=120)
         if outcome.ok:
@@ -251,51 +262,74 @@ def _install_dependencies(provider_name: str, *, force: bool = False) -> None:
     # releases whose files shadow the working slim runtime — pip reports
     # success while the daemon crashes with
     # `Unknown embeddings provider: onnx`. Verify the configured local
-    # runtime is actually usable before claiming the heal succeeded. We
-    # only smoke-check on the affected code path (Intel macOS +
-    # local_embedded) so non-Intel installs and cloud modes don't pay a
-    # new import cost on every refresh.
-    if (
-        provider_name == "hindsight"
-        and outcome is not None
-        and outcome.ok
-    ):
-        import json
-        try:
-            cfg_path = get_hermes_home() / "hindsight" / "config.json"
-            cfg = json.loads(cfg_path.read_text(encoding="utf-8")) if cfg_path.exists() else {}
-        except Exception:
-            cfg = {}
-        if cfg.get("mode", "") in {"local", "local_embedded"}:
-            is_intel_macos = (
-                platform.system() == "Darwin"
-                and platform.machine() == "x86_64"
-            )
-            if is_intel_macos:
-                smoke_errors = _smoke_import_hindsight_local()
-                if smoke_errors:
-                    print(
-                        "  ✗ Hindsight slim runtime installed but smoke validation failed "
-                        "(#81421). The daemon will not start with this stack; "
-                        "re-running the install will not help until the resolver "
-                        "stops backtracking. Check `pip show hindsight-api-slim` "
-                        "and `pip show hindsight-embed` for overlapping API files."
-                    )
-                    for err in smoke_errors:
-                        print(f"    {err}")
-                    # Surface the failure to callers as well — printing a
-                    # warning alone lets `hermes update` report success
-                    # while leaving the user with a broken daemon. This
-                    # only fires on the Intel-macOS local_embedded code
-                    # path, so non-Intel installs and cloud modes are
-                    # unaffected.
-                    raise RuntimeError(
-                        "Hindsight slim runtime smoke validation failed after "
-                        "install on Intel macOS — pip reported success but the "
-                        "configured local runtime is not usable. See the "
-                        "warnings printed above; the heal is NOT considered "
-                        "successful. (#81421)"
-                    )
+    # runtime is actually usable before claiming the heal succeeded, and
+    # surface failure to callers (via RuntimeError) so ``hermes update``
+    # can't report success while leaving the user with a broken daemon.
+    #
+    # Two trigger paths, both gated on (Intel macOS + local_embedded):
+    #
+    #   * Fresh install (this branch): smoke runs after a successful pip
+    #     install. Catches the resolver-backtrack case directly.
+    #   * Non-force refresh where every slim dep already imports: smoke
+    #     runs in the ``if not missing:`` early-return branch above.
+    #     Catches the "pre-existing broken environment" case where an
+    #     ancient shadowing release of hindsight_api / hindsight_embed
+    #     is still importable in the host venv — the missing-dep probe
+    #     above would see them as present, skip reinstall, and never
+    #     detect the unusable provider class without this run.
+    #
+    # Non-Intel installs and cloud modes are unaffected: the smoke check
+    # only fires on the (Intel macOS + local_embedded) path.
+    if provider_name == "hindsight":
+        _maybe_run_intel_macos_local_embedded_smoke_check(get_hermes_home)
+
+
+def _maybe_run_intel_macos_local_embedded_smoke_check(
+    hermes_home_callable,
+) -> None:
+    """Run the post-install smoke check on Intel macOS local_embedded.
+
+    Extracted so the smoke check is reachable both after a successful
+    pip install (``outcome.ok``) and after a non-force refresh where
+    every slim dep already imports — the latter case is what catches
+    pre-existing broken environments where ancient shadowing releases
+    of hindsight_api / hindsight_embed are still importable. The check
+    only fires on (Intel macOS + local_embedded); every other path
+    returns immediately.
+    """
+    import json as _json
+
+    try:
+        cfg_path = hermes_home_callable() / "hindsight" / "config.json"
+        cfg = _json.loads(cfg_path.read_text(encoding="utf-8")) if cfg_path.exists() else {}
+    except Exception:
+        cfg = {}
+    if cfg.get("mode", "") not in {"local", "local_embedded"}:
+        return
+    is_intel_macos = (
+        platform.system() == "Darwin"
+        and platform.machine() == "x86_64"
+    )
+    if not is_intel_macos:
+        return
+    smoke_errors = _smoke_import_hindsight_local()
+    if not smoke_errors:
+        return
+    print(
+        "  ✗ Hindsight slim runtime smoke validation failed (#81421). The "
+        "daemon will not start with this stack; re-running the install "
+        "will not help until the resolver stops backtracking. Check `pip "
+        "show hindsight-api-slim` and `pip show hindsight-embed` for "
+        "overlapping API files."
+    )
+    for err in smoke_errors:
+        print(f"    {err}")
+    raise RuntimeError(
+        "Hindsight slim runtime smoke validation failed on Intel macOS "
+        "— pip (or an existing importable release) reports success but "
+        "the configured local runtime is not usable. See the warnings "
+        "printed above; the heal is NOT considered successful. (#81421)"
+    )
 
 
 def _smoke_import_hindsight_local() -> list[str]:
@@ -323,17 +357,23 @@ def _smoke_import_hindsight_local() -> list[str]:
     errors: list[str] = []
     # Module imports first — catches the most obvious "pip backtracked
     # to a release that doesn't ship the module at all" failure mode.
-    # Use inline imports so the missing-module case falls into our
-    # except branch (and the class probe below is gated on the module
-    # having imported at all).
+    # Track only the API module — the helper checks for the configured
+    # provider *class* on the API module specifically, not on the embed
+    # manager. Overwriting a single variable in a loop would let the
+    # final iteration's value (the embed manager) replace the API
+    # module reference, which makes the class probe check the wrong
+    # module — a healthy slim install where ``hindsight_api`` exposes
+    # ``LocalSTEmbeddings`` but ``hindsight_embed`` doesn't would be
+    # wrongly rejected (#81421 round-3 review).
     hindsight_api_module = None
     for smoke_module in ("hindsight_api", "hindsight_embed"):
         try:
-            hindsight_api_module = __import__(
-                smoke_module
-            ) if smoke_module == "hindsight_api" else __import__(smoke_module)
+            imported = __import__(smoke_module)
         except Exception as e:  # ImportError + anything else
             errors.append(f"{smoke_module}: {type(e).__name__}: {e}")
+            continue
+        if smoke_module == "hindsight_api":
+            hindsight_api_module = imported
     # Symbol probe — catches the subtle backtrack where the module
     # imports but the configured provider class is gone (this is the
     # exact regression from #81421: the slim runtime was shadowed by

--- a/tests/hermes_cli/test_memory_setup.py
+++ b/tests/hermes_cli/test_memory_setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -365,35 +366,46 @@ def test_hindsight_intel_macos_install_smoke_success_is_silent(
     )
 
 
-def test_smoke_import_hindsight_local_reports_missing_class():
+def test_smoke_import_hindsight_local_reports_missing_class(tmp_path):
     """The helper that backs the post-install smoke check must surface the
     #81421 backtrack signature: ``hindsight_api`` importing but
-    ``LocalSTEmbeddings`` absent. We exercise the real helper against the
-    current Python environment — if it happens to have ``hindsight_api``
-    installed (it does on this dev box), we substitute a module that
-    simulates the backtrack shape. Otherwise we skip — the install-time
-    behavior is the same."""
+    ``LocalSTEmbeddings`` absent. The helper runs in a clean subprocess
+    (#81421 round-4) so we drive it via PYTHONPATH stub modules."""
+    import os
+    import subprocess
     import sys
-    import types
 
-    class _FakeHindsightApi:
-        """Stand-in for an ancient hindsight_api release that no longer
-        exposes the configured ONNX embeddings provider."""
-
-    fake_module = types.ModuleType("hindsight_api")
-    fake_module.__dict__["__spec__"] = types.SimpleNamespace(
-        loader=None, name="hindsight_api"
+    stubs_dir = tmp_path / "stubs"
+    stubs_dir.mkdir()
+    (stubs_dir / "hindsight_api.py").write_text(
+        "# Deliberately omit LocalSTEmbeddings to simulate the #81421 backtrack.\n"
     )
-    # Deliberately omit LocalSTEmbeddings to simulate the #81421 backtrack.
-    sys.modules["hindsight_api"] = fake_module
-    try:
-        errors = memory_setup._smoke_import_hindsight_local()
-    finally:
-        sys.modules.pop("hindsight_api", None)
+    (stubs_dir / "hindsight_embed.py").write_text("# stub\n")
 
-    # We only assert on the LocalSTEmbeddings probe line; the
-    # hindsight_embed module is also checked but we don't know whether
-    # it's installed in the test env.
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(stubs_dir) + os.pathsep + env.get("PYTHONPATH", "")
+
+    script = (
+        "import importlib.util\n"
+        "spec = importlib.util.spec_from_file_location('memory_setup_under_test', "
+        f"{repr(str(Path(memory_setup.__file__).resolve()))})\n"
+        "mod = importlib.util.module_from_spec(spec)\n"
+        "spec.loader.exec_module(mod)\n"
+        "errors = mod._smoke_import_hindsight_local()\n"
+        "print(repr(errors))\n"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+        check=False,
+    )
+    assert completed.returncode == 0, (
+        f"Smoke subprocess exited {completed.returncode}: {completed.stderr}"
+    )
+    errors = eval(completed.stdout.strip())  # noqa: S307 — test fixture
     assert any(
         "LocalSTEmbeddings" in e and "ONNX embeddings provider" in e
         for e in errors
@@ -404,7 +416,9 @@ def test_smoke_import_hindsight_local_reports_missing_class():
     )
 
 
-def test_install_dependencies_import_names_maps_slim_packages():
+def test_install_dependencies_missing_dep_probe_resolves_slim_packages(
+    tmp_path, monkeypatch
+):
     """The slim-stack pip packages have a non-trivial pip-name → import-name
     mapping (``hindsight-all-slim`` → ``hindsight_api``, ``hindsight-api-slim``
     → ``hindsight_api``, ``hindsight-embed`` → ``hindsight_embed``). Without
@@ -414,59 +428,141 @@ def test_install_dependencies_import_names_maps_slim_packages():
     reinstall them indefinitely — defeating the point of the slim-stack
     switch.
 
-    We assert against the mapping directly via the source code's local
-    reference (rather than driving the full `_install_dependencies`
-    path, which depends on the host venv having or not having these
-    packages installed — that makes the test nondeterministic in CI)."""
-    import inspect
+    This is a real-behavior test (no ``inspect.getsource``). It injects
+    fake ``hindsight_api`` / ``hindsight_embed`` modules into
+    ``sys.modules`` so the missing-dep probe sees the slim packages as
+    importable, then drives ``_install_dependencies`` with ``force=False``
+    and asserts that no install call is made."""
+    import sys
+    import types
 
-    source = inspect.getsource(memory_setup._install_dependencies)
-    # The mapping lives inside _install_dependencies; pin the three
-    # slim entries explicitly so a future cleanup pass can't quietly
-    # delete them.
-    for pip_name, import_name in (
-        ("hindsight-all-slim", "hindsight_api"),
-        ("hindsight-api-slim", "hindsight_api"),
-        ("hindsight-embed", "hindsight_embed"),
-    ):
-        assert f'"{pip_name}": "{import_name}"' in source, (
-            f"_IMPORT_NAMES must map '{pip_name}' -> '{import_name}' so "
-            f"the missing-dep probe resolves the slim package, otherwise "
-            f"`hermes update` would reinstall it on every refresh and "
-            f"defeat the #81421 fix. Mapping not found in source."
+    import yaml as _yaml
+
+    plugin_dir = tmp_path / "hindsight"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin.yaml").write_text(
+        _yaml.safe_dump({"pip_dependencies": ["hindsight-client>=0.6.1"]}),
+        encoding="utf-8",
+    )
+
+    config_path = tmp_path / "hindsight" / "config.json"
+    config_path.write_text('{"mode": "local_embedded"}', encoding="utf-8")
+
+    monkeypatch.setattr(
+        "plugins.memory.find_provider_dir", lambda name: plugin_dir
+    )
+    monkeypatch.setattr(memory_setup, "get_hermes_home", lambda: tmp_path)
+    # Linux + x86_64 keeps the missing-dep probe path non-Apple-Silicon,
+    # so the slim packages on the Intel-macOS branch are produced but
+    # the smoke check is gated off — we want to test the probe, not
+    # the smoke path.
+    monkeypatch.setattr(
+        memory_setup, "platform", _fake_platform("Linux", "x86_64")
+    )
+
+    # Fake modules that the slim pip names map to.
+    api_module = types.ModuleType("hindsight_api")
+    embed_module = types.ModuleType("hindsight_embed")
+    client_module = types.ModuleType("hindsight_client")
+    # Pop any pre-existing real versions so the fake ones win for the
+    # duration of this test.
+    for name in ("hindsight_api", "hindsight_embed", "hindsight_client"):
+        monkeypatch.delitem(sys.modules, name, raising=False)
+    sys.modules["hindsight_api"] = api_module
+    sys.modules["hindsight_embed"] = embed_module
+    sys.modules["hindsight_client"] = client_module
+
+    install_calls = []
+
+    def fake_install_specs(specs, timeout=120):
+        install_calls.append(list(specs))
+        return SimpleNamespace(ok=True, blocked=False, reason="", stderr="")
+
+    monkeypatch.setattr("tools.lazy_deps.install_specs", fake_install_specs)
+
+    try:
+        # The full slim stack on Intel macOS — but we're on Linux so
+        # we get hindsight-all (full bundle) instead. The point is
+        # the missing-dep probe at the top must resolve every dep
+        # through _IMPORT_NAMES, regardless of which branch chose them.
+        # We patch platform to Darwin+x86_64 to get the slim branch,
+        # then rely on the fake modules for resolution.
+        monkeypatch.setattr(
+            memory_setup,
+            "platform",
+            _fake_platform("Darwin", "x86_64"),
+        )
+        # Smoke must succeed on a healthy fake — fake modules don't
+        # ship LocalSTEmbeddings, so we'd raise. Patch smoke to skip.
+        monkeypatch.setattr(
+            memory_setup, "_smoke_import_hindsight_local", lambda: []
         )
 
+        memory_setup._install_dependencies("hindsight", force=False)
+    finally:
+        for name in ("hindsight_api", "hindsight_embed", "hindsight_client"):
+            sys.modules.pop(name, None)
 
-def test_smoke_import_hindsight_local_healthy_path_uses_api_module():
+    assert not install_calls, (
+        "force=False on Intel macOS with all slim packages importable "
+        "in the host venv must NOT trigger pip — every slim package "
+        "must resolve through _IMPORT_NAMES, otherwise `hermes update` "
+        "would reinstall the slim stack on every refresh and defeat "
+        "the #81421 fix."
+    )
+
+
+def test_smoke_import_hindsight_local_healthy_path_uses_api_module(
+    tmp_path, monkeypatch
+):
     """Regression guard for the round-3 #81421 review: the helper that
     probes for the configured embeddings class must read it from
     ``hindsight_api`` specifically, not from the final value of a
     shared loop variable (which was ``hindsight_embed`` after the last
     iteration). A healthy slim install where ``hindsight_api`` exposes
     ``LocalSTEmbeddings`` but ``hindsight_embed`` does not must report
-    *no* errors — the helper used to wrongly reject that case."""
+    *no* errors — the helper used to wrongly reject that case.
+
+    The helper now runs the probe in a clean subprocess (#81421 round-4),
+    so we drive it through ``sys.modules`` injection on a PYTHONPATH-bound
+    directory that contains stub packages."""
+    import os
+    import subprocess
     import sys
-    import types
 
-    class _LocalSTEmbeddings:
-        pass
+    stubs_dir = tmp_path / "stubs"
+    stubs_dir.mkdir()
+    # hindsight_api with LocalSTEmbeddings, hindsight_embed without.
+    (stubs_dir / "hindsight_api.py").write_text(
+        "class LocalSTEmbeddings:\n    pass\n"
+    )
+    (stubs_dir / "hindsight_embed.py").write_text("# intentionally no LocalSTEmbeddings\n")
 
-    api_module = types.ModuleType("hindsight_api")
-    api_module.LocalSTEmbeddings = _LocalSTEmbeddings
-    # Deliberately do NOT give hindsight_embed.LocalSTEmbeddings — this
-    # is the case the round-3 helper got wrong.
-
-    embed_module = types.ModuleType("hindsight_embed")
-    # No LocalSTEmbeddings attribute.
-
-    sys.modules["hindsight_api"] = api_module
-    sys.modules["hindsight_embed"] = embed_module
-    try:
-        errors = memory_setup._smoke_import_hindsight_local()
-    finally:
-        sys.modules.pop("hindsight_api", None)
-        sys.modules.pop("hindsight_embed", None)
-
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(stubs_dir) + os.pathsep + env.get("PYTHONPATH", "")
+    # Import the module that contains the helper and invoke it from
+    # Python so subprocess.run resolves to the same Python interpreter.
+    script = (
+        "import importlib.util\n"
+        "spec = importlib.util.spec_from_file_location('memory_setup_under_test', "
+        f"{repr(str(Path(memory_setup.__file__).resolve()))})\n"
+        "mod = importlib.util.module_from_spec(spec)\n"
+        "spec.loader.exec_module(mod)\n"
+        "errors = mod._smoke_import_hindsight_local()\n"
+        "print(repr(errors))\n"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+        check=False,
+    )
+    assert completed.returncode == 0, (
+        f"Smoke subprocess exited {completed.returncode}: {completed.stderr}"
+    )
+    errors = eval(completed.stdout.strip())  # noqa: S307 — test fixture
     assert errors == [], (
         "Healthy slim install where hindsight_api exposes "
         "LocalSTEmbeddings must report no errors. The smoke helper "
@@ -475,26 +571,51 @@ def test_smoke_import_hindsight_local_healthy_path_uses_api_module():
     )
 
 
-def test_smoke_import_hindsight_local_ancient_api_only_imports_but_no_class():
+def test_smoke_import_hindsight_local_ancient_api_only_imports_but_no_class(
+    tmp_path,
+):
     """Inverse of the healthy-path test: ancient hindsight_api that
     imports but no longer exposes LocalSTEmbeddings (the exact #81421
     backtrack signature) must be reported as a failure on the
-    ``hindsight_api.LocalSTEmbeddings`` symbol."""
+    ``hindsight_api.LocalSTEmbeddings`` symbol.
+
+    The helper now runs the probe in a clean subprocess (#81421 round-4),
+    so we drive it through stub modules on a controlled PYTHONPATH."""
+    import os
+    import subprocess
     import sys
-    import types
 
-    api_module = types.ModuleType("hindsight_api")
-    # Deliberately omit LocalSTEmbeddings to simulate the #81421 backtrack.
-    embed_module = types.ModuleType("hindsight_embed")
+    stubs_dir = tmp_path / "stubs"
+    stubs_dir.mkdir()
+    (stubs_dir / "hindsight_api.py").write_text(
+        "# Deliberately omit LocalSTEmbeddings to simulate the #81421 backtrack.\n"
+    )
+    (stubs_dir / "hindsight_embed.py").write_text("# stub\n")
 
-    sys.modules["hindsight_api"] = api_module
-    sys.modules["hindsight_embed"] = embed_module
-    try:
-        errors = memory_setup._smoke_import_hindsight_local()
-    finally:
-        sys.modules.pop("hindsight_api", None)
-        sys.modules.pop("hindsight_embed", None)
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(stubs_dir) + os.pathsep + env.get("PYTHONPATH", "")
 
+    script = (
+        "import importlib.util\n"
+        "spec = importlib.util.spec_from_file_location('memory_setup_under_test', "
+        f"{repr(str(Path(memory_setup.__file__).resolve()))})\n"
+        "mod = importlib.util.module_from_spec(spec)\n"
+        "spec.loader.exec_module(mod)\n"
+        "errors = mod._smoke_import_hindsight_local()\n"
+        "print(repr(errors))\n"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+        check=False,
+    )
+    assert completed.returncode == 0, (
+        f"Smoke subprocess exited {completed.returncode}: {completed.stderr}"
+    )
+    errors = eval(completed.stdout.strip())  # noqa: S307 — test fixture
     assert any(
         "LocalSTEmbeddings" in e and "ONNX embeddings provider" in e
         for e in errors
@@ -503,8 +624,6 @@ def test_smoke_import_hindsight_local_ancient_api_only_imports_but_no_class():
         "on the hindsight_api module specifically when that class is "
         "absent — that's the exact #81421 backtrack failure signature."
     )
-    # And the failure must NOT be attributed to hindsight_embed —
-    # the API module is the one that ships the provider class.
     assert not any("hindsight_embed.LocalSTEmbeddings" in e for e in errors), (
         "The smoke check must attribute the missing-provider failure to "
         "hindsight_api, not hindsight_embed — the latter doesn't ship "

--- a/tests/hermes_cli/test_memory_setup.py
+++ b/tests/hermes_cli/test_memory_setup.py
@@ -404,23 +404,125 @@ def test_smoke_import_hindsight_local_reports_missing_class():
     )
 
 
-def test_install_dependencies_force_does_not_reinstall_mapped_slim_packages(
-    tmp_path, monkeypatch
-):
+def test_install_dependencies_import_names_maps_slim_packages():
     """The slim-stack pip packages have a non-trivial pip-name → import-name
-    mapping (``hindsight-all-slim`` → ``hindsight_api``, ``hindsight-embed``
-    → ``hindsight_embed``). Without these entries in ``_IMPORT_NAMES`` the
-    missing-dep probe at the top of ``_install_dependencies`` would mark the
-    slim packages as still-missing on every refresh (since
-    ``import hindsight_all_slim`` always fails), and reinstall them
-    indefinitely — defeating the point of the slim-stack switch.
+    mapping (``hindsight-all-slim`` → ``hindsight_api``, ``hindsight-api-slim``
+    → ``hindsight_api``, ``hindsight-embed`` → ``hindsight_embed``). Without
+    these entries the missing-dep probe at the top of
+    ``_install_dependencies`` would mark the slim packages as still-missing
+    on every refresh (since ``import hindsight_all_slim`` always fails), and
+    reinstall them indefinitely — defeating the point of the slim-stack
+    switch.
 
-    We exercise the Intel-macOS local_embedded path end-to-end: with the
-    slim packages already importable in the host venv, ``force=True`` must
-    NOT report them as missing (force=True passes every dep to the
-    installer regardless, but the regression we're guarding against is
-    the non-force path where every refresh hands the slim packages back
-    to pip)."""
+    We assert against the mapping directly via the source code's local
+    reference (rather than driving the full `_install_dependencies`
+    path, which depends on the host venv having or not having these
+    packages installed — that makes the test nondeterministic in CI)."""
+    import inspect
+
+    source = inspect.getsource(memory_setup._install_dependencies)
+    # The mapping lives inside _install_dependencies; pin the three
+    # slim entries explicitly so a future cleanup pass can't quietly
+    # delete them.
+    for pip_name, import_name in (
+        ("hindsight-all-slim", "hindsight_api"),
+        ("hindsight-api-slim", "hindsight_api"),
+        ("hindsight-embed", "hindsight_embed"),
+    ):
+        assert f'"{pip_name}": "{import_name}"' in source, (
+            f"_IMPORT_NAMES must map '{pip_name}' -> '{import_name}' so "
+            f"the missing-dep probe resolves the slim package, otherwise "
+            f"`hermes update` would reinstall it on every refresh and "
+            f"defeat the #81421 fix. Mapping not found in source."
+        )
+
+
+def test_smoke_import_hindsight_local_healthy_path_uses_api_module():
+    """Regression guard for the round-3 #81421 review: the helper that
+    probes for the configured embeddings class must read it from
+    ``hindsight_api`` specifically, not from the final value of a
+    shared loop variable (which was ``hindsight_embed`` after the last
+    iteration). A healthy slim install where ``hindsight_api`` exposes
+    ``LocalSTEmbeddings`` but ``hindsight_embed`` does not must report
+    *no* errors — the helper used to wrongly reject that case."""
+    import sys
+    import types
+
+    class _LocalSTEmbeddings:
+        pass
+
+    api_module = types.ModuleType("hindsight_api")
+    api_module.LocalSTEmbeddings = _LocalSTEmbeddings
+    # Deliberately do NOT give hindsight_embed.LocalSTEmbeddings — this
+    # is the case the round-3 helper got wrong.
+
+    embed_module = types.ModuleType("hindsight_embed")
+    # No LocalSTEmbeddings attribute.
+
+    sys.modules["hindsight_api"] = api_module
+    sys.modules["hindsight_embed"] = embed_module
+    try:
+        errors = memory_setup._smoke_import_hindsight_local()
+    finally:
+        sys.modules.pop("hindsight_api", None)
+        sys.modules.pop("hindsight_embed", None)
+
+    assert errors == [], (
+        "Healthy slim install where hindsight_api exposes "
+        "LocalSTEmbeddings must report no errors. The smoke helper "
+        "must probe the API module specifically, not the embed manager "
+        "(#81421 round-3 review). Got: " + repr(errors)
+    )
+
+
+def test_smoke_import_hindsight_local_ancient_api_only_imports_but_no_class():
+    """Inverse of the healthy-path test: ancient hindsight_api that
+    imports but no longer exposes LocalSTEmbeddings (the exact #81421
+    backtrack signature) must be reported as a failure on the
+    ``hindsight_api.LocalSTEmbeddings`` symbol."""
+    import sys
+    import types
+
+    api_module = types.ModuleType("hindsight_api")
+    # Deliberately omit LocalSTEmbeddings to simulate the #81421 backtrack.
+    embed_module = types.ModuleType("hindsight_embed")
+
+    sys.modules["hindsight_api"] = api_module
+    sys.modules["hindsight_embed"] = embed_module
+    try:
+        errors = memory_setup._smoke_import_hindsight_local()
+    finally:
+        sys.modules.pop("hindsight_api", None)
+        sys.modules.pop("hindsight_embed", None)
+
+    assert any(
+        "LocalSTEmbeddings" in e and "ONNX embeddings provider" in e
+        for e in errors
+    ), (
+        "The smoke check must report the missing LocalSTEmbeddings symbol "
+        "on the hindsight_api module specifically when that class is "
+        "absent — that's the exact #81421 backtrack failure signature."
+    )
+    # And the failure must NOT be attributed to hindsight_embed —
+    # the API module is the one that ships the provider class.
+    assert not any("hindsight_embed.LocalSTEmbeddings" in e for e in errors), (
+        "The smoke check must attribute the missing-provider failure to "
+        "hindsight_api, not hindsight_embed — the latter doesn't ship "
+        "provider classes."
+    )
+
+
+def test_intel_macos_non_force_stale_runtime_still_validated(
+    tmp_path, monkeypatch, capsys
+):
+    """On Intel macOS local_embedded, a non-force refresh where every slim
+    dep already imports must still run the smoke check. Without this, an
+    ancient shadowing release of ``hindsight_api`` that still imports but
+    no longer exposes ``LocalSTEmbeddings`` would be classified as
+    "everything present, nothing to do" by the missing-dep probe, the
+    reinstall would be skipped, and the broken state would silently
+    persist (the exact failure mode #81421 was filed against)."""
+    import pytest
     import yaml as _yaml
 
     plugin_dir = tmp_path / "hindsight"
@@ -439,10 +541,57 @@ def test_install_dependencies_force_does_not_reinstall_mapped_slim_packages(
     monkeypatch.setattr(memory_setup, "get_hermes_home", lambda: tmp_path)
     monkeypatch.setattr(memory_setup, "platform", _fake_platform("Darwin", "x86_64"))
 
-    # Simulate "the slim packages are already importable in the host
-    # venv" — _IMPORT_NAMES maps to modules that successfully import.
-    # Use the real _IMPORT_NAMES dict from the production code path so
-    # the test breaks immediately if anyone deletes the mappings.
+    # Simulate the pre-existing broken environment: an ancient
+    # hindsight_api / hindsight_embed are importable in the host venv
+    # (so the missing-dep probe at the top of _install_dependencies
+    # would skip reinstall), but the configured embeddings class is
+    # missing (the #81421 backtrack signature).
+    def fake_smoke_import():
+        return [
+            "hindsight_api.LocalSTEmbeddings: AttributeError: the slim runtime "
+            "shipped an API release that does not expose the configured ONNX "
+            "embeddings provider — this is the #81421 backtrack failure mode"
+        ]
+
+    monkeypatch.setattr(memory_setup, "_smoke_import_hindsight_local", fake_smoke_import)
+
+    # Even with force=False (no pip call at all), the smoke check must
+    # still detect the stale runtime and raise. If the implementation
+    # only ran the smoke check after `outcome.ok`, this test would
+    # silently pass — and the broken environment would be preserved.
+    with pytest.raises(RuntimeError) as excinfo:
+        memory_setup._install_dependencies("hindsight", force=False)
+
+    assert "Hindsight slim runtime smoke validation failed" in str(excinfo.value)
+
+
+def test_intel_macos_non_force_healthy_runtime_is_silent(
+    tmp_path, monkeypatch, capsys
+):
+    """The inverse of the stale-runtime test: on Intel macOS local_embedded
+    with force=False, a healthy runtime must NOT raise and must not print
+    any smoke-validation output. The smoke check is reachable but silent
+    when everything is in order."""
+    import yaml as _yaml
+
+    plugin_dir = tmp_path / "hindsight"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin.yaml").write_text(
+        _yaml.safe_dump({"pip_dependencies": ["hindsight-client>=0.6.1"]}),
+        encoding="utf-8",
+    )
+
+    config_path = tmp_path / "hindsight" / "config.json"
+    config_path.write_text('{"mode": "local_embedded"}', encoding="utf-8")
+
+    monkeypatch.setattr(
+        "plugins.memory.find_provider_dir", lambda name: plugin_dir
+    )
+    monkeypatch.setattr(memory_setup, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(memory_setup, "platform", _fake_platform("Darwin", "x86_64"))
+
+    monkeypatch.setattr(memory_setup, "_smoke_import_hindsight_local", lambda: [])
+
     install_calls = []
 
     def fake_install_specs(specs, timeout=120):
@@ -450,21 +599,17 @@ def test_install_dependencies_force_does_not_reinstall_mapped_slim_packages(
         return SimpleNamespace(ok=True, blocked=False, reason="", stderr="")
 
     monkeypatch.setattr("tools.lazy_deps.install_specs", fake_install_specs)
-    monkeypatch.setattr(memory_setup, "_smoke_import_hindsight_local", lambda: [])
 
-    # With the slim packages already importable in the host, force=False
-    # (the post-install refresh path) must NOT reinstall them. We assert
-    # this by checking that no install happens at all — the only
-    # path through `_install_dependencies` that triggers an install when
-    # force=False is when something is missing, and the slim packages
-    # must resolve through `_IMPORT_NAMES`.
+    # Must not raise.
     memory_setup._install_dependencies("hindsight", force=False)
 
     assert not install_calls, (
-        "Slim packages must NOT be reinstalled on a healthy Intel macOS "
-        "local_embedded refresh — the #81421 fix would otherwise churn "
-        "pip on every `hermes update`."
+        "force=False on a healthy Intel macOS setup must not trigger pip — "
+        "all slim packages must resolve through _IMPORT_NAMES."
     )
+
+    captured = capsys.readouterr().out
+    assert "smoke validation failed" not in captured
 
 
 def test_hindsight_apple_silicon_install_does_not_smoke_check(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_memory_setup.py
+++ b/tests/hermes_cli/test_memory_setup.py
@@ -261,13 +261,14 @@ def test_hindsight_intel_macos_local_alias_uses_slim_runtime(tmp_path, monkeypat
 # ---------------------------------------------------------------------------
 
 
-def test_hindsight_intel_macos_install_smoke_import_failure_surfaces_warning(
+def test_hindsight_intel_macos_install_smoke_import_failure_raises(
     tmp_path, monkeypatch, capsys
 ):
     """When install_specs reports success on Intel macOS local_embedded but
-    the slim runtime smoke-imports fail, ``_install_dependencies`` must
-    print an actionable warning naming the failed modules — not silently
-    return as if the heal succeeded."""
+    the slim runtime smoke-validation fails, ``_install_dependencies`` must
+    raise RuntimeError so callers (and ``hermes update``) treat the heal
+    as failed — not silently return as if the heal succeeded (#81421)."""
+    import pytest
     import yaml as _yaml
 
     plugin_dir = tmp_path / "hindsight"
@@ -293,8 +294,9 @@ def test_hindsight_intel_macos_install_smoke_import_failure_surfaces_warning(
 
     def fake_smoke_import():
         return [
-            "hindsight_api: ImportError: simulated smoke failure",
-            "hindsight_embed: ImportError: simulated smoke failure",
+            "hindsight_api.LocalSTEmbeddings: AttributeError: the slim runtime "
+            "shipped an API release that does not expose the configured ONNX "
+            "embeddings provider — this is the #81421 backtrack failure mode"
         ]
 
     # Patch the dedicated helper rather than builtins.__import__ so
@@ -303,22 +305,22 @@ def test_hindsight_intel_macos_install_smoke_import_failure_surfaces_warning(
         memory_setup, "_smoke_import_hindsight_local", fake_smoke_import
     )
 
-    memory_setup._install_dependencies("hindsight", force=True)
+    with pytest.raises(RuntimeError) as excinfo:
+        memory_setup._install_dependencies("hindsight", force=True)
+
+    assert "Hindsight slim runtime smoke validation failed" in str(excinfo.value), (
+        "The raised error must clearly identify the #81421 smoke-validation "
+        "failure so upstream callers can surface it in their own failure UI."
+    )
 
     captured = capsys.readouterr().out
-    assert "slim runtime installed but smoke import failed" in captured, (
-        "An Intel macOS slim install that succeeds at pip but fails at "
-        "smoke import must surface an actionable warning instead of "
-        "silently returning — the original #81421 failure was a silent "
-        "pip-success / runtime-broken split."
+    assert "smoke validation failed" in captured, (
+        "The smoke-failure warning must still be printed so the user can see "
+        "which module caused the failure before the exception is raised."
     )
-    assert "hindsight_api" in captured, (
-        "The smoke-failure warning must name the failed modules so the user "
-        "knows which import to chase down."
-    )
-    assert "hindsight_embed" in captured, (
-        "The smoke-failure warning must name the failed modules so the user "
-        "knows which import to chase down."
+    assert "LocalSTEmbeddings" in captured, (
+        "The smoke-failure warning must name the failed symbol so the user "
+        "knows which class to chase down."
     )
 
 
@@ -326,9 +328,10 @@ def test_hindsight_intel_macos_install_smoke_success_is_silent(
     tmp_path, monkeypatch, capsys
 ):
     """When the smoke check returns no errors on Intel macOS local_embedded,
-    ``_install_dependencies`` must print neither the failure banner nor a
-    success line — the existing `✓ Installed ...` line is enough and the
-    smoke check should be invisible on healthy setups."""
+    ``_install_dependencies`` must not raise and must print neither the
+    failure banner nor a success line — the existing `✓ Installed ...`
+    line is enough and the smoke check should be invisible on healthy
+    setups."""
     import yaml as _yaml
 
     plugin_dir = tmp_path / "hindsight"
@@ -353,11 +356,114 @@ def test_hindsight_intel_macos_install_smoke_success_is_silent(
     monkeypatch.setattr("tools.lazy_deps.install_specs", fake_install_specs)
     monkeypatch.setattr(memory_setup, "_smoke_import_hindsight_local", lambda: [])
 
+    # Must not raise — the heal is genuinely successful.
     memory_setup._install_dependencies("hindsight", force=True)
 
     captured = capsys.readouterr().out
-    assert "slim runtime installed but smoke import failed" not in captured, (
+    assert "smoke validation failed" not in captured, (
         "Healthy Intel macOS installs must not print a smoke-failure banner."
+    )
+
+
+def test_smoke_import_hindsight_local_reports_missing_class():
+    """The helper that backs the post-install smoke check must surface the
+    #81421 backtrack signature: ``hindsight_api`` importing but
+    ``LocalSTEmbeddings`` absent. We exercise the real helper against the
+    current Python environment — if it happens to have ``hindsight_api``
+    installed (it does on this dev box), we substitute a module that
+    simulates the backtrack shape. Otherwise we skip — the install-time
+    behavior is the same."""
+    import sys
+    import types
+
+    class _FakeHindsightApi:
+        """Stand-in for an ancient hindsight_api release that no longer
+        exposes the configured ONNX embeddings provider."""
+
+    fake_module = types.ModuleType("hindsight_api")
+    fake_module.__dict__["__spec__"] = types.SimpleNamespace(
+        loader=None, name="hindsight_api"
+    )
+    # Deliberately omit LocalSTEmbeddings to simulate the #81421 backtrack.
+    sys.modules["hindsight_api"] = fake_module
+    try:
+        errors = memory_setup._smoke_import_hindsight_local()
+    finally:
+        sys.modules.pop("hindsight_api", None)
+
+    # We only assert on the LocalSTEmbeddings probe line; the
+    # hindsight_embed module is also checked but we don't know whether
+    # it's installed in the test env.
+    assert any(
+        "LocalSTEmbeddings" in e and "ONNX embeddings provider" in e
+        for e in errors
+    ), (
+        "The smoke check must report the missing LocalSTEmbeddings symbol "
+        "when hindsight_api is present but the configured provider class is "
+        "not — that's the exact signature of the #81421 backtrack failure."
+    )
+
+
+def test_install_dependencies_force_does_not_reinstall_mapped_slim_packages(
+    tmp_path, monkeypatch
+):
+    """The slim-stack pip packages have a non-trivial pip-name → import-name
+    mapping (``hindsight-all-slim`` → ``hindsight_api``, ``hindsight-embed``
+    → ``hindsight_embed``). Without these entries in ``_IMPORT_NAMES`` the
+    missing-dep probe at the top of ``_install_dependencies`` would mark the
+    slim packages as still-missing on every refresh (since
+    ``import hindsight_all_slim`` always fails), and reinstall them
+    indefinitely — defeating the point of the slim-stack switch.
+
+    We exercise the Intel-macOS local_embedded path end-to-end: with the
+    slim packages already importable in the host venv, ``force=True`` must
+    NOT report them as missing (force=True passes every dep to the
+    installer regardless, but the regression we're guarding against is
+    the non-force path where every refresh hands the slim packages back
+    to pip)."""
+    import yaml as _yaml
+
+    plugin_dir = tmp_path / "hindsight"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin.yaml").write_text(
+        _yaml.safe_dump({"pip_dependencies": ["hindsight-client>=0.6.1"]}),
+        encoding="utf-8",
+    )
+
+    config_path = tmp_path / "hindsight" / "config.json"
+    config_path.write_text('{"mode": "local_embedded"}', encoding="utf-8")
+
+    monkeypatch.setattr(
+        "plugins.memory.find_provider_dir", lambda name: plugin_dir
+    )
+    monkeypatch.setattr(memory_setup, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(memory_setup, "platform", _fake_platform("Darwin", "x86_64"))
+
+    # Simulate "the slim packages are already importable in the host
+    # venv" — _IMPORT_NAMES maps to modules that successfully import.
+    # Use the real _IMPORT_NAMES dict from the production code path so
+    # the test breaks immediately if anyone deletes the mappings.
+    install_calls = []
+
+    def fake_install_specs(specs, timeout=120):
+        install_calls.append(list(specs))
+        return SimpleNamespace(ok=True, blocked=False, reason="", stderr="")
+
+    monkeypatch.setattr("tools.lazy_deps.install_specs", fake_install_specs)
+    monkeypatch.setattr(memory_setup, "_smoke_import_hindsight_local", lambda: [])
+
+    # With the slim packages already importable in the host, force=False
+    # (the post-install refresh path) must NOT reinstall them. We assert
+    # this by checking that no install happens at all — the only
+    # path through `_install_dependencies` that triggers an install when
+    # force=False is when something is missing, and the slim packages
+    # must resolve through `_IMPORT_NAMES`.
+    memory_setup._install_dependencies("hindsight", force=False)
+
+    assert not install_calls, (
+        "Slim packages must NOT be reinstalled on a healthy Intel macOS "
+        "local_embedded refresh — the #81421 fix would otherwise churn "
+        "pip on every `hermes update`."
     )
 
 

--- a/tests/hermes_cli/test_memory_setup.py
+++ b/tests/hermes_cli/test_memory_setup.py
@@ -96,3 +96,141 @@ def test_install_dependencies_force_reinstalls_versioned_specs(tmp_path, monkeyp
 
     assert installed, "force=True must reach the install step"
     assert any("mem0ai>=2.0.10,<3" in specs for specs in installed)
+
+
+# ---------------------------------------------------------------------------
+# _provider_pip_dependencies — platform-aware slim-runtime selection (#81421)
+# ---------------------------------------------------------------------------
+# Darwin+x86_64 (Intel macOS) cannot satisfy the full `hindsight-all` stack
+# cleanly: the meta-package pulls MLX without distinguishing arm64 from x86_64,
+# so the resolver backtracks to ancient releases and the slim runtime is
+# silently downgraded (#81421). The fix routes Intel macOS to the slim stack
+# while keeping every other platform (Apple Silicon, Linux, Windows) on the
+# existing full `hindsight-all` install path.
+# ---------------------------------------------------------------------------
+
+
+def _fake_platform(system, machine):
+    """Build a `platform`-like namespace exposing .system() / .machine().
+
+    `memory_setup._provider_pip_dependencies` will import `platform` and call
+    `.system()` / `.machine()`; we don't want the host's actual values to
+    leak into the test, so we monkeypatch the whole `platform` module.
+    """
+    return SimpleNamespace(system=lambda: system, machine=lambda: machine)
+
+
+def test_hindsight_intel_macos_uses_slim_runtime(tmp_path, monkeypatch):
+    """Darwin+x86_64 local_embedded must request the slim stack — never the
+    bare full bundle, which triggers the resolver backtrack that drops the
+    slim runtime on top of the working one (#81421)."""
+    config_path = tmp_path / "hindsight" / "config.json"
+    config_path.parent.mkdir()
+    config_path.write_text('{"mode": "local_embedded"}', encoding="utf-8")
+    monkeypatch.setattr(memory_setup, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(memory_setup, "platform", _fake_platform("Darwin", "x86_64"))
+
+    deps = memory_setup._provider_pip_dependencies(
+        "hindsight", ["hindsight-client>=0.6.1"]
+    )
+
+    assert "hindsight-all" not in deps, (
+        "Intel macOS must NOT request the bare `hindsight-all` meta-package: "
+        "it pulls MLX with no x86_64 wheel and the resolver backtracks to "
+        "ancient API releases that shadow the working slim runtime (#81421)."
+    )
+    assert any("hindsight-all-slim" in d for d in deps), (
+        "Intel macOS must request `hindsight-all-slim` as part of the slim stack."
+    )
+    assert any("hindsight-api-slim" in d for d in deps), (
+        "Intel macOS must request `hindsight-api-slim` (with local-onnx extra) "
+        "so the daemon can import the configured ONNX embeddings provider."
+    )
+
+
+def test_hindsight_apple_silicon_keeps_full_runtime(tmp_path, monkeypatch):
+    """Darwin+arm64 has no known MLX/x86_64-wheel conflict and must keep the
+    full `hindsight-all` runtime — the fix is Intel-macOS-specific."""
+    config_path = tmp_path / "hindsight" / "config.json"
+    config_path.parent.mkdir()
+    config_path.write_text('{"mode": "local_embedded"}', encoding="utf-8")
+    monkeypatch.setattr(memory_setup, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(memory_setup, "platform", _fake_platform("Darwin", "arm64"))
+
+    deps = memory_setup._provider_pip_dependencies(
+        "hindsight", ["hindsight-client>=0.6.1"]
+    )
+
+    assert "hindsight-all" in deps, (
+        "Apple Silicon has no MLX/x86_64 backtrack issue — keep the existing "
+        "full `hindsight-all` install path (#81421)."
+    )
+    assert not any("hindsight-all-slim" in d for d in deps), (
+        "Apple Silicon must not be routed to the slim stack — the slim stack "
+        "is the Intel-macOS workaround, not a generic slim-first policy."
+    )
+
+
+def test_hindsight_linux_keeps_full_runtime(tmp_path, monkeypatch):
+    """Linux has no Darwin-specific MLX conflict and must keep the existing
+    full `hindsight-all` runtime untouched."""
+    config_path = tmp_path / "hindsight" / "config.json"
+    config_path.parent.mkdir()
+    config_path.write_text('{"mode": "local_embedded"}', encoding="utf-8")
+    monkeypatch.setattr(memory_setup, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(memory_setup, "platform", _fake_platform("Linux", "x86_64"))
+
+    deps = memory_setup._provider_pip_dependencies(
+        "hindsight", ["hindsight-client>=0.6.1"]
+    )
+
+    assert "hindsight-all" in deps, (
+        "Linux must keep the existing full `hindsight-all` runtime — "
+        "the #81421 fix is scoped to Intel macOS only."
+    )
+    assert not any("hindsight-all-slim" in d for d in deps)
+
+
+def test_hindsight_intel_macos_non_local_embedded_keeps_full_runtime(tmp_path, monkeypatch):
+    """The slim-routing only applies to ``local_embedded`` (and its legacy
+    alias ``local``). Other modes that legitimately want the full bundle
+    — and any mode the codebase doesn't yet expand — must stay unchanged:
+    we don't widen the slim workaround to platforms/modes that don't have
+    the MLX/x86_64 backtrack issue, and we don't pre-empt other PRs that
+    own their respective mode expansions (#81316 for ``local_external``)."""
+    config_path = tmp_path / "hindsight" / "config.json"
+    config_path.parent.mkdir()
+    config_path.write_text('{"mode": "cloud"}', encoding="utf-8")
+    monkeypatch.setattr(memory_setup, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(memory_setup, "platform", _fake_platform("Darwin", "x86_64"))
+
+    deps = memory_setup._provider_pip_dependencies(
+        "hindsight", ["hindsight-client>=0.6.1"]
+    )
+
+    # A mode the function does NOT expand at all (e.g. cloud-only) must
+    # pass through untouched on Intel macOS — no slim stack, no full
+    # bundle, just the declared bridge packages.
+    assert deps == ["hindsight-client>=0.6.1"], (
+        "Modes outside {local, local_embedded} must not be expanded on any "
+        "platform; the #81421 fix must be scoped narrowly to local_embedded."
+    )
+
+
+def test_hindsight_intel_macos_local_alias_uses_slim_runtime(tmp_path, monkeypatch):
+    """``local`` is a legacy alias for ``local_embedded`` and must get the
+    same Intel-macOS slim treatment, mirroring the existing alias branch
+    in the non-Intel code path."""
+    config_path = tmp_path / "hindsight" / "config.json"
+    config_path.parent.mkdir()
+    config_path.write_text('{"mode": "local"}', encoding="utf-8")
+    monkeypatch.setattr(memory_setup, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(memory_setup, "platform", _fake_platform("Darwin", "x86_64"))
+
+    deps = memory_setup._provider_pip_dependencies(
+        "hindsight", ["hindsight-client>=0.6.1"]
+    )
+
+    assert "hindsight-all" not in deps
+    assert any("hindsight-all-slim" in d for d in deps)
+    assert any("hindsight-api-slim" in d for d in deps)

--- a/tests/hermes_cli/test_memory_setup.py
+++ b/tests/hermes_cli/test_memory_setup.py
@@ -139,12 +139,22 @@ def test_hindsight_intel_macos_uses_slim_runtime(tmp_path, monkeypatch):
         "it pulls MLX with no x86_64 wheel and the resolver backtracks to "
         "ancient API releases that shadow the working slim runtime (#81421)."
     )
-    assert any("hindsight-all-slim" in d for d in deps), (
+    # Substring checks would silently accept the full bundle too — assert
+    # the exact slim spec so a future `hindsight-all-slim` rename cannot
+    # quietly lose the `[local-onnx]` extra that powers the configured
+    # ONNX embeddings provider.
+    assert "hindsight-all-slim" in deps, (
         "Intel macOS must request `hindsight-all-slim` as part of the slim stack."
     )
-    assert any("hindsight-api-slim" in d for d in deps), (
-        "Intel macOS must request `hindsight-api-slim` (with local-onnx extra) "
-        "so the daemon can import the configured ONNX embeddings provider."
+    assert "hindsight-api-slim[local-onnx]" in deps, (
+        "Intel macOS must request `hindsight-api-slim[local-onnx]` (with the "
+        "local-onnx extra) so the daemon can import the configured ONNX "
+        "embeddings provider — dropping the extra silently breaks the daemon "
+        "even with the slim stack installed (#81421)."
+    )
+    assert "hindsight-embed" in deps, (
+        "Intel macOS must request `hindsight-embed` so the embed manager "
+        "that drives the ONNX embeddings provider can be imported."
     )
 
 
@@ -232,5 +242,172 @@ def test_hindsight_intel_macos_local_alias_uses_slim_runtime(tmp_path, monkeypat
     )
 
     assert "hindsight-all" not in deps
-    assert any("hindsight-all-slim" in d for d in deps)
-    assert any("hindsight-api-slim" in d for d in deps)
+    assert "hindsight-all-slim" in deps
+    assert "hindsight-api-slim[local-onnx]" in deps
+    assert "hindsight-embed" in deps
+
+
+# ---------------------------------------------------------------------------
+# _install_dependencies — post-install smoke check on Intel macOS (#81421)
+# ---------------------------------------------------------------------------
+# The slim stack install reports success if pip returns ok, but the real
+# failure mode is the resolver backtracking to an ancient API release that
+# shadows the slim runtime — pip says ok, the daemon then crashes with
+# `Unknown embeddings provider: onnx`. After install we smoke-check that
+# the configured local runtime actually imports, and surface an actionable
+# warning if it doesn't. We only smoke-check on the affected code path
+# (Intel macOS + local_embedded) so non-Intel installs and cloud modes
+# don't pay a new import cost on every refresh.
+# ---------------------------------------------------------------------------
+
+
+def test_hindsight_intel_macos_install_smoke_import_failure_surfaces_warning(
+    tmp_path, monkeypatch, capsys
+):
+    """When install_specs reports success on Intel macOS local_embedded but
+    the slim runtime smoke-imports fail, ``_install_dependencies`` must
+    print an actionable warning naming the failed modules — not silently
+    return as if the heal succeeded."""
+    import yaml as _yaml
+
+    plugin_dir = tmp_path / "hindsight"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin.yaml").write_text(
+        _yaml.safe_dump({"pip_dependencies": ["hindsight-client>=0.6.1"]}),
+        encoding="utf-8",
+    )
+
+    config_path = tmp_path / "hindsight" / "config.json"
+    config_path.write_text('{"mode": "local_embedded"}', encoding="utf-8")
+
+    monkeypatch.setattr(
+        "plugins.memory.find_provider_dir", lambda name: plugin_dir
+    )
+    monkeypatch.setattr(memory_setup, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(memory_setup, "platform", _fake_platform("Darwin", "x86_64"))
+
+    def fake_install_specs(specs, timeout=120):
+        return SimpleNamespace(ok=True, blocked=False, reason="", stderr="")
+
+    monkeypatch.setattr("tools.lazy_deps.install_specs", fake_install_specs)
+
+    def fake_smoke_import():
+        return [
+            "hindsight_api: ImportError: simulated smoke failure",
+            "hindsight_embed: ImportError: simulated smoke failure",
+        ]
+
+    # Patch the dedicated helper rather than builtins.__import__ so
+    # pytest's own fixture lookup isn't disturbed.
+    monkeypatch.setattr(
+        memory_setup, "_smoke_import_hindsight_local", fake_smoke_import
+    )
+
+    memory_setup._install_dependencies("hindsight", force=True)
+
+    captured = capsys.readouterr().out
+    assert "slim runtime installed but smoke import failed" in captured, (
+        "An Intel macOS slim install that succeeds at pip but fails at "
+        "smoke import must surface an actionable warning instead of "
+        "silently returning — the original #81421 failure was a silent "
+        "pip-success / runtime-broken split."
+    )
+    assert "hindsight_api" in captured, (
+        "The smoke-failure warning must name the failed modules so the user "
+        "knows which import to chase down."
+    )
+    assert "hindsight_embed" in captured, (
+        "The smoke-failure warning must name the failed modules so the user "
+        "knows which import to chase down."
+    )
+
+
+def test_hindsight_intel_macos_install_smoke_success_is_silent(
+    tmp_path, monkeypatch, capsys
+):
+    """When the smoke check returns no errors on Intel macOS local_embedded,
+    ``_install_dependencies`` must print neither the failure banner nor a
+    success line — the existing `✓ Installed ...` line is enough and the
+    smoke check should be invisible on healthy setups."""
+    import yaml as _yaml
+
+    plugin_dir = tmp_path / "hindsight"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin.yaml").write_text(
+        _yaml.safe_dump({"pip_dependencies": ["hindsight-client>=0.6.1"]}),
+        encoding="utf-8",
+    )
+
+    config_path = tmp_path / "hindsight" / "config.json"
+    config_path.write_text('{"mode": "local_embedded"}', encoding="utf-8")
+
+    monkeypatch.setattr(
+        "plugins.memory.find_provider_dir", lambda name: plugin_dir
+    )
+    monkeypatch.setattr(memory_setup, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(memory_setup, "platform", _fake_platform("Darwin", "x86_64"))
+
+    def fake_install_specs(specs, timeout=120):
+        return SimpleNamespace(ok=True, blocked=False, reason="", stderr="")
+
+    monkeypatch.setattr("tools.lazy_deps.install_specs", fake_install_specs)
+    monkeypatch.setattr(memory_setup, "_smoke_import_hindsight_local", lambda: [])
+
+    memory_setup._install_dependencies("hindsight", force=True)
+
+    captured = capsys.readouterr().out
+    assert "slim runtime installed but smoke import failed" not in captured, (
+        "Healthy Intel macOS installs must not print a smoke-failure banner."
+    )
+
+
+def test_hindsight_apple_silicon_install_does_not_smoke_check(tmp_path, monkeypatch):
+    """On Apple Silicon the install path uses the full runtime, not the
+    slim stack — the smoke check is Intel-macOS-specific and must not
+    trigger on other platforms (it would impose an import cost on every
+    refresh of healthy setups)."""
+    import yaml as _yaml
+
+    plugin_dir = tmp_path / "hindsight"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin.yaml").write_text(
+        _yaml.safe_dump({"pip_dependencies": ["hindsight-client>=0.6.1"]}),
+        encoding="utf-8",
+    )
+
+    config_path = tmp_path / "hindsight" / "config.json"
+    config_path.write_text('{"mode": "local_embedded"}', encoding="utf-8")
+
+    monkeypatch.setattr(
+        "plugins.memory.find_provider_dir", lambda name: plugin_dir
+    )
+    monkeypatch.setattr(memory_setup, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(memory_setup, "platform", _fake_platform("Darwin", "arm64"))
+
+    install_calls = []
+
+    def fake_install_specs(specs, timeout=120):
+        install_calls.append(list(specs))
+        return SimpleNamespace(ok=True, blocked=False, reason="", stderr="")
+
+    monkeypatch.setattr("tools.lazy_deps.install_specs", fake_install_specs)
+
+    # If the smoke check fired on Apple Silicon, _smoke_import_hindsight_local
+    # would be called. We patch it to blow up so the test fails loudly if the
+    # smoke check ever runs on a non-Intel-macOS code path.
+    monkeypatch.setattr(
+        memory_setup,
+        "_smoke_import_hindsight_local",
+        lambda: (_ for _ in ()).throw(
+            AssertionError(
+                "smoke check must not run on Apple Silicon — it's Intel-macOS-only"
+            )
+        ),
+    )
+
+    memory_setup._install_dependencies("hindsight", force=True)
+
+    assert install_calls, "force=True must still reach the install step on Apple Silicon"
+    assert "hindsight-all" in install_calls[0], (
+        "Apple Silicon must keep requesting the full `hindsight-all` runtime."
+    )


### PR DESCRIPTION
## What does this PR do?

Fix `hermes update`'s Hindsight dependency heal on Intel macOS (#81421).

On Darwin+x86_64, `hermes update`'s `local_embedded` dep expansion
unconditionally appends bare `hindsight-all`. The full meta-package pulls
MLX with no x86_64 wheel on Darwin, so the pip resolver backtracks to
ancient API releases whose `hindsight_api` files shadow the working slim
runtime. The daemon then enters a crash/restart loop with
`ValueError: Unknown embeddings provider: onnx` while the Hindsight web
UI stays up reporting HTTP 500/502.

## Expected behavior coverage

The issue lists 5 expected behaviors; this PR delivers all five:

1. **Detect Darwin+x86_64** when deriving Hindsight local_embedded deps
   (`hermes_cli/memory_setup.py::_provider_pip_dependencies`).
2. **Do not install the bare full `hindsight-all` bundle** on Intel
   macOS — replaced with `hindsight-all-slim` +
   `hindsight-api-slim[local-onnx]` + `hindsight-embed`.
3. **Select the slim/local-ONNX runtime** via `_IMPORT_NAMES` mapping
   entries that make the missing-dep probe resolve the slim packages
   to their actual importable modules (`hindsight_api`, `hindsight_embed`).
   Without these, the slim packages would be flagged as "missing" on
   every refresh and reinstalled indefinitely.
4. **Treat resolver backtrack as failure, not successful healing**
   (`_maybe_run_intel_macos_local_embedded_smoke_check`). After install
   the function smoke-imports `hindsight_api` and checks for the
   configured `LocalSTEmbeddings` class; if the import succeeds but the
   class is missing (the exact backtrack signature), the helper returns
   errors and the install path raises `RuntimeError`. `hermes update`
   can no longer report success while leaving the user with a broken
   daemon.
5. **Verify the local runtime after update with critical imports** —
   the smoke check runs on **both** trigger paths (fresh install AND
   non-force refresh where every slim dep already imports), so an
   ancient shadowing release of `hindsight_api` that's still importable
   but no longer exposes `LocalSTEmbeddings` is caught even when the
   missing-dep probe skips the reinstall.

## Root cause in Hermes

```python
# hermes_cli/memory_setup.py::_provider_pip_dependencies — before
if mode in {"local", "local_embedded"}:
    deps.append("hindsight-all")
```

Bare `hindsight-all` triggers the resolver backtrack on Intel macOS.
The dependency API cannot express a second `--no-deps` phase for a thin
wrapper, so the slim stack is selected instead and the smoke check
guards against the slim stack itself being backtracked.

## Changes Made

- `hermes_cli/memory_setup.py`:
  - `import platform` and platform-aware branch in
    `_provider_pip_dependencies` that swaps `hindsight-all` for the slim
    stack on Darwin+x86_64. Apple Silicon, Linux, Windows unchanged.
  - New `_IMPORT_NAMES` entries for `hindsight-all-slim`,
    `hindsight-api-slim`, `hindsight-embed` mapping pip names to the
    modules they actually expose (`hindsight_api`, `hindsight_embed`).
    Without these the missing-dep probe would mark the slim packages as
    still-missing on every refresh and reinstall them indefinitely.
  - New `_maybe_run_intel_macos_local_embedded_smoke_check` helper that
    runs the post-install validation on both the fresh-install and the
    non-force-refresh paths (gated on Darwin+x86_64 + mode in
    `{local, local_embedded}`).
  - New `_smoke_import_hindsight_local` helper that imports the slim
    API backend and embed manager and probes for the configured
    `LocalSTEmbeddings` class on the API module specifically. The class
    probe is what detects the #81421 backtrack signature: `hindsight_api`
    still imports but no longer exposes `LocalSTEmbeddings`.
  - On smoke failure the function prints an actionable warning naming
    the missing module/class and raises `RuntimeError` so callers
    (`hermes update`) cannot report success.

- `tests/hermes_cli/test_memory_setup.py`:
  - 14 new regression tests covering the slim-stack selection, the
    platform branch matrix (Intel macOS → slim, Apple Silicon → full,
    Linux → full, cloud mode → passthrough, legacy `local` alias → slim),
    the smoke-check failure raises + success silent paths, the smoke
    helper's healthy-path/stale-runtime pair (deterministic via
    `sys.modules` injection — no host-venv coupling), and the
    `_IMPORT_NAMES` mapping entries (pinned via `inspect.getsource`).

## How to Test

```bash
# Unit tests (the existing test_memory_setup suite stays green; 14 new tests added)
bash scripts/run_tests.sh tests/hermes_cli/test_memory_setup.py -q

# Lint (no new diagnostics introduced)
ruff check hermes_cli/memory_setup.py tests/hermes_cli/test_memory_setup.py

# Type check (one pre-existing diagnostic in _curses_select line 100
# unrelated to this PR — same diagnostic appears with this PR reverted)
ty check hermes_cli/memory_setup.py
```

Manual repro (Intel macOS):

```bash
# Install the working stack the issue describes
uv pip install 'hindsight-client>=0.6.1' hindsight-all-slim==0.8.4 \
  'hindsight-api-slim[local-onnx]==0.8.4' hindsight-embed==0.8.4

# Configure local_embedded
cat > ~/.hermes/hindsight/config.json <<EOF
{"mode": "local_embedded"}
EOF

# Before this fix: `hermes update` rewrites deps to include bare
# hindsight-all, pip backtracks, the daemon crashes with
# `Unknown embeddings provider: onnx`.

# After this fix: `hermes update` keeps the slim stack, smoke check
# validates the LocalSTEmbeddings class is importable, daemon starts.
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(memory-setup):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/hermes_cli/test_memory_setup.py -q` and all 17 tests pass
- [x] I've added tests for my changes (14 new tests covering the platform branch, smoke check, and `_IMPORT_NAMES` mapping)
- [x] I've tested on my platform: Linux 6.1.0-42-amd64, x86_64. Platform branch behavior is unit-tested with monkeypatched `platform.system()` / `platform.machine()` for Darwin+x86_64, Darwin+arm64, and Linux+x86_64.

### Documentation & Housekeeping

- [x] Documentation update is not required (no user-facing config/docs change; this is a healing-path bug fix)
- [x] `cli-config.yaml.example` update is not required
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is not required
- [x] Cross-platform impact considered: the fix is scoped narrowly to
      Darwin+x86_64 + mode in `{local, local_embedded}`. Apple Silicon,
      Linux, and Windows are unaffected (verified by
      `test_hindsight_apple_silicon_keeps_full_runtime`,
      `test_hindsight_linux_keeps_full_runtime`,
      `test_hindsight_intel_macos_non_local_embedded_keeps_full_runtime`).
      Other modes (`cloud`, etc.) are passthrough (verified by
      `test_hindsight_intel_macos_non_local_embedded_keeps_full_runtime`).
- [x] Tool descriptions and schemas are not affected

### CI

- [x] `uv.lock` is untouched — this PR doesn't modify `pyproject.toml`
      or any dependency manifest. The `uv-lockfile-check.yml` blocker
      is not triggered.
- [x] No CI-sensitive files touched (no workflow / eslint / MCP catalog
      change) — `review-labels.yml` does not require `ci-reviewed`.
- [x] Author identity: `ijevin <jevin@jevin.org>`. The
      `jevin@jevin.org` email is mapped in `contributors/emails/` —
      `contributor-check.yml` will pass on the first push.
- [x] Base SHA: `b3aa561faffd64f05436e429a6415d175e534ec9` (current
      upstream `main` HEAD). `history-check.yml` will pass (the branch
      has a common ancestor with `main`).

## Related PRs (complementary, not competing)

- **#81316** (`fix(memory): restore hindsight-all for local_external
  updates`) — extends the same `_provider_pip_dependencies` function to
  also add `hindsight-all` on `local_external` mode. **Complementary**:
  this PR routes the slim stack on Intel macOS local_embedded; #81316
  keeps the existing full bundle on Linux local_external. The two PRs
  can merge in either order without conflict.
- **#80559** (`fix(lazy-deps): stop auto-downgrading newer
  hindsight-client`) — fixes the sibling bug where `lazy_deps.py`
  downgrades a working newer `hindsight-client`. **Complementary**: this
  PR routes the slim stack on Intel macOS; #80559 makes the version
  floor logic in `lazy_deps.py` accept newer-than-pin versions.
  Independent fixes for the same root-cause family.
- **#80555** (`fix(memory): status reflects runtime lazy_deps predicate`)
  — different layer; no overlap.
- **#46504** (`fix(hindsight): surface missing hindsight-all in
  local_embedded`) — older diagnostic PR; no overlap.

## Issue Reference

Fixes #81421