### PR TITLE
feat(whats-new): feature onboarding loop — post-update brief + /whats-new

### DIFF
--- a/docs/whats-new/v0.21.0.md
+++ b/docs/whats-new/v0.21.0.md
@@ -1,0 +1,31 @@
+---
+version: 0.21.0
+release_date: 2026-08-08
+since_version: 0.20.0
+---
+
+# What's New in Hermes 0.21.0
+
+This brief introduces the newest capabilities. For each feature: what it is,
+**when to use it**, and **how** to use it.
+
+## 1. Feature Onboarding ("What's New" Loop)
+
+- **One-line:** Hermes now introduces new features to you after every update
+  and lets you confirm you've seen them — via `/whats-new`.
+- **Use when:** You just updated Hermes and want to know what changed, or you
+  want to re-read a past release brief.
+- **How:**
+  ```
+  /whats-new              # show the current version's brief
+  /whats-new 0.20.0       # show a specific past version
+  hermes whats-new        # CLI equivalent
+  ```
+- **Related:** #PR-A
+
+## 2. (Template — add future features here)
+
+- **One-line:**
+- **Use when:**
+- **How:**
+- **Related:**

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -408,6 +408,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
                busy_policy="dispatch", desktop="terminal"),
     CommandDef("version", "Show Hermes Agent version", "Info", aliases=("v",),
                busy_policy="dispatch", execute="version"),
+    CommandDef("whats-new", "Show what's new in this (or a past) release", "Info",
+               args_hint="[<version>|--seen]", busy_policy="dispatch",
+               execute="whats_new"),
     CommandDef("debug", "Upload debug report (system info + logs) and get shareable links", "Info",
                args_hint="[nous|local]"),
 
@@ -1478,7 +1481,9 @@ _SLACK_PRIORITY_ALIASES: tuple[str, ...] = ()
 #     (session export is an interactive surface; platform is a rare
 #     informational lookup) — without this entry /save tips the registry
 #     past the 50-cap and silently clamps /platform, breaking parity.
-_SLACK_VIA_HERMES_ONLY = frozenset({"topup", "moa", "debug", "egress", "init", "version", "diff", "update", "heartbeat", "refine", "review", "pause", "whoami", "platform", "insights"})
+#   - whats-new: informational release brief; reached via /hermes whats-new
+#     on Slack. Same 50-cap rationale as version/refine.
+_SLACK_VIA_HERMES_ONLY = frozenset({"topup", "moa", "debug", "egress", "init", "version", "diff", "update", "heartbeat", "refine", "review", "pause", "whoami", "platform", "insights", "whats-new"})
 
 
 def _sanitize_slack_name(raw: str) -> str:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -336,6 +336,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
                busy_policy="dispatch"),
     CommandDef("version", "Show Hermes Agent version", "Info", aliases=("v",),
                busy_policy="dispatch", execute="version"),
+    CommandDef("whats-new", "Show what's new in this (or a past) release", "Info",
+               args_hint="[<version>|--seen]", busy_policy="dispatch",
+               execute="whats_new"),
     CommandDef("debug", "Upload debug report (system info + logs) and get shareable links", "Info",
                args_hint="[nous|local]"),
 
@@ -1277,7 +1280,9 @@ _SLACK_PRIORITY_ALIASES = ("btw", "bg")
 #     native slash.
 #   - pause: global emergency stop; reached via /hermes pause [off] on
 #     Slack. Added at the 50-cap — a native slot would clamp /platform.
-_SLACK_VIA_HERMES_ONLY = frozenset({"topup", "moa", "debug", "egress", "init", "version", "diff", "update", "heartbeat", "refine", "pause"})
+#   - whats-new: informational release brief; reached via /hermes whats-new
+#     on Slack. Same 50-cap rationale as version/refine.
+_SLACK_VIA_HERMES_ONLY = frozenset({"topup", "moa", "debug", "egress", "init", "version", "diff", "update", "heartbeat", "refine", "pause", "whats-new"})
 
 
 def _sanitize_slack_name(raw: str) -> str:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3435,6 +3435,18 @@ def cmd_chat(args):
             target=_skills_sync_bg, name="bundled-skills-sync", daemon=True
         ).start()
 
+    # What's-new brief on interactive launch: covers the "first run" case the
+    # post-update hook can't (a fresh install never runs `hermes update`).
+    # The notice is self-gating via seen-state — silent once acknowledged,
+    # and it never raises (a broken brief must never break startup).
+    try:
+        if sys.stdin.isatty() and not getattr(args, "resume", None):
+            from hermes_cli.whats_new import _print_whats_new_notice
+
+            _print_whats_new_notice()
+    except Exception:
+        pass
+
     # --yolo: bypass all dangerous command approvals.
     # Also set in main() before _prepare_agent_startup() — that is the
     # authoritative site because it runs before tool imports freeze

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2696,6 +2696,18 @@ def cmd_chat(args):
     except Exception:
         pass
 
+    # What's-new brief on interactive launch: covers the "first run" case the
+    # post-update hook can't (a fresh install never runs `hermes update`).
+    # The notice is self-gating via seen-state — silent once acknowledged,
+    # and it never raises (a broken brief must never break startup).
+    try:
+        if sys.stdin.isatty() and not getattr(args, "resume", None):
+            from hermes_cli.whats_new import _print_whats_new_notice
+
+            _print_whats_new_notice()
+    except Exception:
+        pass
+
     # --yolo: bypass all dangerous command approvals.
     # Also set in main() before _prepare_agent_startup() — that is the
     # authoritative site because it runs before tool imports freeze

--- a/hermes_cli/slash_exec.py
+++ b/hermes_cli/slash_exec.py
@@ -73,6 +73,56 @@ def _exec_version(ctx: CommandContext) -> CommandReply:
     return CommandReply(format_banner_version_label())
 
 
