### PR TITLE
fix(kimi): send top-level reasoning_effort for K3 max

### DIFF
--- a/plugins/model-providers/kimi-coding/__init__.py
+++ b/plugins/model-providers/kimi-coding/__init__.py
@@ -87,7 +87,7 @@ class KimiProfile(ProviderProfile):
         # Enabled: prefer an explicit effort; only fall back to extra_body
         # thinking when no recognized effort is requested.
         effort = (reasoning_config.get("effort") or "").strip().lower()
-        if effort in {"low", "medium", "high"}:
+        if effort in {"low", "medium", "high", "max"}:
             top_level["reasoning_effort"] = effort
         else:
             extra_body["thinking"] = {"type": "enabled"}

--- a/tests/plugins/model_providers/test_kimi_profile.py
+++ b/tests/plugins/model_providers/test_kimi_profile.py
@@ -45,8 +45,10 @@ class TestKimiReasoningWireShape:
         assert extra_body == {"thinking": {"type": "enabled"}}
         assert top_level == {}
 
-    @pytest.mark.parametrize("effort", ["low", "medium", "high"])
+    @pytest.mark.parametrize("effort", ["low", "medium", "high", "max"])
     def test_explicit_effort_sends_effort_only(self, kimi_profile, effort):
+        """Known Kimi effort levels (incl. K3's ``max``) go out as the top-level
+        ``reasoning_effort`` — never paired with ``extra_body.thinking``."""
         extra_body, top_level = kimi_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": effort}
         )
@@ -60,9 +62,9 @@ class TestKimiReasoningWireShape:
         assert extra_body == {"thinking": {"type": "enabled"}}
         assert top_level == {}
 
-    @pytest.mark.parametrize("effort", ["", "garbage", "xhigh", "max"])
+    @pytest.mark.parametrize("effort", ["", "garbage", "xhigh"])
     def test_unrecognized_effort_falls_back_to_thinking(self, kimi_profile, effort):
-        """Unknown/strong efforts aren't in Moonshot's low|medium|high set, so
+        """Unknown/strong efforts aren't in Moonshot's low|medium|high|max set, so
         we drop to the thinking toggle rather than sending an invalid effort."""
         extra_body, top_level = kimi_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": effort}


### PR DESCRIPTION
K3's `reasoning_effort` supports `low`/`high`/`max` at the request top level, but the recognized-effort set in `KimiProfile.build_api_kwargs_extras` stopped at `high` — a `max` effort config silently fell back to the `extra_body.thinking` toggle instead of emitting `reasoning_effort=max`.

Add `"max"` to the set and cover it in the parametrized wire-shape test (tests updated: `max` moves from the unrecognized-effort list to the explicit-effort list).

Verified: 17/17 tests pass in `tests/plugins/model_providers/test_kimi_profile.py`; live `kimi-k3`/Kimi Code endpoint accepts `reasoning_effort=max`.