### PR TITLE
fix(verify): bound _run_phase_command's output buffer and reap its process group on timeout

### DIFF
--- a/agent/verify/runner.py
+++ b/agent/verify/runner.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import os
 import signal
 import subprocess
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -100,6 +101,45 @@ def _tail(text: str, limit: int = _TAIL_CHARS) -> str:
     return text[-limit:] if len(text) > limit else text
 
 
+class _BoundedOutputReader:
+    """Drain a subprocess's stdout while it runs, keeping only the last
+    ``limit`` characters.
+
+    ``subprocess.run(..., stdout=subprocess.PIPE)`` buffers the ENTIRE
+    output in memory before ``_tail()`` ever gets a chance to truncate it —
+    a verbose phase command (a chatty test runner, a build tool with
+    progress spam) can grow that buffer without bound for the whole
+    ``timeout`` window. Draining concurrently with a bounded tail caps the
+    worst case at ``limit`` regardless of how much the command prints.
+    """
+
+    def __init__(self, stream: Any, limit: int = _TAIL_CHARS) -> None:
+        self._stream = stream
+        self._limit = limit
+        self._buf = ""
+        self._lock = threading.Lock()
+        self._thread = threading.Thread(target=self._pump, daemon=True)
+
+    def start(self) -> "_BoundedOutputReader":
+        self._thread.start()
+        return self
+
+    def _pump(self) -> None:
+        try:
+            for line in self._stream:
+                with self._lock:
+                    self._buf = (self._buf + line)[-self._limit :]
+        except (OSError, ValueError):
+            # Pipe closed under us (process killed) — whatever we captured stands.
+            pass
+
+    def result(self, timeout: float = 5.0) -> str:
+        """Captured tail. Never raises: diagnostics must not fail the run."""
+        self._thread.join(timeout)
+        with self._lock:
+            return self._buf
+
+
 def _run_phase_command(
     phase: str,
     command: str,
@@ -108,28 +148,31 @@ def _run_phase_command(
     on_output: Callable[[str], None] | None = None,
 ) -> PhaseResult:
     started = time.monotonic()
+    # start_new_session puts the command (and every process it spawns) in its
+    # own process group, so a timeout can terminate the WHOLE tree via
+    # _terminate_process_group — the same pattern _run_start_phase already
+    # uses. Plain proc.kill() only signals the direct `sh` wrapper; a phase
+    # that spawned children (jest workers, npm build chains, dev servers)
+    # would leave them orphaned and still running, holding ports/fds.
+    proc = subprocess.Popen(
+        command,
+        shell=True,  # project-authored commands; see module docstring
+        cwd=str(root),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,  # own process group for clean teardown
+        text=True,
+        errors="replace",
+    )
+    reader = _BoundedOutputReader(proc.stdout).start() if proc.stdout is not None else None
     try:
-        proc = subprocess.run(
-            command,
-            shell=True,  # project-authored commands; see module docstring
-            cwd=str(root),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            timeout=timeout,
-            text=True,
-            errors="replace",
-        )
-        output = proc.stdout or ""
-        exit_code: int | None = proc.returncode
+        exit_code: int | None = proc.wait(timeout=timeout)
         timed_out = False
-    except subprocess.TimeoutExpired as exc:
-        raw = exc.output
-        if isinstance(raw, bytes):
-            output = raw.decode("utf-8", errors="replace")
-        else:
-            output = raw or ""
+    except subprocess.TimeoutExpired:
+        _terminate_process_group(proc)
         exit_code = None
         timed_out = True
+    output = reader.result() if reader is not None else ""
     duration = time.monotonic() - started
     if on_output and output:
         on_output(output)

--- a/agent/verify/runner.py
+++ b/agent/verify/runner.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import os
 import signal
 import subprocess
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -100,6 +101,45 @@ def _tail(text: str, limit: int = _TAIL_CHARS) -> str:
     return text[-limit:] if len(text) > limit else text
 
 
+class _BoundedOutputReader:
+    """Drain a subprocess's stdout while it runs, keeping only the last
+    ``limit`` characters.
+
+    ``subprocess.run(..., stdout=subprocess.PIPE)`` buffers the ENTIRE
+    output in memory before ``_tail()`` ever gets a chance to truncate it —
+    a verbose phase command (a chatty test runner, a build tool with
+    progress spam) can grow that buffer without bound for the whole
+    ``timeout`` window. Draining concurrently with a bounded tail caps the
+    worst case at ``limit`` regardless of how much the command prints.
+    """
+
+    def __init__(self, stream: Any, limit: int = _TAIL_CHARS) -> None:
+        self._stream = stream
+        self._limit = limit
+        self._buf = ""
+        self._lock = threading.Lock()
+        self._thread = threading.Thread(target=self._pump, daemon=True)
+
+    def start(self) -> "_BoundedOutputReader":
+        self._thread.start()
+        return self
+
+    def _pump(self) -> None:
+        try:
+            for line in self._stream:
+                with self._lock:
+                    self._buf = (self._buf + line)[-self._limit :]
+        except (OSError, ValueError):
+            # Pipe closed under us (process killed) — whatever we captured stands.
+            pass
+
+    def result(self, timeout: float = 5.0) -> str:
+        """Captured tail. Never raises: diagnostics must not fail the run."""
+        self._thread.join(timeout)
+        with self._lock:
+            return self._buf
+
+
 def _run_phase_command(
     phase: str,
     command: str,
@@ -108,28 +148,25 @@ def _run_phase_command(
     on_output: Callable[[str], None] | None = None,
 ) -> PhaseResult:
     started = time.monotonic()
+    proc = subprocess.Popen(
+        command,
+        shell=True,  # project-authored commands; see module docstring
+        cwd=str(root),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        errors="replace",
+    )
+    reader = _BoundedOutputReader(proc.stdout).start() if proc.stdout is not None else None
     try:
-        proc = subprocess.run(
-            command,
-            shell=True,  # project-authored commands; see module docstring
-            cwd=str(root),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            timeout=timeout,
-            text=True,
-            errors="replace",
-        )
-        output = proc.stdout or ""
-        exit_code: int | None = proc.returncode
+        exit_code: int | None = proc.wait(timeout=timeout)
         timed_out = False
-    except subprocess.TimeoutExpired as exc:
-        raw = exc.output
-        if isinstance(raw, bytes):
-            output = raw.decode("utf-8", errors="replace")
-        else:
-            output = raw or ""
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
         exit_code = None
         timed_out = True
+    output = reader.result() if reader is not None else ""
     duration = time.monotonic() - started
     if on_output and output:
         on_output(output)

--- a/tests/verify/test_environment_and_runner.py
+++ b/tests/verify/test_environment_and_runner.py
@@ -92,6 +92,23 @@ class TestRunner:
         result = run_verify(tmp_path, recipe, skip_start=True)
         assert "hello-verify" in result.phases[0].output_tail
 
+    def test_chatty_phase_command_still_completes_and_tail_is_bounded(self, tmp_path):
+        """A phase command printing far more than the tail limit before
+        exiting must not be collected unbounded in memory — see
+        _BoundedOutputReader. This exercises the real Popen + drain path,
+        not just the reader class in isolation."""
+        from agent.verify.runner import _TAIL_CHARS
+
+        recipe = Recipe(
+            name="x",
+            test=["python3 -c \"[print('x' * 200) for _ in range(2000)]\""],
+        )
+        result = run_verify(tmp_path, recipe, skip_start=True)
+        assert result.ok
+        assert not result.phases[0].timed_out
+        assert result.phases[0].exit_code == 0
+        assert len(result.phases[0].output_tail) <= _TAIL_CHARS
+
     def test_phase_selection(self, tmp_path):
         recipe = Recipe(name="x", bootstrap=["true"], build=["true"], test=["true"])
         result = run_verify(tmp_path, recipe, phases=("test",))
@@ -103,6 +120,43 @@ class TestRunner:
         assert not result.ok
         assert result.phases[0].timed_out
         assert result.phases[0].exit_code is None
+
+    def test_phase_timeout_reaps_whole_process_tree(self, tmp_path):
+        """A timed-out phase must not orphan the command's children.
+
+        ``proc.kill()`` on a plain (default process-group) Popen only
+        signals the direct `sh -c` wrapper — a phase that spawned children
+        (jest workers, npm build chains, dev servers) leaves them orphaned
+        and still running, holding ports/fds. _run_phase_command now spawns
+        with start_new_session=True and reaps the whole group via
+        _terminate_process_group on timeout, same as _run_start_phase.
+        """
+        import os
+        import shutil
+
+        if shutil.which("bash") is None:
+            import pytest
+
+            pytest.skip("bash required")
+
+        def _pid_alive(pid: int) -> bool:
+            try:
+                os.kill(pid, 0)
+                return True
+            except (ProcessLookupError, PermissionError):
+                return False
+
+        from agent.verify.runner import _run_phase_command
+
+        pidfile = tmp_path / "child.pid"
+        cmd = f"bash -c 'sleep 30 & echo $! > {pidfile}; wait'"
+        result = _run_phase_command("test", cmd, tmp_path, timeout=1.0)
+        assert result.timed_out
+        child_pid = int(pidfile.read_text().strip())
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and _pid_alive(child_pid):
+            time.sleep(0.1)
+        assert not _pid_alive(child_pid), "phase child survived the timeout"
 
     def test_commands_run_in_project_root(self, tmp_path):
         (tmp_path / "marker.txt").write_text("here", encoding="utf-8")
@@ -187,3 +241,21 @@ class TestReadiness:
         finally:
             server.shutdown()
             thread.join(timeout=5)
+
+
+class TestBoundedOutputReader:
+    def test_keeps_only_the_tail_while_draining(self):
+        from agent.verify.runner import _BoundedOutputReader
+
+        # 500 lines of 10 chars (+ newline) = 5500 chars total, well past a
+        # small limit — the reader must never hold more than `limit` chars
+        # even mid-drain, not just after truncating a fully-collected string.
+        lines = [f"line-{i:04d}\n" for i in range(500)]
+        reader = _BoundedOutputReader(iter(lines), limit=100).start()
+
+        result = reader.result(timeout=5)
+
+        assert len(result) <= 100
+        # The tail survives; the head (line-0000) does not.
+        assert "line-0499" in result
+        assert "line-0000" not in result

--- a/tests/verify/test_environment_and_runner.py
+++ b/tests/verify/test_environment_and_runner.py
@@ -92,6 +92,23 @@ class TestRunner:
         result = run_verify(tmp_path, recipe, skip_start=True)
         assert "hello-verify" in result.phases[0].output_tail
 
+    def test_chatty_phase_command_still_completes_and_tail_is_bounded(self, tmp_path):
+        """A phase command printing far more than the tail limit before
+        exiting must not be collected unbounded in memory — see
+        _BoundedOutputReader. This exercises the real Popen + drain path,
+        not just the reader class in isolation."""
+        from agent.verify.runner import _TAIL_CHARS
+
+        recipe = Recipe(
+            name="x",
+            test=["python3 -c \"[print('x' * 200) for _ in range(2000)]\""],
+        )
+        result = run_verify(tmp_path, recipe, skip_start=True)
+        assert result.ok
+        assert not result.phases[0].timed_out
+        assert result.phases[0].exit_code == 0
+        assert len(result.phases[0].output_tail) <= _TAIL_CHARS
+
     def test_phase_selection(self, tmp_path):
         recipe = Recipe(name="x", bootstrap=["true"], build=["true"], test=["true"])
         result = run_verify(tmp_path, recipe, phases=("test",))
@@ -187,3 +204,21 @@ class TestReadiness:
         finally:
             server.shutdown()
             thread.join(timeout=5)
+
+
+class TestBoundedOutputReader:
+    def test_keeps_only_the_tail_while_draining(self):
+        from agent.verify.runner import _BoundedOutputReader
+
+        # 500 lines of 10 chars (+ newline) = 5500 chars total, well past a
+        # small limit — the reader must never hold more than `limit` chars
+        # even mid-drain, not just after truncating a fully-collected string.
+        lines = [f"line-{i:04d}\n" for i in range(500)]
+        reader = _BoundedOutputReader(iter(lines), limit=100).start()
+
+        result = reader.result(timeout=5)
+
+        assert len(result) <= 100
+        # The tail survives; the head (line-0000) does not.
+        assert "line-0499" in result
+        assert "line-0000" not in result


### PR DESCRIPTION
## What does this PR do?

**#81228** (this week) fixed `agent/verify/runner.py::_run_start_phase`: `subprocess.run(..., stdout=subprocess.PIPE)` buffers a command's ENTIRE output in memory before `_tail()` ever gets a chance to truncate it, so a chatty process can grow that buffer without bound for the whole poll window. #81228's fix was a threaded `_BackgroundOutputReader` that drains the stream concurrently, keeping only the last `limit` characters.

`_run_phase_command` — the OTHER function in this same file, with the identical `subprocess.run(..., stdout=subprocess.PIPE, timeout=timeout)` pattern — was left unfixed for the memory-bound issue. Separately, its timeout path only ever signaled the direct `sh -c` wrapper: a phase that spawned children (jest workers, npm build chains, dev servers) left them orphaned and still running after a timeout, holding ports/fds. `_run_start_phase` already had the correct fix for *that* problem too, via `start_new_session=True` + `_terminate_process_group`.

## Fix (now combined — see update below)

This PR originally scoped itself to *only* the memory-bound fix, explicitly leaving process-group reaping to **#81344** (open the same day, same function) to avoid overlap. A review caught that this split doesn't actually work: both PRs rewrite the identical `subprocess.run` block in `_run_phase_command`, so whichever merges first forces the other into a conflicting rebase — and worse, since neither fix is a superset of the other, landing only one leaves the other's bug in place (mine alone: orphaned children still survive a timeout; #81344 alone: `proc.communicate(timeout=timeout)` still buffers full output in memory, reintroducing the exact issue this PR fixes).

Updated this PR to carry **both** mechanisms, mirroring `_run_start_phase`'s own reference implementation exactly:
- `_BoundedOutputReader` (unchanged from the original scope of this PR) — a background thread draining stdout concurrently, capping memory at `_TAIL_CHARS` regardless of how much the command prints.
- `start_new_session=True` on the `Popen` call + `_terminate_process_group(proc)` on timeout (ported from `_run_start_phase`, reusing the exact same helper) — reaps the whole process tree, not just the direct child.

## Testing

- `TestBoundedOutputReader.test_keeps_only_the_tail_while_draining` — feeds the reader 5500 chars via an iterator with `limit=100`, asserts the result never exceeds the limit and contains only the tail.
- `test_chatty_phase_command_still_completes_and_tail_is_bounded` — integration-level sanity check through the real `Popen` + drain path with a command printing 2000 lines.
- New `test_phase_timeout_reaps_whole_process_tree` — spawns a backgrounded grandchild (`bash -c 'sleep 30 & echo $! > pidfile; wait'`) with a 1s timeout and asserts the child is actually dead afterward. Mutation-verified: fails with `"phase child survived the timeout"` against the plain-`Popen`/`proc.kill()` code (i.e. this PR's own pre-update state).
- Mutation-verify on the memory-bound side unchanged from the original submission (see prior test plan below).
- Full `tests/verify/` suite: 78 passed. `ruff check` clean.

## Note on #81344

No longer "no shared concern" — both PRs touch the identical `subprocess.run` block in `_run_phase_command`, and this PR now carries the combined fix (bounded output + process-group reaping) that a reviewer pointed out neither PR alone provides. Once this lands, #81344's change to the same lines would be redundant.