### PR TITLE
fix(gateway): fan out session stream events to every attached frontend (#81286)

### DIFF
--- a/tests/tui_gateway/test_multi_client_session_routing.py
+++ b/tests/tui_gateway/test_multi_client_session_routing.py
@@ -1,0 +1,133 @@
+"""Per-session stream routing fans out to every registered transport.
+
+Regression coverage for #81286 — two frontends (Web Dashboard + Desktop)
+attached to the same backend session must both receive live stream events,
+not just whichever one most recently submitted. The previous implementation
+overwrote ``session["transport"]`` on every ``prompt.submit``, silently
+freezing the other frontend until it submitted again.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import List
+
+
+class _RecordingTransport:
+    """Minimal Transport stand-in that records the frames written to it."""
+
+    def __init__(self) -> None:
+        self.frames: List[dict] = []
+
+    def write(self, obj: dict) -> bool:
+        self.frames.append(obj)
+        return True
+
+    def close(self) -> None:
+        pass
+
+
+def test_session_event_fans_out_to_multiple_frontends(monkeypatch):
+    """write_json routes a session-scoped event to every transport registered
+    on that session's fan-out set, not just the most recent submitter."""
+    from tui_gateway import server
+
+    sid = "session-shared-by-web-and-desktop"
+    a = _RecordingTransport()
+    b = _RecordingTransport()
+    server._sessions[sid] = {
+        "transport": a,
+        "transports": {a, b},
+    }
+    try:
+        frame = server._event_frame("message.delta", sid, {"text": "hello"})
+        delivered = server.write_json(frame)
+        assert delivered is True
+        assert a.frames == [frame]
+        assert b.frames == [frame]
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_session_event_falls_back_to_legacy_transport(monkeypatch):
+    """If a session has not been migrated to the ``transports`` set yet and
+    only carries the legacy single-transport field, write_json must still
+    deliver to that transport so existing readers keep working."""
+    from tui_gateway import server
+
+    sid = "legacy-session-no-set"
+    a = _RecordingTransport()
+    server._sessions[sid] = {"transport": a}
+    try:
+        frame = server._event_frame("message.delta", sid, {"text": "hi"})
+        assert server.write_json(frame) is True
+        assert a.frames == [frame]
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_unregister_removes_transport_from_session_fanout(monkeypatch):
+    """ws.disconnect calls unregister_live_transport; the helper must drop
+    the closing transport from every per-session fan-out set so a dead
+    socket is never written to via the fan-out path and the other peer
+    keeps receiving."""
+    from tui_gateway import server
+
+    sid = "session-with-disconnecting-peer"
+    b = _RecordingTransport()
+    server._sessions[sid] = {
+        # ``transport`` is intentionally NOT set here — the legacy fallback
+        # is exercised by a separate test. We want this test to isolate the
+        # fan-out set behaviour.
+        "transports": set(),
+    }
+    a = _RecordingTransport()
+    server._sessions[sid]["transports"] = {a, b}
+    try:
+        # Peer A disconnects.
+        server.unregister_live_transport(a)
+
+        assert server._sessions[sid]["transports"] == {b}
+        assert a not in server._live_transports
+
+        frame = server._event_frame("message.complete", sid, {"text": "done"})
+        server.write_json(frame)
+        assert a.frames == []
+        assert b.frames == [frame]
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_unregister_is_safe_with_legacy_sessions(monkeypatch):
+    """unregister_live_transport must not blow up on sessions that never
+    had a transports set (only the legacy single-transport field)."""
+    from tui_gateway import server
+
+    sid = "legacy-only"
+    a = _RecordingTransport()
+    server._sessions[sid] = {"transport": a}
+    try:
+        # Should be a silent no-op for the session dict.
+        server.unregister_live_transport(a)
+        assert server._sessions[sid] == {"transport": a}
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_session_event_with_no_transport_falls_through(monkeypatch):
+    """A session that has been reaped (no transport at all) must not crash
+    write_json; it falls through to the contextvar/stdio path."""
+    from tui_gateway import server
+
+    sid = "session-with-no-transport"
+    server._sessions[sid] = {}
+    try:
+        # No transports — write_json should return False (no delivery) but
+        # not raise.
+        frame = server._event_frame("message.complete", sid, {"text": "x"})
+        # The stdio transport is the module-level fallback; we only assert
+        # the function returns a bool without touching a missing transport.
+        result = server.write_json(frame)
+        assert isinstance(result, bool)
+    finally:
+        server._sessions.pop(sid, None)

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -528,6 +528,10 @@ class ComputeHost:
         session = server._sessions.get(sid)
         if session is not None:
             session["transport"] = self._transport
+            # Keep the multi-frontend fan-out set in sync so an already-open
+            # session on another transport keeps receiving events after a
+            # second frontend attaches (#81286).
+            session.setdefault("transports", set()).add(self._transport)
             if frame.get("cols") is not None:
                 session["cols"] = int(frame.get("cols") or 80)
             if frame.get("cwd"):
@@ -630,6 +634,7 @@ class ComputeHost:
             }
         session = server._sessions[sid]
         session["transport"] = self._transport
