### PR TITLE
fix(desktop): move sessions between projects without duplication

### DIFF
--- a/apps/desktop/src/app/chat/session-drag.test.ts
+++ b/apps/desktop/src/app/chat/session-drag.test.ts
@@ -131,4 +131,21 @@ describe('session drop targeting for project conversation groups', () => {
 
     expect(assignSessionConversationGroup).toHaveBeenCalledWith('dragged', 'p_sk', 'cg_ito')
   })
+
+  it('moves a session into a project when its overview header is the drop target', () => {
+    document.body.innerHTML = `
+      <div id="row"></div>
+      <div data-conversation-group-drop data-project-id="p_wedding" data-group-id=""></div>
+    `
+    stubRect(document.querySelector('[data-conversation-group-drop]')!, {
+      left: 100,
+      top: 100,
+      right: 400,
+      bottom: 160
+    })
+
+    dragTo(document.getElementById('row')!, 200, 130)
+
+    expect(assignSessionConversationGroup).toHaveBeenCalledWith('dragged', 'p_wedding', null)
+  })
 })

--- a/apps/desktop/src/app/chat/session-drag.test.ts
+++ b/apps/desktop/src/app/chat/session-drag.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { group } from '@/components/pane-shell/tree/model'
 import { $layoutTree } from '@/components/pane-shell/tree/store'
+import { assignSessionConversationGroup } from '@/store/projects'
 import { openSessionTile } from '@/store/session-states'
 
 import { requestComposerInsertRefs } from './composer/focus'
@@ -16,6 +17,7 @@ import { startSessionDrag } from './session-drag'
  */
 
 vi.mock('@/store/session-states', () => ({ openSessionTile: vi.fn() }))
+vi.mock('@/store/projects', () => ({ assignSessionConversationGroup: vi.fn() }))
 vi.mock('./composer/focus', () => ({ requestComposerInsertRefs: vi.fn() }))
 
 const ZONE = { left: 0, top: 0, right: 1000, bottom: 800 }
@@ -109,5 +111,24 @@ describe('session drop targeting across stacked tabs', () => {
 
     expect(requestComposerInsertRefs).not.toHaveBeenCalled()
     expect(openSessionTile).not.toHaveBeenCalled()
+  })
+})
+
+describe('session drop targeting for project conversation groups', () => {
+  it('moves a session into the conversation group under the pointer', () => {
+    document.body.innerHTML = `
+      <div id="row"></div>
+      <div data-conversation-group-drop data-project-id="p_sk" data-group-id="cg_ito"></div>
+    `
+    stubRect(document.querySelector('[data-conversation-group-drop]')!, {
+      left: 100,
+      top: 100,
+      right: 400,
+      bottom: 220
+    })
+
+    dragTo(document.getElementById('row')!, 200, 160)
+
+    expect(assignSessionConversationGroup).toHaveBeenCalledWith('dragged', 'p_sk', 'cg_ito')
   })
 })

--- a/apps/desktop/src/app/chat/session-drag.ts
+++ b/apps/desktop/src/app/chat/session-drag.ts
@@ -49,6 +49,7 @@ import {
   SESSION_TILE_DRAG
 } from '@/components/pane-shell/tree/store'
 import type { EngineZone, ZoneRect } from '@/components/pane-shell/tree/zones-engine'
+import { assignSessionConversationGroup } from '@/store/projects'
 import { openSessionTile, type TileDock } from '@/store/session-states'
 
 import { requestComposerInsertRefs } from './composer/focus'
@@ -60,6 +61,13 @@ import { type SessionDragPayload, sessionInlineRef, sessionLabel } from './compo
 interface SurfaceSnapshot {
   anchor: string
   composerTarget: string
+  rect: ZoneRect
+}
+
+interface ConversationGroupSnapshot {
+  element: HTMLElement
+  groupId: null | string
+  projectId: string
   rect: ZoneRect
 }
 
