### PR TITLE
fix(agent): treat max-iteration nudge as synthetic during compaction (salvage #78594)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2317,11 +2317,12 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             defer_logical_completion=True,
         )
 
-    summary_request = (
-        "You've reached the maximum number of tool-calling iterations allowed. "
-        "Please provide a final response summarizing what you've found and accomplished so far, "
-        "without calling any more tools."
-    )
+    # Shared constant so compaction recognizers can identify this runtime nudge
+    # by its stable content after SessionDB projection strips metadata flags
+    # (see MAX_ITERATIONS_SUMMARY_REQUEST / _is_synthetic_compression_user_turn).
+    from agent.context_compressor import MAX_ITERATIONS_SUMMARY_REQUEST
+
+    summary_request = MAX_ITERATIONS_SUMMARY_REQUEST
     messages.append({"role": "user", "content": summary_request})
 
     try:

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -168,6 +168,15 @@ _LEGACY_COMPRESSION_CONTINUATION_USER_CONTENT = (
     "This marker exists because the compacted transcript contained "
     "no preserved user turn."
 )
+# Runtime nudge appended by ``handle_max_iterations`` as a ``role="user"`` row.
+# SessionDB projection strips underscore-prefixed metadata, so a synthetic flag
+# would not survive persistence; the stable content string is the authoritative
+# marker for compaction recognizers (mirrors the continuation/todo markers).
+MAX_ITERATIONS_SUMMARY_REQUEST = (
+    "You've reached the maximum number of tool-calling iterations allowed. "
+    "Please provide a final response summarizing what you've found and accomplished so far, "
+    "without calling any more tools."
+)
 
 
 def _fresh_compaction_message_copy(msg: Dict[str, Any]) -> Dict[str, Any]:
@@ -4368,6 +4377,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         return text in {
             COMPRESSION_CONTINUATION_USER_CONTENT,
             _LEGACY_COMPRESSION_CONTINUATION_USER_CONTENT,
+            MAX_ITERATIONS_SUMMARY_REQUEST,
         } or text.startswith(
             TODO_INJECTION_HEADER + "\n"
         )

--- a/tests/agent/test_context_compressor_zero_user_provenance.py
+++ b/tests/agent/test_context_compressor_zero_user_provenance.py
@@ -11,6 +11,7 @@ from agent.context_compressor import (
     COMPRESSED_SUMMARY_HAS_USER_TURN_KEY,
     COMPRESSED_SUMMARY_METADATA_KEY,
     HISTORICAL_TASK_HEADING,
+    MAX_ITERATIONS_SUMMARY_REQUEST,
     SUMMARY_PREFIX,
     ContextCompressor,
     _NO_USER_TASK_SENTINEL,
@@ -200,6 +201,40 @@ def test_zero_user_provenance_survives_iterative_compaction(compressor):
     ]
     assert len(second_handoffs) == 1
     assert second_handoffs[0][COMPRESSED_SUMMARY_HAS_USER_TURN_KEY] is False
+
+
+def test_max_iterations_nudge_is_synthetic_not_actionable():
+    """#78580: the max-iteration runtime nudge is runtime scaffolding, not a
+    human turn. It is appended as ``role="user"`` and persisted verbatim in
+    state.db (metadata flags do not survive projection), so recognition must be
+    content-based — exactly like the continuation/todo markers."""
+    # The projected form: a bare role/content row with no internal metadata.
+    nudge = {"role": "user", "content": MAX_ITERATIONS_SUMMARY_REQUEST}
+
+    assert ContextCompressor._is_synthetic_compression_user_turn(nudge) is True
+    # A real human turn with the same shape stays actionable.
+    human = {"role": "user", "content": "Ship the release notes for v2."}
+    assert ContextCompressor._is_synthetic_compression_user_turn(human) is False
+    assert ContextCompressor._transcript_has_real_user_turn([nudge]) is False
+    assert ContextCompressor._transcript_has_real_user_turn([human, nudge]) is True
+
+
+def test_real_task_wins_over_trailing_max_iterations_nudge(compressor):
+    """The tail anchor must resolve to the human task, not the nudge that the
+    runtime appended after it when iterations were exhausted."""
+    human = {"role": "user", "content": "Refactor the auth module and add tests."}
+    messages = [
+        human,
+        {"role": "assistant", "content": "Working on it.", "tool_calls": [
+            {"id": "c1", "function": {"name": "terminal", "arguments": "{}"}}
+        ]},
+        {"role": "tool", "tool_call_id": "c1", "content": "ok"},
+        {"role": "user", "content": MAX_ITERATIONS_SUMMARY_REQUEST},
+    ]
+
+    idx = compressor._find_last_user_message_idx(messages, head_end=0)
+    assert idx == 0, "nudge was selected as the anchor instead of the human task"
+    assert messages[idx]["content"] == human["content"]
 
 
 def test_compress_context_todo_snapshot_stays_synthetic_across_two_boundaries(


### PR DESCRIPTION
## Summary

When the agent hits its max tool-calling iterations, the runtime appends a summary request as a plain `role="user"` message. Later context compaction treated that runtime nudge as the latest human task — anchoring compaction on it, counting it toward protected user turns, feeding it into auto-focus, and demoting or dropping the user's real request. After this change the nudge is recognized as synthetic scaffolding on every compaction path.

Salvage of #78594 by @PRATHAMESH75 (cherry-picked, authorship preserved). Fixes #78580.

## Changes

- `agent/context_compressor.py`: new shared `MAX_ITERATIONS_SUMMARY_REQUEST` constant (single source of truth between producer and recognizer); `_is_synthetic_compression_user_turn()` recognizes it — the correct chokepoint, since `_is_real_user_message()` delegates to it, transitively covering anchor selection, min-tail user accounting, `_transcript_has_real_user_turn`, auto-focus derivation, and task-snapshot grounding.
- `agent/chat_completion_helpers.py`: `handle_max_iterations()` uses the shared constant.
- 2 regression tests: projected (metadata-free) nudge row is synthetic while a same-shape human turn is not; tail anchor resolves to the human task, not the trailing nudge.

Content-based recognition is required because SessionDB projection strips underscore-prefixed metadata — a flag would not survive persistence.

Note: #81103 attempted the same fix via `_SYNTHETIC_USER_PREFIXES`/`_SYNTHETIC_USER_FLAGS`, which only feed `_is_real_user_message()` — anchor selection and tail accounting stayed broken (probe-verified). This chokepoint fix is a strict superset.

## Validation

| Check | Result |
|---|---|
| test_context_compressor.py + zero_user_provenance + turn_finalizer_iteration_limit_exit | 130 passed |
| Deterministic probe: anchor idx, auto-focus, provenance, task snapshot | all resolve to the human task |
| ruff | clean |

Closes #78594
