### PR TITLE
fix(browser): isolate Lightpanda and Chrome fallback flags

### DIFF
--- a/tests/tools/test_browser_lightpanda.py
+++ b/tests/tools/test_browser_lightpanda.py
@@ -195,6 +195,60 @@ class TestCleanupResetsEngineCache:
 
 
 # ---------------------------------------------------------------------------
+# Chrome fallback behavior
+# ---------------------------------------------------------------------------
+
+class TestChromeFallback:
+    """Chrome fallback must hand off from Lightpanda without leaking engine policy."""
+
+    def test_uses_non_recursive_lightpanda_get_url(self):
+        import tools.browser_tool as bt
+
+        with patch("tools.browser_tool._run_browser_command", return_value={
+                 "success": True, "data": {"url": "https://example.com/"}
+             }) as run_command, \
+             patch("tools.browser_tool._find_agent_browser", side_effect=FileNotFoundError("stop")):
+            result = bt._run_chrome_fallback_command(
+                "task1", "screenshot", [], timeout=30
+            )
+
+        run_command.assert_called_once_with(
+            "task1", "get", ["url"], timeout=10, _engine_override="lightpanda"
+        )
+        assert result == {"success": False, "error": "stop"}
+
+    def test_chrome_fallback_injects_required_sandbox_args(self):
+        import tools.browser_tool as bt
+
+        captured_envs = []
+        mock_proc = MagicMock()
+        mock_proc.wait.return_value = None
+        mock_proc.returncode = 1
+
+        def capture_popen(_cmd, **kwargs):
+            captured_envs.append(kwargs["env"])
+            return mock_proc
+
+        with patch("tools.browser_tool._run_browser_command", return_value={
+                 "success": True, "data": {"url": "https://example.com/"}
+             }), \
+             patch("tools.browser_tool._find_agent_browser", return_value="/usr/bin/agent-browser"), \
+             patch("tools.browser_tool._chromium_installed", return_value=True), \
+             patch("tools.browser_tool._needs_chromium_sandbox_bypass", return_value=True), \
+             patch("subprocess.Popen", side_effect=capture_popen):
+            result = bt._run_chrome_fallback_command(
+                "task1", "screenshot", [], timeout=30
+            )
+
+        assert result["success"] is False
+        assert captured_envs
+        assert all(
+            env.get("AGENT_BROWSER_ARGS") == "--no-sandbox,--disable-dev-shm-usage"
+            for env in captured_envs
+        )
+
+
+# ---------------------------------------------------------------------------
 # fallback warning annotation
 # ---------------------------------------------------------------------------
 
@@ -346,7 +400,7 @@ class TestEngineOverride:
     def test_no_override_uses_cached_engine(
         self, _camofox, _cdp, _cloud, _chromium, _local, _find, _session
     ):
-        """Without _engine_override, the cached engine is used."""
+        """Lightpanda gets neither auto-injected nor inherited Chrome arguments."""
         import tools.browser_tool as bt
 
         bt._cached_browser_engine = "lightpanda"
@@ -355,12 +409,14 @@ class TestEngineOverride:
         _session.return_value = {"session_name": "test-sess"}
 
         captured_cmds = []
+        captured_envs = []
         mock_proc = MagicMock()
         mock_proc.wait.return_value = None
         mock_proc.returncode = 0
 
         def capture_popen(cmd, **kwargs):
             captured_cmds.append(cmd)
+            captured_envs.append(kwargs["env"])
             return mock_proc
 
         # Return a substantive snapshot so the LP fallback does NOT trigger.
@@ -375,14 +431,26 @@ class TestEngineOverride:
                  __exit__=MagicMock(return_value=False),
              ))), \
              patch("tools.interrupt.is_interrupted", return_value=False), \
-             patch("tools.browser_tool._write_owner_pid"):
+             patch("tools.browser_tool._needs_chromium_sandbox_bypass", return_value=True), \
+             patch("tools.browser_tool._write_owner_pid"), \
+             patch.dict(os.environ, {}, clear=True):
+            # AppArmor/root detection would normally auto-inject Chromium args.
             bt._run_browser_command("task1", "snapshot", [])
 
-        # SHOULD contain "--engine lightpanda"
-        assert len(captured_cmds) == 1
-        assert "--engine" in captured_cmds[0]
-        engine_idx = captured_cmds[0].index("--engine")
-        assert captured_cmds[0][engine_idx + 1] == "lightpanda"
+            # User-supplied current and legacy Chromium knobs must also be removed.
+            with patch.dict(os.environ, {
+                "AGENT_BROWSER_ARGS": "--no-sandbox",
+                "AGENT_BROWSER_CHROME_FLAGS": "--disable-dev-shm-usage",
+            }):
+                bt._run_browser_command("task1", "snapshot", [])
+
+        assert len(captured_cmds) == 2
+        for command, environment in zip(captured_cmds, captured_envs):
+            assert "--engine" in command
+            engine_idx = command.index("--engine")
+            assert command[engine_idx + 1] == "lightpanda"
+            assert "AGENT_BROWSER_ARGS" not in environment
+            assert "AGENT_BROWSER_CHROME_FLAGS" not in environment
 
     def test_hybrid_local_sidecar_injects_engine_even_with_cloud_provider(self):
         """A task::local sidecar is local even when global cloud config exists."""

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -358,6 +358,20 @@ def _needs_chromium_sandbox_bypass() -> bool:
     return False
 
 
