### PR TITLE
fix(opencode-go): send x-opencode-session header for session affinity

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -221,6 +221,32 @@ def _merge_nous_portal_messages_extra_body(agent, anthropic_kwargs: dict) -> dic
     return anthropic_kwargs
 
 
+def _merge_opencode_go_session_header(agent, kwargs: dict) -> dict:
+    """Merge OpenCode Go's ``x-opencode-session`` header onto non-OpenAI-wire kwargs.
+
+    ``OpenCodeGoProfile.build_api_kwargs_extras`` is only consulted by the
+    chat_completions transport; the anthropic_messages route opencode-go's
+    MiniMax/Qwen routing uses (and the codex_responses route, for parity)
+    must merge the session-affinity header themselves. See #81584.
+    """
+    if getattr(agent, "provider", None) != "opencode-go":
+        return kwargs
+    try:
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("opencode-go")
+        if profile is not None:
+            _, top_level = profile.build_api_kwargs_extras(
+                model=agent.model, session_id=getattr(agent, "session_id", None)
+            )
+            extra_headers = top_level.get("extra_headers")
+            if extra_headers:
+                kwargs.setdefault("extra_headers", {}).update(extra_headers)
+    except Exception as exc:  # noqa: BLE001 — never block a turn on a header
+        logger.debug("OpenCode Go session-header merge failed: %s", exc)
+    return kwargs
+
+
 def _env_float(name: str, default: float) -> float:
     try:
         return float(os.getenv(name, str(default)))
@@ -1358,7 +1384,8 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
         # the profile hook that produces them is only consulted by the
         # OpenAI-wire transport. Merge them here so Messages traffic keeps
         # product attribution and sticky routing.
-        return _merge_nous_portal_messages_extra_body(agent, anthropic_kwargs)
+        anthropic_kwargs = _merge_nous_portal_messages_extra_body(agent, anthropic_kwargs)
+        return _merge_opencode_go_session_header(agent, anthropic_kwargs)
 
     # AWS Bedrock native Converse API — bypasses the OpenAI client entirely.
     # The adapter handles message/tool conversion and boto3 calls directly.
@@ -1423,7 +1450,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
                     getattr(agent, "log_prefix", ""), exc,
                 )
 
-        return _ct.build_kwargs(
+        codex_kwargs = _ct.build_kwargs(
             model=agent.model,
             messages=_msgs_for_codex,
             tools=tools_for_api,
@@ -1442,6 +1469,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
                 getattr(agent, "_codex_reasoning_replay_enabled", True)
             ),
         )
+        return _merge_opencode_go_session_header(agent, codex_kwargs)
 
     # ── chat_completions (default) ─────────────────────────────────────
     _ct = agent._get_transport()

--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from agent.portal_tags import get_conversation_context
+from agent.transports.codex import _cache_scope_from_session_id
 from providers import register_provider
 from providers.base import ProviderProfile
 
