### PR TITLE
perf(ci): build only en locale in docs-site-checks

### DIFF
--- a/.github/workflows/docs-site-checks.yml
+++ b/.github/workflows/docs-site-checks.yml
@@ -49,5 +49,8 @@ jobs:
         working-directory: website
 
       - name: Build Docusaurus
-        run: npm run build
+        # Build only the default (en) locale in CI — the full bilingual
+        # build runs in deploy-site.yml on push-to-main / release.
+        # Same pattern Docusaurus uses internally (build:fast --locale en).
+        run: npm run build:fast
         working-directory: website

--- a/website/package.json
+++ b/website/package.json
@@ -8,6 +8,7 @@
     "start": "docusaurus start",
     "prebuild": "node scripts/prebuild.mjs",
     "build": "docusaurus build",
+    "build:fast": "docusaurus build --locale en",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",


### PR DESCRIPTION
## Summary

The `Docs Site / docs-site-checks` job is the CI critical path at ~4m12s. The single `Build Docusaurus` step accounts for 198s (79%) of that time, building all locales (en + zh-Hans, ~700 pages + search index).

This PR adds a `build:fast` script (`docusaurus build --locale en`) and uses it in CI checks, halving the build step by skipping the Chinese locale compilation and search indexing. The full bilingual build still runs in `deploy-site.yml` for production deploys.

Same pattern Docusaurus uses internally — their `build:fast` script runs `build --locale en` for CI and preview builds ([PR #4611](https://github.com/facebook/docusaurus/pull/4611), [PR #7788](https://github.com/facebook/docusaurus/pull/7788)).

## Changes

- `website/package.json`: add `"build:fast": "docusaurus build --locale en"`
- `.github/workflows/docs-site-checks.yml`: `npm run build` → `npm run build:fast`
- `deploy-site.yml`: **unchanged** — still runs `npm run build` (all locales)

## Validation

| | Before | After (expected) |
|---|---|---|
| Build Docusaurus step | 198s (en + zh-Hans) | ~100s (en only) |
| Docs Site job total | 252s (4m12s) | ~150s (~2m30s) |
| Deploy workflow | Full bilingual build | Unchanged |

Measured on PR #81606's CI run. The zh-Hans locale has 317 markdown files (~4.4 MB) that no longer need MDX compilation, HTML generation, or search index building in PR checks.