### PR TITLE
fix(agent): read Telegram rich_messages config from correct path

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -954,7 +954,8 @@ PLATFORM_HINTS = {
 }
 
 # Telegram rich-messages extension — only injected when the user has opted in
-# to ``platforms.telegram.extra.rich_messages: true``.  The base
+# to ``gateway.platforms.telegram.extra.rich_messages: true`` (or the
+# top-level ``platforms.telegram.extra.rich_messages``).  The base
 # PLATFORM_HINTS["telegram"] covers MarkdownV2-compatible constructs; this
 # extension adds the Bot API 10.1 rich-Markdown guidance (tables, task lists,
 # collapsible details, math, etc.).

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -445,18 +445,22 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             pass
 
     # For Telegram: append the rich-messages extension only when the user has
-    # opted in to ``platforms.telegram.extra.rich_messages: true``.  The base
-    # hint covers MarkdownV2-compatible constructs; the extension adds Bot API
-    # 10.1 guidance (tables, task lists, math, collapsible details, etc.).
+    # opted in to ``gateway.platforms.telegram.extra.rich_messages: true``
+    # (the canonical location the adapter reads from).  Merge with the
+    # top-level ``platforms.telegram.extra`` so config-wizard writes and
+    # dashboard-setup keys are also visible — same precedence the adapter
+    # uses: top-level platform overrides gateway.platforms at the leaf.
     if platform_key == "telegram" and _default_hint:
         try:
             from hermes_cli.config import load_config_readonly
             _cfg = load_config_readonly()
-            _tg_extra = ((_cfg.get("platforms") or {}).get("telegram") or {}).get("extra") or {}
+            _gw_tg_extra = (((_cfg.get("gateway") or {}).get("platforms") or {}).get("telegram") or {}).get("extra") or {}
+            _top_tg_extra = ((_cfg.get("platforms") or {}).get("telegram") or {}).get("extra") or {}
+            _tg_extra = {**_gw_tg_extra, **_top_tg_extra}
             if _tg_extra.get("rich_messages"):
                 _default_hint = _default_hint.rstrip() + " " + TELEGRAM_RICH_MESSAGES_HINT
-        except Exception:
-            pass  # Config read failure — fall back to base hint only
+        except ImportError:
+            pass  # Config module not available — fall back to base hint only
 
     _effective_hint = _resolve_platform_hint(agent, platform_key, _default_hint)
     if platform_key == "tui" and _effective_hint:

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -463,8 +463,8 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             _tg_extra = {**_gw_tg_extra, **_top_tg_extra}
             if _tg_extra.get("rich_messages"):
                 _default_hint = _default_hint.rstrip() + " " + TELEGRAM_RICH_MESSAGES_HINT
-        except ImportError:
-            pass  # Config module not available — fall back to base hint only
+        except Exception:
+            pass  # Config read failure — fall back to base hint only
 
     _effective_hint = _resolve_platform_hint(agent, platform_key, _default_hint)
     if platform_key == "tui" and _effective_hint:

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -454,8 +454,12 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         try:
             from hermes_cli.config import load_config_readonly
             _cfg = load_config_readonly()
-            _gw_tg_extra = (((_cfg.get("gateway") or {}).get("platforms") or {}).get("telegram") or {}).get("extra") or {}
-            _top_tg_extra = ((_cfg.get("platforms") or {}).get("telegram") or {}).get("extra") or {}
+            _gw_tg_extra = (((_cfg.get("gateway") or {}).get("platforms") or {}).get("telegram") or {}).get("extra")
+            _top_tg_extra = ((_cfg.get("platforms") or {}).get("telegram") or {}).get("extra")
+            if not isinstance(_gw_tg_extra, dict):
+                _gw_tg_extra = {}
+            if not isinstance(_top_tg_extra, dict):
+                _top_tg_extra = {}
             _tg_extra = {**_gw_tg_extra, **_top_tg_extra}
             if _tg_extra.get("rich_messages"):
                 _default_hint = _default_hint.rstrip() + " " + TELEGRAM_RICH_MESSAGES_HINT

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -189,34 +189,65 @@ class TestTelegramRichMessagesHint:
     """Verify that TELEGRAM_RICH_MESSAGES_HINT is conditionally included."""
 
     def test_base_hint_without_rich_messages(self, monkeypatch):