+def _apply_chromium_sandbox_args(browser_env: Dict[str, str]) -> None:
+    """Add required Chromium sandbox flags without overriding user settings."""
+    if (
+        "AGENT_BROWSER_ARGS" not in browser_env
+        and "AGENT_BROWSER_CHROME_FLAGS" not in browser_env
+        and _needs_chromium_sandbox_bypass()
+    ):
+        logger.debug(
+            "browser: sandbox bypass needed (root/docker/AppArmor userns) — "
+            "injecting --no-sandbox"
+        )
+        browser_env["AGENT_BROWSER_ARGS"] = "--no-sandbox,--disable-dev-shm-usage"
+
+
 def _read_command_output_files(stdout_path: str, stderr_path: str) -> tuple[str, str]:
     """Best-effort read of agent-browser stdout/stderr temp files."""
     stdout = stderr = ""
@@ -1116,15 +1130,16 @@ def _run_chrome_fallback_command(
     """
     import uuid
 
-    # 1. Grab the current URL from the Lightpanda session. Use
-    # ``_engine_override=\"auto\"`` so this helper does not recursively trigger
-    # Lightpanda→Chrome fallback if the eval call itself fails.
+    # 1. Grab the current URL from the Lightpanda session. ``get url`` is not
+    # fallback-eligible, so an error cannot recursively trigger this helper.
+    # Keep the explicit Lightpanda override so Chromium-only environment flags
+    # are stripped while querying the already-running Lightpanda daemon.
     url_result = _run_browser_command(
-        task_id, "eval", ["window.location.href"], timeout=10, _engine_override="auto"
+        task_id, "get", ["url"], timeout=10, _engine_override="lightpanda"
     )
     current_url = None
     if url_result.get("success"):
-        current_url = url_result.get("data", {}).get("result", "").strip().strip('"').strip("'")
+        current_url = str(url_result.get("data", {}).get("url", "")).strip()
     if not current_url:
         logger.warning("Chrome fallback: could not determine current URL from LP session")
         return {"success": False, "error": "Chrome fallback failed: could not determine current URL"}
@@ -1171,6 +1186,10 @@ def _run_chrome_fallback_command(
 
     if "AGENT_BROWSER_IDLE_TIMEOUT_MS" not in browser_env:
         browser_env["AGENT_BROWSER_IDLE_TIMEOUT_MS"] = str(BROWSER_SESSION_INACTIVITY_TIMEOUT * 1000)
+
+    # This helper bypasses _run_browser_command, so apply the same Chromium
+    # sandbox policy explicitly.
+    _apply_chromium_sandbox_args(browser_env)
 
     def _run_tmp(cmd: str, cmd_args: List[str]) -> Dict[str, Any]:
         full = base_args + [cmd] + cmd_args
@@ -2579,26 +2598,14 @@ def _run_browser_command(
             idle_ms = str(BROWSER_SESSION_INACTIVITY_TIMEOUT * 1000)
             browser_env["AGENT_BROWSER_IDLE_TIMEOUT_MS"] = idle_ms
 
-        # Inject --no-sandbox when needed (issue #15765):
-        # - Running as root: Chromium always refuses to start without it
-        # - Ubuntu 23.10+ / AppArmor systems: unprivileged user namespaces
-        #   are restricted, causing Chromium to exit with "No usable sandbox"
-        #   even for non-root users running under systemd or containers.
-        # Honour either the legacy AGENT_BROWSER_CHROME_FLAGS (never consumed by
-        # agent-browser itself, but documented in older notes) or the real
-        # AGENT_BROWSER_ARGS — if the user pre-sets either, don't overwrite it.
-        if (
-            "AGENT_BROWSER_ARGS" not in browser_env
-            and "AGENT_BROWSER_CHROME_FLAGS" not in browser_env
-        ):
-            if _needs_chromium_sandbox_bypass():
-                logger.debug(
-                    "browser: sandbox bypass needed (root/docker/AppArmor userns) — "
-                    "injecting --no-sandbox"
-                )
-                browser_env["AGENT_BROWSER_ARGS"] = (
-                    "--no-sandbox,--disable-dev-shm-usage"
-                )
+        # Chromium-only launch flags are rejected by Lightpanda. Strip both
+        # the current and legacy variables for Lightpanda commands; explicit
+        # Chrome commands and fallback use the shared Chromium policy.
+        if engine == "lightpanda":
+            browser_env.pop("AGENT_BROWSER_ARGS", None)
+            browser_env.pop("AGENT_BROWSER_CHROME_FLAGS", None)
+        else:
+            _apply_chromium_sandbox_args(browser_env)
 
         # Use temp files for stdout/stderr instead of pipes.
         # agent-browser starts a background daemon that inherits file


### PR DESCRIPTION
## What does this PR do?

Fixes the complete Lightpanda → Chrome handoff on Linux hosts where Chromium needs sandbox-bypass arguments.

Hermes currently copies or auto-injects `AGENT_BROWSER_ARGS` for every local engine. `agent-browser` rejects those Chromium-only arguments when `--engine lightpanda` is active. Once that happens, the fallback path has two additional problems: it queries the Lightpanda URL with an `auto` override that reintroduces the same poisoned environment, and its temporary Chrome process does not apply Hermes's sandbox policy.

This PR keeps the two engine environments separate and uses one sandbox policy for every Chrome launch path.

## Related Issue

Related to and supersedes #29139, which identified the inherited-variable case. This PR preserves that contribution with a `Co-authored-by` trailer and also covers the maintainer-requested auto-injection regression plus the two fallback failures.

Follow-up to the Lightpanda fallback work in #20672. The sandbox context originated in #15765.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Strip inherited `AGENT_BROWSER_ARGS` and legacy `AGENT_BROWSER_CHROME_FLAGS` from Lightpanda commands.
- Prevent automatic root/Docker/AppArmor Chromium flags from being injected into Lightpanda.
- Query the active Lightpanda session with non-fallback-eligible `get url` before Chrome handoff, avoiding recursive fallback and preserving the correct engine environment.
- Centralize Chromium sandbox-argument injection and apply it to temporary Chrome fallback sessions.
- Add regression coverage for all three failure modes.

## How to Test

1. On Ubuntu 23.10+ / 24.04, Docker, or another environment where `_needs_chromium_sandbox_bypass()` is true, configure `browser.engine: lightpanda`.
2. Optionally pre-set both Chrome variables to make the boundary explicit:
   ```bash
   export AGENT_BROWSER_ARGS='--no-sandbox,--disable-dev-shm-usage'
   export AGENT_BROWSER_CHROME_FLAGS='--legacy-test-flag'
   ```
3. Navigate and snapshot a public page. Lightpanda should succeed without `Custom Chrome arguments (--args) are not supported with Lightpanda`.
4. Request a screenshot. Hermes should recover the current Lightpanda URL and complete the operation through Chrome fallback.

Verified manually on Ubuntu 24.04 / Linux 6.8 with both variables present:

- Lightpanda navigation: success (`https://example.com/`, title `Example Domain`)
- Lightpanda accessibility snapshot: success (2 refs)
- Chrome screenshot fallback: success with structured `lightpanda → chrome` metadata

Automated checks:

- `npx --yes agent-browser@0.26.0 --engine lightpanda ... open/get url/close --json` — pinned-version compatibility passed with the expected `{data: {url}}` shape
- `uv run --extra dev pytest tests/tools/test_browser_lightpanda.py -o 'addopts=' -q` — 25 passed
- `uv run --extra dev pytest tests/tools/test_browser*.py -o 'addopts=' -q` — 331 passed, 7 skipped
- `uv run --extra dev ruff check tools/browser_tool.py tests/tools/test_browser_lightpanda.py` — passed
- `uv run --no-sync python scripts/check-windows-footguns.py --diff origin/main` — passed
- `scripts/run_tests.sh` — started per contributor guidance; stopped at 18% after 4,950 passes and 9 failures in unrelated agent/CLI tests (this branch changes only `tools/browser_tool.py` and its Lightpanda tests). The focused and complete browser suites above are green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 / Linux 6.8

### Documentation & Housekeeping

- [x] Relevant documentation: N/A — no public API or configuration change
- [x] `cli-config.yaml.example`: N/A — no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A — no workflow or architecture change
- [x] Cross-platform impact considered: Lightpanda env isolation is OS-independent; sandbox detection remains unchanged and Chrome-only
- [x] Tool descriptions/schemas: N/A — no tool contract change

## Screenshots / Logs

Before:

```text
Custom Chrome arguments (`--args`) are not supported with Lightpanda
Chrome fallback failed: could not determine current URL
```

After:

```json
{
  "navigate_success": true,
  "url": "https://example.com/",
  "title": "Example Domain",
  "snapshot_success": true,
  "screenshot_success": true,
  "browser_engine_fallback": {
    "from": "lightpanda",
    "to": "chrome"
  }
}
```
