### PR TITLE
fix(web): explicitly register dashboard Tailwind sources

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,4 +1,8 @@
 @import 'tailwindcss';
+
+/* Keep dashboard sources discoverable when an enclosing repository ignores this path. */
+@source './';
+
 /* `fonts.css` must come BEFORE `globals.css`: as of @nous-research/ui 0.14.x,
    `globals.css` only declares the `--font-*` CSS variables (Collapse, Rules
    Compressed/Expanded, Mondwest). The `@font-face` registrations live in


### PR DESCRIPTION
## What does this PR do?

This PR explicitly registers the dashboard's own source directory with Tailwind:

```css
@source './';
```

Tailwind CSS v4 excludes Git-ignored files from automatic source detection. In an affected portable build, Hermes was vendored under `src/hermes-agent` while the enclosing repository ignored `src/`. The Vite build still completed successfully, but the generated stylesheet omitted dashboard layout utilities such as `w-64`, `h-dvh`, and `lg:sticky`, causing the shell and sidebar layout to collapse.

Hermes already uses explicit source registration for its design-system dependency:

```css
@source '../node_modules/@nous-research/ui/dist';
```

That keeps utilities used by the published UI bundle available when automatic detection is insufficient. However, the dashboard's own TSX sources still rely entirely on automatic detection. This change applies the same explicit-source approach to `web/src`, completing the existing configuration rather than introducing a packaging-specific mechanism.

The path is relative to `web/src/index.css`, so the dashboard sources remain discoverable independently of an enclosing repository's ignore rules. No build scripts, runtime code, or application behavior are changed.

## Related Issue

None.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `@source './';` to `web/src/index.css`.
- Added a short comment documenting why automatic detection is not sufficient here.

## How to Test

1. Vendor Hermes under a path ignored by an enclosing repository and run the dashboard production build.
2. Inspect `hermes_cli/web_dist/assets/index-*.css`.
3. Verify that utilities used by the dashboard's TSX sources are present and that the dashboard layout renders normally.

In the affected portable build, current behavior produced a successful 61.85 kB CSS bundle that omitted `w-64`, `h-dvh`, and `lg:sticky`. Adding `@source './';` produced the complete bundle and restored the layout. A normal WSL checkout also builds successfully with this change (112.19 kB CSS bundle).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 portable build and WSL 2

The full Python suite is unrelated to this CSS-only change and did not complete cleanly in the local environment. The relevant web checks passed: 27 Vitest files / 191 tests, ESLint with 0 errors (26 existing warnings), and the production build.

No automated test was added because asserting specific generated utility names would couple the build to the dashboard's current class names. The regression was verified through the affected production build and generated CSS instead.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; the source comment documents the constraint
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A; CSS source discovery only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

| Build | Result | Generated CSS |
|---|---|---|
| Affected vendored build without explicit dashboard source | Build succeeds | 61.85 kB; missing `w-64`, `h-dvh`, and `lg:sticky` |
| Same build with `@source './';` | Build succeeds | Complete dashboard utilities; layout restored |
| Normal WSL checkout with this change | Build succeeds | 112.19 kB |
