### PR TITLE
fix(gateway): prevent stdio backpressure stalls

### DIFF
--- a/contributors/emails/eloklam@users.noreply.github.com
+++ b/contributors/emails/eloklam@users.noreply.github.com
@@ -1,0 +1,2 @@
+eloklam
+# upstream TUI backpressure fix PR

--- a/tests/tui_gateway/test_stream_backpressure.py
+++ b/tests/tui_gateway/test_stream_backpressure.py
@@ -1,0 +1,482 @@
+"""TUI-only mid-response stop: stdio backpressure must never block the
+provider streaming thread.
+
+Reproduction
+------------
+The TUI gateway streams ``message.delta`` frames to the Ink client over a
+stdio pipe.  When the client stops draining stdout (heavy re-render, React
+reconciliation pause, frozen terminal), the OS pipe buffer fills and a
+synchronous ``stream.write()`` blocks the thread that is consuming the
+provider stream — the interrupt check never runs and the turn appears hung
+with no way to cancel.
+
+``test_sync_stdio_transport_blocks_on_wedged_sink`` reproduces that stall
+deterministically with a blocked sink.  The fix routes TUI frames through
+:class:`~tui_gateway.transport.BufferedStreamWriter` — a bounded,
+coalescing writer drained by a dedicated thread — so the streaming
+producer never blocks, ordering is preserved, control/completion frames
+survive backpressure, and a wedged sink degrades to a bounded wait +
+clean peer-gone signal instead of an agent deadlock.
+"""
+
+import json
+import logging
+import threading
+import time
+
+import pytest
+
+from tui_gateway.transport import (
+    BufferedStreamWriter,
+    StdioTransport,
+)
+
+# ── Deterministic sinks ────────────────────────────────────────────────
+
+
+class BlockingSink:
+    """A stream whose ``write()`` blocks until :meth:`release` — a
+    deterministic stand-in for a full stdout pipe the Ink client isn't
+    draining.  Writes that happen after release are recorded in order.
+
+    ``started`` is set the moment the first ``write()`` is entered (before
+    it blocks), so tests can wait until the writer is provably wedged
+    inside the sink.
+    """
+
+    def __init__(self):
+        self._release = threading.Event()
+        self.started = threading.Event()
+        self.lines = []
+        self._lock = threading.Lock()
+
+    def block(self):
+        self._release.clear()
+
+    def release(self):
+        self._release.set()
+
+    def write(self, s):
+        self.started.set()
+        # Safety bound only — tests release the sink before this expires.
+        self._release.wait(timeout=30)
+        with self._lock:
+            self.lines.append(s)
+
+    def flush(self):
+        pass
+
+
+class RecordingSink:
+    """A non-blocking sink that records every write in order."""
+
+    def __init__(self):
+        self.lines = []
+        self._lock = threading.Lock()
+
+    def write(self, s):
+        with self._lock:
+            self.lines.append(s)
+
+    def flush(self):
+        pass
+
+
+def _make_writer(sink, **kwargs):
+    inner = StdioTransport(lambda: sink, threading.Lock())
+    return BufferedStreamWriter(inner, **kwargs)
+
+
+def delta_frame(text, sid="s1"):
+    return {
+        "jsonrpc": "2.0",
+        "method": "event",
+        "params": {
+            "type": "message.delta",
+            "session_id": sid,
+            "payload": {"text": text},
+        },
+    }
+
+
+def control_frame(event_type, payload=None, sid="s1"):
+    params = {"type": event_type, "session_id": sid}
+    if payload is not None:
+        params["payload"] = payload
+    return {"jsonrpc": "2.0", "method": "event", "params": params}
+
+
+def frame_types(sink):
+    return [json.loads(line)["params"]["type"] for line in sink.lines]
+
+
+# ── Root-cause reproduction ────────────────────────────────────────────
+
+
+def test_sync_stdio_transport_blocks_on_wedged_sink():
+    """A synchronous write to a full pipe blocks the producer thread.
+
+    This is the exact stall behind the TUI mid-response stop: the provider
+    streaming thread blocks inside StdioTransport.write and never reaches
+    the interrupt check.  BufferedStreamWriter exists to keep that thread
+    off the sink entirely.
+    """
+    sink = BlockingSink()
+    transport = StdioTransport(lambda: sink, threading.Lock())
+
+    def producer():
+        transport.write(delta_frame("tok"))
+
+    t = threading.Thread(target=producer, daemon=True)
+    t.start()
+    t.join(timeout=0.3)
+    assert t.is_alive(), "sync write must block on a wedged sink"
+    sink.release()
+    t.join(timeout=1.0)
+    assert not t.is_alive()
+
+
+# ── Non-blocking push ──────────────────────────────────────────────────
+
+
+def test_delta_push_never_blocks_while_sink_wedged():
+    """The provider streaming thread's delta push must return instantly even
+    when the writer is blocked on a full pipe."""
+    sink = BlockingSink()  # wedged: writes block until released
+    writer = _make_writer(sink)
+    try:
+        start = time.monotonic()
+        for i in range(500):
+            assert writer.write(delta_frame(f"tok-{i}")) is True
+        elapsed = time.monotonic() - start
+        assert elapsed < 0.5, f"delta push blocked: {elapsed:.3f}s for 500 pushes"
+    finally:
+        sink.release()
+        writer.close()
+    # Everything coalesced into the pending batch reaches the sink once the
+    # writer can drain — no delta silently lost in the healthy path.
+    assert len(sink.lines) == 500
+
+
+# ── Ordering ───────────────────────────────────────────────────────────
+
+
+def test_control_frame_never_overtakes_queued_deltas():
+    """message.complete (and any control frame) must land after the deltas
+    that preceded it — even when the sink was wedged in between."""
+    sink = BlockingSink()
+    writer = _make_writer(sink)
+    try:
+        writer.write(delta_frame("a"))
+        writer.write(delta_frame("b"))
+        assert writer.write(control_frame("message.complete", {"text": "ab"})) is True
+        # Let the writer consume the batch and wedge on the sink so the
+        # assertion exercises the in-flight queue order, not the close-drain.
+        time.sleep(0.05)
+        assert sink.lines == []  # wedged — nothing hit the sink yet
+    finally:
+        sink.release()
+        writer.close()
+    assert frame_types(sink) == [
+        "message.delta",
+        "message.delta",
+        "message.complete",
+    ]
+    texts = [json.loads(line)["params"]["payload"]["text"] for line in sink.lines]
+    assert texts == ["a", "b", "ab"]
+
+
+def test_rpc_response_ordered_after_pending_deltas():
+    """A non-event RPC response (e.g. session.status poll during a turn)
+    must not overtake deltas still in the coalescing buffer."""
+    sink = BlockingSink()
+    writer = _make_writer(sink)
+    try:
+        writer.write(delta_frame("x"))
+        writer.write(delta_frame("y"))
+        resp = {"jsonrpc": "2.0", "id": 7, "result": {"ok": True}}
+        assert writer.write(resp) is True
+        time.sleep(0.05)
+    finally:
+        sink.release()
+        writer.close()
+    lines = sink.lines
+    assert len(lines) == 3
+    assert json.loads(lines[0])["params"]["type"] == "message.delta"
+    assert json.loads(lines[1])["params"]["type"] == "message.delta"
+    assert json.loads(lines[2]).get("id") == 7
+
+
+# ── Bounded backpressure ───────────────────────────────────────────────
+
+
+def test_control_push_is_bounded_when_writer_wedged():
+    """A control-frame push waits at most control_push_timeout_s for queue
+    space, then signals a dead peer instead of deadlocking the agent."""
+    sink = BlockingSink()
+    writer = _make_writer(
+        sink, queue_maxsize=2, control_push_timeout_s=0.25, coalesce_s=0.01
+    )
+    try:
+        # Push one control batch and let the writer dequeue it and wedge on
+        # the blocked sink — it cannot dequeue anything further.
+        assert writer.write(control_frame("tool.start", {"name": "t0"})) is True
+        time.sleep(0.05)
+        assert sink.lines == []  # writer is wedged on the sink, nothing drained
+        # Fill the bounded queue behind the wedged writer.
+        assert writer.write(control_frame("tool.start", {"name": "t1"})) is True
+        assert writer.write(control_frame("tool.start", {"name": "t2"})) is True
+        start = time.monotonic()
+        ok = writer.write(control_frame("tool.start", {"name": "t3"}))
+        elapsed = time.monotonic() - start
+        assert ok is False, "wedged control push must eventually report peer dead"
+        assert 0.2 <= elapsed < 1.0, f"control push not bounded: {elapsed:.3f}s"
+    finally:
+        sink.release()
+        writer.close()
+
+
+def test_deltas_dropped_under_backpressure_but_control_survives():
+    """Deltas are droppable (display-only; message.complete is canonical),
+    so the pending batch stays memory-bounded and a control frame still
+    enqueues and lands after the surviving deltas."""
+    sink = BlockingSink()
+    writer = _make_writer(
+        sink, queue_maxsize=4, max_pending_deltas=8, coalesce_s=0.01
+    )
+    try:
+        for i in range(200):
+            writer.write(delta_frame(f"tok-{i}"))
+        with writer._pending_lock:
+            assert len(writer._pending) <= 8, "pending delta batch must stay bounded"
+        assert writer.write(control_frame("message.complete", {"text": "done"})) is True
+        time.sleep(0.05)
+    finally:
+        sink.release()
+        writer.close()
+    types = frame_types(sink)
+    assert types[-1] == "message.complete", "canonical complete must never be dropped"
+    deltas = [t for t in types if t == "message.delta"]
+    assert len(deltas) < 200, "overflow deltas must be dropped, not queued forever"
+
+
+# ── Writer lifecycle ───────────────────────────────────────────────────
+
+
+def test_close_drains_pending_and_joins_writer():
+    """close() flushes coalesced deltas that no control frame carried, and
+    joins the writer thread so it cannot leak."""
+    sink = RecordingSink()
+    writer = _make_writer(sink, coalesce_s=0.05)
+    writer.write(delta_frame("a"))
+    writer.write(delta_frame("b"))
+    writer.write(delta_frame("c"))
+    writer.close()
+    assert writer._thread is None or not writer._thread.is_alive()
+    assert len(sink.lines) == 3
+
+
+def test_writer_thread_does_not_leak():
+    sink = RecordingSink()
+    writer = _make_writer(sink)
+    writer.write(delta_frame("a"))
+    writer.write(control_frame("message.complete", {"text": "a"}))
+    writer.close()
+    assert not any(t.name == "tui-stdio-writer" for t in threading.enumerate())
+
+
+def test_writer_thread_is_lazy_and_daemon():
+    """No thread is spawned until the first frame — importing/creating the
+    writer in a non-TUI context is side-effect free, and the writer thread
+    is daemon so a wedged sink can never strand interpreter shutdown."""
+    sink = RecordingSink()
+    writer = _make_writer(sink)
+    assert writer._thread is None
+    writer.write(delta_frame("a"))
+    assert writer._thread is not None
+    assert writer._thread.daemon is True
+    writer.close()
+
+
+# ── Wiring ─────────────────────────────────────────────────────────────
+
+
+def test_entry_installs_buffered_writer():
+    """The TUI entry point wraps the stdio transport in the non-blocking
+    writer; the module default stays the plain synchronous StdioTransport
+    so non-TUI transports and stdout-monkeypatching tests are unchanged."""
+    from tui_gateway import entry as entry_mod
+    from tui_gateway import server
+
+    original = server._stdio_transport
+    try:
+        entry_mod._install_stream_writer()
+        wrapped = server._stdio_transport
+        # Check against entry's own class reference: test_protocol reloads
+        # tui_gateway.transport in-process, which can replace the module's
+        # class object without affecting already-created instances.
+        assert isinstance(wrapped, entry_mod.BufferedStreamWriter)
+        assert wrapped._inner is original
+    finally:
+        server._stdio_transport = original
+
+
+# ── Control ordering fence ────────────────────────────────────────────
+# Regression: a control frame drains the pending delta batch, then blocks
+# on queue.put because the queue is full.  A delta produced *after* that
+# control push began must NOT be opportunistically flushed to the sink
+# before the control — the writer holds its delta flush while any control
+# batch is claimed-but-unwritten (`_control_claimed`).
+
+
+def test_later_delta_never_reaches_sink_before_waiting_control():
+    """Deterministic concurrent regression for the control/delta race.
+
+    Setup: queue_maxsize=2, writer wedged on the blocked sink.  Push A
+    (writer drains it and wedges), then fill the queue with B and C.  Push
+    D from another thread — it claims the (empty) pending batch, then must
+    block on queue.put because the queue is full and the writer can't
+    drain.  Only once D's claim is registered (``_control_claimed == 4``)
+    push a later delta.  Release the sink; the delta must land AFTER D.
+    """
+    sink = BlockingSink()
+    writer = _make_writer(
+        sink, queue_maxsize=2, control_push_timeout_s=5.0, coalesce_s=0.01
+    )
+    t = None
+    try:
+        # A drains and the writer wedges inside the sink.
+        assert writer.write(control_frame("tool.start", {"name": "A"})) is True
+        assert sink.started.wait(1.0), "writer never wedged on the sink"
+        # Fill the queue: B and C occupy both slots.
+        assert writer.write(control_frame("tool.start", {"name": "B"})) is True
+        assert writer.write(control_frame("tool.start", {"name": "C"})) is True
+        assert writer._queue.qsize() == 2, "queue must be full"
+
+        # D claims pending then blocks on queue.put (full + writer wedged).
+        push_result = {}
+
+        def push_d():
+            push_result["ok"] = writer.write(control_frame("tool.start", {"name": "D"}))
+
+        t = threading.Thread(target=push_d, daemon=True)
+        t.start()
+        # Deterministic rendezvous: D has claimed the pending batch (under
+        # _pending_lock) and is now blocked in put — with the queue full
+        # and the writer wedged it cannot complete until the sink drains.
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            with writer._pending_lock:
+                if writer._control_claimed == 4:
+                    break
+            time.sleep(0.005)
+        else:
+            raise AssertionError("control push D never claimed the pending batch")
+        # The later delta — must NOT reach the sink before D.
+        assert writer.write(delta_frame("late")) is True
+        time.sleep(0.02)  # give a buggy writer time to misorder
+        assert sink.lines == [], "nothing may reach the sink while wedged"
+    finally:
+        sink.release()
+        writer.close()
+        # D must have completed its (bounded) push after the sink drained.
+        if t is not None and t.is_alive():
+            t.join(timeout=1.0)
+    # Wire order: A, B, C, D — then the delta, never before D.
+    names = [
+        json.loads(line)["params"].get("payload", {}).get("name") for line in sink.lines
+    ]
+    assert names[:-1] == ["A", "B", "C", "D"], f"order violated: {names}"
+    assert names[-1] is None, f"delta must be last, got: {names}"
+
+
+# ── Close without STOP ────────────────────────────────────────────────
+# Regression: close() cannot enqueue _STOP when the queue is full; once
+# the sink recovers and queued work drains, the closed writer must exit on
+# its own instead of waiting forever for a STOP that never arrives.
+
+
+def test_closed_writer_exits_after_drain_without_stop():
+    """close() with a full queue: _STOP can't be enqueued, but the writer
+    exits once queued work drains after the sink recovers."""
+    sink = BlockingSink()
+    writer = _make_writer(
+        sink, queue_maxsize=2, close_join_timeout_s=0.05, coalesce_s=0.01
+    )
+    try:
+        assert writer.write(control_frame("tool.start", {"name": "A"})) is True
+        assert sink.started.wait(1.0), "writer never wedged on the sink"
+        assert writer.write(control_frame("tool.start", {"name": "B"})) is True
+        assert writer.write(control_frame("tool.start", {"name": "C"})) is True
+        assert writer._queue.qsize() == 2, "queue must be full"
+        # close() with a full queue: the _STOP enqueue times out (queue
+        # still holds B and C) and the join times out (writer still wedged
+        # on A).  close() returns without ever enqueueing _STOP.
+        writer.close()
+        assert writer._queue.qsize() == 2, "_STOP must not have been enqueued"
+        assert writer._thread is not None and writer._thread.is_alive()
+    finally:
+        # Recover the sink ONLY — no second close() here: the writer must
+        # exit on its own, never seeing a _STOP sentinel.
+        sink.release()
+    # Sink recovers: writer drains A, B, C, then must exit on its own.
+    thread = writer._thread
+    assert thread is not None
+    thread.join(timeout=2.0)
+    assert not thread.is_alive(), "closed writer must exit after draining without _STOP"
+    names = [
+        json.loads(line)["params"].get("payload", {}).get("name") for line in sink.lines
+    ]
+    assert names == ["A", "B", "C"], f"queued work not drained: {names}"
+    writer.close()  # cleanup only; the writer thread is already gone
+
+
+# ── Inner exception visibility ────────────────────────────────────────
+# A peer-gone inner error is a clean disconnect (write returns False, no
+# crash).  A programming/host error (non-JSON-safe payload, ENOSPC, ...)
+# must NOT masquerade as a clean disconnect: it is logged with its
+# traceback and re-raised so the gateway's thread panic hook records it in
+# the crash log — the same visibility StdioTransport.write documents.
+
+
+class RaisingTransport:
+    """Minimal Transport whose write() raises a fixed exception."""
+
+    def __init__(self, exc):
+        self._exc = exc
+
+    def write(self, obj):
+        raise self._exc
+
+    def close(self):
+        pass
+
+
+def test_peer_gone_inner_exception_is_clean_disconnect():
+    """BrokenPipeError from the inner sink is peer-gone: the writer stops,
+    the transport reports dead, and no exception escapes to the caller."""
+    inner = RaisingTransport(BrokenPipeError("Broken pipe"))
+    writer = BufferedStreamWriter(inner, coalesce_s=0.01)
+    assert writer.write(delta_frame("a")) is True  # enqueue is non-blocking
+    writer._thread.join(timeout=1.0)
+    assert not writer._thread.is_alive()
+    assert writer._closed is True
+    assert writer.write(delta_frame("b")) is False
+
+
+def test_programming_error_is_logged_and_re_raised(caplog):
+    """A non-peer-gone inner exception (e.g. a non-JSON-serialisable
+    payload) is NOT swallowed as a clean disconnect: it is logged with its
+    traceback and re-raised so the crash-log/panic-hook path records it."""
+    inner = RaisingTransport(TypeError("Object of type set is not JSON serializable"))
+    writer = BufferedStreamWriter(inner, coalesce_s=0.01)
+    with caplog.at_level(logging.ERROR, logger="tui_gateway.transport"):
+        assert writer.write(delta_frame("a")) is True
+        writer._thread.join(timeout=1.0)
+    assert not writer._thread.is_alive()
+    assert writer._closed is True
+    assert writer.write(delta_frame("b")) is False
+    assert any(
+        r.levelno >= logging.ERROR and "inner write failed" in r.getMessage()
+        for r in caplog.records
+    ), "programming error must be logged, not silently peer-gone"

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -21,7 +21,7 @@ from tui_gateway._stdin_recovery import handle_spurious_eof
 
 from tui_gateway import server
 from tui_gateway.server import _CRASH_LOG, dispatch, resolve_skin, write_json
