### PR TITLE
fix(skills): follow symlinked skill dirs in _find_skill and learning graph

### DIFF
--- a/agent/learning_graph.py
+++ b/agent/learning_graph.py
@@ -75,9 +75,10 @@ def _category(fm: dict[str, Any], skill_md: Path) -> str:
 
 
 def _iter_skill_files(roots: list[tuple[str, Path]]):
+    from agent.skill_utils import iter_skill_index_files
     for source, root in roots:
         if root.exists():
-            for path in root.rglob("SKILL.md"):
+            for path in iter_skill_index_files(root, "SKILL.md"):
                 yield source, path
 
 


### PR DESCRIPTION
Problem
Path.rglob() does not follow directory symlinks. Skills that are symlinked into the skills dir from elsewhere (e.g. lark-* -> ~/.agents/skills/*) are invisible to _find_skill() in tools/skill_manager_tool.py and to the learning graph scanner in agent/learning_graph.py.

Symptom
The skills list API (/api/skills, which scans with os.walk(followlinks=True)) shows symlinked skills like lark-base.
Opening the same skill in the desktop app "技能与工具" (Skills & Tools) UI calls /api/learning/node -> _find_skill(), which scans with Path.rglob() and cannot find the symlinked skill, returning skill 'lark-base' not found.
Fix
Use iter_skill_index_files() (an os.walk(..., followlinks=True) based scanner that already powers the skills list) in both places, so detail/edit and learning-graph discovery behave consistently with the list.

Verification
_find_skill('lark-base') returned None before, now returns the resolved skill path.
_find_skill() for regular (non-symlinked) skills is unaffected.
iter_skill_index_files() already excludes support dirs (references/templates/assets/scripts), VCS, and dependency dirs.