### PR TITLE
fix: close SessionDB read connections safely

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4162,9 +4162,28 @@ def generate_launchd_plist() -> str:
     
     <key>RunAtLoad</key>
     <true/>
-    
+
     <key>KeepAlive</key>
     <true/>
+
+    <!-- launchd otherwise inherits macOS's low per-process default open-file
+         ceiling (often ~256), which a long-lived gateway blows through fast:
+         every kanban board's kanban.db (+ -wal/-shm), every concurrent
+         session, and every Discord/Telegram/provider/MCP connection counts
+         against it. This is headroom against slow fd leaks and legitimate
+         growth (more boards, more sessions) — not a fix for any leak itself,
+         which must still be found and closed at the source. -->
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>65536</integer>
+    </dict>
+
+    <key>HardResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>65536</integer>
+    </dict>
 
     <!-- ThrottleInterval raises launchd's default 10s minimum respawn interval
          to 30s so a crash-looping gateway can't hammer launchd into a rapid

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2520,12 +2520,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # read-only connections so they never queue behind writer flushes on
         # self._lock. See _read_ctx().
         self._read_local = threading.local()
-        # Strong set of all live read connections across all threads.  We
-        # hold a reference so short-lived reader threads' connections are
-        # not GC'd without close() — that would leak tracked fds in
-        # _live_connections.  close() drains this set.
-        self._read_conns: "set[sqlite3.Connection]" = set()
-        self._read_conns_lock = threading.Lock()
+        # Live read connections and their owning threads. Stable threads keep
+        # reusing their connection; a new reader reaps connections whose
+        # short-lived owner has exited. close() drains every remaining entry.
+        self._read_conns: "dict[sqlite3.Connection, threading.Thread]" = {}
+        self._read_conns_lock = threading.Condition(threading.Lock())
+        self._read_conns_opening = 0
+        # Active _read_ctx() operations by connection. The lifecycle
+        # condition makes connection acquisition + active marking atomic with
+        # close/reap decisions, so no reader can be closed during a SELECT.
+        self._read_conns_active: "dict[sqlite3.Connection, int]" = {}
         # Set when close() begins.  _get_read_conn checks this under the
         # lock so a reader that finishes opening after the drain finds the
         # shutdown in progress and closes its own connection immediately.
@@ -2759,7 +2763,31 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
     # ── Read-path split ──
 
