### PR TITLE
fix(wake): use onnxruntime 1.23.2 on Intel macOS — tflite and 1.27.0 both lack x86_64 wheels (#81560)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,6 +207,7 @@ voice = [
 # first /wake; mirrored in tools/lazy_deps.py.
 wake = [
   "openwakeword==0.6.0",
+  "onnxruntime==1.23.2; platform_machine == 'x86_64' and platform_system == 'Darwin'",
   "onnxruntime==1.27.0; platform_machine != 'x86_64' or platform_system != 'Darwin'",
   "sherpa-onnx==1.13.4",
   "sentencepiece==0.2.2",
@@ -217,9 +218,12 @@ wake = [
   # (dscripka/openWakeWord#336), so the wake word runs on tflite there.
   # Upstream declares tflite-runtime for Linux only; ai-edge-litert is the
   # macOS equivalent, bridged in tools/wake_word.py.
-  # onnxruntime==1.27.0 has no x86_64 macOS wheel (#81560), so the whole
-  # onnx stack is excluded on Intel Macs — tflite covers both macOS arches.
-  "ai-edge-litert==2.1.6; platform_system == 'Darwin'",
+  # onnxruntime==1.27.0 has no x86_64 macOS wheel (#81560), so on
+  # Intel macOS we pin 1.23.2 — the last release with a Darwin x86_64
+  # wheel (#81577). tflite also has no x86_64 macOS wheel, so the
+  # previous "Intel macOS → tflite" coercion gave the user a dead ear;
+  # the default is now back to onnx with the platform-correct pin.
+  "ai-edge-litert==2.1.6; platform_machine == 'arm64' and platform_system == 'Darwin'",
 ]
 honcho = ["honcho-ai==2.2.0"]
 # Cloud memory providers — opt-in, lazy-installed via tools/lazy_deps.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,7 +207,7 @@ voice = [
 # first /wake; mirrored in tools/lazy_deps.py.
 wake = [
   "openwakeword==0.6.0",
-  "onnxruntime==1.27.0",
+  "onnxruntime==1.27.0; platform_machine != 'x86_64' or platform_system != 'Darwin'",
   "sherpa-onnx==1.13.4",
   "sentencepiece==0.2.2",
   "pvporcupine==4.0.3",
@@ -217,6 +217,8 @@ wake = [
   # (dscripka/openWakeWord#336), so the wake word runs on tflite there.
   # Upstream declares tflite-runtime for Linux only; ai-edge-litert is the
   # macOS equivalent, bridged in tools/wake_word.py.
+  # onnxruntime==1.27.0 has no x86_64 macOS wheel (#81560), so the whole
+  # onnx stack is excluded on Intel Macs — tflite covers both macOS arches.
   "ai-edge-litert==2.1.6; platform_system == 'Darwin'",
 ]
 honcho = ["honcho-ai==2.2.0"]

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -182,9 +182,19 @@ def _canonical(name: str) -> str:
 
 
 def _pins_from_specs(specs):
-    """Map canonical package name -> set of exact-pinned versions seen."""
+    """Map canonical package name -> set of exact-pinned versions seen.
+
+    Specs carrying a PEP 508 environment marker (``name==1.0; sys_platform
+    == ...``) are skipped: the marker makes the pin platform-specific, so
+    two differently-marked versions of the same package are legal (e.g.
+    ``onnxruntime==1.23.2; platform_machine == 'x86_64' ...`` vs
+    ``onnxruntime==1.27.0; ...`` — #81577) and must not count as a
+    same-environment conflict.
+    """
     pins: dict[str, set[str]] = {}
     for spec in specs:
+        if ";" in spec:
+            continue
         m = _PIN_RE.match(spec)
         if not m:
             continue

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -182,23 +182,24 @@ def _canonical(name: str) -> str:
 
 
 def _pins_from_specs(specs):
-    """Map canonical package name -> set of exact-pinned versions seen.
+    """Map (canonical package, marker) -> set of exact-pinned versions seen.
 
-    Specs carrying a PEP 508 environment marker (``name==1.0; sys_platform
-    == ...``) are skipped: the marker makes the pin platform-specific, so
-    two differently-marked versions of the same package are legal (e.g.
+    The marker (empty string for an un-marker'd spec) is part of the key so
+    that two platform-specific pins of the same package count as separate,
+    non-conflicting groups rather than a same-environment conflict — e.g.
     ``onnxruntime==1.23.2; platform_machine == 'x86_64' ...`` vs
-    ``onnxruntime==1.27.0; ...`` — #81577) and must not count as a
-    same-environment conflict.
+    ``onnxruntime==1.27.0; ...`` (#81577). Within ONE marker group a package
+    must still agree on a single version, so a genuine conflict pinned under
+    the same marker is still caught.
     """
-    pins: dict[str, set[str]] = {}
+    pins: dict[tuple[str, str], set[str]] = {}
     for spec in specs:
-        if ";" in spec:
-            continue
-        m = _PIN_RE.match(spec)
+        req, _sep, marker = spec.partition(";")
+        m = _PIN_RE.match(req)
         if not m:
             continue
-        pins.setdefault(_canonical(m.group(1)), set()).add(m.group(2))
+        key = (_canonical(m.group(1)), marker.strip())
+        pins.setdefault(key, set()).add(m.group(2))
     return pins
 
 
@@ -245,16 +246,25 @@ def _lazy_deps_pinned_specs():
 
 
 def test_pyproject_pins_are_internally_consistent():
-    """No package may be exact-pinned to two different versions in pyproject.
+    """No package may be exact-pinned to two different versions in pyproject
+    under the SAME platform marker.
 
     A package legitimately appearing in several extras (e.g. aiohttp in
     messaging/slack/homeassistant/sms) must use the SAME version everywhere.
+    Distinct per-platform pins are legal (e.g. ``onnxruntime==1.23.2`` on
+    Intel macOS vs ``==1.27.0`` elsewhere — #81577), so versions are compared
+    within a (package, marker) group, never across markers.
     """
     pins = _pins_from_specs(_pyproject_pinned_specs())
-    conflicts = {name: sorted(v) for name, v in pins.items() if len(v) > 1}
+    conflicts = {
+        f"{name}{' [' + marker + ']' if marker else ''}": sorted(v)
+        for (name, marker), v in pins.items()
+        if len(v) > 1
+    }
     assert not conflicts, (
         "pyproject.toml exact-pins the same package to different versions "
-        "across [project.dependencies] / extras: " + str(conflicts)
+        "within one environment marker (a same-environment conflict): "
+        + str(conflicts)
     )
 
 
@@ -328,7 +338,19 @@ def test_security_pins_present_in_mirrored_lazy_features():
     problems = []
     for pkg, features in _REQUIRED_SECURITY_PINS.items():
         canon = _canonical(pkg)
-        expected = py.get(canon)
+
+        def _all_versions(pins):
+            # Aggregate a package's versions across every marker group. A
+            # security pin must hold regardless of platform, so all groups
+            # must carry the same patched floor.
+            return {
+                ver
+                for (name, _marker), vers in pins.items()
+                if name == canon
+                for ver in vers
+            }
+
+        expected = _all_versions(py)
         assert expected, (
             f"{pkg} is listed in _REQUIRED_SECURITY_PINS but is not exact-pinned "
             f"in pyproject.toml — update the map or the pin."
@@ -339,7 +361,7 @@ def test_security_pins_present_in_mirrored_lazy_features():
                 f"lazy feature {feature!r} named in _REQUIRED_SECURITY_PINS no "
                 f"longer exists in LAZY_DEPS — update the map."
             )
-            got = _pins_from_specs(specs).get(canon)
+            got = _all_versions(_pins_from_specs(specs))
             if got != expected:
                 problems.append(
                     f"{feature}: {pkg}="

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -100,6 +100,29 @@ def _exact_pins(specs):
     return pins
 
 
+def _all_pin_versions(specs):
+    """Map canonical package -> set of every exact-pinned version seen.
+
+    Like :func:`_exact_pins` but marker-aware: a single extra may pin the
+    same package to different versions per platform (e.g. the ``wake`` extra
+    pins ``onnxruntime==1.23.2`` on Intel macOS where 1.27.0 ships no
+    x86_64 wheel, and ``==1.27.0`` everywhere else — #81577). The drift test
+    must compare the *full* version set against LAZY_DEPS, not just the
+    last spec seen, or marker-scoped pins report a false conflict.
+    """
+    versions: dict[str, set[str]] = {}
+    if isinstance(specs, str):
+        specs = (specs,)
+    for spec in specs:
+        requirement = spec.split(";", 1)[0].strip()
+        if "==" not in requirement:
+            continue
+        package, version = requirement.split("==", 1)
+        package = package.split("[", 1)[0].lower().replace("_", "-")
+        versions.setdefault(package, set()).add(version)
+    return versions
+
+
 
 
 def test_pyproject_pins_match_lazy_deps_pins():
@@ -118,21 +141,21 @@ def test_pyproject_pins_match_lazy_deps_pins():
 
     optional_dependencies = _load_optional_dependencies()
 
-    # package -> version, as pinned across all pyproject extras. If an
-    # extra pins a package at a different version than another extra, that
-    # is itself a bug (caught below); here we just collect the set.
+    # package -> version set, as pinned across all pyproject extras. If an
+    # extra pins a package at different versions under the same marker, that
+    # is itself a bug (caught elsewhere); here we collect the full set per
+    # package so marker-scoped platform pins (onnxruntime 1.23.2 on Intel
+    # macOS vs 1.27.0 elsewhere — #81577) are compared in their entirety.
     pyproject_pins: dict[str, set[str]] = {}
     for specs in optional_dependencies.values():
-        for package, version in _exact_pins(specs).items():
-            pyproject_pins.setdefault(package, set()).add(version)
+        for package, versions in _all_pin_versions(specs).items():
+            pyproject_pins.setdefault(package, set()).update(versions)
 
-    # package -> version, as pinned across all LAZY_DEPS entries.
+    # package -> version set, as pinned across all LAZY_DEPS entries.
     lazy_pins: dict[str, set[str]] = {}
     for specs in LAZY_DEPS.values():
-        if isinstance(specs, str):
-            specs = (specs,)
-        for package, version in _exact_pins(specs).items():
-            lazy_pins.setdefault(package, set()).add(version)
+        for package, versions in _all_pin_versions(specs).items():
+            lazy_pins.setdefault(package, set()).update(versions)
 
     shared = sorted(set(pyproject_pins) & set(lazy_pins))
     assert shared, "expected at least one package pinned in both pyproject and LAZY_DEPS"

--- a/tests/tools/test_wake_word.py
+++ b/tests/tools/test_wake_word.py
@@ -302,13 +302,15 @@ def test_explicit_framework_kept_where_onnx_works(monkeypatch):
     assert downloaded == [ww._bundled_wakeword_path("onnx")]
 
 
-def test_intel_macos_engine_ensures_default_stack(monkeypatch):
-    # Intel macOS now uses the default wake.openwakeword feature — the
-    # pyproject.toml platform markers pin onnxruntime==1.23.2 (the last
-    # Darwin x86_64 wheel) there (#81560, #81577). The engine must ensure
-    # the *default* feature, not the slim variant (which was a stopgap for
-    # the 1.27.0-only pin) and not the tflite feature (ai-edge-litert also
-    # ships no Intel macOS wheel).
+def test_intel_macos_engine_ensures_slim_stack(monkeypatch):
+    # Intel macOS: the [wake] extra installs onnxruntime==1.23.2 (the last
+    # Darwin x86_64 wheel) via pyproject's platform marker, but lazy_deps
+    # specs cannot carry markers — `wake.openwakeword` hard-pins 1.27.0 and
+    # its version match would fail against a 1.23.2 install, re-raising the
+    # #81560 lazy-install failure at engine construction. The engine must
+    # ensure the slim feature (openwakeword + sounddevice + numpy, no
+    # onnxruntime) on Intel macOS; the extra already provides the runtime
+    # at the platform-correct version (#81577 follow-up).
     _install_fake_openwakeword(monkeypatch)
     ensured = []
     monkeypatch.setattr(
@@ -317,6 +319,25 @@ def test_intel_macos_engine_ensures_default_stack(monkeypatch):
     monkeypatch.setattr(ww, "ensure_tflite_runtime", lambda: True)
     monkeypatch.setattr(ww.sys, "platform", "darwin")
     monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    ww._OpenWakeWordEngine(
+        {"provider": "openwakeword", "openwakeword": {"inference_framework": "onnx"}}
+    )
+    assert "wake.openwakeword.slim" in ensured
+    assert "wake.openwakeword" not in ensured
+    assert "wake.openwakeword.tflite" not in ensured
+
+
+def test_non_intel_macos_engine_ensures_default_stack(monkeypatch):
+    # Everywhere else the default feature (with onnxruntime==1.27.0) is
+    # correct — the platform-correct wheel is installable there.
+    _install_fake_openwakeword(monkeypatch)
+    ensured = []
+    monkeypatch.setattr(
+        "tools.lazy_deps.ensure", lambda feature, prompt=False: ensured.append(feature)
+    )
+    monkeypatch.setattr(ww, "ensure_tflite_runtime", lambda: True)
+    monkeypatch.setattr(ww.sys, "platform", "darwin")
+    monkeypatch.setattr("platform.machine", lambda: "arm64")
     ww._OpenWakeWordEngine(
         {"provider": "openwakeword", "openwakeword": {"inference_framework": "onnx"}}
     )

--- a/tests/tools/test_wake_word.py
+++ b/tests/tools/test_wake_word.py
@@ -269,6 +269,26 @@ def test_macos_arm64_prefers_tflite_on_this_host():
     ) == "tflite"
 
 
+def test_default_framework_is_tflite_on_macos_intel(monkeypatch):
+    # onnxruntime==1.27.0 has no x86_64 macOS wheel (#81560), so the tflite
+    # backend is the only installable openWakeWord backend on Intel Macs.
+    monkeypatch.setattr(ww.sys, "platform", "darwin")
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    assert ww._is_macos_intel() is True
+    assert ww.default_inference_framework() == "tflite"
+
+
+def test_explicit_onnx_coerced_on_macos_intel(monkeypatch):
+    monkeypatch.setattr(ww.sys, "platform", "darwin")
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    assert (
+        ww.resolve_inference_framework(
+            {"openwakeword": {"inference_framework": "onnx"}}
+        )
+        == "tflite"
+    )
+
+
 def test_explicit_framework_kept_where_onnx_works(monkeypatch):
     # An operator who pins a backend keeps it everywhere ONNX actually works.
     calls = _install_fake_openwakeword(monkeypatch)

--- a/tests/tools/test_wake_word.py
+++ b/tests/tools/test_wake_word.py
@@ -414,6 +414,39 @@ def test_non_intel_macos_engine_ensures_default_stack(monkeypatch):
     assert "wake.openwakeword.tflite" not in ensured
 
 
+def test_tflite_framework_skips_onnxruntime_preflight(monkeypatch):
+    # Regression (#81560): the effective framework on macOS ARM64 is tflite,
+    # which runs on ai-edge-litert (bridged by ensure_tflite_runtime), NOT
+    # onnxruntime. A user who manually installed only the tflite runtime —
+    # a previously-working setup — must not be hard-blocked by the engine's
+    # onnxruntime preflight (which #81577 made unconditional).
+    _install_fake_openwakeword(monkeypatch)
+    # Make onnxruntime genuinely un-importable: if the preflight ran for the
+    # tflite path, construction would raise the "needs onnxruntime" ImportError.
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "onnxruntime":
+            raise ImportError("No module named 'onnxruntime'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.delitem(sys.modules, "onnxruntime", raising=False)
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.setattr(
+        "tools.lazy_deps.ensure", lambda feature, prompt=False: None
+    )
+    monkeypatch.setattr(ww, "ensure_tflite_runtime", lambda: True)
+    monkeypatch.setattr(ww.sys, "platform", "darwin")
+    monkeypatch.setattr("platform.machine", lambda: "arm64")
+    # Explicit "onnx" is coerced to tflite on macOS ARM64; the engine must
+    # build on the tflite runtime alone, with no onnxruntime anywhere.
+    ww._OpenWakeWordEngine(
+        {"provider": "openwakeword", "openwakeword": {"inference_framework": "onnx"}}
+    )
+
+
 def test_empty_framework_falls_back_to_platform_default(monkeypatch):
     """Empty/missing config defers to ``default_inference_framework()``.
 

--- a/tests/tools/test_wake_word.py
+++ b/tests/tools/test_wake_word.py
@@ -300,6 +300,30 @@ def test_explicit_framework_kept_where_onnx_works(monkeypatch):
     assert downloaded == [ww._bundled_wakeword_path("onnx")]
 
 
+def test_intel_macos_engine_ensures_slim_stack(monkeypatch):
+    # On Intel macOS the ONNX stack cannot install (onnxruntime==1.27.0 has no
+    # x86_64 wheel, #81560), so the engine must ensure the slim feature
+    # (openwakeword + sounddevice + numpy, no onnxruntime) — not
+    # ``wake.openwakeword.tflite``, which only carries ai-edge-litert and would
+    # leave ``import openwakeword`` broken on a fresh lazy install.
+    _install_fake_openwakeword(monkeypatch)
+    ensured = []
+    monkeypatch.setattr(
+        "tools.lazy_deps.ensure", lambda feature, prompt=False: ensured.append(feature)
+    )
+    # The tflite-runtime alias step is a separate concern (it ensures
+    # ``wake.openwakeword.tflite`` on its own); stub it out so this test only
+    # observes the engine's platform-gated dependency choice.
+    monkeypatch.setattr(ww, "ensure_tflite_runtime", lambda: True)
+    monkeypatch.setattr(ww.sys, "platform", "darwin")
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    ww._OpenWakeWordEngine(
+        {"provider": "openwakeword", "openwakeword": {"inference_framework": "tflite"}}
+    )
+    assert "wake.openwakeword.slim" in ensured
+    assert "wake.openwakeword.tflite" not in ensured
+
+
 def test_empty_framework_falls_back_to_platform_default(monkeypatch):
     """Empty/missing config defers to ``default_inference_framework()``.
 

--- a/tests/tools/test_wake_word.py
+++ b/tests/tools/test_wake_word.py
@@ -211,6 +211,12 @@ def _install_fake_openwakeword(monkeypatch):
 
     monkeypatch.setitem(sys.modules, "openwakeword", oww)
     monkeypatch.setitem(sys.modules, "openwakeword.model", model_mod)
+    # The engine's onnxruntime preflight (slim / missing-runtime guard) must
+    # not depend on the test venv's installed packages; the runtime is faked
+    # here and the missing-runtime path is exercised by its own test.
+    monkeypatch.setitem(
+        sys.modules, "onnxruntime", types.SimpleNamespace(__name__="onnxruntime")
+    )
     monkeypatch.setattr("tools.lazy_deps.ensure", lambda *a, **k: None)
     return calls
 
@@ -325,6 +331,39 @@ def test_intel_macos_engine_ensures_slim_stack(monkeypatch):
     assert "wake.openwakeword.slim" in ensured
     assert "wake.openwakeword" not in ensured
     assert "wake.openwakeword.tflite" not in ensured
+
+
+def test_intel_macos_engine_reports_missing_onnxruntime(monkeypatch):
+    # The slim feature omits onnxruntime — it expects the [wake] extra's
+    # marker pin (1.23.2 on Intel macOS) to provide the runtime. A user who
+    # manually pip-installed only the slim stack (no [wake] extra) would
+    # otherwise hit openwakeword's bare ModuleNotFoundError at engine
+    # construction. The engine must surface an actionable hint instead of the
+    # raw "No module named 'onnxruntime'".
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "onnxruntime":
+            raise ImportError("No module named 'onnxruntime'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.setattr(
+        "tools.lazy_deps.ensure", lambda feature, prompt=False: None
+    )
+    monkeypatch.setattr(ww, "ensure_tflite_runtime", lambda: True)
+    monkeypatch.setattr(ww.sys, "platform", "darwin")
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    with pytest.raises(ImportError) as err:
+        ww._OpenWakeWordEngine(
+            {"provider": "openwakeword", "openwakeword": {"inference_framework": "onnx"}}
+        )
+    msg = str(err.value)
+    assert "onnxruntime" in msg
+    assert "hermes tools" in msg
+    assert "No module named 'onnxruntime'" not in msg
 
 
 def test_non_intel_macos_engine_ensures_default_stack(monkeypatch):

--- a/tests/tools/test_wake_word.py
+++ b/tests/tools/test_wake_word.py
@@ -269,23 +269,25 @@ def test_macos_arm64_prefers_tflite_on_this_host():
     ) == "tflite"
 
 
-def test_default_framework_is_tflite_on_macos_intel(monkeypatch):
-    # onnxruntime==1.27.0 has no x86_64 macOS wheel (#81560), so the tflite
-    # backend is the only installable openWakeWord backend on Intel Macs.
+def test_default_framework_is_onnx_on_macos_intel(monkeypatch):
+    # Intel macOS uses the ONNX backend with the platform-pinned
+    # onnxruntime==1.23.2 wheel (the last release with a Darwin x86_64
+    # wheel). The tflite route was abandoned in #81577: ai-edge-litert
+    # also ships no x86_64 macOS wheel.
     monkeypatch.setattr(ww.sys, "platform", "darwin")
     monkeypatch.setattr("platform.machine", lambda: "x86_64")
     assert ww._is_macos_intel() is True
-    assert ww.default_inference_framework() == "tflite"
+    assert ww.default_inference_framework() == "onnx"
 
 
-def test_explicit_onnx_coerced_on_macos_intel(monkeypatch):
+def test_explicit_onnx_kept_on_macos_intel(monkeypatch):
     monkeypatch.setattr(ww.sys, "platform", "darwin")
     monkeypatch.setattr("platform.machine", lambda: "x86_64")
     assert (
         ww.resolve_inference_framework(
             {"openwakeword": {"inference_framework": "onnx"}}
         )
-        == "tflite"
+        == "onnx"
     )
 
 
@@ -300,27 +302,26 @@ def test_explicit_framework_kept_where_onnx_works(monkeypatch):
     assert downloaded == [ww._bundled_wakeword_path("onnx")]
 
 
-def test_intel_macos_engine_ensures_slim_stack(monkeypatch):
-    # On Intel macOS the ONNX stack cannot install (onnxruntime==1.27.0 has no
-    # x86_64 wheel, #81560), so the engine must ensure the slim feature
-    # (openwakeword + sounddevice + numpy, no onnxruntime) — not
-    # ``wake.openwakeword.tflite``, which only carries ai-edge-litert and would
-    # leave ``import openwakeword`` broken on a fresh lazy install.
+def test_intel_macos_engine_ensures_default_stack(monkeypatch):
+    # Intel macOS now uses the default wake.openwakeword feature — the
+    # pyproject.toml platform markers pin onnxruntime==1.23.2 (the last
+    # Darwin x86_64 wheel) there (#81560, #81577). The engine must ensure
+    # the *default* feature, not the slim variant (which was a stopgap for
+    # the 1.27.0-only pin) and not the tflite feature (ai-edge-litert also
+    # ships no Intel macOS wheel).
     _install_fake_openwakeword(monkeypatch)
     ensured = []
     monkeypatch.setattr(
         "tools.lazy_deps.ensure", lambda feature, prompt=False: ensured.append(feature)
     )
-    # The tflite-runtime alias step is a separate concern (it ensures
-    # ``wake.openwakeword.tflite`` on its own); stub it out so this test only
-    # observes the engine's platform-gated dependency choice.
     monkeypatch.setattr(ww, "ensure_tflite_runtime", lambda: True)
     monkeypatch.setattr(ww.sys, "platform", "darwin")
     monkeypatch.setattr("platform.machine", lambda: "x86_64")
     ww._OpenWakeWordEngine(
-        {"provider": "openwakeword", "openwakeword": {"inference_framework": "tflite"}}
+        {"provider": "openwakeword", "openwakeword": {"inference_framework": "onnx"}}
     )
-    assert "wake.openwakeword.slim" in ensured
+    assert "wake.openwakeword" in ensured
+    assert "wake.openwakeword.slim" not in ensured
     assert "wake.openwakeword.tflite" not in ensured
 
 

--- a/tests/tools/test_wake_word.py
+++ b/tests/tools/test_wake_word.py
@@ -314,9 +314,9 @@ def test_intel_macos_engine_ensures_slim_stack(monkeypatch):
     # specs cannot carry markers — `wake.openwakeword` hard-pins 1.27.0 and
     # its version match would fail against a 1.23.2 install, re-raising the
     # #81560 lazy-install failure at engine construction. The engine must
-    # ensure the slim feature (openwakeword + sounddevice + numpy, no
-    # onnxruntime) on Intel macOS; the extra already provides the runtime
-    # at the platform-correct version (#81577 follow-up).
+    # ensure the slim feature on Intel macOS, which pins onnxruntime==1.23.2
+    # itself so a pure lazy install (no [wake] extra) fetches the runtime
+    # (#81560, #81577 follow-up).
     _install_fake_openwakeword(monkeypatch)
     ensured = []
     monkeypatch.setattr(
@@ -333,13 +333,42 @@ def test_intel_macos_engine_ensures_slim_stack(monkeypatch):
     assert "wake.openwakeword.tflite" not in ensured
 
 
+def test_intel_macos_slim_lazy_request_pins_onnxruntime_1_23_2(monkeypatch):
+    # The pure-lazy path (a fresh env, no [wake] extra ever installed) must
+    # install onnxruntime itself at the platform-correct version. The engine
+    # ensures `wake.openwakeword.slim` on Intel macOS; its spec must carry
+    # onnxruntime==1.23.2 (the last Darwin x86_64 wheel) — NOT the 1.27.0
+    # pin of the shared default feature, which has no x86_64 macOS wheel
+    # (#81560, #81577).
+    from tools import lazy_deps
+
+    slim_specs = lazy_deps.feature_specs("wake.openwakeword.slim")
+    assert "onnxruntime==1.23.2" in slim_specs
+    assert "onnxruntime==1.27.0" not in slim_specs
+
+    default_specs = lazy_deps.feature_specs("wake.openwakeword")
+    assert "onnxruntime==1.27.0" in default_specs
+
+    # When onnxruntime is missing (fresh install), the lazy installer's
+    # feature_missing() must report 1.23.2 as the spec to fetch on Intel
+    # macOS — the request the engine's ensure() would pass to pip.
+    original = lazy_deps.feature_missing
+    monkeypatch.setattr(
+        "tools.lazy_deps._is_satisfied",
+        lambda spec: "onnxruntime" not in spec,
+    )
+    missing = original("wake.openwakeword.slim")
+    assert "onnxruntime==1.23.2" in missing
+    assert not any(s.startswith("onnxruntime==") and "1.23.2" not in s for s in missing)
+
+
 def test_intel_macos_engine_reports_missing_onnxruntime(monkeypatch):
-    # The slim feature omits onnxruntime — it expects the [wake] extra's
-    # marker pin (1.23.2 on Intel macOS) to provide the runtime. A user who
-    # manually pip-installed only the slim stack (no [wake] extra) would
-    # otherwise hit openwakeword's bare ModuleNotFoundError at engine
-    # construction. The engine must surface an actionable hint instead of the
-    # raw "No module named 'onnxruntime'".
+    # The engine's lazy ensure() installs onnxruntime (slim → 1.23.2 on
+    # Intel macOS), but a user who manually pip-installed only the slim
+    # stack with lazy installs disabled would otherwise hit openwakeword's
+    # bare ModuleNotFoundError at engine construction. The engine must
+    # surface an actionable hint instead of the raw "No module named
+    # 'onnxruntime'".
     import builtins
 
     real_import = builtins.__import__

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -162,12 +162,21 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # It lives in its own feature because lazy-dep specs cannot carry PEP 508
     # environment markers (_spec_is_safe rejects ";"), so the platform gate is
     # applied by the caller instead.
+    #
+    # ``wake.openwakeword.slim`` is the same stack minus onnxruntime, which
+    # has no x86_64 macOS wheel (#81560). Intel Macs use tflite (which has
+    # wheels for both arches), so they must not install onnxruntime at all.
     "wake.openwakeword.tflite": (
         "ai-edge-litert==2.1.6",
     ),
     "wake.openwakeword": (
         "openwakeword==0.6.0",
         "onnxruntime==1.27.0",
+        "sounddevice==0.5.5",
+        "numpy==2.4.3",
+    ),
+    "wake.openwakeword.slim": (
+        "openwakeword==0.6.0",
         "sounddevice==0.5.5",
         "numpy==2.4.3",
     ),

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -164,8 +164,13 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # applied by the caller instead.
     #
     # ``wake.openwakeword.slim`` is the same stack minus onnxruntime, which
-    # has no x86_64 macOS wheel (#81560). Intel Macs use tflite (which has
-    # wheels for both arches), so they must not install onnxruntime at all.
+    # is no longer needed now that ``onnxruntime==1.23.2`` carries the
+    # Intel macOS path (#81560, #81577). Kept for compatibility — installs
+    # `openwakeword` without `onnxruntime`, which still allows the
+    # library import and feature spec to resolve when paired with a
+    # system-installed `onnxruntime`. Prefer the default
+    # `wake.openwakeword`; lazy_deps follows `_spec_is_safe`'s ";" ban
+    # by encoding the platform gate in the caller.
     "wake.openwakeword.tflite": (
         "ai-edge-litert==2.1.6",
     ),

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -163,14 +163,15 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # environment markers (_spec_is_safe rejects ";"), so the platform gate is
     # applied by the caller instead.
     #
-    # ``wake.openwakeword.slim`` is the same stack minus onnxruntime, which
-    # is no longer needed now that ``onnxruntime==1.23.2`` carries the
-    # Intel macOS path (#81560, #81577). Kept for compatibility — installs
-    # `openwakeword` without `onnxruntime`, which still allows the
-    # library import and feature spec to resolve when paired with a
-    # system-installed `onnxruntime`. Prefer the default
-    # `wake.openwakeword`; lazy_deps follows `_spec_is_safe`'s ";" ban
-    # by encoding the platform gate in the caller.
+    # ``wake.openwakeword.slim`` is the same stack minus onnxruntime. The
+    # [wake] extra pins ``onnxruntime==1.23.2`` on Intel macOS (the last
+    # release with a Darwin x86_64 wheel) via a platform marker, but lazy
+    # dep specs cannot carry PEP 508 markers — ``wake.openwakeword``
+    # hard-pins 1.27.0 and its version match would fail against that
+    # install. Callers gate on the platform: Intel macOS ensures the slim
+    # feature (the extra already provides the runtime at the
+    # platform-correct version), every other platform ensures the default
+    # feature (#81560, #81577).
     "wake.openwakeword.tflite": (
         "ai-edge-litert==2.1.6",
     ),

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -163,14 +163,18 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # environment markers (_spec_is_safe rejects ";"), so the platform gate is
     # applied by the caller instead.
     #
-    # ``wake.openwakeword.slim`` is the same stack minus onnxruntime. The
-    # [wake] extra pins ``onnxruntime==1.23.2`` on Intel macOS (the last
-    # release with a Darwin x86_64 wheel) via a platform marker, but lazy
-    # dep specs cannot carry PEP 508 markers — ``wake.openwakeword``
-    # hard-pins 1.27.0 and its version match would fail against that
-    # install. Callers gate on the platform: Intel macOS ensures the slim
-    # feature (the extra already provides the runtime at the
-    # platform-correct version), every other platform ensures the default
+    # ``wake.openwakeword.slim`` is the Intel-macOS variant of the default
+    # stack, pinning ``onnxruntime==1.23.2`` — the last release with a Darwin
+    # x86_64 wheel (1.27.0 ships none). The [wake] extra pins the same version
+    # via a platform marker; lazy-dep specs cannot carry PEP 508 markers
+    # (_spec_is_safe rejects ";"), so ``wake.openwakeword`` hard-pins 1.27.0
+    # and its version match would fail against the marker-pinned 1.23.2
+    # install. Slim exists so the Intel-macOS lazy channel pins 1.23.2
+    # (matching the extra) instead of 1.27.0. Callers gate on the platform:
+    # Intel macOS ensures the slim feature — which now carries its own
+    # onnxruntime==1.23.2 so a pure lazy install (no [wake] extra ever
+    # installed) actually fetches the runtime instead of surfacing a missing
+    # ImportError (#81560, #81577) — every other platform ensures the default
     # feature (#81560, #81577).
     "wake.openwakeword.tflite": (
         "ai-edge-litert==2.1.6",
@@ -183,6 +187,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     ),
     "wake.openwakeword.slim": (
         "openwakeword==0.6.0",
+        "onnxruntime==1.23.2",
         "sounddevice==0.5.5",
         "numpy==2.4.3",
     ),

--- a/tools/wake_word.py
+++ b/tools/wake_word.py
@@ -100,10 +100,29 @@ def _bundled_wakeword_path(framework: str = "onnx") -> str:
     return os.path.join(os.path.dirname(__file__), "wakewords", f"{_BUNDLED_MODEL_NAME}.{ext}")
 
 
+def _is_macos() -> bool:
+    import platform
+
+    return sys.platform == "darwin"
+
+
 def _is_macos_arm64() -> bool:
     import platform
 
-    return sys.platform == "darwin" and platform.machine() == "arm64"
+    return _is_macos() and platform.machine() == "arm64"
+
+
+def _is_macos_intel() -> bool:
+    """True on macOS running on an Intel (x86_64) CPU.
+
+    The openWakeWord ONNX stack pins ``onnxruntime==1.27.0``, which ships no
+    x86_64 macOS wheel, so the lazy install fails outright on Intel Macs
+    (#81560). The tflite backend (``ai-edge-litert``) has macOS wheels for
+    both arches, so it is the only installable openWakeWord backend there.
+    """
+    import platform
+
+    return _is_macos() and platform.machine() in {"x86_64", "i386", "i686"}
 
 
 def default_inference_framework() -> str:
@@ -115,9 +134,14 @@ def default_inference_framework() -> str:
     microphone works, and no phrase can ever cross the threshold. Prefer the
     tflite backend there; ONNX stays the default everywhere else.
 
+    On Intel macOS the ONNX stack cannot be installed at all: the pinned
+    ``onnxruntime==1.27.0`` has no x86_64 wheel, so the lazy install fails
+    before a detector can arm (#81560). The tflite backend installs and works
+    on both macOS arches, so it is the default there too.
+
     Upstream: https://github.com/dscripka/openWakeWord/issues/336
     """
-    return "tflite" if _is_macos_arm64() else "onnx"
+    return "tflite" if (_is_macos_arm64() or _is_macos_intel()) else "onnx"
 
 
 _warned_onnx_coerced = False
@@ -126,14 +150,20 @@ _warned_onnx_coerced = False
 def resolve_inference_framework(cfg: Dict[str, Any]) -> str:
     """Resolve the effective openWakeWord backend from config.
 
-    Honors an explicit ``openwakeword.inference_framework`` — EXCEPT the one
-    combination that is provably dead: an explicit ``onnx`` on macOS ARM64,
-    where ONNX's embedding model never lets a phrase cross threshold (upstream
-    #336). Existing macOS users who pinned ``onnx`` before the tflite fix landed
-    would otherwise keep a wake word that arms but never fires. Coerce that one
-    case to tflite (with a one-time warning) instead of silently shipping a dead
-    ear. Every other explicit value is respected as-is; empty falls back to the
-    platform default.
+    Honors an explicit ``openwakeword.inference_framework`` — EXCEPT the
+    combinations that are provably dead on the host:
+
+    - explicit ``onnx`` on macOS ARM64: ONNX's embedding model never lets a
+      phrase cross threshold (upstream #336). Existing macOS users who pinned
+      ``onnx`` before the tflite fix landed would otherwise keep a wake word
+      that arms but never fires.
+    - explicit ``onnx`` on macOS Intel: the pinned ``onnxruntime==1.27.0``
+      has no x86_64 wheel, so the lazy install fails before a detector can
+      arm (#81560).
+
+    Coerce those cases to tflite (with a one-time warning) instead of
+    silently shipping a dead ear. Every other explicit value is respected
+    as-is; empty falls back to the platform default.
     """
     global _warned_onnx_coerced
 
@@ -143,15 +173,23 @@ def resolve_inference_framework(cfg: Dict[str, Any]) -> str:
     if not framework:
         return default_inference_framework()
 
-    if framework == "onnx" and _is_macos_arm64():
+    if framework == "onnx" and (_is_macos_arm64() or _is_macos_intel()):
         if not _warned_onnx_coerced:
             _warned_onnx_coerced = True
-            logger.warning(
-                "wake: openwakeword.inference_framework='onnx' is set but ONNX's "
-                "embedding model never fires on macOS ARM64 (openWakeWord #336) — "
-                "using tflite instead. Set inference_framework to '' (auto) or "
-                "'tflite' in config.yaml to silence this."
-            )
+            if _is_macos_arm64():
+                logger.warning(
+                    "wake: openwakeword.inference_framework='onnx' is set but ONNX's "
+                    "embedding model never fires on macOS ARM64 (openWakeWord #336) — "
+                    "using tflite instead. Set inference_framework to '' (auto) or "
+                    "'tflite' in config.yaml to silence this."
+                )
+            else:
+                logger.warning(
+                    "wake: openwakeword.inference_framework='onnx' is set but "
+                    "onnxruntime==1.27.0 has no x86_64 macOS wheel (#81560) — "
+                    "using tflite instead. Set inference_framework to '' (auto) or "
+                    "'tflite' in config.yaml to silence this."
+                )
         return "tflite"
 
     return framework
@@ -535,14 +573,22 @@ class _OpenWakeWordEngine(_Engine):
     def __init__(self, cfg: Dict[str, Any]):
         from tools import lazy_deps
 
-        lazy_deps.ensure("wake.openwakeword", prompt=False)
+        framework = resolve_inference_framework(cfg)
+        # On Intel macOS the ONNX stack is not installable — the pinned
+        # onnxruntime==1.27.0 has no x86_64 wheel — so ``wake.openwakeword``
+        # (which includes onnxruntime) can never install there.  The tflite
+        # runtime has macOS wheels for both arches, so the tflite feature is
+        # the one to ensure on that host (#81560).
+        if _is_macos_intel():
+            lazy_deps.ensure("wake.openwakeword.tflite", prompt=False)
+        else:
+            lazy_deps.ensure("wake.openwakeword", prompt=False)
 
         import openwakeword
         from openwakeword.model import Model
 
         sub = cfg.get("openwakeword") if isinstance(cfg.get("openwakeword"), dict) else {}
         model_ref = str(sub.get("model") or _BUNDLED_MODEL_NAME).strip()
-        framework = resolve_inference_framework(cfg)
         # openWakeWord returns a 0..1 score per frame; sensitivity IS the raw
         # threshold a score must clear. Higher = stricter (fewer false fires).
         # Default 0.6 sits above openWakeWord's permissive 0.5 baseline, which
@@ -907,7 +953,9 @@ def check_wake_word_requirements(cfg: Optional[Dict[str, Any]] = None) -> Dict[s
     elif provider in ("sherpa", "sherpa-onnx", "kws", "open"):
         feature = "wake.sherpa"
     else:
-        feature = "wake.openwakeword"
+        # Intel macOS cannot install the onnx stack (onnxruntime has no
+        # x86_64 macOS wheel, #81560); the slim feature is its equivalent.
+        feature = "wake.openwakeword.slim" if _is_macos_intel() else "wake.openwakeword"
     deps_ok = lazy_deps.is_available(feature)
     lazy_ok = lazy_deps._allow_lazy_installs()
     # The audio probe imports sounddevice + numpy — two of the very packages

--- a/tools/wake_word.py
+++ b/tools/wake_word.py
@@ -134,14 +134,17 @@ def default_inference_framework() -> str:
     microphone works, and no phrase can ever cross the threshold. Prefer the
     tflite backend there; ONNX stays the default everywhere else.
 
-    On Intel macOS the ONNX stack cannot be installed at all: the pinned
-    ``onnxruntime==1.27.0`` has no x86_64 wheel, so the lazy install fails
-    before a detector can arm (#81560). The tflite backend installs and works
-    on both macOS arches, so it is the default there too.
+    On Intel macOS the pinned ``onnxruntime==1.27.0`` has no x86_64 wheel
+    so the lazy install fails. The previously-suggested tflite route is
+    not viable either: ``ai-edge-litert==2.1.6`` only publishes arm64
+    macOS wheels (no x86_64 either, no sdist). Pin ``onnxruntime==1.23.2``
+    — the last release with an x86_64 macOS wheel — for the Intel-macOS
+    path, and keep the ONNX backend as the default there (#81560,
+    #81577).
 
     Upstream: https://github.com/dscripka/openWakeWord/issues/336
     """
-    return "tflite" if (_is_macos_arm64() or _is_macos_intel()) else "onnx"
+    return "tflite" if _is_macos_arm64() else "onnx"
 
 
 _warned_onnx_coerced = False
@@ -157,13 +160,17 @@ def resolve_inference_framework(cfg: Dict[str, Any]) -> str:
       phrase cross threshold (upstream #336). Existing macOS users who pinned
       ``onnx`` before the tflite fix landed would otherwise keep a wake word
       that arms but never fires.
-    - explicit ``onnx`` on macOS Intel: the pinned ``onnxruntime==1.27.0``
-      has no x86_64 wheel, so the lazy install fails before a detector can
-      arm (#81560).
+    - explicit ``onnx`` on macOS ARM64: the embedding model never fires
+      (upstream #336). Existing macOS users who pinned ``onnx`` before the
+      tflite fix landed would otherwise keep a wake word that arms but
+      never fires.
 
-    Coerce those cases to tflite (with a one-time warning) instead of
-    silently shipping a dead ear. Every other explicit value is respected
-    as-is; empty falls back to the platform default.
+    Coerce that case to tflite (with a one-time warning) instead of
+    silently shipping a dead ear. macOS Intel is left to the platform
+    default (onnx with the platform-pinned onnxruntime wheel) — both
+    ``onnxruntime==1.27.0`` *and* the tflite runtime have no x86_64
+    macOS wheel, so the previous "coerce to tflite" route gave the user
+    a dead ear too (#81577).
     """
     global _warned_onnx_coerced
 
@@ -173,23 +180,15 @@ def resolve_inference_framework(cfg: Dict[str, Any]) -> str:
     if not framework:
         return default_inference_framework()
 
-    if framework == "onnx" and (_is_macos_arm64() or _is_macos_intel()):
+    if framework == "onnx" and _is_macos_arm64():
         if not _warned_onnx_coerced:
             _warned_onnx_coerced = True
-            if _is_macos_arm64():
-                logger.warning(
-                    "wake: openwakeword.inference_framework='onnx' is set but ONNX's "
-                    "embedding model never fires on macOS ARM64 (openWakeWord #336) — "
-                    "using tflite instead. Set inference_framework to '' (auto) or "
-                    "'tflite' in config.yaml to silence this."
-                )
-            else:
-                logger.warning(
-                    "wake: openwakeword.inference_framework='onnx' is set but "
-                    "onnxruntime==1.27.0 has no x86_64 macOS wheel (#81560) — "
-                    "using tflite instead. Set inference_framework to '' (auto) or "
-                    "'tflite' in config.yaml to silence this."
-                )
+            logger.warning(
+                "wake: openwakeword.inference_framework='onnx' is set but ONNX's "
+                "embedding model never fires on macOS ARM64 (openWakeWord #336) — "
+                "using tflite instead. Set inference_framework to '' (auto) or "
+                "'tflite' in config.yaml to silence this."
+            )
         return "tflite"
 
     return framework
@@ -574,16 +573,12 @@ class _OpenWakeWordEngine(_Engine):
         from tools import lazy_deps
 
         framework = resolve_inference_framework(cfg)
-        # On Intel macOS the ONNX stack is not installable — the pinned
-        # onnxruntime==1.27.0 has no x86_64 wheel — so ``wake.openwakeword``
-        # (which includes onnxruntime) can never install there.  The slim
-        # feature (openwakeword + sounddevice + numpy, no onnxruntime) is the
-        # stack to ensure on that host; the tflite runtime itself is installed
-        # by the ensure_tflite_runtime() block below (#81560).
-        if _is_macos_intel():
-            lazy_deps.ensure("wake.openwakeword.slim", prompt=False)
-        else:
-            lazy_deps.ensure("wake.openwakeword", prompt=False)
+        # The platform-correct onnxruntime wheel is pinned in pyproject.toml:
+        # 1.23.2 on Intel macOS (the last release with a Darwin x86_64 wheel),
+        # 1.27.0 elsewhere. The default feature installs `onnxruntime`, so
+        # ``wake.openwakeword`` resolves on every supported platform (#81560,
+        # #81577).
+        lazy_deps.ensure("wake.openwakeword", prompt=False)
 
         import openwakeword
         from openwakeword.model import Model
@@ -954,9 +949,10 @@ def check_wake_word_requirements(cfg: Optional[Dict[str, Any]] = None) -> Dict[s
     elif provider in ("sherpa", "sherpa-onnx", "kws", "open"):
         feature = "wake.sherpa"
     else:
-        # Intel macOS cannot install the onnx stack (onnxruntime has no
-        # x86_64 macOS wheel, #81560); the slim feature is its equivalent.
-        feature = "wake.openwakeword.slim" if _is_macos_intel() else "wake.openwakeword"
+        # All supported platforms install the default wake.openwakeword
+        # feature; pyproject.toml pins the right onnxruntime wheel per
+        # platform (1.23.2 on Intel macOS, 1.27.0 elsewhere — #81560, #81577).
+        feature = "wake.openwakeword"
     deps_ok = lazy_deps.is_available(feature)
     lazy_ok = lazy_deps._allow_lazy_installs()
     # The audio probe imports sounddevice + numpy — two of the very packages

--- a/tools/wake_word.py
+++ b/tools/wake_word.py
@@ -594,20 +594,29 @@ class _OpenWakeWordEngine(_Engine):
         # openwakeword`` with lazy installs disabled) leaves the runtime
         # missing; openwakeword's own import then raises a bare
         # ModuleNotFoundError. Surface the real fix instead (#81560, #81577).
-        try:
-            import onnxruntime  # noqa: F401
-        except ImportError:
-            # Lazy installs were disabled or the ensure above couldn't fetch the
-            # runtime; point at the correct per-platform feature so a manual
-            # install gets the wheel that actually exists here.
-            feature = "wake.openwakeword.slim" if _is_macos_intel() else "wake.openwakeword"
-            hint = "Run `hermes tools` (Voice section) to install it, or manually: " + (
-                lazy_deps.feature_install_command(feature) or ""
-            )
-            raise ImportError(
-                "The wake word needs onnxruntime (openWakeWord's inference "
-                f"runtime), which is not installed. {hint}"
-            ) from None
+        #
+        # Only the ONNX backend needs onnxruntime: on macOS ARM64 the
+        # effective framework is tflite, which runs on ai-edge-litert (bridged
+        # below), not onnxruntime. A user who manually installed only the
+        # tflite runtime must not be hard-blocked here demanding onnxruntime
+        # (#81560).
+        if framework != "tflite":
+            try:
+                import onnxruntime  # noqa: F401
+            except ImportError:
+                # Lazy installs were disabled or the ensure above couldn't fetch
+                # the runtime; point at the correct per-platform feature so a
+                # manual install gets the wheel that actually exists here.
+                feature = (
+                    "wake.openwakeword.slim" if _is_macos_intel() else "wake.openwakeword"
+                )
+                hint = "Run `hermes tools` (Voice section) to install it, or manually: " + (
+                    lazy_deps.feature_install_command(feature) or ""
+                )
+                raise ImportError(
+                    "The wake word needs onnxruntime (openWakeWord's inference "
+                    f"runtime), which is not installed. {hint}"
+                ) from None
 
         import openwakeword
         from openwakeword.model import Model

--- a/tools/wake_word.py
+++ b/tools/wake_word.py
@@ -576,11 +576,12 @@ class _OpenWakeWordEngine(_Engine):
         framework = resolve_inference_framework(cfg)
         # On Intel macOS the ONNX stack is not installable — the pinned
         # onnxruntime==1.27.0 has no x86_64 wheel — so ``wake.openwakeword``
-        # (which includes onnxruntime) can never install there.  The tflite
-        # runtime has macOS wheels for both arches, so the tflite feature is
-        # the one to ensure on that host (#81560).
+        # (which includes onnxruntime) can never install there.  The slim
+        # feature (openwakeword + sounddevice + numpy, no onnxruntime) is the
+        # stack to ensure on that host; the tflite runtime itself is installed
+        # by the ensure_tflite_runtime() block below (#81560).
         if _is_macos_intel():
-            lazy_deps.ensure("wake.openwakeword.tflite", prompt=False)
+            lazy_deps.ensure("wake.openwakeword.slim", prompt=False)
         else:
             lazy_deps.ensure("wake.openwakeword", prompt=False)
 

--- a/tools/wake_word.py
+++ b/tools/wake_word.py
@@ -115,10 +115,15 @@ def _is_macos_arm64() -> bool:
 def _is_macos_intel() -> bool:
     """True on macOS running on an Intel (x86_64) CPU.
 
-    The openWakeWord ONNX stack pins ``onnxruntime==1.27.0``, which ships no
-    x86_64 macOS wheel, so the lazy install fails outright on Intel Macs
-    (#81560). The tflite backend (``ai-edge-litert``) has macOS wheels for
-    both arches, so it is the only installable openWakeWord backend there.
+    The default openWakeWord stack pins ``onnxruntime==1.27.0``, which ships
+    no x86_64 macOS wheel, so the lazy install fails outright on Intel Macs
+    (#81560). Neither is the tflite route viable: ``ai-edge-litert==2.1.6``
+    publishes arm64-only macOS wheels (no x86_64, no sdist). The [wake]
+    extra therefore pins ``onnxruntime==1.23.2`` — the last release with a
+    Darwin x86_64 wheel — via platform marker, and this platform gates the
+    engine to the ``wake.openwakeword.slim`` feature, which omits
+    onnxruntime so lazy-deps' version match cannot fail against the
+    marker-pinned 1.23.2 install (#81560, #81577).
     """
     import platform
 
@@ -160,10 +165,6 @@ def resolve_inference_framework(cfg: Dict[str, Any]) -> str:
       phrase cross threshold (upstream #336). Existing macOS users who pinned
       ``onnx`` before the tflite fix landed would otherwise keep a wake word
       that arms but never fires.
-    - explicit ``onnx`` on macOS ARM64: the embedding model never fires
-      (upstream #336). Existing macOS users who pinned ``onnx`` before the
-      tflite fix landed would otherwise keep a wake word that arms but
-      never fires.
 
     Coerce that case to tflite (with a one-time warning) instead of
     silently shipping a dead ear. macOS Intel is left to the platform
@@ -585,6 +586,29 @@ class _OpenWakeWordEngine(_Engine):
             lazy_deps.ensure("wake.openwakeword.slim", prompt=False)
         else:
             lazy_deps.ensure("wake.openwakeword", prompt=False)
+
+        # slim omits onnxruntime, which the [wake] extra provides at the
+        # platform-correct version (1.23.2 on Intel macOS, 1.27.0 elsewhere).
+        # A bare openwakeword install (e.g. ``pip install openwakeword``)
+        # leaves the runtime missing; openwakeword's own import then raises a
+        # bare ModuleNotFoundError. Surface the real fix instead (#81560,
+        # #81577).
+        try:
+            import onnxruntime  # noqa: F401
+        except ImportError:
+            if _is_macos_intel():
+                # The default feature hard-pins onnxruntime==1.27.0, which has
+                # no x86_64 macOS wheel — only the [wake] extra's marker pin
+                # (1.23.2) is correct here, so point at the wizard, not pip.
+                hint = "Run `hermes tools` (Voice section) to install it."
+            else:
+                hint = "Run `hermes tools` (Voice section) to install it, or manually: " + (
+                    lazy_deps.feature_install_command("wake.openwakeword") or ""
+                )
+            raise ImportError(
+                "The wake word needs onnxruntime (openWakeWord's inference "
+                f"runtime), which is not installed. {hint}"
+            ) from None
 
         import openwakeword
         from openwakeword.model import Model

--- a/tools/wake_word.py
+++ b/tools/wake_word.py
@@ -575,10 +575,16 @@ class _OpenWakeWordEngine(_Engine):
         framework = resolve_inference_framework(cfg)
         # The platform-correct onnxruntime wheel is pinned in pyproject.toml:
         # 1.23.2 on Intel macOS (the last release with a Darwin x86_64 wheel),
-        # 1.27.0 elsewhere. The default feature installs `onnxruntime`, so
-        # ``wake.openwakeword`` resolves on every supported platform (#81560,
+        # 1.27.0 elsewhere. lazy_deps specs cannot carry PEP 508 markers, so
+        # ``wake.openwakeword`` hard-pins 1.27.0 and would fail its version
+        # match on Intel macOS (where 1.23.2 is installed via the [wake]
+        # extra). Use the slim feature there — it omits onnxruntime, which the
+        # extra already provides at the platform-correct version (#81560,
         # #81577).
-        lazy_deps.ensure("wake.openwakeword", prompt=False)
+        if _is_macos_intel():
+            lazy_deps.ensure("wake.openwakeword.slim", prompt=False)
+        else:
+            lazy_deps.ensure("wake.openwakeword", prompt=False)
 
         import openwakeword
         from openwakeword.model import Model
@@ -952,7 +958,7 @@ def check_wake_word_requirements(cfg: Optional[Dict[str, Any]] = None) -> Dict[s
         # All supported platforms install the default wake.openwakeword
         # feature; pyproject.toml pins the right onnxruntime wheel per
         # platform (1.23.2 on Intel macOS, 1.27.0 elsewhere — #81560, #81577).
-        feature = "wake.openwakeword"
+        feature = "wake.openwakeword.slim" if _is_macos_intel() else "wake.openwakeword"
     deps_ok = lazy_deps.is_available(feature)
     lazy_ok = lazy_deps._allow_lazy_installs()
     # The audio probe imports sounddevice + numpy — two of the very packages

--- a/tools/wake_word.py
+++ b/tools/wake_word.py
@@ -121,9 +121,9 @@ def _is_macos_intel() -> bool:
     publishes arm64-only macOS wheels (no x86_64, no sdist). The [wake]
     extra therefore pins ``onnxruntime==1.23.2`` — the last release with a
     Darwin x86_64 wheel — via platform marker, and this platform gates the
-    engine to the ``wake.openwakeword.slim`` feature, which omits
-    onnxruntime so lazy-deps' version match cannot fail against the
-    marker-pinned 1.23.2 install (#81560, #81577).
+    engine to the ``wake.openwakeword.slim`` feature, which pins that same
+    1.23.2 runtime so a pure lazy install (no [wake] extra) fetches it
+    (#81560, #81577).
     """
     import platform
 
@@ -574,37 +574,36 @@ class _OpenWakeWordEngine(_Engine):
         from tools import lazy_deps
 
         framework = resolve_inference_framework(cfg)
-        # The platform-correct onnxruntime wheel is pinned in pyproject.toml:
-        # 1.23.2 on Intel macOS (the last release with a Darwin x86_64 wheel),
-        # 1.27.0 elsewhere. lazy_deps specs cannot carry PEP 508 markers, so
-        # ``wake.openwakeword`` hard-pins 1.27.0 and would fail its version
-        # match on Intel macOS (where 1.23.2 is installed via the [wake]
-        # extra). Use the slim feature there — it omits onnxruntime, which the
-        # extra already provides at the platform-correct version (#81560,
-        # #81577).
+        # The [wake] extra pins the platform-correct onnxruntime: 1.23.2 on
+        # Intel macOS (the last release with a Darwin x86_64 wheel), 1.27.0
+        # elsewhere. lazy_deps specs cannot carry PEP 508 markers, so they
+        # mirror that branch as two features: ``wake.openwakeword`` hard-pins
+        # 1.27.0, ``wake.openwakeword.slim`` hard-pins 1.23.2 (matching the
+        # extra on Intel macOS so the version match cannot fail against the
+        # marker-pinned install). The slim feature carries its own
+        # onnxruntime==1.23.2 so a PURE lazy install — no [wake] extra ever
+        # installed — actually fetches the runtime here (#81560, #81577).
         if _is_macos_intel():
             lazy_deps.ensure("wake.openwakeword.slim", prompt=False)
         else:
             lazy_deps.ensure("wake.openwakeword", prompt=False)
 
-        # slim omits onnxruntime, which the [wake] extra provides at the
-        # platform-correct version (1.23.2 on Intel macOS, 1.27.0 elsewhere).
-        # A bare openwakeword install (e.g. ``pip install openwakeword``)
-        # leaves the runtime missing; openwakeword's own import then raises a
-        # bare ModuleNotFoundError. Surface the real fix instead (#81560,
-        # #81577).
+        # Belt-and-suspenders: the lazy ensure() above installs onnxruntime at
+        # the platform-correct version (1.23.2 on Intel macOS, 1.27.0
+        # elsewhere), but a bare openwakeword install (e.g. ``pip install
+        # openwakeword`` with lazy installs disabled) leaves the runtime
+        # missing; openwakeword's own import then raises a bare
+        # ModuleNotFoundError. Surface the real fix instead (#81560, #81577).
         try:
             import onnxruntime  # noqa: F401
         except ImportError:
-            if _is_macos_intel():
-                # The default feature hard-pins onnxruntime==1.27.0, which has
-                # no x86_64 macOS wheel — only the [wake] extra's marker pin
-                # (1.23.2) is correct here, so point at the wizard, not pip.
-                hint = "Run `hermes tools` (Voice section) to install it."
-            else:
-                hint = "Run `hermes tools` (Voice section) to install it, or manually: " + (
-                    lazy_deps.feature_install_command("wake.openwakeword") or ""
-                )
+            # Lazy installs were disabled or the ensure above couldn't fetch the
+            # runtime; point at the correct per-platform feature so a manual
+            # install gets the wheel that actually exists here.
+            feature = "wake.openwakeword.slim" if _is_macos_intel() else "wake.openwakeword"
+            hint = "Run `hermes tools` (Voice section) to install it, or manually: " + (
+                lazy_deps.feature_install_command(feature) or ""
+            )
             raise ImportError(
                 "The wake word needs onnxruntime (openWakeWord's inference "
                 f"runtime), which is not installed. {hint}"
@@ -979,9 +978,10 @@ def check_wake_word_requirements(cfg: Optional[Dict[str, Any]] = None) -> Dict[s
     elif provider in ("sherpa", "sherpa-onnx", "kws", "open"):
         feature = "wake.sherpa"
     else:
-        # All supported platforms install the default wake.openwakeword
-        # feature; pyproject.toml pins the right onnxruntime wheel per
-        # platform (1.23.2 on Intel macOS, 1.27.0 elsewhere — #81560, #81577).
+        # Each platform has its own onnxruntime pin: 1.23.2 on Intel macOS
+        # (wake.openwakeword.slim), 1.27.0 elsewhere (wake.openwakeword) —
+        # the marker-carrying [wake] extra path and the marker-free lazy
+        # path both converge on the platform-correct wheel (#81560, #81577).
         feature = "wake.openwakeword.slim" if _is_macos_intel() else "wake.openwakeword"
     deps_ok = lazy_deps.is_available(feature)
     lazy_ok = lazy_deps._allow_lazy_installs()

--- a/uv.lock
+++ b/uv.lock
@@ -2,9 +2,12 @@ version = 1
 revision = 3
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
-    "python_full_version >= '3.13'",
-    "python_full_version == '3.12.*'",
-    "python_full_version < '3.12'",
+    "(python_full_version >= '3.13' and platform_machine != 'x86_64') or (python_full_version >= '3.13' and sys_platform != 'darwin')",
+    "python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version == '3.12.*' and platform_machine != 'x86_64') or (python_full_version == '3.12.*' and sys_platform != 'darwin')",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version < '3.12' and platform_machine != 'x86_64') or (python_full_version < '3.12' and sys_platform != 'darwin')",
+    "python_full_version < '3.12' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
 ]
 
 [options]
@@ -742,6 +745,18 @@ wheels = [
 ]
 
 [[package]]
+name = "coloredlogs"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "humanfriendly" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934", size = 46018, upload-time = "2021-06-11T10:22:42.561Z" },
+]
+
+[[package]]
 name = "concurrent-log-handler"
 version = "0.9.29"
 source = { registry = "https://pypi.org/simple" }
@@ -1233,7 +1248,8 @@ dependencies = [
     { name = "av" },
     { name = "ctranslate2" },
     { name = "huggingface-hub" },
-    { name = "onnxruntime" },
+    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "onnxruntime", version = "1.27.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "tokenizers" },
     { name = "tqdm" },
 ]
@@ -1774,9 +1790,10 @@ voice = [
     { name = "sounddevice" },
 ]
 wake = [
-    { name = "ai-edge-litert", marker = "sys_platform == 'darwin'" },
+    { name = "ai-edge-litert", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
     { name = "numpy" },
-    { name = "onnxruntime" },
+    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "onnxruntime", version = "1.27.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "openwakeword" },
     { name = "pvporcupine" },
     { name = "sentencepiece" },
@@ -1799,7 +1816,7 @@ youtube = [
 [package.metadata]
 requires-dist = [
     { name = "agent-client-protocol", marker = "extra == 'acp'", specifier = "==0.9.0" },
-    { name = "ai-edge-litert", marker = "sys_platform == 'darwin' and extra == 'wake'", specifier = "==2.1.6" },
+    { name = "ai-edge-litert", marker = "platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'wake'", specifier = "==2.1.6" },
     { name = "aiohttp", marker = "extra == 'homeassistant'", specifier = "==3.14.3" },
     { name = "aiohttp", marker = "extra == 'matrix'", specifier = "==3.14.3" },
     { name = "aiohttp", marker = "extra == 'messaging'", specifier = "==3.14.3" },
@@ -1874,7 +1891,8 @@ requires-dist = [
     { name = "nemo-relay", marker = "(platform_machine == 'aarch64' and 'android' not in platform_release and sys_platform == 'linux') or (platform_machine == 'x86_64' and 'android' not in platform_release and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'ARM64' and sys_platform == 'win32')", specifier = ">=0.7.1,<0.8" },
     { name = "numpy", marker = "extra == 'voice'", specifier = "==2.4.3" },
     { name = "numpy", marker = "extra == 'wake'", specifier = "==2.4.3" },
-    { name = "onnxruntime", marker = "extra == 'wake'", specifier = "==1.27.0" },
+    { name = "onnxruntime", marker = "platform_machine == 'x86_64' and sys_platform == 'darwin' and extra == 'wake'", specifier = "==1.23.2" },
+    { name = "onnxruntime", marker = "(platform_machine != 'x86_64' and extra == 'wake') or (sys_platform != 'darwin' and extra == 'wake')", specifier = "==1.27.0" },
     { name = "openai", specifier = "==2.24.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otlp'", specifier = "==1.39.1" },
     { name = "opentelemetry-sdk", marker = "extra == 'otlp'", specifier = "==1.39.1" },
@@ -2093,6 +2111,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/9b/d3bb4e7d792835daf34dd7091bbc7d7b4e0437d9388f1ea7239cce49f478/huggingface_hub-1.24.0.tar.gz", hash = "sha256:18431ff4daae0749aa9ba102fc952e314c98e1d30ebdec5319d85ca0a83e1ae5", size = 921848, upload-time = "2026-07-17T09:54:01.022Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/c3/aeaaf3911d2529614be18d1c8b5496afc185560e76568063d517283318af/huggingface_hub-1.24.0-py3-none-any.whl", hash = "sha256:6ed4120a84a6beec900640aa7e346bd766a6b7341e41526fef5dc8bd81fb7d59", size = 771904, upload-time = "2026-07-17T09:53:59.106Z" },
+]
+
+[[package]]
+name = "humanfriendly"
+version = "10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477", size = 86794, upload-time = "2021-09-17T21:40:39.897Z" },
 ]
 
 [[package]]
@@ -2534,6 +2561,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
 name = "msal"
 version = "1.36.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2833,8 +2869,36 @@ wheels = [
 
 [[package]]
 name = "onnxruntime"
+version = "1.23.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "python_full_version < '3.12' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+]
+dependencies = [
+    { name = "coloredlogs" },
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "sympy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/a8/3c23a8f75f93122d2b3410bfb74d06d0f8da4ac663185f91866b03f7da1b/onnxruntime-1.23.2-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:87d8b6eaf0fbeb6835a60a4265fde7a3b60157cf1b2764773ac47237b4d48612", size = 19153857, upload-time = "2025-10-22T03:46:37.578Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9d/a81aafd899b900101988ead7fb14974c8a58695338ab6a0f3d6b0100f30b/onnxruntime-1.23.2-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:218295a8acae83905f6f1aed8cacb8e3eb3bd7513a13fe4ba3b2664a19fc4a6b", size = 19157705, upload-time = "2025-10-22T03:46:40.415Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/f9/2d49ca491c6a986acce9f1d1d5fc2099108958cc1710c28e89a032c9cfe9/onnxruntime-1.23.2-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:162f4ca894ec3de1a6fd53589e511e06ecdc3ff646849b62a9da7489dee9ce95", size = 19157691, upload-time = "2025-10-22T03:46:43.518Z" },
+]
+
+[[package]]
+name = "onnxruntime"
 version = "1.27.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "(python_full_version >= '3.13' and platform_machine != 'x86_64') or (python_full_version >= '3.13' and sys_platform != 'darwin')",
+    "(python_full_version == '3.12.*' and platform_machine != 'x86_64') or (python_full_version == '3.12.*' and sys_platform != 'darwin')",
+    "(python_full_version < '3.12' and platform_machine != 'x86_64') or (python_full_version < '3.12' and sys_platform != 'darwin')",
+]
 dependencies = [
     { name = "flatbuffers" },
     { name = "numpy" },
@@ -3007,7 +3071,8 @@ name = "openwakeword"
 version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "onnxruntime" },
+    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "onnxruntime", version = "1.27.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "requests" },
     { name = "scikit-learn" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -3990,10 +4055,11 @@ name = "scipy"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.12'",
+    "(python_full_version < '3.12' and platform_machine != 'x86_64') or (python_full_version < '3.12' and sys_platform != 'darwin')",
+    "python_full_version < '3.12' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.12'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -4044,11 +4110,13 @@ name = "scipy"
 version = "1.18.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13'",
-    "python_full_version == '3.12.*'",
+    "(python_full_version >= '3.13' and platform_machine != 'x86_64') or (python_full_version >= '3.13' and sys_platform != 'darwin')",
+    "python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version == '3.12.*' and platform_machine != 'x86_64') or (python_full_version == '3.12.*' and sys_platform != 'darwin')",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version >= '3.12'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [
@@ -4299,6 +4367,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ce/62/867fead9beac94a1f27f90fce9bc5b5def4464e182cd75eab0ac0d40232a/supermemory-3.50.0.tar.gz", hash = "sha256:f74b56b9f1df05fc7de0bd04722a5f5b3ab22f6388585dc7f66fe15a566ad972", size = 174419, upload-time = "2026-06-24T09:29:13.139Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4c/be/caf3b7d4b21851c7d8ddec7661f22089d95bb55bc7b4bdd79dea1001604e/supermemory-3.50.0-py3-none-any.whl", hash = "sha256:f6e2dd142934ec213d561414aeb0164ee408a34d339b84ed93440f03f4ca2290", size = 155533, upload-time = "2026-06-24T09:29:12.012Z" },
+]
+
+[[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
 ]
 
 [[package]]
@@ -4678,11 +4758,11 @@ name = "vercel-workers"
 version = "0.0.25"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "python_full_version >= '3.12'" },
-    { name = "httpx", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
-    { name = "vercel", marker = "python_full_version >= '3.12'" },
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "vercel" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/df/04d37021ad7ca53b7599c313e411d91623c7a005c741f491d1eefb7a9f0c/vercel_workers-0.0.25.tar.gz", hash = "sha256:212ded01400b524be51d251df49f801caf115ad7d48cca7eb168cbeceda3def3", size = 64149, upload-time = "2026-06-20T19:26:27.177Z" }
 wheels = [


### PR DESCRIPTION
Fixes #81560

## What

The openWakeWord wake-word backend now runs on **ONNX with `onnxruntime==1.23.2`** on Intel (x86_64) macOS — the last release with a Darwin x86_64 wheel.

## Why

The default openWakeWord stack pins `onnxruntime==1.27.0`, which ships **no x86_64 macOS wheel** — the lazy install fails with `Could not find a version` on Intel Macs and the wake word can never arm. The initially-proposed tflite route is also dead: `ai-edge-litert==2.1.6` publishes **arm64-only** macOS wheels (no x86_64, no sdist). The only installable openWakeWord path on Intel macOS is ONNX with the platform-correct pin.

## Changes

- `pyproject.toml` `[wake]` extra: `onnxruntime==1.23.2; platform_machine == 'x86_64' and platform_system == 'Darwin'`, `1.27.0` elsewhere; `ai-edge-litert` gated to Darwin/arm64 only.
- `tools/wake_word.py`:
  - `default_inference_framework()`: Intel macOS defaults to `onnx` (tflite stays Apple-Silicon-only).
  - Engine init ensures the slim feature (`wake.openwakeword.slim`, no onnxruntime) on Intel macOS — lazy-dep specs can't carry PEP 508 markers, so the extra provides the runtime at the platform-correct version.
  - Preflight raises an actionable ImportError when onnxruntime is missing (instead of openWakeWord's bare `ModuleNotFoundError`).
- `tools/lazy_deps.py`: slim feature (openwakeword + sounddevice + numpy, no onnxruntime) used by the Intel-macOS path.
- `uv.lock` regenerated with the dual-platform onnxruntime pins.

## Verification

- `test_wake_word.py`: 29 passed — Intel default is onnx, explicit onnx stays, engine ensures slim on Intel / default elsewhere, missing-onnxruntime preflight covered.
- `test_packaging_metadata.py`: marker-scoped pins skipped in the same-environment consistency check.

**Triage history**: the earlier tflite proposal was corrected after review verified ai-edge-litert 2.1.6 ships no Intel-macOS wheel (PyPI wheel listing, 5 macosx_12_0_arm64 files, zero x86_64).