### PR TITLE
fix(desktop): restore pet.info backstop after live-sync regression

### DIFF
--- a/apps/desktop/src/components/pet/floating-pet-poll.test.ts
+++ b/apps/desktop/src/components/pet/floating-pet-poll.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { petInfoPollIntervalMs } from './pet-info-poll'
+
+describe('petInfoPollIntervalMs', () => {
+  it('uses the slow backstop on event-capable backends (active or not)', () => {
+    expect(petInfoPollIntervalMs(true, false)).toBe(15_000)
+    expect(petInfoPollIntervalMs(true, true)).toBe(15_000)
+  })
+
+  it('keeps the legacy fast-while-inactive cadence without change events', () => {
+    expect(petInfoPollIntervalMs(false, false)).toBe(3_000)
+    expect(petInfoPollIntervalMs(false, true)).toBe(15_000)
+  })
+})

--- a/apps/desktop/src/components/pet/floating-pet.tsx
+++ b/apps/desktop/src/components/pet/floating-pet.tsx
@@ -26,6 +26,7 @@ import { $gatewayState } from '@/store/session'
 import { isSecondaryWindow } from '@/store/windows'
 import { useTheme } from '@/themes/context'
 
+import { PET_STARTUP_RETRY_MS, petInfoPollIntervalMs } from './pet-info-poll'
 import { PetSprite, roamWalkRow } from './pet-sprite'
 import { usePetRoam } from './use-pet-roam'
 import { type PetZoomAnchor, usePetZoomGesture } from './use-pet-zoom-gesture'
