### PR TITLE
Harden the Desktop renderer: webview attach-time preferences + a packaged-build CSP

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -209,6 +209,7 @@ import {
 import { formatBlockerMessage, formatProbeFailedMessage, scanVenvBlockers } from './venv-blocker-scan'
 import { fetchMarketplaceThemes, searchMarketplaceThemes } from './vscode-marketplace'
 import { createWakeIndicatorWindowController } from './wake-indicator-window'
+import { applyWebviewHardening, shouldBlockWebviewAttach } from './webview-hardening'
 import {
   computeWindowOptions,
   debounce,
@@ -11823,6 +11824,25 @@ if (!_gotSingleInstanceLock) {
     })
   })
 }
+
+// Chat windows enable `webviewTag`, so any script in the renderer can create a
+// <webview> and ask for its own webPreferences via element attributes. The
+// preview pane sets safe ones; this makes them mandatory for every guest,
+// however it was created. Registered at module scope (not inside whenReady) so
+// no window can attach a guest before the guard is listening. See
+// electron/webview-hardening.ts for why this belongs here rather than in markup.
+app.on('web-contents-created', (_event, contents) => {
+  contents.on('will-attach-webview', (event, webPreferences, params) => {
+    if (shouldBlockWebviewAttach(params)) {
+      rememberLog(`[webview] blocked guest carrying its own preload: ${params.preload}`)
+      event.preventDefault()
+
+      return
+    }
+
+    applyWebviewHardening(webPreferences)
+  })
+})
 
 // macOS delivers deep links via 'open-url' — register early (can fire before
 // whenReady; handleDeepLink queues until the renderer is ready).

--- a/apps/desktop/electron/webview-hardening.test.ts
+++ b/apps/desktop/electron/webview-hardening.test.ts
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+import { test } from 'vitest'
+
+import { applyWebviewHardening, hardenedWebviewPreferences, shouldBlockWebviewAttach } from './webview-hardening'
+
+const mainSource = () => readFileSync(fileURLToPath(new URL('./main.ts', import.meta.url)), 'utf8')
+
+test('hardenedWebviewPreferences strips a guest-requested nodeIntegration', () => {
+  const hardened = hardenedWebviewPreferences({ nodeIntegration: true })
+
+  assert.equal(hardened.nodeIntegration, false)
+})
+
+test('hardenedWebviewPreferences strips every Node-bearing escalation key at once', () => {
+  const hardened = hardenedWebviewPreferences({
+    contextIsolation: false,
+    nodeIntegration: true,
+    nodeIntegrationInSubFrames: true,
+    nodeIntegrationInWorker: true,
+    sandbox: false,
+    webSecurity: false
+  })
+
+  assert.deepEqual(
+    {
+      contextIsolation: hardened.contextIsolation,
+      nodeIntegration: hardened.nodeIntegration,
+      nodeIntegrationInSubFrames: hardened.nodeIntegrationInSubFrames,
+      nodeIntegrationInWorker: hardened.nodeIntegrationInWorker,
+      sandbox: hardened.sandbox,
+      webSecurity: hardened.webSecurity
+    },
+    {
+      contextIsolation: true,
+      nodeIntegration: false,
+      nodeIntegrationInSubFrames: false,
+      nodeIntegrationInWorker: false,
+      sandbox: true,
+      webSecurity: true
+    }
+  )
+})
+
+test('hardenedWebviewPreferences drops a guest preload instead of forwarding it', () => {
+  const hardened = hardenedWebviewPreferences({ preload: '/tmp/evil-preload.js' })
+
+  assert.equal('preload' in hardened, false)
+})
+
+test('hardenedWebviewPreferences refuses to let a guest re-enable the webview tag', () => {
+  const hardened = hardenedWebviewPreferences({ webviewTag: true })
+
+  assert.equal(hardened.webviewTag, false)
+})
+
+test('hardenedWebviewPreferences preserves unrelated preferences the preview pane relies on', () => {
+  const hardened = hardenedWebviewPreferences({ partition: 'persist:hermes-preview', transparent: true })
+
+  assert.equal(hardened.partition, 'persist:hermes-preview')
+  assert.equal(hardened.transparent, true)
+})
+
+test('hardenedWebviewPreferences is safe on an empty request', () => {
+  const hardened = hardenedWebviewPreferences()
+
+  assert.equal(hardened.nodeIntegration, false)
+  assert.equal(hardened.contextIsolation, true)
+  assert.equal(hardened.sandbox, true)
+})
+
+test('shouldBlockWebviewAttach refuses a guest that brings its own preload', () => {
+  assert.equal(shouldBlockWebviewAttach({ preload: '/tmp/evil-preload.js' }), true)
+})
+
+test('shouldBlockWebviewAttach allows the ordinary preview guest', () => {
+  assert.equal(shouldBlockWebviewAttach({ src: 'https://example.com/' } as { preload?: unknown }), false)
+  assert.equal(shouldBlockWebviewAttach({}), false)
+  assert.equal(shouldBlockWebviewAttach({ preload: '' }), false)
+})
+
+// Electron honours whatever is left on the live object, so a delete-only key
+// (preload) must really be gone — Object.assign alone would have kept it.
+test('applyWebviewHardening deletes a guest preload from the live object', () => {
+  const live: Record<string, unknown> = { nodeIntegration: true, preload: '/tmp/evil-preload.js' }
+
+  applyWebviewHardening(live)
+
+  assert.equal('preload' in live, false)
+  assert.equal(live.nodeIntegration, false)
+})
+
+test('applyWebviewHardening mutates in place and returns the same object', () => {
+  const live: Record<string, unknown> = { partition: 'persist:hermes-preview' }
+
+  assert.equal(applyWebviewHardening(live), live)
+  assert.equal(live.partition, 'persist:hermes-preview')
+  assert.equal(live.sandbox, true)
+})
+
+// The pure helper only protects anything if main.ts actually subscribes. This is
+// the regression that would otherwise rot silently: someone deletes the wiring,
+// every unit test above still passes, and webviewTag is unguarded again.
+test('main.ts wires the hardening into will-attach-webview', () => {
+  const source = mainSource()
+
+  assert.match(source, /will-attach-webview/)
+  assert.match(source, /applyWebviewHardening/)
+  assert.match(source, /shouldBlockWebviewAttach/)
+})

