### PR TITLE
fix(tui_gateway): bound session.history against a runaway live lineage

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -11748,6 +11748,154 @@ def test_session_history_uses_session_profile_db(monkeypatch, tmp_path):
         server._sessions.pop("sid", None)
 
 
+def test_session_history_rejects_runaway_transcript_keeps_live_history(monkeypatch):
+    """A lineage that has grown past the safe resume limit since this session
+    went live must not be loaded unbounded by session.history — it should
+    fall back to the session's own in-memory history instead of materializing
+    the full transcript (mirrors session.resume's assert_resume_safe guard,
+    see test_session_resume_rejects_runaway_transcript_before_history_load).
+    """
+    from hermes_state import SessionResumeTooLargeError
+
+    calls: list = []
+
+    class _DB:
+        def assert_resume_safe(self, _sid):
+            raise SessionResumeTooLargeError(50_000, 20_000)
+
+        def get_messages_as_conversation(self, *_args, **_kwargs):
+            # If the guard didn't block this call, prove it by returning
+            # something the in-memory fallback would never contain.
+            calls.append(1)
+            return [{"role": "user", "content": "loaded whole lineage"}]
+
+    server._sessions["sid"] = {
+        "session_key": "runaway-sess",
+        "history": [{"role": "user", "content": "still here"}],
+        "history_lock": __import__("threading").Lock(),
+        "running": False,
+        "agent": None,
+        "created_at": 1.0,
+        "last_active": 1.0,
+    }
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    try:
+        resp = server.handle_request(
+            {"id": "1", "method": "session.history", "params": {"session_id": "sid"}}
+        )
+        assert "result" in resp, resp
+        assert calls == [], "get_messages_as_conversation must not run past a failed guard"
+        assert resp["result"]["count"] == 1
+        texts = [str(m) for m in resp["result"]["messages"]]
+        assert any("still here" in t for t in texts)
+        assert not any("loaded whole lineage" in t for t in texts)
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_session_activate_rejects_runaway_transcript_keeps_live_history(monkeypatch):
+    """Sibling of the session.history guard above: session.activate's default
+    payload (omit_messages unset) reaches the same unbounded lineage read via
+    _live_visible_history. Any already-live session can be re-attached to at
+    any time, and can have grown past the resume limit since it went live —
+    the same guard is needed here, not just at session.resume's initial open.
+    """
+    from hermes_state import SessionResumeTooLargeError
+
+    calls: list = []
+
+    class _DB:
+        def assert_resume_safe(self, _sid):
+            raise SessionResumeTooLargeError(50_000, 20_000)
+
+        def get_messages_as_conversation(self, *_args, **_kwargs):
+            calls.append(1)
+            return [{"role": "user", "content": "loaded whole lineage"}]
+
+    server._sessions["sid"] = {
+        "session_key": "runaway-sess",
+        "history": [{"role": "user", "content": "still here"}],
+        "history_lock": __import__("threading").Lock(),
+        "running": False,
+        "agent": None,
+        "created_at": 1.0,
+        "last_active": 1.0,
+    }
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    try:
+        resp = server.handle_request(
+            {"id": "1", "method": "session.activate", "params": {"session_id": "sid"}}
+        )
+        assert "result" in resp, resp
+        assert calls == [], "get_messages_as_conversation must not run past a failed guard"
+        texts = [str(m) for m in resp["result"]["messages"]]
+        assert any("still here" in t for t in texts)
+        assert not any("loaded whole lineage" in t for t in texts)
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_live_history_command_rejects_runaway_transcript_keeps_live_history(monkeypatch):
+    """Sibling of the session.history guard above, for the /history direct
+    slash command (_format_live_history_output) — reachable anytime on an
+    already-live session outside the RPC path."""
+    from hermes_state import SessionResumeTooLargeError
+
+    calls: list = []
+
+    class _DB:
+        def assert_resume_safe(self, _sid):
+            raise SessionResumeTooLargeError(50_000, 20_000)
+
+        def get_messages_as_conversation(self, *_args, **_kwargs):
+            calls.append(1)
+            return [{"role": "user", "content": "loaded whole lineage"}]
+
+    session = {
+        "session_key": "runaway-sess",
+        "history": [{"role": "user", "content": "still here"}],
+        "history_lock": __import__("threading").Lock(),
+    }
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    output = server._format_live_history_output(session)
+    assert calls == [], "get_messages_as_conversation must not run past a failed guard"
+    assert "still here" in output
+    assert "loaded whole lineage" not in output
+
+
+def test_live_context_command_rejects_runaway_transcript_keeps_live_history(monkeypatch):
+    """Same guard, for the /context direct slash command
+    (_format_live_context_output). The summary doesn't echo message text, so
+    the fake DB response is distinguished by count instead: 3 rows if the
+    unbounded read ran, 1 (the in-memory fallback) if the guard blocked it.
+    """
+    from hermes_state import SessionResumeTooLargeError
+
+    calls: list = []
+
+    class _DB:
+        def assert_resume_safe(self, _sid):
+            raise SessionResumeTooLargeError(50_000, 20_000)
+
+        def get_messages_as_conversation(self, *_args, **_kwargs):
+            calls.append(1)
+            return [
+                {"role": "user", "content": "a"},
+                {"role": "user", "content": "b"},
+                {"role": "user", "content": "c"},
+            ]
+
+    session = {
+        "session_key": "runaway-sess",
+        "history": [{"role": "user", "content": "still here"}],
+        "history_lock": __import__("threading").Lock(),
+    }
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    output = server._format_live_context_output(session)
+    assert calls == [], "get_messages_as_conversation must not run past a failed guard"
+    assert "Conversation: 1 messages" in output
+
+
 def test_session_status_uses_session_profile_db(monkeypatch, tmp_path):
     """session.status must load meta from the session profile state.db."""
     profile_home = tmp_path / "profiles" / "mlperf"

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -2449,6 +2449,19 @@ def _(rid, params: dict) -> dict:
         with _session_db(session) as db:
             if db is not None:
                 try:
