### PR TITLE
fix(tui): don't resurrect cleared slash text when an image attach resolves

### DIFF
--- a/ui-tui/src/__tests__/useComposerState.test.ts
+++ b/ui-tui/src/__tests__/useComposerState.test.ts
@@ -1,6 +1,41 @@
 import { describe, expect, it } from 'vitest'
 
-import { looksLikeDroppedPath } from '../app/useComposerState.js'
+import { looksLikeDroppedPath, mergeAttachmentResult } from '../app/useComposerState.js'
+
+describe('mergeAttachmentResult (stale-capture guard)', () => {
+  it('keeps the captured value when the line did not change', () => {
+    const next = { value: '/image /tmp/a.png[[ Image 1 ]]', cursor: 22 }
+
+    expect(mergeAttachmentResult('/image /tmp/a.png', '/image /tmp/a.png', next)).toBe(
+      '/image /tmp/a.png[[ Image 1 ]]'
+    )
+  })
+
+  it('drops the stale slash text when the submit cleared the line', () => {
+    // A `/image` slash submits the slash text and clears the line before the
+    // attach RPC resolves; the resolved token must not resurrect the
+    // submitted `/image <path>` text (the 2^n-1 marker-accumulation bug).
+    const next = { value: '/image /tmp/a.png[[ Image 1 ]]', cursor: 22 }
+
+    expect(mergeAttachmentResult('/image /tmp/a.png', '', next)).toBe('[[ Image 1 ]]')
+  })
+
+  it('preserves text typed while the attach was in flight', () => {
+    const next = { value: 'a[[ Image 1 ]]', cursor: 1 }
+
+    expect(mergeAttachmentResult('a', 'abc', next)).toBe('abc[[ Image 1 ]]')
+  })
+
+  it('keeps the caption that followed the path on a drag-drop attach', () => {
+    // Drag-drop of "~/shot.png look at this" attaches with a caption; the
+    // line is not cleared in that flow, so the full value is kept.
+    const next = { value: '~/shot.png[[ Image 1 ]] look at this', cursor: 31 }
+
+    expect(mergeAttachmentResult('~/shot.png', '~/shot.png', next)).toBe(
+      '~/shot.png[[ Image 1 ]] look at this'
+    )
+  })
+})
 
 describe('looksLikeDroppedPath', () => {
   it('recognizes macOS screenshot temp paths and file URIs', () => {

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -33,6 +33,30 @@ import { getUiState } from './uiStore.js'
 const TOKEN_MAX_COUNT = 32
 const TOKEN_MAX_TOTAL_BYTES = 4 * 1024 * 1024
 
+/**
+ * Merge an asynchronously-resolved attachment result into the composer line.
+ *
+ * `next.value` is built from the `captured` line at the time the attach RPC
+ * was issued. The line can change while the RPC is in flight — most notably a
+ * `/image` slash command, which submits the slash text and CLEARS the line
+ * before the token lands. Writing the stale captured value back would
+ * resurrect the submitted `/image <path>` text; every subsequent Enter would
+ * re-run it and re-attach the same image, doubling the `[[ Image N ]]`
+ * markers each time (1 → 3 → 7 → …). When the line changed, keep only the NEW
+ * text (token + caption) and append it to the current line.
+ */
+export const mergeAttachmentResult = (
+  captured: string,
+  current: string,
+  next: ComposerPasteResult
+): string => {
+  if (current === captured) {
+    return next.value
+  }
+
+  return current + next.value.slice(captured.length)
+}
+
 const trimTokens = (tokens: ComposerToken[]): ComposerToken[] => {
   let total = 0
   const out: ComposerToken[] = []
@@ -354,7 +378,14 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
 
       void attach(current, current.length).then(next => {
         if (next) {
-          setInput(next.value)
+          // The attach RPC resolves asynchronously; the line may have been
+          // cleared or edited while it was in flight. A `/image` slash
+          // command submits the slash text and clears the line, then the
+          // token lands — writing the STALE captured value back would
+          // resurrect the submitted `/image <path>` text, and every
+          // subsequent Enter would re-run it and re-attach the same image
+          // (the `[[ Image N ]]` markers double each time: 1 → 3 → 7 → …).
+          setInput(mergeAttachmentResult(current, inputRef.current, next))
         }
       })
     },


### PR DESCRIPTION
Fixes #81611

## Root cause

`appendAttachment` in `ui-tui/src/app/useComposerState.ts` captured the composer line *before* the attach RPC (`const current = inputRef.current`) and wrote that stale value back on resolution:

```ts
void attach(current, current.length).then(next => {
  if (next) setInput(next.value)   // ← stale: resurrects submitted slash text
})
```

A `/image <path>` slash command (which the dashboard drives on image paste: burst `/image <path>` then Return, `web/src/pages/ChatPage.tsx`) submits the slash text and **clears the line** *before* the `image.attach` RPC resolves. When the token then lands, `setInput(next.value)` resurrects the submitted `/image <path>` text on top of the fresh token. Every subsequent Enter re-submits `/image <path> [[ Image N ]]` as a slash: the gateway re-attaches the same file and returns the trailing markers as `remainder`, which is inserted again — the markers double each time (1 → 3 → 7 → …) until the composer is unusable.

## Fix

New pure helper `mergeAttachmentResult(captured, current, next)`:

- line unchanged → keep the full resolved value (normal paste, drag-drop with caption)
- line changed (slash cleared it, user typed meanwhile) → keep only the NEW text (token + caption, `next.value.slice(captured.length)`) appended to the **current** line, never the stale captured text

This fixes the whole bug class: any async attach whose RPC resolves after the composer was cleared no longer resurrects the submitted command text, so Enter can't re-run it.

## Validation

- `useComposerState.test.ts` — 13/13 (4 new regression tests: cleared-line, unchanged-line, in-flight-typing, caption attach)
- `attachments.test.ts` + `queueSubmission.test.ts` — 18/18
- Full ui-tui suite: 1418 passed; the only failing test (`widgetSdk` error-chip, loaders) fails identically without this change on this checkout (incomplete workspace `node_modules` — lodash-es/chalk/emoji-regex missing), i.e. pre-existing and unrelated.