-from tui_gateway.transport import TeeTransport
+from tui_gateway.transport import BufferedStreamWriter, TeeTransport
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +62,22 @@ def _install_sidecar_publisher() -> None:
     server._stdio_transport = TeeTransport(
         server._stdio_transport, WsPublisherTransport(url)
     )
+
+
+def _install_stream_writer() -> None:
+    """Wrap the stdio transport in a bounded, non-blocking writer.
+
+    The provider streaming thread emits ``message.delta`` frames from inside
+    the model-read loop; a synchronous write to a full stdout pipe (the Ink
+    client is mid-render or frozen) would block that thread and freeze the
+    turn — the interrupt check never fires and the TUI looks hung with no
+    way to cancel.  :class:`~tui_gateway.transport.BufferedStreamWriter`
+    decouples producers from the sink (bounded queue + dedicated writer
+    thread, coalesced deltas, ordered control frames).  TUI-only: the
+    WebSocket/desktop surfaces already coalesce on their own transport
+    (``tui_gateway.ws``).
+    """
+    server._stdio_transport = BufferedStreamWriter(server._stdio_transport)
 
 
 # How long to wait for orderly shutdown (atexit + finalisers) before
@@ -420,6 +436,11 @@ def ensure_mcp_discovery_started() -> None:
 
 def main():
     _install_sidecar_publisher()
