### PR TITLE
fix(slack): insert resolved display names literally when humanizing mentions (salvage #78837)

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3922,7 +3922,17 @@ class SlackAdapter(BasePlatformAdapter):
             # (keeps the message intact rather than emptying a mention).
             display = (name or uid).strip() or uid
             # Replace both the bare and labelled forms of this exact ID.
-            text = re.sub(rf"<@{uid}(?:\|[^>]*)?>", f"@{display}", text)
+            # The replacement goes in as a *function* so the resolved name is
+            # inserted verbatim: as a template string, ``re`` parses backslash
+            # escapes in it, and a display name is arbitrary user-set text.
+            # ``dev\ops`` raises ``re.error: bad escape \o``, ``a\1b`` raises
+            # on the group reference, and ``\g<0>`` silently re-injects the
+            # raw ``<@UID>`` this method exists to remove.
+            text = re.sub(
+                rf"<@{uid}(?:\|[^>]*)?>",
+                lambda _m, _name=f"@{display}": _name,
+                text,
+            )
         return text
 
     def _build_identity_prompt(self, team_id: str = "") -> str:

--- a/tests/gateway/test_slack_mention_humanization.py
+++ b/tests/gateway/test_slack_mention_humanization.py
@@ -95,6 +95,46 @@ async def test_handles_labelled_mention_form():
     assert out == "@Alice Example hi"
 
 
+@pytest.mark.asyncio
+async def test_backslash_in_display_name_does_not_raise():
+    """A display name is arbitrary user-set text. Fed to ``re.sub`` as a
+    replacement template it is parsed for escapes, so ``dev\\ops`` blew up
+    with ``re.error: bad escape \\o`` and the inbound message was lost."""
+    adapter = _adapter_with_names({"U07DEV": r"dev\ops"})
+    out = await adapter._humanize_user_mentions("ping <@U07DEV> please", chat_id="C1")
+    assert out == r"ping @dev\ops please"
+
+
+@pytest.mark.asyncio
+async def test_group_reference_in_display_name_is_literal():
+    """``\\1`` in a name is a group reference in a replacement template — with
+    no groups in the pattern it raised ``invalid group reference``."""
+    adapter = _adapter_with_names({"U07ODD": r"a\1b"})
+    out = await adapter._humanize_user_mentions("hi <@U07ODD>", chat_id="C1")
+    assert out == r"hi @a\1b"
+
+
+@pytest.mark.asyncio
+async def test_named_group_reference_does_not_reinject_the_raw_id():
+    """``\\g<0>`` expands to the whole match, silently putting the opaque
+    ``<@UID>`` back — the exact token this method exists to remove."""
+    adapter = _adapter_with_names({"U07ODD": r"\g<0>"})
+    out = await adapter._humanize_user_mentions("hi <@U07ODD>", chat_id="C1")
+    assert "<@" not in out
+    assert out == r"hi @\g<0>"
+
+
+@pytest.mark.asyncio
+async def test_one_odd_name_does_not_break_the_other_mentions():
+    adapter = _adapter_with_names(
+        {"U07DEV": r"dev\ops", "U07ALICE": "Alice Example"}
+    )
+    out = await adapter._humanize_user_mentions(
+        "<@U07DEV> and <@U07ALICE> ship it", chat_id="C1"
+    )
+    assert out == r"@dev\ops and @Alice Example ship it"
+
+
 # ----- _build_identity_prompt --------------------------------------------------
 
 def test_identity_prompt_names_the_bot():


### PR DESCRIPTION
## Summary
Slack inbound mention humanization no longer crashes (or silently re-injects raw `<@UID>` tokens) when a user's display name contains regex-template characters.

Salvage of #78837 by @Drexuxux — cherry-picked onto current main with authorship preserved; applied cleanly, no follow-up fixes needed.

Root cause: `_humanize_user_mentions` passed the resolved display name as `re.sub`'s replacement string, where `re` parses it as a template. Display names are arbitrary user-set text: `dev\ops` → `re.error: bad escape \o`, `a\1b` → invalid group reference, `\g<0>` → silently re-injects the raw mention token. The call site sits outside any try in `_handle_slack_message`, so the raise drops every inbound message mentioning that user.

## Changes
- `plugins/platforms/slack/adapter.py`: replacement passed as a function (`lambda _m, _name=f"@{display}": _name`) so the name lands verbatim — same shape the Matrix adapter uses for outbound mention rewrite.
- `tests/gateway/test_slack_mention_humanization.py`: 4 regression tests (`dev\ops`, `\1`, `\g<0>`, plain name).

## Validation
| | Before | After |
|---|---|---|
| Display name `dev\ops` | `re.error`, message dropped | `@dev\ops` inserted, message processed |
| Display name `\g<0>` | raw `<@UID>` re-injected | name inserted verbatim |
| tests/gateway/test_slack_mention_humanization.py | — | 7/7 pass |

Sibling-site audit: swept `re.sub` across all platform adapters for dynamic replacement strings — the other dynamic call sites (telegram trigger-strip, mattermost mention-strip) only use dynamic *patterns* under `re.escape`, with constant replacements; no other instance of this bug class.

## Infographic

![Mentions inserted literally](https://v3b.fal.media/files/b/0aa583ca/T4jh3M7bYK-5ueOZYFzp3_lAv4Ym0U.png)