-        """When rich_messages is False (default), only the base hint is used."""
+        """When rich_messages is False, only the base hint is used."""
         agent = _make_agent(platform="telegram")
-        # Mock config to return rich_messages: false (default)
         with patch("hermes_cli.config.load_config_readonly") as mock_cfg:
             mock_cfg.return_value = {
-                "platforms": {"telegram": {"extra": {"rich_messages": False}}}
+                "gateway": {"platforms": {"telegram": {"extra": {"rich_messages": False}}}}
             }
             stable = _stable_prompt(agent)
-        # Base hint should be present
         assert "Standard Markdown is automatically converted" in stable
-        # Rich-messages extension should NOT be present
         assert "lean into it" not in stable
         assert "task lists" not in stable
 
     def test_rich_hint_with_rich_messages_enabled(self, monkeypatch):
-        """When rich_messages is True, the rich-messages extension is appended."""
+        """When rich_messages is True in gateway.platforms, the extension
+        is appended (the canonical/primary location)."""
+        agent = _make_agent(platform="telegram")
+        with patch("hermes_cli.config.load_config_readonly") as mock_cfg:
+            mock_cfg.return_value = {
+                "gateway": {"platforms": {"telegram": {"extra": {"rich_messages": True}}}}
+            }
+            stable = _stable_prompt(agent)
+        assert "lean into it" in stable
+        assert "task lists" in stable
+        assert "math/formulas" in stable
+
+    def test_rich_hint_from_top_level_platforms(self):
+        """Top-level ``platforms.telegram.extra.rich_messages`` is merged
+        alongside gateway.platforms, so it works on its own."""
         agent = _make_agent(platform="telegram")
         with patch("hermes_cli.config.load_config_readonly") as mock_cfg:
             mock_cfg.return_value = {
                 "platforms": {"telegram": {"extra": {"rich_messages": True}}}
             }
             stable = _stable_prompt(agent)
-        # Base hint should be present
-        assert "Standard Markdown is automatically converted" in stable
-        # Rich-messages extension should be present
         assert "lean into it" in stable
         assert "task lists" in stable
-        assert "math/formulas" in stable
+
+    def test_top_level_overrides_gateway_rich_messages(self):
+        """Top-level ``platforms.telegram.extra`` wins over gateway.platforms
+        at the leaf, matching the adapter's merge precedence."""
+        agent = _make_agent(platform="telegram")
+        with patch("hermes_cli.config.load_config_readonly") as mock_cfg:
+            mock_cfg.return_value = {
+                "gateway": {"platforms": {"telegram": {"extra": {"rich_messages": False}}}},
+                "platforms": {"telegram": {"extra": {"rich_messages": True}}},
+            }
+            stable = _stable_prompt(agent)
+        assert "lean into it" in stable
+
+    def test_gateway_extra_other_keys_does_not_block_top_level_rich_messages(self):
+        """When gateway.platforms.telegram.extra has other keys but not
+        rich_messages, the top-level rich_messages still activates."""
+        agent = _make_agent(platform="telegram")
+        with patch("hermes_cli.config.load_config_readonly") as mock_cfg:
+            mock_cfg.return_value = {
+                "gateway": {"platforms": {"telegram": {"extra": {"disable_link_previews": True}}}},
+                "platforms": {"telegram": {"extra": {"rich_messages": True}}},
+            }
+            stable = _stable_prompt(agent)
+        assert "lean into it" in stable
 
     def test_base_hint_without_config(self, monkeypatch):
         """When config has no telegram section, only base hint is used."""

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -259,6 +259,48 @@ class TestTelegramRichMessagesHint:
         assert "lean into it" not in stable
 
 
