### PR TITLE
feat(desktop): render MCP Apps ui:// embedded HTML resources in tool results

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool/extract-embedded-html.test.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/extract-embedded-html.test.ts
@@ -8,13 +8,23 @@ describe('extractEmbeddedHtml', () => {
     expect(extractEmbeddedHtml('not an object')).toBe('')
   })
 
-  it('returns empty string when content has no resource items', () => {
+  it('returns empty string when no embedded HTML is present', () => {
+    expect(extractEmbeddedHtml({ result: 'plain text' })).toBe('')
     expect(extractEmbeddedHtml({ content: [{ type: 'text', text: 'hello' }] })).toBe('')
     expect(extractEmbeddedHtml({ content: 'just a string' })).toBe('')
     expect(extractEmbeddedHtml({ content: [] })).toBe('')
+    expect(extractEmbeddedHtml({})).toBe('')
   })
 
-  it('extracts HTML from a content array with a resource item', () => {
+  it('extracts HTML from _embedded_html field (primary path)', () => {
+    const result = {
+      result: '{"balance":2.5}',
+      _embedded_html: '<!DOCTYPE html><html><body>Balance Card</body></html>',
+    }
+    expect(extractEmbeddedHtml(result)).toBe('<!DOCTYPE html><html><body>Balance Card</body></html>')
+  })
+
+  it('extracts HTML from a content array with a resource item (secondary path)', () => {
     const result = {
       content: [
         { type: 'text', text: '{"balance":2.5}' },
@@ -29,6 +39,19 @@ describe('extractEmbeddedHtml', () => {
       ],
     }
     expect(extractEmbeddedHtml(result)).toBe('<!DOCTYPE html><html><body>Balance Card</body></html>')
+  })
+
+  it('prefers _embedded_html over content array', () => {
+    const result = {
+      _embedded_html: '<html>from field</html>',
+      content: [
+        {
+          type: 'resource',
+          resource: { mimeType: 'text/html', text: '<html>from content</html>' },
+        },
+      ],
+    }
+    expect(extractEmbeddedHtml(result)).toBe('<html>from field</html>')
   })
 
   it('returns empty string for non-HTML resources', () => {
@@ -47,6 +70,11 @@ describe('extractEmbeddedHtml', () => {
     expect(extractEmbeddedHtml(result)).toBe('')
   })
 
+  it('returns empty string when _embedded_html is empty', () => {
+    expect(extractEmbeddedHtml({ _embedded_html: '' })).toBe('')
+    expect(extractEmbeddedHtml({ _embedded_html: '   ' })).toBe('')
+  })
+
   it('returns empty string when resource text is empty', () => {
     const result = {
       content: [
@@ -61,29 +89,5 @@ describe('extractEmbeddedHtml', () => {
       ],
     }
     expect(extractEmbeddedHtml(result)).toBe('')
-  })
-
-  it('extracts HTML from a resource with additional unknown fields', () => {
-    const result = {
-      content: [
-        { type: 'text', text: 'result text' },
-        {
-          type: 'resource',
-          resource: {
-            uri: 'ui://example/swap-card',
-            mimeType: 'text/html',
-            text: '<html><body>Swap Card</body></html>',
-            blobs: ['extra-data'],
-          },
-        },
-      ],
-    }
-    expect(extractEmbeddedHtml(result)).toBe('<html><body>Swap Card</body></html>')
-  })
-
-  it('returns empty string when content is missing', () => {
-    expect(extractEmbeddedHtml({ success: true })).toBe('')
-    expect(extractEmbeddedHtml({ data: { balance: 1 } })).toBe('')
-    expect(extractEmbeddedHtml({})).toBe('')
   })
 })

--- a/apps/desktop/src/components/assistant-ui/tool/extract-embedded-html.test.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/extract-embedded-html.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import { extractEmbeddedHtml } from './fallback-model'
+
+describe('extractEmbeddedHtml', () => {
+  it('returns empty string for null/undefined', () => {
+    expect(extractEmbeddedHtml(null)).toBe('')
+    expect(extractEmbeddedHtml(undefined)).toBe('')
+    expect(extractEmbeddedHtml('not an object')).toBe('')
+  })
+
+  it('returns empty string when content has no resource items', () => {
+    expect(extractEmbeddedHtml({ content: [{ type: 'text', text: 'hello' }] })).toBe('')
+    expect(extractEmbeddedHtml({ content: 'just a string' })).toBe('')
+    expect(extractEmbeddedHtml({ content: [] })).toBe('')
+  })
+
+  it('extracts HTML from a direct content array with a resource item', () => {
+    const result = {
+      content: [
+        { type: 'text', text: '{"sol":2.5}' },
+        {
+          type: 'resource',
+          resource: {
+            uri: 'ui://sap/balance-card',
+            mimeType: 'text/html',
+            text: '<!DOCTYPE html><html><body>SAP Balance Card</body></html>',
+          },
+        },
+      ],
+    }
+    expect(extractEmbeddedHtml(result)).toBe('<!DOCTYPE html><html><body>SAP Balance Card</body></html>')
+  })
+
+  it('extracts HTML from a wrapped success envelope', () => {
+    const result = {
+      success: true,
+      tool: 'sol_get_balance',
+      hostedPricing: 'free',
+      data: {
+        content: [
+          { type: 'text', text: '{"sol":2.5}' },
+          {
+            type: 'resource',
+            resource: {
+              uri: 'ui://sap/balance-card',
+              mimeType: 'text/html',
+              text: '<html><body>Wrapped Card</body></html>',
+            },
+          },
+        ],
+      },
+    }
+    expect(extractEmbeddedHtml(result)).toBe('<html><body>Wrapped Card</body></html>')
+  })
+
+  it('returns empty string for non-HTML resources', () => {
+    const result = {
+      content: [
+        {
+          type: 'resource',
+          resource: {
+            uri: 'file://some/file.json',
+            mimeType: 'application/json',
+            text: '{"data": 1}',
+          },
+        },
+      ],
+    }
+    expect(extractEmbeddedHtml(result)).toBe('')
+  })
+
+  it('returns empty string when resource text is empty', () => {
+    const result = {
+      content: [
+        {
+          type: 'resource',
+          resource: {
+            uri: 'ui://sap/balance-card',
+            mimeType: 'text/html',
+            text: '',
+          },
+        },
+      ],
+    }
+    expect(extractEmbeddedHtml(result)).toBe('')
+  })
+
+  it('prefers direct content over wrapped data', () => {
+    const result = {
+      content: [
+        {
+          type: 'resource',
+          resource: { mimeType: 'text/html', text: '<html>direct</html>' },
+        },
+      ],
+      data: {
+        content: [
+          {
+            type: 'resource',
+            resource: { mimeType: 'text/html', text: '<html>wrapped</html>' },
+          },
+        ],
+      },
+    }
+    expect(extractEmbeddedHtml(result)).toBe('<html>direct</html>')
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/tool/extract-embedded-html.test.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/extract-embedded-html.test.ts
@@ -14,43 +14,21 @@ describe('extractEmbeddedHtml', () => {
     expect(extractEmbeddedHtml({ content: [] })).toBe('')
   })
 
-  it('extracts HTML from a direct content array with a resource item', () => {
+  it('extracts HTML from a content array with a resource item', () => {
     const result = {
       content: [
-        { type: 'text', text: '{"sol":2.5}' },
+        { type: 'text', text: '{"balance":2.5}' },
         {
           type: 'resource',
           resource: {
-            uri: 'ui://sap/balance-card',
+            uri: 'ui://example/balance-card',
             mimeType: 'text/html',
-            text: '<!DOCTYPE html><html><body>SAP Balance Card</body></html>',
+            text: '<!DOCTYPE html><html><body>Balance Card</body></html>',
           },
         },
       ],
     }
-    expect(extractEmbeddedHtml(result)).toBe('<!DOCTYPE html><html><body>SAP Balance Card</body></html>')
-  })
-
-  it('extracts HTML from a wrapped success envelope', () => {
-    const result = {
-      success: true,
-      tool: 'sol_get_balance',
-      hostedPricing: 'free',
-      data: {
-        content: [
-          { type: 'text', text: '{"sol":2.5}' },
-          {
-            type: 'resource',
-            resource: {
-              uri: 'ui://sap/balance-card',
-              mimeType: 'text/html',
-              text: '<html><body>Wrapped Card</body></html>',
-            },
-          },
-        ],
-      },
-    }
-    expect(extractEmbeddedHtml(result)).toBe('<html><body>Wrapped Card</body></html>')
+    expect(extractEmbeddedHtml(result)).toBe('<!DOCTYPE html><html><body>Balance Card</body></html>')
   })
 
   it('returns empty string for non-HTML resources', () => {
@@ -75,7 +53,7 @@ describe('extractEmbeddedHtml', () => {
         {
           type: 'resource',
           resource: {
-            uri: 'ui://sap/balance-card',
+            uri: 'ui://example/card',
             mimeType: 'text/html',
             text: '',
           },
@@ -85,23 +63,27 @@ describe('extractEmbeddedHtml', () => {
     expect(extractEmbeddedHtml(result)).toBe('')
   })
 
-  it('prefers direct content over wrapped data', () => {
+  it('extracts HTML from a resource with additional unknown fields', () => {
     const result = {
       content: [
+        { type: 'text', text: 'result text' },
         {
           type: 'resource',
-          resource: { mimeType: 'text/html', text: '<html>direct</html>' },
+          resource: {
+            uri: 'ui://example/swap-card',
+            mimeType: 'text/html',
+            text: '<html><body>Swap Card</body></html>',
+            blobs: ['extra-data'],
+          },
         },
       ],
-      data: {
-        content: [
-          {
-            type: 'resource',
-            resource: { mimeType: 'text/html', text: '<html>wrapped</html>' },
-          },
-        ],
-      },
     }
-    expect(extractEmbeddedHtml(result)).toBe('<html>direct</html>')
+    expect(extractEmbeddedHtml(result)).toBe('<html><body>Swap Card</body></html>')
+  })
+
+  it('returns empty string when content is missing', () => {
+    expect(extractEmbeddedHtml({ success: true })).toBe('')
+    expect(extractEmbeddedHtml({ data: { balance: 1 } })).toBe('')
+    expect(extractEmbeddedHtml({})).toBe('')
   })
 })

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
@@ -607,6 +607,48 @@ export function firstStringField(record: Record<string, unknown>, keys: readonly
   return ''
 }
 
+/**
+ * Extract embedded HTML from an MCP tool result that follows the MCP Apps
+ * extension: a `content` array containing a `{ type: 'resource', resource:
+ * { mimeType: 'text/html', text: string } }` item. Returns the HTML string
+ * when found, empty string otherwise.
+ *
+ * Also checks `data.content` for results wrapped in a success envelope
+ * (common for SAP MCP and similar servers that wrap tool output).
+ */
+export function extractEmbeddedHtml(result: unknown): string {
+  const record = parseMaybeObject(result)
+  if (!record) return ''
+
+  const checkContent = (content: unknown): string => {
+    if (!Array.isArray(content)) return ''
+    for (const item of content) {
+      const entry = parseMaybeObject(item)
+      if (!entry) continue
+      if (entry.type === 'resource') {
+        const resource = parseMaybeObject(entry.resource)
+        if (resource && resource.mimeType === 'text/html' && typeof resource.text === 'string' && resource.text.trim()) {
+          return resource.text
+        }
+      }
+    }
+    return ''
+  }
+
+  // Direct content array
+  const direct = checkContent(record.content)
+  if (direct) return direct
+
+  // Wrapped in a success envelope (e.g. { success, tool, data: { content: [...] } })
+  const dataRecord = parseMaybeObject(record.data)
+  if (dataRecord) {
+    const wrapped = checkContent(dataRecord.content)
+    if (wrapped) return wrapped
+  }
+
+  return ''
+}
+
 function collectResultItems(value: unknown): unknown[] {
   if (Array.isArray(value)) {
     return value

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
@@ -608,15 +608,25 @@ export function firstStringField(record: Record<string, unknown>, keys: readonly
 }
 
 /**
- * Extract embedded HTML from an MCP tool result that follows the MCP Apps
- * extension: a `content` array containing a `{ type: 'resource', resource:
- * { mimeType: 'text/html', text: string } }` item. Returns the HTML string
- * when found, empty string otherwise.
+ * Extract embedded HTML from an MCP tool result. Checks two sources:
+ * 1. `_embedded_html` field — set by the MCP tool handler when a content
+ *    block has type=resource with mimeType=text/html. This is the
+ *    primary path for MCP Apps cards.
+ * 2. `content` array — the standard MCP content array with a resource
+ *    item of mimeType text/html. This handles results that preserve
+ *    the full content array (e.g. from local MCP servers).
  */
 export function extractEmbeddedHtml(result: unknown): string {
   const record = parseMaybeObject(result)
   if (!record) return ''
 
+  // Check _embedded_html field (set by the MCP tool handler)
+  const embeddedField = record._embedded_html
+  if (typeof embeddedField === 'string' && embeddedField.trim()) {
+    return embeddedField
+  }
+
+  // Check content array for resource items
   const content = record.content
   if (!Array.isArray(content)) return ''
 

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
@@ -612,38 +612,23 @@ export function firstStringField(record: Record<string, unknown>, keys: readonly
  * extension: a `content` array containing a `{ type: 'resource', resource:
  * { mimeType: 'text/html', text: string } }` item. Returns the HTML string
  * when found, empty string otherwise.
- *
- * Also checks `data.content` for results wrapped in a success envelope
- * (common for SAP MCP and similar servers that wrap tool output).
  */
 export function extractEmbeddedHtml(result: unknown): string {
   const record = parseMaybeObject(result)
   if (!record) return ''
 
-  const checkContent = (content: unknown): string => {
-    if (!Array.isArray(content)) return ''
-    for (const item of content) {
-      const entry = parseMaybeObject(item)
-      if (!entry) continue
-      if (entry.type === 'resource') {
-        const resource = parseMaybeObject(entry.resource)
-        if (resource && resource.mimeType === 'text/html' && typeof resource.text === 'string' && resource.text.trim()) {
-          return resource.text
-        }
+  const content = record.content
+  if (!Array.isArray(content)) return ''
+
+  for (const item of content) {
+    const entry = parseMaybeObject(item)
+    if (!entry) continue
+    if (entry.type === 'resource') {
+      const resource = parseMaybeObject(entry.resource)
+      if (resource && resource.mimeType === 'text/html' && typeof resource.text === 'string' && resource.text.trim()) {
+        return resource.text
       }
     }
-    return ''
-  }
-
-  // Direct content array
-  const direct = checkContent(record.content)
-  if (direct) return direct
-
-  // Wrapped in a success envelope (e.g. { success, tool, data: { content: [...] } })
-  const dataRecord = parseMaybeObject(record.data)
-  if (dataRecord) {
-    const wrapped = checkContent(dataRecord.content)
-    if (wrapped) return wrapped
   }
 
   return ''

--- a/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
@@ -52,6 +52,7 @@ import {
   clampForDisplay,
   cleanVisibleText,
   countDiffLineStats,
+  extractEmbeddedHtml,
   inlineDiffFromResult,
   isCardTool,
   isFileEditTool,
@@ -697,6 +698,20 @@ function ToolEntry({ part }: ToolEntryProps) {
                 )}
               </div>
             ))}
+          {(() => {
+            const embeddedHtml = extractEmbeddedHtml(result)
+            if (!embeddedHtml) return null
+            return (
+              <div className="mt-2 overflow-hidden rounded-lg border border-(--ui-stroke-secondary)" data-slot="tool-embedded-html">
+                <iframe
+                  srcDoc={embeddedHtml}
+                  sandbox="allow-same-origin"
+                  className="h-[240px] w-full border-0"
+                  style={{ minHeight: '200px', background: 'transparent' }}
+                />
+              </div>
+            )
+          })()}
           {toolViewMode === 'technical' && <ToolPayloadDisclosure args={part.args} result={part.result} />}
         </div>
       )}

--- a/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
@@ -703,9 +703,20 @@ function ToolEntry({ part }: ToolEntryProps) {
             if (!embeddedHtml) return null
             return (
               <div className="mt-2 overflow-hidden rounded-lg border border-(--ui-stroke-secondary)" data-slot="tool-embedded-html">
+                {/*
+                 * Security: sandbox without any allow-* flags is the most
+                 * restrictive iframe policy. The embedded HTML from MCP
+                 * servers is untrusted content — it must not execute scripts,
+                 * access the parent DOM, submit forms, or make network
+                 * requests. MCP Apps cards are pure visual (inline CSS,
+                 * inline base64 images, no JavaScript). If a card needs
+                 * interactivity in the future, use sandbox="allow-scripts"
+                 * (never allow-same-origin together with allow-scripts,
+                 * as that combination lets the iframe escape its sandbox).
+                 */}
                 <iframe
                   srcDoc={embeddedHtml}
-                  sandbox="allow-same-origin"
+                  sandbox=""
                   className="h-[240px] w-full border-0"
                   style={{ minHeight: '200px', background: 'transparent' }}
                 />

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5284,6 +5284,23 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     )
             text_result = "\n".join(parts) if parts else ""
 
+            # Preserve embedded HTML resources from the MCP Apps extension
+            # so the desktop client can render them as visual cards. When a
+            # content block is a resource with mimeType text/html, the HTML
+            # text is already in text_result (via _render_mcp_resource_block),
+            # but we also capture it separately so the desktop can distinguish
+            # it from plain text and render it in an iframe.
+            embedded_html = ""
+            for block in (result.content or []):
+                if not hasattr(block, "resource") or block.resource is None:
+                    continue
+                resource = block.resource
+                if getattr(resource, "mimeType", None) == "text/html":
+                    html_text = getattr(resource, "text", None)
+                    if html_text and isinstance(html_text, str) and html_text.strip():
+                        embedded_html = html_text
+                        break
+
             # Combine content + structuredContent when both are present.
             # MCP spec: content is model-oriented (text), structuredContent
             # is machine-oriented (JSON metadata).  For an AI agent, content
@@ -5291,12 +5308,21 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             structured = getattr(result, "structuredContent", None)
             if structured is not None:
                 if text_result:
-                    return json.dumps({
+                    result_obj = {
                         "result": text_result,
                         "structuredContent": structured,
-                    }, ensure_ascii=False)
-                return json.dumps({"result": structured}, ensure_ascii=False)
-            return json.dumps({"result": text_result}, ensure_ascii=False)
+                    }
+                    if embedded_html:
+                        result_obj["_embedded_html"] = embedded_html
+                    return json.dumps(result_obj, ensure_ascii=False)
+                result_obj = {"result": structured}
+                if embedded_html:
+                    result_obj["_embedded_html"] = embedded_html
+                return json.dumps(result_obj, ensure_ascii=False)
+            result_obj = {"result": text_result}
+            if embedded_html:
+                result_obj["_embedded_html"] = embedded_html
+            return json.dumps(result_obj, ensure_ascii=False)
 
         def _call_once():
             return _run_on_mcp_loop(_call, timeout=tool_timeout)


### PR DESCRIPTION
## Summary

MCP servers implementing the MCP Apps extension return tool results with a `content` array containing a `{ type: "resource", resource: { mimeType: "text/html", text: string } }` item. The gateway flattened all content items to text for model consumption, losing the card structure.

This PR preserves the embedded HTML through the gateway and renders it in a sandboxed iframe in the desktop.

## Changes

### Gateway (Python)

- **`tools/mcp_tool.py`**: When an MCP tool result contains a content block with `type=resource` and `mimeType=text/html`, the HTML text is captured in an `_embedded_html` field in the tool result JSON. The HTML is also included in the text result (via `_render_mcp_resource_block`) for model consumption, so the agent still sees the card content.

  The desktop already receives the parsed tool result through the dashboard gateway's `tool.complete` handler (`_on_tool_complete` in `tui_gateway/server.py`), which puts `payload["result"] = json.loads(result)` — so the `_embedded_html` field flows through to the desktop's `parseMaybeJsonObject(payload?.result)` in `chat-messages.ts` without any changes to the event payload.

### Desktop (TypeScript/React)

- **`fallback-model/index.ts`**: New `extractEmbeddedHtml(result)` function. Checks two sources:
  1. `_embedded_html` field in the parsed tool result (set by the gateway for all MCP tools, local and remote)
  2. `content` array with a `type=resource` item of `mimeType=text/html` (standard MCP content array, for local servers that preserve the full structure)

- **`fallback.tsx`**: When `extractEmbeddedHtml` returns non-empty HTML, it renders a sandboxed iframe (`sandbox=""`, `srcdoc`) below the existing text detail. The iframe uses `srcdoc` so no network requests are made. The text/JSON detail remains visible above (additive, not replacing).

- **`extract-embedded-html.test.ts`**: 8 unit tests covering `_embedded_html` field, content array resource items, non-HTML resources, empty text, precedence rules, and missing content.

## Design decisions

- **Additive, not replacing**: The text/JSON detail is still shown. The embedded HTML card appears below it. No regression for tools without embedded HTML.

- **Sandboxed iframe with `srcdoc`**: `sandbox=""` is the most restrictive policy — no scripts, no DOM access, no forms, no network. MCP Apps cards are pure visual (inline CSS, base64 images, no JavaScript). If interactivity is needed in the future, use `sandbox="allow-scripts"` (never combined with `allow-same-origin`, as that combination lets the iframe escape its sandbox).

- **Two-path extraction**: The `_embedded_html` field is the primary path (works for all MCP tools since the gateway sets it). The `content` array path is secondary (for local MCP servers that preserve the full content array). Both are checked to maximize compatibility.

- **No new tool classification**: The rendering is result-driven, not name-driven. Any MCP tool that returns embedded HTML gets the card. No allowlist or tool-name pattern matching needed.

- **Minimal surface change**: 3 files changed across the gateway and desktop. No changes to tool classification, tool registration, session management, event payloads, or message alternation.

## Testing

- `npx vitest run --project ui src/components/assistant-ui/tool/extract-embedded-html.test.ts` — 8/8 pass
- `npx vitest run --project ui src/components/assistant-ui/tool/fallback.test.ts` — 10/10 pass (no regression)
- `npx vitest run --project ui src/components/assistant-ui/tool/fallback-model.test.ts` — 30/31 pass (1 pre-existing failure on main, unrelated)
- Full suite: `npx vitest run --project ui` — 3588/3593 pass (5 pre-existing failures on main, all unrelated: billing settings, time formatting, clampForDisplay)
- **E2E verified**: MCP server returns `_embedded_html` with balance card HTML. Hermes dev build renders the card inline in the conversation thread as a dark-themed glassmorphic card with protocol logos and balance display.

## Commits

1. `fd3075a` feat(desktop): render MCP Apps ui:// embedded HTML resources in tool results
2. `3330ab6` security: use most restrictive iframe sandbox for untrusted MCP HTML
3. `d554c59` refactor: generalize extractEmbeddedHtml to standard MCP content array only
4. `00b96ea` feat: preserve embedded HTML in MCP tool results for desktop rendering