### PR TITLE
fix(cli): report serve-mode backends in dashboard/serve --status (#81564)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10283,6 +10283,11 @@ def _report_dashboard_status() -> int:
     so the status path must report both modes too — otherwise a detached
     ``serve`` backend (what Desktop spawns) is invisible to ``--status``
     while still being stopped by ``--stop`` (#81564).
+
+    A process launched with ``--port 0`` (auto-assigned port, the Desktop
+    SSH backend) has no real port in the cmdline, so the listening probe
+    cannot run; the process is still reported when alive so ``--status``
+    stays consistent with ``--stop``, which kills by PID.
     """
     from gateway.status import _pid_exists
 
@@ -10292,7 +10297,12 @@ def _report_dashboard_status() -> int:
         if runtime is None:
             continue
         mode, host, port = runtime
-        if port <= 0 or not _pid_exists(pid):
+        if not _pid_exists(pid):
+            continue
+        # Auto-assigned ports (--port 0) can't be probed from the cmdline;
+        # the process is reported by PID alone.
+        if port <= 0:
+            live.append((mode, pid, command))
             continue
         if not _dashboard_listening(host, port):
             continue

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10275,30 +10275,42 @@ def _render_distribution_plan(plan) -> None:
 
 
 def _report_dashboard_status() -> int:
-    """Print live listening dashboard processes and return the count."""
+    """Print live listening dashboard/serve processes and return the count.
+
+    Both ``hermes dashboard`` and ``hermes serve`` run the same web server;
+    the stop path (``_find_stale_dashboard_pids`` →
+    ``_parse_dashboard_runtime``) already treats them as one process class,
+    so the status path must report both modes too — otherwise a detached
+    ``serve`` backend (what Desktop spawns) is invisible to ``--status``
+    while still being stopped by ``--stop`` (#81564).
+    """
     from gateway.status import _pid_exists
 
-    live: list[tuple[int, str]] = []
+    live: list[tuple[str, int, str]] = []
     for pid, command in _self()._scan_dashboard_processes():
         runtime = _parse_dashboard_runtime(command)
         if runtime is None:
             continue
         mode, host, port = runtime
-        if mode != "dashboard":
-            continue
         if port <= 0 or not _pid_exists(pid):
             continue
         if not _dashboard_listening(host, port):
             continue
-        live.append((pid, command))
+        live.append((mode, pid, command))
 
     if not live:
-        print("No hermes dashboard processes running.")
+        print("No hermes dashboard/serve processes running.")
         return 0
 
-    print(f"{len(live)} hermes dashboard process(es) running:")
-    for pid, command in live:
-        print(f"    PID {pid}: {command}")
+    # Group by mode so dashboard vs serve backends are reported distinctly.
+    dashboards = [entry for entry in live if entry[0] == "dashboard"]
+    serves = [entry for entry in live if entry[0] == "serve"]
+    for label, entries in (("dashboard", dashboards), ("serve", serves)):
+        if not entries:
+            continue
+        print(f"{len(entries)} hermes {label} process(es) running:")
+        for _mode, pid, command in entries:
+            print(f"    PID {pid}: {command}")
     return len(live)
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9911,30 +9911,42 @@ def _render_distribution_plan(plan) -> None:
 
 
 def _report_dashboard_status() -> int:
-    """Print live listening dashboard processes and return the count."""
+    """Print live listening dashboard/serve processes and return the count.
+
+    Both ``hermes dashboard`` and ``hermes serve`` run the same web server;
+    the stop path (``_find_stale_dashboard_pids`` →
+    ``_parse_dashboard_runtime``) already treats them as one process class,
+    so the status path must report both modes too — otherwise a detached
+    ``serve`` backend (what Desktop spawns) is invisible to ``--status``
+    while still being stopped by ``--stop`` (#81564).
+    """
     from gateway.status import _pid_exists
 
-    live: list[tuple[int, str]] = []
+    live: list[tuple[str, int, str]] = []
     for pid, command in _scan_dashboard_processes():
         runtime = _parse_dashboard_runtime(command)
         if runtime is None:
             continue
         mode, host, port = runtime
-        if mode != "dashboard":
-            continue
         if port <= 0 or not _pid_exists(pid):
             continue
         if not _dashboard_listening(host, port):
             continue
-        live.append((pid, command))
+        live.append((mode, pid, command))
 
     if not live:
-        print("No hermes dashboard processes running.")
+        print("No hermes dashboard/serve processes running.")
         return 0
 
-    print(f"{len(live)} hermes dashboard process(es) running:")
-    for pid, command in live:
-        print(f"    PID {pid}: {command}")
+    # Group by mode so dashboard vs serve backends are reported distinctly.
+    dashboards = [entry for entry in live if entry[0] == "dashboard"]
+    serves = [entry for entry in live if entry[0] == "serve"]
+    for label, entries in (("dashboard", dashboards), ("serve", serves)):
+        if not entries:
+            continue
+        print(f"{len(entries)} hermes {label} process(es) running:")
+        for _mode, pid, command in entries:
+            print(f"    PID {pid}: {command}")
     return len(live)
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9919,6 +9919,11 @@ def _report_dashboard_status() -> int:
     so the status path must report both modes too — otherwise a detached
     ``serve`` backend (what Desktop spawns) is invisible to ``--status``
     while still being stopped by ``--stop`` (#81564).
+
+    A process launched with ``--port 0`` (auto-assigned port, the Desktop
+    SSH backend) has no real port in the cmdline, so the listening probe
+    cannot run; the process is still reported when alive so ``--status``
+    stays consistent with ``--stop``, which kills by PID.
     """
     from gateway.status import _pid_exists
 
@@ -9928,7 +9933,12 @@ def _report_dashboard_status() -> int:
         if runtime is None:
             continue
         mode, host, port = runtime
-        if port <= 0 or not _pid_exists(pid):
+        if not _pid_exists(pid):
+            continue
+        # Auto-assigned ports (--port 0) can't be probed from the cmdline;
+        # the process is reported by PID alone.
+        if port <= 0:
+            live.append((mode, pid, command))
             continue
         if not _dashboard_listening(host, port):
             continue

--- a/tests/hermes_cli/test_dashboard_lifecycle_flags.py
+++ b/tests/hermes_cli/test_dashboard_lifecycle_flags.py
@@ -92,6 +92,23 @@ class TestDashboardStatus:
         assert "1 hermes dashboard process(es) running" in out
         assert "hermes serve process" not in out
 
+    def test_status_reports_autoassigned_port_backends(self, capsys):
+        """A serve backend launched with --port 0 (auto-assigned port, the
+        Desktop SSH backend) has no real port in the cmdline; it must still
+        be reported by PID so --status stays consistent with --stop
+        (#81564 review feedback)."""
+        processes = [
+            (12345, "hermes serve --isolated --host 127.0.0.1 --port 0 --ssh-session-token-file /tmp/tok"),
+        ]
+        with patch("hermes_cli.main._scan_dashboard_processes", return_value=processes), \
+             patch("gateway.status._pid_exists", return_value=True), \
+             pytest.raises(SystemExit) as exc:
+            cmd_dashboard(_ns(status=True))
+        assert exc.value.code == 0
+        out = capsys.readouterr().out
+        assert "1 hermes serve process(es) running" in out
+        assert "PID 12345" in out
+
 
     def test_status_does_not_try_to_import_fastapi(self):
         """`--status` must not require dashboard runtime deps — it's a

--- a/tests/hermes_cli/test_dashboard_lifecycle_flags.py
+++ b/tests/hermes_cli/test_dashboard_lifecycle_flags.py
@@ -35,7 +35,7 @@ class TestDashboardStatus:
             cmd_dashboard(_ns(status=True))
         assert exc.value.code == 0
         out = capsys.readouterr().out
-        assert "No hermes dashboard processes running" in out
+        assert "No hermes dashboard/serve processes running" in out
 
     def test_status_with_processes(self, capsys):
         processes = [
@@ -53,6 +53,44 @@ class TestDashboardStatus:
         assert "2 hermes dashboard process(es) running" in out
         assert "PID 12345" in out
         assert "PID 12346" in out
+
+    def test_status_reports_serve_mode_backends(self, capsys):
+        """A detached ``hermes serve`` backend (what Desktop spawns) must be
+        visible to --status, matching the stop path which already treats
+        serve and dashboard as one process class (#81564)."""
+        processes = [
+            (12345, "hermes dashboard --port 9119"),
+            (12346, "hermes serve --port 9120"),
+        ]
+        with patch("hermes_cli.main._scan_dashboard_processes", return_value=processes), \
+             patch("gateway.status._pid_exists", return_value=True), \
+             patch("hermes_cli.main._dashboard_listening", return_value=True), \
+             pytest.raises(SystemExit) as exc:
+            cmd_dashboard(_ns(status=True))
+        assert exc.value.code == 0
+        out = capsys.readouterr().out
+        assert "1 hermes dashboard process(es) running" in out
+        assert "1 hermes serve process(es) running" in out
+        assert "PID 12345" in out
+        assert "PID 12346" in out
+
+    def test_status_ignores_non_server_processes(self, capsys):
+        """Non-server processes must not be reported, and the mode grouping
+        must stay accurate (#81564)."""
+        processes = [
+            (12345, "hermes dashboard --port 9119"),
+            # Not a server cmdline — must not be parsed as dashboard/serve.
+            (12346, "vim /tmp/hermes_dashboard_notes.txt"),
+        ]
+        with patch("hermes_cli.main._scan_dashboard_processes", return_value=processes), \
+             patch("gateway.status._pid_exists", return_value=True), \
+             patch("hermes_cli.main._dashboard_listening", return_value=True), \
+             pytest.raises(SystemExit) as exc:
+            cmd_dashboard(_ns(status=True))
+        assert exc.value.code == 0
+        out = capsys.readouterr().out
+        assert "1 hermes dashboard process(es) running" in out
+        assert "hermes serve process" not in out
 
 
     def test_status_does_not_try_to_import_fastapi(self):


### PR DESCRIPTION
Fixes #81564

## What

`hermes dashboard --status` / `hermes serve --status` now report **both** dashboard and serve-mode backends.

## Why

`_report_dashboard_status` filtered scanned processes to `mode == "dashboard"`, so a detached `hermes serve` backend (exactly what the Desktop app spawns) was invisible to `--status` — yet `--stop` killed it. The stop path's `_parse_dashboard_runtime` already treats dashboard and serve as one process class; the status path was the odd one out.

## Changes

- `hermes_cli/main.py`: lift the `mode != "dashboard"` filter; group the live report by mode (`N hermes dashboard process(es) running` / `N hermes serve process(es) running`); empty-state message covers both modes.
- `tests/hermes_cli/test_dashboard_lifecycle_flags.py`: regression tests for serve-mode visibility, mode grouping, and non-server cmdline exclusion.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_dashboard_lifecycle_flags.py` → 10 passed.