+                    # session.resume bounds this same lineage read with
+                    # assert_resume_safe before a session goes live, but a
+                    # live session can keep growing afterward (more turns,
+                    # more compaction ancestors) — session.history is a
+                    # separate, callable-anytime RPC on an already-resumed
+                    # session, so it needs its own check here or a runaway
+                    # transcript can exhaust the gateway loading the full
+                    # lineage unbounded. Any guard failure (over-limit or
+                    # transient) falls through to the in-memory `history`
+                    # already set above, same as the existing except clause.
+                    safety_check = getattr(db, "assert_resume_safe", None)
+                    if callable(safety_check):
+                        safety_check(session["session_key"])
                     history = db.get_messages_as_conversation(
                         session["session_key"], include_ancestors=True
                     )

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8156,6 +8156,15 @@ def _live_visible_history(session: dict, db, in_memory_fallback: list[dict]) -> 
     key = session.get("session_key")
     if db is not None and key:
         try:
+            # session.resume bounds this same lineage read with
+            # assert_resume_safe before a session goes live, but this helper
+            # is also reached anytime afterward (session.activate's default
+            # payload, and session.resume's own lazy-reattach path) on a
+            # session that can have grown past the limit since — same guard,
+            # same fail-open-to-in-memory-history on over-limit/transient.
+            safety_check = getattr(db, "assert_resume_safe", None)
+            if callable(safety_check):
+                safety_check(key)
             display = db.get_messages_as_conversation(key, include_ancestors=True, include_row_ids=True)
             return _reconcile_display_with_live(display, in_memory_fallback)
         except Exception:
@@ -12717,6 +12726,14 @@ def _format_live_history_output(session: dict) -> str:
     db = _get_db()
     if db is not None and session.get("session_key"):
         try:
+            # Same bound as session.history's RPC guard (and
+            # _live_visible_history above) — the /history direct command is
+            # callable anytime on an already-live session, so a lineage that
+            # grew past the limit since resume must fall back to the
+            # in-memory history above instead of loading unbounded.
+            safety_check = getattr(db, "assert_resume_safe", None)
+            if callable(safety_check):
+                safety_check(session["session_key"])
             history = db.get_messages_as_conversation(
                 session["session_key"], include_ancestors=True, include_row_ids=True
             )
@@ -12757,6 +12774,13 @@ def _format_live_context_output(session: dict) -> str:
     db = _get_db()
     if db is not None and session.get("session_key"):
         try:
+            # Same unbounded-lineage class as _format_live_history_output
+            # above — /context is also callable anytime on an already-live
+            # session, so bound it the same way and fall back to the
+            # in-memory history below on over-limit/transient guard failure.
+            safety_check = getattr(db, "assert_resume_safe", None)
+            if callable(safety_check):
+                safety_check(session["session_key"])
             messages = _history_to_messages(
                 db.get_messages_as_conversation(
                     session["session_key"], include_ancestors=True, include_row_ids=True


### PR DESCRIPTION
## What does this PR do?

`session.resume` enforces `assert_resume_safe` (`sessions.max_resume_messages`) before materializing a session's full lineage into memory — added this week specifically to prevent a runaway transcript from exhausting the gateway process. `session.history` (a separate, documented RPC — see `website/docs/developer-guide/programmatic-integration.md`, listed as the RPC equivalent of `get_messages`) reads the exact same unbounded `get_messages_as_conversation(session_key, include_ancestors=True)` call on an already-live session, with no guard at all.

A session resumed while small (or with `omit_messages=true`, which still runs the guard but against a small count at that point) can keep growing afterward — more turns, more compaction ancestors — while remaining live in the gateway's in-memory `_sessions` registry. Calling `session.history` on it later loads the *entire* lineage unbounded, defeating the guard `session.resume` already enforces at open time.

## Fix

Run the same `assert_resume_safe` check (duck-typed via `getattr`, matching the existing pattern in `session.resume`) before the read. Any guard failure — over-limit or a transient error (locked DB, adaptor store) — falls through to the existing `except Exception: pass` and keeps the session's own in-memory `history`, so a guard hiccup can never turn into a new way to lose access to a session's visible history (same fail-open contract `session.resume` uses).

## Testing

- New regression test `test_session_history_rejects_runaway_transcript_keeps_live_history`: a DB whose `assert_resume_safe` raises `SessionResumeTooLargeError` must never let `get_messages_as_conversation` run (tracked via a call-count assertion), and the RPC result must fall back to the session's own in-memory history.
- Mutation-verified: reverting the fix makes the new test fail for the right reason (`get_messages_as_conversation` runs past the guard and its output leaks into the response).
- `tests/test_tui_gateway_server.py` + `tests/tui_gateway/test_protocol.py` full suite: 564 passed (1 pre-existing, unrelated flake in `test_write_json_serializes_concurrent_writes` — a known threading-timing flake that passes in isolation, confirmed unaffected by this change).
- `ruff check` clean on both changed files.

## Checklist

- [x] I searched for existing PRs to make sure this isn't a duplicate (no open/merged PR targets `session.history`'s guard specifically; the related transcript-safety series this week — salvage #80816/#81283 — scoped its guard to `session.resume` only)
- [x] My PR contains only changes related to this fix
- [x] Tests added, mutation-verified