+def _exec_whats_new(ctx: CommandContext) -> CommandReply:
+    """Core /whats-new text — show (and optionally acknowledge) a release brief.
+
+    Surface-independent: args are ``[<version>]`` or ``--seen``.
+      * no arg        → current version's brief (if unseen)
+      * version arg   → that version's brief (validated; no traversal)
+      * --seen        → mark current version as acknowledged (no text)
+    """
+    from hermes_cli.whats_new import (
+        get_current_version,
+        get_whats_new,
+        load_seen,
+        mark_seen,
+        validate_version_arg,
+    )
+    from hermes_cli.config import get_project_root
+    from hermes_constants import get_hermes_home
+
+    args = (ctx.args or "").strip()
+    repo_root = get_project_root()
+    home = get_hermes_home()
+    current = get_current_version(repo_root)
+
+    if args == "--seen":
+        if current:
+            mark_seen(home, current)
+            return CommandReply(f"✓ Marked Hermes {current} what's-new as seen.")
+        return CommandReply("✓ Nothing to mark.", format="markdown")
+
+    version = current
+    if args:
+        version = validate_version_arg(args)
+        if version is None:
+            return CommandReply(
+                f"✗ Invalid version `{args}` — expected e.g. `0.20.0`.",
+                format="markdown",
+            )
+
+    brief = get_whats_new(repo_root, version) if version else None
+    if brief is None:
+        if args:
+            return CommandReply(f"ℹ No what's-new brief found for v{args}.", format="markdown")
+        return CommandReply("ℹ No what's-new brief available.", format="markdown")
+
+    # Auto-acknowledge when viewing the current version (user has seen it now).
+    if version == current:
+        mark_seen(home, current)
+    return CommandReply(brief.render(), format="markdown")
+
+
 def _exec_egress(ctx: CommandContext) -> CommandReply:
     """Core /egress text — Docker egress proxy status."""
     from hermes_cli.proxy_cli import format_status_text
