### PR TITLE
fix(local-env): preserve command bytes through Git Bash

### DIFF
--- a/tests/tools/test_local_env_windows_transport.py
+++ b/tests/tools/test_local_env_windows_transport.py
@@ -1,0 +1,62 @@
+"""Windows Git Bash command transport preserves the user's command bytes."""
+
+import glob
+import platform
+
+import pytest
+
+from tools.environments.local import LocalEnvironment
+
+pytestmark = pytest.mark.skipif(
+    platform.system() != "Windows",
+    reason="exercises the Windows argv to Git Bash boundary",
+)
+
+
+@pytest.fixture
+def env(tmp_path):
+    environment = LocalEnvironment(cwd=str(tmp_path), timeout=30)
+    yield environment
+    environment.cleanup()
+
+
+def test_backslash_content_survives_byte_exact(env, tmp_path):
+    target = tmp_path / "content.txt"
+    cmd = r"printf '%s' 'a\nb\\d' > " + "'" + target.as_posix() + "'"
+
+    result = env.execute(cmd, timeout=30)
+
+    assert result["returncode"] == 0
+    assert target.read_bytes() == rb"a\nb\\d"
+
+
+def test_heredoc_multiline_backslashes_survive(env, tmp_path):
+    target = tmp_path / "heredoc.txt"
+    cmd = (
+        f"cat > '{target.as_posix()}' <<'EOF'\n"
+        "line1 C:\\Users\\x\n"
+        "line2\n"
+        "EOF"
+    )
+
+    result = env.execute(cmd, timeout=30)
+
+    assert result["returncode"] == 0
+    assert target.read_bytes() == b"line1 C:\\Users\\x\nline2\n"
+
+
+def test_exit_codes_and_environment_snapshot_still_propagate(env):
+    assert env.execute("false", timeout=30)["returncode"] == 1
+    env.execute("export HERMES_TRANSPORT_PROBE=portable", timeout=30)
+    result = env.execute("echo relay=$HERMES_TRANSPORT_PROBE", timeout=30)
+    assert (result.get("output") or "").strip() == "relay=portable"
+
+
+def test_transport_file_is_removed_before_command_runs(env):
+    snap_dir = str(env._snapshot_path.rsplit("/", 1)[0])
+    result = env.execute(
+        f"grep -r HERMES_SELF_MATCH_CANARY '{snap_dir}' ; true", timeout=30
+    )
+
+    assert "HERMES_SELF_MATCH_CANARY" not in (result.get("output") or "")
+    assert glob.glob(f"{env._snapshot_path}.cmd.*") == []

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -804,11 +804,15 @@ class BaseEnvironment(ABC):
         """
         return shlex.quote(path)
 
+    def _emit_user_command(self, command: str) -> str:
+        """Return the script line(s) that execute a user's command."""
+
+        escaped = command.replace("'", "'\\''")
+        return f"eval '{escaped}'"
+
     def _wrap_command(self, command: str, cwd: str) -> str:
         """Build the full bash script that sources snapshot, cd's, runs command,
         re-dumps env vars, and emits CWD markers."""
-        escaped = command.replace("'", "'\\''")
-
         # Quote the snapshot path (see init_session — LocalEnvironment
         # rewrites ``C:/...`` to ``/c/...`` so MSYS doesn't mangle it).
         _quoted_snap = self._quote_shell_path(self._snapshot_path)
@@ -865,7 +869,7 @@ class BaseEnvironment(ABC):
         parts.append(f"builtin cd -- {quoted_cwd} || exit 126")
 
         # Run the actual command
-        parts.append(f"eval '{escaped}'")
+        parts.append(self._emit_user_command(command))
         parts.append("__hermes_ec=$?")
         # Restrict Hermes metadata files without changing the user's command
         # umask. Snapshot files may contain env-carried secrets.

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import uuid
 from collections.abc import Mapping
 from pathlib import Path
 
@@ -1483,6 +1484,24 @@ class LocalEnvironment(BaseEnvironment):
         """Rewrite native/mixed Windows paths before quoting for Git Bash."""
         return _quote_bash_path(path)
 
+    def _emit_user_command(self, command: str) -> str:
+        """Avoid Windows argv re-parsing by transporting commands in a file."""
+
+        if not _IS_WINDOWS:
+            return super()._emit_user_command(command)
+        cmd_path = f"{self._snapshot_path}.cmd.{uuid.uuid4().hex[:12]}.sh"
+        with open(cmd_path, "w", encoding="utf-8", newline="\n") as fh:
+            fh.write(command)
+            if not command.endswith("\n"):
+                fh.write("\n")
+        quoted = _quote_bash_path(cmd_path)
+        return (
+            f"__hermes_cmd_text=$(cat -- {quoted}) || "
+            "{ echo 'hermes: command file unreadable' >&2; exit 125; }\n"
+            f"rm -f -- {quoted} 2>/dev/null\n"
+            'eval "$__hermes_cmd_text"'
+        )
+
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
                   stdin_data: str | None = None) -> subprocess.Popen:
@@ -1674,14 +1693,15 @@ class LocalEnvironment(BaseEnvironment):
                 os.unlink(f)
             except OSError:
                 pass
-        # Remove any orphaned atomic-write temp snapshots (snap.tmp.<bashpid>)
-        # a failed/interrupted mv could have left behind (#38249).
+        # Remove orphaned atomic snapshots and per-call command transports.
         try:
             import glob
-            for tmp in glob.glob(f"{self._snapshot_path}.tmp.*"):
-                try:
-                    os.unlink(tmp)
-                except OSError:
-                    pass
+            for pattern in (f"{self._snapshot_path}.tmp.*",
+                            f"{self._snapshot_path}.cmd.*"):
+                for tmp in glob.glob(pattern):
+                    try:
+                        os.unlink(tmp)
+                    except OSError:
+                        pass
         except Exception:
             pass


### PR DESCRIPTION
## Summary

- add a byte-preserving command-emission seam to `BaseEnvironment` without changing its default behavior
- on Windows LocalEnvironment, transport each user command through a unique temporary file instead of the Windows argv/Git Bash re-parse boundary
- delete the transport before execution and sweep interrupted-call leftovers during cleanup

## Reproduction and root cause

The complete wrapper script is passed through Windows process argv to MSYS Git Bash. CPython command-line quoting and the MSYS re-parser do not preserve all backslash/quote sequences, so valid command text can arrive changed before the existing `eval` runs.

On Windows only, the command bytes now travel in a per-call UTF-8/LF file. Bash reads them into a variable, removes the file, then performs the same single `eval` parse. POSIX and remote environment backends retain the original inline behavior.

## Tests

- new real Git Bash transport tests: 4 passed (byte-exact backslashes, heredoc, exit/env relay, delete-before-execute)
- `test_base_environment.py`: 18 passed; 3 unrelated Windows baseline failures hardcode `/bin/bash`
- `git diff --check` — passed

No product, Sidecar, UI, tracing, cursor, persona, or Optical Agent code is included.
