### PR TITLE
fix(desktop): restore hidden tab bar from sidebar row menu

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
@@ -1,6 +1,8 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { atom } from 'nanostores'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { isWorkspaceTabBarHidden, showWorkspaceTabBar } from '@/components/pane-shell/tree/store'
 
 import { SessionActionsMenu } from './session-actions-menu'
 
@@ -14,6 +16,8 @@ vi.mock('@/components/pane-shell/tree/store', () => ({
   closeAllTreeTabs: vi.fn(),
   closeOtherTreeTabs: vi.fn(),
   closeTreeTabsToRight: vi.fn(),
+  isWorkspaceTabBarHidden: vi.fn(() => false),
+  showWorkspaceTabBar: vi.fn(),
   treeTabCloseTargets: vi.fn(() => null)
 }))
 vi.mock('@/hermes', () => ({ renameSession: vi.fn() }))
@@ -37,6 +41,7 @@ vi.mock('@/i18n', () => ({
           copyIdFailed: 'Failed to copy ID',
           export: 'Export',
           hideTabBar: 'Hide tab bar',
+          showTabBar: 'Show tab bar',
           pin: 'Pin',
           rename: 'Rename',
           renameDesc: 'Leave empty to clear.',
@@ -95,6 +100,24 @@ function renderMenu() {
 }
 
 describe('SessionActionsMenu', () => {
+  beforeEach(() => {
+    vi.mocked(isWorkspaceTabBarHidden).mockReset().mockReturnValue(false)
+    vi.mocked(showWorkspaceTabBar).mockReset()
+  })
+
+  async function openMenu() {
+    const trigger = screen.getByRole('button', { name: 'Session actions' })
+
+    // Radix's dropdown trigger opens on pointerdown (not on the synthetic
+    // 'click' fireEvent alone would dispatch), so fire the full mouse
+    // sequence a real click produces.
+    fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.pointerUp(trigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.click(trigger)
+
+    await screen.findByRole('menu')
+  }
+
   it('opens the dropdown on click without a tooltip on the kebab', async () => {
     renderMenu()
 
@@ -112,5 +135,24 @@ describe('SessionActionsMenu', () => {
     expect(await screen.findByRole('menu')).toBeTruthy()
     expect(screen.getByRole('menuitem', { name: /rename/i })).toBeTruthy()
     expect(screen.getByRole('menuitem', { name: /archive/i })).toBeTruthy()
+  })
+
+  it('offers "Show tab bar" only while the workspace tab bar is hidden, and restores it', async () => {
+    vi.mocked(isWorkspaceTabBarHidden).mockReturnValue(true)
+    renderMenu()
+    await openMenu()
+
+    const item = screen.getByRole('menuitem', { name: /show tab bar/i })
+
+    expect(item).toBeTruthy()
+    fireEvent.click(item)
+    expect(vi.mocked(showWorkspaceTabBar)).toHaveBeenCalledTimes(1)
+  })
+
+  it('hides "Show tab bar" while the workspace tab bar is visible', async () => {
+    renderMenu()
+    await openMenu()
+
+    expect(screen.queryByRole('menuitem', { name: /show tab bar/i })).toBeNull()
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -7,7 +7,9 @@ import {
   closeAllTreeTabs,
   closeOtherTreeTabs,
   closeTreeTabsToRight,
+  isWorkspaceTabBarHidden,
   reloadTreePane,
+  showWorkspaceTabBar,
   treeTabCloseTargets
 } from '@/components/pane-shell/tree/store'
 import {
@@ -421,6 +423,20 @@ function useSessionActions({
             onSelect: () => {
               triggerHaptic('selection')
               onHideTabBar()
+            }
+          })}
+        </>
+      )}
+      {isWorkspaceTabBarHidden() && (
+        <>
+          <kit.Separator />
+          {renderActionItem(kit, {
+            disabled: false,
+            icon: 'eye',
+            label: r.showTabBar,
+            onSelect: () => {
+              triggerHaptic('selection')
+              showWorkspaceTabBar()
             }
           })}
         </>

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -1578,6 +1578,29 @@ export function collapseTreePane(paneId: string) {
   }
 }
 
+/** Read-only: is the workspace zone's header (the main tab bar) explicitly
+ *  hidden? Read at menu-open time via `.get()` — never a render-time
+ *  subscription (layout-tree reads must stay render-free, see tree-group.tsx).
+ *  Only an EXPLICIT hide (headerHidden: true) counts; a lone pane's auto-hide
+ *  default is not a user state to restore. */
+export function isWorkspaceTabBarHidden(): boolean {
+  const tree = $layoutTree.get()
+
+  return tree ? findGroupOfPane(tree, 'workspace')?.headerHidden === true : false
+}
+
+/** Flip the workspace zone's sticky tab bar back on. The off switch lives on
+ *  the main tab's context menu — unreachable once the bar is hidden — so this
+ *  is the symmetrical restore for the always-reachable sidebar row menu. */
+export function showWorkspaceTabBar(): void {
+  const tree = $layoutTree.get()
+  const group = tree ? findGroupOfPane(tree, 'workspace') : null
+
+  if (group) {
+    setTreeGroupHeaderHidden(group.id, false)
+  }
+}
+
 /** Hide/show a zone's header entirely (double-click gesture). */
 export function setTreeGroupHeaderHidden(groupId: string, headerHidden: boolean) {
   const tree = $layoutTree.get()

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1645,6 +1645,7 @@ export const ar = defineLocale({
       backgroundRunning: 'تعمل في الخلفية',
       finishedUnread: 'اكتملت وفيها جديد',
       hideTabBar: 'إخفاء شريط التبويبات',
+      showTabBar: 'إظهار شريط التبويبات',
       openInNewTab: 'فتح في تبويب جديد',
       openInSplit: 'فتح في تقسيم',
       ownedByProfile: profile => `مملوكة للملف الشخصي ${profile}`,

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1943,6 +1943,7 @@ export const en: Translations = {
       archive: 'Archive',
       newWindow: 'New window',
       hideTabBar: 'Hide tab bar',
+      showTabBar: 'Show tab bar',
       openInNewTab: 'Open in new tab',
       openInSplit: 'Open in split',
       copyIdFailed: 'Could not copy session ID',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1637,6 +1637,7 @@ export interface Translations {
       archive: string
       newWindow: string
       hideTabBar: string
+      showTabBar: string
       openInNewTab: string
       openInSplit: string
       copyIdFailed: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2135,6 +2135,7 @@ export const zh: Translations = {
       archive: '归档',
       newWindow: '新窗口',
       hideTabBar: '隐藏标签栏',
+      showTabBar: '显示标签栏',
       openInNewTab: '在新标签页中打开',
       openInSplit: '在分屏中打开',
       copyIdFailed: '无法复制会话 ID',


### PR DESCRIPTION
## What does this PR do?

The main tab's context menu offers "Hide tab bar" — but once the bar is hidden, that menu disappears with it, and the session tile swallows right-clicks on the chat body (`stopPropagation` in session-tile.tsx), so the zone menu's "Show header" is unreachable too. The only escape was Ctrl+T (a new tab force-pins the header back on), which is undiscoverable.

This PR adds the symmetrical restore: the **sidebar session row menu** (kebab ⋮ + right-click — always reachable, independent of the tab bar) shows **"Show tab bar"** whenever the workspace zone's header is explicitly hidden, and clicking it flips `headerHidden` back off.

Why the sidebar: it is the only menu surface that does not depend on the tab bar existing. The menu item reads `isWorkspaceTabBarHidden()` lazily at menu-open time (`.get()`, no `$layoutTree` render subscription — that is a documented perf red line, see tree-group.tsx), and only surfaces for an **explicit** hide (`headerHidden === true`); a lone pane's auto-hide default is not treated as user state to restore.

## Related Issue

No existing issue filed — this is a trapped-state bug found while using the desktop app. Happy to file one if maintainers prefer.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/components/pane-shell/tree/store.ts` — add `isWorkspaceTabBarHidden()` (read-only, `.get()`-based) and `showWorkspaceTabBar()` (symmetrical restore via `setTreeGroupHeaderHidden(false)`).
- `apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx` — render "Show tab bar" item (icon `eye`) in the session menu when the workspace header is explicitly hidden; calls `showWorkspaceTabBar()`.
- `apps/desktop/src/i18n/{types,en,zh,ar}.ts` — add `showTabBar` string (en/zh/ar translated; ja/zh-hant fall back to English via `defineLocale`).
- `apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx` — 2 new tests: item appears only while hidden + click restores; absent while visible.

## How to Test

1. Open a session. Right-click the **main tab** → "Hide tab bar". The tab strip disappears.
2. In the left sidebar, open any session row's **⋮ menu** (or right-click the row).
3. "Show tab bar" is present. Click it → the tab strip returns.
4. With the bar visible, reopen the row menu → "Show tab bar" is absent.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (n/a — renderer-only change)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Verification (local, Windows 11)

- `npm run test:ui -- src/app/chat/sidebar/session-actions-menu.test.tsx` → 3/3 pass
- `npx tsc -p . --noEmit` → no errors
- `npx eslint` on changed files → no issues
- `npx prettier --check` on changed files → all formatted
- Rebased onto latest `origin/main` (no conflicts; upstream did not touch these files)

## Known limitations

- `ja`/`zh-hant` locales lack the new key and fall back to English via `defineLocale` merge (consistent with how `hideTabBar` is handled there today).
- The item renders on any session menu while the bar is hidden (surface-agnostic); calling `showWorkspaceTabBar()` when already visible is a guarded no-op.
