### PR TITLE
fix(agent): skip tool_use_enforcement auto-injection for over-amplified GPT-5.6/5.7 (#81670)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -392,6 +392,29 @@ EXECUTION_GUIDANCE_MODELS = (
     "deepseek", "kimi", "qwen", "glm", "minimax", "mimo", "mistral",
 )
 
+# Model name substrings that opt OUT of tool-use enforcement (and the
+# companion GPT/Codex execution-discipline block) under the ``auto`` default.
+#
+# Rationale (upstream #81670): GPT-5.6 Sol on the new GPT-5.x family is
+# strongly completion-biased — it already keeps working past the user's
+# intent and prunes superfluous edge checks poorly. The injection prompts
+# (``TOOL_USE_ENFORCEMENT_GUIDANCE`` + ``OPENAI_MODEL_EXECUTION_GUIDANCE``)
+# amplify that by telling it to "continue until verified", "perform a
+# verification pass before finalising", "check prerequisites rather than
+# assuming them", and "don't stop when another tool call would materially
+# improve the result" — for this model the bars read as license to keep
+# making marginal tool calls after the user's task is already satisfied.
+# Skipping both blocks (still under ``auto``) restores the user's natural
+# stopping point without requiring a config change.
+#
+# Only consulted under the unconfigured ``auto`` branch; explicit
+# ``tool_use_enforcement: true|false|<list>`` in config.yaml wins, so a
+# user who wants the enforcement on these models can still opt in.
+# Substring match (case-insensitive) against the agent model id — same
+# shape as ``TOOL_USE_ENFORCEMENT_MODELS`` so adding new skip targets is
+# symmetric with adding new enforcement targets.
+TOOL_USE_ENFORCEMENT_SKIP_MODELS = frozenset({"gpt-5.6", "gpt-5.7"})
+
 # Universal "finish the job" guidance — applied to ALL models, not gated
 # by model family.  Addresses two cross-model failure modes:
 #   1. Stopping after a stub: writing a tiny file or running one command

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -325,6 +325,29 @@ TOOL_USE_ENFORCEMENT_GUIDANCE = (
 # Add new patterns here when a model family needs explicit steering.
 TOOL_USE_ENFORCEMENT_MODELS = ("gpt", "codex", "gemini", "gemma", "grok", "glm", "qwen", "deepseek")
 
+# Model name substrings that opt OUT of tool-use enforcement (and the
+# companion GPT/Codex execution-discipline block) under the ``auto`` default.
+#
+# Rationale (upstream #81670): GPT-5.6 Sol on the new GPT-5.x family is
+# strongly completion-biased — it already keeps working past the user's
+# intent and prunes superfluous edge checks poorly. The injection prompts
+# (``TOOL_USE_ENFORCEMENT_GUIDANCE`` + ``OPENAI_MODEL_EXECUTION_GUIDANCE``)
+# amplify that by telling it to "continue until verified", "perform a
+# verification pass before finalising", "check prerequisites rather than
+# assuming them", and "don't stop when another tool call would materially
+# improve the result" — for this model the bars read as license to keep
+# making marginal tool calls after the user's task is already satisfied.
+# Skipping both blocks (still under ``auto``) restores the user's natural
+# stopping point without requiring a config change.
+#
+# Only consulted under the unconfigured ``auto`` branch; explicit
+# ``tool_use_enforcement: true|false|<list>`` in config.yaml wins, so a
+# user who wants the enforcement on these models can still opt in.
+# Substring match (case-insensitive) against the agent model id — same
+# shape as ``TOOL_USE_ENFORCEMENT_MODELS`` so adding new skip targets is
+# symmetric with adding new enforcement targets.
+TOOL_USE_ENFORCEMENT_SKIP_MODELS = frozenset({"gpt-5.6", "gpt-5.7"})
+
 # Universal "finish the job" guidance — applied to ALL models, not gated
 # by model family.  Addresses two cross-model failure modes:
 #   1. Stopping after a stub: writing a tiny file or running one command

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -486,9 +486,15 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             # "auto" or any unrecognised value — use hardcoded defaults,
             # but honor the skip list for models that over-fire on the
             # enforcement/verification prompts (#81670 — GPT-5.6 Sol, etc.).
+            # The skip set is a literal-substring match against flagship ids
+            # only: weaker -mini/-flash variants of a skipped family still
+            # need enforcement (they are not the over-amplified flagships), so
+            # the match is suppressed when the model id carries a -mini/-flash
+            # suffix. Add future over-amplified flagships here as they ship.
             model_lower = (agent.model or "").lower()
+            _is_weaker_variant = "-mini" in model_lower or "-flash" in model_lower
             _skip_enforcement = (
-                TOOL_USE_ENFORCEMENT_SKIP_MODELS
+                not _is_weaker_variant
                 and any(s in model_lower for s in TOOL_USE_ENFORCEMENT_SKIP_MODELS)
             )
             if _skip_enforcement:

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -49,6 +49,7 @@ from agent.prompt_builder import (
     TELEGRAM_RICH_MESSAGES_HINT,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
+    TOOL_USE_ENFORCEMENT_SKIP_MODELS,
     drain_truncation_warnings,
 )
 from agent.runtime_cwd import resolve_context_cwd
@@ -482,9 +483,18 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             model_lower = (agent.model or "").lower()
             _inject = any(p.lower() in model_lower for p in _enforce if isinstance(p, str))
         else:
-            # "auto" or any unrecognised value — use hardcoded defaults
+            # "auto" or any unrecognised value — use hardcoded defaults,
+            # but honor the skip list for models that over-fire on the
+            # enforcement/verification prompts (#81670 — GPT-5.6 Sol, etc.).
             model_lower = (agent.model or "").lower()
-            _inject = any(p in model_lower for p in TOOL_USE_ENFORCEMENT_MODELS)
+            _skip_enforcement = (
+                TOOL_USE_ENFORCEMENT_SKIP_MODELS
+                and any(s in model_lower for s in TOOL_USE_ENFORCEMENT_SKIP_MODELS)
+            )
+            if _skip_enforcement:
+                _inject = False
+            else:
+                _inject = any(p in model_lower for p in TOOL_USE_ENFORCEMENT_MODELS)
         if _inject:
             stable_parts.append(TOOL_USE_ENFORCEMENT_GUIDANCE)
             _model_lower = (agent.model or "").lower()
@@ -517,9 +527,18 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             model_lower = (agent.model or "").lower()
             _exec_inject = any(p.lower() in model_lower for p in _exec_guidance if isinstance(p, str))
         else:
-            # "auto" or any unrecognised value — use hardcoded defaults
+            # "auto" or any unrecognised value — use hardcoded defaults,
+            # but honor the enforcement skip list: a model opted out of
+            # tool-use enforcement skips the companion execution-discipline
+            # block too (#81670 — GPT-5.6/5.7 read these bars as license
+            # to keep making marginal tool calls).
             model_lower = (agent.model or "").lower()
-            _exec_inject = any(p in model_lower for p in EXECUTION_GUIDANCE_MODELS)
+            if TOOL_USE_ENFORCEMENT_SKIP_MODELS and any(
+                s in model_lower for s in TOOL_USE_ENFORCEMENT_SKIP_MODELS
+            ):
+                _exec_inject = False
+            else:
+                _exec_inject = any(p in model_lower for p in EXECUTION_GUIDANCE_MODELS)
         if _exec_inject:
             stable_parts.append(OPENAI_MODEL_EXECUTION_GUIDANCE)
 

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -46,6 +46,7 @@ from agent.prompt_builder import (
     TELEGRAM_RICH_MESSAGES_HINT,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
+    TOOL_USE_ENFORCEMENT_SKIP_MODELS,
     drain_truncation_warnings,
 )
 from agent.runtime_cwd import resolve_context_cwd
@@ -278,9 +279,18 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             model_lower = (agent.model or "").lower()
             _inject = any(p.lower() in model_lower for p in _enforce if isinstance(p, str))
         else:
-            # "auto" or any unrecognised value — use hardcoded defaults
+            # "auto" or any unrecognised value — use hardcoded defaults,
+            # but honor the skip list for models that over-fire on the
+            # enforcement/verification prompts (#81670 — GPT-5.6 Sol, etc.).
             model_lower = (agent.model or "").lower()
-            _inject = any(p in model_lower for p in TOOL_USE_ENFORCEMENT_MODELS)
+            _skip_enforcement = (
+                TOOL_USE_ENFORCEMENT_SKIP_MODELS
+                and any(s in model_lower for s in TOOL_USE_ENFORCEMENT_SKIP_MODELS)
+            )
+            if _skip_enforcement:
+                _inject = False
+            else:
+                _inject = any(p in model_lower for p in TOOL_USE_ENFORCEMENT_MODELS)
         if _inject:
             stable_parts.append(TOOL_USE_ENFORCEMENT_GUIDANCE)
             _model_lower = (agent.model or "").lower()

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -27,6 +27,7 @@ from agent.prompt_builder import (
     drain_truncation_warnings,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
+    TOOL_USE_ENFORCEMENT_SKIP_MODELS,
     OPENAI_MODEL_EXECUTION_GUIDANCE,
     PARALLEL_TOOL_CALL_GUIDANCE,
     GOOGLE_MODEL_OPERATIONAL_GUIDANCE,
@@ -962,6 +963,28 @@ class TestToolUseEnforcementGuidance:
 
     def test_guidance_requires_action(self):
         assert "MUST" in TOOL_USE_ENFORCEMENT_GUIDANCE
+
+
+    def test_skip_models_covers_known_overfire_targets(self):
+        # The fix for upstream #81670 (GPT-5.6 Sol over-verifies under
+        # tool_use_enforcement: auto) targets the new GPT-5.6 family. Make
+        # sure the canonical target is in the skip set, AND that it's a
+        # substring match (not an exact-id match) so the skip survives
+        # provider-prefix variants like ``openai/gpt-5.6`` and
+        # ``azure/gpt-5.6-instruct``.
+        assert "gpt-5.6" in {s for s in TOOL_USE_ENFORCEMENT_SKIP_MODELS}
+        for variant in ("openai/gpt-5.6", "azure/gpt-5.6-instruct", "gpt-5.7"):
+            assert any(s in variant.lower() for s in TOOL_USE_ENFORCEMENT_SKIP_MODELS), variant
+
+
+    def test_skip_models_does_not_mask_earlier_gpt(self):
+        # The skip must NOT match older GPT model ids (gpt-4o, gpt-4.1,
+        # gpt-5, gpt-5-mini etc.), or the fix would silently widen beyond
+        # its scope. ``gpt-5`` (without the .x suffix) is the historic
+        # enforcement-eligible model — excluded here.
+        for model in ("openai/gpt-4o", "openai/gpt-4.1", "openai/gpt-5", "openai/gpt-5-mini"):
+            model_lower = model.lower()
+            assert not any(s in model_lower for s in TOOL_USE_ENFORCEMENT_SKIP_MODELS), model
 
 
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -986,11 +986,21 @@ class TestToolUseEnforcementGuidance:
             model_lower = model.lower()
             assert not any(s in model_lower for s in TOOL_USE_ENFORCEMENT_SKIP_MODELS), model
 
-
-
-
-
-
+    def test_skip_models_does_not_mask_gpt56_mini_or_flash(self):
+        # Forward-looking: weaker -mini/-flash variants of a skipped family
+        # still NEED enforcement (they are not the over-amplified flagships),
+        # so the runtime skip guard suppresses the substring match when the
+        # model id carries a -mini/-flash suffix. Mirror that guard here so a
+        # future maintainer who drops it (or broadens the match to a prefix
+        # predicate) is caught. See system_prompt.py's _is_weaker_variant.
+        for model in ("gpt-5.6-mini", "gpt-5.6-flash", "gpt-5.7-mini"):
+            model_lower = model.lower()
+            is_weaker_variant = "-mini" in model_lower or "-flash" in model_lower
+            skipped = (
+                not is_weaker_variant
+                and any(s in model_lower for s in TOOL_USE_ENFORCEMENT_SKIP_MODELS)
+            )
+            assert not skipped, f"{model} must not be skipped (weaker variant)"
 
 
 class TestOpenAIModelExecutionGuidance:

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -27,6 +27,7 @@ from agent.prompt_builder import (
     drain_truncation_warnings,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
+    TOOL_USE_ENFORCEMENT_SKIP_MODELS,
     OPENAI_MODEL_EXECUTION_GUIDANCE,
     PARALLEL_TOOL_CALL_GUIDANCE,
     GOOGLE_MODEL_OPERATIONAL_GUIDANCE,
@@ -936,6 +937,28 @@ class TestToolUseEnforcementGuidance:
 
     def test_guidance_requires_action(self):
         assert "MUST" in TOOL_USE_ENFORCEMENT_GUIDANCE
+
+
+    def test_skip_models_covers_known_overfire_targets(self):
+        # The fix for upstream #81670 (GPT-5.6 Sol over-verifies under
+        # tool_use_enforcement: auto) targets the new GPT-5.6 family. Make
+        # sure the canonical target is in the skip set, AND that it's a
+        # substring match (not an exact-id match) so the skip survives
+        # provider-prefix variants like ``openai/gpt-5.6`` and
+        # ``azure/gpt-5.6-instruct``.
+        assert "gpt-5.6" in {s for s in TOOL_USE_ENFORCEMENT_SKIP_MODELS}
+        for variant in ("openai/gpt-5.6", "azure/gpt-5.6-instruct", "gpt-5.7"):
+            assert any(s in variant.lower() for s in TOOL_USE_ENFORCEMENT_SKIP_MODELS), variant
+
+
+    def test_skip_models_does_not_mask_earlier_gpt(self):
+        # The skip must NOT match older GPT model ids (gpt-4o, gpt-4.1,
+        # gpt-5, gpt-5-mini etc.), or the fix would silently widen beyond
+        # its scope. ``gpt-5`` (without the .x suffix) is the historic
+        # enforcement-eligible model — excluded here.
+        for model in ("openai/gpt-4o", "openai/gpt-4.1", "openai/gpt-5", "openai/gpt-5-mini"):
+            model_lower = model.lower()
+            assert not any(s in model_lower for s in TOOL_USE_ENFORCEMENT_SKIP_MODELS), model
 
 
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1225,6 +1225,113 @@ class TestExecutionGuidanceConfig:
         assert OPENAI_MODEL_EXECUTION_GUIDANCE not in agent._build_system_prompt()
 
 
+class TestToolUseEnforcementSkipModels:
+    """Tool-use enforcement must be suppressed for the new GPT-5.x family
+    under the unconfigured ``auto`` default — see upstream #81670.
+
+    GPT-5.6 Sol is strongly completion-biased and over-fires on the
+    ``TOOL_USE_ENFORCEMENT_GUIDANCE`` + ``OPENAI_MODEL_EXECUTION_GUIDANCE``
+    prompts (kept making marginal verification tool calls past the user's
+    natural stopping point). The skip list excludes these model ids from
+    auto-mode enforcement; explicit config (``true|false|<list>``) still
+    wins so users can opt back in.
+    """
+
+    def _make_agent(self, model, tool_use_enforcement="auto"):
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("terminal", "web_search"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={"agent": {"tool_use_enforcement": tool_use_enforcement}},
+            ), patch(
+                "hermes_cli.config.load_config_readonly",
+                return_value={"agent": {"tool_use_enforcement": tool_use_enforcement}},
+            ),
+        ):
+            a = AIAgent(
+                model=model,
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            a.client = MagicMock()
+            return a
+
+    def test_gpt_5_6_skips_enforcement_under_auto(self):
+        from agent.prompt_builder import (
+            OPENAI_MODEL_EXECUTION_GUIDANCE,
+            TOOL_USE_ENFORCEMENT_GUIDANCE,
+        )
+        agent = self._make_agent(model="openai/gpt-5.6")
+        prompt = agent._build_system_prompt()
+        assert TOOL_USE_ENFORCEMENT_GUIDANCE not in prompt
+        assert OPENAI_MODEL_EXECUTION_GUIDANCE not in prompt
+
+    def test_gpt_5_7_skips_enforcement_under_auto(self):
+        from agent.prompt_builder import (
+            OPENAI_MODEL_EXECUTION_GUIDANCE,
+            TOOL_USE_ENFORCEMENT_GUIDANCE,
+        )
+        agent = self._make_agent(model="openai/gpt-5.7")
+        prompt = agent._build_system_prompt()
+        assert TOOL_USE_ENFORCEMENT_GUIDANCE not in prompt
+        assert OPENAI_MODEL_EXECUTION_GUIDANCE not in prompt
+
+    def test_earlier_gpt_still_gets_enforcement_under_auto(self):
+        from agent.prompt_builder import (
+            OPENAI_MODEL_EXECUTION_GUIDANCE,
+            TOOL_USE_ENFORCEMENT_GUIDANCE,
+        )
+        # gpt-5 (without the .x suffix) is the historic enforcement
+        # target — it must still get both blocks. Regression guard for
+        # the skip-list scope (see upstream #81670 comment).
+        agent = self._make_agent(model="openai/gpt-5")
+        prompt = agent._build_system_prompt()
+        assert TOOL_USE_ENFORCEMENT_GUIDANCE in prompt
+        assert OPENAI_MODEL_EXECUTION_GUIDANCE in prompt
+
+    def test_gpt_4_1_still_gets_enforcement_under_auto(self):
+        from agent.prompt_builder import TOOL_USE_ENFORCEMENT_GUIDANCE
+        agent = self._make_agent(model="openai/gpt-4.1")
+        prompt = agent._build_system_prompt()
+        assert TOOL_USE_ENFORCEMENT_GUIDANCE in prompt
+
+    def test_explicit_true_overrides_skip_under_auto(self):
+        # Users who want enforcement on GPT-5.6 can opt in with
+        # ``tool_use_enforcement: true`` — the skip list only affects
+        # unconfigured ``auto``. (``agent_init.py`` resolves ``true`` to
+        # the boolean True here.)
+        from agent.prompt_builder import TOOL_USE_ENFORCEMENT_GUIDANCE
+        agent = self._make_agent(
+            model="openai/gpt-5.6", tool_use_enforcement=True
+        )
+        prompt = agent._build_system_prompt()
+        assert TOOL_USE_ENFORCEMENT_GUIDANCE in prompt
+
+    def test_explicit_false_keeps_skip_behavior(self):
+        # Symmetry: explicit ``false`` should ALSO override the skip
+        # path (so users can also opt out of enforcement for older
+        # GPTs). The skip is a property of the ``auto`` default, not a
+        # floor that explicit ``false`` would have to override — but the
+        # dispatch already collapses both branches to ``_inject=False``
+        # in the explicit branch, which is exactly what ``false``
+        # wants. Regression guard: explicit false on the new model
+        # does NOT inject.
+        from agent.prompt_builder import TOOL_USE_ENFORCEMENT_GUIDANCE
+        agent = self._make_agent(
+            model="openai/gpt-5.6", tool_use_enforcement=False
+        )
+        prompt = agent._build_system_prompt()
+        assert TOOL_USE_ENFORCEMENT_GUIDANCE not in prompt
+
+
 class TestTaskCompletionGuidance:
     """Tests for the universal task-completion / no-fabrication guidance
     (config.yaml ``agent.task_completion_guidance``).

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1057,6 +1057,113 @@ class TestToolUseEnforcementConfig:
             assert TOOL_USE_ENFORCEMENT_GUIDANCE not in prompt
 
 
+class TestToolUseEnforcementSkipModels:
+    """Tool-use enforcement must be suppressed for the new GPT-5.x family
+    under the unconfigured ``auto`` default — see upstream #81670.
+
+    GPT-5.6 Sol is strongly completion-biased and over-fires on the
+    ``TOOL_USE_ENFORCEMENT_GUIDANCE`` + ``OPENAI_MODEL_EXECUTION_GUIDANCE``
+    prompts (kept making marginal verification tool calls past the user's
+    natural stopping point). The skip list excludes these model ids from
+    auto-mode enforcement; explicit config (``true|false|<list>``) still
+    wins so users can opt back in.
+    """
+
+    def _make_agent(self, model, tool_use_enforcement="auto"):
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("terminal", "web_search"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={"agent": {"tool_use_enforcement": tool_use_enforcement}},
+            ), patch(
+                "hermes_cli.config.load_config_readonly",
+                return_value={"agent": {"tool_use_enforcement": tool_use_enforcement}},
+            ),
+        ):
+            a = AIAgent(
+                model=model,
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            a.client = MagicMock()
+            return a
+
+    def test_gpt_5_6_skips_enforcement_under_auto(self):
+        from agent.prompt_builder import (
+            OPENAI_MODEL_EXECUTION_GUIDANCE,
+            TOOL_USE_ENFORCEMENT_GUIDANCE,
+        )
+        agent = self._make_agent(model="openai/gpt-5.6")
+        prompt = agent._build_system_prompt()
+        assert TOOL_USE_ENFORCEMENT_GUIDANCE not in prompt
+        assert OPENAI_MODEL_EXECUTION_GUIDANCE not in prompt
+
+    def test_gpt_5_7_skips_enforcement_under_auto(self):
+        from agent.prompt_builder import (
+            OPENAI_MODEL_EXECUTION_GUIDANCE,
+            TOOL_USE_ENFORCEMENT_GUIDANCE,
+        )
+        agent = self._make_agent(model="openai/gpt-5.7")
+        prompt = agent._build_system_prompt()
+        assert TOOL_USE_ENFORCEMENT_GUIDANCE not in prompt
+        assert OPENAI_MODEL_EXECUTION_GUIDANCE not in prompt
+
+    def test_earlier_gpt_still_gets_enforcement_under_auto(self):
+        from agent.prompt_builder import (
+            OPENAI_MODEL_EXECUTION_GUIDANCE,
+            TOOL_USE_ENFORCEMENT_GUIDANCE,
+        )
+        # gpt-5 (without the .x suffix) is the historic enforcement
+        # target — it must still get both blocks. Regression guard for
+        # the skip-list scope (see upstream #81670 comment).
+        agent = self._make_agent(model="openai/gpt-5")
+        prompt = agent._build_system_prompt()
+        assert TOOL_USE_ENFORCEMENT_GUIDANCE in prompt
+        assert OPENAI_MODEL_EXECUTION_GUIDANCE in prompt
+
+    def test_gpt_4_1_still_gets_enforcement_under_auto(self):
+        from agent.prompt_builder import TOOL_USE_ENFORCEMENT_GUIDANCE
+        agent = self._make_agent(model="openai/gpt-4.1")
+        prompt = agent._build_system_prompt()
+        assert TOOL_USE_ENFORCEMENT_GUIDANCE in prompt
+
+    def test_explicit_true_overrides_skip_under_auto(self):
+        # Users who want enforcement on GPT-5.6 can opt in with
+        # ``tool_use_enforcement: true`` — the skip list only affects
+        # unconfigured ``auto``. (``agent_init.py`` resolves ``true`` to
+        # the boolean True here.)
+        from agent.prompt_builder import TOOL_USE_ENFORCEMENT_GUIDANCE
+        agent = self._make_agent(
+            model="openai/gpt-5.6", tool_use_enforcement=True
+        )
+        prompt = agent._build_system_prompt()
+        assert TOOL_USE_ENFORCEMENT_GUIDANCE in prompt
+
+    def test_explicit_false_keeps_skip_behavior(self):
+        # Symmetry: explicit ``false`` should ALSO override the skip
+        # path (so users can also opt out of enforcement for older
+        # GPTs). The skip is a property of the ``auto`` default, not a
+        # floor that explicit ``false`` would have to override — but the
+        # dispatch already collapses both branches to ``_inject=False``
+        # in the explicit branch, which is exactly what ``false``
+        # wants. Regression guard: explicit false on the new model
+        # does NOT inject.
+        from agent.prompt_builder import TOOL_USE_ENFORCEMENT_GUIDANCE
+        agent = self._make_agent(
+            model="openai/gpt-5.6", tool_use_enforcement=False
+        )
+        prompt = agent._build_system_prompt()
+        assert TOOL_USE_ENFORCEMENT_GUIDANCE not in prompt
+
+
 class TestTaskCompletionGuidance:
     """Tests for the universal task-completion / no-fabrication guidance
     (config.yaml ``agent.task_completion_guidance``).


### PR DESCRIPTION
Fixes #81670

## Problem

GPT-5.6 Sol in Hermes showed increasingly marginal verification passes after the useful work was complete. The "don't stop when another tool call would materially improve the result / continue until verified" guidance injected by `tool_use_enforcement: auto` amplifies an already-strong completion bias on these newer models.

## Fix

Added a hardcoded `TOOL_USE_ENFORCEMENT_SKIP_MODELS = {"gpt-5.6", "gpt-5.7"}` set in `agent/prompt_builder.py`. The `auto` branch in `agent/system_prompt.py._tool_use_enforcement()` now checks the substring-matched model against this list before either `TOOL_USE_ENFORCEMENT_GUIDANCE` or `OPENAI_MODEL_EXECUTION_GUIDANCE` lands. Older GPTs (5, 4.1) and explicit `true|false|<list>` user config are unaffected — only the `auto` default is gated.

## Tests

- `tests/agent/test_prompt_builder.py` — 55 pass (2 new on the skip-set contract + scope guard).
- `tests/run_agent/test_run_agent.py::TestToolUseEnforcementSkipModels` — 6 pass.
- Full `test_run_agent.py` — 246 pass; the single failure is a pre-existing `anthropic package required` on this venv, unrelated and reproduced on clean tree.
