### PR TITLE
feat(telegram): add bidirectional contextual reactions

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -132,6 +132,13 @@ def _mark_notify_metadata(metadata: dict | None) -> dict:
     return notify_metadata
 
 
+def _is_deferred_followup_event(event) -> bool:
+    """Return true for events that must queue and cannot answer prompts."""
+    return bool(getattr(event, "internal", False)) or bool(
+        (getattr(event, "metadata", None) or {}).get("deferred_followup_event")
+    )
+
+
 def _reply_anchor_for_event(event) -> str | None:
     """Return reply_to id for platforms that need reply semantics.
 
@@ -6042,7 +6049,7 @@ class BasePlatformAdapter(ABC):
             # Same shape as the /approve deadlock fix (PR #4926) — both
             # cases are "agent thread blocked on Event.wait, message must
             # reach the resolver before being treated as a new turn."
-            if not cmd:
+            if not cmd and not _is_deferred_followup_event(event):
                 try:
                     from tools import clarify_gateway as _clarify_mod
                     _has_text_clarify = (
@@ -6186,7 +6193,8 @@ class BasePlatformAdapter(ABC):
         # typing_task stays None; _stop_typing_refresh already no-ops on None.
         _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
         typing_task: Optional[asyncio.Task] = None
-        if getattr(self.config, "typing_indicator", True):
+        if (getattr(self.config, "typing_indicator", True)
+                and not event.metadata.get("suppress_typing")):
             _keep_typing_kwargs: Dict[str, Any] = {"metadata": _thread_metadata}
             try:
                 _keep_typing_sig = inspect.signature(self._keep_typing)

--- a/gateway/rich_sent_store.py
+++ b/gateway/rich_sent_store.py
@@ -17,11 +17,14 @@ from __future__ import annotations
 
 import json
 import os
+import threading
 import time
 from typing import Optional
 
 _MAX_ENTRIES = 1000
 _MAX_TEXT_CHARS = 2000
+_MAX_AGE_SECONDS = 30 * 24 * 60 * 60
+_LOCK = threading.Lock()
 
 
 def _store_path() -> str:
@@ -36,9 +39,43 @@ def _key(chat_id, message_id) -> str:
     return f"{chat_id}:{message_id}"
 
 
-def record(chat_id, message_id, text: Optional[str]) -> None:
-    """Persist ``text`` for ``(chat_id, message_id)``. No-op on any failure."""
-    if not text or message_id is None or chat_id is None:
+def _timestamp(entry) -> float:
+    try:
+        return float(entry.get("ts", 0)) if isinstance(entry, dict) else 0.0
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _store_paths() -> list[tuple[str | None, str]]:
+    """Return default, current and named-profile index paths."""
+    from hermes_constants import get_default_hermes_root, get_hermes_home
+
+    root, current = get_default_hermes_root(), get_hermes_home()
+    paths = [
+        (None, root / "state" / "rich_sent_index.json"),
+        *((home.name, home / "state" / "rich_sent_index.json")
+          for home in sorted(root.glob("profiles/*")) if home.is_dir()),
+    ]
+    profile = current.name if current.parent == root / "profiles" else None
+    paths.append((profile, _store_path()))
+    return list({os.path.abspath(path): (profile, os.fspath(path))
+                 for profile, path in paths}.values())
+
+
+def record(
+    chat_id, message_id, text: Optional[str], *, thread_id=None, sender_id=None
+) -> None:
+    with _LOCK:
+        _record_unlocked(
+            chat_id, message_id, text, thread_id=thread_id, sender_id=sender_id
+        )
+
+
+def _record_unlocked(
+    chat_id, message_id, text: Optional[str], *, thread_id=None, sender_id=None
+) -> None:
+    """Persist text and optional reaction-routing metadata."""
+    if message_id is None or chat_id is None:
         return
     path = _store_path()
     try:
@@ -50,14 +87,19 @@ def record(chat_id, message_id, text: Optional[str]) -> None:
                 data = {}
         except (FileNotFoundError, ValueError):
             data = {}
-        data[_key(chat_id, message_id)] = {
-            "t": text[:_MAX_TEXT_CHARS],
-            "ts": int(time.time()),
-        }
+        key = _key(chat_id, message_id)
+        previous = data.get(key)
+        entry = dict(previous) if isinstance(previous, dict) else {}
+        entry.update({"t": (text or "")[:_MAX_TEXT_CHARS], "ts": int(time.time())})
+        if thread_id not in {None, ""}:
+            entry["thread_id"] = str(thread_id)
+        if sender_id not in {None, ""}:
+            entry["sender_id"] = str(sender_id)
+        data[key] = entry
         # Trim oldest by timestamp when over cap.
         if len(data) > _MAX_ENTRIES:
             for k, _ in sorted(
-                data.items(), key=lambda kv: kv[1].get("ts", 0)
+                data.items(), key=lambda kv: _timestamp(kv[1])
             )[: len(data) - _MAX_ENTRIES]:
                 data.pop(k, None)
         tmp = f"{path}.tmp.{os.getpid()}"
@@ -66,6 +108,26 @@ def record(chat_id, message_id, text: Optional[str]) -> None:
         os.replace(tmp, path)  # atomic; tolerates concurrent writers racing
     except Exception:
         return
+
+
+def lookup_entry(chat_id, message_id, *, all_profiles: bool = False) -> Optional[dict]:
+    """Return one unambiguous fresh entry, optionally searching every profile."""
+    if message_id is None or chat_id is None:
+        return None
+    now, matches = time.time(), []
+    for profile, path in _store_paths() if all_profiles else [(None, _store_path())]:
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                entry = json.load(fh).get(_key(chat_id, message_id))
+            # Missing / bad / expired timestamps fail closed for ownership.
+            age = now - _timestamp(entry)
+            if isinstance(entry, dict) and 0 <= age <= _MAX_AGE_SECONDS:
+                entry = dict(entry)
+                entry["profile"] = profile
+                matches.append(entry)
+        except (FileNotFoundError, OSError, ValueError, AttributeError, TypeError):
+            pass
+    return matches[0] if len(matches) == 1 else None
 
 
 def lookup(chat_id, message_id) -> Optional[str]:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2429,6 +2429,7 @@ from gateway.platforms.base import (
     EphemeralReply,
     MessageEvent,
     MessageType,
+    _is_deferred_followup_event,
     _prefix_within_utf16_limit,
     _reply_anchor_for_event,
     build_auto_tts_output_path,
@@ -3866,15 +3867,9 @@ class TurnRunner:
         if event_type not in {"tool.started",}:
             return
 
-        # Never render a progress bubble for the clarify tool.  The
-        # adapter's send_clarify IS the user-facing rendering (interactive
-        # buttons or the numbered-text fallback), so a progress bubble is
-        # pure duplication — and in verbose mode it dumps the raw
-        # tool-call args JSON ({"question": ..., "choices": [...]}) into
-        # the chat.  Because the progress queue drains on a background
-        # task, that raw JSON typically lands right underneath the
-        # rendered prompt (#52374).
-        if tool_name == "clarify":
+        # These tools provide their own visible result. A progress bubble would
+        # duplicate it and break reaction-only turns.
+        if tool_name in {"clarify", "telegram_react"}:
             return
 
         # Suppress tool-progress bubbles once the user has sent `stop`.
@@ -8995,7 +8990,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # we deliver it ourselves (mirroring the draining-case send above).
         try:
             from tools.approval import has_blocking_approval
-            if has_blocking_approval(session_key):
+            if not _is_deferred_followup_event(event) and has_blocking_approval(session_key):
                 _raw_text = (event.text or "").strip().lower()
                 _approve_words = {"approve", "yes", "ok", "okay", "confirm", "y", "👍"}
                 _deny_words = {"deny", "no", "reject", "cancel", "n", "👎"}
@@ -9052,7 +9047,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not adapter:
             return False  # let default path handle it
 
-        # --- Internal synthetic events must never interrupt/steer ---
+        # --- Synthetic and weak-signal events must never interrupt/steer ---
         # Async-delegation completions (delegate_task(background=true)) and
         # background-process completions (terminal notify_on_complete) re-enter
         # the originating session as internal MessageEvents. When the session
@@ -9063,7 +9058,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # never splices into a running turn. Fall through to the base adapter,
         # which queues internal events silently (no interrupt, no ack) so they
         # cascade after the current turn finishes.
-        if getattr(event, "internal", False):
+        if _is_deferred_followup_event(event):
             return False
 
         _busy_state = self._peek_session_state(session_key)
@@ -14670,6 +14665,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Internal events (e.g. background-process completion notifications)
         # are system-generated and must skip user authorization.
         is_internal = bool(getattr(event, "internal", False))
+        is_deferred_followup = _is_deferred_followup_event(event)
 
         # Ignored-channel guard runs FIRST — before startup-restore queueing,
         # plugin hooks, auth, and session setup — so a configured ignored
@@ -14901,7 +14897,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # consumed as update answers instead of being dispatched normally.
         _quick_key = self._session_key_for_source(source)
         _up_state = self._peek_session_state(_quick_key)
-        if _up_state is not None and _up_state.persistent.update_prompt_pending:
+        if (
+            not is_deferred_followup
+            and _up_state is not None
+            and _up_state.persistent.update_prompt_pending
+        ):
             raw = (event.text or "").strip()
             # Accept /approve and /deny as shorthand for yes/no
             cmd = event.get_command()
@@ -14973,13 +14973,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # to the second option, arbitrary text becomes a custom answer). Slash
         # commands still bypass this path so /stop and friends keep working.
         _clarify_mod = None
-        try:
-            from tools import clarify_gateway as _clarify_mod
-            _pending_clarify = _clarify_mod.get_pending_for_session(
-                _quick_key, include_choice_prompts=True,
-            )
-        except Exception:
-            _pending_clarify = None
+        _pending_clarify = None
+        if not is_deferred_followup:
+            try:
+                from tools import clarify_gateway as _clarify_mod
+                _pending_clarify = _clarify_mod.get_pending_for_session(
+                    _quick_key, include_choice_prompts=True,
+                )
+            except Exception:
+                _pending_clarify = None
         if _pending_clarify is not None and _clarify_mod is not None:
             _clarify_has_audio = bool(self._pending_event_audio_paths(event))
             _raw_clarify_reply = await self._prepare_clarify_reply_text(event)
@@ -15035,7 +15037,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # precedence — /approve there unblocks the waiting tool thread.
         # Slash-confirm only catches /approve when no tool approval is live.
         from tools import slash_confirm as _slash_confirm_mod
-        _pending_confirm = _slash_confirm_mod.get_pending(_quick_key)
+        _pending_confirm = (
+            None if is_deferred_followup
+            else _slash_confirm_mod.get_pending(_quick_key)
+        )
         _tool_approval_live = False
         try:
             from tools.approval import has_blocking_approval

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -22,7 +22,11 @@ from contextvars import ContextVar
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Set, Any
 
+from plugins.platforms.telegram.reactions import canonical_standard_emoji
+
 logger = logging.getLogger(__name__)
+
+_THREAD_ID_UNSET = object()
 
 
 def _redact_telegram_error_text(error: object) -> str:
@@ -247,6 +251,10 @@ try:
         ContextTypes,
         filters,
     )
+    try:
+        from telegram.ext import MessageReactionHandler
+    except ImportError:
+        MessageReactionHandler = None
     from telegram.constants import ParseMode, ChatType
     from telegram.request import HTTPXRequest
     TELEGRAM_AVAILABLE = True
@@ -262,6 +270,7 @@ except ImportError:
     CommandHandler = Any
     CallbackQueryHandler = Any
     TelegramMessageHandler = Any
+    MessageReactionHandler = None
     HTTPXRequest = Any
     filters = None
     ParseMode = None
@@ -414,6 +423,7 @@ def check_telegram_requirements() -> bool:
     global TELEGRAM_AVAILABLE, Update, Bot, Message, InlineKeyboardButton
     global InlineKeyboardMarkup, LinkPreviewOptions, Application
     global CommandHandler, CallbackQueryHandler, TelegramMessageHandler
+    global MessageReactionHandler
     global ContextTypes, filters, ParseMode, ChatType, HTTPXRequest
     if TELEGRAM_AVAILABLE:
         return True
@@ -435,6 +445,10 @@ def check_telegram_requirements() -> bool:
             MessageHandler as _MH,
             ContextTypes as _CT, filters as _filters,
         )
+        try:
+            from telegram.ext import MessageReactionHandler as _MRH
+        except ImportError:
+            _MRH = None
         from telegram.constants import ParseMode as _PM, ChatType as _CtT
         from telegram.request import HTTPXRequest as _HR
     except ImportError:
@@ -449,6 +463,7 @@ def check_telegram_requirements() -> bool:
     CommandHandler = _CH
     CallbackQueryHandler = _CQH
     TelegramMessageHandler = _MH
+    MessageReactionHandler = _MRH
     ContextTypes = _CT
     filters = _filters
     ParseMode = _PM
@@ -682,6 +697,7 @@ class TelegramAdapter(BasePlatformAdapter):
     _TEXT_BATCH_FAST_DELAY_S = 0.18
     _TEXT_BATCH_SHORT_LEN = 1024
     _TEXT_BATCH_SHORT_DELAY_S = 0.24
+    _REACTION_UPDATE_DEDUP_LIMIT = 512
 
     @staticmethod
     def _env_float_clamped(
@@ -792,6 +808,8 @@ class TelegramAdapter(BasePlatformAdapter):
         self._polling_conflict_recovery_generation: Optional[int] = None
         self._polling_network_error_count: int = 0
         self._polling_generation: int = 0
+        self._seen_reaction_update_ids: Dict[str, None] = {}  # reaction update-id dedup
+        self._intentional_reaction_targets: Set[tuple[str, str]] = set()  # vs lifecycle overwrite
         self._polling_progress_event = asyncio.Event()
         self._polling_progress_accepting: bool = False
         self._polling_progress_verifier_task: Optional[asyncio.Task] = None
@@ -926,6 +944,63 @@ class TelegramAdapter(BasePlatformAdapter):
         torn-down session, producing stale/duplicate deliveries.
         """
         return bool(getattr(self, "_drop_delayed_deliveries", False))
