### PR TITLE
fix(ollama): clamp reasoning for non-thinking local models

### DIFF
--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -13,6 +13,7 @@ Volcengine ARK, vLLM, llama.cpp). Key quirks:
 """
 
 from typing import Any
+from urllib.parse import urlparse
 
 from providers import register_provider
 from providers.base import ProviderProfile
@@ -20,6 +21,19 @@ from providers.base import ProviderProfile
 
 class CustomProfile(ProviderProfile):
     """Custom/Ollama local provider — think=false and num_ctx support."""
+
+    @staticmethod
+    def _is_ollama_endpoint(base_url: str | None) -> bool:
+        """Return whether ``base_url`` uses Ollama's native default port.
+
+        CustomProfile also fronts vLLM, llama.cpp, and hosted OpenAI-compatible
+        endpoints.  Restrict capability clamping to port 11434 so an unknown
+        hosted endpoint keeps its existing reasoning-effort behavior.
+        """
+        try:
+            return urlparse(str(base_url or "")).port == 11434
+        except ValueError:
+            return False
 
     def build_api_kwargs_extras(
         self,
@@ -30,6 +44,19 @@ class CustomProfile(ProviderProfile):
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         extra_body: dict[str, Any] = {}
         top_level: dict[str, Any] = {}
+
+        # Desktop sessions persist their own reasoning-effort override.  A
+        # session created with "medium" can therefore outlive a later global
+        # config change to "none".  Ollama rejects that stale override with an
+        # HTTP 400 when the selected model does not advertise ``thinking``.
+        # Capability metadata is passed explicitly by the transport, so clamp
+        # only the authoritative Ollama/non-thinking combination.  Thinking
+        # Ollama models and non-Ollama custom endpoints keep normal behavior.
+        _ollama_non_thinking = (
+            self._is_ollama_endpoint(ctx.get("base_url"))
+            and "supports_reasoning" in ctx
+            and ctx.get("supports_reasoning") is False
+        )
 
         # Ollama context window
         if ollama_num_ctx:
@@ -51,7 +78,10 @@ class CustomProfile(ProviderProfile):
         # Ollama-only flag and thinking is already server-default-on for these
         # backends, so forcing it risks a 400 on GLM/vLLM endpoints that don't
         # recognize it. Mirrors the DeepSeek/Zai profile precedent.
-        if reasoning_config and isinstance(reasoning_config, dict):
+        if _ollama_non_thinking:
+            top_level["reasoning_effort"] = "none"
+            extra_body["think"] = False
+        elif reasoning_config and isinstance(reasoning_config, dict):
             _effort = (reasoning_config.get("effort") or "").strip().lower()
             _enabled = reasoning_config.get("enabled", True)
             if _effort == "none" or _enabled is False:

--- a/run_agent.py
+++ b/run_agent.py
@@ -47,6 +47,7 @@ import threading
 import uuid
 import warnings
 from typing import List, Dict, Any, Optional, Callable
+from urllib.parse import urlparse
 # NOTE: `from openai import OpenAI` is deliberately NOT at module top — the
 # SDK pulls ~240 ms of imports. We expose `OpenAI` as a thin proxy object
 # that imports the SDK on first call/isinstance check. This preserves:
@@ -7034,6 +7035,28 @@ class AIAgent:
         from agent.chat_completion_helpers import build_api_kwargs
         return build_api_kwargs(self, api_messages, tools_for_api=tools_for_api)
 
+    def _is_ollama_reasoning_endpoint(self) -> bool:
+        """Return whether the active route is an Ollama API endpoint.
+
+        ``provider=custom`` covers several OpenAI-compatible servers, so a
+        generic local/private URL is not enough. Use only explicit Ollama
+        identities: the dedicated provider, the genuine Ollama Cloud host,
+        or Ollama's native default port. Parsing the port avoids treating a
+        hostile or accidental ``:11434`` path fragment as an Ollama route.
+        """
+        if (self.provider or "").strip().lower() == "ollama":
+            return True
+        if base_url_host_matches(self._base_url_lower, "ollama.com"):
+            return True
+        raw_base_url = str(self.base_url or "").strip()
+        try:
+            parsed = urlparse(
+                raw_base_url if "://" in raw_base_url else f"//{raw_base_url}"
+            )
+            return parsed.port == 11434
+        except ValueError:
+            return False
+
     def _supports_reasoning_extra_body(self) -> bool:
         """Return True when reasoning extra_body is safe to send for this route/model.
 
@@ -7063,7 +7086,7 @@ class AIAgent:
         # /api/show capabilities list is authoritative — emit reasoning_effort
         # only for models that declare the "thinking" capability. deepseek-v4
         # has it; gemma3 / qwen3-coder don't. Cached per (model, base_url).
-        if base_url_host_matches(self._base_url_lower, "ollama.com"):
+        if self._is_ollama_reasoning_endpoint():
             return self._ollama_supports_thinking_cached()
         if "openrouter" not in self._base_url_lower:
             return False

