### PR TITLE
fix(desktop): recover the tile and regenerate paths from a dead runtime id

### DIFF
--- a/apps/desktop/src/app/chat/session-tile-actions.test.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.test.ts
@@ -1,0 +1,134 @@
+import { renderHook } from '@testing-library/react'
+import { act } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { MAIN_COMPOSER_SCOPE } from './composer/scope'
+
+const requestGatewayMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/app/gateway/hooks/use-gateway-request', () => ({
+  useGatewayRequest: () => ({ requestGateway: requestGatewayMock })
+}))
+
+const { setSessionTileDelegate } = await import('@/store/session-states')
+const { useSessionTileActions } = await import('./session-tile-actions')
+
+const RUNTIME_SESSION_ID = 'rt-tile-current'
+const STORED_SESSION_ID = 'stored-tile-db'
+const RECOVERED_SESSION_ID = 'rt-tile-recovered'
+
+function renderTileActions() {
+  return renderHook(() =>
+    useSessionTileActions({
+      runtimeId: RUNTIME_SESSION_ID,
+      scope: MAIN_COMPOSER_SCOPE,
+      storedSessionId: STORED_SESSION_ID
+    })
+  )
+}
+
+// A tile's cancelRun/steerPrompt/reloadFromMessage each build their own
+// requestGateway call directly instead of going through the shared
+// submitPromptText pipeline (which already wraps its call in
+// withSessionNotFoundResume) — see use-prompt-actions/index.test.tsx's
+// "sleep/wake session recovery" suite for the same regression on the
+// primary chat's own reloadFromMessage.
+describe('useSessionTileActions sleep/wake session recovery', () => {
+  beforeEach(() => {
+    setSessionTileDelegate({
+      archiveSession: vi.fn(async () => undefined),
+      branchSession: vi.fn(async () => undefined),
+      deleteSession: vi.fn(async () => undefined),
+      executeSlash: vi.fn(async () => undefined),
+      interruptSession: vi.fn(async () => undefined),
+      resumeTile: vi.fn(async () => RUNTIME_SESSION_ID),
+      submitToSession: vi.fn(async () => undefined),
+      updateSession: vi.fn((_runtimeId, updater) =>
+        updater({
+          attachedImages: [],
+          busy: false,
+          cwd: null,
+          messages: [],
+          model: null,
+          streamId: null,
+          storedSessionId: STORED_SESSION_ID
+        } as never)
+      )
+    })
+  })
+
+  afterEach(() => {
+    requestGatewayMock.mockReset()
+    vi.restoreAllMocks()
+  })
+
+  it('resumes the stored session and retries once when session.interrupt reports "session not found"', async () => {
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    let interruptAttempts = 0
+
+    requestGatewayMock.mockImplementation(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'session.interrupt') {
+        interruptAttempts += 1
+
+        if (interruptAttempts === 1) {
+          throw new Error('session not found')
+        }
+
+        return {}
+      }
+
+      if (method === 'session.resume') {
+        return { session_id: RECOVERED_SESSION_ID }
+      }
+
+      return {}
+    })
+
+    const { result } = renderTileActions()
+
+    await act(async () => {
+      await result.current.cancelRun()
+    })
+
+    // First interrupt (stale id) → session.resume (stored id) → retry interrupt (fresh id).
+    expect(calls.map(c => c.method)).toEqual(['session.interrupt', 'session.resume', 'session.interrupt'])
+    expect(calls[0]?.params).toEqual({ session_id: RUNTIME_SESSION_ID })
+    expect(calls[1]?.params).toEqual({ session_id: STORED_SESSION_ID, source: 'desktop', omit_messages: true })
+    expect(calls[2]?.params).toEqual({ session_id: RECOVERED_SESSION_ID })
+  })
+
+  it('resumes the stored session and retries once when session.redirect (steer) reports "session not found"', async () => {
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    let redirectAttempts = 0
+
+    requestGatewayMock.mockImplementation(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'session.redirect') {
+        redirectAttempts += 1
+
+        if (redirectAttempts === 1) {
+          throw new Error('session not found')
+        }
+
+        return { status: 'redirected' }
+      }
+
+      if (method === 'session.resume') {
+        return { session_id: RECOVERED_SESSION_ID }
+      }
+
+      return {}
+    })
+
+    const { result } = renderTileActions()
+
+    const ok = await act(async () => result.current.steerPrompt('actually use Postgres'))
+
+    expect(ok).toBe(true)
+    expect(calls.map(c => c.method)).toEqual(['session.redirect', 'session.resume', 'session.redirect'])
+    expect(calls[2]?.params).toEqual({ session_id: RECOVERED_SESSION_ID, text: 'actually use Postgres' })
+  })
+})

