### PR TITLE
fix(desktop): shield math spans from the visible-prose rewrites

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
@@ -306,4 +306,28 @@ describe('preprocessMarkdown', () => {
     expect(output).toContain('\\$5')
     expect(output).toContain('\\$10')
   })
+
+  it('keeps a radical index inside inline math', () => {
+    expect(preprocessMarkdown('$\\sqrt[3]{8}$')).toBe('$\\sqrt[3]{8}$')
+  })
+
+  it('keeps a radical index inside display math', () => {
+    expect(preprocessMarkdown('$$\\sqrt[3]{8}$$')).toBe('$$\\sqrt[3]{8}$$')
+  })
+
+  it('keeps a radical index inside a multiline display block', () => {
+    const input = ['$$', '\\sqrt[3]{8} + \\sqrt[4]{16}', '$$'].join('\n')
+
+    expect(preprocessMarkdown(input)).toBe(input)
+  })
+
+  it('keeps a radical index in math that arrived as bracket delimiters', () => {
+    expect(preprocessMarkdown('\\(\\sqrt[3]{8}\\)')).toContain('$\\sqrt[3]{8}$')
+  })
+
+  it('still strips a citation marker in prose that also contains math', () => {
+    const output = preprocessMarkdown('Per the paper[2], $\\sqrt[3]{8}$ is 2.')
+
+    expect(output).toBe('Per the paper, $\\sqrt[3]{8}$ is 2.')
+  })
 })

--- a/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
@@ -330,4 +330,10 @@ describe('preprocessMarkdown', () => {
 
     expect(output).toBe('Per the paper, $\\sqrt[3]{8}$ is 2.')
   })
+
+  it('shields inline math whose body contains an escaped dollar', () => {
+    const output = preprocessMarkdown('$\\sqrt[3]{8} + \\$5$')
+
+    expect(output).toContain('\\sqrt[3]{8}')
+  })
 })

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -11,6 +11,11 @@ const FENCE_LINE_RE = /^([ \t]*)(`{3,}|~{3,})([^\n]*)$/
 const EMPTY_FENCE_BLOCK_RE = /(^|\n)[ \t]*(?:`{3,}|~{3,})[^\n]*\n[ \t]*(?:`{3,}|~{3,})[ \t]*(?=\n|$)/g
 const CODE_FENCE_SPLIT_RE = /((?:```|~~~)[\s\S]*?(?:```|~~~))/g
 const INLINE_CODE_SPLIT_RE = /(`[^`\n]+`)/g
+// Math spans as remark-math will see them: a `$$…$$` block, which may span
+// lines, or a same-line `$…$`. A delimiter escaped as `\$` is prose — that is
+// exactly how escapeCurrencyDollarsPreservingMath marks a price, so the
+// lookbehinds keep `\$5 and \$10` out of the math branch.
+const MATH_SPAN_SPLIT_RE = /((?<!\\)\$\$[\s\S]*?(?<!\\)\$\$|(?<!\\)\$[^\n$]+?(?<!\\)\$)/g
 const LATEX_DISPLAY_OPEN_LINE_RE = /^([ \t]*(?:>[ \t]*)*(?:(?:[-+*]|\d+[.)])[ \t]+)?[ \t]*)\\{1,2}\[[ \t]*\r?$/
 const LATEX_DISPLAY_CLOSE_LINE_RE = /^([ \t]*(?:>[ \t]*)*(?:(?:[-+*]|\d+[.)])[ \t]+)?[ \t]*)\\{1,2}\][ \t]*\r?$/
 const CUSTOM_DISPLAY_MATH_LINE_RE = /^([ \t]*(?:>[ \t]*)*(?:(?:[-+*]|\d+[.)])[ \t]+)?[ \t]*)\[\/math\][ \t]*\r?$/
@@ -144,17 +149,35 @@ function autoLinkRawUrls(text: string): string {
   })
 }
 