@@ -56,7 +58,35 @@ class OpenCodeGoProfile(ProviderProfile):
         return self.default_max_tokens
 
     def build_api_kwargs_extras(
-        self, *, reasoning_config: dict | None = None, model: str | None = None, **context
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        model: str | None = None,
+        session_id: str | None = None,
+        **context,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        extra_body, top_level = self._reasoning_api_kwargs_extras(
+            reasoning_config=reasoning_config, model=model
+        )
+
+        # OpenCode Go's chat_completions relay 400s "Model is unavailable" for
+        # some backends (e.g. deepseek-v4-flash) unless a stable per-conversation
+        # session-affinity header is present. Reuse the same session_id
+        # resolution as OpenRouter's x-grok-conv-id (ambient conversation
+        # context first, falling back to the explicit session_id, so
+        # auxiliary calls with no session handle still get one) so the value
+        # stays stable across turns and rotates when the conversation does,
+        # without leaking to other providers. See hermes-agent#81584.
+        session_key = _cache_scope_from_session_id(get_conversation_context() or session_id)
+        if session_key:
+            extra_headers = dict(top_level.get("extra_headers") or {})
+            extra_headers["x-opencode-session"] = session_key
+            top_level["extra_headers"] = extra_headers
+
+        return extra_body, top_level
+
+    def _reasoning_api_kwargs_extras(
+        self, *, reasoning_config: dict | None = None, model: str | None = None
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         extra_body: dict[str, Any] = {}
         top_level: dict[str, Any] = {}

--- a/tests/plugins/model_providers/test_opencode_go_profile.py
+++ b/tests/plugins/model_providers/test_opencode_go_profile.py
@@ -129,6 +129,47 @@ class TestOpenCodeGoModelGating:
         assert top_level == {}
 
 
+class TestOpenCodeGoSessionAffinityHeader:
+    """OpenCode Go's chat_completions relay 400s some backends (e.g.
+    deepseek-v4-flash) without a stable per-conversation session-affinity
+    header (#81584)."""
+
+    def test_session_id_sets_affinity_header(self, opencode_go_profile):
+        _, top_level = opencode_go_profile.build_api_kwargs_extras(
+            model="deepseek-v4-flash",
+            session_id="sess-abc123",
+        )
+        assert top_level["extra_headers"]["x-opencode-session"] == "sess-abc123"
+
+    def test_header_normalizes_cron_timestamp(self, opencode_go_profile):
+        _, first = opencode_go_profile.build_api_kwargs_extras(
+            model="deepseek-v4-flash", session_id="cron_job42_20260801_090000",
+        )
+        _, second = opencode_go_profile.build_api_kwargs_extras(
+            model="deepseek-v4-flash", session_id="cron_job42_20260802_090000",
+        )
+        assert first["extra_headers"]["x-opencode-session"] == "cron_job42"
+        assert (
+            first["extra_headers"]["x-opencode-session"]
+            == second["extra_headers"]["x-opencode-session"]
+        )
+
+    def test_no_session_id_omits_header(self, opencode_go_profile):
+        _, top_level = opencode_go_profile.build_api_kwargs_extras(
+            model="deepseek-v4-flash",
+        )
+        assert "extra_headers" not in top_level
+
+    def test_header_coexists_with_reasoning_top_level_kwargs(self, opencode_go_profile):
+        _, top_level = opencode_go_profile.build_api_kwargs_extras(
+            model="kimi-k2.6",
+            reasoning_config={"enabled": True, "effort": "high"},
+            session_id="sess-xyz",
+        )
+        assert top_level["reasoning_effort"] == "high"
+        assert top_level["extra_headers"]["x-opencode-session"] == "sess-xyz"
+
+
 class TestOpenCodeGoFullKwargsIntegration:
     """End-to-end transport kwargs include the profile-provided controls."""
 

--- a/tests/plugins/model_providers/test_opencode_go_profile.py
+++ b/tests/plugins/model_providers/test_opencode_go_profile.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 
@@ -168,6 +170,79 @@ class TestOpenCodeGoSessionAffinityHeader:
         )
         assert top_level["reasoning_effort"] == "high"
         assert top_level["extra_headers"]["x-opencode-session"] == "sess-xyz"
+
+
+class TestOpenCodeGoSessionHeaderOtherTransports:
+    """MiniMax/Qwen on OpenCode Go route through anthropic_messages, and (for
+    parity) codex_responses is covered too — build_api_kwargs_extras is only
+    consulted by the chat_completions transport, so build_api_kwargs must
+    merge the header itself on those other routes (#81584)."""
+
+    def _build_anthropic_kwargs(self, session_id="sess-abc123"):
+        from agent.chat_completion_helpers import build_api_kwargs
+        from agent.transports.anthropic import AnthropicTransport
+
+        transport = AnthropicTransport()
+        agent = SimpleNamespace(
+            api_mode="anthropic_messages",
+            provider="opencode-go",
+            model="minimax-m2.7",
+            session_id=session_id,
+            tools=None,
+            max_tokens=1024,
+            reasoning_config=None,
+            request_overrides={},
+            context_compressor=None,
+            _ephemeral_max_output_tokens=None,
+            _is_anthropic_oauth=False,
+            _anthropic_base_url="https://opencode.ai/zen/go/v1",
+            _oauth_1m_beta_disabled=False,
+            _get_transport=lambda: transport,
+            _prepare_anthropic_messages_for_api=lambda msgs: msgs,
+            _anthropic_preserve_dots=lambda: False,
+        )
+        return build_api_kwargs(agent, [{"role": "user", "content": "hi"}])
+
+    def _build_codex_kwargs(self, session_id="sess-abc123"):
+        from agent.chat_completion_helpers import build_api_kwargs
+        from agent.transports.codex import ResponsesApiTransport
+
+        transport = ResponsesApiTransport()
+        agent = SimpleNamespace(
+            api_mode="codex_responses",
+            provider="opencode-go",
+            model="glm-5",
+            session_id=session_id,
+            tools=None,
+            base_url="https://opencode.ai/zen/go/v1",
+            _base_url_hostname="opencode.ai",
+            _base_url_lower="https://opencode.ai/zen/go/v1",
+            max_tokens=1024,
+            reasoning_config=None,
+            request_overrides={},
+            _get_transport=lambda: transport,
+            _prepare_messages_for_non_vision_model=lambda msgs: msgs,
+            _resolved_api_call_timeout=lambda: 30.0,
+            _github_models_reasoning_extra_body=lambda: None,
+            _codex_reasoning_replay_enabled=True,
+        )
+        return build_api_kwargs(agent, [{"role": "user", "content": "hi"}])
+
+    def test_anthropic_messages_route_gets_the_affinity_header(self):
+        kwargs = self._build_anthropic_kwargs(session_id="sess-abc123")
+        assert kwargs["extra_headers"]["x-opencode-session"] == "sess-abc123"
+
+    def test_codex_responses_route_gets_the_affinity_header(self):
+        kwargs = self._build_codex_kwargs(session_id="sess-abc123")
+        assert kwargs["extra_headers"]["x-opencode-session"] == "sess-abc123"
+
+    def test_non_opencode_go_provider_is_untouched_on_anthropic_messages(self):
+        from agent.chat_completion_helpers import _merge_opencode_go_session_header
+
+        kwargs = {"model": "claude-opus-4-8"}
+        agent = SimpleNamespace(provider="nous", model="claude-opus-4-8", session_id="s")
+        assert _merge_opencode_go_session_header(agent, kwargs) is kwargs
+        assert "extra_headers" not in kwargs
 
 
 class TestOpenCodeGoFullKwargsIntegration:


### PR DESCRIPTION
## What does this PR do?

OpenCode Go's `chat_completions` relay returns HTTP 400 `Model is unavailable` for
some backends (confirmed for `deepseek-v4-flash`) unless the request carries a
stable, opaque `x-opencode-session` header. Hermes' `opencode-go` provider profile
never sent that header, so the very first request to an affected model fails.

This adds `x-opencode-session` to `OpenCodeGoProfile.build_api_kwargs_extras`,
resolved with the same pattern already used for OpenRouter's `x-grok-conv-id`
sticky-routing header: the ambient conversation context first, falling back to
the explicit `session_id`, normalized through the existing
`_cache_scope_from_session_id` helper. That keeps the value:

- stable across turns of the same conversation,
- correctly rotated after session rotation/compression (it's derived from the
  session-lineage root, same as the OpenRouter/xAI header),
- scoped to this provider only — it's added inside the `opencode-go` profile's
  own hook, so it can't leak into other providers' requests.

This does **not** send any official-OpenCode-CLI impersonation headers
(`User-Agent: opencode-cli`, `x-opencode-client: cli`) — only the honest,
non-impersonating session-affinity header, matching the approach the issue
explicitly asks for.

## Related Issue

Fixes #81584
Fixes #81832

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/model-providers/opencode-zen/__init__.py`: `OpenCodeGoProfile.build_api_kwargs_extras`
  now attaches `extra_headers["x-opencode-session"]` whenever a conversation/session
  id is available, on top of the existing reasoning-control logic (moved unchanged
  into a private `_reasoning_api_kwargs_extras` helper).
- `tests/plugins/model_providers/test_opencode_go_profile.py`: added
  `TestOpenCodeGoSessionAffinityHeader` covering header presence with a
  `session_id`, cron-timestamp normalization/stability (mirrors the existing
  OpenRouter grok-header test), header omission with no session context, and
  coexistence with the existing reasoning `top_level` kwargs.

## How to Test

1. `python -m pytest tests/plugins/model_providers/test_opencode_go_profile.py -q`
2. Reproduce the failure without the fix: `git checkout HEAD~1 -- plugins/model-providers/opencode-zen/__init__.py`,
   rerun the new tests (they fail with `KeyError: 'extra_headers'`), then
   `git checkout HEAD -- plugins/model-providers/opencode-zen/__init__.py` to restore the fix.

### Actual output

Without the fix (source reverted, tests kept):
```
FAILED ...::TestOpenCodeGoSessionAffinityHeader::test_session_id_sets_affinity_header - KeyError: 'extra_headers'
FAILED ...::TestOpenCodeGoSessionAffinityHeader::test_header_normalizes_cron_timestamp - KeyError: 'extra_headers'
FAILED ...::TestOpenCodeGoSessionAffinityHeader::test_header_coexists_with_reasoning_top_level_kwargs - KeyError: 'extra_headers'
3 failed, 1 passed, 20 deselected in 1.02s
```

With the fix:
```
........................
24 passed in 2.07s
```

Also ran the broader related suites with no regressions:
```
tests/plugins/model_providers/test_opencode_go_profile.py
tests/providers/test_provider_profiles.py
tests/hermes_cli/test_opencode_go_validation_fallback.py
tests/hermes_cli/test_opencode_zen_model_limit.py
tests/hermes_cli/test_model_switch_opencode_anthropic.py
tests/hermes_cli/test_opencode_go_flat_namespace.py
tests/hermes_cli/test_opencode_go_in_model_list.py
tests/agent/transports/test_chat_completions.py
tests/agent/test_auxiliary_client.py
=> 51 + 45 + 172 passed, 0 failed
```
`ruff check` on both changed files: all checks passed.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(opencode-go):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` (relevant subset — see above) and all tests pass
- [x] I've added tests for my changes
- [x] Tested on Ubuntu 24.04

### Documentation & Housekeeping

- [x] N/A — no user-facing config/docs changes

## AI assistance disclosure

This PR was prepared with AI assistance (Claude, via an autonomous coding agent),
reviewed and tested before submission.

