### PR TITLE
fix(gateway): self-reacquire scoped lock when start_time is null or differs

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -1391,7 +1391,15 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
         except (KeyError, TypeError, ValueError):
             existing_pid = None
 
-        if existing_pid == os.getpid() and existing.get("start_time") == record.get("start_time"):
+        # Same live PID as this process: always self-reacquire.
+        # ``start_time`` is a PID-reuse guard for *other* PIDs; it cannot
+        # distinguish two processes that share the caller's own PID (impossible
+        # while we are alive). Requiring start_time equality here falsely
+        # rejects reconnects when the on-disk record has ``start_time: null``
+        # (older writers / psutil failure at first write) while the freshly
+        # built record has a real value — the gateway then reports itself as
+        # the foreign squatter of its own token (#81468).
+        if existing_pid == os.getpid():
             _write_json_file(lock_path, record)
             return True, existing
 
@@ -1503,8 +1511,10 @@ def release_scoped_lock(scope: str, identity: str) -> None:
         return
     if existing.get("pid") != os.getpid():
         return
-    if existing.get("start_time") != _get_process_start_time(os.getpid()):
-        return
+    # Same PID as the live process means we own the lock. Do not require
+    # start_time equality: on-disk null vs a live fingerprint (macOS/psutil
+    # timing) would otherwise leave the lock stuck across Discord/Telegram
+    # reconnects (#81468). start_time only guards PID reuse for *other* PIDs.
     try:
         lock_path.unlink(missing_ok=True)
     except OSError:

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -474,6 +474,37 @@ class TestScopedLocks:
 
         assert not lock_path.exists()
 
+    def test_acquire_scoped_lock_self_reacquires_when_start_times_differ(
+        self, tmp_path, monkeypatch
+    ):
+        """Same PID with two known, differing start_time values must self-reacquire.
+
+        The on-disk record may carry a stale integer (from a previous run or a
+        psutil transient) while the live process now reports a different value.
+        Since the PID is ours, start_time equality is not required.
+        """
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "discord-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": os.getpid(),
+            "start_time": 111,
+            "kind": "hermes-gateway",
+            "argv": ["hermes_cli/main.py", "gateway", "run", "--replace"],
+            "scope": "discord-bot-token",
+        }))
+
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 987654321)
+
+        acquired, existing = status.acquire_scoped_lock(
+            "discord-bot-token", "secret", metadata={"platform": "discord"}
+        )
+
+        assert acquired is True
+        assert existing["pid"] == os.getpid()
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+        assert payload["start_time"] == 987654321
 
     def test_acquire_scoped_lock_race_second_acquirer_loses(self, tmp_path, monkeypatch):
         """Two racing starters both observe the same stale lock. The loser's

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -418,6 +418,62 @@ class TestScopedLocks:
         assert payload["pid"] == os.getpid()
         assert payload["metadata"]["platform"] == "telegram"
 
+    def test_acquire_scoped_lock_self_reacquires_when_disk_start_time_null(
+        self, tmp_path, monkeypatch
+    ):
+        """#81468: same PID with on-disk start_time=null must self-reacquire.
+
+        After Discord 503 reconnect, the scoped lock still names this process
+        but may carry ``start_time: null`` (psutil miss at first write). The
+        freshly built record has a real fingerprint. Requiring equality made
+        the gateway report its own PID as a foreign token squatter.
+        """
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "discord-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": os.getpid(),
+            "start_time": None,
+            "kind": "hermes-gateway",
+            "argv": ["hermes_cli/main.py", "--profile", "milena", "gateway", "run", "--replace"],
+            "scope": "discord-bot-token",
+        }))
+
+        # Live process can resolve start_time; disk cannot — the mismatch
+        # that previously failed the self-reacquire short-circuit.
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 987654321)
+        # If we wrongly fall through to staleness, a gateway-looking self PID
+        # would be treated as a live foreign holder (return False).
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_looks_like_gateway_process", lambda pid: True)
+
+        acquired, existing = status.acquire_scoped_lock(
+            "discord-bot-token", "secret", metadata={"platform": "discord"}
+        )
+
+        assert acquired is True
+        assert existing["pid"] == os.getpid()
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+        assert payload["start_time"] == 987654321
+        assert payload["metadata"]["platform"] == "discord"
+
+    def test_release_scoped_lock_allows_null_disk_start_time(self, tmp_path, monkeypatch):
+        """#81468: release must not no-op when disk start_time is null."""
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "discord-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": os.getpid(),
+            "start_time": None,
+            "kind": "hermes-gateway",
+        }))
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 987654321)
+
+        status.release_scoped_lock("discord-bot-token", "secret")
+
+        assert not lock_path.exists()
+
 
     def test_acquire_scoped_lock_race_second_acquirer_loses(self, tmp_path, monkeypatch):
         """Two racing starters both observe the same stale lock. The loser's


### PR DESCRIPTION
## Summary
Gateway scoped locks no longer falsely reject self-reacquire when the on-disk `start_time` is null or differs from the live value — fixing Discord/Telegram reconnect loops where the gateway reported its own PID as a foreign squatter of its own bot token.

Root cause: `acquire_scoped_lock` and `release_scoped_lock` required BOTH `pid` AND `start_time` to match for the self-PID path. On macOS (no `/proc`), psutil can transiently fail at lock-write time, leaving `start_time: null` on disk while the live record has a real value. The mismatch caused the self-reacquire short-circuit to fail, falling through to the staleness check which correctly found the PID alive and gateway-shaped (it's us) — so it refused acquisition. The gateway then reported its own PID as the squatter.

## Changes
- `gateway/status.py`: `acquire_scoped_lock` self-PID path now fires on PID match alone (start_time is a PID-reuse guard for *other* PIDs; it cannot distinguish two processes sharing our own PID, which is impossible while we're alive). Same fix in `release_scoped_lock`.
- `tests/gateway/test_status.py`: 3 regression tests — null disk start_time self-reacquire, null disk start_time release, and both-known-differing non-null start_time self-reacquire.

The staleness check for *other* PIDs (start_time + cmdline + gateway-shape) is untouched — PID-reuse protection for foreign PIDs remains fully intact.

## Validation
| | Before | After |
|---|---|---|
| test_status.py | 51 passed | 54 passed |
| Ruff | clean | clean |
| E2E self-reacquire (null start_time) | fails | passes |
| E2E self-reacquire (differing non-null) | fails | passes |
| E2E other-PID blocking | passes | passes |
| E2E PID-reuse detection | passes | passes |

Based on #81475 by @HexLab98. Additional test case inspired by #81495 by @JoaoMarcos44.

Closes #81468
