### PR TITLE
fix(curator): exclude .venv/caches from skill snapshots

### DIFF
--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -49,7 +49,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import get_hermes_home
-from agent.skill_utils import is_excluded_skill_path
+from agent.skill_utils import is_excluded_skill_path, EXCLUDED_SKILL_DIRS
 from hermes_cli.sizefmt import format_bytes
 
 logger = logging.getLogger(__name__)
@@ -70,6 +70,21 @@ _ID_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z(-\d{2})?$")
 
 def _backups_dir() -> Path:
     return get_hermes_home() / "skills" / ".curator_backups"
+
+
+def _tar_filter(ti: tarfile.TarInfo):
+    """Keep virtualenvs / VCS / caches out of the snapshot.
+
+    ``tf.add(recursive=True)`` walks into everything; only the *top level* was
+    filtered before, so a skill carrying its own ``.venv`` (torch, opencv,
+    model weights) was rolled into every weekly snapshot — GBs of content that
+    is not restorable anyway, since ``pyvenv.cfg`` hard-codes absolute
+    interpreter paths. Reuses the same exclusion set the skill scanners use.
+    """
+    parts = Path(ti.name).parts
+    if any(p in EXCLUDED_SKILL_DIRS for p in parts):
+        return None
+    return ti
 
 
 def _skills_dir() -> Path:
@@ -268,7 +283,8 @@ def snapshot_skills(reason: str = "manual", *, protect_ids: Optional[Set[str]] =
                     continue
                 # arcname: store paths relative to skills/ so extraction
                 # drops cleanly back into the skills dir.
-                tf.add(str(entry), arcname=entry.name, recursive=True)
+                tf.add(str(entry), arcname=entry.name, recursive=True,
+                       filter=_tar_filter)
         # Capture cron/jobs.json alongside the tarball. Never fails the
         # snapshot — the skills side is the core guarantee; cron is
         # additive. We still record in the manifest whether it was

--- a/tests/agent/test_curator_backup_venv_exclusion.py
+++ b/tests/agent/test_curator_backup_venv_exclusion.py
@@ -1,0 +1,34 @@
+"""Regression: curator snapshots must exclude .venv / caches, not just top-level.
+
+Before the fix, `tarfile.add(recursive=True)` only filtered _EXCLUDE_TOP_LEVEL
+(.curator_backups, .hub); skill-internal .venv dirs (torch, opencv, model
+weights) were rolled into every weekly snapshot — GBs of non-restorable content
+that also made the snapshot corrupt mid-flight on large trees.
+"""
+
+import tarfile
+from pathlib import Path
+
+from agent.curator_backup import _tar_filter
+
+
+def test_venv_paths_excluded():
+    keep = tarfile.TarInfo("skills/realesrgan/SKILL.md")
+    venv_py = tarfile.TarInfo("skills/realesrgan/.venv/Scripts/python.exe")
+    venv_lib = tarfile.TarInfo("skills/realesrgan/.venv/Lib/site-packages/torch/__init__.py")
+    pycache = tarfile.TarInfo("skills/foo/__pycache__/mod.cpython-311.pyc")
+    node_mod = tarfile.TarInfo("skills/foo/node_modules/pkg/index.js")
+
+    assert _tar_filter(keep) is not None
+    assert _tar_filter(venv_py) is None
+    assert _tar_filter(venv_lib) is None
+    assert _tar_filter(pycache) is None
+    assert _tar_filter(node_mod) is None
+
+
+def test_hub_top_level_still_excluded_by_caller_only():
+    # .hub is in EXCLUDED_SKILL_DIRS too, so nested .hub content is also dropped
+    # by _tar_filter — that is fine; the *top-level* .hub is excluded separately
+    # by _EXCLUDE_TOP_LEVEL in the snapshot loop, not here.
+    nested = tarfile.TarInfo("skills/foo/.hub/lock.json")
+    assert _tar_filter(nested) is None


### PR DESCRIPTION
## Symptom
`hermes curator backup` (and the automatic pre-run snapshot) packed every skill's internal `.venv` into the tarball. With three skills carrying bundled venvs (torch/opencv/model weights), `~/.hermes/skills/.curator_backups` grew to **1.3 GB**, the snapshot run took 180s+ (timeout), and at least one snapshot was written **corrupt** (`EOFError`, missing `manifest.json`).

## Root cause
`agent/curator_backup.py` only filtered `_EXCLUDE_TOP_LEVEL = {".curator_backups", ".hub"}` at the *top level*:
```python
tf.add(str(entry), arcname=entry.name, recursive=True)
```
`recursive=True` then walks into everything. The shared `EXCLUDED_SKILL_DIRS` set (`.venv`, `node_modules`, `__pycache__`, `site-packages`, …) that the skill scanners use was **never applied** to the tar path. Since `pyvenv.cfg` hard-codes absolute interpreter paths, this content is not restorable across machines anyway — snapshotting it is pure waste + a corruption risk on large trees.

## Fix
Reuse the existing `EXCLUDED_SKILL_DIRS` via a `filter=` callback — no new exclusion rules invented:
```python
from agent.skill_utils import is_excluded_skill_path, EXCLUDED_SKILL_DIRS

def _tar_filter(ti):
    if any(p in EXCLUDED_SKILL_DIRS for p in Path(ti.name).parts):
        return None
    return ti
# tf.add(..., recursive=True, filter=_tar_filter)
```

## Verification
- New regression test `tests/agent/test_curator_backup_venv_exclusion.py`: **2 passed** (venv/pycache/caches dropped; ordinary SKILL.md kept).
- Real snapshot: 165.6 MB with **0** venv/pycache entries and 283 SKILL.md files (the 284th on disk is `.hub/quarantine/dspy/SKILL.md`, correctly excluded by `_EXCLUDE_TOP_LEVEL`, not by the filter — so 283 is correct). Before the fix, a snapshot held 41156 venv files / 783 MB.
- Full curator suite unaffected.

## Environment
Windows 10, Python 3.11.