### PR TITLE
fix(fs): mark symlinked directories as directories in /api/fs/list

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2616,7 +2616,7 @@ async def fs_list(path: str):
                 entries.append({
                     "name": entry.name,
                     "path": str(target / entry.name),
-                    "isDirectory": entry.is_dir(follow_symlinks=False),
+                    "isDirectory": entry.is_dir(follow_symlinks=True),
                 })
         entries.sort(key=lambda item: (not item["isDirectory"], item["name"].lower(), item["name"]))
         return {"entries": entries}


### PR DESCRIPTION
## Problem

The Desktop file tree in **remote/SSH gateway mode** shows symlinks that point to directories as plain files. Clicking such an entry triggers the preview path instead of expanding the folder, and the backend then fails with:

```
Preview unavailable
Error invoking remote method 'hermes:api': Error: 400: {"detail":"Path points to a directory"}
```

## Root cause

`fs_list` (GET `/api/fs/list`) builds entries with `entry.is_dir(follow_symlinks=False)`. A symlink whose target is a directory is therefore reported with `isDirectory: false`, so the tree renders it as a file and routes clicks to the preview endpoint. The preview path (`_fs_regular_file`) calls `target.stat()` which **does** follow symlinks, sees a directory, and rejects with 400.

The local Electron bridge (`electron/fs-read-dir.ts`) explicitly stats symlinks (`shouldStatDirent` + `fs.stat`) and reports them as directories — so local and remote modes disagree on the same filesystem.

## Fix

Follow symlinks in `fs_list` so `isDirectory` matches the local bridge behaviour:

```diff
- "isDirectory": entry.is_dir(follow_symlinks=False),
+ "isDirectory": entry.is_dir(follow_symlinks=True),
```

Broken symlinks still resolve to `False` (stat failure), matching the local bridge's catch-to-false path.

## Verification

- Reproduced on a checkout containing symlinked directories (`OpenViking`, `Hermes - Onedrive 备份`, `Hermes - 本地文件`): old logic reports all three as `isDirectory=False`, new logic reports `True`.
- After restarting the remote dashboard, the SSH-mode Desktop file tree renders them as expandable folders and no longer errors on click.