### PR TITLE
fix(cli): show serve-mode backends in --status, matching --stop

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9914,27 +9914,30 @@ def _report_dashboard_status() -> int:
     """Print live listening dashboard processes and return the count."""
     from gateway.status import _pid_exists
 
-    live: list[tuple[int, str]] = []
+    # Report serve-mode alongside dashboard-mode. ``--stop`` reaps whatever
+    # _scan_dashboard_processes finds, with no mode filter, so a status that
+    # hides serve-mode leaves the Desktop's detached SSH backends invisible to
+    # the only CLI that can clean them up, and contradicts the --status help
+    # text ("Show running Hermes web server processes").
+    live: list[tuple[int, str, str]] = []
     for pid, command in _scan_dashboard_processes():
         runtime = _parse_dashboard_runtime(command)
         if runtime is None:
             continue
         mode, host, port = runtime
-        if mode != "dashboard":
-            continue
         if port <= 0 or not _pid_exists(pid):
             continue
         if not _dashboard_listening(host, port):
             continue
-        live.append((pid, command))
+        live.append((pid, mode, command))
 
     if not live:
-        print("No hermes dashboard processes running.")
+        print("No hermes web server processes running.")
         return 0
 
-    print(f"{len(live)} hermes dashboard process(es) running:")
-    for pid, command in live:
-        print(f"    PID {pid}: {command}")
+    print(f"{len(live)} hermes web server process(es) running:")
+    for pid, mode, command in live:
+        print(f"    PID {pid} [{mode}]: {command}")
     return len(live)
 
 

--- a/tests/hermes_cli/test_dashboard_lifecycle_flags.py
+++ b/tests/hermes_cli/test_dashboard_lifecycle_flags.py
@@ -35,7 +35,7 @@ class TestDashboardStatus:
             cmd_dashboard(_ns(status=True))
         assert exc.value.code == 0
         out = capsys.readouterr().out