+    # Capture the transport BEFORE the writer wrap so main() can restore it
+    # on the way out — in-process callers (the entry-point test harness)
+    # must not observe a closed BufferedStreamWriter afterwards.
+    _pre_writer_transport = server._stdio_transport
+    _install_stream_writer()
 
     # MCP tool discovery — backgrounded so a slow or unreachable MCP server
     # can't freeze TUI startup (a dead stdio/http server burns 1+2+4s of
@@ -484,6 +505,19 @@ def main():
             if not write_json(resp):
                 _log_exit(f"response write failed for method={method!r} (broken stdout pipe)")
                 sys.exit(0)
+
+    # Best-effort drain of the non-blocking writer before interpreter
+    # shutdown (bounded join; the thread is daemon and cannot strand exit).
+    try:
+        server._stdio_transport.close()
+    except Exception:
+        logger.debug("stdio stream writer close failed at exit", exc_info=True)
+    # Restore the pre-writer transport: the writer's bounded drain belongs to
+    # the process lifetime, not to module state.  In-process callers of
+    # main() (entry-point tests with stubbed I/O) get the pristine transport
+    # back; the real TUI process exits right after, so the restore is a
+    # no-op there.
+    server._stdio_transport = _pre_writer_transport
 
 
 if __name__ == "__main__":

