### PR TITLE
chore: AUTHOR_MAP for WolftacDigital (PR #49945 salvage)

### DIFF
--- a/contributors/emails/jonathan@wolftacdigital.com
+++ b/contributors/emails/jonathan@wolftacdigital.com
@@ -1,0 +1,1 @@
+WolftacDigital


### PR DESCRIPTION
## Summary
Adds contributor email mapping for @WolftacDigital so the attribution audit passes for the upcoming salvage of PR #49945.

## Changes
- `contributors/emails/jonathan@wolftacdigital.com` → `WolftacDigital`

## Validation
File follows the existing `contributors/emails/<email>` convention (just the GitHub login as file content).