+
+    def _register_reaction_handler(self, app: Any) -> None:
+        if not self._coerce_bool_extra("inbound_reactions", False):
+            return
+        cls = MessageReactionHandler
+        kind = getattr(cls, "MESSAGE_REACTION_UPDATED", None)
+        if cls is None or kind is None:
+            logger.warning("[Telegram] inbound_reactions unavailable: reaction updates unsupported")
+            return
+        app.add_handler(cls(self._handle_message_reaction, message_reaction_types=kind))
+
+    def _record_sent_message(
+        self, chat_id: Any, message_id: Any, text: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None, *, effective_thread_id: Any = _THREAD_ID_UNSET,
+    ) -> None:
+        if chat_id is None or message_id is None:  # ownership + rich-reply index
+            return
+        if not self._coerce_bool_extra("inbound_reactions", False) and not (
+            text and getattr(self, "_rich_messages_enabled", False)
+        ):
+            return
+        try:
+            from gateway import rich_sent_store
+            from gateway.session_context import get_session_env
+            requested = self._metadata_thread_id(metadata or {})
+            if effective_thread_id is _THREAD_ID_UNSET:
+                thread_id = requested or get_session_env("HERMES_SESSION_THREAD_ID", "") or None
+            else:
+                thread_id = None if effective_thread_id is None else str(effective_thread_id)
+            if thread_id is None and requested == self._GENERAL_TOPIC_THREAD_ID:
+                thread_id = requested  # General stays logical "1" when wire-omitted
+            rich_sent_store.record(
+                str(chat_id), str(message_id), text, thread_id=thread_id,
+                sender_id=getattr(getattr(self, "_bot", None), "id", None),
+            )
+        except Exception:
+            pass
+
+    def _record_sent_result(
+        self, chat_id: Any, result: Any, text: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None, *, effective_thread_id: Any = _THREAD_ID_UNSET,
+    ) -> None:
+        for message in result if isinstance(result, (list, tuple)) else (result,):
+            read = message.get if isinstance(message, dict) else (
+                lambda name, default=None, m=message: getattr(m, name, default)
+            )
+            chat = read("chat")
+            forum = bool(read("is_topic_message")) or bool(
+                chat.get("is_forum") if isinstance(chat, dict) else getattr(chat, "is_forum", False)
+            )
+            thread_id = read("message_thread_id", _THREAD_ID_UNSET) if forum else _THREAD_ID_UNSET
+            if thread_id is _THREAD_ID_UNSET or thread_id is None:
+                thread_id = effective_thread_id
+            self._record_sent_message(
+                chat_id, read("message_id"), read("text") or read("caption") or text or "",
+                metadata, effective_thread_id=thread_id,
+            )
 
     def _notification_kwargs(
         self, metadata: Optional[Dict[str, Any]]
@@ -1421,7 +1496,13 @@ class TelegramAdapter(BasePlatformAdapter):
     ) -> Any:
         """Retry stale private-topic media replies once without the topic anchor."""
         try:
-            return await send_fn(**send_kwargs)
+            result = await send_fn(**send_kwargs)
+            self._record_sent_result(
+                send_kwargs.get("chat_id"), result,
+                send_kwargs.get("text") or send_kwargs.get("caption"), metadata,
+                effective_thread_id=send_kwargs.get("message_thread_id", _THREAD_ID_UNSET),
+            )
+            return result
         except Exception as send_err:
             if not self._should_retry_without_dm_topic_reply_anchor(
                 send_err,
@@ -1442,7 +1523,13 @@ class TelegramAdapter(BasePlatformAdapter):
             retry_kwargs["reply_to_message_id"] = None
             retry_kwargs.pop("message_thread_id", None)
             retry_kwargs.pop("direct_messages_topic_id", None)
-            return await send_fn(**retry_kwargs)
+            result = await send_fn(**retry_kwargs)
+            self._record_sent_result(
+                retry_kwargs.get("chat_id"), result,
+                retry_kwargs.get("text") or retry_kwargs.get("caption"), {},
+                effective_thread_id=None,
+            )
+            return result
 
     def _fallback_ips(self) -> list[str]:
         """Return validated fallback IPs from config (populated by _apply_env_overrides)."""
@@ -1955,11 +2042,11 @@ class TelegramAdapter(BasePlatformAdapter):
         if message_id is not None:
             # Telegram won't echo rich content in reply_to_message, so remember
             # what we sent — replies to this message resolve via this index.
-            try:
-                from gateway import rich_sent_store
-                rich_sent_store.record(str(chat_id), str(message_id), content)
-            except Exception:
-                pass
+            self._record_sent_result(
+                chat_id, msg if msg is not None else {"message_id": message_id},
+                content, metadata,
+                effective_thread_id=thread_kwargs.get("message_thread_id", _THREAD_ID_UNSET),
+            )
         return SendResult(
             success=True,
             message_id=str(message_id) if message_id is not None else None,
@@ -2014,6 +2101,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 # rich message; treat as a successful no-op so the caller does
                 # not fall through to a redundant legacy edit.
                 if "not modified" in str(exc).lower():
+                    self._record_sent_message(chat_id, message_id, content, metadata)
                     return SendResult(success=True, message_id=message_id)
                 logger.debug(
                     "[%s] rich editMessageText rejected (%s) — falling back to MarkdownV2 edit",
@@ -2021,6 +2109,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
                 return None
             if "not modified" in str(exc).lower():
+                self._record_sent_message(chat_id, message_id, content, metadata)
                 return SendResult(success=True, message_id=message_id)
             err_str = str(exc).lower()
             try:
@@ -2043,11 +2132,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # first rich send, so mirror the fresh-send index here too: a streamed
         # final finalized via editMessageText is otherwise never recorded, and
         # replies to it would have no native echo to recover from.
-        try:
-            from gateway import rich_sent_store
-            rich_sent_store.record(str(chat_id), str(message_id), content)
-        except Exception:
-            pass
+        self._record_sent_message(chat_id, message_id, content, metadata)
         return SendResult(success=True, message_id=message_id)
 
     def _should_attempt_rich_draft(self, content: str) -> bool:
@@ -3555,10 +3640,14 @@ class TelegramAdapter(BasePlatformAdapter):
                     # Send a seed message so the topic is visible in Telegram's client.
                     # Empty topics are hidden by the client UI until they contain a message.
                     try:
-                        await self._bot.send_message(
+                        seed_message = await self._bot.send_message(
                             chat_id=normalize_telegram_chat_id(chat_id),
                             message_thread_id=thread_id,
                             text=f"\U0001f4cc {topic_name}",
+                        )
+                        self._record_sent_result(
+                            chat_id, seed_message, f"\U0001f4cc {topic_name}",
+                            {"thread_id": str(thread_id)},
                         )
                     except Exception as seed_err:
                         logger.debug(
@@ -3910,6 +3999,7 @@ class TelegramAdapter(BasePlatformAdapter):
             ))
             # Handle inline keyboard button callbacks (update prompts)
             self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
+            self._register_reaction_handler(self._app)
             
             # Start polling — retry initialize() for transient TLS resets.
             # Each attempt is capped by _init_timeout so a single unreachable
@@ -4041,6 +4131,7 @@ class TelegramAdapter(BasePlatformAdapter):
                             self._handle_media_message
                         ))
                         self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
+                        self._register_reaction_handler(self._app)
                         # Best-effort discard the old app's resources
                         try:
                             await _shutdown_abandoned_app(old_app)
@@ -4796,6 +4887,9 @@ class TelegramAdapter(BasePlatformAdapter):
                                 continue
                         raise
                 message_ids.append(str(msg.message_id))
+                self._record_sent_result(
+                    chat_id, msg, chunk, metadata, effective_thread_id=effective_thread_id,
+                )
 
             # Re-trigger typing indicator after sending a message.
             # Telegram clears the typing state when a new message is delivered,
@@ -4968,6 +5062,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
                 if _saturated_preview:
                     self._last_overflow_preview[_preview_key] = content
+                self._record_sent_message(chat_id, message_id, content, metadata)
                 return SendResult(success=True, message_id=message_id)
 
             formatted = self.format_message(content)
@@ -4981,6 +5076,7 @@ class TelegramAdapter(BasePlatformAdapter):
             except Exception as fmt_err:
                 # "Message is not modified" is a no-op, not an error
                 if "not modified" in str(fmt_err).lower():
+                    self._record_sent_message(chat_id, message_id, content, metadata)
                     return SendResult(success=True, message_id=message_id)
                 # Fallback: strip MarkdownV2 escapes and retry as clean plain text
                 safe_format_error = _redact_telegram_error_text(fmt_err)
@@ -4995,11 +5091,13 @@ class TelegramAdapter(BasePlatformAdapter):
                     message_id=int(message_id),
                     text=_plain,
                 )
+            self._record_sent_message(chat_id, message_id, content, metadata)
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
             err_str = str(e).lower()
             # "Message is not modified" — content identical, treat as success
             if "not modified" in err_str:
+                self._record_sent_message(chat_id, message_id, content, metadata)
                 return SendResult(success=True, message_id=message_id)
             # Reactive split-and-deliver: parse_mode formatting can inflate
             # the payload past the limit even when the raw text was under
@@ -5024,6 +5122,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     text=truncated,
                 )
                 self._last_overflow_preview[_preview_key] = truncated
+                self._record_sent_message(chat_id, message_id, truncated, metadata)
                 return SendResult(success=True, message_id=message_id)
             # Flood control / RetryAfter — short waits are retried inline,
             # long waits return a failure immediately so streaming can fall back
@@ -5048,6 +5147,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         message_id=int(message_id),
                         text=content,
                     )
+                    self._record_sent_message(chat_id, message_id, content, metadata)
                     return SendResult(success=True, message_id=message_id)
                 except Exception as retry_err:
                     safe_retry_error = _redact_telegram_error_text(retry_err)
@@ -5186,6 +5286,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
                 return SendResult(success=False, error=_redact_telegram_error_text(e))
 