-    def _get_read_conn(self) -> Optional[sqlite3.Connection]:
+    def _reap_dead_read_conns_locked(self) -> None:
+        """Close readers whose owning threads have exited.
+
+        Caller holds ``_read_conns_lock`` so reaping cannot race registration
+        or the final drain in :meth:`close`.
+        """
+        for conn, owner in list(self._read_conns.items()):
+            if owner.is_alive() or self._read_conns_active.get(conn, 0):
+                continue
+            try:
+                conn.close()
+            except Exception:
+                # Keep it tracked so close() or a later reap can retry. A
+                # lifecycle cleanup failure must be visible, but must not make
+                # an otherwise healthy reader fail to open.
+                logger.warning(
+                    "failed to reap a read-only state.db connection",
+                    exc_info=True,
+                )
+            else:
+                del self._read_conns[conn]
+
+    def _get_read_conn(
+        self, *, mark_active: bool = False
+    ) -> Optional[sqlite3.Connection]:
         """Per-thread read-only connection, or None when unavailable.
 
         Only used under WAL: WAL readers see a consistent snapshot and never
@@ -2776,41 +2804,110 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return None
         conn = getattr(self._read_local, "conn", None)
         if conn is not None:
-            return conn
-        if getattr(self._read_local, "failed", False):
-            return None
-        try:
-            conn = _connect_tracked_db(
-                f"file:{self.db_path}?mode=ro",
-                tracking_path=self.db_path,
-                uri=True,
-                timeout=5.0,
-                isolation_level=None,
-            )
-            conn.row_factory = sqlite3.Row
-            apply_database_pragmas(conn, db_label="state.db")
-            # Load the CJK tokenizer extension on this connection so
-            # messages_fts_cjk queries work on the read path. The .so
-            # registers the tokenizer in the connection's in-memory
-            # registry, not the database file, so mode=ro is fine.
-            if self._fts_cjk_loaded:
-                load_fts5_cjk_extension(conn)
             with self._read_conns_lock:
-                if self._read_conns_closed:
-                    # close() already drained — don't register; close
-                    # immediately so no tracked fd leaks.
-                    conn.close()
+                if self._read_conns_closed or conn not in self._read_conns:
+                    # A foreign close may have drained this thread's cached
+                    # connection. Never hand that stale object back out.
+                    self._read_local.conn = None
                     self._read_local.failed = True
                     return None
-                self._read_conns.add(conn)
-        except sqlite3.Error:
-            # Mark this thread failed so we don't retry the open on every
-            # query; the locked writer connection still serves reads.
-            self._read_local.failed = True
-            logger.debug("read-only connection open failed for %s", self.db_path, exc_info=True)
+                if mark_active:
+                    self._read_conns_active[conn] = (
+                        self._read_conns_active.get(conn, 0) + 1
+                    )
+                return conn
+        if getattr(self._read_local, "failed", False):
             return None
-        self._read_local.conn = conn
-        return conn
+        with self._read_conns_lock:
+            if self._read_conns_closed:
+                self._read_local.failed = True
+                return None
+            self._read_conns_opening += 1
+        conn = None
+        registered = False
+        try:
+            try:
+                conn = _connect_tracked_db(
+                    f"file:{self.db_path}?mode=ro",
+                    tracking_path=self.db_path,
+                    uri=True,
+                    timeout=5.0,
+                    isolation_level=None,
+                    # Connections remain thread-owned for query execution.
+                    # This only permits lifecycle management to close them
+                    # after an owner exits or when SessionDB closes from
+                    # another thread.
+                    check_same_thread=False,
+                )
+                conn.row_factory = sqlite3.Row
+                apply_database_pragmas(conn, db_label="state.db")
+                # Load the CJK tokenizer extension on this connection so
+                # messages_fts_cjk queries work on the read path. The .so
+                # registers the tokenizer in the connection's in-memory
+                # registry, not the database file, so mode=ro is fine.
+                if self._fts_cjk_loaded:
+                    load_fts5_cjk_extension(conn)
+            except sqlite3.Error:
+                # Mark this thread failed so we don't retry the open on every
+                # query; the locked writer connection still serves reads.
+                self._read_local.failed = True
+                logger.debug(
+                    "read-only connection open failed for %s",
+                    self.db_path,
+                    exc_info=True,
+                )
+                return None
+
+            with self._read_conns_lock:
+                if self._read_conns_closed:
+                    # close() began while this connection was opening. The
+                    # outer finally closes it before waking the final drain.
+                    self._read_local.failed = True
+                    return None
+                self._reap_dead_read_conns_locked()
+                self._read_conns[conn] = threading.current_thread()
+                if mark_active:
+                    self._read_conns_active[conn] = (
+                        self._read_conns_active.get(conn, 0) + 1
+                    )
+                registered = True
+
+            self._read_local.conn = conn
+            return conn
+        finally:
+            # Once opening is counted, every exit (including unexpected
+            # pragma/extension exceptions) must wake close(). Never let an
+            # unpublished connection escape: close it before the decrement so
+            # close() cannot return while its descriptor is still live.
+            try:
+                if conn is not None and not registered:
+                    try:
+                        conn.close()
+                    except Exception:
+                        # A failed close remains tracked for a later reap or
+                        # close() retry. This is lifecycle-only bookkeeping:
+                        # the connection is never returned to the caller.
+                        logger.warning(
+                            "failed to close an unpublished read-only "
+                            "state.db connection",
+                            exc_info=True,
+                        )
+                        with self._read_conns_lock:
+                            self._read_conns[conn] = threading.current_thread()
+            finally:
+                with self._read_conns_lock:
+                    self._read_conns_opening -= 1
+                    self._read_conns_lock.notify_all()
+
+    def _release_read_conn(self, conn: sqlite3.Connection) -> None:
+        """Release one active _read_ctx() operation and wake final drain."""
+        with self._read_conns_lock:
+            active = self._read_conns_active.get(conn, 0)
+            if active <= 1:
+                self._read_conns_active.pop(conn, None)
+            else:
+                self._read_conns_active[conn] = active - 1
+            self._read_conns_lock.notify_all()
 
     @contextmanager
     def _read_ctx(self):
@@ -2822,9 +2919,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         Non-WAL or read-conn failure: the shared writer connection under
         self._lock, byte-for-byte the legacy behavior.
         """
