### PR TITLE
fix(dashboard): serialize the model-assignment config read-modify-write

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6651,183 +6651,184 @@ def _apply_model_assignment_sync(
     load_config/save_config lands in the requested profile.  Raises
     HTTPException for validation errors — the async wrapper re-raises them.
     """
-    cfg = load_config()
+    with _CONFIG_MUTATION_LOCK:
+        cfg = load_config()
 
-    if scope == "main":
-        if not provider or not model:
-            raise HTTPException(status_code=400, detail="provider and model required for main")
-        provider, model = _normalize_main_model_assignment(provider, model)
-        providers_cfg = cfg.get("providers")
-        provider_entry = providers_cfg.get(provider) if isinstance(providers_cfg, dict) else None
-        if not base_url and isinstance(provider_entry, dict) and provider_entry.get("base_url"):
-            base_url = str(provider_entry.get("base_url") or "").strip()
-        model_cfg = _apply_main_model_assignment(
-            cfg.get("model", {}), provider, model, base_url, api_key
-        )
-        # Fall back to the provider entry's stored key only when the request
-        # didn't carry one — same precedence as the base_url fill above. An
-        # unconditional overwrite silently discards a key the caller is
-        # rotating in, and model.api_key outranks the environment at client
-        # construction (#62269), so the stale key keeps authenticating.
-        if (
-            not api_key
-            and isinstance(provider_entry, dict)
-            and provider_entry.get("api_key")
-        ):
-            model_cfg["api_key"] = provider_entry["api_key"]
-        cfg["model"] = model_cfg
+        if scope == "main":
+            if not provider or not model:
+                raise HTTPException(status_code=400, detail="provider and model required for main")
+            provider, model = _normalize_main_model_assignment(provider, model)
+            providers_cfg = cfg.get("providers")
+            provider_entry = providers_cfg.get(provider) if isinstance(providers_cfg, dict) else None
+            if not base_url and isinstance(provider_entry, dict) and provider_entry.get("base_url"):
+                base_url = str(provider_entry.get("base_url") or "").strip()
+            model_cfg = _apply_main_model_assignment(
+                cfg.get("model", {}), provider, model, base_url, api_key
+            )
+            # Fall back to the provider entry's stored key only when the request
+            # didn't carry one — same precedence as the base_url fill above. An
+            # unconditional overwrite silently discards a key the caller is
+            # rotating in, and model.api_key outranks the environment at client
+            # construction (#62269), so the stale key keeps authenticating.
+            if (
+                not api_key
+                and isinstance(provider_entry, dict)
+                and provider_entry.get("api_key")
+            ):
+                model_cfg["api_key"] = provider_entry["api_key"]
+            cfg["model"] = model_cfg
 
-        # When switching the main provider to Nous, mirror the CLI's
-        # post-model-selection behaviour (hermes_cli/main.py
-        # prompt_enable_tool_gateway / tools_config apply_nous_managed_defaults):
-        # auto-route any *unconfigured* tools through the Nous Tool Gateway.
-        # This is purely additive — apply_nous_managed_defaults skips every
-        # tool where the user already has a direct key (FIRECRAWL_API_KEY,
-        # FAL_KEY, etc.) or an explicit backend/provider in config, so it
-        # never overwrites a user's own setup. GUI users thus land on the
-        # gateway the same way CLI users do, without a separate prompt.
-        gateway_tools: list[str] = []
-        if provider.strip().lower() == "nous":
-            try:
-                from hermes_cli.nous_subscription import apply_nous_managed_defaults
-                from hermes_cli.tools_config import _get_platform_tools
+            # When switching the main provider to Nous, mirror the CLI's
+            # post-model-selection behaviour (hermes_cli/main.py
+            # prompt_enable_tool_gateway / tools_config apply_nous_managed_defaults):
+            # auto-route any *unconfigured* tools through the Nous Tool Gateway.
+            # This is purely additive — apply_nous_managed_defaults skips every
+            # tool where the user already has a direct key (FIRECRAWL_API_KEY,
+            # FAL_KEY, etc.) or an explicit backend/provider in config, so it
+            # never overwrites a user's own setup. GUI users thus land on the
+            # gateway the same way CLI users do, without a separate prompt.
+            gateway_tools: list[str] = []
+            if provider.strip().lower() == "nous":
+                try:
+                    from hermes_cli.nous_subscription import apply_nous_managed_defaults
+                    from hermes_cli.tools_config import _get_platform_tools
 
-                enabled = _get_platform_tools(
-                    cfg, "cli", include_default_mcp_servers=False
-                )
-                changed = apply_nous_managed_defaults(
-                    cfg,
-                    enabled_toolsets=enabled,
-                    force_fresh=True,
-                )
-                gateway_tools = sorted(changed)
-            except Exception:
-                # Portal lookup hiccups / non-subscriber / non-nous gating
-                # must never block saving the model assignment.
-                _log.debug("apply_nous_managed_defaults skipped", exc_info=True)
+                    enabled = _get_platform_tools(
+                        cfg, "cli", include_default_mcp_servers=False
+                    )
+                    changed = apply_nous_managed_defaults(
+                        cfg,
+                        enabled_toolsets=enabled,
+                        force_fresh=True,
+                    )
+                    gateway_tools = sorted(changed)
+                except Exception:
+                    # Portal lookup hiccups / non-subscriber / non-nous gating
+                    # must never block saving the model assignment.
+                    _log.debug("apply_nous_managed_defaults skipped", exc_info=True)
 
-        save_config(cfg)
+            save_config(cfg)
 
-        # Register a named ``custom_providers`` entry for a custom/local
-        # endpoint, mirroring the ``hermes model`` custom flow
-        # (_save_custom_provider). Without this the endpoint only lives in
-        # ``model.*`` and the picker has no proper ready row for it — the
-        # GUI then surfaces a "needs setup" dead-end on the bare ``custom``
-        # provider. Dedups by base_url, so re-saving is idempotent.
-        if provider.strip().lower() in {"custom", "local"} and base_url:
-            try:
-                from hermes_cli.main import _auto_provider_name, _save_custom_provider
+            # Register a named ``custom_providers`` entry for a custom/local
+            # endpoint, mirroring the ``hermes model`` custom flow
+            # (_save_custom_provider). Without this the endpoint only lives in
+            # ``model.*`` and the picker has no proper ready row for it — the
+            # GUI then surfaces a "needs setup" dead-end on the bare ``custom``
+            # provider. Dedups by base_url, so re-saving is idempotent.
+            if provider.strip().lower() in {"custom", "local"} and base_url:
+                try:
+                    from hermes_cli.main import _auto_provider_name, _save_custom_provider
 
-                _save_custom_provider(
-                    base_url,
-                    api_key,
-                    model,
-                    name=_auto_provider_name(base_url),
-                )
-            except Exception:
-                # Never block the assignment on the bookkeeping write —
-                # model.* is already persisted and routable.
-                _log.debug("custom_providers registration skipped", exc_info=True)
+                    _save_custom_provider(
+                        base_url,
+                        api_key,
+                        model,
+                        name=_auto_provider_name(base_url),
+                    )
+                except Exception:
+                    # Never block the assignment on the bookkeeping write —
+                    # model.* is already persisted and routable.
+                    _log.debug("custom_providers registration skipped", exc_info=True)
 
-        # Surface auxiliary slots still pinned to a *different* provider than
-        # the new main one. Switching the main model does NOT touch aux pins
-        # (they're independent, sticky per-task overrides — see
-        # auxiliary_client._resolve_auto). A user who switches main away from
-        # a now-unpaid provider (e.g. nous with $0 balance) keeps paying 402s
-        # on every background aux call until they reset those pins. We never
-        # auto-clear them — pinning aux to a cheaper/different model is a
-        # legitimate config — but we tell the caller so the UI can offer a
-        # "reset to main" nudge instead of silently burning credits.
-        new_provider = provider.strip().lower()
-        stale_aux: list[dict] = []
-        aux_cfg = cfg.get("auxiliary", {})
-        if isinstance(aux_cfg, dict):
+            # Surface auxiliary slots still pinned to a *different* provider than
+            # the new main one. Switching the main model does NOT touch aux pins
+            # (they're independent, sticky per-task overrides — see
+            # auxiliary_client._resolve_auto). A user who switches main away from
+            # a now-unpaid provider (e.g. nous with $0 balance) keeps paying 402s
+            # on every background aux call until they reset those pins. We never
+            # auto-clear them — pinning aux to a cheaper/different model is a
+            # legitimate config — but we tell the caller so the UI can offer a
+            # "reset to main" nudge instead of silently burning credits.
+            new_provider = provider.strip().lower()
+            stale_aux: list[dict] = []
+            aux_cfg = cfg.get("auxiliary", {})
+            if isinstance(aux_cfg, dict):
+                for slot in _AUX_TASK_SLOTS:
+                    slot_cfg = aux_cfg.get(slot)
+                    if not isinstance(slot_cfg, dict):
+                        continue
+                    slot_provider = str(slot_cfg.get("provider", "") or "").strip()
+                    if (
+                        slot_provider
+                        and slot_provider.lower() not in {"auto", ""}
+                        and slot_provider.lower() != new_provider
+                    ):
+                        stale_aux.append({
+                            "task": slot,
+                            "provider": slot_provider,
+                            "model": str(slot_cfg.get("model", "") or ""),
+                        })
+
+            return {
+                "ok": True,
+                "scope": "main",
+                "provider": provider,
+                "model": model,
+                "base_url": model_cfg.get("base_url", ""),
+                "gateway_tools": gateway_tools,
+                "stale_aux": stale_aux,
+            }
+
+        # scope == "auxiliary"
+        aux = cfg.get("auxiliary")
+        if not isinstance(aux, dict):
+            aux = {}
+
+        if task == "__reset__":
+            # Reset every slot to provider="auto", model="" — keeps other fields intact.
             for slot in _AUX_TASK_SLOTS:
-                slot_cfg = aux_cfg.get(slot)
+                slot_cfg = aux.get(slot)
                 if not isinstance(slot_cfg, dict):
-                    continue
-                slot_provider = str(slot_cfg.get("provider", "") or "").strip()
-                if (
-                    slot_provider
-                    and slot_provider.lower() not in {"auto", ""}
-                    and slot_provider.lower() != new_provider
-                ):
-                    stale_aux.append({
-                        "task": slot,
-                        "provider": slot_provider,
-                        "model": str(slot_cfg.get("model", "") or ""),
-                    })
+                    slot_cfg = {}
+                slot_cfg["provider"] = "auto"
+                slot_cfg["model"] = ""
+                slot_cfg.pop("base_url", None)
+                clear_model_endpoint_credentials(slot_cfg)
+                aux[slot] = slot_cfg
+            cfg["auxiliary"] = aux
+            save_config(cfg)
+            return {"ok": True, "scope": "auxiliary", "reset": True}
 
-        return {
-            "ok": True,
-            "scope": "main",
-            "provider": provider,
-            "model": model,
-            "base_url": model_cfg.get("base_url", ""),
-            "gateway_tools": gateway_tools,
-            "stale_aux": stale_aux,
-        }
+        if not provider:
+            raise HTTPException(status_code=400, detail="provider required for auxiliary")
 
-    # scope == "auxiliary"
-    aux = cfg.get("auxiliary")
-    if not isinstance(aux, dict):
-        aux = {}
-
-    if task == "__reset__":
-        # Reset every slot to provider="auto", model="" — keeps other fields intact.
-        for slot in _AUX_TASK_SLOTS:
+        targets = [task] if task else list(_AUX_TASK_SLOTS)
+        for slot in targets:
+            if slot not in _AUX_TASK_SLOTS:
+                raise HTTPException(status_code=400, detail=f"unknown auxiliary task: {slot}")
             slot_cfg = aux.get(slot)
             if not isinstance(slot_cfg, dict):
                 slot_cfg = {}
-            slot_cfg["provider"] = "auto"
-            slot_cfg["model"] = ""
-            slot_cfg.pop("base_url", None)
-            clear_model_endpoint_credentials(slot_cfg)
+            prev_provider = str(slot_cfg.get("provider") or "").strip().lower()
+            new_provider = provider.strip().lower()
+            slot_cfg["provider"] = provider
+            slot_cfg["model"] = model
+            if base_url:
+                # Sibling of the main-slot endpoint handling (#65254): an aux
+                # assignment for a custom/local endpoint must carry its own
+                # base_url, or the slot silently rebinds to whatever
+                # model.base_url happens to hold — and breaks entirely once the
+                # main slot switches away and clears it. The auxiliary resolver
+                # already reads auxiliary.<task>.base_url/api_key
+                # (_resolve_task_provider_model), so persisting them here is
+                # what actually wires the endpoint in.
+                slot_cfg["base_url"] = base_url
+                if api_key:
+                    slot_cfg["api_key"] = api_key
+            elif new_provider != prev_provider and new_provider != "custom":
+                slot_cfg.pop("base_url", None)
+                clear_model_endpoint_credentials(slot_cfg)
             aux[slot] = slot_cfg
+
         cfg["auxiliary"] = aux
         save_config(cfg)
-        return {"ok": True, "scope": "auxiliary", "reset": True}
-
-    if not provider:
-        raise HTTPException(status_code=400, detail="provider required for auxiliary")
-
-    targets = [task] if task else list(_AUX_TASK_SLOTS)
-    for slot in targets:
-        if slot not in _AUX_TASK_SLOTS:
-            raise HTTPException(status_code=400, detail=f"unknown auxiliary task: {slot}")
-        slot_cfg = aux.get(slot)
-        if not isinstance(slot_cfg, dict):
-            slot_cfg = {}
-        prev_provider = str(slot_cfg.get("provider") or "").strip().lower()
-        new_provider = provider.strip().lower()
-        slot_cfg["provider"] = provider
-        slot_cfg["model"] = model
-        if base_url:
-            # Sibling of the main-slot endpoint handling (#65254): an aux
-            # assignment for a custom/local endpoint must carry its own
-            # base_url, or the slot silently rebinds to whatever
-            # model.base_url happens to hold — and breaks entirely once the
-            # main slot switches away and clears it. The auxiliary resolver
-            # already reads auxiliary.<task>.base_url/api_key
-            # (_resolve_task_provider_model), so persisting them here is
-            # what actually wires the endpoint in.
-            slot_cfg["base_url"] = base_url
-            if api_key:
-                slot_cfg["api_key"] = api_key
-        elif new_provider != prev_provider and new_provider != "custom":
-            slot_cfg.pop("base_url", None)
-            clear_model_endpoint_credentials(slot_cfg)
-        aux[slot] = slot_cfg
-
-    cfg["auxiliary"] = aux
-    save_config(cfg)
-    return {
-        "ok": True,
-        "scope": "auxiliary",
-        "tasks": targets,
-        "provider": provider,
-        "model": model,
-    }
+        return {
+            "ok": True,
+            "scope": "auxiliary",
+            "tasks": targets,
+            "provider": provider,
+            "model": model,
+        }
 
 
 

--- a/tests/hermes_cli/test_web_server_config_offloop.py
+++ b/tests/hermes_cli/test_web_server_config_offloop.py
@@ -316,3 +316,72 @@ class TestConfigMutationLock:
             "PUT /api/dashboard/plugin-providers is not holding "
             "_CONFIG_MUTATION_LOCK around its read-modify-write span"
         )
+
+    def test_model_set_serialized_against_other_writers(self):
+        """POST /api/model/set (_apply_model_assignment_sync) does config RMW
+        off-loop (asyncio.to_thread) same as every other handler in this
+        class — it must hold the same _CONFIG_MUTATION_LOCK, or a concurrent
+        locked writer's update gets erased by its stale save."""
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+        from hermes_cli import web_server
+        from hermes_cli.config import load_config
+
+        client = TestClient(web_server.app)
+        client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+
+        results = []
+
+        def _put_model():
+            resp = client.post(
+                "/api/model/set",
+                json={
+                    "scope": "auxiliary",
+                    "task": "vision",
+                    "provider": "anthropic",
+                    "model": "claude-haiku",
+                    "confirm_expensive_model": True,
+                },
+            )
+            results.append(("model", resp.status_code))
+
+        def _put_theme():
+            resp = client.put("/api/dashboard/theme", json={"name": "midnight"})
+            results.append(("theme", resp.status_code))
+
+        # Slow down save_config so an unserialized theme write can land
+        # inside the model-set writer's RMW span and be erased by its stale
+        # save. With the mutation lock the whole span is serialized and both
+        # writes survive.
+        real_save = web_server.save_config
+
+        def _slow_save(cfg, **kwargs):
+            time.sleep(0.15)
+            return real_save(cfg, **kwargs)
+
+        threads = []
+        try:
+            web_server.save_config = _slow_save
+            t_model = threading.Thread(target=_put_model)
+            t_theme = threading.Thread(target=_put_theme)
+            threads = [t_model, t_theme]
+            t_model.start()
+            time.sleep(0.05)  # let the model writer enter its RMW span first
+            t_theme.start()
+        finally:
+            for t in threads:
+                t.join()
+            web_server.save_config = real_save
+
+        assert all(code == 200 for _, code in results), results
+        cfg = load_config()
+        assert (cfg.get("auxiliary") or {}).get("vision", {}).get("provider") == "anthropic", (
+            "auxiliary.vision write lost — model-set RMW not serialized"
+        )
+        assert (cfg.get("dashboard") or {}).get("theme") == "midnight", (
+            "theme write lost to a concurrent model-set write — "
+            "POST /api/model/set is not holding "
+            "_CONFIG_MUTATION_LOCK around its read-modify-write span"
+        )


### PR DESCRIPTION
## What does this PR do?

`965a54878` introduced `_CONFIG_MUTATION_LOCK` this week ("held across the whole load→mutate→save span in all seven RMW handlers") to close a race the off-loop config-handler move opened: `config.py`'s `_CONFIG_LOCK` covers each `load_config()`/`save_config()` call individually, never the span between them — when these handlers ran on the event loop, the loop itself accidentally serialized the whole cycle, but off-loop (`asyncio.to_thread`) two concurrent handlers can interleave `load→mutate→save` and silently drop one another's writes. A follow-up (`4ecdee38a`) found and closed more gaps the same day.

`_apply_model_assignment_sync` — the synchronous body of `POST /api/model/set`, already running off-loop via `asyncio.to_thread` — was never brought into that sweep. It does the exact same `load_config()` → mutate → `save_config()` shape (three exit points: main-scope, auxiliary `__reset__`, and per-task auxiliary) with no lock at all. A concurrent write from any of the already-protected handlers (theme, MCP servers, plugin providers, hooks, etc.) landing inside its span gets silently erased by its stale `save_config(cfg)`, or vice versa.

## Fix

Wrap the whole function body in `_CONFIG_MUTATION_LOCK`, matching the established pattern (`_CONFIG_MUTATION_LOCK` is an `RLock` specifically so a locked section calling helpers that also take it can't self-deadlock — e.g. the nested `_save_custom_provider` call for custom/local endpoints, which does its own independent load/save).

## Testing

- New regression test `test_model_set_serialized_against_other_writers` (mirrors the existing `test_concurrent_distinct_updates_both_survive` / `test_plugin_providers_put_serialized_against_other_writers` in the same class): races `POST /api/model/set` (auxiliary scope) against `PUT /api/dashboard/theme` with a slowed `save_config` to widen the interleave window, asserts both writes survive.
- Mutation-verified: reverting the fix makes the new test fail for the right reason (`assert 'auto' == 'anthropic'` — the auxiliary write is silently lost to the concurrent theme write).
- `tests/hermes_cli/test_web_server_config_offloop.py`: 6 passed.
- `tests/hermes_cli/test_web_server.py` (full suite, 4420 lines): 143 passed, 1 pre-existing skip.
- `ruff check` clean on both changed files.

## Checklist

- [x] I searched for existing PRs to make sure this isn't a duplicate. #81598 (open, same day) independently found and fixed the identical bug class in a *different* handler (`PUT /api/memory/providers/{name}/config`) — confirmed by diff inspection it does not touch `_apply_model_assignment_sync`, no overlap.
- [x] My PR contains only changes related to this fix
- [x] Tests added, mutation-verified