### PR TITLE
fix(stt): honour configured compute_type on the Apple Silicon forced-CPU path

### DIFF
--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1597,11 +1597,18 @@ def _load_local_whisper_model(model_name: str, device: str = "auto", compute_typ
 
     from faster_whisper import WhisperModel
     if force_cpu:
+        # Stay on CPU to avoid the native device-autodetection crash, but honour
+        # an EXPLICIT ``stt.local.compute_type``. The crash this guard exists for
+        # is about DEVICE probing, not about quantisation, so silently replacing
+        # a user's configured compute_type with int8 discards configuration for
+        # no safety benefit. "auto"/unset still falls back to int8.
+        forced_compute = compute_type if compute_type and compute_type != "auto" else "int8"
         logger.info(
             "Apple Silicon/Rosetta detected — loading faster-whisper on CPU "
-            "(int8) to avoid native device autodetection crashes"
+            "(%s) to avoid native device autodetection crashes",
+            forced_compute,
         )
-        return WhisperModel(model_name, device="cpu", compute_type="int8")
+        return WhisperModel(model_name, device="cpu", compute_type=forced_compute)
 
     try:
         return WhisperModel(model_name, device=device, compute_type=compute_type)


### PR DESCRIPTION
## The bug

`_load_local_whisper_model` accepts a `compute_type` sourced from `stt.local.compute_type`, but the Apple Silicon/Rosetta forced-CPU branch returns early with a **hardcoded** `compute_type="int8"`, silently discarding the user's configuration:

```python
if force_cpu:
    logger.info("Apple Silicon/Rosetta detected — loading faster-whisper on CPU (int8) ...")
    return WhisperModel(model_name, device="cpu", compute_type="int8")   # <- config dropped
```

## This repo's own test already catches it

`test_config_device_and_compute_type_passed_to_whisper` — added for #8319, which exists *precisely* because these values must reach `WhisperModel` — asserts `compute_type="float32"` is forwarded. It passes in CI only because Linux runners never enter the forced-CPU branch. On any Apple Silicon machine, against unmodified `main`:

```
E       AssertionError: expected call not found.
E       Expected: mock('base', device='cpu', compute_type='float32')
E         Actual: mock('base', device='cpu', compute_type='int8')
```

## Why this is safe

The forced-CPU guard exists because native **device** autodetection aborts on some Apple Silicon/Rosetta installs (multiple Intel OpenMP runtimes loaded). That is orthogonal to **quantisation** — overriding an explicit `compute_type` buys no safety and loses configuration.

This keeps the guard's actual purpose (stay on CPU, no device probing) while honouring an explicit `compute_type`. `"auto"`/unset still falls back to `int8`, so default behaviour is unchanged. The log line now names the value actually used instead of always claiming `int8`.

## Verification

- **No test changes.** The existing test simply starts passing on macOS.
- `tests/tools/test_transcription_tools.py` → **50 passed** on this branch.
- **RED-proof:** reverting only this diff (`git checkout HEAD -- tools/transcription_tools.py`) turns that test RED again with the exact assertion above.