### PR TITLE
fix(tools): classify git apply/am as self-repo worktree mutations

### DIFF
--- a/tests/tools/test_self_repo_guard.py
+++ b/tests/tools/test_self_repo_guard.py
@@ -43,6 +43,11 @@ class TestBlocksMutationsInSourceRepo:
             "clean -fd",
             "cherry-pick abc123",
             "revert HEAD",
+            "apply patch.diff",
+            "apply --whitespace=fix patch.diff",
+            "am mbox.patch",
+            "am --abort",
+            "am --skip",
         ],
     )
     def test_cwd_inside_repo(self, repo, sub):
@@ -177,6 +182,11 @@ class TestAllowsSafeCommands:
             "git fetch origin main",
             "git worktree add /tmp/wt feature-branch",
             "git push fork feature-branch",
+            "git apply --check patch.diff",
+            "git apply --stat patch.diff",
+            "git apply --numstat patch.diff",
+            "git apply --summary patch.diff",
+            "git am --show-current-patch",
             "ls -la",
             "grep -rn checkout tools/",
         ],

--- a/tools/self_repo_guard.py
+++ b/tools/self_repo_guard.py
@@ -42,12 +42,12 @@ _KNOWN_GIT_BUILTINS = frozenset({
     "branch",
     "bundle",
     "cat-file",
-    # `reset`/`stash`/`clean`/`restore` reach this set only in their SAFE
-    # forms — _mutates_worktree classifies the dangerous forms first (see
-    # _inspect_git) — so listing them here only prevents a pointless
-    # `git config --get alias.<sub>` subprocess for `stash list`,
-    # `reset --soft`, `clean -n`, `restore --staged`, which agent dev
-    # sessions run constantly inside the source repo.
+    # `reset`/`stash`/`clean`/`restore`/`am`/`apply` reach this set only in
+    # their SAFE forms — _mutates_worktree classifies the dangerous forms
+    # first (see _inspect_git) — so listing them here only prevents a
+    # pointless `git config --get alias.<sub>` subprocess for `stash list`,
+    # `reset --soft`, `clean -n`, `restore --staged`, `apply --check`, which
+    # agent dev sessions run constantly inside the source repo.
     "clean",
     "clone",
     "commit",
@@ -533,6 +533,19 @@ def _mutates_worktree(subcommand: str, args: list[str]) -> bool:
             for arg in args
         )
         return worktree or not staged
+    if subcommand == "apply":
+        # `--check`/`--stat`/`--numstat`/`--summary` only report what the
+        # patch WOULD do; every other form writes the patched content to
+        # disk exactly like the worktree mutations above.
+        inspect_only = frozenset({"--check", "--stat", "--numstat", "--summary"})
+        return not any(arg in inspect_only for arg in args)
+    if subcommand == "am":
+        # `git am` applies-and-commits a patch series (mutating the tree AND
+        # HEAD) for every form except pure session inspection; --abort and
+        # --skip both reset tracked files to recover from a stopped am, so
+        # they stay classified as mutating too.
+        inspect_only = frozenset({"--show-current-patch"})
+        return not any(arg in inspect_only for arg in args)
     return subcommand in _WORKTREE_MUTATIONS
 
 


### PR DESCRIPTION
## What does this PR do?

`_KNOWN_GIT_BUILTINS` lists `am` and `apply` as guaranteed-safe git subcommands. `_inspect_git()` checks `_mutates_worktree()` first (which only recognizes `checkout/switch/rebase/merge/pull/restore/clean/cherry-pick/revert/bisect` plus special-cased `reset`/`stash`), then falls straight through to `subcommand in _KNOWN_GIT_BUILTINS: return None` for anything not caught there — so `apply`/`am` were treated as guaranteed-safe, never evaluated for mutation risk, and `terminal(command="git apply someone-elses.patch")` (or `git am`) run inside the Hermes source checkout would silently mutate files under the live interpreter, unblocked.

Both subcommands rewrite the working tree exactly like the subcommands the guard already blocks: `git apply <patch>` writes the patched content straight to disk; `git am <mailbox>` applies-and-commits a patch series (mutating HEAD too) — the identical "module-version-skew under the live interpreter" hazard the guard's own docstring describes for `checkout`/`reset`/`stash`/`clean`/`cherry-pick`/`revert`.

Empirically verified against the live classifier before the fix:
```
_mutates_worktree("apply", ["patch.diff"])  -> False (not blocked)
_mutates_worktree("am", ["mbox.patch"])     -> False (not blocked)
_mutates_worktree("checkout", ["main"])     -> True  (blocked)
```

## Fix

Add per-subcommand handling to `_mutates_worktree`, mirroring the existing `reset`/`stash`/`clean`/`restore` carve-outs:
- `apply`'s inspection-only forms (`--check`/`--stat`/`--numstat`/`--summary`, which only report what the patch would do) stay classified as safe — they still short-circuit through `_KNOWN_GIT_BUILTINS` without a pointless `git config --get alias.<sub>` subprocess.
- `am --show-current-patch` (pure session inspection) stays safe.
- Every other form is now classified as a mutation, including `--abort`/`--skip` — both reset tracked files to recover from a stopped `am`, so they carry the same worktree-mutation risk as the rest.

## Testing

- 5 new parametrized cases in `TestBlocksMutationsInSourceRepo` (`apply patch.diff`, `apply --whitespace=fix patch.diff`, `am mbox.patch`, `am --abort`, `am --skip`) and 5 new cases in `TestAllowsSafeCommands` (`apply --check/--stat/--numstat/--summary`, `am --show-current-patch`) — all run through the real end-to-end `detect_self_repo_git_mutation()` entry point against a real temp git repo, matching every other case in this file.
- Mutation-verified: reverting the fix makes all 5 new "blocks" cases fail for the right reason (`assert False is True`).
- Full `tests/tools/test_self_repo_guard.py`: 121 passed.
- `tests/tools/test_terminal_tool.py` (the consumer of this guard): 10 passed.
- `ruff check` clean on both changed files.

## Note on a same-day sibling PR

**#81664** (opened today) fixes a *different* bug in the same file — the alias-recursion depth limit fails open (`return None` instead of blocking) at `_inspect_git()` line ~605 and `_find_mutation()`. That's textually adjacent to but does not overlap this PR's changes (`_KNOWN_GIT_BUILTINS` comment + new `_mutates_worktree` branches, ~40 lines away) — confirmed by diff inspection, no shared lines.

## Checklist

- [x] I searched for existing PRs to make sure this isn't a duplicate — no open/merged PR targets `apply`/`am` classification specifically.
- [x] My PR contains only changes related to this fix
- [x] Tests added, mutation-verified