--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -45,7 +45,7 @@ import {
   truncateSubmitParams
 } from '../session/hooks/use-prompt-actions/rewind'
 import { useSubmitPrompt } from '../session/hooks/use-prompt-actions/submit'
-import { type SubmitTextOptions } from '../session/hooks/use-prompt-actions/utils'
+import { type SubmitTextOptions, withSessionNotFoundResume } from '../session/hooks/use-prompt-actions/utils'
 import { upsertOptimisticSession } from '../session/hooks/use-session-actions/utils'
 
 import type { ComposerScope } from './composer/scope'
@@ -274,7 +274,17 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
     clearClarifyRequest(undefined, sessionId)
 
     try {
-      await requestGateway('session.interrupt', { session_id: sessionId })
+      await withSessionNotFoundResume(
+        sessionId,
+        storedIdRef.current,
+        liveId => requestGateway('session.interrupt', { session_id: liveId }),
+        {
+          requestGateway,
+          onRecovered: recoveredId => {
+            runtimeIdRef.current = recoveredId
+          }
+        }
+      )
     } catch (err) {
       notifyError(err, copy.stopFailed)
     }
@@ -332,10 +342,17 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
         })
 
       try {
-        const result = await requestGateway<{ status?: string }>('session.redirect', {
-          session_id: sessionId,
-          text
-        })
+        const { result } = await withSessionNotFoundResume(
+          sessionId,
+          storedIdRef.current,
+          liveId => requestGateway<{ status?: string }>('session.redirect', { session_id: liveId, text }),
+          {
+            requestGateway,
+            onRecovered: recoveredId => {
+              runtimeIdRef.current = recoveredId
+            }
+          }
+        )
 
         if (result?.status === 'redirected') {
           triggerHaptic('submit')
@@ -393,14 +410,25 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
       update(current => applyReloadOptimistic(current, plan))
 
       try {
-        await requestGateway(
-          'prompt.submit',
+        await withSessionNotFoundResume(
+          runtimeIdRef.current,
+          storedIdRef.current,
+          liveId =>
+            requestGateway(
+              'prompt.submit',
+              {
+                session_id: liveId,
+                text: plan.text,
+                ...truncateSubmitParams(plan.truncateOrdinal)
+              },
+              PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
+            ),
           {
-            session_id: runtimeIdRef.current,
-            text: plan.text,
-            ...truncateSubmitParams(plan.truncateOrdinal)
-          },
-          PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
+            requestGateway,
+            onRecovered: recoveredId => {
+              runtimeIdRef.current = recoveredId
+            }
+          }
         )
       } catch (err) {
         update(current => ({ ...current, busy: false, awaitingResponse: false }))

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -2748,6 +2748,65 @@ describe('usePromptActions sleep/wake session recovery', () => {
     expect(calls[2]?.params).toEqual({ session_id: RECOVERED_SESSION_ID, text: 'message after wake' })
   })
 
+  it('resumes the stored session and retries once when reloadFromMessage (regenerate) reports "session not found"', async () => {
+    // reloadFromMessage builds its own prompt.submit call inline instead of
+    // going through the shared send() path submitText/redirectPrompt use, so
+    // it needs the same sleep/wake recovery independently — otherwise
+    // "Regenerate" on a stale session surfaces a raw error instead of
+    // silently resuming, same as the general submit case above.
+    //
+    // reloadFromMessage bails early on $busy — an earlier suite in this file
+    // can leave it true (see the stale-closure describe block's own note),
+    // so reset it defensively rather than relying on run order.
+    $busy.set(false)
+    setMessages([
+      { id: 'u1', parts: [textPart('original prompt')], role: 'user', timestamp: 0 },
+      { id: 'a1', parts: [textPart('reply')], role: 'assistant', timestamp: 1 }
+    ] as never)
+
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    let submitAttempts = 0
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'prompt.submit') {
+        submitAttempts += 1
+
+        if (submitAttempts === 1) {
+          throw new Error('session not found')
+        }
+
+        return {} as never
+      }
+
+      if (method === 'session.resume') {
+        return { session_id: RECOVERED_SESSION_ID } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        storedSessionId={STORED_SESSION_ID}
+      />
+    )
+
+    await handle!.reloadFromMessage('u1')
+
+    // First submit (stale id) → session.resume (stored id) → retry submit (fresh id).
+    expect(calls.map(c => c.method)).toEqual(['prompt.submit', 'session.resume', 'prompt.submit'])
+    expect(calls[1]?.params).toEqual({ session_id: STORED_SESSION_ID, source: 'desktop', omit_messages: true })
+    expect(calls[2]?.params).toEqual(
+      expect.objectContaining({ session_id: RECOVERED_SESSION_ID, text: 'original prompt' })
+    )
+  })
+
   // #67603 (second symptom): a recovery resume must re-register on the session's
   // OWNING profile. Resuming on whichever profile is live forks the conversation
   // into the wrong profile's DB — the session then appears under both profiles.

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -788,14 +788,26 @@ export function usePromptActions({
       updateSessionState(sessionId, state => applyReloadOptimistic(state, plan))
 
       try {
-        await requestGateway(
-          'prompt.submit',
+        await withSessionNotFoundResume(
+          sessionId,
+          selectedStoredSessionIdRef.current,
+          liveId =>
+            requestGateway(
+              'prompt.submit',
+              {
+                session_id: liveId,
+                text: plan.text,
+                ...truncateSubmitParams(plan.truncateOrdinal)
+              },
+              PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
+            ),
           {
-            session_id: sessionId,
-            text: plan.text,
-            ...truncateSubmitParams(plan.truncateOrdinal)
-          },
-          PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
+            requestGateway,
+            onRecovered: recoveredId => {
+              activeSessionIdRef.current = recoveredId
+              setActiveSessionId(recoveredId)
+            }
+          }
         )
       } catch (err) {
         updateSessionState(sessionId, state => ({
@@ -806,7 +818,7 @@ export function usePromptActions({
         notifyError(err, copy.regenerateFailed)
       }
     },
-    [activeSessionIdRef, copy.regenerateFailed, requestGateway, updateSessionState]
+    [activeSessionIdRef, copy.regenerateFailed, requestGateway, selectedStoredSessionIdRef, updateSessionState]
   )
 
   // Cursor-style "restore checkpoint": rewind the conversation to a past user


### PR DESCRIPTION
## What does this PR do?

**#81261** (merged yesterday) claims to "recover every session-scoped RPC" after a stale runtime-session drop — the sleep/wake 404 where the gateway's in-memory session table clears but the durable stored session survives, and `withSessionNotFoundResume` resumes it and retries once. Reading the current code after that merge, two call sites still build their gateway call directly instead of routing through it:

1. **`session-tile-actions.ts`'s own `cancelRun`/`steerPrompt`/`reloadFromMessage`** — the tile's own UI handlers, wired directly by `session-tile.tsx` as `onCancel`/`onSteer`/`onReload`. This is distinct from `use-session-tile-delegate.ts`'s `interruptSession`/`submitToSession` (used by *external* callers like `quick-entry-bridge`/`wiring.tsx`), which #81261 did wrap — the tile's own composer actions are a separate, unwrapped code path.
2. **`use-prompt-actions/index.ts`'s `reloadFromMessage`** (the primary chat's own "Regenerate") — it builds its `prompt.submit` call inline instead of going through the shared `send()` helper every other action in this file (`redirectPrompt`, `submitText`) uses, so it never picked up the recovery wrapper either.

**Concrete scenario:** after sleep/wake (the exact scenario #81261 targets), clicking "Stop" or "Regenerate" on any tile, sending a steering correction from a tile, or clicking "Regenerate" on the primary chat surfaces a raw "session not found" error instead of silently resuming — even though #81261 landed the day before with exactly that title.

## Fix

Wrap all four call sites in `withSessionNotFoundResume`, mirroring the existing pattern each file already uses elsewhere in the same file (`submitRewind`/`syncAttachmentsForSubmit` in `session-tile-actions.ts`; `redirectPrompt`/`send` in `index.ts`): resolve the stored session, resume once, retry, and rebind the live runtime ref via `onRecovered`.

## Testing

- New `apps/desktop/src/app/chat/session-tile-actions.test.ts` (this file had zero test coverage before this PR) — 2 tests covering `cancelRun` and `steerPrompt`'s recovery, mirroring the existing sleep/wake recovery test pattern from `use-prompt-actions/index.test.tsx` and `use-session-tile-delegate.test.ts`.
- New `test_...reloadFromMessage (regenerate) reports "session not found"` in `use-prompt-actions/index.test.tsx`'s existing "sleep/wake session recovery" suite.
- Mutation-verified: reverting each production file makes its new test(s) fail for the right reason (empty/incomplete RPC call sequence, or `expect(ok).toBe(true)` failing).
- Full desktop vitest suite: **4530 passed, 2 skipped** (481 test files).
- `tsc --noEmit`: clean, no errors.
- `eslint` could not be run in this sandbox (not installed by `npm ci --workspace=hermes` here) — flagging honestly rather than skipping the note.

## Checklist

- [x] I searched for existing PRs to make sure this isn't a duplicate — no open/merged PR targets these four call sites specifically; #81261 (already merged, confirmed by reading the live post-merge code) covers different call sites in the same general area.
- [x] My PR contains only changes related to this fix
- [x] Tests added, mutation-verified