### PR TITLE
fix(delegate): subagents get a dedicated SessionDB, not the parent's (#81267)

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -31,6 +31,7 @@ from tools.delegate_tool import (
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
 )
+from hermes_state import SessionDB
 
 
 def _make_mock_parent(depth=0):
@@ -286,6 +287,55 @@ class TestDelegateTask(unittest.TestCase):
             self.assertEqual(kwargs["api_key"], parent.api_key)
             self.assertEqual(kwargs["provider"], parent.provider)
             self.assertEqual(kwargs["api_mode"], parent.api_mode)
+
+    def test_child_gets_dedicated_session_db_not_parents_handle(self):
+        """#81267: children must not share the parent's SessionDB object.
+
+        cron run_job closes its per-job SessionDB in its finally block while
+        a fire-and-forget background delegation subagent is still flushing on
+        a daemon thread. A SHARED handle then has ``_conn=None`` and every
+        child flush raises ``'NoneType' object has no attribute 'execute'`` —
+        the failure is downgraded to a WARNING and the child's transcript is
+        silently dropped. Each child must own a dedicated connection that no
+        parent teardown can close, released by the child's own close().
+        """
+        parent = _make_mock_parent(depth=0)
+        parent_db = SessionDB()
+        parent._session_db = parent_db
+        try:
+            with patch("run_agent.AIAgent") as MockAgent:
+                mock_child = MagicMock()
+                MockAgent.return_value = mock_child
+
+                _build_child_agent(
+                    task_index=0,
+                    goal="test",
+                    context=None,
+                    toolsets=None,
+                    model="test-model",
+                    max_iterations=5,
+                    parent_agent=parent,
+                    task_count=1,
+                )
+
+                _, kwargs = MockAgent.call_args
+                self.assertEqual(mock_child._owns_session_db, True)
+
+            child_db = kwargs["session_db"]
+            self.assertIsInstance(child_db, SessionDB)
+            self.assertIsNot(child_db, parent_db)
+
+            # Parent teardown (cron run_job finally, gateway session end)
+            # must not break the child's handle — the #81267 crash mechanism.
+            parent_db.close()
+            self.assertIsNotNone(child_db._conn)
+            child_db.create_session(
+                session_id="child-session-81267",
+                source="subagent",
+                model="test-model",
+            )
+        finally:
+            parent_db.close()
 
     def test_nous_child_rederives_api_mode_from_model(self):
         """Portal is dual-wire — same provider + different model prefix must

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -337,6 +337,33 @@ class TestDelegateTask(unittest.TestCase):
         finally:
             parent_db.close()
 
+    def test_child_without_parent_db_still_degrades_to_none(self):
+        """Parent without a SessionDB -> child gets None (pre-fix behaviour).
+
+        The dedicated-handle path must not change the degradation contract:
+        a parent that never opened a session store (headless/oneshot runs,
+        test doubles) still yields ``session_db=None`` children.
+        """
+        parent = _make_mock_parent(depth=0)
+        parent._session_db = None
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            _build_child_agent(
+                task_index=0,
+                goal="test",
+                context=None,
+                toolsets=None,
+                model="test-model",
+                max_iterations=5,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+            _, kwargs = MockAgent.call_args
+            self.assertIsNone(kwargs["session_db"])
+
     def test_nous_child_rederives_api_mode_from_model(self):
         """Portal is dual-wire — same provider + different model prefix must
         not inherit the parent's Messages/chat_completions mode verbatim."""

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -364,6 +364,55 @@ class TestDelegateTask(unittest.TestCase):
             _, kwargs = MockAgent.call_args
             self.assertIsNone(kwargs["session_db"])
 