-        conn = self._get_read_conn()
+        conn = self._get_read_conn(mark_active=True)
         if conn is not None:
-            yield conn
+            try:
+                yield conn
+            finally:
+                self._release_read_conn(conn)
             return
         with self._lock:
             yield self._conn
@@ -3336,22 +3436,28 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # (instance, function), so this removes exactly our registration;
         # no-op when the writer never started.
         atexit.unregister(self._drain_token_queue_at_exit)
-        # Close all read-only connections across all threads.  Per-thread
-        # connections live in threading.local() and would otherwise be GC'd
-        # without calling close(), leaking tracked fds in _live_connections.
-        # The strong set holds references so short-lived reader threads'
-        # connections survive until close() drains them.  Setting the closed
-        # flag under the lock prevents a reader from registering a new
-        # connection after the drain.
+        # Close all read-only connections across all threads. Setting the
+        # closed flag under the lifecycle lock prevents a reader from
+        # registering after this drain; check_same_thread=False makes these
+        # real cross-thread closes rather than swallowed ProgrammingErrors.
         with self._read_conns_lock:
             self._read_conns_closed = True
-            read_conns = list(self._read_conns)
-            self._read_conns.clear()
-        for conn in read_conns:
-            try:
-                conn.close()
-            except Exception:
-                pass
+            while self._read_conns_opening or self._read_conns_active:
+                self._read_conns_lock.wait()
+            for conn in list(self._read_conns):
+                try:
+                    conn.close()
+                except Exception:
+                    # Keep failed entries tracked for an idempotent retry.
+                    # close() historically did not raise for read-connection
+                    # cleanup, so report loudly without breaking shutdown
+                    # callers that rely on that compatibility.
+                    logger.warning(
+                        "failed to close a read-only state.db connection",
+                        exc_info=True,
+                    )
+                else:
+                    del self._read_conns[conn]
         self._read_local.conn = None
         with self._lock:
             if self._conn:

