### PR TITLE
fix(matrix): use localpart for password login

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1803,8 +1803,14 @@ class MatrixAdapter(BasePlatformAdapter):
                 return False
         elif self._password and self._user_id:
             try:
+                # Some homeservers (e.g. nope.chat) require the localpart
+                # rather than a fully-qualified Matrix User ID for password
+                # login. Strip the leading ``@`` and server part if present.
+                login_identifier = self._user_id
+                if login_identifier.startswith("@"):
+                    login_identifier = login_identifier[1:].split(":", 1)[0]
                 resp = await client.login(
-                    identifier=self._user_id,
+                    identifier=login_identifier,
                     password=self._password,
                     device_name="Hermes Agent",
                     device_id=self._device_id or None,

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1249,6 +1249,56 @@ class TestMatrixPasswordLoginDeviceId:
 
         await adapter.disconnect()
 
+    @pytest.mark.asyncio
+    async def test_password_login_identifier_uses_localpart(self):
+        """Password login must use the localpart, not the full Matrix user ID.
+
+        Some homeservers (e.g. nope.chat) reject ``identifier=@user:server``
+        for ``m.login.password`` and only accept the localpart. This is a
+        regression test for that behavior.
+        """
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        config = PlatformConfig(
+            enabled=True,
+            extra={
+                "homeserver": "https://matrix.example.org",
+                "user_id": "@bot:example.org",
+                "password": "secret",
+            },
+        )
+        adapter = MatrixAdapter(config)
+
+        fake_mautrix_mods = _make_fake_mautrix()
+
+        mock_client = MagicMock()
+        mock_client.mxid = "@bot:example.org"
+        mock_client.device_id = None
+        mock_client.state_store = MagicMock()
+        mock_client.sync_store = MagicMock()
+        mock_client.crypto = None
+        mock_client.login = AsyncMock(
+            return_value=MagicMock(device_id="PW_DEVICE", access_token="tok")
+        )
+        mock_client.sync = AsyncMock(return_value={"rooms": {"join": {}}})
+        mock_client.add_event_handler = MagicMock()
+        mock_client.api = MagicMock()
+        mock_client.api.token = ""
+        mock_client.api.session = MagicMock()
+        mock_client.api.session.close = AsyncMock()
+
+        fake_mautrix_mods["mautrix.client"].Client = MagicMock(return_value=mock_client)
+
+        with patch.dict("sys.modules", fake_mautrix_mods):
+            with patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
+                with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
+                    assert await adapter.connect() is True
+
+        mock_client.login.assert_awaited_once()
+        assert mock_client.login.call_args.kwargs["identifier"] == "bot"
+
+        await adapter.disconnect()
+
 
 class TestMatrixDeviceIdConfig:
     """MATRIX_DEVICE_ID should be plumbed through gateway config."""


### PR DESCRIPTION
Some Matrix homeservers (e.g. nope.chat) reject a fully-qualified user ID as the identifier for m.login.password and require the bare localpart. This patch extracts the localpart before calling client.login().

- Adds a regression test covering the identifier passed to login.
- Ran the full tests/gateway/test_matrix.py suite: 113 passed.

Generated with [Devin](https://devin.ai)