### PR TITLE
fix(providers/alibaba-coding-plan): emit flat reasoning_effort — OpenRouter-shaped reasoning object gets silently blackholed by Aliyun gateway

### DIFF
--- a/plugins/model-providers/alibaba-coding-plan/__init__.py
+++ b/plugins/model-providers/alibaba-coding-plan/__init__.py
@@ -4,10 +4,38 @@ Separate from the standard `alibaba` profile because it hits a different
 endpoint (coding-intl.dashscope.aliyuncs.com) with a dedicated API key tier.
 """
 
+from typing import Any
+
 from providers import register_provider
 from providers.base import ProviderProfile
 
-alibaba_coding_plan = ProviderProfile(
+
+class AlibabaCodingPlanProfile(ProviderProfile):
+    """Alibaba Coding Plan — flat ``reasoning_effort`` wire shape.
+
+    The generic fallback in ``_build_call_kwargs`` emits OpenRouter-shaped
+    ``extra_body.reasoning = {"enabled": ..., "effort": ...}`` for profiles
+    that don't handle reasoning. Aliyun's compatible-mode gateway (istio-envoy)
+    does not reject that object — it silently blackholes the entire request
+    (zero response bytes until client timeout), verified 2026-08-08 with
+    byte-identical curl replays: ``reasoning: {...}`` → hang; flat
+    ``reasoning_effort: "medium"`` → 200 with reasoning_tokens populated.
+    """
+
+    def build_api_kwargs_extras(
+        self, *, reasoning_config: dict | None = None, **context: Any
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        if not reasoning_config or not isinstance(reasoning_config, dict):
+            return {}, {}
+        if reasoning_config.get("enabled") is False:
+            # No documented "thinking off" field on the compatible-mode wire;
+            # omitting keeps the server default instead of risking a blackhole.
+            return {}, {}
+        effort = reasoning_config.get("effort") or "medium"
+        return {}, {"reasoning_effort": effort}
+
+
+alibaba_coding_plan = AlibabaCodingPlanProfile(
     name="alibaba-coding-plan",
     aliases=("alibaba_coding", "alibaba-coding", "dashscope-coding"),
     display_name="Alibaba Cloud (Coding Plan)",

--- a/tests/plugins/model_providers/test_alibaba_coding_plan_profile.py
+++ b/tests/plugins/model_providers/test_alibaba_coding_plan_profile.py
@@ -1,0 +1,100 @@
+"""Unit tests for the Alibaba Coding Plan provider profile's reasoning wiring.
+
+Bug class (verified against the live Aliyun gateway, 2026-08-08): the generic
+``_build_call_kwargs`` fallback emits OpenRouter-shaped
+``extra_body.reasoning = {"enabled": ..., "effort": ...}`` for providers whose
+profile has no reasoning hook. Aliyun's compatible-mode gateway does not
+reject that object — it silently blackholes the request: zero response bytes,
+no error, no RST, until the client gives up (observed hangs of 25min–7.8h;
+reproduced with byte-identical curl replays on three client stacks). The flat
+top-level ``reasoning_effort`` field is honored (200 + reasoning_tokens).
+
+These tests pin the profile's wire-shape contract so the OpenRouter-shaped
+object can never leak onto the Aliyun wire again, without going live.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def alibaba_profile():
+    """Resolve the registered profile through the real discovery path."""
+    # ``model_tools`` triggers plugin discovery on import, which is what
+    # registers the profile in the global provider registry.
+    import model_tools  # noqa: F401
+    import providers
+
+    profile = providers.get_provider_profile("alibaba-coding-plan")
+    assert profile is not None, "alibaba-coding-plan provider profile must be registered"
+    return profile
+
+
+class TestAlibabaReasoningWireShape:
+    """``build_api_kwargs_extras`` produces Aliyun's accepted wire format."""
+
+    def test_no_preference_omits_reasoning(self, alibaba_profile):
+        """No reasoning_config → send nothing; server default applies."""
+        extra_body, top_level = alibaba_profile.build_api_kwargs_extras(
+            reasoning_config=None, model="qwen3.8-max"
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+    def test_enabled_sends_flat_reasoning_effort(self, alibaba_profile):
+        """Enabled+effort → flat top-level ``reasoning_effort`` — the shape
+        Aliyun provably honors — never the OpenRouter-shaped object."""
+        extra_body, top_level = alibaba_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "medium"}, model="qwen3.8-max"
+        )
+        assert extra_body == {}
+        assert top_level == {"reasoning_effort": "medium"}
+
+    def test_enabled_without_effort_defaults_medium(self, alibaba_profile):
+        extra_body, top_level = alibaba_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True}, model="qwen3.8-max"
+        )
+        assert extra_body == {}
+        assert top_level == {"reasoning_effort": "medium"}
+
+    def test_disabled_omits_reasoning(self, alibaba_profile):
+        """``enabled=False`` → omit the field entirely.
+
+        The compatible-mode wire has no documented thinking-off parameter;
+        omitting keeps the server default instead of risking another
+        unrecognized-field blackhole.
+        """
+        extra_body, top_level = alibaba_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False}, model="qwen3.8-max"
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+
+class TestAlibabaEndToEndCallKwargs:
+    """Through ``_build_call_kwargs``: the OpenRouter-shaped fallback object
+    must not leak for this provider (the actual 2026-08 blackhole path)."""
+
+    def _kwargs(self, reasoning_config):
+        from agent.auxiliary_client import _build_call_kwargs
+
+        return _build_call_kwargs(
+            provider="alibaba-coding-plan",
+            model="qwen3.8-max",
+            messages=[{"role": "user", "content": "ping"}],
+            max_tokens=1800,
+            task="moa_reference",
+            reasoning_config=reasoning_config,
+            base_url="https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+        )
+
+    def test_flat_effort_on_wire_no_reasoning_object(self):
+        kw = self._kwargs({"enabled": True, "effort": "high"})
+        assert kw.get("reasoning_effort") == "high"
+        assert "reasoning" not in (kw.get("extra_body") or {})
+
+    def test_no_reasoning_config_sends_nothing(self):
+        kw = self._kwargs(None)
+        assert "reasoning_effort" not in kw
+        assert "reasoning" not in (kw.get("extra_body") or {})


### PR DESCRIPTION
## Symptom

Any call to `alibaba-coding-plan` that carries a reasoning config (e.g. a MoA reference slot with `reasoning_effort`, or any auxiliary task with `reasoning_effort` configured) **hangs forever**: the request is accepted, then zero response bytes — no 400, no RST, no error. Client-side read timeouts never fire; observed hangs from 25 minutes to 7.8 **hours**.

## Root cause

`_build_call_kwargs` falls back to the OpenRouter-shaped `extra_body.reasoning = {"enabled": ..., "effort": ...}` object for any provider whose profile lacks a reasoning hook. Aliyun's compatible-mode gateway (istio-envoy) **silently blackholes that object**. This started between 2026-08-07 03:12 and 08:44 UTC+8 with zero Hermes code changes on this path — a server-side behavior change (previously the same object went through fine).

## Evidence (all replayable)

- Byte-level: hung calls show `bytes_in` frozen at TLS-handshake size (`nettop` double-sample) — the response never starts.
- Byte-identical curl replay of the captured wire body → **hangs** (0 bytes, client timeout). Same body with `reasoning:{...}` swapped for flat `reasoning_effort:"medium"` → **200 in ~85s**, `reasoning_tokens` populated.
- Reproduced on three client stacks (httpx / urllib / curl) and two network routes (proxy tunnel / direct).
- Timing alibi: `git log` shows no Hermes change on the alibaba path between the last-known-good and first-bad windows.

## Fix

`AlibabaCodingPlanProfile.build_api_kwargs_extras` emits flat top-level `reasoning_effort` (the shape Aliyun honors — same pattern as `kimi-coding`). `enabled=False` omits the field: there is no documented thinking-off parameter on this wire, and an unrecognized field is exactly the blackhole risk being fixed.

## Universality note (why this is framed beyond one provider)

Every chat.completions provider **without** a profile reasoning hook currently receives the OpenRouter-shaped fallback. In-tree exposed profiles include: `actual`, `alibaba`, `arcee`, `azure-foundry`, `deepinfra`, `fireworks`, `gmi`, `huggingface`, `kilocode`, `novita`, `nvidia`, `stepfun`, `xai`, `xiaomi` (Anthropic/Codex adapter paths consume the field before it hits the wire). Aliyun is the **proven** blackhole case; this PR fixes it and pins the contract. Other gateways may 400 or silently drop the same object — each needs its own wire evidence before claiming the same fix, but maintainers may want to audit the fallback's default shape.

## Tests

New `tests/plugins/model_providers/test_alibaba_coding_plan_profile.py` pins the contract both at the profile hook and end-to-end through `_build_call_kwargs` (asserts the OpenRouter-shaped object never leaks for this provider):

- RED (on main): 3 failed — the failure diff shows `extra_body: {'reasoning': {'effort': 'high', 'enabled': True}}` leaking, exactly the blackholed shape
- GREEN: 6/6
- Regressions (`HERMES_TEST_FILE_RETRIES=0`): `tests/plugins/model_providers/` 177/177, auxiliary suites (`test_auxiliary_client`, `test_auxiliary_config_bridge`, `test_auxiliary_transient_retry`) 185/185