### PR TITLE
refactor(agent): drop the run_agent classify_persistence_error delegating wrapper

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1473,7 +1473,7 @@ def run_conversation(
     # cached gateway agent must recover on the next message if storage did.
     agent._incremental_persistence_failed = False
     # Cause of the most recent persistence failure this turn ('locked',
-    # 'disk', or 'unknown' — see run_agent.classify_persistence_error).
+    # 'disk', or 'unknown' — see hermes_state.classify_persistence_error).
     # Reset alongside the failure flag so a lock-contention diagnosis from a
     # previous turn can never leak into this turn's user-facing explanation.
     agent._last_persistence_error_cause = None
@@ -6510,7 +6510,7 @@ def run_conversation(
                     )
                 except Exception as exc:
                     _tool_turn_persisted = False
-                    from run_agent import classify_persistence_error
+                    from hermes_state import classify_persistence_error
                     agent._last_persistence_error_cause = (
                         classify_persistence_error(exc)
                     )

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -200,7 +200,7 @@ def _flush_session_db_after_tool_progress(
         return persisted
     except Exception as exc:
         agent._incremental_persistence_failed = True
-        from run_agent import classify_persistence_error
+        from hermes_state import classify_persistence_error
         agent._last_persistence_error_cause = classify_persistence_error(exc)
         logger.warning("Incremental tool-call persistence failed after %s: %s", stage, exc)
         return False

--- a/run_agent.py
+++ b/run_agent.py
@@ -279,23 +279,6 @@ _MAX_TOOL_WORKERS = 8
 _DB_PERSISTED_MARKER = "_db_persisted"
 
 
-def classify_persistence_error(exc_or_str) -> str:
-    """Classify a session-persistence failure into a coarse cause bucket.
-
-    Thin delegating wrapper: the canonical implementation lives in
-    ``hermes_state`` (beside ``is_disk_full_error``, whose disk-full
-    patterns it reuses so the two classifiers can never drift apart).
-    Kept importable from this module because the turn-finalizer contract
-    and existing callers reference ``run_agent.classify_persistence_error``.
-    The import stays lazy to preserve this module's fast import path —
-    every real caller already has hermes_state loaded (the error being
-    classified came from a SessionDB write).
-    """
-    from hermes_state import classify_persistence_error as _impl
-
-    return _impl(exc_or_str)
-
-
 # Guard so the OpenRouter metadata pre-warm thread is only spawned once per
 # process, not once per AIAgent instantiation.  Without this, long-running
 # gateway processes leak one OS thread per incoming message and eventually
@@ -2323,6 +2306,8 @@ class AIAgent:
             # before it is swallowed into a bare ``False`` — classify it here
             # so the turn-end explanation can distinguish lock contention
             # ("storage was busy, send it again") from disk-full/read-only.
+            from hermes_state import classify_persistence_error
+
             self._last_persistence_error_cause = classify_persistence_error(e)
             logger.warning("Session DB append_message failed: %s", e)
             return False

--- a/tests/run_agent/test_turn_completion_explainer.py
+++ b/tests/run_agent/test_turn_completion_explainer.py
@@ -159,7 +159,7 @@ def test_explanation_cause_ignored_for_other_reasons():
 def test_classify_persistence_error_categories():
     import sqlite3
 
-    from run_agent import classify_persistence_error
+    from hermes_state import classify_persistence_error
 
     assert classify_persistence_error(
         sqlite3.OperationalError("database is locked")
@@ -183,7 +183,7 @@ def test_classify_persistence_error_reuses_disk_full_markers():
     must classify as 'disk' — the two classifiers can never drift apart."""
     import errno
 
-    from run_agent import classify_persistence_error
+    from hermes_state import classify_persistence_error
 
     assert classify_persistence_error("ENOSPC writing state.db") == "disk"
     assert classify_persistence_error(
@@ -203,7 +203,7 @@ def test_classify_persistence_error_compression_busy_is_locked():
         CompressionSessionBusyError,
         SessionCompressionInProgressError,
     )
-    from run_agent import classify_persistence_error
+    from hermes_state import classify_persistence_error
 
     assert classify_persistence_error(
         SessionCompressionInProgressError(


### PR DESCRIPTION
## Summary

Post-merge simplify follow-up to #81613: removes the `run_agent.classify_persistence_error` delegating wrapper — every caller now imports the canonical `hermes_state.classify_persistence_error` directly.

The wrapper's docstring justified itself with "existing callers reference `run_agent.classify_persistence_error`", but every one of those callers was introduced by the same PR — there was never a pre-existing import path to preserve. Direct imports match how `is_disk_full_error` (the sibling classifier in the same module) is already consumed from `tui_gateway` and `hermes_cli`.

## Changes
- `run_agent.py`: wrapper deleted; the flush handler's own use imports from `hermes_state` lazily
- `agent/conversation_loop.py`, `agent/tool_executor.py`: exception-handler imports point at `hermes_state`
- `tests/run_agent/test_turn_completion_explainer.py`: test imports updated

No behavior change; imports remain lazy inside the exception handlers (cold path).

## Validation
| Check | Result |
|---|---|
| Explainer + incremental-persistence + gateway normalize suites | 36 passed |
| `ruff check` on touched files | clean |
| `grep run_agent.classify` repo-wide | 0 remaining references |
