### PR TITLE
fix(whatsapp): carry latest message id in rapid text merge paths (#59582)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2515,6 +2515,15 @@ def merge_pending_message_event(
         ):
             if event.text:
                 existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
+            # The merged event represents the latest inbound message for
+            # reply-anchor purposes; otherwise the bot's reply quotes an
+            # earlier message in the burst (issue #59582).
+            latest_message_id = getattr(event, "message_id", None)
+            latest_anchor = latest_message_id or getattr(event, "reply_to_message_id", None)
+            if latest_message_id is not None:
+                existing.message_id = str(latest_message_id)
+            if latest_anchor is not None and hasattr(existing, "reply_to_message_id"):
+                existing.reply_to_message_id = str(latest_anchor)
             return
 
     pending_messages[session_key] = event

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1409,6 +1409,14 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             if event.text:
                 existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
             existing._last_chunk_len = chunk_len  # type: ignore[attr-defined]
+            # Rapid-fire text bursts must reply-anchor to the latest chunk,
+            # otherwise the bot's reply quotes an earlier message (issue #59582).
+            latest_message_id = getattr(event, "message_id", None)
+            latest_anchor = latest_message_id or getattr(event, "reply_to_message_id", None)
+            if latest_message_id is not None:
+                existing.message_id = str(latest_message_id)
+            if latest_anchor is not None and hasattr(existing, "reply_to_message_id"):
+                existing.reply_to_message_id = str(latest_anchor)
             if event.media_urls:
                 existing.media_urls.extend(event.media_urls)
                 existing.media_types.extend(event.media_types)

