### PR TITLE
fix(status): detect self-hosted Firecrawl

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -209,8 +209,16 @@ def show_status(args):
         if name == "Anthropic":
             continue
         value = _resolve_env(env_ref)
-        has_key = bool(value)
-        display = redact_key(value)
+        self_hosted_firecrawl = False
+        if name == "Firecrawl":
+            value = value.strip()
+            self_hosted_firecrawl = bool(
+                (get_env_value("FIRECRAWL_API_URL") or "").strip()
+            )
+        if self_hosted_firecrawl and not value:
+            has_key, display = True, "self-hosted"
+        else:
+            has_key, display = bool(value), redact_key(value)
         print(f"  {name:<12}  {check_mark(has_key)} {display}")
 
     from hermes_cli.auth import get_anthropic_key

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -15,6 +15,23 @@ def test_show_status_all_does_not_print_tavily_key_value(monkeypatch, capsys, tm
     assert sentinel not in output
 
 
+def test_show_status_reports_self_hosted_firecrawl_without_key(
+    monkeypatch, capsys, tmp_path
+):
+    self_hosted_url = "https://firecrawl.internal.example.test:3002"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("FIRECRAWL_API_URL", self_hosted_url)
+    monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    firecrawl_row = next(line for line in output.splitlines() if "Firecrawl" in line)
+    assert "self-hosted" in firecrawl_row.lower()
+    assert "not set" not in firecrawl_row.lower()
+    assert self_hosted_url not in output
+
+
 def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys, tmp_path):
     from hermes_cli import status as status_mod
     import hermes_cli.auth as auth_mod


### PR DESCRIPTION
## What does this PR do?

`hermes status` currently checks only `FIRECRAWL_API_KEY`, so a working self-hosted Firecrawl deployment configured through `FIRECRAWL_API_URL` is incorrectly reported as `not set`.

This change recognizes a non-empty self-hosted endpoint as configured and displays `self-hosted` without exposing the endpoint. Cloud API-key behavior and redaction remain unchanged.

## Related Issue

No linked issue. The bug was reproduced against current `main` with a self-hosted Firecrawl endpoint and no cloud API key.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `hermes_cli/status.py` to recognize `FIRECRAWL_API_URL` when no Firecrawl API key is configured.
- Display `self-hosted` instead of the endpoint, preserving share-safe status output.
- Add a regression test covering URL-only self-hosted configuration and endpoint privacy.

## How to Test

1. Configure `FIRECRAWL_API_URL` without `FIRECRAWL_API_KEY`.
2. Run `hermes status --all`.
3. Confirm the Firecrawl row reports `✓ self-hosted` and does not print the endpoint.
4. Run `scripts/run_tests.sh tests/hermes_cli/test_status.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs and issues to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run the full test suite and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on Linux (Ubuntu, Python 3.11)

### Documentation & Housekeeping

- [x] Relevant documentation: N/A — no configuration keys or user workflow changed
- [x] `cli-config.yaml.example`: N/A — no configuration keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A — no architecture or workflow changes
- [x] Cross-platform impact considered: environment resolution and text rendering are platform-independent
- [x] Tool descriptions/schemas: N/A — no model tool behavior changed

## Screenshots / Logs

```text
Firecrawl     ✓ self-hosted
```

Focused and CLI-suite verification:

```text
tests/hermes_cli/test_status.py: 11 passed
scripts/run_tests.sh tests/hermes_cli: 4,501 passed
ruff check hermes_cli/status.py tests/hermes_cli/test_status.py: passed
git diff --check: passed
```