+        self._record_sent_message(chat_id, message_id, first_chunk, metadata)
+
         # Step 2 — send each remaining chunk as a continuation message,
         # threaded as a reply to the previous so the user sees them as a
         # contiguous block.  We call self._bot.send_message directly so the
@@ -5295,6 +5397,10 @@ class TelegramAdapter(BasePlatformAdapter):
                     continuation_message_ids=tuple(continuation_ids),
                 )
             new_id = str(getattr(sent_msg, "message_id", "")) or prev_id
+            self._record_sent_result(
+                chat_id, sent_msg, chunk, metadata,
+                effective_thread_id=thread_kwargs.get("message_thread_id", _THREAD_ID_UNSET),
+            )
             continuation_ids.append(new_id)
             delivered_chunks.append(chunk)
             prev_id = new_id
@@ -5457,7 +5563,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
         return SendResult(success=False, error="draft_rejected")
 
-    async def _send_message_with_thread_fallback(self, **kwargs):
+    async def _send_message_with_thread_fallback(self, *, _logical_thread_id=None, **kwargs):
         """Send a Telegram message, retrying once without message_thread_id
         if Telegram returns 'Message thread not found'.
 
@@ -5472,7 +5578,16 @@ class TelegramAdapter(BasePlatformAdapter):
 
         message_thread_id = kwargs.get("message_thread_id")
         try:
-            return await self._bot.send_message(**kwargs)
+            result = await self._bot.send_message(**kwargs)
+            effective = (
+                "1" if message_thread_id is None and str(_logical_thread_id) == "1"
+                else message_thread_id
+            )
+            self._record_sent_result(
+                kwargs.get("chat_id"), result, kwargs.get("text") or kwargs.get("caption"),
+                {"thread_id": _logical_thread_id}, effective_thread_id=effective,
+            )
+            return result
         except Exception as send_err:
             if (
                 message_thread_id is not None
@@ -5493,7 +5608,13 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
                 retry_kwargs = dict(kwargs)
                 retry_kwargs.pop("message_thread_id", None)
-                return await self._bot.send_message(**retry_kwargs)
+                result = await self._bot.send_message(**retry_kwargs)
+                self._record_sent_result(
+                    retry_kwargs.get("chat_id"), result,
+                    retry_kwargs.get("text") or retry_kwargs.get("caption"), {},
+                    effective_thread_id=None,
+                )
+                return result
             raise
 
     async def send_update_prompt(
@@ -5520,6 +5641,7 @@ class TelegramAdapter(BasePlatformAdapter):
             thread_id = self._metadata_thread_id(metadata)
             reply_to_id = self._reply_to_message_id_for_send(None, metadata, reply_to_mode=self._reply_to_mode)
             msg = await self._send_message_with_thread_fallback(
+                _logical_thread_id=thread_id,
                 chat_id=normalize_telegram_chat_id(chat_id),
                 text=text,
                 parse_mode=ParseMode.MARKDOWN_V2,
@@ -5615,7 +5737,9 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             )
 
-            msg = await self._send_message_with_thread_fallback(**kwargs)
+            msg = await self._send_message_with_thread_fallback(
+                _logical_thread_id=thread_id, **kwargs
+            )
 
             # Store session_key keyed by approval_id for the callback handler
             self._approval_state[approval_id] = session_key
@@ -5666,7 +5790,9 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             )
 
-            msg = await self._send_message_with_thread_fallback(**kwargs)
+            msg = await self._send_message_with_thread_fallback(
+                _logical_thread_id=thread_id, **kwargs
+            )
             self._slash_confirm_state[confirm_id] = session_key
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
@@ -5748,7 +5874,9 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             )
 
-            msg = await self._send_message_with_thread_fallback(**kwargs)
+            msg = await self._send_message_with_thread_fallback(
+                _logical_thread_id=thread_id, **kwargs
+            )
             self._clarify_state[clarify_id] = session_key
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
@@ -5796,6 +5924,7 @@ class TelegramAdapter(BasePlatformAdapter):
             thread_id = metadata.get("thread_id") if metadata else None
             reply_to_id = self._reply_to_message_id_for_send(None, metadata, reply_to_mode=self._reply_to_mode)
             msg = await self._send_message_with_thread_fallback(
+                _logical_thread_id=thread_id,
                 chat_id=normalize_telegram_chat_id(chat_id),
                 text=text,
                 parse_mode=ParseMode.MARKDOWN_V2,
@@ -5866,6 +5995,7 @@ class TelegramAdapter(BasePlatformAdapter):
             thread_id = metadata.get("thread_id") if metadata else None
             reply_to_id = self._reply_to_message_id_for_send(None, metadata, reply_to_mode=self._reply_to_mode)
             msg = await self._send_message_with_thread_fallback(
+                _logical_thread_id=thread_id,
                 chat_id=normalize_telegram_chat_id(chat_id),
                 text=self.format_message(title),
                 parse_mode=ParseMode.MARKDOWN_V2,
@@ -6638,7 +6768,15 @@ class TelegramAdapter(BasePlatformAdapter):
                                     reply_to_mode=self._reply_to_mode
                                 )
                             )
-                        await self._send_message_with_thread_fallback(**send_kwargs)
+                        logical_thread_id = thread_id
+                        if logical_thread_id is None:
+                            runner = getattr(self, "gateway_runner", None)
+                            get_source = getattr(runner, "_get_cached_session_source", None)
+                            source = get_source(session_key) if callable(get_source) else None
+                            logical_thread_id = getattr(source, "thread_id", None)
+                        await self._send_message_with_thread_fallback(
+                            _logical_thread_id=logical_thread_id, **send_kwargs
+                        )
                 except Exception as exc:
                     logger.error("[%s] slash-confirm callback failed: %s", self.name, exc, exc_info=True)
             return
@@ -9921,21 +10059,150 @@ class TelegramAdapter(BasePlatformAdapter):
             timestamp=message.date,
         )
 
+    @staticmethod
+    def _reaction_delta(old: Any, new: Any) -> tuple[List[str], List[str]]:
+        def emojis(values: Any) -> List[str]:
+            seen: List[str] = []
+            for item in values or ():
+                value = item if isinstance(item, str) else getattr(item, "emoji", None)
+                if value and (text := str(value)) not in seen:
+                    seen.append(text)
+            return seen
+        old_v, new_v = emojis(old), emojis(new)
+        return [v for v in new_v if v not in old_v], [v for v in old_v if v not in new_v]
+
+    @staticmethod
+    def _reaction_note(added: List[str], removed: List[str], target_text: Optional[str]) -> str:
+        # Bracketed prose: added then removed, plus optional quoted target text.
+        parts = ([f"added {' '.join(added)}"] if added else []) + (
+            [f"removed {' '.join(removed)}"] if removed else []
+        )
+        note = "[Telegram reaction: " + "; ".join(parts)
+        text = " ".join(str(target_text or "").split())[:240].replace("\\", "\\\\").replace('"', '\\"')
+        return note + (f'; on Hermes message "{text}"' if text else "") + "]"
+
+    def _claim_reaction_update(self, update_id: Any) -> bool:
+        if update_id is None:
+            return True
+        seen = self.__dict__.setdefault("_seen_reaction_update_ids", {})
+        key = str(update_id)
+        if key in seen:
+            return False
+        seen[key] = None
+        if len(seen) > self._REACTION_UPDATE_DEDUP_LIMIT:
+            seen.pop(next(iter(seen)))
+        return True
+
+    async def _handle_message_reaction(self, update: Any, context: Any = None) -> None:
+        """Route an authorised reaction through the normal message pipeline."""
+        reaction = getattr(update, "message_reaction", None)
+        chat, user = getattr(reaction, "chat", None), getattr(reaction, "user", None)
+        message_id = getattr(reaction, "message_id", None)
+        if not (chat and user and message_id) or getattr(user, "is_bot", False):
+            return
+        actor_id, chat_id = str(getattr(user, "id", "") or ""), str(getattr(chat, "id", "") or "")
+        added, removed = self._reaction_delta(
+            getattr(reaction, "old_reaction", ()), getattr(reaction, "new_reaction", ())
+        )
+        if not (actor_id and chat_id and (added or removed)):
+            return
+        raw = str(getattr(getattr(chat, "type", "group"), "value", getattr(chat, "type", "group")))
+        raw = raw.split(".")[-1].lower()
+        chat_type = "dm" if raw in {"private", "dm"} else "channel" if raw == "channel" else "group"
+        # Adapter allowlist prefilter (False rejects); runner auth still runs below.
+        if self._is_sender_authorized(actor_id, chat_type, chat_id) is False:
+            return
+        try:
+            from gateway import rich_sent_store
+            entry = rich_sent_store.lookup_entry(chat_id, str(message_id), all_profiles=True)
+        except Exception:
+            return
+        # Complete ownership required — legacy / missing sender fails closed.
+        sender_id = str((entry or {}).get("sender_id") or "")
+        if not entry or sender_id != str(getattr(getattr(self, "_bot", None), "id", "")):
+            return
+        runner = getattr(self, "gateway_runner", None) or getattr(
+            getattr(self, "_message_handler", None), "__self__", None
+        )
+        owner = getattr(runner, "_authorization_adapter", None) if runner else None
+        try:
+            if not callable(owner) or owner(Platform.TELEGRAM, entry.get("profile")) is not self:
+                return
+        except Exception:
+            return
+        thread_id = str(entry.get("thread_id") or "") or None
+        if getattr(chat, "is_forum", False) and thread_id is None:
+            return
+        actor_name = str(getattr(user, "username", "") or getattr(user, "full_name", "") or "") or None
+        try:
+            source = self.build_source(
+                chat_id=chat_id,
+                chat_name=str(getattr(chat, "title", "") or getattr(chat, "full_name", "") or "") or None,
+                chat_type=chat_type, user_id=actor_id, user_name=actor_name,
+                thread_id=thread_id, message_id=None, is_bot=False,
+            )
+            source.profile = entry.get("profile")
+            authorize = getattr(runner, "_is_user_authorized", None)
+            if not callable(authorize) or not authorize(source):
+                return
+        except Exception:
+            return
+        if not self._claim_reaction_update(getattr(update, "update_id", None)):
+            return
+        guidance = (
+            "An authorized Telegram user reacted to a Hermes message. Use the "
+            "reaction as context. If it answers a question or otherwise advances the "
+            "conversation, reply briefly; otherwise return NO_REPLY. "
+            "Reaction events have no outgoing Telegram target; do not call telegram_react. "
+            "A reaction alone does not authorize consequential or risky action."
+        )
+        try:
+            from gateway.platforms.base import resolve_channel_prompt
+            extra = getattr(getattr(self, "config", None), "extra", {}) or {}
+            configured = resolve_channel_prompt(
+                extra, thread_id or chat_id, chat_id if thread_id else None
+            )
+        except Exception:
+            configured = None
+        await self.handle_message(MessageEvent(
+            text=self._reaction_note(added, removed, entry.get("t")), source=source,
+            raw_message=reaction, message_id=str(message_id),
+            platform_update_id=getattr(update, "update_id", None),
+            user_id=actor_id, user_name=actor_name, reply_to_message_id=str(message_id),
+            reply_to_text=str(entry.get("t") or "") or None, reply_to_is_own_message=True,
+            channel_prompt="\n\n".join(v for v in (configured, guidance) if v),
+            metadata={"deferred_followup_event": True, "suppress_typing": True},
+        ))
+
     # ── Message reactions (processing lifecycle) ──────────────────────────
 
     def _reactions_enabled(self) -> bool:
         """Check if message reactions are enabled via config/env."""
         return os.getenv("TELEGRAM_REACTIONS", "false").lower() not in {"false", "0", "no"}
 
+    async def add_current_reaction(self, chat_id: str, message_id: str, emoji: str) -> bool:
+        """React to the inbound message for the current turn."""
+        if not (chat_id and message_id and (emoji or "").strip()):
+            return False
+        success = await self._set_reaction(chat_id, str(message_id), emoji)
+        if success and self._reactions_enabled():
+            self.__dict__.setdefault("_intentional_reaction_targets", set()).add(
+                (str(chat_id), str(message_id))
+            )
+        return success
+
     async def _set_reaction(self, chat_id: str, message_id: str, emoji: str) -> bool:
         """Set a single emoji reaction on a Telegram message."""
         if not self._bot:
+            return False
+        canonical = canonical_standard_emoji(emoji)
+        if canonical is None:
             return False
         try:
             await self._bot.set_message_reaction(
                 chat_id=normalize_telegram_chat_id(chat_id),
                 message_id=int(message_id),
-                reaction=emoji,
+                reaction=canonical,
             )
             return True
         except Exception as e:
@@ -9964,12 +10231,14 @@ class TelegramAdapter(BasePlatformAdapter):
             return False
 
     async def on_processing_start(self, event: MessageEvent) -> None:
-        """Add an in-progress reaction when message processing begins."""
-        if not self._reactions_enabled():
-            return
+        """Add the optional lifecycle status reaction."""
         chat_id = getattr(event.source, "chat_id", None)
         message_id = getattr(event, "message_id", None)
+        meta = getattr(event, "metadata", None) or {}
+        if not self._reactions_enabled() or meta.get("deferred_followup_event"):
+            return
         if chat_id and message_id:
+            getattr(self, "_intentional_reaction_targets", set()).discard((str(chat_id), str(message_id)))
             await self._set_reaction(chat_id, message_id, "\U0001f440")
 
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
@@ -9985,20 +10254,23 @@ class TelegramAdapter(BasePlatformAdapter):
         another agent run to swap it to 👍/👎 — which never happens if the
         cancellation was the last activity in the chat.
         """
