### PR TITLE
fix(execute_code): split TCP RPC buffer into lines so concatenated responses parse (#81610)

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -115,6 +115,21 @@ class TestHermesToolsGeneration(unittest.TestCase):
         self.assertIn("_seq_lock = threading.Lock()", src)
         self.assertIn("with _seq_lock:", src)
 
+    def test_tcp_transport_parses_concatenated_responses(self):
+        """Regression (#81610): TCP recv() can surface a delayed ack from a
+        previous in-flight call in the same buffer as the current response.
+        Naive json.loads() on the whole buffer raises ``Extra data``; the
+        template must parse each newline-terminated line independently and
+        return the last (current) response."""
+        src = generate_hermes_tools_module(["terminal"], transport="tcp")
+        # The template must split on the newline separator and parse the
+        # last line, not call json.loads on the raw concatenated buffer.
+        self.assertIn('split("\\n")', src)
+        self.assertIn("lines = [line for line in", src)
+        self.assertNotIn("raw = buf.decode().strip()", src)
+        # Empty buffer must surface a clear error rather than crashing.
+        self.assertIn("Agent returned an empty response", src)
+
 
 class TestExecuteCodeRemoteTempDir(unittest.TestCase):
     def test_execute_remote_uses_backend_temp_dir_for_sandbox(self):

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -118,17 +118,46 @@ class TestHermesToolsGeneration(unittest.TestCase):
     def test_tcp_transport_parses_concatenated_responses(self):
         """Regression (#81610): TCP recv() can surface a delayed ack from a
         previous in-flight call in the same buffer as the current response.
-        Naive json.loads() on the whole buffer raises ``Extra data``; the
+        Naive json.loads() on the whole raw buffer raises ``Extra data``; the
         template must parse each newline-terminated line independently and
         return the last (current) response."""
         src = generate_hermes_tools_module(["terminal"], transport="tcp")
-        # The template must split on the newline separator and parse the
-        # last line, not call json.loads on the raw concatenated buffer.
-        self.assertIn('split("\\n")', src)
-        self.assertIn("lines = [line for line in", src)
-        self.assertNotIn("raw = buf.decode().strip()", src)
-        # Empty buffer must surface a clear error rather than crashing.
-        self.assertIn("Agent returned an empty response", src)
+        # Behavioural check: exec the generated module in an isolated
+        # namespace and drive the real buffer-parse path with a genuine
+        # two-line concatenated buffer (delayed ack + current response).
+        # A textual marker like split("\\n") would not catch a regression
+        # that keeps the text but parses the wrong line.
+        ns = {}
+        exec(compile(src, "<generated>", "exec"), ns)
+        parse = ns["_parse_response"]
+        # First line: a delayed ack / older response from a prior in-flight
+        # call. Second line: the current response. Both newline-terminated.
+        current = {"output": "hello world", "exit_code": 0, "tool": "terminal"}
+        buf = (
+            json.dumps({"ack": True, "seq": 1}).encode()
+            + b"\n"
+            + json.dumps(current).encode()
+            + b"\n"
+        )
+        # Must return the LAST (current) object, not the stale ack, and must
+        # not raise json.JSONDecodeError from parsing the whole buffer.
+        self.assertEqual(parse(buf), current)
+        # Same shape as the old code produced for a single clean response.
+        self.assertEqual(parse(json.dumps(current).encode() + b"\n"), current)
+        # A string-wrapped JSON payload (server double-encoded result) still
+        # collapses to the inner object.
+        self.assertEqual(parse(json.dumps(json.dumps(current)).encode() + b"\n"), current)
+        # Empty / whitespace-only buffer must surface a clear error, not a
+        # confusing json.JSONDecodeError or silently an empty result.
+        with self.assertRaisesRegex(RuntimeError, "empty response"):
+            parse(b"\n\n   \n")
+        # A response whose final line is incomplete (no trailing newline yet)
+        # but is still valid JSON on its own must still parse.
+        self.assertEqual(parse(json.dumps(current).encode()), current)
+        # Naive json.loads on the raw concatenated buffer would blow up:
+        # confirm the fix is what makes the difference.
+        with self.assertRaises(json.JSONDecodeError):
+            json.loads(buf)  # "Extra data" — proves two objects concatenated
 
 
 class TestExecuteCodeRemoteTempDir(unittest.TestCase):

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -561,8 +561,16 @@ def _call(tool_name, args):
             buf += chunk
             if buf.endswith(b"\\n"):
                 break
-    raw = buf.decode().strip()
-    result = json.loads(raw)
+    # The transport uses newline-terminated JSON, but Windows TCP can
+    # surface a partial earlier response in the same recv() burst (e.g. a
+    # delayed ack from a previous in-flight call), giving us
+    # ``json.JSONDecodeError: Extra data`` on the naive ``json.loads``.
+    # Parse each line independently and return the last complete object
+    # — every response is newline-terminated by the server (#81610).
+    lines = [line for line in buf.decode("utf-8", errors="replace").split("\\n") if line.strip()]
+    if not lines:
+        raise RuntimeError("Agent returned an empty response")
+    result = json.loads(lines[-1])
     if isinstance(result, str):
         try:
             return json.loads(result)

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -543,6 +543,28 @@ def _connect():
         _sock.settimeout(300)
     return _sock
 
+def _parse_response(buf):
+    """Parse the newline-terminated RPC response buffer and return the last
+    complete object.
+
+    The transport uses newline-terminated JSON, but Windows TCP can surface
+    a partial earlier response in the same recv() burst (e.g. a delayed ack
+    from a previous in-flight call), giving us ``json.JSONDecodeError:
+    Extra data`` on a naive ``json.loads(buf.decode())``. Parse each line
+    independently and return the last complete object — every response is
+    newline-terminated by the server (#81610).
+    """
+    lines = [line for line in buf.decode("utf-8", errors="replace").split("\\n") if line.strip()]
+    if not lines:
+        raise RuntimeError("Agent returned an empty response")
+    result = json.loads(lines[-1])
+    if isinstance(result, str):
+        try:
+            return json.loads(result)
+        except (json.JSONDecodeError, TypeError):
+            return result
+    return result
+
 def _call(tool_name, args):
     """Send a tool call to the parent process and return the parsed result."""
     request = json.dumps({
@@ -561,22 +583,7 @@ def _call(tool_name, args):
             buf += chunk
             if buf.endswith(b"\\n"):
                 break
-    # The transport uses newline-terminated JSON, but Windows TCP can
-    # surface a partial earlier response in the same recv() burst (e.g. a
-    # delayed ack from a previous in-flight call), giving us
-    # ``json.JSONDecodeError: Extra data`` on the naive ``json.loads``.
-    # Parse each line independently and return the last complete object
-    # — every response is newline-terminated by the server (#81610).
-    lines = [line for line in buf.decode("utf-8", errors="replace").split("\\n") if line.strip()]
-    if not lines:
-        raise RuntimeError("Agent returned an empty response")
-    result = json.loads(lines[-1])
-    if isinstance(result, str):
-        try:
-            return json.loads(result)
-        except (json.JSONDecodeError, TypeError):
-            return result
-    return result
+    return _parse_response(buf)
 
 '''
 


### PR DESCRIPTION
Fixes #81610

## What

The sandbox RPC client's TCP `recv()` loop now splits the buffer into newline-terminated lines and parses the last complete object, instead of calling `json.loads()` on the concatenated buffer.

## Why

On Windows (native, not WSL), `recv()` can surface a delayed ack from a previous in-flight call in the same buffer as the current response, so the buffer contains multiple newline-terminated JSON lines. The old template called `json.loads(buf.decode().strip())` on the whole buffer, which raised `JSONDecodeError: Extra data`. When the parser happened to land on an earlier empty response from a prior call, the call silently returned `matches=0` — a false negative that is more dangerous than a hard failure because downstream code may assume the search was valid.

## Changes

- The TCP `_call` template now `buf.decode(...).split("\n")`, drops blank lines, and parses the last complete object. Every response is newline-terminated by the server, so the most recent line is the current call's response.
- Empty buffers surface a clear error ("Agent returned an empty response") instead of an uncaught IndexError on the split list.

## Note

The fix is in the generated `hermes_tools.py` stub template (the `_TCP_TRANSPORT_HEADER` block in `tools/code_execution_tool.py`), not in a runtime `tools/` module — sandboxes generate the stub on the fly from this template. Existing sandboxes regenerate the stub at the next `hermes_tools` import.

## Verification

- `scripts/run_tests.sh tests/tools/test_code_execution.py::TestHermesToolsGeneration` → 6 passed (5 existing + 1 new regression test).