### PR TITLE
fix(security-check): normalize known-safe paths on Windows

### DIFF
--- a/scripts/check_subprocess_stdin.py
+++ b/scripts/check_subprocess_stdin.py
@@ -65,6 +65,12 @@ KNOWN_SAFE = {
     "plugins/security-guidance/patterns.py",  # subprocess mentions are in reminder strings, not calls
 }
 
+
+def portable_relative_path(path: Path, root: Path) -> str:
+    """Return the forward-slash namespace used by path policy tables."""
+
+    return path.relative_to(root).as_posix()
+
 # Inline marker that exempts a single subprocess call from this check.
 # Put it in a comment on (or within) the call when the process MUST inherit
 # stdin — e.g. an interactive login the user explicitly invokes. Travels with
@@ -170,7 +176,7 @@ def main() -> int:
             continue
 
         for py_file in dirpath.rglob("*.py"):
-            rel = str(py_file.relative_to(repo_root))
+            rel = portable_relative_path(py_file, repo_root)
 
             # Skip known-safe files.
             if rel in KNOWN_SAFE:

--- a/tests/tools/test_subprocess_stdin_guard.py
+++ b/tests/tools/test_subprocess_stdin_guard.py
@@ -8,7 +8,7 @@ subprocess calls are added without stdin=subprocess.DEVNULL.
 import importlib.util
 import subprocess
 import sys
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "scripts" / "check_subprocess_stdin.py"
@@ -67,4 +67,13 @@ def test_inline_noqa_marker_exempts_a_call():
         "x.py",
     )
     assert exempt == [], "inline marker should exempt the call"
+
+
+def test_known_safe_paths_use_the_guard_portable_namespace():
+    guard = _load_guard()
+
+    root = PureWindowsPath(r"C:\repo")
+    path = root / "agent" / "shell_hooks.py"
+    assert guard.portable_relative_path(path, root) == "agent/shell_hooks.py"
+    assert guard.portable_relative_path(path, root) in guard.KNOWN_SAFE
 


### PR DESCRIPTION
## Summary

- normalize repository-relative paths to forward slashes before comparing them with `KNOWN_SAFE`
- add a Windows-path behavior test for the portable policy namespace

## Reproduction and root cause

`str(Path.relative_to(...))` emits backslashes on Windows, but `KNOWN_SAFE` entries use forward slashes. The allowlist therefore cannot match on Windows and intentionally safe subprocess sites are reported as violations.

The guard now uses `PurePath.as_posix()` through a small helper, leaving scanning and policy unchanged on POSIX.

## Tests

- `scripts/run_tests.sh tests/tools/test_subprocess_stdin_guard.py` — 4 passed
- `git diff --check` — passed

No product or Optical Agent code is included.
