### PR TITLE
feat(providers): add QwenCloud Token Plan as native provider

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -376,6 +376,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("ALIBABA_CODING_PLAN_API_KEY", "DASHSCOPE_API_KEY"),
         base_url_env_var="ALIBABA_CODING_PLAN_BASE_URL",
     ),
+    "qwencloud": ProviderConfig(
+        id="qwencloud",
+        name="QwenCloud (Token Plan)",
+        auth_type="api_key",
+        inference_base_url="https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+        api_key_env_vars=("QWENCLOUD_API_KEY",),
+        base_url_env_var="QWENCLOUD_BASE_URL",
+    ),
     "minimax-cn": ProviderConfig(
         id="minimax-cn",
         name="MiniMax (China)",
@@ -2016,6 +2024,8 @@ def resolve_provider(
         "minimax-portal": "minimax-oauth", "minimax-global": "minimax-oauth", "minimax_oauth": "minimax-oauth",
         "alibaba_coding": "alibaba-coding-plan", "alibaba-coding": "alibaba-coding-plan",
         "alibaba_coding_plan": "alibaba-coding-plan",
+        "qwencloud-token-plan": "qwencloud", "qwencloud_token_plan": "qwencloud",
+        "qwen-cloud": "qwencloud",
         "claude": "anthropic", "claude-code": "anthropic",
         "github": "copilot", "github-copilot": "copilot",
         "github-models": "copilot", "github-model": "copilot",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -556,6 +556,17 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "glm-4.7",
         "MiniMax-M2.5",
     ],
+    # QwenCloud Token Plan — separate endpoint
+    # (token-plan.ap-southeast-1.maas.aliyuncs.com) and billing tier from
+    # alibaba (DashScope) and alibaba-coding-plan. First-party Qwen models.
+    "qwencloud": [
+        "qwen3.8-max",
+        "qwen3.7-plus",
+        "qwen3.6-plus",
+        "qwen3.5-plus",
+        "qwen3-coder-plus",
+        "qwen3-coder-next",
+    ],
     # Curated HF model list — only agentic models that map to OpenRouter defaults.
     "huggingface": [
         "moonshotai/Kimi-K2.5",
@@ -1124,6 +1135,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("openai-codex",   "OpenAI Codex",             "OpenAI Codex (Codex CLI via ChatGPT subscription or API key)"),
     ProviderEntry("openai-api",     "OpenAI API",               "OpenAI API (api.openai.com, API key)"),
     ProviderEntry("alibaba",        "Qwen Cloud",               "Qwen Cloud / DashScope (Qwen + multi-provider)"),
+    ProviderEntry("qwencloud",      "QwenCloud (Token Plan)",   "QwenCloud Token Plan (2500 credits/week, OpenAI-compatible token-plan endpoint)"),
     ProviderEntry("xai-oauth",      "xAI Grok OAuth (SuperGrok / Premium+)", "xAI Grok OAuth (SuperGrok / Premium+ subscription)"),
     ProviderEntry("xiaomi",         "Xiaomi MiMo",              "Xiaomi MiMo (MiMo-V2.5 and V2 models: pro, omni, flash)"),
     ProviderEntry("tencent-tokenhub", "Tencent TokenHub",       "Tencent TokenHub (Hy3 Preview via tokenhub.tencentmaas.com)"),
@@ -1206,7 +1218,7 @@ PROVIDER_GROUPS: dict[str, tuple[str, str, list[str]]] = {
     "xai":      ("xAI Grok",        "Direct API or SuperGrok / Premium+ OAuth",        ["xai", "xai-oauth"]),
     "google":   ("Google Gemini",   "Google AI Studio (API key)",                     ["gemini"]),
     "openai":   ("OpenAI",          "Codex CLI or direct OpenAI API",                  ["openai-codex", "openai-api"]),
-    "qwen":     ("Qwen",            "Qwen Cloud / DashScope, Coding Plan & Qwen CLI OAuth", ["alibaba", "alibaba-coding-plan", "qwen-oauth"]),
+    "qwen":     ("Qwen",            "Qwen Cloud / DashScope, Coding Plan, Token Plan & Qwen CLI OAuth", ["alibaba", "alibaba-coding-plan", "qwencloud", "qwen-oauth"]),
     "opencode": ("OpenCode",        "Zen pay-as-you-go or Go subscription",            ["opencode-zen", "opencode-go"]),
     "copilot":  ("GitHub Copilot",  "GitHub token API or copilot --acp process",       ["copilot", "copilot-acp"]),
 }
@@ -1337,6 +1349,9 @@ _PROVIDER_ALIASES = {
     "aliyun": "alibaba",
     "qwen": "alibaba",
     "alibaba-cloud": "alibaba",
+    "qwencloud-token-plan": "qwencloud",
+    "qwencloud_token_plan": "qwencloud",
+    "qwen-cloud": "qwencloud",
     "qwen-portal": "qwen-oauth",
     "hf": "huggingface",
     "hugging-face": "huggingface",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -142,6 +142,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="openai_chat",
         base_url_env_var="ALIBABA_CODING_PLAN_BASE_URL",
     ),
+    "qwencloud": HermesOverlay(
+        transport="openai_chat",
+        extra_env_vars=("QWENCLOUD_API_KEY",),
+        base_url_override="https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+        base_url_env_var="QWENCLOUD_BASE_URL",
+    ),
     "vercel": HermesOverlay(
         transport="openai_chat",
         is_aggregator=True,
@@ -349,6 +355,11 @@ ALIASES: Dict[str, str] = {
     "alibaba-coding": "alibaba-coding-plan",
     "alibaba_coding_plan": "alibaba-coding-plan",
 
+    # qwencloud (QwenCloud Token Plan)
+    "qwencloud-token-plan": "qwencloud",
+    "qwencloud_token_plan": "qwencloud",
+    "qwen-cloud": "qwencloud",
+
     # huggingface
     "hf": "huggingface",
     "hugging-face": "huggingface",
@@ -421,6 +432,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "upstage": "Upstage Solar",
     "actual": "Actual Computer",
     "tencent-tokenhub": "Tencent TokenHub",
+    "qwencloud": "QwenCloud (Token Plan)",
     "lmstudio": "LM Studio",
     "local": "Local endpoint",
     "bedrock": "AWS Bedrock",

--- a/tests/hermes_cli/test_qwencloud_provider.py
+++ b/tests/hermes_cli/test_qwencloud_provider.py
@@ -1,0 +1,207 @@
+"""Tests for QwenCloud Token Plan provider support.
+
+QwenCloud (home.qwencloud.com) offers a Token Plan subscription ($6/mo,
+2500 credits/week) with an OpenAI-compatible API at a distinct endpoint
+(token-plan.ap-southeast-1.maas.aliyuncs.com) that differs from the
+existing `alibaba` (DashScope) and `alibaba-coding-plan` providers.
+"""
+
+import pytest
+
+from hermes_cli.auth import (
+    PROVIDER_REGISTRY,
+    resolve_provider,
+    get_api_key_provider_status,
+    resolve_api_key_provider_credentials,
+)
+
+
+# Other provider env vars to clear during auto-detection tests
+_OTHER_PROVIDER_KEYS = (
+    "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "DEEPSEEK_API_KEY",
+    "GOOGLE_API_KEY", "GEMINI_API_KEY", "DASHSCOPE_API_KEY",
+    "XAI_API_KEY", "KIMI_API_KEY", "KIMI_CN_API_KEY",
+    "MINIMAX_API_KEY", "MINIMAX_CN_API_KEY", "AI_GATEWAY_API_KEY",
+    "KILOCODE_API_KEY", "HF_TOKEN", "GLM_API_KEY", "ZAI_API_KEY",
+    "XIAOMI_API_KEY", "TOKENHUB_API_KEY", "OPENROUTER_API_KEY",
+    "COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN", "ARCEEAI_API_KEY",
+)
+
+
+QWENCLOUD_BASE_URL = "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1"
+
+
+# =============================================================================
+# Provider Registry
+# =============================================================================
+
+
+class TestQwencloudProviderRegistry:
+    """Verify qwencloud is registered correctly in the PROVIDER_REGISTRY."""
+
+    def test_registered(self):
+        assert "qwencloud" in PROVIDER_REGISTRY
+
+    def test_inference_base_url(self):
+        assert PROVIDER_REGISTRY["qwencloud"].inference_base_url == QWENCLOUD_BASE_URL
+
+    def test_not_custom(self, monkeypatch):
+        """qwencloud must be a first-class provider, not the custom workaround."""
+        for key in _OTHER_PROVIDER_KEYS:
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("QWENCLOUD_API_KEY", "sk-sp-test")
+        assert resolve_provider("qwencloud") == "qwencloud"
+
+
+# =============================================================================
+# Aliases
+# =============================================================================
+
+
+class TestQwencloudAliases:
+    """All aliases should resolve to 'qwencloud'."""
+
+    @pytest.mark.parametrize("alias", [
+        "qwencloud", "qwencloud-token-plan", "qwencloud_token_plan", "qwen-cloud",
+    ])
+    def test_alias_resolves(self, alias, monkeypatch):
+        for key in _OTHER_PROVIDER_KEYS:
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("QWENCLOUD_API_KEY", "sk-sp-test")
+        assert resolve_provider(alias) == "qwencloud"
+
+    def test_normalize_provider_models_py(self):
+        from hermes_cli.models import normalize_provider
+        assert normalize_provider("qwencloud-token-plan") == "qwencloud"
+        assert normalize_provider("qwencloud_token_plan") == "qwencloud"
+        assert normalize_provider("qwen-cloud") == "qwencloud"
+
+    def test_normalize_provider_providers_py(self):
+        from hermes_cli.providers import normalize_provider
+        assert normalize_provider("qwencloud-token-plan") == "qwencloud"
+        assert normalize_provider("qwencloud_token_plan") == "qwencloud"
+        assert normalize_provider("qwen-cloud") == "qwencloud"
+
+
+# =============================================================================
+# Credentials
+# =============================================================================
+
+
+class TestQwencloudCredentials:
+    """Test credential resolution for the qwencloud provider."""
+
+    def test_resolve_credentials_with_default_base_url(self, monkeypatch):
+        monkeypatch.setenv("QWENCLOUD_API_KEY", "sk-sp-test")
+        monkeypatch.delenv("QWENCLOUD_BASE_URL", raising=False)
+        creds = resolve_api_key_provider_credentials("qwencloud")
+        assert creds["api_key"] == "sk-sp-test"
+        assert creds["base_url"] == QWENCLOUD_BASE_URL
+
+    def test_resolve_credentials_with_env_base_url_override(self, monkeypatch):
+        monkeypatch.setenv("QWENCLOUD_API_KEY", "sk-sp-test")
+        monkeypatch.setenv("QWENCLOUD_BASE_URL", "https://custom.example.com/v1")
+        creds = resolve_api_key_provider_credentials("qwencloud")
+        assert creds["base_url"] == "https://custom.example.com/v1"
+
+    def test_status_configured(self, monkeypatch):
+        monkeypatch.setenv("QWENCLOUD_API_KEY", "sk-sp-test")
+        status = get_api_key_provider_status("qwencloud")
+        assert status["configured"]
+        assert status["base_url"] == QWENCLOUD_BASE_URL
+
+    def test_openrouter_key_does_not_make_qwencloud_configured(self, monkeypatch):
+        """OpenRouter users should NOT see qwencloud as configured."""
+        monkeypatch.delenv("QWENCLOUD_API_KEY", raising=False)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        status = get_api_key_provider_status("qwencloud")
+        assert not status["configured"]
+
+
+# =============================================================================
+# Model catalog
+# =============================================================================
+
+
+class TestQwencloudModelCatalog:
+    """QwenCloud Token Plan static model list."""
+
+    def test_static_model_list_exists(self):
+        from hermes_cli.models import _PROVIDER_MODELS
+        assert "qwencloud" in _PROVIDER_MODELS
+        assert len(_PROVIDER_MODELS["qwencloud"]) >= 1
+
+    def test_default_model_is_in_catalog(self):
+        """The non-interactive default must come from the static catalog so a
+        missing model never escalates to an unbilled flagship."""
+        from hermes_cli.models import get_default_model_for_provider, _PROVIDER_MODELS
+        default = get_default_model_for_provider("qwencloud")
+        assert default
+        assert default in _PROVIDER_MODELS["qwencloud"]
+
+
+# =============================================================================
+# CANONICAL_PROVIDERS (hermes model picker)
+# =============================================================================
+
+
+class TestQwencloudCanonicalProvider:
+    """QwenCloud Token Plan appears in the interactive model picker."""
+
+    def test_in_canonical_providers(self):
+        from hermes_cli.models import CANONICAL_PROVIDERS
+        slugs = [p.slug for p in CANONICAL_PROVIDERS]
+        assert "qwencloud" in slugs
+
+    def test_folded_into_qwen_group(self):
+        from hermes_cli.models import provider_group_for_slug
+        assert provider_group_for_slug("qwencloud") == "qwen"
+
+
+# =============================================================================
+# _KNOWN_PROVIDER_NAMES (models.py)
+# =============================================================================
+
+
+class TestQwencloudKnownProviderNames:
+    """Verify qwencloud and its aliases are recognized as valid provider
+    names for the ``provider:model`` syntax."""
+
+    @pytest.mark.parametrize("alias", [
+        "qwencloud", "qwencloud-token-plan", "qwencloud_token_plan", "qwen-cloud",
+    ])
+    def test_alias_known(self, alias):
+        from hermes_cli.models import _KNOWN_PROVIDER_NAMES
+        assert alias in _KNOWN_PROVIDER_NAMES
+
+
+# =============================================================================
+# providers.py (unified provider module)
+# =============================================================================
+
+
+class TestQwencloudProvidersModule:
+    """Test QwenCloud in the unified providers module."""
+
+    def test_overlay_exists(self):
+        from hermes_cli.providers import HERMES_OVERLAYS
+        assert "qwencloud" in HERMES_OVERLAYS
+        overlay = HERMES_OVERLAYS["qwencloud"]
+        assert overlay.transport == "openai_chat"
+        assert overlay.base_url_env_var == "QWENCLOUD_BASE_URL"
+        assert overlay.base_url_override == QWENCLOUD_BASE_URL
+        assert not overlay.is_aggregator
+
+    def test_api_mode_is_chat_completions(self):
+        from hermes_cli.providers import HERMES_OVERLAYS, TRANSPORT_TO_API_MODE
+        overlay = HERMES_OVERLAYS["qwencloud"]
+        api_mode = TRANSPORT_TO_API_MODE[overlay.transport]
+        assert api_mode == "chat_completions"
+
+    def test_get_provider(self):
+        from hermes_cli.providers import get_provider
+        pdef = get_provider("qwencloud", allow_network=False)
+        assert pdef is not None
+        assert pdef.id == "qwencloud"
+        assert pdef.transport == "openai_chat"
+        assert pdef.base_url == QWENCLOUD_BASE_URL


### PR DESCRIPTION
## Summary
QwenCloud (home.qwencloud.com) offers a Token Plan subscription ($6/mo, 2500 credits/week) with an OpenAI-compatible API at a distinct endpoint that differs from the existing `alibaba` (DashScope) and `alibaba-coding-plan` providers. Users previously had to configure it as a `custom` provider with a manual base_url/api_key.

## Change
Registers QwenCloud as a **native** provider, mirroring the `alibaba-coding-plan` pattern:
- `hermes_cli/providers.py`: `HERMES_OVERLAYS["qwencloud"]` (openai_chat transport, `base_url_override` = token-plan endpoint, `QWENCLOUD_BASE_URL` env, `QWENCLOUD_API_KEY` extra env); aliases `qwencloud-token-plan`/`qwencloud_token_plan`/`qwen-cloud` → `qwencloud`; label "QwenCloud (Token Plan)".
- `hermes_cli/auth.py`: `PROVIDER_REGISTRY["qwencloud"]` — ProviderConfig with `inference_base_url=https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1`, `api_key_env_vars=("QWENCLOUD_API_KEY",)`, `base_url_env_var=QWENCLOUD_BASE_URL`; aliases in `_PROVIDER_ALIASES`.
- `hermes_cli/models.py`: `_PROVIDER_MODELS["qwencloud"]` (qwen3.8-max, qwen3.7-plus, qwen3.6-plus, qwen3.5-plus, qwen3-coder-plus, qwen3-coder-next); entry in `CANONICAL_PROVIDERS` (appears in `hermes model` pickers/setup); `qwen` group gains `qwencloud` member.
- Tests: `tests/hermes_cli/test_qwencloud_provider.py` (24 new — registration, aliases, base_url resolution, picker visibility).

## Verification
- `tests/hermes_cli/test_qwencloud_provider.py`: **24 passed**.

Closes #81587