### PR TITLE
fix(ssl_guard): tolerate truststore SSLContext.get_ca_certs() NotImplementedError on Windows

### DIFF
--- a/agent/ssl_guard.py
+++ b/agent/ssl_guard.py
@@ -55,7 +55,13 @@ def _validate_bundle_path(label: str, value: str, *, require_substantial: bool =
         ctx = ssl.create_default_context(cafile=str(path))
     except Exception as exc:
         raise _ssl_err(f"{label} CA bundle at {value} cannot be loaded: {exc}") from exc
-    if not ctx.get_ca_certs():
+    try:
+        loaded_certs = ctx.get_ca_certs()
+    except NotImplementedError:
+        # truststore-backed SSLContext (Windows OS trust store) doesn't
+        # implement get_ca_certs(); bundle was already validated above.
+        return
+    if not loaded_certs:
         raise _ssl_err(f"{label} CA bundle at {value} did not load any certificates")
 
 

--- a/tests/agent/test_ssl_ca_guard.py
+++ b/tests/agent/test_ssl_ca_guard.py
@@ -19,8 +19,6 @@ def test_healthy_bundle_passes(monkeypatch):
     verify_ca_bundle()
 
 
-
-
 def test_empty_certifi_bundle_raises_ssl_error(monkeypatch, tmp_path):
     """Empty file is treated as a corrupted bundle."""
     fake = tmp_path / "empty.pem"
@@ -44,7 +42,33 @@ def test_missing_explicit_ca_bundle_env_raises_before_httpx(monkeypatch, tmp_pat
     assert "force-reinstall" in message
 
 
+def test_truststore_get_ca_certs_not_implemented_is_accepted(monkeypatch, tmp_path):
+    """A truststore-backed SSLContext (Windows OS trust store) raises
+    NotImplementedError from get_ca_certs(). The guard must accept the
+    already-loaded bundle rather than fail.
 
+    Regression for the empty-message ``Failed to initialize OpenAI client:``
+    seen on every fresh agent init on Windows (str(NotImplementedError()) == "").
+    """
+    from agent import ssl_guard
 
+    bundle = tmp_path / "bundle.pem"
+    bundle.write_text(
+        "-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n",
+        encoding="utf-8",
+    )
 
+    class _TruststoreLikeContext:
+        def get_ca_certs(self, binary_form=False):  # noqa: ARG002 - mirror ssl API
+            raise NotImplementedError()
 
+    # create_default_context(cafile=...) loads the bundle fine; only the
+    # post-load introspection is unsupported under truststore.
+    monkeypatch.setattr(
+        ssl_guard.ssl, "create_default_context", lambda *a, **k: _TruststoreLikeContext()
+    )
+    monkeypatch.setenv("SSL_CERT_FILE", str(bundle))
+
+    # Must not raise on the explicit env bundle nor the certifi check.
+    verify_ca_bundle()
+    verify_ca_bundle_with_fallback()


### PR DESCRIPTION
## Summary
On Windows, `truststore.inject_into_ssl()` replaces `ssl.SSLContext` with an OS-trust-store-backed context whose `get_ca_certs()` raises `NotImplementedError` (empty message). The ssl_guard called it unguarded, crashing every fresh agent init with an opaque `Failed to initialize OpenAI client:` error — hitting the CLI one-shot, API server, and Desktop app.

Root cause: `agent/ssl_guard.py:_validate_bundle_path()` line 57 did `if not ctx.get_ca_certs():` — under truststore this raises `NotImplementedError()` whose `str()` is `""`, producing the empty-detail `RuntimeError`.

Fix: wrap `ctx.get_ca_certs()` in `try/except NotImplementedError: return`. `ssl.create_default_context(cafile=...)` above already validates the bundle is parseable, so the post-load introspection is safe to skip.

Closes #49014, #49937
Supersedes #49945, #49023, #53970

## Changes
- `agent/ssl_guard.py`: try/except NotImplementedError around `ctx.get_ca_certs()` + early return (8 lines)
- `tests/agent/test_ssl_ca_guard.py`: regression test for truststore-backed SSLContext (27 lines)

## Validation
| | Before | After |
|---|---|---|
| truststore `get_ca_certs()` | `NotImplementedError` → empty `RuntimeError` | passes (bundle already validated) |
| empty cert list | `SSLConfigurationError` | `SSLConfigurationError` (unchanged) |
| unparseable bundle | `SSLConfigurationError` | `SSLConfigurationError` (unchanged) |
| targeted tests | 6 passed | 7 passed (incl. new regression) |
| mutation check | N/A | replacing `NotImplementedError` with `ValueError` → test FAILS (has teeth) |

## Credit
Salvaged from PR #49945 by @WolftacDigital (cherry-picked, comment trimmed).
- PR #49023 by @tt-a1i was submitted first (Jun 19) with the same fix + `logger.debug` + an additional large-invalid-bundle test — credited as co-discoverer.
- PR #53970 by @guanyang-wang used a higher-fidelity mock (real SSLContext with monkey-patched `get_ca_certs`) — credited as co-discoverer.
