### PR TITLE
fix(desktop): preserve redirect reply order

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -603,9 +603,14 @@ export function useMessageStream({
         if (streamId && prev.some(m => m.id === streamId)) {
           nextMessages = prev.map(m => (m.id === streamId ? completeMessage(m) : m))
         } else {
+          const latestUserIndex = prev.map(message => message.role).lastIndexOf('user')
           const fallbackIndex = [...prev]
+            .map((message, index) => ({ message, index }))
             .reverse()
-            .findIndex(message => message.role === 'assistant' && !message.hidden)
+            .findIndex(
+              ({ message, index }) =>
+                index > latestUserIndex && message.role === 'assistant' && !message.hidden
+            )
 
           if (fallbackIndex >= 0) {
             const index = prev.length - 1 - fallbackIndex

--- a/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ClientSessionState } from '@/app/types'
-import { chatMessageText } from '@/lib/chat-messages'
+import { chatMessageText, textPart } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { clearSessionTodos } from '@/store/todos'
 import type { RpcEvent } from '@/types/hermes'
@@ -18,10 +18,16 @@ let sessionStates: Map<string, ClientSessionState>
 let mockCompleteSound: ReturnType<typeof vi.fn>
 let mockHaptic: ReturnType<typeof vi.fn>
 
-function Harness() {
+function Harness({ seedMessages = [] }: { seedMessages?: ClientSessionState['messages'] }) {
   const activeSessionIdRef = useRef<string | null>(SID)
   const sessionStateByRuntimeIdRef = useRef(new Map<string, ClientSessionState>())
   const queryClientRef = useRef(new QueryClient())
+
+  if (seedMessages.length && !sessionStateByRuntimeIdRef.current.has(SID)) {
+    const initial = { ...createClientSessionState(), messages: seedMessages }
+    sessionStateByRuntimeIdRef.current.set(SID, initial)
+    sessionStates.set(SID, initial)
+  }
 
   const stream = useMessageStream({
     activeSessionIdRef,
@@ -47,9 +53,9 @@ function Harness() {
   return null
 }
 
-async function mountStream() {
+async function mountStream(seedMessages: ClientSessionState['messages'] = []) {
   sessionStates = new Map()
-  render(<Harness />)
+  render(<Harness seedMessages={seedMessages} />)
   await waitFor(() => expect(handleEvent).not.toBeNull())
 }
 
@@ -184,6 +190,27 @@ describe('useMessageStream interim text sealing', () => {
     // Turn is still active — busy stays true
     expect(getState().busy).toBe(true)
     expect(getState().interimBoundaryPending).toBe(true)
+  })
+
+  it('starts the redirected reply after the correction instead of reusing the old bubble', async () => {
+    await mountStream([
+      { id: 'user-1', role: 'user', parts: [textPart('original prompt')] },
+      { id: 'assistant-1', role: 'assistant', interim: true, parts: [textPart('old partial reply')] },
+      { id: 'user-2', role: 'user', parts: [textPart('use the local fix')] }
+    ])
+    await start()
+
+    await delta('new reply')
+    await complete('new reply')
+
+    expect(
+      getState().messages.map(message => `${message.role}:${chatMessageText(message)}`)
+    ).toEqual([
+      'user:original prompt',
+      'assistant:old partial reply',
+      'user:use the local fix',
+      'assistant:new reply'
+    ])
   })
 
   it('settles an identical final onto a non-previewed interim (tool-call turn) instead of duplicating (#63679)', async () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -106,7 +106,8 @@ function Harness({
   selectedStoredSessionIdRef: selectedStoredSessionIdRefProp,
   storedSessionId,
   activeSessionId,
-  createBackendSessionForSend
+  createBackendSessionForSend,
+  seedState
 }: {
   activeSessionIdRef?: MutableRefObject<string | null>
   busyRef?: MutableRefObject<boolean>
@@ -125,6 +126,7 @@ function Harness({
   requestGateway: <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<T>
   resumeStoredSession?: (storedSessionId: string) => Promise<void> | void
   seedMessages?: unknown[]
+  seedState?: Record<string, unknown>
   selectedStoredSessionIdRef?: MutableRefObject<string | null>
   storedSessionId?: null | string
   activeSessionId?: null | string
@@ -146,7 +148,8 @@ function Harness({
     messages: seedMessages ?? [],
     busy: false,
     awaitingResponse: false,
-    interrupted: true
+    interrupted: true,
+    ...seedState
   } as never)
 
   const actions = usePromptActions({
@@ -2094,6 +2097,65 @@ describe('usePromptActions redirectPrompt', () => {
     expect((capturedStates.at(-1)?.messages as unknown[]).at(-1)).toMatchObject({
       role: 'user',
       parts: [{ type: 'text', text: 'nudge the run' }]
+    })
+  })
+
+  it('keeps the old reply before the redirect and starts the retried reply after it', async () => {
+    const requestGateway = vi.fn(async () => ({ status: 'redirected' }) as never)
+    const capturedStates: Record<string, unknown>[] = []
+
+    const seedMessages = [
+      { id: 'u1', role: 'user', parts: [textPart('original prompt')] },
+      { id: 'a1', role: 'assistant', interim: true, parts: [textPart('checking the files')] },
+      { id: 'a2', role: 'assistant', pending: true, parts: [textPart('continuing the check')] }
+    ]
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={state => capturedStates.push(state)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        seedMessages={seedMessages}
+      />
+    )
+
+    expect(await handle!.redirectPrompt('use the local fix')).toBe(true)
+
+    const messages = capturedStates.at(-1)?.messages as { role: string; parts: { text?: string }[] }[]
+    expect(messages.map(message => message.parts.map(part => part.text ?? '').join(''))).toEqual([
+      'original prompt',
+      'checking the files',
+      'continuing the check',
+      'use the local fix'
+    ])
+  })
+
+  it('seals the active stream before appending a redirect correction', async () => {
+    const requestGateway = vi.fn(async () => ({ status: 'redirected' }) as never)
+    const capturedStates: Record<string, unknown>[] = []
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={state => capturedStates.push(state)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        seedMessages={[{ id: 'stream-1', role: 'assistant', pending: true, parts: [textPart('partial')] }]}
+        seedState={{ streamId: 'stream-1', busy: true, awaitingResponse: true, interrupted: false }}
+      />
+    )
+
+    expect(await handle!.redirectPrompt('use the local fix')).toBe(true)
+
+    const state = capturedStates.at(-1) as Record<string, unknown>
+    expect(state.streamId).toBeNull()
+    expect((state.messages as { id: string; pending?: boolean; interim?: boolean }[])[0]).toMatchObject({
+      id: 'stream-1',
+      pending: false,
+      interim: true
     })
   })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -279,7 +279,7 @@ export function usePromptActions({
       role: ChatMessage['role'],
       text: string,
       storedSessionId?: string | null,
-      options: { insertBeforeActiveReply?: boolean } = {}
+      options: { appendAfterActiveReply?: boolean } = {}
     ) => {
       // Strip ANSI: slash-command output from the backend worker carries SGR
       // color codes (e.g. "Unknown command" in red). The ESC byte is invisible
@@ -302,23 +302,40 @@ export function usePromptActions({
             parts: [textPart(body)]
           }
 
-          const streamIndex =
-            options.insertBeforeActiveReply && state.streamId
-              ? state.messages.findIndex(candidate => candidate.id === state.streamId)
-              : -1
-
-          const lastAssistantIndex = options.insertBeforeActiveReply
-            ? state.messages.map(candidate => candidate.role).lastIndexOf('assistant')
-            : -1
-
-          const insertionIndex = streamIndex >= 0 ? streamIndex : lastAssistantIndex
+          // A redirect is a new user boundary after the partial reply that was
+          // already shown. Keep the old assistant segments in place, then put
+          // the correction at the tail so the retried answer is rendered after
+          // it. The active stream must also be sealed here: redirect() cancels
+          // the provider request and retries inside the same gateway turn, so
+          // no second message.start event is guaranteed to clear streamId for
+          // us. Leaving it set would append the retried answer to the old
+          // bubble, placing the answer before its correction.
+          const activeStreamId = options.appendAfterActiveReply ? state.streamId : null
+          const messagesBeforeAppend =
+            activeStreamId === null
+              ? state.messages
+              : state.messages.map(candidate =>
+                  candidate.id === activeStreamId
+                    ? { ...candidate, pending: false, interim: true }
+                    : candidate
+                )
+          const insertionIndex = options.appendAfterActiveReply ? messagesBeforeAppend.length : -1
 
           const messages =
             insertionIndex >= 0
-              ? [...state.messages.slice(0, insertionIndex), message, ...state.messages.slice(insertionIndex)]
-              : [...state.messages, message]
+              ? [...messagesBeforeAppend.slice(0, insertionIndex), message, ...messagesBeforeAppend.slice(insertionIndex)]
+              : [...messagesBeforeAppend, message]
 
-          return { ...state, messages }
+          return {
+            ...state,
+            messages,
+            ...(options.appendAfterActiveReply
+              ? {
+                  streamId: null,
+                  interimBoundaryPending: activeStreamId !== null || state.interimBoundaryPending
+                }
+              : {})
+          }
         },
         storedSessionId ?? selectedStoredSessionIdRef.current
       )
@@ -721,10 +738,10 @@ export function usePromptActions({
       // transcript rather than a system note that changes role after reload.
       const send = async (id: string): Promise<boolean> => {
         // Redirect aborts the model request, so the completion event can race
-        // its RPC response. Insert before the live reply *before* awaiting the
-        // gateway; appending after the response leaves the correction below a
-        // reply that the redirect has already replaced.
-        const messageId = appendSessionTextMessage(id, 'user', text, undefined, { insertBeforeActiveReply: true })
+        // its RPC response. Seal the visible partial and append the correction
+        // before awaiting the gateway; the retried stream then starts after the
+        // correction even though the gateway keeps the same logical turn.
+        const messageId = appendSessionTextMessage(id, 'user', text, undefined, { appendAfterActiveReply: true })
 
         const discardOptimisticMessage = () =>
           updateSessionState(id, state => ({


### PR DESCRIPTION
## Summary

Fix reply ordering when a prompt is redirected during an active response. The existing partial reply is sealed, the corrected user prompt stays after it, and the retried reply starts after the correction.

## Validation

- 119 targeted UI tests passed
- Verified in Hermes Local Fix on macOS