### PR TITLE
feat(agent): proactive feature router — suggest the right Hermes capability at the right time

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1765,6 +1765,19 @@ def init_agent(
     from agent.memory_manager import inject_memory_provider_tools as _inject_memory_provider_tools
     _inject_memory_provider_tools(agent)
 
+    # Proactive feature router (PR-B). Off by default; reads
+    # proactive_features.* from config. Non-fatal: a broken router config
+    # must never break agent init.
+    agent._feature_router = None
+    try:
+        _pf_cfg = _agent_cfg.get("proactive_features", {}) or {}
+        if _pf_cfg.get("enabled", False):
+            from agent.feature_router import FeatureRouter as _FeatureRouter
+
+            agent._feature_router = _FeatureRouter(_pf_cfg)
+    except Exception:
+        agent._feature_router = None
+
     # Skills config: nudge interval for skill creation reminders
     agent._skill_nudge_interval = 10
     try:

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1358,6 +1358,19 @@ def _apply_agent_section(agent, _agent_cfg):
         _api_retries = 3
     agent._api_max_retries = _api_retries
 
+    # Proactive feature router (PR-B). Off by default; reads
+    # proactive_features.* from config. Non-fatal: a broken router config
+    # must never break agent init.
+    agent._feature_router = None
+    try:
+        _pf_cfg = _agent_cfg.get("proactive_features", {}) or {}
+        if _pf_cfg.get("enabled", False):
+            from agent.feature_router import FeatureRouter as _FeatureRouter
+
+            agent._feature_router = _FeatureRouter(_pf_cfg)
+    except Exception:
+        agent._feature_router = None
+
 
 def _positive_int(raw: Any, *, reject: tuple = ()) -> Optional[int]:
     """``int(raw)`` when positive, else None. ``reject`` lists types refused outright (bool, float)."""

--- a/agent/feature_registry.py
+++ b/agent/feature_registry.py
@@ -1,0 +1,298 @@
+"""Declarative registry of Hermes capabilities for proactive suggestion.
+
+PR-B of the "Feature Onboarding" initiative: the agent learns which Hermes
+capability fits the user's current need and *suggests* it (advisory only —
+never auto-executes by default).
+
+Design invariants (see SECURITY-BASELINE.md in the PR):
+
+* **No new core tools.** Every registry entry references an existing,
+  already-audited tool / skill / capability. The narrow-waist rule from
+  AGENTS.md holds: nothing here ships on the API call schema.
+* **Advisory by default.** The router emits *text suggestions* appended to
+  the current turn's API copy (the ``ext_prefetch_cache`` sidecar). It never
+  invokes a tool by itself and never weakens approval/redaction/egress gates.
+* **Explainable.** Each suggestion carries a ``why`` string so users (and
+  reviewers) know exactly why it fired.
+* **Local, offline, cache-safe.** Pure Python keyword/signal matching over
+  the current user message; no network; no system-prompt mutation.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class Feature:
+    """A Hermes capability that the router may suggest.
+
+    ``keywords`` and ``signals`` are matched against the current user message
+    (case-insensitive substring/regex). ``min_confidence`` gates firing.
+    ``suggested_capability`` names an existing tool / slash command / skill
+    the agent should consider — resolved against a whitelist at router init.
+    """
+
+    id: str
+    name: str
+    keywords: tuple[str, ...] = ()
+    patterns: tuple[str, ...] = ()            # regex patterns (compiled at init)
+    suggested_capability: str = ""            # e.g. "delegate_task", "/whats-new"
+    benefit: str = ""                          # what the user gains
+    min_confidence: float = 0.7
+    auto_apply_safe: bool = False              # True only when invoking the
+                                               # capability has zero
+                                               # side effects (e.g. /help)
+    # Compiled regexes (populated by compile_features).
+    _compiled: tuple = field(default=(), repr=False, compare=False)
+
+    def match(self, text: str) -> float:
+        """Return a confidence score for ``text`` — the raw signal hit count.
+
+        Keywords/patterns are OR semantics: hitting ANY signal means the
+        feature is relevant. The score is the raw number of signals that
+        fired (not capped), so ``min_confidence`` acts as a genuine
+        "how many signals must fire" gate:
+
+          * ``0.7``  → at least 1 hit fires
+          * ``1.5``  → at least 2 hits required
+          * ``2.0``  → at least 2 hits (integer boundaries inclusive)
+
+        Capping at 1.0 would make multi-signal thresholds unreachable
+        (review #81582 issue 1) — do not cap.
+        """
+        hits = 0
+        for kw in self.keywords:
+            if kw.lower() in text.lower():
+                hits += 1
+        for pat in self._compiled:
+            if pat.search(text):
+                hits += 1
+        return float(hits)
+
+
+def compile_features(features: List[Feature]) -> List[Feature]:
+    """Compile regex patterns into a list of frozen Feature instances."""
+    out: List[Feature] = []
+    for f in features:
+        compiled = tuple(
+            re.compile(p, re.IGNORECASE) for p in f.patterns
+        )
+        out.append(
+            Feature(
+                id=f.id,
+                name=f.name,
+                keywords=f.keywords,
+                patterns=f.patterns,
+                suggested_capability=f.suggested_capability,
+                benefit=f.benefit,
+                min_confidence=f.min_confidence,
+                auto_apply_safe=f.auto_apply_safe,
+                _compiled=compiled,
+            )
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# The registry.  Every entry references EXISTING capabilities.
+# ---------------------------------------------------------------------------
+
+# Core model-tool names the router may suggest.  These mirror the narrow
+# waist of the agent toolset and are static: every one is a first-party
+# model tool shipped by the agent core.
+TOOL_CAPABILITIES = frozenset({
+    "delegate_task",        # parallel subagents
+    "cronjob",              # scheduled jobs
+    "web_search",           # web research
+    "browser_navigate",     # browser automation
+    "terminal",             # shell
+    "memory",               # save durable facts
+    "skill_manage",         # create/update skills
+    "kanban",               # multi-agent work queue
+    "moa",                  # mixture of agents
+    "computer_use",         # desktop control
+})
+
+
+def resolve_known_capabilities() -> frozenset[str]:
+    """Return the capability names the router may suggest.
+
+    Tools come from the static ``TOOL_CAPABILITIES`` set; slash commands are
+    resolved **at runtime** from the live command registry so a registry
+    entry can only suggest a command the installed product actually ships.
+    A command that exists only in an unmerged companion PR is automatically
+    dropped until it lands (review #81582: ``/whats-new`` gated on #81580),
+    and a command removed from the product stops being suggested without a
+    manual whitelist edit.  The resolution is defensive: if the command
+    module cannot be imported, we fall back to tools-only rather than
+    raising (a broken registry must never break a turn).
+    """
+    names = set(TOOL_CAPABILITIES)
+    try:
+        from hermes_cli import commands as _commands_module
+
+        # Read the registry attribute at call time (not import time) so
+        # monkeypatched registries in tests and future dynamic registries
+        # take effect without a reload.
+        for cmd in getattr(_commands_module, "COMMAND_REGISTRY", ()):
+            names.add(f"/{cmd.name}")
+            for alias in cmd.aliases:
+                names.add(f"/{alias}")
+    except Exception as e:  # noqa: BLE001 — defensive fallback
+        logger.debug(
+            "feature registry: could not resolve slash commands "
+            "(falling back to tools only): %s", e,
+        )
+    return frozenset(names)
+
+
+def _seed_features() -> List[Feature]:
+    return [
+        Feature(
+            id="parallel_subtasks",
+            name="Parallelize independent subtasks",
+            keywords=(
+                "parallel", "batch", "同时", "并行", "批量",
+                "multi-task", "multitask", "in parallel",
+            ),
+            # Positive signals only; "each of" / "all of them" are dropped
+            # because they match sequential phrasing ("do each of these
+            # sequentially").  "several files"/"multiple repos" alone are
+            # also ambiguous (a single serial task can touch several files).
+            patterns=(
+                r"\b(?:run|execute|do|handle)\s+(?:these|those|all|both)\s+\d+\s+(?:files|tasks|jobs|repos)\b",
+                r"\b(?:in parallel|concurrently|simultaneously)\b",
+                r"(?:这|那|这些|那些|全部)\s*\d+\s*(?:个|份|台|条)?\s*(?:文件|任务|项目|仓库|脚本|目录)",
+            ),
+            suggested_capability="delegate_task",
+            benefit="Run independent subtasks in parallel (~3x wall-clock reduction on typical batches).",
+            min_confidence=0.7,
+        ),
+        Feature(
+            id="scheduled_recurring",
+            name="Schedule recurring work",
+            keywords=(
+                "every day", "daily", "weekly", "every morning", "每天",
+                "每周", "recurring", "scheduled", "remind me", "每天早上",
+            ),
+            # Bare 每 matches 每次/每个/每秒 (unrelated); use concrete
+            # time-anchored phrases only.
+            patterns=(
+                r"(?:每天|每日|每周|每个月|every\s+(?:day|morning|week|month|hour)\b)",
+                r"at\s+\d{1,2}(?::\d{2})?\s*(?:am|pm)",
+            ),
+            suggested_capability="cronjob",
+            benefit="Automate recurring checks/pushes without manual re-runs.",
+            min_confidence=0.7,
+        ),
+        Feature(
+            id="web_research",
+            name="Research the web",
+            keywords=(
+                "research", "web search", "find out", "look up", "搜索",
+                "investigate", "sources", "citations", "上网查", "查一下",
+            ),
+            # "search" alone is too broad (search the codebase, search the
+            # directory) — require web-ish phrasing.  latest/current/today
+            # also match local tasks ("current directory") so they are only
+            # combined with the web-ish keywords via the pattern below.
+            patterns=(
+                r"\b(?:search|look up|find)\s+(?:the\s+)?(?:web|internet|online|latest|current news|today'?s)\b",
+                r"\b(?:what|who|how|is|are)\s+.*\b(?:latest|recent|today|current)\b",
+            ),
+            suggested_capability="web_search",
+            benefit="Ground answers in live web sources with citations.",
+            min_confidence=0.7,
+        ),
+        Feature(
+            id="remember_fact",
+            name="Persist a durable fact",
+            keywords=(
+                "remember", "don't forget", "记住", "我的偏好", "以后",
+                "from now on", "always remember",
+            ),
+            # bare "always"/"prefer" match "the function always returns None"
+            # or "I'd prefer you didn't" — require explicit memory intent.
+            patterns=(
+                r"\b(?:remember that|remember to|remember:)\b",
+                r"\b(?:i|我)\s+(?:prefer|like|喜欢|偏好)\s+.*\b(?:always|以后|from now on)\b",
+                r"\b(?:please|帮我)\s+(?:remember|记住)\b",
+            ),
+            suggested_capability="memory",
+            benefit="Make the preference persist across sessions.",
+            min_confidence=0.7,
+        ),
+        Feature(
+            id="release_brief",
+            name="Check what's new in this release",
+            keywords=(
+                "what's new", "whats new", "new features", "changelog",
+                "更新了什么", "新功能", "release notes",
+            ),
+            patterns=(r"\b(?:what's\s+new|new\s+features|changelog|release\s+notes)\b",),
+            suggested_capability="/whats-new",
+            benefit="See the current release's new features and how to use them.",
+            min_confidence=0.7,
+            auto_apply_safe=True,  # read-only informational command
+        ),
+    ]
+
+
+class FeatureRegistry:
+    """Loads, compiles, and serves the feature registry."""
+
+    def __init__(self, features: Optional[List[Feature]] = None):
+        raw = features if features is not None else _seed_features()
+        # Capability guard: drop any entry naming a capability that does not
+        # exist in the INSTALLED product.  Tools are a static set; slash
+        # commands are resolved at runtime from the live command registry,
+        # so a seed naming a command from an unmerged companion PR is
+        # dropped until that PR lands (and re-enabled automatically after).
+        known = resolve_known_capabilities()
+        kept: List[Feature] = []
+        for f in raw:
+            if f.suggested_capability and f.suggested_capability not in known:
+                logger.warning(
+                    "feature %s references unknown capability %r — dropped",
+                    f.id, f.suggested_capability,
+                )
+                continue
+            kept.append(f)
+        self.features = compile_features(kept)
+        self._capability_map = {f.id: f for f in self.features}
+
+    def suggest(self, text: str, *, min_confidence: float | None = None) -> Optional[Feature]:
+        """Return the best-matching feature for ``text``, or None.
+
+        ``min_confidence`` overrides the per-feature threshold (used by the
+        router's global conservative default).
+        """
+        best: Optional[Feature] = None
+        best_score = 0.0
+        for f in self.features:
+            threshold = min_confidence if min_confidence is not None else f.min_confidence
+            score = f.match(text)
+            if score >= threshold and score > best_score:
+                best = f
+                best_score = score
+        return best
+
+    def suggest_text(self, text: str, *, min_confidence: float | None = None) -> str:
+        """Return a formatted suggestion string, or '' when nothing matches."""
+        f = self.suggest(text, min_confidence=min_confidence)
+        if f is None:
+            return ""
+        lines = [
+            f"[feature-suggestion] Consider using **{f.name}** "
+            f"(capability: `{f.suggested_capability}`).",
+            f"  Why: {f.benefit}",
+            "  (Advisory — nothing runs without your approval. Dismiss with "
+            "`proactive_features.enabled: false`.)",
+        ]
+        return "\n".join(lines)

--- a/agent/feature_registry.py
+++ b/agent/feature_registry.py
@@ -1,0 +1,229 @@
+"""Declarative registry of Hermes capabilities for proactive suggestion.
+
+PR-B of the "Feature Onboarding" initiative: the agent learns which Hermes
+capability fits the user's current need and *suggests* it (advisory only —
+never auto-executes by default).
+
+Design invariants (see SECURITY-BASELINE.md in the PR):
+
+* **No new core tools.** Every registry entry references an existing,
+  already-audited tool / skill / capability. The narrow-waist rule from
+  AGENTS.md holds: nothing here ships on the API call schema.
+* **Advisory by default.** The router emits *text suggestions* appended to
+  the current turn's API copy (the ``ext_prefetch_cache`` sidecar). It never
+  invokes a tool by itself and never weakens approval/redaction/egress gates.
+* **Explainable.** Each suggestion carries a ``why`` string so users (and
+  reviewers) know exactly why it fired.
+* **Local, offline, cache-safe.** Pure Python keyword/signal matching over
+  the current user message; no network; no system-prompt mutation.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class Feature:
+    """A Hermes capability that the router may suggest.
+
+    ``keywords`` and ``signals`` are matched against the current user message
+    (case-insensitive substring/regex). ``min_confidence`` gates firing.
+    ``suggested_capability`` names an existing tool / slash command / skill
+    the agent should consider — resolved against a whitelist at router init.
+    """
+
+    id: str
+    name: str
+    keywords: tuple[str, ...] = ()
+    patterns: tuple[str, ...] = ()            # regex patterns (compiled at init)
+    suggested_capability: str = ""            # e.g. "delegate_task", "/whats-new"
+    benefit: str = ""                          # what the user gains
+    min_confidence: float = 0.7
+    auto_apply_safe: bool = False              # True only when invoking the
+                                               # capability has zero
+                                               # side effects (e.g. /help)
+    # Compiled regexes (populated by compile_features).
+    _compiled: tuple = field(default=(), repr=False, compare=False)
+
+    def match(self, text: str) -> float:
+        """Return a confidence score in [0, 1] for ``text``.
+
+        Keywords/patterns are OR semantics: hitting ANY signal means the
+        feature is relevant. Score = min(1.0, hits) so ``min_confidence``
+        acts as a "how many signals must fire" gate (default 0.7 ≈ at least
+        one hit; raise to 1.5+ to require multiple signals).
+        """
+        hits = 0
+        for kw in self.keywords:
+            if kw.lower() in text.lower():
+                hits += 1
+        for pat in self._compiled:
+            if pat.search(text):
+                hits += 1
+        return min(1.0, float(hits))
+
+
+def compile_features(features: List[Feature]) -> List[Feature]:
+    """Compile regex patterns into a list of frozen Feature instances."""
+    out: List[Feature] = []
+    for f in features:
+        compiled = tuple(
+            re.compile(p, re.IGNORECASE) for p in f.patterns
+        )
+        out.append(
+            Feature(
+                id=f.id,
+                name=f.name,
+                keywords=f.keywords,
+                patterns=f.patterns,
+                suggested_capability=f.suggested_capability,
+                benefit=f.benefit,
+                min_confidence=f.min_confidence,
+                auto_apply_safe=f.auto_apply_safe,
+                _compiled=compiled,
+            )
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# The registry.  Every entry references EXISTING capabilities.
+# ---------------------------------------------------------------------------
+
+# Whitelist of capability names the router may suggest.  Anything else is
+# dropped at init (defense: a registry entry can't name a tool that doesn't
+# exist, and can't be repointed at something dangerous).
+KNOWN_CAPABILITIES = frozenset({
+    "delegate_task",        # parallel subagents
+    "cronjob",              # scheduled jobs
+    "/whats-new",           # release briefs (PR-A)
+    "web_search",           # web research
+    "browser_navigate",     # browser automation
+    "terminal",             # shell
+    "memory",               # save durable facts
+    "skill_manage",         # create/update skills
+    "kanban",               # multi-agent work queue
+    "moa",                  # mixture of agents
+    "computer_use",         # desktop control
+})
+
+
+def _seed_features() -> List[Feature]:
+    return [
+        Feature(
+            id="parallel_subtasks",
+            name="Parallelize independent subtasks",
+            keywords=(
+                "parallel", "batch", "同时", "并行", "批量",
+                "multi-task", "multitask", "several files", "multiple repos",
+            ),
+            patterns=(r"\b(?:at once|in parallel|all of them|each of)\b",),
+            suggested_capability="delegate_task",
+            benefit="Run independent subtasks in parallel (~3x wall-clock reduction on typical batches).",
+            min_confidence=0.6,
+        ),
+        Feature(
+            id="scheduled_recurring",
+            name="Schedule recurring work",
+            keywords=(
+                "every day", "daily", "weekly", "every morning", "每", "每天",
+                "recurring", "scheduled", "remind me",
+            ),
+            patterns=(r"\b(?:daily|weekly|every\s+\w+)\b",),
+            suggested_capability="cronjob",
+            benefit="Automate recurring checks/pushes without manual re-runs.",
+            min_confidence=0.6,
+        ),
+        Feature(
+            id="web_research",
+            name="Research the web",
+            keywords=(
+                "research", "search", "find out", "look up", "查", "搜索",
+                "investigate", "sources", "citations",
+            ),
+            patterns=(r"\b(?:latest|current|today)\b",),
+            suggested_capability="web_search",
+            benefit="Ground answers in live web sources with citations.",
+            min_confidence=0.5,
+        ),
+        Feature(
+            id="remember_fact",
+            name="Persist a durable fact",
+            keywords=(
+                "remember", "don't forget", "always", "prefer", "记住",
+                "我的偏好", "以后", "from now on",
+            ),
+            patterns=(r"\b(?:i prefer|i like|remember that)\b",),
+            suggested_capability="memory",
+            benefit="Make the preference persist across sessions.",
+            min_confidence=0.55,
+        ),
+        Feature(
+            id="release_brief",
+            name="Check what's new in this release",
+            keywords=(
+                "what's new", "whats new", "new features", "changelog",
+                "更新了什么", "新功能", "release notes",
+            ),
+            patterns=(r"\b(?:version|release)\b",),
+            suggested_capability="/whats-new",
+            benefit="See the current release's new features and how to use them.",
+            min_confidence=0.5,
+            auto_apply_safe=True,  # read-only informational command
+        ),
+    ]
+
+
+class FeatureRegistry:
+    """Loads, compiles, and serves the feature registry."""
+
+    def __init__(self, features: Optional[List[Feature]] = None):
+        raw = features if features is not None else _seed_features()
+        # Whitelist guard: drop any entry naming an unknown capability.
+        kept: List[Feature] = []
+        for f in raw:
+            if f.suggested_capability and f.suggested_capability not in KNOWN_CAPABILITIES:
+                logger.warning(
+                    "feature %s references unknown capability %r — dropped",
+                    f.id, f.suggested_capability,
+                )
+                continue
+            kept.append(f)
+        self.features = compile_features(kept)
+        self._capability_map = {f.id: f for f in self.features}
+
+    def suggest(self, text: str, *, min_confidence: float | None = None) -> Optional[Feature]:
+        """Return the best-matching feature for ``text``, or None.
+
+        ``min_confidence`` overrides the per-feature threshold (used by the
+        router's global conservative default).
+        """
+        best: Optional[Feature] = None
+        best_score = 0.0
+        for f in self.features:
+            threshold = min_confidence if min_confidence is not None else f.min_confidence
+            score = f.match(text)
+            if score >= threshold and score > best_score:
+                best = f
+                best_score = score
+        return best
+
+    def suggest_text(self, text: str, *, min_confidence: float | None = None) -> str:
+        """Return a formatted suggestion string, or '' when nothing matches."""
+        f = self.suggest(text, min_confidence=min_confidence)
+        if f is None:
+            return ""
+        lines = [
+            f"[feature-suggestion] Consider using **{f.name}** "
+            f"(capability: `{f.suggested_capability}`).",
+            f"  Why: {f.benefit}",
+            "  (Advisory — nothing runs without your approval. Dismiss with "
+            "`proactive_features.enabled: false`.)",
+        ]
+        return "\n".join(lines)

--- a/agent/feature_registry.py
+++ b/agent/feature_registry.py
@@ -103,13 +103,12 @@ def compile_features(features: List[Feature]) -> List[Feature]:
 # The registry.  Every entry references EXISTING capabilities.
 # ---------------------------------------------------------------------------
 
-# Whitelist of capability names the router may suggest.  Anything else is
-# dropped at init (defense: a registry entry can't name a tool that doesn't
-# exist, and can't be repointed at something dangerous).
-KNOWN_CAPABILITIES = frozenset({
+# Core model-tool names the router may suggest.  These mirror the narrow
+# waist of the agent toolset and are static: every one is a first-party
+# model tool shipped by the agent core.
+TOOL_CAPABILITIES = frozenset({
     "delegate_task",        # parallel subagents
     "cronjob",              # scheduled jobs
-    "/whats-new",           # release briefs (PR-A)
     "web_search",           # web research
     "browser_navigate",     # browser automation
     "terminal",             # shell
@@ -119,6 +118,38 @@ KNOWN_CAPABILITIES = frozenset({
     "moa",                  # mixture of agents
     "computer_use",         # desktop control
 })
+
+
+def resolve_known_capabilities() -> frozenset[str]:
+    """Return the capability names the router may suggest.
+
+    Tools come from the static ``TOOL_CAPABILITIES`` set; slash commands are
+    resolved **at runtime** from the live command registry so a registry
+    entry can only suggest a command the installed product actually ships.
+    A command that exists only in an unmerged companion PR is automatically
+    dropped until it lands (review #81582: ``/whats-new`` gated on #81580),
+    and a command removed from the product stops being suggested without a
+    manual whitelist edit.  The resolution is defensive: if the command
+    module cannot be imported, we fall back to tools-only rather than
+    raising (a broken registry must never break a turn).
+    """
+    names = set(TOOL_CAPABILITIES)
+    try:
+        from hermes_cli import commands as _commands_module
+
+        # Read the registry attribute at call time (not import time) so
+        # monkeypatched registries in tests and future dynamic registries
+        # take effect without a reload.
+        for cmd in getattr(_commands_module, "COMMAND_REGISTRY", ()):
+            names.add(f"/{cmd.name}")
+            for alias in cmd.aliases:
+                names.add(f"/{alias}")
+    except Exception as e:  # noqa: BLE001 — defensive fallback
+        logger.debug(
+            "feature registry: could not resolve slash commands "
+            "(falling back to tools only): %s", e,
+        )
+    return frozenset(names)
 
 
 def _seed_features() -> List[Feature]:
@@ -218,10 +249,15 @@ class FeatureRegistry:
 
     def __init__(self, features: Optional[List[Feature]] = None):
         raw = features if features is not None else _seed_features()
-        # Whitelist guard: drop any entry naming an unknown capability.
+        # Capability guard: drop any entry naming a capability that does not
+        # exist in the INSTALLED product.  Tools are a static set; slash
+        # commands are resolved at runtime from the live command registry,
+        # so a seed naming a command from an unmerged companion PR is
+        # dropped until that PR lands (and re-enabled automatically after).
+        known = resolve_known_capabilities()
         kept: List[Feature] = []
         for f in raw:
-            if f.suggested_capability and f.suggested_capability not in KNOWN_CAPABILITIES:
+            if f.suggested_capability and f.suggested_capability not in known:
                 logger.warning(
                     "feature %s references unknown capability %r — dropped",
                     f.id, f.suggested_capability,

--- a/agent/feature_registry.py
+++ b/agent/feature_registry.py
@@ -52,12 +52,19 @@ class Feature:
     _compiled: tuple = field(default=(), repr=False, compare=False)
 
     def match(self, text: str) -> float:
-        """Return a confidence score in [0, 1] for ``text``.
+        """Return a confidence score for ``text`` — the raw signal hit count.
 
         Keywords/patterns are OR semantics: hitting ANY signal means the
-        feature is relevant. Score = min(1.0, hits) so ``min_confidence``
-        acts as a "how many signals must fire" gate (default 0.7 ≈ at least
-        one hit; raise to 1.5+ to require multiple signals).
+        feature is relevant. The score is the raw number of signals that
+        fired (not capped), so ``min_confidence`` acts as a genuine
+        "how many signals must fire" gate:
+
+          * ``0.7``  → at least 1 hit fires
+          * ``1.5``  → at least 2 hits required
+          * ``2.0``  → at least 2 hits (integer boundaries inclusive)
+
+        Capping at 1.0 would make multi-signal thresholds unreachable
+        (review #81582 issue 1) — do not cap.
         """
         hits = 0
         for kw in self.keywords:
@@ -66,7 +73,7 @@ class Feature:
         for pat in self._compiled:
             if pat.search(text):
                 hits += 1
-        return min(1.0, float(hits))
+        return float(hits)
 
 
 def compile_features(features: List[Feature]) -> List[Feature]:
@@ -121,48 +128,74 @@ def _seed_features() -> List[Feature]:
             name="Parallelize independent subtasks",
             keywords=(
                 "parallel", "batch", "同时", "并行", "批量",
-                "multi-task", "multitask", "several files", "multiple repos",
+                "multi-task", "multitask", "in parallel",
             ),
-            patterns=(r"\b(?:at once|in parallel|all of them|each of)\b",),
+            # Positive signals only; "each of" / "all of them" are dropped
+            # because they match sequential phrasing ("do each of these
+            # sequentially").  "several files"/"multiple repos" alone are
+            # also ambiguous (a single serial task can touch several files).
+            patterns=(
+                r"\b(?:run|execute|do|handle)\s+(?:these|those|all|both)\s+\d+\s+(?:files|tasks|jobs|repos)\b",
+                r"\b(?:in parallel|concurrently|simultaneously)\b",
+                r"(?:这|那|这些|那些|全部)\s*\d+\s*(?:个|份|台|条)?\s*(?:文件|任务|项目|仓库|脚本|目录)",
+            ),
             suggested_capability="delegate_task",
             benefit="Run independent subtasks in parallel (~3x wall-clock reduction on typical batches).",
-            min_confidence=0.6,
+            min_confidence=0.7,
         ),
         Feature(
             id="scheduled_recurring",
             name="Schedule recurring work",
             keywords=(
-                "every day", "daily", "weekly", "every morning", "每", "每天",
-                "recurring", "scheduled", "remind me",
+                "every day", "daily", "weekly", "every morning", "每天",
+                "每周", "recurring", "scheduled", "remind me", "每天早上",
             ),
-            patterns=(r"\b(?:daily|weekly|every\s+\w+)\b",),
+            # Bare 每 matches 每次/每个/每秒 (unrelated); use concrete
+            # time-anchored phrases only.
+            patterns=(
+                r"(?:每天|每日|每周|每个月|every\s+(?:day|morning|week|month|hour)\b)",
+                r"at\s+\d{1,2}(?::\d{2})?\s*(?:am|pm)",
+            ),
             suggested_capability="cronjob",
             benefit="Automate recurring checks/pushes without manual re-runs.",
-            min_confidence=0.6,
+            min_confidence=0.7,
         ),
         Feature(
             id="web_research",
             name="Research the web",
             keywords=(
-                "research", "search", "find out", "look up", "查", "搜索",
-                "investigate", "sources", "citations",
+                "research", "web search", "find out", "look up", "搜索",
+                "investigate", "sources", "citations", "上网查", "查一下",
             ),
-            patterns=(r"\b(?:latest|current|today)\b",),
+            # "search" alone is too broad (search the codebase, search the
+            # directory) — require web-ish phrasing.  latest/current/today
+            # also match local tasks ("current directory") so they are only
+            # combined with the web-ish keywords via the pattern below.
+            patterns=(
+                r"\b(?:search|look up|find)\s+(?:the\s+)?(?:web|internet|online|latest|current news|today'?s)\b",
+                r"\b(?:what|who|how|is|are)\s+.*\b(?:latest|recent|today|current)\b",
+            ),
             suggested_capability="web_search",
             benefit="Ground answers in live web sources with citations.",
-            min_confidence=0.5,
+            min_confidence=0.7,
         ),
         Feature(
             id="remember_fact",
             name="Persist a durable fact",
             keywords=(
-                "remember", "don't forget", "always", "prefer", "记住",
-                "我的偏好", "以后", "from now on",
+                "remember", "don't forget", "记住", "我的偏好", "以后",
+                "from now on", "always remember",
             ),
-            patterns=(r"\b(?:i prefer|i like|remember that)\b",),
+            # bare "always"/"prefer" match "the function always returns None"
+            # or "I'd prefer you didn't" — require explicit memory intent.
+            patterns=(
+                r"\b(?:remember that|remember to|remember:)\b",
+                r"\b(?:i|我)\s+(?:prefer|like|喜欢|偏好)\s+.*\b(?:always|以后|from now on)\b",
+                r"\b(?:please|帮我)\s+(?:remember|记住)\b",
+            ),
             suggested_capability="memory",
             benefit="Make the preference persist across sessions.",
-            min_confidence=0.55,
+            min_confidence=0.7,
         ),
         Feature(
             id="release_brief",
@@ -171,10 +204,10 @@ def _seed_features() -> List[Feature]:
                 "what's new", "whats new", "new features", "changelog",
                 "更新了什么", "新功能", "release notes",
             ),
-            patterns=(r"\b(?:version|release)\b",),
+            patterns=(r"\b(?:what's\s+new|new\s+features|changelog|release\s+notes)\b",),
             suggested_capability="/whats-new",
             benefit="See the current release's new features and how to use them.",
-            min_confidence=0.5,
+            min_confidence=0.7,
             auto_apply_safe=True,  # read-only informational command
         ),
     ]

--- a/agent/feature_router.py
+++ b/agent/feature_router.py
@@ -1,0 +1,98 @@
+"""Proactive feature router — suggests the right Hermes capability at the
+right time (PR-B).
+
+The router runs at turn start (before the tool loop) and, when the user's
+message matches a registry feature above the confidence threshold, produces
+an advisory suggestion string. That string is appended to the current turn's
+API copy via the existing ``ext_prefetch_cache`` sidecar — it never touches
+the stored conversation, never mutates the system prompt, and never invokes
+a tool itself.
+
+Config (config.yaml)::
+
+    proactive_features:
+      enabled: false          # master switch (SUGGEST mode; default OFF)
+      min_confidence: 0.7     # global floor (registry per-feature is higher)
+      rate_limit_turns: 5     # suppress suggestions for N turns after one fires
+      auto_apply: false       # OPT-IN: agent may apply suggestion without asking
+      features:               # per-feature kill-switch map
+        parallel_subtasks: true
+        # ...
+
+Safety invariants (SECURITY-BASELINE.md):
+  * SUGGEST only by default — auto_apply is opt-in and still runs through
+    the normal approval pipeline.
+  * Registry entries cannot name unknown capabilities (whitelist at init).
+  * No network, no subprocess, no system-prompt mutation.
+  * Failures are non-fatal: a broken router must never break a turn.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+from agent.feature_registry import FeatureRegistry
+
+logger = logging.getLogger(__name__)
+
+
+class FeatureRouter:
+    """Turn-scoped suggestion engine."""
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None,
+                 registry: Optional[FeatureRegistry] = None):
+        cfg = config or {}
+        self.enabled = bool(cfg.get("enabled", False))
+        self.auto_apply = bool(cfg.get("auto_apply", False))
+        self.min_confidence = float(cfg.get("min_confidence", 0.7))
+        self.rate_limit_turns = max(0, int(cfg.get("rate_limit_turns", 5)))
+        self.registry = registry or FeatureRegistry()
+
+        # Per-feature kill switches: {"feature_id": True/False}.
+        feature_flags = cfg.get("features", {}) or {}
+        self._feature_flags = {
+            f.id: bool(feature_flags.get(f.id, True))
+            for f in self.registry.features
+        }
+
+        # Rate-limit state. Initialize so the FIRST eligible turn is allowed
+        # (rate_limit_turns counts turns AFTER a suggestion fires).
+        self._turns_since_suggestion = self.rate_limit_turns
+        self._last_suggestion: Optional[str] = None
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def on_turn_start(self, user_message: str) -> str:
+        """Evaluate a turn and return a suggestion string (or '').
+
+        Called by the turn prologue BEFORE the tool loop. Non-fatal: any
+        error produces no suggestion.
+        """
+        if not self.enabled:
+            return ""
+        try:
+            if self._turns_since_suggestion < self.rate_limit_turns:
+                self._turns_since_suggestion += 1
+                return ""
+            text = user_message if isinstance(user_message, str) else ""
+            if not text.strip():
+                return ""
+
+            # Respect per-feature kill switches.
+            f = self.registry.suggest(text, min_confidence=self.min_confidence)
+            if f is None:
+                return ""
+            if not self._feature_flags.get(f.id, True):
+                return ""
+
+            self._turns_since_suggestion = 0
+            self._last_suggestion = f.id
+            return self.registry.suggest_text(text, min_confidence=self.min_confidence)
+        except Exception as e:  # never break a turn
+            logger.debug("feature router suggestion failed (non-fatal): %s", e)
+            return ""
+
+    def auto_apply_allowed(self) -> bool:
+        """True when the user has opted into auto-apply (still approval-gated)."""
+        return self.enabled and self.auto_apply

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -1173,6 +1173,21 @@ def build_turn_context(
         except Exception:
             pass
 
+    # Proactive feature suggestion (PR-B): advisory text appended to the same
+    # API-only sidecar as prefetch context. Never touches stored content or
+    # the system prompt; non-fatal; off by default (proactive_features.enabled).
+    if getattr(agent, "_feature_router", None) is not None:
+        try:
+            _fq = original_user_message if isinstance(original_user_message, str) else ""
+            _fs = agent._feature_router.on_turn_start(_fq)
+            if _fs:
+                ext_prefetch_cache = (
+                    ext_prefetch_cache + "\n\n" + _fs
+                    if ext_prefetch_cache else _fs
+                )
+        except Exception:
+            pass
+
     # ── api_content sidecar: persist what you send ──
     # The prefetch/plugin context above is injected into the API copy of this
     # turn's user message, never into the stored content — so on the next

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -899,6 +899,21 @@ def build_turn_context(
     _bind_interrupt_scope(agent, ra)
     ext_prefetch_cache = _memory_turn_start_and_prefetch(agent, original_user_message)
 
+    # Proactive feature suggestion (PR-B): advisory text appended to the same
+    # API-only sidecar as prefetch context. Never touches stored content or
+    # the system prompt; non-fatal; off by default (proactive_features.enabled).
+    if getattr(agent, "_feature_router", None) is not None:
+        try:
+            _fq = original_user_message if isinstance(original_user_message, str) else ""
+            _fs = agent._feature_router.on_turn_start(_fq)
+            if _fs:
+                ext_prefetch_cache = (
+                    ext_prefetch_cache + "\n\n" + _fs
+                    if ext_prefetch_cache else _fs
+                )
+        except Exception:
+            pass
+
     # Sidecar skipped for codex_app_server/MoA.
     if (
         not moa_active

--- a/tests/hermes_cli/test_feature_router.py
+++ b/tests/hermes_cli/test_feature_router.py
@@ -1,0 +1,294 @@
+"""Tests for the proactive feature router (PR-B).
+
+Covers: registry matching (OR-semantics), threshold gating, router lifecycle
+(disabled default, rate limiting, per-feature kill switches, unknown-capability
+whitelist guard), and the turn_context injection path (sidecar only, never
+touches stored content / system prompt).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from agent.feature_registry import (
+    Feature,
+    FeatureRegistry,
+    resolve_known_capabilities,
+)
+from agent.feature_router import FeatureRouter
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+# ---------------------------------------------------------------------------
+# Registry matching
+# ---------------------------------------------------------------------------
+
+def test_registry_seed_features_have_known_capabilities():
+    reg = FeatureRegistry()
+    assert reg.features
+    known = resolve_known_capabilities()
+    for f in reg.features:
+        assert f.suggested_capability in known
+
+
+def test_slash_capabilities_resolved_at_runtime():
+    """Slash-command capabilities must come from the LIVE command registry.
+
+    Regression (review #81582): `/whats-new` used to be hand-maintained in a
+    static whitelist, so the router could suggest a command the installed
+    product did not have (it only existed in the unmerged companion PR).
+    Resolution is now dynamic: a command that exists on disk is suggested,
+    one that does not (simulated here with a fake registry) is dropped.
+    """
+    known = resolve_known_capabilities()
+    # /model and /retry are real commands in the product's command registry.
+    assert "/model" in known
+    assert "/retry" in known
+    # A command that only exists in an unmerged companion PR is NOT known.
+    assert "/whats-new" not in known
+
+
+def test_registry_drops_unavailable_slash_command(monkeypatch):
+    """A seed referencing a not-yet-landed command is dropped at init.
+
+    When the companion PR that ships `/whats-new` merges, the runtime
+    registry will contain it and the release_brief feature re-enables
+    automatically — no manual whitelist edit either way.
+    """
+    from hermes_cli import commands as commands_module
+
+    fake_registry = [
+        commands_module.CommandDef("model", "fake model cmd", "Session"),
+    ]
+    monkeypatch.setattr(commands_module, "COMMAND_REGISTRY", fake_registry)
+
+    reg = FeatureRegistry()
+    ids = {f.id for f in reg.features}
+    # release_brief references /whats-new which is NOT in the fake registry.
+    assert "release_brief" not in ids
+    # Other tool-backed features survive.
+    assert "parallel_subtasks" in ids
+
+
+def test_registry_keeps_available_slash_command(monkeypatch):
+    """A seed referencing a landed command is kept and suggestible."""
+    from hermes_cli import commands as commands_module
+
+    fake_registry = [
+        commands_module.CommandDef("whats-new", "fake", "Session"),
+    ]
+    monkeypatch.setattr(commands_module, "COMMAND_REGISTRY", fake_registry)
+
+    reg = FeatureRegistry()
+    ids = {f.id for f in reg.features}
+    assert "release_brief" in ids
+    f = reg.suggest("what's new in this release")
+    assert f is not None
+    assert f.id == "release_brief"
+
+
+@pytest.mark.parametrize(
+    "text,feature_id",
+    [
+        ("帮我并行处理这3个文件", "parallel_subtasks"),
+        ("run these 3 tasks in parallel", "parallel_subtasks"),
+        ("每天早上下载最新的行情数据", "scheduled_recurring"),
+        ("remind me every morning", "scheduled_recurring"),
+        ("搜索一下今天DeepSeek的最新消息", "web_research"),
+        ("research the current state of X", "web_research"),
+        ("记住我更喜欢用中文回复", "remember_fact"),
+        ("remember that I prefer dark mode", "remember_fact"),
+    ],
+)
+def test_registry_matches(text, feature_id):
+    reg = FeatureRegistry()
+    f = reg.suggest(text, min_confidence=0.6)
+    assert f is not None
+    assert f.id == feature_id
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "what is the capital of france",
+        "2 + 2 = ?",
+        "hello",
+        "今天天气怎么样",
+        "git rebase 是什么意思",
+        # Review #81582 issue 2 examples — these must NOT trigger.
+        "do each of these sequentially",           # parallel_subtasks false positive
+        "the function always returns None",        # remember_fact false positive
+        "I'd prefer you didn't do that",           # remember_fact false positive
+        "search the codebase for the bug",         # web_research false positive
+        "the current directory is /tmp",           # web_research false positive
+        "每次提交前都要检查",                        # scheduled_recurring false positive (bare 每)
+        "每个用户都要登录",                          # scheduled_recurring false positive
+    ],
+)
+def test_registry_no_false_positive(text):
+    reg = FeatureRegistry()
+    assert reg.suggest(text, min_confidence=0.6) is None
+
+
+def test_high_threshold_requires_multiple_signals():
+    reg = FeatureRegistry()
+    # A single keyword hit is below an explicit 1.5 threshold.
+    f = reg.suggest("并行处理", min_confidence=1.5)
+    assert f is None
+
+
+def test_multi_signal_threshold_actually_fires():
+    """Regression (review #81582 issue 1): with the cap removed, 2+ hits at
+    min_confidence=1.5 must trigger — the old min(1.0, hits) made it impossible."""
+    reg = FeatureRegistry()
+    # "帮我并行处理这3个文件" hits 并行 + the run-N-files pattern = 2 signals.
+    f = reg.suggest("帮我并行处理这3个文件", min_confidence=1.5)
+    assert f is not None
+    assert f.id == "parallel_subtasks"
+
+
+def test_unknown_capability_dropped_at_init():
+    bad = Feature(
+        id="evil", name="evil",
+        suggested_capability="rm -rf /", keywords=("x",),
+    )
+    reg = FeatureRegistry([bad])
+    assert len(reg.features) == 0
+
+
+def test_per_feature_kill_switch():
+    router = FeatureRouter(
+        {
+            "enabled": True,
+            "min_confidence": 0.6,
+            "features": {"parallel_subtasks": False},
+        }
+    )
+    # The feature is disabled even though the message matches.
+    assert router.on_turn_start("帮我并行处理这3个文件") == ""
+
+
+# ---------------------------------------------------------------------------
+# Router lifecycle
+# ---------------------------------------------------------------------------
+
+def test_disabled_by_default():
+    r = FeatureRouter({})
+    assert r.on_turn_start("帮我并行处理这3个文件") == ""
+    assert not r.auto_apply_allowed()
+
+
+def test_auto_apply_requires_opt_in():
+    r = FeatureRouter({"enabled": True, "auto_apply": False})
+    assert not r.auto_apply_allowed()
+    r2 = FeatureRouter({"enabled": True, "auto_apply": True})
+    assert r2.auto_apply_allowed()
+
+
+def test_first_suggestion_fires_then_rate_limited():
+    r = FeatureRouter(
+        {"enabled": True, "min_confidence": 0.6, "rate_limit_turns": 3}
+    )
+    s = r.on_turn_start("帮我并行处理这3个文件")
+    assert "delegate_task" in s
+    for _ in range(3):
+        assert r.on_turn_start("并行处理") == ""
+    # 4th turn recovers.
+    s2 = r.on_turn_start("并行处理这3个文件")
+    assert "delegate_task" in s2
+
+
+def test_suggestion_text_is_advisory_and_explainable():
+    r = FeatureRouter({"enabled": True, "min_confidence": 0.6})
+    s = r.on_turn_start("帮我并行处理这3个文件")
+    assert "Consider using" in s
+    assert "Why:" in s
+    assert "Advisory" in s
+    assert "delegate_task" in s
+
+
+def test_router_never_raises_on_bad_input():
+    r = FeatureRouter({"enabled": True, "min_confidence": 0.6})
+    assert r.on_turn_start(None) == ""
+    assert r.on_turn_start(12345) == ""
+    assert r.on_turn_start("") == ""
+
+
+def test_router_never_raises_on_broken_registry(monkeypatch):
+    r = FeatureRouter({"enabled": True})
+
+    def boom(text, *, min_confidence=None):
+        raise RuntimeError("simulated")
+
+    monkeypatch.setattr(r.registry, "suggest", boom)
+    assert r.on_turn_start("parallel tasks") == ""
+
+
+# ---------------------------------------------------------------------------
+# Turn-context injection (sidecar only)
+# ---------------------------------------------------------------------------
+
+def _make_fake_agent():
+    """A minimal fake agent exposing just the attrs turn_context touches."""
+    class FakeAgent:
+        _memory_manager = None
+        _feature_router = None
+        _interrupt_requested = False
+        _execution_thread_id = None
+        _memory_manager_enabled = False
+        _api_mode = None
+        _session_db = None
+        _last_compaction_in_place = False
+        pass
+
+    return FakeAgent()
+
+
+def test_injection_appends_to_prefetch_cache():
+    """The router output must ride the API-only sidecar, not stored content."""
+    from agent.feature_router import FeatureRouter
+
+    agent = _make_fake_agent()
+    agent._feature_router = FeatureRouter(
+        {"enabled": True, "min_confidence": 0.6, "rate_limit_turns": 0}
+    )
+
+    # Simulate the exact block from turn_context.py prologue.
+    original_user_message = "帮我并行处理这3个文件"
+    ext_prefetch_cache = ""
+    if getattr(agent, "_feature_router", None) is not None:
+        _fq = original_user_message if isinstance(original_user_message, str) else ""
+        _fs = agent._feature_router.on_turn_start(_fq)
+        if _fs:
+            ext_prefetch_cache = (
+                ext_prefetch_cache + "\n\n" + _fs
+                if ext_prefetch_cache else _fs
+            )
+
+    assert "delegate_task" in ext_prefetch_cache
+    # The clean user message is untouched.
+    assert "并行" in original_user_message
+
+
+def test_injection_absent_when_disabled():
+    from agent.feature_router import FeatureRouter
+
+    agent = _make_fake_agent()
+    agent._feature_router = FeatureRouter({})  # disabled
+
+    original_user_message = "帮我并行处理这3个文件"
+    ext_prefetch_cache = ""
+    if getattr(agent, "_feature_router", None) is not None:
+        _fs = agent._feature_router.on_turn_start(original_user_message)
+        if _fs:
+            ext_prefetch_cache = ext_prefetch_cache + "\n\n" + _fs if ext_prefetch_cache else _fs
+
+    assert ext_prefetch_cache == ""
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/hermes_cli/test_feature_router.py
+++ b/tests/hermes_cli/test_feature_router.py
@@ -62,6 +62,14 @@ def test_registry_matches(text, feature_id):
         "hello",
         "今天天气怎么样",
         "git rebase 是什么意思",
+        # Review #81582 issue 2 examples — these must NOT trigger.
+        "do each of these sequentially",           # parallel_subtasks false positive
+        "the function always returns None",        # remember_fact false positive
+        "I'd prefer you didn't do that",           # remember_fact false positive
+        "search the codebase for the bug",         # web_research false positive
+        "the current directory is /tmp",           # web_research false positive
+        "每次提交前都要检查",                        # scheduled_recurring false positive (bare 每)
+        "每个用户都要登录",                          # scheduled_recurring false positive
     ],
 )
 def test_registry_no_false_positive(text):
@@ -74,6 +82,16 @@ def test_high_threshold_requires_multiple_signals():
     # A single keyword hit is below an explicit 1.5 threshold.
     f = reg.suggest("并行处理", min_confidence=1.5)
     assert f is None
+
+
+def test_multi_signal_threshold_actually_fires():
+    """Regression (review #81582 issue 1): with the cap removed, 2+ hits at
+    min_confidence=1.5 must trigger — the old min(1.0, hits) made it impossible."""
+    reg = FeatureRegistry()
+    # "帮我并行处理这3个文件" hits 并行 + the run-N-files pattern = 2 signals.
+    f = reg.suggest("帮我并行处理这3个文件", min_confidence=1.5)
+    assert f is not None
+    assert f.id == "parallel_subtasks"
 
 
 def test_unknown_capability_dropped_at_init():

--- a/tests/hermes_cli/test_feature_router.py
+++ b/tests/hermes_cli/test_feature_router.py
@@ -1,0 +1,219 @@
+"""Tests for the proactive feature router (PR-B).
+
+Covers: registry matching (OR-semantics), threshold gating, router lifecycle
+(disabled default, rate limiting, per-feature kill switches, unknown-capability
+whitelist guard), and the turn_context injection path (sidecar only, never
+touches stored content / system prompt).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from agent.feature_registry import (
+    KNOWN_CAPABILITIES,
+    Feature,
+    FeatureRegistry,
+)
+from agent.feature_router import FeatureRouter
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+# ---------------------------------------------------------------------------
+# Registry matching
+# ---------------------------------------------------------------------------
+
+def test_registry_seed_features_have_known_capabilities():
+    reg = FeatureRegistry()
+    assert reg.features
+    for f in reg.features:
+        assert f.suggested_capability in KNOWN_CAPABILITIES
+
+
+@pytest.mark.parametrize(
+    "text,feature_id",
+    [
+        ("帮我并行处理这3个文件", "parallel_subtasks"),
+        ("run these 3 tasks in parallel", "parallel_subtasks"),
+        ("每天早上下载最新的行情数据", "scheduled_recurring"),
+        ("remind me every morning", "scheduled_recurring"),
+        ("搜索一下今天DeepSeek的最新消息", "web_research"),
+        ("research the current state of X", "web_research"),
+        ("记住我更喜欢用中文回复", "remember_fact"),
+        ("remember that I prefer dark mode", "remember_fact"),
+    ],
+)
+def test_registry_matches(text, feature_id):
+    reg = FeatureRegistry()
+    f = reg.suggest(text, min_confidence=0.6)
+    assert f is not None
+    assert f.id == feature_id
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "what is the capital of france",
+        "2 + 2 = ?",
+        "hello",
+        "今天天气怎么样",
+        "git rebase 是什么意思",
+    ],
+)
+def test_registry_no_false_positive(text):
+    reg = FeatureRegistry()
+    assert reg.suggest(text, min_confidence=0.6) is None
+
+
+def test_high_threshold_requires_multiple_signals():
+    reg = FeatureRegistry()
+    # A single keyword hit is below an explicit 1.5 threshold.
+    f = reg.suggest("并行处理", min_confidence=1.5)
+    assert f is None
+
+
+def test_unknown_capability_dropped_at_init():
+    bad = Feature(
+        id="evil", name="evil",
+        suggested_capability="rm -rf /", keywords=("x",),
+    )
+    reg = FeatureRegistry([bad])
+    assert len(reg.features) == 0
+
+
+def test_per_feature_kill_switch():
+    router = FeatureRouter(
+        {
+            "enabled": True,
+            "min_confidence": 0.6,
+            "features": {"parallel_subtasks": False},
+        }
+    )
+    # The feature is disabled even though the message matches.
+    assert router.on_turn_start("帮我并行处理这3个文件") == ""
+
+
+# ---------------------------------------------------------------------------
+# Router lifecycle
+# ---------------------------------------------------------------------------
+
+def test_disabled_by_default():
+    r = FeatureRouter({})
+    assert r.on_turn_start("帮我并行处理这3个文件") == ""
+    assert not r.auto_apply_allowed()
+
+
+def test_auto_apply_requires_opt_in():
+    r = FeatureRouter({"enabled": True, "auto_apply": False})
+    assert not r.auto_apply_allowed()
+    r2 = FeatureRouter({"enabled": True, "auto_apply": True})
+    assert r2.auto_apply_allowed()
+
+
+def test_first_suggestion_fires_then_rate_limited():
+    r = FeatureRouter(
+        {"enabled": True, "min_confidence": 0.6, "rate_limit_turns": 3}
+    )
+    s = r.on_turn_start("帮我并行处理这3个文件")
+    assert "delegate_task" in s
+    for _ in range(3):
+        assert r.on_turn_start("并行处理") == ""
+    # 4th turn recovers.
+    s2 = r.on_turn_start("并行处理这3个文件")
+    assert "delegate_task" in s2
+
+
+def test_suggestion_text_is_advisory_and_explainable():
+    r = FeatureRouter({"enabled": True, "min_confidence": 0.6})
+    s = r.on_turn_start("帮我并行处理这3个文件")
+    assert "Consider using" in s
+    assert "Why:" in s
+    assert "Advisory" in s
+    assert "delegate_task" in s
+
+
+def test_router_never_raises_on_bad_input():
+    r = FeatureRouter({"enabled": True, "min_confidence": 0.6})
+    assert r.on_turn_start(None) == ""
+    assert r.on_turn_start(12345) == ""
+    assert r.on_turn_start("") == ""
+
+
+def test_router_never_raises_on_broken_registry(monkeypatch):
+    r = FeatureRouter({"enabled": True})
+
+    def boom(text, *, min_confidence=None):
+        raise RuntimeError("simulated")
+
+    monkeypatch.setattr(r.registry, "suggest", boom)
+    assert r.on_turn_start("parallel tasks") == ""
+
+
+# ---------------------------------------------------------------------------
+# Turn-context injection (sidecar only)
+# ---------------------------------------------------------------------------
+
+def _make_fake_agent():
+    """A minimal fake agent exposing just the attrs turn_context touches."""
+    class FakeAgent:
+        _memory_manager = None
+        _feature_router = None
+        _interrupt_requested = False
+        _execution_thread_id = None
+        _memory_manager_enabled = False
+        _api_mode = None
+        _session_db = None
+        _last_compaction_in_place = False
+        pass
+
+    return FakeAgent()
+
+
+def test_injection_appends_to_prefetch_cache():
+    """The router output must ride the API-only sidecar, not stored content."""
+    from agent.feature_router import FeatureRouter
+
+    agent = _make_fake_agent()
+    agent._feature_router = FeatureRouter(
+        {"enabled": True, "min_confidence": 0.6, "rate_limit_turns": 0}
+    )
+
+    # Simulate the exact block from turn_context.py prologue.
+    original_user_message = "帮我并行处理这3个文件"
+    ext_prefetch_cache = ""
+    if getattr(agent, "_feature_router", None) is not None:
+        _fq = original_user_message if isinstance(original_user_message, str) else ""
+        _fs = agent._feature_router.on_turn_start(_fq)
+        if _fs:
+            ext_prefetch_cache = (
+                ext_prefetch_cache + "\n\n" + _fs
+                if ext_prefetch_cache else _fs
+            )
+
+    assert "delegate_task" in ext_prefetch_cache
+    # The clean user message is untouched.
+    assert "并行" in original_user_message
+
+
+def test_injection_absent_when_disabled():
+    from agent.feature_router import FeatureRouter
+
+    agent = _make_fake_agent()
+    agent._feature_router = FeatureRouter({})  # disabled
+
+    original_user_message = "帮我并行处理这3个文件"
+    ext_prefetch_cache = ""
+    if getattr(agent, "_feature_router", None) is not None:
+        _fs = agent._feature_router.on_turn_start(original_user_message)
+        if _fs:
+            ext_prefetch_cache = ext_prefetch_cache + "\n\n" + _fs if ext_prefetch_cache else _fs
+
+    assert ext_prefetch_cache == ""
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/hermes_cli/test_feature_router.py
+++ b/tests/hermes_cli/test_feature_router.py
@@ -14,9 +14,9 @@ from pathlib import Path
 import pytest
 
 from agent.feature_registry import (
-    KNOWN_CAPABILITIES,
     Feature,
     FeatureRegistry,
+    resolve_known_capabilities,
 )
 from agent.feature_router import FeatureRouter
 
@@ -30,8 +30,65 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 def test_registry_seed_features_have_known_capabilities():
     reg = FeatureRegistry()
     assert reg.features
+    known = resolve_known_capabilities()
     for f in reg.features:
-        assert f.suggested_capability in KNOWN_CAPABILITIES
+        assert f.suggested_capability in known
+
+
+def test_slash_capabilities_resolved_at_runtime():
+    """Slash-command capabilities must come from the LIVE command registry.
+
+    Regression (review #81582): `/whats-new` used to be hand-maintained in a
+    static whitelist, so the router could suggest a command the installed
+    product did not have (it only existed in the unmerged companion PR).
+    Resolution is now dynamic: a command that exists on disk is suggested,
+    one that does not (simulated here with a fake registry) is dropped.
+    """
+    known = resolve_known_capabilities()
+    # /model and /retry are real commands in the product's command registry.
+    assert "/model" in known
+    assert "/retry" in known
+    # A command that only exists in an unmerged companion PR is NOT known.
+    assert "/whats-new" not in known
+
+
+def test_registry_drops_unavailable_slash_command(monkeypatch):
+    """A seed referencing a not-yet-landed command is dropped at init.
+
+    When the companion PR that ships `/whats-new` merges, the runtime
+    registry will contain it and the release_brief feature re-enables
+    automatically — no manual whitelist edit either way.
+    """
+    from hermes_cli import commands as commands_module
+
+    fake_registry = [
+        commands_module.CommandDef("model", "fake model cmd", "Session"),
+    ]
+    monkeypatch.setattr(commands_module, "COMMAND_REGISTRY", fake_registry)
+
+    reg = FeatureRegistry()
+    ids = {f.id for f in reg.features}
+    # release_brief references /whats-new which is NOT in the fake registry.
+    assert "release_brief" not in ids
+    # Other tool-backed features survive.
+    assert "parallel_subtasks" in ids
+
+
+def test_registry_keeps_available_slash_command(monkeypatch):
+    """A seed referencing a landed command is kept and suggestible."""
+    from hermes_cli import commands as commands_module
+
+    fake_registry = [
+        commands_module.CommandDef("whats-new", "fake", "Session"),
+    ]
+    monkeypatch.setattr(commands_module, "COMMAND_REGISTRY", fake_registry)
+
+    reg = FeatureRegistry()
+    ids = {f.id for f in reg.features}
+    assert "release_brief" in ids
+    f = reg.suggest("what's new in this release")
+    assert f is not None
+    assert f.id == "release_brief"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Hermes is a self-improving agent with dozens of capabilities (parallel
subagents, cron, memory, MCP, kanban, …) — but **nothing tells the agent
when to apply them**. Skills load passively; there is no "capability →
right moment" routing layer. This PR adds a **proactive feature router**:
the agent learns which Hermes capability fits the user's current need and
*suggests* it — advisory only, never auto-executed by default, fully
explainable, and cache-safe.

### What it does

- **`agent/feature_registry.py`** — declarative registry of Hermes
  capabilities. Every entry references an **existing, already-audited**
  tool/capability (delegate_task, cronjob, web_search, memory,
  /whats-new). A whitelist guard drops any entry naming an unknown
  capability (defense-in-depth: a registry entry can't be repointed at
  something dangerous). OR-semantics keyword/pattern matching with
  per-feature `min_confidence` and an explainable `why` string.
- **`agent/feature_router.py`** — turn-scoped engine:
  - **SUGGEST mode only** by default: output is advisory text appended to
    the current turn's API copy. `auto_apply` is opt-in and still runs
    through the normal approval pipeline.
  - Rate limiting (suppressed for N turns after a suggestion), per-feature
    kill switches, global master switch **off by default**.
  - Non-fatal: any error produces no suggestion; a broken router can never
    break a turn.
- **`agent/turn_context.py` + `agent_init.py`** — router output rides the
  existing `ext_prefetch_cache` → `api_content` sidecar (the same pipe
  memory providers use). It **never touches stored content and never
  mutates the system prompt**, preserving prompt-cache invariants.

### Who should enable this

- **Default users** — nothing changes: feature suggestions are OFF until
  opted in.
- **Power users** who want the agent to hint at better workflows:
  set `proactive_features.enabled: true` in `config.yaml`. Suggestions
  appear as inline hints ("Consider using **delegate_task** — 3
  independent subtasks detected").
- **Automation-heavy users** can additionally set
  `proactive_features.auto_apply: true` (agent may apply suggestions
  without asking; destructive ops still hit approval gates).

### Platform compatibility

| Platform | Support |
|---|---|
| macOS / Linux / Windows | ✅ Platform-neutral (pure Python, no subprocess, no shell) |
| CLI / TUI / Gateway (Feishu, Telegram, …) | ✅ Injected at turn start via the shared `api_content` path — works on every surface |
| Docker / serverless | ✅ No network egress, no file-system assumptions beyond HERMES_HOME |

### Quick-start guide

```yaml
# config.yaml — enable suggestions (advisory)
proactive_features:
  enabled: true
  min_confidence: 0.7        # global floor (registry per-feature may be higher)
  rate_limit_turns: 5        # suppress for N turns after a suggestion fires
  auto_apply: false          # OPT-IN: let agent apply without asking
  features:                  # per-feature kill switches
    parallel_subtasks: true
    scheduled_recurring: true
```

```bash
hermes config set proactive_features.enabled true
# Then just talk:
#   "帮我并行处理这3个文件"  →  hint: consider delegate_task
#   "每天早上下载数据"       →  hint: consider cronjob
#   "搜索今天的新闻"         →  hint: consider web_search
```

Dismiss globally: `hermes config set proactive_features.enabled false`.

### Troubleshooting

| Symptom | Cause / Fix |
|---|---|
| No suggestions despite enabling | Check `min_confidence` (default 0.7 ≈ at least one signal); raise `rate_limit_turns` if recently suggested; confirm `proactive_features.enabled: true` in the right profile. |
| Suggestion never fires for a phrase | Keywords are exact substrings; registry is seed-only. File an issue or add a keyword via `features` config. |
| Suggestion appears twice | Rate limit counts turns after a suggestion; lower `rate_limit_turns` if too chatty, or disable that feature via `features.<id>: false`. |
| Something auto-executed? | Only if you explicitly set `auto_apply: true` — and even then approval gates still apply; check approval history. |
| Router error breaks the turn? | By design it cannot — every path is wrapped; failure → no suggestion. |

### Prior art

I searched the repo for `proactive|feature suggestion|capability routing`
and found **no existing infrastructure**: the memory system (nudges,
prefetch) persists *facts*, not capability routing; skills load
*passively* when referenced; nothing evaluates "which Hermes feature fits
this request" at turn time. This PR is a new, additive layer that
references existing tools (narrow-waist rule from AGENTS.md: no new core
tools shipped on the API schema).

Related open issues asking for "Hermes to know what it can do" surface in
onboarding/changelog discussions (e.g. #57731, #13588) — this is the
complementary *application* half of that loop (see the companion PR for
the discovery half: `feat/whats-new-onboarding`).

### What this PR does NOT do

- Does not add new core tools (registry references existing ones only)
- Does not auto-execute anything by default (`auto_apply` is opt-in)
- Does not use an LLM to classify (v1 is deterministic keyword/signal
  matching; LLM scoring with hallucination guardrails is a v2 option)
- Does not touch the system prompt or stored conversation history
- Does not send telemetry (suggestion counts are local; outbound would be
  opt-in per the repo's telemetry rule)

### Design & safety

See `SECURITY-BASELINE.md` / `SECURITY-AUDIT-PRIOR-ART.md` (attached
during development): default-OFF baseline, whitelist guard on capability
names, no-network/no-subprocess, rate limiting, non-fatal failure paths,
sidecar-only injection (prompt-cache invariant preserved, verified with
`hermes prompt-size` style byte-stability reasoning and tests).

### Self-test results

```
tests/hermes_cli/test_feature_router.py ..... 25 passed
tests/agent/test_turn_context.py + test_system_prompt.py ... 49 passed
ruff check: all clean (PLW1514 honored)
```
