### PR TITLE
fix(slack): bind approval and slash-confirm buttons to opaque tokens

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5836,6 +5836,7 @@ class TurnRunner:
                             allow_permanent=approval_data.get("allow_permanent", True),
                             allow_session=approval_data.get("allow_session", True),
                             smart_denied=approval_data.get("smart_denied", False),
+                            request_id=approval_data.get("request_id"),
                         ),
                         ctx._loop_for_step,
                         logger=logger,

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -11,6 +11,7 @@ Uses slack-bolt (Python) with Socket Mode for:
 import asyncio
 import contextvars
 import inspect
+import itertools
 import json
 import logging
 import os
@@ -962,6 +963,12 @@ class SlackAdapter(BasePlatformAdapter):
         # be workspace-scoped markers (team_id, ts) in multi-workspace mode.
         self._approval_resolved: Dict[Any, bool] = {}
         self._APPROVAL_RESOLVED_MAX = 1000
+        # Server-side approval token state: opaque approval_id → session_key.
+        # Block Kit button values carry only the token, never the session key.
+        self._approval_state: Dict[int, str] = {}
+        self._approval_counter = itertools.count(1)
+        # Same server-side indirection for slash-command confirmations.
+        self._slash_confirm_state: Dict[str, str] = {}
         # Same guard for clarify prompts (interactive multiple-choice
         # buttons); mirrors _approval_resolved.
         self._clarify_resolved: Dict[Any, bool] = {}
@@ -6405,13 +6412,22 @@ class SlackAdapter(BasePlatformAdapter):
             budget = 3000 - len(header) - len(reason) - len("``````\n") - len("...")
             cmd_preview = command[:budget] + "..." if len(command) > budget else command
 
+            # Mint an opaque approval token; the button value carries only this
+            # id. The real session_key is resolved server-side on click.
+            approval_id = next(self._approval_counter)
+            self._approval_state[approval_id] = session_key
+            self._trim_oldest_dict_entries(
+                self._approval_state, self._APPROVAL_RESOLVED_MAX
+            )
+            token = str(approval_id)
+
             actions = [
                 {
                     "type": "button",
                     "text": {"type": "plain_text", "text": "Allow Once"},
                     "style": "primary",
                     "action_id": "hermes_approve_once",
-                    "value": session_key,
+                    "value": token,
                 },
             ]
             if not smart_denied and allow_session:
@@ -6419,21 +6435,21 @@ class SlackAdapter(BasePlatformAdapter):
                     "type": "button",
                     "text": {"type": "plain_text", "text": "Allow Session"},
                     "action_id": "hermes_approve_session",
