### PR TITLE
fix(desktop): isolate slash skill catalogs by profile

### DIFF
--- a/agent/skill_bundles.py
+++ b/agent/skill_bundles.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+import threading
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -61,6 +62,8 @@ _BUNDLE_MULTI_HYPHEN = re.compile(r"-{2,}")
 
 _bundles_cache: Dict[str, Dict[str, Any]] = {}
 _bundles_cache_mtime: Optional[float] = None
+_bundles_cache_home: Optional[Path] = None
+_bundles_cache_lock = threading.RLock()
 
 
 def _bundles_dir() -> Path:
@@ -172,7 +175,14 @@ def scan_bundles() -> Dict[str, Dict[str, Any]]:
     bundle info dict. Later bundles with a duplicate slug are skipped with
     a warning (first wins, alphabetical order).
     """
-    global _bundles_cache, _bundles_cache_mtime
+    with _bundles_cache_lock:
+        return _scan_bundles_locked()
+
+
+def _scan_bundles_locked() -> Dict[str, Dict[str, Any]]:
+    """Build and atomically publish one profile's bundle snapshot."""
+    global _bundles_cache, _bundles_cache_mtime, _bundles_cache_home
+    home = _bundles_dir()
     files = _iter_bundle_files()
     out: Dict[str, Dict[str, Any]] = {}
     for f in files:
@@ -189,6 +199,7 @@ def scan_bundles() -> Dict[str, Dict[str, Any]]:
         out[key] = info
     _bundles_cache = out
     _bundles_cache_mtime = _max_mtime(files)
+    _bundles_cache_home = home
     return out
 
 
@@ -198,11 +209,17 @@ def get_skill_bundles() -> Dict[str, Dict[str, Any]]:
     Cheap to call repeatedly: only rescans when the bundles directory or
     any bundle file's mtime is newer than the cached snapshot.
     """
-    files = _iter_bundle_files()
-    current_mtime = _max_mtime(files)
-    if not _bundles_cache or _bundles_cache_mtime != current_mtime:
-        scan_bundles()
-    return _bundles_cache
+    with _bundles_cache_lock:
+        home = _bundles_dir()
+        files = _iter_bundle_files()
+        current_mtime = _max_mtime(files)
+        if (
+            not _bundles_cache
+            or _bundles_cache_home != home
+            or _bundles_cache_mtime != current_mtime
+        ):
+            return _scan_bundles_locked()
+        return _bundles_cache
 
 
 def resolve_bundle_command_key(command: str) -> Optional[str]:
@@ -228,8 +245,13 @@ def reload_bundles() -> Dict[str, Any]:
     def _snapshot(cmds: Dict[str, Dict[str, Any]]) -> Dict[str, str]:
         return {k.lstrip("/"): (v or {}).get("description", "") for k, v in cmds.items()}
 
-    before = _snapshot(_bundles_cache)
-    new = scan_bundles()
+    with _bundles_cache_lock:
+        before = (
+            _snapshot(_bundles_cache)
+            if _bundles_cache_home == _bundles_dir()
+            else {}
+        )
+        new = _scan_bundles_locked()
     after = _snapshot(new)
 
     added_names = sorted(set(after) - set(before))

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -8,11 +8,16 @@ import json
 import logging
 import os
 import re
+import threading
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from hermes_constants import display_hermes_home
+#<<<<<<< HEAD
+#from hermes_constants import display_hermes_home
 from agent.prompt_cache_boundary import register_stable_prefix
+#=======
+from hermes_constants import display_hermes_home, get_hermes_home
+#>>>>>>> ed8c2ff525 (fix(desktop): isolate slash skill catalogs by profile)
 from agent.skill_preprocessing import (
     expand_inline_shell as _expand_inline_shell,
     load_skills_config as _load_skills_config,
@@ -23,6 +28,8 @@ logger = logging.getLogger(__name__)
 
 _skill_commands: Dict[str, Dict[str, Any]] = {}
 _skill_commands_platform: Optional[str] = None
+_skill_commands_home: Optional[Path] = None
+_skill_commands_lock = threading.RLock()
 # Patterns for sanitizing skill names into clean hyphen-separated slugs.
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
@@ -400,25 +407,40 @@ def _build_skill_message(
 
 
 def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
-    """Scan ~/.hermes/skills/ and return a mapping of /command -> skill info.
+    """Scan the active profile's skills and return a /command mapping.
 
     Returns:
         Dict mapping "/skill-name" to {name, description, skill_md_path, skill_dir}.
     """