@@ -89,12 +90,15 @@ function loadPosition(): Point {
  * pets rewritten on disk (or renamed/rebuilt by the hatch flow) repaint without
  * restarting the app.
  *
+ * Event-capable backends also drive refreshes via `pet.changed`, but a slow
+ * backstop poll stays in place: the watcher seeds the pet signature silently
+ * at gateway boot and only broadcasts when it *moves*, and the one-shot
+ * connect pull can race a still-warming `pet.info` (fail-open enabled:false).
+ * Without the backstop the mascot stays hidden until Settings re-seeds it.
+ *
  * Promotion to a separate frameless OS-level window is a follow-up — the
  * sprite + state logic here is reused as-is, only the host changes.
  */
-const PET_POLL_MS = 3000
-const PET_ACTIVE_REFRESH_MS = 15000
-
 export function FloatingPet() {
   const { requestGateway } = useGatewayRequest()
   const { resolvedMode } = useTheme()
@@ -129,11 +133,9 @@ export function FloatingPet() {
   // edge can't leave the window cropping it. Shared by drag + the reclamp effect.
   const clamp = useCallback(({ x, y }: Point): Point => clampPoint(x, y, petW, petH), [petW, petH])
 
-  // Fetch pet.info on connect, then let pet.changed drive refreshes: the
-  // change watcher broadcasts when /pet (de)activates a pet or the hatch flow
-  // rewrites a sheet, so event-capable backends need no interval at all —
-  // users with no pet especially (this used to poll hardest for them). Older
-  // backends keep the legacy fast-while-inactive poll.
+  // Fetch pet.info on connect. pet.changed re-runs this effect when the
+  // signature moves; a slow backstop covers silent seed + cold-start races.
+  // Older backends (no change_events) keep the legacy fast-while-inactive poll.
   const active = info.enabled && Boolean(info.spritesheetBase64)
   useEffect(() => {
     if (gatewayState !== 'open') {
@@ -208,29 +210,50 @@ export function FloatingPet() {
       }
     }
 
+    const pullIfVisible = () => {
+      if (document.visibilityState === 'visible') {
+        void pull()
+      }
+    }
+
     void pull()
     window.addEventListener('focus', pull)
 
-    // Event-capable backend: pet.changed re-runs this effect (petChange dep),
-    // so no timer. Legacy backend: the historical poll.
-    const timer = changeEventsAvailable
-      ? null
-      : window.setInterval(
-          () => {
-            if (document.visibilityState === 'visible') {
-              void pull()
-            }
-          },
-          active ? PET_ACTIVE_REFRESH_MS : PET_POLL_MS
-        )
+    // Cover the cold-start race where the first pull hit fail-open enabled:false
+    // before the pet store was warm. Skip further retries once the mascot is live.
+    const startupRetryTimers = PET_STARTUP_RETRY_MS.map(delay =>
+      window.setTimeout(() => {
+        if (cancelled) {
+          return
+        }
+
+        const current = $petInfo.get()
+
+        if (current.enabled && current.spritesheetBase64) {
+          return
+        }
+
+        pullIfVisible()
+      }, delay)
+    )
+
+    // Always keep a timer. Event-capable backends use the slow backstop (same
+    // contract as cron/sessions in use-background-sync); legacy keeps the
+    // historical fast-while-inactive cadence.
+    const timer = window.setInterval(
+      pullIfVisible,
+      petInfoPollIntervalMs(changeEventsAvailable, active)
+    )
 
     return () => {
       cancelled = true
       window.removeEventListener('focus', pull)
 
-      if (timer !== null) {
-        window.clearInterval(timer)
+      for (const id of startupRetryTimers) {
+        window.clearTimeout(id)
       }
+
+      window.clearInterval(timer)
     }
   }, [gatewayState, active, changeEventsAvailable, petChange, requestGateway])
 

--- a/apps/desktop/src/components/pet/pet-info-poll.ts
+++ b/apps/desktop/src/components/pet/pet-info-poll.ts
@@ -1,0 +1,25 @@
+/** Cadences for the floating-pet `pet.info` refresh timer.
+
+Event-capable backends rely on `pet.changed` for live updates but still need
+a slow backstop: the gateway seeds the pet signature silently at boot and only
+broadcasts when it *moves*, and the one-shot connect pull can race a still-
+warming backend (`pet.info` fail-opens to `enabled:false`).
+*/
+
+export const PET_POLL_MS = 3_000
+export const PET_ACTIVE_REFRESH_MS = 15_000
+/** Slow safety net when `pet.changed` is available. */
+export const PET_BACKSTOP_MS = 15_000
+/** Cold-start retries after the first connect pull (fail-open recovery). */
+export const PET_STARTUP_RETRY_MS = [1_000, 3_000, 8_000] as const
+
+export function petInfoPollIntervalMs(
+  changeEventsAvailable: boolean,
+  active: boolean
+): number {
+  if (changeEventsAvailable) {
+    return PET_BACKSTOP_MS
+  }
+
+  return active ? PET_ACTIVE_REFRESH_MS : PET_POLL_MS
+}


### PR DESCRIPTION
## What does this PR do?

Restores self-healing for the desktop pet after cold start.

#73673 switched the floating pet to event-driven `pet.changed` updates and dropped the interval entirely when the backend advertises change events. That left a hole on normal relaunches:

1. The first `pet.info` pull rides raw WebSocket open, before the backend is fully warm.
2. `pet.info` is fail-open and returns `{enabled: false}` on transient errors.
3. The change watcher seeds the pet signature silently at boot and only broadcasts when the signature *moves*. A normal restart never moves it, so no event arrives.
4. `$petInfo` stays at its default disabled state. Opening Settings → Appearance runs `syncInfo()` and the pet pops in.

Other live-sync surfaces (cron, sessions) kept slow backstops. The pet was the outlier. This PR brings it back in line: keep a 15s backstop when change events are available, keep the legacy 3s/15s cadence on older backends, and retry the initial pull at 1s / 3s / 8s if the mascot still is not live.

Verified locally: enabled pet appears after relaunch without opening Settings.

## Related Issue

Fixes #81618
Fixes #81624

Related: #73673 (regression introduced here), #55920 (overlay restore is separate, but benefits once `$petInfo` seeds correctly)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/components/pet/floating-pet.tsx` — always keep a poll timer (slow backstop when `changeEventsAvailable`, legacy cadence otherwise) plus short cold-start retries that stop once the pet is live
- `apps/desktop/src/components/pet/pet-info-poll.ts` — pure interval helper so the cadence contract is easy to test
- `apps/desktop/src/components/pet/floating-pet-poll.test.ts` — covers event-capable vs legacy interval selection

## How to Test

1. Install and enable a pet (`hermes pets install <slug> --select`, or `display.pet.enabled: true` with a selected pet).
2. Fully quit the Hermes desktop app.
3. Relaunch. Do **not** open Settings.
4. Within a few seconds (startup retries at 1s/3s/8s, backstop at 15s) the in-window pet should appear. If the overlay was popped out, it should restore once `active` becomes true.
5. Confirm that opening Settings → Appearance is no longer required to make the pet show up.
6. Optional: `cd apps/desktop && npx vitest run src/components/pet/floating-pet-poll.test.ts`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (N/A: TypeScript-only desktop change)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows (desktop app, local checkout)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) (renderer-only, same code path on all desktop platforms)
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A

## Screenshots / Logs

Local repro matched #81618 / #81624: pet missing after relaunch until Settings → Appearance. After this change, the pet appears on its own within the startup retry window without opening Settings.