### PR TITLE
fix(model-picker): serve cached custom-provider catalog on no-probe picker opens

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2720,10 +2720,16 @@ def list_authenticated_providers(
                     and _ep_url_norm == _current_base_url_norm
                 )
             )
-            should_probe = _can_probe_custom_provider(row_is_current=_ep_is_current) and bool(api_url) and discover and (
+            # See section 4: when live probing is suppressed for latency, a
+            # warm same-fingerprint cache entry still serves the full catalog
+            # with no network round-trip.
+            _discovery_allowed = bool(api_url) and discover and (
                 bool(api_key) or not has_explicit_models
             )
-            if should_probe:
+            _probe_live = _discovery_allowed and _can_probe_custom_provider(
+                row_is_current=_ep_is_current
+            )
+            if _discovery_allowed:
                 try:
                     from hermes_cli.models import cached_fetch_api_models
                     live_models = cached_fetch_api_models(
@@ -2731,6 +2737,7 @@ def list_authenticated_providers(
                         api_url,
                         timeout=1.5 if for_picker else 5.0,  # picker: fail fast so a slow custom endpoint doesn't block /model
                         headers=_extra_headers_from_config(ep_cfg) or None,
+                        cache_only=not _probe_live,
                     )
                     if live_models:
                         models_list = live_models
@@ -2793,19 +2800,22 @@ def list_authenticated_providers(
         )
     ):
         _models = [current_model] if current_model else []
-        if refresh or probe_current_custom_provider:
-            try:
-                from hermes_cli.models import cached_fetch_api_models
+        # As in sections 3 and 4: with live probing suppressed, fall back to
+        # the cached catalog rather than to the single active model.
+        _probe_live = bool(refresh or probe_current_custom_provider)
+        try:
+            from hermes_cli.models import cached_fetch_api_models
 
-                _live_models = cached_fetch_api_models(
-                    "",
-                    str(current_base_url).strip().rstrip("/"),
-                    timeout=1.5 if for_picker else 5.0,  # picker: fail fast on a slow current endpoint
-                )
-                if _live_models:
-                    _models = _live_models
-            except Exception:
-                pass
+            _live_models = cached_fetch_api_models(
+                "",
+                str(current_base_url).strip().rstrip("/"),
+                timeout=1.5 if for_picker else 5.0,  # picker: fail fast on a slow current endpoint
+                cache_only=not _probe_live,
+            )
+            if _live_models:
+                _models = _live_models
+        except Exception:
+            pass
         results.append({
             "slug": "custom",
             "name": "Custom endpoint",
@@ -3031,13 +3041,20 @@ def list_authenticated_providers(
                 and _grp_url_norm == _current_base_url_norm
                 and _current_base_url_group_count == 1
             )
-            should_probe = (
-                _can_probe_custom_provider(row_is_current=_grp_is_current)
-                and bool(api_url)
+            # Discovery is what the user's config asks for; probing is how we
+            # get it. When the caller suppresses live probing for latency, the
+            # already-discovered catalog on disk still answers the question
+            # without a round-trip — skipping it too is what collapsed a
+            # multi-model endpoint to its config-declared subset.
+            _discovery_allowed = (
+                bool(api_url)
                 and (bool(api_key) or not grp.get("has_explicit_models"))
                 and grp.get("discover_models", True)
             )
-            if should_probe:
+            _probe_live = _discovery_allowed and _can_probe_custom_provider(
+                row_is_current=_grp_is_current
+            )
+            if _discovery_allowed:
                 try:
                     from hermes_cli.models import cached_fetch_api_models
 
@@ -3046,6 +3063,7 @@ def list_authenticated_providers(
                         api_url,
                         timeout=1.5 if for_picker else 5.0,  # picker: fail fast so a slow custom endpoint doesn't block /model
                         headers=grp.get("extra_headers") or None,
+                        cache_only=not _probe_live,
                     )
                     if live_models:
                         grp["models"] = live_models
@@ -3053,9 +3071,12 @@ def list_authenticated_providers(
                         # Auto-save discovered models back to config so
                         # ``discover_models: false`` has a populated cache
                         # on the next read.  A failed save is non-fatal.
-                        _save_discovered_models_to_config(
-                            api_url, live_models
-                        )
+                        # Only after a real probe: a cache hit is already the
+                        # product of an earlier probe that saved it.
+                        if _probe_live:
+                            _save_discovered_models_to_config(
+                                api_url, live_models
+                            )
                 except Exception:
                     pass
             results.append({

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -4704,6 +4704,7 @@ def cached_fetch_api_models(
     api_mode: Optional[str] = None,
     headers: Optional[dict[str, str]] = None,
     force_refresh: bool = False,
+    cache_only: bool = False,
     ttl_seconds: int = _PROVIDER_MODELS_CACHE_TTL,
 ) -> Optional[list[str]]:
     """Disk-cached wrapper around :func:`fetch_api_models` for custom endpoints.
@@ -4717,9 +4718,18 @@ def cached_fetch_api_models(
     last same-fingerprint result rather than an empty list. Returns whatever
     :func:`fetch_api_models` would (a list or ``None``); corrupt cache rows
     degrade to a live fetch instead of raising.
+
+    ``cache_only`` serves a previously-discovered catalog without touching
+    the network at all — no live fetch, no background revalidation — and
+    returns ``None`` when nothing usable is cached. Callers that deliberately
+    skip live probing for latency reasons (GUI picker opens, which must not
+    block on a stopped local endpoint) use this so a warm catalog still
+    reaches the picker instead of collapsing to the config-declared subset.
     """
     normalized_url = str(base_url or "").strip().rstrip("/").lower()
     if not normalized_url:
+        if cache_only:
+            return None
         # No base_url means nothing to key the cache on — fall through to a
         # live call so callers keep getting fetch_api_models' own behavior.
         return fetch_api_models(
@@ -4731,6 +4741,17 @@ def cached_fetch_api_models(
     cache = _load_provider_models_cache()
     entry = cache.get(cache_key)
     now = time.time()
+
+    if cache_only:
+        # Same trust window as the stale-while-revalidate tier below, minus
+        # the revalidation: an entry this side of the bound is good enough to
+        # render, and anything older is treated as a miss so the caller falls
+        # back to its configured list rather than showing a stale catalog.
+        if force_refresh or not _cache_entry_valid(entry, fp):
+            return None
+        if now - entry["at"] >= _PROVIDER_MODELS_STALE_SERVE_MAX:
+            return None
+        return list(entry["models"])
 
     if not force_refresh and _cache_entry_valid(entry, fp):
         age = now - entry["at"]

--- a/tests/hermes_cli/test_cached_fetch_api_models.py
+++ b/tests/hermes_cli/test_cached_fetch_api_models.py
@@ -128,6 +128,73 @@ class TestCachedFetchApiModels:
         assert out is None
         save.assert_not_called()
 
+
+class TestCacheOnly:
+    """``cache_only=True`` is the no-network read used by picker opens that
+    deliberately skip live probing. It must answer from disk or not at all —
+    never a live fetch, never a background revalidation."""
+
+    def _entry(self, models, age_seconds, fp="fp"):
+        return {"fp": fp, "at": time.time() - age_seconds, "models": list(models)}
+
+    def _call(self, cache, *, fp="fp", **kwargs):
+        import hermes_cli.models as mod
+
+        with patch.object(mod, "_load_provider_models_cache", return_value=cache), \
+             patch.object(mod, "_custom_endpoint_fingerprint", return_value=fp), \
+             patch.object(mod, "_save_provider_models_cache") as save, \
+             patch.object(mod, "_spawn_swr_refresh") as swr, \
+             patch.object(mod, "fetch_api_models") as live:
+            out = mod.cached_fetch_api_models(
+                "sk-key", "https://gw.example.com/v1", cache_only=True, **kwargs
+            )
+        live.assert_not_called()
+        swr.assert_not_called()
+        save.assert_not_called()
+        return out
+
+    def test_fresh_entry_is_served(self):
+        cache = {"custom:https://gw.example.com/v1": self._entry(["m1", "m2"], 10)}
+        assert self._call(cache) == ["m1", "m2"]
+
+    def test_entry_past_ttl_is_still_served_within_the_stale_window(self):
+        """The TTL governs when to *revalidate*, and cache_only cannot. Inside
+        the stale-serve bound the entry is still the best answer available —
+        collapsing to the config subset an hour in would reintroduce the bug."""
+        import hermes_cli.models as mod
+
+        age = mod._PROVIDER_MODELS_CACHE_TTL + 60
+        cache = {"custom:https://gw.example.com/v1": self._entry(["m1", "m2"], age)}
+        assert self._call(cache) == ["m1", "m2"]
+
+    def test_entry_beyond_the_stale_window_is_a_miss(self):
+        import hermes_cli.models as mod
+
+        age = mod._PROVIDER_MODELS_STALE_SERVE_MAX + 60
+        cache = {"custom:https://gw.example.com/v1": self._entry(["ancient"], age)}
+        assert self._call(cache) is None
+
+    def test_empty_cache_is_a_miss(self):
+        assert self._call({}) is None
+
+    def test_rotated_credentials_are_a_miss(self):
+        cache = {"custom:https://gw.example.com/v1": self._entry(["old"], 10, fp="old-fp")}
+        assert self._call(cache, fp="new-fp") is None
+
+    def test_force_refresh_is_a_miss_rather_than_a_live_fetch(self):
+        """cache_only outranks force_refresh: the caller has said no network,
+        so an un-revalidatable entry is withheld instead of fetched."""
+        cache = {"custom:https://gw.example.com/v1": self._entry(["m1"], 10)}
+        assert self._call(cache, force_refresh=True) is None
+
+    def test_missing_base_url_is_a_miss_rather_than_a_live_fetch(self):
+        import hermes_cli.models as mod
+
+        with patch.object(mod, "fetch_api_models") as live:
+            out = mod.cached_fetch_api_models("sk-key", "", cache_only=True)
+        assert out is None
+        live.assert_not_called()
+
     def test_empty_live_result_is_not_persisted(self):
         """An empty list from a transient error must never pin an empty
         cache entry over real data on the next open."""

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -5,6 +5,8 @@ shared slash-command pipeline (`/model` in CLI/gateway/Telegram) historically
 only looked at `providers:`.
 """
 
+import time
+
 import hermes_cli.providers as providers_mod
 import pytest
 from hermes_cli.model_switch import list_authenticated_providers, switch_model
@@ -972,3 +974,205 @@ def test_custom_provider_dict_models_pin_requires_discover_false(monkeypatch):
     row = next(p for p in providers if p["name"] == "Local Ollama")
     assert calls == []
     assert row["models"] == ["llama3"]
+
+
+# ─── No-probe picker opens still serve the cached catalog ───────────────
+#
+# #58183 stopped GUI picker opens from live-probing saved custom endpoints so
+# a stopped local server could not stall the picker. It skipped the cached
+# read along with the network one, so a non-current endpoint collapsed to the
+# one model named in config even with a full catalog already on disk. These
+# pin both halves: the cache is served, the network is not touched.
+
+
+_LOCAL_ENDPOINT = "http://127.0.0.1:8000/v1"
+_LOCAL_CATALOG = [f"omlx-model-{i}" for i in range(1, 9)]
+
+
+def _seed_custom_model_cache(monkeypatch, models, *, age_seconds=10):
+    """Put *models* on disk for ``_LOCAL_ENDPOINT`` under the no-credential
+    fingerprint the picker probes local endpoints with."""
+    import hermes_cli.models as models_mod
+
+    fp = models_mod._custom_endpoint_fingerprint("", None, None)
+    cache = {
+        f"custom:{_LOCAL_ENDPOINT}": {
+            "fp": fp,
+            "at": time.time() - age_seconds,
+            "models": list(models),
+        }
+    }
+    monkeypatch.setattr(models_mod, "_load_provider_models_cache", lambda: cache)
+
+
+def _no_probe_local_row(monkeypatch, *, custom_providers=None, user_providers=None,
+                        current_provider="nous", **kwargs):
+    """Run the GUI picker path (no live probing) and return the local row
+    plus every base_url a live fetch was attempted against."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    fetched = []
+
+    def fetch(_api_key, base_url, **_kwargs):
+        fetched.append(base_url)
+        return ["should-not-be-reached"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fetch)
+
+    providers = list_authenticated_providers(
+        current_provider=current_provider,
+        user_providers=user_providers or {},
+        custom_providers=custom_providers or [],
+        for_picker=True,
+        refresh=False,
+        probe_custom_providers=False,
+        probe_current_custom_provider=True,
+        **kwargs,
+    )
+    row = next(
+        (p for p in providers if _LOCAL_ENDPOINT in str(p.get("api_url", ""))), None
+    )
+    return row, fetched
+
+
+def test_no_probe_open_serves_cached_catalog_for_custom_provider(monkeypatch):
+    """A ``custom_providers`` endpoint that is not the current provider still
+    shows its full discovered catalog, from cache, with no network call."""
+    _seed_custom_model_cache(monkeypatch, _LOCAL_CATALOG)
+
+    row, fetched = _no_probe_local_row(
+        monkeypatch,
+        custom_providers=[
+            {
+                "name": "Local (127.0.0.1:8000)",
+                "base_url": _LOCAL_ENDPOINT,
+                "model": "omlx-model-1",
+            }
+        ],
+    )
+
+    assert row is not None
+    assert row["is_current"] is False
+    assert row["models"] == _LOCAL_CATALOG
+    assert row["total_models"] == len(_LOCAL_CATALOG)
+    assert fetched == []
+
+
+def test_no_probe_open_serves_cached_catalog_for_user_provider(monkeypatch):
+    """Same contract for a ``providers:`` entry (section 3)."""
+    _seed_custom_model_cache(monkeypatch, _LOCAL_CATALOG)
+
+    row, fetched = _no_probe_local_row(
+        monkeypatch,
+        user_providers={
+            "local-8000": {
+                "name": "Local (127.0.0.1:8000)",
+                "base_url": _LOCAL_ENDPOINT,
+                "default_model": "omlx-model-1",
+            }
+        },
+    )
+
+    assert row is not None
+    assert row["models"] == _LOCAL_CATALOG
+    assert fetched == []
+
+
+def test_no_probe_open_serves_cached_catalog_for_bare_custom_endpoint(monkeypatch):
+    """Same contract for the bare ``provider: custom`` shape (section 3b),
+    where the fallback would otherwise be the single active model."""
+    _seed_custom_model_cache(monkeypatch, _LOCAL_CATALOG)
+
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    fetched = []
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_api_models",
+        lambda _k, base_url, **_kw: (fetched.append(base_url), None)[1],
+    )
+
+    providers = list_authenticated_providers(
+        current_provider="custom",
+        current_base_url=_LOCAL_ENDPOINT,
+        current_model="omlx-model-1",
+        user_providers={},
+        custom_providers=[],
+        for_picker=True,
+        refresh=False,
+        probe_custom_providers=False,
+        probe_current_custom_provider=False,
+    )
+
+    row = next(p for p in providers if p["slug"] == "custom")
+    assert row["models"] == _LOCAL_CATALOG
+    assert fetched == []
+
+
+def test_no_probe_open_without_cache_keeps_configured_models_and_stays_offline(
+    monkeypatch,
+):
+    """The #58183 guarantee: a cold cache must not trigger a live probe. The
+    row degrades to its configured list rather than stalling on a dead port."""
+    _seed_custom_model_cache(monkeypatch, [], age_seconds=10)
+
+    row, fetched = _no_probe_local_row(
+        monkeypatch,
+        custom_providers=[
+            {
+                "name": "Local (127.0.0.1:8000)",
+                "base_url": _LOCAL_ENDPOINT,
+                "model": "omlx-model-1",
+            }
+        ],
+    )
+
+    assert row is not None
+    assert row["models"] == ["omlx-model-1"]
+    assert fetched == []
+
+
+def test_no_probe_open_respects_discover_models_false(monkeypatch):
+    """A user who pinned their catalog must not have it replaced from cache."""
+    _seed_custom_model_cache(monkeypatch, _LOCAL_CATALOG)
+
+    row, fetched = _no_probe_local_row(
+        monkeypatch,
+        custom_providers=[
+            {
+                "name": "Local (127.0.0.1:8000)",
+                "base_url": _LOCAL_ENDPOINT,
+                "model": "pinned-model",
+                "models": ["pinned-model"],
+                "discover_models": False,
+            }
+        ],
+    )
+
+    assert row is not None
+    assert row["models"] == ["pinned-model"]
+    assert fetched == []
+
+
+def test_cached_catalog_is_not_written_back_to_config(monkeypatch):
+    """Only a real probe persists discovered models; a cache hit is already
+    the product of the probe that saved it."""
+    _seed_custom_model_cache(monkeypatch, _LOCAL_CATALOG)
+    saves = []
+    monkeypatch.setattr(
+        "hermes_cli.model_switch._save_discovered_models_to_config",
+        lambda api_url, model_ids: saves.append((api_url, model_ids)),
+    )
+
+    row, _ = _no_probe_local_row(
+        monkeypatch,
+        custom_providers=[
+            {
+                "name": "Local (127.0.0.1:8000)",
+                "base_url": _LOCAL_ENDPOINT,
+                "model": "omlx-model-1",
+            }
+        ],
+    )
+
+    assert row["models"] == _LOCAL_CATALOG
+    assert saves == []


### PR DESCRIPTION
## Summary

The Desktop/dashboard model picker shows only the model(s) named in `config.yaml` for a saved custom OpenAI-compatible provider, even when a full catalog for that endpoint is already sitting in `provider_models_cache.json`. Reported against v0.20.0 (`5292074`): a local oMLX-style server on `127.0.0.1:8000` with **8 models loaded** renders **1** in the picker, while `GET /api/model/options?refresh=true` returns all 8.

## Root cause

#58183 stopped GUI picker opens from live-probing saved custom endpoints, so a stopped local server could not stall the picker. Correct goal — but it gated the entire discovery block rather than just the network call, so `cached_fetch_api_models()` got skipped along with `fetch_api_models()`:

```python
should_probe = (
    _can_probe_custom_provider(row_is_current=_grp_is_current)   # latency gate
    and bool(api_url)
    and (bool(api_key) or not grp.get("has_explicit_models"))    # user-intent gates
    and grp.get("discover_models", True)
)
if should_probe:
    live_models = cached_fetch_api_models(...)
```

A normal picker open passes `probe_custom_providers=False, probe_current_custom_provider=True`, so only the **current** provider's row is probed. Every other custom row falls through to the models declared in its config entry — typically the single `model:` written when the provider was added — even though `cached_fetch_api_models()` would have returned the full catalog from disk with **no network I/O** on a warm same-fingerprint entry.

That is why the symptom is invisible to `curl`: every REST check in the report passed `refresh=true`, which flips `probe_custom_providers` back on.

### Reproduction (real imports, temp `HERMES_HOME`, zero network)

Seed the disk cache with 8 models, then list providers with the endpoint **not** current:

| Row | Models before | Models after |
|---|---|---|
| local endpoint, not current | **1** (`omlx-model-1`) | **8** (full cached catalog) |
| local endpoint, is current | 8 | 8 |

Same cache, same config, same call — the only variable is `is_current`.

## Changes

- `hermes_cli/models.py` — `cache_only` on `cached_fetch_api_models()`: serves a valid same-fingerprint entry within the existing stale-serve window, never fetches, never spawns a background revalidation, returns `None` on a miss. `cache_only` outranks `force_refresh` (the caller has said no network).
- `hermes_cli/model_switch.py` — all three custom-endpoint sites in `list_authenticated_providers()` (sections 3, 3b, 4) now separate **what the user's config permits** (`discover_models`, an explicit `models:` allowlist) from **how we may obtain it**. Suppressing the probe downgrades to a cached read instead of skipping discovery. A cache hit does not call `_save_discovered_models_to_config()` — the probe that populated the cache already did.

## Behavior preserved

- **#58183's latency win.** A cold cache is a miss, so picker opens against offline endpoints still make **zero** network calls. Verified with three dead local ports and a spy on `fetch_api_models`: 0 live fetches.
- **`discover_models: false` still pins** the configured catalog — the cache cannot override a user's explicit narrowing.
- Explicit Refresh is unchanged (full live probe of every custom provider).

## Test plan

- `scripts/run_tests.sh tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_cached_fetch_api_models.py -q` → **66 passed**
- `scripts/run_tests.sh tests/hermes_cli/test_inventory.py tests/hermes_cli/test_picker_prewarm.py tests/test_tui_gateway_server.py tests/hermes_cli/test_model_catalog.py tests/hermes_cli/test_model_cache_swr.py tests/hermes_cli/test_models.py tests/hermes_cli/test_user_providers_model_switch.py tests/hermes_cli/test_custom_provider_model_switch.py tests/acp/test_server.py -q` → **521 passed**
- `scripts/run_tests.sh tests/hermes_cli/ -q` → identical failure set to clean `main` (20 files / 47 tests, all host-environment: git, pty, kanban, update, sqlite I/O). No regressions.

New coverage asserts contracts, not snapshots: cache-hit/miss boundaries for `cache_only`, full-catalog rendering across all three provider shapes with a warm cache, cold-cache degradation with zero fetches, `discover_models: false` pinning, and no config write-back on a cache hit.

## Relationship to #81556

[#81556](https://github.com/NousResearch/hermes-agent/pull/81556) targets the same symptom from the **write** side — persisting discovered models into `config.yaml` from the `hermes model` flow. This is the **read** side, and the two are complementary: #81556 only helps providers added or refreshed through that specific CLI flow, and cannot help an endpoint whose lineup changes after config was written (exactly the local-model-server case here). This fix makes any endpoint that has ever been probed render its full catalog, regardless of which surface probed it.