### PR TITLE
fix(voice): capture at the device's native rate in the VAD listeners

### DIFF
--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -1165,7 +1165,11 @@ class TestListenForSpeechCapture:
         written = {}
         monkeypatch.setattr(
             "tools.voice_mode.AudioRecorder._write_wav",
-            staticmethod(lambda audio: written.update(audio=audio) or "/tmp/barge.wav"),
+            staticmethod(
+                lambda audio, sample_rate=None: written.update(
+                    audio=audio, sample_rate=sample_rate
+                ) or "/tmp/barge.wav"
+            ),
         )
         from tools.voice_mode import listen_for_speech
         stops = iter([False] * 200 + [True] * 10_000)
@@ -1215,7 +1219,11 @@ class TestFullDuplexListen:
         written = {}
         monkeypatch.setattr(
             "tools.voice_mode.AudioRecorder._write_wav",
-            staticmethod(lambda audio: written.update(audio=audio) or "/tmp/fd.wav"),
+            staticmethod(
+                lambda audio, sample_rate=None: written.update(
+                    audio=audio, sample_rate=sample_rate
+                ) or "/tmp/fd.wav"
+            ),
         )
         from tools.voice_mode import full_duplex_listen
 
@@ -1368,6 +1376,63 @@ class TestDefaultInputSamplerate:
         assert wav_path is not None
         with wave.open(wav_path, "rb") as wf:
             assert wf.getframerate() == 48000
