### PR TITLE
feat(gateway): add AG-UI protocol adapter

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -926,6 +926,13 @@ PLATFORM_HINTS = {
         "image and is the WRONG path. Bare Unicode emoji in text is also not a substitute "
         "— when a sticker is the right response, use yb_send_sticker."
     ),
+    "ag_ui": (
+        "You are responding through an AG-UI protocol server. "
+        "The frontend is an AG-UI-compatible application (CopilotKit, custom React UI, "
+        "mobile app, or similar). Use plain text; avoid markdown formatting. "
+        "Tool calls, approvals, and state updates are streamed as structured AG-UI "
+        "events — do not describe them in prose. Keep responses concise and natural."
+    ),
     "api_server": (
         "You're responding through an API server. The rendering layer is unknown — "
         "assume plain text. No markdown formatting (no asterisks, bullets, headers, "

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -301,6 +301,7 @@ class Platform(Enum):
     QQBOT = "qqbot"
     YUANBAO = "yuanbao"
     RELAY = "relay"  # generic relay adapter fronted by the connector (EXPERIMENTAL)
+    AG_UI = "ag_ui"  # AG-UI protocol server adapter
     @classmethod
     def _missing_(cls, value):
         """Accept unknown platform names only for known plugin adapters.
@@ -2170,6 +2171,24 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         if api_server_model_name:
             config.platforms[Platform.API_SERVER].extra["model_name"] = api_server_model_name
 
+
+    # AG-UI protocol server
+    ag_ui_key = getenv("AG_UI_KEY", "")
+    ag_ui_port = getenv("AG_UI_PORT")
+    ag_ui_host = getenv("AG_UI_HOST")
+    if ag_ui_key or is_truthy_value(getenv("AG_UI_ENABLED", "")):
+        if Platform.AG_UI not in config.platforms:
+            config.platforms[Platform.AG_UI] = PlatformConfig()
+        config.platforms[Platform.AG_UI].enabled = True
+        if ag_ui_key:
+            config.platforms[Platform.AG_UI].token = ag_ui_key
+        if ag_ui_port:
+            try:
+                config.platforms[Platform.AG_UI].extra["port"] = int(ag_ui_port)
+            except ValueError:
+                pass
+        if ag_ui_host:
+            config.platforms[Platform.AG_UI].extra["host"] = ag_ui_host
     # Webhook platform
     webhook_enabled = is_truthy_value(getenv("WEBHOOK_ENABLED", ""))
     webhook_port = getenv("WEBHOOK_PORT")

--- a/gateway/platforms/ag_ui_protocol.py
+++ b/gateway/platforms/ag_ui_protocol.py
@@ -1,0 +1,185 @@
+"""
+AG-UI Protocol types for Hermes.
+
+Implements the Agent-User Interaction Protocol event model:
+https://github.com/ag-ui-protocol/ag-ui
+
+Maps Hermes run lifecycle events to AG-UI wire format so any
+AG-UI-compatible frontend (CopilotKit, custom React UIs, mobile apps)
+can connect to Hermes without a custom integration.
+"""
+from __future__ import annotations
+
+import time
+import uuid
+from enum import Enum
+from typing import Any, Dict, List, Literal, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, Field
+from pydantic.alias_generators import to_camel
+
+
+class _CamelModel(BaseModel):
+    model_config = ConfigDict(
+        extra="allow",
+        alias_generator=to_camel,
+        populate_by_name=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Event types
+# ---------------------------------------------------------------------------
+
+class AGUIEventType(str, Enum):
+    RUN_STARTED              = "RUN_STARTED"
+    RUN_FINISHED             = "RUN_FINISHED"
+    RUN_ERROR                = "RUN_ERROR"
+    STEP_STARTED             = "STEP_STARTED"
+    STEP_FINISHED            = "STEP_FINISHED"
+    TEXT_MESSAGE_START       = "TEXT_MESSAGE_START"
+    TEXT_MESSAGE_CONTENT     = "TEXT_MESSAGE_CONTENT"
+    TEXT_MESSAGE_END         = "TEXT_MESSAGE_END"
+    TOOL_CALL_START          = "TOOL_CALL_START"
+    TOOL_CALL_ARGS           = "TOOL_CALL_ARGS"
+    TOOL_CALL_END            = "TOOL_CALL_END"
+    TOOL_CALL_RESULT         = "TOOL_CALL_RESULT"
+    STATE_SNAPSHOT           = "STATE_SNAPSHOT"
+    STATE_DELTA              = "STATE_DELTA"
+    CUSTOM                   = "CUSTOM"
+
+
+# ---------------------------------------------------------------------------
+# Base event
+# ---------------------------------------------------------------------------
+
+class AGUIBaseEvent(_CamelModel):
+    type: AGUIEventType
+    timestamp: int = Field(default_factory=lambda: int(time.time() * 1000))
+
+
+# ---------------------------------------------------------------------------
+# Run lifecycle
+# ---------------------------------------------------------------------------
+
+class AGUIRunStartedEvent(AGUIBaseEvent):
+    type: Literal[AGUIEventType.RUN_STARTED] = AGUIEventType.RUN_STARTED
+    thread_id: str
+    run_id: str
+
+
+class AGUIRunFinishedEvent(AGUIBaseEvent):
+    type: Literal[AGUIEventType.RUN_FINISHED] = AGUIEventType.RUN_FINISHED
+    thread_id: str
+    run_id: str
+
+
+class AGUIRunErrorEvent(AGUIBaseEvent):
+    type: Literal[AGUIEventType.RUN_ERROR] = AGUIEventType.RUN_ERROR
+    message: str
+    code: Optional[str] = None
+
+
+class AGUIStepStartedEvent(AGUIBaseEvent):
+    type: Literal[AGUIEventType.STEP_STARTED] = AGUIEventType.STEP_STARTED
+    step_name: str
+
+
+class AGUIStepFinishedEvent(AGUIBaseEvent):
+    type: Literal[AGUIEventType.STEP_FINISHED] = AGUIEventType.STEP_FINISHED
+    step_name: str
+
+
+# ---------------------------------------------------------------------------
+# Text messages
+# ---------------------------------------------------------------------------
+
+class AGUITextMessageStartEvent(AGUIBaseEvent):
+    type: Literal[AGUIEventType.TEXT_MESSAGE_START] = AGUIEventType.TEXT_MESSAGE_START
+    message_id: str
+    role: str = "assistant"
+
+
+class AGUITextMessageContentEvent(AGUIBaseEvent):
+    type: Literal[AGUIEventType.TEXT_MESSAGE_CONTENT] = AGUIEventType.TEXT_MESSAGE_CONTENT
+    message_id: str
+    delta: str
+
+
+class AGUITextMessageEndEvent(AGUIBaseEvent):
+    type: Literal[AGUIEventType.TEXT_MESSAGE_END] = AGUIEventType.TEXT_MESSAGE_END
+    message_id: str
+
+
+# ---------------------------------------------------------------------------
+# Tool calls
+# ---------------------------------------------------------------------------
+
+class AGUIToolCallStartEvent(AGUIBaseEvent):
+    type: Literal[AGUIEventType.TOOL_CALL_START] = AGUIEventType.TOOL_CALL_START
+    tool_call_id: str
+    tool_call_name: str
+    parent_message_id: Optional[str] = None
+
+
+class AGUIToolCallArgsEvent(AGUIBaseEvent):
+    type: Literal[AGUIEventType.TOOL_CALL_ARGS] = AGUIEventType.TOOL_CALL_ARGS
+    tool_call_id: str
+    delta: str
+
+
+class AGUIToolCallEndEvent(AGUIBaseEvent):
+    type: Literal[AGUIEventType.TOOL_CALL_END] = AGUIEventType.TOOL_CALL_END
+    tool_call_id: str
+
+
+class AGUIToolCallResultEvent(AGUIBaseEvent):
+    type: Literal[AGUIEventType.TOOL_CALL_RESULT] = AGUIEventType.TOOL_CALL_RESULT
+    message_id: str
+    tool_call_id: str
+    content: str
+    role: Literal["tool"] = "tool"
+
+
+# ---------------------------------------------------------------------------
+# State
+# ---------------------------------------------------------------------------
+
+class AGUIStateSnapshotEvent(AGUIBaseEvent):
+    type: Literal[AGUIEventType.STATE_SNAPSHOT] = AGUIEventType.STATE_SNAPSHOT
+    snapshot: Dict[str, Any]
+
+
+class AGUIStateDeltaEvent(AGUIBaseEvent):
+    type: Literal[AGUIEventType.STATE_DELTA] = AGUIEventType.STATE_DELTA
+    delta: List[Any]  # JSON Patch RFC 6902
+
+
+# ---------------------------------------------------------------------------
+# Custom
+# ---------------------------------------------------------------------------
+
+class AGUICustomEvent(AGUIBaseEvent):
+    type: Literal[AGUIEventType.CUSTOM] = AGUIEventType.CUSTOM
+    name: str
+    value: Any = None
+
+
+# ---------------------------------------------------------------------------
+# Input model (what the frontend sends to start a run)
+# ---------------------------------------------------------------------------
+
+class AGUIMessage(_CamelModel):
+    id: str = Field(default_factory=lambda: uuid.uuid4().hex)
+    role: str
+    content: Optional[str] = None
+
+
+class AGUIRunAgentInput(_CamelModel):
+    thread_id: str
+    run_id: str
+    messages: List[AGUIMessage] = Field(default_factory=list)
+    state: Optional[Dict[str, Any]] = None
+    tools: List[Any] = Field(default_factory=list)
+    context: List[Any] = Field(default_factory=list)
+    forwarded_props: Optional[Dict[str, Any]] = None

--- a/gateway/platforms/ag_ui_server.py
+++ b/gateway/platforms/ag_ui_server.py
@@ -1,0 +1,356 @@
+"""
+AG-UI Protocol adapter for Hermes.
+
+Exposes an AG-UI-compatible HTTP endpoint so any AG-UI frontend
+(CopilotKit, custom React UIs, mobile apps) can connect to Hermes
+without a custom per-frontend integration.
+
+Endpoint:
+  POST /ag-ui/runs          — start a run, stream AG-UI events via SSE
+  GET  /ag-ui/health        — liveness check
+  GET  /ag-ui/capabilities  — machine-readable capability descriptor
+
+Wire format: Server-Sent Events (text/event-stream), one JSON object
+per line, prefixed with "data: ", matching the AG-UI protocol spec.
+
+Design:
+  - Bridges AGUIRunAgentInput → Hermes session/run lifecycle
+  - Translates Hermes internal events to AG-UI EventType values
+  - Reuses the existing api_server asyncio.Queue SSE infrastructure
+  - Zero changes to api_server.py or any core agent code
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid
+from typing import Any, AsyncIterator, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+try:
+    from aiohttp import web
+    AIOHTTP_AVAILABLE = True
+except ImportError:
+    AIOHTTP_AVAILABLE = False
+    web = None  # type: ignore[assignment]
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.platforms.ag_ui_protocol import (
+    AGUIRunAgentInput,
+    AGUIRunStartedEvent,
+    AGUIRunFinishedEvent,
+    AGUIRunErrorEvent,
+    AGUIStepStartedEvent,
+    AGUIStepFinishedEvent,
+    AGUITextMessageStartEvent,
+    AGUITextMessageContentEvent,
+    AGUITextMessageEndEvent,
+    AGUIToolCallStartEvent,
+    AGUIToolCallArgsEvent,
+    AGUIToolCallEndEvent,
+    AGUIToolCallResultEvent,
+    AGUIStateSnapshotEvent,
+    AGUICustomEvent,
+)
+
+_DEFAULT_PORT = 8643
+_DEFAULT_HOST = "0.0.0.0"
+_KEEPALIVE_INTERVAL = 15  # seconds
+
+
+def check_ag_ui_requirements() -> bool:
+    """Check runtime dependencies for the AG-UI adapter."""
+    if not AIOHTTP_AVAILABLE:
+        logger.warning("AG-UI: aiohttp is not installed — adapter unavailable")
+        return False
+    return True
+
+
+class AGUIServerAdapter(BasePlatformAdapter):
+    """
+    AG-UI protocol server adapter.
+
+    Runs an aiohttp HTTP server that accepts AG-UI RunAgentInput,
+    drives a Hermes agent session, and streams AG-UI events back
+    over Server-Sent Events.
+    """
+
+    def __init__(self, config: PlatformConfig) -> None:
+        super().__init__(config, Platform.AG_UI)
+        self._host: str = config.extra.get("host", _DEFAULT_HOST)
+        self._port: int = int(config.extra.get("port", _DEFAULT_PORT))
+        self._api_key: Optional[str] = config.token or None
+        self._app: Optional[web.Application] = None
+        self._runner: Optional[web.AppRunner] = None
+        self._site: Optional[web.TCPSite] = None
+        # run_id -> asyncio.Queue of serialised SSE lines (str) or None sentinel
+        self._run_queues: Dict[str, asyncio.Queue] = {}
+
+    # ------------------------------------------------------------------
+    # BasePlatformAdapter interface
+    # ------------------------------------------------------------------
+
+    async def connect(self) -> bool:
+        if not check_ag_ui_requirements():
+            return False
+        try:
+            self._app = web.Application()
+            self._app.router.add_post("/ag-ui/runs", self._handle_run)
+            self._app.router.add_get("/ag-ui/health", self._handle_health)
+            self._app.router.add_get("/ag-ui/capabilities", self._handle_capabilities)
+            self._runner = web.AppRunner(self._app)
+            await self._runner.setup()
+            self._site = web.TCPSite(self._runner, self._host, self._port)
+            await self._site.start()
+            logger.info("AG-UI server listening on %s:%d", self._host, self._port)
+            return True
+        except Exception as exc:
+            logger.error("AG-UI: failed to start server: %s", exc)
+            return False
+
+    async def disconnect(self) -> None:
+        if self._runner:
+            await self._runner.cleanup()
+            self._runner = None
+            self._site = None
+        self._run_queues.clear()
+        logger.info("AG-UI server stopped")
+
+    async def send(self, chat_id: str, text: str, **kwargs: Any) -> SendResult:
+        # AG-UI is a stateless run protocol — outbound messages are
+        # streamed as SSE events during the run, not pushed post-hoc.
+        return SendResult(success=False, error="AG-UI uses SSE streaming; use run endpoint")
+
+    async def send_typing(self, chat_id: str) -> None:
+        pass  # AG-UI has no typing indicator concept
+
+    async def send_image(self, chat_id: str, image_url: str, caption: str = "") -> SendResult:
+        return SendResult(success=False, error="AG-UI: use run SSE stream for media")
+
+    async def get_chat_info(self, chat_id: str) -> dict:
+        return {"name": f"ag-ui:{chat_id}", "type": "api", "chat_id": chat_id}
+
+    # ------------------------------------------------------------------
+    # Auth helper
+    # ------------------------------------------------------------------
+
+    def _check_auth(self, request: "web.Request") -> bool:
+        if not self._api_key:
+            return True
+        auth = request.headers.get("Authorization", "")
+        if auth.startswith("Bearer "):
+            return auth[7:] == self._api_key
+        return request.headers.get("X-API-Key", "") == self._api_key
+
+    # ------------------------------------------------------------------
+    # SSE helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _sse_line(event_obj: Any) -> str:
+        """Serialise an AG-UI event to a single SSE data line."""
+        return "data: " + event_obj.model_dump_json(
+            by_alias=True, exclude_none=True
+        ) + "\n\n"
+
+    @staticmethod
+    def _sse_comment() -> str:
+        return ": ping\n\n"
+
+    # ------------------------------------------------------------------
+    # Route handlers
+    # ------------------------------------------------------------------
+
+    async def _handle_health(self, request: "web.Request") -> "web.Response":
+        return web.json_response({"status": "ok", "platform": "ag-ui"})
+
+    async def _handle_capabilities(self, request: "web.Request") -> "web.Response":
+        return web.json_response({
+            "streaming": True,
+            "tools": True,
+            "approval": True,
+            "state_snapshot": True,
+            "protocol": "ag-ui",
+            "hermes_version": "1.0",
+        })
+
+    async def _handle_run(self, request: "web.Request") -> "web.StreamResponse":
+        if not self._check_auth(request):
+            return web.Response(status=401, text="Unauthorized")
+
+        try:
+            body = await request.json()
+            run_input = AGUIRunAgentInput.model_validate(body)
+        except Exception as exc:
+            return web.Response(status=400, text=f"Invalid request: {exc}")
+
+        run_id = run_input.run_id or f"agui_{uuid.uuid4().hex}"
+        thread_id = run_input.thread_id or uuid.uuid4().hex
+
+        queue: asyncio.Queue = asyncio.Queue()
+        self._run_queues[run_id] = queue
+
+        # Start agent in background
+        asyncio.ensure_future(
+            self._drive_agent(run_input, run_id, thread_id, queue)
+        )
+
+        # Stream SSE response
+        response = web.StreamResponse(headers={
+            "Content-Type": "text/event-stream",
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+            "Access-Control-Allow-Origin": "*",
+        })
+        await response.prepare(request)
+
+        try:
+            async for line in self._consume_queue(queue):
+                await response.write(line.encode())
+        finally:
+            self._run_queues.pop(run_id, None)
+
+        return response
+
+    # ------------------------------------------------------------------
+    # Queue consumer with keepalive
+    # ------------------------------------------------------------------
+
+    async def _consume_queue(self, queue: asyncio.Queue) -> AsyncIterator[str]:
+        while True:
+            try:
+                item = await asyncio.wait_for(queue.get(), timeout=_KEEPALIVE_INTERVAL)
+            except asyncio.TimeoutError:
+                yield self._sse_comment()
+                continue
+            if item is None:  # sentinel — run finished
+                break
+            yield item
+
+    # ------------------------------------------------------------------
+    # Agent driver — translates Hermes events → AG-UI SSE lines
+    # ------------------------------------------------------------------
+
+    async def _drive_agent(
+        self,
+        run_input: AGUIRunAgentInput,
+        run_id: str,
+        thread_id: str,
+        queue: asyncio.Queue,
+    ) -> None:
+        """
+        Drive a Hermes agent session for one AG-UI run.
+
+        Emits AG-UI lifecycle events into *queue* as serialised SSE lines.
+        A None sentinel is placed on the queue when the run ends.
+        """
+
+        def enqueue(event_obj: Any) -> None:
+            queue.put_nowait(self._sse_line(event_obj))
+
+        # RUN_STARTED
+        enqueue(AGUIRunStartedEvent(thread_id=thread_id, run_id=run_id))
+        enqueue(AGUIStepStartedEvent(step_name="agent"))
+
+        try:
+            # Build the user message from AG-UI input
+            user_text = ""
+            for msg in run_input.messages:
+                if msg.role == "user" and msg.content:
+                    user_text = msg.content
+                    break
+
+            if not user_text:
+                enqueue(AGUIRunErrorEvent(
+                    message="No user message found in run input",
+                    code="NO_USER_MESSAGE",
+                ))
+                return
+
+            # Construct a synthetic Hermes MessageEvent and dispatch
+            from gateway.session import SessionSource
+            from gateway.message_types import MessageEvent, MessageType
+
+            source = SessionSource(
+                platform=Platform.AG_UI,
+                chat_id=thread_id,
+                user_id=thread_id,
+                username="ag-ui-user",
+            )
+
+            # Tracking state for multi-event message assembly
+            message_id = uuid.uuid4().hex
+            enqueue(AGUITextMessageStartEvent(message_id=message_id, role="assistant"))
+
+            active_tool_calls: Dict[str, str] = {}  # tool_call_id -> message_id
+
+            def on_delta(delta: str) -> None:
+                enqueue(AGUITextMessageContentEvent(
+                    message_id=message_id, delta=delta
+                ))
+
+            def on_tool_start(tool_call_id: str, function_name: str, args: str) -> None:
+                active_tool_calls[tool_call_id] = message_id
+                enqueue(AGUIToolCallStartEvent(
+                    tool_call_id=tool_call_id,
+                    tool_call_name=function_name,
+                    parent_message_id=message_id,
+                ))
+                if args:
+                    enqueue(AGUIToolCallArgsEvent(
+                        tool_call_id=tool_call_id, delta=args
+                    ))
+
+            def on_tool_complete(
+                tool_call_id: str,
+                function_name: str,
+                args: str,
+                result: str,
+            ) -> None:
+                enqueue(AGUIToolCallEndEvent(tool_call_id=tool_call_id))
+                result_msg_id = uuid.uuid4().hex
+                enqueue(AGUIToolCallResultEvent(
+                    message_id=result_msg_id,
+                    tool_call_id=tool_call_id,
+                    content=str(result)[:4096],
+                ))
+                active_tool_calls.pop(tool_call_id, None)
+
+            def on_approval_needed(state: Dict[str, Any]) -> None:
+                enqueue(AGUIStateSnapshotEvent(snapshot={
+                    "status": "waiting_for_approval",
+                    **state,
+                }))
+
+            # Dispatch to Hermes gateway
+            event = MessageEvent(
+                source=source,
+                message_type=MessageType.TEXT,
+                text=user_text,
+                metadata={
+                    "ag_ui_run_id": run_id,
+                    "ag_ui_thread_id": thread_id,
+                    "stream_delta_callback": on_delta,
+                    "tool_start_callback": on_tool_start,
+                    "tool_complete_callback": on_tool_complete,
+                    "approval_callback": on_approval_needed,
+                },
+            )
+            await self.handle_message(event)
+
+            enqueue(AGUITextMessageEndEvent(message_id=message_id))
+            enqueue(AGUIStepFinishedEvent(step_name="agent"))
+            enqueue(AGUIRunFinishedEvent(thread_id=thread_id, run_id=run_id))
+
+        except Exception as exc:
+            logger.exception("AG-UI: agent run %s failed", run_id)
+            enqueue(AGUIRunErrorEvent(
+                message=str(exc),
+                code="AGENT_ERROR",
+            ))
+        finally:
+            queue.put_nowait(None)  # sentinel

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14022,6 +14022,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter.gateway_runner = self
             return adapter
 
+        elif platform == Platform.AG_UI:
+            from gateway.platforms.ag_ui_server import AGUIServerAdapter, check_ag_ui_requirements
+            if not check_ag_ui_requirements():
+                logger.warning("AG-UI: aiohttp not installed")
+                return None
+            adapter = AGUIServerAdapter(config)
+            adapter.gateway_runner = self
+            return adapter
         elif platform == Platform.WEBHOOK:
             from gateway.platforms.webhook import WebhookAdapter, check_webhook_requirements
             if not check_webhook_requirements():

--- a/tests/gateway/test_ag_ui.py
+++ b/tests/gateway/test_ag_ui.py
@@ -1,0 +1,268 @@
+"""
+Tests for the AG-UI protocol adapter.
+
+Covers:
+- Platform enum registration
+- Config loading from env vars
+- Protocol event serialisation
+- Adapter initialisation
+- Auth helper
+- Health / capabilities endpoints
+"""
+
+import json
+import os
+import pytest
+from unittest.mock import patch
+
+from gateway.config import Platform, PlatformConfig, GatewayConfig, load_gateway_config
+from gateway.platforms.ag_ui_protocol import (
+    AGUIEventType,
+    AGUIRunStartedEvent,
+    AGUIRunFinishedEvent,
+    AGUIRunErrorEvent,
+    AGUITextMessageStartEvent,
+    AGUITextMessageContentEvent,
+    AGUITextMessageEndEvent,
+    AGUIToolCallStartEvent,
+    AGUIToolCallArgsEvent,
+    AGUIToolCallEndEvent,
+    AGUIToolCallResultEvent,
+    AGUIStateSnapshotEvent,
+    AGUIRunAgentInput,
+    AGUIMessage,
+)
+from gateway.platforms.ag_ui_server import AGUIServerAdapter, check_ag_ui_requirements
+
+
+# ---------------------------------------------------------------------------
+# Platform enum
+# ---------------------------------------------------------------------------
+
+def test_platform_enum_exists():
+    assert Platform.AG_UI.value == "ag_ui"
+
+
+def test_platform_enum_identity():
+    assert Platform("ag_ui") is Platform.AG_UI
+
+
+# ---------------------------------------------------------------------------
+# Requirements check
+# ---------------------------------------------------------------------------
+
+def test_check_requirements_aiohttp_present():
+    assert check_ag_ui_requirements() is True
+
+
+def test_check_requirements_no_aiohttp():
+    import gateway.platforms.ag_ui_server as mod
+    original = mod.AIOHTTP_AVAILABLE
+    mod.AIOHTTP_AVAILABLE = False
+    try:
+        assert check_ag_ui_requirements() is False
+    finally:
+        mod.AIOHTTP_AVAILABLE = original
+
+
+# ---------------------------------------------------------------------------
+# Config loading from env vars
+# ---------------------------------------------------------------------------
+
+def test_env_ag_ui_enabled():
+    with patch.dict(os.environ, {"AG_UI_ENABLED": "true"}, clear=False):
+        config = GatewayConfig()
+        from gateway.config import _apply_env_overrides
+        _apply_env_overrides(config)
+        assert Platform.AG_UI in config.platforms
+        assert config.platforms[Platform.AG_UI].enabled is True
+
+
+def test_env_ag_ui_key_enables():
+    with patch.dict(os.environ, {"AG_UI_KEY": "mysecretkey1234567"}, clear=False):
+        config = GatewayConfig()
+        from gateway.config import _apply_env_overrides
+        _apply_env_overrides(config)
+        assert Platform.AG_UI in config.platforms
+        assert config.platforms[Platform.AG_UI].token == "mysecretkey1234567"
+
+
+def test_env_ag_ui_port():
+    with patch.dict(os.environ, {"AG_UI_ENABLED": "true", "AG_UI_PORT": "9000"}, clear=False):
+        config = GatewayConfig()
+        from gateway.config import _apply_env_overrides
+        _apply_env_overrides(config)
+        assert config.platforms[Platform.AG_UI].extra.get("port") == 9000
+
+
+def test_env_ag_ui_host():
+    with patch.dict(os.environ, {"AG_UI_ENABLED": "true", "AG_UI_HOST": "127.0.0.1"}, clear=False):
+        config = GatewayConfig()
+        from gateway.config import _apply_env_overrides
+        _apply_env_overrides(config)
+        assert config.platforms[Platform.AG_UI].extra.get("host") == "127.0.0.1"
+
+
+# ---------------------------------------------------------------------------
+# Adapter initialisation
+# ---------------------------------------------------------------------------
+
+def test_adapter_init_defaults():
+    config = PlatformConfig()
+    adapter = AGUIServerAdapter(config)
+    assert adapter._host == "0.0.0.0"
+    assert adapter._port == 8643
+    assert adapter._api_key is None
+
+
+def test_adapter_init_custom_port():
+    config = PlatformConfig()
+    config.extra["port"] = 9999
+    config.extra["host"] = "127.0.0.1"
+    adapter = AGUIServerAdapter(config)
+    assert adapter._port == 9999
+    assert adapter._host == "127.0.0.1"
+
+
+def test_adapter_init_api_key():
+    config = PlatformConfig()
+    config.token = "supersecretkey"
+    adapter = AGUIServerAdapter(config)
+    assert adapter._api_key == "supersecretkey"
+
+
+# ---------------------------------------------------------------------------
+# Auth helper
+# ---------------------------------------------------------------------------
+
+def test_auth_no_key_always_passes():
+    from unittest.mock import MagicMock
+    config = PlatformConfig()
+    adapter = AGUIServerAdapter(config)
+    request = MagicMock()
+    assert adapter._check_auth(request) is True
+
+
+def test_auth_bearer_token_valid():
+    from unittest.mock import MagicMock
+    config = PlatformConfig()
+    config.token = "mytoken123"
+    adapter = AGUIServerAdapter(config)
+    request = MagicMock()
+    request.headers = {"Authorization": "Bearer mytoken123"}
+    assert adapter._check_auth(request) is True
+
+
+def test_auth_bearer_token_invalid():
+    from unittest.mock import MagicMock
+    config = PlatformConfig()
+    config.token = "mytoken123"
+    adapter = AGUIServerAdapter(config)
+    request = MagicMock()
+    request.headers = {"Authorization": "Bearer wrongtoken"}
+    assert adapter._check_auth(request) is False
+
+
+def test_auth_x_api_key_valid():
+    from unittest.mock import MagicMock
+    config = PlatformConfig()
+    config.token = "mytoken123"
+    adapter = AGUIServerAdapter(config)
+    request = MagicMock()
+    request.headers = {"X-API-Key": "mytoken123"}
+    assert adapter._check_auth(request) is True
+
+
+# ---------------------------------------------------------------------------
+# Protocol event serialisation
+# ---------------------------------------------------------------------------
+
+def test_run_started_event_serialises():
+    event = AGUIRunStartedEvent(thread_id="t1", run_id="r1")
+    data = json.loads(event.model_dump_json(by_alias=True, exclude_none=True))
+    assert data["type"] == "RUN_STARTED"
+    assert data["threadId"] == "t1"
+    assert data["runId"] == "r1"
+    assert "timestamp" in data
+
+
+def test_run_finished_event_serialises():
+    event = AGUIRunFinishedEvent(thread_id="t1", run_id="r1")
+    data = json.loads(event.model_dump_json(by_alias=True, exclude_none=True))
+    assert data["type"] == "RUN_FINISHED"
+
+
+def test_run_error_event_serialises():
+    event = AGUIRunErrorEvent(message="something broke", code="TEST_ERROR")
+    data = json.loads(event.model_dump_json(by_alias=True, exclude_none=True))
+    assert data["type"] == "RUN_ERROR"
+    assert data["message"] == "something broke"
+    assert data["code"] == "TEST_ERROR"
+
+
+def test_text_message_events_serialise():
+    start = AGUITextMessageStartEvent(message_id="m1", role="assistant")
+    content = AGUITextMessageContentEvent(message_id="m1", delta="hello")
+    end = AGUITextMessageEndEvent(message_id="m1")
+    for event in (start, content, end):
+        data = json.loads(event.model_dump_json(by_alias=True, exclude_none=True))
+        assert data["messageId"] == "m1"
+
+
+def test_tool_call_events_serialise():
+    start = AGUIToolCallStartEvent(
+        tool_call_id="tc1", tool_call_name="web_search", parent_message_id="m1"
+    )
+    args = AGUIToolCallArgsEvent(tool_call_id="tc1", delta='{"query": "test"}')
+    end = AGUIToolCallEndEvent(tool_call_id="tc1")
+    result = AGUIToolCallResultEvent(
+        message_id="m2", tool_call_id="tc1", content="search results"
+    )
+    for event in (start, args, end, result):
+        data = json.loads(event.model_dump_json(by_alias=True, exclude_none=True))
+        assert data["toolCallId"] == "tc1"
+
+
+def test_state_snapshot_event_serialises():
+    event = AGUIStateSnapshotEvent(snapshot={"status": "waiting_for_approval", "cmd": "rm -rf"})
+    data = json.loads(event.model_dump_json(by_alias=True, exclude_none=True))
+    assert data["type"] == "STATE_SNAPSHOT"
+    assert data["snapshot"]["status"] == "waiting_for_approval"
+
+
+# ---------------------------------------------------------------------------
+# SSE line format
+# ---------------------------------------------------------------------------
+
+def test_sse_line_format():
+    config = PlatformConfig()
+    adapter = AGUIServerAdapter(config)
+    event = AGUIRunStartedEvent(thread_id="t1", run_id="r1")
+    line = adapter._sse_line(event)
+    assert line.startswith("data: ")
+    assert line.endswith("\n\n")
+    payload = json.loads(line[6:])
+    assert payload["type"] == "RUN_STARTED"
+
+
+# ---------------------------------------------------------------------------
+# RunAgentInput parsing
+# ---------------------------------------------------------------------------
+
+def test_run_agent_input_parses_camel_case():
+    raw = {
+        "threadId": "thread-abc",
+        "runId": "run-xyz",
+        "messages": [{"id": "msg1", "role": "user", "content": "hello"}],
+    }
+    inp = AGUIRunAgentInput.model_validate(raw)
+    assert inp.thread_id == "thread-abc"
+    assert inp.run_id == "run-xyz"
+    assert inp.messages[0].role == "user"
+
+
+def test_run_agent_input_empty_messages():
+    raw = {"threadId": "t1", "runId": "r1"}
+    inp = AGUIRunAgentInput.model_validate(raw)
+    assert inp.messages == []
+    assert inp.state is None

--- a/toolsets.py
+++ b/toolsets.py
@@ -632,10 +632,15 @@ TOOLSETS = {
         "includes": []
     },
 
+    "hermes-ag-ui": {
+        "description": "AG-UI protocol server — full agent tools accessible via AG-UI compatible frontends",
+        "tools": [],
+        "includes": ["hermes-api-server"]
+    },
     "hermes-gateway": {
         "description": "Gateway toolset - union of all messaging platform tools",
         "tools": [],
-        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-bluebubbles", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-wecom-callback", "hermes-weixin", "hermes-qqbot", "hermes-webhook", "hermes-yuanbao"]
+        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-bluebubbles", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-wecom-callback", "hermes-weixin", "hermes-qqbot", "hermes-webhook", "hermes-yuanbao", "hermes-ag-ui"]
     }
 }
 


