### PR TITLE
refactor: consolidate six duplicate byte formatters into hermes_cli.sizefmt

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -13,7 +13,7 @@ from typing import Awaitable, Callable
 
 from agent.model_metadata import estimate_tokens_rough
 from hermes_cli._subprocess_compat import IS_WINDOWS, windows_hide_flags
-from hermes_cli.sizefmt import format_bytes as _human_bytes
+from hermes_cli.sizefmt import format_bytes
 
 _QUOTED_REFERENCE_VALUE = r'(?:`[^`\n]+`|"[^"\n]+"|\'[^\'\n]+\')'
 REFERENCE_PATTERN = re.compile(
@@ -559,7 +559,7 @@ def _binary_reference_block(ref: ContextReference, path: Path) -> str:
     mime, _ = mimetypes.guess_type(path.name)
     mime = mime or "application/octet-stream"
     try:
-        size = _human_bytes(path.stat().st_size)
+        size = format_bytes(path.stat().st_size)
     except OSError:
         size = "unknown size"
     return (

--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -13,6 +13,7 @@ from typing import Awaitable, Callable
 
 from agent.model_metadata import estimate_tokens_rough
 from hermes_cli._subprocess_compat import IS_WINDOWS, windows_hide_flags
+from hermes_cli.sizefmt import format_bytes as _human_bytes
 
 _QUOTED_REFERENCE_VALUE = r'(?:`[^`\n]+`|"[^"\n]+"|\'[^\'\n]+\')'
 REFERENCE_PATTERN = re.compile(
@@ -552,15 +553,6 @@ def _rg_files(path: Path, cwd: Path, limit: int) -> list[Path] | None:
         return None
     files = [Path(line.strip()) for line in result.stdout.splitlines() if line.strip()]
     return files[:limit]
-
-
-def _human_bytes(n: int) -> str:
-    size = float(n)
-    for unit in ("B", "KB", "MB", "GB"):
-        if size < 1024 or unit == "GB":
-            return f"{int(size)} {unit}" if unit == "B" else f"{size:.1f} {unit}"
-        size /= 1024
-    return f"{size:.1f} GB"
 
 
 def _binary_reference_block(ref: ContextReference, path: Path) -> str:

--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -50,10 +50,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import get_hermes_home
 from agent.skill_utils import is_excluded_skill_path
-
-# Shared byte formatter; public name ``format_size`` is part of this module's
-# established surface, so alias rather than churn the callers.
-from hermes_cli.sizefmt import format_bytes as format_size
+from hermes_cli.sizefmt import format_bytes
 
 logger = logging.getLogger(__name__)
 
@@ -749,6 +746,6 @@ def summarize_backups() -> str:
             f"{r.get('id','?'):<24}  "
             f"{(r.get('reason','?') or '?')[:40]:<40}  "
             f"{r.get('skill_files', 0):>6}  "
-            f"{format_size(int(r.get('archive_bytes', 0))):>8}"
+            f"{format_bytes(int(r.get('archive_bytes', 0))):>8}"
         )
     return "\n".join(lines)

--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -51,6 +51,10 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 from hermes_constants import get_hermes_home
 from agent.skill_utils import is_excluded_skill_path
 
+# Shared byte formatter; public name ``format_size`` is part of this module's
+# established surface, so alias rather than churn the callers.
+from hermes_cli.sizefmt import format_bytes as format_size
+
 logger = logging.getLogger(__name__)
 
 
@@ -732,13 +736,6 @@ def rollback(backup_id: Optional[str] = None) -> Tuple[bool, str, Optional[Path]
 # ---------------------------------------------------------------------------
 # Human-readable summary for CLI
 # ---------------------------------------------------------------------------
-
-def format_size(n: int) -> str:
-    for unit in ("B", "KB", "MB", "GB"):
-        if n < 1024 or unit == "GB":
-            return f"{n:.1f} {unit}" if unit != "B" else f"{n} B"
-        n /= 1024
-    return f"{n:.1f} GB"
 
 
 def summarize_backups() -> str:

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -25,6 +25,10 @@ from typing import Any, Dict, List, Optional
 
 from hermes_constants import get_default_hermes_root, get_hermes_home, display_hermes_home
 
+# Shared formatter; the private alias is kept because claw.py and the backup
+# tests import ``_format_size`` from this module.
+from hermes_cli.sizefmt import format_bytes as _format_size
+
 logger = logging.getLogger(__name__)
 
 
@@ -573,15 +577,6 @@ def copy_db_and_verify(src: Path, dst: Path) -> bool:
 # ---------------------------------------------------------------------------
 # Backup
 # ---------------------------------------------------------------------------
-
-def _format_size(nbytes: int) -> str:
-    """Human-readable file size."""
-    for unit in ("B", "KB", "MB", "GB"):
-        if nbytes < 1024:
-            return f"{nbytes:.1f} {unit}" if unit != "B" else f"{nbytes} {unit}"
-        nbytes /= 1024
-    return f"{nbytes:.1f} TB"
-
 
 def run_backup(args) -> None:
     """Create a zip backup of the Hermes home directory."""

--- a/hermes_cli/checkpoints.py
+++ b/hermes_cli/checkpoints.py
@@ -27,14 +27,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional
 
-from hermes_cli.sizefmt import format_bytes
-
-
-def _fmt_bytes(n: Optional[int]) -> str:
-    # Delegates to the shared formatter; ``or 0`` preserves this module's
-    # historical None/0 -> "0 B" display (the shared helper renders None
-    # as "?", which is wrong for a size total that is genuinely zero).
-    return format_bytes(n or 0)
+from hermes_cli.sizefmt import format_bytes as _fmt_bytes
 
 
 def _fmt_ts(ts: Any) -> str:

--- a/hermes_cli/checkpoints.py
+++ b/hermes_cli/checkpoints.py
@@ -27,17 +27,14 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional
 
+from hermes_cli.sizefmt import format_bytes
 
-def _fmt_bytes(n: int) -> str:
-    units = ("B", "KB", "MB", "GB", "TB")
-    size = float(n or 0)
-    for unit in units:
-        if size < 1024 or unit == units[-1]:
-            if unit == "B":
-                return f"{int(size)} {unit}"
-            return f"{size:.1f} {unit}"
-        size /= 1024
-    return f"{size:.1f} TB"
+
+def _fmt_bytes(n: Optional[int]) -> str:
+    # Delegates to the shared formatter; ``or 0`` preserves this module's
+    # historical None/0 -> "0 B" display (the shared helper renders None
+    # as "?", which is wrong for a size total that is genuinely zero).
+    return format_bytes(n or 0)
 
 
 def _fmt_ts(ts: Any) -> str:

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -221,19 +221,9 @@ def check_info(text: str):
 STATE_DB_SIZE_WARN_BYTES = 1 * 1024 * 1024 * 1024   # 1 GiB logical size
 
 
-def _human_bytes(n) -> str:
-    """1234567 → '1.2 MB' (GB/MB/KB/B)."""
-    try:
-        n = int(n)
-    except (TypeError, ValueError):
-        return "?"
-    if n >= 1024 ** 3:
-        return f"{n / (1024 ** 3):.1f} GB"
-    if n >= 1024 ** 2:
-        return f"{n / (1024 ** 2):.1f} MB"
-    if n >= 1024:
-        return f"{n / 1024:.1f} KB"
-    return f"{n} B"
+# Shared byte formatter (private alias: this module's rendering helpers and
+# tests refer to ``_human_bytes``).
+from hermes_cli.sizefmt import format_bytes as _human_bytes
 
 
 def _render_state_db_stats(stats: dict, holders=None) -> list:

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -221,8 +221,8 @@ def check_info(text: str):
 STATE_DB_SIZE_WARN_BYTES = 1 * 1024 * 1024 * 1024   # 1 GiB logical size
 
 
-# Shared byte formatter (private alias: this module's rendering helpers and
-# tests refer to ``_human_bytes``).
+# Shared byte formatter, aliased to the name this module's three rendering
+# call sites already use.
 from hermes_cli.sizefmt import format_bytes as _human_bytes
 
 

--- a/hermes_cli/sizefmt.py
+++ b/hermes_cli/sizefmt.py
@@ -1,0 +1,38 @@
+"""Small shared size-formatting helpers for CLI/agent output.
+
+Public home for the human-readable byte formatter that previously existed
+as five near-identical private copies (``hermes_cli/backup.py``,
+``hermes_cli/checkpoints.py``, ``hermes_cli/doctor.py``,
+``agent/context_references.py``, ``agent/curator_backup.py``). Sibling of
+``hermes_cli.timefmt``, and kept dependency-free for the same reason:
+lightweight consumers must not drag in the whole CLI surface.
+
+Two in-repo formatters intentionally do NOT delegate here:
+
+* ``hermes_cli/session_recovery.py`` uses binary suffixes (KiB/MiB/GiB)
+  throughout its recovery report — a deliberate, self-consistent style.
+* ``gateway/platforms/qqbot/chunked_upload.py`` renders bytes with one
+  decimal ("100.0 B", pinned by tests) inside a self-contained upload
+  protocol module.
+"""
+
+from __future__ import annotations
+
+
+def format_bytes(n, *, fallback: str = "?") -> str:
+    """1234567 -> '1.2 MB' (B/KB/MB/GB/TB; integer bytes, one decimal above).
+
+    Accepts anything ``float()`` accepts; returns *fallback* for None or
+    unparseable input so display call sites never raise.
+    """
+    try:
+        size = float(n)
+    except (TypeError, ValueError):
+        return fallback
+    if size < 1024:
+        return f"{int(size)} B"
+    for unit in ("KB", "MB", "GB", "TB"):
+        size /= 1024.0
+        if size < 1024 or unit == "TB":
+            return f"{size:.1f} {unit}"
+    return f"{size:.1f} TB"  # unreachable; keeps type-checkers satisfied

--- a/hermes_cli/sizefmt.py
+++ b/hermes_cli/sizefmt.py
@@ -1,11 +1,8 @@
 """Small shared size-formatting helpers for CLI/agent output.
 
-Public home for the human-readable byte formatter that previously existed
-as five near-identical private copies (``hermes_cli/backup.py``,
-``hermes_cli/checkpoints.py``, ``hermes_cli/doctor.py``,
-``agent/context_references.py``, ``agent/curator_backup.py``). Sibling of
-``hermes_cli.timefmt``, and kept dependency-free for the same reason:
-lightweight consumers must not drag in the whole CLI surface.
+Sibling of ``hermes_cli.timefmt`` (same extraction rationale: a tiny
+purpose-named module lightweight consumers can import without dragging in
+the CLI surface). Replaces six near-identical private byte formatters.
 
 Two in-repo formatters intentionally do NOT delegate here:
 
@@ -19,20 +16,21 @@ Two in-repo formatters intentionally do NOT delegate here:
 from __future__ import annotations
 
 
-def format_bytes(n, *, fallback: str = "?") -> str:
+def format_bytes(n) -> str:
     """1234567 -> '1.2 MB' (B/KB/MB/GB/TB; integer bytes, one decimal above).
 
-    Accepts anything ``float()`` accepts; returns *fallback* for None or
-    unparseable input so display call sites never raise.
+    Accepts anything ``float()`` accepts; returns ``"?"`` for None or
+    unparseable input so display call sites never raise (contract inherited
+    from doctor's original copy — its stats dict tolerates None fields).
     """
     try:
         size = float(n)
     except (TypeError, ValueError):
-        return fallback
+        return "?"
     if size < 1024:
         return f"{int(size)} B"
-    for unit in ("KB", "MB", "GB", "TB"):
+    for unit in ("KB", "MB", "GB"):
         size /= 1024.0
-        if size < 1024 or unit == "TB":
+        if size < 1024:
             return f"{size:.1f} {unit}"
-    return f"{size:.1f} TB"  # unreachable; keeps type-checkers satisfied
+    return f"{size / 1024.0:.1f} TB"

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2692,12 +2692,9 @@ def _run_pre_update_backup(args) -> Optional[str]:
         size_bytes = 0
 
     # Human-readable size
-    size_str = f"{size_bytes} B"
-    for unit in ("KB", "MB", "GB"):
-        if size_bytes < 1024:
-            break
-        size_bytes /= 1024
-        size_str = f"{size_bytes:.1f} {unit}"
+    from hermes_cli.sizefmt import format_bytes
+
+    size_str = format_bytes(size_bytes)
 
     # Render path using display_hermes_home so the user sees ~/.hermes/...
     try:

--- a/tests/hermes_cli/test_sizefmt.py
+++ b/tests/hermes_cli/test_sizefmt.py
@@ -1,10 +1,10 @@
 """Tests for the shared byte formatter (hermes_cli.sizefmt).
 
-Consolidates five near-identical private formatters (backup, checkpoints,
-doctor, context_references, curator_backup). The contract below locks the
-shared behavior, including the two deliberate changes vs the old copies:
-a real TB tier (doctor/context_references/curator_backup previously
-rendered 1 TiB as '1024.0 GB') and non-raising fallback for None/garbage.
+Consolidates six near-identical formatters (backup, checkpoints, doctor,
+update_cmd, context_references, curator_backup). The contract below locks
+the shared behavior, including the one deliberate change vs the old
+copies: a real TB tier (doctor/context_references/curator_backup
+previously rendered 1 TiB as '1024.0 GB').
 """
 
 import pytest
@@ -40,24 +40,23 @@ def test_format_bytes_tb_tier_not_gb_overflow():
 
 
 def test_format_bytes_never_raises():
+    """Doctor's stats dict tolerates None in every field; the formatter must
+    render (not raise) for None/garbage."""
     assert format_bytes(None) == "?"
     assert format_bytes("garbage") == "?"
     assert format_bytes("2048") == "2.0 KB"  # numeric strings accepted
-    assert format_bytes(None, fallback="unknown") == "unknown"
 
 
-def test_delegating_aliases_share_the_implementation():
-    """The five migrated call sites must all resolve to the shared helper
-    (checkpoints wraps it to preserve its None -> '0 B' display)."""
-    from agent.context_references import _human_bytes as ctx
-    from agent.curator_backup import format_size as curator
+def test_migrated_sites_render_through_the_shared_helper():
+    """Behavior contract for the aliased call sites: the module-local names
+    must render byte-identically to the shared helper (how they delegate is
+    an implementation detail — only the rendering is pinned)."""
     from hermes_cli.backup import _format_size as backup
     from hermes_cli.checkpoints import _fmt_bytes as checkpoints
     from hermes_cli.doctor import _human_bytes as doctor
 
-    assert backup is format_bytes
-    assert ctx is format_bytes
-    assert curator is format_bytes
-    assert doctor is format_bytes
-    assert checkpoints(None) == "0 B"
-    assert checkpoints(2048) == format_bytes(2048)
+    for n in (0, 512, 2048, 1234567, 1024**3, 1024**4):
+        expected = format_bytes(n)
+        assert backup(n) == expected
+        assert checkpoints(n) == expected
+        assert doctor(n) == expected

--- a/tests/hermes_cli/test_sizefmt.py
+++ b/tests/hermes_cli/test_sizefmt.py
@@ -1,0 +1,63 @@
+"""Tests for the shared byte formatter (hermes_cli.sizefmt).
+
+Consolidates five near-identical private formatters (backup, checkpoints,
+doctor, context_references, curator_backup). The contract below locks the
+shared behavior, including the two deliberate changes vs the old copies:
+a real TB tier (doctor/context_references/curator_backup previously
+rendered 1 TiB as '1024.0 GB') and non-raising fallback for None/garbage.
+"""
+
+import pytest
+
+from hermes_cli.sizefmt import format_bytes
+
+
+@pytest.mark.parametrize(
+    "n,expected",
+    [
+        (0, "0 B"),
+        (1, "1 B"),
+        (512, "512 B"),
+        (1023, "1023 B"),
+        (1024, "1.0 KB"),
+        (1536, "1.5 KB"),
+        (1024**2, "1.0 MB"),
+        (1234567, "1.2 MB"),
+        (1024**3, "1.0 GB"),
+        (1024**4, "1.0 TB"),
+        (2 * 1024**4, "2.0 TB"),
+    ],
+)
+def test_format_bytes_tiers(n, expected):
+    assert format_bytes(n) == expected
+
+
+def test_format_bytes_tb_tier_not_gb_overflow():
+    """The old doctor/context_references/curator_backup copies topped out at
+    GB and rendered 1 TiB as '1024.0 GB' — the shared helper must not."""
+    assert "TB" in format_bytes(1024**4)
+    assert "1024" not in format_bytes(1024**4)
+
+
+def test_format_bytes_never_raises():
+    assert format_bytes(None) == "?"
+    assert format_bytes("garbage") == "?"
+    assert format_bytes("2048") == "2.0 KB"  # numeric strings accepted
+    assert format_bytes(None, fallback="unknown") == "unknown"
+
+
+def test_delegating_aliases_share_the_implementation():
+    """The five migrated call sites must all resolve to the shared helper
+    (checkpoints wraps it to preserve its None -> '0 B' display)."""
+    from agent.context_references import _human_bytes as ctx
+    from agent.curator_backup import format_size as curator
+    from hermes_cli.backup import _format_size as backup
+    from hermes_cli.checkpoints import _fmt_bytes as checkpoints
+    from hermes_cli.doctor import _human_bytes as doctor
+
+    assert backup is format_bytes
+    assert ctx is format_bytes
+    assert curator is format_bytes
+    assert doctor is format_bytes
+    assert checkpoints(None) == "0 B"
+    assert checkpoints(2048) == format_bytes(2048)


### PR DESCRIPTION
## Summary

One shared human-readable byte formatter (`hermes_cli/sizefmt.py::format_bytes`) replaces **six** near-identical private copies — and fixes the silent `1024.0 GB` bug three of them shared.

This came out of the #80693/#81613 review: `doctor._human_bytes` was yet another hand-rolled copy of the same formatter, flagged by the code-reuse pass as a repo-wide consolidation candidate.

## The problem

Six modules each carried their own byte formatter, drifting in small ways:

| Copy | Quirk |
|---|---|
| `hermes_cli/backup.py::_format_size` | correct TB tier |
| `hermes_cli/checkpoints.py::_fmt_bytes` | correct TB tier |
| `hermes_cli/update_cmd.py` (inline, backup-size display) | tops out at GB |
| `hermes_cli/doctor.py::_human_bytes` | **tops out at GB** — renders 1 TiB as `1024.0 GB` |
| `agent/context_references.py::_human_bytes` | **tops out at GB** |
| `agent/curator_backup.py::format_size` | **tops out at GB** |

The GB cap is not hypothetical for doctor: it sits in the exact code path (#81613's state.db health section) built for multi-gigabyte databases — a 1 TB+ state.db would report `1024.0 GB`.

## Why a new module (placement rationale)

The helper is consumed from both `agent/*` and `hermes_cli/*`, so its home must be import-light. A new tiny purpose-named module is this repo's **established pattern for exactly this case**: `hermes_cli/timefmt.py` was itself created (commit 58e3dcf3d, Aug 2) as a brand-new single-function module extracted from `hermes_cli.main`, for the same "lightweight consumers must not drag in the CLI surface" reason — and `agent/* → hermes_cli/<small dependency-free helper>` is the established direction (8 `agent/*` modules already import `hermes_cli._subprocess_compat`). Folding `format_bytes` into `timefmt.py` would make that module's name false; no other honest existing home exists (`hermes_constants` is path resolution, `colors.py` is ANSI, `hermes_state_common` imports agent code). Import cost measured: ~0.5 ms, stdlib-free, no package side effects.

## The fix

- New `hermes_cli/sizefmt.py::format_bytes` — B/KB/MB/GB/TB tiers, integer bytes, one decimal above, non-raising `"?"` fallback for None/garbage (inherited from doctor's copy, whose stats dict tolerates None fields).
- `backup._format_size` and `doctor._human_bytes` keep their local names as aliases (claw.py + backup tests pin the former; three doctor call sites use the latter). `checkpoints._fmt_bytes` is a plain alias. `update_cmd`, `curator_backup`, and `context_references` call `format_bytes` directly (single call sites, zero external importers).

**Deliberately NOT migrated** (behavior differs on purpose):
- `hermes_cli/session_recovery.py::_format_bytes` — binary suffixes (KiB/MiB/GiB) throughout its recovery report, a self-consistent style
- `gateway/platforms/qqbot/chunked_upload.py::format_size` — `100.0 B` one-decimal style pinned by its protocol tests, inside a self-contained upload module

Both exclusions are documented in the module docstring so the next reader doesn't re-flag them. Fixed-unit compact displays (`prompt_size._fmt_kb`, `commands.py` `{…:.0f}K`, etc.) are not general formatters and are left alone.

## Behavior change (the only one)

Values ≥ 1 TiB now render as `X.X TB` instead of `NNNN.N GB` in doctor, update-backup display, context-reference binary blocks, and curator backup summaries. Everything below 1 TiB is byte-identical — verified empirically per-site against all six verbatim originals over a 16-value corpus (the TB tier was the only divergence).

## Validation

| Check | Result |
|---|---|
| Parity harness: shared helper vs 6 verbatim originals × 16 values | identical except the intended TB fix |
| Contract tests (`tests/hermes_cli/test_sizefmt.py`: tier table, TB-tier guard, never-raises, per-site behavior equality) | 14 passed; mutation-checked red → green |
| Existing suites (backup, checkpoints, doctor, state-db stats, session_recovery, qqbot, cmd_update, zip two-phase/atomic-replace, context_references, curator_backup) | 231 passed |
| Live E2E: doctor state.db rendering + curator backup summary on a real 2.9 GB DB | correct output via the shared helper |
| `ruff check` on all touched files | clean |

## LOC accounting (refactor honesty)

55 duplicated production lines deleted across six sites; the new module is 35 lines of which ~15 are docstring (including the two documented exclusions). Duplicated *logic*: 6 copies → 1.