--- a/tests/plugins/model_providers/test_custom_profile.py
+++ b/tests/plugins/model_providers/test_custom_profile.py
@@ -96,6 +96,39 @@ class TestCustomReasoningWireShape:
         )
         assert eb.get("think") is not True
 
+    def test_local_ollama_nonthinking_model_clamps_stale_effort(self, custom_profile):
+        """A persisted Desktop effort must not 400 a non-thinking Ollama model."""
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "medium"},
+            model="granite4.1:8b-hermes64k",
+            base_url="http://127.0.0.1:11434/v1",
+            supports_reasoning=False,
+        )
+        assert eb == {"think": False}
+        assert tl == {"reasoning_effort": "none"}
+
+    def test_local_ollama_thinking_model_keeps_requested_effort(self, custom_profile):
+        """Capability clamping must not disable a thinking-capable model."""
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "medium"},
+            model="qwen3:4b-hermes64k",
+            base_url="http://127.0.0.1:11434/v1",
+            supports_reasoning=True,
+        )
+        assert eb == {}
+        assert tl == {"reasoning_effort": "medium"}
+
+    def test_non_ollama_custom_endpoint_keeps_existing_behavior(self, custom_profile):
+        """A custom GLM/vLLM endpoint is not reclassified as Ollama."""
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="glm-5.2",
+            base_url="https://ark.example.com/v1",
+            supports_reasoning=False,
+        )
+        assert eb == {}
+        assert tl == {"reasoning_effort": "high"}
+
 
 class TestCustomReasoningWithNumCtx:
     """Ollama num_ctx and reasoning are independent and compose."""
@@ -106,4 +139,3 @@ class TestCustomReasoningWithNumCtx:
         )
         assert eb == {"options": {"num_ctx": 8192}}
         assert tl == {}
-

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -6170,6 +6170,31 @@ class TestSupportsReasoningExtraBody:
             agent.model = model
             assert agent._supports_reasoning_extra_body() is True, model
 
+    @pytest.mark.parametrize("supported", [True, False])
+    def test_local_ollama_uses_native_capability_probe(self, supported):
+        agent = self._make_agent()
+        agent.provider = "custom"
+        agent.base_url = "http://127.0.0.1:11434/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "qwen3:4b" if supported else "granite4.1:8b"
+
+        with patch.object(
+            agent, "_ollama_supports_thinking_cached", return_value=supported
+        ) as probe:
+            assert agent._supports_reasoning_extra_body() is supported
+        probe.assert_called_once_with()
+
+    def test_non_ollama_custom_endpoint_does_not_probe(self):
+        agent = self._make_agent()
+        agent.provider = "custom"
+        agent.base_url = "https://ark.example.com/v1/:11434"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "glm-5.2"
+
+        with patch.object(agent, "_ollama_supports_thinking_cached") as probe:
+            assert agent._supports_reasoning_extra_body() is False
+        probe.assert_not_called()
+
 
 class TestMemoryContextSanitization:
     """sanitize_context() helper correctness — used at provider boundaries."""


### PR DESCRIPTION
## Summary

- Prevent persisted `reasoning_effort` values from breaking local Ollama models that do not support thinking.
- Preserve requested reasoning for thinking-capable local Ollama models.
- Preserve existing behavior for non-Ollama custom OpenAI-compatible endpoints.

## Technical implementation details

- Recognize Ollama reasoning routes by the explicit `ollama` provider, the genuine `ollama.com` host, or parsed port `11434` (without matching path fragments).
- Reuse Ollama's cached `/api/show` capability probe for local models, rather than assuming every local model can reason.
- When a local Ollama model reports no `thinking` capability, clamp a stale session-level effort to top-level `reasoning_effort="none"` and `extra_body.think=false`.
- Leave thinking-capable Ollama models and non-Ollama custom endpoints on their existing reasoning paths.
- Add provider-wire and runtime-detection regression coverage.

## Testing steps

- `uv run --isolated --with ruff==0.15.10 ruff check plugins/model-providers/custom/__init__.py run_agent.py tests/plugins/model_providers/test_custom_profile.py tests/run_agent/test_run_agent.py`
  - Result: all checks passed.
- `uv run --isolated --with pytest==9.1.1 --with 'anthropic>=0.39.0' python -m pytest tests/plugins/model_providers tests/run_agent/test_run_agent.py -q`
  - Result: `418 passed, 1 warning`.
  - The warning is an existing thread-fixture warning in `test_direct_session_db_flushes_share_marker_claim`; no test failed.
- Manual local smoke with `granite4.1:8b-hermes64k` and a persisted `medium` effort returned `HERMES_MEDIUM_CLAMP_OK` instead of HTTP 400.

## Related issues/tickets

- Closes #59660.
- Related: #25758, #65233, #11237.
