### PR TITLE
fix(read_file): ignore trailing U+FFFD sampling artifact in binary detection

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -673,3 +673,28 @@ class TestReadNonUtf8IsBinary:
         ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
         # Proper UTF-8 (including non-ASCII) must still read as text.
         assert ops._is_likely_binary("notes.txt", "café résumé\nsecond\n") is False
+
+    def test_cjk_byte_cut_tail_replacement_not_flagged(self, tmp_path):
+        """Regression: the sample is `head -c 1000` — an arbitrary BYTE cut.
+        When the boundary lands inside a multi-byte UTF-8 char (common in
+        dense CJK documents), errors=replace appends a trailing U+FFFD. That
+        tail replacement char is a sampling artifact, not binary content, so
+        it must not flip the file to read-only binary.
+        """
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        # Real shape: content_sample is ALREADY the `head -c 1000` output
+        # decoded with errors=replace, so it is <= ~1000 chars with a single
+        # trailing U+FFFD where the byte cut landed mid-sequence. The
+        # [0:1000] re-slice inside _is_likely_binary must not drop it.
+        dense_cjk = "射频天线创新系统与毫米波滤波器设计" * 50  # 950 chars, every char is 3 bytes
+        artifact_sample = dense_cjk + "\ufffd"
+        assert len(artifact_sample) <= 1000 and artifact_sample.endswith("\ufffd")
+        assert ops._is_likely_binary("notes.txt", artifact_sample) is False
+
+    def test_interior_replacement_char_still_flagged_binary(self, tmp_path):
+        """U+FFFD outside the 4-char tail window is still genuine binary
+        content (UTF-16, compressed data, mojibake) and must be flagged.
+        """
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        sample = "中文中文\ufffd中文中文"  # replacement char sits in the interior
+        assert ops._is_likely_binary("notes.txt", sample) is True

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -903,11 +903,21 @@ class ShellFileOperations(FileOperations):
             # sample carries the replacement char as binary (read-only) so the
             # agent can't corrupt it. Legitimate UTF-8 text effectively never
             # contains U+FFFD.
-            if "\ufffd" in content_sample[:1000]:
+            sample = content_sample[:1000]
+            # EXCEPT one place legit UTF-8 text does produce U+FFFD: the
+            # sample itself is `head -c 1000` — an arbitrary BYTE cut. When
+            # the boundary lands inside a multi-byte UTF-8 char (common in
+            # dense CJK documents), errors=replace appends a trailing U+FFFD
+            # that is a sampling artifact, not binary content. Real binary
+            # (UTF-16, compressed data, etc.) yields replacement chars
+            # throughout the sample, never only at the tail. So ignore U+FFFD
+            # in the last 4 chars (max UTF-8 sequence length) before judging.
+            interior = sample[:-4] if len(sample) > 4 else ""
+            if "\ufffd" in interior:
                 return True
-            non_printable = sum(1 for c in content_sample[:1000]
+            non_printable = sum(1 for c in sample
                                if ord(c) < 32 and c not in '\n\r\t')
-            return non_printable / min(len(content_sample), 1000) > 0.30
+            return non_printable / min(len(sample), 1000) > 0.30
         
         return False
     


### PR DESCRIPTION
## What does this PR do?

`read_file` samples the first 1000 **bytes** via `head -c 1000`, and the terminal layer decodes that output with `errors="replace"`. When the byte boundary lands inside a multi-byte UTF-8 character — which is common in dense CJK/Turkish documents, where a single character is 3 bytes — the decode appends a single trailing U+FFFD that the file never contained.

`_is_likely_binary` treated **any** U+FFFD in the sample as proof of binary content, so perfectly valid UTF-8 text was rejected with "Binary file - cannot display as text". A file of 999 ASCII bytes + one multibyte char starting at byte 1000 fails; the same content one byte earlier in the file reads fine.

The fix: real binary content (UTF-16, compressed data, mojibake) produces replacement chars **throughout** the sample, never only at the tail. The check now ignores U+FFFD inside the last 4 characters (the maximum UTF-8 sequence length) before judging — a trailing artifact from the byte cut is no longer mistaken for binary, while U+FFFD anywhere in the sample's interior still flags the file as binary.

## Related Issue

Fixes #76886, #80308

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/file_operations.py` — `_is_likely_binary`: only consider U+FFFD in the sample interior (excluding the last 4 chars, max UTF-8 sequence length) as binary evidence; reuse the sliced `sample` consistently for the non-printable ratio.
- `tests/tools/test_file_operations.py` — two regression tests in `TestReadNonUtf8IsBinary`:
  - `test_cjk_byte_cut_tail_replacement_not_flagged`: dense CJK text + a trailing U+FFFD (the exact shape produced by `head -c 1000` + `errors="replace"`) must read as text.
  - `test_interior_replacement_char_still_flagged_binary`: U+FFFD outside the 4-char tail window is still genuine binary and must be flagged.

## How to Test

Reproduction (from #76886, works on current `main`):

```sh
printf 'a%.0s' $(seq 999) > fails.md && printf '\303\247\nx\n' >> fails.md  # 'ç' starts at byte 1000
read_file fails.md   # main: is_binary: true (wrong); this PR: reads normally
```

Regression tests:

```sh
python -m pytest tests/tools/test_file_operations.py -k "binary or replacement or utf8 or cjk" -v
# 6 passed — the 2 pre-existing binary-detection tests still pass (no behavior change
# for real binary), plus the 2 new regression tests.
```

Verified on Windows 10 + git-bash (MSYS2) backend. Note: I could not run the full `pytest tests/ -q` suite from this Windows environment; the related test files pass (95 tests run, 81 pass + 14 pre-existing environment failures unrelated to this change, confirmed identical with the patch stashed — symlink-permission and sensitive-path cases that fail on this platform regardless).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — *see How to Test; full suite not runnable on this Windows setup, related tests verified*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10 + git-bash

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — behavior is observable via the reproduction steps above.
