### PR TITLE
fix(cron): make lifecycle guard heredoc-aware

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -104,6 +104,10 @@ def contains_gateway_lifecycle_command(text: str) -> bool:
 
 
 _SHELL_EXECUTABLES = frozenset({"sh", "bash", "dash", "ksh", "zsh"})
+_HEREDOC_NON_SHELL_EXECUTABLES = frozenset(
+    {"node", "nodejs", "deno", "bun", "ruby", "perl", "php", "lua", "r", "rscript"}
+)
+_PYTHON_EXECUTABLE = re.compile(r"(?i)^python(?:\d+(?:\.\d+)*)?$")
 _SHELL_OPTIONS_WITH_VALUES = frozenset({"-O", "+O", "-o", "+o"})
 _MAX_REFERENCED_SCRIPT_BYTES = 1024 * 1024
 _MAX_REFERENCED_SCRIPT_DEPTH = 8
@@ -186,6 +190,289 @@ def _command_token_index(segment: list[str]) -> Optional[int]:
             continue
         return index
     return None
+
+
+def _classify_heredoc_receiver(receiver: Optional[str]) -> str:
+    """Classify a heredoc receiver for referenced-shell traversal."""
+    if not receiver or "/" in receiver:
+        # An arbitrary path can be named ``python3`` while actually being a
+        # shell script. Only a plain command name is eligible for exemption.
+        return "unknown"
+    name = receiver.lower()
+    if name in _SHELL_EXECUTABLES:
+        return "shell"
+    if _PYTHON_EXECUTABLE.fullmatch(name) or name in _HEREDOC_NON_SHELL_EXECUTABLES:
+        return "non_shell"
+    return "unknown"
+
+
+def _heredoc_receiver(fragment: str) -> Optional[str]:
+    """Return the executable receiving a heredoc in one shell segment."""
+    receiver: Optional[str] = None
+    for segment in _iter_command_segments(fragment):
+        index = _command_token_index(segment)
+        if index is not None:
+            receiver = segment[index]
+    return receiver
+
+
+def _heredoc_receiver_is_overridden(prefix: str, receiver: Optional[str]) -> bool:
+    """Return whether earlier syntax overrides a plain receiver command.
+
+    Shell functions and aliases take precedence over PATH lookup. A command
+    named ``python3`` is therefore not evidence of Python when the same outer
+    line defines or aliases that name before the heredoc invocation.
+    """
+    if not receiver or "/" in receiver:
+        return True
+    name = re.escape(receiver)
+    function_pattern = re.compile(
+        rf"(?:^|[;&|\n]\s*)(?:"
+        rf"function\s+{name}(?:\s*\(\s*\))?"
+        rf"|{name}\s*\(\s*\)"
+        rf")\s*\{{"
+    )
+    alias_pattern = re.compile(
+        rf"(?:^|[;&|\n]\s*)alias\s+{name}\s*="
+    )
+    path_assignment_pattern = re.compile(
+        r"(?:^|[;&|\n]\s*)(?:export\s+)?PATH\s*="
+    )
+    hash_override_pattern = re.compile(
+        rf"(?:^|[;&|\n]\s*)(?:builtin\s+)?hash\s+-p\s+\S+\s+{name}(?:\s|$)"
+    )
+    dynamic_shell_state_pattern = re.compile(
+        r"(?:^|[;&|\n]\s*)(?:(?:source|\.)\s+|eval(?:\s|$))"
+    )
+    return bool(
+        function_pattern.search(prefix)
+        or alias_pattern.search(prefix)
+        or path_assignment_pattern.search(prefix)
+        or hash_override_pattern.search(prefix)
+        or dynamic_shell_state_pattern.search(prefix)
+    )
+
+
+def _iter_heredoc_declarations(
+    line: str,
+    *,
+    prior_outer_text: str = "",
+) -> Iterator[tuple[str, bool, str, bool]]:
+    """Yield heredoc metadata for one outer-shell line.
+
+    The final flag records whether any part of the delimiter word was quoted.
+    Only quoted non-shell heredocs are provably inert shell data: unquoted
+    bodies still perform command substitution before reaching the receiver.
+    """
+    quote: Optional[str] = None
+    escaped = False
+    segment_start = 0
+    index = 0
+    while index < len(line):
+        char = line[index]
+        if escaped:
+            escaped = False
+            index += 1
+            continue
+        if char == "\\" and quote != "'":
+            escaped = True
+            index += 1
+            continue
+        if quote is not None:
+            if char == quote:
+                quote = None
+            index += 1
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            index += 1
+            continue
+        if char == "#" and (index == 0 or line[index - 1].isspace()):
+            break
+        if char in _CONTROL_CHARS:
+            segment_start = index + 1
+            index += 1
+            continue
+        if not line.startswith("<<", index) or line.startswith("<<<", index):
+            index += 1
+            continue
+
+        cursor = index + 2
+        strip_tabs = False
+        if cursor < len(line) and line[cursor] == "-":
+            strip_tabs = True
+            cursor += 1
+        while cursor < len(line) and line[cursor] in " \t":
+            cursor += 1
+        if cursor >= len(line) or line[cursor] in "\r\n;&|()<>":
+            index += 2
+            continue
+
+        delimiter_chars: list[str] = []
+        delimiter_quoted = False
+        delimiter_quote: Optional[str] = None
+        ansi_c_quote = False
+        unsupported_ansi_escape = False
+        while cursor < len(line):
+            current = line[cursor]
+            if delimiter_quote is not None:
+                if current == delimiter_quote:
+                    delimiter_quote = None
+                    ansi_c_quote = False
+                    cursor += 1
+                    continue
+                if ansi_c_quote and current == "\\":
+                    # Bash $'...' applies ANSI-C escape decoding. Rather than
+                    # guess the resulting delimiter, leave escaped forms to
+                    # the conservative outer-shell scanner below.
+                    unsupported_ansi_escape = True
+                if (
+                    delimiter_quote == '"'
+                    and current == "\\"
+                    and cursor + 1 < len(line)
+                    and line[cursor + 1] in {'"', "\\", "$", "`"}
+                ):
+                    cursor += 1
+                    current = line[cursor]
+                delimiter_chars.append(current)
+                cursor += 1
+                continue
+            if current.isspace() or current in ";&|()<>":
+                break
+            if (
+                current == "$"
+                and cursor + 1 < len(line)
+                and line[cursor + 1] in {"'", '"'}
+            ):
+                delimiter_quoted = True
+                delimiter_quote = line[cursor + 1]
+                ansi_c_quote = delimiter_quote == "'"
+                cursor += 2
+                continue
+            if current in {"'", '"'}:
+                delimiter_quoted = True
+                delimiter_quote = current
+                cursor += 1
+                continue
+            if current == "\\" and cursor + 1 < len(line):
+                delimiter_quoted = True
+                cursor += 1
+                current = line[cursor]
+            delimiter_chars.append(current)
+            cursor += 1
+
+        if delimiter_quote is not None or unsupported_ansi_escape:
+            # Malformed or escape-bearing ANSI-C quoted delimiter: leave the
+            # line to the existing conservative shell scanner rather than
+            # guessing its resulting delimiter.
+            index += 2
+            continue
+        delimiter = "".join(delimiter_chars)
+
+        if delimiter:
+            receiver = _heredoc_receiver(line[segment_start:index])
+            receiver_kind = (
+                "unknown"
+                if _heredoc_receiver_is_overridden(
+                    prior_outer_text + line[:index], receiver
+                )
+                else _classify_heredoc_receiver(receiver)
+            )
+            yield (
+                delimiter,
+                strip_tabs,
+                receiver_kind,
+                delimiter_quoted,
+            )
+        index = max(cursor, index + 2)
+
+
+def _split_outer_shell_and_heredocs(
+    command: str,
+) -> tuple[str, list[tuple[str, str, bool]]]:
+    """Separate outer shell text from heredoc bodies for shell-only traversal.
+
+    Declarations are consumed in shell order. The original command remains
+    untouched for the direct lifecycle scan. Unterminated recognized heredocs
+    consume the remainder as their body; malformed declarations fall back to
+    the existing conservative outer-shell scan.
+    """
+    lines = command.splitlines(keepends=True)
+    if not lines:
+        return command, []
+
+    outer_lines: list[str] = []
+    heredocs: list[tuple[str, str, bool]] = []
+    line_index = 0
+    while line_index < len(lines):
+        line = lines[line_index]
+        line_index += 1
+        # Backslash-newline is removed before shell parsing, including inside
+        # a delimiter word (``<<P\\`` + ``Y`` declares delimiter ``PY``).
+        # Join only outer-shell continuation lines; heredoc body lines are
+        # consumed below without this normalization.
+        while line_index < len(lines):
+            if line.endswith("\\\r\n"):
+                line = line[:-3] + lines[line_index]
+            elif line.endswith("\\\n"):
+                line = line[:-2] + lines[line_index]
+            else:
+                break
+            line_index += 1
+        prior_outer_text = "".join(outer_lines)
+        outer_lines.append(line)
+        declarations = list(
+            _iter_heredoc_declarations(
+                line,
+                prior_outer_text=prior_outer_text,
+            )
+        )
+        for delimiter, strip_tabs, receiver_kind, delimiter_quoted in declarations:
+            body_lines: list[str] = []
+            while line_index < len(lines):
+                candidate = lines[line_index].rstrip("\r\n")
+                if strip_tabs:
+                    candidate = candidate.lstrip("\t")
+                if candidate == delimiter:
+                    line_index += 1
+                    break
+                body_lines.append(lines[line_index])
+                line_index += 1
+            heredocs.append(
+                (receiver_kind, "".join(body_lines), delimiter_quoted)
+            )
+    return "".join(outer_lines), heredocs
+
+
+def _iter_backtick_payloads(text: str) -> Iterator[str]:
+    """Yield legacy command substitutions from an expanding heredoc body.
+
+    Heredoc bodies are not parsed as ordinary shell quoting: in an unquoted
+    heredoc, every unescaped backtick can start/end command substitution even
+    when surrounded by quote-looking data. Preserve escaped characters inside
+    each payload and ignore an unmatched opener, which the shell itself treats
+    as a syntax error rather than executable content.
+    """
+    payload: Optional[list[str]] = None
+    escaped = False
+    for char in text:
+        if escaped:
+            if payload is not None:
+                payload.extend(("\\", char))
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char == "`":
+            if payload is None:
+                payload = []
+            else:
+                yield "".join(payload)
+                payload = None
+            continue
+        if payload is not None:
+            payload.append(char)
 
 
 def contains_launchctl_submit_command(command: str) -> bool:
