### PR TITLE
fix(local-env): retain native Windows cwd

### DIFF
--- a/tests/tools/test_local_env_windows_cwd.py
+++ b/tests/tools/test_local_env_windows_cwd.py
@@ -1,0 +1,53 @@
+"""LocalEnvironment retains a native Windows cwd after each Git Bash call."""
+
+import ntpath
+import platform
+import shutil
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tools.environments.local import LocalEnvironment
+
+pytestmark = pytest.mark.skipif(
+    platform.system() != "Windows",
+    reason="exercises Git Bash's native pwd output",
+)
+
+
+@pytest.fixture
+def temp_tree():
+    root = Path(tempfile.mkdtemp(prefix="hermes-cwd-"))
+    yield root
+    shutil.rmtree(root, ignore_errors=True)
+
+
+def test_temp_and_space_path_remain_native_after_cd(temp_tree):
+    target = temp_tree / "spaced dir"
+    target.mkdir()
+    env = LocalEnvironment(cwd=str(temp_tree), timeout=30)
+    try:
+        result = env.execute(f"cd '{target.as_posix()}'", timeout=30)
+
+        assert result["returncode"] == 0
+        assert env.cwd == ntpath.normpath(str(target))
+        assert Path(env.cwd).is_dir()
+    finally:
+        env.cleanup()
+
+
+def test_drive_form_probe_is_canonicalized_for_non_c_drive():
+    env = LocalEnvironment.__new__(LocalEnvironment)
+    env.cwd = r"C:\old"
+    env._cwd_marker = "__HERMES_CWD_TEST__"
+    result = {
+        "output": "ok\n__HERMES_CWD_TEST__D:/Work Space/demo__HERMES_CWD_TEST__\n"
+    }
+
+    with patch("tools.environments.local.os.path.isdir", return_value=True):
+        env._extract_cwd_from_output(result)
+
+    assert env.cwd == r"D:\Work Space\demo"
+    assert result["output"] == "ok"

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -804,6 +804,8 @@ class BaseEnvironment(ABC):
         """
         return shlex.quote(path)
 
+    _cwd_probe_command = "pwd -P"
+
     def _wrap_command(self, command: str, cwd: str) -> str:
         """Build the full bash script that sources snapshot, cd's, runs command,
         re-dumps env vars, and emits CWD markers."""
@@ -894,7 +896,7 @@ class BaseEnvironment(ABC):
         # end with a newline (e.g. printf 'exact'). We'll strip this
         # injected newline in _extract_cwd_from_output.
         parts.append(
-            f"printf '\\n{self._cwd_marker}%s{self._cwd_marker}\\n' \"$(pwd -P)\""
+            f"printf '\\n{self._cwd_marker}%s{self._cwd_marker}\\n' \"$({self._cwd_probe_command})\""
         )
         parts.append("exit $__hermes_ec")
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1424,6 +1424,8 @@ class LocalEnvironment(BaseEnvironment):
     def __init__(self, cwd: str = "", timeout: int = 60, env: dict = None):
         cwd = _resolve_local_initial_cwd(cwd)
         super().__init__(cwd=cwd, timeout=timeout, env=env)
+        if _IS_WINDOWS:
+            self._cwd_probe_command = "pwd -W"
         self.init_session()
 
     def get_temp_dir(self) -> str:
@@ -1660,6 +1662,8 @@ class LocalEnvironment(BaseEnvironment):
         super()._extract_cwd_from_output(result)
         if self.cwd != prev_cwd:
             normalized = _msys_to_windows_path(self.cwd) if _IS_WINDOWS else self.cwd
+            if _IS_WINDOWS and re.match(r'^[a-zA-Z]:[\\/]', normalized or ""):
+                normalized = ntpath.normpath(normalized)
             if normalized and os.path.isdir(normalized):
                 self.cwd = normalized
             else:


### PR DESCRIPTION
## Summary

- make the cwd marker command overridable while preserving `pwd -P` for existing backends
- use Git Bash `pwd -W` for Windows LocalEnvironment so the marker contains a native drive path
- canonicalize `C:/...` / `D:/...` marker values with `ntpath`

## Reproduction and root cause

Git Bash `pwd -P` can report MSYS mount aliases such as `/tmp/...` for `%TEMP%`. The host-side converter only has enough information to map drive forms (`/c/...`), so a valid `cd` into `%TEMP%` can be rejected as nonexistent and LocalEnvironment silently rolls back its cwd.

`pwd -W` reports a Windows drive form directly. The override is Windows-local; POSIX and other environment backends continue using `pwd -P`.

## Tests

- new real Git Bash/native cwd tests: 2 passed (`%TEMP%` + spaces, non-C drive-form normalization)
- existing cwd/MSYS tests: 24 passed; 2 unrelated Windows baseline failures contain POSIX-only root/separator expectations
- `git diff --check` — passed

No product, UI, tracing, cursor, persona, Sidecar, or Optical Agent code is included.
