### PR TITLE
fix(desktop): guard incremental thread sync against reordered or duplicated exports

### DIFF
--- a/apps/desktop/src/lib/incremental-external-store-runtime.test.ts
+++ b/apps/desktop/src/lib/incremental-external-store-runtime.test.ts
@@ -141,4 +141,35 @@ describe('syncRepositoryIncrementally', () => {
 
     expect(result.map(item => item.id)).toEqual(['a'])
   })
+
+  it('rebuilds instead of diffing when ids keep their length but reorder', () => {
+    const a = message('a', 'one')
+    const b = message('b', 'two')
+    const runtime = runtimeWith(chain([a, b]))
+    const repository = (runtime as unknown as { repository: MessageRepository }).repository
+    const addOrUpdate = vi.spyOn(repository, 'addOrUpdateMessage')
+
+    // Same length, same ids — but the store swapped the order. An in-place
+    // diff would silently leave the tree in the OLD order (stale thread);
+    // the order check forces the full rebuild so the swap is reflected.
+    const result = syncRepositoryIncrementally(runtime, exported(chain([b, a])))
+
+    expect(result.map(item => item.id)).toEqual(['b', 'a'])
+    expect(addOrUpdate).toHaveBeenCalled()
+  })
+
+  it('rebuilds instead of diffing when the incoming export contains a duplicated id', () => {
+    const a = message('a', 'one')
+    const runtime = runtimeWith(chain([a]))
+    const repository = (runtime as unknown as { repository: MessageRepository }).repository
+    const addOrUpdate = vi.spyOn(repository, 'addOrUpdateMessage')
+
+    // A doubled id in the store export (upstream transcript bug) must not
+    // reach the repository tree: the tree holds one node per id, and a
+    // silent diff would render the same turn twice.
+    const result = syncRepositoryIncrementally(runtime, exported(chain([a, a])))
+
+    expect(result.map(item => item.id)).toEqual(['a'])
+    expect(addOrUpdate).toHaveBeenCalledTimes(1)
+  })
 })

--- a/apps/desktop/src/lib/incremental-external-store-runtime.ts
+++ b/apps/desktop/src/lib/incremental-external-store-runtime.ts
@@ -57,6 +57,26 @@ function applyChangedMessages(
     return false
   }
 
+  // The incremental fast path is only valid for IN-PLACE content updates on
+  // an unchanged order. A same-length structural change — an insert paired
+  // with a delete, a reorder, or a duplicated id in either export — must
+  // fall back to the full rebuild: diffing per item below would leave the
+  // repository tree in the OLD order while the store advertises the NEW one,
+  // so the runtime keeps rendering a stale thread (and a duplicated id
+  // renders the same turn twice) that only a rebuild can heal.
+  for (let index = 0; index < incoming.length; index += 1) {
+    if (existing[index]?.message.id !== incoming[index]?.message.id) {
+      return false
+    }
+  }
+
+  const existingIds = new Set(existing.map(item => item.message.id))
+  const incomingIds = new Set(incoming.map(item => item.message.id))
+
+  if (existingIds.size !== existing.length || incomingIds.size !== incoming.length) {
+    return false
+  }
+
   const existingById = new Map(existing.map(item => [item.message.id, item]))
 
   for (const item of incoming) {
@@ -109,7 +129,19 @@ export function syncRepositoryIncrementally(
     }
   }
 
+  // Rebuild with per-id dedup: the repository tree can only hold ONE node
+  // per id, and linking the same id twice (a duplicated store export)
+  // self-parents the node and hangs getMessages in an infinite prev-walk.
+  // Keep the first occurrence — the later copy carries the same id, so it
+  // is the row we already added.
+  const seenIncoming = new Set<string>()
+
   for (const { message, parentId } of incoming) {
+    if (seenIncoming.has(message.id)) {
+      continue
+    }
+
+    seenIncoming.add(message.id)
     repository.addOrUpdateMessage(parentId, message)
   }
 


### PR DESCRIPTION
## Summary

Hardens the desktop's incremental thread sync (`syncRepositoryIncrementally`) against two structural corruptions that the incremental fast path currently lets through silently:

1. **Reordered exports**: `applyChangedMessages` only compared lengths before diffing per item, so a same-length structural change (an insert paired with a delete, or a reorder) returned `true` while leaving the repository tree in its OLD order. The runtime then kept rendering a stale thread — only a full rebuild could heal it. The new order check declines the fast path and falls back to the full rebuild.
2. **Duplicated ids**: a duplicated id in the incoming store export slipped past the per-item diff (the map lookup only sees the last copy). Diffing is now declined, and the rebuild loop dedupes by id — linking the same id twice would self-parent the node and hang `getMessages` in an infinite `prev`-walk.

This is the same failure class the `seenIds` guard in `useRuntimeMessageRepository` (app/chat/runtime-repository.ts) defends one layer up ("A repeated id is a transcript bug upstream, but it must not reach the repository"); this PR defends the tree itself, at the sync boundary.

## Context

Reported in #81772: the desktop occasionally renders the entire message list twice (a stale snapshot + a live copy), reproduced across sessions, temporarily healed by restarting the app. The renderer-side duplication path is still under investigation (likely the keep-alive pane mechanism family — #71406 / #81351), but these guards make the incremental runtime structurally unable to produce a doubled or stale thread from a duplicated/reordered store export, and they remove a silent-divergence bug that could strand a thread in a stale state indefinitely.

## Changes

- `applyChangedMessages`: require the incoming id sequence to match the existing export order before taking the fast path; reject duplicated ids on either side
- rebuild loop: dedupe by id (keep the first occurrence — the later copy carries the same id, so it is the row already added)

## Tests

- reordered ids with equal length → full rebuild, order reflected
- duplicated id in the incoming export → single occurrence, one `addOrUpdateMessage` call

All 9 tests in `incremental-external-store-runtime.test.ts` pass, plus 32 related tests (`runtime-repository`, `chat-runtime`) and `tsc --noEmit`.
