### PR TITLE
fix(plugins/langfuse): propagate session_id/tags to child observations; mark failed calls instead of closing them silently

### DIFF
--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -699,7 +699,8 @@ def _start_child_observation(state: TraceState, *, client: Langfuse, name: str, 
 
 
 def _end_observation(observation: Any, *, output: Any = None, metadata: Optional[dict] = None,
-                     usage_details: Optional[dict] = None, cost_details: Optional[dict] = None) -> None:
+                     usage_details: Optional[dict] = None, cost_details: Optional[dict] = None,
+                     level: Optional[str] = None, status_message: Optional[str] = None) -> None:
     if observation is None:
         return
     try:
@@ -712,6 +713,10 @@ def _end_observation(observation: Any, *, output: Any = None, metadata: Optional
             update_kwargs["usage_details"] = usage_details
         if cost_details:
             update_kwargs["cost_details"] = cost_details
+        if level is not None:
+            update_kwargs["level"] = level
+        if status_message is not None:
+            update_kwargs["status_message"] = status_message
         if update_kwargs:
             observation.update(**update_kwargs)
         observation.end()
@@ -768,13 +773,29 @@ def _finish_trace(task_key: str, *, output: Any = None) -> None:
         return
 
     try:
+        # Anything still here never received its post_api_request/post_tool_call
+        # completion (both pop their entry on a normal finish) — the turn ended
+        # (retries exhausted, exception, disconnect) without a recorded response
+        # for this call. Mark it accordingly instead of closing it silently.
         for observation in state.generations.values():
-            _end_observation(observation)
+            _end_observation(
+                observation,
+                level="ERROR",
+                status_message="Turn ended without a recorded response for this call.",
+            )
         for observation in state.tools.values():
-            _end_observation(observation)
+            _end_observation(
+                observation,
+                level="ERROR",
+                status_message="Turn ended before this tool call's result was recorded.",
+            )
         for queue in state.pending_tools_by_name.values():
             for observation in queue:
-                _end_observation(observation)
+                _end_observation(
+                    observation,
+                    level="ERROR",
+                    status_message="Turn ended before this tool call's result was recorded.",
+                )
         final_output = _merge_trace_output(output, state)
         if final_output is not None:
             state.root_span.set_trace_io(output=final_output)
@@ -915,7 +936,11 @@ def on_pre_llm_request(
         state.last_updated_at = time.time()
         previous = state.generations.pop(req_key, None)
         if previous is not None:
-            _end_observation(previous)
+            _end_observation(
+                previous,
+                level="WARNING",
+                status_message="Retried: no response was recorded for this attempt before the next attempt started.",
+            )
         state.generations[req_key] = _start_child_observation(
             state,
             client=client,

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -50,6 +50,12 @@ class TraceState:
     pending_tools_by_name: Dict[str, list] = field(default_factory=dict)
     turn_tool_calls: list[dict[str, Any]] = field(default_factory=list)
     last_updated_at: float = field(default_factory=time.time)
+    session_id: str = ""
+    # propagate_attributes() context, entered in _start_root_trace and held
+    # open for the trace's whole lifetime so that child observations created
+    # by later hook invocations inherit session_id/tags. Closed in
+    # _finish_trace / _evict_stale_locked.
+    attr_ctx: Any = None
 
 
 _STATE_LOCK = threading.Lock()
@@ -621,33 +627,31 @@ def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform:
     if session_id:
         trace_ctx["session_id"] = session_id
 
+    tags = ["hermes", "langfuse"]
+    if platform:
+        tags.append(f"channel:{platform}")
+
+    # propagate_attributes() applies session_id/tags only to observations
+    # created while its context is open. Entering and exiting it around just
+    # the root span's creation would leave every child observation — the
+    # LLM-call generations and tool spans created by later hook invocations —
+    # without session_id or tags, silently breaking session-level cost/token
+    # aggregation. Enter it manually and hold it open in TraceState (closed
+    # in _finish_trace / _evict_stale_locked), the same way root_ctx itself
+    # is already held open across hooks.
+    attr_ctx = None
     if propagate_attributes is not None:
         try:
-            with propagate_attributes(
+            attr_ctx = propagate_attributes(
                 session_id=session_id or task_key,
                 trace_name="Hermes turn",
-                tags=["hermes", "langfuse"],
-            ):
-                root_ctx = client.start_as_current_observation(
-                    trace_context=trace_ctx,
-                    name="Hermes turn",
-                    as_type="chain",
-                    input=trace_input,
-                    metadata=metadata,
-                    end_on_exit=False,
-                )
-                root_span = root_ctx.__enter__()
-        except Exception:
-            root_ctx = client.start_as_current_observation(
-                trace_context=trace_ctx,
-                name="Hermes turn",
-                as_type="chain",
-                input=trace_input,
-                metadata=metadata,
-                end_on_exit=False,
+                tags=tags,
             )
-            root_span = root_ctx.__enter__()
-    else:
+            attr_ctx.__enter__()
+        except Exception:
+            attr_ctx = None
+
+    try:
         root_ctx = client.start_as_current_observation(
             trace_context=trace_ctx,
             name="Hermes turn",
@@ -657,6 +661,14 @@ def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform:
             end_on_exit=False,
         )
         root_span = root_ctx.__enter__()
+    except Exception:
+        if attr_ctx is not None:
+            try:
+                attr_ctx.__exit__(None, None, None)
+            except Exception:
+                pass
+            attr_ctx = None
+        raise
 
     try:
         root_span.set_trace_io(input=trace_input)
@@ -664,7 +676,13 @@ def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform:
         pass
 
     _debug(f"started trace {trace_id} for {task_key}")
-    return TraceState(trace_id=trace_id, root_ctx=root_ctx, root_span=root_span)
+    return TraceState(
+        trace_id=trace_id,
+        root_ctx=root_ctx,
+        root_span=root_span,
+        session_id=session_id,
+        attr_ctx=attr_ctx,
+    )
 
 
 def _start_child_observation(state: TraceState, *, client: Langfuse, name: str, as_type: str,
@@ -732,6 +750,11 @@ def _evict_stale_locked() -> None:
             state.root_span.end()
         except Exception as exc:  # pragma: no cover - fail-open
             _debug(f"evict stale trace failed: {exc}")
+        if state.attr_ctx is not None:
+            try:
+                state.attr_ctx.__exit__(None, None, None)
+            except Exception:
+                pass
 
 
 def _finish_trace(task_key: str, *, output: Any = None) -> None:
@@ -760,6 +783,11 @@ def _finish_trace(task_key: str, *, output: Any = None) -> None:
     except Exception as exc:  # pragma: no cover - fail-open
         _debug(f"finish trace failed: {exc}")
     finally:
+        if state.attr_ctx is not None:
+            try:
+                state.attr_ctx.__exit__(None, None, None)
+            except Exception:
+                pass
         try:
             client.flush()
         except Exception:

--- a/tests/plugins/test_langfuse_observability_plugin.py
+++ b/tests/plugins/test_langfuse_observability_plugin.py
@@ -1,0 +1,308 @@
+"""Tests for the bundled Langfuse observability plugin.
+
+Covers ``plugins/observability/langfuse/__init__.py``:
+
+  * session_id/tags propagation — the ``propagate_attributes()`` context is
+    held open for the trace's whole lifetime so child observations (LLM-call
+    generations, tool spans) inherit session_id/tags, and it is closed
+    exactly once on both the normal-finish and eviction paths.
+  * ``channel:<platform>`` trace tag derived from the hook's platform value.
+  * error visibility — observations still open at turn end are closed with
+    ``level=ERROR`` + status message; a generation superseded by a retry of
+    the same ``api_call_count`` is closed with ``level=WARNING``; successful
+    calls keep the default level with no status message.
+
+All Langfuse SDK surface is faked; no network, no real SDK required.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fakes for the Langfuse SDK surface the plugin touches
+# ---------------------------------------------------------------------------
+
+
+class FakeObservation:
+    """Records update()/end() calls; spawns child observations."""
+
+    def __init__(self, name="root"):
+        self.name = name
+        self.updates = []
+        self.ended = False
+        self.children = []
+        self.trace_io = {}
+
+    def start_observation(self, *, name, as_type, input, metadata=None,
+                          model=None, model_parameters=None):
+        child = FakeObservation(name=name)
+        self.children.append(child)
+        return child
+
+    def update(self, **kwargs):
+        self.updates.append(kwargs)
+
+    def end(self):
+        self.ended = True
+
+    def set_trace_io(self, **kwargs):
+        self.trace_io.update(kwargs)
+
+
+class FakeRootCtx:
+    """Stands in for start_as_current_observation()'s context manager."""
+
+    def __init__(self, span):
+        self.span = span
+
+    def __enter__(self):
+        return self.span
+
+    def __exit__(self, *exc):
+        return False
+
+
+class FakePropagateCtx:
+    """Records enter/exit so tests can assert on context lifetime."""
+
+    def __init__(self, kwargs):
+        self.kwargs = kwargs
+        self.entered = 0
+        self.exited = 0
+
+    def __enter__(self):
+        self.entered += 1
+        return self
+
+    def __exit__(self, *exc):
+        self.exited += 1
+        return False
+
+
+class FakeClient:
+    def __init__(self):
+        self.root_spans = []
+        self.flushed = 0
+
+    def create_trace_id(self, seed=""):
+        return f"trace-{len(self.root_spans)}"
+
+    def start_as_current_observation(self, *, trace_context, name, as_type,
+                                     input, metadata=None, end_on_exit=False):
+        span = FakeObservation(name=name)
+        span.trace_context = trace_context
+        self.root_spans.append(span)
+        return FakeRootCtx(span)
+
+    def flush(self):
+        self.flushed += 1
+
+
+# ---------------------------------------------------------------------------
+# Plugin loading
+# ---------------------------------------------------------------------------
+
+
+def _load_plugin():
+    """Import a fresh instance of the plugin module from the repo path."""
+    repo_root = Path(__file__).resolve().parents[2]
+    path = repo_root / "plugins" / "observability" / "langfuse" / "__init__.py"
+    name = "test_langfuse_plugin_instance"
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        # Fresh instance per test; drop the registration either way.
+        sys.modules.pop(name, None)
+    return module
+
+
+@pytest.fixture()
+def plugin():
+    module = _load_plugin()
+    module._LANGFUSE_CLIENT = FakeClient()
+
+    propagate_ctxs = []
+
+    def fake_propagate_attributes(**kwargs):
+        ctx = FakePropagateCtx(kwargs)
+        propagate_ctxs.append(ctx)
+        return ctx
+
+    module.propagate_attributes = fake_propagate_attributes
+    module._test_propagate_ctxs = propagate_ctxs
+    return module
+
+
+def _assistant_message(content="OK", tool_calls=None):
+    msg = types.SimpleNamespace()
+    msg.content = content
+    msg.tool_calls = tool_calls or []
+    return msg
+
+
+TURN = dict(
+    task_id="task-1",
+    session_id="session-abc",
+    turn_id="turn-1",
+    api_request_id="req-1",
+    platform="telegram",
+    model="test-model",
+    provider="test-provider",
+    api_mode="test",
+)
+
+
+def _start_request(plugin_module, api_call_count=1):
+    plugin_module.on_pre_llm_request(
+        **TURN,
+        api_call_count=api_call_count,
+        request_messages=[{"role": "user", "content": "hello"}],
+    )
+
+
+def _complete_request(plugin_module, api_call_count=1, content="done"):
+    plugin_module.on_post_llm_call(
+        task_id=TURN["task_id"],
+        session_id=TURN["session_id"],
+        turn_id=TURN["turn_id"],
+        api_request_id=TURN["api_request_id"],
+        provider=TURN["provider"],
+        model=TURN["model"],
+        api_call_count=api_call_count,
+        assistant_message=_assistant_message(content=content),
+        finish_reason="stop",
+        usage=None,
+    )
+
+
+def _task_key(plugin_module):
+    return plugin_module._trace_key(
+        TURN["task_id"],
+        TURN["session_id"],
+        turn_id=TURN["turn_id"],
+        api_request_id=TURN["api_request_id"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# session_id / tags propagation
+# ---------------------------------------------------------------------------
+
+
+def test_propagate_context_held_open_until_finish(plugin):
+    _start_request(plugin)
+
+    (ctx,) = plugin._test_propagate_ctxs
+    assert ctx.entered == 1
+    # The whole point of the fix: the context must still be open after the
+    # root-trace hook returns, so observations created by later hook
+    # invocations inherit session_id/tags.
+    assert ctx.exited == 0
+    assert ctx.kwargs["session_id"] == "session-abc"
+
+    # Completing the turn (content, no tool calls) finishes the trace and
+    # closes the context exactly once.
+    _complete_request(plugin)
+    assert ctx.exited == 1
+    assert not plugin._TRACE_STATE
+
+
+def test_channel_tag_from_platform(plugin):
+    _start_request(plugin)
+    (ctx,) = plugin._test_propagate_ctxs
+    assert "channel:telegram" in ctx.kwargs["tags"]
+    assert "hermes" in ctx.kwargs["tags"]
+
+
+def test_eviction_closes_propagate_context(plugin, monkeypatch):
+    monkeypatch.setattr(plugin, "_MAX_TRACE_STATE", 1)
+    _start_request(plugin)
+    first_ctx = plugin._test_propagate_ctxs[0]
+
+    # A second turn evicts the first (cap is 1).
+    plugin.on_pre_llm_request(
+        **{**TURN, "turn_id": "turn-2", "api_request_id": "req-2"},
+        api_call_count=1,
+        request_messages=[{"role": "user", "content": "again"}],
+    )
+    assert first_ctx.exited == 1
+
+
+# ---------------------------------------------------------------------------
+# error visibility
+# ---------------------------------------------------------------------------
+
+
+def test_unfinished_generation_marked_error_on_finish(plugin):
+    _start_request(plugin)
+    root_span = plugin._LANGFUSE_CLIENT.root_spans[0]
+    (generation,) = root_span.children
+
+    # Turn ends without post_api_request ever firing (retries exhausted).
+    plugin._finish_trace(_task_key(plugin), output=None)
+
+    assert generation.ended
+    merged = {k: v for update in generation.updates for k, v in update.items()}
+    assert merged.get("level") == "ERROR"
+    assert "without a recorded response" in merged.get("status_message", "")
+
+
+def test_unfinished_tool_marked_error_on_finish(plugin):
+    _start_request(plugin)
+    plugin.on_pre_tool_call(
+        tool_name="terminal",
+        args={"command": "true"},
+        task_id=TURN["task_id"],
+        session_id=TURN["session_id"],
+        turn_id=TURN["turn_id"],
+        tool_call_id="call-1",
+    )
+    root_span = plugin._LANGFUSE_CLIENT.root_spans[0]
+    tool_obs = root_span.children[-1]
+
+    plugin._finish_trace(_task_key(plugin), output=None)
+
+    merged = {k: v for update in tool_obs.updates for k, v in update.items()}
+    assert merged.get("level") == "ERROR"
+    assert "tool call's result" in merged.get("status_message", "")
+
+
+def test_retry_superseded_generation_marked_warning(plugin):
+    _start_request(plugin, api_call_count=1)
+    root_span = plugin._LANGFUSE_CLIENT.root_spans[0]
+    first_generation = root_span.children[0]
+
+    # Same api_call_count fires again: a retry superseding the first attempt.
+    _start_request(plugin, api_call_count=1)
+    second_generation = root_span.children[1]
+
+    merged = {k: v for update in first_generation.updates for k, v in update.items()}
+    assert first_generation.ended
+    assert merged.get("level") == "WARNING"
+    assert "Retried" in merged.get("status_message", "")
+
+    # The retry that completes normally stays at the default level.
+    _complete_request(plugin, api_call_count=1)
+    for update in second_generation.updates:
+        assert "level" not in update
+        assert "status_message" not in update
+
+
+def test_successful_call_keeps_default_level(plugin):
+    _start_request(plugin)
+    _complete_request(plugin)
+
+    root_span = plugin._LANGFUSE_CLIENT.root_spans[0]
+    (generation,) = root_span.children
+    assert generation.ended
+    for update in generation.updates:
+        assert "level" not in update
+        assert "status_message" not in update


### PR DESCRIPTION
> **Disclosure:** This PR was authored by an AI assistant (Claude) working through a real,
> interactive troubleshooting session on my self-hosted deployment. Both fixes were applied and
> validated in production there (synthetic turns + live gateway traffic) before this PR was
> opened; the regression tests included here reproduce that validation without a live backend.

## What does this PR do?

Fixes two independent defects in the bundled `observability/langfuse` plugin, both in
`plugins/observability/langfuse/__init__.py`, one commit each:

**1. `session_id`/tags never reach child observations (#81730).**
`_start_root_trace` opened `propagate_attributes(...)` as a `with` block around only the root
span's creation. Per the Langfuse SDK contract, propagated attributes apply only to observations
created *while that context is open* — and every `LLM call N` generation and `Tool: *` span is
created later, in separate hook invocations. Result: only the root chain span carried
`session_id`/tags; on my deployment 94% of tokens landed in a `sessionId: null` bucket when
aggregating observations by session. The fix holds the context open for the trace's lifetime
(entered manually in `_start_root_trace`, stored on `TraceState`, exited in `_finish_trace` /
`_evict_stale_locked` — mirroring how `root_ctx` is already held open), and adds a
`channel:<platform>` tag so traces can be filtered by trigger source.

**2. Failed/abandoned calls indistinguishable from successes (#81731).**
No observation was ever marked `level=WARNING/ERROR`, and `post_api_request` only fires on the
success path in `conversation_loop.py` — when retries exhaust with no response, the generation
opened by `pre_api_request` was closed bare, looking identical to a success. The fix closes
still-open observations at turn end with `level=ERROR` + `status_message`, and closes a
generation superseded by a retry of the same `api_call_count` with `level=WARNING`. Successful
calls are untouched (level kwargs are opt-in on `_end_observation`; existing call sites for the
success path pass nothing).

## Related Issue

Fixes #81730
Fixes #81731

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `plugins/observability/langfuse/__init__.py`
  - `TraceState`: new `session_id` / `attr_ctx` fields; `attr_ctx` holds the open
    `propagate_attributes()` context across hook invocations.
  - `_start_root_trace`: builds tags (incl. `channel:<platform>`), enters the propagate context
    manually (fail-open; exits before re-raising if root-span creation fails).
  - `_finish_trace` / `_evict_stale_locked`: exit the propagate context; close leftover
    generation/tool observations with `level=ERROR` + status message.
  - `on_pre_llm_request`: close a retry-superseded stale generation with `level=WARNING`.
  - `_end_observation`: optional `level` / `status_message` kwargs.
- `tests/plugins/test_langfuse_observability_plugin.py` (new — first tests for this plugin):
  7 cases covering context lifetime (normal finish + eviction), channel tag, ERROR marking for
  never-completed generations and tools, WARNING for superseded retries, and no-false-positive
  on the success path. All Langfuse SDK surface is faked; no network or SDK install needed.

## How to Test

1. `pytest tests/plugins/test_langfuse_observability_plugin.py -v` → 7 passed.
2. End-to-end (needs a Langfuse backend + plugin credentials): run
   `hermes chat -q 'reply with OK' -Q`, then fetch the trace's observations via
   `GET /api/public/v2/observations?traceId=...` — child GENERATION/TOOL observations now carry
   `sessionId` and `channel:<platform>` tags (before: `sessionId: ""`, `tags: []`).
3. Error path: drive `on_pre_llm_request` then `_finish_trace` without an intervening
   `on_post_llm_call` (what the tests do) — the generation lands as `level=ERROR` with
   "Turn ended without a recorded response for this call."

Production validation on my deployment (hermes-agent v2026.8.3, Docker gateway, langfuse SDK
4.14.1, self-hosted Langfuse v4.4.0): both fixes live since 2026-08-08; verified on synthetic
turns and live Telegram-gateway traffic; per-session token aggregation went from 94%
null-bucket to fully attributed; no false-positive ERROR/WARNING levels observed on successful
traffic.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (nearest: #71556, a distinct session_id-selection bug in the same plugin)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the touched test scope (`pytest tests/plugins/test_langfuse_observability_plugin.py tests/plugins/test_disk_cleanup_plugin.py -q`) and all tests pass; full suite left to CI
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 12 (Docker, official image), dev tests on macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing config or behavior contract change; failure marking uses standard Langfuse fields)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure-Python plugin logic, no OS surface)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A