### PR TITLE
fix(memory): default missing action to add when content is supplied (#81542)

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -296,6 +296,30 @@ class TestMemoryToolDispatcher:
         assert result["success"] is False
         assert "not available" in result["error"]
 
+    def test_missing_action_with_content_defaults_to_add(self, store):
+        """A single-op call that omits ``action`` (strict schemas leave it
+        optional for the batch shape) but supplies ``content`` must default to
+        add instead of failing with 'Unknown action None' (#81542)."""
+        result = json.loads(memory_tool(content="preference: user likes dark mode", store=store))
+        assert result["success"] is True
+        assert "preference: user likes dark mode" in store._entries_for("memory")
+
+    def test_missing_action_without_content_errors_helpfully(self, store):
+        """No action and no content: still a clear error (can't guess intent),
+        but the message must not be the bare 'Unknown action None'."""
+        result = json.loads(memory_tool(store=store))
+        assert result["success"] is False
+        assert "Unknown action 'None'" in result["error"]
+        assert "operations" in result["error"]
+
+    def test_missing_action_with_old_text_errors(self, store):
+        """No action but old_text present: ambiguous (replace or remove?) —
+        keep the explicit error rather than guessing."""
+        store.add("memory", "fact A")
+        result = json.loads(memory_tool(old_text="fact A", store=store))
+        assert result["success"] is False
+        assert "Unknown action 'None'" in result["error"]
+
 
     def test_replace_missing_content_still_distinct_error(self, store):
         # When old_text IS present but content is missing, keep the original

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -1085,6 +1085,21 @@ def memory_tool(
         return json.dumps(result, ensure_ascii=False)
 
     # --- Single-op path ---------------------------------------------------
+    # Some models omit ``action`` on single-op calls (the schema leaves it
+    # optional to accommodate the batch shape).  When content is supplied and
+    # no old_text is present, the only sensible intent is an add — default to
+    # it instead of rejecting with "Unknown action 'None'" (#81542).
+    if not action:
+        if content and not old_text:
+            action = "add"
+        else:
+            return tool_error(
+                "Unknown action 'None'. Use: add, replace, remove — or pass "
+                "'operations' for a batch. Omit 'action' only when adding with "
+                "'content'.",
+                success=False,
+            )
+
     # Validate required params BEFORE the gate so an invalid write is rejected
     # immediately instead of being staged and only failing at approve time.
     if action == "add" and not content:


### PR DESCRIPTION
Fixes #81542 (part 1 — the 'Unknown action None' dispatch bug)

## What

A single-op `memory` call that omits `action` (strict providers fill optional schema fields with JSON null) now defaults to `add` when `content` is supplied, instead of failing with `Unknown action 'None'`.

## Why

`MEMORY_SCHEMA` leaves `action` optional to accommodate the batch (`operations`) shape, so a single-op call from a strict provider arrives with `action=None`. The dispatcher then falls through to the unknown-action error even though the model's intent is unambiguous (content present, no old_text).

## Behavior

- `action=None` + `content` + no `old_text` → `add` (the only sensible intent).
- `action=None` + no content → explicit error naming the valid actions and the batch alternative.
- `action=None` + only `old_text` → explicit error (ambiguous between replace/remove — can't guess).

## Verification

- `scripts/run_tests.sh tests/tools/test_memory_tool.py` → 37 passed (34 existing + 3 new regression tests).

Note: issue #81542 also describes auto-eviction thrashing at the char cap. On current main that path is already replaced by the consolidation-failure flow (`_consolidation_failure`, #42405) — adds at capacity are rejected with a retry/batch instruction instead of silently evicting. This PR addresses the remaining dispatch bug only.