-        if not self._reactions_enabled():
+        meta = getattr(event, "metadata", None) or {}
+        if meta.get("deferred_followup_event") or not self._reactions_enabled():
             return
         chat_id = getattr(event.source, "chat_id", None)
         message_id = getattr(event, "message_id", None)
         if not (chat_id and message_id):
             return
+        intentional = getattr(self, "_intentional_reaction_targets", set())
+        target = (str(chat_id), str(message_id))
+        if target in intentional:
+            intentional.discard(target)
+            return
         if outcome == ProcessingOutcome.CANCELLED:
             await self._clear_reactions(chat_id, message_id)
         else:
-            await self._set_reaction(
-                chat_id,
-                message_id,
-                "\U0001f44d" if outcome == ProcessingOutcome.SUCCESS else "\U0001f44e",
-            )
+            emoji = "\U0001f44d" if outcome == ProcessingOutcome.SUCCESS else "\U0001f44e"
+            await self._set_reaction(chat_id, message_id, emoji)
 
 
 # ──────────────────────────────────────────────────────────────────────────

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -10093,6 +10093,50 @@ class TelegramAdapter(BasePlatformAdapter):
             seen.pop(next(iter(seen)))
         return True
 
+    def _proposal_approval_reactions(self) -> Set[str]:
+        """Return configured standard reactions that approve one safe proposal."""
+        extra = getattr(getattr(self, "config", None), "extra", {}) or {}
+        raw = extra.get("proposal_approval_reactions", ())
+        values = (raw,) if isinstance(raw, str) else raw
+        if not isinstance(values, (list, tuple, set, frozenset)):
+            return set()
+        return {
+            canonical
+            for value in values
+            if (canonical := canonical_standard_emoji(str(value))) is not None
+        }
+
+    def _reaction_guidance(self, added: List[str]) -> str:
+        """Build ephemeral guidance for one authenticated reaction turn."""
+        configured = self._proposal_approval_reactions()
+        approvals = sorted(
+            canonical
+            for value in added
+            if (canonical := canonical_standard_emoji(value)) in configured
+        )
+        guidance = (
+            "An authorized Telegram user reacted to a Hermes-authored message. "
+            "Interpret the reaction against the quoted message and apply any explicit "
+            "reaction convention in the user's persistent profile. A reaction may "
+            "acknowledge a statement, express emotion, reverse feedback, approve a "
+            "proposed next action, or answer a question. If it answers a question or "
+            "otherwise advances the conversation, handle that context; otherwise return "
+            "exactly NO_REPLY. Reaction events have no outgoing Telegram target, so do "
+            "not call telegram_react. A reaction alone does not authorize consequential "
+            "or risky action."
+        )
+        if approvals:
+            joined = " ".join(approvals)
+            guidance += (
+                f" The added reaction {joined} is configured as approval of the exact "
+                "proposal in the quoted Hermes message. If and only if that message "
+                "contains a concrete, unambiguous, non-consequential next action, treat "
+                "this event as an action request and execute exactly that proposal in "
+                "this turn; do not merely acknowledge it or return NO_REPLY, and do not "
+                "broaden its scope."
+            )
+        return guidance
+
     async def _handle_message_reaction(self, update: Any, context: Any = None) -> None:
         """Route an authorised reaction through the normal message pipeline."""
         reaction = getattr(update, "message_reaction", None)
@@ -10149,13 +10193,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         if not self._claim_reaction_update(getattr(update, "update_id", None)):
             return
-        guidance = (
-            "An authorized Telegram user reacted to a Hermes message. Use the "
-            "reaction as context. If it answers a question or otherwise advances the "
-            "conversation, reply briefly; otherwise return NO_REPLY. "
-            "Reaction events have no outgoing Telegram target; do not call telegram_react. "
-            "A reaction alone does not authorize consequential or risky action."
-        )
+        guidance = self._reaction_guidance(added)
         try:
             from gateway.platforms.base import resolve_channel_prompt
             extra = getattr(getattr(self, "config", None), "extra", {}) or {}

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -10180,10 +10180,21 @@ class TelegramAdapter(BasePlatformAdapter):
         """Check if message reactions are enabled via config/env."""
         return os.getenv("TELEGRAM_REACTIONS", "false").lower() not in {"false", "0", "no"}
 
-    async def add_current_reaction(self, chat_id: str, message_id: str, emoji: str) -> bool:
-        """React to the inbound message for the current turn."""
-        if not (chat_id and message_id and (emoji or "").strip()):
+    def _reaction_session_key(self, event: MessageEvent) -> Optional[str]:
+        """Resolve the durable session key for a live Telegram event."""
+        runner = getattr(self, "gateway_runner", None) or getattr(
+            getattr(self, "_message_handler", None), "__self__", None
+        )
+        resolve = getattr(runner, "_session_key_for_source", None)
+        key = resolve(event.source) if callable(resolve) else None
+        return str(key) if key else None
+
+    async def add_current_reaction(self, session_key: str, emoji: str) -> bool:
+        """React only to the ordinary inbound message driving this live turn."""
+        target = getattr(self, "_current_reaction_targets", {}).get(session_key)
+        if not target or not (emoji or "").strip():
             return False
+        chat_id, message_id = target
         success = await self._set_reaction(chat_id, str(message_id), emoji)
         if success and self._reactions_enabled():
             self.__dict__.setdefault("_intentional_reaction_targets", set()).add(
@@ -10231,10 +10242,16 @@ class TelegramAdapter(BasePlatformAdapter):
             return False
 
     async def on_processing_start(self, event: MessageEvent) -> None:
-        """Add the optional lifecycle status reaction."""
+        """Bind the current inbound target and add optional lifecycle status."""
         chat_id = getattr(event.source, "chat_id", None)
         message_id = getattr(event, "message_id", None)
         meta = getattr(event, "metadata", None) or {}
+        session_key = self._reaction_session_key(event)
+        if session_key:
+            targets = self.__dict__.setdefault("_current_reaction_targets", {})
+            targets.pop(session_key, None)
+            if not meta.get("deferred_followup_event") and chat_id and message_id:
+                targets[session_key] = (str(chat_id), str(message_id))
         if not self._reactions_enabled() or meta.get("deferred_followup_event"):
             return
         if chat_id and message_id:
@@ -10254,6 +10271,9 @@ class TelegramAdapter(BasePlatformAdapter):
         another agent run to swap it to 👍/👎 — which never happens if the
         cancellation was the last activity in the chat.
         """
+        session_key = self._reaction_session_key(event)
+        if session_key:
+            getattr(self, "_current_reaction_targets", {}).pop(session_key, None)
         meta = getattr(event, "metadata", None) or {}
         if meta.get("deferred_followup_event") or not self._reactions_enabled():
             return

--- a/plugins/platforms/telegram/reactions.py
+++ b/plugins/platforms/telegram/reactions.py
@@ -1,0 +1,24 @@
+"""Canonical Telegram standard reaction emoji."""
+
+
+def canonical_standard_emoji(emoji: str) -> str | None:
+    """Return Telegram's canonical form for a standard reaction emoji."""
+    raw = str(emoji or "").strip()
+    if not raw:
+        return None
+    try:
+        from telegram.constants import ReactionEmoji
+
+        allowed = tuple(str(getattr(item, "value", item)) for item in ReactionEmoji)
+    except (ImportError, TypeError):
+        allowed = ()
+    if not allowed:
+        # Older / minimal PTB: still validate the value at the Bot API boundary.
+        return raw if "\u200d" in raw else raw.rstrip("\ufe0e\ufe0f") or raw
+    if raw in allowed:
+        return raw
+    bare = raw.replace("\ufe0e", "").replace("\ufe0f", "")
+    for value in allowed:
+        if value.replace("\ufe0e", "").replace("\ufe0f", "") == bare:
+            return value
+    return None

--- a/tests/gateway/test_internal_event_never_interrupts_busy_session.py
+++ b/tests/gateway/test_internal_event_never_interrupts_busy_session.py
@@ -40,9 +40,11 @@ sys.modules.setdefault("telegram.constants", _tg.constants)
 sys.modules.setdefault("telegram.ext", types.ModuleType("telegram.ext"))
 
 from gateway.platforms.base import (  # noqa: E402
+    BasePlatformAdapter,
     MessageEvent,
     MessageType,
     SessionSource,
+    _is_deferred_followup_event,
     build_session_key,
 )
 from gateway.run import GatewayRunner  # noqa: E402
@@ -62,6 +64,13 @@ def _make_internal_event(text: str = "[async delegation completed]") -> MessageE
         message_id="msg1",
         internal=True,
     )
+
+
+def _reaction_followup(text: str = "[Telegram reaction: added 👍]") -> MessageEvent:
+    event = _make_internal_event(text)
+    event.internal = False
+    event.metadata = {"deferred_followup_event": True}
+    return event
 
 
 def _make_runner() -> GatewayRunner:
@@ -126,4 +135,75 @@ async def test_internal_event_does_not_interrupt_busy_session() -> None:
     # No "⚡ Interrupting current task" (or any) ack for a synthetic event.
     adapter._send_with_retry.assert_not_called()
 
