### PR TITLE
fix(relay): run subscriber flush off the asyncio loop on session close (#81617)

### DIFF
--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import atexit
 import asyncio
+import concurrent.futures
 import contextvars
 import importlib
 import inspect
@@ -17,6 +18,14 @@ from typing import Any, Callable
 from hermes_constants import get_hermes_home
 
 logger = logging.getLogger(__name__)
+
+# One worker thread reused across flush fallbacks; a shared executor is far
+# cheaper than constructing a fresh pool on every session close. The thread
+# only ever runs ``relay.subscribers.flush``, which is idempotent.
+_subscribers_executor = concurrent.futures.ThreadPoolExecutor(
+    max_workers=1,
+    thread_name_prefix="hermes-relay-flush",
+)
 
 SESSION_SCOPE = "hermes.session"
 TURN_SCOPE = "hermes.turn"
@@ -126,6 +135,29 @@ def pop_relay_scope(
     ):
         kwargs = {key: value for key, value in kwargs.items() if key in params}
     return pop(handle, **kwargs)
+
+_FLUSH_ASYNCIO_TIMEOUT_S = 5
+
+
+def flush_subscribers_safely(relay: Any) -> None:
+    """Flush ``relay.subscribers`` without blocking a running asyncio loop.
+
+    ``relay.subscribers.flush`` is synchronous and raises
+    ``RuntimeError: cannot block a running asyncio event loop`` when invoked
+    from a coroutine; uncaught, that would tear down the gateway. Delegate the
+    drain to the shared worker thread instead so it still completes. Any other
+    :class:`RuntimeError` (for example Relay not initialised) is re-raised so
+    the caller can surface it as a session/closing failure.
+    """
+    try:
+        relay.subscribers.flush()
+    except RuntimeError as exc:
+        if "asyncio" not in str(exc).lower():
+            raise
+        _subscribers_executor.submit(relay.subscribers.flush).result(
+            timeout=_FLUSH_ASYNCIO_TIMEOUT_S,
+        )
+
 
 
 @dataclass

--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import atexit
 import asyncio
+import concurrent.futures
 import contextvars
 import importlib
 import inspect
@@ -17,6 +18,14 @@ from hermes_constants import get_hermes_home
 
 logger = logging.getLogger(__name__)
 
+# One worker thread reused across flush fallbacks; a shared executor is far
+# cheaper than constructing a fresh pool on every session close. The thread
+# only ever runs ``relay.subscribers.flush``, which is idempotent.
+_subscribers_executor = concurrent.futures.ThreadPoolExecutor(
+    max_workers=1,
+    thread_name_prefix="hermes-relay-flush",
+)
+
 SESSION_SCOPE = "hermes.session"
 TURN_SCOPE = "hermes.turn"
 LOGICAL_LLM_SCOPE = "hermes.logical_llm_call"
@@ -24,6 +33,28 @@ RUNTIME_SCHEMA_KEY = "hermes.relay.schema_version"
 RUNTIME_SCHEMA_VERSION = "hermes.relay.runtime.v1"
 RUNTIME_INSTANCE_KEY = "hermes.relay.runtime_instance"
 _PROFILE_KEY_CACHE: dict[str, str] = {}
+
+_FLUSH_ASYNCIO_TIMEOUT_S = 5
+
+
+def flush_subscribers_safely(relay: Any) -> None:
+    """Flush ``relay.subscribers`` without blocking a running asyncio loop.
+
+    ``relay.subscribers.flush`` is synchronous and raises
+    ``RuntimeError: cannot block a running asyncio event loop`` when invoked
+    from a coroutine; uncaught, that would tear down the gateway. Delegate the
+    drain to the shared worker thread instead so it still completes. Any other
+    :class:`RuntimeError` (for example Relay not initialised) is re-raised so
+    the caller can surface it as a session/closing failure.
+    """
+    try:
+        relay.subscribers.flush()
+    except RuntimeError as exc:
+        if "asyncio" not in str(exc).lower():
+            raise
+        _subscribers_executor.submit(relay.subscribers.flush).result(
+            timeout=_FLUSH_ASYNCIO_TIMEOUT_S,
+        )
 
 
 @dataclass
@@ -327,7 +358,7 @@ class RelayRuntime:
                 except Exception as exc:
                     failures.append(f"session scope close failed: {exc}")
         try:
-            self.relay.subscribers.flush()
+            flush_subscribers_safely(self.relay)
         except Exception as exc:
             failures.append(f"subscriber flush failed: {exc}")
         with self._sessions_lock:

--- a/hermes_cli/observability/relay_shared_metrics.py
+++ b/hermes_cli/observability/relay_shared_metrics.py
@@ -600,7 +600,7 @@ class _Runtime:
             finished = self._finish_task(session, task_id, event)
         if finished:
             try:
-                self.relay.subscribers.flush()
+                relay_runtime.flush_subscribers_safely(self.relay)
             except Exception:
                 logger.warning(
                     "Hermes shared-metrics task flush failed",
@@ -633,7 +633,7 @@ class _Runtime:
                 )
             self._end_pending_model_calls(session, event)
         try:
-            self.relay.subscribers.flush()
+            relay_runtime.flush_subscribers_safely(self.relay)
         except Exception as exc:
             failures.append(f"subscriber flush failed: {exc}")
         else:
@@ -657,7 +657,7 @@ class _Runtime:
         if not self._registered:
             return
         try:
-            self.relay.subscribers.flush()
+            relay_runtime.flush_subscribers_safely(self.relay)
         except Exception:
             logger.warning(
                 "Hermes shared-metrics shutdown flush failed",

--- a/tests/agent/test_relay_runtime_flush.py
+++ b/tests/agent/test_relay_runtime_flush.py
@@ -1,0 +1,112 @@
+"""Regression tests for flush_subscribers_safely (issue #81617).
+
+The gateway crashed with an uncaught ``RuntimeError: cannot block a running
+asyncio event loop`` because ``relay.subscribers.flush()`` is synchronous and
+was invoked inside the running event loop on every agent-mode session close.
+These tests pin the shared helper's three behaviours:
+
+- outside a running loop the underlying flush is called directly;
+- the asyncio RuntimeError is diverted to a worker thread and does not raise;
+- any other error is re-raised for the caller to surface.
+"""
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from agent import relay_runtime
+
+
+class _FakeSubscribers:
+    """A subscribers facade whose flush can be scripted for each case."""
+
+    def __init__(
+        self,
+        error: BaseException | None = None,
+        *,
+        raise_once: bool = False,
+    ) -> None:
+        self.error = error
+        self.raise_once = raise_once
+        self.calls: list[str] = []
+        self.threads: list[int] = []
+
+    def flush(self) -> None:
+        self.calls.append("flush")
+        self.threads.append(threading.get_ident())
+        if self.error is not None:
+            error = self.error
+            if self.raise_once:
+                self.error = None
+            raise error
+
+
+def _fake_relay(subscribers: _FakeSubscribers) -> object:
+    return SimpleNamespace(subscribers=subscribers)
+
+
+def test_flush_calls_direct_outside_loop(monkeypatch) -> None:
+    subscribers = _FakeSubscribers()
+    relay = _fake_relay(subscribers)
+
+    def _explode(*args, **kwargs):  # pragma: no cover - asserted below.
+        raise AssertionError("direct flush must not touch the thread pool")
+
+    monkeypatch.setattr(relay_runtime._subscribers_executor, "submit", _explode)
+    relay_runtime.flush_subscribers_safely(relay)
+    assert subscribers.calls == ["flush"]
+
+
+def test_flush_asyncio_runtime_error_delegates_to_worker_thread() -> None:
+    # The asyncio error is loop-thread-specific: it fires on the direct call
+    # on the caller thread, and the worker-thread retry succeeds.
+    subscribers = _FakeSubscribers(
+        error=RuntimeError("cannot block a running asyncio event loop"),
+        raise_once=True,
+    )
+    relay = _fake_relay(subscribers)
+    relay_runtime.flush_subscribers_safely(relay)
+    # The direct call raised, but a retry on the worker thread flushed.
+    assert subscribers.calls == ["flush", "flush"]
+    # The second flush really ran on a different thread than the caller.
+    caller_thread = subscribers.threads[0]
+    assert any(thread_id != caller_thread for thread_id in subscribers.threads[1:])
+
+
+def test_flush_asyncio_error_does_not_raise_under_running_loop() -> None:
+    import asyncio
+
+    subscribers = _FakeSubscribers(
+        error=RuntimeError("cannot block a running asyncio event loop"),
+        raise_once=True,
+    )
+    relay = _fake_relay(subscribers)
+
+    async def exercise() -> None:
+        # The helper must survive an invocation made from a live event loop,
+        # which is the exact gateway scenario from the issue.
+        relay_runtime.flush_subscribers_safely(relay)
+
+    asyncio.run(exercise())
+    assert subscribers.calls == ["flush", "flush"]
+
+
+def test_flush_non_asyncio_runtime_error_is_re_raised() -> None:
+    subscribers = _FakeSubscribers(error=RuntimeError("Relay not initialised"))
+    relay = _fake_relay(subscribers)
+    with pytest.raises(RuntimeError, match="Relay not initialised"):
+        relay_runtime.flush_subscribers_safely(relay)
+
+
+def test_flush_other_exception_types_propagate_untransformed() -> None:
+    """Only RuntimeError naming asyncio is special-cased; OSError and
+    ValueError bubble up untouched."""
+    subscribers = _FakeSubscribers(error=OSError("io"))
+    with pytest.raises(OSError, match="io"):
+        relay_runtime.flush_subscribers_safely(_fake_relay(subscribers))
+    subscribers = _FakeSubscribers(error=ValueError("bad"))
+    with pytest.raises(ValueError, match="bad"):
+        relay_runtime.flush_subscribers_safely(_fake_relay(subscribers))


### PR DESCRIPTION
Fixes #81617

## Problem

`subscribers.flush()` is synchronous and blocking, but was called directly inside the asyncio event loop at 4 sites. On Python 3.11+ (asyncio debug / running-loop detection) it raises `RuntimeError: cannot block a running asyncio event loop`, uncaught, killing the gateway — 160+ crashes over 2 months, taking down iLink/WeChat delivery each time.

## Fix

New module-level `flush_subscribers_safely(relay)` helper in `agent/relay_runtime.py`:

- Direct `flush()` when no loop conflict.
- On `RuntimeError` mentioning asyncio, falls back to a **reused** single-worker `ThreadPoolExecutor` (module-level singleton, not a new pool per call) with a 5s timeout.
- Non-asyncio `RuntimeError` (e.g. relay not initialized) is re-raised so session teardown records the failure.

All 4 affected call sites now route through the helper:
- `agent/relay_runtime.py` (session scope close)
- `hermes_cli/observability/relay_shared_metrics.py` (task finish, session close, shutdown)

## Tests

New `tests/agent/test_relay_runtime_flush.py` (5 cases): direct flush outside loop, running-loop error routes to thread without raising, real `asyncio.run` scenario, non-asyncio RuntimeError re-raised, other exceptions pass through. 149/149 relay-related tests pass locally.
