### PR TITLE
fix(simplex): use structured /_send for all DM text sends

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -830,15 +830,17 @@ class SimplexAdapter(BasePlatformAdapter):
 
         if content:
             corr_id = self._make_corr_id()
+            # Structured form: addresses by ID, and json.dumps escapes
+            # newlines + special chars correctly.  The bare @id text
+            # syntax is unreliable for DMs — the daemon silently drops
+            # messages when it cannot resolve the display name.
+            composed = json.dumps(
+                [{"msgContent": {"type": "text", "text": content}}]
+            )
             if chat_id.startswith("group:"):
-                # Structured form: addresses by numeric ID, and json.dumps
-                # escapes newlines + special chars correctly.
-                composed = json.dumps(
-                    [{"msgContent": {"type": "text", "text": content}}]
-                )
                 cmd_str = f"/_send #{chat_id[6:]} json {composed}"
             else:
-                cmd_str = f"@{chat_id} {content}"
+                cmd_str = f"/_send @{chat_id} json {composed}"
 
             await self._send_ws({"corrId": corr_id, "cmd": cmd_str})
 

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -1262,16 +1262,13 @@ async def _standalone_send(
         return {"error": "SimpleX standalone send: SIMPLEX_WS_URL is required"}
 
     try:
+        composed = json.dumps(
+            [{"msgContent": {"type": "text", "text": message}}]
+        )
         if chat_id.startswith("group:"):
             group_id = chat_id[6:]
-            composed = json.dumps(
-                [{"msgContent": {"type": "text", "text": message}}]
-            )
             cmd_str = f"/_send #{group_id} json {composed}"
         else:
-            composed = json.dumps(
-                [{"msgContent": {"type": "text", "text": message}}]
-            )
             cmd_str = f"/_send @{chat_id} json {composed}"
 
         payload = {

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -1269,8 +1269,10 @@ async def _standalone_send(
             )
             cmd_str = f"/_send #{group_id} json {composed}"
         else:
-            # Direct contacts are addressed by display name without brackets.
-            cmd_str = f"@{chat_id} {message}"
+            composed = json.dumps(
+                [{"msgContent": {"type": "text", "text": message}}]
+            )
+            cmd_str = f"/_send @{chat_id} json {composed}"
 
         payload = {
             "corrId": f"{_CORR_PREFIX}snd-{int(time.time() * 1000)}",

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -133,6 +133,35 @@ def test_corr_id_pending_set_self_trims():
 # 7. Outbound send (mocked WS)
 # ---------------------------------------------------------------------------
 
+@pytest.mark.asyncio
+async def test_send_dm():
+    """DMs use the structured ``/_send @<id> json [...]`` form.
+
+    The bare ``@<id> text`` chat-command form is unreliable — the
+    daemon silently drops messages when it cannot resolve the display
+    name.  The structured ``/_send`` form addresses by ID and
+    survives newlines/quoting through ``json.dumps``, matching what
+    ``send_image`` and ``send_document`` already do.
+    """
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+
+    mock_ws = AsyncMock()
+    adapter._ws = mock_ws
+
+    result = await adapter.send("contact-42", "Hello, SimpleX!")
+    mock_ws.send.assert_called_once()
+    payload = json.loads(mock_ws.send.call_args[0][0])
+    assert payload["cmd"].startswith("/_send @contact-42 json ")
+    msg_content = json.loads(payload["cmd"].split(" json ", 1)[1])[0][
+        "msgContent"
+    ]
+    assert msg_content == {"type": "text", "text": "Hello, SimpleX!"}
+    assert payload["corrId"].startswith(_CORR_PREFIX)
+    assert result.success is True
+
+
 
 @pytest.mark.asyncio
 async def test_send_group():

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -298,6 +298,64 @@ async def test_standalone_send_missing_websockets(monkeypatch):
             sys.modules["websockets"] = saved_websockets
 
 
+@pytest.mark.asyncio
+async def test_standalone_send_defaults_to_local_daemon(monkeypatch):
+    monkeypatch.delenv("SIMPLEX_WS_URL", raising=False)
+    pconfig = MagicMock()
+    pconfig.extra = {}
+
+    sent_payloads = []
+
+    class DummyWs:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def send(self, payload):
+            sent_payloads.append(json.loads(payload))
+
+    def fake_connect(url, **kwargs):
+        assert url == "ws://127.0.0.1:5225"
+        assert kwargs["open_timeout"] == 10
+        assert kwargs["close_timeout"] == 5
+        return DummyWs()
+
+    import websockets
+    monkeypatch.setattr(websockets, "connect", fake_connect)
+
+    result = await _standalone_send(pconfig, "contact-42", "hi")
+    assert result == {"success": True, "platform": "simplex", "chat_id": "contact-42"}
+    assert sent_payloads[0]["cmd"].startswith("/_send @contact-42 json ")
+    msg_content = json.loads(
+        sent_payloads[0]["cmd"].split(" json ", 1)[1]
+    )[0]["msgContent"]
+    assert msg_content == {"type": "text", "text": "hi"}
+
+
+@pytest.mark.asyncio
+async def test_health_monitor_does_not_reconnect_quiet_healthy_ws(monkeypatch):
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+    adapter._running = True
+    adapter._last_ws_activity = 0
+    adapter._ws = AsyncMock()
+
+    monkeypatch.setattr(_simplex, "HEALTH_CHECK_INTERVAL", 0.01)
+    monkeypatch.setattr(_simplex, "HEALTH_CHECK_STALE_THRESHOLD", 0.01)
+
+    task = asyncio.create_task(adapter._health_monitor())
+    await asyncio.sleep(0.03)
+    adapter._running = False
+    await asyncio.wait_for(task, timeout=1)
+
+    adapter._ws.close.assert_not_called()
+
+
+
+
 # ---------------------------------------------------------------------------
 # 10. register() — plugin-side metadata
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
SimpleX DM replies and standalone sends no longer silently drop — both `send()` and `_standalone_send()` now use the structured `/_send @<id> json [...]` form that `send_image`, `send_document`, and group sends already use.

The bare `@<id> text` chat-command form is unreliable for DMs: the SimpleX daemon treats the `@<id>` as a display-name lookup, not a numeric ID, so when it can't resolve the display name it silently drops the message. The numeric contact ID Hermes stores in `channel_directory.json` gets sent as if it were a username.

## Changes
- `plugins/platforms/simplex/adapter.py` `send()`: replaced bare `@{chat_id} {content}` with `/_send @{chat_id} json {composed}`, hoisting the `json.dumps` call above the group/DM branch so both share it.
- `plugins/platforms/simplex/adapter.py` `_standalone_send()`: same fix for the standalone send path (used by `send_message` tool for proactive/scheduled sends).
- `tests/gateway/test_simplex_plugin.py`: added `test_send_dm` and `test_standalone_send_defaults_to_local_daemon`, both asserting the structured `/_send` format.

## Attribution
Cherry-picked from @liuhao1024's PRs #44444 and #46377 with authorship preserved. Both PRs were 9737 commits behind main; #46377 is a superset containing both commits.

Closes #44444
Closes #46377
