### PR TITLE
fix: cause-aware session-persistence errors, gateway recovery message, doctor state.db stats (salvage #80693)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1472,6 +1472,11 @@ def run_conversation(
     # A configured SessionDB append failure halts only the affected turn. A
     # cached gateway agent must recover on the next message if storage did.
     agent._incremental_persistence_failed = False
+    # Cause of the most recent persistence failure this turn ('locked',
+    # 'disk', or 'unknown' — see run_agent.classify_persistence_error).
+    # Reset alongside the failure flag so a lock-contention diagnosis from a
+    # previous turn can never leak into this turn's user-facing explanation.
+    agent._last_persistence_error_cause = None
 
     # Main conversation loop counters (pure locals consumed by the loop below).
     api_call_count = 0
@@ -6505,6 +6510,10 @@ def run_conversation(
                     )
                 except Exception as exc:
                     _tool_turn_persisted = False
+                    from run_agent import classify_persistence_error
+                    agent._last_persistence_error_cause = (
+                        classify_persistence_error(exc)
+                    )
                     logger.warning(
                         "Incremental tool-call persistence failed before execution "
                         "(session=%s): %s",
@@ -6517,6 +6526,10 @@ def run_conversation(
                     # run side-effecting tools from state that exists only in
                     # this process. Breaking also avoids retrying the same
                     # unpersisted turn until the iteration budget is exhausted.
+                    # The flush may have classified the cause internally; if
+                    # nothing was recorded, the cause is genuinely unknown.
+                    if getattr(agent, "_last_persistence_error_cause", None) is None:
+                        agent._last_persistence_error_cause = "unknown"
                     _turn_exit_reason = "session_persistence_failed"
                     final_response = ""
                     failed = True

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -192,9 +192,16 @@ def _flush_session_db_after_tool_progress(
         persisted = agent._flush_messages_to_session_db(messages) is not False
         if not persisted:
             agent._incremental_persistence_failed = True
+            # The flush caught its own exception and returned False; the
+            # classified cause (if any) was captured at the catch site. Only
+            # fall back to 'unknown' when nothing more specific is recorded.
+            if getattr(agent, "_last_persistence_error_cause", None) is None:
+                agent._last_persistence_error_cause = "unknown"
         return persisted
     except Exception as exc:
         agent._incremental_persistence_failed = True
+        from run_agent import classify_persistence_error
+        agent._last_persistence_error_cause = classify_persistence_error(exc)
         logger.warning("Incremental tool-call persistence failed after %s: %s", stage, exc)
         return False
 

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -529,7 +529,8 @@ def finalize_turn(
                     or _is_partial_stream_recovery
                 ):
                     _explanation = agent._format_turn_completion_explanation(
-                        _turn_exit_reason
+                        _turn_exit_reason,
+                        getattr(agent, "_last_persistence_error_cause", None),
                     )
                     if _explanation:
                         if _is_empty_terminal:
@@ -675,11 +676,20 @@ def finalize_turn(
         result["guardrail"] = agent._tool_guardrail_halt_decision.to_metadata()
     # Persistence failures already set failed=True + an explanation in
     # final_response; also stamp `error` so gateway surfaces status="error"
-    # (and desktop can toast disk-full) instead of a quiet complete frame.
+    # (and desktop can toast the cause) instead of a quiet complete frame.
     if failed and str(_turn_exit_reason) == "session_persistence_failed":
         result["error"] = final_response or (
-            "session storage could not be written — free disk space and try again"
+            "session storage could not be written — check the state database "
+            "health (`hermes doctor`), then send your message again"
         )
+        # Machine-readable cause for the gateway/desktop: exactly
+        # 'session_persistence_failed:<locked|disk|unknown>'. Never clobber a
+        # failure_reason another path already stamped on this result.
+        if "failure_reason" not in result:
+            _cause = getattr(agent, "_last_persistence_error_cause", None)
+            result["failure_reason"] = (
+                "session_persistence_failed:" + (_cause or "unknown")
+            )
     # Surface any post-loop cleanup failures so the caller can distinguish a
     # clean turn from one whose trajectory/session/resource teardown raised
     # (the response is still returned either way — #8049).

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4255,7 +4255,11 @@ def run_job(
             # one-argument render would let cause-refined explainer text slip
             # through and be delivered as a cron warning.
             _explainer_variants = []
-            for _cause in (None, "locked", "disk", "unknown"):
+            try:
+                from hermes_state import PERSISTENCE_ERROR_CAUSES as _causes
+            except Exception:
+                _causes = ("locked", "disk", "unknown")
+            for _cause in (None, *_causes):
                 try:
                     _variant = AIAgent._format_turn_completion_explanation(
                         turn_exit_reason, _cause

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4250,11 +4250,29 @@ def run_job(
         # and soft-failure marking below apply — restoring pre-#34452 silence
         # for scheduled jobs without disabling the explainer everywhere.
         if final_response.strip() and turn_exit_reason:
-            try:
-                _explainer_text = AIAgent._format_turn_completion_explanation(turn_exit_reason)
-            except Exception:
-                _explainer_text = ""
-            if _explainer_text and final_response.strip() == _explainer_text.strip():
+            # The formatter's wording varies by persistence cause (locked /
+            # disk / unknown), so render every variant — matching only the
+            # one-argument render would let cause-refined explainer text slip
+            # through and be delivered as a cron warning.
+            _explainer_variants = []
+            for _cause in (None, "locked", "disk", "unknown"):
+                try:
+                    _variant = AIAgent._format_turn_completion_explanation(
+                        turn_exit_reason, _cause
+                    )
+                except TypeError:
+                    # Older single-argument formatter (or a test double).
+                    try:
+                        _variant = AIAgent._format_turn_completion_explanation(
+                            turn_exit_reason
+                        )
+                    except Exception:
+                        _variant = ""
+                except Exception:
+                    _variant = ""
+                if _variant:
+                    _explainer_variants.append(_variant.strip())
+            if final_response.strip() in _explainer_variants:
                 logger.info(
                     "Job '%s': abnormal empty turn (%s) — suppressing explainer for cron delivery",
                     job_id,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3487,8 +3487,33 @@ def _normalize_empty_agent_response(
         return response
 
     if agent_result.get("failed"):
-        error_detail = agent_result.get("error", "unknown error")
+        # None-safe: the gateway result dict is built with
+        # ``'error': holder.get('error')`` and can carry an EXPLICIT None,
+        # which bypasses dict.get's default and would render
+        # "The request failed: None".
+        error_detail = agent_result.get("error") or "unknown error"
         error_str = str(error_detail).lower()
+        # Session-persistence failures get a dedicated recovery message.
+        # Suggesting /reset here would be actively harmful: it destroys the
+        # user's conversation context and does nothing to fix the underlying
+        # storage problem (lock contention, disk exhaustion, ...).
+        failure_reason = str(agent_result.get("failure_reason") or "")
+        if failure_reason.startswith("session_persistence_failed") or (
+            "session storage" in error_str
+        ):
+            if failure_reason.endswith(":disk") or "disk" in error_str:
+                return (
+                    "⚠️ Session storage was temporarily unavailable, so this "
+                    "turn was stopped to protect your conversation history. "
+                    "Please check available disk space, then send your "
+                    "message again."
+                )
+            return (
+                "⚠️ Session storage was temporarily unavailable, so this "
+                "turn was stopped to protect your conversation history. "
+                "Your message was recorded — please send it again in a "
+                "moment."
+            )
         is_context_failure = any(
             p in error_str
             for p in ("context", "token", "too large", "too long", "exceed", "payload")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3511,8 +3511,8 @@ def _normalize_empty_agent_response(
             return (
                 "⚠️ Session storage was temporarily unavailable, so this "
                 "turn was stopped to protect your conversation history. "
-                "Your message was recorded — please send it again in a "
-                "moment."
+                "Your message should already be saved — please send it "
+                "again in a moment."
             )
         is_context_failure = any(
             p in error_str

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -309,14 +309,11 @@ def _render_state_db_stats(stats: dict, holders=None) -> list:
             f"({detail})",
         ))
 
-    # Advisory: WAL runaway — checkpoints are not landing.
-    if wal is not None and wal > STATE_DB_WAL_WARN_BYTES:
-        lines.append((
-            "warn",
-            f"state.db WAL is very large ({_human_bytes(wal)})",
-            "(checkpoints may not be completing — a long-lived reader or "
-            "stuck process can block them; see 'hermes doctor --fix')",
-        ))
+    # WAL runaway is deliberately NOT warned here: the pre-existing WAL
+    # check later in the state.db section already warns above 50 MB and
+    # offers a checkpoint via --fix; a second warning at a higher threshold
+    # would only duplicate it. STATE_DB_WAL_WARN_BYTES remains for callers
+    # (dashboards) that consume the stats dict without that legacy check.
 
     return lines
 

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -216,6 +216,111 @@ def check_info(text: str):
     print(f"    {color('→', Colors.CYAN)} {text}")
 
 
+# ── state.db health/stats thresholds (advisory only — module constants,
+# deliberately NOT config: doctor warnings are guidance, not policy) ──
+STATE_DB_SIZE_WARN_BYTES = 1 * 1024 * 1024 * 1024   # 1 GiB logical size
+STATE_DB_WAL_WARN_BYTES = 256 * 1024 * 1024          # 256 MiB WAL
+
+
+def _human_bytes(n) -> str:
+    """1234567 → '1.2 MB' (GB/MB/KB/B)."""
+    try:
+        n = int(n)
+    except (TypeError, ValueError):
+        return "?"
+    if n >= 1024 ** 3:
+        return f"{n / (1024 ** 3):.1f} GB"
+    if n >= 1024 ** 2:
+        return f"{n / (1024 ** 2):.1f} MB"
+    if n >= 1024:
+        return f"{n / 1024:.1f} KB"
+    return f"{n} B"
+
+
+def _render_state_db_stats(stats: dict, holders=None) -> list:
+    """Turn a collect_state_db_stats() dict into doctor output lines.
+
+    Returns a list of ``(kind, text, detail)`` tuples where kind is one of
+    'info' / 'warn'. Pure formatting — no I/O — so it is unit-testable
+    without spawning the doctor CLI. Tolerates None in every field.
+    """
+    lines: list = []
+    stats = stats or {}
+
+    logical = stats.get("logical_size_bytes")
+    wal = stats.get("wal_size_bytes")
+    freelist = stats.get("freelist_count")
+
+    size_bits = []
+    if logical is not None:
+        size_bits.append(f"logical size {_human_bytes(logical)}")
+    if stats.get("page_count") is not None:
+        size_bits.append(f"{stats['page_count']:,} pages")
+    if freelist is not None:
+        size_bits.append(f"{freelist:,} free")
+    if wal is not None:
+        size_bits.append(f"WAL {_human_bytes(wal)}")
+    if size_bits:
+        lines.append(("info", "state.db " + ", ".join(size_bits), ""))
+
+    row_bits = []
+    if stats.get("messages") is not None:
+        row_bits.append(f"{stats['messages']:,} messages")
+    if stats.get("sessions") is not None:
+        row_bits.append(f"{stats['sessions']:,} sessions")
+    if stats.get("journal_mode"):
+        row_bits.append(f"journal_mode={stats['journal_mode']}")
+    if holders is not None:
+        row_bits.append(f"{holders} process(es) holding the DB open")
+    if row_bits:
+        lines.append(("info", ", ".join(row_bits), ""))
+
+    fts = stats.get("fts_tables")
+    if fts:
+        present = [t for t, ok in fts.items() if ok]
+        lines.append((
+            "info",
+            "FTS tables: " + (", ".join(present) if present else "none"),
+            "",
+        ))
+
+    # Advisory: oversized database. Suggest auto_prune, and — when the v23
+    # FTS rebuild is pending OR the DB still carries the legacy inline
+    # trigram layout (fts_storage_version marker absent) — the offline
+    # optimize-storage pass that migrates/compacts the FTS indexes.
+    if logical is not None and logical > STATE_DB_SIZE_WARN_BYTES:
+        detail = (
+            "consider enabling sessions.auto_prune in config.yaml "
+            "to bound growth"
+        )
+        legacy_trigram = (
+            fts is not None
+            and fts.get("messages_fts_trigram")
+            and stats.get("fts_storage_version") is None
+        )
+        if stats.get("fts_rebuild_pending") or legacy_trigram:
+            detail += (
+                "; run 'hermes sessions optimize-storage' offline "
+                "(with the gateway stopped) to compact FTS storage"
+            )
+        lines.append((
+            "warn",
+            f"state.db is large ({_human_bytes(logical)})",
+            f"({detail})",
+        ))
+
+    # Advisory: WAL runaway — checkpoints are not landing.
+    if wal is not None and wal > STATE_DB_WAL_WARN_BYTES:
+        lines.append((
+            "warn",
+            f"state.db WAL is very large ({_human_bytes(wal)})",
+            "(checkpoints may not be completing — a long-lived reader or "
+            "stuck process can block them; see 'hermes doctor --fix')",
+        ))
+
+    return lines
+
+
 def _section(title: str) -> None:
     """Print a doctor section banner: blank line + bold cyan ◆ title."""
     print()
@@ -1594,6 +1699,36 @@ def run_doctor(args):
                     )
             else:
                 check_warn(f"{_DHH}/state.db exists but has issues: {e}")
+
+        # Health/stats snapshot (#statedb-visibility): a multi-GB state.db
+        # with a runaway WAL was previously invisible to every Hermes
+        # surface. Strictly read-only (mode=ro) so it is safe against a
+        # live DB held by the gateway; any failure degrades to one info
+        # line rather than failing doctor.
+        try:
+            from hermes_state import collect_state_db_stats, count_db_holders
+
+            _db_stats = collect_state_db_stats(state_db_path)
+            _db_holders = count_db_holders(state_db_path)
+            for _kind, _text, _detail in _render_state_db_stats(
+                _db_stats, holders=_db_holders
+            ):
+                if _kind == "warn":
+                    check_warn(_text, _detail)
+                    if "auto_prune" in _detail:
+                        issues.append(
+                            "state.db is large — enable sessions.auto_prune "
+                            "in config.yaml"
+                            + (
+                                " and run 'hermes sessions optimize-storage' "
+                                "offline (gateway stopped)"
+                                if "optimize-storage" in _detail else ""
+                            )
+                        )
+                else:
+                    check_info(_text + (f" {_detail}" if _detail else ""))
+        except Exception as _stats_exc:
+            check_info(f"state.db stats unavailable ({_stats_exc})")
     else:
         check_info(f"{_DHH}/state.db not created yet (will be created on first session)")
 

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -219,7 +219,6 @@ def check_info(text: str):
 # ── state.db health/stats thresholds (advisory only — module constants,
 # deliberately NOT config: doctor warnings are guidance, not policy) ──
 STATE_DB_SIZE_WARN_BYTES = 1 * 1024 * 1024 * 1024   # 1 GiB logical size
-STATE_DB_WAL_WARN_BYTES = 256 * 1024 * 1024          # 256 MiB WAL
 
 
 def _human_bytes(n) -> str:
@@ -312,8 +311,7 @@ def _render_state_db_stats(stats: dict, holders=None) -> list:
     # WAL runaway is deliberately NOT warned here: the pre-existing WAL
     # check later in the state.db section already warns above 50 MB and
     # offers a checkpoint via --fix; a second warning at a higher threshold
-    # would only duplicate it. STATE_DB_WAL_WARN_BYTES remains for callers
-    # (dashboards) that consume the stats dict without that legacy check.
+    # would only duplicate it.
 
     return lines
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2220,8 +2220,14 @@ def collect_state_db_stats(db_path: Path) -> Dict[str, Any]:
     try:
         # mode=ro refuses to create the file and refuses every write; a
         # short timeout keeps doctor snappy when a writer holds the lock.
-        conn = sqlite3.connect(
-            f"file:{Path(db_path)}?mode=ro", uri=True, timeout=2.0
+        # Route through the tracked connect so byte-probe helpers
+        # (read_header_bytes_preopen) see this connection and refuse raw
+        # opens that could cancel our POSIX locks mid-read.
+        conn = _connect_tracked_db(
+            f"file:{Path(db_path)}?mode=ro",
+            tracking_path=Path(db_path),
+            uri=True,
+            timeout=2.0,
         )
     except Exception as exc:
         logger.debug("collect_state_db_stats: cannot open %s read-only: %s",

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1367,6 +1367,58 @@ def is_disk_full_error(exc: BaseException | str | None) -> bool:
     return any(marker in lowered for marker in _DISK_FULL_MARKERS)
 
 
+# Every cause bucket classify_persistence_error can return. Consumers that
+# enumerate causes (e.g. the cron scheduler's explainer-variant suppression)
+# must iterate this tuple instead of hardcoding the list, so adding a bucket
+# can never silently desynchronize them.
+PERSISTENCE_ERROR_CAUSES = ("locked", "disk", "unknown")
+
+
+def classify_persistence_error(exc_or_str) -> str:
+    """Classify a session-persistence failure into a coarse cause bucket.
+
+    Fast-failing a turn on a SessionDB write error is deliberate (the
+    transcript would otherwise be lost on restart), but the *guidance* the
+    user gets must match the cause: sustained SQLite write-lock contention
+    ("database is locked" on a shared state.db) needs "storage was busy,
+    send it again", while a full disk or read-only database needs the
+    disk-space/permissions advice. Returns one of PERSISTENCE_ERROR_CAUSES:
+
+    * ``"locked"``  — lock/busy contention (another process holds the write
+      lock, or a live compression lease refused the write); transient,
+      retry-later guidance applies.
+    * ``"disk"``    — disk full / read-only / permission-shaped failures
+      (delegates the disk-full patterns to :func:`is_disk_full_error` so the
+      two classifiers can never drift apart — e.g. ENOSPC).
+    * ``"unknown"`` — anything else (or no visible exception at all).
+    """
+    if exc_or_str is None:
+        return "unknown"
+    # A refused write during a live compression lease is contention, not
+    # storage damage — but its message ("is being compressed by another
+    # writer" / "Compression lease lost") contains neither "locked" nor
+    # "busy", so it must be matched by type and by phrase (for strings that
+    # survived RPC wrapping).
+    if isinstance(exc_or_str, CompressionSessionBusyError):
+        return "locked"
+    text = str(exc_or_str).lower()
+    if (
+        "locked" in text
+        or "busy" in text
+        or "being compressed" in text
+        or "compression lease" in text
+    ):
+        return "locked"
+    if (
+        is_disk_full_error(exc_or_str)
+        or "disk" in text
+        or "readonly" in text
+        or "read-only" in text
+    ):
+        return "disk"
+    return "unknown"
+
+
 def _claim_repair_attempt(db_path: Path) -> bool:
     """Claim the one-shot repair attempt for *db_path* in this process.
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2162,6 +2162,178 @@ def quarantine_zeroed_state_db(path: Path) -> Optional[Path]:
             handle.close()
 
 
+# ── Read-only health/stats probes (hermes doctor, dashboards) ──────────
+
+
+def collect_state_db_stats(db_path: Path) -> Dict[str, Any]:
+    """Best-effort, strictly read-only stats snapshot of a state.db file.
+
+    Opens the database with ``mode=ro`` (URI) and a short timeout so it can
+    run against a *live* database held by a gateway without ever taking a
+    write lock or mutating the file. Every field is collected independently:
+    a failed pragma/SELECT yields ``None`` for that field, and the helper
+    itself never raises.
+
+    Deliberately does NOT instantiate :class:`SessionDB` — its constructor
+    runs schema DDL (migrations, FTS table creation), which is exactly the
+    kind of write a diagnostics probe must never perform.
+
+    Returned keys (all present, any may be None on failure):
+
+    - ``page_count``, ``page_size``, ``freelist_count`` — PRAGMA values
+    - ``logical_size_bytes`` — page_count * page_size (post-checkpoint size)
+    - ``wal_size_bytes`` — stat() of ``<db>-wal`` (0 when absent)
+    - ``journal_mode`` — PRAGMA journal_mode string
+    - ``messages`` / ``sessions`` — row counts
+    - ``fts_tables`` — dict of {table_name: bool} presence for
+      messages_fts / messages_fts_trigram / messages_fts_cjk
+    - ``fts_storage_version`` — int from state_meta, None when the marker is
+      absent (legacy pre-v23 inline layout)
+    - ``fts_rebuild_pending`` — True when the deferred v23 backfill has not
+      finished (high_water present and progress < high_water)
+    - ``fts_rebuild_high_water`` / ``fts_rebuild_progress`` — raw ints
+    """
+    stats: Dict[str, Any] = {
+        "page_count": None,
+        "page_size": None,
+        "freelist_count": None,
+        "logical_size_bytes": None,
+        "wal_size_bytes": None,
+        "journal_mode": None,
+        "messages": None,
+        "sessions": None,
+        "fts_tables": None,
+        "fts_storage_version": None,
+        "fts_rebuild_pending": None,
+        "fts_rebuild_high_water": None,
+        "fts_rebuild_progress": None,
+    }
+
+    # WAL sidecar size needs no connection at all.
+    try:
+        wal_path = Path(str(db_path) + "-wal")
+        stats["wal_size_bytes"] = wal_path.stat().st_size if wal_path.exists() else 0
+    except OSError:
+        pass
+
+    conn = None
+    try:
+        # mode=ro refuses to create the file and refuses every write; a
+        # short timeout keeps doctor snappy when a writer holds the lock.
+        conn = sqlite3.connect(
+            f"file:{Path(db_path)}?mode=ro", uri=True, timeout=2.0
+        )
+    except Exception as exc:
+        logger.debug("collect_state_db_stats: cannot open %s read-only: %s",
+                     db_path, exc)
+        return stats
+
+    def _scalar(sql: str) -> Any:
+        try:
+            row = conn.execute(sql).fetchone()
+            return row[0] if row else None
+        except Exception:
+            return None
+
+    try:
+        pc = _scalar("PRAGMA page_count")
+        ps = _scalar("PRAGMA page_size")
+        stats["page_count"] = int(pc) if pc is not None else None
+        stats["page_size"] = int(ps) if ps is not None else None
+        if stats["page_count"] is not None and stats["page_size"] is not None:
+            stats["logical_size_bytes"] = stats["page_count"] * stats["page_size"]
+
+        fl = _scalar("PRAGMA freelist_count")
+        stats["freelist_count"] = int(fl) if fl is not None else None
+
+        jm = _scalar("PRAGMA journal_mode")
+        stats["journal_mode"] = str(jm) if jm is not None else None
+
+        msgs = _scalar("SELECT COUNT(*) FROM messages")
+        stats["messages"] = int(msgs) if msgs is not None else None
+        sess = _scalar("SELECT COUNT(*) FROM sessions")
+        stats["sessions"] = int(sess) if sess is not None else None
+
+        # FTS table presence via sqlite_master (never SELECTs from the
+        # virtual tables themselves — a corrupt index must not fail stats).
+        try:
+            names = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'table' "
+                    "AND name IN (?, ?, ?)",
+                    ("messages_fts", "messages_fts_trigram", "messages_fts_cjk"),
+                ).fetchall()
+            }
+            stats["fts_tables"] = {
+                t: (t in names)
+                for t in ("messages_fts", "messages_fts_trigram", "messages_fts_cjk")
+            }
+        except Exception:
+            pass
+
+        # Raw state_meta reads — cheap, and independent of SessionDB.
+        def _meta_int(key: str) -> Optional[int]:
+            try:
+                row = conn.execute(
+                    "SELECT value FROM state_meta WHERE key = ?", (key,)
+                ).fetchone()
+                return int(row[0]) if row and row[0] is not None else None
+            except Exception:
+                return None
+
+        stats["fts_storage_version"] = _meta_int("fts_storage_version")
+        high_water = _meta_int("fts_rebuild_high_water")
+        progress = _meta_int("fts_rebuild_progress")
+        stats["fts_rebuild_high_water"] = high_water
+        stats["fts_rebuild_progress"] = progress
+        if high_water is None:
+            stats["fts_rebuild_pending"] = False
+        else:
+            stats["fts_rebuild_pending"] = (progress or 0) < high_water
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+    return stats
+
+
+def count_db_holders(db_path: Path) -> Optional[int]:
+    """Best-effort count of processes holding ``db_path`` open (Linux only).
+
+    Scans ``/proc/*/fd`` symlinks for the resolved database path. Returns
+    the number of distinct PIDs with the file open, or ``None`` on any
+    error or on non-Linux platforms. Never raises; no lsof dependency.
+    Unreadable per-process fd dirs (other users' processes without root)
+    are silently skipped, so the count is a lower bound.
+    """
+    try:
+        if not sys.platform.startswith("linux"):
+            return None
+        target = os.path.realpath(str(db_path))
+        holders = 0
+        for pid in os.listdir("/proc"):
+            if not pid.isdigit():
+                continue
+            fd_dir = f"/proc/{pid}/fd"
+            try:
+                fds = os.listdir(fd_dir)
+            except OSError:
+                continue  # process gone or not ours
+            for fd in fds:
+                try:
+                    if os.readlink(f"{fd_dir}/{fd}") == target:
+                        holders += 1
+                        break  # one hit per PID
+                except OSError:
+                    continue
+        return holders
+    except Exception:
+        return None
+
+
 class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin):
     """
     SQLite-backed session storage with FTS5 search.

--- a/run_agent.py
+++ b/run_agent.py
@@ -3719,8 +3719,8 @@ class AIAgent:
                     prefix
                     + "the turn was stopped because session storage was busy "
                     "(another Hermes process was writing to the state "
-                    "database). Your message was saved — please send it "
-                    "again in a moment."
+                    "database). Your message should already be saved — "
+                    "please send it again in a moment."
                 )
             if cause == "disk":
                 return (

--- a/run_agent.py
+++ b/run_agent.py
@@ -282,32 +282,18 @@ _DB_PERSISTED_MARKER = "_db_persisted"
 def classify_persistence_error(exc_or_str) -> str:
     """Classify a session-persistence failure into a coarse cause bucket.
 
-    Fast-failing a turn on a SessionDB write error is deliberate (the
-    transcript would otherwise be lost on restart), but the *guidance* the
-    user gets must match the cause: sustained SQLite write-lock contention
-    ("database is locked" on a shared state.db) needs "storage was busy,
-    send it again", while a full disk or read-only database needs the
-    disk-space/permissions advice. Returns one of:
-
-    * ``"locked"``  — lock/busy contention (another process holds the write
-      lock); transient, retry-later guidance applies.
-    * ``"disk"``    — disk full / read-only / permission-shaped failures.
-    * ``"unknown"`` — anything else (or no visible exception at all).
+    Thin delegating wrapper: the canonical implementation lives in
+    ``hermes_state`` (beside ``is_disk_full_error``, whose disk-full
+    patterns it reuses so the two classifiers can never drift apart).
+    Kept importable from this module because the turn-finalizer contract
+    and existing callers reference ``run_agent.classify_persistence_error``.
+    The import stays lazy to preserve this module's fast import path —
+    every real caller already has hermes_state loaded (the error being
+    classified came from a SessionDB write).
     """
-    if exc_or_str is None:
-        return "unknown"
-    text = str(exc_or_str).lower()
-    if "locked" in text or "busy" in text:
-        return "locked"
-    if (
-        "disk" in text
-        or "readonly" in text
-        or "read-only" in text
-        or "no space" in text
-        or "database or disk is full" in text
-    ):
-        return "disk"
-    return "unknown"
+    from hermes_state import classify_persistence_error as _impl
+
+    return _impl(exc_or_str)
 
 
 # Guard so the OpenRouter metadata pre-warm thread is only spawned once per

--- a/run_agent.py
+++ b/run_agent.py
@@ -279,6 +279,37 @@ _MAX_TOOL_WORKERS = 8
 _DB_PERSISTED_MARKER = "_db_persisted"
 
 
+def classify_persistence_error(exc_or_str) -> str:
+    """Classify a session-persistence failure into a coarse cause bucket.
+
+    Fast-failing a turn on a SessionDB write error is deliberate (the
+    transcript would otherwise be lost on restart), but the *guidance* the
+    user gets must match the cause: sustained SQLite write-lock contention
+    ("database is locked" on a shared state.db) needs "storage was busy,
+    send it again", while a full disk or read-only database needs the
+    disk-space/permissions advice. Returns one of:
+
+    * ``"locked"``  — lock/busy contention (another process holds the write
+      lock); transient, retry-later guidance applies.
+    * ``"disk"``    — disk full / read-only / permission-shaped failures.
+    * ``"unknown"`` — anything else (or no visible exception at all).
+    """
+    if exc_or_str is None:
+        return "unknown"
+    text = str(exc_or_str).lower()
+    if "locked" in text or "busy" in text:
+        return "locked"
+    if (
+        "disk" in text
+        or "readonly" in text
+        or "read-only" in text
+        or "no space" in text
+        or "database or disk is full" in text
+    ):
+        return "disk"
+    return "unknown"
+
+
 # Guard so the OpenRouter metadata pre-warm thread is only spawned once per
 # process, not once per AIAgent instantiation.  Without this, long-running
 # gateway processes leak one OS thread per incoming message and eventually
@@ -2302,6 +2333,11 @@ class AIAgent:
             # Force a full re-scan on the next flush: an exception mid-loop
             # leaves messages with mixed dispositions.
             self._db_flush_scan_prefix = None
+            # This is the one place the underlying SQLite error is visible
+            # before it is swallowed into a bare ``False`` — classify it here
+            # so the turn-end explanation can distinguish lock contention
+            # ("storage was busy, send it again") from disk-full/read-only.
+            self._last_persistence_error_cause = classify_persistence_error(e)
             logger.warning("Session DB append_message failed: %s", e)
             return False
 
@@ -3579,7 +3615,9 @@ class AIAgent:
         return True  # safe default: explainer on
 
     @staticmethod
-    def _format_turn_completion_explanation(turn_exit_reason: str) -> str:
+    def _format_turn_completion_explanation(
+        turn_exit_reason: str, persistence_cause: Optional[str] = None
+    ) -> str:
         """Render a user-facing explanation for an abnormal turn ending.
 
         Maps the internal ``turn_exit_reason`` to a short, actionable
@@ -3587,6 +3625,13 @@ class AIAgent:
         content after retries, a partial/truncated stream, a still-pending
         tool result, or an iteration/budget limit) is never silent from
         the UI's perspective — the symptom users report in #34452.
+
+        ``persistence_cause`` refines the ``session_persistence_failed``
+        wording (see ``classify_persistence_error``): lock contention gets
+        "storage was busy, send it again" instead of the disk-space advice,
+        which was a misdiagnosis for that failure mode. It is optional and
+        ignored for every other reason, so one-argument callers keep the
+        exact behavior they had before.
 
         Returns an empty string for reasons that are NOT abnormal (e.g.
         a normal ``text_response(...)`` exit), so callers can concatenate
@@ -3668,12 +3713,30 @@ class AIAgent:
                 "let it summarize."
             )
         if reason == "session_persistence_failed":
+            cause = persistence_cause or "unknown"
+            if cause == "locked":
+                return (
+                    prefix
+                    + "the turn was stopped because session storage was busy "
+                    "(another Hermes process was writing to the state "
+                    "database). Your message was saved — please send it "
+                    "again in a moment."
+                )
+            if cause == "disk":
+                return (
+                    prefix
+                    + "the turn was stopped because session storage could not "
+                    "be written (the transcript would have been lost on "
+                    "restart). This is often a full disk — free some space "
+                    "(or fix state.db permissions), then send your message "
+                    "again."
+                )
             return (
                 prefix
                 + "the turn was stopped because session storage could not be "
                 "written (the transcript would have been lost on restart). "
-                "This is often a full disk — free some space (or fix state.db "
-                "permissions), then send your message again."
+                "Check the state database health (`hermes doctor`), then "
+                "send your message again."
             )
         # Unknown/diagnostic-only reasons (e.g. "unknown", guardrail_halt
         # which already surfaces its own message) — don't second-guess.

--- a/tests/gateway/test_normalize_empty_agent_response.py
+++ b/tests/gateway/test_normalize_empty_agent_response.py
@@ -1,0 +1,128 @@
+"""Unit tests for persistence-failure-aware messaging in
+``_normalize_empty_agent_response``.
+
+When a turn is stopped because session persistence failed (SQLite lock
+contention, disk exhaustion, ...), the user must NOT be told to /reset —
+that destroys their conversation context and does nothing to fix storage.
+They must also never see 'The request failed: None' when the gateway result
+dict carries an explicit ``error: None``.
+"""
+
+import pytest
+
+from gateway.run import _normalize_empty_agent_response
+
+
+class TestPersistenceFailureRecoveryMessage:
+    """Failed turns whose failure_reason marks a session-persistence
+    failure get a dedicated recovery message: reassure the user their
+    history is protected, tell them to resend — never suggest /reset."""
+
+    def test_locked_persistence_failure_gets_recovery_message(self):
+        agent_result = {
+            "final_response": "",
+            "failed": True,
+            "failure_reason": "session_persistence_failed:locked",
+            "error": "session storage was locked by another writer",
+            "api_calls": 2,
+        }
+
+        response = _normalize_empty_agent_response(agent_result, "", history_len=10)
+
+        assert "send it again" in response.lower()
+        assert "/reset" not in response
+        assert "unknown error" not in response.lower()
+
+    def test_disk_persistence_failure_mentions_disk(self):
+        agent_result = {
+            "final_response": "",
+            "failed": True,
+            "failure_reason": "session_persistence_failed:disk",
+            "error": "session storage write failed: disk full",
+            "api_calls": 1,
+        }
+
+        response = _normalize_empty_agent_response(agent_result, "", history_len=10)
+
+        assert "disk" in response.lower()
+        assert "/reset" not in response
+        assert "unknown error" not in response.lower()
+
+    def test_unknown_cause_persistence_failure_still_avoids_reset(self):
+        agent_result = {
+            "final_response": "",
+            "failed": True,
+            "failure_reason": "session_persistence_failed:unknown",
+            "error": "session storage failure",
+            "api_calls": 1,
+        }
+
+        response = _normalize_empty_agent_response(agent_result, "", history_len=10)
+
+        assert "/reset" not in response
+        assert "send it again" in response.lower()
+
+    def test_legacy_shape_error_text_mentioning_session_storage(self):
+        """Legacy failed results carry no failure_reason but an error text
+        naming session storage — they must get the same recovery message."""
+        agent_result = {
+            "final_response": "",
+            "failed": True,
+            "error": "turn stopped: session storage unavailable",
+            "api_calls": 1,
+        }
+
+        response = _normalize_empty_agent_response(agent_result, "", history_len=10)
+
+        assert "/reset" not in response
+        assert "send it again" in response.lower()
+
+
+class TestExplicitNoneErrorIsNoneSafe:
+    """The gateway result dict is built with ``'error': holder.get('error')``
+    and can carry an EXPLICIT None, which bypasses dict.get defaults."""
+
+    def test_explicit_none_error_never_renders_none(self):
+        agent_result = {
+            "final_response": "",
+            "failed": True,
+            "error": None,
+            "api_calls": 1,
+        }
+
+        response = _normalize_empty_agent_response(agent_result, "", history_len=10)
+
+        assert "None" not in response
+        # Non-persistence generic failures may legitimately say
+        # 'unknown error' — the defect is rendering the literal None.
+        assert "unknown error" in response.lower()
+
+
+class TestGenericFailureRegression:
+    """Non-persistence failures keep the existing byte-identical message."""
+
+    def test_provider_error_still_formats_request_failed(self):
+        agent_result = {
+            "final_response": "",
+            "failed": True,
+            "error": "provider exploded",
+            "api_calls": 1,
+        }
+
+        response = _normalize_empty_agent_response(agent_result, "", history_len=10)
+
+        assert "The request failed: provider exploded" in response
+        assert "/reset" in response
+
+    def test_context_failure_branch_unchanged(self):
+        agent_result = {
+            "final_response": "",
+            "failed": True,
+            "error": "prompt exceeds context window",
+            "api_calls": 1,
+        }
+
+        response = _normalize_empty_agent_response(agent_result, "", history_len=60)
+
+        assert "context window" in response
+        assert "/compact" in response

--- a/tests/run_agent/test_tool_call_incremental_persistence.py
+++ b/tests/run_agent/test_tool_call_incremental_persistence.py
@@ -241,6 +241,88 @@ def test_failed_assistant_persist_blocks_ui_projection_and_tool_side_effects():
     assert result["failed"] is True
     assert result["completed"] is False
     assert result["turn_exit_reason"] == "session_persistence_failed"
+    # No exception was visible (flush returned False), so the cause is
+    # unknown — but the machine-readable contract fields must still be set.
+    assert result["failure_reason"] == "session_persistence_failed:unknown"
+    assert isinstance(result.get("error"), str) and result["error"].strip() != ""
+
+
+def test_locked_flush_exception_surfaces_locked_cause_in_result_contract():
+    """SQLite write-lock contention must surface as a 'locked' cause.
+
+    Gateway contract: result['failure_reason'] is exactly
+    'session_persistence_failed:locked' and result['error'] is a non-empty
+    string whose wording talks about busy storage, NOT disk space.
+    """
+    import sqlite3
+
+    agent = _make_agent()
+    tool_call = _mock_tool_call(call_id="must-not-run")
+    agent.client.chat.completions.create.return_value = _mock_response(
+        content="I'll inspect the repository now.",
+        finish_reason="tool_calls",
+        tool_calls=[tool_call],
+    )
+    agent._flush_messages_to_session_db = MagicMock(
+        side_effect=sqlite3.OperationalError("database is locked")
+    )
+    agent.interim_assistant_callback = MagicMock()
+    agent._execute_tool_calls = MagicMock()
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("inspect the repository")
+
+    agent.interim_assistant_callback.assert_not_called()
+    agent._execute_tool_calls.assert_not_called()
+    assert result["failed"] is True
+    assert result["turn_exit_reason"] == "session_persistence_failed"
+    assert result["failure_reason"] == "session_persistence_failed:locked"
+    assert isinstance(result.get("error"), str) and result["error"].strip() != ""
+    assert "busy" in result["error"].lower()
+    assert "disk" not in result["error"].lower()
+
+
+def test_persistence_cause_resets_between_turns():
+    """A locked failure on turn 1 must not leak its cause into turn 2."""
+    import sqlite3
+
+    agent = _make_agent()
+    tool_call = _mock_tool_call(call_id="must-not-run")
+    agent.client.chat.completions.create.return_value = _mock_response(
+        content="I'll inspect the repository now.",
+        finish_reason="tool_calls",
+        tool_calls=[tool_call],
+    )
+    agent._flush_messages_to_session_db = MagicMock(
+        side_effect=sqlite3.OperationalError("database is locked")
+    )
+    agent._execute_tool_calls = MagicMock()
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        first = agent.run_conversation("inspect the repository")
+        assert first["failure_reason"] == "session_persistence_failed:locked"
+
+        # Storage recovered but the flush function now reports a bare False
+        # (no exception): the stale 'locked' cause must not be reused.
+        agent.client.chat.completions.create.side_effect = None
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="I'll inspect the repository now.",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call(call_id="must-not-run-2")],
+        )
+        agent._flush_messages_to_session_db = MagicMock(return_value=False)
+        second = agent.run_conversation("inspect the repository again")
+
+    assert second["turn_exit_reason"] == "session_persistence_failed"
+    assert second["failure_reason"] == "session_persistence_failed:unknown"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/run_agent/test_turn_completion_explainer.py
+++ b/tests/run_agent/test_turn_completion_explainer.py
@@ -177,6 +177,66 @@ def test_classify_persistence_error_categories():
     assert classify_persistence_error("") == "unknown"
 
 
+def test_classify_persistence_error_reuses_disk_full_markers():
+    """The disk bucket delegates to hermes_state.is_disk_full_error, so
+    every marker that helper recognizes (ENOSPC, 'not enough space', ...)
+    must classify as 'disk' — the two classifiers can never drift apart."""
+    import errno
+
+    from run_agent import classify_persistence_error
+
+    assert classify_persistence_error("ENOSPC writing state.db") == "disk"
+    assert classify_persistence_error(
+        "There is not enough space on the disk"
+    ) == "disk"
+    assert classify_persistence_error(
+        OSError(errno.ENOSPC, "No space left on device")
+    ) == "disk"
+
+
+def test_classify_persistence_error_compression_busy_is_locked():
+    """A live compression lease refusing the write is contention, not
+    storage damage — but its message contains neither 'locked' nor 'busy',
+    so it must classify by exception type (and by phrase for RPC-wrapped
+    strings). This is the exact failure mode of issue #81227."""
+    from hermes_state import (
+        CompressionSessionBusyError,
+        SessionCompressionInProgressError,
+    )
+    from run_agent import classify_persistence_error
+
+    assert classify_persistence_error(
+        SessionCompressionInProgressError(
+            "Session 'abc' is being compressed by another writer"
+        )
+    ) == "locked"
+    assert classify_persistence_error(
+        CompressionSessionBusyError("Compression lease lost before publication: abc")
+    ) == "locked"
+    # RPC-wrapped string forms (exception type lost in transit).
+    assert classify_persistence_error(
+        "Session 'abc' is being compressed by another writer"
+    ) == "locked"
+    assert classify_persistence_error(
+        "Compression lease lost before publication: abc"
+    ) == "locked"
+
+
+def test_persistence_error_causes_tuple_matches_classifier():
+    """PERSISTENCE_ERROR_CAUSES must cover every value the classifier can
+    return (consumers like cron suppression iterate it)."""
+    from hermes_state import PERSISTENCE_ERROR_CAUSES, classify_persistence_error
+
+    probes = (
+        "database is locked",
+        "database or disk is full",
+        "something else entirely",
+        None,
+    )
+    for probe in probes:
+        assert classify_persistence_error(probe) in PERSISTENCE_ERROR_CAUSES
+
+
 # --------------------------------------------------------------------------
 # 2. Enable/disable seam
 # --------------------------------------------------------------------------

--- a/tests/run_agent/test_turn_completion_explainer.py
+++ b/tests/run_agent/test_turn_completion_explainer.py
@@ -94,6 +94,90 @@ def test_explanation_for_max_iterations_reached_prefix_match():
 
 
 # --------------------------------------------------------------------------
+# 1b. Cause-aware session-persistence wording
+# --------------------------------------------------------------------------
+def test_explanation_persistence_locked_cause_says_busy_not_disk():
+    """Write-lock contention must NOT be misdiagnosed as a disk problem."""
+    out = AIAgent._format_turn_completion_explanation(
+        "session_persistence_failed", "locked"
+    )
+    lower = out.lower()
+    assert "busy" in lower
+    assert "saved" in lower
+    assert "send it again" in lower
+    assert "disk" not in lower
+    assert "permission" not in lower
+
+
+def test_explanation_persistence_disk_cause_keeps_disk_wording():
+    out = AIAgent._format_turn_completion_explanation(
+        "session_persistence_failed", "disk"
+    )
+    lower = out.lower()
+    assert "disk" in lower
+    assert "free some space" in lower or "disk space" in lower
+
+
+def test_explanation_persistence_unknown_cause_is_neutral():
+    """None/'unknown' cause must not claim disk-full — point at diagnostics."""
+    for cause in (None, "unknown"):
+        out = AIAgent._format_turn_completion_explanation(
+            "session_persistence_failed", cause
+        )
+        lower = out.lower()
+        assert out.strip() != ""
+        assert "disk space" not in lower
+        assert "full disk" not in lower
+        assert "hermes doctor" in lower
+        assert "again" in lower
+
+
+def test_explanation_persistence_one_arg_backward_compat():
+    """Existing one-arg callers must keep working (optional second param)."""
+    out = AIAgent._format_turn_completion_explanation("session_persistence_failed")
+    assert out.strip() != ""
+    assert "session storage" in out.lower()
+
+
+def test_explanation_cause_ignored_for_other_reasons():
+    """The cause parameter must not perturb non-persistence reasons."""
+    assert (
+        AIAgent._format_turn_completion_explanation(
+            "text_response(finish_reason=stop)", "locked"
+        )
+        == ""
+    )
+    out = AIAgent._format_turn_completion_explanation(
+        "max_iterations_reached(10/10)", "locked"
+    )
+    assert "iteration" in out.lower()
+
+
+# --------------------------------------------------------------------------
+# 1c. classify_persistence_error — the pure cause classifier
+# --------------------------------------------------------------------------
+def test_classify_persistence_error_categories():
+    import sqlite3
+
+    from run_agent import classify_persistence_error
+
+    assert classify_persistence_error(
+        sqlite3.OperationalError("database is locked")
+    ) == "locked"
+    assert classify_persistence_error("SQLITE_BUSY: busy") == "locked"
+    assert classify_persistence_error(
+        sqlite3.OperationalError("database or disk is full")
+    ) == "disk"
+    assert classify_persistence_error("attempt to write a readonly database") == "disk"
+    assert classify_persistence_error("read-only file system") == "disk"
+    assert classify_persistence_error("no space left on device") == "disk"
+    assert classify_persistence_error("disk I/O error") == "disk"
+    assert classify_persistence_error("something else entirely") == "unknown"
+    assert classify_persistence_error(None) == "unknown"
+    assert classify_persistence_error("") == "unknown"
+
+
+# --------------------------------------------------------------------------
 # 2. Enable/disable seam
 # --------------------------------------------------------------------------
 def test_explainer_enabled_by_default():

--- a/tests/test_state_db_stats.py
+++ b/tests/test_state_db_stats.py
@@ -208,14 +208,18 @@ def test_render_large_db_legacy_trigram_suggests_optimize():
     assert "optimize-storage" in blob
 
 
-def test_render_warns_on_large_wal():
+def test_render_does_not_duplicate_legacy_wal_warning():
+    """A large WAL must NOT warn here: doctor's pre-existing WAL check
+    (50 MB threshold, with a --fix checkpoint) already covers it, and a
+    second warning at a higher threshold would duplicate the output."""
     from hermes_cli.doctor import STATE_DB_WAL_WARN_BYTES, _render_state_db_stats
 
     lines = _render_state_db_stats(
         _base_stats(wal_size_bytes=STATE_DB_WAL_WARN_BYTES + 1), holders=None
     )
-    blob = " ".join(" ".join(str(p) for p in line) for line in lines).lower()
-    assert "checkpoint" in blob
+    warns = [line for line in lines if line[0] == "warn"]
+    blob = " ".join(" ".join(str(p) for p in line) for line in warns).lower()
+    assert "wal" not in blob
 
 
 def test_render_handles_all_none_stats():

--- a/tests/test_state_db_stats.py
+++ b/tests/test_state_db_stats.py
@@ -212,10 +212,10 @@ def test_render_does_not_duplicate_legacy_wal_warning():
     """A large WAL must NOT warn here: doctor's pre-existing WAL check
     (50 MB threshold, with a --fix checkpoint) already covers it, and a
     second warning at a higher threshold would duplicate the output."""
-    from hermes_cli.doctor import STATE_DB_WAL_WARN_BYTES, _render_state_db_stats
+    from hermes_cli.doctor import _render_state_db_stats
 
     lines = _render_state_db_stats(
-        _base_stats(wal_size_bytes=STATE_DB_WAL_WARN_BYTES + 1), holders=None
+        _base_stats(wal_size_bytes=256 * 1024 * 1024 + 1), holders=None
     )
     warns = [line for line in lines if line[0] == "warn"]
     blob = " ".join(" ".join(str(p) for p in line) for line in warns).lower()

--- a/tests/test_state_db_stats.py
+++ b/tests/test_state_db_stats.py
@@ -1,0 +1,227 @@
+"""Tests for state.db health/stats collection (hermes doctor section).
+
+Covers:
+- ``hermes_state.collect_state_db_stats``: read-only, best-effort stats
+  (page_count, freelist, WAL size, journal mode, row counts, FTS presence,
+  pending v23 FTS-rebuild bookkeeping).
+- ``hermes_state.count_db_holders``: /proc-based best-effort probe for how
+  many processes hold the DB file open (Linux only; None elsewhere/on error).
+- ``hermes_cli.doctor._render_state_db_stats``: formatting/threshold helper
+  the doctor state.db section prints from.
+"""
+
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+from hermes_state import SessionDB, collect_state_db_stats, count_db_holders
+
+
+@pytest.fixture()
+def populated_db(tmp_path):
+    """A real state.db built through SessionDB's public API, then closed."""
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    db.create_session("sess-alpha", "cli")
+    db.create_session("sess-beta", "cli")
+    db.append_message("sess-alpha", "user", "hello world one")
+    db.append_message("sess-alpha", "assistant", "hi back")
+    db.append_message("sess-beta", "user", "second session message")
+    db.close()
+    return db_path
+
+
+# ── collect_state_db_stats ──────────────────────────────────────────────
+
+
+def test_collect_stats_sane_values(populated_db):
+    stats = collect_state_db_stats(populated_db)
+
+    assert isinstance(stats, dict)
+    assert stats["page_count"] and stats["page_count"] > 0
+    assert stats["page_size"] and stats["page_size"] > 0
+    assert stats["logical_size_bytes"] == stats["page_count"] * stats["page_size"]
+    assert isinstance(stats["freelist_count"], int) and stats["freelist_count"] >= 0
+    assert isinstance(stats["wal_size_bytes"], int) and stats["wal_size_bytes"] >= 0
+    assert isinstance(stats["journal_mode"], str) and stats["journal_mode"]
+    assert stats["messages"] >= 3
+    assert stats["sessions"] >= 2
+
+    fts = stats["fts_tables"]
+    assert set(fts) == {"messages_fts", "messages_fts_trigram", "messages_fts_cjk"}
+    for name, present in fts.items():
+        assert isinstance(present, bool), name
+    # Layout marker is absent (None) on legacy DBs, an int once stamped.
+    assert stats["fts_storage_version"] is None or isinstance(
+        stats["fts_storage_version"], int
+    )
+
+    # No rebuild pending on a fresh DB.
+    assert stats["fts_rebuild_pending"] in (False, None)
+
+
+def test_collect_stats_is_read_only(populated_db):
+    before_bytes = populated_db.read_bytes()
+    before_mtime = populated_db.stat().st_mtime_ns
+
+    collect_state_db_stats(populated_db)
+
+    assert populated_db.read_bytes() == before_bytes
+    assert populated_db.stat().st_mtime_ns == before_mtime
+    # No stray -wal/-shm growth from the probe either: a subsequent normal
+    # open must still work.
+    db = SessionDB(db_path=populated_db)
+    assert db.get_session("sess-alpha") is not None
+    db.close()
+
+
+def test_collect_stats_missing_file_never_raises(tmp_path):
+    stats = collect_state_db_stats(tmp_path / "nope" / "state.db")
+    assert isinstance(stats, dict)
+    assert stats["page_count"] is None
+    assert stats["messages"] is None
+    assert stats["logical_size_bytes"] is None
+
+
+def test_collect_stats_rebuild_pending_flag(populated_db):
+    # Simulate the v23 deferred-rebuild bookkeeping directly in state_meta.
+    conn = sqlite3.connect(str(populated_db))
+    conn.execute(
+        "INSERT OR REPLACE INTO state_meta(key, value) VALUES ('fts_rebuild_high_water', '100')"
+    )
+    conn.execute(
+        "INSERT OR REPLACE INTO state_meta(key, value) VALUES ('fts_rebuild_progress', '40')"
+    )
+    conn.commit()
+    conn.close()
+
+    stats = collect_state_db_stats(populated_db)
+    assert stats["fts_rebuild_pending"] is True
+    assert stats["fts_rebuild_high_water"] == 100
+    assert stats["fts_rebuild_progress"] == 40
+
+
+# ── count_db_holders ────────────────────────────────────────────────────
+
+
+def test_count_db_holders_sees_open_connection(populated_db):
+    conn = sqlite3.connect(str(populated_db))
+    try:
+        holders = count_db_holders(populated_db)
+        if sys.platform.startswith("linux"):
+            assert isinstance(holders, int)
+            assert holders >= 1
+        else:
+            assert holders is None
+    finally:
+        conn.close()
+
+
+def test_count_db_holders_missing_path_no_raise(tmp_path):
+    holders = count_db_holders(tmp_path / "absent.db")
+    assert holders is None or isinstance(holders, int)
+
+
+# ── doctor rendering helper ─────────────────────────────────────────────
+
+
+def _base_stats(**overrides):
+    stats = {
+        "page_count": 100,
+        "page_size": 4096,
+        "freelist_count": 2,
+        "logical_size_bytes": 100 * 4096,
+        "wal_size_bytes": 1024,
+        "journal_mode": "wal",
+        "messages": 42,
+        "sessions": 7,
+        "fts_tables": {
+            "messages_fts": True,
+            "messages_fts_trigram": True,
+            "messages_fts_cjk": False,
+        },
+        "fts_storage_version": 1,
+        "fts_rebuild_pending": False,
+        "fts_rebuild_high_water": None,
+        "fts_rebuild_progress": None,
+    }
+    stats.update(overrides)
+    return stats
+
+
+def test_render_healthy_stats_no_warnings():
+    from hermes_cli.doctor import _render_state_db_stats
+
+    lines = _render_state_db_stats(_base_stats(), holders=2)
+    kinds = [k for k, *_ in lines]
+    assert "warn" not in kinds
+    joined = " | ".join(text for _, text, *_ in lines)
+    assert "42" in joined  # messages
+    assert "7" in joined  # sessions
+    assert "wal" in joined.lower()
+    assert "2" in joined  # holders
+
+
+def test_render_warns_on_large_db():
+    from hermes_cli.doctor import (
+        STATE_DB_SIZE_WARN_BYTES,
+        _render_state_db_stats,
+    )
+
+    big = STATE_DB_SIZE_WARN_BYTES + 1
+    lines = _render_state_db_stats(
+        _base_stats(logical_size_bytes=big, page_count=big // 4096, page_size=4096),
+        holders=None,
+    )
+    warns = [t for k, t, *rest in lines if k == "warn"] + [
+        " ".join(rest) for k, t, *rest in lines if k == "warn"
+    ]
+    blob = " ".join(str(x) for x in warns)
+    assert "auto_prune" in blob
+    assert "config.yaml" in blob
+
+
+def test_render_large_db_with_pending_rebuild_suggests_optimize():
+    from hermes_cli.doctor import STATE_DB_SIZE_WARN_BYTES, _render_state_db_stats
+
+    big = STATE_DB_SIZE_WARN_BYTES + 1
+    lines = _render_state_db_stats(
+        _base_stats(logical_size_bytes=big, fts_rebuild_pending=True),
+        holders=None,
+    )
+    blob = " ".join(" ".join(str(p) for p in line) for line in lines)
+    assert "optimize-storage" in blob
+
+
+def test_render_large_db_legacy_trigram_suggests_optimize():
+    from hermes_cli.doctor import STATE_DB_SIZE_WARN_BYTES, _render_state_db_stats
+
+    big = STATE_DB_SIZE_WARN_BYTES + 1
+    lines = _render_state_db_stats(
+        _base_stats(logical_size_bytes=big, fts_storage_version=None),
+        holders=None,
+    )
+    blob = " ".join(" ".join(str(p) for p in line) for line in lines)
+    assert "optimize-storage" in blob
+
+
+def test_render_warns_on_large_wal():
+    from hermes_cli.doctor import STATE_DB_WAL_WARN_BYTES, _render_state_db_stats
+
+    lines = _render_state_db_stats(
+        _base_stats(wal_size_bytes=STATE_DB_WAL_WARN_BYTES + 1), holders=None
+    )
+    blob = " ".join(" ".join(str(p) for p in line) for line in lines).lower()
+    assert "checkpoint" in blob
+
+
+def test_render_handles_all_none_stats():
+    from hermes_cli.doctor import _render_state_db_stats
+
+    empty = {k: None for k in _base_stats()}
+    empty["fts_tables"] = None
+    lines = _render_state_db_stats(empty, holders=None)
+    assert isinstance(lines, list)  # must not raise


### PR DESCRIPTION
## Summary

Salvage of #80693 by @victor-kyriazakos (all 4 commits cherry-picked with authorship preserved) plus one review follow-up commit. When a turn dies with `session_persistence_failed`, every surface previously misdiagnosed it: the explainer always blamed a full disk (including for pure SQLite lock contention), the gateway rendered "The request failed: unknown error" and advised `/reset` (which destroys the conversation and fixes nothing), and there was no operator visibility into state.db health.

## What the salvaged commits do (unchanged from #80693)

1. **fix(agent)** — `classify_persistence_error()` (locked / disk / unknown), applied at the one site where the SQLite error is still visible before it is swallowed into a bare `False`. Cause threads through the turn explainer (optional backward-compatible parameter) and is stamped machine-readably on the result: `failure_reason = "session_persistence_failed:<cause>"`, with `error` guaranteed non-empty. Cause state resets at turn start; cron explainer-suppression matches every cause variant.
2. **fix(gateway)** — None-safe error lookup (an explicit `error: None` bypassed `dict.get`'s default and rendered "The request failed: None"), plus a dedicated recovery branch for persistence failures that never suggests `/reset`.
3. **feat(doctor)** — `collect_state_db_stats()` (strictly read-only `mode=ro` URI connection via the tracked-connect helper, per-field best-effort, never instantiates `SessionDB`) and a `/proc`-based `count_db_holders()`. Doctor reports logical size, pages/freelist, WAL size, message/session counts, journal mode, holder count, FTS shape and deferred-rebuild status, and warns above 1 GiB with concrete guidance.
4. **review** — contributor's own pre-push follow-ups (tracked ro-connection, single WAL warning, hedged locked wording).

## Review follow-up commit (new in this salvage)

- **Canonical classifier moved to `hermes_state`** beside `is_disk_full_error`, delegating the disk bucket to it — the #80693 version provably missed `"ENOSPC writing state.db"` and `"not enough space"` (classified `unknown` while `is_disk_full_error` returns True). `run_agent.classify_persistence_error` remains as a thin lazy delegating wrapper so the documented import path and the module's fast import survive.
- **`CompressionSessionBusyError` now classifies as `locked`** (by type, and by message phrase for RPC-wrapped strings). This is the motivating failure mode of #81227 — the exception stringifies to "is being compressed by another writer", which contains neither "locked" nor "busy", so the substring heuristic alone bucketed it `unknown`.
- **`PERSISTENCE_ERROR_CAUSES` exported and iterated by the cron suppression** instead of a hardcoded tuple, so adding a cause bucket can never silently desynchronize cron delivery (the exact bug class the cron hunk fixes).
- **Gateway locked/unknown wording hedged** ("should already be saved" instead of "was recorded") to match the explainer — the early turn-start persist may also have failed. (Same point raised by the triage sweeper comment on #80693.)
- **Dropped `STATE_DB_WAL_WARN_BYTES`** — speculative dead constant with no consumer; the pre-existing 50 MB doctor WAL check covers the warning.

## Validation

| Check | Result |
|---|---|
| Targeted suites (explainer + incremental persistence + gateway normalize + state stats + disk-full + hermes_state) | 52 + 196 passed |
| Mutation checks (classifier locked-branch, gateway branch, stats collector, compression-busy branch, disk delegation) | all red → restored → green |
| Live probe on a real 2.9 GB / 441k-message state.db | stats in 0.12 s, mtime byte-identical, doctor warns correctly |
| Crash-residue WAL probe (wal present, no shm, read-only dir) | reads fine, never raises |
| Import order both directions (`hermes_state`↔`run_agent`) | clean, no circular import |
| `ruff check` on all touched files | clean |
| Pre-existing failure `tests/cron/test_monitor_kind.py::test_unchanged_output_suppresses_agent_run` | fails identically on `origin/main` — unrelated |

## Credit

Based on #80693 by @victor-kyriazakos — commits cherry-picked with authorship preserved. The compression-lock classification design point comes from #81248 by @Enough1122 (competing PR for #81227), credited here; #81248 can be closed as superseded once this merges.

Closes #80693. Addresses the misleading-error half of #81227 (compression-lock contention now reported as busy storage, not disk-full).
