### PR TITLE
fix(stt): retry OpenAI transcription after audio transcode

### DIFF
--- a/contributors/emails/xuezhao@gmail.com
+++ b/contributors/emails/xuezhao@gmail.com
@@ -1,0 +1,1 @@
+xuezhaolan

--- a/tests/tools/test_stt_openai_transcode_retry.py
+++ b/tests/tools/test_stt_openai_transcode_retry.py
@@ -1,0 +1,82 @@
+import types
+
+import pytest
+
+import tools.transcription_tools as tt
+
+
+class _FakeAPIError(Exception):
+    def __init__(self, message: str, *, status_code=None):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class _FakeBadRequestError(_FakeAPIError):
+    pass
+
+
+def _install_fake_openai(monkeypatch, calls, first_error):
+    class FakeTranscriptions:
+        def create(self, **kwargs):
+            calls.append(kwargs["file"].name)
+            if len(calls) == 1:
+                raise first_error
+            return {"text": "retry ok"}
+
+    class FakeAudio:
+        def __init__(self):
+            self.transcriptions = FakeTranscriptions()
+
+    class FakeOpenAI:
+        def __init__(self, **_kwargs):
+            self.audio = FakeAudio()
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    fake_openai = types.SimpleNamespace(
+        OpenAI=FakeOpenAI,
+        APIError=_FakeAPIError,
+        APIConnectionError=type("APIConnectionError", (Exception,), {}),
+        APITimeoutError=type("APITimeoutError", (Exception,), {}),
+        BadRequestError=_FakeBadRequestError,
+    )
+    monkeypatch.setitem(__import__("sys").modules, "openai", fake_openai)
+    monkeypatch.setattr(tt, "_HAS_OPENAI", True)
+
+
+def test_openai_stt_retries_5xx_webm_after_transcoding(monkeypatch, tmp_path):
+    source = tmp_path / "voice.webm"
+    source.write_bytes(b"webm-ish")
+    calls = []
+    _install_fake_openai(monkeypatch, calls, _FakeAPIError("upstream decoder failed", status_code=500))
+
+    def fake_transcode(file_path, work_dir):
+        converted = tmp_path / "voice.m4a"
+        converted.write_bytes(b"m4a-ish")
+        return str(converted), None
+
+    monkeypatch.setattr(tt, "_transcode_audio_for_stt", fake_transcode)
+    monkeypatch.setattr(tt, "_resolve_stt_language", lambda _provider: None)
+
+    result = tt._transcribe_openai(str(source), "gpt-4o-transcribe", api_key="test")
+
+    assert result == {"success": True, "transcript": "retry ok", "provider": "openai"}
+    assert calls == [str(source), str(tmp_path / "voice.m4a")]
+
+
+def test_openai_stt_does_not_retry_unrelated_5xx_for_plain_wav(monkeypatch, tmp_path):
+    source = tmp_path / "voice.wav"
+    source.write_bytes(b"wav-ish")
+    calls = []
+    _install_fake_openai(monkeypatch, calls, _FakeAPIError("temporary server outage", status_code=500))
+    transcode = pytest.fail
+    monkeypatch.setattr(tt, "_transcode_audio_for_stt", transcode)
+    monkeypatch.setattr(tt, "_resolve_stt_language", lambda _provider: None)
+
+    result = tt._transcribe_openai(str(source), "gpt-4o-transcribe", api_key="test")
+
+    assert result["success"] is False
+    assert result["error"].startswith("API error:")
+    assert calls == [str(source)]

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2027,6 +2027,42 @@ def _transcribe_groq(file_path: str, model_name: str) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
+_STT_TRANSCODE_RETRY_EXTENSIONS = {".webm", ".ogg", ".oga", ".opus", ".caf"}
+_STT_TRANSCODE_RETRY_TERMS = (
+    "unsupported file",
+    "unsupported audio",
+    "unsupported audio format",
+    "corrupted",
+    "corrupt",
+    "invalid file",
+    "invalid audio",
+    "container",
+)
+
+
+def _should_retry_stt_after_transcode(exc: Exception, file_path: str) -> bool:
+    """Return whether an OpenAI-compatible STT rejection may be container-specific.
+
+    Some transcription models reject browser/voice-note containers before the
+    audio decoder can inspect the stream. The SDK surfaces those rejections as
+    normal 400s on some endpoints and as APIError/5xx on others, so gate the
+    retry by both the error shape and the source container instead of only the
+    concrete exception class.
+    """
+    suffix = Path(file_path).suffix.lower()
+    message = str(exc).lower()
+    is_bad_request = exc.__class__.__name__ == "BadRequestError"
+
+    if is_bad_request and any(term in message for term in _STT_TRANSCODE_RETRY_TERMS):
+        return True
+
+    status_code = getattr(exc, "status_code", None)
+    if isinstance(status_code, int) and 500 <= status_code < 600:
+        return suffix in _STT_TRANSCODE_RETRY_EXTENSIONS
+
+    return False
+
+
 def _transcribe_openai(
     file_path: str,
     model_name: str,
@@ -2096,13 +2132,14 @@ def _transcribe_openai(
             with tempfile.TemporaryDirectory(prefix="hermes-stt-") as work_dir:
                 try:
                     transcription = _create_transcription(file_path)
-                except BadRequestError as exc:
-                    message = str(exc).lower()
-                    if not any(k in message for k in ("unsupported", "corrupted", "invalid file")):
+                except (BadRequestError, APIError) as exc:
+                    if not _should_retry_stt_after_transcode(exc, file_path):
                         raise
                     # Newer models (e.g. gpt-4o-transcribe) reject some containers
-                    # whisper-1 accepted (notably Ogg/Opus voice notes). Transcode
-                    # to a compact .m4a and retry once.
+                    # whisper-1 accepted (notably Ogg/Opus/WebM voice notes).
+                    # Some compatible endpoints surface this as a 5xx APIError
+                    # instead of BadRequestError. Transcode to a compact .m4a
+                    # and retry once.
                     converted_path, transcode_error = _transcode_audio_for_stt(file_path, work_dir)
                     if transcode_error:
                         return {"success": False, "transcript": "", "error": transcode_error}


### PR DESCRIPTION
## Summary
- Retries OpenAI transcription after transcoding when the original audio is rejected as an unsupported/invalid/corrupt audio file.
- Adds a guarded retry path for transient OpenAI/API 5xx failures on container-heavy input extensions that may be fixed by normalization.
- Adds focused regression tests covering successful retry and non-retry API failures.

## Test Plan
- python -m pytest tests/tools/test_stt_openai_transcode_retry.py -q -o 'addopts='
- git diff --check
- staged secret/static security scan
- Codex independent diff review: passed