+@pytest.mark.asyncio
+async def test_reaction_deferred_busy_clarify_update_confirm(monkeypatch) -> None:
+    """FIFO busy queue; no interrupt/steer/approval; skip clarify/update/slash-confirm."""
+    from types import SimpleNamespace
+    from tools import clarify_gateway
+    from tests.gateway.test_clarify_thread_followup_not_swallowed import (
+        _FellThroughIntercept, _StubAdapter, _event, _make_runner as _clarify_runner,
+    )
+
+    # Busy FIFO + dangerous-approval isolation
+    runner = _make_runner()
+    runner._busy_input_mode = "interrupt"
+    adapter = _make_adapter()
+    event = _reaction_followup()
+    sk = build_session_key(event.source)
+    parent = _make_running_parent()
+    parent._supports_active_turn_redirect = True
+    parent.redirect.return_value = True
+    runner._running_agents[sk] = parent
+    runner.adapters[event.source.platform] = adapter
+    approval = MagicMock(return_value=True)
+    monkeypatch.setattr("tools.approval.has_blocking_approval", approval)
+    assert await runner._handle_active_session_busy_message(event, sk) is False
+    parent.redirect.assert_not_called()
+    parent.interrupt.assert_not_called()
+    adapter._send_with_retry.assert_not_called()
+    approval.assert_not_called()
+
+    # Classification
+    ordinary = _make_internal_event("ordinary text"); ordinary.internal = False
+    assert _is_deferred_followup_event(_make_internal_event()) is True
+    assert _is_deferred_followup_event(_reaction_followup()) is True
+    assert _is_deferred_followup_event(ordinary) is False
+
+    # Clarify queues instead of answering
+    event = _reaction_followup()
+    session_key = build_session_key(event.source)
+    adapter = MagicMock()
+    adapter.name = "test"
+    adapter.config = MagicMock(); adapter.config.extra = {}
+    adapter._message_handler = AsyncMock()
+    adapter._topic_recovery_fn = None
+    adapter._active_sessions = {session_key: object()}
+    adapter._pending_messages = {}
+    adapter._heal_stale_session_lock = MagicMock()
+    adapter._busy_session_handler = AsyncMock(return_value=False)
+    adapter._is_queue_text_debounce_candidate = MagicMock(return_value=False)
+    monkeypatch.setattr(clarify_gateway, "get_pending_for_session", lambda *_a, **_k: object())
+    await BasePlatformAdapter.handle_message(adapter, event)
+    adapter._message_handler.assert_not_awaited()
+    adapter._busy_session_handler.assert_awaited_once_with(event, session_key)
+    assert adapter._pending_messages[session_key] is event
+
+    # Update + slash-confirm fall through
+    clarify_runner = _clarify_runner(_StubAdapter())
+    state = SimpleNamespace(
+        persistent=SimpleNamespace(update_prompt_pending=True),
+        turn=SimpleNamespace(started_ts=0, agent=None),
+    )
+    setattr(clarify_runner, "_peek_session_state", lambda session_key: state)
+    update_event = _event("[Telegram reaction: added 👍]")
+    update_event.metadata = {"deferred_followup_event": True}
+    pending = MagicMock(side_effect=AssertionError("deferred event queried confirm"))
+    monkeypatch.setattr("tools.slash_confirm.get_pending", pending)
+    monkeypatch.setattr("tools.approval.has_blocking_approval", lambda key: False)
+    setattr(clarify_runner, "_is_session_running", MagicMock(side_effect=_FellThroughIntercept))
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *a, **k: [])
+    with pytest.raises(_FellThroughIntercept):
+        await clarify_runner._handle_message(update_event)
+    assert state.persistent.update_prompt_pending is True
+    pending.assert_not_called()
 

--- a/tests/gateway/test_keep_typing_timeout.py
+++ b/tests/gateway/test_keep_typing_timeout.py
@@ -22,16 +22,19 @@ the bubble stays visible across provider stalls.
 """
 
 import asyncio
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from gateway.platforms.base import (
     BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
     Platform,
     PlatformConfig,
     SendResult,
 )
+from gateway.session import SessionSource, build_session_key
 
 
 class _StubAdapter(BasePlatformAdapter):
@@ -52,6 +55,35 @@ class _StubAdapter(BasePlatformAdapter):
 
 
 class TestKeepTypingTimeoutPerTick:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(("suppress", "expected"), [(False, 1), (True, 0)])
+    async def test_event_can_suppress_typing_refresh(self, suppress, expected):
+        adapter = _StubAdapter()
+        adapter._keep_typing = AsyncMock()
+        adapter._stop_typing_refresh = AsyncMock()
+
+        async def handler(_event):
+            await asyncio.sleep(0)
+            return None
+
+        adapter.set_message_handler(handler)
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="123",
+            chat_type="private",
+            user_id="42",
+        )
+        event = MessageEvent(
+            text="event",
+            source=source,
+            message_type=MessageType.TEXT,
+            metadata={"suppress_typing": suppress},
+        )
+
+        await adapter._process_message_background(event, build_session_key(source))
+
+        assert adapter._keep_typing.await_count == expected
+
     @pytest.mark.asyncio
     async def test_slow_send_typing_does_not_block_cadence(self, monkeypatch):
         """A send_typing that hangs longer than the per-tick budget must be

--- a/tests/gateway/test_telegram_reactions.py
+++ b/tests/gateway/test_telegram_reactions.py
@@ -1,7 +1,13 @@
 """Tests for Telegram message reactions tied to processing lifecycle hooks."""
 
+import json
+import os
+import subprocess
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 
@@ -10,14 +16,15 @@ from gateway.platforms.base import MessageEvent, MessageType, ProcessingOutcome
 from gateway.session import SessionSource
 
 
-def _make_adapter(**extra_env):
+def _make_adapter(**extra):
     from plugins.platforms.telegram.adapter import TelegramAdapter
 
     adapter = object.__new__(TelegramAdapter)
     adapter.platform = Platform.TELEGRAM
-    adapter.config = PlatformConfig(enabled=True, token="fake-token")
+    adapter.config = PlatformConfig(enabled=True, token="fake-token", extra=extra)
     adapter._bot = AsyncMock()
     adapter._bot.set_message_reaction = AsyncMock()
+    adapter._intentional_reaction_targets = set()
     return adapter
 
 
@@ -150,7 +157,308 @@ def test_config_bridges_telegram_reactions(monkeypatch, tmp_path):
     from gateway.config import load_gateway_config
     load_gateway_config()
 
-    import os
     assert os.getenv("TELEGRAM_REACTIONS") == "true"
 
 
