### PR TITLE
fix(gateway): stop typing before final delivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6108,6 +6108,14 @@ class BasePlatformAdapter(ABC):
                     except Exception as tts_err:
                         logger.warning("[%s] Auto-TTS failed: %s", self.name, tts_err)
 
+                # Stop the refresh loop before the first user-visible final
+                # delivery.  Telegram has no explicit "clear typing" action:
+                # if an in-flight refresh is processed after sendMessage, the
+                # client shows the bot typing for ~5 seconds after it replied.
+                # Cancelling and awaiting the task here closes that race while
+                # preserving the indicator during handler and TTS generation.
+                await _stop_typing_task()
+
                 # Play TTS audio before text (voice-first experience)
                 _tts_caption_delivered = False
                 _tts_cleanup_paths = {_tts_requested_path, _tts_path} - {None}

--- a/tests/gateway/test_ephemeral_reply.py
+++ b/tests/gateway/test_ephemeral_reply.py
@@ -182,9 +182,11 @@ async def test_process_message_unwraps_ephemeral_before_send():
     adapter.set_message_handler(_handler)
 
     sleeps: list[float] = []
+    real_sleep = asyncio.sleep
 
     async def _fake_sleep(duration):
         sleeps.append(duration)
+        await real_sleep(0)
 
     event = _make_event()
     session_key = "agent:main:telegram:private:42"
@@ -194,7 +196,7 @@ async def test_process_message_unwraps_ephemeral_before_send():
         await adapter._process_message_background(event, session_key)
         # Pump until the detached delete task completes.
         for _ in range(10):
-            await asyncio.sleep(0)
+            await real_sleep(0)
 
     # Sent text is the unwrapped string, NOT repr(EphemeralReply(...))
     adapter._send_with_retry.assert_called_once()

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1093,6 +1093,59 @@ async def test_base_processing_stops_typing_before_hung_post_delivery_callback(
 
 
 @pytest.mark.asyncio
+async def test_base_processing_stops_typing_before_final_delivery():
+    """The final response must be sent only after the typing refresh is stopped.
+
+    Telegram has no explicit "clear typing" API.  A refresh request that races
+    behind the final message leaves the bot visibly typing for up to five
+    seconds after it has already replied.
+    """
+    adapter = ProgressCaptureAdapter()
+    events = []
+
+    async def _handler(event):
+        await asyncio.sleep(0)
+        return "done"
+
+    async def _stop_typing(chat_id):
+        events.append("typing-stopped")
+        await ProgressCaptureAdapter.stop_typing(adapter, chat_id)
+
+    original_send_with_retry = adapter._send_with_retry
+
+    async def _record_final_delivery(*args, **kwargs):
+        events.append("final-delivery")
+        return await original_send_with_retry(*args, **kwargs)
+
+    adapter.set_message_handler(_handler)
+    adapter.stop_typing = _stop_typing
+    adapter._send_with_retry = _record_final_delivery
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        thread_id="4",
+    )
+    event = MessageEvent(
+        text="hello",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="msg-1",
+    )
+    session_key = "agent:main:telegram:group:-1001:4"
+    adapter._active_sessions[session_key] = asyncio.Event()
+
+    await asyncio.wait_for(
+        adapter._process_message_background(event, session_key), timeout=1.0
+    )
+
+    assert "typing-stopped" in events
+    assert "final-delivery" in events
+    assert events.index("typing-stopped") < events.index("final-delivery")
+
+
+@pytest.mark.asyncio
 async def test_run_agent_drops_tool_progress_after_generation_invalidation(monkeypatch, tmp_path):
     import yaml
 


### PR DESCRIPTION
## Summary
- stop the typing refresh task before the first user-visible final delivery
- prevent Telegram from showing a stale typing indicator after the bot replies
- add a behavior-level ordering regression test
- make the ephemeral-delete test yield the real event loop instead of depending on internal await count

## Verification
- 16 targeted gateway tests pass on the local runtime base
- the same 16 tests pass on current upstream/main
- regression test fails before the fix with order `final-delivery -> typing-stopped`