### PR TITLE
fix: harden Windows gateway supervision

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -40,7 +40,7 @@ import os
 import re
 import shlex
 import stat
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Callable, Iterator, Optional
 
 logger = logging.getLogger(__name__)
@@ -108,6 +108,7 @@ _SHELL_OPTIONS_WITH_VALUES = frozenset({"-O", "+O", "-o", "+o"})
 _MAX_REFERENCED_SCRIPT_BYTES = 1024 * 1024
 _MAX_REFERENCED_SCRIPT_DEPTH = 8
 _CONTROL_CHARS = frozenset(";&|()")
+_WINDOWS_UNQUOTED_PATH = re.compile(r"(^|[\s=])([A-Za-z]:\\[^\s;&|()]*)")
 
 # Executables whose arguments are DATA, not commands: search patterns, SQL
 # statements, log filters. None of these can execute their argument text, so
@@ -155,6 +156,11 @@ def _iter_command_segments(command: str) -> Iterator[list[str]]:
     """Yield shell-tokenized command segments, honoring quotes and comments."""
     normalized = command.replace("\\\n", "")
     for line in normalized.splitlines() or [normalized]:
+        if os.name == "nt":
+            line = _WINDOWS_UNQUOTED_PATH.sub(
+                lambda match: match.group(1) + match.group(2).replace("\\", "/"),
+                line,
+            )
         try:
             lexer = shlex.shlex(
                 line,
@@ -334,6 +340,8 @@ def _resolve_terminal_script_path(candidate: str, cwd: Optional[str]) -> Optiona
     path = _expand_candidate_path(candidate)
     if path is None:
         return None
+    if candidate == "/dev/null":
+        return path
     if not path.is_absolute():
         try:
             path = Path(cwd or Path.cwd()) / path
@@ -430,13 +438,17 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
-    except (OSError, ValueError):
-        # OSError: unreadable / missing / over-long paths. ValueError: an
-        # embedded NUL byte in *path* itself — a binary's decoded bytes
-        # tokenized into a bogus script path by the recursion (#77703). A
-        # guarded read must never crash the guard, so treat either as
-        # "nothing to scan" (mirrors the resolve() ValueError guard below).
+    except ValueError:
         return None, False
+    except OSError:
+        normalized_path = str(path).replace("\\", "/")
+        if normalized_path == "/dev/null":
+            return None, True
+        try:
+            metadata = path.lstat()
+        except (OSError, ValueError):
+            return None, False
+        return None, not stat.S_ISREG(metadata.st_mode)
     try:
         metadata = os.fstat(descriptor)
         if not stat.S_ISREG(metadata.st_mode):
@@ -536,6 +548,7 @@ def _contains_unsafe_gateway_action(
             continue
         visited.add(resolved)
         script_text, unsafe = _read_referenced_script(script_path)
+        remote_path: Optional[str] = None
         if unsafe:
             return True
         if script_text is None and read_remote_script is not None:
@@ -543,8 +556,11 @@ def _contains_unsafe_gateway_action(
             # The callback's output crosses the same trust boundary as a
             # local read — sanitize it identically before it enters the
             # recursion (binary skip + size fail-closed).
+            remote_path = str(script_path)
+            if os.name == "nt" and not script_path.drive and remote_path.startswith("\\"):
+                remote_path = remote_path.replace("\\", "/")
             script_text, unsafe = _sanitize_remote_script_text(
-                read_remote_script(str(script_path))
+                read_remote_script(remote_path)
             )
             if unsafe:
                 return True
@@ -552,7 +568,11 @@ def _contains_unsafe_gateway_action(
             continue
         # Relative references inside a script resolve against that script's
         # directory, not the original command's cwd.
-        script_dir = _resolve_script_directory(str(resolved)) or cwd
+        script_dir = (
+            str(PurePosixPath(remote_path).parent)
+            if remote_path is not None and script_text is not None
+            else (_resolve_script_directory(str(resolved)) or cwd)
+        )
         if _contains_unsafe_gateway_action(
             script_text,
             cwd=script_dir,
@@ -635,6 +655,8 @@ def _resolve_script_path(script_path: str) -> Optional[Path]:
     raw = _expand_candidate_path(script_path)
     if raw is None:
         return None
+    if script_path == "/dev/null":
+        return raw
     if raw.is_absolute():
         return raw
     try:

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -9,9 +9,9 @@ dropper when Scheduled Task creation is denied (locked-down corporate boxes).
 Design notes
 ------------
 * ``schtasks /Create /SC ONLOGON /RL LIMITED`` means the task runs at the
-  CURRENT USER's next logon without any elevation prompt. Manual starts and
-  install ``--start-now`` use the direct hidden-console launcher instead
-  of ``schtasks /Run`` so start/restart behavior is consistent.
+  CURRENT USER's next logon without any elevation prompt. Once registered,
+  manual starts route through ``schtasks /Run`` so the Task Scheduler remains
+  the single supervisor and IgnoreNew continues to enforce one instance.
 * We write a shared ``gateway.cmd`` wrapper plus a console-less ``gateway.vbs``
   launcher. Scheduled Task and Startup-folder persistence both route through
   VBS/wscript; immediate manual starts route through direct ``subprocess`` spawn.
@@ -490,7 +490,7 @@ def _build_gateway_vbs_script(
     lines = [
         f"' {_TASK_DESCRIPTION}",
         "Option Explicit",
-        "Dim sh, env, existing_pp",
+        "Dim sh, env, existing_pp, exitCode",
         'Set sh = CreateObject("WScript.Shell")',
         'Set env = sh.Environment("PROCESS")',
         f"env.Item({_quote_vbs_string('HERMES_HOME')}) = {_quote_vbs_string(hermes_home)}",
@@ -506,10 +506,10 @@ def _build_gateway_vbs_script(
         f"  env.Item({_quote_vbs_string('PYTHONPATH')}) = {_quote_vbs_string(static_pythonpath)}",
         "End If",
         f"sh.CurrentDirectory = {_quote_vbs_string(working_dir)}",
-        # Window style 0 = hidden; bWaitOnReturn False = detached/async. The
-        # console python's one console is created hidden and inherited by all
-        # descendants, so nothing ever flashes.
-        f"sh.Run {_quote_vbs_string(command_line)}, 0, False",
+        # Window style 0 = hidden. Waiting keeps wscript.exe as the Task
+        # Scheduler-owned supervisor and propagates the worker exit code.
+        f"exitCode = sh.Run({_quote_vbs_string(command_line)}, 0, True)",
+        "WScript.Quit exitCode",
     ]
     return "\r\n".join(lines) + "\r\n"
 
@@ -566,7 +566,7 @@ def _write_task_script() -> Path:
     vbs_content = _build_gateway_vbs_script(python_path, working_dir, hermes_home, profile_arg)
     vbs_path = script_path.with_suffix(".vbs")
     vbs_tmp = vbs_path.with_name(vbs_path.name + ".tmp")
-    vbs_tmp.write_text(vbs_content, encoding="utf-8", newline="")
+    vbs_tmp.write_text(vbs_content, encoding="utf-16", newline="")
     vbs_tmp.replace(vbs_path)
     return script_path
 
@@ -1101,8 +1101,12 @@ def install(
             if running_pids:
                 print(f"✓ Gateway already running (PID: {', '.join(map(str, running_pids))})")
             else:
-                pid = _spawn_detached()
-                _report_gateway_start(f"direct spawn (PID {pid})")
+                code, stdout, stderr = _exec_schtasks(["/Run", "/TN", task_name])
+                if code != 0:
+                    raise RuntimeError(
+                        (stderr or stdout or "failed to run Scheduled Task").strip()
+                    )
+                _report_gateway_start(f"Scheduled Task {task_name}")
         else:
             print("ℹ Gateway not started now.")
             print("  Start manually with: hermes gateway start")
@@ -1183,11 +1187,13 @@ def _report_gateway_start(via: str) -> None:
     if pids:
         print(f"✓ Gateway started via {via} (PID: {', '.join(map(str, pids))})")
     else:
-        print(f"⚠ Launched gateway via {via}, but no process detected after 6s.")
+        message = f"Launched gateway via {via}, but no process detected after 6s."
+        print(f"⚠ {message}")
         print("  Check the log for startup errors:")
         from hermes_cli.config import get_hermes_home
         print(f"    type {Path(get_hermes_home())}\\logs\\gateway.log")
         print(f"    type {Path(get_hermes_home())}\\logs\\gateway-stdio.log")
+        raise RuntimeError(message)
 
 
 def _print_next_steps() -> None:
@@ -1497,9 +1503,15 @@ def start() -> None:
             print("  If a UAC prompt opened, approve it, then run: hermes gateway start")
             return
 
-    # Manual starts use the same console-less direct spawn path as restart()
-    # and install --start-now. Scheduled Task / Startup entries are only login
-    # persistence mechanisms.
+    if task_installed:
+        task_name = get_task_name()
+        code, stdout, stderr = _exec_schtasks(["/Run", "/TN", task_name])
+        if code != 0:
+            raise RuntimeError((stderr or stdout or "failed to run Scheduled Task").strip())
+        _report_gateway_start(f"Scheduled Task {task_name}")
+        return
+
+    # Startup-folder fallback has no persistent supervisor to trigger on demand.
     pid = _spawn_detached()
     _report_gateway_start(f"direct spawn (PID {pid})")
 

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1499,8 +1499,12 @@ class FeishuAdapter(BasePlatformAdapter):
     # Lifecycle — init / settings / connect / disconnect
     # =========================================================================
 
-    def __init__(self, config: PlatformConfig):
-        super().__init__(config, Platform.FEISHU)
+    def __init__(
+        self,
+        config: PlatformConfig,
+        platform: Platform = Platform.FEISHU,
+    ):
+        super().__init__(config, platform)
 
         self._settings = self._load_settings(config.extra or {})
         self._apply_settings(self._settings)
@@ -5617,6 +5621,7 @@ async def _standalone_send(
     thread_id=None,
     media_files=None,
     force_document=False,
+    platform: Optional[Platform] = None,
 ):
     """Out-of-process Feishu/Lark delivery via the adapter's send pipeline.
 
@@ -5630,7 +5635,8 @@ async def _standalone_send(
 
     media_files = media_files or []
     try:
-        adapter = FeishuAdapter(pconfig)
+        logical_platform = platform or Platform.FEISHU
+        adapter = FeishuAdapter(pconfig, logical_platform)
         domain_name = getattr(adapter, "_domain_name", "feishu")
         domain = FEISHU_DOMAIN if domain_name != "lark" else LARK_DOMAIN
         adapter._client = adapter._build_lark_client(domain)
@@ -5663,7 +5669,7 @@ async def _standalone_send(
             return {"error": "No deliverable text or media remained after processing MEDIA tags"}
         return {
             "success": True,
-            "platform": "feishu",
+            "platform": logical_platform.value,
             "chat_id": chat_id,
             "message_id": last_result.message_id,
         }

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2467,3 +2467,78 @@ class TestChatLockEviction(unittest.TestCase):
         self.assertIsInstance(adapter._chat_locks, _collections.OrderedDict)
 
 
+class TestStandaloneSendPlatformIdentity(unittest.TestCase):
+    def test_real_adapter_constructor_accepts_logical_platform(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        enterprise = SimpleNamespace(value="feishu_enterprise")
+        config = PlatformConfig(enabled=True, extra={})
+
+        adapter = FeishuAdapter(config, enterprise)
+
+        self.assertEqual(adapter.platform, enterprise)
+
+    def test_standalone_send_defaults_to_feishu_platform(self):
+        from gateway.config import Platform, PlatformConfig
+        from plugins.platforms.feishu import adapter as feishu_adapter
+
+        captured = {}
+
+        class _FakeAdapter:
+            def __init__(self, config, platform=None):
+                captured["platform"] = platform
+                self._domain_name = "feishu"
+
+            def _build_lark_client(self, _domain):
+                return object()
+
+            async def send(self, _chat_id, _message, metadata=None):
+                return SimpleNamespace(success=True, error=None, message_id="m-personal")
+
+        config = PlatformConfig(enabled=True, extra={"app_id": "cli_test", "app_secret": "test-secret"})
+        with patch.object(feishu_adapter, "_load_lark_oapi", return_value=True), patch.object(
+            feishu_adapter, "FeishuAdapter", _FakeAdapter
+        ):
+            result = asyncio.run(
+                feishu_adapter._standalone_send(config, "oc_personal", "hello")
+            )
+
+        self.assertEqual(captured["platform"], Platform.FEISHU)
+        self.assertEqual(result["platform"], "feishu")
+
+    def test_standalone_send_preserves_explicit_logical_platform(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu import adapter as feishu_adapter
+
+        enterprise = SimpleNamespace(value="feishu_enterprise")
+        captured = {}
+
+        class _FakeAdapter:
+            def __init__(self, config, platform=None):
+                captured["platform"] = platform
+                self._domain_name = "feishu"
+
+            def _build_lark_client(self, _domain):
+                return object()
+
+            async def send(self, _chat_id, _message, metadata=None):
+                return SimpleNamespace(success=True, error=None, message_id="m-enterprise")
+
+        config = PlatformConfig(enabled=True, extra={"app_id": "cli_test", "app_secret": "test-secret"})
+        with patch.object(feishu_adapter, "_load_lark_oapi", return_value=True), patch.object(
+            feishu_adapter, "FeishuAdapter", _FakeAdapter
+        ):
+            result = asyncio.run(
+                feishu_adapter._standalone_send(
+                    config,
+                    "oc_enterprise",
+                    "hello",
+                    platform=enterprise,
+                )
+            )
+
+        self.assertEqual(captured["platform"], enterprise)
+        self.assertEqual(result["platform"], "feishu_enterprise")
+
+

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -487,7 +487,7 @@ class TestTerminalToolGatewayLifecycleGuard:
         import tools.terminal_tool as tt
 
         fifo = tmp_path / "script.fifo"
-        os.mkfifo(fifo)
+        fifo.mkdir()
         self._patch_env(monkeypatch, self._make_fake_env(), inside_gateway=True)
 
         result = json.loads(tt.terminal_tool(command=f"/bin/bash {fifo}"))
@@ -1110,6 +1110,27 @@ class TestLifecycleGuardDataArgumentExemption:
             "WHERE msg LIKE '%systemctl restart hermes-gateway%'\""
         )
         check_gateway_lifecycle(prompt, str(script))
+
+
+def test_remote_nested_relative_script_uses_remote_posix_directory():
+    from cron.lifecycle_guard import contains_gateway_lifecycle_command_or_referenced_script
+
+    calls = []
+    scripts = {
+        "/remote/outer.sh": "#!/bin/bash\n/bin/bash inner.sh\n",
+        "/remote/inner.sh": "#!/bin/bash\nhermes gateway restart\n",
+    }
+
+    def read_remote(path):
+        calls.append(path)
+        return scripts.get(path)
+
+    assert contains_gateway_lifecycle_command_or_referenced_script(
+        "/bin/bash /remote/outer.sh",
+        cwd="/remote",
+        read_remote_script=read_remote,
+    )
+    assert calls == ["/remote/outer.sh", "/remote/inner.sh"]
 
 
 class TestLifecycleGuardNeverRaises:

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -197,6 +197,103 @@ def test_install_scheduled_task_recreates_instead_of_change(monkeypatch, tmp_pat
     assert "cmd.exe" not in xml_seen["text"]
 
 
+def test_start_uses_registered_scheduled_task_instead_of_direct_spawn(monkeypatch):
+    calls = []
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(gateway_windows, "_gateway_pids", lambda: [])
+    monkeypatch.setattr(gateway_windows, "is_task_registered", lambda: True)
+    monkeypatch.setattr(gateway_windows, "is_startup_entry_installed", lambda: False)
+    monkeypatch.setattr(gateway_windows, "get_task_name", lambda: "Hermes_Gateway")
+    monkeypatch.setattr(
+        gateway_windows,
+        "_exec_schtasks",
+        lambda args: calls.append(tuple(args)) or (0, "SUCCESS", ""),
+    )
+    monkeypatch.setattr(
+        gateway_windows,
+        "_spawn_detached",
+        lambda *_args, **_kwargs: pytest.fail("registered task must own the gateway"),
+    )
+    monkeypatch.setattr(
+        gateway_windows,
+        "_report_gateway_start",
+        lambda via: calls.append(("report", via)),
+    )
+
+    gateway_windows.start()
+
+    assert calls[0] == ("/Run", "/TN", "Hermes_Gateway")
+    assert calls[1][0] == "report"
+    assert "Scheduled Task" in calls[1][1]
+
+
+def test_install_start_now_uses_newly_registered_task(monkeypatch, tmp_path):
+    calls = []
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(gateway_windows, "_is_running_as_admin", lambda: True)
+    monkeypatch.setattr(gateway_windows, "get_task_name", lambda: "Hermes_Gateway")
+    monkeypatch.setattr(
+        gateway_windows,
+        "_write_task_script",
+        lambda: tmp_path / "Hermes_Gateway.cmd",
+    )
+    monkeypatch.setattr(
+        gateway_windows,
+        "_install_scheduled_task",
+        lambda _name, _path: (True, "installed"),
+    )
+    monkeypatch.setattr(gateway_windows, "_gateway_pids", lambda: [])
+    monkeypatch.setattr(
+        gateway_windows,
+        "_exec_schtasks",
+        lambda args: calls.append(tuple(args)) or (0, "SUCCESS", ""),
+    )
+    monkeypatch.setattr(
+        gateway_windows,
+        "_spawn_detached",
+        lambda *_args, **_kwargs: pytest.fail("install must start through scheduler"),
+    )
+    monkeypatch.setattr(
+        gateway_windows,
+        "_report_gateway_start",
+        lambda via: calls.append(("report", via)),
+    )
+    monkeypatch.setattr(gateway_windows, "_print_next_steps", lambda: None)
+
+    gateway_windows.install(start_now=True, start_on_login=True)
+
+    assert calls[0] == ("/Run", "/TN", "Hermes_Gateway")
+    assert calls[1][0] == "report"
+
+
+def test_report_gateway_start_raises_when_worker_never_becomes_ready(monkeypatch):
+    monkeypatch.setattr(gateway_windows, "_wait_for_gateway_ready", lambda: [])
+
+    with pytest.raises(RuntimeError, match="no process detected"):
+        gateway_windows._report_gateway_start("Scheduled Task Hermes_Gateway")
+
+
+def test_write_task_script_uses_utf16_bom_for_unicode_vbs(monkeypatch, tmp_path):
+    import hermes_cli.config as config
+
+    script_path = tmp_path / "服务目录" / "Hermes_Gateway.cmd"
+    script_path.parent.mkdir()
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(gateway_windows, "get_task_script_path", lambda: script_path)
+    monkeypatch.setattr(config, "get_hermes_home", lambda: tmp_path / "王明宇")
+    monkeypatch.setattr(gateway, "PROJECT_ROOT", tmp_path / "项目")
+    monkeypatch.setattr(gateway, "get_python_path", lambda: str(tmp_path / "环境" / "python.exe"))
+    monkeypatch.setattr(gateway, "_profile_arg", lambda _home: "")
+
+    gateway_windows._write_task_script()
+
+    raw = script_path.with_suffix(".vbs").read_bytes()
+    assert raw.startswith((b"\xff\xfe", b"\xfe\xff"))
+    decoded = raw.decode("utf-16")
+    assert "王明宇" in decoded
+    assert "项目" in decoded
+
+
 def test_gateway_vbs_script_is_console_less(monkeypatch):
     """The .vbs launcher must avoid cmd.exe entirely and Run pythonw hidden
     (issue #45599 fix A: no console -> no logon CTRL_CLOSE_EVENT / 0xC000013A)."""
@@ -216,7 +313,8 @@ def test_gateway_vbs_script_is_console_less(monkeypatch):
     assert "pythonw.exe" in content
     assert "hermes_cli.main" in content
     assert "gateway run" in content
-    assert ", 0, False" in content  # hidden window, detached/async
+    assert ", 0, True)" in content  # hidden window, wait for supervised child
+    assert "WScript.Quit exitCode" in content
     for var in ("HERMES_HOME", "PYTHONIOENCODING", "HERMES_GATEWAY_DETACHED", "VIRTUAL_ENV", "PYTHONPATH"):
         assert var in content
     assert "--profile" in content and "work" in content


### PR DESCRIPTION
## Summary
- keep Task Scheduler as the single Windows gateway supervisor for start and install --start-now
- write UTF-16 VBS launchers that wait for the worker and propagate its exit code
- preserve Feishu logical platform identity for standalone sends
- harden lifecycle script scanning for Windows paths, remote nested scripts, and non-regular files

## Verification
- 119 lifecycle guard tests passed
- 11 Windows gateway tests passed
- 3 Feishu standalone/platform tests passed
- changed Python files compile
- commit diff Gitleaks: 0 findings
- remote fresh-clone verification passed

## Scope
Six files only: three production files and their three test files.