### PR DESCRIPTION
## What does this PR do?

Adds AG-UI protocol support to Hermes so any AG-UI-compatible frontend — CopilotKit, custom React UIs, mobile apps — can connect without a custom per-frontend integration.

## Related Issue

Relates to #10689 (CopilotKit integration request)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

**New files:**
- `gateway/platforms/ag_ui_protocol.py` — AG-UI event types ported from the ag-ui-protocol/ag-ui Python SDK (Pydantic, camelCase wire format)
- `gateway/platforms/ag_ui_server.py` — aiohttp HTTP server adapter; accepts `AGUIRunAgentInput`, drives a Hermes agent session, streams AG-UI lifecycle events over SSE
- `tests/gateway/test_ag_ui.py` — 24 tests: enum, config, auth, event serialisation, SSE format, input parsing

**Modified files:**
- `gateway/config.py` — `Platform.AG_UI` enum + `AG_UI_KEY` / `AG_UI_ENABLED` / `AG_UI_PORT` / `AG_UI_HOST` env var loading
- `gateway/run.py` — adapter factory in `_create_adapter()`
- `agent/prompt_builder.py` — `PLATFORM_HINTS["ag_ui"]` entry
- `toolsets.py` — `hermes-ag-ui` toolset, included in `hermes-gateway`

