### PR TITLE
fix(tui): trace accepted prompt submissions

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import subprocess
 import sys
@@ -203,7 +204,7 @@ def test_default_config_seeds_dashboard_process_isolation_keys():
     assert dashboard["compute_host_respawn_max"] == 3
 
 
-def test_prompt_submit_dispatches_to_compute_host_when_turn_isolation_enabled(monkeypatch):
+def test_prompt_submit_dispatches_to_compute_host_when_turn_isolation_enabled(monkeypatch, caplog):
     class FakeSupervisor:
         def __init__(self):
             self.frames = []
@@ -242,13 +243,14 @@ def test_prompt_submit_dispatches_to_compute_host_when_turn_isolation_enabled(mo
     monkeypatch.setattr(server, "_get_compute_host_supervisor", lambda _cfg=None: fake_supervisor)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "submit",
-                "method": "prompt.submit",
-                "params": {"session_id": "iso-sid", "text": "hello"},
-            }
-        )
+        with caplog.at_level(logging.INFO, logger="tui_gateway.server"):
+            resp = server.handle_request(
+                {
+                    "id": "submit",
+                    "method": "prompt.submit",
+                    "params": {"session_id": "iso-sid", "text": "hello"},
+                }
+            )
         assert resp["result"] == {"status": "streaming", "turn_isolation": True}
         assert fake_supervisor.frames[0]["type"] == "turn.start"
         assert fake_supervisor.frames[0]["sid"] == "iso-sid"
@@ -257,6 +259,11 @@ def test_prompt_submit_dispatches_to_compute_host_when_turn_isolation_enabled(mo
         assert server._sessions["iso-sid"]["history"] == seed_history
         assert parent_writes == {"ensure_session": 0, "persist_seed": 0}
         assert server._sessions["iso-sid"]["running"] is True
+        assert any(
+            "prompt accepted: request_id=submit session=iso-sid" in message
+            and "route=compute_host" in message
+            for message in caplog.messages
+        )
 
         fake_supervisor.callback(
             {
@@ -270,6 +277,67 @@ def test_prompt_submit_dispatches_to_compute_host_when_turn_isolation_enabled(mo
         assert server._sessions["iso-sid"]["history_version"] == 1
     finally:
         server._sessions.pop("iso-sid", None)
+
+
+def test_prompt_submit_logs_accepted_desktop_turn_without_prompt_text(
+    monkeypatch, caplog
+):
+    class _ImmediateThread:
+        def __init__(self, target=None, **_kwargs):
+            self._target = target
+
+        def start(self):
+            assert self._target is not None
+            self._target()
+
+    session = _session(
+        source="desktop",
+        profile_home="/tmp/profiles/kimi",
+        transport=types.SimpleNamespace(_peer="127.0.0.1:4321"),
+    )
+    server._sessions["desktop-sid"] = session
+    delivered = []
+    monkeypatch.setattr(server, "_ensure_active_session_slot", lambda *_args: None)
+    monkeypatch.setattr(
+        server,
+        "_load_dashboard_process_isolation_config",
+        lambda: {"turn_isolation": False},
+    )
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda _session: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda _sid, _session: None)
+    monkeypatch.setattr(
+        server, "_wait_agent_for_prompt", lambda _session, _rid, _sid: None
+    )
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda rid, sid, _session, text: delivered.append((rid, sid, text)),
+    )
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+
+    try:
+        with caplog.at_level(logging.INFO, logger="tui_gateway.server"):
+            response = server.handle_request({
+                "id": "desktop-request",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "desktop-sid",
+                    "text": "do not put this prompt in the logs",
+                },
+            })
+    finally:
+        server._sessions.pop("desktop-sid", None)
+
+    assert response["result"] == {"status": "streaming"}
+    assert delivered == [
+        ("desktop-request", "desktop-sid", "do not put this prompt in the logs")
+    ]
+    messages = "\n".join(caplog.messages)
+    assert "prompt accepted: request_id=desktop-request session=desktop-sid" in messages
+    assert "source=desktop route=in_process profile=kimi" in messages
+    assert "transport=SimpleNamespace peer=127.0.0.1:4321" in messages
+    assert "do not put this prompt in the logs" not in messages
 
 
 def test_compute_host_explicit_images_do_not_clear_later_attachment(monkeypatch):

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -315,6 +315,7 @@ def _(rid, params: dict) -> dict:
             f"session storage could not be written: {exc}",
         )
     _start_agent_build(sid, session)
+    _log_prompt_accepted(rid, sid, session, route="in_process")
 
     def run_after_agent_ready() -> None:
         # Patient wait (#63078): the user's message is already the accepted

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1799,7 +1799,32 @@ def _submit_prompt_to_compute_host(
         session["_compute_host_active"] = True
         if image_paths is None:
             session["attached_images"] = []
+    _log_prompt_accepted(rid, sid, session, route="compute_host")
     return _ok(rid, {"status": "streaming", "turn_isolation": True})
+
+
+def _log_prompt_accepted(rid: Any, sid: str, session: dict, *, route: str) -> None:
+    """Record an accepted Desktop/TUI prompt without exposing its content.
+
+    The message is emitted only after the in-process turn is ready to run or
+    the compute host accepted its frame.  It gives incident captures a stable
+    request/session/process correlation point without logging user text.
+    """
+    transport = current_transport() or session.get("transport")
+    profile_home = session.get("profile_home")
+    profile = Path(str(profile_home)).name if profile_home else _current_profile_name()
+    logger.info(
+        "prompt accepted: request_id=%s session=%s source=%s route=%s "
+        "profile=%s pid=%s transport=%s peer=%s",
+        rid,
+        sid,
+        _session_source(session),
+        route,
+        profile,
+        os.getpid(),
+        type(transport).__name__ if transport is not None else "none",
+        getattr(transport, "_peer", "stdio"),
+    )
 
 
 def _send_compute_host_control(


### PR DESCRIPTION
## What changed and why

Per the reporter's 2026-08-08 clarification, Desktop prompts have no normal acceptance record in either `agent.log` or `gateway.log`, leaving no way to correlate a client send with the backend process that dispatched it. Add a single INFO record after a prompt is accepted for execution, covering both in-process and compute-host routes. It records request/session IDs, source, route, profile name, process ID, transport type, and peer; it never records prompt content.

## Addressing maintainer feedback

- #80916 is merged and fixes the in-flight compression-strip race. This PR does not alter that behavior.
- #79293 is the superseded predecessor proposal to #80916. This PR does not revive it.

The remaining report is a Desktop/backend attribution gap, so this change is intentionally limited to a trace point needed for a future correlated capture.

## How to test

- `pytest tests/test_tui_gateway_server.py -q -x --timeout=60 -k 'prompt_submit_dispatches_to_compute_host_when_turn_isolation_enabled or prompt_submit_logs_accepted_desktop_turn_without_prompt_text'`
- `ruff check tui_gateway/server.py tui_gateway/methods_prompt.py tests/test_tui_gateway_server.py`
- Attempted the prescribed full suite; collection is blocked in this sandbox because FastAPI/Uvicorn are absent and the managed Python environment rejects the automatic dependency install.

## What platforms tested on

- macOS sandbox, Python 3.14

Addresses #79278

Refs #79278

<!-- autocontrib:worker-id=issue-followup-192cb6ac kind=pr-open -->