### PR TITLE
fix(skills): follow symlinked skill dirs in _find_skill and learning graph

### DIFF
--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -650,11 +650,16 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     external dirs configured via skills.external_dirs.  Returns
     {"path": Path} or None.
     """
-    from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path
+    from agent.skill_utils import (
+        get_all_skills_dirs,
+        is_excluded_skill_path,
+        iter_skill_index_files,
+    )
     for skills_dir in get_all_skills_dirs():
         if not skills_dir.exists():
             continue
-        for skill_md in skills_dir.rglob("SKILL.md"):
+        # iter_skill_index_files uses os.walk(followlinks=True); rglob skips symlinked skill dirs
+        for skill_md in iter_skill_index_files(skills_dir, "SKILL.md"):
             if is_excluded_skill_path(skill_md):
                 continue
             if skill_md.parent.name == name:


### PR DESCRIPTION
Problem
Path.rglob() does not follow directory symlinks. Skills that are symlinked into the skills dir from elsewhere (e.g. lark-* -> ~/.agents/skills/*) are invisible to _find_skill() in tools/skill_manager_tool.py and to the learning graph scanner in agent/learning_graph.py.

Symptom
The skills list API (/api/skills, which scans with os.walk(followlinks=True)) shows symlinked skills like lark-base.
Opening the same skill in the desktop app "技能与工具" (Skills & Tools) UI calls /api/learning/node -> _find_skill(), which scans with Path.rglob() and cannot find the symlinked skill, returning skill 'lark-base' not found.
Fix
Use iter_skill_index_files() (an os.walk(..., followlinks=True) based scanner that already powers the skills list) in both places, so detail/edit and learning-graph discovery behave consistently with the list.

Verification
_find_skill('lark-base') returned None before, now returns the resolved skill path.
_find_skill() for regular (non-symlinked) skills is unaffected.
iter_skill_index_files() already excludes support dirs (references/templates/assets/scripts), VCS, and dependency dirs.