--- a/tests/test_session_db_read_path_split.py
+++ b/tests/test_session_db_read_path_split.py
@@ -8,11 +8,45 @@ per-thread read-only connection under WAL, never touch self._lock, and fall
 back to the legacy locked path when WAL or the read connection is missing.
 """
 
+import os
+import sqlite3
 import threading
 
 import pytest
 
+import hermes_state
 from hermes_state import SessionDB
+
+
+def _count_open_fds():
+    for fd_dir in ("/proc/self/fd", "/dev/fd"):
+        try:
+            with os.scandir(fd_dir) as entries:
+                return sum(1 for _ in entries)
+        except OSError:
+            continue
+    pytest.skip("process fd directory is unavailable")
+
+
+def _start_checked_thread(target):
+    failures = []
+
+    def checked_target():
+        try:
+            target()
+        except BaseException as exc:
+            failures.append(exc)
+
+    thread = threading.Thread(target=checked_target)
+    thread.start()
+    return thread, failures
+
+
+def _join_checked_thread(thread, failures, *, message="worker did not finish"):
+    thread.join(timeout=5.0)
+    assert not thread.is_alive(), message
+    if failures:
+        raise failures[0]
 
 
 @pytest.fixture()
@@ -167,3 +201,298 @@ def test_session_resume_reads_do_not_take_writer_lock(db):
         assert len(done["ancestor_prefix"]) == 2
     finally:
         db._lock.release()
+
+
+def test_close_closes_read_connection_owned_by_another_thread(db):
+    """close() must close the fd, not only forget the tracked connection."""
+    db._wal_active = True
+    opened = threading.Event()
+    closed = threading.Event()
+    outcome = {}
+
+    def reader():
+        conn = db._get_read_conn()
+        assert conn is not None
+        opened.set()
+        closed.wait(timeout=5.0)
+        outcome["cached_after_close"] = db._get_read_conn()
+        try:
+            conn.execute("SELECT 1").fetchone()
+        except Exception as exc:  # inspected by the parent thread
+            outcome["error"] = exc
+        else:
+            outcome["usable_after_close"] = True
+
+    thread, failures = _start_checked_thread(reader)
+    assert opened.wait(timeout=5.0), "reader did not open its connection"
+
+    db.close()
+    closed.set()
+    _join_checked_thread(thread, failures)
+
+    error = outcome.get("error")
+    assert isinstance(error, sqlite3.ProgrammingError)
+    assert "closed" in str(error).lower()
+    assert outcome["cached_after_close"] is None
+    assert "usable_after_close" not in outcome
+    db.close()
+
+
+def test_close_waits_for_active_read_operation(db, monkeypatch):
+    """close() must drain an active reader before closing its connection."""
+    db._wal_active = True
+    operation_started = threading.Event()
+    allow_operation_to_finish = threading.Event()
+    close_returned = threading.Event()
+    outcome = {}
+    real_connect = hermes_state._connect_tracked_db
+
+    class ControllableConnection:
+        def __init__(self, conn):
+            object.__setattr__(self, "_conn", conn)
+            object.__setattr__(self, "close_calls", 0)
+
+        def __getattr__(self, name):
+            return getattr(self._conn, name)
+
+        def __setattr__(self, name, value):
+            if name in {"_conn", "close_calls"}:
+                object.__setattr__(self, name, value)
+            else:
+                setattr(self._conn, name, value)
+
+        def execute(self, sql, *args, **kwargs):
+            if sql == "SELECT 1":
+                operation_started.set()
+                assert allow_operation_to_finish.wait(timeout=5.0)
+            return self._conn.execute(sql, *args, **kwargs)
+
+        def close(self):
+            self.close_calls += 1
+            self._conn.close()
+
+    def controllable_connect(*args, **kwargs):
+        conn = ControllableConnection(real_connect(*args, **kwargs))
+        outcome["conn"] = conn
+        return conn
+
+    monkeypatch.setattr(hermes_state, "_connect_tracked_db", controllable_connect)
+
+    def reader():
+        with db._read_ctx() as conn:
+            outcome["value"] = conn.execute("SELECT 1").fetchone()[0]
+
+    reader_thread, reader_failures = _start_checked_thread(reader)
+    assert operation_started.wait(timeout=5.0), "reader did not start its query"
+
+    def closer():
+        db.close()
+        close_returned.set()
+
+    close_thread, close_failures = _start_checked_thread(closer)
+    try:
+        with db._read_conns_lock:
+            assert db._read_conns_closed
+            assert outcome["conn"].close_calls == 0
+            assert not close_returned.is_set()
+    finally:
+        allow_operation_to_finish.set()
+
+    _join_checked_thread(reader_thread, reader_failures)
+    _join_checked_thread(close_thread, close_failures, message="close() deadlocked")
+
+    assert outcome["value"] == 1
+    assert outcome["conn"].close_calls == 1
+    assert close_returned.is_set()
+
+
+def test_read_ctx_exception_releases_active_operation(db):
+    """An exception inside a read context must not strand close() waiting."""
+    db._wal_active = True
+
+    with pytest.raises(RuntimeError, match="simulated read failure"):
+        with db._read_ctx():
+            raise RuntimeError("simulated read failure")
+
+    with db._read_conns_lock:
+        assert not db._read_conns_active
+
+
+def test_reaper_skips_dead_owner_connection_with_active_operation(db):
+    """Dead-owner reaping must never close a connection marked active."""
+
+    class RecordingConnection:
+        def __init__(self):
+            self.close_calls = 0
+
+        def close(self):
+            self.close_calls += 1
+
+    owner = threading.Thread(target=lambda: None)
+    owner.start()
+    owner.join(timeout=5.0)
+    assert not owner.is_alive()
+    conn = RecordingConnection()
+
+    with db._read_conns_lock:
+        db._read_conns[conn] = owner
+        db._read_conns_active[conn] = 1
+        db._reap_dead_read_conns_locked()
+        assert conn.close_calls == 0
+        assert conn in db._read_conns
+
+        db._read_conns_active.pop(conn)
+        db._reap_dead_read_conns_locked()
+        assert conn.close_calls == 1
+        assert conn not in db._read_conns
+
+
+def test_read_conn_open_racing_close_is_closed(db, monkeypatch):
+    """A reader opened during close must not escape the final drain."""
+    db._wal_active = True
+    opened = threading.Event()
+    resume_open = threading.Event()
+    outcome = {}
+    real_connect = hermes_state._connect_tracked_db
+
+    def blocking_connect(*args, **kwargs):
+        conn = real_connect(*args, **kwargs)
+        outcome["conn"] = conn
+        opened.set()
+        resume_open.wait(timeout=5.0)
+        return conn
+
+    monkeypatch.setattr(hermes_state, "_connect_tracked_db", blocking_connect)
+
+    def reader():
+        outcome["result"] = db._get_read_conn()
+
+    thread, reader_failures = _start_checked_thread(reader)
+    assert opened.wait(timeout=5.0), "reader did not reach the open race"
+
+    close_returned = threading.Event()
+
+    def closer():
+        db.close()
+        close_returned.set()
+
+    close_thread, close_failures = _start_checked_thread(closer)
+    with db._read_conns_lock:
+        assert db._read_conns_closed
+        assert not close_returned.is_set()
+    resume_open.set()
+    _join_checked_thread(thread, reader_failures)
+    _join_checked_thread(close_thread, close_failures, message="close() deadlocked")
+
+    assert close_returned.is_set()
+    assert outcome["result"] is None
+    assert not db._read_conns
+    with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+        outcome["conn"].execute("SELECT 1")
+
+
+def test_unexpected_read_conn_setup_error_releases_opening_accounting(
+    db, monkeypatch
+):
+    """A non-SQLite setup error must not strand close() on the Condition."""
+    db._wal_active = True
+    opened = {}
+    real_connect = hermes_state._connect_tracked_db
+
+    def recording_connect(*args, **kwargs):
+        conn = real_connect(*args, **kwargs)
+        opened["conn"] = conn
+        return conn
+
+    def unexpected_pragma_error(*_args, **_kwargs):
+        raise RuntimeError("unexpected pragma setup failure")
+
+    monkeypatch.setattr(hermes_state, "_connect_tracked_db", recording_connect)
+    monkeypatch.setattr(
+        hermes_state,
+        "apply_database_pragmas",
+        unexpected_pragma_error,
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="unexpected pragma setup failure"):
+            db._get_read_conn()
+
+        with db._read_conns_lock:
+            assert db._read_conns_opening == 0
+        assert not db._read_conns
+        with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+            opened["conn"].execute("SELECT 1")
+    finally:
+        # Keep this regression test cleanup-safe if the accounting bug is
+        # reintroduced, so the fixture's close() reports a failure instead of
+        # hanging the entire test process forever.
+        with db._read_conns_lock:
+            if db._read_conns_opening:
+                db._read_conns_opening = 0
+                db._read_conns_lock.notify_all()
+        conn = opened.get("conn")
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
+
+
+def test_short_lived_reader_connections_are_reaped(db):
+    """Completed reader threads must not accumulate on a long-lived DB."""
+    db._wal_active = True
+    stable_conn = db._get_read_conn()
+    assert stable_conn is not None
+
+    for _ in range(30):
+        thread, failures = _start_checked_thread(lambda: db.get_session("s1"))
+        _join_checked_thread(thread, failures)
+
+    assert len(db._read_conns) <= 2
+    assert stable_conn in db._read_conns
+    assert db._read_conns[stable_conn] is threading.current_thread()
+    assert db._get_read_conn() is stable_conn
+    assert stable_conn.execute("SELECT 1").fetchone()[0] == 1
+
+
+def test_short_lived_readers_do_not_leak_process_fds(db):
+    """The retained SQLite descriptors stay bounded across completed threads."""
+    db._wal_active = True
+    before = _count_open_fds()
+
+    for _ in range(30):
+        thread, failures = _start_checked_thread(lambda: db.get_session("s1"))
+        _join_checked_thread(thread, failures)
+
+    after = _count_open_fds()
+    assert after <= before + 6, f"process fds grew from {before} to {after}"
+
+
+def test_close_logs_read_conn_error_and_retries_idempotently(db, caplog):
+    """A failed read close stays tracked without making close() newly raise."""
+
+    class FlakyConnection:
+        def __init__(self):
+            self.close_calls = 0
+
+        def close(self):
+            self.close_calls += 1
+            if self.close_calls == 1:
+                raise RuntimeError("simulated read close failure")
+
+    conn = FlakyConnection()
+    with db._read_conns_lock:
+        db._read_conns[conn] = threading.current_thread()
+
+    with caplog.at_level("WARNING"):
+        db.close()
+
+    assert conn.close_calls == 1
+    assert conn in db._read_conns
+    assert "failed to close a read-only state.db connection" in caplog.text
+
+    db.close()
+    assert conn.close_calls == 2
+    assert conn not in db._read_conns
+    db.close()


### PR DESCRIPTION
## Summary

Fix a long-lived `SessionDB` file-descriptor leak caused by per-thread SQLite read connections that could not be closed safely from the shutdown thread.

This PR also preserves a separate macOS launchd safety-margin commit that raises the gateway file-descriptor limit. The limit increase mitigates immediate exhaustion; the `SessionDB` commit fixes the underlying retained-connection behavior.

## Root cause

`SessionDB` created read-only SQLite connections per thread with `check_same_thread=True` and retained them in `_read_conns`. When cleanup later ran from another thread, SQLite rejected cross-thread close attempts, leaving descriptors open after worker threads exited.

## Changes

- track read-connection ownership explicitly
- allow controlled cross-thread cleanup
- reclaim connections owned by terminated threads
- wait for active readers before closing their connections
- handle connections opened concurrently with `SessionDB.close()`
- keep `close()` retryable when cleanup cannot complete immediately
- add regression coverage for cross-thread cleanup, active readers, and repeated short-lived thread waves
- raise the macOS launchd soft and hard `NumberOfFiles` limits to `65536` in a separate commit

## Commit separation

1. `fix: raise gateway launchd file descriptor limit`
2. `fix: close SessionDB read connections safely`

## Verification

- SessionDB FD regression suite: `12 passed, 5 skipped`
- gateway/launchd tests: `78 passed`
- broader state and async SessionDB selection: `349 passed, 1 deselected`
- SessionDB ownership and teardown selection: `37 passed`
- repeated 20-thread-wave reproducer: three consecutive passes; final cleanup returned to 4 open descriptors
- independent read-only review: `PASS — no blocking findings`

The known timing-sensitive write-lock test was kept separate from this change; its failure reproduces independently of the SessionDB diff.

## Operational scope

No gateway restart, deployment, or runtime configuration change is part of this PR.
