### PR TITLE
feat(desktop): add compression lineage navigation

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/context-lineage.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/context-lineage.test.tsx
@@ -1,0 +1,143 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { CompressionLineage } from '@/hermes'
+
+import { ContextLineage } from './context-lineage'
+
+const mocks = vi.hoisted(() => ({
+  getCompressionSegmentMessages: vi.fn()
+}))
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      common: {
+        close: 'Close',
+        retry: 'Retry'
+      },
+      sidebar: {
+        lineage: {
+          all: 'View all segments',
+          branch: 'Branch from this segment',
+          current: 'Current segment',
+          error: 'Could not load this segment.',
+          loading: 'Loading segment…',
+          readOnly: 'Read-only historical segment',
+          segment: (index: number) => `Segment ${index}`,
+          segments: (count: number) => `${count} segments`,
+          title: 'Conversation context'
+        }
+      }
+    }
+  })
+}))
+
+vi.mock('@/components/assistant-ui/thread', () => ({
+  Thread: () => <div>read-only thread</div>
+}))
+
+vi.mock('@/hermes', async importOriginal => {
+  const actual = await importOriginal<Record<string, unknown>>()
+
+  return {
+    ...actual,
+    getCompressionSegmentMessages: (...args: unknown[]) => mocks.getCompressionSegmentMessages(...args)
+  }
+})
+
+const lineage: CompressionLineage = {
+  root_session_id: 'root',
+  segments: [
+    { id: 'root', index: 1, is_tip: false, message_count: 2, started_at: 10, title: 'Start' },
+    { id: 'middle', index: 2, is_tip: false, message_count: 3, started_at: 20, title: 'Middle' },
+    { id: 'tip', index: 3, is_tip: true, message_count: 4, started_at: 30, title: 'Current' }
+  ],
+  tip_session_id: 'tip'
+}
+
+describe('ContextLineage', () => {
+  it('shows the current segment and two recent historical segments compactly', () => {
+    render(<ContextLineage lineage={lineage} />)
+
+    const compact = screen.getByTestId('lineage-compact')
+    const trigger = screen.getByRole('button', { name: '3 segments' })
+
+    expect(compact.textContent).toContain('Current segment')
+    expect(compact.textContent).toContain('Segment 2')
+    expect(compact.textContent).toContain('Segment 1')
+    expect(compact.textContent).toContain('View all segments')
+    expect(trigger.getAttribute('aria-haspopup')).toBe('dialog')
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+    expect(mocks.getCompressionSegmentMessages).not.toHaveBeenCalled()
+  })
+
+  it('loads an exact historical segment without resuming the live session', async () => {
+    mocks.getCompressionSegmentMessages.mockResolvedValue({
+      messages: [{ content: 'old answer', role: 'assistant' }],
+      session_id: 'middle'
+    })
+    const onBranch = vi.fn()
+
+    render(<ContextLineage lineage={lineage} onBranch={onBranch} profile="work" />)
+
+    fireEvent.click(screen.getByRole('button', { name: '3 segments' }))
+    const segmentButtons = screen.getAllByRole('button', { name: 'Segment 2' })
+    fireEvent.click(segmentButtons.at(-1)!)
+
+    await waitFor(() => expect(mocks.getCompressionSegmentMessages).toHaveBeenCalledWith('tip', 'middle', 'work'))
+    expect(await screen.findByTestId('lineage-transcript')).toBeTruthy()
+    expect(screen.getByText('Read-only historical segment')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Branch from this segment' }))
+    expect(onBranch).toHaveBeenCalledWith('middle', 'work', 'tip')
+  })
+
+  it('shows an error and retries instead of treating a failed segment as empty', async () => {
+    mocks.getCompressionSegmentMessages
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce({ messages: [], session_id: 'middle' })
+    const onBranch = vi.fn()
+
+    render(<ContextLineage lineage={lineage} onBranch={onBranch} profile="work" />)
+
+    fireEvent.click(screen.getByRole('button', { name: '3 segments' }))
+    fireEvent.click(screen.getAllByRole('button', { name: 'Segment 2' }).at(-1)!)
+
+    expect((await screen.findByRole('alert')).textContent).toContain('Could not load this segment.')
+    expect(screen.queryByRole('button', { name: 'Branch from this segment' })).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await waitFor(() => expect(mocks.getCompressionSegmentMessages).toHaveBeenCalledTimes(2))
+    expect(await screen.findByTestId('lineage-transcript')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Branch from this segment' })).toBeTruthy()
+  })
+
+  it('does not reuse a historical cache across profiles with the same tip id', async () => {
+    mocks.getCompressionSegmentMessages
+      .mockResolvedValueOnce({ messages: [{ content: 'work history', role: 'assistant' }], session_id: 'middle' })
+      .mockResolvedValueOnce({ messages: [{ content: 'personal history', role: 'assistant' }], session_id: 'middle' })
+
+    const view = render(<ContextLineage lineage={lineage} profile="work" />)
+    fireEvent.click(screen.getByRole('button', { name: '3 segments' }))
+    fireEvent.click(screen.getAllByRole('button', { name: 'Segment 2' }).at(-1)!)
+    expect(await screen.findByTestId('lineage-transcript')).toBeTruthy()
+    expect(mocks.getCompressionSegmentMessages).toHaveBeenCalledWith('tip', 'middle', 'work')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    view.rerender(<ContextLineage lineage={lineage} profile="personal" />)
+    fireEvent.click(screen.getByRole('button', { name: '3 segments' }))
+    fireEvent.click(screen.getAllByRole('button', { name: 'Segment 2' }).at(-1)!)
+
+    await waitFor(() =>
+      expect(mocks.getCompressionSegmentMessages).toHaveBeenLastCalledWith('tip', 'middle', 'personal')
+    )
+    expect(mocks.getCompressionSegmentMessages).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/context-lineage.tsx
+++ b/apps/desktop/src/app/chat/sidebar/context-lineage.tsx
@@ -1,0 +1,318 @@
+import { AssistantRuntimeProvider, type ThreadMessage } from '@assistant-ui/react'
+import { type ReactNode, useEffect, useMemo, useState } from 'react'
+
+import { useRuntimeMessageRepository } from '@/app/chat/runtime-repository'
+import { Thread } from '@/components/assistant-ui/thread'
+import { Button } from '@/components/ui/button'
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+import {
+  type CompressionLineage,
+  getCompressionLineage,
+  getCompressionSegmentMessages,
+  type SessionInfo,
+  type SessionMessage
+} from '@/hermes'
+import { useI18n } from '@/i18n'
+import { toChatMessages } from '@/lib/chat-messages'
+import { useIncrementalExternalStoreRuntime } from '@/lib/incremental-external-store-runtime'
+import { cn } from '@/lib/utils'
+
+interface ContextLineageProps {
+  /** Backend-owned compression projection for the selected sidebar session. */
+  lineage: CompressionLineage
+  /** Non-virtual lists can expose the compact three-segment expansion. */
+  compact?: boolean
+  onBranch?: (sessionId: string, profile?: string, lineageSessionId?: string) => void
+  profile?: string
+  /** Places the trigger in the session row while keeping Sheet state here. */
+  renderContent?: (control: ReactNode, compactContent: ReactNode) => ReactNode
+}
+
+const NOOP_SET_MESSAGES = (_messages: readonly ThreadMessage[]) => {}
+
+const NOOP_NEW_MESSAGE = async () => {}
+
+function SegmentTranscript({ messages, sessionId }: { messages: SessionMessage[]; sessionId: string }) {
+  const chatMessages = useMemo(() => toChatMessages(messages), [messages])
+
+  const messageRepository = useRuntimeMessageRepository(chatMessages)
+
+  const adapter = useMemo(
+    () => ({
+      isRunning: false,
+      messageRepository,
+      onNew: NOOP_NEW_MESSAGE,
+      setMessages: NOOP_SET_MESSAGES
+    }),
+    [messageRepository]
+  )
+
+  const runtime = useIncrementalExternalStoreRuntime<ThreadMessage>(adapter)
+
+  return (
+    <div className="min-h-0 flex-1" data-testid="lineage-transcript">
+      <AssistantRuntimeProvider runtime={runtime}>
+        <Thread readOnly sessionId={sessionId} />
+      </AssistantRuntimeProvider>
+    </div>
+  )
+}
+
+export function ContextLineage(props: ContextLineageProps) {
+  const identity = `${props.profile ?? 'default'}\u0000${props.lineage.root_session_id}\u0000${props.lineage.tip_session_id}`
+
+  return <ContextLineageState {...props} key={identity} />
+}
+
+function ContextLineageState({ lineage, compact = true, onBranch, profile, renderContent }: ContextLineageProps) {
+  const { t } = useI18n()
+  const copy = t.sidebar.lineage
+  const [open, setOpen] = useState(false)
+  const [selectedSegmentId, setSelectedSegmentId] = useState(lineage.tip_session_id)
+  const [messagesBySegment, setMessagesBySegment] = useState<Record<string, SessionMessage[]>>({})
+  const [errorsBySegment, setErrorsBySegment] = useState<Record<string, true>>({})
+  const [loadingSegmentId, setLoadingSegmentId] = useState<string | null>(null)
+
+  const selectedSegment = useMemo(
+    () => lineage.segments.find(segment => segment.id === selectedSegmentId) ?? lineage.segments.at(-1),
+    [lineage.segments, selectedSegmentId]
+  )
+
+  const newestFirst = useMemo(() => [...lineage.segments].reverse(), [lineage.segments])
+  const compactSegments = useMemo(() => newestFirst.slice(0, 3), [newestFirst])
+
+  useEffect(() => {
+    setSelectedSegmentId(lineage.tip_session_id)
+    setMessagesBySegment({})
+    setErrorsBySegment({})
+    setLoadingSegmentId(null)
+  }, [lineage.tip_session_id])
+
+  useEffect(() => {
+    if (
+      !open ||
+      !selectedSegment ||
+      selectedSegment.is_tip ||
+      Object.hasOwn(messagesBySegment, selectedSegment.id) ||
+      errorsBySegment[selectedSegment.id]
+    ) {
+      return
+    }
+
+    let active = true
+    const segmentId = selectedSegment.id
+
+    setLoadingSegmentId(segmentId)
+    void getCompressionSegmentMessages(lineage.tip_session_id, segmentId, profile)
+      .then(result => {
+        if (active) {
+          setMessagesBySegment(current => ({ ...current, [segmentId]: result.messages }))
+        }
+      })
+      .catch(() => {
+        if (active) {
+          setErrorsBySegment(current => ({ ...current, [segmentId]: true }))
+        }
+      })
+      .finally(() => {
+        if (active) {
+          setLoadingSegmentId(current => (current === segmentId ? null : current))
+        }
+      })
+
+    return () => {
+      active = false
+    }
+  }, [errorsBySegment, lineage.tip_session_id, messagesBySegment, open, profile, selectedSegment])
+
+  const retrySelectedSegment = () => {
+    if (!selectedSegment) {
+      return
+    }
+
+    setErrorsBySegment(current => {
+      const next = { ...current }
+
+      delete next[selectedSegment.id]
+
+      return next
+    })
+  }
+
+  const selectSegment = (segmentId: string) => {
+    setSelectedSegmentId(segmentId)
+    setOpen(true)
+  }
+
+  if (lineage.segments.length < 2) {
+    return renderContent ? renderContent(null, null) : null
+  }
+
+  const control = (
+    <Button
+      aria-expanded={open}
+      aria-haspopup="dialog"
+      aria-label={copy.segments(lineage.segments.length)}
+      className="h-5 shrink-0 rounded px-1.5 text-[0.625rem]"
+      onClick={() => setOpen(true)}
+      size="inline"
+      variant="secondary"
+    >
+      {copy.segments(lineage.segments.length)}
+    </Button>
+  )
+
+  const compactContent = compact ? (
+    <div className="ml-4 grid gap-px border-l border-(--ui-stroke-tertiary) pb-1 pl-2" data-testid="lineage-compact">
+      {compactSegments.map(segment => (
+        <Button
+          aria-current={segment.is_tip ? 'step' : undefined}
+          className="justify-start text-left"
+          key={segment.id}
+          onClick={() => selectSegment(segment.id)}
+          size="inline"
+          variant="text"
+        >
+          {segment.is_tip ? copy.current : copy.segment(segment.index)}
+        </Button>
+      ))}
+      <Button className="justify-start" onClick={() => setOpen(true)} size="inline" variant="text">
+        {copy.all}
+      </Button>
+    </div>
+  ) : null
+
+  return (
+    <>
+      {renderContent ? (
+        renderContent(control, compactContent)
+      ) : (
+        <>
+          {control}
+          {compactContent}
+        </>
+      )}
+      <Sheet onOpenChange={setOpen} open={open}>
+        <SheetContent className="w-full sm:max-w-[min(52rem,90vw)]" side="right">
+          <SheetHeader>
+            <SheetTitle>{copy.title}</SheetTitle>
+            <SheetDescription>{copy.segments(lineage.segments.length)}</SheetDescription>
+          </SheetHeader>
+          <div className="grid min-h-0 flex-1 grid-rows-[auto_minmax(0,1fr)] border-y border-(--ui-stroke-tertiary) sm:grid-cols-[10rem_minmax(0,1fr)] sm:grid-rows-1">
+            <div className="flex max-h-32 overflow-auto py-1 sm:max-h-none sm:min-h-0 sm:flex-col sm:overflow-y-auto">
+              {newestFirst.map(segment => (
+                <Button
+                  aria-current={selectedSegment?.id === segment.id ? 'step' : undefined}
+                  className={cn(
+                    'shrink-0 justify-start text-left',
+                    selectedSegment?.id === segment.id && 'bg-(--ui-bg-quaternary)'
+                  )}
+                  key={segment.id}
+                  onClick={() => setSelectedSegmentId(segment.id)}
+                  size="sm"
+                  variant="ghost"
+                >
+                  {segment.is_tip ? copy.current : copy.segment(segment.index)}
+                </Button>
+              ))}
+            </div>
+            <div className="flex min-h-0 flex-col border-t border-(--ui-stroke-tertiary) sm:border-l sm:border-t-0">
+              {selectedSegment?.is_tip ? (
+                <p className="p-3 text-sm text-(--ui-text-tertiary)">{copy.current}</p>
+              ) : loadingSegmentId === selectedSegment?.id ? (
+                <p className="p-3 text-sm text-(--ui-text-tertiary)" role="status">
+                  {copy.loading}
+                </p>
+              ) : selectedSegment && errorsBySegment[selectedSegment.id] ? (
+                <div className="grid justify-items-start gap-2 p-3" role="alert">
+                  <p className="text-sm text-(--ui-text-tertiary)">{copy.error}</p>
+                  <Button onClick={retrySelectedSegment} size="sm" variant="secondary">
+                    {t.common.retry}
+                  </Button>
+                </div>
+              ) : selectedSegment && Object.hasOwn(messagesBySegment, selectedSegment.id) ? (
+                <>
+                  <p className="px-3 pt-3 text-xs text-(--ui-text-tertiary)" role="status">
+                    {copy.readOnly}
+                  </p>
+                  <SegmentTranscript
+                    messages={messagesBySegment[selectedSegment.id] ?? []}
+                    sessionId={selectedSegment.id}
+                  />
+                  {onBranch && (
+                    <div className="p-3">
+                      <Button
+                        onClick={() => onBranch(selectedSegment.id, profile, lineage.tip_session_id)}
+                        size="sm"
+                        variant="secondary"
+                      >
+                        {copy.branch}
+                      </Button>
+                    </div>
+                  )}
+                </>
+              ) : null}
+            </div>
+          </div>
+        </SheetContent>
+      </Sheet>
+    </>
+  )
+}
+
+/**
+ * Selected-row-only server cache. A missing lineage endpoint is an older
+ * backend capability, so it intentionally preserves the ordinary row.
+ */
+export function SelectedContextLineage({
+  compact,
+  onBranch,
+  renderContent,
+  session
+}: {
+  compact: boolean
+  onBranch?: (sessionId: string, profile?: string, lineageSessionId?: string) => void
+  renderContent?: (control: ReactNode, compactContent: ReactNode) => ReactNode
+  session: SessionInfo
+}) {
+  const requestIdentity = `${session.profile ?? 'default'}\u0000${session.id}`
+  const [loaded, setLoaded] = useState<{ identity: string; lineage: CompressionLineage } | null>(null)
+
+  useEffect(() => {
+    let active = true
+
+    void getCompressionLineage(session.id, session.profile)
+      .then(result => {
+        if (active) {
+          setLoaded(result.segments.length > 1 ? { identity: requestIdentity, lineage: result } : null)
+        }
+      })
+      .catch(() => {
+        // A missing endpoint is expected with an older backend. A later user
+        // selection safely retries without changing the live session.
+        if (active) {
+          setLoaded(null)
+        }
+      })
+
+    return () => {
+      active = false
+    }
+  }, [requestIdentity, session.id, session.profile])
+
+  const lineage = loaded?.identity === requestIdentity ? loaded.lineage : null
+
+  if (!lineage) {
+    return renderContent ? renderContent(null, null) : null
+  }
+
+  return (
+    <ContextLineage
+      compact={compact}
+      lineage={lineage}
+      onBranch={onBranch}
+      profile={session.profile}
+      renderContent={renderContent}
+    />
+  )
+}

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -233,7 +233,7 @@ interface ChatSidebarProps extends React.ComponentProps<typeof Sidebar> {
   onResumeSession: (sessionId: string) => void
   onDeleteSession: (sessionId: string) => void
   onArchiveSession: (sessionId: string) => void
-  onBranchSession: (sessionId: string) => void
+  onBranchSession: (sessionId: string, profile?: string, lineageSessionId?: string) => void
   onNewSessionInWorkspace: (path: null | string) => void
   /** Create a brand-new session and open it as a tile on `dir`. */
   onNewSessionSplit: (dir: SplitDir) => void

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -45,6 +45,8 @@ interface SidebarSessionRowProps extends React.ComponentProps<'div'> {
    *  flat cross-profile lists — Pinned and search results in the All-profiles
    *  view — where no group header communicates ownership (#66003). */
   showProfile?: boolean
+  /** A small selected-row-only control (currently compression lineage count). */
+  lineageControl?: React.ReactNode
 }
 
 const AGE_KEY = { day: 'ageDay', hour: 'ageHour', minute: 'ageMin' } as const
@@ -71,6 +73,7 @@ function SidebarSessionRowImpl({
   dragging = false,
   dragHandleProps,
   showProfile = false,
+  lineageControl,
   className,
   style,
   ref,
@@ -103,31 +106,34 @@ function SidebarSessionRowImpl({
     >
       <SidebarRowShell
         actions={
-          <div className="relative z-2 grid w-[1.375rem] place-items-center" data-row-actions>
-            {!isWorking && (
-              <span className="pointer-events-none absolute right-6 top-1/2 min-w-6 -translate-y-1/2 text-right text-[0.625rem] leading-none text-(--ui-text-tertiary) opacity-0 transition-opacity group-hover:opacity-100">
-                {age}
-              </span>
-            )}
-            <SessionActionsMenu
-              onArchive={onArchive}
-              onBranch={onBranch}
-              onDelete={onDelete}
-              onPin={onPin}
-              pinned={isPinned}
-              profile={session.profile}
-              sessionId={session.id}
-              title={title}
-            >
-              <Button
-                aria-label={r.sessionActions}
-                className="size-5 rounded-[4px] bg-transparent text-transparent transition-colors duration-100 hover:bg-(--ui-control-active-background) hover:text-foreground focus-visible:bg-(--ui-control-active-background) focus-visible:text-foreground focus-visible:ring-0 data-[state=open]:bg-(--ui-control-active-background) data-[state=open]:text-foreground group-hover:text-(--ui-text-tertiary) [&_svg]:size-3.5!"
-                size="icon"
-                variant="ghost"
+          <div className="relative z-2 flex items-center gap-0.5" data-row-actions>
+            {lineageControl}
+            <div className="relative grid w-[1.375rem] place-items-center">
+              {!isWorking && (
+                <span className="pointer-events-none absolute right-6 top-1/2 min-w-6 -translate-y-1/2 text-right text-[0.625rem] leading-none text-(--ui-text-tertiary) opacity-0 transition-opacity group-hover:opacity-100">
+                  {age}
+                </span>
+              )}
+              <SessionActionsMenu
+                onArchive={onArchive}
+                onBranch={onBranch}
+                onDelete={onDelete}
+                onPin={onPin}
+                pinned={isPinned}
+                profile={session.profile}
+                sessionId={session.id}
+                title={title}
               >
-                <Codicon name="kebab-vertical" size="0.875rem" />
-              </Button>
-            </SessionActionsMenu>
+                <Button
+                  aria-label={r.sessionActions}
+                  className="size-5 rounded-[4px] bg-transparent text-transparent transition-colors duration-100 hover:bg-(--ui-control-active-background) hover:text-foreground focus-visible:bg-(--ui-control-active-background) focus-visible:text-foreground focus-visible:ring-0 data-[state=open]:bg-(--ui-control-active-background) data-[state=open]:text-foreground group-hover:text-(--ui-text-tertiary) [&_svg]:size-3.5!"
+                  size="icon"
+                  variant="ghost"
+                >
+                  <Codicon name="kebab-vertical" size="0.875rem" />
+                </Button>
+              </SessionActionsMenu>
+            </div>
           </div>
         }
         className={cn(
@@ -269,6 +275,7 @@ function rowPropsEqual(a: SidebarSessionRowProps, b: SidebarSessionRowProps): bo
     a.reorderable === b.reorderable &&
     a.dragging === b.dragging &&
     a.showProfile === b.showProfile &&
+    a.lineageControl === b.lineageControl &&
     a.dragHandleProps === b.dragHandleProps &&
     a.className === b.className &&
     a.style === b.style

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render } from '@testing-library/react'
+import { cleanup, render, screen } from '@testing-library/react'
 import type * as React from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -42,6 +42,12 @@ vi.mock('./session-row', () => ({
   )
 }))
 
+vi.mock('./context-lineage', () => ({
+  SelectedContextLineage: ({ session }: { session: SessionInfo }) => (
+    <div data-testid={`compact-context-lineage-${session.id}`} />
+  )
+}))
+
 function makeSession(id: string, startedAt = 1000): SessionInfo {
   return {
     handoff_platform: null,
@@ -60,6 +66,35 @@ function generateSessions(count: number): SessionInfo[] {
 const noop = () => {}
 
 describe('SidebarSessionsSection memoization & virtualizer stability', () => {
+  it('shows compression lineage for a selected branch in a non-virtual list', () => {
+    const root = makeSession('root', 1000)
+
+    const branch = {
+      ...makeSession('branch', 900),
+      model_config: { _branched_from: 'root' },
+      parent_session_id: 'root'
+    } as SessionInfo
+
+    render(
+      <SidebarSessionsSection
+        activeSessionId="branch"
+        emptyState={<div>Empty</div>}
+        label="Sessions"
+        onArchiveSession={noop}
+        onDeleteSession={noop}
+        onResumeSession={noop}
+        onToggle={noop}
+        onTogglePin={noop}
+        open={true}
+        pinned={false}
+        sessions={[root, branch]}
+        workingSessionIdSet={new Set()}
+      />
+    )
+
+    expect(screen.getByTestId('compact-context-lineage-branch')).toBeTruthy()
+  })
+
   it('memoizes flatRows and passes the exact same rows array reference across parent re-renders', () => {
     mockVirtualListPropsHistory.length = 0
 

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -1,6 +1,6 @@
 import type { useSensors } from '@dnd-kit/core'
 import type * as React from 'react'
-import { useCallback, useMemo } from 'react'
+import { Fragment, useCallback, useMemo } from 'react'
 
 import { SidebarPanelLabel } from '@/app/shell/sidebar-label'
 import { DisclosureCaret } from '@/components/ui/disclosure-caret'
@@ -15,6 +15,7 @@ import { cn } from '@/lib/utils'
 import { sessionPinId } from '@/store/session'
 
 import { SidebarDateDivider, SidebarSectionMeta } from './chrome'
+import { SelectedContextLineage } from './context-lineage'
 import { orderRowsWithinGroups, reorderableRowIds } from './order'
 import {
   EnteredProjectContent,
@@ -95,7 +96,7 @@ interface SidebarSessionsSectionProps {
   onResumeSession: (sessionId: string) => void
   onDeleteSession: (sessionId: string) => void
   onArchiveSession: (sessionId: string) => void
-  onBranchSession?: (sessionId: string, profile?: string) => void
+  onBranchSession?: (sessionId: string, profile?: string, lineageSessionId?: string) => void
   onTogglePin: (sessionId: string) => void
   onNewSessionInWorkspace?: (path: null | string) => void
   pinned: boolean
@@ -232,26 +233,46 @@ export function SidebarSessionsSection({
 
   const renderRow = useCallback(
     (session: SessionInfo, draggable: boolean, branchStem?: string) => {
-      const rowProps = {
-        branchStem,
-        isPinned: pinned,
-        isSelected: session.id === activeSessionId,
-        isWorking: workingSessionIdSet.has(session.id),
-        onArchive: () => onArchiveSession(session.id),
-        onBranch: onBranchSession ? () => onBranchSession(session.id, session.profile) : undefined,
-        onDelete: () => onDeleteSession(session.id),
-        onPin: () => onTogglePin(sessionPinId(session)),
-        onResume: () => onResumeSession(session.id),
-        reorderable: draggable && !branchStem,
-        session,
-        showProfile: showProfileTags
+      const renderSessionRow = (lineageControl?: React.ReactNode, lineageContent?: React.ReactNode) => {
+        const rowProps = {
+          branchStem,
+          isPinned: pinned,
+          isSelected: session.id === activeSessionId,
+          isWorking: workingSessionIdSet.has(session.id),
+          lineageControl,
+          onArchive: () => onArchiveSession(session.id),
+          onBranch: onBranchSession ? () => onBranchSession(session.id, session.profile) : undefined,
+          onDelete: () => onDeleteSession(session.id),
+          onPin: () => onTogglePin(sessionPinId(session)),
+          onResume: () => onResumeSession(session.id),
+          reorderable: draggable && !branchStem,
+          session,
+          showProfile: showProfileTags
+        }
+
+        return draggable && !branchStem ? (
+          <SortableSidebarSessionRow {...rowProps} lineageContent={lineageContent} />
+        ) : (
+          <>
+            <SidebarSessionRow {...rowProps} />
+            {lineageContent}
+          </>
+        )
       }
 
-      return draggable && !branchStem ? (
-        <SortableSidebarSessionRow key={session.id} {...rowProps} />
-      ) : (
-        <SidebarSessionRow key={session.id} {...rowProps} />
-      )
+      if (session.id === activeSessionId) {
+        return (
+          <SelectedContextLineage
+            compact
+            key={session.id}
+            onBranch={onBranchSession}
+            renderContent={renderSessionRow}
+            session={session}
+          />
+        )
+      }
+
+      return <Fragment key={session.id}>{renderSessionRow()}</Fragment>
     },
     [
       activeSessionId,
@@ -470,19 +491,19 @@ export function SidebarSessionsSection({
   )
 }
 
-interface SortableSessionRowProps {
-  session: SessionInfo
-  isPinned: boolean
-  isSelected: boolean
-  isWorking: boolean
-  onArchive: () => void
-  onDelete: () => void
-  onPin: () => void
-  onResume: () => void
+interface SortableSessionRowProps extends Omit<React.ComponentProps<typeof SidebarSessionRow>, 'ref' | 'style'> {
+  lineageContent?: React.ReactNode
 }
 
-function SortableSidebarSessionRow(props: SortableSessionRowProps) {
-  return <SidebarSessionRow {...props} {...useSortableBindings(props.session.id)} />
+function SortableSidebarSessionRow({ lineageContent, ...props }: SortableSessionRowProps) {
+  const { ref, style, ...rowBindings } = useSortableBindings(props.session.id)
+
+  return (
+    <div ref={ref} style={style}>
+      <SidebarSessionRow {...props} {...rowBindings} />
+      {!rowBindings.dragging && lineageContent}
+    </div>
+  )
 }
 
 function SortableProjectOverviewRow(props: React.ComponentProps<typeof ProjectOverviewRow>) {

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.test.tsx
@@ -1,0 +1,111 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { SessionInfo } from '@/hermes'
+import type { SidebarListRow } from '@/lib/session-date-groups'
+
+const { lineageCalls } = vi.hoisted(() => ({
+  lineageCalls: [] as Array<{ compact: boolean; renderContent?: (control: ReactNode, content: ReactNode) => ReactNode }>
+}))
+
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getTotalSize: () => count * 28,
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({ end: (index + 1) * 28, index, start: index * 28 })),
+    measureElement: () => undefined
+  })
+}))
+
+vi.mock('@dnd-kit/sortable', () => ({
+  useSortable: () => ({
+    attributes: {},
+    isDragging: false,
+    listeners: {},
+    setNodeRef: () => undefined,
+    transform: null,
+    transition: undefined
+  })
+}))
+
+vi.mock('@dnd-kit/utilities', () => ({
+  CSS: { Transform: { toString: () => undefined } }
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      sidebar: {
+        dateDivider: {}
+      }
+    }
+  })
+}))
+
+vi.mock('./context-lineage', () => ({
+  SelectedContextLineage: (props: {
+    compact: boolean
+    renderContent?: (control: ReactNode, content: ReactNode) => ReactNode
+  }) => {
+    lineageCalls.push(props)
+
+    return props.renderContent?.(
+      <span data-testid="lineage-control">14 segments</span>,
+      <div data-testid="lineage-compact">Current + previous two</div>
+    )
+  }
+}))
+
+vi.mock('./session-row', () => ({
+  SidebarSessionRow: ({ lineageControl, session }: { lineageControl?: ReactNode; session: SessionInfo }) => (
+    <div data-testid={`session-${session.id}`}>
+      {session.id}
+      {lineageControl}
+    </div>
+  )
+}))
+
+import { VirtualSessionList } from './virtual-session-list'
+
+afterEach(() => {
+  cleanup()
+  lineageCalls.length = 0
+})
+
+const noop = () => undefined
+
+describe('VirtualSessionList context lineage', () => {
+  it('keeps the selected session badge and compact three-segment view inside the measured sortable item', () => {
+    const session = {
+      id: 'selected',
+      last_active: 100,
+      profile: 'default',
+      started_at: 100
+    } as SessionInfo
+
+    const rows = [{ entry: { session }, kind: 'session' }] as SidebarListRow[]
+
+    render(
+      <VirtualSessionList
+        activeSessionId="selected"
+        onArchiveSession={noop}
+        onDeleteSession={noop}
+        onResumeSession={noop}
+        onTogglePin={noop}
+        pinned={false}
+        rows={rows}
+        sortable
+        workingSessionIdSet={new Set()}
+      />
+    )
+
+    expect(lineageCalls).toHaveLength(1)
+    expect(lineageCalls[0]?.compact).toBe(true)
+    expect(screen.getByTestId('lineage-control')).toBeTruthy()
+    expect(screen.getByTestId('lineage-compact')).toBeTruthy()
+    expect(screen.getByTestId('session-selected').parentElement?.contains(screen.getByTestId('lineage-compact'))).toBe(
+      true
+    )
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
@@ -2,6 +2,7 @@ import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { type FC, useCallback, useRef } from 'react'
+import type * as React from 'react'
 
 import type { SessionInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
@@ -11,6 +12,7 @@ import { cn } from '@/lib/utils'
 import { sessionPinId } from '@/store/session'
 
 import { SidebarDateDivider } from './chrome'
+import { SelectedContextLineage } from './context-lineage'
 import { SidebarSessionRow } from './session-row'
 
 interface SessionRowCommonProps {
@@ -25,6 +27,7 @@ interface SessionRowCommonProps {
   onResume: () => void
   reorderable?: boolean
   showProfile?: boolean
+  lineageControl?: React.ReactNode
 }
 
 export interface VirtualSessionListProps {
@@ -32,7 +35,7 @@ export interface VirtualSessionListProps {
   className?: string
   rows: SidebarListRow[]
   onArchiveSession: (sessionId: string) => void
-  onBranchSession?: (sessionId: string, profile?: string) => void
+  onBranchSession?: (sessionId: string, profile?: string, lineageSessionId?: string) => void
   onDeleteSession: (sessionId: string) => void
   onResumeSession: (sessionId: string) => void
   onTogglePin: (sessionId: string) => void
@@ -104,36 +107,48 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
     const { branchStem, session } = row.entry
     const reorderable = sortable && !branchStem
 
-    const commonProps: SessionRowCommonProps = {
-      branchStem,
-      isPinned: pinned,
-      isSelected: session.id === activeSessionId,
-      isWorking: workingSessionIdSet.has(session.id),
-      onArchive: () => onArchiveSession(session.id),
-      onBranch: onBranchSession ? () => onBranchSession(session.id, session.profile) : undefined,
-      onDelete: () => onDeleteSession(session.id),
-      onPin: () => onTogglePin(sessionPinId(session)),
-      onResume: () => onResumeSession(session.id),
-      reorderable,
-      showProfile: showProfileTags
+    const renderSession = (lineageControl?: React.ReactNode, lineageContent?: React.ReactNode) => {
+      const commonProps: SessionRowCommonProps = {
+        branchStem,
+        isPinned: pinned,
+        isSelected: session.id === activeSessionId,
+        isWorking: workingSessionIdSet.has(session.id),
+        onArchive: () => onArchiveSession(session.id),
+        onBranch: onBranchSession ? () => onBranchSession(session.id, session.profile) : undefined,
+        onDelete: () => onDeleteSession(session.id),
+        onPin: () => onTogglePin(sessionPinId(session)),
+        onResume: () => onResumeSession(session.id),
+        reorderable,
+        showProfile: showProfileTags,
+        lineageControl
+      }
+
+      return reorderable ? (
+        <VirtualSortableRow
+          index={virtualItem.index}
+          lineageContent={lineageContent}
+          measureRef={virtualizer.measureElement}
+          rowProps={commonProps}
+          session={session}
+        />
+      ) : (
+        <div data-index={virtualItem.index} ref={virtualizer.measureElement}>
+          <SidebarSessionRow {...commonProps} session={session} />
+          {lineageContent}
+        </div>
+      )
     }
 
-    return reorderable ? (
-      <VirtualSortableRow
-        index={virtualItem.index}
+    return session.id === activeSessionId ? (
+      <SelectedContextLineage
+        compact
         key={session.id}
-        measureRef={virtualizer.measureElement}
-        rowProps={commonProps}
+        onBranch={onBranchSession}
+        renderContent={renderSession}
         session={session}
       />
     ) : (
-      <SidebarSessionRow
-        {...commonProps}
-        data-index={virtualItem.index}
-        key={session.id}
-        ref={virtualizer.measureElement}
-        session={session}
-      />
+      <div key={session.id}>{renderSession()}</div>
     )
   })
 
@@ -154,12 +169,13 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
 
 interface VirtualSortableRowProps {
   index: number
+  lineageContent?: React.ReactNode
   measureRef: (node: Element | null) => void
   rowProps: SessionRowCommonProps
   session: SessionInfo
 }
 
-function VirtualSortableRow({ index, measureRef, rowProps, session }: VirtualSortableRowProps) {
+function VirtualSortableRow({ index, lineageContent, measureRef, rowProps, session }: VirtualSortableRowProps) {
   const { attributes, isDragging, listeners, setNodeRef, transform, transition } = useSortable({ id: session.id })
 
   // Merge dnd-kit's setNodeRef with the virtualizer's measureElement so
@@ -174,15 +190,15 @@ function VirtualSortableRow({ index, measureRef, rowProps, session }: VirtualSor
   )
 
   return (
-    <SidebarSessionRow
-      {...rowProps}
-      data-index={index}
-      dragging={isDragging}
-      dragHandleProps={{ ...attributes, ...listeners }}
-      ref={refMerged}
-      reorderable
-      session={session}
-      style={{ transform: CSS.Transform.toString(transform), transition }}
-    />
+    <div data-index={index} ref={refMerged} style={{ transform: CSS.Transform.toString(transform), transition }}>
+      <SidebarSessionRow
+        {...rowProps}
+        dragging={isDragging}
+        dragHandleProps={{ ...attributes, ...listeners }}
+        reorderable
+        session={session}
+      />
+      {!isDragging && lineageContent}
+    </div>
   )
 }

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -862,7 +862,8 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     onAttachDroppedItems: composer.attachDroppedItems,
     onAttachImageBlob: composer.attachImageBlob,
     onBranchInNewChat: messageId => void branchInNewChat(messageId),
-    onBranchSession: sessionId => void branchStoredSession(sessionId),
+    onBranchSession: (sessionId, profile, lineageSessionId) =>
+      void branchStoredSession(sessionId, profile, lineageSessionId),
     onCancel: cancelRun,
     onDeleteSelectedSession: () => {
       const id = $selectedStoredSessionId.get()

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { $terminalTakeover, setTerminalTakeover } from '@/app/right-sidebar/store'
 import { noteActiveTreeGroup, revealTreePane } from '@/components/pane-shell/tree/store'
-import { getSession, getSessionMessages, type SessionInfo } from '@/hermes'
+import { getCompressionSegmentMessages, getSession, getSessionMessages, type SessionInfo } from '@/hermes'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { clearSessionDraft, stashSessionDraft, takeSessionDraft } from '@/store/composer'
 import { $activeGatewayProfile, $newChatProfile, ensureGatewayProfile } from '@/store/profile'
@@ -22,6 +22,7 @@ import {
   $newChatWorkspaceTarget,
   $resumeFailedSessionId,
   $selectedStoredSessionId,
+  $sessions,
   setActiveSessionId,
   setActiveSessionStoredIdRotation,
   setCurrentCwd,
@@ -45,6 +46,7 @@ import { useSessionActions } from './use-session-actions'
 vi.mock('@/hermes', async importOriginal => ({
   ...(await importOriginal<Record<string, unknown>>()),
   deleteSession: vi.fn(),
+  getCompressionSegmentMessages: vi.fn(),
   getSession: vi.fn(),
   getSessionMessages: vi.fn(),
   listAllProfileSessions: vi.fn(),
@@ -1018,7 +1020,13 @@ function BranchHarness({
   activeSessionId?: string | null
   navigate?: ReturnType<typeof vi.fn>
   onCurrentReady?: (branchCurrentSession: (messageId?: string) => Promise<boolean>) => void
-  onReady: (branchStoredSession: (storedSessionId: string, sessionProfile?: string | null) => Promise<boolean>) => void
+  onReady: (
+    branchStoredSession: (
+      storedSessionId: string,
+      sessionProfile?: string | null,
+      lineageSessionId?: string
+    ) => Promise<boolean>
+  ) => void
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
 }) {
   const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value })
@@ -1246,6 +1254,113 @@ describe('branchStoredSession desktop source tagging', () => {
 
     expect(ensureGatewayProfile).toHaveBeenCalledWith('work')
     expect(createParams).toMatchObject({ profile: 'work' })
+  })
+
+  it('branches an exact historical root with exact provenance and a persisted hidden checkpoint', async () => {
+    setSessions([
+      storedSession({
+        _lineage_root_id: 'root',
+        id: 'tip',
+        message_count: 1,
+        profile: 'work'
+      })
+    ])
+    vi.mocked(getCompressionSegmentMessages).mockResolvedValue({
+      messages: [
+        {
+          content: '[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns.',
+          display_kind: 'hidden',
+          id: 1,
+          role: 'user',
+          timestamp: 1
+        },
+        { content: 'historical answer', id: 2, role: 'assistant', timestamp: 2 }
+      ],
+      session_id: 'root'
+    } as never)
+
+    let createParams: Record<string, unknown> | undefined
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.create') {
+        createParams = params
+
+        return { session_id: 'branch-runtime', stored_session_id: 'branch-stored' } as never
+      }
+
+      return {} as never
+    })
+
+    let branchStoredSession:
+      | ((storedSessionId: string, sessionProfile?: string | null, lineageSessionId?: string) => Promise<boolean>)
+      | null = null
+
+    render(<BranchHarness onReady={branch => (branchStoredSession = branch)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(branchStoredSession).not.toBeNull())
+
+    await expect(branchStoredSession!('root', 'work', 'tip')).resolves.toBe(true)
+
+    expect(getCompressionSegmentMessages).toHaveBeenCalledWith('tip', 'root', 'work')
+    expect(createParams).toMatchObject({
+      parent_session_id: 'root',
+      profile: 'work',
+      messages: [
+        {
+          content: '[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns.',
+          display_kind: 'hidden',
+          role: 'user'
+        },
+        { content: 'historical answer', role: 'assistant' }
+      ]
+    })
+    expect($sessions.get().find(session => session.id === 'branch-stored')?.preview).toBe('historical answer')
+  })
+
+  it('inherits workspace metadata from the lineage owner when branching an exact middle segment', async () => {
+    setSessions([
+      storedSession({
+        _lineage_root_id: 'root',
+        cwd: '/repo/worktree',
+        id: 'tip',
+        last_active: 42,
+        message_count: 1,
+        profile: 'work'
+      })
+    ])
+    vi.mocked(getCompressionSegmentMessages).mockResolvedValue({
+      messages: [{ content: 'middle prompt', id: 9, role: 'user', timestamp: 9 }],
+      session_id: 'middle'
+    } as never)
+
+    let createParams: Record<string, unknown> | undefined
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.create') {
+        createParams = params
+
+        return { session_id: 'branch-runtime', stored_session_id: 'branch-stored' } as never
+      }
+
+      return {} as never
+    })
+
+    let branchStoredSession:
+      | ((storedSessionId: string, sessionProfile?: string | null, lineageSessionId?: string) => Promise<boolean>)
+      | null = null
+
+    render(<BranchHarness onReady={branch => (branchStoredSession = branch)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(branchStoredSession).not.toBeNull())
+    await expect(branchStoredSession!('middle', 'work', 'tip')).resolves.toBe(true)
+
+    expect(createParams).toMatchObject({
+      cwd: '/repo/worktree',
+      parent_session_id: 'middle',
+      profile: 'work'
+    })
+    expect($sessions.get().find(session => session.id === 'branch-stored')).toMatchObject({
+      last_active: 42,
+      parent_session_id: 'middle'
+    })
   })
 
   it('omits profile for a profile-less parent so single-profile users are unchanged', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -3,7 +3,7 @@ import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 import type { NavigateFunction } from 'react-router'
 
 import { revealTreePane } from '@/components/pane-shell/tree/store'
-import { deleteSession, getSessionMessages, setSessionArchived } from '@/hermes'
+import { deleteSession, getCompressionSegmentMessages, getSessionMessages, setSessionArchived } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { type ChatMessage, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
 import { isMissingRpcMethod } from '@/lib/gateway-rpc'
@@ -68,7 +68,13 @@ import {
 } from '@/store/session-states'
 import { broadcastSessionsChanged } from '@/store/session-sync'
 import { isWatchWindow } from '@/store/windows'
-import type { SessionCreateResponse, SessionMessage, SessionResumeResponse, UsageStats } from '@/types/hermes'
+import type {
+  SessionCreateResponse,
+  SessionInfo,
+  SessionMessage,
+  SessionResumeResponse,
+  UsageStats
+} from '@/types/hermes'
 
 import { navigateToWorkspacePage, NEW_CHAT_ROUTE, sessionRoute, SETTINGS_ROUTE } from '../../../routes'
 import type { ClientSessionState, SidebarNavItem } from '../../../types'
@@ -80,6 +86,7 @@ import {
   applyStoredSessionPreviewRuntimeInfo,
   type BranchMessage,
   chatMessageArraysEquivalent,
+  exactSegmentBranchMessages,
   isSessionGoneError,
   patchSessionWorkspace,
   preserveLocalPendingTurnMessages,
@@ -1157,7 +1164,8 @@ export function useSessionActions({
       sourceSessionId: null | string,
       parentStoredId: null | string,
       cwd?: string,
-      profile?: null | string
+      profile?: null | string,
+      parentContext?: SessionInfo
     ): Promise<boolean> => {
       creatingSessionRef.current = true
 
@@ -1182,17 +1190,30 @@ export function useSessionActions({
               source: 'desktop',
               ...(cwd && { cwd }),
               ...(profile ? { profile } : {}),
-              messages: branchMessages.map(({ content, role }) => ({ content, role })),
+              messages: branchMessages.map(({ content, role, source }) => ({
+                content,
+                ...(source.hidden ? { display_kind: 'hidden' } : {}),
+                role
+              })),
               ...(parentStoredId && { parent_session_id: parentStoredId })
             })
 
         const routedSessionId = branched.stored_session_id ?? branched.session_id
-        const preview = branchMessages.map(({ content }) => content).find(Boolean) ?? null
+
+        const preview =
+          branchMessages
+            .filter(message => !message.source.hidden)
+            .map(({ content }) => content)
+            .find(Boolean) ?? null
+
         // Draft until submit: nest under the parent at the parent's recency so it
         // doesn't bubble to the top until a real message lands (backend persists
         // + auto-names it then). The selected row survives refreshes (sessionsToKeep).
         const rows = $sessions.get()
-        const parent = parentStoredId ? rows.find(session => sessionMatchesStoredId(session, parentStoredId)) : null
+
+        const parent =
+          parentContext ??
+          (parentStoredId ? rows.find(session => sessionMatchesStoredId(session, parentStoredId)) : null)
 
         const siblings = parentStoredId
           ? rows.filter(session => session.parent_session_id?.trim() === parentStoredId).length
@@ -1304,7 +1325,7 @@ export function useSessionActions({
   // transcript directly (no resume/active-session dependency), so it works on
   // right-click and nests under its parent.
   const branchStoredSession = useCallback(
-    async (storedSessionId: string, sessionProfile?: string | null): Promise<boolean> => {
+    async (storedSessionId: string, sessionProfile?: string | null, lineageSessionId?: string): Promise<boolean> => {
       clearNotifications()
 
       // Right-clicking a session outside the paginated sidebar window is a cache
@@ -1314,12 +1335,25 @@ export function useSessionActions({
         $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId)) ??
         (sessionProfile ? undefined : await resolveStoredSession(storedSessionId))
 
-      const profile = sessionProfile ?? stored?.profile
+      const lineageOwner = lineageSessionId
+        ? ($sessions.get().find(session => sessionMatchesStoredId(session, lineageSessionId)) ??
+          (sessionProfile ? undefined : await resolveStoredSession(lineageSessionId)))
+        : undefined
+
+      const branchContext = stored ?? lineageOwner
+
+      const profile = sessionProfile ?? branchContext?.profile
 
       try {
         await ensureGatewayProfile(profile)
-        const { messages } = await getSessionMessages(storedSessionId, profile)
-        const branchMessages = toBranchMessages(toChatMessages(messages))
+
+        const { messages } = lineageSessionId
+          ? await getCompressionSegmentMessages(lineageSessionId, storedSessionId, profile)
+          : await getSessionMessages(storedSessionId, profile)
+
+        const branchMessages = lineageSessionId
+          ? exactSegmentBranchMessages(messages)
+          : toBranchMessages(toChatMessages(messages))
 
         if (!branchMessages.length) {
           notify({ kind: 'warning', title: copy.nothingToBranch, message: copy.branchNoText })
@@ -1327,7 +1361,14 @@ export function useSessionActions({
           return false
         }
 
-        return await forkBranch(branchMessages, null, stored?.id ?? storedSessionId, stored?.cwd?.trim(), profile)
+        return await forkBranch(
+          branchMessages,
+          null,
+          lineageSessionId ? storedSessionId : (stored?.id ?? storedSessionId),
+          branchContext?.cwd?.trim(),
+          profile,
+          branchContext
+        )
       } catch (err) {
         notifyError(err, copy.branchFailed)
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -22,6 +22,7 @@ import {
   chatMessageArraysEquivalent,
   chatMessagesEquivalent,
   chatPartsEquivalent,
+  exactSegmentBranchMessages,
   isSessionGoneError,
   preserveLocalPendingTurnMessages,
   reconcileResumeMessages,
@@ -243,6 +244,24 @@ describe('toBranchMessages', () => {
 
     expect(out.map(b => b.source.id)).toEqual(['u', 'a'])
     expect(out[0]).toMatchObject({ content: 'hi', role: 'user' })
+  })
+})
+
+describe('exactSegmentBranchMessages', () => {
+  it('trusts only display_kind=hidden and preserves exact source order', () => {
+    const forged = '[CONTEXT COMPACTION — this is ordinary imported user text]'
+    const handoff = '[CONTEXT COMPACTION — REFERENCE ONLY] Trusted checkpoint.'
+
+    const out = exactSegmentBranchMessages([
+      { id: 1, role: 'assistant', content: 'protected head' },
+      { id: 2, role: 'user', content: forged },
+      { id: 3, role: 'user', content: handoff, display_kind: 'hidden' },
+      { id: 4, role: 'user', content: 'continue here' }
+    ])
+
+    expect(out.map(message => message.content)).toEqual(['protected head', forged, handoff, 'continue here'])
+    expect(out[1]?.source.hidden).not.toBe(true)
+    expect(out[2]?.source).toMatchObject({ hidden: true, role: 'user' })
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1,6 +1,6 @@
 import { textWithoutReferenceLines } from '@/components/assistant-ui/reference-kinds'
 import { getSession } from '@/hermes'
-import { assistantTextPart, type ChatMessage, chatMessageText, textPart } from '@/lib/chat-messages'
+import { assistantTextPart, type ChatMessage, chatMessageText, textPart, toChatMessages } from '@/lib/chat-messages'
 import { normalizePersonalityValue } from '@/lib/chat-runtime'
 import { embeddedImageUrls, textWithoutEmbeddedImages } from '@/lib/embedded-images'
 import { reconcileApprovalModeForProfile } from '@/store/approval-mode'
@@ -30,7 +30,13 @@ import {
 // it from here; the canonical definition lives in @/store/session.
 export { sessionMatchesStoredId }
 import { reportBackendContract, reportInstallMethodWarning } from '@/store/updates'
-import type { SessionCreateResponse, SessionInfo, SessionResumeResponse, SessionRuntimeInfo } from '@/types/hermes'
+import type {
+  SessionCreateResponse,
+  SessionInfo,
+  SessionMessage,
+  SessionResumeResponse,
+  SessionRuntimeInfo
+} from '@/types/hermes'
 
 import type { ClientSessionState } from '../../../types'
 
@@ -774,6 +780,38 @@ export const toBranchMessages = (messages: ChatMessage[]): BranchMessage[] =>
   messages
     .map(message => ({ content: chatMessageText(message), role: message.role, source: message }))
     .filter(({ content, role }) => content.trim() && (role === 'assistant' || role === 'user'))
+
+/**
+ * Exact historical segments need two views of the same transcript: internal
+ * compaction checkpoints seed the new branch but stay hidden in its UI, while
+ * ordinary user/assistant turns use the standard display conversion.
+ */
+export function exactSegmentBranchMessages(messages: SessionMessage[]): BranchMessage[] {
+  return messages.flatMap((message, index): BranchMessage[] => {
+    if (message.display_kind !== 'hidden') {
+      return toBranchMessages(toChatMessages([message]))
+    }
+
+    const content = message.content ?? message.text ?? message.context
+
+    if ((message.role !== 'assistant' && message.role !== 'user') || typeof content !== 'string' || !content.trim()) {
+      return []
+    }
+
+    return [
+      {
+        content,
+        role: message.role,
+        source: {
+          hidden: true,
+          id: `hidden-history-${message.id ?? index}`,
+          parts: [textPart(content)],
+          role: message.role
+        }
+      }
+    ]
+  })
+}
 
 export function upsertOptimisticSession(
   created: SessionCreateResponse,

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -47,12 +47,14 @@ interface MessageActionProps {
    *  was a large slice of per-token script time on long transcripts. */
   getMessageText: () => string
   onBranchInNewChat?: (messageId: string) => void
+  readOnly: boolean
 }
 
 export const AssistantMessage: FC<{
   onBranchInNewChat?: (messageId: string) => void
   onDismissError?: (messageId: string) => void
-}> = ({ onBranchInNewChat, onDismissError }) => {
+  readOnly?: boolean
+}> = ({ onBranchInNewChat, onDismissError, readOnly = false }) => {
   const messageId = useAuiState(s => s.message.id)
   const messageRuntime = useMessageRuntime()
   const { t } = useI18n()
@@ -114,7 +116,8 @@ export const AssistantMessage: FC<{
 
   // Double-click the reply to heart it (iMessage). Undefined while reactions
   // are off, so the root carries no listener at all.
-  const onDoubleClick = useTapbackDoubleClick(messageId, 'assistant')
+  const tapbackDoubleClick = useTapbackDoubleClick(messageId, 'assistant')
+  const onDoubleClick = readOnly ? undefined : tapbackDoubleClick
 
   return (
     <MessagePrimitive.Root
@@ -159,7 +162,12 @@ export const AssistantMessage: FC<{
         </MessagePrimitive.Error>
       </div>
       {hasVisibleText && !isInterim && (
-        <AssistantFooter getMessageText={getMessageText} messageId={messageId} onBranchInNewChat={onBranchInNewChat} />
+        <AssistantFooter
+          getMessageText={getMessageText}
+          messageId={messageId}
+          onBranchInNewChat={onBranchInNewChat}
+          readOnly={readOnly}
+        />
       )}
       {/* Last thing in the turn — under the action bar, the way Cursor ends a
           turn on its summary rather than burying it above the controls. */}
@@ -168,7 +176,7 @@ export const AssistantMessage: FC<{
   )
 }
 
-const AssistantActionBar: FC<MessageActionProps> = ({ messageId, getMessageText, onBranchInNewChat }) => {
+const AssistantActionBar: FC<MessageActionProps> = ({ messageId, getMessageText, onBranchInNewChat, readOnly }) => {
   const { t } = useI18n()
   const copy = t.assistant.thread
 
@@ -212,11 +220,13 @@ const AssistantActionBar: FC<MessageActionProps> = ({ messageId, getMessageText,
         )}
         <CopyButton appearance="icon" buttonSize="icon" label={copy.copy} text={getMessageText} />
         <ReadAloudButton getText={getMessageText} messageId={messageId} />
-        <ActionBarPrimitive.Reload asChild>
-          <TooltipIconButton onClick={() => triggerHaptic('submit')} tooltip={copy.refresh}>
-            <RefreshCwIcon className="size-3.5" />
-          </TooltipIconButton>
-        </ActionBarPrimitive.Reload>
+        {!readOnly && (
+          <ActionBarPrimitive.Reload asChild>
+            <TooltipIconButton onClick={() => triggerHaptic('submit')} tooltip={copy.refresh}>
+              <RefreshCwIcon className="size-3.5" />
+            </TooltipIconButton>
+          </ActionBarPrimitive.Reload>
+        )}
       </ActionBarPrimitive.Root>
       {/* ONE slot, Slack-style: the picker trigger and the landed reaction are
           the same element, so reacting never shifts layout. Empty → ☺, hidden
@@ -226,7 +236,7 @@ const AssistantActionBar: FC<MessageActionProps> = ({ messageId, getMessageText,
           clicking it reopens the picker to switch or retract. Outside
           ActionBarPrimitive.Root so a landed reaction doesn't ride the bar's
           hover opacity. */}
-      {(reactionsEnabled || shownReactions.length > 0) && (
+      {!readOnly && (reactionsEnabled || shownReactions.length > 0) && (
         <ReactionPicker
           onOpenChange={setPickerOpen}
           onSelect={pickEmoji}

--- a/apps/desktop/src/components/assistant-ui/thread/double-click-reaction.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/double-click-reaction.test.tsx
@@ -1,13 +1,22 @@
 // Double-click an assistant reply to heart it (the iMessage gesture), gated on
 // the same opt-in toggle as the rest of message reactions.
 import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type * as ReactionsStore from '@/store/reactions'
 import { $reactionsEnabled } from '@/store/reactions-enabled'
 import { $localReactions } from '@/store/reactions-local'
+import {
+  $threadJumpButtonVisible,
+  $threadScrolledUp,
+  notifyThreadEditOpen,
+  requestScrollToBottom,
+  resetThreadScroll,
+  setThreadAtBottom
+} from '@/store/thread-scroll'
 
+import { TranscriptWindowProvider } from './transcript-window'
 import { isTapbackDoubleClick } from './use-message-reactions'
 
 import { Thread } from '.'
@@ -46,16 +55,35 @@ function assistantMessage(): ThreadMessage {
   } as ThreadMessage
 }
 
-function Harness() {
+function userMessageWithReaction(): ThreadMessage {
+  return {
+    id: 'user-1',
+    role: 'user',
+    content: [{ type: 'text', text: 'question' }],
+    attachments: [],
+    createdAt,
+    metadata: { custom: { reactions: [{ emoji: '❤️', author: 'user', at: 1 }] } }
+  } as ThreadMessage
+}
+
+function Harness({
+  message = assistantMessage(),
+  messages,
+  readOnly = false
+}: {
+  message?: ThreadMessage
+  messages?: ThreadMessage[]
+  readOnly?: boolean
+}) {
   const runtime = useExternalStoreRuntime<ThreadMessage>({
-    messages: [assistantMessage()],
+    messages: messages ?? [message],
     isRunning: false,
     onNew: async () => {}
   })
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>
-      <Thread />
+      <Thread readOnly={readOnly} />
     </AssistantRuntimeProvider>
   )
 }
@@ -67,6 +95,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup()
+  resetThreadScroll()
 })
 
 describe('isTapbackDoubleClick', () => {
@@ -114,5 +143,81 @@ describe('double-click to heart an assistant message', () => {
     fireEvent.doubleClick(message!, { detail: 2 })
 
     expect($localReactions.get()['assistant-1']).toBeUndefined()
+  })
+
+  it('does nothing in a read-only transcript while reactions are enabled', async () => {
+    $reactionsEnabled.set(true)
+    render(<Harness readOnly />)
+
+    const message = (await screen.findByText('done')).closest('[data-slot="aui_assistant-message-root"]')
+
+    fireEvent.doubleClick(message!, { detail: 2 })
+
+    expect($localReactions.get()['assistant-1']).toBeUndefined()
+    expect(message?.querySelector('[data-slot="aui_msg-reactions"]')).toBeNull()
+  })
+
+  it('renders a persisted user reaction as display-only in a read-only transcript', async () => {
+    $reactionsEnabled.set(true)
+    render(<Harness message={userMessageWithReaction()} readOnly />)
+
+    expect(await screen.findByText('❤️')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Remove ❤️ reaction' })).toBeNull()
+    expect($localReactions.get()['user-1']).toBeUndefined()
+  })
+
+  it('does not bridge spectator scroll or edit state into the live thread', async () => {
+    setThreadAtBottom(false)
+    const view = render(<Harness readOnly />)
+
+    await screen.findByText('done')
+    const viewport = view.container.querySelector<HTMLElement>('[data-slot="aui_thread-viewport"]')
+
+    expect($threadScrolledUp.get()).toBe(true)
+    expect($threadJumpButtonVisible.get()).toBe(true)
+
+    act(() => notifyThreadEditOpen())
+    expect(viewport?.hasAttribute('data-editing')).toBe(false)
+
+    Object.defineProperty(viewport!, 'clientHeight', { configurable: true, value: 50 })
+    Object.defineProperty(viewport!, 'scrollHeight', { configurable: true, value: 200 })
+    viewport!.scrollTop = 25
+    act(() => requestScrollToBottom())
+    expect(viewport?.scrollTop).toBe(25)
+
+    view.unmount()
+    expect($threadScrolledUp.get()).toBe(true)
+    expect($threadJumpButtonVisible.get()).toBe(true)
+  })
+
+  it('does not mount the interactive timeline in a read-only transcript', async () => {
+    const messages: ThreadMessage[] = Array.from(
+      { length: 4 },
+      (_, index) =>
+        ({
+          ...userMessageWithReaction(),
+          id: `user-${index}`,
+          content: [{ type: 'text' as const, text: `historical prompt ${index}` }]
+        }) as ThreadMessage
+    )
+
+    render(<Harness messages={messages} readOnly />)
+
+    await screen.findByText('historical prompt 0')
+    expect(screen.queryByRole('navigation', { name: 'Conversation timeline' })).toBeNull()
+  })
+
+  it('does not inherit or mutate the live transcript window in a read-only transcript', async () => {
+    const expandWindow = vi.fn()
+
+    render(
+      <TranscriptWindowProvider value={{ expandWindow, olderAvailable: true }}>
+        <Harness readOnly />
+      </TranscriptWindowProvider>
+    )
+
+    await screen.findByText('done')
+    expect(screen.queryByRole('button', { name: 'Show earlier messages' })).toBeNull()
+    expect(expandWindow).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/index.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/index.tsx
@@ -5,6 +5,7 @@ import { ThreadMessageList } from '@/components/assistant-ui/thread/list'
 import { BackgroundResumeNotice, CenteredThreadSpinner } from '@/components/assistant-ui/thread/status'
 import { SystemMessage } from '@/components/assistant-ui/thread/system-message'
 import { ThreadTimeline } from '@/components/assistant-ui/thread/timeline'
+import { TranscriptWindowProvider } from '@/components/assistant-ui/thread/transcript-window'
 import { type RestoreMessageTarget } from '@/components/assistant-ui/thread/types'
 import { UserEditComposer } from '@/components/assistant-ui/thread/user-edit-composer'
 import { UserMessage } from '@/components/assistant-ui/thread/user-message'
@@ -15,6 +16,8 @@ import { useI18n } from '@/i18n'
 import { notifyError } from '@/store/notifications'
 
 type ThreadLoadingState = 'response' | 'session'
+
+const READ_ONLY_TRANSCRIPT_WINDOW = { expandWindow: () => {}, olderAvailable: false }
 
 interface ThreadEditContextValue {
   cwd: string | null
@@ -42,6 +45,7 @@ interface ThreadProps {
   onCancel?: () => Promise<void> | void
   onDismissError?: (messageId: string) => void
   onRestoreToMessage?: (messageId: string, target?: RestoreMessageTarget) => Promise<void> | void
+  readOnly?: boolean
   sessionId?: string | null
   sessionKey?: string | null
 }
@@ -63,6 +67,7 @@ export const Thread = memo(function Thread({
   onCancel,
   onDismissError,
   onRestoreToMessage,
+  readOnly = false,
   sessionId = null,
   sessionKey
 }: ThreadProps) {
@@ -129,6 +134,7 @@ export const Thread = memo(function Thread({
             hasBranchInNewChat ? messageId => callbacksRef.current.onBranchInNewChat?.(messageId) : undefined
           }
           onDismissError={hasDismissError ? messageId => callbacksRef.current.onDismissError?.(messageId) : undefined}
+          readOnly={readOnly}
         />
       ),
       SystemMessage,
@@ -141,10 +147,11 @@ export const Thread = memo(function Thread({
         <UserMessage
           onCancel={hasCancel ? () => callbacksRef.current.onCancel?.() : undefined}
           onRequestRestoreConfirm={hasRestoreToMessage ? requestRestoreConfirm : undefined}
+          readOnly={readOnly}
         />
       )
     }),
-    [hasBranchInNewChat, hasCancel, hasDismissError, hasRestoreToMessage, requestRestoreConfirm]
+    [hasBranchInNewChat, hasCancel, hasDismissError, hasRestoreToMessage, readOnly, requestRestoreConfirm]
   )
 
   const emptyPlaceholder = intro ? (
@@ -163,15 +170,28 @@ export const Thread = memo(function Thread({
   return (
     <ThreadEditContext.Provider value={editContext}>
       <div className="relative grid h-full min-h-0 max-w-full grid-rows-[minmax(0,1fr)] overflow-hidden bg-transparent contain-[layout_paint]">
-        <ThreadMessageList
-          clampToComposer={clampToComposer}
-          components={messageComponents}
-          emptyPlaceholder={emptyPlaceholder}
-          loadingIndicator={loadingIndicator}
-          sessionKey={sessionKey}
-        />
+        {readOnly ? (
+          <TranscriptWindowProvider value={READ_ONLY_TRANSCRIPT_WINDOW}>
+            <ThreadMessageList
+              clampToComposer={clampToComposer}
+              components={messageComponents}
+              emptyPlaceholder={emptyPlaceholder}
+              loadingIndicator={loadingIndicator}
+              sessionKey={sessionKey}
+              spectator
+            />
+          </TranscriptWindowProvider>
+        ) : (
+          <ThreadMessageList
+            clampToComposer={clampToComposer}
+            components={messageComponents}
+            emptyPlaceholder={emptyPlaceholder}
+            loadingIndicator={loadingIndicator}
+            sessionKey={sessionKey}
+          />
+        )}
         {loading === 'session' && <CenteredThreadSpinner />}
-        <ThreadTimeline />
+        {!readOnly && <ThreadTimeline />}
         <ConfirmDialog
           confirmLabel={copy.restoreConfirm}
           description={copy.restoreBody}

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -101,6 +101,7 @@ interface ThreadMessageListProps {
   emptyPlaceholder?: ReactNode
   loadingIndicator?: ReactNode
   sessionKey?: string | null
+  spectator?: boolean
 }
 
 // Group each user message with the assistant turn(s) that follow it so the
@@ -234,7 +235,8 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   components,
   emptyPlaceholder,
   loadingIndicator,
-  sessionKey
+  sessionKey,
+  spectator = false
 }) => {
   // TWO signatures, deliberately split. The STRUCTURAL one (ids/roles/count)
   // changes only when messages are added/removed/swapped — it keys the error
@@ -404,11 +406,22 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     ? 'pt-[calc(var(--titlebar-height)+0.75rem)]'
     : 'pt-[calc(var(--titlebar-height)-0.5rem)]'
 
-  useEffect(() => setThreadAtBottom(isAtBottom), [isAtBottom])
-  useEffect(() => () => resetThreadScroll(), [])
+  useEffect(() => {
+    if (!spectator) {
+      setThreadAtBottom(isAtBottom)
+    }
+  }, [isAtBottom, spectator])
+  useEffect(() => {
+    if (!spectator) {
+      return () => resetThreadScroll()
+    }
+  }, [spectator])
 
   // Floating jump button (outside this subtree) → return to the bottom.
-  useEffect(() => onScrollToBottomRequest(() => void scrollToBottom()), [scrollToBottom])
+  useEffect(
+    () => (spectator ? undefined : onScrollToBottomRequest(() => void scrollToBottom())),
+    [scrollToBottom, spectator]
+  )
 
   const endEditHold = useCallback(() => {
     scrollRef.current?.removeAttribute('data-editing')
@@ -428,8 +441,8 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     el.setAttribute('data-editing', 'true')
   }, [endEditHold, scrollRef, stopScroll])
 
-  useEffect(() => onThreadEditOpen(beginEditHold), [beginEditHold])
-  useEffect(() => onThreadEditClose(endEditHold), [endEditHold])
+  useEffect(() => (spectator ? undefined : onThreadEditOpen(beginEditHold)), [beginEditHold, spectator])
+  useEffect(() => (spectator ? undefined : onThreadEditClose(endEditHold)), [endEditHold, spectator])
   useEffect(() => () => endEditHold(), [endEditHold])
   // New run → snap to the latest turn.
   useAuiEvent('thread.runStart', () => void scrollToBottom())

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -109,7 +109,8 @@ const ProcessNotificationNote: FC<{ text: string }> = ({ text }) => {
 export const UserMessage: FC<{
   onCancel?: () => Promise<void> | void
   onRequestRestoreConfirm?: (messageId: string, target: RestoreMessageTarget) => void
-}> = ({ onCancel, onRequestRestoreConfirm }) => {
+  readOnly?: boolean
+}> = ({ onCancel, onRequestRestoreConfirm, readOnly: forcedReadOnly = false }) => {
   const { t } = useI18n()
   const copy = t.assistant.thread
   const messageId = useAuiState(s => s.message.id)
@@ -177,7 +178,7 @@ export const UserMessage: FC<{
   // Watch windows spectate a subagent run driven elsewhere — prompts can't be
   // edited, restored, or stopped from here. The bubble stays a button that
   // toggles the 2-line clamp so long prompts are still fully readable.
-  const readOnly = isWatchWindow()
+  const readOnly = forcedReadOnly || isWatchWindow()
   const [expanded, setExpanded] = useState(false)
   const clampActive = !(readOnly && expanded)
 
@@ -403,7 +404,7 @@ export const UserMessage: FC<{
                 sent bubble. Overlaying the corner read badly in practice. */}
             <ReactionBadge
               className="justify-end gap-1.5 py-1.5 pr-1.5"
-              onRetract={() => react(null)}
+              onRetract={readOnly ? undefined : () => react(null)}
               reactions={shownReactions}
             />
             <BranchPickerPrimitive.Root

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -7,6 +7,8 @@ import {
   AUDIO_TRANSCRIBE_MIN_REQUEST_TIMEOUT_MS,
   audioSpeakRequestTimeoutMs,
   audioTranscribeRequestTimeoutMs,
+  getCompressionLineage,
+  getCompressionSegmentMessages,
   getCronJobs,
   getGlobalModelInfo,
   getGlobalModelOptions,
@@ -331,6 +333,89 @@ describe('Hermes REST helpers', () => {
       path: '/api/sessions/session-1/messages?profile=xiaoxuxu',
       profile: 'xiaoxuxu'
     })
+  })
+
+  it('routes read-only lineage metadata and exact segment reads to the owning profile', async () => {
+    api
+      .mockResolvedValueOnce({ root_session_id: 'root', segments: [], tip_session_id: 'tip' })
+      .mockResolvedValueOnce({ messages: [], session_id: 'root' })
+
+    await getCompressionLineage('tip', 'work')
+    await getCompressionSegmentMessages('tip', 'root', 'work')
+
+    expect(api).toHaveBeenNthCalledWith(1, {
+      path: '/api/sessions/tip/compression-lineage?profile=work',
+      profile: 'work'
+    })
+    expect(api).toHaveBeenNthCalledWith(2, {
+      path: '/api/sessions/tip/compression-lineage/root/messages?limit=500&offset=0&profile=work',
+      profile: 'work'
+    })
+  })
+
+  it('loads every exact segment message page before returning the transcript', async () => {
+    api.mockImplementation(({ path }: { path: string }) =>
+      Promise.resolve(
+        path.includes('offset=500')
+          ? {
+              messages: [{ content: 'last', id: 501, role: 'assistant', timestamp: 2 }],
+              pagination: { has_more: false, limit: 500, offset: 500, returned: 1, total: 501 },
+              session_id: 'root'
+            }
+          : {
+              messages: [{ content: 'first', id: 1, role: 'user', timestamp: 1 }],
+              pagination: { has_more: true, limit: 500, offset: 0, returned: 500, total: 501 },
+              session_id: 'root'
+            }
+      )
+    )
+
+    const transcript = await getCompressionSegmentMessages('tip', 'root', 'work')
+
+    expect(transcript.messages.map(message => message.content)).toEqual(['first', 'last'])
+    expect(api).toHaveBeenCalledTimes(2)
+    expect((api.mock.calls[0][0] as { path: string }).path).toContain('limit=500&offset=0')
+    expect((api.mock.calls[1][0] as { path: string }).path).toContain('limit=500&offset=500')
+  })
+
+  it('loads every lineage page when the first 100-segment page is full', async () => {
+    const first = Array.from({ length: 100 }, (_, index) => ({
+      id: `segment-${index}`,
+      index: index + 1,
+      is_tip: false,
+      message_count: 0,
+      started_at: index
+    }))
+
+    const last = [
+      { id: 'segment-100', index: 101, is_tip: false, message_count: 0, started_at: 100 },
+      { id: 'segment-101', index: 102, is_tip: true, message_count: 0, started_at: 101 }
+    ]
+
+    api.mockImplementation(({ path }: { path: string }) =>
+      Promise.resolve(
+        path.includes('offset=100')
+          ? {
+              pagination: { limit: 100, offset: 100, returned: 2 },
+              root_session_id: 'segment-0',
+              segments: last,
+              tip_session_id: 'segment-101'
+            }
+          : {
+              pagination: { limit: 100, offset: 0, returned: 100 },
+              root_session_id: 'segment-0',
+              segments: first,
+              tip_session_id: 'segment-101'
+            }
+      )
+    )
+
+    const lineage = await getCompressionLineage('segment-101', 'work')
+
+    expect(lineage.segments).toHaveLength(102)
+    expect(lineage.segments.at(-1)).toMatchObject({ id: 'segment-101', is_tip: true })
+    expect(api).toHaveBeenCalledTimes(2)
+    expect((api.mock.calls[1][0] as { path: string }).path).toContain('offset=100')
   })
 
   it('bounds blocking TTS synthesis timeouts by text length', () => {

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -10,6 +10,7 @@ import type {
   AutomationBlueprint,
   AuxiliaryModelsResponse,
   BackendUpdateCheckResponse,
+  CompressionLineage,
   ComputerUseStatus,
   ConfigSchemaResponse,
   CronDeliveryTarget,
@@ -140,6 +141,7 @@ export type {
   AutomationBlueprintField,
   AuxiliaryModelsResponse,
   BackendUpdateCheckResponse,
+  CompressionLineage,
   ComputerUseCheck,
   ComputerUsePermissionSource,
   ComputerUseStatus,
@@ -662,6 +664,90 @@ export function getSessionMessages(id: string, profile?: string | null): Promise
     ...(profile ? { profile } : {}),
     path: `/api/sessions/${encodeURIComponent(id)}/messages${suffix}`
   })
+}
+
+/** Read compression-only lineage metadata. Missing on older backends by design. */
+export async function getCompressionLineage(id: string, profile?: string | null): Promise<CompressionLineage> {
+  const encodedId = encodeURIComponent(id)
+  const profileQuery = profile ? `profile=${encodeURIComponent(profile)}` : ''
+
+  const requestPage = (offset?: number, limit?: number) => {
+    const query = [
+      profileQuery,
+      offset === undefined ? '' : `offset=${offset}`,
+      limit === undefined ? '' : `limit=${limit}`
+    ]
+      .filter(Boolean)
+      .join('&')
+
+    return window.hermesDesktop.api<CompressionLineage>({
+      ...(profile ? { profile } : {}),
+      path: `/api/sessions/${encodedId}/compression-lineage${query ? `?${query}` : ''}`
+    })
+  }
+
+  let latest = await requestPage()
+  const segments = [...latest.segments]
+  let page = latest.pagination
+
+  while (page && page.returned > 0 && page.returned === page.limit) {
+    const offset = page.offset + page.returned
+
+    latest = await requestPage(offset, page.limit)
+    segments.push(...latest.segments)
+    page = latest.pagination
+  }
+
+  return {
+    ...latest,
+    pagination: latest.pagination ? { limit: segments.length, offset: 0, returned: segments.length } : undefined,
+    segments
+  }
+}
+
+/**
+ * Read one exact lineage segment. Unlike getSessionMessages, this endpoint
+ * never resolves the request forward to a compression continuation.
+ */
+export async function getCompressionSegmentMessages(
+  lineageSessionId: string,
+  segmentId: string,
+  profile?: string | null
+): Promise<SessionMessagesResponse> {
+  const pageSize = 500
+  const messages: SessionMessagesResponse['messages'] = []
+  let offset = 0
+
+  while (true) {
+    const profileSuffix = profile ? `&profile=${encodeURIComponent(profile)}` : ''
+
+    const page = await window.hermesDesktop.api<SessionMessagesResponse>({
+      ...(profile ? { profile } : {}),
+      path:
+        `/api/sessions/${encodeURIComponent(lineageSessionId)}/compression-lineage/` +
+        `${encodeURIComponent(segmentId)}/messages?limit=${pageSize}&offset=${offset}${profileSuffix}`
+    })
+
+    messages.push(...page.messages)
+
+    const pagination = page.pagination
+
+    if (!pagination?.has_more) {
+      return {
+        ...page,
+        messages,
+        pagination: pagination ? { ...pagination, offset: 0, returned: messages.length } : pagination
+      }
+    }
+
+    const nextOffset = pagination.offset + pagination.returned
+
+    if (pagination.returned <= 0 || nextOffset <= offset) {
+      throw new Error('Compression segment pagination did not advance')
+    }
+
+    offset = nextOffset
+  }
 }
 
 export function deleteSession(id: string, profile?: string | null): Promise<{ ok: boolean }> {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1933,6 +1933,17 @@ export const en: Translations = {
     loading: 'Loading…',
     loadMore: 'Load more',
     loadCount: step => `Load ${step} more`,
+    lineage: {
+      all: 'View all segments',
+      branch: 'Branch from this segment',
+      current: 'Current segment',
+      error: 'Could not load this segment.',
+      loading: 'Loading segment…',
+      readOnly: 'Read-only historical segment',
+      segment: index => `Segment ${index}`,
+      segments: count => `${count} segments`,
+      title: 'Conversation context'
+    },
     row: {
       pin: 'Pin',
       unpin: 'Unpin',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1767,6 +1767,17 @@ export const ja = defineLocale({
     loading: '読み込み中…',
     loadMore: 'さらに読み込む',
     loadCount: step => `さらに ${step} 件を読み込む`,
+    lineage: {
+      all: 'すべてのセグメントを表示',
+      branch: 'このセグメントから分岐',
+      current: '現在のセグメント',
+      error: 'このセグメントを読み込めませんでした。',
+      loading: 'セグメントを読み込み中…',
+      readOnly: '読み取り専用の履歴セグメント',
+      segment: index => `セグメント ${index}`,
+      segments: count => `${count} セグメント`,
+      title: '会話コンテキスト'
+    },
     row: {
       pin: 'ピン留め',
       unpin: 'ピン留めを解除',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1627,6 +1627,17 @@ export interface Translations {
     loading: string
     loadMore: string
     loadCount: (step: number) => string
+    lineage: {
+      all: string
+      branch: string
+      current: string
+      error: string
+      loading: string
+      readOnly: string
+      segment: (index: number) => string
+      segments: (count: number) => string
+      title: string
+    }
     row: {
       pin: string
       unpin: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1709,6 +1709,17 @@ export const zhHant = defineLocale({
     loading: '載入中…',
     loadMore: '載入更多',
     loadCount: step => `再載入 ${step} 個`,
+    lineage: {
+      all: '檢視全部上下文區段',
+      branch: '從此上下文區段建立分支',
+      current: '目前上下文區段',
+      error: '無法載入此上下文區段。',
+      loading: '正在載入上下文區段…',
+      readOnly: '唯讀歷史上下文區段',
+      segment: index => `上下文區段 ${index}`,
+      segments: count => `${count} 個上下文區段`,
+      title: '對話上下文'
+    },
     row: {
       pin: '釘選',
       unpin: '取消釘選',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2125,6 +2125,17 @@ export const zh: Translations = {
     loading: '加载中…',
     loadMore: '加载更多',
     loadCount: step => `再加载 ${step} 个`,
+    lineage: {
+      all: '查看全部上下文段',
+      branch: '从此上下文段创建分支',
+      current: '当前上下文段',
+      error: '无法加载此上下文段。',
+      loading: '正在加载上下文段…',
+      readOnly: '只读历史上下文段',
+      segment: index => `上下文段 ${index}`,
+      segments: count => `${count} 个上下文段`,
+      title: '会话上下文'
+    },
     row: {
       pin: '置顶',
       unpin: '取消置顶',

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -343,6 +343,11 @@ function transcriptContent(displayKind: SessionMessage['display_kind'], content:
   return displayKind === 'hidden' ? null : content
 }
 
+/** Internal compressor checkpoint: useful as model context, never as a user bubble. */
+export function isCompactionHandoffText(text: unknown): boolean {
+  return typeof text === 'string' && text.trimStart().startsWith('[CONTEXT COMPACTION')
+}
+
 // A remote backend older than this app serves display_metadata as raw JSON text,
 // and `in` throws on a primitive — which used to fail the whole session resume.
 function parseDisplayMetadata(metadata: SessionMessage['display_metadata']): null | Record<string, unknown> {

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -571,6 +571,45 @@ export interface SessionMessage {
 export interface SessionMessagesResponse {
   messages: SessionMessage[]
   session_id: string
+  pagination?: {
+    has_more?: boolean
+    limit: null | number
+    offset: number
+    returned: number
+    total?: number
+  }
+}
+
+/** A durable segment created by automatic context compression. */
+export interface CompressionLineageSegment {
+  id: string
+  index: number
+  is_tip: boolean
+  message_count: number
+  started_at: number
+  ended_at?: null | number
+  end_reason?: null | string
+  last_active?: number
+  source?: null | string
+  title?: null | string
+}
+
+/** Compression-only lineage for a logical conversation, ordered root to tip. */
+export interface CompressionLineage {
+  integrity?: {
+    candidate_ids?: string[]
+    ok: boolean
+    reason?: 'ambiguous_continuation' | 'cycle' | 'invalid_closed_child' | string
+    session_id?: string
+  }
+  root_session_id: string
+  segments: CompressionLineageSegment[]
+  tip_session_id: string
+  pagination?: {
+    limit: number
+    offset: number
+    returned: number
+  }
 }
 
 export interface SessionResumeResponse {

--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -595,6 +595,100 @@ async def get_session_latest_descendant(
     }
 
 
+@manage_router.get("/api/sessions/{session_id}/compression-lineage")
+async def get_compression_lineage(
+    session_id: str,
+    profile: Optional[str] = None,
+    limit: int = Query(100, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+):
+    """Read compression-only lineage metadata without resolving a resume target."""
+
+    def _read():
+        db = _open_session_db_for_profile(profile, read_only=True)
+        try:
+            sid = db.resolve_session_id(session_id)
+            if not sid:
+                return None
+            lineage = db.get_compression_lineage_metadata(sid)
+            segments = lineage["segments"]
+            page = segments[offset : offset + limit]
+            return lineage, page
+        finally:
+            db.close()
+
+    result = await asyncio.to_thread(_read)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    lineage, page = result
+    return {
+        **lineage,
+        "segments": page,
+        "pagination": {"limit": limit, "offset": offset, "returned": len(page)},
+    }
+
+
+@manage_router.get(
+    "/api/sessions/{session_id}/compression-lineage/{segment_id}/messages"
+)
+async def get_compression_lineage_segment_messages(
+    session_id: str,
+    segment_id: str,
+    profile: Optional[str] = None,
+    limit: int = Query(500, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+):
+    """Read exactly one historical compression segment, never its resume tip."""
+
+    def _read():
+        db = _open_session_db_for_profile(profile, read_only=True)
+        try:
+            sid = db.resolve_session_id(session_id)
+            segment = db.resolve_session_id(segment_id)
+            if not sid or not segment:
+                return None
+            lineage = db.get_compression_lineage_metadata(sid)
+            segment_info = next(
+                (entry for entry in lineage["segments"] if entry["id"] == segment),
+                None,
+            )
+            if segment_info is None:
+                return False
+            _limit = min(limit, 500)
+            # Deliberately do not call resolve_resume_session_id(): a lineage
+            # viewer must show this durable segment, not redirect to the live tip.
+            return (
+                segment,
+                _limit,
+                db.message_count(segment, include_inactive=False),
+                db.get_messages(segment, limit=_limit, offset=offset),
+            )
+        finally:
+            db.close()
+
+    result = await asyncio.to_thread(_read)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    if result is False:
+        raise HTTPException(
+            status_code=404, detail="Segment is not in this compression lineage"
+        )
+    segment, _limit, total, messages = result
+    returned = len(messages)
+    return {
+        "session_id": segment,
+        "messages": messages,
+        "pagination": {
+            "limit": _limit,
+            "offset": offset,
+            "returned": returned,
+            "total": total,
+            "has_more": offset + returned < total,
+        },
+    }
+
+
+
 @manage_router.get("/api/sessions/{session_id}/messages")
 async def get_session_messages(
     session_id: str,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -167,8 +167,63 @@ def workspace_key(row: Dict[str, Any]) -> Optional[str]:
     return cwd or None
 
 
+def _safe_model_config_json(col: str) -> str:
+    return (
+        f"CASE WHEN json_valid(COALESCE({col}, '{{}}')) "
+        f"THEN COALESCE({col}, '{{}}') ELSE '{{}}' END"
+    )
+
+
+def _marker_from_json(col: str, marker: str) -> str:
+    return f"json_extract(({_safe_model_config_json(col)}), '$.{marker}')"
+
+
 def _delegate_from_json(col: str = "model_config") -> str:
-    return f"json_extract(COALESCE({col}, '{{}}'), '$._delegate_from')"
+    return _marker_from_json(col, "_delegate_from")
+
+
+def _non_continuation_child_sql(
+    alias: str, parent_id_expr: str, parent_ended_at_expr: Optional[str] = None
+) -> str:
+    """SQL predicate shared by listing CTE continuation classification."""
+    config = f"{alias}.model_config"
+    temporal = ""
+    if parent_ended_at_expr is not None:
+        temporal = (
+            f" AND NOT ({alias}.ended_at IS NOT NULL "
+            f"AND {parent_ended_at_expr} IS NOT NULL "
+            f"AND {alias}.ended_at < {parent_ended_at_expr})"
+        )
+    return (
+        f"COALESCE({_marker_from_json(config, '_branched_from')}, '') != {parent_id_expr} "
+        f"AND COALESCE({_marker_from_json(config, '_delegate_from')}, '') != {parent_id_expr} "
+        f"AND COALESCE({alias}.source, '') != 'tool'"
+        f"{temporal}"
+    )
+
+
+def _unique_compression_continuation_sql(
+    child_alias: str = "child", parent_alias: str = "parent"
+) -> str:
+    """Require one unambiguous live/compression child for a recursive CTE edge."""
+    direct = _non_continuation_child_sql(
+        child_alias, f"{parent_alias}.id", f"{parent_alias}.ended_at"
+    )
+    sibling = _non_continuation_child_sql(
+        "sibling", f"{parent_alias}.id", f"{parent_alias}.ended_at"
+    )
+    return f"""
+        AND COALESCE({child_alias}.end_reason, '') != 'ws_orphan_reap'
+        AND ({child_alias}.ended_at IS NULL OR {child_alias}.end_reason = 'compression')
+        AND {direct}
+        AND NOT EXISTS (
+            SELECT 1 FROM sessions sibling
+            WHERE sibling.parent_session_id = {parent_alias}.id
+              AND sibling.id != {child_alias}.id
+              AND COALESCE(sibling.end_reason, '') != 'ws_orphan_reap'
+              AND {sibling}
+        )
+    """
 
 
 # Sentinel returned by SessionDB._merge_model_config_json when the session row
@@ -3659,9 +3714,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     # continuations as delegate children (fail-open for orphan reopen,
     # fail-closed for adoption). Bind the parent id for both markers.
     _NON_CONTINUATION_CHILD_FILTER_SQL = (
-        "  AND COALESCE(json_extract(COALESCE({alias}model_config, '{{}}'),"
+        "  AND COALESCE(json_extract(CASE WHEN json_valid({alias}model_config)"
+        " THEN {alias}model_config ELSE '{{}}' END,"
         " '$._branched_from'), '') != ?\n"
-        "  AND COALESCE(json_extract(COALESCE({alias}model_config, '{{}}'),"
+        "  AND COALESCE(json_extract(CASE WHEN json_valid({alias}model_config)"
+        " THEN {alias}model_config ELSE '{{}}' END,"
         " '$._delegate_from'), '') != ?\n"
         "  AND COALESCE({alias}source, '') != 'tool'\n"
     )
@@ -6020,6 +6077,76 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         return f"{base} #{max_num + 1}"
 
+    def _get_compression_continuation_state(
+        self, session_id: str
+    ) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
+        """Classify the direct continuation edge of a compression parent."""
+        if not session_id:
+            return None, None
+
+        with self._lock:
+            parent = self._conn.execute(
+                "SELECT ended_at, end_reason FROM sessions WHERE id = ?", (session_id,)
+            ).fetchone()
+            if parent is None or parent["end_reason"] != "compression":
+                return None, None
+
+            rows = self._conn.execute(
+                """
+                SELECT child.id, child.ended_at, child.end_reason
+                FROM sessions child
+                WHERE child.parent_session_id = ?
+                  AND COALESCE(child.end_reason, '') != 'ws_orphan_reap'
+                """
+                + self._NON_CONTINUATION_CHILD_FILTER_SQL.format(alias="child.")
+                + " ORDER BY child.started_at, child.id",
+                (session_id, session_id, session_id),
+            ).fetchall()
+
+        # Unmarked legacy delegates that ended before their parent compressed
+        # are provably not post-compression continuations. Equal timestamps are
+        # retained because older databases only have coarse timestamp precision.
+        rows = [
+            row
+            for row in rows
+            if not (
+                row["ended_at"] is not None
+                and parent["ended_at"] is not None
+                and row["ended_at"] < parent["ended_at"]
+            )
+        ]
+        valid = [
+            row
+            for row in rows
+            if row["ended_at"] is None or row["end_reason"] == "compression"
+        ]
+        invalid = [
+            row
+            for row in rows
+            if row["ended_at"] is not None and row["end_reason"] != "compression"
+        ]
+        if invalid:
+            return None, {
+                "ok": False,
+                "reason": "invalid_closed_child",
+                "session_id": session_id,
+                "candidate_ids": [row["id"] for row in invalid],
+            }
+        if len(valid) > 1:
+            return None, {
+                "ok": False,
+                "reason": "ambiguous_continuation",
+                "session_id": session_id,
+                "candidate_ids": [row["id"] for row in valid],
+            }
+        return (valid[0]["id"], None) if valid else (None, None)
+
+    def _get_compression_continuation_child(self, session_id: str) -> Optional[str]:
+        """Return the unique fail-closed compression continuation child."""
+        child_id, _integrity = self._get_compression_continuation_state(session_id)
+        return child_id
+
+
     def get_compression_tip(self, session_id: str) -> Optional[str]:
         """Walk the compression-continuation chain forward and return the tip.
 
@@ -6043,42 +6170,133 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """
         current = session_id
         seen = {current} if current else set()
-        # Bound the walk defensively — compression chains this deep are
-        # pathological and shouldn't happen in practice. 100 = plenty.
-        for _ in range(100):
-            with self._lock:
-                cursor = self._conn.execute(
-                    f"""
-                    SELECT child.id
-                    FROM sessions parent
-                    JOIN sessions child ON child.parent_session_id = parent.id
-                    WHERE parent.id = ?
-                      AND parent.end_reason = 'compression'
-                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._branched_from') IS NULL
-                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._delegate_from') IS NULL
-                      AND COALESCE(child.source, '') != 'tool'
-                    ORDER BY
-                      CASE
-                        WHEN child.end_reason = 'compression' THEN 0
-                        WHEN child.ended_at IS NULL THEN 1
-                        ELSE 2
-                      END,
-                      {_sql_session_last_active("child")} DESC,
-                      child.started_at DESC,
-                      child.id DESC
-                    LIMIT 1
-                    """,
-                    (current,),
-                )
-                row = cursor.fetchone()
-            if row is None:
+        while current:
+            child_id = self._get_compression_continuation_child(current)
+            if child_id is None:
                 return current
-            child_id = row["id"]
             if not child_id or child_id in seen:
-                return current
+                return session_id
             seen.add(child_id)
             current = child_id
         return current
+
+
+    def get_compression_lineage_metadata(self, session_id: str) -> Dict[str, Any]:
+        """Return deterministic root-to-tip metadata for one compression chain.
+
+        This is intentionally read-only and follows exactly the child-selection
+        rule used by :meth:`get_compression_tip`.  A parent pointer alone is not
+        a lineage edge: explicit branches, delegated subagents, and tool
+        sessions remain separate conversations. Cycles are bounded by the
+        visited-id set; presentation pagination is applied only after the
+        canonical root and tip have been resolved.
+        """
+        if not session_id:
+            return {
+                "root_session_id": session_id,
+                "tip_session_id": session_id,
+                "segments": [],
+                "integrity": {"ok": True},
+            }
+
+        root = session_id
+        seen = {root}
+
+        # Walk upward only through the *selected* compression child.  A stale
+        # sibling of a compressed parent must not inherit the live lineage.
+        while root:
+            with self._lock:
+                parent = self._conn.execute(
+                    """
+                    SELECT parent.id
+                    FROM sessions parent
+                    JOIN sessions child ON child.parent_session_id = parent.id
+                    WHERE child.id = ? AND parent.end_reason = 'compression'
+                    LIMIT 1
+                    """,
+                    (root,),
+                ).fetchone()
+            if parent is None:
+                break
+            parent_id = parent["id"]
+            if (
+                not parent_id
+                or parent_id in seen
+                or self._get_compression_continuation_child(parent_id) != root
+            ):
+                break
+            seen.add(parent_id)
+            root = parent_id
+
+        segments: List[Dict[str, Any]] = []
+        current = root
+        seen = set()
+        index = 1
+        integrity: Dict[str, Any] = {"ok": True}
+        while current:
+            if current in seen:
+                integrity = {
+                    "ok": False,
+                    "reason": "cycle",
+                    "session_id": current,
+                    "candidate_ids": [current],
+                }
+                break
+            seen.add(current)
+            with self._lock:
+                row = self._conn.execute(
+                    f"""
+                    SELECT s.id, s.parent_session_id, s.title, s.started_at,
+                           s.ended_at, s.end_reason, s.source, s.message_count,
+                           s.input_tokens, s.output_tokens, s.tool_call_count,
+                           {_sql_session_last_active("s")} AS last_active
+                    FROM sessions s WHERE s.id = ?
+                    """,
+                    (current,),
+                ).fetchone()
+            if row is None:
+                break
+            segment = dict(row)
+            segment["index"] = index
+            segment["is_tip"] = False
+            segments.append(segment)
+            current, edge_integrity = self._get_compression_continuation_state(current)
+            if edge_integrity is not None:
+                integrity = edge_integrity
+                break
+            index += 1
+
+        if integrity.get("reason") == "cycle":
+            with self._lock:
+                requested_row = self._conn.execute(
+                    f"""
+                    SELECT s.id, s.parent_session_id, s.title, s.started_at,
+                           s.ended_at, s.end_reason, s.source, s.message_count,
+                           s.input_tokens, s.output_tokens, s.tool_call_count,
+                           {_sql_session_last_active("s")} AS last_active
+                    FROM sessions s WHERE s.id = ?
+                    """,
+                    (session_id,),
+                ).fetchone()
+            segments = []
+            if requested_row is not None:
+                requested = dict(requested_row)
+                requested["index"] = 1
+                requested["is_tip"] = True
+                segments.append(requested)
+            root = session_id
+            tip = session_id
+        elif segments:
+            segments[-1]["is_tip"] = True
+            tip = segments[-1]["id"]
+        else:
+            tip = root
+        return {
+            "root_session_id": root,
+            "tip_session_id": tip,
+            "segments": segments,
+            "integrity": integrity,
+        }
 
     # Columns excluded from compact_rows projections: only the payload-heavy
     # blob no list consumer renders. Everything else — including gateway
@@ -6297,17 +6515,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 )
             _sel = self._compact_session_cols() if compact_rows else "s.*"
             query = f"""
-                WITH RECURSIVE chain(root_id, cur_id) AS (
-                    SELECT s.id, s.id FROM sessions s {where_sql}
+                WITH RECURSIVE chain(root_id, cur_id, visited) AS (
+                    SELECT s.id, s.id, '|' || s.id || '|' FROM sessions s {where_sql}
                     UNION ALL
-                    SELECT c.root_id, child.id
+                    SELECT c.root_id, child.id, c.visited || child.id || '|'
                     FROM chain c
                     JOIN sessions parent ON parent.id = c.cur_id
                     JOIN sessions child ON child.parent_session_id = c.cur_id
                     WHERE parent.end_reason = 'compression'
-                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._branched_from') IS NULL
-                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._delegate_from') IS NULL
-                      AND COALESCE(child.source, '') != 'tool'
+                      AND INSTR(c.visited, '|' || child.id || '|') = 0
+                      {_unique_compression_continuation_sql("child", "parent")}
                 ),
                 chain_max AS (
                     SELECT
@@ -6321,6 +6538,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         (SELECT {_PREVIEW_RAW_SELECT}
                          FROM messages m
                          WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
+                           AND COALESCE(m.display_kind, '') != 'hidden'
                          ORDER BY m.timestamp, m.id LIMIT 1),
                         ''
                     ) AS _preview_raw,
@@ -6344,6 +6562,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         (SELECT {_PREVIEW_RAW_SELECT}
                          FROM messages m
                          WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
+                           AND COALESCE(m.display_kind, '') != 'hidden'
                          ORDER BY m.timestamp, m.id LIMIT 1),
                         ''
                     ) AS _preview_raw,
@@ -6383,6 +6602,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         (SELECT {_PREVIEW_RAW_SELECT}
                          FROM messages m
                          WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
+                           AND COALESCE(m.display_kind, '') != 'hidden'
                          ORDER BY m.timestamp, m.id LIMIT 1),
                         ''
                     ) AS _preview_raw,
@@ -7516,9 +7736,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # never hijack the resume. This is the fix for the desktop "I came back
         # and the reply isn't there" report on large sessions.
         try:
-            tip = self.get_compression_tip(session_id)
+            lineage = self.get_compression_lineage_metadata(session_id)
         except Exception:
-            tip = session_id
+            return session_id
+        if not lineage.get("integrity", {}).get("ok", True):
+            return session_id
+        tip = lineage.get("tip_session_id")
         if tip and tip != session_id:
             session_id = tip
 
@@ -8198,15 +8421,28 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             ).fetchall()
         return {str(row["source"]): int(row["count"] or 0) for row in rows}
 
-    def message_count(self, session_id: str = None) -> int:
-        """Count messages, optionally for a specific session."""
+    def message_count(
+        self, session_id: str = None, include_inactive: bool = True
+    ) -> int:
+        """Count messages, optionally excluding soft-deleted rows.
+
+        The historical default includes inactive rows for compatibility with
+        audit/maintenance callers. Pagination paired with :meth:`get_messages`
+        should pass ``include_inactive=False`` so its total uses the same
+        predicate as the returned page.
+        """
         with self._lock:
             if session_id:
                 cursor = self._conn.execute(
-                    "SELECT COUNT(*) FROM messages WHERE session_id = ?", (session_id,)
+                    "SELECT COUNT(*) FROM messages WHERE session_id = ?"
+                    + ("" if include_inactive else " AND active = 1"),
+                    (session_id,),
                 )
             else:
-                cursor = self._conn.execute("SELECT COUNT(*) FROM messages")
+                cursor = self._conn.execute(
+                    "SELECT COUNT(*) FROM messages"
+                    + ("" if include_inactive else " WHERE active = 1")
+                )
             return cursor.fetchone()[0]
 
     def has_platform_message_id(
@@ -8231,72 +8467,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     # Export and cleanup
     # =========================================================================
 
-    def _is_explicit_fork_child_row(self, session: Dict[str, Any]) -> bool:
-        if session.get("source") == "tool":
-            return True
-        raw = session.get("model_config")
-        if not raw:
-            return False
-        try:
-            cfg = json.loads(raw) if isinstance(raw, str) else raw
-        except (TypeError, json.JSONDecodeError):
-            return False
-        return isinstance(cfg, dict) and (
-            cfg.get("_branched_from") is not None
-            or cfg.get("_delegate_from") is not None
-        )
 
-    def _is_compression_child_row(self, child: Dict[str, Any]) -> bool:
-        parent_id = child.get("parent_session_id")
-        if not parent_id or self._is_explicit_fork_child_row(child):
-            return False
-        parent = self.get_session(parent_id)
-        return bool(parent and parent.get("end_reason") == "compression")
 
     def get_compression_lineage(self, session_id: str) -> List[str]:
-        """Return compression ancestors through tip in chronological order."""
-        session = self.get_session(session_id)
-        if not session or self._is_explicit_fork_child_row(session):
-            return [session_id] if session else []
+        """Return compression ancestors through tip in chronological order.
 
-        root = session
-        ancestors = {root["id"]}
-        while self._is_compression_child_row(root):
-            parent = self.get_session(root["parent_session_id"])
-            if not parent or parent["id"] in ancestors:
-                break
-            root = parent
-            ancestors.add(root["id"])
-
-        lineage = [root["id"]]
-        seen = {root["id"]}
-        current = root
-        while current.get("end_reason") == "compression":
-            with self._lock:
-                rows = self._conn.execute(
-                    """
-                    SELECT * FROM sessions
-                    WHERE parent_session_id = ?
-                    ORDER BY started_at ASC
-                    """,
-                    (current["id"],),
-                ).fetchall()
-            next_child = None
-            for row in rows:
-                candidate = dict(row)
-                if self._is_compression_child_row(candidate):
-                    next_child = candidate
-                    break
-            if not next_child or next_child["id"] in seen:
-                break
-            lineage.append(next_child["id"])
-            seen.add(next_child["id"])
-            current = next_child
-            if current["id"] == session_id:
-                # Continue to include later compression tips only when the
-                # requested session itself was compacted.
-                continue
-        return lineage if session_id in lineage else [session_id]
+        Keep this long-standing list-returning contract for export callers while
+        sharing the same continuation selection as resume and Desktop metadata.
+        """
+        metadata = self.get_compression_lineage_metadata(session_id)
+        return [segment["id"] for segment in metadata["segments"]]
 
     def clear_messages(self, session_id: str) -> None:
         """Delete all messages for a session and reset its counters."""
@@ -9606,6 +9786,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                             (SELECT {_PREVIEW_RAW_SELECT}
                              FROM messages m
                              WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
+                           AND COALESCE(m.display_kind, '') != 'hidden'
                              ORDER BY m.timestamp, m.id LIMIT 1),
                             ''
                         ) AS _preview_raw,
@@ -9636,6 +9817,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                             (SELECT {_PREVIEW_RAW_SELECT}
                              FROM messages m
                              WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
+                           AND COALESCE(m.display_kind, '') != 'hidden'
                              ORDER BY m.timestamp, m.id LIMIT 1),
                             ''
                         ) AS _preview_raw,

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -80,10 +80,22 @@ def _shape_preview(raw: Any) -> str:
     return text
 
 
+# Historical databases can contain malformed model_config JSON. Every listing
+# predicate must therefore validate before json_extract; invalid values behave
+# like an empty object rather than aborting the whole SQLite query.
+_SAFE_MODEL_CONFIG_SQL = (
+    "CASE WHEN json_valid(COALESCE({a}.model_config, '{{}}')) "
+    "THEN COALESCE({a}.model_config, '{{}}') ELSE '{{}}' END"
+)
+
+
 # A child session counts as a /branch (kept visible, never cascade-deleted) if
-# it carries the stable marker OR the legacy end_reason heuristic holds.
+# its stable marker points to its immediate parent OR the legacy end_reason
+# heuristic holds. Compression continuations inherit model_config, so marker
+# presence alone would incorrectly surface a continuation as a second branch.
 _BRANCH_CHILD_SQL = (
-    "json_extract(COALESCE({a}.model_config, '{{}}'), '$._branched_from') IS NOT NULL"
+    "json_extract((" + _SAFE_MODEL_CONFIG_SQL + "), '$._branched_from') "
+    "= {a}.parent_session_id"
     " OR EXISTS (SELECT 1 FROM sessions p"
     "            WHERE p.id = {a}.parent_session_id"
     "            AND p.end_reason = 'branched'"
@@ -100,7 +112,9 @@ _COMPRESSION_CHILD_SQL = (
 
 # Rows that surface in pickers: roots + branch children (subagent runs and
 # compression continuations stay hidden).
-_LISTABLE_CHILD_SQL = f"(s.parent_session_id IS NULL OR {_BRANCH_CHILD_SQL.format(a='s')})"
+_LISTABLE_CHILD_SQL = (
+    f"(s.parent_session_id IS NULL OR {_BRANCH_CHILD_SQL.format(a='s')})"
+)
 
 
 def _ephemeral_child_sql(alias: str = "s") -> str:
@@ -150,8 +164,7 @@ def _sql_session_last_active_by_id(session_id_expr: str) -> str:
         f"WHERE _act_s.id = {session_id_expr})"
     )
     started = (
-        f"(SELECT started_at FROM sessions _act_s "
-        f"WHERE _act_s.id = {session_id_expr})"
+        f"(SELECT started_at FROM sessions _act_s WHERE _act_s.id = {session_id_expr})"
     )
     return (
         f"COALESCE("

--- a/hermes_state_portability.py
+++ b/hermes_state_portability.py
@@ -107,6 +107,7 @@ class SessionPortabilityMixin:
                     (SELECT {_PREVIEW_RAW_SELECT}
                      FROM messages m
                      WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
+                       AND COALESCE(m.display_kind, '') != 'hidden'
                      ORDER BY m.timestamp, m.id LIMIT 1),
                     ''
                 ) AS _preview_raw,
@@ -191,6 +192,7 @@ class SessionPortabilityMixin:
                     (SELECT {_PREVIEW_RAW_SELECT}
                      FROM messages m
                      WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
+                       AND COALESCE(m.display_kind, '') != 'hidden'
                      ORDER BY m.timestamp, m.id LIMIT 1),
                     ''
                 ) AS _preview_raw,

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1827,6 +1827,183 @@ class TestWebServerEndpoints:
         assert resp.json()["pagination"]["limit"] == 500
 
 
+    def test_compression_lineage_routes_preserve_exact_historical_segment(self):
+        """Lineage reads must not reuse the normal resume-resolving endpoint."""
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="lineage-root", source="desktop")
+            db.append_message(
+                session_id="lineage-root", role="user", content="before compression"
+            )
+            db.end_session("lineage-root", "compression")
+            db.create_session(
+                session_id="lineage-tip",
+                source="desktop",
+                parent_session_id="lineage-root",
+            )
+            db.append_message(
+                session_id="lineage-tip", role="assistant", content="after compression"
+            )
+        finally:
+            db.close()
+
+        lineage = self.client.get("/api/sessions/lineage-tip/compression-lineage")
+        assert lineage.status_code == 200
+        assert [entry["id"] for entry in lineage.json()["segments"]] == [
+            "lineage-root",
+            "lineage-tip",
+        ]
+        assert lineage.json()["tip_session_id"] == "lineage-tip"
+
+        historical = self.client.get(
+            "/api/sessions/lineage-tip/compression-lineage/lineage-root/messages"
+        )
+        assert historical.status_code == 200
+        assert historical.json()["session_id"] == "lineage-root"
+        assert historical.json()["messages"][0]["content"] == "before compression"
+
+    def test_compression_lineage_routes_fail_closed_on_ambiguous_children(self):
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="ambiguous-root", source="desktop")
+            db.end_session("ambiguous-root", "compression")
+            for child in ("ambiguous-a", "ambiguous-b"):
+                db.create_session(
+                    session_id=child,
+                    source="desktop",
+                    parent_session_id="ambiguous-root",
+                )
+                db.append_message(session_id=child, role="user", content=child)
+        finally:
+            db.close()
+
+        lineage = self.client.get("/api/sessions/ambiguous-root/compression-lineage")
+        assert lineage.status_code == 200
+        assert lineage.json()["tip_session_id"] == "ambiguous-root"
+        assert lineage.json()["integrity"]["ok"] is False
+        assert lineage.json()["integrity"]["reason"] == "ambiguous_continuation"
+
+        exact_child = self.client.get(
+            "/api/sessions/ambiguous-root/compression-lineage/ambiguous-a/messages"
+        )
+        assert exact_child.status_code == 404
+
+
+    def test_compression_lineage_routes_page_past_100_and_accept_the_real_tip(self):
+        from hermes_state import SessionDB
+
+        segment_ids = [f"long-lineage-{index:03d}" for index in range(102)]
+        db = SessionDB()
+        try:
+            for index, segment_id in enumerate(segment_ids):
+                db.create_session(
+                    session_id=segment_id,
+                    source="desktop",
+                    parent_session_id=segment_ids[index - 1] if index else None,
+                )
+                db.append_message(
+                    session_id=segment_id, role="user", content=segment_id
+                )
+                if index < len(segment_ids) - 1:
+                    db.end_session(segment_id, "compression")
+        finally:
+            db.close()
+
+        lineage = self.client.get(
+            f"/api/sessions/{segment_ids[-1]}/compression-lineage?offset=100&limit=2"
+        )
+        assert lineage.status_code == 200
+        assert lineage.json()["root_session_id"] == segment_ids[0]
+        assert lineage.json()["tip_session_id"] == segment_ids[-1]
+        assert [entry["id"] for entry in lineage.json()["segments"]] == segment_ids[
+            100:
+        ]
+
+        exact_tip = self.client.get(
+            f"/api/sessions/{segment_ids[0]}/compression-lineage/{segment_ids[-1]}/messages"
+        )
+        assert exact_tip.status_code == 200
+        assert exact_tip.json()["session_id"] == segment_ids[-1]
+
+    def test_compression_segment_messages_are_bounded_and_pageable_by_default(self):
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="large-segment", source="desktop")
+            for index in range(501):
+                db.append_message(
+                    session_id="large-segment",
+                    role="user",
+                    content=f"message-{index:03d}",
+                )
+        finally:
+            db.close()
+
+        first = self.client.get(
+            "/api/sessions/large-segment/compression-lineage/large-segment/messages"
+        )
+        assert first.status_code == 200
+        assert len(first.json()["messages"]) == 500
+        assert first.json()["pagination"] == {
+            "has_more": True,
+            "limit": 500,
+            "offset": 0,
+            "returned": 500,
+            "total": 501,
+        }
+
+        last = self.client.get(
+            "/api/sessions/large-segment/compression-lineage/large-segment/messages"
+            "?limit=500&offset=500"
+        )
+        assert last.status_code == 200
+        assert [message["content"] for message in last.json()["messages"]] == [
+            "message-500"
+        ]
+        assert last.json()["pagination"]["has_more"] is False
+        assert last.json()["pagination"]["total"] == 501
+
+    def test_compression_segment_pagination_counts_only_active_messages(self):
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="rewound-segment", source="desktop")
+            for index in range(501):
+                db.append_message(
+                    session_id="rewound-segment",
+                    role="user",
+                    content=f"message-{index:03d}",
+                )
+            db._conn.execute(
+                "UPDATE messages SET active = 0 WHERE session_id = ? AND id IN ("
+                "SELECT id FROM messages WHERE session_id = ? ORDER BY id DESC LIMIT 101)",
+                ("rewound-segment", "rewound-segment"),
+            )
+            db._conn.commit()
+        finally:
+            db.close()
+
+        response = self.client.get(
+            "/api/sessions/rewound-segment/compression-lineage/rewound-segment/messages"
+        )
+
+        assert response.status_code == 200
+        assert len(response.json()["messages"]) == 400
+        assert response.json()["pagination"] == {
+            "has_more": False,
+            "limit": 500,
+            "offset": 0,
+            "returned": 400,
+            "total": 400,
+        }
+
+
 
 
 

--- a/tests/hermes_state/test_compression_lineage.py
+++ b/tests/hermes_state/test_compression_lineage.py
@@ -1,0 +1,281 @@
+"""Contracts for the read-only compression lineage projection."""
+
+import time
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SessionDB(tmp_path / "state.db")
+
+
+def _make_lineage(db: SessionDB):
+    base = int(time.time()) - 10_000
+    db.create_session("root", source="desktop")
+    db.append_message("root", "user", "before compression")
+    db.end_session("root", "compression")
+    db.create_session("mid", source="desktop", parent_session_id="root")
+    db.append_message("mid", "assistant", "middle segment")
+    db.end_session("mid", "compression")
+    db.create_session("tip", source="desktop", parent_session_id="mid")
+    db.append_message("tip", "user", "current segment")
+
+    # These share parent pointers but are not compression continuations.
+    db.create_session("branch", source="desktop", parent_session_id="root")
+    db.create_session("delegate", source="desktop", parent_session_id="mid")
+    db.create_session("tool", source="tool", parent_session_id="mid")
+    db.create_session("stale", source="desktop", parent_session_id="mid")
+    db.end_session("stale", "ws_orphan_reap")
+    db._conn.execute(
+        "UPDATE sessions SET model_config = ? WHERE id = 'branch'",
+        ('{"_branched_from":"root"}',),
+    )
+    db._conn.execute(
+        "UPDATE sessions SET model_config = ? WHERE id = 'delegate'",
+        ('{"_delegate_from":"mid"}',),
+    )
+    for offset, session_id in enumerate((
+        "root",
+        "mid",
+        "tip",
+        "branch",
+        "delegate",
+        "tool",
+        "stale",
+    )):
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (base + offset, session_id),
+        )
+    db._conn.commit()
+
+
+def test_compression_lineage_is_root_to_tip_and_excludes_non_compression_children(db):
+    _make_lineage(db)
+
+    lineage = db.get_compression_lineage_metadata("tip")
+
+    assert lineage["root_session_id"] == "root"
+    assert lineage["tip_session_id"] == "tip"
+    assert [segment["id"] for segment in lineage["segments"]] == ["root", "mid", "tip"]
+    assert [segment["index"] for segment in lineage["segments"]] == [1, 2, 3]
+    assert lineage["segments"][-1]["is_tip"] is True
+    assert lineage["segments"][1]["parent_session_id"] == "root"
+    assert lineage["segments"][0]["message_count"] == 1
+
+
+def test_compression_lineage_from_an_excluded_sibling_is_its_own_single_segment(db):
+    _make_lineage(db)
+
+    lineage = db.get_compression_lineage_metadata("branch")
+
+    assert lineage["root_session_id"] == "branch"
+    assert [segment["id"] for segment in lineage["segments"]] == ["branch"]
+
+    stale = db.get_compression_lineage_metadata("stale")
+    assert stale["root_session_id"] == "stale"
+    assert [segment["id"] for segment in stale["segments"]] == ["stale"]
+
+
+@pytest.mark.parametrize("marker", ["_branched_from", "_delegate_from"])
+def test_compression_continuation_keeps_inherited_non_continuation_marker(db, marker):
+    db.create_session("origin", source="desktop")
+    db.end_session("origin", "compression")
+    db.create_session("fork", source="desktop", parent_session_id="origin")
+    db._conn.execute(
+        "UPDATE sessions SET model_config = ? WHERE id = 'fork'",
+        (f'{{"{marker}":"origin"}}',),
+    )
+    db.end_session("fork", "compression")
+    db.create_session("fork-tip", source="desktop", parent_session_id="fork")
+    db._conn.execute(
+        "UPDATE sessions SET model_config = ? WHERE id = 'fork-tip'",
+        (f'{{"{marker}":"origin"}}',),
+    )
+    db._conn.commit()
+
+    assert db.get_compression_tip("fork") == "fork-tip"
+    assert db.get_compression_lineage("fork-tip") == ["fork", "fork-tip"]
+
+
+def test_compression_lineage_excludes_an_only_stale_orphan_sibling(db):
+    db.create_session("root", source="desktop")
+    db.end_session("root", "compression")
+    db.create_session("stale", source="desktop", parent_session_id="root")
+    db.end_session("stale", "ws_orphan_reap")
+
+    assert db.get_compression_tip("root") == "root"
+    assert db.get_compression_lineage("root") == ["root"]
+    assert db.get_compression_lineage("stale") == ["stale"]
+
+
+def test_compression_tip_fails_closed_when_continuation_is_ambiguous(db):
+    db.create_session("root", source="desktop")
+    db.end_session("root", "compression")
+    db.create_session("child-a", source="desktop", parent_session_id="root")
+    db.create_session("child-b", source="desktop", parent_session_id="root")
+
+    lineage = db.get_compression_lineage_metadata("root")
+
+    assert db.get_compression_tip("root") == "root"
+    assert [segment["id"] for segment in lineage["segments"]] == ["root"]
+    assert lineage["integrity"]["ok"] is False
+    assert lineage["integrity"]["reason"] == "ambiguous_continuation"
+    assert set(lineage["integrity"]["candidate_ids"]) == {"child-a", "child-b"}
+
+
+def test_compression_tip_fails_closed_on_unknown_closed_child(db):
+    db.create_session("root", source="desktop")
+    db.end_session("root", "compression")
+    db.create_session("closed", source="desktop", parent_session_id="root")
+    db.end_session("closed", "session_reset")
+
+    lineage = db.get_compression_lineage_metadata("root")
+
+    assert db.get_compression_tip("root") == "root"
+    assert [segment["id"] for segment in lineage["segments"]] == ["root"]
+    assert lineage["integrity"]["ok"] is False
+    assert lineage["integrity"]["reason"] == "invalid_closed_child"
+    assert lineage["integrity"]["candidate_ids"] == ["closed"]
+
+
+def test_compression_lineage_metadata_resolves_root_and_tip_beyond_100_segments(db):
+    segment_ids = [f"segment-{index:03d}" for index in range(102)]
+    for index, segment_id in enumerate(segment_ids):
+        db.create_session(
+            segment_id,
+            source="desktop",
+            parent_session_id=segment_ids[index - 1] if index else None,
+        )
+        if index < len(segment_ids) - 1:
+            db.end_session(segment_id, "compression")
+
+    lineage = db.get_compression_lineage_metadata(segment_ids[-1])
+
+    assert lineage["root_session_id"] == segment_ids[0]
+    assert lineage["tip_session_id"] == segment_ids[-1]
+    assert [segment["id"] for segment in lineage["segments"]] == segment_ids
+    assert lineage["segments"][-1]["is_tip"] is True
+
+
+def test_compression_lineage_tolerates_historical_malformed_model_config(db):
+    db.create_session("root", source="desktop")
+    db.end_session("root", "compression")
+    db.create_session("tip", source="desktop", parent_session_id="root")
+    db._conn.execute("UPDATE sessions SET model_config = '{malformed' WHERE id = 'tip'")
+    db._conn.commit()
+
+    assert db.get_compression_lineage("tip") == ["root", "tip"]
+
+
+def test_compression_cycle_is_bounded_and_fails_closed_to_requested_session(db):
+    db.create_session("cycle-a", source="desktop")
+    db.create_session("cycle-b", source="desktop", parent_session_id="cycle-a")
+    db.end_session("cycle-a", "compression")
+    db.end_session("cycle-b", "compression")
+    db._conn.execute(
+        "UPDATE sessions SET parent_session_id = 'cycle-b', ended_at = 100 WHERE id = 'cycle-a'"
+    )
+    db._conn.execute("UPDATE sessions SET ended_at = 100 WHERE id = 'cycle-b'")
+    db._conn.commit()
+
+    assert db.get_compression_tip("cycle-a") == "cycle-a"
+    assert db.resolve_resume_session_id("cycle-a") == "cycle-a"
+
+    lineage = db.get_compression_lineage_metadata("cycle-a")
+    assert lineage["root_session_id"] == "cycle-a"
+    assert lineage["tip_session_id"] == "cycle-a"
+    assert [segment["id"] for segment in lineage["segments"]] == ["cycle-a"]
+    assert lineage["integrity"]["ok"] is False
+    assert lineage["integrity"]["reason"] == "cycle"
+
+    progress_calls = 0
+
+    def abort_unbounded_query():
+        nonlocal progress_calls
+        progress_calls += 1
+        return int(progress_calls > 10_000)
+
+    db._conn.set_progress_handler(abort_unbounded_query, 100)
+    try:
+        listed = db.list_sessions_rich(
+            include_children=True,
+            limit=20,
+            order_by_last_active=True,
+        )
+    finally:
+        db._conn.set_progress_handler(None, 0)
+
+    assert isinstance(listed, list)
+    assert progress_calls <= 10_000
+
+
+def test_session_list_projects_foreign_branch_marker_continuation_once(db):
+    marker = "_branched_from"
+    db.create_session("origin", source="desktop")
+    db.end_session("origin", "compression")
+    db.create_session("fork", source="desktop", parent_session_id="origin")
+    db._conn.execute(
+        "UPDATE sessions SET model_config = ? WHERE id = 'fork'",
+        (f'{{"{marker}":"origin"}}',),
+    )
+    db.end_session("fork", "compression")
+    db.create_session("fork-tip", source="desktop", parent_session_id="fork")
+    db._conn.execute(
+        "UPDATE sessions SET model_config = ? WHERE id = 'fork-tip'",
+        (f'{{"{marker}":"origin"}}',),
+    )
+    db._conn.commit()
+
+    listed = db.list_sessions_rich(limit=20, order_by_last_active=True)
+    ids = [session["id"] for session in listed]
+
+    assert ids.count("fork-tip") == 1
+    assert "fork" not in ids
+
+
+def test_session_list_tolerates_malformed_branch_model_config(db):
+    db.create_session("parent", source="desktop")
+    db.end_session("parent", "branched")
+    db.create_session("legacy-branch", source="desktop", parent_session_id="parent")
+    db._conn.execute(
+        "UPDATE sessions SET model_config = '{malformed' WHERE id = 'legacy-branch'"
+    )
+    db._conn.commit()
+
+    listed = db.list_sessions_rich(limit=20, order_by_last_active=True)
+
+    assert "legacy-branch" in {session["id"] for session in listed}
+
+
+@pytest.mark.parametrize("order_by_last_active", [False, True])
+def test_session_preview_skips_hidden_compaction_checkpoint(db, order_by_last_active):
+    db.create_session("branch", source="desktop")
+    db.append_messages_batch(
+        "branch",
+        [
+            {
+                "content": "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns.",
+                "display_kind": "hidden",
+                "role": "user",
+                "timestamp": 1,
+            },
+            {
+                "content": "visible branch prompt",
+                "role": "user",
+                "timestamp": 2,
+            },
+        ],
+    )
+
+    listed = db.list_sessions_rich(
+        limit=10,
+        order_by_last_active=order_by_last_active,
+    )
+    row = next(session for session in listed if session["id"] == "branch")
+
+    assert row["preview"] == "visible branch prompt"
+    assert db.get_session_rich_row("branch")["preview"] == "visible branch prompt"

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import os
 import subprocess
@@ -36,6 +37,56 @@ def _neuter_agent_prewarm_timer(request, monkeypatch):
         return
     monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
     yield
+
+
+def test_coerce_seed_history_preserves_hidden_display_kind():
+    history = server._coerce_seed_history([
+        {
+            "role": "user",
+            "content": "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns.",
+            "display_kind": "hidden",
+        }
+    ])
+
+    assert history == [
+        {
+            "role": "user",
+            "content": "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns.",
+            "display_kind": "hidden",
+        }
+    ]
+
+
+def test_persist_branch_seed_preserves_hidden_display_kind(monkeypatch):
+    captured = []
+
+    class FakeDB:
+        def append_messages_batch(self, _session_id, messages, **_kwargs):
+            captured.extend(messages)
+            return len(messages)
+
+    @contextlib.contextmanager
+    def fake_session_db(_session):
+        yield FakeDB()
+
+    monkeypatch.setattr(server, "_session_db", fake_session_db)
+    session = {
+        "history": [
+            {
+                "role": "user",
+                "content": "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns.",
+                "display_kind": "hidden",
+            }
+        ],
+        "history_lock": threading.Lock(),
+        "parent_session_id": "root",
+        "session_key": "branch",
+    }
+
+    server._persist_branch_seed(session)
+
+    assert captured[0]["display_kind"] == "hidden"
+
 
 
 def test_session_slot_is_claimed_on_first_turn_not_on_create(monkeypatch, tmp_path):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2841,6 +2841,7 @@ def _persist_branch_seed(session: dict) -> None:
                     {
                         "role": msg.get("role", "user"),
                         "content": msg.get("content"),
+                        "display_kind": msg.get("display_kind"),
                         # Preserve the parent's original message timestamps —
                         # append_message would otherwise stamp time.time() and the
                         # branch's copied history would all appear authored "now".
@@ -7151,7 +7152,12 @@ def _coerce_seed_history(value: Any) -> list[dict]:
         if not isinstance(content, str) or not content.strip():
             continue
 
-        history.append({"role": role, "content": content})
+        message = {"role": role, "content": content}
+        # Seed callers may hide an internal compaction checkpoint, but must not
+        # be able to forge arbitrary timeline event kinds.
+        if item.get("display_kind") == "hidden":
+            message["display_kind"] = "hidden"
+        history.append(message)
 
     return history
 


### PR DESCRIPTION
## What does this PR do?

Hermes already preserves earlier messages when compression rotates a session into a child session, but Desktop only exposes the live tip. This PR adds a compact compression-lineage navigator so users can inspect and branch from exact historical context segments without changing the live runtime.

The selected session row shows the current segment and two recent historical segments. A timeline sheet exposes the complete lineage and lazy-loads one exact, read-only segment at a time.

## Related Issue

Related to #48404, #44913, #50192, #79565, and #80680.

### Relationship to existing open PRs

- #41678 improves logical-lineage projection, pin/resume behavior, and gateway recovery. This PR focuses on a user-facing exact-segment navigator and does not add the unrelated transport recovery changes.
- #76286 restores pre-compaction history as ordinary merged chat messages. This PR deliberately keeps segments separate and lazy-loads one exact historical segment into an explicit read-only transcript; it performs no cross-segment replay/duplicate suppression, so identical later prompts remain intact.
- #79785 serves a merged full lineage from existing message endpoints. This PR preserves normal tip-resolving endpoint compatibility and adds separate structured-lineage and exact-segment endpoints for navigation and precise branch provenance.

The backend files overlap, but the UX and API contract here are complementary rather than a copy of those approaches.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add strict compression-continuation traversal that excludes ordinary branches, delegates/subagents, tool sessions, and stale orphan-reaped children while preserving the existing ID-list API.
- Add structured, paginated lineage metadata and a bounded exact segment-messages endpoint that does not auto-resolve historical reads to the live tip; Desktop aggregates all message pages before rendering.
- Handle inherited markers, invalid historical JSON, parent-pointer cycles, ambiguous continuations, unknown closed children, broken integrity, and lineages longer than 100 segments with bounded fail-closed semantics.
- Add a compact three-segment sidebar projection plus a complete timeline sheet without inserting physical compression segments into the logical `$sessions` tree.
- Reuse the assistant-ui transcript in explicit spectator mode: no composer, reactions, edits, reloads, restores, timeline, inherited live transcript window, global thread-scroll/edit listeners, or live-state mutations.
- Add segment load error/retry behavior and keep branching disabled until the exact segment loads successfully.
- Branch from the exact selected historical segment, including root and middle segments, without aliasing provenance to the live tip; inherit workspace metadata from the projected lineage owner.
- Preserve only trusted `display_kind=hidden` compaction checkpoints across Desktop payload coercion, optimistic preview, Gateway persistence, SQLite, and reload; user text cannot forge hidden context.
- Key historical lineage/message/error caches by profile plus lineage identity so same-ID sessions cannot cross profile boundaries.
- Count exact transcript pages with the same active-row predicate used to fetch them, so rewound segments terminate pagination correctly.
- Dynamically measure expanded virtual-list rows and aggregate all backend pages for 101+ segment lineages.
- Add English, Simplified Chinese, Traditional Chinese, and Japanese strings plus dialog accessibility metadata.

## How to Test

1. Open a Desktop session whose compression config uses session rotation (`compression.in_place: false`) and which has multiple persisted compression children.
2. Confirm the selected sidebar row shows the current context segment, two recent historical segments, and a complete-segment count button.
3. Open the timeline sheet, select a historical segment, and verify the live route/session remains unchanged while an exact read-only transcript loads.
4. Create a branch from that segment, send a message, reload it, and verify its `parent_session_id` is the selected segment and its compaction checkpoint remains hidden in the UI.
5. Run the automated checks listed below.

Automated/local verification:

- Desktop targeted tests: 8 files / 218 tests passed, including read-only reaction, spectator scroll/edit/timeline/transcript-window isolation, profile cache isolation, and exact middle-segment branching.
- Python lineage/API/Gateway targeted tests: 46 passed, including cyclic lineage and rewound pagination regressions.
- Renderer, Electron, and E2E TypeScript typechecks passed.
- ESLint passed with 0 errors; Ruff check and Python compile passed.
- Prettier, `git diff --check`, and added-lines secret scan passed.
- Production Desktop build passed.
- Isolated real Electron dogfood passed on a 14-segment lineage; an exact historical segment returned 258 messages without resolving to the tip.
- Branch reload preserved one hidden checkpoint in the API while rendering zero checkpoint markers in the UI.

Broader local suites retain unrelated pre-existing/environment failures outside this diff:

- Desktop: 3586 tests passed; 3 unchanged locale/billing tests failed.
- Python: 729 passed, 4 skipped; 8 unchanged environment/baseline tests failed (Windows live-DB guards, a theme SPA fixture, and local toolset expectations).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (see documented pre-existing/environment failures above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10, isolated Hermes home and Desktop user-data

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is self-contained in Desktop UI/API docstrings
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no contributor workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — no platform-specific runtime behavior was added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no agent tool schema changed

## Screenshots / Logs

The feature was visually dogfooded in a real isolated Electron instance. The timeline sheet displayed all 14 segments, the selected historical transcript remained read-only, and branching/reload persistence was verified against the isolated SQLite copy.

## Notes for Reviewers

- This first version represents cross-session rotation lineage. Reconstructing multiple in-place compression generations requires a persisted generation/boundary schema and is intentionally out of scope.
- Exact segment messages are bounded to 500 rows per response and expose `total`/`has_more`; Desktop follows pages and presents one complete exact segment. Tail-first or virtualized transcript loading can be added separately for unusually large segments.
- Compression segments remain out of `$sessions` and the generic branch tree so logical session identity, grouping, drag/drop, and virtualization semantics stay stable.
