### PR TITLE
fix(tools): reach the STT transcode-and-retry path on 5xx container rejections

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -1230,3 +1230,79 @@ class TestRunCommandSttIdleTimeout:
             )
 
         assert "starting pass 1" in (excinfo.value.stderr or "")
+
+
+# ============================================================================
+# _transcribe_openai — 5xx transcode-and-retry (#81644)
+# ============================================================================
+
+
+class TestTranscribeOpenaiFiveXxRetry:
+    """A 5xx rejection of the audio container must reach the
+    transcode-and-retry path, not propagate as a plain API error."""
+
+    def _status_error(self, status_code: int, message: str) -> Exception:
+        import httpx
+        from openai import APIStatusError
+
+        request = httpx.Request(
+            "POST", "https://api.example.com/v1/audio/transcriptions"
+        )
+        return APIStatusError(
+            message,
+            response=httpx.Response(status_code, request=request),
+            body={"type": "system_error"},
+        )
+
+    def test_server_error_triggers_transcode_and_retry(self, sample_wav, tmp_path):
+        """The provider rejects the container with a 5xx (the gapgpt case in
+        #81644): the transcode-and-retry must run and succeed."""
+        converted = tmp_path / "retry.m4a"
+        converted.write_bytes(b"fake audio")
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create.side_effect = [
+            self._status_error(503, "503 system_error"),  # first attempt: 5xx
+            "retried transcript",                          # retry after transcode
+        ]
+
+        with patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("openai.OpenAI", return_value=mock_client), \
+             patch(
+                 "tools.transcription_tools._transcode_audio_for_stt",
+                 return_value=(str(converted), None),
+             ):
+            from tools.transcription_tools import _transcribe_openai
+            result = _transcribe_openai(
+                sample_wav, "gpt-4o-transcribe", api_key="sk-test"
+            )
+
+        assert result["success"] is True
+        assert result["transcript"] == "retried transcript"
+        assert mock_client.audio.transcriptions.create.call_count == 2
+
+    def test_container_400_still_transcodes(self, sample_wav, tmp_path):
+        """The original 400-with-container-hint path keeps working."""
+        converted = tmp_path / "retry.m4a"
+        converted.write_bytes(b"fake audio")
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create.side_effect = [
+            self._status_error(
+                400, "Invalid file format: unsupported audio container"
+            ),
+            "retried transcript",
+        ]
+
+        with patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("openai.OpenAI", return_value=mock_client), \
+             patch(
+                 "tools.transcription_tools._transcode_audio_for_stt",
+                 return_value=(str(converted), None),
+             ):
+            from tools.transcription_tools import _transcribe_openai
+            result = _transcribe_openai(
+                sample_wav, "whisper-1", api_key="sk-test"
+            )
+
+        assert result["success"] is True
+        assert result["transcript"] == "retried transcript"
+        assert mock_client.audio.transcriptions.create.call_count == 2

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -1349,3 +1349,77 @@ class TestExplicitOpenaiSelectionError:
 
         assert result["success"] is False
         assert "No STT provider available" in result["error"]
+
+# _transcribe_openai — 5xx transcode-and-retry (#81644)
+# ============================================================================
+
+
+class TestTranscribeOpenaiFiveXxRetry:
+    """A 5xx rejection of the audio container must reach the
+    transcode-and-retry path, not propagate as a plain API error."""
+
+    def _status_error(self, status_code: int, message: str) -> Exception:
+        import httpx
+        from openai import APIStatusError
+
+        request = httpx.Request(
+            "POST", "https://api.example.com/v1/audio/transcriptions"
+        )
+        return APIStatusError(
+            message,
+            response=httpx.Response(status_code, request=request),
+            body={"type": "system_error"},
+        )
+
+    def test_server_error_triggers_transcode_and_retry(self, sample_wav, tmp_path):
+        """The provider rejects the container with a 5xx (the gapgpt case in
+        #81644): the transcode-and-retry must run and succeed."""
+        converted = tmp_path / "retry.m4a"
+        converted.write_bytes(b"fake audio")
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create.side_effect = [
+            self._status_error(503, "503 system_error"),  # first attempt: 5xx
+            "retried transcript",                          # retry after transcode
+        ]
+
+        with patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("openai.OpenAI", return_value=mock_client), \
+             patch(
+                 "tools.transcription_cloud._transcode_audio_for_stt",
+                 return_value=(str(converted), None),
+             ):
+            from tools.transcription_tools import _transcribe_openai
+            result = _transcribe_openai(
+                sample_wav, "gpt-4o-transcribe", api_key="sk-test"
+            )
+
+        assert result["success"] is True
+        assert result["transcript"] == "retried transcript"
+        assert mock_client.audio.transcriptions.create.call_count == 2
+
+    def test_container_400_still_transcodes(self, sample_wav, tmp_path):
+        """The original 400-with-container-hint path keeps working."""
+        converted = tmp_path / "retry.m4a"
+        converted.write_bytes(b"fake audio")
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create.side_effect = [
+            self._status_error(
+                400, "Invalid file format: unsupported audio container"
+            ),
+            "retried transcript",
+        ]
+
+        with patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("openai.OpenAI", return_value=mock_client), \
+             patch(
+                 "tools.transcription_cloud._transcode_audio_for_stt",
+                 return_value=(str(converted), None),
+             ):
+            from tools.transcription_tools import _transcribe_openai
+            result = _transcribe_openai(
+                sample_wav, "whisper-1", api_key="sk-test"
+            )
+
+        assert result["success"] is True
+        assert result["transcript"] == "retried transcript"
+        assert mock_client.audio.transcriptions.create.call_count == 2