--- a/tui_gateway/transport.py
+++ b/tui_gateway/transport.py
@@ -27,6 +27,7 @@ import errno
 import json
 import logging
 import os
+import queue
 import threading
 from typing import Any, Callable, Optional, Protocol, runtime_checkable
 
@@ -43,6 +44,28 @@ _PEER_GONE_ERRNOS = frozenset({
 } - {-1})
 
 logger = logging.getLogger(__name__)
+
+
+def _is_peer_gone(exc: BaseException) -> bool:
+    """True when *exc* means "the peer is gone" rather than a host problem.
+
+    Mirrors StdioTransport.write's classification so the async writer
+    thread treats exactly the same errors as a clean disconnect and keeps
+    programming/host errors (non-JSON-safe payloads, encoding misconfig,
+    ENOSPC, ...) visible as exceptions instead of swallowing them.
+    """
+    if isinstance(exc, BrokenPipeError):
+        return True
+    if isinstance(exc, ValueError):
+        # ValueError("I/O operation on closed file") is the ONLY ValueError
+        # that means "peer gone".  UnicodeEncodeError (a ValueError subclass
+        # for misconfigured locales) is a real bug — keep it visible.
+        if isinstance(exc, UnicodeEncodeError):
+            return False
+        return "closed file" in str(exc)
+    if isinstance(exc, OSError):
+        return exc.errno in _PEER_GONE_ERRNOS
+    return False
 
 # Optional knob: when true, StdioTransport does not call ``stream.flush``
 # after writing.  Use this on environments where a half-closed pipe (TUI