--- a/apps/desktop/electron/webview-hardening.ts
+++ b/apps/desktop/electron/webview-hardening.ts
@@ -1,0 +1,96 @@
+/**
+ * `<webview>` attach-time hardening.
+ *
+ * Chat windows run with `webviewTag: true` (session-windows.ts) because the
+ * preview pane embeds a real `<webview>` for local/remote page previews. That
+ * flag is a renderer capability: ANY script running in the renderer can create
+ * a `<webview>` element, and the element's own attributes — `nodeintegration`,
+ * `preload`, `webpreferences`, `allowpopups`, `disablewebsecurity` — are what
+ * Electron uses to build the guest's webPreferences. The preview pane sets safe
+ * ones, but nothing forces every other creator to.
+ *
+ * `will-attach-webview` is the only place the main process gets to overrule
+ * that, which is why Electron's security checklist ("Verify WebView options
+ * before creation") puts the check here rather than trusting the markup. This
+ * module holds the pure decision so it can be unit-tested without Electron,
+ * matching how the rest of electron/*.ts splits testable logic out of main.ts.
+ *
+ * This is defence in depth: reaching it requires script execution in the
+ * renderer already. The point is that such a foothold must not be promotable to
+ * Node — a `<webview nodeintegration>` would hand the guest `require()` in-process.
+ */
+
+/** webPreferences keys that must never survive attach, whatever the markup asked for. */
+const FORBIDDEN_PREFERENCE_KEYS = [
+  'allowRunningInsecureContent',
+  'contextIsolation',
+  'experimentalFeatures',
+  'nodeIntegration',
+  'nodeIntegrationInSubFrames',
+  'nodeIntegrationInWorker',
+  'preload',
+  'sandbox',
+  'webSecurity',
+  'webviewTag'
+] as const
+
+/**
+ * Rewrite a guest's webPreferences to the only shape Desktop supports.
+ *
+ * Deletes rather than overwrites the Node-bearing keys the guest asked for, then
+ * re-asserts the safe values, so an unknown future key spelled like `preload`
+ * cannot survive by being set twice. `nodeIntegration` is written explicitly
+ * (not merely deleted) so the result is self-describing at the call site.
+ */
+export function hardenedWebviewPreferences(requested: object = {}): Record<string, unknown> {
+  const hardened: Record<string, unknown> = { ...requested }
+
+  for (const key of FORBIDDEN_PREFERENCE_KEYS) {
+    delete hardened[key]
+  }
+
+  hardened.contextIsolation = true
+  hardened.nodeIntegration = false
+  hardened.nodeIntegrationInSubFrames = false
+  hardened.nodeIntegrationInWorker = false
+  hardened.sandbox = true
+  hardened.webSecurity = true
+  hardened.webviewTag = false
+
+  return hardened
+}
+
+/**
+ * Mutate Electron's live `webPreferences` object into the hardened shape.
+ *
+ * `will-attach-webview` hands the handler the real object and honours whatever
+ * is left on it after the listener returns — so a key must be *deleted*, not
+ * merely overwritten. `Object.assign(target, hardened())` would silently keep a
+ * guest-supplied `preload`, which is the one key with no safe value to write.
+ */
+export function applyWebviewHardening<T extends object>(target: T): T {
+  const hardened = hardenedWebviewPreferences(target)
+  // Electron's WebPreferences has no index signature; the delete pass needs one.
+  const view = target as Record<string, unknown>
+
+  for (const key of Object.keys(view)) {
+    if (!(key in hardened)) {
+      delete view[key]
+    }
+  }
+
+  return Object.assign(target, hardened)
+}
+
+/**
+ * Should this `<webview>` be allowed to attach at all?
+ *
+ * A guest carrying its own `preload` is the one case worth refusing outright
+ * rather than sanitising: a preload runs before page script with the guest's
+ * privileges, and no legitimate Desktop surface sets one. Everything else is
+ * repairable by {@link hardenedWebviewPreferences}, and destroying those guests
+ * would break the preview pane for no security gain.
+ */
+export function shouldBlockWebviewAttach(params: { preload?: unknown } = {}): boolean {
+  return typeof params.preload === 'string' && params.preload.length > 0
+}