+
+    def test_listen_for_speech_captures_at_device_native_rate(self, mock_sd, monkeypatch):
+        """listen_for_speech must open its InputStream — and write its WAV —
+        at the device's native rate, same as AudioRecorder, not the fixed
+        16 kHz SAMPLE_RATE constant (some devices reject a bare-16 kHz
+        stream; see test_wav_written_at_capture_rate)."""
+        np = pytest.importorskip("numpy")
+        mock_sd.query_devices.return_value = {"default_samplerate": 48000.0}
+        calib_blocks = 14  # 400ms / 30ms default calibration_ms
+        levels = [0] * calib_blocks + [5000] * 30 + [0] * 500
+        stream = _FakeInputStream(np, levels)
+        mock_sd.InputStream.return_value = stream
+        written = {}
+        monkeypatch.setattr(
+            "tools.voice_mode.AudioRecorder._write_wav",
+            staticmethod(
+                lambda audio, sample_rate=None: written.update(
+                    sample_rate=sample_rate
+                ) or "/tmp/barge.wav"
+            ),
+        )
+        from tools.voice_mode import listen_for_speech
+
+        stops = iter([False] * 200 + [True] * 10_000)
+        path = listen_for_speech(lambda: next(stops), capture=True)
+
+        assert path == "/tmp/barge.wav"
+        assert mock_sd.InputStream.call_args.kwargs["samplerate"] == 48000
+        assert written.get("sample_rate") == 48000
+
+    def test_full_duplex_listen_captures_at_device_native_rate(self, mock_sd, monkeypatch):
+        """full_duplex_listen must open its InputStream — and write its WAV
+        — at the device's native rate, same as listen_for_speech/
+        AudioRecorder."""
+        np = pytest.importorskip("numpy")
+        mock_sd.query_devices.return_value = {"default_samplerate": 48000.0}
+        calib_blocks = 15  # 450ms / 30ms default calibration_ms
+        levels = [100] * calib_blocks + [5000] * 30 + [0] * 500
+        stream = _FakeInputStream(np, levels)
+        mock_sd.InputStream.return_value = stream
+        written = {}
+        monkeypatch.setattr(
+            "tools.voice_mode.AudioRecorder._write_wav",
+            staticmethod(
+                lambda audio, sample_rate=None: written.update(
+                    sample_rate=sample_rate
+                ) or "/tmp/fd.wav"
+            ),
+        )
+        from tools.voice_mode import full_duplex_listen
+
+        stops = iter([False] * len(levels) + [True] * 10_000)
+        path = full_duplex_listen(lambda: next(stops), is_playing=lambda: False)
+
+        assert path == "/tmp/fd.wav"
+        assert mock_sd.InputStream.call_args.kwargs["samplerate"] == 48000
+        assert written.get("sample_rate") == 48000
 
 
 class TestWSL2PowerShellFallback:

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -1839,7 +1839,15 @@ def listen_for_speech(
 
     from collections import deque
 
-    block = int(SAMPLE_RATE * 0.03)  # 30ms blocks
+    # Some devices reject a bare-16 kHz InputStream (PaErrorCode -9997);
+    # AudioRecorder already captures at the device's native rate for this
+    # reason (see _default_input_samplerate). block is sized off the same
+    # rate so every *_blocks count below still spans its documented 30ms —
+    # sizing it off the fixed SAMPLE_RATE constant while opening the stream
+    # at a different rate would silently desync the block-count timers
+    # (calibration/trip/endpoint durations) from wall-clock time.
+    capture_rate = _default_input_samplerate(sd)
+    block = int(capture_rate * 0.03)  # 30ms blocks
     calib_blocks = max(1, calibration_ms // 30)
     trip_blocks = max(1, sustained_ms // 30)
     endpoint_blocks = max(1, endpoint_silence_ms // 30)
@@ -1858,7 +1866,7 @@ def listen_for_speech(
     block_idx = 0  # block counter for diagnostic logging
 
     try:
-        with sd.InputStream(samplerate=SAMPLE_RATE, channels=1, dtype="int16", blocksize=block) as stream:
+        with sd.InputStream(samplerate=capture_rate, channels=1, dtype="int16", blocksize=block) as stream:
             while not should_stop():
                 data, _ = stream.read(block)
                 rms = float(np.sqrt(np.mean(data.astype(np.float64) ** 2)))
@@ -1956,7 +1964,9 @@ def listen_for_speech(
                     quiet = quiet + 1 if rms < SILENCE_RMS_THRESHOLD else 0
                     if quiet >= endpoint_blocks:
                         break
-                return AudioRecorder._write_wav(np.concatenate(frames, axis=0))
+                return AudioRecorder._write_wav(
+                    np.concatenate(frames, axis=0), sample_rate=capture_rate
+                )
     except Exception as e:
         logger.debug("Barge-in listener failed: %s", e)
     return None if capture else False
@@ -2062,7 +2072,12 @@ def full_duplex_listen(
 
     from collections import deque
 
-    block = int(SAMPLE_RATE * 0.03)  # 30ms blocks
+    # See listen_for_speech's identical capture_rate handling: some devices
+    # reject a bare-16 kHz InputStream, so capture at the device's native
+    # rate and size block off it so every *_blocks count below still spans
+    # its documented 30ms.
+    capture_rate = _default_input_samplerate(sd)
+    block = int(capture_rate * 0.03)  # 30ms blocks
     calib_blocks = max(1, calibration_ms // 30)
     trip_blocks = max(1, sustained_ms // 30)
     trip_needed = max(1, int(round(trip_blocks * 0.8)))
@@ -2084,7 +2099,7 @@ def full_duplex_listen(
 
     try:
         with sd.InputStream(
-            samplerate=SAMPLE_RATE, channels=1, dtype="int16", blocksize=block
+            samplerate=capture_rate, channels=1, dtype="int16", blocksize=block
         ) as stream:
             while not should_stop():
                 data, _ = stream.read(block)
@@ -2195,7 +2210,9 @@ def full_duplex_listen(
                     quiet = quiet + 1 if rms < SILENCE_RMS_THRESHOLD else 0
                     if quiet >= endpoint_blocks:
                         break
-                return AudioRecorder._write_wav(np.concatenate(frames, axis=0))
+                return AudioRecorder._write_wav(
+                    np.concatenate(frames, axis=0), sample_rate=capture_rate
+                )
     except Exception as e:
         logger.debug("Full-duplex listener failed: %s", e)
     return None


### PR DESCRIPTION
## What does this PR do?

`AudioRecorder` (push-to-talk, merged via salvage of #61463/#20788) and the wake-word detector (`e3be3b048`, this week) both open their microphone `InputStream` at the device's native sample rate instead of a hard-coded 16 kHz — some devices (WASAPI, USB mics exposed via ALSA `hw`) reject a bare 16 kHz capture request outright (`PaErrorCode -9997`) or degrade badly.

`listen_for_speech` (the barge-in VAD monitor) and `full_duplex_listen` (the full-turn voice listener CLI and TUI both call) were never brought up to the same fix — they still hard-code `samplerate=SAMPLE_RATE` on their `sd.InputStream`, and write the captured WAV via `AudioRecorder._write_wav` without a `sample_rate` override (so it silently defaults to 16 kHz regardless of what was actually captured).

**Concrete failure on a non-16kHz-native device:**
- `sd.InputStream(samplerate=16000, ...)` can fail to open at all (same `PaErrorCode -9997` `AudioRecorder` was fixed for), breaking barge-in/full-duplex voice mode outright, or
- if the host API silently resamples in shared mode, the resulting WAV header still claims 16 kHz while the audio inside is at the device's real rate — pitch-shifted playback and wrong-duration/garbled transcription downstream.

## Fix

Resolve the device's native rate once via the same `_default_input_samplerate()` helper `AudioRecorder` already uses, then:
- size the 30ms VAD block off that rate (`int(capture_rate * 0.03)`) — the calibration/trip/endpoint timers are block-*count*-based and assume each block is genuinely 30ms of audio, so sizing the block off a fixed 16 kHz while opening the stream at a different rate would silently desync those timers from wall-clock time;
- open the `InputStream` at `capture_rate`;
- pass `sample_rate=capture_rate` through to `AudioRecorder._write_wav`.

The RMS-based VAD thresholds (`SILENCE_RMS_THRESHOLD`, `PLAYBACK_MIN_TRIGGER`, `TRIGGER_CEILING`) are int16-amplitude-based, not sample-rate-dependent, so they're unaffected.

## Testing

- Two new regression tests (`test_listen_for_speech_captures_at_device_native_rate`, `test_full_duplex_listen_captures_at_device_native_rate`) mock a 48 kHz device (mirroring the existing `test_wav_written_at_capture_rate` for `AudioRecorder`) and assert both the `InputStream(samplerate=...)` kwarg and the `_write_wav(sample_rate=...)` kwarg equal 48000.
- Mutation-verified: reverting the production fix makes both new tests fail for the right reason (`assert 16000 == 48000`).
- Full `tests/tools/test_voice_mode.py`: 59 passed (5 pre-existing, unrelated failures in `TestPulseSocketReachable`/`TestPlayBeep`/`TestWSL2PowerShellFallback` — confirmed identical failure count/names on unmodified `main` in this sandbox, unaffected by this change).
- `ruff check` clean on both changed files.

## Checklist

- [x] I searched for existing PRs to make sure this isn't a duplicate (no open/merged PR targets `listen_for_speech`/`full_duplex_listen`'s sample-rate handling; the sibling fixes for `AudioRecorder` and the wake-word detector are already merged)
- [x] My PR contains only changes related to this fix
- [x] Tests added, mutation-verified