@@ -181,6 +204,314 @@ class StdioTransport:
 
     def close(self) -> None:
         return None
+
+
+# ── Non-blocking stream writer (TUI backpressure fix) ─────────────────
+# The TUI gateway streams JSON-RPC frames to the Ink client over a stdio
+# pipe.  When the client stops draining stdout (heavy re-render, React
+# reconciliation pause, frozen terminal), the OS pipe buffer fills and a
+# synchronous ``stream.write()`` blocks the thread that is consuming the
+# provider stream — the interrupt check never runs and the turn appears
+# hung with no way to cancel.
+#
+# BufferedStreamWriter decouples producers from the sink with a bounded
+# queue drained by one dedicated writer thread:
+#
+#   * Streaming frames (``message.delta`` / ``reasoning.delta`` /
+#     ``thinking.delta``) coalesce into a single pending batch and are
+#     pushed WITHOUT ever blocking the producer.  When the writer can't
+#     keep up, accumulated deltas are dropped — cosmetic only, because the
+#     canonical response text always arrives in the terminal
+#     ``message.complete`` frame.
+#   * Control frames (RPC responses, ``message.complete``, tool events,
+#     ...) drain the pending deltas ahead of themselves into ONE queue
+#     item, so on-the-wire order is preserved.  A control push waits at
+#     most ``_STREAM_CONTROL_PUSH_TIMEOUT_S`` for queue space; a sink that
+#     is still wedged then degrades to the transport's normal peer-gone
+#     signal (``False``) instead of deadlocking the agent thread.
+#   * Control ordering fence: a control frame that drains the pending
+#     batch claims it (``_control_claimed``) until its queue item has been
+#     written by the writer.  The writer's opportunistic delta flush is
+#     held while any claim is outstanding, so a delta produced *after* a
+#     control push began can never reach the sink before that control —
+#     even when the control push is still blocked waiting for queue space.
+#   * ``close()`` signals the writer and joins with a bounded timeout, so
+#     a wedged write can never leak a thread past process teardown (the
+#     thread is daemon and dies with the process if the pipe never drains).
+#     If the queue is full at close time (so ``_STOP`` can't be enqueued),
+#     the writer still exits on its own once queued + pending work drains.
+#
+# This mirrors the coalescing semantics the WebSocket transport already
+# has (``tui_gateway.ws.WSTransport``) for the same high-frequency frame
+# types; here the flush boundary is the writer thread instead of an event
+# loop.  Only the TUI entry point installs it (``tui_gateway.entry``), so
+# non-TUI transports and the synchronous module default are unchanged.
+
+# High-frequency, display-only frames eligible for coalescing.  Keep in
+# sync with ``tui_gateway.ws._STREAMING_EVENT_TYPES``.
+_STREAMING_EVENT_TYPES = frozenset({
+    "message.delta",
+    "reasoning.delta",
+    "thinking.delta",
+})
+
+# Bounded queue depth, in flush batches (not frames — deltas coalesce into
+# one batch).  Control frames are the typical occupants once the writer is
+# wedged behind a full pipe.
+_STREAM_QUEUE_MAXSIZE = 256
+# Max time a control-frame push waits for queue space before treating the
+# peer as dead.  Matches the WS transport's slow-write bound
+# (``tui_gateway.ws._WS_WRITE_TIMEOUT_S``); a local stdio pipe that stays
+# full for this long means the Ink client is effectively gone.
+_STREAM_CONTROL_PUSH_TIMEOUT_S = 10.0
+# Max time a streamed token waits in the pending batch before flush
+# (~30 fps cadence; mirrors ``tui_gateway.ws._TOKEN_COALESCE_S``).
+_STREAM_TOKEN_COALESCE_S = 0.033
+# Memory bound for the pending delta batch while the writer is wedged:
+# once reached, older accumulated deltas are dropped (display-only).
+_STREAM_MAX_PENDING_DELTAS = 512
+# Bounded join budget for close(); a writer wedged on a full pipe cannot
+# strand the caller.
+_STREAM_CLOSE_JOIN_TIMEOUT_S = 1.0
+
+_STOP = object()
+
+
+class BufferedStreamWriter:
+    """Transport wrapper that keeps producer threads off a blocking sink.
+
+    Implements the :class:`Transport` protocol (``write``/``close``) so it
+    can stand in for any transport the gateway already uses.  See the
+    module comment above for the backpressure rationale and ordering
+    guarantees.
+    """
+
+    __slots__ = (
+        "_inner",
+        "_queue",
+        "_pending",
+        "_pending_lock",
+        "_thread_lock",
+        "_thread",
+        "_closed",
+        "_control_claimed",
+        "_coalesce_s",
+        "_control_push_timeout_s",
+        "_max_pending_deltas",
+        "_close_join_timeout_s",
+    )
+
+    def __init__(
+        self,
+        inner: Transport,
+        *,
+        queue_maxsize: int = _STREAM_QUEUE_MAXSIZE,
+        control_push_timeout_s: float = _STREAM_CONTROL_PUSH_TIMEOUT_S,
+        coalesce_s: float = _STREAM_TOKEN_COALESCE_S,
+        max_pending_deltas: int = _STREAM_MAX_PENDING_DELTAS,
+        close_join_timeout_s: float = _STREAM_CLOSE_JOIN_TIMEOUT_S,
+    ) -> None:
+        self._inner = inner
+        self._queue: queue.Queue = queue.Queue(maxsize=queue_maxsize)
+        self._pending: list[dict] = []
+        self._pending_lock = threading.Lock()
+        self._thread_lock = threading.Lock()
+        self._thread: threading.Thread | None = None
+        self._closed = False
+        # Number of control batches that have drained the pending delta
+        # batch but have not yet been written to the sink.  While nonzero,
+        # the writer's opportunistic delta flush is held so a later delta
+        # can never overtake a control frame (see _drain_loop).
+        self._control_claimed = 0
+        self._coalesce_s = coalesce_s
+        self._control_push_timeout_s = control_push_timeout_s
+        self._max_pending_deltas = max_pending_deltas
+        self._close_join_timeout_s = close_join_timeout_s
+
+    @staticmethod
+    def _is_streaming_frame(obj: dict) -> bool:
+        """True for high-frequency per-token frames eligible for coalescing."""
+        params = obj.get("params") if isinstance(obj, dict) else None
+        if not isinstance(params, dict):
+            return False
+        return params.get("type") in _STREAMING_EVENT_TYPES
+
+    def _ensure_writer(self) -> None:
+        """Lazily start the writer thread on first frame.
+
+        Starting on first write keeps creation side-effect free for the
+        module default (which is never wrapped in production) and for tests
+        that construct writers but emit nothing.
+        """
+        with self._thread_lock:
+            if self._thread is None or not self._thread.is_alive():
+                self._thread = threading.Thread(
+                    target=self._drain_loop,
+                    name="tui-stdio-writer",
+                    daemon=True,
+                )
+                self._thread.start()
+
+    def write(self, obj: dict) -> bool:
+        """Enqueue one frame.  Streaming frames never block; control frames
+        wait at most ``control_push_timeout_s`` for queue space, then return
+        ``False`` (peer gone) so the caller's normal dead-transport handling
+        applies instead of deadlocking the agent."""
+        if self._closed:
+            return False
+        self._ensure_writer()
+
+        if self._is_streaming_frame(obj):
+            # Coalesce into the pending batch; return immediately.  The
+            # writer thread flushes the batch on its coalesce cadence or
+            # when a control frame drains it.
+            with self._pending_lock:
+                if self._closed:
+                    return False
+                if len(self._pending) >= self._max_pending_deltas:
+                    # Writer is wedged behind a full pipe — keep only the
+                    # newest delta and drop the backlog.  Display-only; the
+                    # terminal message.complete frame carries the canonical
+                    # text.
+                    self._pending = [obj]
+                else:
+                    self._pending.append(obj)
+            return True
+
+        # Control frame: append it behind the pending deltas in ONE queue
+        # item so it can never overtake the tokens it follows.  Claim the
+        # batch before the (possibly blocking) put: while the claim is
+        # outstanding the writer holds its opportunistic delta flush, so a
+        # delta produced after this control push began can never reach the
+        # sink before the control (see _drain_loop).
+        with self._pending_lock:
+            batch = self._pending
+            self._pending = []
+            batch = batch + [obj]
+            self._control_claimed += 1
+        try:
+            self._queue.put(batch, timeout=self._control_push_timeout_s)
+        except queue.Full:
+            logger.warning(
+                "stdio stream writer wedged: no queue space after %.0fs — "
+                "treating peer as dead",
+                self._control_push_timeout_s,
+            )
+            # The claim never made it to the queue — release it so a
+            # subsequent close/drain does not wait on a phantom control.
+            with self._pending_lock:
+                self._control_claimed -= 1
+            self._closed = True
+            return False
+        return not self._closed
+
+    def _write_batch(self, batch: list[dict]) -> bool:
+        """Write one batch to the inner transport.  Returns False when the
+        peer is gone (inner returned False or raised a peer-gone error); the
+        writer loop then stops instead of churning against a dead pipe.
+
+        Programming/host errors (non-JSON-safe payloads, encoding misconfig,
+        ENOSPC, ...) are NOT treated as a clean disconnect: they are logged
+        with their traceback and re-raised so the gateway's thread panic
+        hook records them in the crash log — the same visibility contract
+        StdioTransport.write documents for its synchronous path.
+        """
+        inner = self._inner
+        for obj in batch:
+            try:
+                if not inner.write(obj):
+                    return False
+            except Exception as exc:
+                if _is_peer_gone(exc):
+                    logger.debug("stdio stream writer peer gone: %s", exc)
+                    return False
+                self._closed = True
+                logger.exception("stdio stream writer inner write failed")
+                raise
+        return True
+
+    def _drain_loop(self) -> None:
+        q = self._queue
+        while True:
+            try:
+                batch = q.get(timeout=self._coalesce_s)
+            except queue.Empty:
+                batch = None
+            if batch is _STOP:
+                break
+            if batch:
+                if not self._write_batch(batch):
+                    self._closed = True
+                    return
+                # Every queued item is a control batch (deltas never enter
+                # the queue), so a successful write releases its claim.
+                with self._pending_lock:
+                    self._control_claimed -= 1
+            # Opportunistically flush deltas that coalesced while the writer
+            # was busy, so a pure delta stream still reaches the client even
+            # with no control frame in sight.  Held while any control batch
+            # is claimed but not yet written — a later delta must never
+            # reach the sink before the control that precedes it.
+            with self._pending_lock:
+                if self._control_claimed:
+                    continue
+                pending = self._pending
+                self._pending = []
+            if pending and not self._write_batch(pending):
+                self._closed = True
+                return
+            # close() may not have been able to enqueue _STOP (queue was
+            # full); once everything queued + pending has drained, a closed
+            # writer exits on its own instead of waiting forever.  With
+            # _closed set, no new claims can arrive, so reaching this check
+            # with an empty queue implies all claims were written above.
+            if self._closed and q.empty() and self._control_claimed == 0:
+                return
+        # Stop requested: drain everything already queued + still-outstanding
+        # claims + the pending batch.  A control whose queue.put was blocked
+        # when close() enqueued _STOP may land AFTER the sentinel (put order
+        # is not claim order); keep draining until every claim is written so
+        # no claimed control — or the deltas held behind it — is dropped.
+        while self._control_claimed > 0 or not q.empty():
+            try:
+                batch = q.get(timeout=min(self._coalesce_s, 0.05))
+            except queue.Empty:
+                batch = None
+            if batch is _STOP or batch is None:
+                continue
+            if not self._write_batch(batch):
+                break
+            with self._pending_lock:
+                self._control_claimed -= 1
+        with self._pending_lock:
+            if self._control_claimed == 0:
+                pending = self._pending
+                self._pending = []
+            else:
+                # A control batch is still claimed but unwritten — hold the
+                # deltas rather than let them overtake it (display-only;
+                # message.complete carries the canonical text).
+                pending = None
+        if pending:
+            self._write_batch(pending)
+
+    def close(self) -> None:
+        """Signal the writer to stop and join it (bounded).
+
+        Remaining queued/pending frames are drained best-effort.  If the
+        writer is wedged on a full pipe the join times out and the daemon
+        thread is left to die with the process — it can never strand
+        shutdown.
+        """
+        self._closed = True
+        thread = self._thread
+        if thread is None:
+            return
+        try:
+            self._queue.put(_STOP, timeout=self._close_join_timeout_s)
+        except queue.Full:
+            pass  # Writer is wedged; it will exit when the pipe drains.
+        thread.join(timeout=self._close_join_timeout_s)
 
 
 class TeeTransport:


### PR DESCRIPTION
## What does this PR do?

Fixes the TUI mid-response hang caused by stdio backpressure. The TUI gateway streams `message.delta` frames to the Ink client over a stdio pipe; when the client stops draining stdout (heavy re-render, reconciliation pause, frozen terminal), the OS pipe buffer fills and a synchronous `stream.write()` blocks the provider streaming thread — the interrupt check never fires and the turn appears hung with no way to cancel.

This PR introduces `BufferedStreamWriter`, a bounded-queue transport wrapper drained by a dedicated writer thread, installed only by `tui_gateway.entry`:

- Streaming frames (`message.delta` / `reasoning.delta` / `thinking.delta`) coalesce into a pending batch and never block the producer; overflow deltas are dropped (display-only — `message.complete` carries the canonical response text).
- Control frames (`message.complete`, tool events, RPC responses) drain pending deltas ahead of themselves into one queue item, preserving on-the-wire order, including under full-queue backpressure (a `_control_claimed` ordering fence prevents a later delta from overtaking a waiting control).
- Control pushes wait a bounded time for queue space, then report the peer dead instead of deadlocking the agent; interrupt/retry stay responsive.
- `close()` drains and joins with a bounded timeout; the writer thread is daemon, and a closed writer exits on its own once queued + pending work drains (no reliance on the `_STOP` sentinel landing when the queue is full).
- Inner exceptions are classified with `_is_peer_gone` (mirroring `StdioTransport.write`): peer-gone errors return `False` cleanly, while programming/host errors (non-JSON-safe payload, ENOSPC, encoding misconfig) are logged with their traceback and re-raised so the gateway's thread panic hook records them in the crash log.