--- a/apps/desktop/scripts/renderer-csp.mjs
+++ b/apps/desktop/scripts/renderer-csp.mjs
@@ -1,0 +1,139 @@
+import { createHash } from 'node:crypto'
+
+/**
+ * Content-Security-Policy for the packaged renderer.
+ *
+ * The production renderer is a `file://` document (electron/main.ts loads
+ * `pathToFileURL(resolveRendererIndex())`), so there are no response headers to
+ * attach a policy to — it has to be a `<meta http-equiv>` injected into the built
+ * HTML. That is why this lives in a build step and not in index.html: the dev
+ * server needs `'unsafe-eval'` and a websocket to Vite, and neither may ever
+ * reach a packaged build.
+ *
+ * Every source below is here because something real breaks without it. The
+ * non-obvious ones, so nobody "tidies" them away:
+ *
+ * - `'wasm-unsafe-eval'` — shiki's Oniguruma engine is instantiated from an
+ *   inlined base64 wasm binary. Without it ALL syntax highlighting silently
+ *   falls back to plain text (chat code blocks, file preview, diffs).
+ * - `blob:` in script-src — the desktop plugin runtime compiles each plugin to a
+ *   `text/javascript` Blob and ESM-imports the blob URL, and the SDK shims it
+ *   rewrites bare specifiers to are themselves blob modules. This runs at module
+ *   scope during boot, so omitting it is a boot-time error toast, not a lazy one.
+ * - `hermes-media:` — local audio/video is streamed through a privileged custom
+ *   Electron scheme, not file:/data:. A custom scheme is never implied by 'self'
+ *   or by a default-src fallback; it must be named literally or every local clip
+ *   dies silently.
+ * - the Google Fonts pair — the DEFAULT theme injects a stylesheet <link> at
+ *   module-evaluation time, so omitting these is a guaranteed violation on every
+ *   launch of a default install. They must be granted together: the stylesheet
+ *   (googleapis) is useless without the font files (gstatic).
+ * - the three embed origins — social embeds inject provider scripts into the
+ *   top-level document by design.
+ *
+ * `worker-src 'none'` is explicit on purpose: the app has no Worker of any kind,
+ * and without it worker-src falls back to script-src — which now contains
+ * `blob:`, silently granting blob: workers we never want.
+ *
+ * `frame-ancestors` is deliberately absent: Chromium ignores it (along with
+ * `sandbox` and `report-uri`) when a policy is delivered via <meta>, so including
+ * it would only log a warning at every boot and read as protection that is not
+ * actually there. Anti-framing for the renderer would need an onHeadersReceived
+ * header instead.
+ *
+ * KNOWN TRADE-OFF: an `about:srcdoc` iframe inherits its embedder's policy, so a
+ * strict script-src also stops scripts inside the HTML-artifact preview
+ * (right-rail/preview-artifact.tsx). Verified by launching Electron 40, not
+ * assumed — a `blob:` iframe inherits identically, so there is no cheap
+ * exemption. Interactive artifacts therefore render statically inline and must
+ * use the existing "Open in browser" action to run. That is the deliberate cost
+ * of closing injected-script execution in a renderer that displays
+ * model-authored markdown.
+ */
+const DIRECTIVES = [
+  ['default-src', ["'none'"]],
+  [
+    'script-src',
+    [
+      "'self'",
+      "'wasm-unsafe-eval'",
+      'blob:',
+      'https://www.instagram.com',
+      'https://www.tiktok.com',
+      'https://platform.twitter.com'
+    ]
+  ],
+  ['style-src', ["'self'", "'unsafe-inline'", 'https://fonts.googleapis.com']],
+  ['img-src', ["'self'", 'data:', 'blob:', 'https:', 'hermes-media:']],
+  ['media-src', ["'self'", 'data:', 'blob:', 'https:', 'hermes-media:']],
+  ['font-src', ["'self'", 'data:', 'https://fonts.gstatic.com']],
+  // Deliberately permissive: the user types an arbitrary gateway host/port at
+  // first run and in settings, and the RENDERER dials it directly. A fixed
+  // allowlist here would break every remote and cloud connection.
+  ['connect-src', ["'self'", 'data:', 'blob:', 'http:', 'https:', 'ws:', 'wss:', 'hermes-media:']],
+  ['frame-src', ["'self'", 'data:', 'blob:', 'https:']],
+  ['worker-src', ["'none'"]],
+  ['object-src', ["'none'"]],
+  ['base-uri', ["'none'"]],
+  ['form-action', ["'none'"]]
+]
+
+const INLINE_SCRIPT = /<script(?![^>]*\ssrc=)([^>]*)>([\s\S]*?)<\/script>/gi
+
+/** sha256-… source expression for one inline script body. */
+export function inlineScriptHash(body) {
+  return `'sha256-${createHash('sha256').update(body, 'utf8').digest('base64')}'`
+}
+
+/**
+ * Hashes of every inline <script> in the document, in source order.
+ *
+ * Read by regex rather than a DOM parse on purpose: the hash covers the exact
+ * bytes between the tags, so re-serializing the document (which would normalise
+ * whitespace) invalidates the very hash we are computing.
+ */
+export function inlineScriptHashes(html) {
+  return [...html.matchAll(INLINE_SCRIPT)].map(match => inlineScriptHash(match[2]))
+}
+
+/** The policy string, with the supplied inline-script hashes folded into script-src. */
+export function buildRendererCsp(hashes = []) {
+  return DIRECTIVES.map(([name, sources]) =>
+    `${name} ${(name === 'script-src' ? [...sources, ...hashes] : sources).join(' ')}`
+  ).join('; ')
+}
+
+/**
+ * Splice the policy in as the first thing in <head>.
+ *
+ * Must precede the boot script it authorises, and must not disturb any other
+ * byte of the document (see inlineScriptHashes).
+ */
+export function injectCspMeta(html) {
+  const policy = buildRendererCsp(inlineScriptHashes(html))
+  const meta = `<meta http-equiv="Content-Security-Policy" content="${policy}">`
+  const head = html.match(/<head[^>]*>/i)
+
+  if (!head) {
+    throw new Error('renderer-csp: no <head> in the built HTML; refusing to ship an unprotected renderer')
+  }
+
+  const at = head.index + head[0].length
+
+  return `${html.slice(0, at)}\n    ${meta}${html.slice(at)}`
+}
+
+/**
+ * Vite plugin. Build only — never the dev server, whose HMR needs sources this
+ * policy forbids.
+ */
+export function rendererCsp() {
+  return {
+    name: 'hermes-renderer-csp',
+    apply: 'build',
+    transformIndexHtml: {
+      order: 'post',
+      handler: html => injectCspMeta(html)
+    }
+  }
+}