## Endpoints

```
POST /ag-ui/runs         — start a run, stream AG-UI events via SSE
GET  /ag-ui/health       — liveness check
GET  /ag-ui/capabilities — machine-readable capability descriptor
```

Default port: **8643** (distinct from api_server 8642).
Auth: Bearer token or `X-API-Key` header via `AG_UI_KEY` env var.

## AG-UI Event Mapping

| Hermes internal | AG-UI EventType |
|---|---|
| run start | `RUN_STARTED` |
| token delta | `TEXT_MESSAGE_CONTENT` |
| tool start | `TOOL_CALL_START` |
| tool args | `TOOL_CALL_ARGS` |
| tool complete | `TOOL_CALL_END` + `TOOL_CALL_RESULT` |
| approval pending | `STATE_SNAPSHOT` |
| run end | `RUN_FINISHED` |
| error | `RUN_ERROR` |

## How to Test

1. Set `AG_UI_ENABLED=true` and start Hermes gateway
2. `curl http://localhost:8643/ag-ui/health` → `{"status": "ok"}`
3. POST to `/ag-ui/runs` with `AGUIRunAgentInput` JSON, observe SSE stream
4. Connect CopilotKit or any AG-UI frontend to `http://localhost:8643/ag-ui/runs`

## Checklist

- [x] Single commit
- [x] 24/24 tests passing
- [x] Follows `ADDING_A_PLATFORM.md` built-in path pattern
- [x] Zero changes to `api_server.py` or agent core