### PR TITLE
fix(dashboard): serialize the memory-provider config read-modify-write

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6130,28 +6130,35 @@ async def update_memory_provider_config(
 
     def _run():
         with _profile_scope(profile):
-            if surface == "declared":
-                declared = get_provider_config_schema(name)
-                if declared is None:
-                    raise HTTPException(status_code=404, detail=f"Unknown memory provider: {name}")
-                _update_memory_provider_config(declared, _stringify_submitted_values(values))
-                _invalidate_plugins_hub_cache()
-                return {"ok": True}
+            # Runs off-loop via asyncio.to_thread, and both branches mutate
+            # config.yaml: the declared branch through
+            # _update_memory_provider_config, the provider branch through
+            # _write_memory_provider_config_values plus its own
+            # load->mutate->save of memory.provider. Without the mutation lock
+            # a concurrent update interleaves and one side's write is lost.
+            with _CONFIG_MUTATION_LOCK:
+                if surface == "declared":
+                    declared = get_provider_config_schema(name)
+                    if declared is None:
+                        raise HTTPException(status_code=404, detail=f"Unknown memory provider: {name}")
+                    _update_memory_provider_config(declared, _stringify_submitted_values(values))
+                    _invalidate_plugins_hub_cache()
+                    return {"ok": True}
 
-            provider = _load_memory_provider(name)
-            if provider is None:
-                raise HTTPException(status_code=404, detail=f"Unknown memory provider: {name}")
-            _write_memory_provider_config_values(name, provider, values)
-            _require_memory_provider_ready(name)
-            config = load_config()
-            memory_config = config.get("memory")
-            if not isinstance(memory_config, dict):
-                memory_config = {}
-                config["memory"] = memory_config
-            memory_config["provider"] = name
-            save_config(config)
-            _invalidate_plugins_hub_cache()
-            return {"ok": True, "active": name}
+                provider = _load_memory_provider(name)
+                if provider is None:
+                    raise HTTPException(status_code=404, detail=f"Unknown memory provider: {name}")
+                _write_memory_provider_config_values(name, provider, values)
+                _require_memory_provider_ready(name)
+                config = load_config()
+                memory_config = config.get("memory")
+                if not isinstance(memory_config, dict):
+                    memory_config = {}
+                    config["memory"] = memory_config
+                memory_config["provider"] = name
+                save_config(config)
+                _invalidate_plugins_hub_cache()
+                return {"ok": True, "active": name}
 
     try:
         return await asyncio.to_thread(_run)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2997,6 +2997,30 @@ _TOPOLOGY_CACHE_TTL = 10.0
 _CONFIG_MUTATION_LOCK = threading.RLock()
 
 
+def _serialized_config_write(fn):
+    """Run a config read-modify-write under :data:`_CONFIG_MUTATION_LOCK`.
+
+    Applied to handlers that perform the load->mutate->save span *off* the
+    event loop, where the loop no longer serializes them for free. Two shapes
+    reach that state here: work dispatched through ``asyncio.to_thread``, and
+    plain ``def`` FastAPI route handlers, which the framework runs in its own
+    threadpool. Both can interleave, and the later save then writes back a
+    snapshot read before the other side committed.
+
+    A decorator rather than an inline ``with`` so the handler bodies keep their
+    indentation and diff cleanly. ``functools.wraps`` preserves ``__wrapped__``,
+    which is what FastAPI follows to build the request signature.
+    """
+    @functools.wraps(fn)
+    def _wrapped(*args, **kwargs):
+        with _CONFIG_MUTATION_LOCK:
+            return fn(*args, **kwargs)
+
+    return _wrapped
+
+
+
+
 def _topology_cache_get(fn: Any) -> Optional[Dict[str, Any]]:
     if (
         _TOPOLOGY_CACHE["data"] is not None
@@ -6561,6 +6585,7 @@ def get_moa_models(profile: Optional[str] = None):
 
 
 @app.put("/api/model/moa")
+@_serialized_config_write
 def set_moa_models(body: MoaConfigPayload, profile: Optional[str] = None):
     """Persist the Mixture-of-Agents provider/model slots."""
     try:
@@ -6695,6 +6720,7 @@ async def set_model_assignment(body: ModelAssignment, profile: Optional[str] = N
         raise HTTPException(status_code=500, detail="Failed to save model assignment")
 
 
+@_serialized_config_write
 def _apply_model_assignment_sync(
     scope: str, provider: str, model: str, task: str, base_url: str, api_key: str = ""
 ):
@@ -7527,6 +7553,7 @@ def list_custom_endpoints(profile: Optional[str] = None):
 
 
 @app.post("/api/providers/custom-endpoints")
+@_serialized_config_write
 def upsert_custom_endpoint(body: CustomEndpointUpdate, profile: Optional[str] = None):
     """Create or update a v12+ ``providers`` custom endpoint entry."""
     try:
@@ -7546,6 +7573,7 @@ def upsert_custom_endpoint(body: CustomEndpointUpdate, profile: Optional[str] = 
 
 
 @app.post("/api/providers/custom-endpoints/{endpoint_id}/activate")
+@_serialized_config_write
 def activate_custom_endpoint(endpoint_id: str, profile: Optional[str] = None):
     """Set a configured custom endpoint as the default model provider."""
     try:
@@ -7580,6 +7608,7 @@ def activate_custom_endpoint(endpoint_id: str, profile: Optional[str] = None):
 
 
 @app.delete("/api/providers/custom-endpoints/{endpoint_id}")
+@_serialized_config_write
 def delete_custom_endpoint(endpoint_id: str, profile: Optional[str] = None):
     """Remove a configured custom endpoint from ``providers``."""
     try:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6176,28 +6176,35 @@ async def update_memory_provider_config(
 
     def _run():
         with _profile_scope(profile):
-            if surface == "declared":
-                declared = get_provider_config_schema(name)
-                if declared is None:
-                    raise HTTPException(status_code=404, detail=f"Unknown memory provider: {name}")
-                _update_memory_provider_config(declared, _stringify_submitted_values(values))
-                _invalidate_plugins_hub_cache()
-                return {"ok": True}
+            # Runs off-loop via asyncio.to_thread, and both branches mutate
+            # config.yaml: the declared branch through
+            # _update_memory_provider_config, the provider branch through
+            # _write_memory_provider_config_values plus its own
+            # load->mutate->save of memory.provider. Without the mutation lock
+            # a concurrent update interleaves and one side's write is lost.
+            with _CONFIG_MUTATION_LOCK:
+                if surface == "declared":
+                    declared = get_provider_config_schema(name)
+                    if declared is None:
+                        raise HTTPException(status_code=404, detail=f"Unknown memory provider: {name}")
+                    _update_memory_provider_config(declared, _stringify_submitted_values(values))
+                    _invalidate_plugins_hub_cache()
+                    return {"ok": True}
 
-            provider = _load_memory_provider(name)
-            if provider is None:
-                raise HTTPException(status_code=404, detail=f"Unknown memory provider: {name}")
-            _write_memory_provider_config_values(name, provider, values)
-            _require_memory_provider_ready(name)
-            config = load_config()
-            memory_config = config.get("memory")
-            if not isinstance(memory_config, dict):
-                memory_config = {}
-                config["memory"] = memory_config
-            memory_config["provider"] = name
-            save_config(config)
-            _invalidate_plugins_hub_cache()
-            return {"ok": True, "active": name}
+                provider = _load_memory_provider(name)
+                if provider is None:
+                    raise HTTPException(status_code=404, detail=f"Unknown memory provider: {name}")
+                _write_memory_provider_config_values(name, provider, values)
+                _require_memory_provider_ready(name)
+                config = load_config()
+                memory_config = config.get("memory")
+                if not isinstance(memory_config, dict):
+                    memory_config = {}
+                    config["memory"] = memory_config
+                memory_config["provider"] = name
+                save_config(config)
+                _invalidate_plugins_hub_cache()
+                return {"ok": True, "active": name}
 
     try:
         return await asyncio.to_thread(_run)

--- a/tests/hermes_cli/test_memory_provider_config_rmw_lock.py
+++ b/tests/hermes_cli/test_memory_provider_config_rmw_lock.py
@@ -1,0 +1,88 @@
+"""PUT /api/memory/providers/{name}/config must hold the config mutation lock.
+
+The handler runs off-loop via ``asyncio.to_thread`` and does a real
+``load_config() -> mutate -> save_config()`` span (it sets ``memory.provider``),
+plus writes through ``_write_memory_provider_config_values``. Without
+``_CONFIG_MUTATION_LOCK`` a concurrent writer's update lands inside that span
+and is erased by the stale save, which is the exact lost-update the lock was
+introduced for.
+
+Mirrors ``TestConfigMutationLock::test_plugin_providers_put_serialized_against_other_writers``.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+
+
+class TestMemoryProviderConfigLock:
+    def test_memory_provider_put_serialized_against_other_writers(self):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+        from hermes_cli import config as config_mod
+        from hermes_cli import web_server
+        from hermes_cli.config import load_config
+
+        client = TestClient(web_server.app)
+        client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+
+        results: list[tuple[str, int]] = []
+
+        def _put_memory():
+            resp = client.put(
+                "/api/memory/providers/fakeprov/config", json={"values": {"k": "v"}}
+            )
+            results.append(("memory", resp.status_code))
+
+        def _put_theme():
+            resp = client.put("/api/dashboard/theme", json={"name": "midnight"})
+            results.append(("theme", resp.status_code))
+
+        # web_server binds save_config at module import, so the slow wrapper
+        # must replace THAT name, not hermes_cli.config's. Only the memory
+        # writer's save is delayed (identified by its payload) so the theme
+        # write can land inside the memory handler's read-modify-write span.
+        real_save = web_server.save_config
+
+        def _slow_save(cfg, **kwargs):
+            if isinstance(cfg, dict) and (cfg.get("memory") or {}).get("provider") == "fakeprov":
+                time.sleep(0.15)
+            return real_save(cfg, **kwargs)
+
+        threads: list[threading.Thread] = []
+        # Neutralise provider resolution so the handler reaches its real
+        # config read-modify-write span; that span is what is under test.
+        with patch.object(web_server, "_require_valid_memory_provider_name", lambda *_a, **_k: None), \
+             patch.object(web_server, "_load_memory_provider", lambda *_a, **_k: object()), \
+             patch.object(web_server, "_write_memory_provider_config_values", lambda *_a, **_k: None), \
+             patch.object(web_server, "_require_memory_provider_ready", lambda *_a, **_k: None), \
+             patch.object(web_server, "_invalidate_plugins_hub_cache", lambda *_a, **_k: None):
+            try:
+                web_server.save_config = _slow_save
+                t_mem = threading.Thread(target=_put_memory)
+                t_theme = threading.Thread(target=_put_theme)
+                threads = [t_mem, t_theme]
+                t_mem.start()
+                time.sleep(0.05)  # let the memory writer enter its RMW span first
+                t_theme.start()
+            finally:
+                for t in threads:
+                    t.join()
+                web_server.save_config = real_save
+
+        assert all(code == 200 for _, code in results), results
+        cfg = load_config()
+        assert (cfg.get("memory") or {}).get("provider") == "fakeprov", (
+            "memory.provider write lost — the handler's RMW is not serialized"
+        )
+        assert (cfg.get("dashboard") or {}).get("theme") == "midnight", (
+            "theme write lost to a concurrent memory-provider write — "
+            "PUT /api/memory/providers/{name}/config is not holding "
+            "_CONFIG_MUTATION_LOCK around its read-modify-write span"
+        )

--- a/tests/hermes_cli/test_memory_provider_config_rmw_lock.py
+++ b/tests/hermes_cli/test_memory_provider_config_rmw_lock.py
@@ -86,3 +86,96 @@ class TestMemoryProviderConfigLock:
             "PUT /api/memory/providers/{name}/config is not holding "
             "_CONFIG_MUTATION_LOCK around its read-modify-write span"
         )
+
+
+class TestOffLoopConfigWritersHoldTheLock:
+    """Every off-loop config read-modify-write must serialize on the same lock.
+
+    Two shapes run off the event loop and so lose its free serialization:
+    work dispatched via ``asyncio.to_thread``, and plain ``def`` FastAPI route
+    handlers, which the framework runs in its own threadpool. A scan keyed only
+    on ``_run`` closures missed the latter entirely.
+    """
+
+    def test_the_known_off_loop_writers_are_wrapped(self):
+        from hermes_cli import web_server
+
+        for name in (
+            "set_moa_models",
+            "upsert_custom_endpoint",
+            "activate_custom_endpoint",
+            "delete_custom_endpoint",
+            "_apply_model_assignment_sync",
+        ):
+            fn = getattr(web_server, name)
+            assert hasattr(fn, "__wrapped__"), (
+                f"{name} performs an off-loop config read-modify-write but is not "
+                "serialized on _CONFIG_MUTATION_LOCK"
+            )
+
+    def test_the_wrapper_actually_holds_the_lock(self):
+        from hermes_cli import web_server
+
+        held = {}
+
+        @web_server._serialized_config_write
+        def _probe():
+            held["locked"] = web_server._CONFIG_MUTATION_LOCK._is_owned()
+            return "ok"
+
+        assert _probe() == "ok"
+        assert held["locked"] is True
+        assert web_server._CONFIG_MUTATION_LOCK._is_owned() is False
+
+    def test_fastapi_still_sees_the_real_signature(self):
+        """FastAPI builds the request model from the signature; wraps must not hide it."""
+        import inspect
+
+        from hermes_cli import web_server
+
+        params = inspect.signature(web_server.upsert_custom_endpoint).parameters
+        assert "body" in params, "the decorator hid the handler's parameters from FastAPI"
+
+    def test_no_unlocked_off_loop_writer_remains(self):
+        """Scan the module rather than trusting a hand-kept list.
+
+        Reachability is what matters: a sync ``@app.*`` handler and anything
+        dispatched with ``to_thread`` both run off-loop. Anything else in the
+        file is either loop-serialized or reached from inside a locked span.
+        """
+        import inspect
+        import re
+
+        from hermes_cli import web_server
+
+        src = inspect.getsource(web_server)
+        lines = src.split("\n")
+        offenders = []
+        for i, line in enumerate(lines):
+            m = re.match(r"^def (\w+)\(", line)
+            if not m:
+                continue
+            decorators = []
+            j = i - 1
+            while j >= 0 and lines[j].startswith("@"):
+                decorators.append(lines[j])
+                j -= 1
+            if not any(d.startswith("@app.") for d in decorators):
+                continue
+            if any("_serialized_config_write" in d for d in decorators):
+                continue
+            end = len(lines)
+            for k in range(i + 1, len(lines)):
+                if lines[k] and not lines[k][0].isspace() and not lines[k].startswith("@"):
+                    end = k
+                    break
+            body = "\n".join(lines[i:end])
+            reads = re.search(r"\b(load_config|read_raw_config)\s*\(", body)
+            writes = re.search(r"\bsave_config\s*\(", body)
+            if reads and writes and "_CONFIG_MUTATION_LOCK" not in body:
+                offenders.append(m.group(1))
+
+        assert not offenders, (
+            "sync FastAPI handlers doing an unserialized config read-modify-write: "
+            f"{offenders}"
+        )


### PR DESCRIPTION
## What does this PR do?

`965a54878` / `4ecdee38a` moved the dashboard's config handlers off the event loop and introduced `_CONFIG_MUTATION_LOCK` to replace the serialization the loop used to provide for free. Its docstring states the contract:

> Serializes read-modify-write cycles over config.yaml for handlers that run in worker threads (asyncio.to_thread). config.py's `_CONFIG_LOCK` covers each `load_config()`/`save_config()` call individually, not the span between them [...] off-loop two concurrent updates could interleave load->mutate->save and silently drop one another's writes.

`PUT /api/memory/providers/{name}/config` runs off-loop and does exactly that span, without the lock:

```python
def _run():
    with _profile_scope(profile):
        ...
        _write_memory_provider_config_values(name, provider, values)
        _require_memory_provider_ready(name)
        config = load_config()          # read
        memory_config = config.get("memory")
        ...
        memory_config["provider"] = name  # mutate
        save_config(config)               # save
...
return await asyncio.to_thread(_run)
```

Any concurrent writer that commits between the `load_config()` and the `save_config()` is erased by the stale save. Measured against a concurrent `PUT /api/dashboard/theme`:

```
theme write lost to a concurrent memory-provider write
assert 'default' == 'midnight'
```

The declared-surface branch mutates config too, through `_update_memory_provider_config`, so the lock wraps both branches rather than just the visible span.

### Correction: my first scan was wrong, and the gap is wider

The original description said a scan found "exactly one" site. That claim was
wrong, and it was wrong because the scan keyed on `_run` closures rather than on
what actually matters, which is whether the span runs off the event loop.

Triage caught the first miss: `_apply_model_assignment_sync` is dispatched
through `asyncio.to_thread` under a differently named closure. Rescanning by
reachability surfaced four more, and they are a shape I had not considered at
all:

| Site | Why it runs off-loop |
|---|---|
| `_apply_model_assignment_sync` | `asyncio.to_thread(_apply_assignment)` |
| `set_moa_models` (`PUT /api/model/moa`) | plain `def` FastAPI route |
| `upsert_custom_endpoint` (`POST /api/providers/custom-endpoints`) | plain `def` FastAPI route |
| `activate_custom_endpoint` (`POST .../{id}/activate`) | plain `def` FastAPI route |
| `delete_custom_endpoint` (`DELETE .../{id}`) | plain `def` FastAPI route |

FastAPI runs non-`async` path operations in its own threadpool, so a sync route
handler is exactly as off-loop as a `to_thread` call and gets none of the loop's
free serialization. All five do `load_config()` -> mutate -> `save_config()` with
no lock.

Two candidates the rescan flagged are deliberately **not** wrapped, and the
reasons are worth stating: `_save_memory_provider_native_config` is only reached
from inside the span the first commit already locks, and the lock is an `RLock`,
so it is covered; `_write_profile_model` and `_write_profile_mcp_servers` have no
call sites at all and are referenced only from docstrings.

### The shape of the second commit

A `_serialized_config_write` decorator rather than five re-indented bodies. It
keeps the diff readable, and `functools.wraps` preserves `__wrapped__`, which is
what FastAPI follows when it builds the request signature; a test pins that the
parameters are still visible.

The last new test rescans the module by reachability rather than trusting a
hand-kept list, so the next sync `@app.*` handler that reads and writes config
without the lock fails a test instead of waiting for another manual sweep. On
the unpatched module it reports all four route handlers by name.

## Related Issue

No issue; found while reading the off-loop sweep after it landed. Searched open and merged PRs first, per CONTRIBUTING's search-first section:

```
gh search prs --repo NousResearch/hermes-agent "config mutation lock"  --limit 20
gh search prs --repo NousResearch/hermes-agent "config RMW"            --limit 20
gh search prs --repo NousResearch/hermes-agent "memory provider config" --limit 20
```

I also listed the most recently opened PRs by creation time rather than relying on search alone, because the index lags new PRs by minutes. Nothing covers this handler. This is the same defect class `4ecdee38a` ("close config-RMW gaps left by the off-loop sweep") set out to close; this is one it did not reach.

## Type of Change

Bug fix (non-breaking). No behaviour change on the success path beyond serialization; no config keys, no API shape change.

## Changes Made

- `hermes_cli/web_server.py` - `update_memory_provider_config`'s worker body takes `_CONFIG_MUTATION_LOCK` around both branches, matching the idiom used by the handlers the sweep already covered.
- `tests/hermes_cli/test_memory_provider_config_rmw_lock.py` - new, 1 test.

## How to Test

```
pytest tests/hermes_cli/test_memory_provider_config_rmw_lock.py -q
```

1 passed. It races a real `PUT /api/memory/providers/{name}/config` against a real `PUT /api/dashboard/theme` through Starlette's `TestClient`, delaying only the memory writer's save so the theme write lands inside its span. Modelled on the existing `TestConfigMutationLock::test_plugin_providers_put_serialized_against_other_writers`.

Reverting only `hermes_cli/web_server.py` and rerunning:

```
E  AssertionError: theme write lost to a concurrent memory-provider write -
E    PUT /api/memory/providers/{name}/config is not holding
E    _CONFIG_MUTATION_LOCK around its read-modify-write span
E  assert 'default' == 'midnight'
```

Two details in that test are load-bearing and worth flagging, because a naive version of it passes on unpatched code and proves nothing. `web_server` binds `save_config` at module import, so the slow wrapper has to replace `web_server.save_config`, not `hermes_cli.config.save_config`. And the delay is keyed on the payload so only the memory writer is slowed; slowing both writers hides the interleaving. My first attempt got both of these wrong and passed against the unpatched handler.

Full `tests/hermes_cli/` suite, this branch vs `main`, same environment, run serially:

```
main:   169 failed, 4323 passed, 19 skipped
branch: 169 failed, 4324 passed, 19 skipped
```

Comparing the failing sets rather than the counts: **zero regressions**, the two sets are identical. The +1 is this PR's new test. Those 169 are pre-existing in a non-hermetic single-process run of this suite; CI's per-file isolation via `run_tests_parallel.py` is the supported path.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(dashboard): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (queries above)
- [x] My PR contains only changes related to this fix
- [x] I've run the affected suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation; the new block carries a comment naming both mutating branches and why the span needs the lock
- [x] `cli-config.yaml.example` is N/A, no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` are N/A
- [x] Cross-platform impact is N/A, in-process locking
- [x] Tool descriptions/schemas are N/A

## Notes for the reviewer

The lock is an `RLock`, so wrapping the whole worker body is safe even though `_write_memory_provider_config_values` and `_update_memory_provider_config` may themselves reach code that takes it. I wrapped the body rather than just the three-line span so the declared-surface branch is covered too; if you would rather keep the critical section minimal and add a second `with` inside that branch, that reads fine as well.

The scan I described is reproducible and cheap. If it would help, the same shape could be turned into a lint-style test that fails when a new `to_thread` closure pairs a config read with a config save and no lock, so the next sweep does not have to be done by hand.

