### PR TITLE
fix(security): validate Bitwarden server_url and terminate bws argv (#77480)

### DIFF
--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -42,6 +42,7 @@ import subprocess
 import tempfile
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 import zipfile
 from pathlib import Path
@@ -128,6 +129,121 @@ def _encrypted_disk_cache_path(home_path: Optional[Path] = None) -> Path:
     from agent.secret_sources._cache import resolve_cache_home
 
     return resolve_cache_home(home_path) / "cache" / _ENCRYPTED_CACHE_BASENAME
+
+
+# ---------------------------------------------------------------------------
+# Validation for the values that reach the bws child
+# ---------------------------------------------------------------------------
+
+# BSM project ids are UUIDs — that is what the `project_id` config key is
+# documented to hold and the only shape `bws secret list` accepts.
+_PROJECT_ID_RE = re.compile(
+    r"\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+    r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\Z"
+)
+
+# Plaintext HTTP is tolerated only against the local machine, where there is no
+# network to sniff.  Everything else carries the access token, so it must be
+# TLS.
+_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "[::1]"})
+
+
+def validate_project_id(project_id: str) -> str:
+    """Return ``project_id`` stripped, or raise :class:`ValueError`.
+
+    The value goes into the ``bws`` argv, so a non-UUID is rejected before the
+    spawn rather than handed to the CLI to interpret.
+    """
+    candidate = (project_id or "").strip()
+    if not candidate:
+        raise ValueError("Bitwarden project_id is empty")
+    if not _PROJECT_ID_RE.match(candidate):
+        raise ValueError(
+            f"secrets.bitwarden.project_id {candidate!r} is not a project UUID "
+            "(xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx).  Run "
+            "`hermes secrets bitwarden setup` to pick a project."
+        )
+    return candidate
+
+
+def validate_server_url(server_url: str) -> str:
+    """Return ``server_url`` stripped, or raise :class:`ValueError`.
+
+    The access token is sent to whatever endpoint this names, so a bad value
+    is an exfiltration channel rather than a typo: a phished setup answer or a
+    committed config pointing at ``http://attacker.example`` ships the token
+    off in cleartext.  An empty string is valid and means "``bws`` default"
+    (US Cloud).
+
+    Rules: HTTPS, a real host, no embedded credentials.  Plaintext HTTP is
+    allowed only for loopback, which self-hosted users tunnelling to a local
+    port rely on and which no one else can observe.
+    """
+    candidate = (server_url or "").strip()
+    if not candidate:
+        return ""
+
+    try:
+        parts = urllib.parse.urlsplit(candidate)
+    except ValueError as exc:  # malformed IPv6 literal, bad port, …
+        raise ValueError(
+            f"secrets.bitwarden.server_url {candidate!r} is not a valid URL: {exc}"
+        ) from exc
+
+    if parts.scheme not in ("https", "http"):
+        raise ValueError(
+            f"secrets.bitwarden.server_url {candidate!r} must be an https:// URL"
+        )
+    if not parts.hostname:
+        raise ValueError(
+            f"secrets.bitwarden.server_url {candidate!r} has no host"
+        )
+    # `user:pass@host` lets a hostile value read as the real vault while
+    # pointing somewhere else — and it would put credentials in the env var.
+    if parts.username or parts.password:
+        raise ValueError(
+            "secrets.bitwarden.server_url must not embed credentials "
+            "(user:pass@host)"
+        )
+    if parts.scheme == "http" and parts.hostname.lower() not in _LOOPBACK_HOSTS:
+        raise ValueError(
+            f"secrets.bitwarden.server_url {candidate!r} uses plaintext http:// "
+            "— the access token would cross the network unencrypted.  Use "
+            "https:// (http:// is accepted only for localhost)."
+        )
+    return candidate
+
+
+def apply_server_url_to_env(env: Dict[str, str], server_url: str) -> Optional[str]:
+    """Set ``BWS_SERVER_URL`` on ``env`` for a bws child.  Returns a warning.
+
+    ``server_url`` is the configured value and wins when set.  When it is
+    empty, ``bws`` would otherwise inherit whatever ``BWS_SERVER_URL`` the
+    parent shell happened to carry — an ambient value that never passed
+    through :func:`validate_server_url`.  Validate it here too and drop it if
+    it fails, so an exported ``http://…`` cannot redirect the token just
+    because it arrived through the environment instead of the config file.
+
+    Returns a human-readable warning when an inherited value was dropped, else
+    ``None``.
+    """
+    if server_url:
+        env["BWS_SERVER_URL"] = server_url
+        return None
+
+    inherited = (env.get("BWS_SERVER_URL") or "").strip()
+    if not inherited:
+        return None
+    try:
+        validate_server_url(inherited)
+    except ValueError as exc:
+        env.pop("BWS_SERVER_URL", None)
+        return (
+            f"Ignoring BWS_SERVER_URL from the environment: {exc}.  "
+            "Falling back to the bws default (US Cloud)."
+        )
+    env["BWS_SERVER_URL"] = inherited
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -513,7 +629,9 @@ def fetch_bitwarden_secrets(
     self-hosted instance — e.g. ``https://vault.bitwarden.eu`` for EU
     Cloud accounts.  When empty, ``bws`` uses its built-in default
     (``https://vault.bitwarden.com``, US Cloud).  This is plumbed into
-    the subprocess as ``BWS_SERVER_URL``.
+    the subprocess as ``BWS_SERVER_URL``.  Both ``project_id`` and
+    ``server_url`` are validated first — see :func:`validate_project_id`
+    and :func:`validate_server_url`.
 
     ``cache_ttl_seconds`` controls the normal fresh cache.  When
     ``encrypted_cache_enabled`` is true, fresh cache entries are written as
@@ -530,10 +648,15 @@ def fetch_bitwarden_secrets(
     """
     if not access_token:
         raise RuntimeError("Bitwarden access token is empty")
-    if not project_id:
-        raise RuntimeError("Bitwarden project_id is empty")
+    # Validate BEFORE the cache lookup: a rejected value must never be able to
+    # serve a cache entry, and the cache key should hold the checked form.
+    try:
+        project_id = validate_project_id(project_id)
+        server_url = validate_server_url(server_url)
+    except ValueError as exc:
+        raise RuntimeError(str(exc)) from exc
 
-    cache_key = (_token_fingerprint(access_token), project_id, server_url or "")
+    cache_key = (_token_fingerprint(access_token), project_id, server_url)
     if use_cache and cache_ttl_seconds > 0:
         cached = _CACHE.get(cache_key)
         if cached and cached.is_fresh(cache_ttl_seconds):
@@ -667,7 +790,9 @@ def _summarize_bws_stderr(raw: str) -> str:
 def _run_bws_list(
     bws: Path, access_token: str, project_id: str, server_url: str = ""
 ) -> Tuple[Dict[str, str], List[str]]:
-    cmd = [str(bws), "secret", "list", project_id, "--output", "json"]
+    # `--` terminates option parsing so the project id can never be read as a
+    # bws flag, whatever it contains.  Matches `op read` in onepassword.py.
+    cmd = [str(bws), "secret", "list", "--output", "json", "--", project_id]
     # bws child intentionally receives the access token.  Under a profile-local
     # fetch it must not inherit sibling credentials from process-global env.
     source_env = get_source_environment()
@@ -682,11 +807,14 @@ def _run_bws_list(
     env.setdefault("NO_COLOR", "1")
     # Region / self-hosted support.  bws defaults to https://vault.bitwarden.com
     # (US Cloud); EU Cloud users need https://vault.bitwarden.eu, and
-    # self-hosted users need their own URL.  When unset, fall back to whatever
-    # BWS_SERVER_URL the caller already had in their shell env (preserved by
-    # the copy above) so manual overrides keep working too.
-    if server_url:
-        env["BWS_SERVER_URL"] = server_url
+    # self-hosted users need their own URL.  When unset, an inherited
+    # BWS_SERVER_URL still applies (manual overrides keep working) but only
+    # once it validates — see apply_server_url_to_env.
+    env_warnings: List[str] = []
+    inherited_warning = apply_server_url_to_env(env, server_url)
+    if inherited_warning:
+        logger.warning("%s", inherited_warning)
+        env_warnings.append(inherited_warning)
 
     try:
         proc = subprocess.run(  # noqa: S603 — bws path is trusted
@@ -716,7 +844,7 @@ def _run_bws_list(
 
     raw = proc.stdout.strip()
     if not raw:
-        return {}, ["bws returned no output (empty project?)"]
+        return {}, env_warnings + ["bws returned no output (empty project?)"]
 
     try:
         payload = json.loads(raw)
@@ -729,7 +857,7 @@ def _run_bws_list(
         )
 
     secrets: Dict[str, str] = {}
-    warnings: List[str] = []
+    warnings: List[str] = list(env_warnings)
     for item in payload:
         if not isinstance(item, dict):
             continue
@@ -904,7 +1032,9 @@ class BitwardenSource(SecretSource):
                 "default": True,
             },
             "server_url": {
-                "description": "Region / self-hosted endpoint (empty = US Cloud)",
+                "description": (
+                    "Region / self-hosted endpoint, https:// (empty = US Cloud)"
+                ),
                 "default": "",
             },
         }

--- a/hermes_cli/secrets_cli.py
+++ b/hermes_cli/secrets_cli.py
@@ -614,8 +614,9 @@ def _list_projects(
     env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=False)
     env["BWS_ACCESS_TOKEN"] = token
     env.setdefault("NO_COLOR", "1")
-    if server_url:
-        env["BWS_SERVER_URL"] = server_url
+    dropped = bw.apply_server_url_to_env(env, server_url)
+    if dropped:
+        console.print(f"  [yellow]{dropped}[/yellow]")
     try:
         res = subprocess.run(
             [str(binary), "project", "list", "--output", "json"],
@@ -682,24 +683,42 @@ def _resolve_server_url(
 
     Returns the chosen URL as a string (empty string = bws default,
     i.e. US Cloud).  Returns None if the user aborted with an empty
-    custom URL.
+    custom URL, or if a non-interactive source supplied a URL that fails
+    :func:`bw.validate_server_url` — setup must not persist an endpoint the
+    fetch path will refuse to use, and the access token is about to be sent
+    there.
     """
+    def _checked(candidate: str, origin: str) -> Optional[str]:
+        try:
+            return bw.validate_server_url(candidate)
+        except ValueError as exc:
+            console.print(f"  [red]✗ {origin}: {exc}[/red]")
+            return None
+
     if args.server_url and args.server_url.strip():
-        return args.server_url.strip()
+        return _checked(args.server_url.strip(), "--server-url")
 
     env_url = os.environ.get("BWS_SERVER_URL", "").strip()
     if env_url:
         console.print(
             f"  Detected [cyan]BWS_SERVER_URL[/cyan]={env_url} in your shell — using it."
         )
-        return env_url
+        return _checked(env_url, "BWS_SERVER_URL")
 
     existing = str(secrets_cfg.get("server_url", "") or "").strip()
     if existing:
-        console.print(
-            f"  Existing config: [cyan]{existing}[/cyan]. "
-            "Press Enter to keep, or pick a different option below."
-        )
+        try:
+            bw.validate_server_url(existing)
+        except ValueError as exc:
+            # A stored bad value shouldn't dead-end setup — that is what the
+            # user came here to fix.  Drop it and fall through to the menu.
+            console.print(f"  [yellow]Ignoring stored server_url: {exc}[/yellow]")
+            existing = ""
+        else:
+            console.print(
+                f"  Existing config: [cyan]{existing}[/cyan]. "
+                "Press Enter to keep, or pick a different option below."
+            )
 
     table = Table(show_header=True, header_style="bold", box=None, padding=(0, 2))
     table.add_column("#", style="cyan", width=4)
@@ -736,10 +755,10 @@ def _resolve_server_url(
             if not custom:
                 console.print("  [red]Empty URL, aborting.[/red]")
                 return None
-            if not custom.startswith(("http://", "https://")):
-                console.print(
-                    "  [yellow]Warning: URL doesn't start with http:// or "
-                    "https:// — bws may reject it.[/yellow]"
-                )
-            return custom
+            try:
+                return bw.validate_server_url(custom)
+            except ValueError as exc:
+                # Interactive: let them try again instead of aborting setup.
+                console.print(f"  [red]{exc}[/red]")
+                continue
         console.print(f"  [red]Out of range — pick 1-{custom_idx}.[/red]")

--- a/tests/test_bitwarden_secrets.py
+++ b/tests/test_bitwarden_secrets.py
@@ -31,6 +31,11 @@ if str(ROOT) not in sys.path:
 from agent.secret_sources import bitwarden as bw  # noqa: E402
 
 
+# BSM project ids are UUIDs and the fetch path rejects anything else, so the
+# fixtures use a well-formed one rather than a placeholder name.
+PROJECT_ID = "3f1a2b4c-5d6e-4f70-8192-a3b4c5d6e7f8"
+
+
 @pytest.fixture(autouse=True)
 def _reset_caches():
     bw._reset_cache_for_tests()
@@ -202,7 +207,7 @@ def test_fetch_server_url_sets_env(monkeypatch, tmp_path):
 
     bw.fetch_bitwarden_secrets(
         access_token="0.t",
-        project_id="p",
+        project_id=PROJECT_ID,
         binary=fake_binary,
         use_cache=False,
         server_url="https://vault.bitwarden.eu",
@@ -249,7 +254,7 @@ def test_env_loader_calls_bsm_when_enabled(tmp_path, monkeypatch):
         "secrets:\n"
         "  bitwarden:\n"
         "    enabled: true\n"
-        "    project_id: 'proj-1'\n"
+        f"    project_id: '{PROJECT_ID}'\n"
         "    access_token_env: 'BWS_ACCESS_TOKEN'\n"
         "    cache_ttl_seconds: 0\n"
         "    override_existing: false\n"
@@ -263,7 +268,7 @@ def test_env_loader_calls_bsm_when_enabled(tmp_path, monkeypatch):
 
     def fake_fetch(**kwargs):
         called["n"] += 1
-        assert kwargs["project_id"] == "proj-1"
+        assert kwargs["project_id"] == PROJECT_ID
         return {"MY_BSM_KEY": "from-bsm"}, []
 
     monkeypatch.setattr(
@@ -321,7 +326,7 @@ def test_disk_cache_key_mismatch_triggers_refetch(monkeypatch, tmp_path):
     }))
 
     secrets, _ = bw.fetch_bitwarden_secrets(
-        access_token="0.t", project_id="proj-1", binary=fake_binary,
+        access_token="0.t", project_id=PROJECT_ID, binary=fake_binary,
         cache_ttl_seconds=300, home_path=home,
     )
     # We must NOT have used the foreign cache entry
@@ -350,7 +355,7 @@ def test_encrypted_cache_writes_without_plaintext(monkeypatch, tmp_path):
     bw._reset_cache_for_tests(home)
     # A successful encrypted write must remove a pre-existing legacy plaintext
     # cache from the migration path.
-    legacy_key = (bw._token_fingerprint("0.t"), "proj-1", "")
+    legacy_key = (bw._token_fingerprint("0.t"), PROJECT_ID, "")
     bw._DISK_CACHE.write(
         legacy_key,
         bw._CachedFetch(secrets={"K1": "legacy"}, fetched_at=time.time()),
@@ -360,7 +365,7 @@ def test_encrypted_cache_writes_without_plaintext(monkeypatch, tmp_path):
     assert bw._disk_cache_path(home).exists()
 
     secrets, warnings = bw.fetch_bitwarden_secrets(
-        access_token="0.t", project_id="proj-1", binary=fake_binary,
+        access_token="0.t", project_id=PROJECT_ID, binary=fake_binary,
         cache_ttl_seconds=0, encrypted_cache_enabled=True,
         encrypted_cache_max_stale_seconds=604800, home_path=home,
     )
@@ -410,7 +415,7 @@ def test_encrypted_cache_falls_back_on_network_error(monkeypatch, tmp_path):
     bw._reset_cache_for_tests(home)
 
     first, _ = bw.fetch_bitwarden_secrets(
-        access_token="0.t", project_id="proj-1", binary=fake_binary,
+        access_token="0.t", project_id=PROJECT_ID, binary=fake_binary,
         cache_ttl_seconds=0, encrypted_cache_enabled=True,
         encrypted_cache_max_stale_seconds=604800, home_path=home,
     )
@@ -418,7 +423,7 @@ def test_encrypted_cache_falls_back_on_network_error(monkeypatch, tmp_path):
     bw._CACHE.clear()
 
     second, warnings = bw.fetch_bitwarden_secrets(
-        access_token="0.t", project_id="proj-1", binary=fake_binary,
+        access_token="0.t", project_id=PROJECT_ID, binary=fake_binary,
         cache_ttl_seconds=0, encrypted_cache_enabled=True,
         encrypted_cache_max_stale_seconds=604800, home_path=home,
     )
@@ -438,7 +443,7 @@ def test_encrypted_cache_falls_back_on_network_error(monkeypatch, tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def _seed_stale_disk_cache(home, *, secrets, age_seconds, project_id="proj-1",
+def _seed_stale_disk_cache(home, *, secrets, age_seconds, project_id=PROJECT_ID,
                            access_token="0.t", server_url=""):
     """Populate the disk cache as if a successful fetch happened `age_seconds`
     ago. Writes the JSON payload directly (same shape the shared DiskCache
@@ -477,7 +482,7 @@ def test_stale_disk_cache_returned_when_bws_fails(monkeypatch, tmp_path):
     monkeypatch.setattr(bw.subprocess, "run", fail_run)
 
     secrets, warnings = bw.fetch_bitwarden_secrets(
-        access_token="0.t", project_id="proj-1", binary=fake_binary,
+        access_token="0.t", project_id=PROJECT_ID, binary=fake_binary,
         cache_ttl_seconds=300, home_path=home,
     )
     assert secrets == {"OPENAI_API_KEY": "sk-old"}
@@ -514,10 +519,182 @@ def test_stale_fallback_skipped_on_auth_failure(monkeypatch, tmp_path):
 
     with pytest.raises(RuntimeError, match="unauthorized"):
         bw.fetch_bitwarden_secrets(
-            access_token="0.t", project_id="proj-1", binary=fake_binary,
+            access_token="0.t", project_id=PROJECT_ID, binary=fake_binary,
             cache_ttl_seconds=300, home_path=home,
         )
 
 
 
 
+# ---------------------------------------------------------------------------
+# Validation of the values that reach the bws child
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "",
+        "https://vault.bitwarden.com",
+        "https://vault.bitwarden.eu",
+        "https://vault.example.com:8443/path",
+        # Loopback is the one place plaintext has nothing to leak to.
+        "http://localhost:8080",
+        "http://127.0.0.1:8080",
+    ],
+)
+def test_validate_server_url_accepts(url):
+    assert bw.validate_server_url(url) == url
+
+
+@pytest.mark.parametrize(
+    "url,reason",
+    [
+        ("http://vault.example.com", "plaintext http"),
+        ("http://10.0.0.5:8080", "plaintext http"),
+        ("https://user:pw@vault.example.com", "must not embed credentials"),
+        ("ftp://vault.example.com", "must be an https:// URL"),
+        ("file:///etc/passwd", "must be an https:// URL"),
+        ("vault.example.com", "must be an https:// URL"),
+        ("https://", "has no host"),
+    ],
+)
+def test_validate_server_url_rejects(url, reason):
+    with pytest.raises(ValueError, match=reason):
+        bw.validate_server_url(url)
+
+
+def test_validate_server_url_strips_surrounding_whitespace():
+    assert bw.validate_server_url("  https://vault.bitwarden.eu  ") == (
+        "https://vault.bitwarden.eu"
+    )
+
+
+@pytest.mark.parametrize(
+    "project_id",
+    ["", "   ", "proj-1", "aaaa-bbbb", "--help", "-o /tmp/x", PROJECT_ID + "x"],
+)
+def test_validate_project_id_rejects(project_id):
+    with pytest.raises(ValueError):
+        bw.validate_project_id(project_id)
+
+
+def test_validate_project_id_accepts_uuid():
+    assert bw.validate_project_id(f"  {PROJECT_ID.upper()}  ") == PROJECT_ID.upper()
+
+
+def test_fetch_rejects_plaintext_server_url(monkeypatch, tmp_path):
+    """A phished/committed http:// endpoint must not receive the token."""
+    fake_binary = tmp_path / "bws"
+    fake_binary.write_text("", encoding="utf-8")
+
+    def explode(*a, **kw):  # pragma: no cover - must never run
+        raise AssertionError("bws must not be spawned for a rejected server_url")
+
+    monkeypatch.setattr(bw.subprocess, "run", explode)
+
+    with pytest.raises(RuntimeError, match="plaintext http"):
+        bw.fetch_bitwarden_secrets(
+            access_token="0.t",
+            project_id=PROJECT_ID,
+            binary=fake_binary,
+            use_cache=False,
+            server_url="http://attacker.example",
+        )
+
+
+def test_fetch_rejects_non_uuid_project_id(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "bws"
+    fake_binary.write_text("", encoding="utf-8")
+
+    def explode(*a, **kw):  # pragma: no cover - must never run
+        raise AssertionError("bws must not be spawned for a rejected project_id")
+
+    monkeypatch.setattr(bw.subprocess, "run", explode)
+
+    with pytest.raises(RuntimeError, match="not a project UUID"):
+        bw.fetch_bitwarden_secrets(
+            access_token="0.t",
+            project_id="--config=/tmp/evil.toml",
+            binary=fake_binary,
+            use_cache=False,
+        )
+
+
+def test_project_id_passed_after_argv_terminator(monkeypatch, tmp_path):
+    """`--` keeps the project id a positional, whatever it contains."""
+    fake_binary = tmp_path / "bws"
+    fake_binary.write_text("", encoding="utf-8")
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+        return mock.Mock(returncode=0, stdout=_fake_bws_payload([]), stderr="")
+
+    monkeypatch.setattr(bw.subprocess, "run", fake_run)
+
+    bw.fetch_bitwarden_secrets(
+        access_token="0.t",
+        project_id=PROJECT_ID,
+        binary=fake_binary,
+        use_cache=False,
+    )
+
+    cmd = captured["cmd"]
+    assert cmd[-2:] == ["--", PROJECT_ID]
+
+
+# ---------------------------------------------------------------------------
+# Ambient BWS_SERVER_URL inherited from the parent environment
+# ---------------------------------------------------------------------------
+
+
+def _run_with_source_env(monkeypatch, tmp_path, source_env, **fetch_kwargs):
+    """Run a fetch with `source_env` as the parent env; return (env, warnings)."""
+    fake_binary = tmp_path / "bws"
+    fake_binary.write_text("", encoding="utf-8")
+    captured_env = {}
+
+    def fake_run(cmd, **kwargs):
+        captured_env.update(kwargs["env"])
+        return mock.Mock(returncode=0, stdout=_fake_bws_payload([]), stderr="")
+
+    monkeypatch.setattr(bw.subprocess, "run", fake_run)
+    monkeypatch.setattr(bw, "get_source_environment", lambda: dict(source_env))
+
+    _secrets, warnings = bw.fetch_bitwarden_secrets(
+        access_token="0.t",
+        project_id=PROJECT_ID,
+        binary=fake_binary,
+        use_cache=False,
+        **fetch_kwargs,
+    )
+    return captured_env, warnings
+
+
+def test_inherited_plaintext_server_url_is_dropped(monkeypatch, tmp_path):
+    """An exported http:// override must not redirect the token either."""
+    env, warnings = _run_with_source_env(
+        monkeypatch, tmp_path, {"BWS_SERVER_URL": "http://attacker.example"}
+    )
+    assert "BWS_SERVER_URL" not in env
+    assert any("Ignoring BWS_SERVER_URL" in w for w in warnings)
+
+
+def test_inherited_https_server_url_still_works(monkeypatch, tmp_path):
+    """A valid shell override keeps working — this is a documented escape hatch."""
+    env, warnings = _run_with_source_env(
+        monkeypatch, tmp_path, {"BWS_SERVER_URL": "https://vault.bitwarden.eu"}
+    )
+    assert env["BWS_SERVER_URL"] == "https://vault.bitwarden.eu"
+    assert warnings == []
+
+
+def test_configured_server_url_wins_over_inherited(monkeypatch, tmp_path):
+    env, _warnings = _run_with_source_env(
+        monkeypatch,
+        tmp_path,
+        {"BWS_SERVER_URL": "https://vault.bitwarden.eu"},
+        server_url="https://vault.example.com",
+    )
+    assert env["BWS_SERVER_URL"] == "https://vault.example.com"

--- a/website/docs/user-guide/secrets/bitwarden.md
+++ b/website/docs/user-guide/secrets/bitwarden.md
@@ -41,7 +41,7 @@ It will:
 
 1. Download and verify `bws v2.0.0` into `~/.hermes/bin/bws`.
 2. Prompt you for the access token (input is hidden). Stored in `~/.hermes/.env` as `BWS_ACCESS_TOKEN`.
-3. Ask which Bitwarden region your machine account belongs to — **US Cloud**, **EU Cloud**, or **self-hosted / custom URL**. Stored in `config.yaml` as `secrets.bitwarden.server_url` and passed to `bws` as `BWS_SERVER_URL`.
+3. Ask which Bitwarden region your machine account belongs to — **US Cloud**, **EU Cloud**, or **self-hosted / custom URL** (`https://`, or `http://` for localhost only). Stored in `config.yaml` as `secrets.bitwarden.server_url` and passed to `bws` as `BWS_SERVER_URL`.
 4. List the projects the machine account can see; pick one. Stored in `config.yaml` as `secrets.bitwarden.project_id`.
 5. Test-fetch the project's secrets and show you which env vars will resolve.
 6. Flip `secrets.bitwarden.enabled: true`.
@@ -116,8 +116,8 @@ secrets:
 |---|---|---|
 | `enabled` | `false` | Master switch. When false, Bitwarden is never contacted. |
 | `access_token_env` | `BWS_ACCESS_TOKEN` | Env var name that holds the bootstrap token. Change this if you already use `BWS_ACCESS_TOKEN` for something else. |
-| `project_id` | `""` | UUID of the project to sync from. |
-| `server_url` | `""` | Bitwarden region or self-hosted endpoint. Empty = `bws` default (US Cloud, `https://vault.bitwarden.com`). Set to `https://vault.bitwarden.eu` for EU Cloud, or your own URL for self-hosted. Plumbed into the `bws` subprocess as `BWS_SERVER_URL`. |
+| `project_id` | `""` | UUID of the project to sync from. Rejected if it isn't UUID-shaped. |
+| `server_url` | `""` | Bitwarden region or self-hosted endpoint. Empty = `bws` default (US Cloud, `https://vault.bitwarden.com`). Set to `https://vault.bitwarden.eu` for EU Cloud, or your own URL for self-hosted. Plumbed into the `bws` subprocess as `BWS_SERVER_URL`. Must be `https://` — the access token is sent to this endpoint, so plaintext `http://` is refused except for `localhost`. A `BWS_SERVER_URL` inherited from your shell is held to the same rule and dropped (with a warning) if it fails. |
 | `cache_ttl_seconds` | `300` | How long an in-process or disk fetch result is reused. Set to `0` to disable fresh-cache reuse. |
 | `encrypted_cache.enabled` | `false` | Store the last successful fetch in an AES-GCM encrypted cache at `~/.hermes/cache/bws_cache.enc.json`. |
 | `encrypted_cache.max_stale_seconds` | `0` | When encrypted caching is enabled, allow that cache to be used only after network/timeout failures, up to this age. Authentication failures never use stale secrets. A successful encrypted write removes the legacy plaintext `cache/bws_cache.json`. |


### PR DESCRIPTION
## What does this PR do?

The `bws` child process receives the BSM access token, so the two values that steer it — where it connects and which project it reads — are security-relevant inputs. Neither was validated. This closes both, plus the environment-inherited variant of the first.

**1. `server_url` accepted anything, including plaintext `http://`.**
A phished setup answer or a committed `config.yaml` pointing at `http://attacker.example` sent the access token to that endpoint, unencrypted. It is now required to be `https://`, with a real host and no embedded `user:pass@` credentials. Plaintext `http://` is still accepted for loopback (`localhost`, `127.0.0.1`, `::1`) — self-hosted users tunnelling to a local port rely on it, and there is no network there to sniff.

**2. An ambient `BWS_SERVER_URL` from the parent shell bypassed even that.**
When the config key was empty, whatever `BWS_SERVER_URL` the caller happened to export was passed through untouched (`bitwarden.py:686-689`). That is a deliberate override escape hatch, so it stays — but it now goes through the same validator, and a value that fails is dropped with a warning instead of silently redirecting the token.

**3. `project_id` was interpolated into the argv with no `--` terminator.**
A value starting with `-` was parsed by `bws` as a flag. Verified against the real bws 2.0.0 binary:

```
$ bws secret list "--help" --output json      # current main's argv shape
Usage: bws.exe secret list [OPTIONS] [PROJECT_ID]      <- parsed as a flag

$ bws secret list --output json -- "--help"   # this PR's shape
error: invalid value '--help' for '[PROJECT_ID]'       <- stays a positional
```

`--` is what `op read` already does when it assembles its argv (`onepassword.py:279`, `cmd += ["--", reference]`). On top of that, `project_id` must now be UUID-shaped, which is what the config key is documented to hold (`"BSM project UUID"`) and the only thing `bws secret list` accepts.

Validation runs **before** the cache lookup, so a rejected value can never serve a cached fetch, and the cache key holds the checked form.

### Why this shape

`validate_server_url` / `validate_project_id` are module-level and public because `hermes_cli/secrets_cli.py` needs the same rules at setup time — persisting an endpoint the fetch path will later refuse is its own bug. `apply_server_url_to_env` keeps the env-var handling in one place so the two `bws` spawn sites (`_run_bws_list`, `_list_projects`) can't drift.

Deliberately **not** a host allowlist: self-hosted Bitwarden means arbitrary hosts are legitimate. The scheme is what protects the token in transit.

## Related Issue

Fixes #77480

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `agent/secret_sources/bitwarden.py`
  - new `validate_server_url()`, `validate_project_id()`, `apply_server_url_to_env()`
  - `fetch_bitwarden_secrets()` validates both inputs before the cache lookup
  - `_run_bws_list()` passes the project id after `--`, and routes the env var through the shared helper; a dropped ambient override is logged and returned in `warnings`
  - `server_url` config-schema description notes the https requirement
- `hermes_cli/secrets_cli.py`
  - `_resolve_server_url()` validates the `--server-url` flag, the `BWS_SERVER_URL` env var, and the interactive custom URL. A stored-but-invalid config value no longer dead-ends setup — it's dropped with a warning and the region menu is shown, since fixing it is why the user ran setup. The interactive prompt re-asks instead of aborting. This replaces the old "warning: doesn't start with http:// or https://, bws may reject it" advisory.
  - `_list_projects()` uses `apply_server_url_to_env()`
- `tests/test_bitwarden_secrets.py` — 28 new test cases across 11 test functions (see below); existing fixtures moved off placeholder project ids (`"p"`, `"proj-1"`) to a well-formed UUID constant
- `website/docs/user-guide/secrets/bitwarden.md` — documents the https requirement and the inherited-env-var rule

## How to Test

```bash
pytest tests/test_bitwarden_secrets.py tests/hermes_cli/test_bitwarden_status.py \
       tests/hermes_cli/test_secrets_bitwarden_non_tty.py -q
```

New coverage:

- `validate_server_url` accepts `""`, both cloud regions, a self-hosted `https://` URL with port and path, and `http://` on loopback; rejects `http://` elsewhere (incl. a private IP), `user:pw@`, `ftp://`, `file://`, a bare hostname, and `https://` with no host
- `validate_project_id` accepts a UUID (any case, surrounding whitespace); rejects empty, `"proj-1"`, `"aaaa-bbbb"`, `"--help"`, `"-o /tmp/x"`, and a near-miss UUID
- a fetch with `server_url="http://attacker.example"` or `project_id="--config=/tmp/evil.toml"` raises before `subprocess.run` is reached at all (the fake asserts it is never called)
- the argv ends with `["--", <uuid>]`
- an inherited `BWS_SERVER_URL=http://attacker.example` is dropped and surfaces a warning; an inherited `https://` one is preserved; a configured value wins over an inherited one

Manual verification of the `--` behaviour used the real pinned binary (`bws 2.0.0`, downloaded via `bw.install_bws()`) — output in the section above. Both argv shapes reach the identical token-decryption stage for a valid UUID, so the terminator changes nothing for the normal path.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — see note below
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (26100), Python 3.12.10

On duplicates: #77027 also touches Bitwarden child-process env, but it strips the **token** and `*_PASSWORD` from children — a different variable and the opposite direction (keeping secrets out of children, rather than validating where the token is sent). No overlap in the lines changed. I found no open PR touching `server_url` validation or the `bws` argv.

Test-run note: on Windows, `test_install_bws_happy_path` and `test_encrypted_cache_writes_without_plaintext` fail on this branch — but they fail identically on unmodified `main` (chmod/0600 semantics), so they're pre-existing and unrelated. Everything else passes: 44 passed in `test_bitwarden_secrets.py` (23 before this PR), plus `tests/secret_sources/`, `tests/hermes_cli/test_bitwarden_status.py`, `tests/hermes_cli/test_secrets_bitwarden_non_tty.py` and `tests/hermes_cli/test_secrets_token_rotation.py` green. Related: #68226 is already open for Windows portability in these tests.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/secrets/bitwarden.md`, docstrings, config-schema description)
- [x] `cli-config.yaml.example` — N/A (no new config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture or workflow change)
- [x] Cross-platform impact considered — pure-Python string/URL validation, no OS-specific paths; `scripts/check-windows-footguns.py` reports nothing on the changed lines
- [x] Tool descriptions/schemas — N/A

## Compatibility

Three configs that used to "work" now fail fast with an actionable message:

- `server_url` on plaintext `http://` to a non-loopback host — this is the vulnerability, and the error names the key and the fix
- `server_url` with embedded credentials, or a non-http(s) scheme
- a non-UUID `project_id` — which `bws` rejects anyway, just with a less clear error

Failures surface through the existing `SecretSource` error path, so they warn and continue rather than blocking startup.

---

🤖 Written with [Claude Code](https://claude.com/claude-code); reviewed and tested by me.