+    def test_child_dedicated_db_follows_parents_db_path(self):
+        """Per-profile parents: the child's dedicated handle must target the
+        parent's database FILE, not the launch profile's default state.db.
+
+        tui_gateway hands agents dedicated per-profile handles
+        (``SessionDB(db_path=<profile_home>/state.db)`` via
+        ``_transfer_db_to_agent``). A bare ``SessionDB()`` in
+        ``_build_child_agent`` would write the child's transcript into the
+        launch profile's db — cross-profile leakage that breaks
+        ``parent_session_id`` lineage and ``session_search``.
+        """
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmp:
+            profile_db_path = Path(tmp) / "profile-work" / "state.db"
+            profile_db_path.parent.mkdir(parents=True)
+            parent = _make_mock_parent(depth=0)
+            parent_db = SessionDB(db_path=profile_db_path)
+            parent._session_db = parent_db
+            child_db = None
+            try:
+                with patch("run_agent.AIAgent") as MockAgent:
+                    MockAgent.return_value = MagicMock()
+
+                    _build_child_agent(
+                        task_index=0,
+                        goal="test",
+                        context=None,
+                        toolsets=None,
+                        model="test-model",
+                        max_iterations=5,
+                        parent_agent=parent,
+                        task_count=1,
+                    )
+
+                    _, kwargs = MockAgent.call_args
+
+                child_db = kwargs["session_db"]
+                self.assertIsInstance(child_db, SessionDB)
+                self.assertIsNot(child_db, parent_db)
+                self.assertEqual(
+                    str(child_db.db_path), str(parent_db.db_path)
+                )
+            finally:
+                if child_db is not None:
+                    child_db.close()
+                parent_db.close()
+
     def test_nous_child_rederives_api_mode_from_model(self):
         """Portal is dual-wire — same provider + different model prefix must
         not inherit the parent's Messages/chat_completions mode verbatim."""

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1612,22 +1612,31 @@ def _build_child_agent(
         child_optional_kwargs["max_tokens"] = child_max_tokens
 
     # Each child gets a DEDICATED SessionDB connection instead of the parent's
-    # live object. The parent's handle is owned by the parent's lifecycle:
-    # cron run_job closes its per-job SessionDB in its finally block while a
-    # fire-and-forget background delegation subagent is still flushing on a
-    # daemon thread, and every subsequent flush then hits the closed handle
-    # ('NoneType' object has no attribute 'execute') — the failure is
-    # downgraded to a WARNING and the child's entire transcript is silently
-    # dropped (#81267). The same teardown-while-child-alive shape exists for
-    # gateway session end and /new mid-delegation, so the child must never
-    # share the parent's handle. A dedicated handle is released by the
-    # child's own close() via the owned flag set below.
+    # live object. The parent's handle is owned by the parent's lifecycle
+    # (cron run_job's finally block, gateway session end, /new) and can be
+    # closed while a fire-and-forget background child is still flushing on a
+    # daemon thread — every subsequent flush then hits the closed handle and
+    # the child's transcript is silently dropped (#81267). A dedicated handle
+    # can't be closed out from under the child; it is released by the child's
+    # own close() via the owned flag set below. It MUST point at the same
+    # database FILE as the parent's handle: parents can hold non-default
+    # per-profile handles (tui_gateway opens SessionDB(db_path=<profile>/
+    # state.db) for non-launch profiles), and a bare SessionDB() would write
+    # the child's transcript into the launch profile's db, breaking
+    # parent_session_id lineage and session_search. AsyncSessionDB wrappers
+    # (gateway) forward .db_path via __getattr__, so this works through them.
     child_session_db = None
-    if getattr(parent_agent, "_session_db", None) is not None:
+    parent_session_db = getattr(parent_agent, "_session_db", None)
+    if parent_session_db is not None:
         try:
             from hermes_state import SessionDB
 
-            child_session_db = SessionDB()
+            _parent_db_path = getattr(parent_session_db, "db_path", None)
+            child_session_db = (
+                SessionDB(db_path=_parent_db_path)
+                if _parent_db_path is not None
+                else SessionDB()
+            )
         except Exception:
             logger.debug(
                 "subagent: failed to open dedicated SessionDB; child persistence disabled",

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1638,47 +1638,58 @@ def _build_child_agent(
     from agent.delegation_context import delegated_child_context
 
     with delegated_child_context():
-        child = AIAgent(
-            base_url=effective_base_url,
-            api_key=effective_api_key,
-            model=effective_model,
-            provider=effective_provider,
-            api_mode=effective_api_mode,
-            acp_command=effective_acp_command,
-            acp_args=effective_acp_args,
-            max_iterations=max_iterations,
+        try:
+            child = AIAgent(
+                base_url=effective_base_url,
+                api_key=effective_api_key,
+                model=effective_model,
+                provider=effective_provider,
+                api_mode=effective_api_mode,
+                acp_command=effective_acp_command,
+                acp_args=effective_acp_args,
+                max_iterations=max_iterations,
 
-            reasoning_config=child_reasoning,
-            prefill_messages=getattr(parent_agent, "prefill_messages", None),
-            fallback_model=parent_fallback,
-            enabled_toolsets=child_toolsets,
-            disabled_toolsets=child_disabled_toolsets,
-            quiet_mode=True,
-            ephemeral_system_prompt=child_prompt,
-            log_prefix=f"[subagent-{task_index}]",
-            platform="subagent",
-            skip_context_files=True,
-            skip_memory=True,
-            clarify_callback=None,
-            thinking_callback=child_thinking_cb,
-            session_db=child_session_db,
-            parent_session_id=getattr(parent_agent, "session_id", None),
-            providers_allowed=child_providers_allowed,
-            providers_ignored=child_providers_ignored,
-            providers_order=child_providers_order,
-            provider_sort=child_provider_sort,
-            provider_require_parameters=child_provider_require_parameters,
-            provider_data_collection=child_provider_data_collection,
-            request_overrides=(
-                dict(override_request_overrides or {})
-                if override_provider
-                else dict(getattr(parent_agent, "request_overrides", {}) or {})
-            ),
-            openrouter_min_coding_score=child_openrouter_min_coding_score,
-            tool_progress_callback=child_progress_cb,
-            iteration_budget=None,  # fresh budget per subagent
-            **child_optional_kwargs,
-        )
+                reasoning_config=child_reasoning,
+                prefill_messages=getattr(parent_agent, "prefill_messages", None),
+                fallback_model=parent_fallback,
+                enabled_toolsets=child_toolsets,
+                disabled_toolsets=child_disabled_toolsets,
+                quiet_mode=True,
+                ephemeral_system_prompt=child_prompt,
+                log_prefix=f"[subagent-{task_index}]",
+                platform="subagent",
+                skip_context_files=True,
+                skip_memory=True,
+                clarify_callback=None,
+                thinking_callback=child_thinking_cb,
+                session_db=child_session_db,
+                parent_session_id=getattr(parent_agent, "session_id", None),
+                providers_allowed=child_providers_allowed,
+                providers_ignored=child_providers_ignored,
+                providers_order=child_providers_order,
+                provider_sort=child_provider_sort,
+                provider_require_parameters=child_provider_require_parameters,
+                provider_data_collection=child_provider_data_collection,
+                request_overrides=(
+                    dict(override_request_overrides or {})
+                    if override_provider
+                    else dict(getattr(parent_agent, "request_overrides", {}) or {})
+                ),
+                openrouter_min_coding_score=child_openrouter_min_coding_score,
+                tool_progress_callback=child_progress_cb,
+                iteration_budget=None,  # fresh budget per subagent
+                **child_optional_kwargs,
+            )
+        except BaseException:
+            # Construction failed: the dedicated handle has no owner and no
+            # child close() will ever run — release it here so the sqlite fds
+            # don't outlive the failed spawn.
+            if child_session_db is not None:
+                try:
+                    child_session_db.close()
+                except Exception:
+                    pass
+            raise
     child._print_fn = getattr(parent_agent, "_print_fn", None)
     # Ownership transfer for the dedicated handle: the child's close() must
     # release it (nothing else holds a reference), and no parent teardown can

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1611,6 +1611,30 @@ def _build_child_agent(
     if isinstance(child_max_tokens, int):
         child_optional_kwargs["max_tokens"] = child_max_tokens
 
+    # Each child gets a DEDICATED SessionDB connection instead of the parent's
+    # live object. The parent's handle is owned by the parent's lifecycle:
+    # cron run_job closes its per-job SessionDB in its finally block while a
+    # fire-and-forget background delegation subagent is still flushing on a
+    # daemon thread, and every subsequent flush then hits the closed handle
+    # ('NoneType' object has no attribute 'execute') — the failure is
+    # downgraded to a WARNING and the child's entire transcript is silently
+    # dropped (#81267). The same teardown-while-child-alive shape exists for
+    # gateway session end and /new mid-delegation, so the child must never
+    # share the parent's handle. A dedicated handle is released by the
+    # child's own close() via the owned flag set below.
+    child_session_db = None
+    if getattr(parent_agent, "_session_db", None) is not None:
+        try:
+            from hermes_state import SessionDB
+
+            child_session_db = SessionDB()
+        except Exception:
+            logger.debug(
+                "subagent: failed to open dedicated SessionDB; child persistence disabled",
+                exc_info=True,
+            )
+            child_session_db = None
+
     from agent.delegation_context import delegated_child_context
 
     with delegated_child_context():
@@ -1637,7 +1661,7 @@ def _build_child_agent(
             skip_memory=True,
             clarify_callback=None,
             thinking_callback=child_thinking_cb,
-            session_db=getattr(parent_agent, "_session_db", None),
+            session_db=child_session_db,
             parent_session_id=getattr(parent_agent, "session_id", None),
             providers_allowed=child_providers_allowed,
             providers_ignored=child_providers_ignored,
@@ -1656,6 +1680,11 @@ def _build_child_agent(
             **child_optional_kwargs,
         )
     child._print_fn = getattr(parent_agent, "_print_fn", None)
+    # Ownership transfer for the dedicated handle: the child's close() must
+    # release it (nothing else holds a reference), and no parent teardown can
+    # close it out from under a background child (#81267).
+    if child_session_db is not None:
+        child._owns_session_db = True
     # Now the child exists, its session id can ride on every relayed event
     # (including the spawn_requested below — first emit happens after this).
     child_session_ref["session_id"] = getattr(child, "session_id", "") or ""


### PR DESCRIPTION
## Summary

Delegation subagents no longer share the parent agent's live SessionDB handle — each child opens a dedicated connection to the parent's database file, owned and released by the child's own `close()`.

Salvages #81343 by @thatssoheil (cherry-picked, authorship preserved) + one follow-up fix.

## The bug (#81267)

Cron `run_job()` closes its per-job SessionDB in its `finally` block while a fire-and-forget background delegation subagent — handed the *same* SessionDB object — is still flushing on a daemon thread. Every subsequent child flush hits the closed handle (`'NoneType' object has no attribute 'execute'`), is downgraded to a WARNING, and the child's entire transcript is silently dropped (144 occurrences over two days on the reporting deployment). The same teardown-while-child-alive shape exists for gateway session end and `/new` mid-delegation, so this fixes the class at the single spawn chokepoint (`_build_child_agent`).

## Changes

- `tools/delegate_tool.py`: `_build_child_agent` opens a dedicated `SessionDB` per child (when the parent has one), sets `child._owns_session_db = True` (the established ownership convention), and closes the fresh handle if `AIAgent()` construction raises (contributor's commits).
- **Follow-up (ours):** the dedicated handle is opened at the **parent handle's `db_path`**, not the default. A bare `SessionDB()` resolves the launch profile's `state.db`, but parents can hold non-default per-profile handles (tui_gateway opens `SessionDB(db_path=<profile_home>/state.db)` for non-launch profiles via `_transfer_db_to_agent`) — a child of such a parent would have written its transcript into the *wrong* database, breaking `parent_session_id` lineage and `session_search` for multi-profile desktop users. E2E-confirmed broken before the follow-up, fixed after. `AsyncSessionDB` (gateway) forwards `.db_path` via `__getattr__`, so the wrapper path works too.
- `tests/tools/test_delegate.py`: 3 tests — dedicated handle survives parent close (verified RED pre-fix by the contributor), degradation to `None` unchanged, and per-profile db_path fidelity (verified RED on the pre-follow-up code).

## Validation

| Check | Result |
|---|---|
| tests/tools/test_delegate.py + async_delegation + apiserver_background + restored_ownership + session_db_ownership_teardown | 105/105 passed |
| E2E (real imports, temp HERMES_HOME): child survives parent close, writes land on disk | PASS |
| E2E: per-profile parent → child targets same db file | PASS (FAIL before follow-up) |
| E2E: construction failure closes the dedicated handle | PASS |
| ruff | clean |

Closes #81343. Fixes #81267 (part A).

## Credit

Original fix by @thatssoheil in #81343 — commits cherry-picked with authorship preserved.
