### PR TITLE
perf(docs-site): split search index by section and stop indexing code blocks

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -61,7 +61,31 @@ const config: Config = {
         ignoreFiles: [
           /^user-guide\/skills\/bundled\//,
           /^user-guide\/skills\/optional\//,
+          // Community-quote collage page: 527 index documents of scraped
+          // testimonials that pollute results and bloat the index. The page
+          // renders a React component; its text isn't reference material.
+          /^user-stories/,
         ],
+        // Split the lunr index into per-section chunks so the browser only
+        // fetches+hydrates the index for the section being searched instead
+        // of one monolithic multi-MB file (16.3 MB by Aug 2026 — 25-30 s of
+        // blank UI on first search). Searches started outside these paths
+        // (e.g. the docs landing page) fall back to all contexts combined.
+        searchContextByPaths: [
+          { label: 'User Guide', path: 'user-guide' },
+          { label: 'Developer Guide', path: 'developer-guide' },
+          { label: 'Guides', path: 'guides' },
+          { label: 'Reference', path: 'reference' },
+          { label: 'Getting Started', path: 'getting-started' },
+          { label: 'Integrations', path: 'integrations' },
+        ],
+        useAllContextsWithNoSearchContext: true,
+        // Don't index fenced code blocks (<pre>). Config/YAML/shell examples
+        // generate huge high-cardinality token dictionaries in lunr (the
+        // biggest single contributor to index size) and nobody searches for
+        // a literal line of a code sample. Inline <code> (command and config
+        // key names in prose) stays indexed.
+        ignoreCssSelectors: ['pre'],
         // Exact-or-prefix matching only (default is edit distance 1).
         // With fuzzy distance 1, "keet" matched "meetings"/"keep" (one
         // edit away after stemming), and multi-word typo queries against


### PR DESCRIPTION
## What does this PR do?

Makes docs search feel instant again. The client-side search index had grown to 16.3 MB raw / ~4.5 MB over the wire (4,500+ indexed docs), and since `@easyops-cn/docusaurus-search-local` shows no spinner, users stared at a completely blank search page for 25-30 seconds before the (correct) results popped in — indistinguishable from "search is broken entirely".

Three config-only levers in `website/docusaurus.config.ts`:

- **`searchContextByPaths`** — the index is now built per section (user-guide, developer-guide, guides, reference, getting-started, integrations). Searching from any docs page fetches only that section's index (e.g. Reference: 1.4 MB raw / 387 KB gz) instead of the 16 MB monolith. The search page gains a section scope dropdown; searches started outside a section (docs landing page) still cover everything via `useAllContextsWithNoSearchContext: true`.
- **`ignoreCssSelectors: ['pre']`** — fenced code blocks are no longer indexed. YAML/shell/config samples were generating huge high-cardinality lunr token dictionaries for text nobody searches literally. Inline `code` in prose (command names, config keys) stays searchable.
- **`ignoreFiles` + `user-stories`** — the community-quote collage page contributed 527 index documents of scraped testimonials that polluted results for generic terms.

## Related Issue

Follow-up to #65103 (fuzzy-distance fix) — same disease, next stage: full-content client-side indexing doesn't scale with the docs tree. This buys headroom now; Algolia DocSearch remains the long-term answer.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `website/docusaurus.config.ts`: added `searchContextByPaths` (6 sections), `useAllContextsWithNoSearchContext: true`, `ignoreCssSelectors: ['pre']`, and `/^user-stories/` in `ignoreFiles`. Config-only; no dependency or code changes.

## How to Test

1. `cd website && npm ci && npm run build`
2. Confirm per-section `search-index-*.json` files exist in `build/` alongside the root index.
3. Serve `build/` under `/docs/` and search "telegram" from a docs page — results should appear in well under a second.

## Measured results (local build, both locales)

| Index | Before | After |
|---|---|---|
| en root ("Everywhere") | 16.3 MB raw / 4.42 MB gz | 13.2 MB raw / 3.57 MB gz |
| en per-section | — | 0.39–8.3 MB raw / 103 KB–2.2 MB gz |
| zh-Hans root | 14.6 MB raw | 12.6 MB raw |

Time-to-first-dropdown-result on a local serve: **~175 ms** searching "telegram" from a section page, **~205 ms** from the landing page (was 25-30 s of blank UI on the live site). Search-page query returns the full 100 results with the new scope selector rendering correctly.

The root index still exists as the "Everywhere" fallback, so worst case is strictly better than before; the common case (searching while reading a section) downloads 87-97% less.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the docs build for both locales and verified index output
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (site config; behavior verified in build output)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've considered cross-platform impact — N/A (static site build)

## Infographic

![docs-search-split-index](https://v3b.fal.media/files/b/0aa5838e/JP4WVIO14XIPQtkkdprIf_Z855CX3w.png)