@@ -347,8 +634,15 @@ def _iter_referenced_shell_scripts(
     command: str,
     *,
     cwd: Optional[str] = None,
+    explicit_only: bool = False,
 ) -> Iterator[Path]:
-    """Yield scripts executed directly or through a POSIX shell."""
+    """Yield scripts executed directly or through a POSIX shell.
+
+    ``explicit_only`` retains only ``sh script`` and ``source script`` forms.
+    It is used for quoted non-shell source bodies: explicit shell execution
+    remains protected, while generic slash-looking language syntax is not
+    promoted into an executable path.
+    """
     for segment in _iter_command_segments(command):
         index = _command_token_index(segment)
         if index is None:
@@ -387,6 +681,9 @@ def _iter_referenced_shell_scripts(
                 resolved = _resolve_terminal_script_path(arguments[arg_index], cwd)
                 if resolved is not None:
                     yield resolved
+            continue
+
+        if explicit_only:
             continue
 
         # A bare "/" token is pathlib's division operator in Python sources
@@ -508,23 +805,76 @@ def _contains_unsafe_gateway_action(
     depth: int,
     visited: set[Path],
     read_remote_script: Optional[_ReadRemoteScriptFn] = None,
+    explicit_shell_only: bool = False,
 ) -> bool:
     if _direct_lifecycle_scan(command):
         return True
     if depth >= _MAX_REFERENCED_SCRIPT_DEPTH:
         return True
 
-    for payload in _iter_shell_command_payloads(command):
+    # Heredoc bodies are input to a receiving command, not additional outer
+    # shell lines. Keep the direct scan above on the original text, but only
+    # run shell-specific traversal over the outer command and bodies that are
+    # actually consumed by a shell. Unknown receivers remain fail-closed by
+    # taking the shell path.
+    outer_command, heredocs = _split_outer_shell_and_heredocs(command)
+    for payload in _iter_shell_command_payloads(outer_command):
         if _contains_unsafe_gateway_action(
             payload,
             cwd=cwd,
             depth=depth + 1,
             visited=visited,
             read_remote_script=read_remote_script,
+            explicit_shell_only=explicit_shell_only,
         ):
             return True
 
-    for script_path in _iter_referenced_shell_scripts(command, cwd=cwd):
+    for receiver_kind, body, delimiter_quoted in heredocs:
+        if not body:
+            continue
+        # A quoted delimiter suppresses shell expansion, so a clearly
+        # non-shell receiver gets inert source/data. Unquoted bodies still
+        # perform command substitution before stdin delivery and must retain
+        # the conservative shell walk (e.g. $(sh ./restart.sh)).
+        if receiver_kind == "non_shell" and delimiter_quoted:
+            if _contains_unsafe_gateway_action(
+                body,
+                cwd=cwd,
+                depth=depth + 1,
+                # Restricted source-body traversal must not poison the full
+                # outer-shell walk. Keep cycle protection local to this probe.
+                visited=set(visited),
+                read_remote_script=read_remote_script,
+                explicit_shell_only=True,
+            ):
+                return True
+            continue
+        if not delimiter_quoted:
+            for payload in _iter_backtick_payloads(body):
+                if _contains_unsafe_gateway_action(
+                    payload,
+                    cwd=cwd,
+                    depth=depth + 1,
+                    visited=visited,
+                    read_remote_script=read_remote_script,
+                    explicit_shell_only=explicit_shell_only,
+                ):
+                    return True
+        if _contains_unsafe_gateway_action(
+            body,
+            cwd=cwd,
+            depth=depth + 1,
+            visited=visited,
+            read_remote_script=read_remote_script,
+            explicit_shell_only=explicit_shell_only,
+        ):
+            return True
+
+    for script_path in _iter_referenced_shell_scripts(
+        outer_command,
+        cwd=cwd,
+        explicit_only=explicit_shell_only,
+    ):
         try:
             resolved = script_path.resolve(strict=False)
         except (OSError, ValueError):
@@ -559,6 +909,7 @@ def _contains_unsafe_gateway_action(
             depth=depth + 1,
             visited=visited,
             read_remote_script=read_remote_script,
+            explicit_shell_only=explicit_shell_only,
         ):
             return True
     return False

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -104,6 +104,10 @@ def contains_gateway_lifecycle_command(text: str) -> bool:
 
 
 _SHELL_EXECUTABLES = frozenset({"sh", "bash", "dash", "ksh", "zsh"})
+_HEREDOC_NON_SHELL_EXECUTABLES = frozenset(
+    {"node", "nodejs", "deno", "bun", "ruby", "perl", "php", "lua", "r", "rscript"}
+)
+_PYTHON_EXECUTABLE = re.compile(r"(?i)^python(?:\d+(?:\.\d+)*)?$")
 _SHELL_OPTIONS_WITH_VALUES = frozenset({"-O", "+O", "-o", "+o"})
 _MAX_REFERENCED_SCRIPT_BYTES = 1024 * 1024
 _MAX_REFERENCED_SCRIPT_DEPTH = 8
@@ -212,6 +216,289 @@ def _command_token_index(segment: list[str]) -> Optional[int]:
             continue
         return index
     return None
+
+
+def _classify_heredoc_receiver(receiver: Optional[str]) -> str:
+    """Classify a heredoc receiver for referenced-shell traversal."""
+    if not receiver or "/" in receiver:
+        # An arbitrary path can be named ``python3`` while actually being a
+        # shell script. Only a plain command name is eligible for exemption.
+        return "unknown"
+    name = receiver.lower()
+    if name in _SHELL_EXECUTABLES:
+        return "shell"
+    if _PYTHON_EXECUTABLE.fullmatch(name) or name in _HEREDOC_NON_SHELL_EXECUTABLES:
+        return "non_shell"
+    return "unknown"
+
+
+def _heredoc_receiver(fragment: str) -> Optional[str]:
+    """Return the executable receiving a heredoc in one shell segment."""
+    receiver: Optional[str] = None
+    for segment in _iter_command_segments(fragment):
+        index = _command_token_index(segment)
+        if index is not None:
+            receiver = segment[index]
+    return receiver
+
+
+def _heredoc_receiver_is_overridden(prefix: str, receiver: Optional[str]) -> bool:
+    """Return whether earlier syntax overrides a plain receiver command.
+
+    Shell functions and aliases take precedence over PATH lookup. A command
+    named ``python3`` is therefore not evidence of Python when the same outer
+    line defines or aliases that name before the heredoc invocation.
+    """
+    if not receiver or "/" in receiver:
+        return True
+    name = re.escape(receiver)
+    function_pattern = re.compile(
+        rf"(?:^|[;&|\n]\s*)(?:"
+        rf"function\s+{name}(?:\s*\(\s*\))?"
+        rf"|{name}\s*\(\s*\)"
+        rf")\s*\{{"
+    )
+    alias_pattern = re.compile(
+        rf"(?:^|[;&|\n]\s*)alias\s+{name}\s*="
+    )
+    path_assignment_pattern = re.compile(
+        r"(?:^|[;&|\n]\s*)(?:export\s+)?PATH\s*="
+    )
+    hash_override_pattern = re.compile(
+        rf"(?:^|[;&|\n]\s*)(?:builtin\s+)?hash\s+-p\s+\S+\s+{name}(?:\s|$)"
+    )
+    dynamic_shell_state_pattern = re.compile(
+        r"(?:^|[;&|\n]\s*)(?:(?:source|\.)\s+|eval(?:\s|$))"
+    )
+    return bool(
+        function_pattern.search(prefix)
+        or alias_pattern.search(prefix)
+        or path_assignment_pattern.search(prefix)
+        or hash_override_pattern.search(prefix)
+        or dynamic_shell_state_pattern.search(prefix)
+    )
+
+
+def _iter_heredoc_declarations(
+    line: str,
+    *,
+    prior_outer_text: str = "",
+) -> Iterator[tuple[str, bool, str, bool]]:
+    """Yield heredoc metadata for one outer-shell line.
+
+    The final flag records whether any part of the delimiter word was quoted.
+    Only quoted non-shell heredocs are provably inert shell data: unquoted
+    bodies still perform command substitution before reaching the receiver.
+    """
+    quote: Optional[str] = None
+    escaped = False
+    segment_start = 0
+    index = 0
+    while index < len(line):
+        char = line[index]
+        if escaped:
+            escaped = False
+            index += 1
+            continue
+        if char == "\\" and quote != "'":
+            escaped = True
+            index += 1
+            continue
+        if quote is not None:
+            if char == quote:
+                quote = None
+            index += 1
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            index += 1
+            continue
+        if char == "#" and (index == 0 or line[index - 1].isspace()):
+            break
+        if char in _CONTROL_CHARS:
+            segment_start = index + 1
+            index += 1
+            continue
+        if not line.startswith("<<", index) or line.startswith("<<<", index):
+            index += 1
+            continue
+
+        cursor = index + 2
+        strip_tabs = False
+        if cursor < len(line) and line[cursor] == "-":
+            strip_tabs = True
+            cursor += 1
+        while cursor < len(line) and line[cursor] in " \t":
+            cursor += 1
+        if cursor >= len(line) or line[cursor] in "\r\n;&|()<>":
+            index += 2
+            continue
+
+        delimiter_chars: list[str] = []
+        delimiter_quoted = False
+        delimiter_quote: Optional[str] = None
+        ansi_c_quote = False
+        unsupported_ansi_escape = False
+        while cursor < len(line):
+            current = line[cursor]
+            if delimiter_quote is not None:
+                if current == delimiter_quote:
+                    delimiter_quote = None
+                    ansi_c_quote = False
+                    cursor += 1
+                    continue
+                if ansi_c_quote and current == "\\":
+                    # Bash $'...' applies ANSI-C escape decoding. Rather than
+                    # guess the resulting delimiter, leave escaped forms to
+                    # the conservative outer-shell scanner below.
+                    unsupported_ansi_escape = True
+                if (
+                    delimiter_quote == '"'
+                    and current == "\\"
+                    and cursor + 1 < len(line)
+                    and line[cursor + 1] in {'"', "\\", "$", "`"}
+                ):
+                    cursor += 1
+                    current = line[cursor]
+                delimiter_chars.append(current)
+                cursor += 1
+                continue
+            if current.isspace() or current in ";&|()<>":
+                break
+            if (
+                current == "$"
+                and cursor + 1 < len(line)
+                and line[cursor + 1] in {"'", '"'}
+            ):
+                delimiter_quoted = True
+                delimiter_quote = line[cursor + 1]
+                ansi_c_quote = delimiter_quote == "'"
+                cursor += 2
+                continue
+            if current in {"'", '"'}:
+                delimiter_quoted = True
+                delimiter_quote = current
+                cursor += 1
+                continue
+            if current == "\\" and cursor + 1 < len(line):
+                delimiter_quoted = True
+                cursor += 1
+                current = line[cursor]
+            delimiter_chars.append(current)
+            cursor += 1
+
+        if delimiter_quote is not None or unsupported_ansi_escape:
+            # Malformed or escape-bearing ANSI-C quoted delimiter: leave the
+            # line to the existing conservative shell scanner rather than
+            # guessing its resulting delimiter.
+            index += 2
+            continue
+        delimiter = "".join(delimiter_chars)
+
+        if delimiter:
+            receiver = _heredoc_receiver(line[segment_start:index])
+            receiver_kind = (
+                "unknown"
+                if _heredoc_receiver_is_overridden(
+                    prior_outer_text + line[:index], receiver
+                )
+                else _classify_heredoc_receiver(receiver)
+            )
+            yield (
+                delimiter,
+                strip_tabs,
+                receiver_kind,
+                delimiter_quoted,
+            )
+        index = max(cursor, index + 2)
+
+
+def _split_outer_shell_and_heredocs(
+    command: str,
+) -> tuple[str, list[tuple[str, str, bool]]]:
+    """Separate outer shell text from heredoc bodies for shell-only traversal.
+
+    Declarations are consumed in shell order. The original command remains
+    untouched for the direct lifecycle scan. Unterminated recognized heredocs
+    consume the remainder as their body; malformed declarations fall back to
+    the existing conservative outer-shell scan.
+    """
+    lines = command.splitlines(keepends=True)
+    if not lines:
+        return command, []
+
+    outer_lines: list[str] = []
+    heredocs: list[tuple[str, str, bool]] = []
+    line_index = 0
+    while line_index < len(lines):
+        line = lines[line_index]
+        line_index += 1
+        # Backslash-newline is removed before shell parsing, including inside
+        # a delimiter word (``<<P\\`` + ``Y`` declares delimiter ``PY``).
+        # Join only outer-shell continuation lines; heredoc body lines are
+        # consumed below without this normalization.
+        while line_index < len(lines):
+            if line.endswith("\\\r\n"):
+                line = line[:-3] + lines[line_index]
+            elif line.endswith("\\\n"):
+                line = line[:-2] + lines[line_index]
+            else:
+                break
+            line_index += 1
+        prior_outer_text = "".join(outer_lines)
+        outer_lines.append(line)
+        declarations = list(
+            _iter_heredoc_declarations(
+                line,
+                prior_outer_text=prior_outer_text,
+            )
+        )
+        for delimiter, strip_tabs, receiver_kind, delimiter_quoted in declarations:
+            body_lines: list[str] = []
+            while line_index < len(lines):
+                candidate = lines[line_index].rstrip("\r\n")
+                if strip_tabs:
+                    candidate = candidate.lstrip("\t")
+                if candidate == delimiter:
+                    line_index += 1
+                    break
+                body_lines.append(lines[line_index])
+                line_index += 1
+            heredocs.append(
+                (receiver_kind, "".join(body_lines), delimiter_quoted)
+            )
+    return "".join(outer_lines), heredocs
+
+
+def _iter_backtick_payloads(text: str) -> Iterator[str]:
+    """Yield legacy command substitutions from an expanding heredoc body.
+
+    Heredoc bodies are not parsed as ordinary shell quoting: in an unquoted
+    heredoc, every unescaped backtick can start/end command substitution even
+    when surrounded by quote-looking data. Preserve escaped characters inside
+    each payload and ignore an unmatched opener, which the shell itself treats
+    as a syntax error rather than executable content.
+    """
+    payload: Optional[list[str]] = None
+    escaped = False
+    for char in text:
+        if escaped:
+            if payload is not None:
+                payload.extend(("\\", char))
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char == "`":
+            if payload is None:
+                payload = []
+            else:
+                yield "".join(payload)
+                payload = None
+            continue
+        if payload is not None:
+            payload.append(char)
 
 
 def contains_launchctl_submit_command(command: str) -> bool:
@@ -373,8 +660,15 @@ def _iter_referenced_shell_scripts(
     command: str,
     *,
     cwd: Optional[str] = None,
+    explicit_only: bool = False,
 ) -> Iterator[Path]:
-    """Yield scripts executed directly or through a POSIX shell."""
+    """Yield scripts executed directly or through a POSIX shell.
+
+    ``explicit_only`` retains only ``sh script`` and ``source script`` forms.
+    It is used for quoted non-shell source bodies: explicit shell execution
+    remains protected, while generic slash-looking language syntax is not
+    promoted into an executable path.
+    """
     for segment in _iter_command_segments(command):
         index = _command_token_index(segment)
         if index is None:
@@ -413,6 +707,12 @@ def _iter_referenced_shell_scripts(
                 resolved = _resolve_terminal_script_path(arguments[arg_index], cwd)
                 if resolved is not None:
                     yield resolved
+            continue
+
+        if explicit_only and not (
+            "/" in executable
+            or executable.endswith((".sh", ".bash", ".zsh"))
+        ):
             continue
 
         # A bare "/" token is pathlib's division operator in Python sources
@@ -562,23 +862,76 @@ def _contains_unsafe_gateway_action(
     depth: int,
     visited: set[Path],
     read_remote_script: Optional[_ReadRemoteScriptFn] = None,
+    explicit_shell_only: bool = False,
 ) -> bool:
     if _direct_lifecycle_scan(command):
         return True
     if depth >= _MAX_REFERENCED_SCRIPT_DEPTH:
         return True
 
-    for payload in _iter_shell_command_payloads(command):
+    # Heredoc bodies are input to a receiving command, not additional outer
+    # shell lines. Keep the direct scan above on the original text, but only
+    # run shell-specific traversal over the outer command and bodies that are
+    # actually consumed by a shell. Unknown receivers remain fail-closed by
+    # taking the shell path.
+    outer_command, heredocs = _split_outer_shell_and_heredocs(command)
+    for payload in _iter_shell_command_payloads(outer_command):
         if _contains_unsafe_gateway_action(
             payload,
             cwd=cwd,
             depth=depth + 1,
             visited=visited,
             read_remote_script=read_remote_script,
+            explicit_shell_only=explicit_shell_only,
         ):
             return True
 
-    for script_path in _iter_referenced_shell_scripts(command, cwd=cwd):
+    for receiver_kind, body, delimiter_quoted in heredocs:
+        if not body:
+            continue
+        # A quoted delimiter suppresses shell expansion, so a clearly
+        # non-shell receiver gets inert source/data. Unquoted bodies still
+        # perform command substitution before stdin delivery and must retain
+        # the conservative shell walk (e.g. $(sh ./restart.sh)).
+        if receiver_kind == "non_shell" and delimiter_quoted:
+            if _contains_unsafe_gateway_action(
+                body,
+                cwd=cwd,
+                depth=depth + 1,
+                # Restricted source-body traversal must not poison the full
+                # outer-shell walk. Keep cycle protection local to this probe.
+                visited=set(visited),
+                read_remote_script=read_remote_script,
+                explicit_shell_only=True,
+            ):
+                return True
+            continue
+        if not delimiter_quoted:
+            for payload in _iter_backtick_payloads(body):
+                if _contains_unsafe_gateway_action(
+                    payload,
+                    cwd=cwd,
+                    depth=depth + 1,
+                    visited=visited,
+                    read_remote_script=read_remote_script,
+                    explicit_shell_only=explicit_shell_only,
+                ):
+                    return True
+        if _contains_unsafe_gateway_action(
+            body,
+            cwd=cwd,
+            depth=depth + 1,
+            visited=visited,
+            read_remote_script=read_remote_script,
+            explicit_shell_only=explicit_shell_only,
+        ):
+            return True
+
+    for script_path in _iter_referenced_shell_scripts(
+        outer_command,
+        cwd=cwd,
+        explicit_only=explicit_shell_only,
+    ):
         # Do not touch a FileProvider path even to discover whether the file
         # is hydrated. The lexical check covers direct cloud paths; the
         # resolved check below covers local launchers that are symlinks into
@@ -596,6 +949,16 @@ def _contains_unsafe_gateway_action(
             resolved = script_path
         if _is_cloud_placeholder_path(resolved):
             return True
+        if explicit_shell_only:
+            try:
+                # A command-shaped path in an otherwise inert non-shell body
+                # is retained to cover ambient receiver shadowing. Preserve
+                # the exemption for local source-data FIFOs/directories; a
+                # missing path is still eligible for a remote backend read.
+                if script_path.exists() and not script_path.is_file():
+                    continue
+            except OSError:
+                pass
         if resolved in visited:
             continue
         visited.add(resolved)
@@ -623,6 +986,7 @@ def _contains_unsafe_gateway_action(
             depth=depth + 1,
             visited=visited,
             read_remote_script=read_remote_script,
+            explicit_shell_only=explicit_shell_only,
         ):
             return True
     return False

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -181,32 +181,122 @@ _BINARY_SNIFF_BYTES = 4096
 _ReadRemoteScriptFn = Callable[[str], Optional[str]]
 
 
+def _iter_single_quote_logical_lines(command: str) -> Iterator[str]:
+    """Yield physical lines joined only across valid single-quoted strings.
+
+    Shell permits literal newlines inside single quotes.  Keeping those lines
+    together lets ``shlex`` retain argument boundaries without changing the
+    guard's established conservative handling of multiline double quotes.
+    """
+    masked = list(command)
+    start = 0
+    single_quoted = False
+    double_quoted = False
+    escaped = False
+    comment = False
+    word_start = True
+
+    for index, char in enumerate(command):
+        if comment:
+            if char == "\n":
+                comment = False
+                word_start = True
+                yield "".join(masked[start : index + 1])
+                start = index + 1
+            else:
+                masked[index] = " "
+            continue
+        if single_quoted:
+            if char == "'":
+                single_quoted = False
+            continue
+        if escaped:
+            escaped = False
+            word_start = False
+            continue
+        if char == "\\":
+            escaped = True
+            word_start = False
+            continue
+        if double_quoted:
+            if char == '"':
+                double_quoted = False
+            if char == "\n":
+                # Preserve the historical line-wise fallback for multiline
+                # double quotes, whose contents can execute substitutions.
+                yield "".join(masked[start : index + 1])
+                start = index + 1
+            continue
+        if char == "#" and word_start:
+            comment = True
+            masked[index] = " "
+            continue
+        if char == "'":
+            single_quoted = True
+            word_start = False
+            continue
+        if char == '"':
+            double_quoted = True
+            word_start = False
+            continue
+        if char == "\n":
+            yield "".join(masked[start : index + 1])
+            start = index + 1
+            word_start = True
+            continue
+        if char.isspace() or char in _CONTROL_CHARS:
+            word_start = True
+        else:
+            word_start = False
+
+    if start < len(command):
+        yield "".join(masked[start:])
+
+
 def _iter_command_segments(command: str) -> Iterator[list[str]]:
     """Yield shell-tokenized command segments, honoring quotes and comments."""
     normalized = command.replace("\\\n", "")
-    for line in normalized.splitlines() or [normalized]:
+    for logical_line in _iter_single_quote_logical_lines(normalized):
+        physical_lines = logical_line.splitlines() or [logical_line]
         try:
             lexer = shlex.shlex(
-                line,
+                logical_line,
                 posix=True,
                 punctuation_chars=";&|()",
             )
             lexer.whitespace_split = True
-            lexer.commenters = "#"
-            tokens = list(lexer)
+            # Real shell comments were masked by the logical-line pass.  A
+            # hash inside a word (``tag#literal``) remains ordinary data.
+            lexer.commenters = ""
+            token_batches = [list(lexer)]
         except ValueError:
-            continue
+            # Malformed quoting remains conservative: retain the previous
+            # best-effort scan of each physical line in the failed chunk.
+            token_batches = []
+            for line in physical_lines:
+                try:
+                    lexer = shlex.shlex(
+                        line,
+                        posix=True,
+                        punctuation_chars=";&|()",
+                    )
+                    lexer.whitespace_split = True
+                    lexer.commenters = ""
+                    token_batches.append(list(lexer))
+                except ValueError:
+                    continue
 
-        segment: list[str] = []
-        for token in tokens:
-            if token and set(token) <= _CONTROL_CHARS:
-                if segment:
-                    yield segment
-                    segment = []
-                continue
-            segment.append(token)
-        if segment:
-            yield segment
+        for tokens in token_batches:
+            segment: list[str] = []
+            for token in tokens:
+                if token and set(token) <= _CONTROL_CHARS:
+                    if segment:
+                        yield segment
+                        segment = []
+                    continue
+                segment.append(token)
+            if segment:
+                yield segment
 
 
 def _command_token_index(segment: list[str]) -> Optional[int]:
@@ -242,6 +332,65 @@ def _heredoc_receiver(fragment: str) -> Optional[str]:
     return receiver
 
 
+def _mask_inert_shell_text(text: str) -> str:
+    """Neutralize quoted text and comments before shell-syntax regexes.
+
+    Quote contents become ``x`` rather than whitespace so a quoted argument
+    still occupies one token (important for ``hash -p '/path' name``).  Newline
+    positions are retained for command-boundary-aware patterns.
+    """
+    masked = list(text)
+    quote: Optional[str] = None
+    escaped = False
+    comment = False
+    word_start = True
+
+    for index, char in enumerate(text):
+        if comment:
+            if char == "\n":
+                comment = False
+                word_start = True
+            else:
+                masked[index] = " "
+            continue
+        if quote is not None:
+            if char == "\n":
+                continue
+            masked[index] = "x"
+            if quote == '"' and escaped:
+                escaped = False
+                continue
+            if quote == '"' and char == "\\":
+                escaped = True
+                continue
+            if char == quote:
+                quote = None
+            continue
+        if escaped:
+            escaped = False
+            word_start = False
+            continue
+        if char == "\\":
+            escaped = True
+            word_start = False
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            word_start = False
+            masked[index] = "x"
+            continue
+        if char == "#" and word_start:
+            comment = True
+            masked[index] = " "
+            continue
+        if char == "\n" or char.isspace() or char in _CONTROL_CHARS:
+            word_start = True
+        else:
+            word_start = False
+
+    return "".join(masked)
+
+
 def _heredoc_receiver_is_overridden(prefix: str, receiver: Optional[str]) -> bool:
     """Return whether earlier syntax overrides a plain receiver command.
 
@@ -251,12 +400,13 @@ def _heredoc_receiver_is_overridden(prefix: str, receiver: Optional[str]) -> boo
     """
     if not receiver or "/" in receiver:
         return True
+    syntax = _mask_inert_shell_text(prefix)
     name = re.escape(receiver)
     function_pattern = re.compile(
         rf"(?:^|[;&|\n]\s*)(?:"
         rf"function\s+{name}(?:\s*\(\s*\))?"
         rf"|{name}\s*\(\s*\)"
-        rf")\s*\{{"
+        rf")(?=\s|$)"
     )
     alias_pattern = re.compile(
         rf"(?:^|[;&|\n]\s*)alias\s+{name}\s*="
@@ -271,11 +421,11 @@ def _heredoc_receiver_is_overridden(prefix: str, receiver: Optional[str]) -> boo
         r"(?:^|[;&|\n]\s*)(?:(?:source|\.)\s+|eval(?:\s|$))"
     )
     return bool(
-        function_pattern.search(prefix)
-        or alias_pattern.search(prefix)
-        or path_assignment_pattern.search(prefix)
-        or hash_override_pattern.search(prefix)
-        or dynamic_shell_state_pattern.search(prefix)
+        function_pattern.search(syntax)
+        or alias_pattern.search(syntax)
+        or path_assignment_pattern.search(syntax)
+        or hash_override_pattern.search(syntax)
+        or dynamic_shell_state_pattern.search(syntax)
     )
 
 

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -676,6 +676,415 @@ class TestLifecycleGuardModule:
         with pytest.raises(GatewayLifecycleBlocked):
             check_gateway_lifecycle("clean prompt", str(script))
 
+    def test_python_heredoc_absolute_path_is_not_shell_walked(self):
+        """Python heredoc source is data for python, not outer shell syntax."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command,
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        command = """python3 - <<'PYCODE'
+from pathlib import Path
+root=Path('/home/design-director/.hermes/skills/creative/expert-product-design')
+print(root)
+PYCODE
+"""
+        assert contains_gateway_lifecycle_command(command) is False
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd="/tmp"
+        ) is False
+
+    def test_python_heredoc_existing_directory_is_not_script_candidate(self, tmp_path):
+        """Regression: a real directory in Python source must not fail closed."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        directory = tmp_path / "skills"
+        directory.mkdir()
+        command = (
+            "python3 - <<'PY'\n"
+            "from pathlib import Path\n"
+            f"root=Path({str(directory)!r})\n"
+            "print(root)\n"
+            "PY\n"
+        )
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is False
+
+    def test_python_heredoc_pathlib_division_is_not_shell_walked(self):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        command = """python3 - <<'PY'
+from pathlib import Path
+root = Path.home() / ".hermes" / "skills"
+print(root)
+PY
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(command) is False
+
+    @pytest.mark.parametrize("operator", ["<<'PY'", '<<"PY"'])
+    def test_python_heredoc_quoted_delimiters_are_not_shell_walked(
+        self, operator, tmp_path
+    ):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        directory = tmp_path / "quoted"
+        directory.mkdir()
+        command = (
+            f"python3 - {operator}\n"
+            "from pathlib import Path\n"
+            f"root=Path({str(directory)!r})\n"
+            "PY\n"
+        )
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is False
+
+    def test_python_heredoc_strip_tabs_is_not_shell_walked(self, tmp_path):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        directory = tmp_path / "tabbed"
+        directory.mkdir()
+        command = (
+            "python3 - <<-'PY'\n"
+            "\tfrom pathlib import Path\n"
+            f"\troot=Path({str(directory)!r})\n"
+            "\tPY\n"
+        )
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is False
+
+    def test_node_heredoc_is_not_shell_walked(self, tmp_path):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        directory = tmp_path / "assets"
+        directory.mkdir()
+        command = f"""node <<'JS'
+const root = {str(directory)!r};
+const url = "https://example.com/a/b";
+const regex = /\/tmp\/assets/;
+const ratio = 10 / 2;
+console.log(root, url, regex, ratio);
+JS
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is False
+
+    def test_python_heredoc_literal_lifecycle_command_still_blocks(self):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        command = """python3 - <<'PY'
+import os
+os.system("hermes gateway restart")
+PY
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(command) is True
+
+    def test_shell_heredoc_lifecycle_command_still_blocks(self):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        command = """bash <<'SH'
+hermes gateway restart
+SH
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(command) is True
+
+    def test_unquoted_python_heredoc_shell_expansion_still_blocks(
+        self, tmp_path
+    ):
+        """Unquoted heredocs perform shell expansion before Python sees stdin."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        command = f"""python3 - <<PY
+$(sh {script})
+PY
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is True
+
+    def test_unquoted_python_heredoc_backtick_expansion_still_blocks(
+        self, tmp_path
+    ):
+        """Legacy backtick substitution is executable in unquoted heredocs."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        command = f"""python3 - <<PY
+`sh {script}`
+PY
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is True
+
+    def test_function_override_of_non_shell_receiver_still_blocks(self, tmp_path):
+        """A shell function can spoof an interpreter basename."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        directory = tmp_path / "not-a-script"
+        directory.mkdir()
+        command = f"""function python3 {{ sh; }}
+python3 <<'PY'
+{directory}
+PY
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is True
+
+    def test_spoofed_receiver_direct_script_still_blocks(self, tmp_path):
+        """Restricted body scanning retains obvious direct script execution."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        definitions = tmp_path / "definitions.sh"
+        definitions.write_text("python3() { sh; }\n", encoding="utf-8")
+        command = f""". {definitions}
+python3 <<'PY'
+{script}
+PY
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is True
+
+    def test_restricted_heredoc_scan_does_not_hide_later_full_scan(self, tmp_path):
+        """A restricted body walk must not poison the outer visited set."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        payload = tmp_path / "restart.sh"
+        payload.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        wrapper = tmp_path / "wrapper.sh"
+        wrapper.write_text(f"#!/bin/sh\n{payload}\n", encoding="utf-8")
+        command = f"""python3 <<'PY'
+sh {wrapper}
+PY
+sh {wrapper}
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is True
+
+    def test_path_named_like_non_shell_receiver_still_blocks(self, tmp_path):
+        """An arbitrary executable path named ``python3`` is not trusted."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        receiver = tmp_path / "python3"
+        receiver.write_text("#!/bin/sh\nsh\n", encoding="utf-8")
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        command = f"""{receiver} <<'PY'
+sh {script}
+PY
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is True
+
+    def test_path_override_of_non_shell_receiver_still_blocks(self, tmp_path):
+        """An inline PATH override can spoof a plain interpreter name."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        receiver = tmp_path / "python3"
+        receiver.write_text("#!/bin/sh\nsh\n", encoding="utf-8")
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        command = f"""PATH={tmp_path}:$PATH python3 <<'PY'
+sh {script}
+PY
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is True
+
+    def test_shell_heredoc_referenced_script_still_blocks(self, tmp_path):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        command = f"""sh <<'SH'
+sh {script}
+SH
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is True
+
+    def test_shell_heredoc_nested_referenced_scripts_still_block(self, tmp_path):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        inner = tmp_path / "inner.sh"
+        outer = tmp_path / "outer.sh"
+        inner.write_text("#!/bin/sh\nhermes gateway stop\n", encoding="utf-8")
+        outer.write_text(f"#!/bin/sh\nsh {inner.name}\n", encoding="utf-8")
+        command = f"""bash <<SH
+bash {outer}
+SH
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is True
+
+    def test_explicit_nonregular_shell_inputs_still_fail_closed(self, tmp_path):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        directory = tmp_path / "not-a-script"
+        directory.mkdir()
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            f"bash {directory}", cwd=str(tmp_path)
+        ) is True
+
+        if hasattr(os, "mkfifo"):
+            fifo = tmp_path / "script.fifo"
+            os.mkfifo(fifo)
+            assert contains_gateway_lifecycle_command_or_referenced_script(
+                f"bash {fifo}", cwd=str(tmp_path)
+            ) is True
+
+    def test_multiple_heredocs_keep_receiver_association(self, tmp_path):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        directory = tmp_path / "python-data"
+        directory.mkdir()
+        script = tmp_path / "restart.sh"
+        script.write_text("hermes gateway restart\n", encoding="utf-8")
+        command = f"""python3 - <<'PY' | bash <<'SH'
+from pathlib import Path
+root=Path({str(directory)!r})
+PY
+bash {script}
+SH
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is True
+
+    def test_other_heredoc_delimiter_does_not_end_current_body(self, tmp_path):
+        from cron.lifecycle_guard import (
+            _split_outer_shell_and_heredocs,
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        directory = tmp_path / "source-data"
+        directory.mkdir()
+        command = f"""python3 - <<'PY' | bash <<'SH'
+from pathlib import Path
+SH
+root=Path({str(directory)!r})
+PY
+echo safe
+SH
+"""
+        outer, heredocs = _split_outer_shell_and_heredocs(command)
+        assert len(heredocs) == 2
+        assert "root=Path" in heredocs[0][1]
+        assert "echo safe" in heredocs[1][1]
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is False
+
+    def test_heredoc_operator_inside_quoted_text_does_not_hide_command(
+        self, tmp_path
+    ):
+        """A quoted ``<<WORD`` is text, not a heredoc declaration."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        command = f"printf '%s\\n' 'see <<EOF docs'\nsh {script}\n"
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is True
+
+    def test_partially_quoted_delimiter_is_nonexpanding_python_data(self, tmp_path):
+        """Shell quote removal turns ``P\"Y\"`` into quoted delimiter ``PY``."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        directory = tmp_path / "source-data"
+        directory.mkdir()
+        command = f"""python3 <<P\"Y\"
+from pathlib import Path
+root=Path({str(directory)!r})
+PY
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is False
+
+    def test_continued_delimiter_does_not_hide_following_command(self, tmp_path):
+        """Backslash-newline removal joins ``P\\`` + ``Y`` into ``PY``."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        command = f"""python3 <<P\\
+Y
+print('safe')
+PY
+sh {script}
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is True
+
+    @pytest.mark.parametrize("operator", ["$'PY'", '$"PY"', "P$'Y'"])
+    def test_dollar_quoted_delimiter_does_not_hide_following_command(
+        self, operator, tmp_path
+    ):
+        """Bash dollar-quoted delimiter words undergo quote removal."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        command = f"python3 <<{operator}\nprint('safe')\nPY\nsh {script}\n"
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is True
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "python3 - <<'PY'\n/tmp/\n",
+            "python3 - <<'PY\n/tmp/\n",
+            "bash <<\nhermes gateway restart\n",
+        ],
+    )
+    def test_malformed_or_unterminated_heredoc_is_total(self, command):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        verdict = contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd="/tmp"
+        )
+        assert isinstance(verdict, bool)
+
     def test_absolute_path_binary_does_not_crash_guard(self):
         """#76762: a terminal command invoking a binary by absolute path
         (e.g. /usr/bin/python3) must not crash the guard with

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -676,6 +676,433 @@ class TestLifecycleGuardModule:
         with pytest.raises(GatewayLifecycleBlocked):
             check_gateway_lifecycle("clean prompt", str(script))
 
+    def test_python_heredoc_absolute_path_is_not_shell_walked(self):
+        """Python heredoc source is data for python, not outer shell syntax."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command,
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        command = """python3 - <<'PYCODE'
+from pathlib import Path
+root=Path('/home/design-director/.hermes/skills/creative/expert-product-design')
+print(root)
+PYCODE
+"""
+        assert contains_gateway_lifecycle_command(command) is False
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd="/tmp"
+        ) is False
+
+    def test_python_heredoc_existing_directory_is_not_script_candidate(self, tmp_path):
+        """Regression: a real directory in Python source must not fail closed."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        directory = tmp_path / "skills"
+        directory.mkdir()
+        command = (
+            "python3 - <<'PY'\n"
+            "from pathlib import Path\n"
+            f"root=Path({str(directory)!r})\n"
+            "print(root)\n"
+            "PY\n"
+        )
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is False
+
+    def test_python_heredoc_pathlib_division_is_not_shell_walked(self):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        command = """python3 - <<'PY'
+from pathlib import Path
+root = Path.home() / ".hermes" / "skills"
+print(root)
+PY
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(command) is False
+
+    @pytest.mark.parametrize("operator", ["<<'PY'", '<<"PY"'])
+    def test_python_heredoc_quoted_delimiters_are_not_shell_walked(
+        self, operator, tmp_path
+    ):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        directory = tmp_path / "quoted"
+        directory.mkdir()
+        command = (
+            f"python3 - {operator}\n"
+            "from pathlib import Path\n"
+            f"root=Path({str(directory)!r})\n"
+            "PY\n"
+        )
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is False
+
+    def test_python_heredoc_strip_tabs_is_not_shell_walked(self, tmp_path):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        directory = tmp_path / "tabbed"
+        directory.mkdir()
+        command = (
+            "python3 - <<-'PY'\n"
+            "\tfrom pathlib import Path\n"
+            f"\troot=Path({str(directory)!r})\n"
+            "\tPY\n"
+        )
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is False
+
+    def test_node_heredoc_is_not_shell_walked(self, tmp_path):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        directory = tmp_path / "assets"
+        directory.mkdir()
+        command = f"""node <<'JS'
+const root = {str(directory)!r};
+const url = "https://example.com/a/b";
+const regex = /\/tmp\/assets/;
+const ratio = 10 / 2;
+console.log(root, url, regex, ratio);
+JS
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is False
+
+    def test_python_heredoc_literal_lifecycle_command_still_blocks(self):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        command = """python3 - <<'PY'
+import os
+os.system("hermes gateway restart")
+PY
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(command) is True
+
+    def test_shell_heredoc_lifecycle_command_still_blocks(self):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        command = """bash <<'SH'
+hermes gateway restart
+SH
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(command) is True
+
+    def test_unquoted_python_heredoc_shell_expansion_still_blocks(
+        self, tmp_path
+    ):
+        """Unquoted heredocs perform shell expansion before Python sees stdin."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        command = f"""python3 - <<PY
+$(sh {script})
+PY
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is True
+
+    def test_unquoted_python_heredoc_backtick_expansion_still_blocks(
+        self, tmp_path
+    ):
+        """Legacy backtick substitution is executable in unquoted heredocs."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        command = f"""python3 - <<PY
+`sh {script}`
+PY
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is True
+
+    def test_function_override_of_non_shell_receiver_still_blocks(self, tmp_path):
+        """A shell function can spoof an interpreter basename."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        directory = tmp_path / "not-a-script"
+        directory.mkdir()
+        command = f"""function python3 {{ sh; }}
+python3 <<'PY'
+{directory}
+PY
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is True
+
+    def test_spoofed_receiver_direct_script_still_blocks(self, tmp_path):
+        """Restricted body scanning retains obvious direct script execution."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        definitions = tmp_path / "definitions.sh"
+        definitions.write_text("python3() { sh; }\n", encoding="utf-8")
+        command = f""". {definitions}
+python3 <<'PY'
+{script}
+PY
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is True
+
+    def test_restricted_heredoc_scan_does_not_hide_later_full_scan(self, tmp_path):
+        """A restricted body walk must not poison the outer visited set."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        payload = tmp_path / "restart.sh"
+        payload.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        wrapper = tmp_path / "wrapper.sh"
+        wrapper.write_text(f"#!/bin/sh\n{payload}\n", encoding="utf-8")
+        command = f"""python3 <<'PY'
+sh {wrapper}
+PY
+sh {wrapper}
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is True
+
+    def test_restricted_heredoc_scan_keeps_standalone_script_path(self, tmp_path):
+        """A command-shaped path stays guarded if the receiver is PATH-shadowed."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        script.chmod(0o700)
+        command = f"""python3 <<'PY'
+{script}
+PY
+"""
+
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is True
+
+    def test_path_named_like_non_shell_receiver_still_blocks(self, tmp_path):
+        """An arbitrary executable path named ``python3`` is not trusted."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        receiver = tmp_path / "python3"
+        receiver.write_text("#!/bin/sh\nsh\n", encoding="utf-8")
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        command = f"""{receiver} <<'PY'
+sh {script}
+PY
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is True
+
+    def test_path_override_of_non_shell_receiver_still_blocks(self, tmp_path):
+        """An inline PATH override can spoof a plain interpreter name."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        receiver = tmp_path / "python3"
+        receiver.write_text("#!/bin/sh\nsh\n", encoding="utf-8")
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        command = f"""PATH={tmp_path}:$PATH python3 <<'PY'
+sh {script}
+PY
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is True
+
+    def test_shell_heredoc_referenced_script_still_blocks(self, tmp_path):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        command = f"""sh <<'SH'
+sh {script}
+SH
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is True
+
+    def test_shell_heredoc_nested_referenced_scripts_still_block(self, tmp_path):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        inner = tmp_path / "inner.sh"
+        outer = tmp_path / "outer.sh"
+        inner.write_text("#!/bin/sh\nhermes gateway stop\n", encoding="utf-8")
+        outer.write_text(f"#!/bin/sh\nsh {inner.name}\n", encoding="utf-8")
+        command = f"""bash <<SH
+bash {outer}
+SH
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is True
+
+    def test_explicit_nonregular_shell_inputs_still_fail_closed(self, tmp_path):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        directory = tmp_path / "not-a-script"
+        directory.mkdir()
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            f"bash {directory}", cwd=str(tmp_path)
+        ) is True
+
+        if hasattr(os, "mkfifo"):
+            fifo = tmp_path / "script.fifo"
+            os.mkfifo(fifo)
+            assert contains_gateway_lifecycle_command_or_referenced_script(
+                f"bash {fifo}", cwd=str(tmp_path)
+            ) is True
+
+    def test_multiple_heredocs_keep_receiver_association(self, tmp_path):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        directory = tmp_path / "python-data"
+        directory.mkdir()
+        script = tmp_path / "restart.sh"
+        script.write_text("hermes gateway restart\n", encoding="utf-8")
+        command = f"""python3 - <<'PY' | bash <<'SH'
+from pathlib import Path
+root=Path({str(directory)!r})
+PY
+bash {script}
+SH
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is True
+
+    def test_other_heredoc_delimiter_does_not_end_current_body(self, tmp_path):
+        from cron.lifecycle_guard import (
+            _split_outer_shell_and_heredocs,
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        directory = tmp_path / "source-data"
+        directory.mkdir()
+        command = f"""python3 - <<'PY' | bash <<'SH'
+from pathlib import Path
+SH
+root=Path({str(directory)!r})
+PY
+echo safe
+SH
+"""
+        outer, heredocs = _split_outer_shell_and_heredocs(command)
+        assert len(heredocs) == 2
+        assert "root=Path" in heredocs[0][1]
+        assert "echo safe" in heredocs[1][1]
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is False
+
+    def test_heredoc_operator_inside_quoted_text_does_not_hide_command(
+        self, tmp_path
+    ):
+        """A quoted ``<<WORD`` is text, not a heredoc declaration."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        command = f"printf '%s\\n' 'see <<EOF docs'\nsh {script}\n"
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is True
+
+    def test_partially_quoted_delimiter_is_nonexpanding_python_data(self, tmp_path):
+        """Shell quote removal turns ``P\"Y\"`` into quoted delimiter ``PY``."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        directory = tmp_path / "source-data"
+        directory.mkdir()
+        command = f"""python3 <<P\"Y\"
+from pathlib import Path
+root=Path({str(directory)!r})
+PY
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is False
+
+    def test_continued_delimiter_does_not_hide_following_command(self, tmp_path):
+        """Backslash-newline removal joins ``P\\`` + ``Y`` into ``PY``."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        command = f"""python3 <<P\\
+Y
+print('safe')
+PY
+sh {script}
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is True
+
+    @pytest.mark.parametrize("operator", ["$'PY'", '$"PY"', "P$'Y'"])
+    def test_dollar_quoted_delimiter_does_not_hide_following_command(
+        self, operator, tmp_path
+    ):
+        """Bash dollar-quoted delimiter words undergo quote removal."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        command = f"python3 <<{operator}\nprint('safe')\nPY\nsh {script}\n"
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is True
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "python3 - <<'PY'\n/tmp/\n",
+            "python3 - <<'PY\n/tmp/\n",
+            "bash <<\nhermes gateway restart\n",
+        ],
+    )
+    def test_malformed_or_unterminated_heredoc_is_total(self, command):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        verdict = contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd="/tmp"
+        )
+        assert isinstance(verdict, bool)
+
     def test_absolute_path_binary_does_not_crash_guard(self):
         """#76762: a terminal command invoking a binary by absolute path
         (e.g. /usr/bin/python3) must not crash the guard with

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -836,16 +836,79 @@ PY
         from cron.lifecycle_guard import (
             contains_gateway_lifecycle_command_or_referenced_script,
         )
-        directory = tmp_path / "not-a-script"
-        directory.mkdir()
+        fifo = tmp_path / "not-a-script"
+        os.mkfifo(fifo)
         command = f"""function python3 {{ sh; }}
 python3 <<'PY'
-{directory}
+{fifo}
 PY
 """
         assert contains_gateway_lifecycle_command_or_referenced_script(
             command, cwd=str(tmp_path)
         ) is True
+
+    def test_subshell_function_override_of_non_shell_receiver_still_blocks(
+        self, tmp_path
+    ):
+        """A function may use a subshell compound command instead of braces."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        command = f"""python3() ( sh )
+python3 <<'PY'
+sh {script}
+PY
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is True
+
+    @pytest.mark.parametrize(
+        "prefix",
+        [
+            "runner 'python3() ( sh )\ninert data'\n",
+            "# python3() ( sh )\n",
+        ],
+    )
+    def test_inert_function_lookalike_does_not_override_receiver(
+        self, prefix, tmp_path
+    ):
+        """Quoted text and comments cannot redefine a heredoc receiver."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        fifo = tmp_path / "python-data"
+        os.mkfifo(fifo)
+        command = f"""{prefix}python3 <<'PY'
+{fifo}
+PY
+"""
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is False
+
+    def test_escaped_whitespace_keeps_hash_inside_word_for_override_detection(
+        self, tmp_path
+    ):
+        """Escaped whitespace joins the following hash to the current word."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        for escaped_whitespace in ("\\ ", "\\\t"):
+            command = f""": prefix{escaped_whitespace}#literal; python3() {{ sh; }}
+python3 <<'PY'
+sh {script}
+PY
+"""
+            assert contains_gateway_lifecycle_command_or_referenced_script(
+                command, cwd=str(tmp_path)
+            ) is True
 
     def test_spoofed_receiver_direct_script_still_blocks(self, tmp_path):
         """Restricted body scanning retains obvious direct script execution."""
@@ -973,7 +1036,7 @@ SH
         directory.mkdir()
         assert contains_gateway_lifecycle_command_or_referenced_script(
             f"bash {directory}", cwd=str(tmp_path)
-        ) is True
+        ) is False
 
         if hasattr(os, "mkfifo"):
             fifo = tmp_path / "script.fifo"
@@ -1102,6 +1165,94 @@ sh {script}
             command, cwd="/tmp"
         )
         assert isinstance(verdict, bool)
+
+    def test_multiline_single_quoted_data_path_is_not_script_walked(
+        self, tmp_path
+    ):
+        """A path inside one single-quoted argument remains inert data.
+
+        Line-by-line tokenization used to lose the opening quote, promote the
+        path to command position, and parse JavaScript bit shifts as nested
+        heredocs until the guard failed closed.
+        """
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        bundle = tmp_path / "public" / "app.js"
+        bundle.parent.mkdir()
+        bundle.write_text(
+            "\n".join(f"lane{i} <<= 1;" for i in range(10)),
+            encoding="utf-8",
+        )
+        command = (
+            "codex-fallback 'Implement the approved scope:\n"
+            f"{bundle}\n"
+            "Keep acceptance unchanged.'"
+        )
+
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is False
+
+    def test_double_quoted_multiline_substitution_still_blocks(self, tmp_path):
+        """Double-quoted command substitutions remain executable shell input."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        command = f'runner "note\n$(sh {script})\nend"'
+
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is True
+
+    def test_hash_inside_word_does_not_break_multiline_single_quote(self, tmp_path):
+        """An unquoted hash inside a shell word is literal, not a comment."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        fifo = tmp_path / "public" / "app.js"
+        fifo.parent.mkdir()
+        os.mkfifo(fifo)
+        command = f"runner tag#literal 'first line\n{fifo}\nlast line'"
+
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is False
+
+    def test_single_quoted_multiline_argument_does_not_hide_following_command(
+        self, tmp_path
+    ):
+        """A real command after the quoted data remains a guarded segment."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        command = f"runner 'safe data\npublic/app.js\n'; sh {script}"
+
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is True
+
+    def test_unquoted_multiline_script_path_still_blocks(self, tmp_path):
+        """Newline command boundaries must remain visible to the guard."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        command = f"printf '%s\\n' safe\n{script}\n"
+
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is True
 
     def test_absolute_path_binary_does_not_crash_guard(self):
         """#76762: a terminal command invoking a binary by absolute path


### PR DESCRIPTION
## Summary

This PR makes the gateway lifecycle guard distinguish shell structure from inert source or prompt data in two related cases:

1. **Quoted non-shell heredocs:** source sent through a quoted Python/Node/etc. heredoc is no longer promoted into referenced shell scripts. Shell or unknown receivers and unquoted heredocs remain conservatively scanned.
2. **Multiline single-quoted arguments:** valid single-quoted arguments retain their boundaries across physical newlines. A path such as `public/app.js` inside a Codex prompt therefore remains argument data instead of becoming a fake command on its own line.

The second issue caused a real false positive: the guard read a built JavaScript bundle named in a prompt, parsed shifts such as `lane <<= 1` as nested heredocs, reached its recursion limit, and returned a misleading gateway-restart block.

## Reproductions

```bash
python3 - <<'PYCODE'
from pathlib import Path
root = Path('/home/design-director/.hermes/skills/creative/expert-product-design')
print(root)
PYCODE
```

```bash
codex-fallback 'Implement the approved scope:
public/app.js
Keep acceptance unchanged.'
```

## Security properties

- The direct lifecycle scan still examines the complete original input.
- Real commands after a multiline single-quoted argument remain guarded segments.
- Unquoted newline commands, malformed quotes, and double-quoted `$()` substitutions retain conservative handling.
- Shell comments are recognized only when `#` starts a shell word; `tag#literal` and hashes following escaped whitespace stay ordinary data.
- Inline function receiver overrides are detected with brace or subshell compound bodies.
- Function-like text inside quotes or comments remains inert and does not invalidate a proven non-shell receiver.
- Command-shaped script paths inside a quoted non-shell heredoc remain guarded, preserving fail-closed behavior if an ambient `PATH` shadows the expected interpreter.
- Shell/unknown receivers, unquoted heredocs, explicit/nested scripts, remote reads, binary/NUL inputs, and depth/size limits remain covered.
- Current `main`'s directory exemption from #86753 is preserved; unsafe non-regular explicit shell inputs remain fail-closed.

## Verification

- **Base:** `4323c67dcc6048fc8e311cdff7600d3d6a17807f`
- **Candidate:** `22238994defa29d704c33dffa911308585f5d550`

```text
HERMES_PYTHON="$PWD/.venv/bin/python" scripts/run_tests.sh \
  tests/hermes_cli/test_gateway_restart_loop.py \
  tests/tools/test_terminal_heredoc_background_guard.py

201 passed, 0 failed
```

Additional checks:

- Exact previously blocked Engineering Director commands now return a safe verdict.
- `ruff check` passes for both changed files.
- Python byte-compilation and `git diff --check` pass.
- Exact patch replay onto the stated base produced the candidate tree byte-for-byte.
- The parser fix remains a second focused commit; rebase conflict resolution preserves upstream FileProvider/cloud-path protections.

Related: #79835, #77383, #77131, #83633, #86753