--- a/tools/transcription_cloud.py
+++ b/tools/transcription_cloud.py
@@ -128,7 +128,7 @@ def _transcribe_openai(
         model_name = DEFAULT_STT_MODEL
 
     def _run(client):
-        from openai import BadRequestError
+        from openai import APIStatusError
 
         def _create_transcription(path: str):
             create_kwargs: Dict[str, Any] = {
@@ -148,8 +148,16 @@ def _transcribe_openai(
         with tempfile.TemporaryDirectory(prefix="hermes-stt-") as work_dir:
             try:
                 transcription = _create_transcription(file_path)
-            except BadRequestError as exc:
-                if not any(k in str(exc).lower() for k in ("unsupported", "corrupted", "invalid file")):
+            except APIStatusError as exc:
+                message = str(exc).lower()
+                # 400s with a container hint mean the audio container was rejected. Some
+                # OpenAI-compatible endpoints (e.g. the gapgpt case in #81644) instead reject
+                # unsupported containers with a 5xx, which never reached this retry path. 5xx is
+                # otherwise ambiguous, but the transcode is cheap and the retry is a single
+                # attempt, so escalate to it whenever the provider hints at a bad container OR
+                # returned a 5xx.
+                is_server_error = (exc.status_code or 0) >= 500
+                if not is_server_error and not any(k in message for k in ("unsupported", "corrupted", "invalid file")):
                     raise
                 # Newer models reject containers whisper-1 accepted (Ogg/Opus voice notes): transcode, retry once.
                 converted_path, transcode_error = _transcode_audio_for_stt(file_path, work_dir)

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2070,7 +2070,7 @@ def _transcribe_openai(
             APIError,
             APIConnectionError,
             APITimeoutError,
-            BadRequestError,
+            APIStatusError,
         )
         client = OpenAI(api_key=api_key, base_url=base_url, timeout=30, max_retries=0)
 
@@ -2096,9 +2096,21 @@ def _transcribe_openai(
             with tempfile.TemporaryDirectory(prefix="hermes-stt-") as work_dir:
                 try:
                     transcription = _create_transcription(file_path)
-                except BadRequestError as exc:
+                except APIStatusError as exc:
                     message = str(exc).lower()
-                    if not any(k in message for k in ("unsupported", "corrupted", "invalid file")):
+                    # 400s with a container hint mean the audio container was
+                    # rejected. Some OpenAI-compatible endpoints (e.g. the
+                    # gapgpt case in #81644) instead reject unsupported
+                    # containers with a 5xx, which never reached this retry
+                    # path. 5xx is otherwise ambiguous, but the transcode is
+                    # cheap and the retry is a single attempt, so escalate to
+                    # it whenever the provider hints at a bad container OR
+                    # returned a 5xx.
+                    is_server_error = (exc.status_code or 0) >= 500
+                    if (
+                        not is_server_error
+                        and not any(k in message for k in ("unsupported", "corrupted", "invalid file"))
+                    ):
                         raise
                     # Newer models (e.g. gpt-4o-transcribe) reject some containers
                     # whisper-1 accepted (notably Ogg/Opus voice notes). Transcode


### PR DESCRIPTION
Fixes #81644

## What

The STT transcode-and-retry fallback only triggered on `BadRequestError` (HTTP 400). OpenAI-compatible endpoints that reject an unsupported audio container with a **5xx** (the issue's case: `503 {"type": "system_error"}` from `api.gapgpt.app`) never reached the ffmpeg fallback — `.webm` blobs failed permanently even with ffmpeg installed.

## Fix

In `_transcribe_openai` (`tools/transcription_tools.py`), catch `APIStatusError` instead of `BadRequestError` and escalate to the transcode-and-retry when:

- the message hints at a bad container (`unsupported` / `corrupted` / `invalid file`), **or**
- the status is a 5xx (`status_code >= 500` — covers 500, 503, 504; the openai SDK only special-cases 500 as `InternalServerError`, the rest surface as plain `APIStatusError`)

The transcode is cheap and the retry is a single attempt. A genuine 5xx still surfaces as the final error if the retry fails (existing `APIError` handler), and non-container 4xx errors (401, 403, 429, 404…) keep propagating unchanged.

## Validation

- `TestTranscribeOpenaiFiveXxRetry`: **2/2** — new regression test asserts a 503 rejection triggers the transcode + retry and succeeds; companion test asserts the original 400-container-hint path still works
- Regression proof: the 5xx test **fails without the fix** (the 503 propagated out of `BadRequestError`) and passes with it
- `tests/tools/test_transcription_tools.py`: 50 passed; the 2 remaining failures (`TestTranscribeLocalExtended` whisper device, `TestRunCommandSttIdleTimeout` stderr progress) fail identically on a clean `upstream/main` checkout — pre-existing, unrelated to this change
