### PR TITLE
fix(stt): reach the transcode retry on 5xx container rejections

### DIFF
--- a/tests/tools/test_managed_media_gateways.py
+++ b/tests/tools/test_managed_media_gateways.py
@@ -164,12 +164,16 @@ def _install_fake_openai_module(captured, transcription_response=None):
         def close(self):
             captured["close_calls"] += 1
 
+    # Mirrors the SDK's real hierarchy: BadRequestError subclasses
+    # APIStatusError, so code that catches the base also catches the 400.
+    _api_status_error = type("APIStatusError", (Exception,), {})
     fake_module = types.SimpleNamespace(
         OpenAI=FakeOpenAI,
         APIError=Exception,
         APIConnectionError=Exception,
         APITimeoutError=Exception,
-        BadRequestError=type("BadRequestError", (Exception,), {}),
+        APIStatusError=_api_status_error,
+        BadRequestError=type("BadRequestError", (_api_status_error,), {}),
     )
     sys.modules["openai"] = fake_module
 

--- a/tests/tools/test_stt_transcode_retry_status.py
+++ b/tests/tools/test_stt_transcode_retry_status.py
@@ -1,0 +1,136 @@
+"""Container rejections must reach the transcode retry whatever status they carry.
+
+The transcode-and-retry fallback (#68732) was gated on ``BadRequestError``, so
+it only ever ran for HTTP 400. OpenAI-compatible providers that answer a
+container they cannot read with a 5xx never reached it: the desktop's ``.webm``
+dictation blobs failed permanently even with ffmpeg installed and a one-line
+transcode available (#81644).
+
+The 5xx bodies carry no usable text (a bare ``system_error``), so widening the
+keyword gate cannot help; the status itself has to be part of the decision.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+class _Err(Exception):
+    """Stands in for openai.APIStatusError, which exposes ``status_code``."""
+
+    def __init__(self, status_code, message=""):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def test_generic_5xx_container_rejection_now_retries():
+    """The reported shape: 503 with a body that names nothing."""
+    from tools.transcription_tools import _should_transcode_and_retry
+
+    exc = _Err(503, '{"error":{"message":"request failed","type":"system_error"}}')
+
+    assert _should_transcode_and_retry(exc) is True
+
+
+@pytest.mark.parametrize("status", [500, 502, 503, 599])
+def test_every_server_status_reaches_the_retry(status):
+    from tools.transcription_tools import _should_transcode_and_retry
+
+    assert _should_transcode_and_retry(_Err(status, "boom")) is True
+
+
+def test_400_still_needs_a_container_hint():
+    """Guard: the historical keyword gate for 400 is unchanged."""
+    from tools.transcription_tools import _should_transcode_and_retry
+
+    assert _should_transcode_and_retry(_Err(400, "Unsupported file format")) is True
+    assert _should_transcode_and_retry(_Err(400, "audio file is corrupted")) is True
+    assert _should_transcode_and_retry(_Err(400, "Invalid file provided")) is True
+
+
+def test_400_without_a_container_hint_still_raises():
+    """Guard: a quota or validation 400 must not spend a transcode."""
+    from tools.transcription_tools import _should_transcode_and_retry
+
+    assert _should_transcode_and_retry(_Err(400, "You exceeded your quota")) is False
+
+
+@pytest.mark.parametrize("status", [401, 403, 404, 409, 429])
+def test_other_client_errors_are_untouched(status):
+    """Guard: widening to APIStatusError must not swallow auth or rate limits."""
+    from tools.transcription_tools import _should_transcode_and_retry
+
+    assert _should_transcode_and_retry(_Err(status, "unsupported")) is False
+
+
+def test_missing_status_does_not_retry():
+    """An exception without a status tells us nothing; re-raise rather than guess."""
+    from tools.transcription_tools import _should_transcode_and_retry
+
+
+    class _NoStatus(Exception):
+        pass
+
+    assert _should_transcode_and_retry(_NoStatus("unsupported")) is False
+    assert _should_transcode_and_retry(_Err(None, "unsupported")) is False
+
+
+def _api_status_error(status: int, message: str):
+    """A real openai.APIStatusError, so the test binds to the SDK's shape."""
+    import httpx
+    import openai
+
+    request = httpx.Request("POST", "https://example.invalid/v1/audio/transcriptions")
+    response = httpx.Response(status, request=request, text=message)
+    return openai.APIStatusError(message, response=response, body=None)
+
+
+def test_end_to_end_5xx_reaches_the_transcode_retry(tmp_path, monkeypatch):
+    """Behavioural probe: the real handler must attempt the transcode on 503.
+
+    Drives _transcribe_openai with a client that rejects the original container
+    with 503 and accepts the transcoded one, which is the reported scenario.
+    """
+    import openai
+
+    from tools import transcription_tools as tt
+
+    src = tmp_path / "dictation.webm"
+    src.write_bytes(b"fake-webm")
+    converted = tmp_path / "converted.m4a"
+    converted.write_bytes(b"fake-m4a")
+
+    calls: list[str] = []
+    transcoded: list[str] = []
+
+    class _Transcriptions:
+        def create(self, **kwargs):
+            name = getattr(kwargs["file"], "name", "")
+            calls.append(name)
+            if name.endswith(".webm"):
+                raise _api_status_error(
+                    503, '{"error":{"message":"request failed","type":"system_error"}}'
+                )
+            return type("_T", (), {"text": "salam donya"})()
+
+    class _Client:
+        audio = type("_A", (), {"transcriptions": _Transcriptions()})()
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(openai, "OpenAI", lambda **_kw: _Client())
+
+    def _fake_transcode(file_path, work_dir):
+        transcoded.append(file_path)
+        return str(converted), None
+
+    monkeypatch.setattr(tt, "_transcode_audio_for_stt", _fake_transcode)
+
+    result = tt._transcribe_openai(str(src), "whisper-1", api_key="k")
+
+    assert transcoded, (
+        "a 503 container rejection never reached the transcode fallback; "
+        f"upload attempts were {calls}"
+    )
+    assert result.get("success") is True
+    assert result.get("transcript") == "salam donya"

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -260,6 +260,32 @@ def _run_ffmpeg_stt_encode(
     )
 
 
