### PR TITLE
fix(desktop): settle whitespace-normalized final onto interim (#81422)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -642,7 +642,7 @@ export function useMessageStream({
               nextMessages = prev.map((message, messageIndex) =>
                 messageIndex === index ? completeMessage(message) : message
               )
-            } else if (interimBoundaryPending && (responsePreviewed || finalContinuesInterim)) {
+            } else if (
               // Settle the interim in place instead of creating a duplicate —
               // the DB has one row, so the live UI must agree. Previously this
               // was gated on `responsePreviewed` alone, so a NON-previewed
@@ -652,6 +652,18 @@ export function useMessageStream({
               // for ordinary tool-call turns while `responsePreviewed` still
               // covers the verify-on-stop continuation-budget case even when the
               // final text was rewritten and no longer shares a prefix.
+              //
+              // The whitespace-equality clause has to fire on `existing.interim`
+              // (not `interimBoundaryPending`): a chained `message.start` between
+              // the interim seal and the final `message.complete` — the pattern
+              // open PR #76583 fixes for the prefix-continuity case — resets
+              // `interimBoundaryPending` to false via
+              // `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts:620`,
+              // making the new clause unreachable when it's exactly the case that
+              // produces a whitespace-equivalent final (#81422, follow-up).
+              (interimBoundaryPending && responsePreviewed) ||
+              finalContinuesInterim
+            ) {
               nextMessages = prev.map((message, messageIndex) =>
                 messageIndex === index ? completeMessage(message) : message
               )

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -11,6 +11,7 @@ import {
   chatMessageText,
   type GatewayEventPayload,
   mergeFinalAssistantText,
+  normalizeWhitespace,
   reasoningPart,
   renderMediaTags,
   upsertToolPart
@@ -625,7 +626,16 @@ export function useMessageStream({
               existing.interim &&
               finalText &&
               existingText &&
-              (finalText === existingText || finalText.startsWith(existingText) || existingText.startsWith(finalText))
+              (finalText === existingText ||
+                finalText.startsWith(existingText) ||
+                existingText.startsWith(finalText) ||
+                // Tool-heavy turns sometimes produce a final whose whitespace
+                // doesn't match the sealed interim exactly (collapsed runs of
+                // spaces, stray newlines, trailing whitespace from the final
+                // decoder). Treat whitespace-normalized equality as a settle
+                // signal so the live UI agrees with the single DB row instead
+                // of appending a duplicate bubble (#81422).
+                normalizeWhitespace(finalText) === normalizeWhitespace(existingText))
             )
 
             if (existing.pending || (!interimBoundaryPending && finalText && existingText === finalText)) {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
@@ -311,4 +311,22 @@ describe('useMessageStream interim text sealing', () => {
     await start()
     expect(getState().interimBoundaryPending).toBe(false)
   })
+
+  it('settles a whitespace-normalized-equivalent final onto a non-previewed interim (#81422)', async () => {
+    await mountStream()
+    await start()
+
+    // Tool-heavy Desktop turn: the streamed interim is sealed with one
+    // whitespace shape; the final decoder collapses whitespace and adds a
+    // trailing space. Neither strict equality nor prefix-either-way matches,
+    // but they are functionally the same reply. Settle onto the sealed
+    // interim so the live UI agrees with the single DB row instead of
+    // appending a duplicate bubble.
+    await delta('here is the final answer')
+    await interim('here is the final answer')
+    await complete('here  is  the  final  answer ')
+
+    const texts = assistantMessages()
+    expect(texts.filter(t => t.replace(/\s+/g, ' ').trim() === 'here is the final answer')).toHaveLength(1)
+  })
 })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
@@ -329,4 +329,52 @@ describe('useMessageStream interim text sealing', () => {
     const texts = assistantMessages()
     expect(texts.filter(t => t.replace(/\s+/g, ' ').trim() === 'here is the final answer')).toHaveLength(1)
   })
+
+  it('settles a whitespace-equivalent final even after a chained message.start resets the boundary flag (#81422)', async () => {
+    await mountStream()
+    await start()
+
+    // Turn 1 streams text that is sealed as an interim at a tool boundary.
+    await delta('here is the final answer')
+    await interim('here is the final answer')
+    expect(getState().interimBoundaryPending).toBe(true)
+
+    // A chained message.start (goal follow-up / completion drain) lands before
+    // the final message.complete and resets interimBoundaryPending to false
+    // (gateway-event.ts message.start handler) — the exact case the gate
+    // widening in the #81566 follow-up exists for.
+    await start()
+    expect(getState().interimBoundaryPending).toBe(false)
+
+    // The final is whitespace-equivalent to the sealed interim but NOT
+    // trim-equal, so neither the legacy exact-match clause nor the old
+    // `interimBoundaryPending && ...` gate can fire. Only finalContinuesInterim
+    // (which keys on existing.interim itself) recognizes it: settle in place,
+    // one bubble. Under the pre-widening gate this appended a duplicate row.
+    await complete('here  is  the  final  answer ')
+
+    const texts = assistantMessages()
+    expect(texts.filter(t => t.replace(/\s+/g, ' ').trim() === 'here is the final answer')).toHaveLength(1)
+  })
+
+  it('appends a genuinely different final instead of settling it onto an older sealed interim', async () => {
+    await mountStream()
+    await start()
+
+    // An earlier (interrupted) tool-call turn sealed an interim whose final
+    // never matched — it stays interim: true in the message list. A chained
+    // start begins a genuinely new turn whose completion has no textual
+    // relationship to that stale interim. finalContinuesInterim requires a
+    // text match, so the new reply must be appended, never settled onto the
+    // old bubble.
+    await delta('stale interim text')
+    await interim('stale interim text')
+    await start()
+    await complete('the answer is 42')
+
+    const texts = assistantMessages()
+    expect(texts).toContain('stale interim text')
+    expect(texts).toContain('the answer is 42')
+    expect(texts).toHaveLength(2)
+  })
 })

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -230,7 +230,17 @@ export function collectUnspokenTurnSpeech(
   return { id, pending, text: parts.join('\n\n') }
 }
 
-const normalizeWs = (value: string) => value.replace(/\s+/g, ' ').trim()
+/**
+ * Collapse runs of any whitespace to a single space and trim the ends.
+ *
+ * Used by `mergeFinalAssistantText` to compare streamed interim text against
+ * the authoritative final response after stripping formatting-only
+ * differences (collapsed whitespace, leading/trailing spaces). Exported so
+ * adjacent settle logic in `use-message-stream` can reuse the same
+ * normalization when deciding whether a sealed interim and a non-previewed
+ * final represent the same assistant message.
+ */
+export const normalizeWhitespace = (value: string) => value.replace(/\s+/g, ' ').trim()
 
 /**
  * Merge the final assistant text into a message's parts.
@@ -244,7 +254,7 @@ const normalizeWs = (value: string) => value.replace(/\s+/g, ' ').trim()
  * - Appends the final text as a new text part.
  */
 export function mergeFinalAssistantText(parts: ChatMessagePart[], finalText: string): ChatMessagePart[] {
-  const dedupeReference = normalizeWs(finalText)
+  const dedupeReference = normalizeWhitespace(finalText)
 
   const kept = parts.filter(part => {
     if (part.type === 'text') {
@@ -262,7 +272,7 @@ export function mergeFinalAssistantText(parts: ChatMessagePart[], finalText: str
     // Reasoning is a restatement only when the final FULLY covers it.
     // The reverse direction is not considered — a short final must not
     // swallow a longer reasoning block (#61447).
-    const r = normalizeWs(part.text)
+    const r = normalizeWhitespace(part.text)
 
     return !(r && dedupeReference.startsWith(r))
   })


### PR DESCRIPTION
Fixes #81422

## Problem

During streaming, the interim message is sealed into a bubble, but when the
final message lands with only whitespace differences from the interim (for
example the model's final output trims trailing whitespace or newlines), the
desktop appended a duplicate bubble instead of settling the final onto the
interim one.

## Fix

Settle the whitespace-normalized final onto the interim bubble instead of
appending a duplicate. The settle now also fires on a chained
`message.start` — the #76583 chained-turn pattern — not only while the
interim-boundary flag is set.

## Tests

`interim-sealing.test.tsx` covers both the plain settle and the chained-turn
variant.
