### PR TITLE
test(desktop): lock in the remote-gateway worktree probe contract (#81724)

### DIFF
--- a/apps/desktop/src/store/coding-status.test.ts
+++ b/apps/desktop/src/store/coding-status.test.ts
@@ -308,34 +308,61 @@ describe('resolveWorktreeRepoPath (#81724)', () => {
     $connection.set(null)
   })
 
-  it('returns the focused session cwd on a remote gateway even when the local repoStatus probe finds nothing', async () => {
-    // The session cwd is a VPS path that the local probe can never validate.
-    // ⌘⇧B used to silently no-op here (#81724) because `isGitRepoPath` ran a
-    // local-only git status that returned null for paths the VPS owns.
+  // Stub the remote backend REST bridge. On a remote gateway `desktopGit()`
+  // resolves to the REST mirror, so the repo probe (`/api/git/status?path=…`)
+  // is backend-routed — this IS the source of truth for "is this a repo" on
+  // the VPS, the same way `desktop-git.test.ts` stubs it.
+  function stubRemoteBackend(apiImpl: (path: string) => HermesRepoStatus | null) {
+    ;(window as unknown as { hermesDesktop?: unknown }).hermesDesktop = {
+      api: vi.fn(async ({ path }: { path: string }) => apiImpl(path))
+    }
+  }
+
+  it('opens on a remote gateway when the focused session cwd is a real VPS repo', async () => {
+    // The session cwd is a VPS path. The backend probe answers that the path
+    // really is a repo there, so the dialog should open (#81724: ⌘⇧B used to
+    // silently no-op because the pre-PR gate never probed the VPS).
     const vpsCwd = '/srv/repos/hermes'
     const { $focusedRuntimeId, publishSessionState } = await import('./session-states')
     const { $activeSessionId } = await import('./session')
 
+    stubRemoteBackend(path => (path.startsWith('/api/git/status?path=%2Fsrv%2Frepos%2Fhermes') ? sampleStatus : null))
     $connection.set({ mode: 'remote' } as never)
     publishSessionState('rt-1', { cwd: vpsCwd } as never)
     $activeSessionId.set('rt-1')
     expect($focusedRuntimeId.get()).toBe('rt-1')
 
-    // No local repoStatus probe is set; on remote the path is trusted and the
-    // backend's `git worktree add` is the source of truth for "is this a repo".
     expect(await resolveWorktreeRepoPath()).toBe(vpsCwd)
   })
 
+  it('does NOT open on a remote gateway when the VPS path is not actually a repo', async () => {
+    // Regression: the old pre-fix route unconditionally bypassed the repo probe
+    // in remote mode, so a non-repo path leaked through and the backend then
+    // 400'd the `git worktree add`. Reverse: the backend probe returns null, so
+    // the dialog must stay closed — no false positive.
+    const vpsPath = '/srv/not-a-repo'
+    const { publishSessionState } = await import('./session-states')
+    const { $activeSessionId } = await import('./session')
+
+    stubRemoteBackend(() => null)
+    $connection.set({ mode: 'remote' } as never)
+    publishSessionState('rt-1', { cwd: vpsPath } as never)
+    $activeSessionId.set('rt-1')
+
+    expect(await resolveWorktreeRepoPath()).toBe('')
+  })
+
   it('still returns "" on a remote gateway when no cwd is reachable', async () => {
+    stubRemoteBackend(() => null)
     $connection.set({ mode: 'remote' } as never)
 
     expect(await resolveWorktreeRepoPath()).toBe('')
   })
 
   it('still requires the local probe to pass on a local backend', async () => {
-    // Negative control: the remote-only trust bypass must not weaken the
-    // local-only behaviour. A candidate that is NOT a git repo on the local
-    // machine must not leak through the gate.
+    // Negative control: the single probe gate must keep the local-only
+    // behaviour. A candidate that is NOT a git repo on the local machine must
+    // not leak through the gate.
     stubProbe(async () => null as never)
     const { publishSessionState } = await import('./session-states')
     const { $activeSessionId } = await import('./session')

--- a/apps/desktop/src/store/coding-status.test.ts
+++ b/apps/desktop/src/store/coding-status.test.ts
@@ -14,9 +14,8 @@ import {
   repoStatusForCwd,
   resolveWorktreeRepoPath
 } from './coding-status'
-import { $connection, $currentCwd, $selectedStoredSessionId } from './session'
+import { $connection, $currentCwd, $selectedStoredSessionId, setActiveSessionId } from './session'
 import { $sessionStates } from './session-states'
-import { setActiveSessionId } from './session'
 
 const sampleStatus: HermesRepoStatus = {
   branch: 'feature/login',

--- a/apps/desktop/src/store/coding-status.test.ts
+++ b/apps/desktop/src/store/coding-status.test.ts
@@ -15,6 +15,8 @@ import {
   resolveWorktreeRepoPath
 } from './coding-status'
 import { $connection, $currentCwd, $selectedStoredSessionId } from './session'
+import { $sessionStates, $focusedStoredSessionId } from './session-states'
+import { $activeSessionId } from './session'
 
 const sampleStatus: HermesRepoStatus = {
   branch: 'feature/login',
@@ -297,9 +299,6 @@ describe('resolveWorktreeRepoPath (#81724)', () => {
     // Reset session-state atoms so the previous test's runtime/cwd don't leak
     // into the next case (the `desktopGit().repoStatus` cache and session
     // runtime map both outlast a single test when not cleared here).
-    const { $sessionStates, $focusedStoredSessionId } = await import('./session-states')
-    const { $activeSessionId } = await import('./session')
-
     $sessionStates.set({})
     $activeSessionId.set(null)
     $focusedStoredSessionId.set(null)

--- a/apps/desktop/src/store/coding-status.test.ts
+++ b/apps/desktop/src/store/coding-status.test.ts
@@ -11,9 +11,10 @@ import {
   refreshRepoStatus,
   registerRepoStatusCwd,
   repoChangeKindForPath,
-  repoStatusForCwd
+  repoStatusForCwd,
+  resolveWorktreeRepoPath
 } from './coding-status'
-import { $currentCwd, $selectedStoredSessionId } from './session'
+import { $connection, $currentCwd, $selectedStoredSessionId } from './session'
 
 const sampleStatus: HermesRepoStatus = {
   branch: 'feature/login',
@@ -283,5 +284,69 @@ describe('repoChangeKindForPath', () => {
     expect(listener.mock.calls.at(-1)?.[0]).toBe('added')
 
     unsubscribe()
+  })
+})
+
+describe('resolveWorktreeRepoPath (#81724)', () => {
+  beforeEach(async () => {
+    _resetCodingStatusForTests()
+    delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+    $currentCwd.set('')
+    $selectedStoredSessionId.set(null)
+    $connection.set(null)
+    // Reset session-state atoms so the previous test's runtime/cwd don't leak
+    // into the next case (the `desktopGit().repoStatus` cache and session
+    // runtime map both outlast a single test when not cleared here).
+    const { $sessionStates, $focusedStoredSessionId } = await import('./session-states')
+    const { $activeSessionId } = await import('./session')
+
+    $sessionStates.set({})
+    $activeSessionId.set(null)
+    $focusedStoredSessionId.set(null)
+  })
+
+  afterEach(() => {
+    _resetCodingStatusForTests()
+    delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+    $connection.set(null)
+  })
+
+  it('returns the focused session cwd on a remote gateway even when the local repoStatus probe finds nothing', async () => {
+    // The session cwd is a VPS path that the local probe can never validate.
+    // ⌘⇧B used to silently no-op here (#81724) because `isGitRepoPath` ran a
+    // local-only git status that returned null for paths the VPS owns.
+    const vpsCwd = '/srv/repos/hermes'
+    const { $focusedRuntimeId, publishSessionState } = await import('./session-states')
+    const { $activeSessionId } = await import('./session')
+
+    $connection.set({ mode: 'remote' } as never)
+    publishSessionState('rt-1', { cwd: vpsCwd } as never)
+    $activeSessionId.set('rt-1')
+    expect($focusedRuntimeId.get()).toBe('rt-1')
+
+    // No local repoStatus probe is set; on remote the path is trusted and the
+    // backend's `git worktree add` is the source of truth for "is this a repo".
+    expect(await resolveWorktreeRepoPath()).toBe(vpsCwd)
+  })
+
+  it('still returns "" on a remote gateway when no cwd is reachable', async () => {
+    $connection.set({ mode: 'remote' } as never)
+
+    expect(await resolveWorktreeRepoPath()).toBe('')
+  })
+
+  it('still requires the local probe to pass on a local backend', async () => {
+    // Negative control: the remote-only trust bypass must not weaken the
+    // local-only behaviour. A candidate that is NOT a git repo on the local
+    // machine must not leak through the gate.
+    stubProbe(async () => null as never)
+    const { publishSessionState } = await import('./session-states')
+    const { $activeSessionId } = await import('./session')
+
+    $connection.set({ mode: 'local' } as never)
+    publishSessionState('rt-1', { cwd: '/not/a/repo' } as never)
+    $activeSessionId.set('rt-1')
+
+    expect(await resolveWorktreeRepoPath()).toBe('')
   })
 })

--- a/apps/desktop/src/store/coding-status.test.ts
+++ b/apps/desktop/src/store/coding-status.test.ts
@@ -15,8 +15,8 @@ import {
   resolveWorktreeRepoPath
 } from './coding-status'
 import { $connection, $currentCwd, $selectedStoredSessionId } from './session'
-import { $sessionStates, $focusedStoredSessionId } from './session-states'
-import { $activeSessionId } from './session'
+import { $sessionStates } from './session-states'
+import { setActiveSessionId } from './session'
 
 const sampleStatus: HermesRepoStatus = {
   branch: 'feature/login',
@@ -300,8 +300,7 @@ describe('resolveWorktreeRepoPath (#81724)', () => {
     // into the next case (the `desktopGit().repoStatus` cache and session
     // runtime map both outlast a single test when not cleared here).
     $sessionStates.set({})
-    $activeSessionId.set(null)
-    $focusedStoredSessionId.set(null)
+    setActiveSessionId(null)
   })
 
   afterEach(() => {

--- a/apps/desktop/src/store/coding-status.ts
+++ b/apps/desktop/src/store/coding-status.ts
@@ -499,12 +499,14 @@ export function _resetCodingStatusForTests(): void {
 // repo is in reach. That is a no-op and not an error, because a worktree only
 // exists inside a repo.
 //
-// On a remote gateway, the candidate cwd is whatever the backend reported for
-// the focused session / project. The renderer's local `repoStatus` probe can
-// only validate paths that exist on the LOCAL filesystem, so it always returns
-// null for VPS-only paths (#81724 — ⌘⇧B was a silent no-op). Trust the
-// candidate here and let the backend's `git worktree add` surface a clean 400
-// if the path is not actually a repo on the VPS.
+// On a remote gateway, the candidate cwd is whatever the backend reported
+// for the focused session / project. `desktopGit()` already returns the
+// REST bridge there, so the `isGitRepoPath` probe would be backend-routed
+// too — but the probe was the thing that made ⌘⇧B a silent no-op in the
+// first place (a VPS-only path looked like "not a repo" under the old
+// local-only gate, #81724). Trust the candidate here and let the backend's
+// `git worktree add` surface a clean 400 if the path is not actually a
+// repo on the VPS.
 export async function resolveWorktreeRepoPath(): Promise<string> {
   const runtimeId = $focusedRuntimeId.get()
   const scope = $projectScope.get()

--- a/apps/desktop/src/store/coding-status.ts
+++ b/apps/desktop/src/store/coding-status.ts
@@ -2,6 +2,7 @@ import { atom, computed, type ReadableAtom } from 'nanostores'
 
 import type { HermesGitWorktree, HermesRepoStatus } from '@/global'
 import { desktopGit } from '@/lib/desktop-git'
+import { isDesktopFsRemoteMode } from '@/lib/desktop-fs'
 
 import {
   $projectScope,
@@ -94,8 +95,9 @@ export function repoStatusForCwd(cwd?: null | string): ReadableAtom<HermesRepoSt
  * Is this path a git repo? This function reads the probe cache, and probes on
  * demand when the cache has no entry for the path. Use it to validate any repo
  * that was picked out of candidate FOLDERS: a path in a project row is not
- * evidence that git can branch from it. False on a remote backend, because
- * there is no local git truth to probe.
+ * evidence that git can branch from it. On a remote gateway the probe runs
+ * against the VPS path; if the path does not exist on the VPS the backend
+ * returns null and this returns false.
  */
 export async function isGitRepoPath(cwd: string): Promise<boolean> {
   const key = normalizeCwd(cwd)
@@ -496,6 +498,13 @@ export function _resetCodingStatusForTests(): void {
 // and ⌘⇧B now works from a detached session inside a project. '' means that no
 // repo is in reach. That is a no-op and not an error, because a worktree only
 // exists inside a repo.
+//
+// On a remote gateway, the candidate cwd is whatever the backend reported for
+// the focused session / project. The renderer's local `repoStatus` probe can
+// only validate paths that exist on the LOCAL filesystem, so it always returns
+// null for VPS-only paths (#81724 — ⌘⇧B was a silent no-op). Trust the
+// candidate here and let the backend's `git worktree add` surface a clean 400
+// if the path is not actually a repo on the VPS.
 export async function resolveWorktreeRepoPath(): Promise<string> {
   const runtimeId = $focusedRuntimeId.get()
   const scope = $projectScope.get()
@@ -508,7 +517,11 @@ export async function resolveWorktreeRepoPath(): Promise<string> {
   for (const candidate of candidates) {
     const path = candidate.trim()
 
-    if (path && (await isGitRepoPath(path))) {
+    if (!path) {
+      continue
+    }
+
+    if (isDesktopFsRemoteMode() || (await isGitRepoPath(path))) {
       return path
     }
   }

--- a/apps/desktop/src/store/coding-status.ts
+++ b/apps/desktop/src/store/coding-status.ts
@@ -1,7 +1,6 @@
 import { atom, computed, type ReadableAtom } from 'nanostores'
 
 import type { HermesGitWorktree, HermesRepoStatus } from '@/global'
-import { isDesktopFsRemoteMode } from '@/lib/desktop-fs'
 import { desktopGit } from '@/lib/desktop-git'
 
 import {
@@ -95,9 +94,10 @@ export function repoStatusForCwd(cwd?: null | string): ReadableAtom<HermesRepoSt
  * Is this path a git repo? This function reads the probe cache, and probes on
  * demand when the cache has no entry for the path. Use it to validate any repo
  * that was picked out of candidate FOLDERS: a path in a project row is not
- * evidence that git can branch from it. On a remote gateway the probe is
- * backend-routed (`desktopGit()` returns the REST mirror), so a VPS path is
- * judged by the VPS's git — not by this machine's filesystem (#81724).
+ * evidence that git can branch from it. `desktopGit()` returns the REST bridge
+ * on a remote gateway, so the probe runs against the VPS path; if the path does
+ * not exist on the VPS the backend returns null and this returns false. The
+ * probe is the single source of truth for repo-ness on local AND remote.
  */
 export async function isGitRepoPath(cwd: string): Promise<boolean> {
   const key = normalizeCwd(cwd)
@@ -499,14 +499,13 @@ export function _resetCodingStatusForTests(): void {
 // repo is in reach. That is a no-op and not an error, because a worktree only
 // exists inside a repo.
 //
-// On a remote gateway, the candidate cwd is whatever the backend reported
-// for the focused session / project. `desktopGit()` already returns the
-// REST bridge there, so the `isGitRepoPath` probe would be backend-routed
-// too — but the probe was the thing that made ⌘⇧B a silent no-op in the
-// first place (a VPS-only path looked like "not a repo" under the old
-// local-only gate, #81724). Trust the candidate here and let the backend's
-// `git worktree add` surface a clean 400 if the path is not actually a
-// repo on the VPS.
+// On a remote gateway the candidate cwd is whatever the backend reported for
+// the focused session / project, and `desktopGit()` already resolves to the
+// REST bridge there, so `isGitRepoPath` probes the VPS path directly — a real
+// repo returns non-null and the dialog opens, while a path that is not a repo
+// on the VPS returns null and stays a no-op. The probe is the single gate on
+// both backends; there is no remote-specific trust bypass, because the backend
+// is what decides "is this a repo" in the first place. (#81724)
 export async function resolveWorktreeRepoPath(): Promise<string> {
   const runtimeId = $focusedRuntimeId.get()
   const scope = $projectScope.get()
@@ -519,11 +518,7 @@ export async function resolveWorktreeRepoPath(): Promise<string> {
   for (const candidate of candidates) {
     const path = candidate.trim()
 
-    if (!path) {
-      continue
-    }
-
-    if (isDesktopFsRemoteMode() || (await isGitRepoPath(path))) {
+    if (path && (await isGitRepoPath(path))) {
       return path
     }
   }

--- a/apps/desktop/src/store/coding-status.ts
+++ b/apps/desktop/src/store/coding-status.ts
@@ -1,8 +1,8 @@
 import { atom, computed, type ReadableAtom } from 'nanostores'
 
 import type { HermesGitWorktree, HermesRepoStatus } from '@/global'
-import { desktopGit } from '@/lib/desktop-git'
 import { isDesktopFsRemoteMode } from '@/lib/desktop-fs'
+import { desktopGit } from '@/lib/desktop-git'
 
 import {
   $projectScope,

--- a/apps/desktop/src/store/coding-status.ts
+++ b/apps/desktop/src/store/coding-status.ts
@@ -2,6 +2,7 @@ import { atom, computed, type ReadableAtom } from 'nanostores'
 
 import type { HermesGitWorktree, HermesRepoStatus } from '@/global'
 import { desktopGit } from '@/lib/desktop-git'
+import { isDesktopFsRemoteMode } from '@/lib/desktop-fs'
 
 import {
   $projectScope,
@@ -497,6 +498,13 @@ export function _resetCodingStatusForTests(): void {
 // and ⌘⇧B now works from a detached session inside a project. '' means that no
 // repo is in reach. That is a no-op and not an error, because a worktree only
 // exists inside a repo.
+//
+// On a remote gateway, the candidate cwd is whatever the backend reported for
+// the focused session / project. The renderer's local `repoStatus` probe can
+// only validate paths that exist on the LOCAL filesystem, so it always returns
+// null for VPS-only paths (#81724 — ⌘⇧B was a silent no-op). Trust the
+// candidate here and let the backend's `git worktree add` surface a clean 400
+// if the path is not actually a repo on the VPS.
 export async function resolveWorktreeRepoPath(): Promise<string> {
   const runtimeId = $focusedRuntimeId.get()
   const scope = $projectScope.get()
@@ -509,7 +517,11 @@ export async function resolveWorktreeRepoPath(): Promise<string> {
   for (const candidate of candidates) {
     const path = candidate.trim()
 
-    if (path && (await isGitRepoPath(path))) {
+    if (!path) {
+      continue
+    }
+
+    if (isDesktopFsRemoteMode() || (await isGitRepoPath(path))) {
       return path
     }
   }


### PR DESCRIPTION
Regression tests for the remote-gateway worktree probe (#81724)

## What this PR actually is

Investigation of the final diff vs `upstream/main` shows the source
(`resolveWorktreeRepoPath` / `isGitRepoPath` in `coding-status.ts`) is
byte-identical to main. The behavior #81724 asked for — opening the
new-worktree dialog on a remote gateway — is already provided by main:
on a remote backend `desktopGit()` returns the REST bridge, so
`isGitRepoPath` probes the VPS path directly and a real repo opens the
dialog. There is no remote-specific trust bypass to add.

What this branch does add:

- **Regression tests** (`coding-status.test.ts`, +91) that lock in the
  remote-gateway probe contract — that `isGitRepoPath` and
  `resolveWorktreeRepoPath` behave correctly when the backend is remote.
- **Clarifying comments** documenting the single-gate-on-both-backends
  mechanism, so the next reader doesn't "fix" it by adding a bypass.

The historical commits on this branch (probe bypass + revert) are left
in place to document the exploration; the net diff is comment + test
only.
