### PR TITLE
fix(cron): stop reporting no_agent script failures as provider errors

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -109,8 +109,18 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     text = (error or "unknown error").strip()
     lower = text.lower()
 
+    # A no_agent job never makes an inference call: the script IS the job, and
+    # `model`/`provider` are unset. Its stdout routinely contains "timed out",
+    # "429" or "401" from whatever the script itself talked to (Sheets, SSH, an
+    # HTTP API). Classifying those as provider failures tells the operator to
+    # debug a fallback chain that was never used, and hides the real error. Skip
+    # provider classification entirely and report the script's own output.
+    provider_classified = not job.get("no_agent")
+
     # Provider/API failures are the common noisy path. Keep these short.
-    if "429" in text or "rate limit" in lower or "usage limit" in lower:
+    if provider_classified and (
+        "429" in text or "rate limit" in lower or "usage limit" in lower
+    ):
         reason = "rate limit"
         if "weekly usage limit" in lower:
             reason = "weekly usage limit"
@@ -122,7 +132,9 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
             "Full details saved in cron output."
         )
 
-    if "readtimeout" in lower or "timed out" in lower or "timeout" in lower:
+    if provider_classified and (
+        "readtimeout" in lower or "timed out" in lower or "timeout" in lower
+    ):
         return (
             f"⚠️ Cron '{job_name}' failed: provider timeout. "
             "Fallback chain was exhausted or unavailable. "
@@ -132,7 +144,9 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     # Match authentication/authorization wording at a word boundary and the
     # 401/403 status codes as whole tokens, so "oauth", "4015" and similar do
     # not trip a misleading auth message.
-    if re.search(r"authenticat|authoriz", lower) or re.search(r"\b(401|403)\b", text):
+    if provider_classified and (
+        re.search(r"authenticat|authoriz", lower) or re.search(r"\b(401|403)\b", text)
+    ):
         return (
             f"⚠️ Cron '{job_name}' failed: provider authentication error. "
             "Full details saved in cron output."

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -131,3 +131,94 @@ def test_run_job_script_nul_path_fails_cleanly(hermes_env):
     ok, output = _run_job_script("~user\x00bad.sh")
     assert ok is False
     assert "Blocked" in output
+
+
+# ---------------------------------------------------------------------------
+# _summarize_cron_failure_for_delivery: no_agent jobs are never provider failures
+# ---------------------------------------------------------------------------
+
+
+NO_AGENT_JOB = {
+    "name": "ng-mirror-sync",
+    "no_agent": True,
+    "script": "sync_ng_mirror.sh",
+    "model": None,
+    "provider": None,
+}
+
+AGENT_JOB = {"name": "daily-recap", "no_agent": False, "model": "x", "provider": "y"}
+
+
+@pytest.mark.parametrize(
+    "error_text",
+    [
+        # Google Sheets read timeout surfaced through a script's stdout.
+        (
+            "Script exited with code 1\nstdout:\n"
+            "Sheet read failed (4x): HTTPSConnectionPool("
+            "host='sheets.googleapis.com', port=443): Read timed out. "
+            "(read timeout=30)"
+        ),
+        # Sheets quota rejection.
+        (
+            "Script exited with code 1\nstdout:\n"
+            "APIError: [429]: Quota exceeded for quota metric 'Read requests'"
+        ),
+        # Remote host unreachable over ssh.
+        "ssh: connect to host 10.0.0.1 port 22: Operation timed out",
+        # Upstream API rejecting the script's own credentials.
+        "urllib.error.HTTPError: HTTP Error 401: Unauthorized",
+    ],
+)
+def test_no_agent_failure_never_reported_as_provider_error(hermes_env, error_text):
+    """A no_agent job makes no inference call, so its failures must never be
+    described as provider/fallback-chain problems.
+
+    The scheduler classified failures by substring alone, so any script whose
+    stdout contained "timed out", "429" or "401" was delivered to the operator
+    as "provider timeout. Fallback chain was exhausted or unavailable" — for a
+    job with model=None and provider=None that never had a fallback chain. That
+    text sends the operator to debug the wrong subsystem and hides the script's
+    real error.
+    """
+    from cron.scheduler import _summarize_cron_failure_for_delivery
+
+    summary = _summarize_cron_failure_for_delivery(NO_AGENT_JOB, error_text)
+
+    assert "provider" not in summary.lower()
+    assert "fallback chain" not in summary.lower()
+    assert "ng-mirror-sync" in summary
+
+
+def test_no_agent_failure_surfaces_the_real_script_error(hermes_env):
+    """The delivered message must carry the script's own error, not a
+    provider-shaped substitute, so the operator can act on it."""
+    from cron.scheduler import _summarize_cron_failure_for_delivery
+
+    summary = _summarize_cron_failure_for_delivery(
+        NO_AGENT_JOB,
+        "Script exited with code 1\nstdout:\n"
+        "Sheet read failed (4x): HTTPSConnectionPool("
+        "host='sheets.googleapis.com', port=443): Read timed out. "
+        "(read timeout=30)",
+    )
+
+    assert "sheets.googleapis.com" in summary
+
+
+@pytest.mark.parametrize(
+    "error_text,expected",
+    [
+        ("Provider call failed: Read timed out", "provider timeout"),
+        ("HTTP 429 rate limit reached", "provider rate limit"),
+        ("Authentication failed for provider", "provider authentication error"),
+    ],
+)
+def test_agent_mode_still_classifies_provider_failures(hermes_env, error_text, expected):
+    """Agent-mode jobs DO call a provider, so the compact provider summaries
+    must be preserved for them."""
+    from cron.scheduler import _summarize_cron_failure_for_delivery
+
+    summary = _summarize_cron_failure_for_delivery(AGENT_JOB, error_text)
+
+    assert expected in summary.lower()


### PR DESCRIPTION
## Problem

A `no_agent` cron job runs a script and never makes an inference call — `model` and `provider` are unset, and there is no fallback chain. But `_summarize_cron_failure_for_delivery()` classified failures by bare substring match on the error text without consulting the job's execution mode:

```python
if "429" in text or "rate limit" in lower or "usage limit" in lower:      # -> "provider rate limit"
if "readtimeout" in lower or "timed out" in lower or "timeout" in lower:  # -> "provider timeout"
if re.search(r"authenticat|authoriz", lower) or re.search(r"\b(401|403)\b", text):  # -> "provider authentication error"
```

Any script whose stdout happens to contain those words is relabelled as a model failure. This is not an edge case: scripts that talk to Google Sheets, SSH, or any HTTP API surface exactly that vocabulary, so it hits most deterministic jobs.

Observed against real captured stdout, `no_agent: true` in every row:

| Real error inside the script | Delivered to the operator | |
|---|---|---|
| `HTTPSConnectionPool(host='sheets.googleapis.com', port=443): Read timed out. (read timeout=30)` | `provider timeout. Fallback chain was exhausted` | ❌ |
| `APIError: [429] Quota exceeded for quota metric 'Read requests'` | `provider quota limit. Fallback chain was exhausted` | ❌ |
| `ssh: connect to host 10.0.0.1 port 22: Operation timed out` | `provider timeout. Fallback chain was exhausted` | ❌ |
| `Traceback… KeyError: 'brand'` | passed through verbatim | ✅ |

The delivered message is actively harmful in two ways: it points the operator at a subsystem the job never used (a fallback chain that does not exist for this job), and it **discards the script's real error**, which is the only actionable part. In our case a transient Sheets read timeout was reported as an exhausted provider chain, sending the investigation into provider/model config instead of the script.

## Fix

Gate the three provider branches on execution mode with a single `provider_classified = not job.get("no_agent")` flag, rather than guarding each condition separately. `no_agent` failures then fall through to the existing generic path, which already strips exception wrappers and reports the script's own output.

Repairing it at the one place the mode is known — instead of adding three independent guards — keeps the branches readable and means a future provider branch inherits the gate by construction. Agent-mode classification is byte-for-byte unchanged.

## Test

Added to `tests/cron/test_cron_no_agent.py`, reusing the existing `hermes_env` fixture:

- `test_no_agent_failure_never_reported_as_provider_error` — parametrized over the four real-world error shapes above; asserts the summary contains neither `provider` nor `fallback chain`.
- `test_no_agent_failure_surfaces_the_real_script_error` — asserts `sheets.googleapis.com` survives into the delivered message, so the operator gets the actionable part.
- `test_agent_mode_still_classifies_provider_failures` — parametrized; asserts agent-mode jobs keep the compact `provider timeout` / `provider rate limit` / `provider authentication error` summaries.

Proof the tests are real guards — reverting only `cron/scheduler.py` to `origin/main` and keeping the tests:

```
5 failed, 9 passed
E  assert 'sheets.googleapis.com' in "⚠️ Cron 'ng-mirror-sync' failed: provider timeout. Fallback chain was exhausted or unavailable. Full details saved in cron output."
```

With the fix applied: `tests/cron/` → **512 passed**.