+def _patch_index(monkeypatch, tmp_path):
+    from gateway import rich_sent_store
+    monkeypatch.setattr(rich_sent_store, "_store_path",
+                        lambda: str(tmp_path / "state" / "rich_sent_index.json"))
+    monkeypatch.setattr("hermes_constants.get_default_hermes_root", lambda: tmp_path / "base")
+    return rich_sent_store
+
+
+def _rx_adapter(
+    monkeypatch, tmp_path, *, authorized=True, thread_id="77", sender_id: str | None = "111"
+):
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+    store = _patch_index(monkeypatch, tmp_path)
+    store.record("-100", "900", "A bot-authored answer", thread_id=thread_id, sender_id=sender_id)
+    runner = SimpleNamespace(_is_user_authorized=Mock(return_value=authorized), _profile_adapters={})
+    adapter = object.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter.gateway_runner = runner
+    adapter._bot = SimpleNamespace(id=111)
+    adapter.handle_message = AsyncMock()
+    adapter._authorization_check = lambda user_id, chat_type=None, chat_id=None: authorized
+    runner._authorization_adapter = lambda platform, profile=None: adapter
+    return adapter, runner
+
+
+def _rx_update(*, old, new, user_id="42", is_bot=False, chat_id="-100", update_id=123):
+    return SimpleNamespace(
+        update_id=update_id,
+        message_reaction=SimpleNamespace(
+            chat=SimpleNamespace(id=chat_id, type="supergroup", is_forum=True),
+            message_id=900,
+            user=SimpleNamespace(
+                id=user_id, username="authorized-user", full_name="Authorized User", is_bot=is_bot
+            ),
+            old_reaction=[SimpleNamespace(emoji=v) for v in old],
+            new_reaction=[SimpleNamespace(emoji=v) for v in new],
+        ),
+    )
+
+
+def _live_adapter(extra):
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+    return TelegramAdapter(PlatformConfig(enabled=True, token="fake-token", extra=extra))
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_off_intentional_survives_overwrite(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "false")
+    adapter = _make_adapter()
+    await adapter.on_processing_start(_make_event())
+    await adapter.on_processing_complete(_make_event(), ProcessingOutcome.SUCCESS)
+    adapter._bot.set_message_reaction.assert_not_awaited()
+    assert not hasattr(adapter, "add_reaction")
+    assert await adapter.add_current_reaction("123", "456", "❤️") is True
+    assert adapter._bot.set_message_reaction.await_args.kwargs["reaction"] == "❤"
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
+    adapter = _make_adapter()
+    event = _make_event()
+    await adapter.on_processing_start(event)
+    assert await adapter.add_current_reaction("123", "456", "❤️") is True
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+    assert [c.kwargs["reaction"] for c in adapter._bot.set_message_reaction.await_args_list] == ["👀", "❤"]
+    assert adapter._intentional_reaction_targets == set()
+
+
+@pytest.mark.parametrize(("enabled", "expected"), [(False, False), (True, True), ("yes", True), ("off", False)])
+def test_inbound_opt_in_and_old_ptb(monkeypatch, caplog, enabled, expected):
+    from plugins.platforms.telegram import adapter as mod
+
+    class FakeRH:
+        MESSAGE_REACTION_UPDATED = "updated"
+        def __init__(self, callback, **kwargs):
+            self.callback, self.kwargs = callback, kwargs
+
+    monkeypatch.setattr(mod, "MessageReactionHandler", FakeRH)
+    handlers = []
+    ad = _make_adapter(inbound_reactions=enabled)
+    ad._register_reaction_handler(SimpleNamespace(add_handler=handlers.append))
+    found = [h for h in handlers if isinstance(h, FakeRH)]
+    assert bool(found) is expected
+    if expected:
+        assert found[0].callback == ad._handle_message_reaction
+        assert found[0].kwargs == {"message_reaction_types": "updated"}
+    if enabled is True:  # once: old/missing PTB keeps connect path alive
+        monkeypatch.setattr(mod, "MessageReactionHandler", None)
+        with caplog.at_level("WARNING"):
+            _make_adapter(inbound_reactions=True)._register_reaction_handler(
+                SimpleNamespace(add_handler=lambda *_: None)
+            )
+        assert "reaction updates unsupported" in caplog.text
+
+
+def test_provenance_contracts(monkeypatch, tmp_path):
+    store = _patch_index(monkeypatch, tmp_path)
+    store.record("123", "456", "first", thread_id="77")
+    store.record("123", "456", "edited")
+    assert store.lookup_entry("123", "456")["thread_id"] == "77"
+    ad = _make_adapter(inbound_reactions=True)
+    ad._bot = SimpleNamespace(id=12345)
+    real_record = store.record
+    rec = Mock()
+    monkeypatch.setattr(store, "record", rec)
+    ad._record_sent_message("123", "456", "answer")
+    assert rec.call_args.kwargs["sender_id"] == 12345
+    off = _make_adapter()
+    off._rich_messages_enabled = False
+    rec2 = Mock()
+    monkeypatch.setattr(store, "record", rec2)
+    off._record_sent_message("123", "456", "answer")
+    rec2.assert_not_called()
+    monkeypatch.setattr(store, "record", real_record)
+    env = {**os.environ, "HERMES_HOME": str(tmp_path / "restart")}
+    subprocess.run([sys.executable, "-c",
+        "from gateway.rich_sent_store import record; record('c','m','text',thread_id='1',sender_id='7')"],
+        check=True, env=env)
+    out = subprocess.run([sys.executable, "-c",
+        "from gateway.rich_sent_store import lookup_entry; print(lookup_entry('c','m'))"],
+        check=True, capture_output=True, text=True, env=env).stdout
+    assert "'thread_id': '1'" in out and "'sender_id': '7'" in out
+    path = tmp_path / "state" / "rich_sent_index.json"
+    monkeypatch.setattr(store, "_MAX_ENTRIES", 20)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"bad:x": {"t": "old", "ts": None}}))
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(lambda i: store.record("c", i, str(i)), range(20)))
+    data = json.loads(path.read_text())
+    assert len(data) == 20 and "bad:x" not in data
+    cur = tmp_path / "current" / "state" / "rich_sent_index.json"
+    sec = tmp_path / "base" / "profiles" / "secondary" / "state" / "rich_sent_index.json"
+    monkeypatch.setattr(store, "_store_path", lambda: str(cur))
+    cur.parent.mkdir(parents=True); sec.parent.mkdir(parents=True)
+    now = store.time.time()
+    cur.write_text(json.dumps({"-100:900": {"t": "one", "ts": now, "thread_id": "77"}}))
+    sec.write_text(json.dumps({"-100:900": {"t": "two", "ts": now, "thread_id": "88"}}))
+    assert store.lookup_entry("-100", "900", all_profiles=True) is None
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+    ad2 = object.__new__(TelegramAdapter)
+    ad2._record_sent_message = Mock()
+    ad2._record_sent_result("-100", SimpleNamespace(
+        message_id=900, message_thread_id=123, is_topic_message=False,
+        chat=SimpleNamespace(is_forum=False), text="answer", caption=None,
+    ), effective_thread_id=None)
+    assert ad2._record_sent_message.call_args.kwargs["effective_thread_id"] is None
+
+
+def test_age_expiry_enforced_on_lookup(monkeypatch, tmp_path):
+    store = _patch_index(monkeypatch, tmp_path)
+    path = tmp_path / "state" / "rich_sent_index.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps({"-100:900": {"t": "ancient", "ts": 1, "thread_id": "77", "sender_id": "111"}}))
+    assert store.lookup_entry("-100", "900") is None
+    path.write_text(json.dumps({"-100:900": {"t": "future", "ts": store.time.time() + 3600}}))
+    assert store.lookup_entry("-100", "900") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("returned_thread", "is_forum", "wire", "logical", "expected", "retry"),
+    [(88, True, 77, "77", 88, False), (None, False, 77, "77", None, True),
+     (None, False, None, "1", "1", False)],
+)
+async def test_thread_fallback_indexes_effective_thread(
+    returned_thread, is_forum, wire, logical, expected, retry
+):
+    adapter = _make_adapter()
+    adapter._is_bad_request_error = adapter._is_thread_not_found_error = lambda e: True
+    adapter._prune_stale_dm_topic_binding = Mock()
+    adapter._record_sent_message = Mock()
+    returned = SimpleNamespace(
+        message_id=999, message_thread_id=returned_thread, is_topic_message=is_forum,
+        chat=SimpleNamespace(is_forum=is_forum), text="fallback message",
+    )
+    adapter._bot.send_message = AsyncMock(
+        side_effect=([RuntimeError("Message thread not found"), returned] if retry else [returned])
+    )
+    kwargs = {"chat_id": "123", "text": "fallback message"}
+    if wire is not None:
+        kwargs["message_thread_id"] = wire
+    assert await adapter._send_message_with_thread_fallback(_logical_thread_id=logical, **kwargs) is returned
+    assert adapter._record_sent_message.call_args.kwargs["effective_thread_id"] == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("old", "new", "added", "removed"),
+    [([], ["❤️"], "added ❤️", None), (["👍"], ["❤️"], "added ❤️", "removed 👍"),
+     (["❤️"], [], None, "removed ❤️")],
+)
+async def test_reaction_delta_routes_deferred_turn(monkeypatch, tmp_path, old, new, added, removed):
+    adapter, runner = _rx_adapter(monkeypatch, tmp_path)
+    await adapter._handle_message_reaction(_rx_update(old=old, new=new))
+    runner._is_user_authorized.assert_called_once()
+    ev = adapter.handle_message.await_args.args[0]
+    assert ev.source is runner._is_user_authorized.call_args.args[0]
+    assert ev.source.thread_id == "77" and ev.source.chat_type == "group"
+    assert ev.metadata["deferred_followup_event"] is True
+    assert ev.metadata["suppress_typing"] is True
+    assert ev.internal is False and ev.reply_to_is_own_message is True
+    assert ev.message_id == ev.reply_to_message_id == "900"
+    if added:
+        assert added in ev.text
+    if removed:
+        assert removed in ev.text
+    assert '"A bot-authored answer"' in ev.text
+    assert "NO_REPLY" in ev.channel_prompt and "consequential or risky action" in ev.channel_prompt
+    assert "answers a question" in ev.channel_prompt
+    assert "do not call telegram_react" in ev.channel_prompt
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "case",
+    ["unauthorized", "bot_actor", "unknown_chat", "missing_thread", "unknown_message",
+     "wrong_bot", "missing_sender", "no_delta"],
+)
+async def test_invalid_reaction_updates_fail_closed(monkeypatch, tmp_path, case):
+    adapter, runner = _rx_adapter(
+        monkeypatch, tmp_path, authorized=case != "unauthorized",
+        thread_id=None if case == "missing_thread" else "77",
+        sender_id=None if case == "missing_sender" else "111",
+    )
+    update = _rx_update(
+        old=["👍"] if case == "no_delta" else [], new=["👍"],
+        is_bot=case == "bot_actor", chat_id="-200" if case == "unknown_chat" else "-100",
+    )
+    if case == "unknown_message":
+        update.message_reaction.message_id = 901
+    elif case == "wrong_bot":
+        adapter._bot = SimpleNamespace(id=222)
+
+    await adapter._handle_message_reaction(update)
+    assert getattr(adapter.handle_message, "await_count", 0) == 0
+    if case != "unauthorized":
+        runner._is_user_authorized.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dedup_multiplex_reply_anchor_and_general_sends(monkeypatch, tmp_path):
+    from gateway.platforms.base import _reply_anchor_for_event
+
+    adapter, runner = _rx_adapter(monkeypatch, tmp_path)
+    update = _rx_update(old=[], new=["👍"], update_id=456)
+    await adapter._handle_message_reaction(update)
+    await adapter._handle_message_reaction(update)
+    assert adapter.handle_message.await_count == 1 and runner._is_user_authorized.call_count == 2
+
+    (tmp_path / "state" / "rich_sent_index.json").unlink()
+    sec = tmp_path / "base" / "profiles" / "secondary" / "state" / "rich_sent_index.json"
+    sec.parent.mkdir(parents=True)
+    sec.write_text(json.dumps({"-100:900": {"t": "answer", "ts": time.time(), "sender_id": "111"}}))
+    adapter.handle_message.reset_mock()
+    update = _rx_update(old=[], new=["👍"])
+    update.message_reaction.chat.is_forum = False
+    update.message_reaction.chat.type = SimpleNamespace(value="private")
+    await adapter._handle_message_reaction(update)
+    ev = adapter.handle_message.await_args.args[0]
+    assert ev.source.profile == "secondary" and ev.source.chat_type == "dm"
+
+    for thread_id, expected in [(None, "900"), ("77", None)]:
+        assert _reply_anchor_for_event(MessageEvent(
+            text="[Telegram reaction: added 👍]",
+            source=SessionSource(platform=Platform.TELEGRAM, chat_id="-100", chat_type="group",
+                                 user_id="42", thread_id=thread_id),
+            message_id="900", reply_to_message_id="900",
+            metadata={"deferred_followup_event": True},
+        )) == expected
+
+    store = _patch_index(monkeypatch, tmp_path)
+    plain = _live_adapter({"rich_messages": False, "inbound_reactions": True})
+    bot = MagicMock(id=111, send_chat_action=AsyncMock())
+    bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=700, message_thread_id=None))
+    plain._bot = bot
+    assert (await plain.send("-100", "The final answer.", metadata={"thread_id": "1", "notify": True})).success
+    assert bot.send_message.await_args.kwargs["message_thread_id"] is None
+    entry = store.lookup_entry("-100", "700")
+    assert entry["thread_id"] == "1" and entry["sender_id"] == "111"
+    plain.gateway_runner = SimpleNamespace(_is_user_authorized=Mock(return_value=True), _profile_adapters={})
+    plain.handle_message = AsyncMock()
+    plain.gateway_runner._authorization_adapter = lambda platform, profile=None: plain
+    upd = _rx_update(old=[], new=["👍"]); upd.message_reaction.message_id = 700
+    await plain._handle_message_reaction(upd)
+    routed = plain.handle_message.await_args.args[0]
+    assert routed.source.thread_id == "1" and routed.metadata["deferred_followup_event"] is True
+
+    rich = _live_adapter({"rich_messages": True, "inbound_reactions": True})
+    rich._bot = MagicMock(id=111, send_chat_action=AsyncMock(),
+        do_api_request=AsyncMock(return_value=SimpleNamespace(message_id=701, message_thread_id=None)))
+    content = "## Results\n\n| Case | Status |\n|---|---|\n| rich | ok |"
+    assert (await rich.send("-100", content, metadata={"thread_id": "1", "notify": True})).success
+    assert "message_thread_id" not in rich._bot.do_api_request.call_args.kwargs["api_kwargs"]
+    assert store.lookup_entry("-100", "701")["thread_id"] == "1"
+
+    overflow = _live_adapter({"rich_messages": False, "inbound_reactions": True})
+    overflow._bot = MagicMock(
+        id=111, edit_message_text=AsyncMock(return_value=SimpleNamespace(message_id=500)),
+        send_message=AsyncMock(return_value=SimpleNamespace(message_id=501, message_thread_id=None)),
+    )
+    assert (await overflow._edit_overflow_split(
+        "-100", "500", "word " * 1200, finalize=True, metadata={"thread_id": "1", "notify": True},
+    )).success
+    assert store.lookup_entry("-100", "500")["thread_id"] == "1"
+    assert store.lookup_entry("-100", "501")["thread_id"] == "1"

--- a/tests/gateway/test_telegram_reactions.py
+++ b/tests/gateway/test_telegram_reactions.py
@@ -209,20 +209,42 @@ def _live_adapter(extra):
 async def test_lifecycle_off_intentional_survives_overwrite(monkeypatch):
     monkeypatch.setenv("TELEGRAM_REACTIONS", "false")
     adapter = _make_adapter()
-    await adapter.on_processing_start(_make_event())
-    await adapter.on_processing_complete(_make_event(), ProcessingOutcome.SUCCESS)
-    adapter._bot.set_message_reaction.assert_not_awaited()
-    assert not hasattr(adapter, "add_reaction")
-    assert await adapter.add_current_reaction("123", "456", "❤️") is True
-    assert adapter._bot.set_message_reaction.await_args.kwargs["reaction"] == "❤"
-    monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
-    adapter = _make_adapter()
+    adapter.gateway_runner = SimpleNamespace(_session_key_for_source=lambda source: "session")
     event = _make_event()
     await adapter.on_processing_start(event)
-    assert await adapter.add_current_reaction("123", "456", "❤️") is True
+    adapter._bot.set_message_reaction.assert_not_awaited()
+    assert adapter._current_reaction_targets == {"session": ("123", "456")}
+    assert not hasattr(adapter, "add_reaction")
+    assert await adapter.add_current_reaction("session", "❤️") is True
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+    assert adapter._bot.set_message_reaction.await_args.kwargs["reaction"] == "❤"
+    assert adapter._bot.set_message_reaction.await_count == 1
+    assert adapter._current_reaction_targets == {}
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
+    adapter = _make_adapter()
+    adapter.gateway_runner = SimpleNamespace(_session_key_for_source=lambda source: "session")
+    event = _make_event()
+    await adapter.on_processing_start(event)
+    assert await adapter.add_current_reaction("session", "❤️") is True
     await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
     assert [c.kwargs["reaction"] for c in adapter._bot.set_message_reaction.await_args_list] == ["👀", "❤"]
     assert adapter._intentional_reaction_targets == set()
+
+
+@pytest.mark.asyncio
+async def test_intentional_reaction_never_uses_stale_session_origin(monkeypatch):
+    """A reset session's old origin id must never become the reaction target."""
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "false")
+    adapter = _make_adapter()
+    adapter.gateway_runner = SimpleNamespace(_session_key_for_source=lambda source: "random")
+    event = _make_event(message_id="30999")
+
+    await adapter.on_processing_start(event)
+    assert await adapter.add_current_reaction("random", "👍") is True
+
+    adapter._bot.set_message_reaction.assert_awaited_once_with(
+        chat_id=123, message_id=30999, reaction="👍"
+    )
 
 
 @pytest.mark.parametrize(("enabled", "expected"), [(False, False), (True, True), ("yes", True), ("off", False)])

--- a/tests/gateway/test_telegram_reactions.py
+++ b/tests/gateway/test_telegram_reactions.py
@@ -169,7 +169,8 @@ def _patch_index(monkeypatch, tmp_path):
 
 
 def _rx_adapter(
-    monkeypatch, tmp_path, *, authorized=True, thread_id="77", sender_id: str | None = "111"
+    monkeypatch, tmp_path, *, authorized=True, thread_id="77", sender_id: str | None = "111",
+    extra=None,
 ):
     from plugins.platforms.telegram.adapter import TelegramAdapter
     store = _patch_index(monkeypatch, tmp_path)
