### PR TITLE
fix(oneshot): consult fallback chain at resolution time (#81209)

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -310,6 +310,68 @@ def _create_session_db_for_oneshot():
         return None
 
 
+def _resolve_with_oneshot_fallback(
+    resolve_fn,
+    get_chain_fn,
+    cfg: dict,
+    **resolve_kwargs,
+) -> dict:
+    """Resolve the primary provider, consulting the fallback chain on AuthError.
+
+    The gateway has a dedicated resolution-time fallback path
+    (``_try_resolve_fallback_provider``); oneshot/CLI previously called
+    ``resolve_runtime_provider`` bare, so a quota-exhausted (429) or
+    auth-failed primary killed ``hermes -z`` for the entire quota window even
+    when a healthy ``fallback_providers`` chain was configured (#81209).
+
+    On success, returns the resolved runtime dict. If the primary raised
+    ``AuthError`` and a fallback entry resolves, returns that entry's runtime
+    with its ``model`` key set to the fallback entry's model so the caller
+    constructs ``AIAgent`` against the correct model name. If no fallback
+    resolves, the original ``AuthError`` propagates. Non-``AuthError``
+    exceptions propagate unchanged.
+    """
+    from hermes_cli.auth import AuthError
+    from hermes_cli.fallback_config import resolve_entry_api_key
+
+    try:
+        return resolve_fn(**resolve_kwargs)
+    except AuthError as auth_exc:
+        fb_list = get_chain_fn(cfg)
+        if not fb_list:
+            raise
+        logging.warning(
+            "Oneshot: primary provider failed (%s) — trying fallback chain",
+            auth_exc,
+        )
+        for entry in fb_list:
+            try:
+                fb_runtime = resolve_fn(
+                    requested=entry.get("provider"),
+                    explicit_base_url=entry.get("base_url"),
+                    explicit_api_key=resolve_entry_api_key(entry),
+                )
+                logging.info(
+                    "Oneshot: fallback provider resolved: %s model=%s",
+                    entry.get("provider") or fb_runtime.get("provider"),
+                    entry.get("model"),
+                )
+                # Inject the fallback entry's model so the caller uses it
+                # for AIAgent construction — mirrors the gateway's
+                # _try_resolve_fallback_provider which returns model from
+                # the entry, not the resolved runtime.
+                fb_runtime["model"] = entry.get("model")
+                return fb_runtime
+            except Exception as fb_exc:
+                logging.debug(
+                    "Oneshot: fallback entry %s failed: %s",
+                    entry.get("provider"), fb_exc,
+                )
+                continue
+        # All fallback entries failed — re-raise the original AuthError.
+        raise
+
+
 def _run_agent(
     prompt: str,
     model: Optional[str] = None,
@@ -382,11 +444,17 @@ def _run_agent(
                 if detected:
                     effective_provider, effective_model = detected
 
-    runtime = resolve_runtime_provider(
+    runtime = _resolve_with_oneshot_fallback(
+        resolve_runtime_provider,
+        get_fallback_chain,
+        cfg,
         requested=effective_provider,
         target_model=effective_model or None,
         explicit_base_url=explicit_base_url_from_alias,
     )
+    # If a fallback entry resolved, its model was injected into runtime so
+    # AIAgent runs with the correct model name.
+    effective_model = runtime.get("model") or effective_model
 
     # Pull in explicit toolsets when provided; otherwise use whatever the user
     # has enabled for "cli". sorted() gives stable ordering for config-derived

--- a/tests/hermes_cli/test_oneshot_fallback.py
+++ b/tests/hermes_cli/test_oneshot_fallback.py
@@ -1,0 +1,312 @@
+"""Regression: oneshot (-z) must try fallback providers when the primary
+provider raises AuthError at resolution time (issue #81209).
+
+The gateway has ``_try_resolve_fallback_provider`` for this; the oneshot lane
+previously called ``resolve_runtime_provider`` bare, so a quota-exhausted (429)
+or auth-failed primary killed ``hermes -z`` for the entire quota window even
+when a healthy ``fallback_providers`` chain was configured.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.auth import AuthError
+
+
+class TestOneshotResolutionTimeFallback:
+    """Oneshot must consult the fallback chain when the primary provider's
+    resolution fails with AuthError — before AIAgent is constructed."""
+
+    def test_auth_error_tries_fallback_provider(self, tmp_path, monkeypatch):
+        """When resolve_runtime_provider raises AuthError on the primary,
+        oneshot must iterate the fallback chain and use the first viable entry.
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        (hermes_home / "config.yaml").write_text(
+            "model:\n"
+            "  provider: openai-codex\n"
+            "  default: gpt-5.5\n"
+            "fallback_providers:\n"
+            "  - provider: openrouter\n"
+            "    model: anthropic/claude-sonnet-4\n"
+        )
+        monkeypatch.setattr("hermes_constants.Path.home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        call_log: list[dict] = []
+
+        def _mock_resolve(**kwargs):
+            call_log.append(kwargs)
+            if len(call_log) == 1:
+                # Primary resolution fails with quota exhaustion.
+                raise AuthError(
+                    "Codex provider quota exhausted (429); retry after 39750s."
+                )
+            # Fallback entry resolves successfully.
+            return {
+                "api_key": "fallback-key",
+                "base_url": "https://openrouter.ai/api/v1",
+                "provider": "openrouter",
+                "requested_provider": "openrouter",
+                "api_mode": "openai_chat",
+                "command": None,
+                "args": None,
+                "credential_pool": None,
+            }
+
+        with (
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                side_effect=_mock_resolve,
+            ),
+            patch("run_agent.AIAgent") as mock_agent_cls,
+            patch("hermes_cli.oneshot._create_session_db_for_oneshot"),
+            patch("hermes_cli.mcp_startup.ensure_mcp_discovery_before_agent_build"),
+        ):
+            mock_agent = mock_agent_cls.return_value
+            mock_agent.run_conversation.return_value = {"final_response": "pong"}
+
+            from hermes_cli.oneshot import _run_agent
+
+            response, _ = _run_agent(prompt="ping", model=None, provider=None)
+
+        # Fallback was attempted.
+        assert len(call_log) >= 2, (
+            f"Expected primary + fallback resolution attempts, got {len(call_log)}"
+        )
+        # The fallback entry's provider was requested.
+        second_call = call_log[1]
+        assert second_call.get("requested") == "openrouter"
+        # AIAgent was constructed with the fallback's credentials.
+        construct_kwargs = mock_agent_cls.call_args
+        assert construct_kwargs.kwargs.get("api_key") == "fallback-key"
+        assert construct_kwargs.kwargs.get("provider") == "openrouter"
+        # The fallback entry's model was used.
+        assert construct_kwargs.kwargs.get("model") == "anthropic/claude-sonnet-4"
+        assert response == "pong"
+
+    def test_no_fallback_chain_reraises_auth_error(self, tmp_path, monkeypatch):
+        """Without a fallback chain configured, the AuthError must propagate."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        (hermes_home / "config.yaml").write_text(
+            "model:\n"
+            "  provider: openai-codex\n"
+            "  default: gpt-5.5\n"
+        )
+        monkeypatch.setattr("hermes_constants.Path.home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        def _mock_resolve(**kwargs):
+            raise AuthError("Codex provider quota exhausted (429)")
+
+        with (
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                side_effect=_mock_resolve,
+            ),
+            patch("hermes_cli.oneshot._create_session_db_for_oneshot"),
+            patch("hermes_cli.mcp_startup.ensure_mcp_discovery_before_agent_build"),
+        ):
+            from hermes_cli.oneshot import _run_agent
+
+            with pytest.raises(AuthError):
+                _run_agent(prompt="ping", model=None, provider=None)
+
+    def test_non_auth_error_reraises_unchanged(self, tmp_path, monkeypatch):
+        """Non-AuthError exceptions (e.g. config errors) must propagate
+        without consulting the fallback chain."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        (hermes_home / "config.yaml").write_text(
+            "model:\n"
+            "  provider: openai-codex\n"
+            "  default: gpt-5.5\n"
+            "fallback_providers:\n"
+            "  - provider: openrouter\n"
+            "    model: anthropic/claude-sonnet-4\n"
+        )
+        monkeypatch.setattr("hermes_constants.Path.home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        call_count = {"n": 0}
+
+        def _mock_resolve(**kwargs):
+            call_count["n"] += 1
+            raise RuntimeError("config file not found")
+
+        with (
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                side_effect=_mock_resolve,
+            ),
+            patch("hermes_cli.oneshot._create_session_db_for_oneshot"),
+            patch("hermes_cli.mcp_startup.ensure_mcp_discovery_before_agent_build"),
+        ):
+            from hermes_cli.oneshot import _run_agent
+
+            with pytest.raises(RuntimeError, match="config file not found"):
+                _run_agent(prompt="ping", model=None, provider=None)
+
+        # Only the primary was attempted — no fallback consultation.
+        assert call_count["n"] == 1
+
+    def test_all_fallback_entries_fail_reraises_auth_error(
+        self, tmp_path, monkeypatch
+    ):
+        """When every fallback entry also fails, the original AuthError must
+        propagate."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        (hermes_home / "config.yaml").write_text(
+            "model:\n"
+            "  provider: openai-codex\n"
+            "  default: gpt-5.5\n"
+            "fallback_providers:\n"
+            "  - provider: openrouter\n"
+            "    model: anthropic/claude-sonnet-4\n"
+            "  - provider: nous\n"
+            "    model: hermes-4\n"
+        )
+        monkeypatch.setattr("hermes_constants.Path.home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        def _mock_resolve(**kwargs):
+            raise AuthError("all providers exhausted")
+
+        with (
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                side_effect=_mock_resolve,
+            ),
+            patch("hermes_cli.oneshot._create_session_db_for_oneshot"),
+            patch("hermes_cli.mcp_startup.ensure_mcp_discovery_before_agent_build"),
+        ):
+            from hermes_cli.oneshot import _run_agent
+
+            with pytest.raises(AuthError, match="all providers exhausted"):
+                _run_agent(prompt="ping", model=None, provider=None)
+
+    def test_second_fallback_entry_used_when_first_fails(
+        self, tmp_path, monkeypatch
+    ):
+        """When the first fallback entry fails, the next one must be tried."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        (hermes_home / "config.yaml").write_text(
+            "model:\n"
+            "  provider: openai-codex\n"
+            "  default: gpt-5.5\n"
+            "fallback_providers:\n"
+            "  - provider: openrouter\n"
+            "    model: anthropic/claude-sonnet-4\n"
+            "  - provider: nous\n"
+            "    model: hermes-4\n"
+        )
+        monkeypatch.setattr("hermes_constants.Path.home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        call_log: list[dict] = []
+
+        def _mock_resolve(**kwargs):
+            call_log.append(kwargs)
+            n = len(call_log)
+            if n == 1:
+                raise AuthError("primary quota exhausted")
+            if n == 2:
+                raise AuthError("openrouter also down")
+            return {
+                "api_key": "nous-key",
+                "base_url": "https://inference-api.nousresearch.com/v1",
+                "provider": "nous",
+                "requested_provider": "nous",
+                "api_mode": "openai_chat",
+                "command": None,
+                "args": None,
+                "credential_pool": None,
+            }
+
+        with (
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                side_effect=_mock_resolve,
+            ),
+            patch("run_agent.AIAgent") as mock_agent_cls,
+            patch("hermes_cli.oneshot._create_session_db_for_oneshot"),
+            patch("hermes_cli.mcp_startup.ensure_mcp_discovery_before_agent_build"),
+        ):
+            mock_agent = mock_agent_cls.return_value
+            mock_agent.run_conversation.return_value = {"final_response": "pong"}
+
+            from hermes_cli.oneshot import _run_agent
+
+            response, _ = _run_agent(prompt="ping", model=None, provider=None)
+
+        # Primary + first fallback + second fallback.
+        assert len(call_log) == 3
+        assert call_log[2].get("requested") == "nous"
+        construct_kwargs = mock_agent_cls.call_args
+        assert construct_kwargs.kwargs.get("provider") == "nous"
+        assert construct_kwargs.kwargs.get("model") == "hermes-4"
+        assert response == "pong"
+
+
+class TestOneshotFallbackHelper:
+    """Direct unit tests for the ``_resolve_with_oneshot_fallback`` helper."""
+
+    def test_primary_success_no_fallback_consulted(self):
+        """When the primary resolves, the fallback chain is never touched."""
+        from hermes_cli.oneshot import _resolve_with_oneshot_fallback
+
+        chain_accessed = {"n": 0}
+
+        def _get_chain(cfg):
+            chain_accessed["n"] += 1
+            return []
+
+        def _resolve_fn(**kwargs):
+            return {"provider": "primary", "api_key": "k"}
+
+        result = _resolve_with_oneshot_fallback(
+            _resolve_fn, _get_chain, {}, requested="primary"
+        )
+        assert result["provider"] == "primary"
+        # Primary success must not inject a model key.
+        assert "model" not in result
+        assert chain_accessed["n"] == 0
+
+    def test_auth_error_with_empty_chain_reraises(self):
+        """Empty fallback chain → AuthError propagates immediately."""
+        from hermes_cli.oneshot import _resolve_with_oneshot_fallback
+
+        def _get_chain(cfg):
+            return []
+
+        def _resolve_fn(**kwargs):
+            raise AuthError("nope")
+
+        with pytest.raises(AuthError, match="nope"):
+            _resolve_with_oneshot_fallback(_resolve_fn, _get_chain, {})
+
+    def test_non_auth_error_propagates_without_chain(self):
+        """A RuntimeError never reaches the fallback chain."""
+        from hermes_cli.oneshot import _resolve_with_oneshot_fallback
+
+        chain_accessed = {"n": 0}
+
+        def _get_chain(cfg):
+            chain_accessed["n"] += 1
+            return [{"provider": "openrouter", "model": "m"}]
+
+        def _resolve_fn(**kwargs):
+            raise RuntimeError("config broken")
+
+        with pytest.raises(RuntimeError, match="config broken"):
+            _resolve_with_oneshot_fallback(_resolve_fn, _get_chain, {})
+
+        assert chain_accessed["n"] == 0


### PR DESCRIPTION
## What

`hermes -z` died for the entire quota window when the primary provider hit a 429 / auth failure, even with a healthy `fallback_providers` chain configured. The oneshot lane called `resolve_runtime_provider()` bare — the `AuthError` propagated **before** `AIAgent` was constructed, so the `fallback_model=_fb` wiring (which handles mid-session failures) never got a chance.

The gateway already has a resolution-time fallback path (`_try_resolve_fallback_provider`); the CLI/oneshot lane had no equivalent.

## How

New helper `_resolve_with_oneshot_fallback()` in `hermes_cli/oneshot.py`, called from `_run_agent` in place of the bare `resolve_runtime_provider` call:

1. Try the primary provider as before.
2. On `AuthError`: walk `get_fallback_chain(cfg)` in order, resolving each entry with `resolve_entry_api_key`. (Matches the gateway pattern which specifically catches `AuthError` → fallback, unlike generic `Exception` which would mask config errors.)
3. First viable fallback entry wins — its `model` is injected into the runtime dict so `AIAgent` constructs against the fallback model.
4. If all fallback entries fail, the original `AuthError` propagates unchanged.
5. Non-`AuthError` exceptions propagate unchanged (no fallback consultation for config/import errors).
6. Empty fallback chain → original `AuthError` propagates (no regression for users without fallback configured).

The existing `fallback_model=_fb` wiring is untouched and still handles mid-session failures.

## Tests

8 regression tests in `tests/hermes_cli/test_oneshot_fallback.py`:

- `test_auth_error_tries_fallback_provider` — the issue scenario: 429 → fallback resolves → agent proceeds with correct model
- `test_no_fallback_chain_reraises_auth_error` — no chain: AuthError propagates unchanged
- `test_non_auth_error_reraises_unchanged` — config error never touches fallback chain
- `test_all_fallback_entries_fail_reraises_auth_error` — all entries exhausted → original AuthError
- `test_second_fallback_entry_used_when_first_fails` — chain walk continues past failed entry
- `test_primary_success_no_fallback_consulted` — primary success never touches fallback
- `test_auth_error_with_empty_chain_reraises` — helper-level empty chain
- `test_non_auth_error_propagates_without_chain` — helper-level non-AuthError

5 of 8 tests are RED on pre-fix code (proving the bug); all 8 GREEN after the fix. Existing `test_oneshot_usage_file.py` (3 tests) continues to pass.

## Competitor

PR #81517 by @Enough1122 addresses the same issue. This fix differs by catching `AuthError` specifically (matching the gateway's `_try_resolve_fallback_provider` pattern) rather than generic `Exception`, avoiding false fallback iteration on config/import errors.

Auto-published by Moonsong via Path B automated pipeline.