### PR TITLE
fix(tools): keep optional document extraction safe across backends (salvage #80326) + docs

### DIFF
--- a/tests/tools/test_lazy_deps_durable_target.py
+++ b/tests/tools/test_lazy_deps_durable_target.py
@@ -197,6 +197,25 @@ class TestInstallArgConstruction:
         assert "--target" not in captured["cmd"]
         assert "--constraint" not in captured["cmd"]
 
+    def test_uv_resolution_failure_does_not_fall_through_to_pip(self, monkeypatch):
+        monkeypatch.delenv(ld._LAZY_TARGET_ENV, raising=False)
+        monkeypatch.setattr("hermes_cli.managed_uv.resolve_uv", lambda: "uv")
+        calls = []
+
+        def fake_run(cmd, *args, **kwargs):
+            calls.append(cmd)
+            if cmd[:3] == ["uv", "pip", "install"]:
+                return subprocess.CompletedProcess(
+                    cmd, 1, "", "release excluded by exclude-newer"
+                )
+            pytest.fail(f"unexpected pip fallback: {cmd}")
+
+        monkeypatch.setattr(ld.subprocess, "run", fake_run)
+        result = ld._venv_pip_install(("fresh-package==1.0.0",))
+        assert not result.success
+        assert "exclude-newer" in result.stderr
+        assert len(calls) == 1
+
 
 @pytest.mark.skipif(
     os.environ.get("HERMES_RUN_NETWORK_TESTS") != "1",

--- a/tests/tools/test_read_extract.py
+++ b/tests/tools/test_read_extract.py
@@ -10,6 +10,7 @@ omission.
 Run with:  python -m pytest tests/tools/test_read_extract.py -v
 """
 
+import base64
 import json
 import os
 import tempfile
@@ -237,8 +238,11 @@ class TestAnydocInitLifecycle(unittest.TestCase):
         self._saved_retry = read_extract.ANYDOC_RETRY_SECONDS
         read_extract._anydoc_module = read_extract._ANYDOC_UNSET
         read_extract._anydoc_failed_at = None
+        self._ensure = mock.patch("tools.lazy_deps.ensure", return_value=None)
+        self._ensure.start()
 
     def tearDown(self):
+        self._ensure.stop()
         self.rex._anydoc_module = self._saved_module
         self.rex._anydoc_failed_at = self._saved_failed_at
         self.rex.ANYDOC_RETRY_SECONDS = self._saved_retry
@@ -255,6 +259,13 @@ class TestAnydocInitLifecycle(unittest.TestCase):
             self.assertIs(self.rex._anydoc(), fake)
             self.assertIs(self.rex._anydoc(), fake)
         self.assertEqual(calls, ["anydoc"])
+
+    def test_failed_reconciliation_does_not_import_unverified_binding(self):
+        with mock.patch(
+            "tools.lazy_deps.ensure", side_effect=RuntimeError("wrong version")
+        ), mock.patch("importlib.import_module") as import_module:
+            self.assertIsNone(self.rex._anydoc())
+        import_module.assert_not_called()
 
     def test_failed_load_is_retried_after_cooldown(self):
         fake = object()
@@ -483,6 +494,53 @@ class TestReadFileToolIntegration(unittest.TestCase):
         res = json.loads(read_file_tool(p))
         self.assertTrue(res.get("extracted_document"))
         self.assertIn("Report body", res["content"])
+
+    def test_backend_only_anydoc_path_uses_transferred_bytes(self):
+        from tools import file_tools, read_extract
+        from tools.file_operations import ReadResult
+
+        payload = br"{\rtf1\ansi Remote body\par}"
+
+        class FakeAnydoc:
+            def to_markdown_bytes(self, data):
+                self.seen = data
+                return "Remote body\n"
+
+        class FakeFileOps:
+            def read_file_bytes(self, path, max_bytes=None):
+                self.path = path
+                return ReadResult(
+                    base64_content=base64.b64encode(payload).decode("ascii"),
+                    file_size=len(payload),
+                    is_binary=True,
+                )
+
+            @staticmethod
+            def _add_line_numbers(content, start_line=1):
+                return "\n".join(
+                    f"{number}|{line}"
+                    for number, line in enumerate(content.split("\n"), start_line)
+                )
+
+        fake_anydoc = FakeAnydoc()
+        fake_ops = FakeFileOps()
+        saved_module = read_extract._anydoc_module
+        read_extract._anydoc_module = fake_anydoc
+        try:
+            with mock.patch.object(file_tools, "_get_file_ops", return_value=fake_ops), \
+                    mock.patch.object(
+                        file_tools,
+                        "_resolve_path_for_task",
+                        return_value=file_tools.PurePosixPath("/workspace/remote.rtf"),
+                    ), mock.patch("os.path.getsize", side_effect=AssertionError("host read")):
+                res = json.loads(read_file_tool("/workspace/remote.rtf", task_id="remote"))
+        finally:
+            read_extract._anydoc_module = saved_module
+
+        self.assertTrue(res.get("extracted_document"))
+        self.assertIn("Remote body", res["content"])
+        self.assertEqual(fake_anydoc.seen, payload)
+        self.assertEqual(fake_ops.path, "/workspace/remote.rtf")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_read_extract.py
+++ b/tests/tools/test_read_extract.py
@@ -647,6 +647,48 @@ class TestPdfCoverageNote(unittest.TestCase):
         note.assert_not_called()
         self.assertEqual(text, "converted\n")
 
+    def test_bytes_path_prepends_note_with_display_path(self):
+        """Backend-transferred PDF bytes get the same warning, and the
+        recovery command names the backend-visible path, not the host
+        temp file the scan ran against."""
+        from tools import read_extract
+        fake_mod = mock.Mock()
+        fake_mod.to_markdown_bytes.return_value = "# Title\n\nBody"
+        seen = {}
+
+        def fake_note(path, display_path=None):
+            seen["scan_path"] = path
+            seen["display_path"] = display_path
+            return f"[EXTRACTION COVERAGE WARNING: test '{display_path}']\n"
+
+        with mock.patch.object(read_extract, "_anydoc",
+                               return_value=fake_mod), \
+             mock.patch.object(read_extract, "_pdf_coverage_note",
+                               side_effect=fake_note):
+            text = read_extract._extract_anydoc_bytes(
+                b"%PDF-1.4 fake", "/workspace/remote.pdf"
+            )
+        self.assertTrue(text.startswith("[EXTRACTION COVERAGE WARNING"))
+        self.assertIn("/workspace/remote.pdf", text)
+        self.assertEqual(seen["display_path"], "/workspace/remote.pdf")
+        # The scanned file is a host temp materialization, already removed.
+        self.assertNotEqual(seen["scan_path"], "/workspace/remote.pdf")
+        self.assertFalse(os.path.exists(seen["scan_path"]))
+
+    def test_bytes_path_no_note_for_non_pdf(self):
+        from tools import read_extract
+        fake_mod = mock.Mock()
+        fake_mod.to_markdown_bytes.return_value = "converted"
+        with mock.patch.object(read_extract, "_anydoc",
+                               return_value=fake_mod), \
+             mock.patch.object(read_extract,
+                               "_pdf_coverage_note_from_bytes") as note:
+            text = read_extract._extract_anydoc_bytes(
+                b"{\\rtf1 fake}", "/workspace/remote.rtf"
+            )
+        note.assert_not_called()
+        self.assertEqual(text, "converted\n")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -25,6 +25,7 @@ Usage:
     result = file_ops.search("TODO", path=".", file_glob="*.py")
 """
 
+import base64
 import os
 import re
 import difflib
@@ -463,6 +464,10 @@ class FileOperations(ABC):
         failure. Always reads to EOF regardless of file size.
         """
         ...
+
+    def read_file_bytes(self, path: str, max_bytes: Optional[int] = None) -> ReadResult:
+        """Read complete binary content as base64 across the backend boundary."""
+        return ReadResult(error="Binary reads are not implemented for this backend")
 
     @abstractmethod
     def write_file(self, path: str, content: str,
@@ -1326,6 +1331,38 @@ class ShellFileOperations(FileOperations):
         return ReadResult(
             content=raw_content,
             file_size=file_size,
+        )
+
+    def read_file_bytes(self, path: str, max_bytes: Optional[int] = None) -> ReadResult:
+        """Read binary-safe bytes from any shell-backed environment."""
+        path = self._expand_path(path)
+        stat_result = self._exec(
+            f"wc -c < {self._escape_shell_arg(path)} 2>/dev/null"
+        )
+        if stat_result.exit_code != 0:
+            return ReadResult(error=f"File not found: {path}")
+        try:
+            file_size = int(_strip_terminal_fence_leaks(stat_result.stdout).strip())
+        except ValueError:
+            return ReadResult(error=f"Could not determine file size: {path}")
+        if max_bytes is not None and file_size > max_bytes:
+            return ReadResult(
+                file_size=file_size,
+                error=f"File is too large ({file_size:,} bytes, limit is {max_bytes:,})",
+            )
+
+        encoded = self._exec(f"base64 < {self._escape_shell_arg(path)}")
+        if encoded.exit_code != 0:
+            return ReadResult(error=f"Failed to read binary file: {encoded.stdout}")
+        compact = "".join(_strip_terminal_fence_leaks(encoded.stdout).split())
+        try:
+            base64.b64decode(compact, validate=True)
+        except (ValueError, base64.binascii.Error):
+            return ReadResult(error=f"Backend returned invalid binary data for: {path}")
+        return ReadResult(
+            base64_content=compact,
+            file_size=file_size,
+            is_binary=True,
         )
 
     def delete_file(self, path: str) -> WriteResult:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """File Tools Module - LLM agent file manipulation tools."""
 
+import base64
 import errno
 import json
 import logging
@@ -1533,15 +1534,30 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
         # ── Structured-document extraction ────────────────────────────
         # Try before the binary-extension guard so .docx/.xlsx can render as text.
         # Malformed documents fall through to the normal path/binary guard.
-        from tools.read_extract import ExtractionError, extract_document_text, is_extractable_document
+        from tools.read_extract import (
+            MAX_DOCUMENT_BYTES,
+            ExtractionError,
+            extract_document_bytes,
+            is_extractable_document,
+        )
 
         if is_extractable_document(str(_resolved)):
+            file_ops = _get_file_ops(task_id)
             try:
-                extracted_text = extract_document_text(str(_resolved))
-            except ExtractionError:
+                binary = file_ops.read_file_bytes(
+                    str(_resolved), max_bytes=MAX_DOCUMENT_BYTES
+                )
+                if binary.error or binary.base64_content is None:
+                    raise ExtractionError(binary.error or "Document bytes unavailable")
+                document_bytes = base64.b64decode(
+                    binary.base64_content, validate=True
+                )
+                extracted_text = extract_document_bytes(
+                    document_bytes, str(_resolved)
+                )
+            except (ExtractionError, ValueError, base64.binascii.Error):
                 logger.debug("document extraction failed for %s", path, exc_info=True)
             else:
-                file_ops = _get_file_ops(task_id)
                 lines = extracted_text.splitlines()
                 total_lines = len(lines)
                 end_line = offset + limit - 1
@@ -1549,7 +1565,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
                 result_dict = {
                     "content": file_ops._add_line_numbers(page_text, offset) if page_text else "",
                     "total_lines": total_lines,
-                    "file_size": os.path.getsize(_resolved),
+                    "file_size": binary.file_size,
                     "truncated": total_lines > end_line,
                     "extracted_document": True,
                 }

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -766,7 +766,17 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                         _activate_target_on_syspath(target)
                     return _InstallResult(True, r.stdout or "", r.stderr or "")
                 logger.debug("uv pip install failed: %s", r.stderr)
-            except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+                # A resolver failure is authoritative. Falling through to pip
+                # here would silently discard uv policy such as exclude-newer
+                # and could install a release that the project quarantined.
+                return _InstallResult(False, r.stdout or "", r.stderr or "")
+            except subprocess.TimeoutExpired as e:
+                logger.debug("uv invocation failed: %s", e)
+                return _InstallResult(False, "", f"uv pip install timed out: {e}")
+            except FileNotFoundError as e:
+                # The resolved uv path disappeared between lookup and spawn.
+                # In that narrow availability failure, the pip tier remains a
+                # valid fallback because uv never evaluated the requirements.
                 logger.debug("uv invocation failed: %s", e)
 
         # Tier 2: python -m pip (with ensurepip bootstrap if needed)

--- a/tools/read_extract.py
+++ b/tools/read_extract.py
@@ -18,6 +18,7 @@ import os
 import posixpath
 import shutil
 import subprocess
+import tempfile
 import threading
 import time
 import zipfile
@@ -25,7 +26,13 @@ from pathlib import Path
 from typing import Any, Optional
 from xml.etree import ElementTree as ET
 
-__all__ = ["EXTRACTABLE_EXTENSIONS", "ExtractionError", "extract_document_text", "is_extractable_document"]
+__all__ = [
+    "EXTRACTABLE_EXTENSIONS",
+    "ExtractionError",
+    "extract_document_bytes",
+    "extract_document_text",
+    "is_extractable_document",
+]
 
 EXTRACTABLE_EXTENSIONS = frozenset({".ipynb", ".docx", ".xlsx"})
 # Formats handled only when the optional anydoc converter is installed.
@@ -41,6 +48,7 @@ MAX_XLSX_BYTES = 50 * 1024 * 1024
 # Rust core with no streaming, and the read_file char budget only applies
 # after conversion, so an unbounded input can pin a tool turn and spike RAM.
 MAX_ANYDOC_BYTES = 50 * 1024 * 1024
+MAX_DOCUMENT_BYTES = 50 * 1024 * 1024
 _MAX_XLSX_ROWS_PER_SHEET = 5000
 _MAX_XLSX_COLS = 256
 
@@ -97,12 +105,14 @@ def _anydoc() -> Optional[Any]:
             # prompt=False: read_file must never block on an install prompt.
             _lazy_ensure("tool.doc_extract", prompt=False)
         except Exception:
-            pass  # lazy install unavailable — fall through to a plain import
+            _anydoc_failed_at = time.monotonic()
+            return None
         try:
             _anydoc_module = importlib.import_module("anydoc")
         except Exception:  # ImportError or a broken native binding
             _anydoc_failed_at = time.monotonic()
             return None
+        _anydoc_failed_at = None
     return _anydoc_module  # type: ignore[return-value]
 
 
@@ -121,6 +131,34 @@ def extract_document_text(path: str) -> str:
     if ext in ANYDOC_EXTENSIONS:
         return _extract_anydoc(path)
     raise ExtractionError(f"Unsupported document type: {path!r}")
+
+
+def extract_document_bytes(data: bytes, path: str) -> str:
+    """Extract a document already fetched across a file backend boundary."""
+    if len(data) > MAX_DOCUMENT_BYTES:
+        raise ExtractionError(
+            f"Document too large to convert ({len(data):,} bytes, limit is {MAX_DOCUMENT_BYTES:,})"
+        )
+    ext = _extension(path)
+    if ext in ANYDOC_EXTENSIONS:
+        return _extract_anydoc_bytes(data, path)
+    if ext not in EXTRACTABLE_EXTENSIONS:
+        raise ExtractionError(f"Unsupported document type: {path!r}")
+
+    # The stdlib extractors are path-oriented. Materialize backend bytes in a
+    # private host temp file, then remove it even when parsing fails.
+    temp_path = ""
+    try:
+        with tempfile.NamedTemporaryFile(suffix=ext, delete=False) as fh:
+            fh.write(data)
+            temp_path = fh.name
+        return extract_document_text(temp_path)
+    finally:
+        if temp_path:
+            try:
+                os.unlink(temp_path)
+            except OSError:
+                pass
 
 
 def _extract_anydoc(path: str) -> str:
@@ -212,8 +250,13 @@ def _page_ranges(pages: list[int]) -> str:
     return ", ".join(parts)
 
 
-def _pdf_coverage_note(path: str) -> str:
-    """A warning footer when many PDF pages produced no text, else ''."""
+def _pdf_coverage_note(path: str, display_path: Optional[str] = None) -> str:
+    """A warning header when many PDF pages produced no text, else ''.
+
+    ``path`` is the file scanned with pdftotext (may be a host temp file
+    for backend-transferred bytes); ``display_path`` is the path shown in
+    the recovery command — the one the agent's terminal can actually see.
+    """
     counts = _pdf_page_char_counts(path)
     if not counts or len(counts) < 2:
         return ""
@@ -226,6 +269,7 @@ def _pdf_coverage_note(path: str) -> str:
         and len(empty) < PDF_COVERAGE_ABSOLUTE_EMPTY
     ):
         return ""
+    shown = display_path or path
     return (
         "[EXTRACTION COVERAGE WARNING: "
         f"{len(empty)} of {total} pages in this PDF yielded no text "
@@ -233,10 +277,57 @@ def _pdf_coverage_note(path: str) -> str:
         "images (or blank) — their content is MISSING from the extracted "
         "text below, even where section headers appear with empty bodies. "
         "To read them: render pages to images with "
-        f"`pdftoppm -jpeg -r 150 -f <first> -l <last> '{path}' /tmp/page` "
+        f"`pdftoppm -jpeg -r 150 -f <first> -l <last> '{shown}' /tmp/page` "
         "and inspect each image with the vision_analyze tool, or use the "
         "ocr-and-documents skill (marker-pdf) for bulk OCR.]\n"
     )
+
+
+def _extract_anydoc_bytes(data: bytes, path: str) -> str:
+    mod = _anydoc()
+    if mod is None:
+        raise ExtractionError(f"Unsupported document type: {path!r}")
+    if len(data) > MAX_ANYDOC_BYTES:
+        raise ExtractionError(
+            f"Document too large to convert ({len(data):,} bytes, limit is {MAX_ANYDOC_BYTES:,})"
+        )
+    try:
+        text = mod.to_markdown_bytes(data)
+    except Exception as exc:
+        raise ExtractionError(f"{type(exc).__name__}: {exc}") from exc
+    if not isinstance(text, str) or not text.strip():
+        raise ExtractionError("Document contains no extractable text")
+    text = text.rstrip("\n") + "\n"
+    if Path(path).suffix.lower() == ".pdf":
+        note = _pdf_coverage_note_from_bytes(data, path)
+        if note:
+            # Prepend: read_file paginates the extraction, so a footer on a
+            # long document would sit on a page the model may never fetch.
+            text = note + text
+    return text
+
+
+def _pdf_coverage_note_from_bytes(data: bytes, display_path: str) -> str:
+    """Coverage note for backend-transferred PDF bytes.
+
+    pdftotext is path-oriented, so materialize the bytes in a private host
+    temp file for the scan; the recovery command still names
+    ``display_path`` — the path the agent's terminal backend can see.
+    """
+    temp_path = ""
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as fh:
+            fh.write(data)
+            temp_path = fh.name
+        return _pdf_coverage_note(temp_path, display_path=display_path)
+    except OSError:
+        return ""
+    finally:
+        if temp_path:
+            try:
+                os.unlink(temp_path)
+            except OSError:
+                pass
 
 
 def _source_text(source) -> str:

--- a/website/docs/user-guide/features/document-extraction.md
+++ b/website/docs/user-guide/features/document-extraction.md
@@ -1,0 +1,55 @@
+---
+sidebar_position: 3
+title: "Document Extraction"
+description: "How read_file converts PDFs, Office documents, and notebooks to text — and what to do when a PDF is scanned images"
+---
+
+# Document Extraction
+
+The `read_file` tool automatically converts common document formats to readable text, so the agent can inspect a PDF or spreadsheet the same way it reads source code.
+
+## Supported formats
+
+| Format | Extensions | Converter | Availability |
+|--------|-----------|-----------|--------------|
+| Jupyter notebooks | `.ipynb` | Built-in (stdlib) | Always |
+| Word documents | `.docx` | Built-in (stdlib) | Always |
+| Excel workbooks | `.xlsx` | Built-in (stdlib) | Always |
+| PDF | `.pdf` | Optional `anydoc` converter | Auto-installed on first use* |
+| Legacy Office | `.doc`, `.ppt`, `.xls`, `.pptx`, and variants | Optional `anydoc` converter | Auto-installed on first use* |
+| OpenDocument | `.odt`, `.ods`, `.odp` | Optional `anydoc` converter | Auto-installed on first use* |
+| Rich text / eBooks | `.rtf`, `.epub` | Optional `anydoc` converter | Auto-installed on first use* |
+
+\* The optional converter is the `firecrawl-anydoc` package, installed lazily where installs are permitted (`security.allow_lazy_installs` in `config.yaml`). Without it, the three stdlib formats still work; other formats fall back to the binary-file guard.
+
+Conversion output is Markdown, paginated through `read_file`'s normal `offset`/`limit` window. Documents over 50 MB are refused to keep tool turns bounded.
+
+Extraction works with remote terminal backends (Docker, Modal, SSH): the file's bytes are transferred across the backend boundary and converted host-side, so a document inside a sandbox reads the same as a local one.
+
+## Scanned PDFs: the coverage warning
+
+PDF conversion reads the **text layer only**. Pages that are scanned images — common in legal documents, resale packages, signed contracts, faxes — contain no text layer and silently convert to nothing. The telltale signature is section headers with empty bodies.
+
+When a meaningful share of pages yields no text (over 20% of the document, or 10+ pages absolute), `read_file` prepends a warning to the extraction:
+
+```
+[EXTRACTION COVERAGE WARNING: 198 of 311 pages in this PDF yielded no
+text (pages 2-29, 33-35, 42-77, 79-85, 92-213, 224, 226). Those pages
+are likely scanned images (or blank) — their content is MISSING from
+the extracted text below ...]
+```
+
+The warning lists the exact page ranges and the recovery paths:
+
+1. **A few pages — render + vision.** Convert the pages to images and read them with the vision tool:
+   ```bash
+   pdftoppm -jpeg -r 150 -f 92 -l 94 document.pdf /tmp/page
+   ```
+   Then inspect each image with `vision_analyze`. Zero extra dependencies (poppler is required for the detection itself).
+2. **Many pages — OCR.** The `ocr-and-documents` skill covers bulk OCR with marker-pdf (90+ languages, handles equations and tables; ~3-5 GB install).
+
+Detection uses poppler's `pdftotext` for per-page text counts. If poppler is not installed, extraction still works — the coverage check is silently skipped.
+
+:::tip
+The agent handles the warning on its own — it will offer to render or OCR the missing pages. If you're reading extractions yourself, treat "header with an empty body" as a scanned section, not a missing one.
+:::

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -71,6 +71,7 @@ const sidebars: SidebarsConfig = {
           label: 'Core',
           items: [
             'user-guide/features/tools',
+            'user-guide/features/document-extraction',
             'user-guide/features/tool-search',
             'user-guide/features/skills',
             'user-guide/features/lsp',


### PR DESCRIPTION
## Summary

Salvages #80326 by @fangliquanflq onto current main: document extraction now transfers bytes across the file-backend boundary instead of re-reading the original path on the host, the lazy installer fails closed when uv's resolver rejects an install, and unreconciled anydoc versions are never imported. Adds a follow-up commit keeping the scanned-PDF coverage warning (#81680) working on the new bytes path, plus a docs page for the whole document-extraction feature.

## Changes

- **Salvaged from #80326** (authorship preserved):
  - `tools/file_operations.py`: `read_file_bytes()` — binary-safe base64 read on any shell backend, with size gate and payload validation.
  - `tools/file_tools.py`: `read_file` routes document extraction through backend bytes; `file_size` comes from the backend, not host `os.path.getsize`.
  - `tools/read_extract.py`: `extract_document_bytes()` + `_extract_anydoc_bytes()`; `_anydoc()` treats a failed lazy-ensure as a real failure (cooldown) instead of importing an unreconciled binding.
  - `tools/lazy_deps.py`: uv resolver failure is authoritative — no pip fallthrough that would discard uv policy (exclude-newer); pip remains a fallback only when the uv binary itself is missing.
- **Follow-up (ours)**: the new bytes path bypassed the #81680 scanned-PDF coverage warning. `_pdf_coverage_note_from_bytes()` materializes transferred bytes in a host temp file for the pdftotext scan and names the backend-visible path in the recovery command. +2 regression tests.
- **Docs**: new `website/docs/user-guide/features/document-extraction.md` (supported formats, remote-backend behavior, the coverage warning and its recovery paths) — the anydoc feature shipped with no docs page. Registered in `sidebars.ts`.

## Validation

| | Result |
|---|---|
| `tests/tools/` read_extract + lazy_deps + file_operations suites | 127 passed, 0 failed |
| E2E: bytes path on real 311-page scanned PDF | Warning prepended, recovery cmd names backend path (not host temp file) |
| E2E: bytes path on clean 12-page PDF | No false positive |
| E2E: full `read_file_tool` | Warning on line 1, `file_size` matches backend byte count |
| Docs | `npx docusaurus build` green |

## Credit

Core fix by @fangliquanflq in #80326 — cherry-picked with authorship preserved.

## Infographic

![Document extraction across backends infographic](https://v3b.fal.media/files/b/0aa58226/oTHsWpyOVpmxCZTLZTWNc_d6DfaIah.png)
