### PR TITLE
test(tui_gateway): stabilize write_json concurrency flake (salvage #81510)

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -896,24 +896,65 @@ class _BrokenStdout:
 
 
 def test_write_json_serializes_concurrent_writes(monkeypatch):
-    out = _ChunkyStdout()
-    monkeypatch.setattr(server, "_real_stdout", out)
+    """Assert StdioTransport holds _stdout_lock across the full stream.write.
 
-    threads = [
-        threading.Thread(target=server.write_json, args=({"seq": i, "text": "x" * 24},))
-        for i in range(8)
-    ]
+    The old char-by-char sleep mock made this test take long enough that
+    leftover background write_json calls from earlier cases in this file
+    could append an extra line (intermittent ``assert 9 == 8`` on CI/main).
+    Match the WS concurrent-send check: count in-flight writes, and only
+    assert on frames that carry this test's marker payload.
+    """
+    marker = "x" * 24
+    active = 0
+    max_active = 0
+    gate = threading.Lock()
+    frames: list[str] = []
 
+    class RecordingStdout:
+        def write(self, text: str) -> int:
+            nonlocal active, max_active
+            with gate:
+                active += 1
+                max_active = max(max_active, active)
+            try:
+                # Release the GIL while "in write" so a missing outer lock
+                # would let another thread bump max_active above 1.
+                time.sleep(0.01)
+                frames.append(text)
+            finally:
+                with gate:
+                    active -= 1
+            return len(text)
+
+        def flush(self) -> None:
+            return None
+
+    monkeypatch.setattr(server, "_real_stdout", RecordingStdout())
+
+    barrier = threading.Barrier(8)
+
+    def _worker(seq: int) -> None:
+        barrier.wait(timeout=5)
+        server.write_json({"seq": seq, "text": marker})
+
+    threads = [threading.Thread(target=_worker, args=(i,)) for i in range(8)]
     for t in threads:
         t.start()
-
     for t in threads:
-        t.join()
+        t.join(timeout=10)
+        assert not t.is_alive()
 
-    lines = "".join(out.parts).splitlines()
+    assert max_active == 1
 
-    assert len(lines) == 8
-    assert {json.loads(line)["seq"] for line in lines} == set(range(8))
+    ours = []
+    for frame in frames:
+        assert frame.endswith("\n"), frame
+        obj = json.loads(frame)
+        if obj.get("text") == marker and "seq" in obj:
+            ours.append(obj)
+
+    assert {obj["seq"] for obj in ours} == set(range(8))
+    assert len(ours) == 8
 
 
 def test_write_json_returns_false_on_broken_pipe(monkeypatch):


### PR DESCRIPTION
## Summary

Salvages #81510 by @fangliquanflq: stabilizes `test_write_json_serializes_concurrent_writes`, the intermittent `assert 9 == 8` flake seen on main and on unrelated PRs (most recently costing #81733 a full rerun).

Root cause was the test, not the code: `StdioTransport.write` locks correctly, but the old char-by-char `sleep(0.0001)` stdout mock stretched the test window long enough for a leftover background `write_json` from an earlier test in the same file to append a 9th line.

## Changes

- `tests/test_tui_gateway_server.py`: rewrite the check to pin the actual invariant — `max_active == 1` in-flight `stream.write` (with a sleep inside write so a missing lock would overlap) — and count only frames carrying this test's marker payload, making it immune to cross-test stdout pollution. Barrier start + bounded joins.

## Validation

| | Result |
|---|---|
| Focused test on current main | pass |
| Sabotage run (lock replaced with nullcontext in `transport.py`) | test FAILS on `max_active == 1` — proves it guards the invariant |
| Restore (byte-identical) | pass |
| Full `tests/test_tui_gateway_server.py` ×3 | 522/522 each run |

## Credit

Fix by @fangliquanflq in #81510 — cherry-picked with authorship preserved.

## Infographic

![Flake fix infographic](https://v3b.fal.media/files/b/0aa583d8/lQWfO7wDLhvhibpEWUEjO_kfyJJSC5.png)
