### PR TITLE
fix(computer-use): isolate approval callbacks by context

### DIFF
--- a/tests/tools/test_computer_use_approval_isolation.py
+++ b/tests/tools/test_computer_use_approval_isolation.py
@@ -11,6 +11,7 @@ default-allow behavior.
 """
 
 import json
+import threading
 
 
 def _install_backend(cu_tool):
@@ -73,3 +74,57 @@ def test_b_still_dispatches_with_default_allow():
     )
     payload = json.loads(result) if isinstance(result, str) else result
     assert not (isinstance(payload, dict) and payload.get("error"))
+
+
+def test_callbacks_are_isolated_across_concurrent_contexts():
+    from tools.computer_use import tool as cu_tool
+
+    barrier = threading.Barrier(2)
+    observed = {}
+    failures = []
+
+    def run(name):
+        def approve(action, args, summary):
+            observed[name] = action
+            return "approve_once"
+
+        token = cu_tool.set_approval_callback(approve)
+        try:
+            barrier.wait(timeout=5)
+            assert cu_tool._request_approval("click", {"element": 1}, name) is None
+        except BaseException as exc:
+            failures.append(exc)
+        finally:
+            cu_tool.reset_approval_callback(token)
+
+    threads = [threading.Thread(target=run, args=(name,)) for name in ("a", "b")]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert failures == []
+    assert observed == {"a": "click", "b": "click"}
+
+
+def test_reset_restores_nested_callback():
+    from tools.computer_use import tool as cu_tool
+
+    events = []
+    outer = cu_tool.set_approval_callback(
+        lambda action, args, summary: events.append("outer") or "approve_once"
+    )
+    try:
+        inner = cu_tool.set_approval_callback(
+            lambda action, args, summary: events.append("inner") or "approve_once"
+        )
+        try:
+            assert cu_tool._request_approval("click", {}, "inner") is None
+        finally:
+            cu_tool.reset_approval_callback(inner)
+        assert cu_tool._request_approval("click", {}, "outer") is None
+    finally:
+        cu_tool.reset_approval_callback(outer)
+
+    assert events == ["inner", "outer"]

--- a/tools/computer_use/__init__.py
+++ b/tools/computer_use/__init__.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 from tools.computer_use.tool import (  # noqa: F401
     handle_computer_use,
     release_computer_use_session,
+    reset_approval_callback,
     set_approval_callback,
     check_computer_use_requirements,
     get_computer_use_schema,

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import atexit
 import base64
+import contextvars
 import json
 import logging
 import os
@@ -63,18 +64,29 @@ logger = logging.getLogger(__name__)
 # Approval & safety
 # ---------------------------------------------------------------------------
 
-_approval_callback = None
+_approval_callback: contextvars.ContextVar[Any] = contextvars.ContextVar(
+    "computer_use_approval_callback",
+    default=None,
+)
 
 
-def set_approval_callback(cb) -> None:
+def set_approval_callback(cb) -> contextvars.Token:
     """Register a callback for computer_use approval prompts (used by CLI).
 
     Matches the terminal_tool._approval_callback pattern. The callback
     receives (action, args, summary) and returns one of:
       "approve_once" | "approve_session" | "always_approve" | "deny".
+
+    The returned token can be passed to :func:`reset_approval_callback` to
+    restore a previous callback after nested or concurrent session work.
     """
-    global _approval_callback
-    _approval_callback = cb
+    return _approval_callback.set(cb)
+
+
+def reset_approval_callback(token: contextvars.Token) -> None:
+    """Restore the approval callback that preceded *token*."""
+
+    _approval_callback.reset(token)
 
 
 # Actions that read, not mutate. Always allowed.
@@ -531,7 +543,7 @@ def _request_approval(action: str, args: Dict[str, Any],
             return None
         if scope_key in _always_allow.get(session_id, set()):
             return None
-    cb = _approval_callback
+    cb = _approval_callback.get()
     if cb is None:
         # No CLI approval wired — default allow. Gateway approval is handled
         # one layer out via the normal tool-approval infra.

--- a/tools/computer_use_tool.py
+++ b/tools/computer_use_tool.py
@@ -12,6 +12,7 @@ from tools.computer_use.tool import (
     check_computer_use_requirements,
     handle_computer_use,
     release_computer_use_session,
+    reset_approval_callback,
     set_approval_callback,
 )
 from tools.registry import registry
@@ -36,6 +37,7 @@ registry.register(
 __all__ = [
     "handle_computer_use",
     "release_computer_use_session",
+    "reset_approval_callback",
     "set_approval_callback",
     "check_computer_use_requirements",
     "release_computer_use_session",


### PR DESCRIPTION
## Summary

- store the Computer Use approval callback in a `ContextVar` instead of a process-global slot
- return a token from `set_approval_callback()` and add `reset_approval_callback(token)` for safe nesting
- re-export the reset API through the existing Computer Use public modules

## Reproduction and root cause

Two concurrent Hermes sessions can register different approval callbacks in the same process. The current module-global slot is last-writer-wins, so one session can route an approval request through another session's callback. A process-global callback does not follow the execution context that registered it.

## Compatibility

The default remains `None`, preserving the existing no-callback behavior. Existing callers may continue to ignore the return value from `set_approval_callback()`.

This PR intentionally contains no execution observer, product UI, cursor, tracing, persona, or Optical Agent code.

## Tests

- `HERMES_PYTHON=<agent-python> scripts/run_tests.sh tests/tools/test_computer_use_approval_isolation.py` — 4 passed
- `git diff --check` — passed

The regression tests cover concurrent callback isolation and nested token restoration.
