### PR TITLE
fix(desktop): declare NSLocalNetworkUsageDescription for macOS 15+ (#81563)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -239,6 +239,7 @@
         "CFBundleName": "Hermes",
         "NSAudioCaptureUsageDescription": "Hermes uses audio capture for voice conversations.",
         "NSCameraUsageDescription": "Hermes uses the camera when a plugin or feature you enable requests it.",
+        "NSLocalNetworkUsageDescription": "Hermes connects to devices on your local network when a plugin or feature you enable requests it.",
         "NSMicrophoneUsageDescription": "Hermes uses the microphone for voice input and voice conversations."
       },
       "gatekeeperAssess": false,

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -214,6 +214,7 @@
         "CFBundleName": "Hermes",
         "NSAudioCaptureUsageDescription": "Hermes uses audio capture for voice conversations.",
         "NSCameraUsageDescription": "Hermes uses the camera when a plugin or feature you enable requests it.",
+        "NSLocalNetworkUsageDescription": "Hermes connects to devices on your local network when a plugin or feature you enable requests it.",
         "NSMicrophoneUsageDescription": "Hermes uses the microphone for voice input and voice conversations."
       },
       "gatekeeperAssess": false,


### PR DESCRIPTION
Fixes #81563

## What

Add `NSLocalNetworkUsageDescription` to `build.mac.extendInfo` in `apps/desktop/package.json`.

## Why

Since macOS 15 (Sequoia), an app that accesses the local network without declaring `NSLocalNetworkUsageDescription` in its Info.plist is denied **silently**: no permission prompt, no entry in System Settings → Privacy & Security → Local Network, and LAN connections are dropped at the network layer (manifesting as `No route to host`). The desktop app's terminal and SSH features can never reach LAN hosts on macOS 15+.

The `extendInfo` block already declares `NSCameraUsageDescription`, `NSMicrophoneUsageDescription`, and `NSAudioCaptureUsageDescription`; the local-network one was simply missing.

## Verification

- `package.json` parses as valid JSON.
- electron-builder copies `extendInfo` keys into the built app's Info.plist, so this lands the usage description at build time with no runtime code change.