+        session.setdefault("transports", set()).add(self._transport)
         session["profile_home"] = profile_home or session.get("profile_home")
         if isinstance(frame.get("attached_images"), list):
             session["attached_images"] = list(frame.get("attached_images") or [])

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -124,10 +124,16 @@ def _(rid, params: dict) -> dict:
     isolation_cfg = _load_dashboard_process_isolation_config()
     turn_isolation = _session_uses_compute_host(session, isolation_cfg)
     # Re-bind to the current client transport for this request. This keeps
-    # streaming events on the active websocket even if an earlier disconnect
-    # or fallback moved the session transport to stdio.
+    # Track every WS transport that has touched this session so two frontends
+    # (Web Dashboard + Desktop) attached to the same session both keep
+    # receiving live stream events after either one submits (#81286).
+    # ``session["transport"]`` is kept in sync for backward compatibility
+    # with the many readers that consult it (busy_transport, transport_token,
+    # _transport_is_dead, etc.); the authoritative fan-out set is
+    # ``session["transports"]``, consumed by ``server.write_json``.
     if (t := current_transport()) is not None:
         session["transport"] = t
+        session.setdefault("transports", set()).add(t)
     while True:
         busy_transport = None
         with session["history_lock"]:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1547,9 +1547,12 @@ def write_json(obj: dict) -> bool:
 
     Precedence:
 