+_STT_CONTAINER_REJECTION_HINTS = ("unsupported", "corrupted", "invalid file")
+
+
+def _should_transcode_and_retry(exc) -> bool:
+    """Whether an API rejection earns one transcode-and-retry.
+
+    ``400``: unchanged. The provider names the problem, so the historical
+    keyword gate still decides; an auth or quota 400 must not trigger a
+    pointless transcode.
+
+    ``5xx``: providers disagree about how to say "I cannot read this
+    container". Some answer a bare ``system_error`` with no usable text
+    (#81644), so there is nothing to keyword-match and gating on 400 alone
+    couples the fallback to one vendor's status conventions. One retry in a
+    different container is the only way to tell a container rejection from a
+    real outage, and it is cheap: if it was an outage the retry fails too and
+    the original error still reaches the caller.
+
+    Every other status (401/403/404/429/...) re-raises, as before.
+    """
+    status = getattr(exc, "status_code", None)
+    if status == 400:
+        return any(k in str(exc).lower() for k in _STT_CONTAINER_REJECTION_HINTS)
+    return isinstance(status, int) and 500 <= status < 600
+
+
 def _transcode_audio_for_stt(file_path: str, work_dir: str) -> tuple[Optional[str], Optional[str]]:
     """Transcode ``file_path`` to a compact, broadly-accepted .m4a for STT upload.
 
@@ -2069,6 +2095,7 @@ def _transcribe_openai(
             OpenAI,
             APIError,
             APIConnectionError,
+            APIStatusError,
             APITimeoutError,
             BadRequestError,
         )
@@ -2096,9 +2123,8 @@ def _transcribe_openai(
             with tempfile.TemporaryDirectory(prefix="hermes-stt-") as work_dir:
                 try:
                     transcription = _create_transcription(file_path)
-                except BadRequestError as exc:
-                    message = str(exc).lower()
-                    if not any(k in message for k in ("unsupported", "corrupted", "invalid file")):
+                except APIStatusError as exc:
+                    if not _should_transcode_and_retry(exc):
                         raise
                     # Newer models (e.g. gpt-4o-transcribe) reject some containers
                     # whisper-1 accepted (notably Ogg/Opus voice notes). Transcode


### PR DESCRIPTION
## What does this PR do?

The transcode-and-retry fallback from #68732 is gated on the exception class, not on what the provider actually said:

```python
try:
    transcription = _create_transcription(file_path)
except BadRequestError as exc:                      # 400 only
    message = str(exc).lower()
    if not any(k in message for k in ("unsupported", "corrupted", "invalid file")):
        raise
```

OpenAI-compatible endpoints that answer a container they cannot read with a 5xx never reach it. The desktop records dictation as `.webm`, so those blobs fail permanently even with ffmpeg installed and a one-line transcode available.

The issue's isolated reproduction is unusually clean: same audio, same endpoint, same model, only the container differs.

```
.mp3  -> 200      .wav  -> 200      .m4a  -> 200      .webm -> 503
```

and the exact conversion the fallback would have performed succeeds:

```
ffmpeg -i real.webm -c:a aac -b:a 64k -ac 1 -ar 16000 conv.m4a   ->  200, correct transcript
```

### Why widening the keyword gate is not enough

The 5xx body carries nothing to match on:

```json
{"error":{"message":"request failed (...)","type":"system_error","code":"system_error"}}
```

No "unsupported", no "corrupted", no "invalid file". Keyword matching cannot recover this case, so the status has to take part in the decision.

### The fix

The catch widens to `APIStatusError` and the decision moves into a small pure predicate:

- **400 is unchanged.** The provider named the problem, so the historical keyword gate still decides. A quota or validation 400 must not spend a transcode.
- **5xx retries once.** Providers disagree about how to say "I cannot read this container", and gating on 400 alone couples the fallback to one vendor's status conventions. One retry in a different container is the only way to tell a container rejection from a real outage, and it is cheap: if it was an outage the retry fails too and the original error still reaches the caller.
- **Every other status re-raises**, exactly as before. Widening the caught class must not start swallowing 401/403/404/429, and a test pins that.

## Related Issue

Fixes #81644 (P2, `tool/tts`, `provider/openai`). Searched open and merged PRs first, per CONTRIBUTING's search-first section:

```
gh search prs --repo NousResearch/hermes-agent "81644"           --limit 12   # 0
gh search prs --repo NousResearch/hermes-agent "transcode retry" --limit 12   # 0
gh search prs --repo NousResearch/hermes-agent "stt 5xx"         --limit 12   # 0
gh search prs --repo NousResearch/hermes-agent "APIStatusError"  --limit 12   # only #60031, streaming backoff
```

Re-run immediately before opening, together with a listing of the most recently created PRs, because the search index lags new PRs by minutes. #81645 is also STT but concerns `compute_type` on Apple Silicon.

The reporter offered to send a patch if the approach was endorsed; nothing was filed, so this implements the approach they described. Happy to close in their favour if they would rather carry it.

## Type of Change

Bug fix (non-breaking). The 400 path is byte-for-byte the previous behaviour.

## Changes Made

- `tools/transcription_tools.py` - added `_should_transcode_and_retry()`; the handler catches `APIStatusError` and delegates the decision to it.
- `tests/tools/test_stt_transcode_retry_status.py` - new, 14 tests.
- `tests/tools/test_managed_media_gateways.py` - the fake `openai` module gains `APIStatusError` (see below).

### The test-helper change, called out

`_install_fake_openai_module` enumerates the SDK surface the production code imports. Adding `APIStatusError` to the new import would otherwise make `from openai import (...)` raise inside the fake, and `test_transcription_uses_model_specific_response_formats` fails with a bare `success is False`. I caught it in the regression diff, not by reading.

I also made the fake's `BadRequestError` subclass the new `APIStatusError`, matching the real SDK hierarchy. Without that the fake would let `except APIStatusError` miss a fake 400 that the real one catches, which is exactly the sort of divergence that makes a passing suite meaningless.

## How to Test

```
pytest tests/tools/test_stt_transcode_retry_status.py -q
```

14 passed. Thirteen exercise the predicate across statuses and messages; the last drives the real `_transcribe_openai` with a client that rejects `.webm` with a genuine `openai.APIStatusError` (503) and accepts the transcoded file, which is the reported scenario end to end.

Reverting only `tools/transcription_tools.py` and rerunning:

```
E  AssertionError: a 503 container rejection never reached the transcode fallback;
E    upload attempts were ['.../dictation.webm']
```

One upload attempt, no transcode. The predicate's own unit tests fail on revert too, since the helper is new, so the behavioural probe above is the one that proves the change.

`tests/tools/` scoped to `-k "transcri or stt or voice or audio"`, this branch vs `main`, same environment, run serially:

```
main:   7 failed, 585 passed
branch: 7 failed, 599 passed
```

Comparing the failing sets rather than the counts: **zero regressions**, the two sets are identical. The +14 is this PR's new tests. I scoped the comparison rather than running all of `tests/tools/` because the full single-process run exceeds ten minutes locally; CI's per-file isolation via `run_tests_parallel.py` covers the rest. The 7 are pre-existing on both sides (WSL2 PowerShell cases running on macOS).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(stt): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (queries above)
- [x] My PR contains only changes related to this fix
- [x] I've run the affected suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation; the predicate's docstring records why 400 keeps its keyword gate and why 5xx cannot have one
- [x] `cli-config.yaml.example` is N/A, no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` are N/A
- [x] Cross-platform impact is N/A; this is status-code handling, and the transcode helper it reaches was already platform-guarded
- [x] Tool descriptions/schemas are N/A

## Notes for the reviewer

The retry stays strictly once, as before: the second call is not itself wrapped, so a 5xx on the transcoded upload surfaces normally rather than looping.

I deliberately did not add a "skip when the file is already `.m4a`" short-circuit. It looks like free savings, but `_transcode_audio_for_stt` also normalises codec, bitrate, channels and sample rate, so an `.m4a` with awkward parameters is a case the retry can still fix. Adding the guard would have quietly narrowed the existing 400 path.