-                    "value": session_key,
+                    "value": token,
                 })
                 if allow_permanent:
                     actions.append({
                         "type": "button",
                         "text": {"type": "plain_text", "text": "Always Allow"},
                         "action_id": "hermes_approve_always",
-                        "value": session_key,
+                        "value": token,
                     })
             actions.append({
                 "type": "button",
                 "text": {"type": "plain_text", "text": "Deny"},
                 "style": "danger",
                 "action_id": "hermes_deny",
-                "value": session_key,
+                "value": token,
             })
             blocks = [
                 {
@@ -6496,9 +6512,13 @@ class SlackAdapter(BasePlatformAdapter):
             _title = (title or "Confirm")[:150]
             budget = 3000 - len(f"*{_title}*\n\n") - len("...")
             body = message[:budget] + "..." if len(message) > budget else message
-            # Encode session_key and confirm_id into the button value so the
-            # callback handler can resolve without extra bookkeeping.
-            value = f"{session_key}|{confirm_id}"
+            # Store the session_key server-side and expose only the confirm_id
+            # in the Block Kit button value, mirroring the approval token pattern.
+            self._slash_confirm_state[confirm_id] = session_key
+            self._trim_oldest_dict_entries(
+                self._slash_confirm_state, self._APPROVAL_RESOLVED_MAX
+            )
+            value = str(confirm_id)
 
             blocks = [
                 {
@@ -6759,11 +6779,14 @@ class SlackAdapter(BasePlatformAdapter):
                 )
                 return
 
-        # Parse session_key|confirm_id back out
-        if "|" not in value:
-            logger.warning("[Slack] Malformed slash-confirm value: %s", value)
+        # Resolve the confirm_id to the real session_key server-side. A
+        # missing/stale confirm_id means the prompt was already resolved or
+        # is forged; fail closed.
+        confirm_id = str(value)
+        session_key = self._slash_confirm_state.pop(confirm_id, "")
+        if not session_key:
+            logger.warning("[Slack] Slash-confirm %s already resolved or unknown", confirm_id)
             return
-        session_key, confirm_id = value.split("|", 1)
 
         choice_map = {
             "hermes_confirm_once": "once",
@@ -6872,7 +6895,7 @@ class SlackAdapter(BasePlatformAdapter):
 
         team_id = self._event_team_id({}, body)
         action_id = action.get("action_id", "")
-        session_key = action.get("value", "")
+        token = action.get("value", "")
         message = body.get("message", {})
         msg_ts = message.get("ts", "")
         channel_id = body.get("channel", {}).get("id", "")
@@ -6923,6 +6946,19 @@ class SlackAdapter(BasePlatformAdapter):
         if msg_ts in self._approval_resolved:
             approval_key = msg_ts
         if self._approval_resolved.pop(approval_key, True):
+            return
+
+        # Resolve the opaque token to the real session_key server-side. A
+        # missing/stale token means the approval was already resolved or is
+        # forged; fail closed.
+        try:
+            approval_id = int(token)
+        except (ValueError, TypeError):
+            logger.warning("[Slack] Invalid approval token: %r", token)
+            return
+        session_key = self._approval_state.pop(approval_id, "")
+        if not session_key:
+            logger.warning("[Slack] Approval token %s already resolved or unknown", token)
             return
 
         # Resolve the approval FIRST — this unblocks the agent thread. Render

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -991,9 +991,11 @@ class SlackAdapter(BasePlatformAdapter):
         # be workspace-scoped markers (team_id, ts) in multi-workspace mode.
         self._approval_resolved: Dict[Any, bool] = {}
         self._APPROVAL_RESOLVED_MAX = 1000
-        # Server-side approval token state: opaque approval_id → session_key.
-        # Block Kit button values carry only the token, never the session key.
-        self._approval_state: Dict[int, str] = {}
+        # Server-side approval token state: opaque approval_id → (session_key,
+        # request_id). Block Kit button values carry only the token, never the
+        # session key; the request id binds the token to the exact queued
+        # request so a stale button cannot advance a different one.
+        self._approval_state: Dict[int, tuple] = {}
         self._approval_counter = itertools.count(1)
         # Same server-side indirection for slash-command confirmations.
         self._slash_confirm_state: Dict[str, str] = {}
@@ -6881,6 +6883,7 @@ class SlackAdapter(BasePlatformAdapter):
         allow_permanent: bool = True,
         allow_session: bool = True,
         smart_denied: bool = False,
+        request_id: Optional[str] = None,
     ) -> SendResult:
         """Send a Block Kit approval prompt with interactive buttons.
 
@@ -6911,9 +6914,10 @@ class SlackAdapter(BasePlatformAdapter):
             cmd_preview = command[:budget] + "..." if len(command) > budget else command
 
             # Mint an opaque approval token; the button value carries only this
-            # id. The real session_key is resolved server-side on click.
+            # id. The real (session_key, entry id) pair is resolved server-side
+            # on click, binding the token to the exact queued request.
             approval_id = next(self._approval_counter)
-            self._approval_state[approval_id] = session_key
+            self._approval_state[approval_id] = (session_key, request_id or "")
             self._trim_oldest_dict_entries(
                 self._approval_state, self._APPROVAL_RESOLVED_MAX
             )
@@ -7454,18 +7458,23 @@ class SlackAdapter(BasePlatformAdapter):
         except (ValueError, TypeError):
             logger.warning("[Slack] Invalid approval token: %r", token)
             return
-        session_key = self._approval_state.pop(approval_id, "")
-        if not session_key:
+        stored = self._approval_state.pop(approval_id, None)
+        if not stored:
             logger.warning("[Slack] Approval token %s already resolved or unknown", token)
             return
+        session_key, request_id = stored
 
         # Resolve the approval FIRST — this unblocks the agent thread. Render
         # after, so a click that lands past the approval timeout (count == 0)
         # shows "expired" instead of falsely claiming the command was approved.
+        # The token is bound to the exact queued request, so a stale button can
+        # never resolve a different request at the head of the session queue.
         try:
             from tools.approval import resolve_gateway_approval
 
-            count = resolve_gateway_approval(session_key, choice)
+            count = resolve_gateway_approval(
+                session_key, choice, request_id=request_id or None
+            )
             logger.info(
                 "Slack button resolved %d approval(s) for session %s (choice=%s, user=%s)",
                 count,

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -11,11 +11,11 @@ Uses slack-bolt (Python) with Socket Mode for:
 import asyncio
 import contextvars
 import inspect
-import itertools
 import json
 import logging
 import os
 import re
+import secrets
 import time
 import unicodedata
 from dataclasses import dataclass, field
@@ -995,8 +995,7 @@ class SlackAdapter(BasePlatformAdapter):
         # request_id). Block Kit button values carry only the token, never the
         # session key; the request id binds the token to the exact queued
         # request so a stale button cannot advance a different one.
-        self._approval_state: Dict[int, tuple] = {}
-        self._approval_counter = itertools.count(1)
+        self._approval_state: Dict[str, tuple] = {}
         # Same server-side indirection for slash-command confirmations.
         self._slash_confirm_state: Dict[str, str] = {}
         # Same guard for clarify prompts (interactive multiple-choice
@@ -6913,15 +6912,14 @@ class SlackAdapter(BasePlatformAdapter):
             budget = 3000 - len(header) - len(reason) - len("``````\n") - len("...")
             cmd_preview = command[:budget] + "..." if len(command) > budget else command
 
-            # Mint an opaque approval token; the button value carries only this
-            # id. The real (session_key, entry id) pair is resolved server-side
-            # on click, binding the token to the exact queued request.
-            approval_id = next(self._approval_counter)
-            self._approval_state[approval_id] = (session_key, request_id or "")
+            # Mint an unguessable approval token; the button value carries
+            # only this id. The real (session_key, entry id) pair is resolved
+            # server-side on click, binding the token to the exact queued request.
+            token = secrets.token_urlsafe(16)
+            self._approval_state[token] = (session_key, request_id or "")
             self._trim_oldest_dict_entries(
                 self._approval_state, self._APPROVAL_RESOLVED_MAX
             )
-            token = str(approval_id)
 
             actions = [
                 {
@@ -7453,12 +7451,10 @@ class SlackAdapter(BasePlatformAdapter):
         # Resolve the opaque token to the real session_key server-side. A
         # missing/stale token means the approval was already resolved or is
         # forged; fail closed.
-        try:
-            approval_id = int(token)
-        except (ValueError, TypeError):
+        if not isinstance(token, str) or not token:
             logger.warning("[Slack] Invalid approval token: %r", token)
             return
-        stored = self._approval_state.pop(approval_id, None)
+        stored = self._approval_state.pop(token, None)
         if not stored:
             logger.warning("[Slack] Approval token %s already resolved or unknown", token)
             return

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -11,6 +11,7 @@ Uses slack-bolt (Python) with Socket Mode for:
 import asyncio
 import contextvars
 import inspect
+import itertools
 import json
 import logging
 import os
@@ -990,6 +991,12 @@ class SlackAdapter(BasePlatformAdapter):
         # be workspace-scoped markers (team_id, ts) in multi-workspace mode.
         self._approval_resolved: Dict[Any, bool] = {}
         self._APPROVAL_RESOLVED_MAX = 1000
+        # Server-side approval token state: opaque approval_id → session_key.
+        # Block Kit button values carry only the token, never the session key.
+        self._approval_state: Dict[int, str] = {}
+        self._approval_counter = itertools.count(1)
+        # Same server-side indirection for slash-command confirmations.
+        self._slash_confirm_state: Dict[str, str] = {}
         # Same guard for clarify prompts (interactive multiple-choice
         # buttons); mirrors _approval_resolved.
         self._clarify_resolved: Dict[Any, bool] = {}
@@ -6903,13 +6910,22 @@ class SlackAdapter(BasePlatformAdapter):
             budget = 3000 - len(header) - len(reason) - len("``````\n") - len("...")
             cmd_preview = command[:budget] + "..." if len(command) > budget else command
 
+            # Mint an opaque approval token; the button value carries only this
+            # id. The real session_key is resolved server-side on click.
+            approval_id = next(self._approval_counter)
+            self._approval_state[approval_id] = session_key
+            self._trim_oldest_dict_entries(
+                self._approval_state, self._APPROVAL_RESOLVED_MAX
+            )
+            token = str(approval_id)
+
             actions = [
                 {
                     "type": "button",
                     "text": {"type": "plain_text", "text": "Allow Once"},
                     "style": "primary",
                     "action_id": "hermes_approve_once",
-                    "value": session_key,
+                    "value": token,
                 },
             ]
             if not smart_denied and allow_session:
@@ -6917,21 +6933,21 @@ class SlackAdapter(BasePlatformAdapter):
                     "type": "button",
                     "text": {"type": "plain_text", "text": "Allow Session"},
                     "action_id": "hermes_approve_session",
-                    "value": session_key,
+                    "value": token,
                 })
                 if allow_permanent:
                     actions.append({
                         "type": "button",
                         "text": {"type": "plain_text", "text": "Always Allow"},
                         "action_id": "hermes_approve_always",
-                        "value": session_key,
+                        "value": token,
                     })
             actions.append({
                 "type": "button",
                 "text": {"type": "plain_text", "text": "Deny"},
                 "style": "danger",
                 "action_id": "hermes_deny",
-                "value": session_key,
+                "value": token,
             })
             blocks = [
                 {
@@ -6994,9 +7010,13 @@ class SlackAdapter(BasePlatformAdapter):
             _title = (title or "Confirm")[:150]
             budget = 3000 - len(f"*{_title}*\n\n") - len("...")
             body = message[:budget] + "..." if len(message) > budget else message
-            # Encode session_key and confirm_id into the button value so the
-            # callback handler can resolve without extra bookkeeping.
-            value = f"{session_key}|{confirm_id}"
+            # Store the session_key server-side and expose only the confirm_id
+            # in the Block Kit button value, mirroring the approval token pattern.
+            self._slash_confirm_state[confirm_id] = session_key
+            self._trim_oldest_dict_entries(
+                self._slash_confirm_state, self._APPROVAL_RESOLVED_MAX
+            )
+            value = str(confirm_id)
 
             blocks = [
                 {
@@ -7257,11 +7277,14 @@ class SlackAdapter(BasePlatformAdapter):
                 )
                 return
 
-        # Parse session_key|confirm_id back out
-        if "|" not in value:
-            logger.warning("[Slack] Malformed slash-confirm value: %s", value)
+        # Resolve the confirm_id to the real session_key server-side. A
+        # missing/stale confirm_id means the prompt was already resolved or
+        # is forged; fail closed.
+        confirm_id = str(value)
+        session_key = self._slash_confirm_state.pop(confirm_id, "")
+        if not session_key:
+            logger.warning("[Slack] Slash-confirm %s already resolved or unknown", confirm_id)
             return
-        session_key, confirm_id = value.split("|", 1)
 
         choice_map = {
             "hermes_confirm_once": "once",
@@ -7370,7 +7393,7 @@ class SlackAdapter(BasePlatformAdapter):
 
         team_id = self._event_team_id({}, body)
         action_id = action.get("action_id", "")
-        session_key = action.get("value", "")
+        token = action.get("value", "")
         message = body.get("message", {})
         msg_ts = message.get("ts", "")
         channel_id = body.get("channel", {}).get("id", "")
@@ -7421,6 +7444,19 @@ class SlackAdapter(BasePlatformAdapter):
         if msg_ts in self._approval_resolved:
             approval_key = msg_ts
         if self._approval_resolved.pop(approval_key, True):
+            return
+
+        # Resolve the opaque token to the real session_key server-side. A
+        # missing/stale token means the approval was already resolved or is
+        # forged; fail closed.
+        try:
+            approval_id = int(token)
+        except (ValueError, TypeError):
+            logger.warning("[Slack] Invalid approval token: %r", token)
+            return
+        session_key = self._approval_state.pop(approval_id, "")
+        if not session_key:
+            logger.warning("[Slack] Approval token %s already resolved or unknown", token)
             return
 
         # Resolve the approval FIRST — this unblocks the agent thread. Render

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -117,9 +117,13 @@ class TestSlackExecApproval:
         assert "hermes_approve_session" in action_ids
         assert "hermes_approve_always" in action_ids
         assert "hermes_deny" in action_ids
-        # Each button carries the session key as value
+        # Each button now carries an opaque numeric token, not the session key.
+        token = elements[0]["value"]
+        assert token != "agent:main:slack:group:C1:1111"
+        assert token.isdigit()
+        assert adapter._approval_state[int(token)] == "agent:main:slack:group:C1:1111"
         for e in elements:
-            assert e["value"] == "agent:main:slack:group:C1:1111"
+            assert e["value"] == token
 
     @pytest.mark.asyncio
     async def test_smart_deny_owner_override_hides_persistent_buttons(self):
@@ -154,6 +158,7 @@ class TestSlackApprovalAction:
         adapter = _make_adapter()
         _attach_auth_runner(adapter)
         adapter._approval_resolved["1.2"] = False
+        adapter._approval_state[1] = "session-key"
 
         # Simulate Slack re-escaping: original was ~2990 chars, but & → &amp;
         # etc. inflates it past 3000.
@@ -167,7 +172,7 @@ class TestSlackApprovalAction:
             "channel": {"id": "C1"},
             "user": {"name": "alice", "id": "U_ALICE"},
         }
-        action = {"action_id": "hermes_approve_once", "value": "session-key"}
+        action = {"action_id": "hermes_approve_once", "value": "1"}
 
         mock_client = adapter._team_clients["T1"]
         mock_client.chat_update = AsyncMock()
@@ -193,6 +198,30 @@ class TestSlackApprovalAction:
             "message": {"ts": "1234.5678", "blocks": []},
             "channel": {"id": "C1"},
             "user": {"name": "mallory", "id": "U_ATTACKER"},
+        }
+        action = {
+            "action_id": "hermes_approve_once",
+            "value": "1",
+        }
+
+        with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
+            await adapter._handle_approval_action(ack, body, action)
+
+        ack.assert_called_once()
+        mock_resolve.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_forged_session_key_button_fails_closed(self, monkeypatch):
+        """A button value carrying the raw session_key must not resolve (#80283)."""
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        adapter._approval_resolved["1234.5678"] = False
+
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "1234.5678", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "owner", "id": "U_OWNER"},
         }
         action = {
             "action_id": "hermes_approve_once",
@@ -237,6 +266,7 @@ class TestSlackSlashConfirmAction:
         adapter = _make_adapter()
         _attach_auth_runner(adapter)
         adapter._approval_resolved["2222.3333"] = False
+        adapter._slash_confirm_state["confirm-1"] = "agent:main:slack:group:C1:1111"
 
         # Simulate Slack re-escaping inflating text past 3000 chars.
         inflated_text = "b" * 2990 + "&lt;" * 10  # 2990 + 40 = 3030 chars
@@ -251,7 +281,7 @@ class TestSlackSlashConfirmAction:
         }
         action = {
             "action_id": "hermes_confirm_once",
-            "value": "agent:main:slack:group:C1:1111|confirm-1",
+            "value": "confirm-1",
         }
 
         mock_client = adapter._team_clients["T1"]

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -117,13 +117,23 @@ class TestSlackExecApproval:
         assert "hermes_approve_session" in action_ids
         assert "hermes_approve_always" in action_ids
         assert "hermes_deny" in action_ids
-        # Each button now carries an opaque numeric token, not the session key.
+        # Each button carries an unguessable token, not the session key.
         token = elements[0]["value"]
         assert token != "agent:main:slack:group:C1:1111"
-        assert token.isdigit()
-        assert adapter._approval_state[int(token)] == ("agent:main:slack:group:C1:1111", "")
+        assert not token.isdigit()
+        assert adapter._approval_state[token] == ("agent:main:slack:group:C1:1111", "")
         for e in elements:
             assert e["value"] == token
+
+        second = await adapter.send_exec_approval(
+            chat_id="C1",
+            command="echo other",
+            session_key="agent:main:slack:group:C1:1111",
+        )
+        assert second.success is True
+        other = mock_client.chat_postMessage.call_args_list[1].kwargs["blocks"][1]["elements"][0]["value"]
+        assert other != token
+        assert not other.isdigit()
 
     @pytest.mark.asyncio
     async def test_smart_deny_owner_override_hides_persistent_buttons(self):
@@ -158,7 +168,7 @@ class TestSlackApprovalAction:
         adapter = _make_adapter()
         _attach_auth_runner(adapter)
         adapter._approval_resolved["1.2"] = False
-        adapter._approval_state[1] = ("session-key", "")
+        adapter._approval_state["tok-1"] = ("session-key", "")
 
         # Simulate Slack re-escaping: original was ~2990 chars, but & → &amp;
         # etc. inflates it past 3000.
@@ -172,7 +182,7 @@ class TestSlackApprovalAction:
             "channel": {"id": "C1"},
             "user": {"name": "alice", "id": "U_ALICE"},
         }
-        action = {"action_id": "hermes_approve_once", "value": "1"}
+        action = {"action_id": "hermes_approve_once", "value": "tok-1"}
 
         mock_client = adapter._team_clients["T1"]
         mock_client.chat_update = AsyncMock()
@@ -241,7 +251,7 @@ class TestSlackApprovalAction:
         adapter = _make_adapter()
         _attach_auth_runner(adapter)
         adapter._approval_resolved["1234.5678"] = False
-        adapter._approval_state[1] = ("session-key", "req-abc")
+        adapter._approval_state["tok-abc"] = ("session-key", "req-abc")
 
         ack = AsyncMock()
         body = {
@@ -249,7 +259,7 @@ class TestSlackApprovalAction:
             "channel": {"id": "C1"},
             "user": {"name": "owner", "id": "U_OWNER"},
         }
-        action = {"action_id": "hermes_approve_once", "value": "1"}
+        action = {"action_id": "hermes_approve_once", "value": "tok-abc"}
         mock_client = adapter._team_clients["T1"]
         mock_client.chat_update = AsyncMock()
 
@@ -267,7 +277,7 @@ class TestSlackApprovalAction:
         adapter = _make_adapter()
         _attach_auth_runner(adapter)
         adapter._approval_resolved["1234.5678"] = False
-        adapter._approval_state[1] = ("session-key", "req-abc")
+        adapter._approval_state["tok-abc"] = ("session-key", "req-abc")
 
         ack = AsyncMock()
         body = {
@@ -275,7 +285,7 @@ class TestSlackApprovalAction:
             "channel": {"id": "C1"},
             "user": {"name": "owner", "id": "U_OWNER"},
         }
-        action = {"action_id": "hermes_approve_once", "value": "1"}
+        action = {"action_id": "hermes_approve_once", "value": "tok-abc"}
         mock_client = adapter._team_clients["T1"]
         mock_client.chat_update = AsyncMock()
 

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -121,7 +121,7 @@ class TestSlackExecApproval:
         token = elements[0]["value"]
         assert token != "agent:main:slack:group:C1:1111"
         assert token.isdigit()
-        assert adapter._approval_state[int(token)] == "agent:main:slack:group:C1:1111"
+        assert adapter._approval_state[int(token)] == ("agent:main:slack:group:C1:1111", "")
         for e in elements:
             assert e["value"] == token
 
@@ -158,7 +158,7 @@ class TestSlackApprovalAction:
         adapter = _make_adapter()
         _attach_auth_runner(adapter)
         adapter._approval_resolved["1.2"] = False
-        adapter._approval_state[1] = "session-key"
+        adapter._approval_state[1] = ("session-key", "")
 
         # Simulate Slack re-escaping: original was ~2990 chars, but & → &amp;
         # etc. inflates it past 3000.
@@ -233,6 +233,57 @@ class TestSlackApprovalAction:
 
         ack.assert_called_once()
         mock_resolve.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_click_resolves_bound_request_not_queue_head(self):
+        """A token bound to a specific request_id resolves that exact request
+        (not the session's oldest FIFO entry) via resolve_gateway_approval."""
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        adapter._approval_resolved["1234.5678"] = False
+        adapter._approval_state[1] = ("session-key", "req-abc")
+
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "1234.5678", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "owner", "id": "U_OWNER"},
+        }
+        action = {"action_id": "hermes_approve_once", "value": "1"}
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+            await adapter._handle_approval_action(ack, body, action)
+
+        mock_resolve.assert_called_once_with(
+            "session-key", "once", request_id="req-abc"
+        )
+
+    @pytest.mark.asyncio
+    async def test_stale_token_reports_expired_when_request_gone(self):
+        """A token whose request already left the queue (timed out/resolved)
+        must not resolve anything and must render as expired."""
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        adapter._approval_resolved["1234.5678"] = False
+        adapter._approval_state[1] = ("session-key", "req-abc")
+
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "1234.5678", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "owner", "id": "U_OWNER"},
+        }
+        action = {"action_id": "hermes_approve_once", "value": "1"}
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        with patch("tools.approval.resolve_gateway_approval", return_value=0):
+            await adapter._handle_approval_action(ack, body, action)
+
+        update_kwargs = mock_client.chat_update.call_args[1]
+        assert "expired" in update_kwargs["text"].lower()
 
 
 class TestSlackInteractiveAuth:

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1626,3 +1626,4 @@ class TestCliApprovalTimeoutClassifiedSeparately:
         assert result.get("user_consent") is False
         assert "timed out without user response" in result["message"]
         assert "Silence is not consent" in result["message"]
