### PR TITLE
feat(gateway): emoji ack for queued busy messages

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -52,6 +52,11 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     # Disable when the platform should steer silently (the text still lands in
     # the active run; only the confirmation echo is suppressed).
     "busy_steer_ack_enabled": True,
+    # When busy_input_mode=queue, react to each enqueued follow-up with this
+    # emoji (e.g. "⏳") so the user gets instant visual confirmation the
+    # message was received and queued. Empty string (default) = disabled —
+    # enqueueing stays silent, preserving prior behavior.
+    "busy_queue_ack_emoji": "",
     # When true, delete tool-progress / "⏳ Working — N min" / status bubbles
     # after the final response lands on platforms that support message
     # deletion (e.g. Telegram). Off by default — progress is still shown

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5070,6 +5070,15 @@ class BasePlatformAdapter(ABC):
                 await add(chat_id, message_id, self._FAIL_EMOJI)
         # CANCELLED: leave the message unreacted.
 
+    async def send_reaction(self, chat_id: str, message_id: str, emoji: str) -> bool:
+        """Best-effort emoji reaction on a platform message.
+
+        Base no-op returning ``False``; adapters with reaction support
+        (Telegram, Discord, ...) override. Used by the gateway for the
+        busy-queue acknowledgment flow (``display.busy_queue_ack_emoji``).
+        """
+        return False
+
     async def _run_processing_hook(self, hook_name: str, *args: Any, **kwargs: Any) -> None:
         """Run a lifecycle hook without letting failures break message flow."""
         hook = getattr(self, hook_name, None)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8837,6 +8837,44 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         self._enqueue_fifo(session_key, event, adapter)
 
+    async def _maybe_ack_busy_queue_reaction(self, event: MessageEvent) -> None:
+        """#81632 — React with ``display.busy_queue_ack_emoji`` on enqueue.
+
+        When ``display.busy_queue_ack_emoji`` is set (default empty =
+        disabled), enqueuing a busy-mode follow-up acknowledges the message
+        with a platform reaction instead of staying silent. Mirrors the
+        ``busy_steer_ack_enabled`` acknowledgment for steer mode. Best-effort:
+        failures are logged at debug level and never break message flow.
+        """
+        from gateway.display_config import resolve_display_setting
+
+        emoji = resolve_display_setting(
+            _load_gateway_config(),
+            _platform_config_key(event.source.platform),
+            "busy_queue_ack_emoji",
+            "",
+        )
+        if not emoji:
+            return
+        adapter = self._adapter_for_source(event.source)
+        if not adapter:
+            return
+        send_reaction = getattr(adapter, "send_reaction", None)
+        if not callable(send_reaction):
+            return
+        chat_id = getattr(event.source, "chat_id", None)
+        message_id = getattr(event, "message_id", None)
+        if not chat_id or not message_id:
+            return
+        try:
+            await send_reaction(chat_id, message_id, str(emoji))
+        except Exception as exc:
+            logger.debug(
+                "Busy-queue reaction ack failed for session %s: %s",
+                event.source.chat_id,
+                exc,
+            )
+
     async def _prepare_busy_steer_text(self, event: MessageEvent) -> str:
         """Return steerable text for a busy follow-up, transcribing voice first.
 
@@ -9131,6 +9169,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         is_queue_mode = effective_mode == "queue"
         is_steer_mode = effective_mode == "steer"
         is_redirect_mode = effective_mode == "interrupt" and redirected
+
+        # #81632 — In queue mode the follow-up was enqueued for later; give
+        # the user instant visual confirmation via a platform reaction
+        # (display.busy_queue_ack_emoji, e.g. "⏳"). No-op when the setting
+        # is empty (default) or the adapter lacks reaction support.
+        if is_queue_mode and not steered and not redirected:
+            await self._maybe_ack_busy_queue_reaction(event)
 
         # If not in queue/steer mode, interrupt the running agent immediately.
         # This aborts in-flight tool calls and causes the agent loop to exit

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1125,6 +1125,10 @@ DEFAULT_CONFIG = {
         # "Steered into current run" confirmation bubble by setting this false.
         # The mid-turn steering itself still happens.
         "busy_steer_ack_enabled": True,
+        # When busy_input_mode="queue", react to each enqueued follow-up with
+        # this emoji (e.g. "⏳") for instant visual confirmation. Empty string
+        # (default) disables the reaction — enqueueing stays silent.
+        "busy_queue_ack_emoji": "",
         # Which interface bare `hermes` (and `hermes chat`) launches by default:
         #   "cli" — the classic prompt_toolkit REPL (default, preserves prior behavior)
         #   "tui" — the modern Ink TUI (same as passing `--tui`)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9933,6 +9933,10 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.debug("[%s] clear reactions failed: %s", self.name, _redact_telegram_error_text(e))
             return False
 
+    async def send_reaction(self, chat_id: str, message_id: str, emoji: str) -> bool:
+        """Best-effort emoji reaction (busy-queue acknowledgment flow)."""
+        return await self._set_reaction(chat_id, message_id, emoji)
+
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Add an in-progress reaction when message processing begins."""
         if not self._reactions_enabled():

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -450,6 +450,121 @@ class TestBusySessionOnboardingHint:
         assert cfg["onboarding"]["seen"]["busy_input_prompt"] is True
 
 
