### PR TITLE
fix: use atomic_config_write for /model persist to correct profile (#81764)

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2003,8 +2003,7 @@ class GatewaySlashCommandsMixin:
                                         _persist_model_cfg.pop("api_mode", None)
                                 else:
                                     clear_model_endpoint_credentials(_persist_model_cfg, clear_base_url=True)
-                                from hermes_cli.config import save_config
-                                save_config(_persist_cfg)
+                                atomic_config_write(config_path, _persist_cfg)
                             except Exception as e:
                                 logger.warning("Failed to persist model switch: %s", e)
 
@@ -2328,8 +2327,7 @@ class GatewaySlashCommandsMixin:
                             model_cfg.pop("api_mode", None)
                     else:
                         clear_model_endpoint_credentials(model_cfg, clear_base_url=True)
-                    from hermes_cli.config import save_config
-                    save_config(cfg)
+                    atomic_config_write(config_path, cfg)
                 except Exception as e:
                     logger.warning("Failed to persist model switch: %s", e)
 


### PR DESCRIPTION
## Summary

Replace `save_config()` with `atomic_config_write(config_path, ...)` at both `/model` persist sites in `gateway/slash_commands.py`.

## Problem

In a multiplexed gateway (`gateway.multiplex_profiles: true`), running `/model <name> --global` from a group routed to a secondary profile:

1. **Reads** the secondary profile's `config.yaml` (correct — `config_path` is resolved from `_command_profile_home`)
2. **Writes** via `save_config()` which always writes to the **default** profile's `config.yaml` (wrong — `save_config()` uses `get_config_path()` → `get_hermes_home()` → default `~/.hermes/config.yaml`)

This overwrites the default profile's entire config with the secondary profile's config, silently destroying `gateway.multiplex_profiles`, `gateway.profile_routes`, and `gateway.platforms.<platform>.extra.group_rules`. After the next gateway restart, group routing stops working.

## Fix

Replace `save_config(_persist_cfg)` / `save_config(cfg)` with `atomic_config_write(config_path, _persist_cfg)` / `atomic_config_write(config_path, cfg)` at both persist sites:

- **Line ~2006**: Interactive picker path
- **Line ~2331**: Text-command path

`atomic_config_write` is already imported at line 43. `config_path` is already correctly resolved at line 1735 to `(_command_profile_home or _hermes_home) / "config.yaml"`.

## Changes

| File | Line | Old | New |
|------|------|-----|-----|
| `gateway/slash_commands.py` | ~2006 | `save_config(_persist_cfg)` | `atomic_config_write(config_path, _persist_cfg)` |
| `gateway/slash_commands.py` | ~2331 | `save_config(cfg)` | `atomic_config_write(config_path, cfg)` |

## Test Plan

- [ ] Verify `/model --global` from a multiplexed group updates the correct profile's config
- [ ] Verify `/model --global` from a DM still works (default profile path)
- [ ] Verify `/model` without `--global` still works
- [ ] Verify config.yaml retains `gateway` section after model switch

Fixes #81764