### PR TITLE
fix(terminal): preserve Hermes launcher after snapshot restore

### DIFF
--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -582,6 +582,30 @@ class TestHermesBinDirOnPath:
         from tools.environments import local as local_mod
         local_mod._HERMES_BIN_DIR = local_mod._SENTINEL
 
+    def test_prefers_sibling_deployment_launcher_over_venv_which(self, monkeypatch):
+        from tools.environments import local as local_mod
+
+        self._reset_cache()
+        monkeypatch.setattr(local_mod.sys, "executable", "/opt/hermes/.venv/bin/python")
+        monkeypatch.setattr(
+            local_mod.shutil,
+            "which",
+            lambda name: "/opt/hermes/.venv/bin/hermes" if name == "hermes" else None,
+        )
+        monkeypatch.setattr(
+            local_mod.os.path,
+            "isfile",
+            lambda path: path == "/opt/hermes/bin/hermes",
+        )
+        monkeypatch.setattr(
+            local_mod.os.path, "isdir", lambda path: path == "/opt/hermes/bin"
+        )
+        monkeypatch.setattr(local_mod.os, "access", lambda path, mode: True)
+        try:
+            assert local_mod._resolve_hermes_bin_dir() == "/opt/hermes/bin"
+        finally:
+            self._reset_cache()
+
     def test_resolves_via_which(self, monkeypatch):
         from tools.environments import local as local_mod
         self._reset_cache()
@@ -609,6 +633,54 @@ class TestHermesBinDirOnPath:
         entries = result["PATH"].split(os.pathsep)
         assert entries[0] == "/opt/hermes/bin"
         assert "/usr/bin" in entries
+
+    def test_post_snapshot_repair_uses_git_bash_path_on_windows(self, monkeypatch):
+        from tools.environments import local as local_mod
+
+        local_mod._HERMES_BIN_DIR = r"C:\Users\Test User\hermes\Scripts"
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+
+        env = object.__new__(LocalEnvironment)
+        try:
+            commands = env._post_snapshot_restore_commands()
+            assert commands[0] == (
+                "__hermes_bin_dir='/c/Users/Test User/hermes/Scripts'"
+            )
+        finally:
+            self._reset_cache()
+
+    @pytest.mark.skipif(os.name == "nt", reason="uses a POSIX executable fixture")
+    def test_snapshot_cannot_remove_hermes_bin_dir(self, tmp_path):
+        """A persisted PATH must not undo the local backend runtime invariant."""
+        from tools.environments import local as local_mod
+
+        fake_bin = tmp_path / "hermes bin"
+        fake_bin.mkdir()
+        fake_hermes = fake_bin / "hermes"
+        fake_hermes.write_text("#!/bin/sh\nprintf 'snapshot-safe\\n'\n")
+        fake_hermes.chmod(0o755)
+
+        local_mod._HERMES_BIN_DIR = str(fake_bin)
+        env = LocalEnvironment(cwd=str(tmp_path), timeout=10)
+        try:
+            # Simulate a snapshot written by an older session or by a command
+            # that replaced PATH after _make_run_env() had repaired it.
+            with open(env._snapshot_path, "w", encoding="utf-8") as snapshot:
+                snapshot.write('declare -x PATH="/usr/bin:/bin"\n')
+            env._snapshot_ready = True
+
+            result = env.execute(
+                'printf "PATH=%s\\n" "$PATH"; command -v hermes && hermes',
+                timeout=10,
+            )
+
+            assert result["returncode"] == 0
+            assert f"PATH={fake_bin}:/usr/bin:/bin" in result["output"]
+            assert str(fake_hermes) in result["output"]
+            assert "snapshot-safe" in result["output"]
+        finally:
+            env.cleanup()
+            self._reset_cache()
 
 
 class TestHermesInternalDynamicSecrets:

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -643,6 +643,61 @@ class TestPruning:
 # =========================================================================
 
 class TestSpawnEnvSanitization:
+    @pytest.mark.skipif(sys.platform == "win32", reason="requires POSIX bash")
+    def test_local_shell_command_repairs_path_after_profile_reset(
+        self, tmp_path, monkeypatch
+    ):
+        from tools.environments import local as local_mod
+        from tools import process_registry as process_mod
+
+        runtime_bin = tmp_path / "hermes bin"
+        runtime_bin.mkdir()
+        hermes = runtime_bin / "hermes"
+        hermes.write_text("#!/bin/sh\nexit 0\n")
+        hermes.chmod(0o755)
+
+        monkeypatch.setattr(
+            local_mod, "_resolve_hermes_bin_dir", lambda: str(runtime_bin)
+        )
+        monkeypatch.setattr(
+            process_mod,
+            "_hermes_path_repair_commands",
+            local_mod._hermes_path_repair_commands,
+        )
+
+        shell_command = process_mod._build_local_shell_command("command -v hermes")
+        result = subprocess.run(
+            ["/bin/bash", "-c", f"export PATH=/usr/bin:/bin; {shell_command}"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == str(hermes)
+
+    def test_spawn_local_injects_path_repair_into_pipe_shell(self, registry):
+        captured = {}
+
+        def fake_popen(cmd, **kwargs):
+            captured["cmd"] = cmd
+            proc = MagicMock()
+            proc.pid = 4321
+            proc.stdout = iter([])
+            proc.poll.return_value = None
+            return proc
+
+        with patch(
+            "tools.process_registry._hermes_path_repair_commands",
+            return_value=("repair-hermes-path",),
+        ), patch("tools.process_registry._find_shell", return_value="/bin/bash"), \
+            patch("subprocess.Popen", side_effect=fake_popen), \
+            patch("threading.Thread", return_value=MagicMock()), \
+            patch.object(registry, "_write_checkpoint"):
+            registry.spawn_local("echo hello", cwd="/tmp")
+
+        assert captured["cmd"][2] == "set +m; repair-hermes-path; echo hello"
+
     def test_spawn_local_strips_blocked_vars_from_background_env(self, registry):
         captured = {}
 
@@ -863,6 +918,10 @@ class TestSpawnRewriteCompoundBackground:
         fake_thread.daemon = False
 
         with patch("tools.process_registry._find_shell", return_value="/bin/bash"), \
+             patch(
+                 "tools.process_registry._hermes_path_repair_commands",
+                 return_value=("repair-hermes-path",),
+             ), \
              patch("tools.process_registry._IS_WINDOWS", False), \
              patch.dict("sys.modules", {"ptyprocess": mock_pty_module}), \
              patch("threading.Thread", return_value=fake_thread), \
@@ -876,6 +935,7 @@ class TestSpawnRewriteCompoundBackground:
         assert mock_pty_module.PtyProcess.spawn.called, \
             "PTY spawn should have been attempted"
         pty_args = mock_pty_module.PtyProcess.spawn.call_args[0][0]
+        assert pty_args[2].startswith("set +m; repair-hermes-path; ")
         assert "&& { node server.js & }" in pty_args[2], \
             f"PTY path should use rewritten command, got: {pty_args[2]}"
         assert session.command == "cd /app && node server.js &"
@@ -1648,6 +1708,13 @@ class TestSystemdCgroupIsolation:
     cgroup, so an OOM in a memory-heavy worker lets systemd-oomd kill the
     ENTIRE gateway cgroup, taking down the messaging control plane.
     """
+
+    @pytest.fixture(autouse=True)
+    def _isolate_cgroup_behavior_from_path_repair(self, monkeypatch):
+        """Keep this suite focused on argv/cgroup wrapping, not PATH policy."""
+        monkeypatch.setattr(
+            "tools.process_registry._hermes_path_repair_commands", lambda: ()
+        )
 
     def _fake_popen_capture(self):
         """Return (fake_popen, captured) where captured["argv"] gets the

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -804,6 +804,16 @@ class BaseEnvironment(ABC):
         """
         return shlex.quote(path)
 
+    def _post_snapshot_restore_commands(self) -> tuple[str, ...]:
+        """Return backend-specific shell commands to run after snapshot restore.
+
+        A session snapshot intentionally restores user environment changes from
+        earlier terminal calls. Backends may nevertheless have runtime PATH or
+        environment invariants that must survive a stale/user-modified snapshot.
+        The default is a no-op; overrides must not include user command data.
+        """
+        return ()
+
     def _wrap_command(self, command: str, cwd: str) -> str:
         """Build the full bash script that sources snapshot, cd's, runs command,
         re-dumps env vars, and emits CWD markers."""
@@ -857,6 +867,11 @@ class BaseEnvironment(ABC):
                 f'else unset {name}; fi'
             )
             parts.append(f"unset {present} {value}")
+
+        # Re-assert backend runtime invariants after the snapshot has restored
+        # persisted environment variables. Doing this before ``source`` would
+        # be ineffective because a stale snapshot can overwrite them again.
+        parts.extend(self._post_snapshot_restore_commands())
 
         # Preserve bare ``~`` expansion, but rewrite ``~/...`` through
         # ``$HOME`` so suffixes with spaces remain a single shell word.

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1083,10 +1083,13 @@ def _resolve_hermes_bin_dir() -> str | None:
     regardless of how the gateway was started.
 
     Resolution order (cheap, no heavy imports):
-      1. ``shutil.which("hermes")`` — normal PATH-installed shim.
-      2. The directory of ``sys.argv[0]`` when it's an absolute path to a
+      1. A deployment launcher next to the active ``.venv``
+         (``<install-root>/bin/hermes``). Container/service installs may put a
+         policy shim there while their process PATH points at the venv first.
+      2. ``shutil.which("hermes")`` — normal PATH-installed shim.
+      3. The directory of ``sys.argv[0]`` when it's an absolute path to a
          real ``hermes`` executable (covers nix-store / venv wrappers).
-      3. The directory of ``sys.executable`` — the running interpreter's
+      4. The directory of ``sys.executable`` — the running interpreter's
          venv ``bin``/``Scripts`` is where its console-scripts live.
     """
     global _HERMES_BIN_DIR
@@ -1095,9 +1098,24 @@ def _resolve_hermes_bin_dir() -> str | None:
 
     candidate: str | None = None
 
-    which = shutil.which("hermes")
-    if which:
-        candidate = os.path.dirname(which)
+    # Service/container distributions can ship a policy launcher alongside
+    # the active .venv (for example privilege alignment in Docker). Activating
+    # the venv puts its raw console-script first on the parent PATH, so ``which``
+    # alone would silently bypass that supported launcher.
+    exe_dir = os.path.dirname(sys.executable) if sys.executable else ""
+    venv_dir = os.path.dirname(exe_dir) if exe_dir else ""
+    if os.path.basename(venv_dir) == ".venv":
+        deployment_dir = os.path.join(os.path.dirname(venv_dir), "bin")
+        deployment_shim = os.path.join(
+            deployment_dir, "hermes.exe" if _IS_WINDOWS else "hermes"
+        )
+        if os.path.isfile(deployment_shim) and os.access(deployment_shim, os.X_OK):
+            candidate = deployment_dir
+
+    if candidate is None:
+        which = shutil.which("hermes")
+        if which:
+            candidate = os.path.dirname(which)
 
     if candidate is None:
         argv0 = sys.argv[0] if sys.argv else ""
@@ -1138,6 +1156,27 @@ def _prepend_hermes_bin_dir(existing_path: str) -> str:
     if bin_dir in entries:
         return existing_path
     return sep.join([bin_dir, *entries])
+
+
+def _hermes_path_repair_commands() -> tuple[str, ...]:
+    """Return shell commands that preserve the resolved Hermes launcher on PATH.
+
+    Login profiles and persisted environment snapshots may replace the process
+    PATH after ``_make_run_env`` repaired it. Keep this shell-side invariant in
+    one place so foreground, background, and PTY execution use identical
+    quoting and deduplication semantics.
+    """
+    bin_dir = _resolve_hermes_bin_dir()
+    if not bin_dir:
+        return ()
+
+    quoted_bin_dir = _quote_bash_path(bin_dir)
+    return (
+        f"__hermes_bin_dir={quoted_bin_dir}",
+        'case ":${PATH-}:" in *":$__hermes_bin_dir:"*) ;; '
+        '*) export PATH="$__hermes_bin_dir${PATH:+:$PATH}" ;; esac',
+        "unset __hermes_bin_dir",
+    )
 
 
 def _managed_runtime_path_entries() -> list[str]:
@@ -1482,6 +1521,17 @@ class LocalEnvironment(BaseEnvironment):
     def _quote_shell_path(self, path: str) -> str:
         """Rewrite native/mixed Windows paths before quoting for Git Bash."""
         return _quote_bash_path(path)
+
+    def _post_snapshot_restore_commands(self) -> tuple[str, ...]:
+        """Keep the Hermes console-script reachable after snapshot restore.
+
+        ``_make_run_env`` repairs PATH for the child process, but the persisted
+        session snapshot is sourced afterwards and may replace PATH with an old
+        or user-modified value. Re-assert the same invariant in the shell after
+        sourcing so bare ``hermes`` remains available without discarding any
+        user PATH entries.
+        """
+        return _hermes_path_repair_commands()
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -43,7 +43,12 @@ import uuid
 from pathlib import Path
 
 _IS_WINDOWS = platform.system() == "Windows"
-from tools.environments.local import _find_shell, _resolve_safe_cwd, _sanitize_subprocess_env
+from tools.environments.local import (
+    _find_shell,
+    _hermes_path_repair_commands,
+    _resolve_safe_cwd,
+    _sanitize_subprocess_env,
+)
 from hermes_cli._subprocess_compat import windows_hide_flags
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
@@ -53,6 +58,11 @@ from hermes_cli.config import get_hermes_home
 from agent.redact import redact_sensitive_text
 
 logger = logging.getLogger(__name__)
+
+
+def _build_local_shell_command(command: str) -> str:
+    """Build a local login-shell command with Hermes' PATH invariant restored."""
+    return "; ".join(("set +m", *_hermes_path_repair_commands(), command))
 
 
 # Checkpoint file for crash recovery (gateway only)
@@ -965,6 +975,7 @@ class ProcessRegistry:
         from tools.terminal_tool import _rewrite_compound_background as _rewrite_bg
 
         safe_command = _rewrite_bg(command)
+        shell_command = _build_local_shell_command(safe_command)
 
         session = ProcessSession(
             id=f"proc_{uuid.uuid4().hex[:12]}",
@@ -986,7 +997,7 @@ class ProcessRegistry:
                 user_shell = _find_shell()
                 pty_env = _sanitize_subprocess_env(os.environ, env_vars)
                 pty_env["PYTHONUNBUFFERED"] = "1"
-                pty_argv = [user_shell, "-lic", f"set +m; {safe_command}"]
+                pty_argv = [user_shell, "-lic", shell_command]
 
                 # Cgroup isolation for PTY mode (#70716, reviewer gap #1):
                 # Wrap the PTY command in a systemd scope so interactive
@@ -1079,7 +1090,7 @@ class ProcessRegistry:
         # kills only the worker instead of taking down the whole gateway
         # cgroup (and the messaging control plane with it).  We only do this
         # for both pipe mode and the PTY path above.
-        shell_argv = [user_shell, "-lic", f"set +m; {safe_command}"]
+        shell_argv = [user_shell, "-lic", shell_command]
         use_systemd_scope = False
         under_supervisor = False
         try:


### PR DESCRIPTION
## Summary
- restore the Hermes launcher directory after a persisted shell-environment snapshot is loaded
- apply the same invariant to foreground, background-pipe, and PTY command paths
- prefer the deployment launcher (`<root>/bin/hermes`) without exposing the whole Hermes venv in the general `PATH`
- preserve existing user `PATH` entries and shell quoting

## Reproduction
A persisted snapshot can replace a valid executor environment with a reduced `PATH` such as `/usr/local/bin:/usr/bin:/bin`. The subsequent login-shell command then cannot resolve `hermes`, even though the deployment launcher exists and the initial run environment was correct.

## Validation
- `160 passed` across the focused environment/terminal/process-registry suites
- `74 passed` across Windows/MSYS compatibility suites
- Ruff clean and `git diff --check` clean
- real reduced-PATH smoke resolves `hermes` to `/opt/hermes/bin/hermes` while `python3` remains `/usr/bin/python3`