+class TestBusyQueueAckEmojiReaction:
+    """#81632 — busy_input_mode=queue reacts with display.busy_queue_ack_emoji."""
+
+    @pytest.mark.asyncio
+    async def test_queue_mode_reacts_when_emoji_configured(self, monkeypatch):
+        """Configured emoji → adapter.send_reaction called on enqueue."""
+        import gateway.run as _gr
+
+        monkeypatch.setattr(
+            _gr,
+            "_load_gateway_config",
+            lambda: {"display": {"busy_queue_ack_emoji": "⏳"}},
+        )
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        adapter = _make_adapter()
+        adapter.send_reaction = AsyncMock(return_value=True)
+
+        event = _make_event(text="follow-up")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        agent._active_children = []
+        runner._running_agents[sk] = agent
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        # Message was enqueued AND acknowledged with the configured emoji.
+        assert adapter._pending_messages.get(sk) is event
+        adapter.send_reaction.assert_awaited_once_with("123", "msg1", "⏳")
+
+    @pytest.mark.asyncio
+    async def test_queue_mode_no_reaction_when_emoji_empty(self, monkeypatch):
+        """Default (empty) emoji → no reaction, enqueueing stays silent."""
+        import gateway.run as _gr
+
+        monkeypatch.setattr(_gr, "_load_gateway_config", lambda: {})
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        adapter = _make_adapter()
+        adapter.send_reaction = AsyncMock(return_value=True)
+
+        event = _make_event(text="follow-up")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        agent._active_children = []
+        runner._running_agents[sk] = agent
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        assert adapter._pending_messages.get(sk) is event
+        adapter.send_reaction.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_steer_mode_never_reacts(self, monkeypatch):
+        """Steer mode (not queue) must not trigger the queue reaction."""
+        import gateway.run as _gr
+
+        monkeypatch.delenv("HERMES_GATEWAY_BUSY_STEER_ACK_ENABLED", raising=False)
+        monkeypatch.setattr(
+            _gr,
+            "_load_gateway_config",
+            lambda: {"display": {"busy_queue_ack_emoji": "⏳"}},
+        )
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "steer"
+        adapter = _make_adapter()
+        adapter.send_reaction = AsyncMock(return_value=True)
+
+        event = _make_event(text="steer me")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        agent._active_children = []
+        runner._running_agents[sk] = agent
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        agent.steer.assert_called_once_with("steer me")
+        adapter.send_reaction.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reaction_failure_never_breaks_enqueue(self, monkeypatch):
+        """A failing adapter reaction must not break the busy-message flow."""
+        import gateway.run as _gr
+
+        monkeypatch.setattr(
+            _gr,
+            "_load_gateway_config",
+            lambda: {"display": {"busy_queue_ack_emoji": "⏳"}},
+        )
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        adapter = _make_adapter()
+        adapter.send_reaction = AsyncMock(side_effect=RuntimeError("reaction boom"))
+
+        event = _make_event(text="follow-up")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        agent._active_children = []
+        runner._running_agents[sk] = agent
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        # Enqueue still happened despite the reaction failure.
+        assert adapter._pending_messages.get(sk) is event
+
+
 class TestLongRunningNotificationOwnership:
     """The long-running heartbeat must stop once its run no longer owns the
     session slot or the executor finished — otherwise a stale

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -170,6 +170,53 @@ class TestPlatformDefaults:
 
 
 # ---------------------------------------------------------------------------
+# busy_queue_ack_emoji (feature #81632)
+# ---------------------------------------------------------------------------
+
+class TestBusyQueueAckEmoji:
+    """display.busy_queue_ack_emoji — reaction ack for busy_input_mode=queue."""
+
+    def test_default_empty_disabled(self):
+        """Unset config resolves to '' — reaction ack disabled by default."""
+        from gateway.display_config import resolve_display_setting
+
+        assert resolve_display_setting({}, "telegram", "busy_queue_ack_emoji") == ""
+
+    def test_global_setting_resolved(self):
+        """display.busy_queue_ack_emoji is read from the global display block."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {"display": {"busy_queue_ack_emoji": "⏳"}}
+        assert resolve_display_setting(config, "telegram", "busy_queue_ack_emoji") == "⏳"
+
+    def test_per_platform_override_wins(self):
+        """display.platforms.<plat>.busy_queue_ack_emoji beats the global value."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "busy_queue_ack_emoji": "⏳",
+                "platforms": {"telegram": {"busy_queue_ack_emoji": "📥"}},
+            }
+        }
+        assert resolve_display_setting(config, "telegram", "busy_queue_ack_emoji") == "📥"
+        assert resolve_display_setting(config, "discord", "busy_queue_ack_emoji") == "⏳"
+
+    def test_empty_string_explicitly_disables(self):
+        """Explicit '' in config disables the ack even for the platform."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {"display": {"platforms": {"telegram": {"busy_queue_ack_emoji": ""}}}}
+        assert resolve_display_setting(config, "telegram", "busy_queue_ack_emoji") == ""
+
+    def test_overrideable_keys_includes_it(self):
+        """The new key participates in per-platform override validation."""
+        from gateway.display_config import OVERRIDEABLE_KEYS
+
+        assert "busy_queue_ack_emoji" in OVERRIDEABLE_KEYS
+
+
+# ---------------------------------------------------------------------------
 # Config migration: tool_progress_overrides → display.platforms
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
When `display.busy_input_mode=queue`, incoming messages during a busy turn are silently enqueued — no visual feedback that the message was received. This is asymmetric with `steer` mode, which has `busy_steer_ack_enabled` to confirm injection.

## Change
- New config `display.busy_queue_ack_emoji` (string, default empty = disabled) — mirrors the existing `busy_steer_ack_enabled` pattern (config.yaml only, no env var).
- `gateway/platforms/base.py`: new generic `async send_reaction(chat_id, message_id, emoji) -> bool` hook (no-op by default); adapters with reaction support override it.
- `plugins/platforms/telegram/adapter.py`: implements `send_reaction` delegating to the existing `_set_reaction` (Bot API `set_message_reaction`).
- `gateway/run.py`: `_maybe_ack_busy_queue_reaction(event)` — resolves the emoji via `resolve_display_setting`, no-op when empty/no adapter/no support, best-effort with try/except. Called at the FIFO enqueue point in `_handle_active_session_busy_message` when `is_queue_mode and not steered and not redirected`.

## Verification
- `tests/gateway/test_display_config.py` (5 new: default empty, global, per-platform override, explicit disable, key in OVERRIDEABLE_KEYS) + `tests/gateway/test_busy_session_ack.py` (4 new covering enqueue → reaction) + photon reactions flow: **39 passed**.

Closes #81632