### PR TITLE
fix(streaming): retry reasoning-only clean stream drops instead of ending the turn silently

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3694,6 +3694,31 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 dropped_tool_names=_dropped_names or None,
             )
 
+        # Reasoning-only stream drop: the upstream closed the connection (or
+        # the SSE stream simply ended) with no finish_reason after delivering
+        # ONLY reasoning/thinking deltas — no content, no tool calls.  This
+        # shape slips past both the zero-chunk guard (reasoning_parts is
+        # non-empty) and the text-only guard below (content_parts is empty),
+        # so without this guard it is silently stamped finish_reason="stop"
+        # with content=None and the turn ends as if complete: the user
+        # watches the thinking block freeze mid-sentence and never gets an
+        # answer, with nothing logged.  Retrying is display-safe here —
+        # deltas_were_sent only tracks visible content deltas, so the retry
+        # loop accepts this, and the re-streamed thinking simply replaces
+        # the frozen partial block.
+        _reasoning_only_dropped_no_finish = (
+            finish_reason is None
+            and reasoning_parts
+            and not content_parts
+            and not tool_calls_acc
+        )
+        if _reasoning_only_dropped_no_finish:
+            raise EmptyStreamError(
+                "Provider stream ended with no finish_reason after delivering "
+                "only reasoning content (possible upstream error or malformed "
+                "SSE response); retrying."
+            )
+
         # Text-only stream drop: the upstream closed the connection (or the
         # SSE stream simply ended) with no finish_reason after delivering
         # text content but no tool calls.  Without this guard the partial

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -150,6 +150,99 @@ class TestCleanStreamEndMidToolCall:
 
 
 
+# ── Clean stream-end after reasoning-only delivery ─────────────────────────
+
+class TestCleanStreamEndReasoningOnly:
+    """The upstream closes the SSE stream cleanly after delivering ONLY
+    reasoning/thinking deltas — no content, no tool calls, no exception,
+    no finish_reason, no [DONE].
+
+    This shape slips past the zero-chunk guard (``reasoning_parts`` is
+    non-empty) and the text-only guard (``content_parts`` is empty), so
+    without a dedicated guard it falls through to
+    ``effective_finish_reason = finish_reason or "stop"`` and the turn
+    ends as if complete: the thinking block freezes mid-sentence, no
+    answer text ever arrives, and nothing is logged.  Retrying is
+    display-safe because ``deltas_were_sent`` only tracks visible
+    content deltas — reasoning deltas don't set it — so the standard
+    EmptyStreamError retry path accepts the retry.
+    """
+
+    def _make_reasoning_chunk(self, reasoning_text):
+        delta = SimpleNamespace(
+            content=None, tool_calls=None,
+            reasoning_content=reasoning_text, reasoning=None,
+        )
+        choice = SimpleNamespace(index=0, delta=delta, finish_reason=None)
+        return SimpleNamespace(choices=[choice], model=None, usage=None)
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_reasoning_only_clean_end_raises_empty_stream(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        from agent.errors import EmptyStreamError
+
+        def _clean_ending_stream():
+            # Thinking arrives, then the generator simply RETURNS
+            # (StopIteration) — no content, no raise, no finish_reason.
+            yield self._make_reasoning_chunk("Let me think about")
+            yield self._make_reasoning_chunk(" this problem step by")
+            # falls off the end — clean close mid-thinking
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = (
+            lambda *a, **kw: _clean_ending_stream()
+        )
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        agent._fire_reasoning_delta = lambda text: None
+
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+        with pytest.raises(EmptyStreamError, match="reasoning"):
+            agent._interruptible_streaming_api_call({})
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_reasoning_only_drop_is_retried_then_succeeds(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        """The reasoning-only drop must ride the standard stream-retry
+        loop: first attempt dies mid-thinking, the retry delivers a
+        complete response."""
+        attempts = {"n": 0}
+
+        def _flaky_stream():
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                yield self._make_reasoning_chunk("Thinking out loud")
+                return  # clean close, no finish_reason — the drop
+            yield self._make_reasoning_chunk("Thinking out loud")
+            yield _make_stream_chunk(content="The answer is 42.")
+            yield _make_stream_chunk(finish_reason="stop")
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = (
+            lambda *a, **kw: _flaky_stream()
+        )
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        agent._fire_stream_delta = lambda text: None
+        agent._fire_reasoning_delta = lambda text: None
+
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "1")
+        response = agent._interruptible_streaming_api_call({})
+
+        assert attempts["n"] == 2, (
+            "A reasoning-only clean stream end must be retried, not "
+            "silently stamped finish_reason='stop' with empty content."
+        )
+        assert response.choices[0].finish_reason == "stop"
+        assert response.choices[0].message.content == "The answer is 42."
+
+
 
 # ── Clean stream-end before any argument byte arrives (#80498) ─────────────
 


### PR DESCRIPTION
## Problem

When the upstream provider closes the SSE stream **cleanly** (no exception, no `finish_reason`, no `[DONE]`) after delivering **only reasoning/thinking deltas** — no content, no tool calls — the mock-response builder in `agent/chat_completion_helpers.py` falls through every existing guard:

- the zero-chunk guard requires empty `reasoning_parts` (here they are non-empty),
- the text-only drop guard (#32086) requires `content_parts` (empty here),
- the tool-args guards (#80498 and siblings) require a tool call.

Result: the response is silently stamped `finish_reason="stop"` with `content=None`. The user watches the thinking block freeze mid-sentence, no answer text ever arrives, the turn ends as if successful, and **nothing is logged**. This is the silent variant of the stream-drop family — the other shapes all got guards; this one did not.

Observed in production with `deepseek/deepseek-v4-flash-0731` via OpenRouter, which wedges or drops streams frequently on long thinking phases (measured: 21 stale-kills on a single day on one gateway; reasoning-phase stalls are the common case for this model). Related: #70871 (UI busy-stuck symptoms), #80498 (tool-call clean-close sibling).

## Fix

Detect the shape explicitly:

```python
finish_reason is None and reasoning_parts and not content_parts and not tool_calls_acc
```

and raise `EmptyStreamError`, routing it into the existing bounded stream-retry loop (`HERMES_STREAM_RETRIES`).

Retrying is display-safe here: `deltas_were_sent` is only set by visible *content* deltas — reasoning deltas don't set it — so the retry loop accepts the retry, and the re-streamed thinking simply replaces the frozen partial block in the UI. When retries are exhausted, the user gets the existing honest "provider returned an empty response stream" error instead of a fake successful turn.

## Tests

`tests/run_agent/test_partial_stream_finish_reason.py` — new `TestCleanStreamEndReasoningOnly`:

1. `test_reasoning_only_clean_end_raises_empty_stream` — reasoning-only stream that ends cleanly must raise `EmptyStreamError` (mutation-verified: without the guard this test fails, the call returns a silent `stop` response).
2. `test_reasoning_only_drop_is_retried_then_succeeds` — first attempt dies mid-thinking, the retry delivers a complete response; asserts the retry actually happened and the final answer is intact.

Full file: 19/19 passing (includes the #80498 tests).