+    def test_gateway_rich_messages_integration_via_real_config(self, tmp_path, monkeypatch):
+        """End-to-end through the real config-resolution chain: a config.yaml
+        under HERMES_HOME with ``gateway.platforms.telegram.extra.rich_messages``
+        must activate the rich hint. ``load_config_readonly`` is NOT mocked here,
+        so this guards against the exact path-mismatch bug this PR fixes.
+        """
+        config_yaml = (
+            "gateway:\n"
+            "  platforms:\n"
+            "    telegram:\n"
+            "      extra:\n"
+            "        rich_messages: true\n"
+        )
+        home = tmp_path / "hermes_home"
+        home.mkdir()
+        (home / "config.yaml").write_text(config_yaml)
+
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        # Point config resolution at the temp file without mocking the loader:
+        # mirror the pattern used in test_config_env_expansion.py.
+        from hermes_cli import config as _cfgmod
+        monkeypatch.setattr(_cfgmod, "get_config_path", lambda: home / "config.yaml")
+
+        agent = _make_agent(platform="telegram")
+        stable = _stable_prompt(agent)
+        assert "lean into it" in stable
+        assert "task lists" in stable
+
+    def test_malformed_extra_value_falls_back_to_base_hint(self, tmp_path, monkeypatch):
+        """A truthy non-mapping ``extra`` must not crash prompt construction —
+        it should fail open to the base hint (Tek's fail-open concern).
+        """
+        agent = _make_agent(platform="telegram")
+        with patch("hermes_cli.config.load_config_readonly") as mock_cfg:
+            mock_cfg.return_value = {
+                "gateway": {"platforms": {"telegram": {"extra": "not-a-map"}}}
+            }
+            stable = _stable_prompt(agent)
+        assert "Standard Markdown is automatically converted" in stable
+        assert "lean into it" not in stable
+
+
 _SKILLS = "SKILLS_INDEX_SENTINEL"
 _CONTEXT = "CONTEXT_FILES_SENTINEL"
 


### PR DESCRIPTION
## Summary
Fixes a config-path mismatch that prevented Telegram's rich-Markdown hint extension (tables, task lists, collapsible details, math) from ever activating when users configured `rich_messages` at the documented canonical location.

## Root cause
`agent/system_prompt.py` read `rich_messages` from the top-level `platforms.telegram.extra` path only, but the Telegram adapter and docs use `gateway.platforms.telegram.extra`. Setting `rich_messages: true` at the canonical path returned `None`, the hint never fired, and the model degraded pipe tables to bullet lists, task lists to plain dashes, etc.

## Changes
- `agent/system_prompt.py` — merge both `gateway.platforms.telegram.extra` and top-level `platforms.telegram.extra` with correct precedence (top-level leaf wins, matching the adapter's `_merge_platform_map` in `gateway/config.py`); `isinstance(dict)` guards on both values so malformed `extra` fails open to the base hint
- `agent/prompt_builder.py` — update stale comment referencing the old config path
- `tests/agent/test_system_prompt.py` — updated existing tests to use canonical path; added integration test (real config-resolution chain, no mock), malformed-extra fail-open test, top-level-only test, precedence test, and mixed-keys test

## Follow-up fix (on top of contributor commits)
Reverted `except ImportError` back to `except Exception`. `load_config_readonly()` calls `ensure_hermes_home()` which raises `FileNotFoundError` (deleted profile) and `RuntimeError` (managed mode) — both unguarded by inner try/except. The `ImportError` narrowing would crash `build_system_prompt_parts()` instead of falling back to the base hint. The `isinstance` guards handle the `TypeError` case; the broad `except Exception` handles the remaining failure surface.

## Attribution
Cherry-picked from PR #72114 by @JoshPaulie (commits `4519a696b`, `50f1eb672`). Authorship preserved via rebase-merge.

Closes #72114