+function rewriteProseSegment(segment: string): string {
+  return linkifySessionRefs(
+    autoLinkRawUrls(segment.replace(/`{3,}/g, '').replace(LOCAL_PREVIEW_URL_RE, '$1').replace(CITATION_MARKER_RE, ''))
+  )
+}
+
+/**
+ * Apply the prose rewrites to visible prose only.
+ *
+ * Inline code has always been shielded here. Math has to be shielded for the
+ * same reason: these rewrites read TeX as prose. `CITATION_MARKER_RE` is the
+ * one that bites — its lookbehind accepts any letter, so the `t` of `\sqrt`
+ * qualifies and `$\sqrt[3]{8}$` loses its index to what looks like a citation
+ * marker, long before KaTeX sees it.
+ *
+ * Split on math spans is odd-index-is-a-delimiter (capturing split), not a
+ * `startsWith('$')` test, so a prose segment that merely opens with a stray
+ * dollar can't be mistaken for math.
+ */
 function normalizeVisibleProse(text: string): string {
   return text
     .split(INLINE_CODE_SPLIT_RE)
     .map(part =>
       part.startsWith('`')
         ? part
-        : linkifySessionRefs(
-            autoLinkRawUrls(
-              part.replace(/`{3,}/g, '').replace(LOCAL_PREVIEW_URL_RE, '$1').replace(CITATION_MARKER_RE, '')
-            )
-          )
+        : part
+            .split(MATH_SPAN_SPLIT_RE)
+            .map((segment, index) => (index % 2 === 1 ? segment : rewriteProseSegment(segment)))
+            .join('')
     )
     .join('')
 }

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -15,7 +15,13 @@ const INLINE_CODE_SPLIT_RE = /(`[^`\n]+`)/g
 // lines, or a same-line `$…$`. A delimiter escaped as `\$` is prose — that is
 // exactly how escapeCurrencyDollarsPreservingMath marks a price, so the
 // lookbehinds keep `\$5 and \$10` out of the math branch.
-const MATH_SPAN_SPLIT_RE = /((?<!\\)\$\$[\s\S]*?(?<!\\)\$\$|(?<!\\)\$[^\n$]+?(?<!\\)\$)/g
+//
+// The inline body steps over escape pairs (`\\[^\n]`) rather than excluding
+// `$` outright, because `\$` is a literal dollar INSIDE math (`$x + \$5$`) and
+// must not end the span — the same distinction findClosingSingleDollar draws
+// via isEscapedAt. The two alternatives are disjoint on their first character,
+// so the body cannot backtrack ambiguously.
+const MATH_SPAN_SPLIT_RE = /((?<!\\)\$\$[\s\S]*?(?<!\\)\$\$|(?<!\\)\$(?:[^\n$\\]|\\[^\n])+?(?<!\\)\$)/g
 const LATEX_DISPLAY_OPEN_LINE_RE = /^([ \t]*(?:>[ \t]*)*(?:(?:[-+*]|\d+[.)])[ \t]+)?[ \t]*)\\{1,2}\[[ \t]*\r?$/
 const LATEX_DISPLAY_CLOSE_LINE_RE = /^([ \t]*(?:>[ \t]*)*(?:(?:[-+*]|\d+[.)])[ \t]+)?[ \t]*)\\{1,2}\][ \t]*\r?$/
 const CUSTOM_DISPLAY_MATH_LINE_RE = /^([ \t]*(?:>[ \t]*)*(?:(?:[-+*]|\d+[.)])[ \t]+)?[ \t]*)\[\/math\][ \t]*\r?$/


### PR DESCRIPTION
## What does this PR do?

`$\sqrt[3]{8}$` renders as a plain square root — the index is silently gone.

This is **not** a KaTeX layout problem. The index never reaches KaTeX. `CITATION_MARKER_RE` (`markdown-preprocess.ts`) strips `[3]` as a citation marker: its lookbehind accepts any letter, so the `t` of `\sqrt` qualifies and `\sqrt[3]{8}` becomes `\sqrt{8}`. That runs inside `normalizeVisibleProse`, which splits out inline code spans but **not** math — so TeX is handed to rewrites written for prose.

It only fires on numeric indices, which is why `\sqrt[n]{8}` survives. That asymmetry is what makes the bug read like a rendering edge case rather than a preprocessing one.

| input | before | after |
|---|---|---|
| `$\sqrt[3]{8}$` | `$\sqrt{8}$` | unchanged |
| `$$\sqrt[3]{8}$$` | `$$\sqrt{8}$$` | unchanged |
| `$\sqrt[n]{8}$` | unchanged | unchanged |
| ` ```math ` fence | unchanged | unchanged |

## Fix

Shield math the same way inline code is already shielded: split each prose part on math spans and apply the rewrites only to the segments between them.

That deliberately covers more than the radical case. `CITATION_MARKER_RE` is the one that bites today, but `autoLinkRawUrls`, `LOCAL_PREVIEW_URL_RE`, the ``` ``` ``` stripper and `linkifySessionRefs` all run in the same pass and can corrupt TeX the same way given different input. Narrowing the citation regex alone would fix this report and leave the shape of the bug in place.

Three details keep the pass narrow:

- The split is capturing, and math segments are identified by **index parity**, not by a leading `$` — so a prose run that merely opens with a stray dollar can't be mistaken for math.
- The inline body steps over escape pairs rather than excluding `$`, because `\$` is a literal dollar *inside* math (`$x + \$5$`) and must not end the span — the same distinction `findClosingSingleDollar` draws via `isEscapedAt`.
- Delimiters escaped as `\$` stay prose. That's exactly how `escapeCurrencyDollarsPreservingMath` marks a price, so `$5 and $10` keeps its existing escaping.

## Related Issue

Related to #80821 — deliberately not using a closing keyword. That issue also reports multi-line display math rendering as raw source, which is a different bug with a different cause, fixed separately in #44589. #80821 should stay open until both land.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/lib/markdown-preprocess.ts`
  - add `MATH_SPAN_SPLIT_RE`, matching math spans as remark-math sees them: a `$$…$$` block (which may span lines) or a same-line `$…$`. An escaped `\$` never acts as a delimiter, but is allowed inside a body
  - extract the existing rewrite chain into `rewriteProseSegment`
  - `normalizeVisibleProse` now splits each non-code part on math spans and rewrites only the prose between them
- `apps/desktop/src/components/assistant-ui/markdown-text.test.ts`
  - six cases: inline, display, and multiline-block radical indices, the index in math that arrived as `\(…\)` bracket delimiters, inline math whose body holds an escaped `\$`, and a guard that a real citation marker in prose alongside math is still stripped

## How to Test

1. Run the focused suite:
   ```
   cd apps/desktop
   npm run test:ui -- src/components/assistant-ui/markdown-text.test.ts
   ```
   41/41 pass.
2. Send `$\sqrt[3]{8}$` and `$$\sqrt[3]{8}$$` in a chat and confirm the index shows above the radical.
3. Confirm `This is the source[0]` still loses its citation marker, and prose prices like `$5 and $10` are unchanged.

Validation completed:

- Focused suite: **41 passed**
- Full desktop UI suite: **3591 passed / 402 files**. Four failures on this machine are pre-existing and unrelated — locale-dependent assertions on `Intl` thousands separators (`1.234.567` vs `1,234,567`) in `billing/index.test.tsx`, `tool/fallback-model.test.ts` and `use-prompt-actions/utils.test.ts`. They fail identically on a clean `main` checkout here with this change stashed.
- `npx tsc -p . --noEmit`: clean
- ESLint on both changed files: clean
- Prettier `--check` on both changed files: clean
- **In the real Electron renderer**, via the desktop mock-backend Playwright harness, on a reply containing four radicals. KaTeX emits `<span class="root">` only for a radical that actually has an index, so that count separates "the index never arrived" from "KaTeX drew it and layout hid it":

  | DOM measure | without this fix | with this fix |
  |---|---|---|
  | `.katex .root` nodes | 1 (only `\sqrt[n]`) | 4 (all of them) |
  | `.katex-error` nodes | 0 | 0 |

  The MathML annotations confirm what KaTeX received: `\sqrt[3]{8}`, `\sqrt[3]{8}`, `\sqrt[n]{8}`, `\sqrt[3]{x^2 + y^2}` — intact, where before the numeric ones arrived as `\sqrt{8}`. Citation stripping and `$5 and $10` were asserted unchanged in the same run.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: desktop TypeScript-only change, no Python touched
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Node 24

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure string preprocessing, no OS-specific code paths. The math-span pattern is line-ending agnostic: the block form matches across newlines, and both inline body alternatives exclude `\n`, so a `\r` never lands inside a span boundary.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

In the rendered output, all four radicals carry their index — ∛8, ∛8, ⁿ√8, ∛(x²+y²) — where previously only the `\sqrt[n]` one did. The citation guard in the same reply (`per the paper[2],`) still renders as `per the paper,`, and `$5 and $10` still renders as literal prose.