--- a/apps/desktop/scripts/renderer-csp.test.mjs
+++ b/apps/desktop/scripts/renderer-csp.test.mjs
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+import { test } from 'vitest'
+
+import { buildRendererCsp, inlineScriptHash, inlineScriptHashes, injectCspMeta, rendererCsp } from './renderer-csp.mjs'
+
+const directive = (policy, name) => {
+  const found = policy.split('; ').find(part => part.startsWith(`${name} `))
+
+  assert.ok(found, `policy is missing the ${name} directive`)
+
+  return found
+}
+
+test('the policy denies everything by default', () => {
+  assert.equal(directive(buildRendererCsp(), 'default-src'), "default-src 'none'")
+})
+
+// Each of these was a real breakage found by launching the app, not a guess.
+// Deleting any one of them silently kills a shipped feature, so pin them.
+test("script-src keeps 'wasm-unsafe-eval' for shiki's Oniguruma engine", () => {
+  assert.match(directive(buildRendererCsp(), 'script-src'), /'wasm-unsafe-eval'/)
+})
+
+test('script-src keeps blob: for the desktop plugin runtime', () => {
+  assert.match(directive(buildRendererCsp(), 'script-src'), /(^|\s)blob:/)
+})
+
+test('media-src and img-src keep the privileged hermes-media: scheme', () => {
+  assert.match(directive(buildRendererCsp(), 'media-src'), /hermes-media:/)
+  assert.match(directive(buildRendererCsp(), 'img-src'), /hermes-media:/)
+})
+
+test('the Google Fonts pair is granted together or not at all', () => {
+  const policy = buildRendererCsp()
+
+  assert.match(directive(policy, 'style-src'), /https:\/\/fonts\.googleapis\.com/)
+  assert.match(directive(policy, 'font-src'), /https:\/\/fonts\.gstatic\.com/)
+})
+
+test('script-src keeps the three social embed provider origins', () => {
+  const scriptSrc = directive(buildRendererCsp(), 'script-src')
+
+  for (const origin of ['https://www.instagram.com', 'https://www.tiktok.com', 'https://platform.twitter.com']) {
+    assert.match(scriptSrc, new RegExp(origin.replace(/[.]/g, '\\.')))
+  }
+})
+
+test('connect-src stays permissive because the user types an arbitrary gateway URL', () => {
+  const connectSrc = directive(buildRendererCsp(), 'connect-src')
+
+  for (const scheme of ['http:', 'https:', 'ws:', 'wss:']) {
+    assert.match(connectSrc, new RegExp(`(^|\\s)${scheme}`))
+  }
+})
+
+// The whole point of the policy. If either of these regresses, injected script
+// executes in a file:// renderer that holds the preload bridge.
+test("script-src never permits 'unsafe-inline' or 'unsafe-eval'", () => {
+  const scriptSrc = directive(buildRendererCsp(['\'sha256-abc\'']), 'script-src')
+
+  assert.doesNotMatch(scriptSrc, /'unsafe-inline'/)
+  assert.doesNotMatch(scriptSrc, /'unsafe-eval'/)
+})
+
+test("worker-src is explicitly 'none' so it cannot inherit blob: from script-src", () => {
+  assert.equal(directive(buildRendererCsp(), 'worker-src'), "worker-src 'none'")
+})
+
+// Chromium ignores frame-ancestors in a <meta>-delivered policy. Including it
+// would log a warning every boot and read as protection that is not there.
+test('the policy omits directives that are ignored when delivered via meta', () => {
+  const policy = buildRendererCsp()
+
+  assert.doesNotMatch(policy, /frame-ancestors/)
+  assert.doesNotMatch(policy, /report-uri/)
+  assert.doesNotMatch(policy, /(^|; )sandbox /)
+})
+
+test('object-src, base-uri and form-action are locked off', () => {
+  const policy = buildRendererCsp()
+
+  assert.equal(directive(policy, 'object-src'), "object-src 'none'")
+  assert.equal(directive(policy, 'base-uri'), "base-uri 'none'")
+  assert.equal(directive(policy, 'form-action'), "form-action 'none'")
+})
+
+test('inline scripts are hashed over their exact bytes, and src-ed scripts are not', () => {
+  const html = '<html><head><script>let a = 1</script><script src="./x.js"></script></head></html>'
+
+  assert.deepEqual(inlineScriptHashes(html), [inlineScriptHash('let a = 1')])
+})
+
+test('a whitespace change to an inline script changes its hash', () => {
+  assert.notEqual(inlineScriptHash('let a = 1'), inlineScriptHash('let a = 1 '))
+})
+
+test('the injected meta carries the hash of the document it was injected into', () => {
+  const html = '<html><head><script>window.boot = 1</script></head><body></body></html>'
+
+  const out = injectCspMeta(html)
+
+  assert.match(out, new RegExp(inlineScriptHash('window.boot = 1').replace(/[+/]/g, char => `\\${char}`)))
+})
+
+test('the meta is spliced in ahead of the boot script it authorises', () => {
+  const html = '<html><head><script>window.boot = 1</script></head><body></body></html>'
+
+  const out = injectCspMeta(html)
+
+  assert.ok(out.indexOf('http-equiv="Content-Security-Policy"') < out.indexOf('<script>'))
+})
+
+test('injection leaves the inline script body byte-identical', () => {
+  const body = '\n  // comment with  awkward   spacing\n  let a = 1\n'
+  const html = `<html><head><script>${body}</script></head></html>`
+
+  assert.ok(injectCspMeta(html).includes(`<script>${body}</script>`))
+})
+
+test('a document with no head is refused rather than shipped unprotected', () => {
+  assert.throws(() => injectCspMeta('<div>no head</div>'), /refusing to ship an unprotected renderer/)
+})
+
+test('the plugin runs on build only, never the dev server', () => {
+  const plugin = rendererCsp()
+
+  assert.equal(plugin.apply, 'build')
+  assert.equal(plugin.transformIndexHtml.order, 'post')
+})
+
+// The policy protects nothing if vite.config.ts stops calling the plugin.
+test('vite.config.ts registers the plugin', () => {
+  const config = readFileSync(fileURLToPath(new URL('../vite.config.ts', import.meta.url)), 'utf8')
+
+  assert.match(config, /rendererCsp/)
+})

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -4,6 +4,8 @@ import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
 import fs from 'fs'
 
