### PR TITLE
fix(tools): don't flag UTF-8 files as binary when the 1000-byte sample cut splits a multi-byte char

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -673,3 +673,48 @@ class TestReadNonUtf8IsBinary:
         ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
         # Proper UTF-8 (including non-ASCII) must still read as text.
         assert ops._is_likely_binary("notes.txt", "café résumé\nsecond\n") is False
+
+    def test_trailing_replacement_char_from_sample_cut_not_binary(self, tmp_path):
+        """`head -c 1000` can cut inside a multi-byte UTF-8 char; the terminal
+        decode turns the truncated tail byte into a TRAILING U+FFFD. That is a
+        sampling artifact — a valid UTF-8 CJK document must not be flagged
+        binary (#81651)."""
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        # 998 ASCII bytes + a truncated 3-byte CJK char → one trailing U+FFFD.
+        sample = ("x" * 998) + "\ufffd"
+        assert ops._is_likely_binary("notes.md", sample) is False
+
+    def test_internal_replacement_char_still_flagged_binary(self, tmp_path):
+        """A genuine non-UTF-8 byte anywhere EXCEPT the sample's trailing edge
+        is still binary — only the cut-artifact U+FFFD chars are ignored."""
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        assert ops._is_likely_binary("notes.txt", "\ufffd" + "ok" * 500) is True
+
+    def test_read_file_cjk_cut_mid_char_returns_text(self, tmp_path):
+        """End-to-end: a UTF-8 CJK file whose 1000-byte sample cut lands
+        inside a character reads as text, not binary."""
+        # The production terminal env decodes stdout with errors="replace"
+        # (a truncated UTF-8 tail byte arrives as U+FFFD); mirror that here.
+        env = MagicMock()
+        env.cwd = str(tmp_path)
+
+        def execute(command, **kwargs):
+            completed = subprocess.run(
+                command,
+                shell=True,
+                text=True,
+                capture_output=True,
+                errors="replace",
+                input=kwargs.get("stdin_data"),
+            )
+            return {"output": completed.stdout, "returncode": completed.returncode}
+
+        env.execute = execute
+        ops = ShellFileOperations(env)
+        path = tmp_path / "doc.md"
+        # 998 ASCII bytes then a 3-byte CJK char = 1001 bytes total; the
+        # `head -c 1000` sample ends one byte into the CJK char.
+        path.write_text(("x" * 998) + "中", encoding="utf-8")
+        result = ops.read_file(str(path))
+        assert result.is_binary is False
+        assert result.error is None

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -903,11 +903,22 @@ class ShellFileOperations(FileOperations):
             # sample carries the replacement char as binary (read-only) so the
             # agent can't corrupt it. Legitimate UTF-8 text effectively never
             # contains U+FFFD.
-            if "\ufffd" in content_sample[:1000]:
+            #
+            # Exception: `head -c 1000` can cut INSIDE a multi-byte UTF-8
+            # character (CJK chars are 3 bytes), and the terminal decode turns
+            # that truncated tail byte into a U+FFFD at the very END of the
+            # sample. That replacement char is a sampling artifact, not file
+            # content — a valid UTF-8 CJK document would be flagged binary on
+            # every read (#81651). A real U+FFFD is visible in the read
+            # content, so stripping trailing ones does not create silent
+            # corruption; genuine non-UTF-8 bytes in the middle of the sample
+            # are still caught below.
+            sample = content_sample.rstrip("\ufffd")
+            if "\ufffd" in sample[:1000]:
                 return True
-            non_printable = sum(1 for c in content_sample[:1000]
+            non_printable = sum(1 for c in sample[:1000]
                                if ord(c) < 32 and c not in '\n\r\t')
-            return non_printable / min(len(content_sample), 1000) > 0.30
+            return non_printable / min(len(sample), 1000) > 0.30
         
         return False
     


### PR DESCRIPTION
Fixes #81651

## Root cause

`read_file` samples the first 1000 bytes via `head -c 1000`. The terminal env decodes stdout with `errors="replace"`, so when the cut lands **inside** a multi-byte UTF-8 character (CJK chars are 3 bytes), the truncated tail byte arrives as a `U+FFFD` replacement character. `_is_likely_binary` treats **any** `U+FFFD` in the sample as binary content — so a perfectly valid UTF-8 CJK document was flagged `Binary file` deterministically (same file, same cut position → always binary).

## Fix

In `_is_likely_binary`, strip **trailing** `U+FFFD` chars before the check — that's the cut artifact:

```python
sample = content_sample.rstrip("\ufffd")
```

- A genuine non-UTF-8 byte anywhere else in the sample is still flagged binary, so the read→edit→write mojibake guard (the reason `U+FFFD` was treated as binary in the first place) is preserved.
- A real `U+FFFD` remains visible in the read content, so it can't corrupt silently.
- The non-printable-ratio check still covers real binary files.

## Validation

- `TestReadNonUtf8IsBinary`: **5/5** — new cases: trailing-U+FFFD sample is text, internal-U+FFFD still binary, and an end-to-end `read_file` of a file whose 1000-byte cut splits a CJK char returns text.
- Full `test_file_operations.py` + `test_file_operations_edge_cases.py`: **70/70 passed**.