-    1. Event frames with a session id → the transport stored on that session,
-       so async events land with the client that owns the session even if
-       the emitting thread has no contextvar binding.
+    1. Event frames with a session id → every transport registered for that
+       session, so two frontends viewing the same session (e.g. Web Dashboard
+       and Desktop) both receive the live stream instead of one freezing when
+       the other submits (#81286). A legacy ``session["transport"]`` is also
+       included as a fallback for any code path that has not been migrated to
+       the ``session["transports"]`` set yet.
     2. Otherwise the transport bound on the current context (set by
        :func:`dispatch` for the lifetime of a request).
     3. Otherwise the module-level stdio transport, matching the historical
@@ -1557,8 +1560,18 @@ def write_json(obj: dict) -> bool:
     """
     if obj.get("method") == "event":
         sid = ((obj.get("params") or {}).get("session_id")) or ""
-        if sid and (t := (_sessions.get(sid) or {}).get("transport")) is not None:
-            return t.write(obj)
+        if sid:
+            session = _sessions.get(sid) or {}
+            transports = session.get("transports")
+            legacy = session.get("transport")
+            targets: list = []
+            if isinstance(transports, set):
+                targets.extend(transports)
+            if legacy is not None and legacy not in targets:
+                targets.append(legacy)
+            if targets:
+                results = [t.write(obj) for t in targets]
+                return any(results)
 
     return (current_transport() or _stdio_transport).write(obj)
 
@@ -1594,6 +1607,15 @@ def unregister_live_transport(transport: Transport | None) -> None:
     """Stop tracking a transport (call on disconnect). Idempotent."""
     with _live_transports_lock:
         _live_transports.discard(transport)
+    # Remove this transport from every per-session fan-out set so a closed
+    # socket does not keep receiving frames and a future submit on a fresh
+    # transport is not silently appended alongside a dead peer (#81286).
+    if transport is None:
+        return
+    for session in _sessions.values():
+        transports = session.get("transports")
+        if isinstance(transports, set):
+            transports.discard(transport)
 
 
 def _broadcast_global_event(event: str, payload: dict | None = None) -> None:
@@ -8074,6 +8096,10 @@ def _live_session_payload(
             session["cols"] = cols
         if transport is not None:
             session["transport"] = transport
+            # Mirror the transport into the multi-frontend fan-out set so
+            # concurrent frontends sharing a resumed session both receive
+            # events (#81286).
+            session.setdefault("transports", set()).add(transport)
         if touch:
             session["last_active"] = time.time()
         in_memory_history = list(session.get("display_history_prefix") or []) + list(


### PR DESCRIPTION
Fixes #81286 — two frontends (Web Dashboard + Desktop) connected to the same backend session: the last one to submit "captures" the session; the other stops receiving live stream events and appears frozen until it types again. Session data is never lost — this is a transport-routing defect.

## Root cause

`tui_gateway/server.py::write_json` routes a session-scoped event frame to a single `session["transport"]`, and every `prompt.submit` overwrites that field (`methods_prompt.py:130`). With two WS clients attached, client B's submit silently replaces A's binding, so all subsequent `message.delta` / `message.complete` / tool frames go to B alone. A is blind until it submits again — which re-captures the stream and freezes B. `active_session_lease` (concurrency-cap slot ownership) is a red herring here; the actual single-point-of-failure is the single-transport-per-session routing.

## Fix

Fan out session-scoped event frames to *every* transport registered on that session, while keeping the legacy `session["transport"]` field intact for the many readers that depend on it (`busy_transport`, `transport_token`, `_transport_is_dead`, orphan detection):

1. **`write_json`** — for an event frame with a session id, deliver to the union of `session["transports"]` (set) and the legacy `session["transport"]` (fallback for sessions that predate the set). Returns `any()` of the write results so a single dead peer doesn't drop the frame for everyone.
2. **`prompt.submit`** — add the current transport to the set instead of (only) overwriting the legacy slot.
3. **`compute_host` attach** and **session resume** — same set-maintenance.
4. **`unregister_live_transport`** (called from `ws.py` on disconnect) — discard the closing transport from every session's fan-out set, so a dead socket is never written to and the surviving peer keeps receiving.

## Tests

New `tests/tui_gateway/test_multi_client_session_routing.py` (5 tests, all green):

- session-scoped event fans out to two frontends on the same session
- legacy-only sessions (no `transports` set) still deliver via the single-transport fallback
- disconnect removes the transport from the fan-out set; the surviving peer still receives
- `unregister_live_transport` is a safe no-op for sessions without the set
- session with no transport falls through without raising

Full `tests/tui_gateway/` suite: 367 passed (excluding 4 pre-existing environment-specific failures on this Windows/Python 3.11 runner: `SIGPIPE`/PID-related compute-host tests that fail identically on the untouched main branch).

## Why this is low-risk

- The legacy `session["transport"]` field is untouched for readers; the set is additive.
- `write_json` still falls through to the contextvar/stdio path when a session has no transports at all (tests prove the no-crash path).
- Global session-less broadcasts (`_live_transports`) are unchanged.
- Dead-transport cleanup mirrors the existing `unregister_live_transport` contract, so socket lifecycle is identical to before — only the per-session fan-out changes.

## Files

- `tui_gateway/server.py` — `write_json` fan-out + `unregister_live_transport` cleanup + resume-path set maintenance.
- `tui_gateway/methods_prompt.py` — `prompt.submit` adds transport to the set.
- `tui_gateway/compute_host.py` — attach paths add transport to the set.
- `tests/tui_gateway/test_multi_client_session_routing.py` — regression tests.
