### PR TITLE
fix(api-server): mark replayed tool calls completed in Responses output items

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -5981,14 +5981,23 @@ class APIServerAdapter(BasePlatformAdapter):
                 for tc in msg["tool_calls"]:
                     func = tc.get("function", {})
                     items.append({
+                        "id": f"fc_{uuid.uuid4().hex[:24]}",
                         "type": "function_call",
+                        # These calls were already executed server-side by the
+                        # Hermes agent; they are replayed for structured tool
+                        # UI only.  Mark them completed (matching the SSE
+                        # streaming path) so OpenAI clients don't interpret
+                        # them as pending calls the client must execute.
+                        "status": "completed",
                         "name": func.get("name", ""),
                         "arguments": func.get("arguments", ""),
                         "call_id": tc.get("id", ""),
                     })
             elif role == "tool":
                 items.append({
+                    "id": f"fco_{uuid.uuid4().hex[:24]}",
                     "type": "function_call_output",
+                    "status": "completed",
                     "call_id": msg.get("tool_call_id", ""),
                     "output": msg.get("content", ""),
                 })

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2033,9 +2033,15 @@ class TestToolCallsInOutput:
             assert output[0]["name"] == "calculator"
             assert output[0]["arguments"] == '{"expression": "6*7"}'
             assert output[0]["call_id"] == "call_abc123"
+            # Replayed server-executed calls must be marked completed so
+            # OpenAI clients don't treat them as pending calls to execute.
+            assert output[0]["status"] == "completed"
+            assert output[0]["id"].startswith("fc_")
             assert output[1]["type"] == "function_call_output"
             assert output[1]["call_id"] == "call_abc123"
             assert output[1]["output"] == "42"
+            assert output[1]["status"] == "completed"
+            assert output[1]["id"].startswith("fco_")
             assert output[2]["type"] == "message"
             assert output[2]["content"][0]["text"] == "The result is 42."
 

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -134,13 +134,15 @@ OpenAI Responses API format. Supports server-side conversation state via `previo
   "status": "completed",
   "model": "hermes-agent",
   "output": [
-    {"type": "function_call", "name": "terminal", "arguments": "{\"command\": \"ls\"}", "call_id": "call_1"},
-    {"type": "function_call_output", "call_id": "call_1", "output": "README.md src/ tests/"},
+    {"type": "function_call", "status": "completed", "name": "terminal", "arguments": "{\"command\": \"ls\"}", "call_id": "call_1"},
+    {"type": "function_call_output", "status": "completed", "call_id": "call_1", "output": "README.md src/ tests/"},
     {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "Your project has..."}]}
   ],
   "usage": {"input_tokens": 50, "output_tokens": 200, "total_tokens": 250}
 }
 ```
+
+Tool calls in the `output` array were already executed server-side by the Hermes agent — they are replayed with `"status": "completed"` for structured tool UI, never as pending calls for the client to execute.
 
 **Inline image input:** `input[].content` can contain `input_text` and `input_image` parts. Both remote URLs and `data:image/...` URLs are supported:
 


### PR DESCRIPTION
## Summary
Non-streaming `/v1/responses` replies now mark replayed tool calls as `"status": "completed"`, so spec-strict OpenAI clients can't interpret them as pending calls the client must execute.

Root cause of a community report where a GPT-5.6 client concluded "a server should not tell an OpenAI client to execute a tool the server already executed itself": `_extract_output_items()` (non-streaming Responses path) built `function_call` / `function_call_output` items with no `status` field and no item `id`, while the SSE streaming path correctly emits `status: in_progress → completed`. Under the OpenAI Responses spec, a `function_call` item without a completed status is a request for the client to run the tool — but these tools were already executed server-side by the Hermes agent and are replayed for structured tool UI only.

## Changes
- `gateway/platforms/api_server.py`: `_extract_output_items()` stamps `"status": "completed"` and spec-shaped item ids (`fc_…` / `fco_…`) on replayed `function_call` / `function_call_output` items, matching the streaming path's terminal shape.
- `tests/gateway/test_api_server.py`: existing output-items test now pins status + id shape.
- `website/docs/user-guide/features/api-server.md`: example updated + explicit note that output tool calls are replayed, never pending.

## Validation
| | Before | After |
|---|---|---|
| Non-streaming `function_call` item | no `status`, no `id` | `status: completed`, `id: fc_…` |
| Non-streaming `function_call_output` item | no `status`, no `id` | `status: completed`, `id: fco_…` |
| SSE streaming path | `completed` (unchanged) | `completed` (unchanged) |
| tests/gateway/test_api_server.py | — | 99/99 pass |

## Infographic

![Replayed, not pending](https://v3b.fal.media/files/b/0aa581e6/u5rB3VhodMMdHRg0_d-wb_UfMCE7aS.png)
