### PR TITLE
fix(agent): persist completed text turns before the loop exits (#81641)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -7469,7 +7469,26 @@ def run_conversation(
                     continue
 
                 messages.append(final_msg)
-                
+                # Make the completed answer durable before leaving the loop.
+                # The text already reached the user through the streaming /
+                # interim display path, which is display-only and never writes
+                # to state.db; the next durable write would otherwise be
+                # finalize_turn's _persist_session, behind post-turn work that
+                # can include micro-compaction's aux-LLM call. A session torn
+                # down inside that window (ws_orphan_reap after a remote 1006
+                # close, container stop) lost a reply the user had already
+                # seen (#81641). Same contract the tool-call exit gets from
+                # #49045 and the verify-on-stop exits above; the
+                # _DB_PERSISTED_MARKER dedup keeps _persist_session idempotent.
+                #
+                # Unlike the tool-call exit, a failed flush must NOT abort the
+                # turn: no side effect runs after this point, the answer is
+                # already produced, and _persist_session retries the write.
+                try:
+                    agent._flush_messages_to_session_db(messages, conversation_history)
+                except Exception:
+                    logger.debug("final text-turn flush failed", exc_info=True)
+
                 _turn_exit_reason = f"text_response(finish_reason={finish_reason})"
                 if not agent.quiet_mode:
                     agent._safe_print(f"🎉 Conversation completed after {api_call_count} OpenAI-compatible API call(s)")

--- a/tests/run_agent/test_81641_text_turn_incremental_persistence.py
+++ b/tests/run_agent/test_81641_text_turn_incremental_persistence.py
@@ -1,0 +1,170 @@
+"""Behavior contract: a completed pure-text assistant turn is durable before
+the conversation loop yields control (#81641).
+
+Neighbouring turn exits already carry this guarantee. The tool-call exit
+flushes the assistant(tool_calls) block before handing control to
+``_execute_tool_calls`` (#49045), and the verify-on-stop / pre_verify exits
+flush ``final_msg`` before appending their nudge (#65919 §7). The ordinary
+``finish_reason=stop`` exit — the common case — did not.
+
+Its only durable write was ``finalize_turn`` -> ``_persist_session``, which
+runs after the loop exits and after post-turn work (interrupt tail repair,
+persist-override rewrite, micro-compaction — which can issue its own aux-LLM
+call). Anything that ended the process or tore the session down inside that
+window lost a reply the user had already been shown: the text reaches the UI
+through the streaming/interim display path, which is display-only and never
+writes to ``state.db``.
+
+Reported against v0.20.0 on a remote (non-loopback) backend, where WS ``1006``
+closures drive ``ws_orphan_reap`` teardown and widen that window: affected
+sessions held user rows with zero assistant rows in ``state.db``.
+
+These tests pin the fix:
+
+1. The completed assistant row is flushed to the session DB *before* the
+   turn's post-loop finalization runs.
+2. A failing flush must not abort the turn — the answer is already produced
+   and delivered, so ``_persist_session`` stays the retry.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def loop_agent():
+    """AIAgent with a mocked OpenAI client (mirrors test_run_agent's fixture)."""
+    from run_agent import AIAgent
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.client = MagicMock()
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.tool_delay = 0
+        agent.compression_enabled = False
+        agent.save_trajectories = False
+        return agent
+
+
+def _run_text_turn(agent, answer: str, *, flush_side_effect=None):
+    """Drive one clean finish_reason=stop turn, recording persistence calls.
+
+    Returns ``(result, events)`` where ``events`` is the ordered log of
+    persistence calls. Flush entries carry a snapshot of the transcript taken
+    *at call time*, so the assertion cannot be satisfied by a later mutation
+    of the same live list.
+    """
+    from tests.run_agent.test_run_agent import _mock_response
+
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(content=answer, finish_reason="stop"),
+    ]
+
+    events: list[tuple[str, object]] = []
+
+    def _record_flush(messages, conversation_history=None):
+        events.append((
+            "flush",
+            [
+                (m.get("role"), m.get("content"))
+                for m in messages
+                if isinstance(m, dict)
+            ],
+        ))
+        if flush_side_effect is not None:
+            raise flush_side_effect
+        return True
+
+    def _record_persist(messages, conversation_history=None):
+        events.append(("persist_session", None))
+
+    with (
+        patch.object(
+            agent, "_flush_messages_to_session_db", side_effect=_record_flush
+        ),
+        patch.object(agent, "_persist_session", side_effect=_record_persist),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("what is 2 + 2?")
+
+    return result, events
+
+
+class TestCompletedTextTurnIncrementalPersistence:
+    def test_completed_text_turn_is_flushed_before_finalization(self, loop_agent):
+        """The assistant row must reach the session DB before the loop exits.
+
+        Asserting on the snapshot taken at flush time (not on the final list)
+        is what makes this mutation-survivable: removing the production flush
+        leaves ``finalize_turn``'s ``_persist_session`` as the first
+        persistence event and the test fails.
+        """
+        answer = "2 + 2 is 4."
+        result, events = _run_text_turn(loop_agent, answer)
+
+        assert result["final_response"] == answer
+
+        # The turn-start crash-resilience write of the user message is itself a
+        # _persist_session call, so "first event" is not the contract. The
+        # contract is that a flush carrying the assistant answer lands before
+        # the FINAL persist_session — the one finalize_turn issues after the
+        # loop exits and after post-turn work.
+        assert any(kind == "flush" for kind, _ in events), (
+            "A completed text turn must flush the assistant row to the session "
+            "DB; no _flush_messages_to_session_db call was observed."
+        )
+
+        answer_flushes = [
+            i
+            for i, (kind, snapshot) in enumerate(events)
+            if kind == "flush" and snapshot and snapshot[-1] == ("assistant", answer)
+        ]
+        assert answer_flushes, (
+            "A flush must carry the completed assistant answer as its "
+            f"transcript tail; observed events: {events!r}"
+        )
+
+        final_persist = max(
+            i for i, (kind, _) in enumerate(events) if kind == "persist_session"
+        )
+        assert answer_flushes[0] < final_persist, (
+            "The assistant row must be durable BEFORE post-loop finalization, "
+            f"but the answer flush at index {answer_flushes[0]} did not precede "
+            f"finalize_turn's _persist_session at index {final_persist}."
+        )
+
+    def test_flush_failure_does_not_abort_the_completed_turn(self, loop_agent):
+        """A transient SQLite failure must not swallow a produced answer.
+
+        The tool-call exit treats a failed flush as fatal because side-effecting
+        tools must not run on state that exists only in this process. Here the
+        turn is already over and the text already delivered, so the turn must
+        still return its answer and still reach ``_persist_session``, which
+        retries the write.
+        """
+        answer = "Still answered."
+        result, events = _run_text_turn(
+            loop_agent, answer, flush_side_effect=RuntimeError("database is locked")
+        )
+
+        assert result["final_response"] == answer, (
+            "A failed incremental flush must not discard the produced answer."
+        )
+        assert ("persist_session", None) in events, (
+            "finalize_turn's _persist_session must still run so the failed "
+            "flush gets retried."
+        )


### PR DESCRIPTION
Fixes #81641

## Summary

A completed **pure-text** assistant turn (`finish_reason=stop`) had no durable write of its own.

Its text reaches the user through the **streaming / interim display path**, which is display-only and never touches `state.db`. The first — and only — durable write was `finalize_turn` → `_persist_session`, which runs *after* the loop exits and *behind* post-turn work that can include micro-compaction's own aux-LLM call.

Anything that ended the process or tore the session down inside that window lost a reply the user had **already been shown**. On a remote (non-loopback) backend the window is easy to hit: WS `1006` closures drive `ws_orphan_reap` teardown. Reporter's affected sessions held user rows and **zero** assistant rows in `state.db`.

## Root cause: an invariant that three of four loop exits already honour

`run_conversation` has four terminal exits. Three already make the assistant row durable before yielding control — the ordinary text exit, the common case, did not.

| Loop exit | Flushed before yielding? | Established by |
|---|---|---|
| Tool-call exit (`conversation_loop.py:6563`) | ✅ before `_execute_tool_calls` | #49045 |
| Verify-on-stop exit (`:7331`) | ✅ before appending nudge | #65919 §7 |
| `pre_verify` exit (`:7403`) | ✅ before appending nudge | #65919 §7 |
| **Ordinary text exit (`:7471`)** | ❌ **nothing until `finalize_turn`** | **this PR** |

So this is not a missing mechanism — it is one exit that was never wired into the mechanism the rest of the loop already uses.

## The fix

Apply the **existing idiom, verbatim**, at the ordinary text exit. No new module, no parallel persistence path, no new config surface.

```python
messages.append(final_msg)
try:
    agent._flush_messages_to_session_db(messages, conversation_history)
except Exception:
    logger.debug("final text-turn flush failed", exc_info=True)
```

**Not a duplicate write.** The intrinsic `_DB_PERSISTED_MARKER` dedup makes the later `_persist_session` a no-op for this row. It is the *same* write, just earlier — no extra rows, no extra I/O.

**Failure is non-fatal here, deliberately.** The tool-call exit treats a failed flush as fatal because side-effecting tools must not run on state that exists only in this process. At the text exit the turn is already over, no side effect follows, and the answer is already produced — so the failure is logged and `_persist_session` remains the retry. Pinned by a test.

## Flow

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[⚡ Model Stream Completes] -->|deltas, display-only| B[🖥️ Interim Display Path]
    B -->|never writes| X[(🗄️ state.db)]
    A --> C{🔀 Turn Exit Kind}

    C -->|tool_calls| D[💾 Flush #49045]
    C -->|verify-on-stop| E[💾 Flush #65919]
    C -->|pre_verify| F[💾 Flush #65919]
    C -->|finish_reason=stop| G[🩸 BEFORE: No Flush]

    G -.->|WS 1006 close -> ws_orphan_reap| H[☠️ Reply Lost Forever]

    C -->|finish_reason=stop| I[✅ AFTER: Flush This PR]
    D --> X
    E --> X
    F --> X
    I --> X

    X --> J[🔒 Durable Before Loop Yields]
    J --> K[⚙️ Post-Turn Work<br/>micro-compaction, aux-LLM]
    K --> L[💾 _persist_session<br/>marker dedup: no-op]

    style G fill:#8b0000,stroke:#ff0038,color:#ffccd5
    style H fill:#8b0000,stroke:#ff0038,color:#ffccd5
    style I fill:#00f0ff,stroke:#ff007f,color:#0a0a16
    style J fill:#00f0ff,stroke:#ff007f,color:#0a0a16
```

## Infographic : 


<img width="941" height="1672" alt="infographic" src="https://github.com/user-attachments/assets/b4c58c50-c7b2-40de-b46d-292abf501ad5" />

## Tests

New: `tests/run_agent/test_81641_text_turn_incremental_persistence.py`

1. **`test_completed_text_turn_is_flushed_before_finalization`** — a flush carrying the assistant answer as its transcript tail must land before the final `_persist_session`. Asserts on a snapshot captured *at flush time*, so a later mutation of the same live list cannot satisfy it.
2. **`test_flush_failure_does_not_abort_the_completed_turn`** — a raising flush must still return the answer and still reach `_persist_session`.

**Mutation-checked.** With the production flush reverted (`git stash`), test 1 fails with `no _flush_messages_to_session_db call was observed`; restored, both pass.

⚠️ Note on test 1's design: the ordering assertion targets the **final** `_persist_session`, not the first persistence event — the turn-*start* crash-resilience write of the user message (`conversation_loop.py:1567`) is itself a `_persist_session` call and legitimately comes first.

## Verification

| Suite | Result |
|---|---|
| New `#81641` tests | **2 passed** |
| Persistence / dedup / compaction regression set (10 files) | **17 failed, 51 passed** — byte-identical failure set to baseline, **0 regressions** |
| Gateway + session-lifecycle (`finalize_session_persist`, `13121_shutdown_inflight_transcript_flush`, `session_messages_shutdown_preserve`, `42039_duplicate_user_message`, `gateway_owned_session_reap`, `session_reclaim_notify`, `verification_continuation_budget`, `partial_stream_finish_reason`) | **55 passed, 0 failed** |
| `tests/run_agent/test_run_agent.py` | 4 failed, 237 passed |

Baseline was captured by stashing only `agent/conversation_loop.py` and re-running the identical selection; `comm -13` over the sorted `FAILED` sets returned **empty**.

All pre-existing failures are one local environment issue, unrelated to this change (it touches no threading):

```
tools/daemon_pool.py:58: AttributeError: 'DaemonThreadPoolExecutor' object has no attribute '_initializer'
```

— a Python 3.14 `concurrent.futures` incompatibility, plus Windows tempdir-cleanup noise in `shutil._rmtree_unsafe`.

## Scope — what this PR deliberately does *not* do

The issue also proposed exposing `ws_ping_interval` / `ws_ping_timeout` and adding a reconnect grace before reaping.

- **Ping-timeout config** belongs to #79635. The hardcoded 20s non-loopback timeout raises the *frequency* of `1006` → reap, but it is not the cause of the loss — with this fix, a reap at that moment no longer loses anything. Left out to keep the root-cause fix reviewable.
- **Reconnect grace already exists**: `_WS_ORPHAN_REAP_GRACE_S`, `HERMES_TUI_WS_ORPHAN_REAP_GRACE_S`, default 20s, `0` disables (`tui_gateway/server.py:175`).

## Related

Same `ws_orphan_reap` mechanism, different failure classes — this PR addresses only the genuine-loss variant:

- #79635 — cosmetic; `state.db` intact
- #79050 / #79455 — renderer-side hydrate/collapse
- #69940 — closest sibling, genuine loss
- #54523 — async routes starving the WS over Tailscale (independent cause of the `1006` drops)

 