-    global _skill_commands, _skill_commands_platform
-    _skill_commands_platform = _resolve_skill_commands_platform()
-    _skill_commands = {}
+    with _skill_commands_lock:
+        return _scan_skill_commands_locked()
+
+
+def _scan_skill_commands_locked() -> Dict[str, Dict[str, Any]]:
+    """Build and atomically publish one profile/platform command snapshot."""
+    global _skill_commands, _skill_commands_platform, _skill_commands_home
+    platform = _resolve_skill_commands_platform()
+    home = get_hermes_home()
+    commands: Dict[str, Dict[str, Any]] = {}
     try:
-        from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
+        from tools.skills_tool import (
+            _get_disabled_skill_names,
+            _parse_frontmatter,
+            _skills_dir,
+            skill_matches_environment,
+            skill_matches_platform,
+        )
         from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
         from hermes_cli.commands import resolve_command
         disabled = _get_disabled_skill_names()
         seen_names: set = set()
 
-        # Scan local dir first, then external dirs
+        # Resolve the local directory at call time. SKILLS_DIR is an
+        # import-time compatibility constant belonging to the launch profile.
         dirs_to_scan = []
-        if SKILLS_DIR.exists():
-            dirs_to_scan.append(SKILLS_DIR)
+        skills_dir = _skills_dir()
+        if skills_dir.exists():
+            dirs_to_scan.append(skills_dir)
         dirs_to_scan.extend(get_external_skills_dirs())
 
         for scan_dir in dirs_to_scan:
@@ -475,14 +497,14 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     # slug (e.g. "git_helper" vs "git-helper"). First-wins
                     # preserves local-before-external precedence.
                     cmd_key = f"/{cmd_name}"
-                    if cmd_key in _skill_commands:
+                    if cmd_key in commands:
                         logger.warning(
                             "Skill %r maps to slash command %s already claimed "
                             "by %r; keeping the first and skipping this one.",
-                            name, cmd_key, _skill_commands[cmd_key]["name"],
+                            name, cmd_key, commands[cmd_key]["name"],
                         )
                         continue