+import { rendererCsp } from './scripts/renderer-csp.mjs'
+
 // `hgui` symlinks a worktree's node_modules to the main checkout. Vite realpaths
 // those before enforcing server.fs.allow, so codicon/font assets resolve outside
 // the worktree root and 404. Whitelist the real node_modules locations.
@@ -76,7 +78,7 @@ const emojibaseAssets = () => ({
 
 export default defineConfig(({ command }) => ({
   base: './',
-  plugins: [react(), tailwindcss(), emojibaseAssets()],
+  plugins: [react(), tailwindcss(), emojibaseAssets(), rendererCsp()],
   css: {
     // Pin an explicit (empty) PostCSS config. Tailwind is handled entirely by
     // `@tailwindcss/vite`, so the renderer needs no PostCSS plugins — and


### PR DESCRIPTION
Two renderer-security hardening changes for Desktop, found while auditing the frontend trust
boundaries. Both are defence in depth — neither fixes a known exploitable bug — and both are
backed by tests plus verification against a real Electron 40 window rather than docs.

Base: `ef9d5f8c060346dd16c4fad0e531de9bd3f9a379`.

---

## 1. Enforce `<webview>` preferences at attach time

Chat windows run with `webviewTag: true` (`electron/session-windows.ts:44`) because the preview
pane embeds a real `<webview>`. That flag is a **renderer** capability: any script in the renderer
can create a `<webview>`, and Electron builds the guest's `webPreferences` from element attributes
(`nodeintegration`, `preload`, `webpreferences`, `disablewebsecurity`).

Nothing overruled those attributes — there was no `will-attach-webview` or `web-contents-created`
handler anywhere in `electron/`. The only thing keeping guests safe was that the one caller you
ship (`preview-pane.tsx:557`) sets safe values in markup. Electron's security checklist puts this
check in the main process for exactly that reason.

Adds a `will-attach-webview` guard that strips the Node-bearing keys, re-asserts
`contextIsolation`/`sandbox`/`webSecurity`, and refuses outright any guest carrying its own
`preload` — the one key with no safe value to write, and one no legitimate surface sets.

The applier mutates the live object rather than `Object.assign`-ing over it: `will-attach-webview`
honours whatever remains on that object, so a guest-supplied `preload` must be **deleted**, not
overwritten. One test asserts `main.ts` still subscribes, so the wiring can't be removed while the
unit tests keep passing.

## 2. Content-Security-Policy for the packaged renderer

The production renderer is a `file://` document with **no CSP at all** — confirmed against the
packaged build, not just dev. It renders model-authored markdown, holds the preload bridge, and
deliberately injects remote third-party embed scripts into the top-level document.

Delivered as a `<meta http-equiv>` spliced in at build time (a `file://` document has no response
headers), via a Vite plugin with `apply: 'build'` so dev-server exemptions can never reach a
package. The single inline boot script is authorised by a **sha256 hash computed from the built
HTML in the same step**, so no `'unsafe-inline'` is needed and the hash can't drift if that script
is edited.

Five allowances are load-bearing. Each was found by breaking the app, and each is pinned by a test:

| Source | Without it |
|---|---|
| `'wasm-unsafe-eval'` | shiki's Oniguruma engine dies → **all** syntax highlighting becomes plain text |
| `blob:` in `script-src` | the plugin runtime ESM-imports plugins as blobs **at module scope** → fails during boot |
| `hermes-media:` | local audio/video uses a privileged custom scheme no `default-src` fallback implies |
| `fonts.googleapis` + `fonts.gstatic` | the **default** theme injects a font `<link>` at module evaluation → violation on every launch of a default install |
| permissive `connect-src` | users type an arbitrary gateway URL and the renderer dials it directly |

`frame-ancestors` is deliberately **absent** — Chromium ignores it in a meta-delivered policy, so
including it would log a warning every boot and read as protection that isn't there.
`worker-src 'none'` is explicit: there is no `Worker` anywhere in the app, and the fallback would
otherwise inherit `blob:` from `script-src`.

### Known trade-off — please review this specifically

An `about:srcdoc` iframe inherits its embedder's policy, so scripts inside the HTML-artifact
preview (`right-rail/preview-artifact.tsx`) no longer run inline. I verified this by launching
Electron 40 rather than assuming it, and also confirmed a `blob:` iframe inherits identically —
so there is no cheap exemption.

Interactive artifacts therefore render statically inline and rely on the existing **"Open in
browser"** action (`preview-artifact.tsx:238`), which already writes a temp file and hands it to
the real browser. That is a deliberate cost of closing injected-script execution in a renderer
that displays model-authored content, but it is a product call — if you'd rather keep inline
artifact interactivity, the alternative is moving that surface to a `<webview>` (which change 1
now secures) and I'm happy to do that instead.

---

## Verification

Against the real built renderer loaded in Electron 40:

```
renderer mounted, #root 45569 chars, CSP violations: 0, other errors: 0
WebAssembly.instantiate -> OK       (shiki will work)
blob: ESM import        -> OK       (plugins will work)
eval()                  -> BLOCKED  (the policy has teeth)
```

| Gate | Result |
|---|---|
| `npm run typecheck --workspace apps/desktop` | pass |
| `npm run lint --workspace apps/desktop` | 0 errors (88 pre-existing warnings, untouched) |
| `npm run test:ui --workspace apps/desktop` | 3589 passed |
| `npm run test:desktop:platforms --workspace apps/desktop` | 968 passed, 2 skipped (+19 new) |
| `npm run build --workspace apps/desktop` | pass; CSP present in `dist/index.html`, hash matches |

Every new test was confirmed to fail against the unfixed code for the intended reason before the
fix landed.

### Not verified here

`npm run test:e2e` could not run: the Hermes Python backend isn't installed in my worktree
(`ModuleNotFoundError: No module named 'yaml'`), so the app can't reach ready state regardless of
CSP. I used the renderer-level verification above instead. **The e2e boot suite and a manual pass
over artifacts, social embeds, media playback, and plugins are worth running before merge** — my
checks covered the boot path exhaustively but not every interactive surface.

No dependency changes. No visible UI changes other than the artifact trade-off noted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