-        assert "No hermes dashboard processes running" in out
+        assert "No hermes web server processes running" in out
 
     def test_status_with_processes(self, capsys):
         processes = [
@@ -50,7 +50,7 @@ class TestDashboardStatus:
         # Status is informational — always exits 0.
         assert exc.value.code == 0
         out = capsys.readouterr().out
-        assert "2 hermes dashboard process(es) running" in out
+        assert "2 hermes web server process(es) running" in out
         assert "PID 12345" in out
         assert "PID 12346" in out
 

--- a/tests/hermes_cli/test_serve_status_symmetry.py
+++ b/tests/hermes_cli/test_serve_status_symmetry.py
@@ -1,0 +1,84 @@
+"""``--status`` must report every process ``--stop`` would reap.
+
+``_find_stale_dashboard_pids`` (the --stop path) returns every pid
+``_scan_dashboard_processes`` finds, with no mode filter, so it reaps both
+``hermes dashboard`` and ``hermes serve``. ``_report_dashboard_status``
+dropped anything whose cmdline did not parse to ``mode == "dashboard"``, so a
+Desktop-spawned detached ``hermes serve`` backend was invisible to the only
+CLI that can clean it up, and --status contradicted its own help text.
+"""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import patch
+
+import pytest
+
+_SERVE = "hermes serve --isolated --host 127.0.0.1 --port 8123 --ssh-owner-nonce abc"
+_DASH = "hermes dashboard --port 9119"
+
+
+def _ns(**kw):
+    defaults = dict(port=9119, host="127.0.0.1", no_open=False, insecure=False,
+                    stop=False, status=False)
+    defaults.update(kw)
+    return argparse.Namespace(**defaults)
+
+
+def _status(processes, capsys):
+    # Imported per call: other tests in this package importlib.reload
+    # hermes_cli.main, so a module-level binding would go stale and the
+    # patches below would target a different module object than the callee.
+    from hermes_cli.main import cmd_dashboard
+
+    with patch("hermes_cli.main._scan_dashboard_processes", return_value=processes), \
+         patch("gateway.status._pid_exists", return_value=True), \
+         patch("hermes_cli.main._dashboard_listening", return_value=True), \
+         pytest.raises(SystemExit) as exc:
+        cmd_dashboard(_ns(status=True))
+    assert exc.value.code == 0
+    return capsys.readouterr().out
+
+
+def test_serve_mode_backend_is_listed(capsys):
+    """The bug: a detached serve backend was filtered out of --status."""
+    out = _status([(4242, _SERVE)], capsys)
+
+    assert "PID 4242" in out, "a serve-mode backend that --stop would kill was not listed"
+    assert "[serve]" in out
+
+
+def test_both_modes_are_listed_together(capsys):
+    out = _status([(1, _DASH), (2, _SERVE)], capsys)
+
+    assert "2 hermes web server process(es) running" in out
+    assert "PID 1 [dashboard]" in out
+    assert "PID 2 [serve]" in out
+
+
+def test_dashboard_only_still_reported(capsys):
+    """Guard: the pre-existing dashboard case keeps working."""
+    out = _status([(1, _DASH)], capsys)
+
+    assert "PID 1 [dashboard]" in out
+
+
+def test_unparseable_cmdlines_are_still_skipped(capsys):
+    """Guard: widening the mode filter must not widen what counts as a match."""
+    out = _status([(9, "/usr/bin/some-other-daemon --port 9119")], capsys)
+
+    assert "No hermes web server processes running" in out
+
+
+def test_dead_or_silent_processes_are_still_skipped(capsys):
+    """Guard: liveness and listening checks are unchanged."""
+    from hermes_cli.main import cmd_dashboard
+
+    with patch("hermes_cli.main._scan_dashboard_processes", return_value=[(7, _SERVE)]), \
+         patch("gateway.status._pid_exists", return_value=True), \
+         patch("hermes_cli.main._dashboard_listening", return_value=False), \
+         pytest.raises(SystemExit):
+        cmd_dashboard(_ns(status=True))
+
+    assert "No hermes web server processes running" in capsys.readouterr().out


### PR DESCRIPTION
## What does this PR do?

`--status` and `--stop` disagree about what a "Hermes web server process" is, and the disagreement hides exactly the processes an operator needs to see.

`--stop` reaps whatever the scanner finds, with no mode filter at all:

```python
def _find_stale_dashboard_pids(*, exclude_pids=None) -> list[int]:
    """Return PIDs of stale ``dashboard``/``serve`` processes for update cleanup."""
    return [pid for pid, _cmd in _scan_dashboard_processes(exclude_pids=exclude_pids)]
```

`--status` throws away everything that is not dashboard-mode:

```python
mode, host, port = runtime
if mode != "dashboard":
    continue
```

`_parse_dashboard_runtime` already classifies both `hermes dashboard` and `hermes serve`, so the scanner sees serve-mode fine; only the status path discards it.

The result is that a Hermes Desktop SSH connection, which spawns a detached `hermes serve --isolated --host 127.0.0.1 --port 0 --ssh-owner-nonce …` on the remote host, is invisible to `--status` while `--stop` kills it. The operator cannot enumerate what the one available cleanup command is about to terminate. The help text takes `--stop`'s side: "Show running Hermes web server processes".

### The fix

Report every mode the scanner already recognises, and label each line with the mode so the two commands describe the same population:

```
2 hermes web server process(es) running:
    PID 1 [dashboard]: hermes dashboard --port 9119
    PID 2 [serve]: hermes serve --isolated --host 127.0.0.1 --port 8123 --ssh-owner-nonce abc
```

I widened `--status` rather than narrowing `--stop` because the reported workflow depends on `--stop` reaping serve backends; taking that away would remove the only way to clean them up. This changes what `--status` prints and nothing about what `--stop` does.

## Related Issue

Fixes #81564 (P2, `comp/cli`, `comp/dashboard`, `comp/desktop`). Searched open and merged PRs first, per CONTRIBUTING's search-first section:

```
gh search prs --repo NousResearch/hermes-agent "81564"          --limit 15   # 0
gh search prs --repo NousResearch/hermes-agent "serve --status" --limit 15   # nothing on this path
gh search prs --repo NousResearch/hermes-agent "dashboard --stop" --limit 15 # #21394, #67587, unrelated
```

I also scanned the 25 most recently opened PRs by title and creation time rather than relying on search alone, because the search index lags new PRs by several minutes.

## Type of Change

Bug fix (non-breaking) for `--stop`; `--status` output changes shape, see below.

## Changes Made

- `hermes_cli/main.py` - `_report_dashboard_status` no longer filters to dashboard-mode and tags each line with its mode; the comment records why the two paths must agree.
- `tests/hermes_cli/test_serve_status_symmetry.py` - new, 5 tests.
- `tests/hermes_cli/test_dashboard_lifecycle_flags.py` - two assertions updated for the new wording (see below).

### The wording change, called out explicitly

The summary lines move from "hermes dashboard process(es)" to "hermes web server process(es)", because the list is no longer dashboards only. That is a user-visible string change and it updates two assertions in the existing `TestDashboardStatus`. The behaviour those two tests cover (empty case exits 0 and says nothing is running; two dashboards are both listed) is unchanged, and "web server process" is the term `--status`'s own help text already uses.

## How to Test

```
pytest tests/hermes_cli/test_serve_status_symmetry.py -q
```

5 passed: a serve-mode backend is listed; both modes are listed together with their labels; the dashboard-only case still works; an unparseable cmdline is still skipped; and a process that is dead or not listening is still skipped.

Reverting only `hermes_cli/main.py` and rerunning:

```
E  AssertionError: a serve-mode backend that --stop would kill was not listed
E  assert 'PID 4242' in 'No hermes dashboard processes running.\n'
```

That is the behavioural probe. Two of the other tests also fail on revert, but only because they assert the new wording; the guard that is wording-independent (`test_unparseable_cmdlines_are_still_skipped`) is about what does *not* match and holds either way.

Full `tests/hermes_cli/` suite, this branch vs `main`, same environment, run serially:

```
main:   169 failed, 4318 passed, 19 skipped
branch: 169 failed, 4323 passed, 19 skipped
```

Comparing the failing sets rather than the counts: **zero regressions**, the two sets are identical. The +5 is this PR's new tests. Those 169 are pre-existing in a non-hermetic single-process run of this suite; CI's per-file isolation via `run_tests_parallel.py` is the supported path.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(cli): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (queries above)
- [x] My PR contains only changes related to this fix
- [x] I've run the affected suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation; the code comment records why status and stop must describe the same population. The `--status` help text already said "web server processes", so it now matches rather than needing a change
- [x] `cli-config.yaml.example` is N/A, no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` are N/A
- [x] Cross-platform impact is N/A; this is a filter on an existing cross-platform process scan
- [x] Tool descriptions/schemas are N/A

## Notes for the reviewer

The new tests import `cmd_dashboard` inside each call rather than at module scope. That is deliberate and worth keeping: other files in `tests/hermes_cli/` call `importlib.reload` on `hermes_cli.main`, and since this file sorts after them, a module-level binding goes stale and the `patch("hermes_cli.main.…")` targets stop matching the callee. The tests passed in isolation and failed in the full-suite run until I made the import per-call, so the pattern is load-bearing rather than stylistic.

One thing I did not change: `--stop` still has no mode filter, so it reaps anything `_scan_dashboard_processes` matches. That is what the reported workflow relies on, but it does mean `--stop` is broader than its own name suggests. If you would rather `--stop` grew a `--mode` selector now that `--status` can show the split, that seems worth its own change rather than folding it in here.