Non-TUI transports (WebSocket, module-default `StdioTransport`) are unchanged. `_append_inflight_delta` and the failed-turn/session recovery path are untouched.

## Related Issue

Related to #81521 (the TUI mid-response stop). This follows up #37633 (the earlier non-blocking stream delta writer attempt).

Scope: this PR addresses the stdio backpressure path — the provider keeps streaming but the stdout pipe to the Ink client fills and blocks the streaming thread. It does not claim to cover every scenario in #81521; in particular, open PR #81601 covers the separate empty-stream retry/relay path (provider returns HTTP 200 with zero chunks / no finish_reason), which is a different failure mode and is not addressed here.

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `tui_gateway/transport.py` — add `BufferedStreamWriter` (bounded-queue, coalescing, dedicated writer thread) + `_is_peer_gone` classification; non-TUI transports unchanged.
- `tui_gateway/entry.py` — install the buffered writer around the stdio transport in `main()` (TUI-only), with best-effort drain + transport restore on exit.
- `tests/tui_gateway/test_stream_backpressure.py` — 14 tests: deterministic stall reproduction, non-blocking push under a wedged sink, control/delta ordering (incl. the full-queue race regression), bounded control push, delta overflow dropping, close-without-STOP exit, writer lifecycle, entry-point wiring, and peer-gone vs programming-error visibility.
- `contributors/emails/eloklam@users.noreply.github.com` — contributor attribution mapping for the author's noreply identity (required by the contributor attribution check).

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. `scripts/run_tests.sh tests/tui_gateway/test_stream_backpressure.py -q` — 14 stream tests pass.
2. `scripts/run_tests.sh tests/tui_gateway tests/test_tui_gateway_server.py` — 923 tests pass across `tests/tui_gateway` (incl. the 14 stream tests) and `tests/test_tui_gateway_server.py`; exit 0.
3. `python -m py_compile tui_gateway/transport.py tui_gateway/entry.py tests/tui_gateway/test_stream_backpressure.py` — clean.
4. Manual repro: pause/freeze the Ink client mid-stream while the gateway emits deltas; the turn must stay cancellable via interrupt instead of hanging (the deterministic `BlockingSink` tests cover the wedged-pipe scenario in CI).

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

Test evidence (run via `scripts/run_tests.sh` on the final branch):

```
tests/tui_gateway/test_stream_backpressure.py: 14 passed, 0 failed
tests/tui_gateway + tests/test_tui_gateway_server.py: 923 passed, 0 failed (exit 0)
py_compile: clean
```

---

This contribution was implemented, tested, and prepared by Hermes Agent on behalf of Enoch Lam (@eloklam).