@@ -109,12 +117,15 @@ export function startSessionDrag(
   let strips: StripSnapshot[] = []
   let surfaces: SurfaceSnapshot[] = []
   let composers: ZoneRect[] = []
+  let conversationGroups: ConversationGroupSnapshot[] = []
   let zoneHost = new Map<string, ReturnType<typeof tileZoneHost>>()
 
   // Commit intent, updated per resolved move (the machinery flushes the final
   // move before commit, so these always match the released-at position).
   let split: { anchor: string; before?: null | string; pos: TileDock } | null = null
   let link: null | string = null
+  let organize: ConversationGroupSnapshot | null = null
+  let highlightedGroup: HTMLElement | null = null
 
   // The drag SOURCE (sidebar row or tile tab). Captured synchronously — React
   // clears `currentTarget` after the pointerdown handler returns, but this runs
@@ -133,6 +144,14 @@ export function startSessionDrag(
       strips = snapshotStrips()
       surfaces = snapshotSurfaces()
       composers = queryAllVisible('[data-slot="composer-root"]').map(snapRect)
+      conversationGroups = queryAllVisible('[data-conversation-group-drop]')
+        .map(element => ({
+          element,
+          groupId: element.dataset.groupId || null,
+          projectId: element.dataset.projectId || '',
+          rect: snapRect(element)
+        }))
+        .filter(target => Boolean(target.projectId))
       zoneHost = new Map(zones.map(zone => [zone.id, tileZoneHost(zone.id)]))
       source?.style.setProperty('opacity', '0.45')
       // The same sentinel the zone overlay + chat surfaces key off — the
@@ -141,12 +160,34 @@ export function startSessionDrag(
     },
 
     onEnd() {
+      highlightedGroup?.removeAttribute('data-session-drag-over')
+      highlightedGroup = null
+
       if (source) {
         source.style.opacity = restoreOpacity
       }
     },
 
     resolveMove(x, y): DropHint | null {
+      const conversationGroup = conversationGroups.find(target => rectContains(target.rect, x, y)) ?? null
+
+      if (conversationGroup) {
+        if (highlightedGroup !== conversationGroup.element) {
+          highlightedGroup?.removeAttribute('data-session-drag-over')
+          conversationGroup.element.setAttribute('data-session-drag-over', 'true')
+          highlightedGroup = conversationGroup.element
+        }
+
+        organize = conversationGroup
+        split = null
+        link = null
+
+        return null
+      }
+
+      highlightedGroup?.removeAttribute('data-session-drag-over')
+      highlightedGroup = null
+      organize = null
       const zone = zones.find(z => rectContains(z.rect, x, y))
       const host = zone ? zoneHost.get(zone.id) : null
 
@@ -192,7 +233,9 @@ export function startSessionDrag(
     },
 
     onCommit() {
-      if (split) {
+      if (organize) {
+        void assignSessionConversationGroup(payload.id, organize.projectId, organize.groupId)
+      } else if (split) {
         openSessionTile(payload.id, split.pos, split.anchor, split.before)
         // A tile for this session may already exist (openSessionTile is
         // idempotent — e.g. persisted from an earlier run): a drop must never

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -70,6 +70,7 @@ import {
   $projectScope,
   $projectTree,
   $projectTreeLoading,
+  $manualSessionProjectIds,
   $removedSessionIds,
   $reposScanning,
   ALL_PROJECTS,
@@ -321,6 +322,7 @@ export function ChatSidebar({
   const projects = useStore($projects)
   const projectTree = useStore($projectTree)
   const projectTreeLoading = useStore($projectTreeLoading)
+  const manualSessionProjectIds = useStore($manualSessionProjectIds)
   const removedSessionIds = useStore($removedSessionIds)
   const reposScanning = useStore($reposScanning)
   const activeProjectId = useStore($activeProjectId)
@@ -738,8 +740,11 @@ export function ChatSidebar({
   // backend now seeds each project folder as an (empty) repo, so the overlay
   // always has a lane to place a new in-project session into.
   const enteredProjectContent = useMemo(
-    () => (enteredProject ? overlayLiveLanes(enteredProject, agentSessions, removedSessionIds) : undefined),
-    [enteredProject, agentSessions, removedSessionIds]
+    () =>
+      enteredProject
+        ? overlayLiveLanes(enteredProject, agentSessions, removedSessionIds, manualSessionProjectIds)
+        : undefined,
+    [enteredProject, agentSessions, removedSessionIds, manualSessionProjectIds]
   )
 
   const scopedRepoPaths = useMemo(
@@ -831,8 +836,16 @@ export function ChatSidebar({
   // session shows under its project instantly (and with its working arc),
   // matching the flat Recents list. Keyed by project id for the rows.
   const overviewPreviews = useMemo<Record<string, SessionInfo[]>>(
-    () => overlayLivePreviews(projectOverview ?? [], agentSessions, projects, PROJECT_PREVIEW_COUNT, removedSessionIds),
-    [projectOverview, agentSessions, projects, removedSessionIds]
+    () =>
+      overlayLivePreviews(
+        projectOverview ?? [],
+        agentSessions,
+        projects,
+        PROJECT_PREVIEW_COUNT,
+        removedSessionIds,
+        manualSessionProjectIds
+      ),
+    [projectOverview, agentSessions, projects, removedSessionIds, manualSessionProjectIds]
   )
 
   const onEnterProject = useCallback(

--- a/apps/desktop/src/app/chat/sidebar/project-dialog.tsx
+++ b/apps/desktop/src/app/chat/sidebar/project-dialog.tsx
@@ -121,9 +121,9 @@ export function ProjectDialog() {
       return
     }
 
-    // A project owns sessions by folder (cwd-prefix), so creation requires at
-    // least one — a folder-less project couldn't hold a session anyway.
-    if (mode === 'create' && trimmed && folders.length) {
+    // Folders remain optional: organizational projects can own sessions through
+    // manual conversation-group assignment without changing those sessions' cwd.
+    if (mode === 'create' && trimmed) {
       await runSubmit(() => createProject({ folders, idea: idea.trim() || undefined, name: trimmed, use: true }))
     }
   }
@@ -291,7 +291,7 @@ export function ProjectDialog() {
               {t.common.cancel}
             </Button>
             <Button
-              disabled={submitting || !name.trim() || (mode === 'create' && folders.length === 0)}
+              disabled={submitting || !name.trim()}
               onClick={() => void submit()}
               type="button"
             >

--- a/apps/desktop/src/app/chat/sidebar/projects/conversation-groups.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/conversation-groups.tsx
@@ -1,0 +1,294 @@
+import type * as React from 'react'
+import { useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { Input } from '@/components/ui/input'
+import type { SessionInfo } from '@/hermes'
+import { cn } from '@/lib/utils'
+import { notifyError } from '@/store/notifications'
+import {
+  createConversationGroup,
+  deleteConversationGroup,
+  renameConversationGroup,
+  reorderConversationGroups
+} from '@/store/projects'
+
+import { SidebarRowStack } from '../chrome'
+
+import { type SidebarConversationGroup, type SidebarProjectTree } from './workspace-groups'
+import { WorkspaceHeader } from './workspace-header'
+
+const copy = {
+  add: '대화 그룹 추가',
+  cancel: '취소',
+  create: '생성',
+  createDescription: '이 프로젝트 안에서 대화 세션을 정리할 그룹 이름을 입력하세요.',
+  createTitle: '새 대화 그룹',
+  delete: '삭제',
+  deleteDescription: '그룹만 삭제됩니다. 포함된 대화는 삭제되지 않고 미분류로 이동합니다.',
+  deleteTitle: '대화 그룹 삭제',
+  edit: '이름 변경',
+  editDescription: '대화 그룹의 새 이름을 입력하세요.',
+  editTitle: '대화 그룹 이름 변경',
+  groupName: '그룹 이름',
+  menu: '대화 그룹 작업',
+  moveDown: '아래로 이동',
+  moveUp: '위로 이동',
+  save: '저장',
+  section: '대화 그룹'
+}
+
+type EditorState = { group?: SidebarConversationGroup; mode: 'create' | 'rename' }
+
+export function ConversationGroups({
+  project,
+  renderRows
+}: {
+  project: SidebarProjectTree
+  renderRows: (sessions: SessionInfo[]) => React.ReactNode
+}) {
+  const groups = project.conversationGroups ?? []
+  const [editor, setEditor] = useState<EditorState | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<SidebarConversationGroup | null>(null)
+  const [name, setName] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  const openCreate = () => {
+    setName('')
+    setEditor({ mode: 'create' })
+  }
+
+  const openRename = (group: SidebarConversationGroup) => {
+    setName(group.label)
+    setEditor({ group, mode: 'rename' })
+  }
+
+  const submit = async () => {
+    const trimmed = name.trim()
+
+    if (!editor || !trimmed) {
+      return
+    }
+
+    setSubmitting(true)
+
+    try {
+      if (editor.mode === 'create') {
+        await createConversationGroup(project.id, trimmed)
+      } else if (editor.group) {
+        await renameConversationGroup(editor.group.id, trimmed)
+      }
+
+      setEditor(null)
+    } catch (error) {
+      notifyError(error, editor.mode === 'create' ? copy.createTitle : copy.editTitle)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const move = async (index: number, delta: -1 | 1) => {
+    const target = index + delta
+
+    if (target < 0 || target >= groups.length) {
+      return
+    }
+
+    const ids = groups.map(group => group.id)
+
+    ;[ids[index], ids[target]] = [ids[target], ids[index]]
+
+    try {
+      await reorderConversationGroups(project.id, ids)
+    } catch (error) {
+      notifyError(error, copy.menu)
+    }
+  }
+
+  const confirmDelete = async () => {
+    const target = deleteTarget
+    setDeleteTarget(null)
+
+    if (!target) {
+      return
+    }
+
+    try {
+      await deleteConversationGroup(target.id)
+    } catch (error) {
+      notifyError(error, copy.deleteTitle)
+    }
+  }
+
+  return (
+    <>
+      <div className="flex min-h-7 items-center gap-1 px-2 pt-1 text-[0.6875rem] font-semibold text-(--ui-text-secondary)">
+        <Codicon className="text-(--ui-text-tertiary)" name="list-tree" size="0.75rem" />
+        <span className="min-w-0 flex-1 truncate">{copy.section}</span>
+        <button
+          aria-label={copy.add}
+          className="grid size-5 shrink-0 place-items-center rounded-sm text-(--ui-text-tertiary) hover:bg-(--ui-control-hover-background) hover:text-foreground"
+          onClick={openCreate}
+          type="button"
+        >
+          <Codicon name="add" size="0.75rem" />
+        </button>
+      </div>
+
+      {groups.map((group, index) => (
+        <ConversationGroupRow
+          group={group}
+          index={index}
+          key={group.id}
+          onDelete={() => setDeleteTarget(group)}
+          onMove={delta => void move(index, delta)}
+          onRename={() => openRename(group)}
+          projectId={project.id}
+          renderRows={renderRows}
+          total={groups.length}
+        />
+      ))}
+
+      <Dialog onOpenChange={open => !open && setEditor(null)} open={Boolean(editor)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{editor?.mode === 'rename' ? copy.editTitle : copy.createTitle}</DialogTitle>
+            <DialogDescription>
+              {editor?.mode === 'rename' ? copy.editDescription : copy.createDescription}
+            </DialogDescription>
+          </DialogHeader>
+          <Input
+            aria-label={copy.groupName}
+            autoFocus
+            disabled={submitting}
+            onChange={event => setName(event.target.value)}
+            onKeyDown={event => {
+              if (event.key === 'Enter') {
+                event.preventDefault()
+                void submit()
+              }
+            }}
+            placeholder={copy.groupName}
+            value={name}
+          />
+          <DialogFooter>
+            <Button disabled={submitting} onClick={() => setEditor(null)} variant="ghost">
+              {copy.cancel}
+            </Button>
+            <Button disabled={submitting || !name.trim()} onClick={() => void submit()}>
+              {editor?.mode === 'rename' ? copy.save : copy.create}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog onOpenChange={open => !open && setDeleteTarget(null)} open={Boolean(deleteTarget)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{`${copy.deleteTitle}: ${deleteTarget?.label ?? ''}`}</DialogTitle>
+            <DialogDescription>{copy.deleteDescription}</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button onClick={() => setDeleteTarget(null)} variant="ghost">
+              {copy.cancel}
+            </Button>
+            <Button onClick={() => void confirmDelete()} variant="destructive">
+              {copy.delete}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
+
+function ConversationGroupRow({
+  group,
+  index,
+  onDelete,
+  onMove,
+  onRename,
+  projectId,
+  renderRows,
+  total
+}: {
+  group: SidebarConversationGroup
+  index: number
+  onDelete: () => void
+  onMove: (delta: -1 | 1) => void
+  onRename: () => void
+  projectId: string
+  renderRows: (sessions: SessionInfo[]) => React.ReactNode
+  total: number
+}) {
+  const [open, setOpen] = useState(true)
+
+  return (
+    <SidebarRowStack
+      className={cn(
+        'rounded-md transition-colors',
+        'data-[session-drag-over=true]:bg-(--ui-control-active-background) data-[session-drag-over=true]:ring-1 data-[session-drag-over=true]:ring-(--ui-stroke-secondary)'
+      )}
+      data-conversation-group-drop
+      data-group-id={group.id}
+      data-project-id={projectId}
+    >
+      <WorkspaceHeader
+        action={
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                aria-label={copy.menu}
+                className="grid size-4 shrink-0 place-items-center rounded-sm text-(--ui-text-quaternary) opacity-0 hover:bg-(--ui-control-hover-background) hover:text-foreground group-hover/workspace:opacity-100 data-[state=open]:opacity-100"
+                onClick={event => event.stopPropagation()}
+                type="button"
+              >
+                <Codicon name="kebab-vertical" size="0.75rem" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-44">
+              <DropdownMenuItem onSelect={onRename}>
+                <Codicon name="edit" size="0.75rem" />
+                {copy.edit}
+              </DropdownMenuItem>
+              <DropdownMenuItem disabled={index === 0} onSelect={() => onMove(-1)}>
+                <Codicon name="arrow-up" size="0.75rem" />
+                {copy.moveUp}
+              </DropdownMenuItem>
+              <DropdownMenuItem disabled={index === total - 1} onSelect={() => onMove(1)}>
+                <Codicon name="arrow-down" size="0.75rem" />
+                {copy.moveDown}
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem className="text-destructive" onSelect={onDelete}>
+                <Codicon name="trash" size="0.75rem" />
+                {copy.delete}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        }
+        icon={<Codicon className="text-(--ui-text-tertiary)" name="folder" size="0.75rem" />}
+        label={`${group.label} (${group.sessions.length})`}
+        onToggle={() => setOpen(value => !value)}
+        open={open}
+      />
+      {open && <SidebarRowStack className="pl-2.5">{renderRows(group.sessions)}</SidebarRowStack>}
+    </SidebarRowStack>
+  )
+}

--- a/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
@@ -22,6 +22,7 @@ import { removeWorktreePath } from '@/store/projects'
 
 import { SidebarRowStack } from '../chrome'
 
+import { ConversationGroups } from './conversation-groups'
 import { useWorkspaceNodeOpen } from './model'
 import { SidebarWorkspaceGroup } from './workspace-group'
 import {
@@ -52,33 +53,74 @@ export function EnteredProjectContent({
   liveSessions?: SessionInfo[]
   removedSessionIds?: ReadonlySet<string>
 }) {
-  if (!project.repos.length) {
-    return null
-  }
-
   // Home's rows aren't anchored to a folder, so there's no repo or worktree
   // structure to show — just the chats.
   if (project.isNoProject) {
     return <>{renderRows(project.repos.flatMap(repo => repo.groups.flatMap(group => group.sessions)))}</>
   }
 
+  const conversationGroups = project.conversationGroups ?? []
+  const groupManager = !project.isAuto ? <ConversationGroups project={project} renderRows={renderRows} /> : null
+
+  if (!project.repos.length) {
+    return groupManager
+  }
+
   const single = project.repos.length === 1
+
+  const repoRows = project.repos.map(repo => (
+    <RepoFlatSection
+      discoveredWorktrees={repo.path ? repoWorktrees?.[repo.path] : undefined}
+      key={repo.id}
+      liveSessions={liveSessions}
+      onNewSession={onNewSession}
+      removedSessionIds={removedSessionIds}
+      renderRows={renderRows}
+      repo={repo}
+      showHeader={!single}
+    />
+  ))
 
   return (
     <>
-      {project.repos.map(repo => (
-        <RepoFlatSection
-          discoveredWorktrees={repo.path ? repoWorktrees?.[repo.path] : undefined}
-          key={repo.id}
-          liveSessions={liveSessions}
-          onNewSession={onNewSession}
-          removedSessionIds={removedSessionIds}
-          renderRows={renderRows}
-          repo={repo}
-          showHeader={!single}
-        />
-      ))}
+      {groupManager}
+      {conversationGroups.length ? (
+        <UngroupedConversationSection projectId={project.id} sessionCount={project.repos.reduce((sum, repo) => sum + repo.sessionCount, 0)}>
+          {repoRows}
+        </UngroupedConversationSection>
+      ) : (
+        repoRows
+      )}
     </>
+  )
+}
+
+function UngroupedConversationSection({
+  children,
+  projectId,
+  sessionCount
+}: {
+  children: React.ReactNode
+  projectId: string
+  sessionCount: number
+}) {
+  const [open, setOpen] = useState(true)
+
+  return (
+    <SidebarRowStack
+      className="rounded-md transition-colors data-[session-drag-over=true]:bg-(--ui-control-active-background) data-[session-drag-over=true]:ring-1 data-[session-drag-over=true]:ring-(--ui-stroke-secondary)"
+      data-conversation-group-drop
+      data-group-id=""
+      data-project-id={projectId}
+    >
+      <WorkspaceHeader
+        icon={<Codicon className="text-(--ui-text-tertiary)" name="inbox" size="0.75rem" />}
+        label={`미분류 (${sessionCount})`}
+        onToggle={() => setOpen(value => !value)}
+        open={open}
+      />
+      {open && <SidebarRowStack className="pl-2.5">{children}</SidebarRowStack>}
+    </SidebarRowStack>
   )
 }
 

--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.test.tsx
@@ -78,4 +78,26 @@ describe('ProjectOverviewRow', () => {
 
     expect(screen.queryByRole('button', { name: 'New session in Home' })).toBeNull()
   })
+
+  it('makes an explicit project header a session drop target without targeting Home or auto projects', () => {
+    const { rerender } = render(<ProjectOverviewRow project={project} />)
+    const explicitHeader = screen.getByRole('button', { name: 'Enter Test D' }).closest('[data-conversation-group-drop]')
+
+    expect(explicitHeader?.getAttribute('data-project-id')).toBe('p1')
+    expect(explicitHeader?.getAttribute('data-group-id')).toBe('')
+
+    rerender(
+      <ProjectOverviewRow
+        project={{ id: '__no_project__', isNoProject: true, label: 'Home' } as unknown as SidebarProjectTree}
+      />
+    )
+    expect(screen.getByRole('button', { name: 'Enter Home' }).closest('[data-conversation-group-drop]')).toBeNull()
+
+    rerender(
+      <ProjectOverviewRow
+        project={{ id: 'auto', isAuto: true, label: 'Auto repo' } as unknown as SidebarProjectTree}
+      />
+    )
+    expect(screen.getByRole('button', { name: 'Enter Auto repo' }).closest('[data-conversation-group-drop]')).toBeNull()
+  })
 })

--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
@@ -92,6 +92,7 @@ export function ProjectOverviewRow({
   const { t } = useI18n()
   const s = t.sidebar
   const isActive = project.id === activeProjectId
+  const isSessionDropTarget = !project.isNoProject && !project.isAuto
   const [open, toggleOpen] = useWorkspaceNodeOpen(project.id)
   // The appearance popover anchors here (the full row) so it opens flush with
   // the sidebar's content edge regardless of which side the sidebar is on.
@@ -124,7 +125,15 @@ export function ProjectOverviewRow({
           {!project.isNoProject && <ProjectMenu anchorRef={rowRef} isActive={isActive} project={project} />}
         </>
       }
-      className={cn('group/workspace', dragging && 'cursor-grabbing bg-(--ui-sidebar-surface-background)')}
+      className={cn(
+        'group/workspace transition-colors',
+        isSessionDropTarget &&
+          'data-[session-drag-over=true]:bg-(--ui-control-active-background) data-[session-drag-over=true]:ring-1 data-[session-drag-over=true]:ring-(--ui-stroke-secondary)',
+        dragging && 'cursor-grabbing bg-(--ui-sidebar-surface-background)'
+      )}
+      data-conversation-group-drop={isSessionDropTarget ? '' : undefined}
+      data-group-id={isSessionDropTarget ? '' : undefined}
+      data-project-id={isSessionDropTarget ? project.id : undefined}
       ref={rowRef}
     >
       <SidebarRowCluster className="min-w-0 flex-1">

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
@@ -623,6 +623,20 @@ describe('sessionProjectColor', () => {
 })
 
 describe('overlayLiveLanes', () => {
+  it('does not reinsert a live session into its cwd project after a manual move', () => {
+    const project = projectNode({
+      id: '/www/app',
+      isAuto: true,
+      repos: [{ id: '/www/app', label: 'app', path: '/www/app', sessionCount: 0, groups: [] }]
+    })
+    const moved = makeSession('/www/app', { id: 'moved', git_branch: 'main' })
+
+    const overlaid = overlayLiveLanes(project, [moved], new Set(), { moved: 'p_wedding' })
+
+    expect(overlaid.repos.flatMap(repo => repo.groups).flatMap(group => group.sessions)).toEqual([])
+    expect(overlaid.sessionCount).toBe(0)
+  })
+
   it('injects a live session into the matching main lane instantly', () => {
     const project = projectNode({
       id: '/www/app',
@@ -833,6 +847,24 @@ describe('overlayLiveLanes', () => {
 })
 
 describe('overlayLivePreviews', () => {
+  it('uses manual project ownership instead of cwd when previewing a moved live session', () => {
+    const oldProject = projectNode({ id: '/www/app', isAuto: true })
+    const weddingProject = projectNode({ id: 'p_wedding' })
+    const moved = makeSession('/www/app', { id: 'moved', started_at: 99, last_active: 99 })
+
+    const previews = overlayLivePreviews(
+      [oldProject, weddingProject],
+      [moved],
+      [],
+      3,
+      new Set(),
+      { moved: 'p_wedding' }
+    )
+
+    expect(previews['/www/app']).toBeUndefined()
+    expect(previews.p_wedding.map(session => session.id)).toEqual(['moved'])
+  })
+
   it('merges live sessions into a project preview, live first, capped to the limit', () => {
     const project = projectNode({
       id: '/www/app',

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -45,6 +45,13 @@ export interface SidebarWorkspaceTree {
   sessionCount: number
 }
 
+export interface SidebarConversationGroup {
+  id: string
+  label: string
+  position: number
+  sessions: SessionInfo[]
+}
+
 /** A project node: human-named (or repo-derived), holds its repo subtree. */
 export interface SidebarProjectTree {
   id: string
@@ -60,6 +67,7 @@ export interface SidebarProjectTree {
   // claimed. It has no folder, so no repo/worktree structure — its one lane
   // exists only to carry the rows.
   isNoProject?: boolean
+  conversationGroups?: SidebarConversationGroup[]
   repos: SidebarWorkspaceTree[]
   sessionCount: number
   // Max activity timestamp across the project's sessions (overview sort key).
@@ -659,6 +667,18 @@ export function excludeProjectSessions(
 
   const previewSessions = project.previewSessions?.filter(session => !isExcluded(session))
 
+  const conversationGroups = (project.conversationGroups ?? []).map(group => {
+    const sessions = group.sessions.filter(session => !isExcluded(session))
+
+    if (sessions.length !== group.sessions.length) {
+      changed = true
+
+      return { ...group, sessions }
+    }
+
+    return group
+  })
+
   changed ||= previewSessions?.length !== project.previewSessions?.length
 
   if (!changed) {
@@ -667,9 +687,12 @@ export function excludeProjectSessions(
 
   return {
     ...project,
+    conversationGroups,
     previewSessions,
     repos,
-    sessionCount: repos.reduce((n, repo) => n + repo.sessionCount, 0)
+    sessionCount:
+      repos.reduce((n, repo) => n + repo.sessionCount, 0) +
+      conversationGroups.reduce((n, group) => n + group.sessions.length, 0)
   }
 }
 
@@ -684,9 +707,11 @@ export function overlayLiveLanes(
   }
 
   let changed = false
+  const groupedIds = new Set((project.conversationGroups ?? []).flatMap(group => group.sessions.map(session => session.id)))
+  const repoLive = groupedIds.size ? live.filter(session => !groupedIds.has(session.id)) : live
 
   const repos = project.repos.map(repo => {
-    const next = overlayRepoLanes(repo, live, removed)
+    const next = overlayRepoLanes(repo, repoLive, removed)
 
     changed ||= next !== repo
 
@@ -697,7 +722,13 @@ export function overlayLiveLanes(
     return project
   }
 
-  return { ...project, repos, sessionCount: repos.reduce((n, repo) => n + repo.sessionCount, 0) }
+  return {
+    ...project,
+    repos,
+    sessionCount:
+      repos.reduce((n, repo) => n + repo.sessionCount, 0) +
+      (project.conversationGroups ?? []).reduce((n, group) => n + group.sessions.length, 0)
+  }
 }
 
 /** Merge live sessions into per-project overview previews, keyed by project id. */

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -700,18 +700,25 @@ export function excludeProjectSessions(
 export function overlayLiveLanes(
   project: SidebarProjectTree,
   live: SessionInfo[],
-  removed: ReadonlySet<string> = NO_REMOVED
+  removed: ReadonlySet<string> = NO_REMOVED,
+  manualProjectIds: Readonly<Record<string, string>> = {}
 ): SidebarProjectTree {
+  const movedElsewhere = Object.entries(manualProjectIds)
+    .filter(([, projectId]) => projectId !== project.id)
+    .map(([sessionId]) => sessionId)
+  const excluded = movedElsewhere.length ? new Set([...removed, ...movedElsewhere]) : removed
+  const projectLive = live.filter(session => !manualProjectIds[session.id] || manualProjectIds[session.id] === project.id)
+
   if (project.isNoProject) {
-    return overlayHomeLane(project, live, removed)
+    return overlayHomeLane(project, projectLive, excluded)
   }
 
   let changed = false
   const groupedIds = new Set((project.conversationGroups ?? []).flatMap(group => group.sessions.map(session => session.id)))
-  const repoLive = groupedIds.size ? live.filter(session => !groupedIds.has(session.id)) : live
+  const repoLive = groupedIds.size ? projectLive.filter(session => !groupedIds.has(session.id)) : projectLive
 
   const repos = project.repos.map(repo => {
-    const next = overlayRepoLanes(repo, repoLive, removed)
+    const next = overlayRepoLanes(repo, repoLive, excluded)
 
     changed ||= next !== repo
 
@@ -737,7 +744,8 @@ export function overlayLivePreviews(
   live: SessionInfo[],
   explicitProjects: ProjectInfo[],
   limit: number,
-  removed: ReadonlySet<string> = new Set()
+  removed: ReadonlySet<string> = new Set(),
+  manualProjectIds: Readonly<Record<string, string>> = {}
 ): Record<string, SessionInfo[]> {
   const byProject = new Map<string, SessionInfo[]>()
 
@@ -747,7 +755,9 @@ export function overlayLivePreviews(
     }
 
     const projectId =
-      liveSessionProjectId(session, explicitProjects) ?? (isDetachedSession(session) ? NO_PROJECT_ID : null)
+      manualProjectIds[session.id] ??
+      liveSessionProjectId(session, explicitProjects) ??
+      (isDetachedSession(session) ? NO_PROJECT_ID : null)
 
     if (!projectId) {
       continue
@@ -762,7 +772,9 @@ export function overlayLivePreviews(
 
   for (const node of projects) {
     const liveRows = byProject.get(node.id) ?? []
-    const base = (node.previewSessions ?? []).filter(session => !removed.has(session.id))
+    const base = (node.previewSessions ?? []).filter(
+      session => !removed.has(session.id) && (!manualProjectIds[session.id] || manualProjectIds[session.id] === node.id)
+    )
 
     if (!liveRows.length && !base.length) {
       continue

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -207,12 +207,15 @@ export function SidebarSessionsSection({
   // render as a drill-in row so the user can see it exists).
   const hasProjectOverview = Boolean(projectOverview?.length)
 
-  // Lanes count as content even with no rows left in them: the backend only
-  // emits a lane that has sessions, so a lane surviving with zero rows means
-  // they were filtered out (pinned) — the branch is real and must still render.
-  // A genuinely empty project has no lanes at all and keeps its empty state.
+  // Explicit projects always render their entered content, even while empty:
+  // organizational projects with no folder need the conversation-group create
+  // affordance before they can hold a session. Auto/Home buckets still require
+  // a real lane or row so their empty state remains clean.
   const hasProjectContent = Boolean(
-    projectContent && (projectContent.sessionCount > 0 || projectContent.repos.some(repo => repo.groups.length > 0))
+    projectContent &&
+      ((!projectContent.isAuto && !projectContent.isNoProject) ||
+        projectContent.sessionCount > 0 ||
+        projectContent.repos.some(repo => repo.groups.length > 0))
   )
 
   const showEmptyState =

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -8,6 +8,7 @@ import { $currentCwd, $selectedStoredSessionId, $sessions, applyConfiguredDefaul
 
 import {
   $activeProjectId,
+  $manualSessionProjectIds,
   $projectScope,
   $projectsRpcAvailable,
   $projectTree,
@@ -461,6 +462,24 @@ describe('repository discovery policy', () => {
 })
 
 describe('project tree profile isolation', () => {
+  it('publishes the backend manual session ownership map with the project tree', async () => {
+    const gateway = {
+      connectionState: 'open',
+      request: vi.fn().mockResolvedValue({
+        active_id: null,
+        manual_session_project_ids: { moved: 'p_wedding' },
+        projects: [],
+        scoped_session_ids: ['moved']
+      })
+    }
+    activeGateway.mockImplementation(() => gateway as never)
+    gatewayAtom.set(gateway as never)
+
+    await refreshProjectTree()
+
+    expect($manualSessionProjectIds.get()).toEqual({ moved: 'p_wedding' })
+  })
+
   it('does not publish a late response from the previous profile', async () => {
     let resolveA: ((value: unknown) => void) | undefined
 

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -42,6 +42,7 @@ export const $activeProjectId = atom<null | string>(null)
 // source of project membership — the desktop no longer derives it.
 export const $projectTree = atom<SidebarProjectTree[]>([])
 export const $projectTreeLoading = atom(false)
+export const $manualSessionProjectIds = atom<Record<string, string>>({})
 
 // False when the connected backend predates the projects.* JSON-RPC surface
 // (same semver label, older install). Null until the first probe.
@@ -445,6 +446,7 @@ interface ProjectTreePayload {
   projects: SidebarProjectTree[]
   active_id: null | string
   scoped_session_ids: string[]
+  manual_session_project_ids?: Record<string, string>
 }
 
 let projectTreeRefreshGeneration = 0
@@ -467,6 +469,7 @@ async function refreshProjectTreeOn(gateway: HermesGateway): Promise<void> {
 
     const scoped = new Set(res.scoped_session_ids ?? [])
     $projectTree.set(res.projects ?? [])
+    $manualSessionProjectIds.set(res.manual_session_project_ids ?? {})
     $activeProjectId.set(res.active_id ?? null)
     const tombstones = $removedSessionIds.get()
 

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -560,6 +560,50 @@ export async function moveSessionToProject(
   void refreshProjectTree()
 }
 
+export async function assignSessionConversationGroup(
+  sessionId: string,
+  projectId: string,
+  groupId: null | string
+): Promise<void> {
+  await gatewayRequest('projects.sessions.assign', {
+    session_id: sessionId,
+    project_id: projectId,
+    group_id: groupId
+  })
+  await refreshProjectTree()
+}
+
+export interface ConversationGroupInfo {
+  id: string
+  project_id: string
+  name: string
+  position: number
+  created_at: number
+}
+
+export async function createConversationGroup(projectId: string, name: string): Promise<void> {
+  await gatewayRequest<{ group: ConversationGroupInfo }>('projects.groups.create', {
+    project_id: projectId,
+    name
+  })
+  await refreshProjectTree()
+}
+
+export async function renameConversationGroup(groupId: string, name: string): Promise<void> {
+  await gatewayRequest<{ group: ConversationGroupInfo }>('projects.groups.update', { id: groupId, name })
+  await refreshProjectTree()
+}
+
+export async function deleteConversationGroup(groupId: string): Promise<void> {
+  await gatewayRequest('projects.groups.delete', { id: groupId })
+  await refreshProjectTree()
+}
+
+export async function reorderConversationGroups(projectId: string, ids: string[]): Promise<void> {
+  await gatewayRequest('projects.groups.reorder', { project_id: projectId, ids })
+  await refreshProjectTree()
+}
+
 export interface RepoDiscoveryPolicy {
   enabled: boolean
   roots: string[]
@@ -786,6 +830,7 @@ function projectInfoToTreeNode(project: ProjectInfo): SidebarProjectTree {
     color: project.color ?? null,
     icon: project.icon ?? null,
     isAuto: false,
+    conversationGroups: [],
     repos: [],
     sessionCount: 0,
     previewSessions: []

--- a/hermes_cli/projects_db.py
+++ b/hermes_cli/projects_db.py
@@ -85,6 +85,27 @@ CREATE TABLE IF NOT EXISTS project_meta (
     value  TEXT
 );
 
+CREATE TABLE IF NOT EXISTS conversation_groups (
+    id          TEXT PRIMARY KEY,
+    project_id  TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    name        TEXT NOT NULL,
+    position    INTEGER NOT NULL,
+    created_at  INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_conversation_groups_project_position
+    ON conversation_groups(project_id, position);
+
+CREATE TABLE IF NOT EXISTS project_session_assignments (
+    session_id   TEXT PRIMARY KEY,
+    project_id   TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    group_id     TEXT REFERENCES conversation_groups(id) ON DELETE SET NULL,
+    assigned_at  INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_project_session_assignments_project
+    ON project_session_assignments(project_id);
+
 -- Git repos found by scanning the filesystem (desktop "repo-first" discovery).
 -- Cached here so the overview is instant after the first scan instead of
 -- re-walking the disk every time the Projects view opens.
@@ -259,6 +280,40 @@ class Project:
             "archived": bool(self.archived),
             "created_at": self.created_at,
             "folders": [f.to_dict() for f in self.folders],
+        }
+
+
+@dataclass
+class ConversationGroup:
+    id: str
+    project_id: str
+    name: str
+    position: int
+    created_at: int
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "project_id": self.project_id,
+            "name": self.name,
+            "position": self.position,
+            "created_at": self.created_at,
+        }
+
+
+@dataclass
+class SessionAssignment:
+    session_id: str
+    project_id: str
+    group_id: Optional[str]
+    assigned_at: int
+
+    def to_dict(self) -> dict:
+        return {
+            "session_id": self.session_id,
+            "project_id": self.project_id,
+            "group_id": self.group_id,
+            "assigned_at": self.assigned_at,
         }
 
 
@@ -588,6 +643,139 @@ def delete_project(conn: sqlite3.Connection, project_id: str) -> bool:
     with write_txn(conn):
         cur = conn.execute("DELETE FROM projects WHERE id = ?", (project_id,))
     return cur.rowcount > 0
+
+
+# ---------------------------------------------------------------------------
+# Conversation groups + manual session organization
+# ---------------------------------------------------------------------------
+
+
+def _new_conversation_group_id() -> str:
+    return "cg_" + secrets.token_hex(4)
+
+
+def _require_project_id(conn: sqlite3.Connection, project_id: str) -> None:
+    if conn.execute("SELECT 1 FROM projects WHERE id = ?", (project_id,)).fetchone() is None:
+        raise ValueError(f"no such project: {project_id}")
+
+
+def create_conversation_group(conn: sqlite3.Connection, project_id: str, name: str) -> str:
+    """Create an ordered, user-managed conversation group within a project."""
+    _require_project_id(conn, project_id)
+    clean_name = str(name or "").strip()
+    if not clean_name:
+        raise ValueError("conversation group name must not be empty")
+    group_id = _new_conversation_group_id()
+    now = _now()
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT COALESCE(MAX(position), -1) + 1 AS next_position "
+            "FROM conversation_groups WHERE project_id = ?",
+            (project_id,),
+        ).fetchone()
+        conn.execute(
+            "INSERT INTO conversation_groups (id, project_id, name, position, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (group_id, project_id, clean_name, int(row["next_position"]), now),
+        )
+    return group_id
+
+
+def list_conversation_groups(conn: sqlite3.Connection, project_id: str) -> List[ConversationGroup]:
+    rows = conn.execute(
+        "SELECT id, project_id, name, position, created_at FROM conversation_groups "
+        "WHERE project_id = ? ORDER BY position ASC, created_at ASC",
+        (project_id,),
+    ).fetchall()
+    return [ConversationGroup(**dict(row)) for row in rows]
+
+
+def get_conversation_group(
+    conn: sqlite3.Connection, group_id: str
+) -> Optional[ConversationGroup]:
+    row = conn.execute(
+        "SELECT id, project_id, name, position, created_at "
+        "FROM conversation_groups WHERE id = ?",
+        (group_id,),
+    ).fetchone()
+    return ConversationGroup(**dict(row)) if row is not None else None
+
+
+def update_conversation_group(
+    conn: sqlite3.Connection, group_id: str, *, name: str
+) -> bool:
+    clean_name = str(name or "").strip()
+    if not clean_name:
+        raise ValueError("conversation group name must not be empty")
+    with write_txn(conn):
+        cur = conn.execute(
+            "UPDATE conversation_groups SET name = ? WHERE id = ?",
+            (clean_name, group_id),
+        )
+    return cur.rowcount > 0
+
+
+def delete_conversation_group(conn: sqlite3.Connection, group_id: str) -> bool:
+    """Delete only the group; SQLite keeps its sessions assigned to the project."""
+    with write_txn(conn):
+        cur = conn.execute("DELETE FROM conversation_groups WHERE id = ?", (group_id,))
+    return cur.rowcount > 0
+
+
+def reorder_conversation_groups(
+    conn: sqlite3.Connection, project_id: str, ordered_ids: Iterable[str]
+) -> None:
+    existing = [group.id for group in list_conversation_groups(conn, project_id)]
+    ordered = list(ordered_ids)
+    if len(ordered) != len(set(ordered)) or set(ordered) != set(existing):
+        raise ValueError("ordered conversation group ids must match the project's groups")
+    with write_txn(conn):
+        conn.executemany(
+            "UPDATE conversation_groups SET position = ? WHERE id = ? AND project_id = ?",
+            [(position, group_id, project_id) for position, group_id in enumerate(ordered)],
+        )
+
+
+def assign_session(
+    conn: sqlite3.Connection,
+    session_id: str,
+    project_id: str,
+    group_id: Optional[str],
+) -> None:
+    """Manually place a durable session without changing its cwd or transcript."""
+    clean_session_id = str(session_id or "").strip()
+    if not clean_session_id:
+        raise ValueError("session_id required")
+    _require_project_id(conn, project_id)
+    if group_id is not None:
+        row = conn.execute(
+            "SELECT project_id FROM conversation_groups WHERE id = ?", (group_id,)
+        ).fetchone()
+        if row is None or row["project_id"] != project_id:
+            raise ValueError("conversation group does not belong to the project")
+    with write_txn(conn):
+        conn.execute(
+            "INSERT INTO project_session_assignments "
+            "(session_id, project_id, group_id, assigned_at) VALUES (?, ?, ?, ?) "
+            "ON CONFLICT(session_id) DO UPDATE SET "
+            "project_id = excluded.project_id, group_id = excluded.group_id, "
+            "assigned_at = excluded.assigned_at",
+            (clean_session_id, project_id, group_id, _now()),
+        )
+
+
+def get_session_assignments(
+    conn: sqlite3.Connection, session_ids: Optional[Iterable[str]] = None
+) -> dict[str, SessionAssignment]:
+    params: list[str] = []
+    sql = "SELECT session_id, project_id, group_id, assigned_at FROM project_session_assignments"
+    if session_ids is not None:
+        params = [str(value) for value in session_ids if str(value)]
+        if not params:
+            return {}
+        sql += f" WHERE session_id IN ({','.join('?' for _ in params)})"
+    rows = conn.execute(sql, params).fetchall()
+    return {row["session_id"]: SessionAssignment(**dict(row)) for row in rows}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_projects_db.py
+++ b/tests/hermes_cli/test_projects_db.py
@@ -101,3 +101,44 @@ def test_per_profile_isolation(tmp_path):
         b.close()
 
 
+def test_conversation_group_crud_and_session_assignment(conn):
+    project_id = pdb.create_project(conn, name="SK 업무")
+
+    first = pdb.create_conversation_group(conn, project_id, "ITO LLM Wiki")
+    second = pdb.create_conversation_group(conn, project_id, "Tib/RV")
+
+    assert [group.name for group in pdb.list_conversation_groups(conn, project_id)] == [
+        "ITO LLM Wiki",
+        "Tib/RV",
+    ]
+
+    assert pdb.update_conversation_group(conn, second, name="Tib / RV") is True
+    pdb.reorder_conversation_groups(conn, project_id, [second, first])
+    assert [group.name for group in pdb.list_conversation_groups(conn, project_id)] == [
+        "Tib / RV",
+        "ITO LLM Wiki",
+    ]
+
+    pdb.assign_session(conn, "session-1", project_id, second)
+    assignment = pdb.get_session_assignments(conn)["session-1"]
+    assert assignment.project_id == project_id
+    assert assignment.group_id == second
+
+    assert pdb.delete_conversation_group(conn, second) is True
+    assignment = pdb.get_session_assignments(conn)["session-1"]
+    assert assignment.project_id == project_id
+    assert assignment.group_id is None
+
+
+def test_session_assignment_can_move_to_ungrouped_without_changing_project(conn):
+    project_id = pdb.create_project(conn, name="주식")
+    group_id = pdb.create_conversation_group(conn, project_id, "SK하이닉스")
+    pdb.assign_session(conn, "session-1", project_id, group_id)
+
+    pdb.assign_session(conn, "session-1", project_id, None)
+
+    assignment = pdb.get_session_assignments(conn)["session-1"]
+    assert assignment.project_id == project_id
+    assert assignment.group_id is None
+
+

--- a/tests/tui_gateway/test_project_tree.py
+++ b/tests/tui_gateway/test_project_tree.py
@@ -340,6 +340,49 @@ def test_explicit_project_claims_sessions_and_beats_auto():
     assert any(p["id"] == "/www/other" and p["isAuto"] for p in tree["projects"])
 
 
+def test_manual_assignment_overrides_cwd_and_places_session_in_conversation_group():
+    project = _project("p_sk", "SK 업무", [])
+    session = _session("/unrelated/repo", branch="main")
+    groups = [
+        {
+            "id": "cg_ito",
+            "project_id": "p_sk",
+            "name": "ITO LLM Wiki",
+            "position": 0,
+        }
+    ]
+    assignments = {
+        session["id"]: {
+            "session_id": session["id"],
+            "project_id": "p_sk",
+            "group_id": "cg_ito",
+        }
+    }
+
+    tree = pt.build_tree(
+        [project],
+        [session],
+        [],
+        resolve=lambda _cwd: None,
+        hydrate=True,
+        conversation_groups=groups,
+        session_assignments=assignments,
+    )
+
+    assert [node["id"] for node in tree["projects"]] == ["p_sk"]
+    node = tree["projects"][0]
+    assert node["sessionCount"] == 1
+    assert node["repos"] == []
+    assert node["conversationGroups"] == [
+        {
+            "id": "cg_ito",
+            "label": "ITO LLM Wiki",
+            "position": 0,
+            "sessions": [session],
+        }
+    ]
+
+
 def test_scoped_session_ids_is_union_of_placed_sessions():
     project = _project("p_app", "App", ["/www/app"])
     resolve = _resolver(

--- a/tests/tui_gateway/test_project_tree.py
+++ b/tests/tui_gateway/test_project_tree.py
@@ -381,6 +381,7 @@ def test_manual_assignment_overrides_cwd_and_places_session_in_conversation_grou
             "sessions": [session],
         }
     ]
+    assert tree["manual_session_project_ids"] == {session["id"]: "p_sk"}
 
 
 def test_scoped_session_ids_is_union_of_placed_sessions():

--- a/tests/tui_gateway/test_projects_rpc.py
+++ b/tests/tui_gateway/test_projects_rpc.py
@@ -55,6 +55,11 @@ def test_methods_registered():
         "projects.archive",
         "projects.set_active",
         "projects.for_cwd",
+        "projects.groups.create",
+        "projects.groups.update",
+        "projects.groups.delete",
+        "projects.groups.reorder",
+        "projects.sessions.assign",
     ):
         assert m in server._methods
 
@@ -224,6 +229,35 @@ def test_delete_removes_project(tmp_path):
 
     assert all(p["id"] != pid for p in payload["projects"])
     assert "projects.delete" in server._methods
+
+
+def test_conversation_group_rpc_crud_and_assignment():
+    project = _call("projects.create", {"name": "SK 업무", "folders": []})["project"]
+    first = _call(
+        "projects.groups.create", {"project_id": project["id"], "name": "ITO LLM Wiki"}
+    )["group"]
+    second = _call(
+        "projects.groups.create", {"project_id": project["id"], "name": "Tib/RV"}
+    )["group"]
+
+    renamed = _call(
+        "projects.groups.update", {"id": second["id"], "name": "Tib / RV"}
+    )["group"]
+    assert renamed["name"] == "Tib / RV"
+
+    reordered = _call(
+        "projects.groups.reorder",
+        {"project_id": project["id"], "ids": [second["id"], first["id"]]},
+    )
+    assert [group["id"] for group in reordered["groups"]] == [second["id"], first["id"]]
+
+    assigned = _call(
+        "projects.sessions.assign",
+        {"session_id": "session-1", "project_id": project["id"], "group_id": second["id"]},
+    )
+    assert assigned["assignment"]["group_id"] == second["id"]
+
+    _call("projects.groups.delete", {"id": second["id"]})
 
 
 def test_discover_repos_is_registered_long_handler():

--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -115,7 +115,15 @@ def _(rid, params: dict) -> dict:
     try:
         db = _get_db()
         if db is None:
-            return _ok(rid, {"projects": [], "active_id": None, "scoped_session_ids": []})
+            return _ok(
+                rid,
+                {
+                    "projects": [],
+                    "active_id": None,
+                    "scoped_session_ids": [],
+                    "manual_session_project_ids": {},
+                },
+            )
 
         tree, active_id = _build_project_tree(
             db,
@@ -126,7 +134,12 @@ def _(rid, params: dict) -> dict:
         )
         return _ok(
             rid,
-            {"projects": tree["projects"], "active_id": active_id, "scoped_session_ids": tree["scoped_session_ids"]},
+            {
+                "projects": tree["projects"],
+                "active_id": active_id,
+                "scoped_session_ids": tree["scoped_session_ids"],
+                "manual_session_project_ids": tree["manual_session_project_ids"],
+            },
         )
     except Exception as e:
         return _err(rid, 5061, str(e))

--- a/tui_gateway/project_tree.py
+++ b/tui_gateway/project_tree.py
@@ -516,6 +516,7 @@ def _project_node(
     preview_sessions: list[dict],
     color: Any = None,
     icon: Any = None,
+    conversation_groups: Optional[list[dict]] = None,
     is_auto: bool = False,
     is_no_project: bool = False,
 ) -> dict:
@@ -530,6 +531,7 @@ def _project_node(
         "sessionCount": session_count,
         "lastActive": last_active,
         "repos": repos,
+        "conversationGroups": conversation_groups or [],
         "previewSessions": preview_sessions,
     }
 
@@ -545,6 +547,8 @@ def build_tree(
     is_junk_root: Optional[Callable[[str], bool]] = None,
     is_junk_cwd: Optional[Callable[[str], bool]] = None,
     exists: Optional[Exists] = None,
+    conversation_groups: Optional[list[dict]] = None,
+    session_assignments: Optional[dict[str, dict]] = None,
 ) -> dict:
     """Build the authoritative project tree.
 
@@ -567,17 +571,41 @@ def build_tree(
     ``previewSessions``. When True (drill-in), lanes carry full session rows.
     """
     active_projects = [p for p in projects if not p.get("archived")]
+    active_by_id = {project["id"]: project for project in active_projects}
+    groups_by_project: dict[str, list[dict]] = {}
+    group_by_id: dict[str, dict] = {}
+    for group in conversation_groups or []:
+        project_id = str(group.get("project_id") or "")
+        group_id = str(group.get("id") or "")
+        if project_id not in active_by_id or not group_id:
+            continue
+        groups_by_project.setdefault(project_id, []).append(group)
+        group_by_id[group_id] = group
+    for groups in groups_by_project.values():
+        groups.sort(key=lambda group: (int(group.get("position") or 0), str(group.get("name") or "")))
+
+    assignments = session_assignments or {}
     _junk = is_junk_root or (lambda _root: False)
     _junk_cwd = is_junk_cwd or (lambda _cwd: False)
     _exists = exists or (lambda _path: True)
     folder_index = _FolderIndex(active_projects)
 
     by_project: dict[str, list[dict]] = {}
+    grouped_session_ids: set[str] = set()
+    sessions_by_group: dict[str, list[dict]] = {}
     unowned: list[dict] = []
     for session in sessions:
-        owner = _project_for_session(session, folder_index, resolve)
+        session_id = str(session.get("id") or "")
+        assignment = assignments.get(session_id) or {}
+        assigned_project = active_by_id.get(str(assignment.get("project_id") or ""))
+        owner = assigned_project or _project_for_session(session, folder_index, resolve)
         if owner:
             by_project.setdefault(owner["id"], []).append(session)
+            group_id = str(assignment.get("group_id") or "")
+            group = group_by_id.get(group_id)
+            if group and group.get("project_id") == owner["id"]:
+                grouped_session_ids.add(session_id)
+                sessions_by_group.setdefault(group_id, []).append(session)
         else:
             unowned.append(session)
 
@@ -598,9 +626,23 @@ def build_tree(
     for project in active_projects:
         psessions = by_project.get(project["id"], [])
         scoped_ids.extend(s["id"] for s in psessions if s.get("id"))
+        repo_sessions = [s for s in psessions if str(s.get("id") or "") not in grouped_session_ids]
         repos = _seed_folder_repos(
-            _build_repos(psessions, resolve, hydrate), project.get("folders") or [], resolve
+            _build_repos(repo_sessions, resolve, hydrate), project.get("folders") or [], resolve
         )
+        rendered_groups = []
+        for group in groups_by_project.get(project["id"], []):
+            group_sessions = sorted(
+                sessions_by_group.get(group["id"], []), key=_session_time, reverse=True
+            )
+            rendered_groups.append(
+                {
+                    "id": group["id"],
+                    "label": group.get("name") or group["id"],
+                    "position": int(group.get("position") or 0),
+                    "sessions": group_sessions if hydrate else [],
+                }
+            )
         result.append(
             _project_node(
                 pid=project["id"],
@@ -608,6 +650,7 @@ def build_tree(
                 path=project.get("primary_path"),
                 color=project.get("color"),
                 icon=project.get("icon"),
+                conversation_groups=rendered_groups,
                 repos=repos,
                 session_count=len(psessions),
                 last_active=_last_active(psessions),

--- a/tui_gateway/project_tree.py
+++ b/tui_gateway/project_tree.py
@@ -565,7 +565,10 @@ def build_tree(
     a scratch dir under /tmp) doesn't get promoted to a phantom AUTO project;
     omit it (remote backends) to keep every candidate.
 
-    Returns ``{"projects": [...], "scoped_session_ids": [...]}``. When
+    Returns ``{"projects": [...], "scoped_session_ids": [...],
+    "manual_session_project_ids": {...}}``. The manual ownership map lets
+    renderer live overlays preserve an explicit project move instead of
+    reclassifying the running session from its unchanged cwd. When
     ``hydrate`` is False (overview), lane ``sessions`` arrays are emptied but
     every count is preserved and each project carries up to ``preview_limit``
     ``previewSessions``. When True (drill-in), lanes carry full session rows.
@@ -585,6 +588,7 @@ def build_tree(
         groups.sort(key=lambda group: (int(group.get("position") or 0), str(group.get("name") or "")))
 
     assignments = session_assignments or {}
+    manual_session_project_ids: dict[str, str] = {}
     _junk = is_junk_root or (lambda _root: False)
     _junk_cwd = is_junk_cwd or (lambda _cwd: False)
     _exists = exists or (lambda _path: True)
@@ -598,6 +602,8 @@ def build_tree(
         session_id = str(session.get("id") or "")
         assignment = assignments.get(session_id) or {}
         assigned_project = active_by_id.get(str(assignment.get("project_id") or ""))
+        if assigned_project and session_id:
+            manual_session_project_ids[session_id] = assigned_project["id"]
         owner = assigned_project or _project_for_session(session, folder_index, resolve)
         if owner:
             by_project.setdefault(owner["id"], []).append(session)
@@ -808,4 +814,8 @@ def build_tree(
             ),
         )
 
-    return {"projects": result, "scoped_session_ids": scoped_ids}
+    return {
+        "projects": result,
+        "scoped_session_ids": scoped_ids,
+        "manual_session_project_ids": manual_session_project_ids,
+    }

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11462,6 +11462,73 @@ def _(rid, params, pdb, conn) -> dict:
     return _ok(rid, _projects_payload(conn))
 
 
+@_projects_method("projects.groups.create")
+def _(rid, params, pdb, conn) -> dict:
+    project_id = str(params.get("project_id") or "")
+    if pdb.get_project(conn, project_id) is None:
+        raise _NoProject
+    group_id = pdb.create_conversation_group(
+        conn, project_id, str(params.get("name") or "")
+    )
+    group = pdb.get_conversation_group(conn, group_id)
+    return _ok(rid, {"group": group.to_dict() if group else None})
+
+
+@_projects_method("projects.groups.update")
+def _(rid, params, pdb, conn) -> dict:
+    group_id = str(params.get("id") or "")
+    if pdb.get_conversation_group(conn, group_id) is None:
+        raise ValueError("no such conversation group")
+    pdb.update_conversation_group(conn, group_id, name=str(params.get("name") or ""))
+    group = pdb.get_conversation_group(conn, group_id)
+    return _ok(rid, {"group": group.to_dict() if group else None})
+
+
+@_projects_method("projects.groups.delete")
+def _(rid, params, pdb, conn) -> dict:
+    group_id = str(params.get("id") or "")
+    group = pdb.get_conversation_group(conn, group_id)
+    if group is None:
+        raise ValueError("no such conversation group")
+    pdb.delete_conversation_group(conn, group_id)
+    return _ok(
+        rid,
+        {
+            "groups": [
+                item.to_dict()
+                for item in pdb.list_conversation_groups(conn, group.project_id)
+            ]
+        },
+    )
+
+
+@_projects_method("projects.groups.reorder")
+def _(rid, params, pdb, conn) -> dict:
+    project_id = str(params.get("project_id") or "")
+    if pdb.get_project(conn, project_id) is None:
+        raise _NoProject
+    pdb.reorder_conversation_groups(conn, project_id, params.get("ids") or [])
+    return _ok(
+        rid,
+        {
+            "groups": [
+                item.to_dict()
+                for item in pdb.list_conversation_groups(conn, project_id)
+            ]
+        },
+    )
+
+
+@_projects_method("projects.sessions.assign")
+def _(rid, params, pdb, conn) -> dict:
+    session_id = str(params.get("session_id") or "")
+    project_id = str(params.get("project_id") or "")
+    group_id = str(params.get("group_id") or "") or None
+    pdb.assign_session(conn, session_id, project_id, group_id)
+    assignment = pdb.get_session_assignments(conn, [session_id]).get(session_id)
+    return _ok(rid, {"assignment": assignment.to_dict() if assignment else None})
+
+
 @_projects_method("projects.set_active")
 def _(rid, params, pdb, conn) -> dict:
     pdb.set_active(conn, _require_project(pdb, conn, params).id if params.get("id") else None)
@@ -11700,7 +11767,7 @@ def _project_tree_row(r: dict) -> dict:
 
 def _project_tree_inputs(
     db, session_limit: int, *, include_discovered: bool
-) -> tuple[list[dict], list[dict], list[dict], str | None]:
+) -> tuple[list[dict], list[dict], list[dict], str | None, list[dict], dict[str, dict]]:
     """Gather (sessions, projects, discovered_repos, active_id) for build_tree.
 
     ``include_discovered`` is the zero-session-repo overview tier; the entered
@@ -11736,6 +11803,17 @@ def _project_tree_inputs(
             )
         projects = [p.to_dict() for p in pdb.list_projects(conn)]
         active_id = pdb.get_active_id(conn)
+        conversation_groups = [
+            group.to_dict()
+            for project in projects
+            for group in pdb.list_conversation_groups(conn, project["id"])
+        ]
+        session_assignments = {
+            session_id: assignment.to_dict()
+            for session_id, assignment in pdb.get_session_assignments(
+                conn, [session["id"] for session in sessions if session.get("id")]
+            ).items()
+        }
         # backfill stays off the hot tree path — grouping uses the live resolver.
         discovered = (
             _discover_repos_payload(
@@ -11748,7 +11826,7 @@ def _project_tree_inputs(
             else []
         )
 
-    return sessions, projects, discovered, active_id
+    return sessions, projects, discovered, active_id, conversation_groups, session_assignments
 
 
 # Per-build memo for `_dir_exists_cached`. Cleared at the top of every
@@ -11779,7 +11857,7 @@ def _build_project_tree(
     from tui_gateway import project_tree
 
     _DIR_EXISTS_CACHE.clear()
-    sessions, projects, discovered, active_id = _project_tree_inputs(
+    sessions, projects, discovered, active_id, conversation_groups, session_assignments = _project_tree_inputs(
         db, session_limit, include_discovered=include_discovered
     )
     tree = project_tree.build_tree(
@@ -11792,6 +11870,8 @@ def _build_project_tree(
         is_junk_root=_is_repo_junk,
         is_junk_cwd=_is_session_cwd_junk,
         exists=_dir_exists_cached,
+        conversation_groups=conversation_groups,
+        session_assignments=session_assignments,
     )
     return tree, active_id
 


### PR DESCRIPTION
## Summary
- add backend-authoritative, profile-local project conversation groups and session assignments
- allow dropping a sidebar session directly onto an explicit project header without changing its transcript, ID, or cwd
- expose manual session ownership to the renderer so live cwd overlays cannot reinsert a moved session into its former auto project
- filter both hydrated lanes and project previews, making a project drop a true move rather than a duplicate projection

## Verification
- .................................................                        [100%]
49 passed in 3.60s (47 passed)
-  (95 passed)
- 
- 
- packaged and deployed locally; verified the moved session has one DB assignment and no longer appears under its former project after Desktop restart
