### PR TITLE
fix(desktop): route target=_blank clicks in preview webview externally (#81660)

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
@@ -110,6 +110,49 @@ describe('PreviewPane console state', () => {
     forgetPreviewStripTools(tabId)
   })
 
+  // The webview has its own webContents, so the BrowserWindow's
+  // setWindowOpenHandler never sees window.open() calls inside the previewed
+  // page. Without routing target="_blank" externally, the click was silent —
+  // Electron's default would either spawn an unmanaged BrowserWindow or
+  // dismiss the request (#81660).
+  it('routes target=_blank clicks from the webview through openExternal', async () => {
+    const openExternal = vi.fn(async () => undefined)
+    vi.stubGlobal('window', {
+      ...window,
+      hermesDesktop: {
+        openExternal
+      }
+    })
+
+    let rendered!: ReturnType<typeof render>
+    await act(async () => {
+      rendered = render(
+        <PreviewPane
+          target={{
+            kind: 'url',
+            label: 'Preview',
+            source: 'http://localhost:5174',
+            url: 'http://localhost:5174'
+          }}
+        />
+      )
+    })
+
+    const webview = rendered.container.querySelector('webview')
+    const newWindow = new Event('new-window', { cancelable: true })
+
+    Object.defineProperty(newWindow, 'url', { value: 'https://example.com/product/42' })
+
+    act(() => {
+      webview?.dispatchEvent(newWindow)
+    })
+
+    expect(openExternal).toHaveBeenCalledWith('https://example.com/product/42')
+    expect(newWindow.defaultPrevented).toBe(true)
+
+    rendered.unmount()
+  })
+
   it('renders authenticated remote HTML safely and honors source mode', async () => {
     const dataUrl = `data:text/html;base64,${btoa('<h1>remote</h1>')}`
 

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Tip } from '@/components/ui/tooltip'
 import { type Translations, useI18n } from '@/i18n'
 import { isDesktopFsRemoteMode } from '@/lib/desktop-fs'
+import { openExternalLink } from '@/lib/external-link'
 import { openPreviewTargetInBrowser, remoteHtmlPreviewDocument } from '@/lib/local-preview'
 import { rafCoalesce } from '@/lib/raf-coalesce'
 import { cn } from '@/lib/utils'
@@ -624,6 +625,22 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
     const onDevToolsOpened = () => setDevtoolsOpen(true)
     const onDevToolsClosed = () => setDevtoolsOpen(false)
 
+    // The webview has its own webContents, so the BrowserWindow's
+    // setWindowOpenHandler never sees links clicked inside it. Without this,
+    // <a target="_blank"> in the previewed page silently fails — the webview's
+    // default would open a bare BrowserWindow without our session/handlers
+    // (#81660). Route through the same IPC bridge as renderer-anchored links.
+    const onNewWindow = (event: Event) => {
+      const url = (event as Event & { url?: string }).url
+
+      if (!url) {
+        return
+      }
+
+      event.preventDefault()
+      openExternalLink(url)
+    }
+
     webview.addEventListener('console-message', onConsole)
     webview.addEventListener('devtools-closed', onDevToolsClosed)
     webview.addEventListener('devtools-opened', onDevToolsOpened)
@@ -632,6 +649,7 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
     webview.addEventListener('did-navigate-in-page', onNavigate)
     webview.addEventListener('did-start-loading', onStart)
     webview.addEventListener('did-stop-loading', onStop)
+    webview.addEventListener('new-window', onNewWindow)
     host.appendChild(webview)
     webviewRef.current = webview
 
@@ -644,6 +662,7 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
       webview.removeEventListener('did-navigate-in-page', onNavigate)
       webview.removeEventListener('did-start-loading', onStart)
       webview.removeEventListener('did-stop-loading', onStop)
+      webview.removeEventListener('new-window', onNewWindow)
       webview.remove()
     }
   }, [appendConsoleEntry, consoleState, copy, isRemoteHtml, isWebPreview, target.url])


### PR DESCRIPTION
## Problem

Clicking a product card with `target="_blank"` inside the Hermes Desktop Preview pane did nothing — the BrowserWindow's `setWindowOpenHandler` only sees renderer-level `window.open`, but the Preview pane renders the target page in a child `<webview>` element whose webContents is independent of the host window. Electron's default behavior either spawned an unmanaged window or silently dropped the request.

## Fix

`apps/desktop/src/app/chat/right-rail/preview-pane.tsx` now installs a `new-window` listener on the `<webview>` element that:
- calls the existing renderer-anchored `openExternalLink` helper (the same IPC bridge every other external link uses), and
- cancels the default window-spawn.

Listener is registered in the existing effect and removed in the cleanup.

## Tests

`preview-pane.test.tsx` — 10/10 pass (1 new + 9 existing). The new case dispatches a cancelable `new-window` event on the webview and asserts `openExternal` was called and `defaultPrevented` is true.