### PR TITLE
fix(agent): resolve file-mutation verifier paths against worktree cwd

### DIFF
--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -285,7 +285,7 @@ def _extract_parallel_scope_paths(
 
     raw_paths: List[str] = []
     if tool_name == "patch" and (function_args.get("mode") or "replace") == "patch":
-        raw_paths.extend(_extract_file_mutation_targets(tool_name, function_args))
+        raw_paths.extend(_extract_file_mutation_targets(tool_name, function_args, execution_cwd))
     else:
         raw_path = function_args.get("path")
         if isinstance(raw_path, str) and raw_path.strip():
@@ -405,61 +405,79 @@ def _append_subdir_hint_to_multimodal(value: Dict[str, Any], hint: str) -> None:
         value["text_summary"] = value["text_summary"] + hint
 
 
-def _extract_file_mutation_targets(tool_name: str, args: Dict[str, Any]) -> List[str]:
+def _extract_file_mutation_targets(
+    tool_name: str,
+    args: Dict[str, Any],
+    execution_cwd: Optional[Path] = None,
+) -> List[str]:
     """Return the file paths a ``write_file`` or ``patch`` call is targeting.
 
     For ``write_file`` and ``patch`` in replace mode this is just ``args["path"]``.
     For ``patch`` in V4A patch mode we parse the patch content for
     ``*** Update File:`` / ``*** Add File:`` / ``*** Delete File:`` headers so
     the verifier can track each file in a multi-file patch separately.
+
+    When *execution_cwd* is supplied, repo-relative targets are canonicalised
+    against it — the directory the tool actually runs in — instead of the
+    process cwd, which differs when the agent runs inside a linked git
+    worktree (#81650). Without *execution_cwd* the raw paths are returned
+    unchanged, preserving the historical behaviour.
     """
     if tool_name not in _FILE_MUTATING_TOOLS:
         return []
+    paths: List[str] = []
     if tool_name == "write_file":
         p = args.get("path")
-        return [str(p)] if p else []
-    # tool_name == "patch"
-    mode = args.get("mode") or "replace"
-    if mode == "replace":
-        p = args.get("path")
-        return [str(p)] if p else []
-    if mode == "patch":
-        body = args.get("patch") or ""
-        if not isinstance(body, str) or not body:
-            return []
-        paths: List[str] = []
-        # ``\s*`` (not ``\s+``) after ``***`` matches patch_parser / file_tools:
-        # they accept ``***Update File:`` with no space after the asterisks.
-        for _m in re.finditer(
-            r'^\*\*\*\s*(?:Update|Add|Delete)\s+File:\s*(.+)$',
-            body,
-            re.MULTILINE,
-        ):
-            p = _m.group(1).strip()
+        if p:
+            paths.append(str(p))
+    else:  # tool_name == "patch"
+        mode = args.get("mode") or "replace"
+        if mode == "replace":
+            p = args.get("path")
             if p:
-                paths.append(p)
-        for _m in re.finditer(
-            r'^\*\*\*\s*Move\s+File:\s*(.+?)\s*->\s*(.+)$',
-            body,
-            re.MULTILINE,
-        ):
-            src = _m.group(1).strip()
-            dst = _m.group(2).strip()
-            if src:
-                paths.append(src)
-            if dst:
-                paths.append(dst)
+                paths.append(str(p))
+        elif mode == "patch":
+            body = args.get("patch") or ""
+            if isinstance(body, str) and body:
+                # ``\s*`` (not ``\s+``) after ``***`` matches patch_parser / file_tools:
+                # they accept ``***Update File:`` with no space after the asterisks.
+                for _m in re.finditer(
+                    r'^\*\*\*\s*(?:Update|Add|Delete)\s+File:\s*(.+)$',
+                    body,
+                    re.MULTILINE,
+                ):
+                    p = _m.group(1).strip()
+                    if p:
+                        paths.append(p)
+                for _m in re.finditer(
+                    r'^\*\*\*\s*Move\s+File:\s*(.+?)\s*->\s*(.+)$',
+                    body,
+                    re.MULTILINE,
+                ):
+                    src = _m.group(1).strip()
+                    dst = _m.group(2).strip()
+                    if src:
+                        paths.append(src)
+                    if dst:
+                        paths.append(dst)
+    if execution_cwd is None:
         return paths
-    return []
+    return [str(_canonical_path(p, execution_cwd)) for p in paths]
 
 
 def _extract_landed_file_mutation_paths(
     tool_name: str,
     args: Dict[str, Any],
     result: Any,
+    execution_cwd: Optional[Path] = None,
 ) -> List[str]:
-    """Return the concrete file paths a successful mutation reports."""
-    targets = _extract_file_mutation_targets(tool_name, args)
+    """Return the concrete file paths a successful mutation reports.
+
+    *execution_cwd* is threaded through to ``_extract_file_mutation_targets``
+    and used to canonicalise repo-relative paths reported by the tool result,
+    mirroring ``_extract_file_mutation_targets`` (#81650).
+    """
+    targets = _extract_file_mutation_targets(tool_name, args, execution_cwd)
     if tool_name not in _FILE_MUTATING_TOOLS or not isinstance(result, str):
         return targets
     try:
@@ -473,11 +491,15 @@ def _extract_landed_file_mutation_paths(
     if isinstance(files, list):
         landed = [str(p) for p in files if p]
         if landed:
-            return landed
+            if execution_cwd is None:
+                return landed
+            return [str(_canonical_path(p, execution_cwd)) for p in landed]
 
     resolved = data.get("resolved_path")
     if resolved:
-        return [str(resolved)]
+        if execution_cwd is None:
+            return [str(resolved)]
+        return [str(_canonical_path(str(resolved), execution_cwd))]
 
     return targets
 

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1452,8 +1452,15 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             # block count as either a failure or a success.
             if not blocked:
                 try:
+                    _env = get_active_env(effective_task_id)
+                    _exec_cwd = (
+                        Path(_env.cwd)
+                        if _env is not None and getattr(_env, "cwd", None)
+                        else None
+                    )
                     agent._record_file_mutation_result(
                         function_name, function_args, function_result, is_error,
+                        execution_cwd=_exec_cwd,
                     )
                 except Exception as _ver_err:
                     logging.debug("file-mutation verifier record failed: %s", _ver_err)
@@ -2209,8 +2216,15 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # turn, not just the parallel ones.
         if not _execution_blocked:
             try:
+                _env = get_active_env(effective_task_id)
+                _exec_cwd = (
+                    Path(_env.cwd)
+                    if _env is not None and getattr(_env, "cwd", None)
+                    else None
+                )
                 agent._record_file_mutation_result(
                     function_name, function_args, function_result, _is_error_result,
+                    execution_cwd=_exec_cwd,
                 )
             except Exception as _ver_err:
                 logging.debug("file-mutation verifier record failed: %s", _ver_err)

--- a/run_agent.py
+++ b/run_agent.py
@@ -3424,6 +3424,7 @@ class AIAgent:
         args: Dict[str, Any],
         result: Any,
         is_error: bool,
+        execution_cwd: Optional[Path] = None,
     ) -> None:
         """Record a ``write_file`` / ``patch`` outcome for the turn-end verifier.
 
@@ -3432,20 +3433,25 @@ class AIAgent:
         model recovered within the turn).  Silently no-ops if the per-turn
         state dict hasn't been initialised yet (e.g. a tool dispatched
         outside ``run_conversation``).
+
+        *execution_cwd* (the working directory the tool actually ran in) is
+        threaded into the target extractors so repo-relative paths are
+        canonicalised against the worktree rather than the process cwd
+        (#81650).
         """
         if tool_name not in _FILE_MUTATING_TOOLS:
             return
         state = getattr(self, "_turn_failed_file_mutations", None)
         if state is None:
             return
-        targets = _extract_file_mutation_targets(tool_name, args)
+        targets = _extract_file_mutation_targets(tool_name, args, execution_cwd)
         if not targets:
             return
         landed = file_mutation_result_landed(tool_name, result)
         if landed:
             changed = getattr(self, "_turn_file_mutation_paths", None)
             if changed is not None:
-                changed.update(_extract_landed_file_mutation_paths(tool_name, args, result))
+                changed.update(_extract_landed_file_mutation_paths(tool_name, args, result, execution_cwd))
         if is_error and not landed:
             preview = _extract_error_preview(result)
             for path in targets:

--- a/tests/agent/test_tool_dispatch_helpers.py
+++ b/tests/agent/test_tool_dispatch_helpers.py
@@ -8,10 +8,14 @@ NOT a regex scan — it's an unconditional architectural mark on every result
 from a known-untrusted source.
 """
 
+import os
+from pathlib import Path
+
 import pytest
 
 from agent.tool_dispatch_helpers import (
     _extract_file_mutation_targets,
+    _extract_landed_file_mutation_paths,
     _is_untrusted_tool,
     _maybe_wrap_untrusted,
     make_tool_result_message,
@@ -209,3 +213,69 @@ class TestFileMutationTargets:
             },
         )
         assert targets == ["old/name.py", "new/name.py"]
+
+    def test_relative_target_resolves_against_execution_cwd_not_process_cwd(
+        self, tmp_path, monkeypatch
+    ):
+        # Simulate a linked worktree: the process cwd differs from the
+        # directory the tool actually runs in (#81650). A repo-relative
+        # target must resolve against the execution cwd (the worktree),
+        # never against the process cwd.
+        process_cwd = tmp_path / "process"
+        process_cwd.mkdir()
+        worktree = tmp_path / "hermes-agent-pr-252"
+        worktree.mkdir()
+        monkeypatch.chdir(process_cwd)
+
+        targets = _extract_file_mutation_targets(
+            "write_file",
+            {"path": "tests/agent/test_x.py"},
+            execution_cwd=worktree,
+        )
+        assert targets == [os.path.realpath(str(worktree / "tests" / "agent" / "test_x.py"))]
+
+    def test_without_execution_cwd_preserves_raw_relative_target(self, tmp_path, monkeypatch):
+        # Historical behaviour: without an execution cwd the raw paths are
+        # returned unchanged — nothing about path resolution changes.
+        monkeypatch.chdir(tmp_path)
+        targets = _extract_file_mutation_targets(
+            "write_file",
+            {"path": "tests/agent/test_x.py"},
+        )
+        assert targets == ["tests/agent/test_x.py"]
+
+    def test_v4a_patch_headers_resolved_against_execution_cwd(self, tmp_path, monkeypatch):
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        monkeypatch.chdir(tmp_path)
+
+        targets = _extract_file_mutation_targets(
+            "patch",
+            {
+                "mode": "patch",
+                "patch": (
+                    "*** Begin Patch\n"
+                    "*** Update File: tests/agent/test_x.py\n"
+                    "*** Add File: new/module.py\n"
+                    "*** End Patch\n"
+                ),
+            },
+            execution_cwd=worktree,
+        )
+        assert targets == [
+            os.path.realpath(str(worktree / "tests" / "agent" / "test_x.py")),
+            os.path.realpath(str(worktree / "new" / "module.py")),
+        ]
+
+    def test_landed_paths_resolved_against_execution_cwd(self, tmp_path, monkeypatch):
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        monkeypatch.chdir(tmp_path)
+
+        landed = _extract_landed_file_mutation_paths(
+            "patch",
+            {"mode": "replace", "path": "tests/agent/test_x.py"},
+            '{"success": true, "files_modified": ["tests/agent/test_x.py"]}',
+            execution_cwd=worktree,
+        )
+        assert landed == [os.path.realpath(str(worktree / "tests" / "agent" / "test_x.py"))]

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -20,6 +20,7 @@ list of files that did NOT change.
 from __future__ import annotations
 
 import json
+import os
 
 import pytest
 
@@ -226,6 +227,66 @@ class TestRecordFileMutationResult:
         # Keep the original error — swapping to the latest would obscure
         # the initial root cause.
         assert "first error" in agent._turn_failed_file_mutations["/tmp/a.md"]["error_preview"]
+
+    def test_failure_recorded_against_execution_cwd(self, tmp_path):
+        """#81650: a repo-relative failure is keyed by its worktree path,
+        not by a path resolved against the process cwd."""
+        agent = _bare_agent()
+        worktree = tmp_path / "hermes-agent-pr-252"
+        worktree.mkdir()
+        agent._record_file_mutation_result(
+            "patch",
+            {
+                "mode": "replace",
+                "path": "tests/agent/test_auxiliary_client.py",
+                "old_string": "x",
+                "new_string": "y",
+            },
+            json.dumps({"success": False, "error": "Could not find old_string"}),
+            is_error=True,
+            execution_cwd=worktree,
+        )
+        expected = os.path.realpath(
+            str(worktree / "tests" / "agent" / "test_auxiliary_client.py")
+        )
+        state = agent._turn_failed_file_mutations
+        assert expected in state
+        assert state[expected]["tool"] == "patch"
+        # The raw relative form must not leak into the per-turn state.
+        assert "tests/agent/test_auxiliary_client.py" not in state
+
+    def test_success_records_landed_path_against_execution_cwd(self, tmp_path):
+        agent = _bare_agent()
+        worktree = tmp_path / "hermes-agent-pr-252"
+        worktree.mkdir()
+        agent._record_file_mutation_result(
+            "patch",
+            {
+                "mode": "replace",
+                "path": "tests/agent/test_auxiliary_client.py",
+                "old_string": "x",
+                "new_string": "y",
+            },
+            json.dumps({"success": True, "diff": "..."}),
+            is_error=False,
+            execution_cwd=worktree,
+        )
+        assert agent._turn_file_mutation_paths == {
+            os.path.realpath(str(worktree / "tests" / "agent" / "test_auxiliary_client.py"))
+        }
+
+    def test_without_execution_cwd_keeps_raw_relative_key(self, tmp_path, monkeypatch):
+        # Historical behaviour preserved: no execution cwd -> raw relative
+        # path stays the state key (same string matches on success).
+        agent = _bare_agent()
+        monkeypatch.chdir(tmp_path)
+        agent._record_file_mutation_result(
+            "patch",
+            {"mode": "replace", "path": "tests/agent/test_x.py", "old_string": "x", "new_string": "y"},
+            json.dumps({"error": "not found"}),
+            is_error=True,
+        )
+        assert "tests/agent/test_x.py" in agent._turn_failed_file_mutations
 
 
 


### PR DESCRIPTION
## Summary
The file-mutation verifier resolved repo-relative paths against the **process CWD** instead of the **worktree CWD**. In a linked git worktree (e.g. `/home/user/hermes-agent-pr-252`), a mutation targeting `tests/agent/test_x.py` was verified as `/home/user/tests/...` (process cwd) instead of `/home/user/hermes-agent-pr-252/tests/...` — producing false negatives ("file not mutated") on valid patches.

## Root Cause
The verifier pipeline (`_extract_file_mutation_targets` → `_record_file_mutation_result` → `_turn_failed_file_mutations`) worked with raw repo-relative paths; only the parallelism planner (`_plan_tool_batch_segments`) received `execution_cwd`. Downstream (`_candidate_cwds` in verification_stop.py, footer) resolved `tests/...` against process cwd → wrong location in worktrees.

## Change
- `agent/tool_dispatch_helpers.py`: `_extract_file_mutation_targets` and `_extract_landed_file_mutation_paths` now accept `execution_cwd` and canonicalize repo-relative targets against it via `_canonical_path` (no `execution_cwd` → raw behavior preserved); planner propagates `execution_cwd` when extracting V4A targets.
- `run_agent.py`: `_record_file_mutation_result(..., execution_cwd=None)` accepts and propagates the cwd to both extractors.
- `agent/tool_executor.py`: both call sites (concurrent + sequential) pass `execution_cwd` derived from `get_active_env(effective_task_id).cwd`.
- Tests: worktree-vs-process-cwd divergence cases (7 new across the two test files).

## Verification
- `tests/agent/test_tool_dispatch_helpers.py` + `tests/run_agent/test_file_mutation_verifier.py`: **50 passed**.

Closes #81650