### PR TITLE
fix(ci): retain previous Pages deploy's hashed assets to stop CDN skew 404s

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -189,6 +189,19 @@ jobs:
             cp website/build/llms-full.txt _site/llms-full.txt
           fi
 
+      - name: Retain previous deployment's hashed assets
+        # Pages keeps only the newest deploy while the CDN serves cached HTML
+        # (max-age=300 + stale-while-revalidate=3600) that references the
+        # PREVIOUS deploy's content-hashed bundles. At our deploy cadence
+        # (several per hour) that left the site with 404ing JS/CSS — dead
+        # search, broken lazy routes — for much of the day. Union-merge the
+        # prior artifact's assets/ into the new tree so stale HTML keeps
+        # working; 7-day retention manifest bounds growth. Best-effort:
+        # never blocks the deploy.
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: python3 scripts/retain_pages_assets.py _site
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3
         with:

--- a/scripts/retain_pages_assets.py
+++ b/scripts/retain_pages_assets.py
@@ -144,7 +144,7 @@ def main() -> int:
             manifest_path = prev_tree / MANIFEST_REL
             if manifest_path.is_file():
                 try:
-                    old_manifest = json.loads(manifest_path.read_text())
+                    old_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
                 except Exception:
                     old_manifest = {}
 
@@ -174,7 +174,8 @@ def main() -> int:
                     copied += 1
 
             (site_dir / MANIFEST_REL).write_text(
-                json.dumps(new_manifest, indent=0, sort_keys=True)
+                json.dumps(new_manifest, indent=0, sort_keys=True),
+                encoding="utf-8",
             )
             log(
                 f"retained {copied} previous asset file(s), "

--- a/scripts/retain_pages_assets.py
+++ b/scripts/retain_pages_assets.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Retain hashed assets from the previous GitHub Pages deployment.
+
+Why: deploy-site.yml deploys on every push to main touching website/** —
+often several times an hour. GitHub Pages keeps ONLY the newest deploy's
+files, while the CDN chain in front (Vercel proxy -> Fastly -> Pages)
+serves cached HTML for up to ~1 hour (max-age=300 +
+stale-while-revalidate=3600). Stale HTML references the PREVIOUS deploy's
+content-hashed bundles (main.<hash>.js, lazy chunks), which the new deploy
+just deleted -> sitewide 404s on JS/CSS, dead search, broken lazy routes,
+for a large fraction of the day at our deploy cadence.
+
+Fix (class fix, not a debounce): before uploading the new Pages artifact,
+download the previous successful deployment's artifact and union-merge its
+hashed asset files into the new tree. Hashed filenames are
+content-addressed, so a name collision means identical content — new build
+always wins, old files are only ADDED when absent.
+
+Growth is bounded by a retention manifest (docs/assets-retention.json in
+the deployed tree): every carried-forward file records when it was first
+retained and is dropped after RETENTION_DAYS. Files present in the current
+build never need entries.
+
+Best-effort by design: any failure prints a warning and exits 0 — asset
+retention must never block a deploy.
+
+Usage: python3 scripts/retain_pages_assets.py <site_dir>
+Requires: gh CLI authenticated (GH_TOKEN), tar. Run from repo root in CI.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+import zipfile
+from pathlib import Path
+
+RETENTION_DAYS = 7
+ARTIFACT_NAME = "github-pages"
+WORKFLOW = "deploy-site.yml"
+MANIFEST_REL = "docs/assets-retention.json"
+# Only content-hashed, immutable output is retained. HTML and data files
+# must always come from the current build.
+RETAIN_DIRS = ("docs/assets/", "docs/zh-Hans/assets/")
+
+
+def log(msg: str) -> None:
+    print(f"[retain-pages-assets] {msg}", flush=True)
+
+
+def warn(msg: str) -> None:
+    print(f"::warning::retain_pages_assets: {msg}", flush=True)
+
+
+def gh_json(args: list[str]):
+    out = subprocess.run(
+        ["gh", *args], check=True, capture_output=True, text=True, timeout=120
+    ).stdout
+    return json.loads(out)
+
+
+def find_previous_artifact() -> dict | None:
+    current_run = os.environ.get("GITHUB_RUN_ID", "")
+    repo = os.environ.get("GITHUB_REPOSITORY", "NousResearch/hermes-agent")
+    runs = gh_json([
+        "run",
+        "list",
+        "--repo",
+        repo,
+        "--workflow",
+        WORKFLOW,
+        "--status",
+        "success",
+        "--limit",
+        "10",
+        "--json",
+        "databaseId",
+    ])
+    for run in runs:
+        run_id = str(run["databaseId"])
+        if run_id == current_run:
+            continue
+        artifacts = gh_json([
+            "api",
+            f"repos/{repo}/actions/runs/{run_id}/artifacts",
+            "--jq",
+            "{artifacts: [.artifacts[] | {id, name, expired}]}",
+        ])["artifacts"]
+        for artifact in artifacts:
+            if artifact["name"] == ARTIFACT_NAME and not artifact["expired"]:
+                log(f"using artifact {artifact['id']} from run {run_id}")
+                return {"repo": repo, "id": artifact["id"]}
+    return None
+
+
+def download_and_extract(repo: str, artifact_id: int, dest: Path) -> Path:
+    zip_path = dest / "artifact.zip"
+    with zip_path.open("wb") as fh:
+        subprocess.run(
+            ["gh", "api", f"repos/{repo}/actions/artifacts/{artifact_id}/zip"],
+            check=True,
+            stdout=fh,
+            timeout=600,
+        )
+    extract_dir = dest / "prev"
+    extract_dir.mkdir()
+    with zipfile.ZipFile(zip_path) as zf:
+        zf.extractall(extract_dir)
+    # Pages artifacts wrap the site in a single tar.
+    tars = list(extract_dir.glob("*.tar"))
+    if tars:
+        tree = dest / "prev_tree"
+        tree.mkdir()
+        with tarfile.open(tars[0]) as tf:
+            tf.extractall(tree, filter="data")
+        return tree
+    return extract_dir
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(__doc__)
+        return 2
+    site_dir = Path(sys.argv[1]).resolve()
+    if not site_dir.is_dir():
+        warn(f"site dir {site_dir} does not exist; skipping retention")
+        return 0
+
+    try:
+        ref = find_previous_artifact()
+        if ref is None:
+            log("no previous github-pages artifact found; nothing to retain")
+            return 0
+        with tempfile.TemporaryDirectory() as td:
+            prev_tree = download_and_extract(ref["repo"], ref["id"], Path(td))
+
+            old_manifest: dict[str, float] = {}
+            manifest_path = prev_tree / MANIFEST_REL
+            if manifest_path.is_file():
+                try:
+                    old_manifest = json.loads(manifest_path.read_text())
+                except Exception:
+                    old_manifest = {}
+
+            now = time.time()
+            cutoff = now - RETENTION_DAYS * 86400
+            new_manifest: dict[str, float] = {}
+            copied = expired = 0
+
+            for retain_root in RETAIN_DIRS:
+                root = prev_tree / retain_root
+                if not root.is_dir():
+                    continue
+                for src in root.rglob("*"):
+                    if not src.is_file():
+                        continue
+                    rel = src.relative_to(prev_tree).as_posix()
+                    target = site_dir / rel
+                    if target.exists():
+                        continue  # present in current build — no entry needed
+                    first_seen = old_manifest.get(rel, now)
+                    if first_seen < cutoff:
+                        expired += 1
+                        continue
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(src, target)
+                    new_manifest[rel] = first_seen
+                    copied += 1
+
+            (site_dir / MANIFEST_REL).write_text(
+                json.dumps(new_manifest, indent=0, sort_keys=True)
+            )
+            log(
+                f"retained {copied} previous asset file(s), "
+                f"expired {expired}, manifest entries {len(new_manifest)}"
+            )
+        return 0
+    except Exception as exc:  # noqa: BLE001 — retention is best-effort
+        warn(f"asset retention failed ({exc!r}); deploying without retention")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What does this PR do?

Fixes the real root cause behind the "docs search is broken entirely" reports: **deploy asset skew**. `deploy-site.yml` fires on every push to main touching `website/**` (measured 12 deploys in one day). GitHub Pages keeps only the newest deploy's files, but the CDN chain in front (Vercel proxy → Fastly → Pages) serves cached HTML for up to ~1 hour (`max-age=300` + `stale-while-revalidate=3600`). That stale HTML references the *previous* deploy's content-hashed bundles — which the new deploy just deleted. Result: sitewide 404s on JS/CSS, dead search (it's 100% client-JS), and broken lazy routes for a large fraction of the day at our deploy cadence.

The fix is retention, not debouncing: debouncing deploys only shrinks the broken window; retaining old hashed assets removes it.

## Related Issue

Companion to #81736 (search index split) — same user-facing symptom, different layer. This PR fixes why the site's JS dies outright; #81736 fixes how much index the search downloads.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`scripts/retain_pages_assets.py`** (new): downloads the previous successful `deploy-site.yml` run's `github-pages` artifact, extracts it, and union-merges `docs/assets/` + `docs/zh-Hans/assets/` into the new `_site` tree before upload. Hashed filenames are content-addressed, so a name collision means identical content — the current build always wins and old files are only *added* when absent. HTML and data files are never retained.
  - Growth is bounded by a 7-day retention manifest (`docs/assets-retention.json`) carried in the deployed tree; carried-forward files expire out after 7 days (far beyond the ~1 h CDN window).
  - Best-effort by design: any failure emits a `::warning::` and exits 0 — retention can never block a deploy.
- **`.github/workflows/deploy-site.yml`**: one new step between "Stage deployment" and "Upload artifact", using the existing app token.

## How to Test

1. Locally: the merge logic was exercised against a simulated previous tree — asserts old bundle + zh-Hans bundle retained, expired manifest entry dropped, HTML untouched, identical shared chunk untouched (2 copied / 1 expired). 
2. After merge: let two deploys land ~10 min apart, then fetch an asset URL from the *first* deploy's HTML — it should return 200 instead of 404. The deploy log prints `retained N previous asset file(s)`.
3. First run after merge finds a previous artifact without a manifest — every retained file starts its 7-day clock then.

## Why this shape

- **Class fix at the one owner**: the deploy workflow is the only place old assets get deleted, so it's the only place to restore them. No debounce band-aid, no per-page workaround.
- **Bounded**: worst case adds ≤7 days of hashed-asset churn to the artifact (assets are ~a few MB per deploy, most files are identical across deploys and cost nothing).
- **Fail-open**: a missing artifact, expired artifact, or API hiccup deploys exactly what we deploy today.

## Infographic

![pages-asset-retention](https://v3b.fal.media/files/b/0aa583cd/R_9He1sDZf7a3TkLEozAB_MqnqKqLB.png)