@@ -177,6 +178,7 @@ def _rx_adapter(
     runner = SimpleNamespace(_is_user_authorized=Mock(return_value=authorized), _profile_adapters={})
     adapter = object.__new__(TelegramAdapter)
     adapter.platform = Platform.TELEGRAM
+    adapter.config = PlatformConfig(enabled=True, token="fake-token", extra=extra or {})
     adapter.gateway_runner = runner
     adapter._bot = SimpleNamespace(id=111)
     adapter.handle_message = AsyncMock()
@@ -389,6 +391,35 @@ async def test_reaction_delta_routes_deferred_turn(monkeypatch, tmp_path, old, n
     assert "NO_REPLY" in ev.channel_prompt and "consequential or risky action" in ev.channel_prompt
     assert "answers a question" in ev.channel_prompt
     assert "do not call telegram_react" in ev.channel_prompt
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("extra", "old", "new", "expected"),
+    [
+        ({}, [], ["👍"], False),
+        ({"proposal_approval_reactions": ["👍"]}, [], ["👍"], True),
+        ({"proposal_approval_reactions": ["👍"]}, ["👍"], [], False),
+        ({"proposal_approval_reactions": ["🆒"]}, [], ["👍"], False),
+    ],
+)
+async def test_proposal_approval_reactions_are_opt_in_added_only(
+    monkeypatch, tmp_path, extra, old, new, expected
+):
+    adapter, _ = _rx_adapter(monkeypatch, tmp_path, extra=extra)
+    await adapter._handle_message_reaction(_rx_update(old=old, new=new))
+    guidance = getattr(adapter.handle_message, "await_args").args[0].channel_prompt
+    assert ("configured as approval of the exact proposal" in guidance) is expected
+    assert ("execute exactly that proposal in this turn" in guidance) is expected
+
+
+def test_proposal_approval_reactions_accept_only_standard_telegram_emoji(monkeypatch):
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.canonical_standard_emoji",
+        lambda value: value if value in {"👍", "🆒"} else None,
+    )
+    adapter = _make_adapter(proposal_approval_reactions=["👍", "🆒", "✅", "👍"])
+    assert adapter._proposal_approval_reactions() == {"👍", "🆒"}
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_telegram_reaction_tool.py
+++ b/tests/tools/test_telegram_reaction_tool.py
@@ -3,11 +3,10 @@ import asyncio, json, queue, subprocess, sys, threading
 from gateway.config import Platform
 from gateway.session import SessionSource
 
