### PR TITLE
fix(dashboard): add idle back-off to PTY pump loop

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14624,6 +14624,10 @@ else:
 
 _RESIZE_RE = re.compile(rb"\x1b\[RESIZE:(\d+);(\d+)\]")
 _PTY_READ_CHUNK_TIMEOUT = 0.2
+# Back-off delay between idle PTY reads so a quiet terminal does not spin
+# the event loop.  A positive sleep lets other coroutines run and keeps
+# dashboard idle CPU low (#42627).
+_PTY_IDLE_BACKOFF = 0.05
 
 # Keep-alive PTY sessions: a terminal connecting with ``?attach=<token>`` is
 # bound to a process that survives disconnect/refresh and is reattachable.
@@ -14658,7 +14662,7 @@ async def _legacy_pump(ws: "WebSocket", bridge) -> None:
                 if chunk is None:  # EOF
                     return
                 if not chunk:  # no data this tick; yield control and retry
-                    await asyncio.sleep(0)
+                    await asyncio.sleep(_PTY_IDLE_BACKOFF)
                     continue
                 try:
                     await ws.send_bytes(chunk)

--- a/tests/hermes_cli/test_web_server_pty_idle_backoff.py
+++ b/tests/hermes_cli/test_web_server_pty_idle_backoff.py
@@ -1,0 +1,73 @@
+"""Regression: dashboard PTY pump must back off when the terminal is idle."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.web_server import _legacy_pump
+
+
+class _FakeBridge:
+    def __init__(self, reads):
+        self._reads = list(reads)
+        self.closed = False
+
+    def read(self, timeout):
+        if self._reads:
+            return self._reads.pop(0)
+        return None
+
+    def write(self, data):
+        pass
+
+    def resize(self, cols, rows):
+        pass
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_legacy_pump_sleeps_on_idle_pty():
+    """An empty PTY read must not spin with ``asyncio.sleep(0)``."""
+    sleeps: list[float] = []
+    first_idle_seen = asyncio.Event()
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+        first_idle_seen.set()
+        # Yield with the real sleep so we don't recurse through the patch.
+        await real_sleep(0)
+
+    bridge = _FakeBridge([b"", b"", None])
+
+    class _FakeWebSocket:
+        def __init__(self):
+            self.sent: list[bytes] = []
+
+        async def send_bytes(self, data):
+            self.sent.append(data)
+
+        async def receive(self):
+            await first_idle_seen.wait()
+            return {"type": "websocket.disconnect"}
+
+        async def close(self):
+            pass
+
+    ws = _FakeWebSocket()
+
+    with patch("hermes_cli.web_server.asyncio.sleep", side_effect=fake_sleep):
+        # _legacy_pump is typed against starlette WebSocket; our fake is an
+        # intentional behavioral shim.  # type: ignore[invalid-argument-type]
+        await _legacy_pump(ws, bridge)
+
+    assert bridge.closed
+    assert sleeps, "pty pump did not call asyncio.sleep on idle ticks"
+    assert all(d > 0 for d in sleeps), (
+        f"idle pump used zero or negative sleeps: {sleeps}"
+    )


### PR DESCRIPTION
## What does this PR do?

Fixes the idle-CPU busy loop in the dashboard PTY-to-WebSocket pump. When a dashboard `/chat` terminal is open but idle, the pump repeatedly called `await asyncio.sleep(0)` after empty PTY reads, causing the dashboard process to consume 20–50% CPU (#42627). This change adds a small positive idle backoff so the event loop is not starved while the terminal is quiet.

## Related Issue

Fixes #42627.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py`
  - Added `_PTY_IDLE_BACKOFF = 0.05` next to `_PTY_READ_CHUNK_TIMEOUT`.
  - Replaced `await asyncio.sleep(0)` with `await asyncio.sleep(_PTY_IDLE_BACKOFF)` in `_legacy_pump` when the PTY returns an empty chunk.
- `tests/hermes_cli/test_web_server_pty_idle_backoff.py`
  - Added a regression test that drives `_legacy_pump` with fake bridge/WebSocket objects, patches `asyncio.sleep`, and asserts every idle tick is delayed by a positive backoff.

## How to Test

1. Run the new regression test:
   ```bash
   uv run pytest tests/hermes_cli/test_web_server_pty_idle_backoff.py -x -q
   ```
2. Run the local check gate:
   ```bash
   scripts/check.sh --project hermes-agent --worktree worktrees/hermes-agent/42627
   ```
3. To observe the difference manually, revert `hermes_cli/web_server.py` line 14665 to `await asyncio.sleep(0)` and re-run the regression test; it fails because `asyncio.sleep` receives `0`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
