### PR TITLE
fix(skills): keep bundle hashes portable on Windows

### DIFF
--- a/tests/tools/test_skills_hash_windows_portability.py
+++ b/tests/tools/test_skills_hash_windows_portability.py
@@ -1,0 +1,26 @@
+"""Skill bundle hashes use the same portable path order on every host."""
+
+from tools.skills_hub import OptionalSkillSource, bundle_content_hash
+from tools.skills_guard import content_hash
+
+
+def _write_demo_skill(root):
+    skill_dir = root / "demo-skill"
+    (skill_dir / "references").mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("same content", encoding="utf-8")
+    (skill_dir / "references" / "checklist.md").write_text(
+        "- [ ] security\n", encoding="utf-8"
+    )
+    return skill_dir
+
+
+def test_optional_bundle_uses_posix_keys_and_matches_installed_hash(tmp_path):
+    skill_dir = _write_demo_skill(tmp_path)
+    source = OptionalSkillSource()
+    source._optional_dir = tmp_path
+
+    bundle = source.fetch("official/demo-skill")
+
+    assert bundle is not None
+    assert set(bundle.files) == {"SKILL.md", "references/checklist.md"}
+    assert bundle_content_hash(bundle) == content_hash(skill_dir)

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -700,11 +700,14 @@ def _content_digest(skill_path: Path) -> str:
     """Canonical SHA-256 over relative paths and exact file bytes."""
     h = hashlib.sha256()
     if skill_path.is_dir():
-        for file_path in sorted(skill_path.rglob("*")):
-            if file_path.is_file():
-                rel = file_path.relative_to(skill_path).as_posix()
-                h.update(rel.encode("utf-8") + b"\x00")
-                h.update(file_path.read_bytes())
+        entries = sorted(
+            (path.relative_to(skill_path).as_posix(), path)
+            for path in skill_path.rglob("*")
+            if path.is_file()
+        )
+        for rel, file_path in entries:
+            h.update(rel.encode("utf-8") + b"\x00")
+            h.update(file_path.read_bytes())
     else:
         h.update(skill_path.read_bytes())
     return h.hexdigest()

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3336,7 +3336,7 @@ class OptionalSkillSource(SkillSource):
                 and "__pycache__" not in f.parts
                 and f.suffix != ".pyc"
             ):
-                rel_path = str(f.relative_to(skill_dir))
+                rel_path = f.relative_to(skill_dir).as_posix()
                 try:
                     files[rel_path] = f.read_bytes()
                 except OSError:


### PR DESCRIPTION
## Summary

- use POSIX relative keys when `OptionalSkillSource` builds an in-memory bundle
- sort installed files by their POSIX relative string, matching `bundle_content_hash()` ordering
- cover a mixed-case `SKILL.md` + lowercase support-directory bundle on Windows

## Reproduction and root cause

On Windows, `str(relative_path)` produces backslash bundle keys, while installed-directory hashing uses POSIX keys. Separately, sorting `Path` objects follows Windows case-folded path ordering, while bundle hashing sorts portable string keys by byte order. A bundle containing `SKILL.md` and `references/...` can therefore report drift immediately after a clean install.

Both hash sides now use the same POSIX key namespace and ordering.

## Tests

- new portability regression: 1 passed
- existing `test_skills_guard.py`: 28 passed, 2 skipped, 1 unrelated Windows symlink-privilege baseline failure
- existing `test_skills_hub.py`: 57 passed, 1 skipped, 2 unrelated Windows newline-baseline failures (text-mode `write_text` produces CRLF in tests that assert LF bytes)
- `git diff --check` — passed

No product, UI, tracing, cursor, persona, Sidecar, or Optical Agent code is included.