+

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -3946,6 +3946,9 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     all_keys = approval_data.get("pattern_keys", [primary_key])
 
     entry = _ApprovalEntry(approval_data)
+    # Expose the exact queue entry to the notify callback so button-based
+    # adapters can bind their token to this request via resolve_gateway_approval(request_id=…).
+    approval_data["request_id"] = entry.data["request_id"]
     with _lock:
         _gateway_queues.setdefault(session_key, []).append(entry)
 


### PR DESCRIPTION
## What does this PR do?

Slack approval and slash-confirm buttons no longer embed the raw `session_key` in Block Kit values. The adapter mints a server-side token, stores `(session_key, request_id)` locally, and resolves the exact queued request on click.

Follow-up: approval tokens are now `secrets.token_urlsafe(16)` instead of a sequential integer, so observing one button does not make the next token guessable.

## Related Issue

Fixes #80283

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `plugins/platforms/slack/adapter.py`: mint unguessable approval tokens; bind each token to `request_id`; fail closed on forged/stale tokens.
- Tests cover mint (non-digit, unique), exact-entry resolution, and stale/expired clicks.

## How to Test

1. `uv run python -m pytest tests/gateway/test_slack_approval_buttons.py -q` → 23 passed.
2. Button values are not session keys and not sequential integers.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_slack_approval_buttons.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A