### PR TITLE
feat(computer-use): support element-targeted typing

### DIFF
--- a/tests/computer_use/test_element_targeted_typing.py
+++ b/tests/computer_use/test_element_targeted_typing.py
@@ -1,0 +1,106 @@
+"""Regression tests for targeting a field before typing into it."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def noop_backend():
+    from tools.computer_use import tool as cu_tool
+
+    cu_tool.reset_backend_for_tests()
+    with patch.dict(os.environ, {"HERMES_COMPUTER_USE_BACKEND": "noop"}, clear=False):
+        yield cu_tool._get_backend()
+    cu_tool.reset_backend_for_tests()
+
+
+def test_schema_exposes_type_delay_bounds():
+    from tools.computer_use.schema import COMPUTER_USE_SCHEMA
+
+    prop = COMPUTER_USE_SCHEMA["parameters"]["properties"]["delay_ms"]
+    assert prop["minimum"] == 0
+    assert prop["maximum"] == 200
+
+
+def test_dispatch_forwards_element_coordinates_and_delay(noop_backend):
+    from tools.computer_use.tool import handle_computer_use
+
+    handle_computer_use({
+        "action": "type",
+        "text": "hello",
+        "element": 4,
+        "coordinate": [30, 40],
+        "delay_ms": 12,
+        "delivery_mode": "foreground",
+    })
+    first = next(c[1] for c in noop_backend.calls if c[0] == "type")
+    assert first == {
+        "text": "hello",
+        "element": 4,
+        "delay_ms": 12,
+        "delivery_mode": "foreground",
+        "bring_to_front": False,
+    }
+
+    noop_backend.calls.clear()
+    handle_computer_use({"action": "type", "text": "world", "coordinate": [30, 40]})
+    second = next(c[1] for c in noop_backend.calls if c[0] == "type")
+    assert second == {
+        "text": "world",
+        "x": 30,
+        "y": 40,
+        "delivery_mode": None,
+        "bring_to_front": False,
+    }
+
+
+def _cua_backend():
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    session = MagicMock()
+    session.supports_capability.return_value = True
+    session.supports_input_property.return_value = True
+    session.call_tool.return_value = {
+        "data": {"message": "ok"},
+        "structuredContent": {},
+        "isError": False,
+    }
+    backend = CuaDriverBackend.__new__(CuaDriverBackend)
+    backend._session = session
+    backend._session_id = "hermes-test"
+    backend._active_pid = 42
+    backend._active_window_id = 99
+    backend._snapshot_tokens = {3: "snapshot:3"}
+    return backend
+
+
+def test_cua_element_target_forwards_snapshot_token_and_delivery():
+    backend = _cua_backend()
+
+    result = backend.type_text(
+        "hello", element=3, delay_ms=17, delivery_mode="foreground"
+    )
+
+    name, args = backend._session.call_tool.call_args.args
+    assert result.ok is True
+    assert name == "type_text"
+    assert args["pid"] == 42
+    assert args["window_id"] == 99
+    assert args["element_index"] == 3
+    assert args["element_token"] == "snapshot:3"
+    assert args["delay_ms"] == 17
+    assert args["delivery_mode"] == "foreground"
+
+
+def test_cua_coordinate_target_is_used_when_element_is_absent():
+    backend = _cua_backend()
+
+    backend.type_text("hello", x=30, y=40, delay_ms=500)
+
+    _, args = backend._session.call_tool.call_args.args
+    assert args["x"] == 30
+    assert args["y"] == 40
+    assert args["delay_ms"] == 200
+    assert "element_index" not in args

--- a/tools/computer_use/backend.py
+++ b/tools/computer_use/backend.py
@@ -179,7 +179,10 @@ class ComputerUseBackend(ABC):
 
     # ── Keyboard ────────────────────────────────────────────────────
     @abstractmethod
-    def type_text(self, text: str, *, delivery_mode: Optional[str] = None,
+    def type_text(self, text: str, *, element: Optional[int] = None,
+                  x: Optional[int] = None, y: Optional[int] = None,
+                  delay_ms: Optional[int] = None,
+                  delivery_mode: Optional[str] = None,
                   bring_to_front: bool = False) -> ActionResult: ...
 
     @abstractmethod

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -2777,7 +2777,10 @@ class CuaDriverBackend(ComputerUseBackend):
         return self._run_input_action("scroll", args, delivery_mode, bring_to_front)
 
     # ── Keyboard ───────────────────────────────────────────────────
-    def type_text(self, text: str, *, delivery_mode: Optional[str] = None,
+    def type_text(self, text: str, *, element: Optional[int] = None,
+                  x: Optional[int] = None, y: Optional[int] = None,
+                  delay_ms: Optional[int] = None,
+                  delivery_mode: Optional[str] = None,
                   bring_to_front: bool = False) -> ActionResult:
         pid = self._active_pid
         window_id = self._active_window_id
@@ -2785,6 +2788,13 @@ class CuaDriverBackend(ComputerUseBackend):
             return ActionResult(ok=False, action="type_text",
                                 message="No active window — call capture() first.")
         args: Dict[str, Any] = {"pid": pid, "window_id": window_id, "text": text}
+        if element is not None:
+            args["element_index"] = int(element)
+        elif x is not None and y is not None:
+            args["x"] = int(x)
+            args["y"] = int(y)
+        if delay_ms is not None:
+            args["delay_ms"] = max(0, min(200, int(delay_ms)))
         return self._run_input_action("type_text", args, delivery_mode, bring_to_front)
 
     def key(self, keys: str, *, delivery_mode: Optional[str] = None,

--- a/tools/computer_use/schema.py
+++ b/tools/computer_use/schema.py
@@ -128,7 +128,7 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
                 "minimum": 1,
                 "maximum": 1000,
             },
-            # ── click / drag / scroll targeting ────────────────────
+            # ── click / drag / scroll / type targeting ─────────────
             "element": {
                 "type": "integer",
                 "description": (
@@ -205,6 +205,15 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
             "text": {
                 "type": "string",
                 "description": "Text to type (respects the current layout).",
+            },
+            "delay_ms": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 200,
+                "description": (
+                    "Optional delay between characters for action='type'. "
+                    "The driver default is 30ms; ignored by atomic UIA value writes."
+                ),
             },
             "keys": {
                 "type": "string",

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -769,8 +769,17 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
         return _maybe_follow_capture(backend, res, capture_after)
 
     if action == "type":
+        type_kwargs: Dict[str, Any] = {}
+        coord = args.get("coordinate") or (None, None)
+        if args.get("element") is not None:
+            type_kwargs["element"] = args.get("element")
+        elif coord and coord[0] is not None:
+            type_kwargs["x"], type_kwargs["y"] = coord[0], coord[1]
+        if args.get("delay_ms") is not None:
+            type_kwargs["delay_ms"] = args.get("delay_ms")
         res = backend.type_text(args.get("text", ""),
-                                delivery_mode=delivery_mode, bring_to_front=bring_to_front)
+                                delivery_mode=delivery_mode, bring_to_front=bring_to_front,
+                                **type_kwargs)
         return _maybe_follow_capture(backend, res, capture_after)
 
     if action == "key":


### PR DESCRIPTION
## Summary

- allow `action='type'` to target a SOM element or `[x, y]` coordinate before typing
- add optional `delay_ms` pacing to the public schema, dispatch, backend contract, and CuaDriver backend
- preserve ordinary focused typing when no target is supplied

## Reproduction and root cause

The current schema exposes `element` and `coordinate`, but the type dispatch drops them and `ComputerUseBackend.type_text()` has no targeting parameters. CuaDriver consequently sends only the active window and text, so typing depends on pre-existing focus even when the model identified the intended field.

The CuaDriver implementation maps `element` to `element_index` (and the existing snapshot-token attachment), otherwise maps complete coordinates to `x`/`y`. Element targeting wins when both are supplied. `delay_ms` is bounded to 0–200 ms.

## Compatibility

All new parameters are optional. Calls that only pass `text`, `delivery_mode`, and `bring_to_front` keep the existing behavior. The dispatch only forwards targeting kwargs when supplied, so older non-CuaDriver backends keep ordinary focused input behavior.

This PR contains no product cursor, UI, tracing, execution-observer, persona, or Optical Agent code.

## Tests

- `HERMES_PYTHON=<agent-python> scripts/run_tests.sh tests/computer_use/test_element_targeted_typing.py` — 4 passed
- `git diff --check` — passed

The full `tests/tools/test_computer_use.py` file was also run on Windows: 75 passed and 2 unrelated existing Windows-baseline tests failed (`test_cli_fallback_reads_screenshot_from_file` uses an unescaped native path in hand-built JSON; `test_linux_default_capture_skips_gnome_shell_helper` is Linux-specific). The isolated regression file is green.
