### PR TITLE
fix(write_approval): dedup replace/remove with identical old_text in stage_write

### DIFF
--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -286,3 +286,102 @@ class TestSkillGist:
         assert wa.skill_gist("remove_file", "demo", file_path="a.py") == "remove a.py from 'demo'"
         assert wa.skill_gist("delete", "demo") == "delete skill 'demo'"
         assert wa.skill_gist("unknown", "demo") == "unknown 'demo'"
+
+
+# ---------------------------------------------------------------------------
+# stage_write dedup — replace/remove with identical old_text (#81671)
+# ---------------------------------------------------------------------------
+
+class TestStageWriteDedup:
+    """stage_write() must not mint a second pending record when a replace/remove
+    with the same subsystem + action + target + old_text is already queued."""
+
+    def test_replace_dedup_returns_existing(self, hermes_home):
+        from tools import write_approval as wa
+
+        first = wa.stage_write(
+            "memory",
+            {"action": "replace", "target": "memory", "old_text": "old fact", "content": "new fact v1"},
+            summary="replace old fact",
+            origin="background_review",
+        )
+        second = wa.stage_write(
+            "memory",
+            {"action": "replace", "target": "memory", "old_text": "old fact", "content": "new fact v2"},
+            summary="replace old fact again",
+            origin="background_review",
+        )
+        assert first["id"] == second["id"], "Dedup must return the existing record, not mint a new one."
+        assert wa.pending_count("memory") == 1
+
+    def test_remove_dedup_returns_existing(self, hermes_home):
+        from tools import write_approval as wa
+
+        first = wa.stage_write(
+            "memory",
+            {"action": "remove", "target": "user", "old_text": "stale entry"},
+            summary="remove stale",
+            origin="background_review",
+        )
+        second = wa.stage_write(
+            "memory",
+            {"action": "remove", "target": "user", "old_text": "stale entry"},
+            summary="remove stale again",
+            origin="background_review",
+        )
+        assert first["id"] == second["id"]
+        assert wa.pending_count("memory") == 1
+
+    def test_add_is_not_deduplicated(self, hermes_home):
+        from tools import write_approval as wa
+
+        first = wa.stage_write(
+            "memory",
+            {"action": "add", "target": "memory", "content": "fact A"},
+            summary="add fact A",
+            origin="background_review",
+        )
+        second = wa.stage_write(
+            "memory",
+            {"action": "add", "target": "memory", "content": "fact A"},
+            summary="add fact A again",
+            origin="background_review",
+        )
+        assert first["id"] != second["id"], "add actions must never be deduplicated."
+        assert wa.pending_count("memory") == 2
+
+    def test_different_old_text_not_deduplicated(self, hermes_home):
+        from tools import write_approval as wa
+
+        first = wa.stage_write(
+            "memory",
+            {"action": "replace", "target": "memory", "old_text": "fact A", "content": "new A"},
+            summary="replace A",
+            origin="background_review",
+        )
+        second = wa.stage_write(
+            "memory",
+            {"action": "replace", "target": "memory", "old_text": "fact B", "content": "new B"},
+            summary="replace B",
+            origin="background_review",
+        )
+        assert first["id"] != second["id"]
+        assert wa.pending_count("memory") == 2
+
+    def test_different_target_not_deduplicated(self, hermes_home):
+        from tools import write_approval as wa
+
+        first = wa.stage_write(
+            "memory",
+            {"action": "replace", "target": "memory", "old_text": "shared fact", "content": "v1"},
+            summary="replace in memory",
+            origin="background_review",
+        )
+        second = wa.stage_write(
+            "memory",
+            {"action": "replace", "target": "user", "old_text": "shared fact", "content": "v2"},
+            summary="replace in user",
+            origin="background_review",
+        )
+        assert first["id"] != second["id"]
+        assert wa.pending_count("memory") == 2

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -129,6 +129,32 @@ def stage_write(subsystem: str, payload: Dict[str, Any],
     logs and still returns a record (the write is simply lost, which is the
     safe failure for an approval gate — nothing is silently committed).
     """
+    # Dedup guard for replace/remove: if an existing pending record targets
+    # the same subsystem + action + target + old_text, return it instead of
+    # minting a new entry. Two background_review passes reaching the same
+    # conclusion should not both land in the queue — the first one wins.
+    # add actions are NOT deduplicated: two independent adds may both be
+    # legitimate (different content, same target).
+    action = payload.get("action", "")
+    if action in ("replace", "remove"):
+        old_text = payload.get("old_text", "")
+        target = payload.get("target", "")
+        try:
+            for existing in list_pending(subsystem):
+                ep = existing.get("payload", {})
+                if (
+                    existing.get("action") == action
+                    and ep.get("target") == target
+                    and ep.get("old_text") == old_text
+                ):
+                    logger.debug(
+                        "stage_write: dedup hit for %s/%s old_text=%r — returning existing id=%s",
+                        subsystem, action, old_text[:60], existing["id"],
+                    )
+                    return existing
+        except Exception as _dedup_err:
+            logger.debug("stage_write: dedup scan failed (non-fatal): %s", _dedup_err)
+
     pid = uuid.uuid4().hex[:8]
     record = {
         "id": pid,


### PR DESCRIPTION
## What does this PR do?

`stage_write()` previously minted a new UUID and wrote a new pending file on every call, with no deduplication. When `background_review` runs twice over the same conversation and reaches the same replace/remove conclusion, two identical queue entries are created — differing only in wording. Reviewers must then recognise and manually discard the duplicate.

## Fix

Before minting a new record for `replace` or `remove` actions, scan the existing pending files via `list_pending()`. If a record with matching `action` + `target` + `old_text` already exists, return it instead of writing a new file.

`add` actions are intentionally excluded from dedup — two independent adds may carry different content and both be legitimate.

The scan is **fail-open**: any exception during the scan falls through to the original write path, so disk errors never block the approval gate.

## What this PR does NOT fix

This PR addresses the staging-layer symptom. The root cause — `background_review` not consulting the pending queue before proposing — is a separate, larger change (noted in #81671) and will require its own PR.

## Changes

- `tools/write_approval.py`: dedup guard in `stage_write()`
- `tests/tools/test_write_approval.py`: 5 regression tests covering replace dedup, remove dedup, add non-dedup, different old_text, different target

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] Tests added and passing (20/20)
- [x] I've tested on my platform: WSL2 Ubuntu

Fixes #81671