### PR TITLE
fix(tools): make DaemonThreadPoolExecutor compatible with Python 3.14

### DIFF
--- a/tools/daemon_pool.py
+++ b/tools/daemon_pool.py
@@ -38,8 +38,14 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
     """ThreadPoolExecutor variant whose workers do not block process exit."""
 
     def _adjust_thread_count(self) -> None:
-        # Mirrors CPython's implementation (3.8–3.13) with two changes:
-        # daemon=True and no _threads_queues registration.
+        # Mirrors CPython's ThreadPoolExecutor._adjust_thread_count but:
+        #  - daemon=True so workers don't block process exit
+        #  - No _threads_queues registration (avoids non-daemon atexit joins)
+        #
+        # Python 3.14+ changed _worker's signature to take a context object
+        # created via _create_worker_context(). Earlier versions used
+        # _worker(executor_reference, work_queue, initializer, initargs).
+        # We adapt to whichever signature the running interpreter uses.
         if self._idle_semaphore.acquire(timeout=0):
             return
 
@@ -48,17 +54,41 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
 
         num_threads = len(self._threads)
         if num_threads < self._max_workers:
-            thread_name = "%s_%d" % (self._thread_name_prefix or self, num_threads)
+            thread_name = "%s_%d" % (
+                self._thread_name_prefix or self,
+                num_threads,
+            )
             t = threading.Thread(
                 name=thread_name,
                 target=_worker,
-                args=(
-                    weakref.ref(self, weakref_cb),
-                    self._work_queue,
-                    self._initializer,
-                    self._initargs,
-                ),
+                args=_daemon_worker_args(self, weakref_cb),
                 daemon=True,
             )
             t.start()
             self._threads.add(t)
+
+
+def _daemon_worker_args(executor, weakref_cb):
+    """Build the args tuple for _worker, compatible across Python versions.
+
+    Python 3.14+: _worker(executor_reference, ctx, work_queue)
+    Python 3.8–3.13: _worker(executor_reference, work_queue, initializer, initargs)
+    """
+    if hasattr(executor, "_create_worker_context"):
+        # Python 3.14+
+        ctx = executor._create_worker_context()
+        return (
+            weakref.ref(executor, weakref_cb),
+            ctx,
+            executor._work_queue,
+        )
+    else:
+        # Python 3.8–3.13
+        initializer = getattr(executor, "_initializer", None)
+        initargs = getattr(executor, "_initargs", ())
+        return (
+            weakref.ref(executor, weakref_cb),
+            executor._work_queue,
+            initializer,
+            initargs,
+        )


### PR DESCRIPTION
## Summary

`DaemonThreadPoolExecutor._adjust_thread_count` (used for parallel tool execution and subagent timeout wrappers) reads `self._initializer` / `self._initargs` directly. Python 3.14 refactored `concurrent.futures.thread`: `ThreadPoolExecutor.__init__` no longer stores those attributes — the initializer now lives in a `WorkerContext` produced by `_create_worker_context()`, and `_worker`'s signature became `(executor_reference, ctx, work_queue)`.

On 3.14 every concurrent tool batch fails at the first worker spawn:

```
AttributeError: 'DaemonThreadPoolExecutor' object has no attribute '_initializer'
```

This breaks any parallel tool batch (skill_view/search_files/read_file/patch fan-out, cron job runs, subagent submit) on interpreters where the venv resolved to Python 3.14.

## Root cause

`tools/daemon_pool.py`, `_adjust_thread_count` — worker args tuple hard-coded `self._initializer, self._initargs`, which only exist on Python ≤3.13.

## Fix

Route worker args through a new `_daemon_worker_args()` helper that adapts to the running interpreter:

- 3.14+: build the `WorkerContext` via `executor._create_worker_context()` and pass `(weakref, ctx, work_queue)`.
- 3.8–3.13: keep the legacy `(weakref, work_queue, initializer, initargs)` tuple, using `getattr` so missing attrs degrade safely.

All call sites (`tools/async_delegation.py`, `tools/skills_hub.py`, `tools/delegate_tool.py`) share the one fixed class, so the whole bug class is covered.

## Verification

- `tests/tools/test_daemon_pool.py` — 3 passed on Python 3.14.4 (the existing tests exercise worker spawn, which is exactly the failing path).
- Manual: submit batches with and without an `initializer`/`initargs` on 3.14.4 — results correct, initializer runs once per worker.
- Live repro: parallel tool batches in the running gateway failed with the AttributeError before the fix and complete normally after.