### PR TITLE
fix(file-tools): preserve POSIX safety guards on Windows hosts

### DIFF
--- a/tests/tools/test_file_tools_windows_posix_guards.py
+++ b/tests/tools/test_file_tools_windows_posix_guards.py
@@ -1,0 +1,45 @@
+"""POSIX safety namespaces remain protected when Hermes runs on Windows."""
+
+import ntpath
+from unittest.mock import patch
+
+
+def _windows_path_semantics(file_tools):
+    return patch.multiple(file_tools.os, path=ntpath, sep="\\")
+
+
+def test_device_and_proc_paths_stay_blocked_with_windows_path_semantics():
+    from tools import file_tools
+
+    blocked = (
+        "/dev/zero",
+        "/dev/stdin",
+        "/proc/self/fd/0",
+        "/proc/123/environ",
+        "/proc/123/task/456/maps",
+    )
+    with _windows_path_semantics(file_tools):
+        assert all(file_tools._is_blocked_device_path(path) for path in blocked)
+
+
+def test_sensitive_posix_write_paths_stay_blocked_on_windows_hosts(monkeypatch):
+    from tools import file_tools
+
+    monkeypatch.setattr(file_tools, "_get_hermes_config_resolved", lambda: None)
+    blocked = (
+        "/etc/hosts",
+        "/boot/loader.conf",
+        "/usr/lib/systemd/system/demo.service",
+        "/var/run/docker.sock",
+    )
+    with _windows_path_semantics(file_tools):
+        assert all(file_tools._check_sensitive_path(path) for path in blocked)
+
+
+def test_windows_native_paths_do_not_match_posix_guards(monkeypatch):
+    from tools import file_tools
+
+    monkeypatch.setattr(file_tools, "_get_hermes_config_resolved", lambda: None)
+    with _windows_path_semantics(file_tools):
+        assert file_tools._is_blocked_device_path(r"C:\\dev\\zero") is False
+        assert file_tools._check_sensitive_path(r"C:\\etc\\hosts") is None

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -514,7 +514,10 @@ def _rewrite_v4a_patch_paths_for_host(
 
 def _is_blocked_device_path(path: str) -> bool:
     """Return True for concrete device/fd paths that can hang reads."""
-    normalized = os.path.normpath(_expand_tilde(path))
+    raw = _expand_tilde(path)
+    if os.sep != "/":
+        raw = raw.replace(os.sep, "/")
+    normalized = posixpath.normpath(raw)
     if normalized in _BLOCKED_DEVICE_PATHS:
         return True
     # /proc/self/fd/0-2 and /proc/<pid>/fd/0-2 are Linux aliases for stdio
@@ -679,14 +682,20 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
     except (OSError, ValueError):
         resolved = filepath
     normalized = os.path.normpath(_expand_tilde(filepath))
+    raw = _expand_tilde(filepath)
+    if os.sep != "/":
+        raw = raw.replace(os.sep, "/")
+    posix_normalized = posixpath.normpath(raw)
     _err = (
         f"Refusing to write to sensitive system path: {filepath}\n"
         "Use the terminal tool with sudo if you need to modify system files."
     )
     for prefix in _SENSITIVE_PATH_PREFIXES:
-        if resolved.startswith(prefix) or normalized.startswith(prefix):
+        if (resolved.startswith(prefix) or normalized.startswith(prefix)
+                or posix_normalized.startswith(prefix)):
             return _err
-    if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
+    if (resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS
+            or posix_normalized in _SENSITIVE_EXACT_PATHS):
         return _err
     # Prevent agents from modifying the Hermes config file directly.
     # approvals.mode and other security settings live here; a malicious or


### PR DESCRIPTION
## Summary

- normalize `/dev` and `/proc` read guards with POSIX path semantics regardless of host OS
- preserve `/etc`, `/boot`, systemd, and Docker socket write guards when Hermes runs on Windows
- add Windows-semantics behavior tests that also reject false positives on native drive paths

## Reproduction and root cause

`os.path.normpath()` is `ntpath.normpath()` on Windows. It rewrites `/` to `\\`, while the device, proc, and sensitive-path rules are all forward-slash POSIX namespaces. The comparisons therefore become inert on Windows. This matters when a Windows Hermes host operates against a Linux/container filesystem where those paths are real.

The fix keeps native normalization for native/Hermes-config comparisons and adds POSIX normalization only for POSIX rule tables.

## Tests

- `scripts/run_tests.sh tests/tools/test_file_tools_windows_posix_guards.py tests/tools/test_file_read_guards.py tests/tools/test_file_write_safety.py`
  - new Windows POSIX regression tests: 3 passed
  - existing read guards: 31 passed, 4 skipped
  - existing write safety: 49 passed, 2 unrelated Windows baseline failures (POSIX mode-bit expectation and unavailable symlink privilege)
- `git diff --check` — passed

No Optical Agent, Sidecar, UI, tracing, cursor, persona, or product protection code is included.
