### PR TITLE
fix(gateway): cap 'auto' memory budget and emit systemd memory ceiling from config (#81625)

### DIFF
--- a/gateway/agent_cache_pressure.py
+++ b/gateway/agent_cache_pressure.py
@@ -41,6 +41,15 @@ _AUTO_BUDGET_FRACTION = 0.65
 # Below this a "budget" is noise — small containers would evict on every pass
 # and never keep a warm prefix.
 _AUTO_BUDGET_FLOOR_MB = 512
+# Ceiling for the budget derived on a host with *no* cgroup limit.  There the
+# fraction has nothing meaningful to divide: 65% of a 62 GB desktop is a 40 GB
+# "budget" the sweep only reaches once the machine is already swap-thrashing
+# and every other process is starving with it (#81625).  An absolute ceiling
+# is the only safe reading of "auto" on an uncapped host — generous next to
+# the ~150 MB an idle gateway needs, low enough that the pass runs while the
+# host still has room.  Operators with heavier workloads set an explicit
+# ``memory_high_mb``.
+_AUTO_UNCAPPED_CEILING_MB = 4096
 
 _DEFAULT_MAX_EVICTIONS_PER_PASS = 16
 # Never let a pressure pass touch the hottest sessions: they are the ones
@@ -156,10 +165,12 @@ def _total_memory_bytes() -> Optional[int]:
 def resolve_memory_high_mb(setting: Any) -> Optional[int]:
     """Resolve the ``memory_high_mb`` setting into an absolute MB budget.
 
-    ``"auto"`` derives a budget from the cgroup limit the gateway runs under
-    (or total RAM when uncapped), which is what makes this fix work out of the
-    box on the containerised/systemd deployments where the leak bites.  A
-    positive number is taken literally; anything falsy disables the pass.
+    ``"auto"`` derives a budget from the cgroup limit the gateway runs under,
+    which is what makes this fix work out of the box on the
+    containerised/systemd deployments where the leak bites.  With no limit to
+    divide it falls back to an absolute ceiling rather than a fraction of
+    total RAM — see ``_AUTO_UNCAPPED_CEILING_MB``.  A positive number is taken
+    literally; anything falsy disables the pass.
     """
     if isinstance(setting, str):
         normalized = setting.strip().lower()
@@ -175,10 +186,16 @@ def resolve_memory_high_mb(setting: Any) -> Optional[int]:
     else:
         return _positive_int(setting)
 
-    limit = _cgroup_limit_bytes() or _total_memory_bytes()
+    limit = _cgroup_limit_bytes()
+    ceiling_mb: Optional[int] = None
+    if not limit:
+        limit = _total_memory_bytes()
+        ceiling_mb = _AUTO_UNCAPPED_CEILING_MB
     if not limit:
         return None
     budget = int(limit * _AUTO_BUDGET_FRACTION / _BYTES_PER_MB)
+    if ceiling_mb is not None:
+        budget = min(budget, ceiling_mb)
     return budget if budget >= _AUTO_BUDGET_FLOOR_MB else None
 
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -11,6 +11,7 @@ Handles loading and validating configuration for:
 import logging
 import os
 import json
+import re
 from pathlib import Path
 from dataclasses import asdict, dataclass, field, is_dataclass
 from typing import Dict, List, Optional, Any, Callable
@@ -188,6 +189,50 @@ def coerce_systemd_watchdog_seconds(
         )
         return 0
     return parsed
+
+
+# systemd accepts a plain byte count, a K/M/G/T/P/E suffixed size, a
+# percentage of physical memory, or the literal ``infinity``.
+_SYSTEMD_MEMORY_LIMIT_RE = re.compile(r"(?:[1-9]\d*[KMGTPE]?|100%|[1-9]\d?%|infinity)\Z")
+
+
+def coerce_systemd_memory_limit(
+    value: Any, key: str = "gateway.systemd_memory_limit"
+) -> str:
+    """Return a systemd-ready memory limit, or ``""`` when unset or unusable.
+
+    The result is interpolated straight into the generated unit file, so
+    refusing everything that is not a recognized systemd size is also what
+    keeps a stray newline in ``config.yaml`` from becoming an extra directive.
+    A rejected value leaves the unit unlimited rather than half-configured.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        logger.warning("Ignoring invalid %s (expected a systemd memory size)", key)
+        return ""
+    if isinstance(value, int):
+        if value <= 0:
+            logger.warning(
+                "Ignoring invalid %s (expected a positive byte count)", key
+            )
+            return ""
+        return str(value)
+    if not isinstance(value, str):
+        logger.warning("Ignoring invalid %s (expected a systemd memory size)", key)
+        return ""
+    raw = value.strip()
+    if not raw:
+        return ""
+    if not raw.isascii() or not _SYSTEMD_MEMORY_LIMIT_RE.match(raw):
+        logger.warning(
+            "Ignoring invalid %s=%r (expected a systemd memory size such as "
+            "8G, 6144M, a byte count, a percentage, or infinity)",
+            key,
+            value,
+        )
+        return ""
+    return raw
 
 
 def _coerce_dict(value: Any) -> Dict[str, Any]:
@@ -930,6 +975,14 @@ class GatewayConfig:
     # disables sd_notify at runtime.
     systemd_watchdog_seconds: int = 0
 
+    # Opt-in cgroup memory ceiling for the generated unit. The gateway
+    # rewrites its own unit file whenever the install drifts, which wipes any
+    # MemoryHigh=/MemoryMax= an operator added by hand (#81625), so the
+    # ceiling has to come from config for the generator to keep emitting it.
+    # Empty means "no directive" — exactly today's behavior.
+    systemd_memory_high: str = ""
+    systemd_memory_max: str = ""
+
     # In-process event-loop liveness watchdog (#69089). A daemon OS thread
     # probes the gateway loop with call_soon_threadsafe; after consecutive
     # missed probes it dumps all-thread stacks and hard-exits with the
@@ -958,6 +1011,12 @@ class GatewayConfig:
     def __post_init__(self) -> None:
         self.systemd_watchdog_seconds = coerce_systemd_watchdog_seconds(
             self.systemd_watchdog_seconds
+        )
+        self.systemd_memory_high = coerce_systemd_memory_limit(
+            self.systemd_memory_high, "gateway.systemd_memory_high"
+        )
+        self.systemd_memory_max = coerce_systemd_memory_limit(
+            self.systemd_memory_max, "gateway.systemd_memory_max"
         )
 
     def get_connected_platforms(self) -> List[Platform]:
@@ -1071,6 +1130,8 @@ class GatewayConfig:
             "max_concurrent_sessions": self.max_concurrent_sessions,
             "multiplex_profiles": self.multiplex_profiles,
             "systemd_watchdog_seconds": self.systemd_watchdog_seconds,
+            "systemd_memory_high": self.systemd_memory_high,
+            "systemd_memory_max": self.systemd_memory_max,
             "loop_watchdog": self.loop_watchdog,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
             "streaming": self.streaming.to_dict(),
@@ -1143,6 +1204,18 @@ class GatewayConfig:
         systemd_watchdog_seconds = coerce_systemd_watchdog_seconds(
             systemd_watchdog_raw, systemd_watchdog_key
         )
+        # __post_init__ coerces these, so only the flat-vs-nested lookup
+        # happens here.
+        systemd_memory_high = (
+            data["systemd_memory_high"]
+            if "systemd_memory_high" in data
+            else nested_gateway.get("systemd_memory_high")
+        )
+        systemd_memory_max = (
+            data["systemd_memory_max"]
+            if "systemd_memory_max" in data
+            else nested_gateway.get("systemd_memory_max")
+        )
         if "loop_watchdog" in data:
             loop_watchdog_raw = data.get("loop_watchdog")
         else:
@@ -1208,6 +1281,8 @@ class GatewayConfig:
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
             multiplex_profiles=_coerce_bool(multiplex_profiles, False),
             systemd_watchdog_seconds=systemd_watchdog_seconds,
+            systemd_memory_high=systemd_memory_high,
+            systemd_memory_max=systemd_memory_max,
             loop_watchdog=loop_watchdog,
             max_concurrent_sessions=max_concurrent_sessions,
             unauthorized_dm_behavior=unauthorized_dm_behavior,
@@ -1369,6 +1444,9 @@ def load_gateway_config() -> GatewayConfig:
                     gw_data["systemd_watchdog_seconds"] = gateway_section[
                         "systemd_watchdog_seconds"
                     ]
+                for _memory_key in ("systemd_memory_high", "systemd_memory_max"):
+                    if _memory_key in gateway_section:
+                        gw_data[_memory_key] = gateway_section[_memory_key]
 
             if "max_concurrent_sessions" in yaml_cfg:
                 gw_data["max_concurrent_sessions"] = yaml_cfg["max_concurrent_sessions"]

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -200,6 +200,62 @@ _SYSTEMD_SIZE = r"\d+(?:\.\d+)?[KMGTPE]?"
 _SYSTEMD_MEMORY_LIMIT_RE = re.compile(
     rf"(?:(?P<size>{_SYSTEMD_SIZE}(?:[ \t]+{_SYSTEMD_SIZE})*)|100%|[1-9]\d?%|infinity)\Z"
 )
+_SYSTEMD_MEMORY_SUFFIXES = {
+    "": 1,
+    "K": 1024,
+    "M": 1024**2,
+    "G": 1024**3,
+    "T": 1024**4,
+    "P": 1024**5,
+    "E": 1024**6,
+}
+
+
+def _comparable_systemd_memory_limit(value: str) -> tuple[str, float] | None:
+    """Return a comparable kind/value for a validated systemd limit.
+
+    Byte sizes and percentages cannot be compared without knowing the unit's
+    physical-memory baseline, so mixed kinds deliberately remain unchecked.
+    ``None`` also keeps this helper private to the cross-field validation path;
+    syntax validation remains the responsibility of ``coerce_systemd_memory_limit``.
+    """
+    if value == "infinity":
+        return ("bytes", float("inf"))
+    if value.endswith("%"):
+        return ("percent", float(value[:-1]))
+    total = 0.0
+    for part in value.split():
+        match = re.fullmatch(r"(\d+(?:\.\d+)?)([KMGTPE]?)", part)
+        if match is None:
+            return None
+        total += float(match.group(1)) * _SYSTEMD_MEMORY_SUFFIXES[match.group(2)]
+    return ("bytes", total)
+
+
+def _validate_systemd_memory_order(
+    high: str, maximum: str
+) -> tuple[str, str]:
+    """Ensure a comparable ``MemoryHigh`` never exceeds ``MemoryMax``.
+
+    If an operator supplies an impossible pair, retain the hard ``MemoryMax``
+    and omit only ``MemoryHigh``. This preserves containment while avoiding a
+    unit that systemd rejects. Mixed byte/percentage units remain accepted
+    because their ordering depends on the host's physical-memory size.
+    """
+    if not high or not maximum:
+        return high, maximum
+    high_value = _comparable_systemd_memory_limit(high)
+    max_value = _comparable_systemd_memory_limit(maximum)
+    if high_value is not None and max_value is not None and high_value[0] == max_value[0]:
+        if high_value[1] > max_value[1]:
+            logger.warning(
+                "Ignoring gateway.systemd_memory_high=%r because it exceeds "
+                "gateway.systemd_memory_max=%r; retaining MemoryMax",
+                high,
+                maximum,
+            )
+            return "", maximum
+    return high, maximum
 
 
 def coerce_systemd_memory_limit(
@@ -239,9 +295,9 @@ def coerce_systemd_memory_limit(
             value,
         )
         return ""
-    if match.group("size") and not any(
+    if match.group("size") and sum(
         float(part.rstrip("KMGTPE")) for part in raw.split()
-    ):
+    ) <= 0:
         logger.warning("Ignoring invalid %s=%r (expected a positive size)", key, value)
         return ""
     return raw
@@ -1029,6 +1085,9 @@ class GatewayConfig:
         )
         self.systemd_memory_max = coerce_systemd_memory_limit(
             self.systemd_memory_max, "gateway.systemd_memory_max"
+        )
+        self.systemd_memory_high, self.systemd_memory_max = _validate_systemd_memory_order(
+            self.systemd_memory_high, self.systemd_memory_max
         )
 
     def get_connected_platforms(self) -> List[Platform]:

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -191,9 +191,15 @@ def coerce_systemd_watchdog_seconds(
     return parsed
 
 
-# systemd accepts a plain byte count, a K/M/G/T/P/E suffixed size, a
-# percentage of physical memory, or the literal ``infinity``.
-_SYSTEMD_MEMORY_LIMIT_RE = re.compile(r"(?:[1-9]\d*[KMGTPE]?|100%|[1-9]\d?%|infinity)\Z")
+# systemd's size grammar: a byte count with an optional fractional part and an
+# optional K/M/G/T/P/E suffix, or a whitespace-separated sum of those. Only
+# spaces and tabs join the parts -- a newline would open a second directive.
+_SYSTEMD_SIZE = r"\d+(?:\.\d+)?[KMGTPE]?"
+# A limit is one of those sizes, a percentage of physical memory, or the
+# literal ``infinity``.
+_SYSTEMD_MEMORY_LIMIT_RE = re.compile(
+    rf"(?:(?P<size>{_SYSTEMD_SIZE}(?:[ \t]+{_SYSTEMD_SIZE})*)|100%|[1-9]\d?%|infinity)\Z"
+)
 
 
 def coerce_systemd_memory_limit(
@@ -224,13 +230,19 @@ def coerce_systemd_memory_limit(
     raw = value.strip()
     if not raw:
         return ""
-    if not raw.isascii() or not _SYSTEMD_MEMORY_LIMIT_RE.match(raw):
+    match = _SYSTEMD_MEMORY_LIMIT_RE.match(raw) if raw.isascii() else None
+    if match is None:
         logger.warning(
             "Ignoring invalid %s=%r (expected a systemd memory size such as "
-            "8G, 6144M, a byte count, a percentage, or infinity)",
+            "8G, 6144M, 1.5G, 1G 500M, a byte count, a percentage, or infinity)",
             key,
             value,
         )
+        return ""
+    if match.group("size") and not any(
+        float(part.rstrip("KMGTPE")) for part in raw.split()
+    ):
+        logger.warning("Ignoring invalid %s=%r (expected a positive size)", key, value)
         return ""
     return raw
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -29,7 +29,11 @@ if os.name == "posix":
 
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 
-from gateway.config import coerce_systemd_watchdog_seconds, load_gateway_config
+from gateway.config import (
+    coerce_systemd_memory_limit,
+    coerce_systemd_watchdog_seconds,
+    load_gateway_config,
+)
 from gateway.status import terminate_pid
 from gateway.restart import (
     DEFAULT_GATEWAY_RESTART_AFTER_TURN_TIMEOUT,
@@ -2800,6 +2804,55 @@ def _systemd_watchdog_service_fields(
     return "notify", f"NotifyAccess=main\nWatchdogSec={seconds}s\n"
 
 
+def _systemd_memory_directives(hermes_home: str | Path | None = None) -> str:
+    """Return the ``MemoryHigh=``/``MemoryMax=`` block for the effective config.
+
+    The unit is regenerated whenever the install drifts, so a ceiling an
+    operator added by hand does not survive (#81625). Emitting it from config
+    is what makes a cgroup limit stick across restarts — and that limit is
+    also what ``gateway/agent_cache_pressure.py`` reads to size the budget for
+    its pressure eviction pass.
+    """
+    override_token = None
+    reset_home_override = None
+    if hermes_home is not None:
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        override_token = set_hermes_home_override(hermes_home)
+        reset_home_override = reset_hermes_home_override
+    try:
+        config = load_gateway_config()
+        limits = (
+            (
+                "MemoryHigh",
+                coerce_systemd_memory_limit(
+                    getattr(config, "systemd_memory_high", ""),
+                    "gateway.systemd_memory_high",
+                ),
+            ),
+            (
+                "MemoryMax",
+                coerce_systemd_memory_limit(
+                    getattr(config, "systemd_memory_max", ""),
+                    "gateway.systemd_memory_max",
+                ),
+            ),
+        )
+        return "".join(f"{directive}={value}\n" for directive, value in limits if value)
+    except Exception:
+        logger.debug(
+            "Could not resolve effective systemd memory configuration",
+            exc_info=True,
+        )
+        return ""
+    finally:
+        if override_token is not None and reset_home_override is not None:
+            reset_home_override(override_token)
+
+
 def _append_node_dir_for_service(
     path_entries: list[str], hermes_root: Path | None = None
 ) -> None:
@@ -2884,6 +2937,7 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
         systemd_type, systemd_watchdog_directives = _systemd_watchdog_service_fields(
             hermes_home
         )
+        systemd_memory_directives = _systemd_memory_directives(hermes_home)
         profile_arg = _profile_arg_for_target_user(hermes_home, home_dir)
         # Remap all paths that may resolve under the calling user's home
         # (e.g. /root/) to the target user's home so the service can
@@ -2918,7 +2972,7 @@ StartLimitIntervalSec=0
 
 [Service]
 Type={systemd_type}
-{systemd_watchdog_directives}User={username}
+{systemd_watchdog_directives}{systemd_memory_directives}User={username}
 Group={group_name}
 ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run
 WorkingDirectory={working_dir}
@@ -2948,6 +3002,7 @@ WantedBy=multi-user.target
     systemd_type, systemd_watchdog_directives = _systemd_watchdog_service_fields(
         hermes_home
     )
+    systemd_memory_directives = _systemd_memory_directives(hermes_home)
     profile_arg = _profile_arg(hermes_home)
     path_entries.extend(_build_user_local_paths(Path.home(), path_entries))
     path_entries.extend(_build_wsl_interop_paths(path_entries))
@@ -2961,7 +3016,7 @@ StartLimitIntervalSec=0
 
 [Service]
 Type={systemd_type}
-{systemd_watchdog_directives}ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run
+{systemd_watchdog_directives}{systemd_memory_directives}ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run
 WorkingDirectory={working_dir}
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2843,8 +2843,9 @@ def _systemd_memory_directives(hermes_home: str | Path | None = None) -> str:
         )
         return "".join(f"{directive}={value}\n" for directive, value in limits if value)
     except Exception:
-        logger.debug(
-            "Could not resolve effective systemd memory configuration",
+        logger.warning(
+            "Could not resolve effective systemd memory configuration; "
+            "generated unit will not include MemoryHigh/MemoryMax",
             exc_info=True,
         )
         return ""

--- a/tests/gateway/test_agent_cache_pressure.py
+++ b/tests/gateway/test_agent_cache_pressure.py
@@ -97,6 +97,48 @@ class TestMemoryBudgetResolution:
 
         assert resolve_memory_high_mb("auto") is None
 
+    def test_auto_on_an_uncapped_host_stays_well_under_total_ram(self, monkeypatch):
+        """A fraction of *total RAM* is not a budget on a desktop (#81625).
+
+        The reported machine had 62 GB of RAM, no cgroup limit and 2 GB of
+        swap: a 0.65-of-total budget only fires at ~40 GB, long after the
+        desktop has frozen and taken every other process with it. With no
+        limit to divide, the only safe budget is an absolute one.
+        """
+        import gateway.agent_cache_pressure as acp
+
+        total_mb = 62 * 1024
+        monkeypatch.setattr(acp, "_cgroup_limit_bytes", lambda: None)
+        monkeypatch.setattr(acp, "_total_memory_bytes", lambda: total_mb * 1024 * 1024)
+
+        budget = resolve_memory_high_mb("auto")
+
+        assert budget is not None
+        assert budget <= acp._AUTO_UNCAPPED_CEILING_MB
+        assert budget < total_mb // 8
+
+    def test_auto_prefers_the_cgroup_limit_over_the_uncapped_ceiling(self, monkeypatch):
+        """A container smaller than the ceiling still gets the tighter budget."""
+        import gateway.agent_cache_pressure as acp
+
+        limit_mb = 2 * 1024
+        monkeypatch.setattr(acp, "_cgroup_limit_bytes", lambda: limit_mb * 1024 * 1024)
+        monkeypatch.setattr(acp, "_total_memory_bytes", lambda: 62 * 1024 * 1024 * 1024)
+
+        budget = resolve_memory_high_mb("auto")
+
+        assert budget is not None
+        assert 0 < budget < limit_mb
+
+    def test_an_explicit_budget_still_overrides_the_uncapped_ceiling(self, monkeypatch):
+        """Operators who know their workload keep the last word."""
+        import gateway.agent_cache_pressure as acp
+
+        monkeypatch.setattr(acp, "_cgroup_limit_bytes", lambda: None)
+        monkeypatch.setattr(acp, "_total_memory_bytes", lambda: 62 * 1024 * 1024 * 1024)
+
+        assert resolve_memory_high_mb(16384) == 16384
+
 
 class TestPersistenceGuard:
     """Soft eviction drops the transcript, so it may only run once the

--- a/tests/hermes_cli/test_systemd_memory_limits_unit.py
+++ b/tests/hermes_cli/test_systemd_memory_limits_unit.py
@@ -1,0 +1,117 @@
+"""Generated service behavior for the opt-in systemd memory ceiling (#81625).
+
+The gateway rewrites its own unit file whenever the install drifts, so an
+operator-added ``MemoryMax=``/``MemoryHigh=`` is wiped on the next start and
+the leak they were containing takes the whole machine down again. The ceiling
+has to come from config so the generator emits it itself.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.config import GatewayConfig, coerce_systemd_memory_limit
+from hermes_cli import gateway as gateway_cli
+
+
+def _unit_with(monkeypatch, data: dict) -> str:
+    monkeypatch.setattr(
+        gateway_cli,
+        "load_gateway_config",
+        lambda: GatewayConfig.from_dict(data),
+        raising=False,
+    )
+    return gateway_cli.generate_systemd_unit(system=False)
+
+
+class TestLimitCoercion:
+    @pytest.mark.parametrize(
+        "value", ["8G", "6144M", "2147483648", "80%", "infinity", " 8G "]
+    )
+    def test_supported_systemd_sizes_are_kept(self, value):
+        assert coerce_systemd_memory_limit(value) == value.strip()
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            None,
+            "",
+            "   ",
+            0,
+            True,
+            "8 GB",
+            "eight",
+            "8G\nExecStartPre=/bin/rm -rf /",
+            "-8G",
+            "8Z",
+        ],
+    )
+    def test_unusable_values_resolve_to_absent(self, value):
+        """A typo must leave the unit unlimited, never half a directive.
+
+        The value is interpolated straight into the unit file, so rejecting
+        an unrecognised token is also the injection guard.
+        """
+        assert coerce_systemd_memory_limit(value) == ""
+
+    def test_integer_bytes_are_accepted(self):
+        assert coerce_systemd_memory_limit(2147483648) == "2147483648"
+
+
+class TestGeneratedUnit:
+    def test_unset_config_emits_no_memory_directives(self, monkeypatch):
+        """Default stays exactly as it is today: no ceiling, no surprise kills."""
+        unit = _unit_with(monkeypatch, {})
+
+        assert "MemoryMax=" not in unit
+        assert "MemoryHigh=" not in unit
+
+    def test_configured_limits_land_in_the_service_section(self, monkeypatch):
+        unit = _unit_with(
+            monkeypatch,
+            {"systemd_memory_high": "6G", "systemd_memory_max": "8G"},
+        )
+
+        assert "MemoryHigh=6G" in unit
+        service = unit.split("[Service]", 1)[1].split("[Install]", 1)[0]
+        assert "MemoryMax=8G" in service
+
+    def test_either_limit_can_be_set_alone(self, monkeypatch):
+        unit = _unit_with(monkeypatch, {"systemd_memory_max": "8G"})
+
+        assert "MemoryMax=8G" in unit
+        assert "MemoryHigh=" not in unit
+
+    def test_nested_gateway_section_is_honoured(self, monkeypatch):
+        unit = _unit_with(monkeypatch, {"gateway": {"systemd_memory_max": "4G"}})
+
+        assert "MemoryMax=4G" in unit
+
+    def test_rejected_value_leaves_the_unit_unlimited(self, monkeypatch):
+        unit = _unit_with(monkeypatch, {"systemd_memory_max": "8 GB"})
+
+        assert "MemoryMax=" not in unit
+
+    def test_system_unit_carries_the_limits_too(self, tmp_path, monkeypatch):
+        """The system unit is a separate template — it must not drift."""
+        target_home = tmp_path / "target"
+        target_home.mkdir()
+        (target_home / "config.yaml").write_text(
+            "gateway:\n  systemd_memory_max: 8G\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "caller"))
+        monkeypatch.setattr(
+            gateway_cli,
+            "_system_service_identity",
+            lambda _user: ("service", "service", str(tmp_path / "account")),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_hermes_home_for_target_user",
+            lambda _home: str(target_home),
+        )
+
+        unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="service")
+
+        assert "MemoryMax=8G" in unit

--- a/tests/hermes_cli/test_systemd_memory_limits_unit.py
+++ b/tests/hermes_cli/test_systemd_memory_limits_unit.py
@@ -77,6 +77,40 @@ class TestLimitCoercion:
 
 
 class TestGeneratedUnit:
+    @pytest.mark.parametrize(
+        ("high", "maximum"),
+        [("8G", "6G"), ("80%", "60%"), ("1G 500M", "1G")],
+    )
+    def test_invalid_order_retains_hard_max_and_drops_high(
+        self, monkeypatch, high, maximum, caplog
+    ):
+        unit = _unit_with(
+            monkeypatch,
+            {"systemd_memory_high": high, "systemd_memory_max": maximum},
+        )
+
+        assert "MemoryHigh=" not in unit
+        assert f"MemoryMax={maximum}" in unit
+        assert "exceeds" in caplog.text
+
+    def test_comparable_limits_allow_equal_values(self, monkeypatch):
+        unit = _unit_with(
+            monkeypatch,
+            {"systemd_memory_high": "8G", "systemd_memory_max": "8G"},
+        )
+
+        assert "MemoryHigh=8G" in unit
+        assert "MemoryMax=8G" in unit
+
+    def test_mixed_byte_and_percentage_limits_are_preserved(self, monkeypatch):
+        unit = _unit_with(
+            monkeypatch,
+            {"systemd_memory_high": "80%", "systemd_memory_max": "8G"},
+        )
+
+        assert "MemoryHigh=80%" in unit
+        assert "MemoryMax=8G" in unit
+
     def test_unset_config_emits_no_memory_directives(self, monkeypatch):
         """Default stays exactly as it is today: no ceiling, no surprise kills."""
         unit = _unit_with(monkeypatch, {})

--- a/tests/hermes_cli/test_systemd_memory_limits_unit.py
+++ b/tests/hermes_cli/test_systemd_memory_limits_unit.py
@@ -26,7 +26,19 @@ def _unit_with(monkeypatch, data: dict) -> str:
 
 class TestLimitCoercion:
     @pytest.mark.parametrize(
-        "value", ["8G", "6144M", "2147483648", "80%", "infinity", " 8G "]
+        "value",
+        [
+            "8G",
+            "6144M",
+            "2147483648",
+            "80%",
+            "infinity",
+            " 8G ",
+            "1.5G",
+            "0.5G",
+            "1G 500M",
+            "1G\t500M",
+        ],
     )
     def test_supported_systemd_sizes_are_kept(self, value):
         assert coerce_systemd_memory_limit(value) == value.strip()
@@ -42,8 +54,14 @@ class TestLimitCoercion:
             "8 GB",
             "eight",
             "8G\nExecStartPre=/bin/rm -rf /",
+            "1G\n500M",
             "-8G",
             "8Z",
+            "1.5.5G",
+            "1,5G",
+            "0",
+            "0G",
+            "0.0G",
         ],
     )
     def test_unusable_values_resolve_to_absent(self, value):

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -936,7 +936,7 @@ agent:
 
 `max_size` and `idle_ttl_secs` bound the cache by count and by time. Neither knows how many bytes it holds, so `memory_high_mb` adds a third bound: once the gateway's own anonymous resident memory crosses the budget, it sheds least-recently-used transcripts, which reload from the stored session on the next turn. Lower it if the gateway is competing for memory with other services; raise it (or set `0` to switch the pass off) if you would rather keep every prefix warm.
 
-`auto` derives the budget from the memory limit the gateway actually runs under — the cgroup limit for a container or systemd unit, total RAM otherwise — so a `MemoryMax`/`MemoryHigh` on the unit is respected without a second number to keep in sync.
+`auto` derives the budget from the memory limit the gateway actually runs under — the cgroup limit for a container or systemd unit — so a `MemoryMax`/`MemoryHigh` on the unit is respected without a second number to keep in sync. On a host with no limit at all there is nothing meaningful to divide, so `auto` falls back to a fixed 4 GB ceiling rather than a share of total RAM: a fraction of a large desktop would only trigger eviction once the machine was already swapping. Set an explicit `memory_high_mb` if your gateway legitimately needs more, and see [the systemd memory ceiling](/user-guide/messaging/#optional-linux-memory-ceiling) for capping the process itself.
 
 Sessions that are mid-turn, the `protect_recent` most recently used ones, and any session whose transcript has not finished being written to disk are never shed. Eviction is logged at WARNING with the measured RSS and the sessions dropped:
 

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -186,6 +186,34 @@ process when they stop. The default `0` keeps the existing `Type=simple`
 behavior. This setting is Linux/systemd-only and does not treat an ordinary
 platform network disconnect as an event-loop failure.
 
+### Optional Linux memory ceiling
+
+A systemd-managed gateway can cap its own memory so a runaway process is
+contained by the kernel instead of dragging the whole machine into swap:
+
+```yaml title="~/.hermes/config.yaml"
+gateway:
+  systemd_memory_high: 6G   # throttle and reclaim past this point
+  systemd_memory_max: 8G    # hard limit; the kernel OOM-kills past this
+```
+
+Regenerate the service unit after changing this setting:
+
+```bash
+hermes gateway install --force
+```
+
+Both accept any size systemd understands (`8G`, `6144M`, a plain byte count, a
+percentage, or `infinity`); an unrecognized value is ignored and leaves the
+unit unlimited. Setting these in config rather than editing the unit by hand
+matters because Hermes rewrites its own unit file whenever the install drifts,
+which would otherwise wipe a hand-added `MemoryMax=`.
+
+The same cgroup limit is what `agent_cache.memory_high_mb: auto` reads to size
+its own budget, so capping the unit also makes the gateway shed cached
+transcripts before it reaches the limit. See
+[Gateway Agent Cache](/user-guide/configuration#gateway-agent-cache).
+
 ## Chat Commands (Inside Messaging)
 
 | Command | Description |

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -203,9 +203,11 @@ Regenerate the service unit after changing this setting:
 hermes gateway install --force
 ```
 
-Both accept any size systemd understands (`8G`, `6144M`, a plain byte count, a
-percentage, or `infinity`); an unrecognized value is ignored and leaves the
-unit unlimited. Setting these in config rather than editing the unit by hand
+Both accept any size systemd understands: a byte count with an optional
+fractional part and an optional `K`/`M`/`G`/`T`/`P`/`E` suffix (`8G`, `6144M`,
+`1.5G`, `2147483648`), a whitespace-separated sum of those (`1G 500M`), a
+percentage of physical memory, or `infinity`. A value outside that grammar —
+or one that adds up to zero — is ignored and leaves the unit unlimited. Setting these in config rather than editing the unit by hand
 matters because Hermes rewrites its own unit file whenever the install drifts,
 which would otherwise wipe a hand-added `MemoryMax=`.
 


### PR DESCRIPTION
Fixes the failure mode reported in #81625, where a leaking gateway takes the
whole machine down with it (~60GB RSS, full-system OOM freeze, every other
process starving before anything sheds a byte).

**Scope, stated plainly:** this does *not* identify the specific 0.20.0
allocator behind the growth rate. It removes the two defects that let that
growth reach the whole machine, both of which are reproducible and testable on
their own.

## Defect 1 — `auto` scaled with host RAM, so the sweep fired too late

`resolve_memory_high_mb("auto")` fell back to 65% of **total host RAM** when no
cgroup limit was discoverable. On the reporter's 62GB desktop that is a ~40GB
budget, so the pressure sweep added in #80764 only fires once the machine is
already swap-thrashing — long past the point where it could help.

There is nothing meaningful for the fraction to divide on an uncapped host, so
`auto` now falls back to an absolute 4GB ceiling (`_AUTO_UNCAPPED_CEILING_MB`):
generous next to the ~150MB an idle gateway needs, low enough that the pass
runs while the host still has room. An explicit `memory_high_mb` still wins.

## Defect 2 — the generated unit had no memory ceiling, and hand-edits were wiped

The gateway rewrites its own systemd unit whenever the install drifts, so a
`MemoryHigh=`/`MemoryMax=` an operator added by hand disappears on the next
start — which is exactly why the reporter could not contain this themselves.
The ceiling now comes from config, so the generator keeps emitting it:

```yaml
gateway:
  systemd_memory_high: 6G   # throttle and reclaim past this point
  systemd_memory_max: 8G    # hard limit; the kernel OOM-kills past this
```

Both unit templates (system and user) carry the directives. Unset means no
directive — exactly today's behavior.

The two halves reinforce each other: capping the unit gives `auto` a real
cgroup limit to read, so the cache sheds transcripts *before* the kernel has to
step in.

## Flow

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    CFG[⚙️ config.yaml<br/>gateway.systemd_memory_high / max] -->|coerce_systemd_memory_limit| GUARD{🛡️ Recognized<br/>systemd Size?}
    GUARD -->|Rejected| UNCAPPED[⚪ No Directive Emitted<br/>Unit Stays Unlimited]
    GUARD -->|Accepted| UNIT[📄 Generated systemd Unit<br/>MemoryHigh= / MemoryMax=]
    UNIT -->|Survives Unit Rewrite On Drift| CGROUP[🔒 Kernel cgroup Limit]

    CGROUP -->|_cgroup_limit_bytes| AUTO[🧮 resolve_memory_high_mb 'auto']
    UNCAPPED -.->|No Limit Discoverable| FLOOR[🚧 Absolute 4GB Ceiling<br/>replaces 65% of total RAM]
    FLOOR --> AUTO

    AUTO -->|Budget| SWEEP[⚡ Agent Cache Pressure Sweep]
    RSS[📈 Anonymous RSS Probe] --> SWEEP
    SWEEP -->|Over Budget| EVICT[♻️ Shed LRU Transcripts<br/>Rebuilt From Persisted Session]
    SWEEP -->|Under Budget| KEEP[✅ Keep Prompt Prefix Warm]

    EVICT --> SAFE[🚀 Machine Stays Responsive]
    CGROUP -->|Last Resort| CONTAIN[🩸 Kernel Contains Gateway Only<br/>Not The Whole Host]
```

## Infographic: 

<img width="1024" height="1024" alt="issue_81663_infographic" src="https://github.com/user-attachments/assets/f1600ec3-2403-4d42-beb6-4c3f7e30bea4" />

## Security note

`coerce_systemd_memory_limit` output is interpolated straight into the unit
file, so rejecting anything that is not a recognized systemd size is also the
injection guard — `"8G\nExecStartPre=/bin/rm -rf /"` resolves to `""`, and a
rejected value leaves the unit unlimited rather than half-configured. Covered
by `test_unusable_values_resolve_to_absent`.

## Test plan

- [x] `tests/hermes_cli/test_systemd_memory_limits_unit.py` — 23 new tests:
      value coercion (accepted sizes, rejected typos, injection attempt,
      integer byte counts) and generated-unit behavior for both the user and
      system templates, including the nested `gateway:` section and the
      "unset emits nothing" default.
- [x] `tests/gateway/test_agent_cache_pressure.py` — 3 new tests pinning the
      uncapped-host ceiling, the cgroup-capped path staying under the limit,
      and an explicit budget overriding the ceiling. 44 passed.
- [x] Combined run of the touched suites (`test_systemd_memory_limits_unit`,
      `test_systemd_watchdog_unit`, `test_config`, `test_agent_cache_pressure`):
      **124 passed**.
- [x] `ruff check` clean on all changed files.
- [x] Broader `tests/hermes_cli -k "systemd or service or gateway"` shows 13
      pre-existing Windows-only failures; identical count and set on a stashed
      baseline, so unrelated to this change.

## Docs

- `website/docs/user-guide/messaging/index.md` — new "Optional Linux memory
  ceiling" section covering both keys, accepted values, and why they belong in
  config rather than in a hand-edited unit.
- `website/docs/user-guide/configuration.md` — corrects the `auto` description,
  which still promised a fraction of total RAM.

## Review follow-up implemented

The follow-up review points are addressed in commit `9cfb6f41c7`:

- **Cross-field validation:** `GatewayConfig.__post_init__` now validates the effective `systemd_memory_high` and `systemd_memory_max` values after individual coercion. Comparable byte sizes, percentages, and `infinity` are checked so `MemoryHigh` cannot exceed `MemoryMax`. When an invalid ordering is supplied, Hermes keeps the hard `MemoryMax`, omits only the conflicting `MemoryHigh`, and emits a warning. This preserves containment while avoiding a unit that systemd rejects.
- **Compound-size validation:** the positive-size guard now validates the total of a whitespace-separated systemd size expression, rather than relying on an `any(...)` check. Zero-valued sums remain rejected; valid expressions such as `1G 500M` remain accepted.
- **Generation failures are visible:** `_systemd_memory_directives` now logs a warning, including the fallback behavior, when effective configuration resolution fails. It still fails safe by emitting no memory directive rather than generating a partially trusted unit.
- **Precedence is explicit:** `agent_cache.memory_high_mb: auto` reads the cgroup limit actually applied to the running gateway. The uncapped-host 4 GB ceiling is only the fallback when no cgroup limit is discoverable; an explicit `memory_high_mb` always wins. The existing tests cover both paths and the new unit tests cover comparable, equal, mixed-unit, and invalid-order configurations.

### Additional validation

- `scripts/run_tests.sh tests/hermes_cli/test_systemd_memory_limits_unit.py tests/gateway/test_agent_cache_pressure.py`
- Result: **82 passed, 0 failed**
- `git diff --check`: clean
- The targeted Ruff executable was unavailable in the local environment; the edited Python files passed the repository write-time syntax/lint checks.

The generated systemd unit remains backward compatible when both settings are unset: no `MemoryHigh=` or `MemoryMax=` directive is emitted.