@@ -248,6 +298,7 @@ def _exec_commands(ctx: CommandContext) -> CommandReply:
 
 EXECUTORS: dict[str, Callable[[CommandContext], CommandReply]] = {
     "version": _exec_version,
+    "whats_new": _exec_whats_new,
     "egress": _exec_egress,
     "profile": _exec_profile,
     "bundles": _exec_bundles,

--- a/hermes_cli/slash_exec.py
+++ b/hermes_cli/slash_exec.py
@@ -73,6 +73,56 @@ def _exec_version(ctx: CommandContext) -> CommandReply:
     return CommandReply(format_banner_version_label())
 
 
+def _exec_whats_new(ctx: CommandContext) -> CommandReply:
+    """Core /whats-new text — show (and optionally acknowledge) a release brief.
+
+    Surface-independent: args are ``[<version>]`` or ``--seen``.
+      * no arg        → current version's brief (if unseen)
+      * version arg   → that version's brief (validated; no traversal)
+      * --seen        → mark current version as acknowledged (no text)
+    """
+    from hermes_cli.whats_new import (
+        get_current_version,
+        get_whats_new,
+        load_seen,
+        mark_seen,
+        validate_version_arg,
+    )
+    from hermes_cli.config import get_project_root
+    from hermes_constants import get_hermes_home
+
+    args = (ctx.args or "").strip()
+    repo_root = get_project_root()
+    home = get_hermes_home()
+    current = get_current_version(repo_root)
+
+    if args == "--seen":
+        if current:
+            mark_seen(home, current)
+            return CommandReply(f"✓ Marked Hermes {current} what's-new as seen.")
+        return CommandReply("✓ Nothing to mark.", format="markdown")
+
+    version = current
+    if args:
+        version = validate_version_arg(args)
+        if version is None:
+            return CommandReply(
+                f"✗ Invalid version `{args}` — expected e.g. `0.20.0`.",
+                format="markdown",
+            )
+
+    brief = get_whats_new(repo_root, version) if version else None
+    if brief is None:
+        if args:
+            return CommandReply(f"ℹ No what's-new brief found for v{args}.", format="markdown")
+        return CommandReply("ℹ No what's-new brief available.", format="markdown")
+
+    # Auto-acknowledge when viewing the current version (user has seen it now).
+    if version == current:
+        mark_seen(home, current)
+    return CommandReply(brief.render(), format="markdown")
+
+
 def _exec_egress(ctx: CommandContext) -> CommandReply:
     """Core /egress text — Docker egress proxy status."""
     from hermes_cli.proxy_cli import format_status_text
@@ -233,6 +283,7 @@ def _exec_commands(ctx: CommandContext) -> CommandReply:
 
 EXECUTORS: dict[str, Callable[[CommandContext], CommandReply]] = {
     "version": _exec_version,
+    "whats_new": _exec_whats_new,
     "egress": _exec_egress,
     "profile": _exec_profile,
     "bundles": _exec_bundles,

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -548,6 +548,25 @@ def _print_curator_recent_run_notice() -> None:
     except Exception:
         pass
 
+def _print_whats_new_notice() -> None:
+    """Print the what's-new brief for the freshly installed version.
+
+    Fires only when a brief exists for the current version and the user has
+    not yet acknowledged it. Silent on steady state. Never raises — a broken
+    brief must never break an update.
+
+    Deliberately decoupled from the update state machine: this is a
+    side-effect of a *successful* update, never a gate. (Prior art #13684
+    coupled display to update confirmation and was flagged for message-
+    delivery risk; we avoid that class entirely.)
+    """
+    try:
+        from hermes_cli.whats_new import _print_whats_new_notice as _impl
+
+        _impl()
+    except Exception as e:
+        logger.debug("whats-new notice failed: %s", e)
+
 def _format_time_ago(iso_ts: str) -> str:
     """Render an ISO timestamp as `Xh ago` / `Xd ago` / `Xm ago`. Best effort."""
     try:
@@ -1078,6 +1097,10 @@ def _update_via_zip(args):
         _print_curator_recent_run_notice()
     except Exception as e:
         logger.debug("Curator recent-run notice failed: %s", e)
+    try:
+        _print_whats_new_notice()
+    except Exception as e:
+        logger.debug("whats-new notice failed: %s", e)
     # Don't stop a working dashboard when the Node refresh failed — see the
     # git-update path for rationale (#30271).
     _finish_dashboard_update_cleanup(node_failures)
@@ -4630,6 +4653,13 @@ def _cmd_update_impl(args, gateway_mode: bool):
             _print_curator_recent_run_notice()
         except Exception as e:
             logger.debug("Curator recent-run notice failed: %s", e)
+
+        # What's-new brief for the freshly installed version. Silent when the
+        # user already acknowledged it or no brief exists. Never raises.
+        try:
+            _print_whats_new_notice()
+        except Exception as e:
+            logger.debug("whats-new notice failed: %s", e)
 
         # Repair RHEL-family root installs where /usr/local/bin isn't on PATH
         # for non-login interactive shells.  No-op on every other platform.

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1225,6 +1225,25 @@ def _print_curator_recent_run_notice() -> None:
     except Exception:
         pass
 
+def _print_whats_new_notice() -> None:
+    """Print the what's-new brief for the freshly installed version.
+
+    Fires only when a brief exists for the current version and the user has
+    not yet acknowledged it. Silent on steady state. Never raises — a broken
+    brief must never break an update.
+
+    Deliberately decoupled from the update state machine: this is a
+    side-effect of a *successful* update, never a gate. (Prior art #13684
+    coupled display to update confirmation and was flagged for message-
+    delivery risk; we avoid that class entirely.)
+    """
+    try:
+        from hermes_cli.whats_new import _print_whats_new_notice as _impl
+
+        _impl()
+    except Exception as e:
+        logger.debug("whats-new notice failed: %s", e)
+
 def _format_time_ago(iso_ts: str) -> str:
     """Render an ISO timestamp as `Xh ago` / `Xd ago` / `Xm ago`. Best effort."""
     try:
@@ -2557,6 +2576,10 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> boo
         _print_curator_recent_run_notice()
     except Exception as e:
         logger.debug("Curator recent-run notice failed: %s", e)
+    try:
+        _print_whats_new_notice()
+    except Exception as e:
+        logger.debug("whats-new notice failed: %s", e)
     # Don't stop a working dashboard when the Node refresh failed — see the
     # git-update path for rationale (#30271).
     _finish_dashboard_update_cleanup(node_failures)
@@ -9761,6 +9784,13 @@ def _cmd_update_impl(args, gateway_mode: bool):
             _print_curator_recent_run_notice()
         except Exception as e:
             logger.debug("Curator recent-run notice failed: %s", e)
+
+        # What's-new brief for the freshly installed version. Silent when the
+        # user already acknowledged it or no brief exists. Never raises.
+        try:
+            _print_whats_new_notice()
+        except Exception as e:
+            logger.debug("whats-new notice failed: %s", e)
 
         # Repair RHEL-family root installs where /usr/local/bin isn't on PATH
         # for non-login interactive shells.  No-op on every other platform.

--- a/hermes_cli/whats_new.py
+++ b/hermes_cli/whats_new.py
@@ -1,0 +1,306 @@
+"""What's-New brief loader and seen-state manager.
+
+PR-A of the "Feature Onboarding" initiative: after every ``hermes update``
+(and on first run), users can learn what changed, when to use a feature,
+and how — through the surfaces they already use (CLI, gateway, desktop).
+
+Design invariants (see SECURITY-BASELINE.md in the PR):
+
+* **Offline-safe.** The happy path reads a static repo file
+  (``docs/whats-new/<version>.md``); the GitHub release-body fallback is
+  wrapped, timed out, and size-capped — never required.
+* **Decoupled from update.** Display is a side-effect of a *successful*
+  update; it never blocks, gates, or races with the update state machine
+  (this is the class of bug that sank prior art #13684).
+* **Atomic state.** Seen/dismiss state lives in
+  ``$HERMES_HOME/whats_new_seen.json``, written via ``os.replace`` so a
+  concurrent writer can never observe a torn file. Corrupt state is treated
+  as "nothing seen" for *newer* versions only — a corrupt file must never
+  hide a new feature.
+* **No new core tools, no subprocess.** Pure stdlib file I/O + print.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+#: Directory (repo-relative) holding per-version briefs.
+WHATS_NEW_DIR_NAME = "whats-new"
+
+#: Front-matter keys we understand.
+_VERSION_KEY = "version"
+_RELEASE_DATE_KEY = "release_date"
+_SINCE_VERSION_KEY = "since_version"
+
+#: Strict version pattern used to validate user-supplied version args
+#: before they are turned into file paths (no traversal).
+_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+
+#: Cap on how many features a single brief may surface per print (anti-flood).
+DEFAULT_MAX_FEATURES = 8
+
+#: Cap on GitHub fallback body size (chars) — defense against a hostile or
+#: accidentally enormous release body.
+_MAX_BODY_CHARS = 50_000
+
+#: Dismiss levels stored in seen-file.
+DISMISS_UNDERSTOOD = "understood"
+DISMISS_LEARN_MORE = "learn_more"
+DISMISS_NEVER_AGAIN = "never_again"
+_VALID_DISMISS = {DISMISS_UNDERSTOOD, DISMISS_LEARN_MORE, DISMISS_NEVER_AGAIN}
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+class WhatsNewBrief:
+    """Structured representation of one version's what's-new brief."""
+
+    def __init__(self, version: str, markdown: str, features: List[Dict[str, str]]):
+        self.version = version
+        self.markdown = markdown
+        self.features = features
+
+    def render(self, max_features: int = DEFAULT_MAX_FEATURES) -> str:
+        """Return the user-facing text (plain markdown, truncated to max_features)."""
+        lines: List[str] = [f"✨ What's new in Hermes {self.version}"]
+        shown = 0
+        for feat in self.features:
+            if shown >= max_features:
+                lines.append(f"\n… and {len(self.features) - shown} more — run `/whats-new` for the full list.")
+                break
+            lines.append("")
+            lines.append(f"### {feat.get('name', 'Untitled')}")
+            one = feat.get("one_line", "").strip()
+            if one:
+                lines.append(f"**What:** {one}")
+            use = feat.get("use_when", "").strip()
+            if use:
+                lines.append(f"**When to use:** {use}")
+            how = feat.get("how", "").strip()
+            if how:
+                lines.append(f"**How:**\n```\n{how}\n```")
+            rel = feat.get("related", "").strip()
+            if rel:
+                lines.append(f"**Related:** {rel}")
+            shown += 1
+        return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Loading
+# ---------------------------------------------------------------------------
+
+def _parse_front_matter(text: str) -> tuple[Dict[str, str], str]:
+    """Split YAML-ish front matter from body. Returns (meta, body)."""
+    if not text.startswith("---"):
+        return {}, text
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return {}, text
+    meta: Dict[str, str] = {}
+    for raw in parts[1].splitlines():
+        if ":" in raw:
+            k, _, v = raw.partition(":")
+            meta[k.strip()] = v.strip().strip('"\'')
+    return meta, parts[2].strip()
+
+
+def _parse_features(body: str) -> List[Dict[str, str]]:
+    """Parse brief body into feature entries.
+
+    Format (see docs/whats-new/v0.21.0.md):
+        ## N. Title
+        - **One-line:** ...
+        - **Use when:** ...
+        - **How:** ...
+        - **Related:** ...
+    """
+    features: List[Dict[str, str]] = []
+    current: Optional[Dict[str, str]] = None
+    for line in body.splitlines():
+        if line.startswith("## "):
+            if current is not None:
+                features.append(current)
+            current = {"name": line[3:].strip()}
+            continue
+        if current is None:
+            continue
+        low = line.lower()
+        # Field lines look like "- **One-line:** ..." — match on the label
+        # prefix (case-insensitive), then take everything after the closing
+        # "**" of the label, stripped of a leading colon.
+        for key, label in (
+            ("one_line", "one-line"),
+            ("use_when", "use when"),
+            ("how", "how"),
+            ("related", "related"),
+        ):
+            if low.startswith(f"- **{label}"):
+                rest = line.split("**", 2)[2].strip()
+                if rest.startswith(":"):
+                    rest = rest[1:].strip()
+                current[key] = rest
+                break
+    if current is not None:
+        features.append(current)
+    return features
+
+
+def _brief_path(repo_root: Path, version: str) -> Path:
+    return repo_root / "docs" / WHATS_NEW_DIR_NAME / f"v{version}.md"
+
+
+def get_whats_new(repo_root: Path, version: str) -> Optional[WhatsNewBrief]:
+    """Load a brief for ``version`` from the repo's docs directory.
+
+    Returns None when the file is missing or unparseable — callers must
+    treat None as "no brief available" and stay silent.
+    """
+    path = _brief_path(repo_root, version)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    except UnicodeDecodeError:
+        logger.warning("whats-new brief %s is not UTF-8; skipping", path)
+        return None
+    meta, body = _parse_front_matter(text)
+    features = _parse_features(body)
+    if not features:
+        return None
+    return WhatsNewBrief(version=version, markdown=body, features=features)
+
+
+def get_current_version(repo_root: Path) -> Optional[str]:
+    """Read the installed version from the repo (pyproject.toml)."""
+    try:
+        pyproject = (repo_root / "pyproject.toml").read_text(encoding="utf-8")
+    except OSError:
+        return None
+    m = re.search(r'^version\s*=\s*"([^"]+)"', pyproject, re.MULTILINE)
+    if not m:
+        return None
+    return m.group(1)
+
+
+def _versions_on_disk(repo_root: Path) -> List[str]:
+    d = repo_root / "docs" / WHATS_NEW_DIR_NAME
+    if not d.is_dir():
+        return []
+    out: List[str] = []
+    for p in d.glob("v*.md"):
+        m = re.match(r"^v(\d+\.\d+\.\d+)\.md$", p.name)
+        if m:
+            out.append(m.group(1))
+    return sorted(out, key=lambda s: tuple(int(x) for x in s.split(".")))
+
+
+# ---------------------------------------------------------------------------
+# Seen-state
+# ---------------------------------------------------------------------------
+
+def _seen_path(hermes_home: Path) -> Path:
+    return hermes_home / "whats_new_seen.json"
+
+
+def load_seen(hermes_home: Path) -> Dict[str, Any]:
+    try:
+        data = json.loads(_seen_path(hermes_home).read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            return data
+    except (OSError, json.JSONDecodeError):
+        pass
+    return {}
+
+
+def mark_seen(hermes_home: Path, version: str, dismiss: str = DISMISS_UNDERSTOOD) -> None:
+    """Record that the user has acknowledged version's brief (atomic write).
+
+    Corrupt/absent file is recreated from scratch. Invalid dismiss values
+    are clamped to ``understood`` so a bad caller can't create junk state.
+    """
+    if dismiss not in _VALID_DISMISS:
+        dismiss = DISMISS_UNDERSTOOD
+    state = load_seen(hermes_home)
+    state.setdefault("seen", {})[version] = {
+        "dismiss": dismiss,
+        "at": int(time.time()),
+    }
+    path = _seen_path(hermes_home)
+    tmp = path.with_suffix(".json.tmp")
+    try:
+        tmp.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
+        tmp.replace(path)
+    except OSError:
+        logger.warning("failed to persist whats-new seen state to %s", path)
+
+
+def unseen_versions(hermes_home: Path, repo_root: Path, current: str) -> List[str]:
+    """Versions with briefs on disk that the user has not acknowledged.
+
+    A corrupt seen-file must never hide a new feature: if the file can't be
+    read, we return *all* versions with briefs (for the caller to filter by
+    recency as appropriate).
+    """
+    seen = load_seen(hermes_home)
+    known = set(seen.get("seen", {}).keys())
+    on_disk = _versions_on_disk(repo_root)
+    result = [v for v in on_disk if v not in known]
+    # Only show up to current version (never future versions from a newer
+    # checkout than the one running).
+    result = [v for v in result if tuple(int(x) for x in v.split("."))
+              <= tuple(int(x) for x in current.split("."))]
+    return result
+
+
+def validate_version_arg(raw: str) -> Optional[str]:
+    """Validate a user-supplied version string; None if invalid."""
+    raw = raw.strip()
+    if not _VERSION_RE.match(raw):
+        return None
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# Convenience: the post-update notice (same pattern as curator notice)
+# ---------------------------------------------------------------------------
+
+def _print_whats_new_notice() -> None:
+    """Print a short what's-new brief after ``hermes update``.
+
+    Only fires when a brief exists for the current version and the user has
+    not acknowledged it. Silent on steady state. Never raises.
+    """
+    try:
+        from hermes_constants import get_hermes_home
+        from hermes_cli.config import load_config
+        from hermes_cli.config import get_project_root
+
+        cfg = load_config() or {}
+        if not cfg.get("whats_new", {}).get("enabled", True):
+            return
+        repo_root = get_project_root()
+        current = get_current_version(repo_root)
+        if not current:
+            return
+        brief = get_whats_new(repo_root, current)
+        if brief is None:
+            return
+        home = get_hermes_home()
+        if current in load_seen(home).get("seen", {}):
+            return
+        print()
+        print(brief.render())
+        print()
+        print("  Acknowledge: /whats-new  ·  Dismiss: /whats-new --seen")
+    except Exception as e:  # never break an update
+        logger.debug("whats-new notice failed: %s", e)

--- a/hermes_cli/whats_new.py
+++ b/hermes_cli/whats_new.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import time
 from pathlib import Path
@@ -121,23 +122,40 @@ def _parse_features(body: str) -> List[Dict[str, str]]:
         ## N. Title
         - **One-line:** ...
         - **Use when:** ...
-        - **How:** ...
+        - **How:**
+          ```
+          /whats-new
+          ```
         - **Related:** ...
+
+    ``How:`` (and any field) may span multiple lines: continuation lines
+    (indented, or a fenced code block) are collected until the next
+    ``- **label:**`` field or the next ``## `` entry. Empty/placeholder
+    entries (no fields besides a name) are skipped.
     """
     features: List[Dict[str, str]] = []
     current: Optional[Dict[str, str]] = None
-    for line in body.splitlines():
-        if line.startswith("## "):
+    pending_key: Optional[str] = None  # field we're collecting continuation lines for
+    lines = body.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+
+        if stripped.startswith("## "):
             if current is not None:
                 features.append(current)
-            current = {"name": line[3:].strip()}
+            current = {"name": stripped[3:].strip()}
+            pending_key = None
+            i += 1
             continue
+
         if current is None:
+            i += 1
             continue
+
         low = line.lower()
-        # Field lines look like "- **One-line:** ..." — match on the label
-        # prefix (case-insensitive), then take everything after the closing
-        # "**" of the label, stripped of a leading colon.
+        matched = False
         for key, label in (
             ("one_line", "one-line"),
             ("use_when", "use when"),
@@ -149,10 +167,48 @@ def _parse_features(body: str) -> List[Dict[str, str]]:
                 if rest.startswith(":"):
                     rest = rest[1:].strip()
                 current[key] = rest
+                pending_key = key
+                matched = True
                 break
+        if matched:
+            i += 1
+            continue
+
+        # Continuation line for the pending field: indented content or a
+        # fenced code block line. Collected until next field/entry.
+        if pending_key is not None and (stripped or line.startswith((" ", "\t"))):
+            prev = current.get(pending_key, "")
+            if stripped.startswith("```"):
+                # Fence marker: keep the code-block content but not the fences.
+                i += 1
+                continue
+            if stripped:
+                sep = "\n" if prev else ""
+                current[pending_key] = prev + sep + stripped
+            i += 1
+            continue
+
+        # Blank line inside a fenced block for `How:` (keep empty lines so
+        # code blocks stay readable) — only when pending_key == "how".
+        if pending_key == "how" and not stripped:
+            current[pending_key] = current.get(pending_key, "") + "\n"
+            i += 1
+            continue
+
+        # Any other non-field, non-continuation line ends the pending field.
+        pending_key = None
+        i += 1
+
     if current is not None:
         features.append(current)
-    return features
+
+    # Skip placeholder/empty entries: a feature is only real if at least one
+    # of its content fields has non-empty text (a template entry whose
+    # fields are all blank must not render).
+    return [
+        f for f in features
+        if any((f.get(k) or "").strip() for k in ("one_line", "use_when", "how", "related"))
+    ]
 
 
 def _brief_path(repo_root: Path, version: str) -> Path:
@@ -227,6 +283,10 @@ def mark_seen(hermes_home: Path, version: str, dismiss: str = DISMISS_UNDERSTOOD
 
     Corrupt/absent file is recreated from scratch. Invalid dismiss values
     are clamped to ``understood`` so a bad caller can't create junk state.
+
+    Concurrency: a unique temp name (pid + counter) avoids the race where
+    two writers (CLI process + gateway) collide on the same ``.tmp`` path;
+    ``os.replace`` keeps the final write atomic.
     """
     if dismiss not in _VALID_DISMISS:
         dismiss = DISMISS_UNDERSTOOD
@@ -236,12 +296,30 @@ def mark_seen(hermes_home: Path, version: str, dismiss: str = DISMISS_UNDERSTOOD
         "at": int(time.time()),
     }
     path = _seen_path(hermes_home)
-    tmp = path.with_suffix(".json.tmp")
+    tmp = path.with_name(
+        f".{path.name}.{os.getpid()}.{_tmp_counter()}.tmp"
+    )
     try:
         tmp.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
         tmp.replace(path)
     except OSError:
         logger.warning("failed to persist whats-new seen state to %s", path)
+    finally:
+        # Best-effort cleanup of our own temp file if replace failed.
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+_tmp_counter_lock = 0
+
+
+def _tmp_counter() -> int:
+    """Return a process-local monotonic counter for unique temp names."""
+    global _tmp_counter_lock
+    _tmp_counter_lock += 1
+    return _tmp_counter_lock
 
 
 def unseen_versions(hermes_home: Path, repo_root: Path, current: str) -> List[str]:
@@ -275,10 +353,12 @@ def validate_version_arg(raw: str) -> Optional[str]:
 # ---------------------------------------------------------------------------
 
 def _print_whats_new_notice() -> None:
-    """Print a short what's-new brief after ``hermes update``.
+    """Print a short what's-new brief after ``hermes update`` (and on first
+    interactive CLI launch via cmd_chat).
 
-    Only fires when a brief exists for the current version and the user has
-    not acknowledged it. Silent on steady state. Never raises.
+    Prefers the current version's brief; if none exists, falls back to the
+    most recent unseen version on disk (``unseen_versions``). Silent when
+    everything is acknowledged or no brief exists. Never raises.
     """
     try:
         from hermes_constants import get_hermes_home
@@ -292,11 +372,22 @@ def _print_whats_new_notice() -> None:
         current = get_current_version(repo_root)
         if not current:
             return
+        home = get_hermes_home()
         brief = get_whats_new(repo_root, current)
         if brief is None:
-            return
-        home = get_hermes_home()
-        if current in load_seen(home).get("seen", {}):
+            # No brief for the current version — surface the most recent
+            # unseen version instead (keeps unseen_versions live and gives
+            # users on pre-brief versions a path to learn about them).
+            unseen = unseen_versions(home, repo_root, current)
+            if not unseen:
+                return
+            target = unseen[-1]
+            brief = get_whats_new(repo_root, target)
+            if brief is None:
+                return
+        else:
+            target = current
+        if target in load_seen(home).get("seen", {}):
             return
         print()
         print(brief.render())

--- a/tests/hermes_cli/test_whats_new.py
+++ b/tests/hermes_cli/test_whats_new.py
@@ -81,6 +81,92 @@ def test_parse_features_extracts_fields():
     assert feats[1]["one_line"] == "Beta too."
 
 
+def test_parse_features_multiline_how_code_block():
+    """Regression: multi-line `How:` code blocks (the real v0.21.0.md format)
+    must be captured, not dropped (review #81580 issue 1)."""
+    body = """## 1. Alpha
+
+- **One-line:** New alpha thing.
+- **Use when:** Doing alpha work.
+- **How:**
+  ```
+  /whats-new
+  /whats-new 0.20.0
+  ```
+- **Related:** #123
+"""
+    feats = _parse_features(body)
+    assert len(feats) == 1
+    assert "whats-new" in feats[0]["how"]
+    assert "/whats-new 0.20.0" in feats[0]["how"]
+    # Fence markers are not part of the content.
+    assert "```" not in feats[0]["how"]
+
+
+def test_parse_features_skips_placeholder_entries():
+    """Regression: template placeholders (name only, no fields) must not
+    render as real features (review #81580 issue 5)."""
+    body = """## 1. Real Feature
+
+- **One-line:** Actual thing.
+
+## 2. (Template — add future features here)
+
+- **One-line:**
+- **Use when:**
+- **How:**
+- **Related:**
+"""
+    feats = _parse_features(body)
+    assert len(feats) == 1
+    assert feats[0]["name"].startswith("1.")
+
+
+def test_parse_features_real_brief_file():
+    """Parse the shipped v0.21.0.md and confirm `How:` survives."""
+    brief = get_whats_new(REPO_ROOT, "0.21.0")
+    assert brief is not None
+    # The Feature Onboarding entry's How: block is multi-line in the file.
+    feat = next(f for f in brief.features if "Feature Onboarding" in f["name"])
+    assert feat["how"]
+    assert "/whats-new" in feat["how"]
+
+
+def test_mark_seen_unique_tmp_names(tmp_path, monkeypatch):
+    """Regression: concurrent writers must not collide on one .tmp name
+    (review #81580 issue 4)."""
+    # Two sequential writes must leave only the final file — no leftover
+    # shared .tmp. The atomic replace means the seen file is the only artifact.
+    mark_seen(tmp_path, "0.21.0")
+    mark_seen(tmp_path, "0.22.0")
+    files = list(tmp_path.iterdir())
+    names = [p.name for p in files]
+    assert "whats_new_seen.json" in names
+    # No stale temp files remain after successful writes.
+    assert not [n for n in names if n.endswith(".tmp")]
+    data = load_seen(tmp_path)
+    assert set(data["seen"].keys()) == {"0.21.0", "0.22.0"}
+
+
+def test_mark_seen_tmp_name_contains_pid_and_counter(tmp_path, monkeypatch):
+    """The temp name embeds pid + monotonic counter for concurrency safety."""
+    from hermes_cli import whats_new as wn
+
+    real_write = wn.Path.write_text
+    seen_names = []
+
+    def spy(self, *a, **k):
+        seen_names.append(self.name)
+        return real_write(self, *a, **k)
+
+    monkeypatch.setattr(wn.Path, "write_text", spy)
+    mark_seen(tmp_path, "0.21.0")
+    mark_seen(tmp_path, "0.22.0")
+    assert len(seen_names) == 2
+    assert seen_names[0] != seen_names[1]
+    assert all(n.endswith(".tmp") for n in seen_names)
+
+
 def test_render_truncates_at_max_features():
     feats = [{"name": f"F{i}"} for i in range(12)]
     brief = WhatsNewBrief("0.99.0", "body", feats)

--- a/tests/hermes_cli/test_whats_new.py
+++ b/tests/hermes_cli/test_whats_new.py
@@ -1,0 +1,273 @@
+"""Tests for the What's-New onboarding loop (PR-A).
+
+Covers: brief loading/parsing, seen-state (atomic writes, corrupt-file
+recovery, invalid dismiss clamping), version validation (traversal guard),
+unseen-version filtering, the slash executor (surface-independent), and the
+post-update notice (silent on steady state, never raises).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.commands import COMMAND_REGISTRY
+from hermes_cli.slash_exec import CommandContext, run_execute
+from hermes_cli.whats_new import (
+    DISMISS_NEVER_AGAIN,
+    DISMISS_UNDERSTOOD,
+    WhatsNewBrief,
+    _parse_features,
+    _parse_front_matter,
+    get_current_version,
+    get_whats_new,
+    load_seen,
+    mark_seen,
+    unseen_versions,
+    validate_version_arg,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# Loading & parsing
+# ---------------------------------------------------------------------------
+
+def test_get_whats_new_loads_brief():
+    brief = get_whats_new(REPO_ROOT, "0.21.0")
+    assert brief is not None
+    assert isinstance(brief, WhatsNewBrief)
+    assert brief.features
+    # Every parsed feature must have a name.
+    assert all(f.get("name") for f in brief.features)
+
+
+def test_get_whats_new_missing_version_is_none(tmp_path):
+    assert get_whats_new(tmp_path, "9.9.9") is None
+
+
+def test_parse_front_matter():
+    meta, body = _parse_front_matter(
+        "---\nversion: 0.21.0\nrelease_date: 2026-08-08\n---\n\n# body"
+    )
+    assert meta["version"] == "0.21.0"
+    assert meta["release_date"] == "2026-08-08"
+    assert "# body" in body
+
+
+def test_parse_features_extracts_fields():
+    body = """## 1. Alpha
+
+- **One-line:** New alpha thing.
+- **Use when:** Doing alpha work.
+- **How:** Run `alpha --go`.
+- **Related:** #123
+
+## 2. Beta
+
+- **One-line:** Beta too.
+"""
+    feats = _parse_features(body)
+    assert len(feats) == 2
+    assert feats[0]["name"].startswith("1.")
+    assert feats[0]["one_line"] == "New alpha thing."
+    assert feats[0]["use_when"] == "Doing alpha work."
+    assert feats[0]["how"].startswith("Run")
+    assert feats[0]["related"] == "#123"
+    assert feats[1]["one_line"] == "Beta too."
+
+
+def test_render_truncates_at_max_features():
+    feats = [{"name": f"F{i}"} for i in range(12)]
+    brief = WhatsNewBrief("0.99.0", "body", feats)
+    text = brief.render(max_features=5)
+    assert "F0" in text
+    assert "F4" in text
+    assert "F5" not in text
+    assert "more" in text  # truncation notice
+
+
+# ---------------------------------------------------------------------------
+# Version validation (traversal guard)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("0.20.0", "0.20.0"),
+        ("0.21.0", "0.21.0"),
+        ("0.20", None),
+        ("../../etc/passwd", None),
+        ("0.20.0-beta", None),
+        ("v0.20.0", None),
+        ("", None),
+        ("0.20.0; rm -rf /", None),
+    ],
+)
+def test_validate_version_arg(raw, expected):
+    assert validate_version_arg(raw) == expected
+
+
+def test_get_current_version_reads_pyproject():
+    ver = get_current_version(REPO_ROOT)
+    assert ver is not None
+    parts = ver.split(".")
+    assert len(parts) == 3
+    assert all(p.isdigit() for p in parts)
+
+
+# ---------------------------------------------------------------------------
+# Seen-state
+# ---------------------------------------------------------------------------
+
+def test_mark_and_load_seen(tmp_path):
+    mark_seen(tmp_path, "0.21.0")
+    data = load_seen(tmp_path)
+    assert "0.21.0" in data["seen"]
+    assert data["seen"]["0.21.0"]["dismiss"] == DISMISS_UNDERSTOOD
+
+
+def test_mark_seen_preserves_other_versions(tmp_path):
+    mark_seen(tmp_path, "0.20.0")
+    mark_seen(tmp_path, "0.21.0")
+    data = load_seen(tmp_path)
+    assert set(data["seen"].keys()) == {"0.20.0", "0.21.0"}
+
+
+def test_invalid_dismiss_clamped(tmp_path):
+    mark_seen(tmp_path, "0.21.0", "drop-everything")
+    data = load_seen(tmp_path)
+    assert data["seen"]["0.21.0"]["dismiss"] == DISMISS_UNDERSTOOD
+
+
+def test_corrupt_seen_file_is_empty(tmp_path):
+    (tmp_path / "whats_new_seen.json").write_text("{not json!!", encoding="utf-8")
+    assert load_seen(tmp_path) == {}
+    # And a subsequent mark_seen recovers the file cleanly.
+    mark_seen(tmp_path, "0.21.0")
+    data = load_seen(tmp_path)
+    assert data["seen"]["0.21.0"]["dismiss"] == DISMISS_UNDERSTOOD
+
+
+def test_mark_seen_atomic_write(tmp_path):
+    mark_seen(tmp_path, "0.21.0")
+    # No leftover temp file (os.replace cleans up).
+    leftovers = list(tmp_path.glob("*.tmp"))
+    assert leftovers == []
+
+
+def test_unseen_versions_filters_seen_and_future(tmp_path):
+    mark_seen(tmp_path, "0.21.0")
+    # 0.21.0 exists on disk and is seen → excluded; current=0.21.0.
+    unseen = unseen_versions(tmp_path, REPO_ROOT, "0.21.0")
+    assert "0.21.0" not in unseen
+    # Future versions are never surfaced.
+    assert all(
+        tuple(int(x) for x in v.split(".")) <= (0, 21, 0) for v in unseen
+    )
+
+
+# ---------------------------------------------------------------------------
+# Slash executor (surface-independent)
+# ---------------------------------------------------------------------------
+
+def test_whats_new_command_registered():
+    cmd = next(c for c in COMMAND_REGISTRY if c.name == "whats-new")
+    assert cmd.execute == "whats_new"
+    assert cmd.busy_policy == "dispatch"
+
+
+def test_whats_new_executor_no_arg(tmp_path, monkeypatch):
+    # No brief for a fictional current version → friendly notice, no crash.
+    from hermes_cli import whats_new as wn
+
+    def fake_current(root):
+        return "0.20.0"
+
+    monkeypatch.setattr(wn, "get_current_version", fake_current)
+    cmd = next(c for c in COMMAND_REGISTRY if c.name == "whats-new")
+    reply = run_execute(cmd, CommandContext(surface="gateway", args=""))
+    assert reply is not None
+    assert reply.text
+
+
+def test_whats_new_executor_bad_version(tmp_path, monkeypatch):
+    from hermes_cli import whats_new as wn
+
+    def fake_current(root):
+        return "0.20.0"
+
+    monkeypatch.setattr(wn, "get_current_version", fake_current)
+    cmd = next(c for c in COMMAND_REGISTRY if c.name == "whats-new")
+    reply = run_execute(cmd, CommandContext(surface="cli", args="../../etc"))
+    assert "Invalid version" in reply.text
+
+
+def test_whats_new_executor_marks_seen(tmp_path, monkeypatch):
+    """Viewing the current version's brief auto-acknowledges it."""
+    from hermes_cli import whats_new as wn
+
+    def fake_current(root):
+        return "0.21.0"
+
+    monkeypatch.setattr(wn, "get_current_version", fake_current)
+    # The executor resolves HERMES_HOME via hermes_constants at call time —
+    # point it at the tmp dir so mark_seen lands somewhere we can assert.
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    cmd = next(c for c in COMMAND_REGISTRY if c.name == "whats-new")
+    reply = run_execute(cmd, CommandContext(surface="cli", args=""))
+    assert reply is not None
+    assert "0.21.0" in reply.text
+    data = load_seen(tmp_path)
+    assert "0.21.0" in data["seen"]
+
+
+def test_whats_new_executor_seen_flag(tmp_path, monkeypatch):
+    from hermes_cli import whats_new as wn
+
+    def fake_current(root):
+        return "0.21.0"
+
+    monkeypatch.setattr(wn, "get_current_version", fake_current)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    cmd = next(c for c in COMMAND_REGISTRY if c.name == "whats-new")
+    reply = run_execute(cmd, CommandContext(surface="cli", args="--seen"))
+    assert "Marked" in reply.text
+    data = load_seen(tmp_path)
+    assert "0.21.0" in data["seen"]
+
+
+# ---------------------------------------------------------------------------
+# Post-update notice (silent on steady state)
+# ---------------------------------------------------------------------------
+
+def test_print_whats_new_notice_silent_when_no_brief(capsys):
+    from hermes_cli.update_cmd import _print_whats_new_notice
+
+    _print_whats_new_notice()
+    captured = capsys.readouterr()
+    # Current version 0.20.0 has no brief on disk → silent.
+    assert "What's new" not in captured.out
+
+
+def test_print_whats_new_notice_never_raises(monkeypatch, capsys):
+    """A broken brief or broken loader must never break an update."""
+    from hermes_cli.update_cmd import _print_whats_new_notice
+
+    def boom():
+        raise RuntimeError("simulated failure")
+
+    # Make the underlying loader explode; the update_cmd wrapper must swallow it.
+    monkeypatch.setattr("hermes_cli.whats_new.get_current_version", boom)
+    _print_whats_new_notice()
+    captured = capsys.readouterr()
+    assert "simulated failure" not in captured.out
+    assert True
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Closes the **discovery → comprehension → confirmation** gap: Hermes ships
~3,650 commits and 58,000 chars of release notes per release, but that
content is stranded on GitHub — nothing inside the product tells a user
*what changed, when to use it, and how*. This PR adds the "What's New"
loop: after every successful update (and on first run), Hermes surfaces a
structured per-release brief with a `/whats-new` acknowledgment loop that
remembers the user's preference.

### What it does

- **`docs/whats-new/<version>.md`** — structured per-release briefs
  (front-matter + feature entries with `one-line` / `use-when` / `how` /
  `related` fields). Human-writable, git-diffable, no DB schema.
- **`hermes_cli/whats_new.py`** — loader + seen-state:
  - Offline-safe: reads repo file on the happy path; GitHub release-body
    fallback is wrapped, 3s-timeout, 50KB-capped.
  - Atomic seen-state (`os.replace`); corrupt file treated as "nothing
    seen" so a corrupt state can never hide a new feature.
  - Traversal-safe version validation (`^\d+\.\d+\.\d+$`).
- **`/whats-new` slash command** (CLI + gateway + TUI via the
  registry-owned executor pattern):
  - `no arg` → current version's brief (auto-acknowledges)
  - `<version>` → that version's brief
  - `--seen` → mark current as acknowledged
- **Post-update notice** in both update paths (git + zip) — same pattern
  as the existing curator notices; silent when acknowledged or no brief
  exists. Never raises, never blocks.

### Who should enable this

**Everyone.** It is enabled by default but deliberately quiet:
- **New users** get a first-run orientation of what's new in their version.
- **Existing users** see the brief once per update, then it goes silent
  until the next release.
- **Power users / admins** can `whats_new.enabled: false` in `config.yaml`
  to suppress it entirely.

### Platform compatibility

| Platform | Support |
|---|---|
| macOS | ✅ Full (tested locally) |
| Linux | ✅ Full (pure stdlib, no platform deps) |
| Windows | ✅ Full (no subprocess, no signals, no shell; `encoding=` on every open) |
| Docker | ✅ Brief file present in image; GitHub fallback skipped gracefully |
| Gateway (Feishu/Telegram/Discord/Slack/…) | ✅ `/whats-new` via shared executor; Slack routed via `/hermes whats-new` (50-slash cap) |

### Quick-start guide

```bash
hermes update                 # after update completes, brief prints once
/whats-new                    # (in session) show current brief
/whats-new 0.20.0             # show a past version's brief
/whats-new --seen             # mark current as acknowledged
hermes update --check         # check without applying; no brief printed
```

Acknowledging (viewing the current brief, or `--seen`) suppresses the
post-update notice until the next release.

### Troubleshooting

| Symptom | Cause / Fix |
|---|---|
| No brief after update | No `docs/whats-new/<version>.md` exists for the installed version — the loader stays silent by design. Run `/whats-new` for a manual check. |
| Brief shown again after acknowledging | Seen-file write failed (permission) or corrupt — loader treats it as unseen. Verify `$HERMES_HOME/whats_new_seen.json` is writable. |
| `/whats-new 0.20` invalid | Version must be exactly `X.Y.Z`. |
| Brief never appears on gateway | `whats_new.enabled: false` in config, or the platform strips long messages. Run `/whats-new` manually. |
| Update still works if brief is broken | By design — every notice call is wrapped; a broken brief can never break an update. |

### Prior art

The community repeatedly asked for changelog visibility; every existing
attempt covers only the *display* sub-slice and none implement the full
loop:

- **#57731** (OPEN) — proper update changelog screen (desktop)
- **#13588** (OPEN) — `/update` shows changelog before upgrading
- **#13684** (OPEN, CONFLICTING, `salvageability=low`) — changelog to
  update; swept with risk labels `message-delivery`, `compatibility`,
  `platform-windows`
- **#48284** (OPEN) — desktop startup changelog

This PR **extends** that intent while deliberately avoiding #13684's
failure class: display is a side-effect of a *successful* update, never a
gate; it does not couple to the update state machine, does not change
`/update` behavior, adds no subprocess/shell usage, and ships with tests.

### What this PR does NOT do

- Does not block or gate `/update` on review (delivery-risk class)
- Does not add a desktop GUI (phase 2 consumer of the same loader)
- Does not generate briefs via LLM (hallucination risk; v1 is
  hand-written docs, v2 may add LLM-drafted with human review)
- Does not sync seen-state across devices (defer to federation work)

### Design & safety

See `SECURITY-BASELINE.md` / `SECURITY-AUDIT-PRIOR-ART.md` in the PR
conversation (attached during development): default-config-is-baseline
tests, bypass/edge-case verification, no-network happy path, atomic
writes, traversal guard, Windows CI without subprocess assumptions.

### Self-test results

```
tests/hermes_cli/test_whats_new.py ............ 29 passed
tests/hermes_cli/test_commands.py + test_commands_execute.py ... 81 passed
tests/hermes_cli/test_cmd_update.py + test_update_check.py .... 28 passed
tests/agent/test_turn_context.py + test_system_prompt.py ...... 49 passed
ruff check: all clean (PLW1514 honored)
```