-def _call_on_gateway(monkeypatch, handler, emoji="❤️", message_id="900", chat_id="-100"):
+def _call_on_gateway(monkeypatch, handler, emoji="❤️"):
     from tools import telegram_reaction_tool as module
     values = {
         "HERMES_SESSION_PLATFORM": "telegram", "HERMES_SESSION_KEY": "secondary-session",
-        "HERMES_SESSION_CHAT_ID": chat_id, "HERMES_SESSION_MESSAGE_ID": message_id,
     }
     monkeypatch.setattr(module, "get_session_env", lambda n, d="": values.get(n, d))
     source = SessionSource(
@@ -36,14 +35,14 @@ def _call_on_gateway(monkeypatch, handler, emoji="❤️", message_id="900", cha
 def test_tool_target_canonical_fail_closed_scope_and_progress(monkeypatch):
     observed = {}
 
-    async def react(_a, chat_id, message_id, emoji):
-        observed.update(chat_id=chat_id, message_id=message_id, emoji=emoji,
+    async def react(_a, session_key, emoji):
+        observed.update(session_key=session_key, emoji=emoji,
                         loop=asyncio.get_running_loop(), thread=threading.get_ident())
         return True
 
     result, loop, thread, source = _call_on_gateway(monkeypatch, react)
     assert result == {"success": True}
-    assert observed == {"chat_id": "-100", "message_id": "900", "emoji": "❤",
+    assert observed == {"session_key": "secondary-session", "emoji": "❤",
                         "loop": loop, "thread": thread.ident}
     assert source.profile == "secondary"
 
@@ -51,10 +50,8 @@ def test_tool_target_canonical_fail_closed_scope_and_progress(monkeypatch):
         return False
 
     # Reaction turns / missing ordinary inbound → no outgoing reaction target.
-    assert _call_on_gateway(monkeypatch, fail, "👍", message_id="")[0] == {
+    assert _call_on_gateway(monkeypatch, fail, "👍")[0] == {
         "error": "The current Telegram message context is unavailable."}
-    assert _call_on_gateway(monkeypatch, fail, "👍", chat_id="-200")[0] == {
-        "error": "The current Telegram session is unavailable."}
 
     from tools import telegram_reaction_tool as module
     monkeypatch.setattr(module, "get_session_env",

--- a/tests/tools/test_telegram_reaction_tool.py
+++ b/tests/tools/test_telegram_reaction_tool.py
@@ -1,0 +1,114 @@
+"""Contract tests for telegram_react (emoji-only, current-turn, eager)."""
+import asyncio, json, queue, subprocess, sys, threading
+from gateway.config import Platform
+from gateway.session import SessionSource
+
+def _call_on_gateway(monkeypatch, handler, emoji="❤️", message_id="900", chat_id="-100"):
+    from tools import telegram_reaction_tool as module
+    values = {
+        "HERMES_SESSION_PLATFORM": "telegram", "HERMES_SESSION_KEY": "secondary-session",
+        "HERMES_SESSION_CHAT_ID": chat_id, "HERMES_SESSION_MESSAGE_ID": message_id,
+    }
+    monkeypatch.setattr(module, "get_session_env", lambda n, d="": values.get(n, d))
+    source = SessionSource(
+        platform=Platform.TELEGRAM, chat_id="-100", chat_type="group",
+        user_id="42", profile="secondary",
+    )
+    loop, ready = asyncio.new_event_loop(), threading.Event()
+
+    def run_loop():
+        asyncio.set_event_loop(loop); ready.set(); loop.run_forever()
+
+    thread = threading.Thread(target=run_loop); thread.start(); ready.wait(timeout=2)
+    adapter = type("A", (), {"add_current_reaction": handler})()
+    runner = type("R", (), {
+        "_gateway_loop": loop,
+        "_get_cached_session_source": lambda self, key: source,
+        "_adapter_for_source": lambda self, current: adapter,
+    })()
+    import gateway.run
+    monkeypatch.setattr(gateway.run, "_gateway_runner_ref", lambda: runner)
+    try:
+        return json.loads(module.telegram_reaction_tool(emoji)), loop, thread, source
+    finally:
+        loop.call_soon_threadsafe(loop.stop); thread.join(timeout=2); loop.close()
+
+def test_tool_target_canonical_fail_closed_scope_and_progress(monkeypatch):
+    observed = {}
+
+    async def react(_a, chat_id, message_id, emoji):
+        observed.update(chat_id=chat_id, message_id=message_id, emoji=emoji,
+                        loop=asyncio.get_running_loop(), thread=threading.get_ident())
+        return True
+
+    result, loop, thread, source = _call_on_gateway(monkeypatch, react)
+    assert result == {"success": True}
+    assert observed == {"chat_id": "-100", "message_id": "900", "emoji": "❤",
+                        "loop": loop, "thread": thread.ident}
+    assert source.profile == "secondary"
+
+    async def fail(*_a):
+        return False
+
+    # Reaction turns / missing ordinary inbound → no outgoing reaction target.
+    assert _call_on_gateway(monkeypatch, fail, "👍", message_id="")[0] == {
+        "error": "The current Telegram message context is unavailable."}
+    assert _call_on_gateway(monkeypatch, fail, "👍", chat_id="-200")[0] == {
+        "error": "The current Telegram session is unavailable."}
+
+    from tools import telegram_reaction_tool as module
+    monkeypatch.setattr(module, "get_session_env",
+                        lambda n, d="": "discord" if n == "HERMES_SESSION_PLATFORM" else d)
+    assert "Telegram session" in json.loads(module.telegram_reaction_tool("👍"))["error"]
+    monkeypatch.setattr(module, "get_session_env",
+                        lambda n, d="": "telegram" if n == "HERMES_SESSION_PLATFORM" else d)
+    monkeypatch.setattr(module, "canonical_standard_emoji", lambda e: None)
+    assert json.loads(module.telegram_reaction_tool("🧠")) == {
+        "error": "Telegram does not support that standard reaction emoji."}
+
+    from gateway.run import TurnRunner
+    from gateway.turn_context import TurnContext
+    from hermes_cli.tools_config import _get_platform_tools
+    from tools import telegram_reaction_tool
+    from tools.registry import registry
+    from tools.tool_search import is_deferrable_tool_name
+    from toolsets import resolve_toolset
+
+    entry = registry.get_entry("telegram_react")
+    assert entry is not None and entry.toolset == "telegram_reactions"
+    assert set(telegram_reaction_tool.SCHEMA["parameters"]["properties"]) == {"emoji"}
+    emoji_help = telegram_reaction_tool.SCHEMA["parameters"]["properties"]["emoji"]["description"]
+    assert "🤣" in emoji_help and "😂" not in emoji_help
+    assert "telegram_react" in resolve_toolset("hermes-telegram")
+    assert "telegram_react" in resolve_toolset("telegram_reactions")
+    assert "telegram_react" not in resolve_toolset("hermes-cli")
+    assert "telegram_react" not in resolve_toolset("hermes-discord")
+    assert "telegram_reactions" in _get_platform_tools({}, "telegram")
+    assert "telegram_reactions" not in _get_platform_tools({}, "discord")
+    assert is_deferrable_tool_name("telegram_react") is False
+    progress = queue.Queue()
+    TurnRunner(  # type: ignore[arg-type]
+        type("G", (), {"_adapter_for_source": lambda self, s: None})(),
+        TurnContext(progress_queue=progress, progress_mode="all",
+                    tool_progress_enabled=True, _run_still_current=lambda: True),
+    ).progress_callback("tool.started", "telegram_react", preview="t", args={"emoji": "👍"})
+    assert progress.empty()
+
+def test_standard_reaction_canonicalization_and_ptb_fallback(monkeypatch):
+    script = r"""
+from telegram.constants import ReactionEmoji
+from plugins.platforms.telegram.reactions import canonical_standard_emoji
+for emoji in [str(getattr(i, "value", i)) for i in ReactionEmoji]:
+    assert canonical_standard_emoji(emoji) == emoji
+    if "\u200d" not in emoji and not emoji.endswith(("\ufe0e", "\ufe0f")):
+        assert canonical_standard_emoji(f"{emoji}\ufe0f") == emoji
+    if "\u200d" in emoji and "\ufe0f" in emoji:
+        assert canonical_standard_emoji(emoji.replace("\ufe0f", "")) == emoji
+assert canonical_standard_emoji("🧠") is None
+"""
+    subprocess.run([sys.executable, "-c", script], check=True)
+    import telegram.constants as tc
+    from plugins.platforms.telegram import reactions
+    monkeypatch.setattr(tc, "ReactionEmoji", ())
+    assert reactions.canonical_standard_emoji("❤️") == "❤"
+    assert reactions.canonical_standard_emoji("👨‍💻") == "👨‍💻"

--- a/tools/telegram_reaction_tool.py
+++ b/tools/telegram_reaction_tool.py
@@ -1,0 +1,74 @@
+"""Intentional reaction tool for the bundled Telegram plugin."""
+
+import asyncio
+import concurrent.futures
+import json
+
+from gateway.session_context import get_session_env
+from plugins.platforms.telegram.reactions import canonical_standard_emoji
+from tools.registry import registry, tool_error
+
+_TIMEOUT = 10.0
+# Model-facing schema stays emoji-only; target comes from session context vars.
+SCHEMA = {
+    "name": "telegram_react",
+    "description": "Add one standard emoji reaction to this turn's inbound Telegram message. "
+                   "Use it as a response, not a processing-status signal. The target is fixed; "
+                   "do not describe the reaction in text.",
+    "parameters": {
+        "type": "object",
+        "properties": {"emoji": {"type": "string", "description": "A standard Telegram reaction, such as 👍, ❤, 🤣, or 👀."}},
+        "required": ["emoji"], "additionalProperties": False,
+    },
+}
+def telegram_reaction_tool(emoji: str) -> str:
+    emoji = (emoji or "").strip()
+    if not emoji:
+        return tool_error("An emoji is required.")
+    if str(get_session_env("HERMES_SESSION_PLATFORM", "")).lower() != "telegram":
+        return tool_error("This tool is only available in a Telegram session.")
+    canonical = canonical_standard_emoji(emoji)
+    if canonical is None:
+        return tool_error("Telegram does not support that standard reaction emoji.")
+    session_key = get_session_env("HERMES_SESSION_KEY", "")
+    chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "")
+    message_id = get_session_env("HERMES_SESSION_MESSAGE_ID", "")
+    if not (session_key and chat_id and message_id):
+        return tool_error("The current Telegram message context is unavailable.")
+    try:
+        from gateway.config import Platform
+        from gateway.run import _gateway_runner_ref
+        runner = _gateway_runner_ref()
+        source = runner._get_cached_session_source(session_key) if runner else None
+        if source is None or source.platform != Platform.TELEGRAM or str(source.chat_id) != str(chat_id):
+            return tool_error("The current Telegram session is unavailable.")
+        react = getattr(runner._adapter_for_source(source), "add_current_reaction", None)
+        loop = getattr(runner, "_gateway_loop", None)
+        if not callable(react) or loop is None or not loop.is_running() or loop.is_closed():
+            return tool_error("The Telegram gateway is not connected.")
+        # Refuse same-loop awaits to avoid deadlock; PTB is gateway-loop bound.
+        try:
+            if asyncio.get_running_loop() is loop:
+                return tool_error("Telegram reaction is unavailable on the gateway loop.")
+        except RuntimeError:
+            pass
+        coroutine = react(chat_id, message_id, canonical)
+        try:
+            future = asyncio.run_coroutine_threadsafe(coroutine, loop)
+        except Exception:
+            coroutine.close()
+            return tool_error("Telegram reaction failed.")
+        try:
+            success = future.result(timeout=_TIMEOUT)
+        except Exception as exc:
+            future.cancel()
+            timed_out = isinstance(exc, concurrent.futures.TimeoutError)
+            return tool_error("Telegram reaction timed out." if timed_out else "Telegram reaction failed.")
+    except Exception:
+        return tool_error("Telegram reaction failed.")
+    return json.dumps({"success": True}) if success else tool_error(
+        "The current Telegram message context is unavailable.")
+registry.register(
+    name="telegram_react", toolset="telegram_reactions", schema=SCHEMA,
+    handler=lambda args, **_: telegram_reaction_tool(args.get("emoji", "")), emoji="💛",
+)

--- a/tools/telegram_reaction_tool.py
+++ b/tools/telegram_reaction_tool.py
@@ -31,16 +31,16 @@ def telegram_reaction_tool(emoji: str) -> str:
     if canonical is None:
         return tool_error("Telegram does not support that standard reaction emoji.")
     session_key = get_session_env("HERMES_SESSION_KEY", "")
-    chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "")
-    message_id = get_session_env("HERMES_SESSION_MESSAGE_ID", "")
-    if not (session_key and chat_id and message_id):
+    if not session_key:
         return tool_error("The current Telegram message context is unavailable.")
     try:
         from gateway.config import Platform
         from gateway.run import _gateway_runner_ref
         runner = _gateway_runner_ref()
-        source = runner._get_cached_session_source(session_key) if runner else None
-        if source is None or source.platform != Platform.TELEGRAM or str(source.chat_id) != str(chat_id):
+        if runner is None:
+            return tool_error("The Telegram gateway is not connected.")
+        source = runner._get_cached_session_source(session_key)
+        if source is None or source.platform != Platform.TELEGRAM:
             return tool_error("The current Telegram session is unavailable.")
         react = getattr(runner._adapter_for_source(source), "add_current_reaction", None)
         loop = getattr(runner, "_gateway_loop", None)
@@ -52,7 +52,7 @@ def telegram_reaction_tool(emoji: str) -> str:
                 return tool_error("Telegram reaction is unavailable on the gateway loop.")
         except RuntimeError:
             pass
-        coroutine = react(chat_id, message_id, canonical)
+        coroutine = react(session_key, canonical)
         try:
             future = asyncio.run_coroutine_threadsafe(coroutine, loop)
         except Exception:

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -201,6 +201,15 @@ def _core_tool_names() -> frozenset[str]:
         return frozenset()
 
 
+def _eager_tool_names() -> frozenset[str]:
+    """Return core and explicitly platform-eager tool names."""
+    try:
+        from toolsets import _HERMES_PLATFORM_EAGER_TOOLS
+        return _core_tool_names() | frozenset(_HERMES_PLATFORM_EAGER_TOOLS)
+    except Exception:
+        return _core_tool_names()
+
+
 def is_deferrable_tool_name(name: str) -> bool:
     """Return True if a tool with this name is *eligible* for deferral.
 
@@ -211,7 +220,7 @@ def is_deferrable_tool_name(name: str) -> bool:
     """
     if name in BRIDGE_TOOL_NAMES:
         return False
-    if name in _core_tool_names():
+    if name in _eager_tool_names():
         return False
     # Check registry toolset for MCP prefix.
     try:

--- a/toolsets.py
+++ b/toolsets.py
@@ -87,6 +87,11 @@ _HERMES_CORE_TOOLS = [
     "computer_use",
 ]
 
+# Platform-specific tools that must remain directly callable when Tool Search
+# assembles a large platform bundle. These are intentionally separate from
+# the shared core so other platforms do not pay their schema.
+_HERMES_PLATFORM_EAGER_TOOLS = frozenset({"telegram_react"})
+
 # Webhook events may originate from untrusted third-party content (for example,
 # public PR titles/comments). Keep the default webhook toolset intentionally
 # constrained to avoid local file/system execution by prompt injection.
@@ -506,7 +511,12 @@ TOOLSETS = {
     "hermes-telegram": {
         "description": "Telegram bot toolset - full access for personal use (terminal has safety checks)",
         "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "includes": ["telegram_reactions"]
+    },
+    "telegram_reactions": {
+        "description": "React to the current inbound Telegram message",
+        "tools": ["telegram_react"],
+        "includes": [],
     },
     
     "hermes-discord": {

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -1199,8 +1199,8 @@ This covers the custom fallback transport layer that Hermes uses for Telegram co
 The bot can add emoji reactions to messages as visual processing feedback:
 
 - 👀 when the bot starts processing your message
-- ✅ when the response is delivered successfully
-- ❌ if an error occurs during processing
+- 👍 when the response is delivered successfully
+- 👎 if an error occurs during processing
 
 Reactions are **disabled by default**. Enable them in `config.yaml`:
 
@@ -1216,12 +1216,27 @@ TELEGRAM_REACTIONS=true
 ```
 
 :::note
-Unlike Discord (where reactions are additive), Telegram's Bot API replaces all bot reactions in a single call. The transition from 👀 to ✅/❌ happens atomically — you won't see both at once.
+Telegram's Bot API replaces all bot reactions in one call, so 👀 changes atomically to 👍/👎. An explicit `telegram_react` reaction is preserved instead.
 :::
 
 :::tip
 If the bot doesn't have permission to add reactions in a group, the reaction calls fail silently and message processing continues normally.
 :::
+
+### Reaction tool and inbound reactions
+
+`telegram_react` adds one standard emoji reaction to the Telegram message that started the current turn. It cannot target another message or send text, and works when automatic processing reactions are disabled.
+
+Inbound reactions are off by default. Enable them with:
+
+```yaml
+platforms:
+  telegram:
+    extra:
+      inbound_reactions: true
+```
+
+An authorized user's standard emoji additions and removals on Hermes messages start turns in the original chat and forum topic. Hermes ignores bot reactions and targets whose message, bot/profile ownership, or topic cannot be verified. Telegram's General topic remains logical thread `1`, although Bot API calls omit that ID. Reactions provide context only; consequential actions still require explicit text.
 
 ## Per-Channel Prompts
 

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -1238,6 +1238,33 @@ platforms:
 
 An authorized user's standard emoji additions and removals on Hermes messages start turns in the original chat and forum topic. Hermes ignores bot reactions and targets whose message, bot/profile ownership, or topic cannot be verified. Telegram's General topic remains logical thread `1`, although Bot API calls omit that ID. Reactions provide context only; consequential actions still require explicit text.
 
+To let selected reactions approve the exact non-consequential proposal in the
+Hermes message being reacted to, configure them explicitly:
+
+```yaml
+platforms:
+  telegram:
+    extra:
+      inbound_reactions: true
+      proposal_approval_reactions:
+        - "👍"
+```
+
+This setting is empty by default. When a configured reaction is **added**, the
+agent is instructed to carry out the proposal only if the target message contains
+a concrete, unambiguous and non-consequential next action. The instruction does
+not broaden the proposal, grant session or permanent permission, or replace the
+normal approval flow for risky operations. Removing a reaction does not add
+approval guidance.
+
+Use a [standard Telegram reaction](https://core.telegram.org/bots/api#reactiontypeemoji)
+that the intended users can select. `👍` is available to non-Premium users and
+is the recommended default.
+Symbols such as `✅` are used in some Hermes approval-button labels but are not
+standard Telegram message reactions. Custom-emoji reactions may require
+Telegram Premium, can be restricted by chat administrators, and are not handled
+by this inbound-reaction path.
+
 ## Per-Channel Prompts
 
 Assign ephemeral system prompts to specific Telegram groups or forum topics. The prompt is injected at runtime on every turn — never persisted to transcript history — so changes take effect immediately.


### PR DESCRIPTION
## Summary

Adds two-way standard reactions for Telegram.

- Reactions from authorized users on Hermes messages are sent to the same session and forum topic with a short quote of the target message.
- Hermes gets a `telegram_react` tool for reacting to the Telegram message that started the current turn.
- An optional list of standard reactions can be treated as approval of the proposal in the reacted-to message.

Inbound reactions are off by default:

```yaml
platforms:
  telegram:
    extra:
      inbound_reactions: true
```

Proposal approval is a separate opt-in:

```yaml
platforms:
  telegram:
    extra:
      inbound_reactions: true
      proposal_approval_reactions:
        - "👍"
```

`👍` is the suggested default because it is a standard Telegram reaction available to non-Premium users. Custom emoji reactions are not handled.

## Behaviour and safety

Hermes records enough information about sent messages to verify the bot, profile, chat and forum topic. These records survive restarts and expire after 30 days.

Reactions received while a task is running wait until that task finishes. They do not interrupt or steer the active turn, and they cannot answer command approvals or other pending prompts.

When a configured approval reaction is added, Hermes is instructed to carry out the proposal only if it is clear and harmless. Each added reaction creates one approval turn. Removing a reaction does not add approval guidance. Completed, unrelated or vague messages are handled as ordinary reaction context. Risky actions still use the existing approval flow.

## Tests

- 39 focused reaction tests passed on the current candidate
- 314 affected regression tests passed on the validated upstream snapshot
- Ruff, Python compilation, dependency and diff checks passed
- live Telegram checks covered outgoing reactions, configured approval reactions, removal, unconfigured reactions, completed and unrelated messages, duplicate prevention, risky and vague proposals, and reactions sent while a task was running

## How this differs from the related PRs

The related PRs split the problem in different ways. #13992 routes a small emoji allowlist using a short-lived in-memory cache. #24149 and #23731 write reaction events to log or feedback files. #53814 and #82063 expose them to hooks or plugins. #54599 maps each emoji to a configured instruction.

This PR combines direct session routing with restart-persistent ownership of the exact Hermes message and supports reactions in both directions. Its optional approval setting does not map an emoji to a command. Instead, each added configured reaction tells Hermes to carry out the clear, harmless proposal in that message. Removed reactions do not add approval guidance, and risky actions still use the existing approval flow. Reactions received during active work wait until the current turn finishes.

Addresses #13942 and #79057.
