### PR TITLE
fix(computer-use): resolve the official Windows CuaDriver install

### DIFF
--- a/tests/computer_use/test_cua_official_windows_install.py
+++ b/tests/computer_use/test_cua_official_windows_install.py
@@ -1,0 +1,38 @@
+"""The runtime resolver finds the official per-user Windows Cua install."""
+
+import os
+from unittest.mock import patch
+
+
+def test_official_windows_install_is_resolved_without_a_fresh_path():
+    from tools.computer_use import cua_backend
+
+    local_app_data = r"C:\Users\test\AppData\Local"
+    expected = (
+        local_app_data
+        + r"\Programs\Cua\cua-driver\bin\cua-driver.exe"
+    )
+    with patch.dict(
+        os.environ,
+        {"LOCALAPPDATA": local_app_data, "PATH": ""},
+        clear=True,
+    ), patch.object(cua_backend.sys, "platform", "win32"), patch.object(
+        cua_backend.shutil,
+        "which",
+        side_effect=lambda value: value if value == expected else None,
+    ):
+        assert cua_backend.resolve_cua_driver_cmd() == expected
+
+
+def test_explicit_override_remains_authoritative():
+    from tools.computer_use import cua_backend
+
+    with patch.dict(
+        os.environ,
+        {"LOCALAPPDATA": r"C:\Users\test\AppData\Local", "PATH": ""},
+        clear=True,
+    ), patch.object(cua_backend.sys, "platform", "win32"), patch.object(
+        cua_backend.shutil, "which", return_value=None
+    ) as which:
+        assert cua_backend.resolve_cua_driver_cmd(r"D:\missing\cua-driver.exe") is None
+        which.assert_called_once_with(r"D:\missing\cua-driver.exe")

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -715,6 +715,18 @@ def _candidate_cua_driver_commands(override: Optional[str] = None) -> List[str]:
             os.path.join(home, ".local", "bin", "cua-driver.exe"),
             os.path.join(home, ".local", "bin", "cua-driver"),
         ])
+        local_app_data = os.environ.get("LOCALAPPDATA", "").strip()
+        if local_app_data:
+            candidates.append(
+                os.path.join(
+                    local_app_data,
+                    "Programs",
+                    "Cua",
+                    "cua-driver",
+                    "bin",
+                    "cua-driver.exe",
+                )
+            )
     else:
         candidates.extend([
             os.path.join(home, ".local", "bin", "cua-driver"),


### PR DESCRIPTION
## Summary

- add the official per-user Windows CuaDriver install directory to runtime resolution
- preserve explicit override authority and existing PATH/`~/.local/bin` candidates
- cover resolution when an already-running host has not inherited the installer-updated registry PATH

## Reproduction and root cause

The official Windows installer places the executable at `%LOCALAPPDATA%\\Programs\\Cua\\cua-driver\\bin\\cua-driver.exe`. It updates the user's registry PATH, but already-running Explorer/Desktop/TUI processes do not inherit that change. Hermes currently probes PATH and `~/.local/bin`, so it can report the driver missing immediately after a successful install.

This runtime resolver change is intentionally independent from updater/POSIX local-bin handling in PR #69189.

## Tests

- resolver + explicit override regression tests: 2 passed
- Computer Use doctor tests: 14 passed, 1 skipped
- real Windows probe with `PATH` cleared resolved the installed executable at the official `%LOCALAPPDATA%` path
- `git diff --check` — passed

No product, UI, cursor, tracing, persona, Sidecar, or Optical Agent code is included.