-                    _skill_commands[cmd_key] = {
+                    commands[cmd_key] = {
                         "name": name,
                         "description": description or f"Invoke the {name} skill",
                         "skill_md_path": str(skill_md),
@@ -492,22 +514,25 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     continue
     except Exception:
         pass
-    return _skill_commands
+    _skill_commands = commands
+    _skill_commands_platform = platform
+    _skill_commands_home = home
+    return commands
 
 
 def get_skill_commands() -> Dict[str, Dict[str, Any]]:
-    """Return the current skill commands mapping (scan first if empty).
+    """Return the current profile's skill-command mapping.
 
-    Rescans when the active platform scope changes (e.g. a gateway
-    process serving Telegram and Discord concurrently) so each platform
-    sees its own ``skills.platform_disabled`` view (#14536).
+    Rescans when the active platform or profile-home scope changes.
     """
-    if (
-        not _skill_commands
-        or _skill_commands_platform != _resolve_skill_commands_platform()
-    ):
-        scan_skill_commands()
-    return _skill_commands
+    with _skill_commands_lock:
+        if (
+            not _skill_commands
+            or _skill_commands_platform != _resolve_skill_commands_platform()
+            or _skill_commands_home != get_hermes_home()
+        ):
+            return _scan_skill_commands_locked()
+        return _skill_commands
 
 
 def reload_skills() -> Dict[str, Any]:
@@ -549,11 +574,13 @@ def reload_skills() -> Dict[str, Any]:
             out[bare] = (info or {}).get("description") or ""
         return out
 
-    before = _snapshot(_skill_commands)
-
-    # Rescan the skills dir. ``scan_skill_commands`` resets
-    # ``_skill_commands = {}`` internally and repopulates it.
-    new_commands = scan_skill_commands()
+    with _skill_commands_lock:
+        current_scope = (
+            _skill_commands_home == get_hermes_home()
+            and _skill_commands_platform == _resolve_skill_commands_platform()
+        )
+        before = _snapshot(_skill_commands) if current_scope else {}
+        new_commands = _scan_skill_commands_locked()
 
     after = _snapshot(new_commands)
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-live-completion-adapter.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-live-completion-adapter.ts
@@ -34,11 +34,15 @@ export function useLiveCompletionAdapter(options: {
    *  an unchanged query would keep serving what it fetched before the source
    *  changed, because the adapter de-dupes on the query alone. */
   epoch?: number
+  /** Identity of the source behind a query (for example profile + session).
+   * Crossing this boundary clears held items and invalidates in-flight work. */
+  scopeKey?: string
   toItem: (entry: CompletionEntry, index: number) => Unstable_TriggerItem
 }): { adapter: Unstable_TriggerAdapter; loading: boolean } {
-  const { enabled, debounceMs = 60, epoch = 0, fetcher, isCached, toItem } = options
+  const { enabled, debounceMs = 60, epoch = 0, scopeKey = '', fetcher, isCached, toItem } = options
 
-  const [state, setState] = useState<{ query: string; items: Unstable_TriggerItem[] }>({
+  const [state, setState] = useState<{ scopeKey: string; query: string; items: Unstable_TriggerItem[] }>({
+    scopeKey,
     query: EMPTY_QUERY,
     items: []
   })
@@ -68,8 +72,17 @@ export function useLiveCompletionAdapter(options: {
     pendingQueryRef.current = null
     tokenRef.current += 1
     setLoading(false)
-    setState({ query: EMPTY_QUERY, items: [] })
-  }, [cancelTimer, enabled])
+    setState({ scopeKey, query: EMPTY_QUERY, items: [] })
+  }, [cancelTimer, enabled, scopeKey])
+
+  // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
+  useEffect(() => {
+    cancelTimer()
+    pendingQueryRef.current = null
+    tokenRef.current += 1
+    setLoading(false)
+    setState({ scopeKey, query: EMPTY_QUERY, items: [] })
+  }, [cancelTimer, scopeKey])
 
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
@@ -110,6 +123,7 @@ export function useLiveCompletionAdapter(options: {
             }
 
             setState({
+              scopeKey,
               query: payload.query,
               items: payload.items.map((entry, index) => toItem(entry, index))
             })
@@ -119,7 +133,7 @@ export function useLiveCompletionAdapter(options: {
               return
             }
 
-            setState({ query, items: [] })
+            setState({ scopeKey, query, items: [] })
           })
           .finally(() => {
             if (token === tokenRef.current) {
@@ -132,7 +146,7 @@ export function useLiveCompletionAdapter(options: {
       // add a frame of empty popover on every keystroke.
       cached ? run() : (timerRef.current = window.setTimeout(run, debounceMs))
     },
-    [cancelTimer, debounceMs, enabled, fetcher, isCached, toItem]
+    [cancelTimer, debounceMs, enabled, fetcher, isCached, scopeKey, toItem]
   )
 
   const adapter = useMemo<Unstable_TriggerAdapter>(
@@ -140,14 +154,14 @@ export function useLiveCompletionAdapter(options: {
       categories: () => [],
       categoryItems: () => [],
       search: (query: string) => {
-        if (query !== state.query) {
+        if (state.scopeKey !== scopeKey || query !== state.query) {
           scheduleFetch(query)
         }
 
-        return state.items
+        return state.scopeKey === scopeKey ? state.items : []
       }
     }),
-    [scheduleFetch, state]
+    [scheduleFetch, scopeKey, state]
   )
 
   return { adapter, loading }

--- a/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { HermesGateway } from '@/hermes'
 import { queryClient } from '@/lib/query-client'
 import { invalidateSlashCompletions } from '@/lib/slash-completion-cache'
+import { $activeGatewayProfile } from '@/store/profile'
 
 import { isSkillItem } from '../composer-utils'
 
@@ -41,19 +42,36 @@ const RANKED_CATALOG = {
 const commandsOf = (items: readonly Unstable_TriggerItem[]) =>
   items.map(item => (item.metadata as { command?: string })?.command)
 
-function harness(gateway: HermesGateway) {
-  const api: { search?: (query: string) => readonly Unstable_TriggerItem[] } = {}
+function deferred<T>() {
+  let resolve!: (value: T) => void
 
-  function Probe() {
-    const { adapter } = useSlashCompletions({ gateway })
+  const promise = new Promise<T>(done => {
+    resolve = done
+  })
+
+  return { promise, resolve }
+}
+
+function harness(gateway: HermesGateway, options: { sessionId?: string | null } = {}) {
+  const api: {
+    search?: (query: string) => readonly Unstable_TriggerItem[]
+    rerenderSession?: (sessionId?: string | null) => void
+  } = {}
+
+  function Probe({ sessionId }: { sessionId?: string | null }) {
+    const { adapter } = useSlashCompletions({ gateway, sessionId })
     api.search = adapter.search
 
     return null
   }
 
-  render(<Probe />)
+  const view = render(<Probe sessionId={options.sessionId} />)
+  api.rerenderSession = sessionId => view.rerender(<Probe sessionId={sessionId} />)
 
-  return api as { search: (query: string) => readonly Unstable_TriggerItem[] }
+  return api as {
+    search: (query: string) => readonly Unstable_TriggerItem[]
+    rerenderSession: (sessionId?: string | null) => void
+  }
 }
 
 /** Drive the adapter until its async fetch has settled into `search`'s result. */
@@ -73,10 +91,95 @@ async function completions(api: { search: (query: string) => readonly Unstable_T
 
 afterEach(() => {
   cleanup()
+  $activeGatewayProfile.set('default')
   queryClient.clear()
 })
 
 describe('useSlashCompletions', () => {
+  it('scopes a new-session catalog and typed completion to the selected profile', async () => {
+    $activeGatewayProfile.set('search')
+
+    const request = vi.fn().mockImplementation((method: string) =>
+      Promise.resolve(method === 'commands.catalog' ? CATALOG : { items: [] })
+    )
+
+    const api = harness({ request } as unknown as HermesGateway)
+
+    await completions(api, '')
+    await completions(api, 'work')
+
+    expect(request).toHaveBeenCalledWith('commands.catalog', { profile: 'search' })
+    expect(request).toHaveBeenCalledWith('complete.slash', { profile: 'search', text: '/work' })
+  })
+
+  it('sends both the selected profile fallback and authoritative session id', async () => {
+    $activeGatewayProfile.set('search')
+    const request = vi.fn().mockResolvedValue(CATALOG)
+    const api = harness({ request } as unknown as HermesGateway, { sessionId: 'sess-search' })
+
+    await completions(api, '')
+
+    expect(request).toHaveBeenCalledWith('commands.catalog', {
+      profile: 'search',
+      session_id: 'sess-search'
+    })
+  })
+
+  it('clears held completions when the session scope changes', async () => {
+    const catalogFor = (name: string) => ({ categories: [], pairs: [[`/${name}`, `${name} skill`]] })
+
+    const request = vi.fn().mockImplementation((_method: string, params: { session_id?: string }) =>
+      Promise.resolve(catalogFor(params.session_id === 'sess-b' ? 'b-only' : 'a-only'))
+    )
+
+    const api = harness({ request } as unknown as HermesGateway, { sessionId: 'sess-a' })
+
+    expect(commandsOf(await completions(api, ''))).toContain('/a-only')
+
+    await act(async () => api.rerenderSession('sess-b'))
+    let immediate: readonly Unstable_TriggerItem[] = []
+    await act(async () => {
+      immediate = api.search('')
+    })
+    expect(commandsOf(immediate)).not.toContain('/a-only')
+    expect(commandsOf(await completions(api, ''))).toContain('/b-only')
+  })
+
+  it('ignores an old session request that resolves after a scope change', async () => {
+    const oldRequest = deferred<typeof CATALOG>()
+    const newCatalog = { categories: [], pairs: [['/b-only', 'B skill']] }
+    const newRequest = deferred<typeof newCatalog>()
+
+    const request = vi.fn().mockImplementation((_method: string, params: { session_id?: string }) =>
+      params.session_id === 'sess-b' ? newRequest.promise : oldRequest.promise
+    )
+
+    const api = harness({ request } as unknown as HermesGateway, { sessionId: 'sess-a' })
+
+    await act(async () => {
+      api.search('')
+      await new Promise(resolve => setTimeout(resolve, 120))
+    })
+
+    await act(async () => api.rerenderSession('sess-b'))
+    await act(async () => {
+      api.search('')
+      await new Promise(resolve => setTimeout(resolve, 120))
+    })
+
+    await act(async () => {
+      oldRequest.resolve(CATALOG)
+      await Promise.resolve()
+    })
+    expect(commandsOf(api.search(''))).not.toContain('/work')
+
+    await act(async () => {
+      newRequest.resolve(newCatalog)
+      await Promise.resolve()
+    })
+    expect(commandsOf(api.search(''))).toContain('/b-only')
+  })
+
   it('serves the bare-slash catalog from cache instead of re-requesting it', async () => {
     const request = vi.fn().mockResolvedValue(CATALOG)
     const api = harness({ request } as unknown as HermesGateway)

--- a/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts
@@ -21,6 +21,7 @@ import {
   peekCachedSlashCompletion
 } from '@/lib/slash-completion-cache'
 import { normalize } from '@/lib/text'
+import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { $sessions } from '@/store/session'
 
 import type { CompletionEntry, CompletionPayload } from './use-live-completion-adapter'
@@ -61,6 +62,7 @@ const SESSION_INLINE_LIMIT = 7
 /** Live `/` completions backed by the gateway's `complete.slash` RPC. */
 export function useSlashCompletions(options: {
   gateway: HermesGateway | null
+  sessionId?: string | null
   /** Desktop theme list — `/skin` is owned client-side, so its arg completions
    *  come from here, not the backend (whose skin list is CLI/TUI-only). */
   skinThemes?: DesktopThemeCommandOption[]
@@ -69,9 +71,11 @@ export function useSlashCompletions(options: {
   adapter: Unstable_TriggerAdapter
   loading: boolean
 } {
-  const { gateway, skinThemes, activeSkin } = options
+  const { gateway, sessionId, skinThemes, activeSkin } = options
   const enabled = Boolean(gateway)
   const epoch = useStore($slashCompletionsEpoch)
+  const activeProfile = normalizeProfileKey(useStore($activeGatewayProfile))
+  const cacheScope = `profile:${activeProfile}:${sessionId ? `session:${sessionId}` : 'no-session'}`
 
   const fetcher = useCallback(
     async (query: string): Promise<CompletionPayload> => {
@@ -143,7 +147,12 @@ export function useSlashCompletions(options: {
       try {
         if (!query) {
           const catalog = filterDesktopCommandsCatalog(
-            await cachedSlashCompletion('catalog', () => gateway.request<CommandsCatalogLike>('commands.catalog'))
+            await cachedSlashCompletion(`catalog:${cacheScope}`, () =>
+              gateway.request<CommandsCatalogLike>('commands.catalog', {
+                profile: activeProfile,
+                ...(sessionId ? { session_id: sessionId } : {})
+              })
+            )
           )
 
           // Prefer the categorized layout so the popover renders section headers
@@ -183,8 +192,12 @@ export function useSlashCompletions(options: {
           return { items, query }
         }
 
-        const result = await cachedSlashCompletion(`slash:${text.toLowerCase()}`, () =>
-          gateway.request<{ items?: CompletionEntry[]; replace_from?: number }>('complete.slash', { text })
+        const result = await cachedSlashCompletion(`slash:${cacheScope}:${text.toLowerCase()}`, () =>
+          gateway.request<{ items?: CompletionEntry[]; replace_from?: number }>('complete.slash', {
+            profile: activeProfile,
+            ...(sessionId ? { session_id: sessionId } : {}),
+            text
+          })
         )
 
         // Arg-completion items (replace_from > 1) carry just the arg stub —
@@ -232,7 +245,7 @@ export function useSlashCompletions(options: {
         // search that hides a match is broken. Usage rides along on the catalog
         // response, which the popover has already fetched by the time anyone
         // types; if it somehow hasn't, order falls back to the backend's.
-        const catalogSkills = peekCachedSlashCompletion<CommandsCatalogLike>('catalog')?.skills
+        const catalogSkills = peekCachedSlashCompletion<CommandsCatalogLike>(`catalog:${cacheScope}`)?.skills
 
         const ranked = [
           ...decorated.filter(item => item.group !== 'Skills'),
@@ -249,7 +262,7 @@ export function useSlashCompletions(options: {
         return { items: [], query }
       }
     },
-    [gateway, skinThemes, activeSkin]
+    [gateway, skinThemes, activeSkin, activeProfile, cacheScope, sessionId]
   )
 
   const toItem = useCallback((entry: CompletionEntry, index: number): Unstable_TriggerItem => {
@@ -291,10 +304,12 @@ export function useSlashCompletions(options: {
         return true
       }
 
-      return hasCachedSlashCompletion(query ? `slash:${text.toLowerCase()}` : 'catalog')
+      return hasCachedSlashCompletion(
+        query ? `slash:${cacheScope}:${text.toLowerCase()}` : `catalog:${cacheScope}`
+      )
     },
-    [skinThemes]
+    [skinThemes, cacheScope]
   )
 
-  return useLiveCompletionAdapter({ enabled, epoch, fetcher, isCached, toItem })
+  return useLiveCompletionAdapter({ enabled, epoch, scopeKey: cacheScope, fetcher, isCached, toItem })
 }

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -195,7 +195,14 @@ export function ChatBar({
 
   const { availableThemes, themeName } = useTheme()
   const at = useAtCompletions({ gateway: gateway ?? null, sessionId: sessionId ?? null, cwd: cwd ?? null })
-  const slash = useSlashCompletions({ activeSkin: themeName, gateway: gateway ?? null, skinThemes: availableThemes })
+
+  const slash = useSlashCompletions({
+    activeSkin: themeName,
+    gateway: gateway ?? null,
+    sessionId: sessionId ?? null,
+    skinThemes: availableThemes
+  })
+
   const emoji = useEmojiCompletions()
 
   const { t } = useI18n()

--- a/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
@@ -114,7 +114,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
   const expanded = draft.includes('\n')
   const canSubmit = draft.trim().length > 0
   const at = useAtCompletions({ cwd, gateway, sessionId })
-  const slash = useSlashCompletions({ gateway })
+  const slash = useSlashCompletions({ gateway, sessionId })
   const emoji = useEmojiCompletions()
 
   // This is the one composer that routinely unmounts, so it is where the focus

--- a/tests/agent/test_skill_bundles.py
+++ b/tests/agent/test_skill_bundles.py
@@ -66,6 +66,7 @@ def bundles_env(tmp_path, monkeypatch):
     import agent.skill_bundles as mod
     mod._bundles_cache = {}
     mod._bundles_cache_mtime = None
+    mod._bundles_cache_home = None
     return bundles_dir, skills_dir
 
 
@@ -105,6 +106,43 @@ class TestScanBundles:
 
 
 class TestGetSkillBundles:
+    def test_cache_is_scoped_by_profile_home_even_when_mtimes_match(self, tmp_path):
+        import agent.skill_bundles as mod
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        home_a = tmp_path / "profile-a"
+        home_b = tmp_path / "profile-b"
+        bundle_a = _make_bundle_yaml(home_a / "skill-bundles", "a-only", ["s1"])
+        bundle_b = _make_bundle_yaml(home_b / "skill-bundles", "b-only", ["s2"])
+
+        # Reproduce the old mtime-only cache collision deterministically.
+        fixed_ns = 1_700_000_000_000_000_000
+        for path in (bundle_a, bundle_b, bundle_a.parent, bundle_b.parent):
+            os.utime(path, ns=(fixed_ns, fixed_ns))
+
+        mod._bundles_cache = {}
+        mod._bundles_cache_mtime = None
+        mod._bundles_cache_home = None
+
+        token = set_hermes_home_override(home_a)
+        try:
+            bundles_a = dict(get_skill_bundles())
+        finally:
+            reset_hermes_home_override(token)
+
+        token = set_hermes_home_override(home_b)
+        try:
+            bundles_b = dict(get_skill_bundles())
+        finally:
+            reset_hermes_home_override(token)
+
+        assert "/a-only" in bundles_a
+        assert "/b-only" not in bundles_a
+        assert "/b-only" in bundles_b
+        assert "/a-only" not in bundles_b
     def test_returns_cache(self, bundles_env):
         bundles_dir, _ = bundles_env
         _make_bundle_yaml(bundles_dir, "a", ["s1"])

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -1,6 +1,7 @@
 """Tests for agent/skill_commands.py — skill slash command scanning and platform filtering."""
 
 import os
+import threading
 from pathlib import Path
 from unittest.mock import patch
 
@@ -51,6 +52,62 @@ def _symlink_category(skills_dir: Path, linked_root: Path, category: str) -> Pat
 
 
 class TestScanSkillCommands:
+
+    def test_concurrent_profile_scans_do_not_mix_commands(self, tmp_path, monkeypatch):
+        """Concurrent gateway RPCs must not share a partially-built cache."""
+        import agent.skill_commands as sc_mod
+        import agent.skill_utils as skill_utils
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        home_a = tmp_path / "profile-a"
+        home_b = tmp_path / "profile-b"
+        _make_skill(home_a / "skills", "profile-a-only")
+        _make_skill(home_b / "skills", "profile-b-only")
+
+        real_iter = skill_utils.iter_skill_index_files
+        first_entered = threading.Event()
+        release_first = threading.Event()
+
+        def controlled_iter(scan_dir, filename):
+            if Path(scan_dir) == home_a / "skills":
+                first_entered.set()
+                assert release_first.wait(timeout=5)
+            yield from real_iter(scan_dir, filename)
+
+        monkeypatch.setattr(skill_utils, "iter_skill_index_files", controlled_iter)
+        monkeypatch.setattr(skill_utils, "get_external_skills_dirs", lambda: [])
+        monkeypatch.setattr(sc_mod, "_skill_commands", {})
+        monkeypatch.setattr(sc_mod, "_skill_commands_platform", None)
+        monkeypatch.setattr(sc_mod, "_skill_commands_home", None)
+
+        results = {}
+
+        def scan_for(label, home):
+            token = set_hermes_home_override(home)
+            try:
+                results[label] = dict(scan_skill_commands())
+            finally:
+                reset_hermes_home_override(token)
+
+        first = threading.Thread(target=scan_for, args=("a", home_a))
+        second = threading.Thread(target=scan_for, args=("b", home_b))
+        first.start()
+        assert first_entered.wait(timeout=5)
+        second.start()
+        second.join(timeout=0.2)
+        release_first.set()
+        first.join(timeout=5)
+        second.join(timeout=5)
+
+        assert not first.is_alive()
+        assert not second.is_alive()
+        assert "/profile-a-only" in results["a"]
+        assert "/profile-b-only" not in results["a"]
+        assert "/profile-b-only" in results["b"]
+        assert "/profile-a-only" not in results["b"]
 
 
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -38,6 +38,79 @@ def _neuter_agent_prewarm_timer(request, monkeypatch):
     yield
 
 
+def test_command_catalog_scopes_skill_resolution_to_session_or_explicit_profile(tmp_path, monkeypatch):
+    """Desktop slash catalog/completion must resolve the selected profile's skills."""
+    from agent import skill_commands
+    from agent import skill_utils
+    from tools import skills_tool
+
+    launch_home = tmp_path / "launch"
+    search_home = tmp_path / "search"
+    for home, name in ((launch_home, "launch-only"), (search_home, "search-only")):
+        skill_dir = home / "skills" / "local" / name
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: {name} skill\n---\n\n#{name}\n",
+            encoding="utf-8",
+        )
+
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", launch_home / "skills")
+    monkeypatch.setattr(skills_tool, "_SKILLS_DIR_AT_IMPORT", launch_home / "skills")
+    monkeypatch.setattr(skill_utils, "get_external_skills_dirs", lambda: [])
+    monkeypatch.setattr(skill_commands, "_skill_commands", {})
+    monkeypatch.setattr(skill_commands, "_skill_commands_platform", None)
+
+    token = set_hermes_home_override(launch_home)
+    try:
+        monkeypatch.setattr(server, "_hermes_home", launch_home)
+        server._sessions["search-session"] = {
+            "profile_home": str(search_home),
+            "session_key": "search-session",
+        }
+        server._sessions["launch-session"] = {
+            "profile_home": None,
+            "session_key": "launch-session",
+        }
+
+        catalog = server._methods["commands.catalog"]("r1", {"session_id": "search-session"})
+        catalog_names = {command for command, _description in catalog["result"]["pairs"]}
+        assert "/search-only" in catalog_names
+        assert "/launch-only" not in catalog_names
+
+        completion = server._methods["complete.slash"](
+            "r2", {"session_id": "search-session", "text": "/search"}
+        )
+        completion_names = {item["text"] for item in completion["result"]["items"]}
+        assert "search-only" in completion_names
+
+        monkeypatch.setattr(
+            server,
+            "_profile_home",
+            lambda name: search_home if name == "search" else None,
+        )
+
+        launch_catalog = server._methods["commands.catalog"](
+            "r3",
+            {"session_id": "launch-session", "profile": "search"},
+        )
+        launch_catalog_names = {
+            command for command, _description in launch_catalog["result"]["pairs"]
+        }
+        assert "/launch-only" in launch_catalog_names
+        assert "/search-only" not in launch_catalog_names
+
+        profile_catalog = server._methods["commands.catalog"]("r4", {"profile": "search"})
+        profile_catalog_names = {
+            command for command, _description in profile_catalog["result"]["pairs"]
+        }
+        assert "/search-only" in profile_catalog_names
+        assert "/launch-only" not in profile_catalog_names
+    finally:
+        server._sessions.pop("search-session", None)
+        server._sessions.pop("launch-session", None)
+        reset_hermes_home_override(token)
+
+
 def test_session_slot_is_claimed_on_first_turn_not_on_create(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir()

--- a/tui_gateway/methods_complete.py
+++ b/tui_gateway/methods_complete.py
@@ -216,6 +216,7 @@ def _(rid, params: dict) -> dict:
 
 
 @method("complete.slash")
+@_profile_scoped
 def _(rid, params: dict) -> dict:
     text = params.get("text", "")
     if not text.startswith("/"):

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -253,6 +253,7 @@ def _(rid, params: dict) -> dict:
 
 
 @method("commands.catalog")
+@_profile_scoped
 def _(rid, params: dict) -> dict:
     """Registry-backed slash metadata for the TUI — categorized, no aliases."""
     try:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1438,17 +1438,36 @@ def _profile_home(profile: str | None) -> Path | None:
 
 
 def _profile_scoped(handler):
-    """Bind ``params['profile']``'s HERMES_HOME around a pet RPC handler.
+    """Bind a profile or owning session's HERMES_HOME around an RPC handler.
 
-    Pets are per-profile: ``display.pet.*`` lives in the profile's config.yaml and
-    sprites install under its ``pets/`` dir (both resolve via ``get_hermes_home``).
-    The desktop sends ``profile`` on pet calls so config + pets dir resolve to the
-    focused profile even in app-global remote mode, where one backend serves every
-    profile. No-op for the launch profile (own-profile backends already resolve it).
+    App-global remote mode serves all profiles from one backend. Newer desktop
+    callers can provide ``params['profile']`` directly; command-oriented RPCs
+    also carry ``session_id``. The server-owned session binding is authoritative
+    and takes precedence over a client profile hint.
     """
 
     def wrapper(rid, params):
-        home = _profile_home(params.get("profile") if isinstance(params, dict) else None)
+        request_params = params if isinstance(params, dict) else {}
+        home = None
+        session = _sessions.get(str(request_params.get("session_id") or ""))
+        if isinstance(session, dict):
+            session_home = session.get("profile_home")
+            if session_home:
+                try:
+                    candidate = Path(session_home)
+                    if candidate.exists():
+                        if candidate.resolve() == Path(_hermes_home).resolve():
+                            return handler(rid, params)
+                        home = candidate
+                except (OSError, TypeError, ValueError):
+                    pass
+            # A server-owned session binding is authoritative even when it is
+            # the launch profile (profile_home is None) or its recorded path is
+            # stale. Do not let a client profile hint retarget that session.
+            if home is None:
+                return handler(rid, params)
+        else:
+            home = _profile_home(request_params.get("profile"))
         if home is None:
             return handler(rid, params)
         token = set_hermes_home_override(home)


### PR DESCRIPTION
## What does this PR do?

Scopes the Desktop slash-command catalog and completion path to the selected multiplex profile.

A remote Desktop session could route normal chat turns to the selected profile while the `/` popover still listed skills from the dashboard launch/default profile. There were two independent leaks:

1. Desktop called `commands.catalog` / `complete.slash` without profile/session context and cached results in process-global keys.
2. The in-process TUI gateway handlers were not profile-scoped, while `scan_skill_commands()` used the launch profile's import-time `SKILLS_DIR` and cached only by platform.

The Desktop now sends both the active profile hint and, when available, the authoritative session ID. Cache keys include profile and session identity. The gateway prefers its server-owned session binding, falls back to the explicit profile only when no binding exists, and resolves/scans the current profile's skills and bundle directories at request time. Concurrent scans build local snapshots and publish them atomically under locks so one profile cannot observe another profile's partially-built catalog.

This is a follow-up to #40677 / #60180. That fix covered profile-aware `skills_tool` resolution and slash worker subprocesses; the in-process `commands.catalog` / `complete.slash` path and Desktop completion cache remained unscoped.

## Related Issue

Follow-up to #40677 and #60180. Related to #75684, but this PR fixes the separate Desktop/TUI catalog-completion path rather than gateway write-approval routing.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts`
  - Send `profile` and optional `session_id` to catalog/completion RPCs.
  - Partition catalog and typed-completion caches by profile and session.
- `apps/desktop/src/app/chat/composer/hooks/use-live-completion-adapter.ts`
  - Clear held items and invalidate in-flight requests when profile/session scope changes.
- `apps/desktop/src/app/chat/composer/index.tsx`
  - Pass the active session ID into slash completions.
- `apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx`
  - Preserve the same session scope while editing a message.
- `tui_gateway/methods_tools.py` / `methods_complete.py`
  - Profile-scope `commands.catalog` and `complete.slash`.
- `tui_gateway/server.py`
  - Prefer server-owned session `profile_home` over client profile hints.
  - Fail closed for an existing launch-profile or invalid session binding rather than cross-routing it.
- `agent/skill_commands.py`
  - Resolve the active profile's skills directory at scan time.
  - Invalidate the command cache when the effective Hermes home changes.
  - Serialize concurrent scans and atomically publish complete snapshots.
- `agent/skill_bundles.py`
  - Scope the bundle cache by effective profile home.
  - Serialize scans and atomically publish complete snapshots.
- Add Desktop and gateway regression coverage for new-session profile hints, session-bound profiles, cache/request isolation, stale in-flight responses, launch-session precedence, concurrent profile scans, and equal-mtime bundle cache collisions.

## How to Test

1. Start one remote Dashboard backend serving multiplex profiles whose skills differ.
2. Connect Hermes Desktop, select a non-default profile, and start a new session.
3. Open `/` and type a profile-local skill prefix. Only that profile's skills should appear; default-only skills must not appear.
4. Switch back to default and verify its catalog remains independent.

Commands run:

```text
scripts/run_tests.sh \
  tests/agent/test_skill_commands.py \
  tests/agent/test_skill_commands_reload.py \
  tests/agent/test_skill_bundles.py \
  tests/gateway/test_bundles_command.py \
  tests/gateway/test_reload_skills_command.py
# 50 passed

scripts/run_tests.sh tests/test_tui_gateway_server.py \
  -k command_catalog_scopes_skill_resolution_to_session_or_explicit_profile
# 1 passed

npm run test:ui --workspace apps/desktop -- \
  src/app/chat/composer/hooks/use-slash-completions.test.tsx
# 9 passed

npm run typecheck --workspace apps/desktop
ruff check agent/skill_commands.py agent/skill_bundles.py \
  tests/agent/test_skill_commands.py tests/agent/test_skill_bundles.py \
  tests/test_tui_gateway_server.py \
  tui_gateway/methods_complete.py tui_gateway/methods_tools.py tui_gateway/server.py
git diff --check

uv run --extra dev pytest tests/test_tui_gateway_server.py -q
# 522 passed, 1 failed: test_ws_orphan_reap_releases_resume_lock_before_slow_teardown
# The same isolated failure reproduces on a clean origin/main worktree.
```

Manual Windows 11 Desktop → WSL Ubuntu remote Dashboard verification also passed with different default/search skill catalogs.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 Desktop with WSL Ubuntu remote Dashboard

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior-only fix with inline rationale
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before the fix, a `search` profile chat answered with the correct profile context while the Desktop `/` popover listed default-profile skills. After the fix and backend restart, the default and search catalogs were distinct and the profile-local list rendered correctly.