--- a/tests/gateway/test_text_batching.py
+++ b/tests/gateway/test_text_batching.py
@@ -9,12 +9,18 @@ Telegram and Feishu.
 """
 
 import asyncio
+from typing import Optional
 from unittest.mock import AsyncMock
 
 import pytest
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import MessageEvent, MessageType, SessionSource
+from gateway.platforms.base import (
+    MessageEvent,
+    MessageType,
+    SessionSource,
+    merge_pending_message_event,
+)
 
 
 # =====================================================================
@@ -26,11 +32,15 @@ def _make_event(
     platform: Platform,
     chat_id: str = "12345",
     msg_type: MessageType = MessageType.TEXT,
+    msg_id: Optional[str] = None,
+    reply_to_id: Optional[str] = None,
 ) -> MessageEvent:
     return MessageEvent(
         text=text,
         message_type=msg_type,
         source=SessionSource(platform=platform, chat_id=chat_id, chat_type="dm"),
+        message_id=msg_id,
+        reply_to_message_id=reply_to_id,
     )
 
 
@@ -272,5 +282,114 @@ class TestFeishuAdaptiveDelay:
 
         await asyncio.sleep(0.15)
         adapter._handle_message_with_guards.assert_called_once()
+
+
+# =====================================================================
+# Busy-session text merge keeps the latest message id as the reply anchor
+# =====================================================================
+
+class TestMergePendingMessageEventLatestIdentity:
+    def test_text_merge_carries_latest_message_id_and_reply_anchor(self):
+        """When two text events are merged, the resulting event's message_id
+        and reply_to_message_id must reflect the LATEST chunk so the bot's
+        reply quotes the newest user message, not the first one (#59582)."""
+        from gateway.platforms.base import build_session_key
+
+        first = _make_event("first part", Platform.WHATSAPP, msg_id="wamid.A")
+        second = _make_event("second part", Platform.WHATSAPP, msg_id="wamid.B")
+        pending: dict[str, MessageEvent] = {}
+        sk = build_session_key(first.source)
+
+        merge_pending_message_event(pending, sk, first, merge_text=True)
+        merge_pending_message_event(pending, sk, second, merge_text=True)
+
+        merged = pending[sk]
+        assert merged.text == "first part\nsecond part"
+        assert merged.message_id == "wamid.B"
+        assert merged.reply_to_message_id == "wamid.B"
+
+    def test_text_merge_falls_back_to_latest_reply_anchor(self):
+        """A later chunk with no message_id of its own but a reply_to anchor
+        still upgrades the merged event's reply anchor."""
+        from gateway.platforms.base import build_session_key
+
+        first = _make_event("first part", Platform.WHATSAPP, msg_id="wamid.A")
+        second = _make_event(
+            "second part",
+            Platform.WHATSAPP,
+            msg_id=None,
+            reply_to_id="wamid.PRIOR",
+        )
+        pending: dict[str, MessageEvent] = {}
+        sk = build_session_key(first.source)
+
+        merge_pending_message_event(pending, sk, first, merge_text=True)
+        merge_pending_message_event(pending, sk, second, merge_text=True)
+
+        merged = pending[sk]
+        assert merged.message_id == "wamid.A"
+        assert merged.reply_to_message_id == "wamid.PRIOR"
+
+
+# =====================================================================
+# WhatsApp (Baileys bridge) text batching
+# =====================================================================
+
+def _make_whatsapp_adapter():
+    """Create a minimal WhatsAppAdapter for testing text batching."""
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    config = PlatformConfig(enabled=True, token="test-token")
+    adapter = object.__new__(WhatsAppAdapter)
+    adapter._platform = Platform.WHATSAPP
+    adapter.config = config
+    adapter._pending_text_batches = {}
+    adapter._pending_text_batch_tasks = {}
+    adapter._text_batch_delay_seconds = 0.1
+    adapter._text_batch_split_delay_seconds = 0.3
+    adapter._active_sessions = {}
+    adapter._pending_messages = {}
+    adapter._message_handler = AsyncMock()
+    adapter.handle_message = AsyncMock()
+    return adapter
+
+
+class TestWhatsAppTextBatching:
+    @pytest.mark.asyncio
+    async def test_single_message_dispatched_after_delay(self):
+        adapter = _make_whatsapp_adapter()
+        event = _make_event("hello world", Platform.WHATSAPP)
+
+        adapter._enqueue_text_event(event)
+
+        adapter.handle_message.assert_not_called()
+        await asyncio.sleep(0.2)
+
+        adapter.handle_message.assert_called_once()
+        assert adapter.handle_message.call_args[0][0].text == "hello world"
+
+    @pytest.mark.asyncio
+    async def test_split_messages_aggregated_with_latest_message_id(self):
+        """Two rapid WhatsApp messages should be merged, and the merged event
+        must carry the latest message_id as the reply anchor (#59582)."""
+        adapter = _make_whatsapp_adapter()
+
+        adapter._enqueue_text_event(
+            _make_event("first part", Platform.WHATSAPP, msg_id="wamid.A")
+        )
+        await asyncio.sleep(0.02)
+        adapter._enqueue_text_event(
+            _make_event("second part", Platform.WHATSAPP, msg_id="wamid.B")
+        )
+
+        adapter.handle_message.assert_not_called()
+        await asyncio.sleep(0.2)
+
+        adapter.handle_message.assert_called_once()
+        dispatched = adapter.handle_message.call_args[0][0]
+        assert "first part" in dispatched.text
+        assert "second part" in dispatched.text
+        assert dispatched.message_id == "wamid.B"
+        assert dispatched.reply_to_message_id == "wamid.B"
 
 


### PR DESCRIPTION
## What does this PR do?

When WhatsApp delivers rapid-fire text messages (e.g. forwarded batches), the bot's reply now anchors to the latest inbound message instead of quoting an earlier message in the burst. The merged event's `message_id` and `reply_to_message_id` are updated to the newest message in both the base adapter merge path and the WhatsApp text batch path.

## Related Issue

Fixes #59582

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `gateway/platforms/base.py`: `merge_pending_message_event` updates `message_id` and `reply_to_message_id` to the latest inbound message when merging text events.
- `plugins/platforms/whatsapp/adapter.py`: `_enqueue_text_event` applies the same reply-anchor update in the WhatsApp rapid-fire text batch merge path.
- Tests for text batching reply anchor behavior.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_text_batching.py` — batching tests pass.
2. Full project checker passes.

## Checklist

- [x] Code follows the project's style and conventions
- [x] Self-review completed
- [x] Tests added/updated and passing