### PR TITLE
fix(desktop): refresh sidebar repo list on a remote gateway instead of going silent (#81723)

### DIFF
--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -448,15 +448,30 @@ describe('repository discovery policy', () => {
     })
   })
 
-  it('does not scan the local filesystem for remote connections', async () => {
+  it('does not scan the local filesystem for remote connections but still refreshes the project tree', async () => {
     isDesktopFsRemoteMode.mockReturnValue(true)
     const scanRepos = vi.fn()
     desktopGit.mockReturnValue({ scanRepos } as never)
+    const request = vi.fn(async (method: string) =>
+      method === 'projects.tree'
+        ? { active_id: null, projects: [], scoped_session_ids: [] }
+        : { accepted: false, repos: [] }
+    )
+    gatewayWith(request)
 
     await scanAndRecordRepos(true)
 
     expect(scanRepos).not.toHaveBeenCalled()
     expect(getHermesConfig).not.toHaveBeenCalled()
+    // The desktop can't crawl the remote host's filesystem, but the
+    // sidebar still has to learn about repos that exist on the host
+    // (`projects.tree` derives them from session cwds server-side).
+    // Regression for #81723: the sidebar used to go silent in remote
+    // mode and never refresh again.
+    expect(request).toHaveBeenCalledWith(
+      'projects.tree',
+      expect.objectContaining({ preview_limit: expect.any(Number) })
+    )
   })
 })
 

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -458,6 +458,7 @@ describe('repository discovery policy', () => {
         : { accepted: false, repos: [] }
     )
     gatewayWith(request)
+    $projectTree.set([{ id: 'seed', name: 'seed', folders: [], lanes: [] } as SidebarProjectTree])
 
     await scanAndRecordRepos(true)
 
@@ -474,6 +475,65 @@ describe('repository discovery policy', () => {
       'projects.tree',
       expect.objectContaining({ preview_limit: expect.any(Number) })
     )
+    // A successful scan refreshes the tree (here to the empty list the mock
+    // tree returns), so a later discover-repos call replaces it instead of
+    // keeping the stale seed.
+    expect($projectTree.get()).toEqual([])
+  })
+
+  it('surfaces a reject from remote discover_repos without clearing the sidebar', async () => {
+    // Backend error (RPC `error` frame) rejects the request — the sidebar must
+    // keep its last known list and flag the failure, not go silently blank.
+    isDesktopFsRemoteMode.mockReturnValue(true)
+    desktopGit.mockReturnValue({ scanRepos: vi.fn() } as never)
+    const request = vi.fn(async (method: string) => {
+      if (method === 'projects.discover_repos') {
+        throw new Error('discover_repos failed')
+      }
+      if (method === 'projects.tree') {
+        return { active_id: null, projects: [], scoped_session_ids: [] }
+      }
+      return { accepted: false, repos: [] }
+    })
+    gatewayWith(request)
+    $projectTree.set([{ id: 'seed', name: 'seed', folders: [], lanes: [] } as SidebarProjectTree])
+
+    await scanAndRecordRepos(true)
+
+    // The tree refresh must NOT run against a failed remote scan ...
+    expect(request).not.toHaveBeenCalledWith(
+      'projects.tree',
+      expect.objectContaining({ preview_limit: expect.any(Number) })
+    )
+    // ... the cached tree is preserved ...
+    expect($projectTree.get()).toEqual([
+      { id: 'seed', name: 'seed', folders: [] as never[], lanes: [] }
+    ])
+  })
+
+  it('does not treat an error-shaped discover_repos response as a successful refresh', async () => {
+    // A resolved-but-error-shaped body (`{accepted:false}` / no `repos`) must
+    // be treated as a failure: keep the old list rather than refreshing into
+    // the silent, empty sidebar of #81723.
+    isDesktopFsRemoteMode.mockReturnValue(true)
+    desktopGit.mockReturnValue({ scanRepos: vi.fn() } as never)
+    const request = vi.fn(async (method: string) =>
+      method === 'projects.tree'
+        ? { active_id: null, projects: [], scoped_session_ids: [] }
+        : { accepted: false }
+    )
+    gatewayWith(request)
+    $projectTree.set([{ id: 'seed', name: 'seed', folders: [], lanes: [] } as SidebarProjectTree])
+
+    await scanAndRecordRepos(true)
+
+    expect(request).not.toHaveBeenCalledWith(
+      'projects.tree',
+      expect.objectContaining({ preview_limit: expect.any(Number) })
+    )
+    expect($projectTree.get()).toEqual([
+      { id: 'seed', name: 'seed', folders: [] as never[], lanes: [] }
+    ])
   })
 })
 

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -458,7 +458,7 @@ describe('repository discovery policy', () => {
         : { accepted: false, repos: [] }
     )
     gatewayWith(request)
-    $projectTree.set([{ id: 'seed', name: 'seed', folders: [], lanes: [] } as SidebarProjectTree])
+    $projectTree.set([{ id: 'seed', label: 'seed', path: null, repos: [], sessionCount: 0 } satisfies SidebarProjectTree])
 
     await scanAndRecordRepos(true)
 
@@ -496,7 +496,7 @@ describe('repository discovery policy', () => {
       return { accepted: false, repos: [] }
     })
     gatewayWith(request)
-    $projectTree.set([{ id: 'seed', name: 'seed', folders: [], lanes: [] } as SidebarProjectTree])
+    $projectTree.set([{ id: 'seed', label: 'seed', path: null, repos: [], sessionCount: 0 } satisfies SidebarProjectTree])
 
     await scanAndRecordRepos(true)
 
@@ -507,7 +507,7 @@ describe('repository discovery policy', () => {
     )
     // ... the cached tree is preserved ...
     expect($projectTree.get()).toEqual([
-      { id: 'seed', name: 'seed', folders: [] as never[], lanes: [] }
+      { id: 'seed', label: 'seed', path: null, repos: [], sessionCount: 0 }
     ])
   })
 
@@ -523,7 +523,7 @@ describe('repository discovery policy', () => {
         : { accepted: false }
     )
     gatewayWith(request)
-    $projectTree.set([{ id: 'seed', name: 'seed', folders: [], lanes: [] } as SidebarProjectTree])
+    $projectTree.set([{ id: 'seed', label: 'seed', path: null, repos: [], sessionCount: 0 } satisfies SidebarProjectTree])
 
     await scanAndRecordRepos(true)
 
@@ -532,7 +532,7 @@ describe('repository discovery policy', () => {
       expect.objectContaining({ preview_limit: expect.any(Number) })
     )
     expect($projectTree.get()).toEqual([
-      { id: 'seed', name: 'seed', folders: [] as never[], lanes: [] }
+      { id: 'seed', label: 'seed', path: null, repos: [], sessionCount: 0 }
     ])
   })
 })

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -463,11 +463,13 @@ describe('repository discovery policy', () => {
 
     expect(scanRepos).not.toHaveBeenCalled()
     expect(getHermesConfig).not.toHaveBeenCalled()
-    // The desktop can't crawl the remote host's filesystem, but the
-    // sidebar still has to learn about repos that exist on the host
-    // (`projects.tree` derives them from session cwds server-side).
-    // Regression for #81723: the sidebar used to go silent in remote
-    // mode and never refresh again.
+    // The desktop can't crawl the remote host's filesystem, so it asks the
+    // host to scan its own discovery roots (`projects.discover_repos` with
+    // `scan: true`) — repos with zero Hermes sessions must still surface —
+    // then refreshes the tree to pick up the merged list. Regression for
+    // #81723: the sidebar used to go silent in remote mode and never
+    // refresh again.
+    expect(request).toHaveBeenCalledWith('projects.discover_repos', { scan: true })
     expect(request).toHaveBeenCalledWith(
       'projects.tree',
       expect.objectContaining({ preview_limit: expect.any(Number) })

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -611,6 +611,19 @@ $gateway.subscribe(syncReposScanning)
 
 export async function scanAndRecordRepos(force = false): Promise<void> {
   if (isDesktopFsRemoteMode()) {
+    // On a remote backend the desktop can't crawl the host filesystem — the
+    // server already derives repos from session cwds (`projects.tree` with
+    // `include_discovered=True`) and from any earlier `projects.record_repos`
+    // pings, so just trigger a refresh and let it surface whatever the
+    // backend knows about (#81723). The sidebar list also listens to the
+    // gateway's own repo-discovery events, so a fresh refresh here catches
+    // any repo the host's session history already knew about.
+    try {
+      const context = await activeProjectsContext()
+      await refreshProjectTreeOn(context.gateway)
+    } catch {
+      // best-effort — refresh is a UI update, not a critical write
+    }
     return
   }
 

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -618,10 +618,31 @@ export async function scanAndRecordRepos(force = false): Promise<void> {
     // the merged session-derived + scanned list.
     try {
       const context = await activeProjectsContext()
-      await gatewayRequestOn(context.gateway, 'projects.discover_repos', { scan: true })
+      const discovered = await gatewayRequestOn<{
+        repos?: unknown
+        discovery_policy?: unknown
+      }>(context.gateway, 'projects.discover_repos', { scan: true })
+
+      // A resolved response must be the discovery shape. Anything else (an
+      // error/`accepted:false` body, or a backend that ignored `scan` and
+      // returned no repo list) means the scan didn't happen — bail out without
+      // touching the tree so the sidebar keeps its last known list instead of
+      // being blanked back to the silent, unpopulated state of #81723.
+      if (discovered?.repos === undefined) {
+        markProjectsRpcFailure(new Error('projects.discover_repos returned no repo list'))
+        return
+      }
+
+      // Remote scan succeeded: refresh the tree so the merged session-derived +
+      // scanned list surfaces. `refreshProjectTreeOn` manages its own success /
+      // stale-backend failure state and keeps the cached tree on any error.
       await refreshProjectTreeOn(context.gateway)
-    } catch {
-      // best-effort — refresh is a UI update, not a critical write
+    } catch (err) {
+      // Surface the failure (stale backend, RPC error, gateway drop) instead
+      // of swallowing it: a silent return is exactly the "sidebar goes quiet"
+      // symptom `scan:true` was meant to fix (#81723). Keep the old list and
+      // let the sidebar show the error/absent state.
+      markProjectsRpcFailure(err)
     }
     return
   }

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -611,15 +611,14 @@ $gateway.subscribe(syncReposScanning)
 
 export async function scanAndRecordRepos(force = false): Promise<void> {
   if (isDesktopFsRemoteMode()) {
-    // On a remote backend the desktop can't crawl the host filesystem — the
-    // server already derives repos from session cwds (`projects.tree` with
-    // `include_discovered=True`) and from any earlier `projects.record_repos`
-    // pings, so just trigger a refresh and let it surface whatever the
-    // backend knows about (#81723). The sidebar list also listens to the
-    // gateway's own repo-discovery events, so a fresh refresh here catches
-    // any repo the host's session history already knew about.
+    // On a remote backend the desktop can't crawl the host filesystem.
+    // Ask the host to scan its own discovery roots (`projects.discover_repos`
+    // with `scan: true` — added in #81723) so repos with zero Hermes
+    // sessions still surface, then refresh the tree so the sidebar picks up
+    // the merged session-derived + scanned list.
     try {
       const context = await activeProjectsContext()
+      await gatewayRequestOn(context.gateway, 'projects.discover_repos', { scan: true })
       await refreshProjectTreeOn(context.gateway)
     } catch {
       // best-effort — refresh is a UI update, not a critical write

--- a/tests/tui_gateway/test_projects_rpc.py
+++ b/tests/tui_gateway/test_projects_rpc.py
@@ -277,6 +277,94 @@ def test_scan_time_is_not_treated_as_session_activity(tmp_path):
     assert active["last_active"] > idle["last_active"]
 
 
+def test_remote_scan_failure_merges_instead_of_replacing_cache(tmp_path, monkeypatch):
+    """A backend scan that can't fully walk its roots must NOT wipe the cache.
+
+    `projects.discover_repos` with `scan:true` asks the remote host to scan its
+    own discovery roots. When one root fails to walk, the scan result is not the
+    authoritative full universe — the previously cached repos must survive so a
+    failed remote refresh can't blank the sidebar back to the silent, empty
+    state of #81723 (regression for MEDIUM: `replace=True` was wiping on every
+    call regardless of success).
+    """
+    from hermes_cli import projects_db as pdb
+    import tui_gateway.server as server
+
+    def _git_repo(path):
+        repo = path
+        repo.mkdir(parents=True)
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        return str(repo)
+
+    # A cached repo the partial scan never visits, parked OUTSIDE the scan roots.
+    seed = _git_repo(tmp_path / "elsewhere" / "seed-repo")
+    with pdb.connect_closing() as conn:
+        pdb.record_discovered_repos(conn, [(seed, "seed-repo")])
+        seeded = [r["root"] for r in pdb.list_discovered_repos(conn)]
+    assert seed in seeded
+
+    good = _git_repo(tmp_path / "good-repo")
+
+    # Force one root to fail to walk: the scan becomes non-authoritative, so it
+    # must merge into the cache, never wipe it.
+    real_walk = os.walk
+    bad_root = str(tmp_path / "unwalkable")
+
+    def _flaky_walk(top, *a, **k):
+        if top == bad_root:
+            raise OSError("boom")
+        yield from real_walk(top, *a, **k)
+
+    monkeypatch.setattr(server.os, "walk", _flaky_walk)
+
+    policy = {"enabled": True, "roots": [good, bad_root], "exclude_paths": []}
+
+    with pdb.connect_closing() as conn:
+        authoritative = server._scan_discovered_repos_remote(conn, policy)
+        joined = [r["root"] for r in pdb.list_discovered_repos(conn)]
+
+    # The scan found the good repo and merged it, but the failed root means the
+    # result is not authoritative, so it must NOT have replaced the cache.
+    assert not authoritative
+    assert good in joined
+    # The seeded repo that the partial scan never saw is still cached.
+    assert seed in joined
+
+
+def test_remote_scan_full_authoritative_replaces_cache(tmp_path):
+    """Only a fully-walked scan may replace the stale cache."""
+    from hermes_cli import projects_db as pdb
+    import tui_gateway.server as server
+
+    def _git_repo(path):
+        repo = path
+        repo.mkdir(parents=True)
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        return str(repo)
+
+    # Park the stale repo OUTSIDE the scan root so the authoritative scan no
+    # longer sees it, and the fresh repo inside the root it walks.
+    stale = _git_repo(tmp_path / "outside" / "stale-repo")
+    scandir = tmp_path / "scandir"
+    scandir.mkdir()
+    fresh = _git_repo(scandir / "fresh-repo")
+
+    with pdb.connect_closing() as conn:
+        pdb.record_discovered_repos(conn, [(stale, "stale-repo")])
+
+    policy = {"enabled": True, "roots": [str(scandir)], "exclude_paths": []}
+
+    with pdb.connect_closing() as conn:
+        authoritative = server._scan_discovered_repos_remote(conn, policy)
+        joined = [r["root"] for r in pdb.list_discovered_repos(conn)]
+
+    assert authoritative
+    assert fresh in joined
+    # A full, authoritative scan replaced the stale cache: the old repo the
+    # scan no longer saw is gone from the authoritative set.
+    assert stale not in joined
+
+
 def test_terminal_session_persists_its_launch_cwd():
     """A terminal session's cwd IS its workspace, so the row must record it.
 

--- a/tests/tui_gateway/test_projects_rpc.py
+++ b/tests/tui_gateway/test_projects_rpc.py
@@ -331,6 +331,51 @@ def test_remote_scan_failure_merges_instead_of_replacing_cache(tmp_path, monkeyp
     assert seed in joined
 
 
+def test_remote_scan_missing_root_does_not_wipe_cache(tmp_path):
+    """A configured discovery root missing on disk must NOT wipe the cache.
+
+    ``os.walk`` on a non-existent root silently yields nothing instead of
+    raising, so a temporarily unavailable root (unmounted volume, moved path)
+    would otherwise make the scan look like a genuinely empty authoritative
+    set and DELETE-replace every cached repo that lived under it. The missing
+    root must contribute nothing, and the scan must merge — never wipe.
+    """
+    from hermes_cli import projects_db as pdb
+    import tui_gateway.server as server
+
+    def _git_repo(path):
+        repo = path
+        repo.mkdir(parents=True)
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        return str(repo)
+
+    # A cached repo the scan never visits, parked OUTSIDE the scan roots.
+    seed = _git_repo(tmp_path / "elsewhere" / "seed-repo")
+    with pdb.connect_closing() as conn:
+        pdb.record_discovered_repos(conn, [(seed, "seed-repo")])
+        seeded = [r["root"] for r in pdb.list_discovered_repos(conn)]
+    assert seed in seeded
+
+    good = _git_repo(tmp_path / "good-repo")
+
+    # This root is configured but does NOT exist on disk. os.walk on it yields
+    # nothing silently — without the guard the scan would stay authoritative
+    # and wipe the cache.
+    missing_root = str(tmp_path / "missing-root")
+
+    policy = {"enabled": True, "roots": [good, missing_root], "exclude_paths": []}
+
+    with pdb.connect_closing() as conn:
+        authoritative = server._scan_discovered_repos_remote(conn, policy)
+        joined = [r["root"] for r in pdb.list_discovered_repos(conn)]
+
+    # The missing root is not authoritative, so the scan must merge, not wipe.
+    assert not authoritative
+    assert good in joined
+    # The seeded repo the missing root would have wiped is still cached.
+    assert seed in joined
+
+
 def test_remote_scan_full_authoritative_replaces_cache(tmp_path):
     """Only a fully-walked scan may replace the stale cache."""
     from hermes_cli import projects_db as pdb

--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -16,62 +16,6 @@ method = _registry.method
 _profile_scoped = _registry.profile_scoped
 
 
-def _scan_discovered_repos_remote(conn, policy: dict) -> None:
-    """Backend-side disk scan of the discovery policy roots.
-
-    The desktop's native repo scan only runs on the local filesystem. On a
-    remote gateway connection the host must scan its own disk so repos with
-    zero Hermes sessions still appear in the sidebar (#81723). Mirrors the
-    desktop's behavior: walk each root (bounded depth), find `.git`
-    directories, record (root, label) pairs into the discovery cache.
-
-    Best-effort: any failure logs and leaves the cache untouched — the
-    session-derived repos from `_discover_repos_payload` still surface.
-    """
-    import logging
-    import os
-
-    logger = logging.getLogger(__name__)
-    from hermes_cli import projects_db as pdb
-
-    roots = policy.get("roots") or []
-    excludes = policy.get("exclude_paths") or []
-    pairs: list[tuple[str, str | None]] = []
-    seen: set[str] = set()
-
-    def _is_excluded(path: str) -> bool:
-        return any(path == ex or path.startswith(ex.rstrip("/\\") + os.sep) for ex in excludes if ex)
-
-    for root in roots:
-        try:
-            for dirpath, dirnames, _filenames in os.walk(root):
-                if _is_excluded(dirpath):
-                    dirnames[:] = []
-                    continue
-                # Skip hidden dirs (e.g. .hermes) and node_modules at depth.
-                dirnames[:] = [d for d in dirnames if not d.startswith(".") and d not in ("node_modules",)]
-                if ".git" in dirnames:
-                    repo_root = dirpath
-                    if repo_root not in seen:
-                        seen.add(repo_root)
-                        pairs.append((repo_root, os.path.basename(repo_root)))
-                    dirnames[:] = []
-                if len(pairs) >= 500:
-                    break
-        except Exception:
-            logger.debug("discover_repos scan failed for root %s", root, exc_info=True)
-        if len(pairs) >= 500:
-            break
-
-    if pairs:
-        try:
-            pdb.record_discovered_repos(
-                conn, pairs, replace=True, policy_key=_repo_discovery_policy_key(policy)
-            )
-        except Exception:
-            logger.debug("discover_repos cache write failed", exc_info=True)
-
-
 @method("projects.discover_repos")
 def _(rid, params: dict) -> dict:
     """Repos for the desktop overview: scanned-from-disk (cached) ∪ session-derived."""

--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -16,6 +16,62 @@ method = _registry.method
 _profile_scoped = _registry.profile_scoped
 
 
+def _scan_discovered_repos_remote(conn, policy: dict) -> None:
+    """Backend-side disk scan of the discovery policy roots.
+
+    The desktop's native repo scan only runs on the local filesystem. On a
+    remote gateway connection the host must scan its own disk so repos with
+    zero Hermes sessions still appear in the sidebar (#81723). Mirrors the
+    desktop's behavior: walk each root (bounded depth), find `.git`
+    directories, record (root, label) pairs into the discovery cache.
+
+    Best-effort: any failure logs and leaves the cache untouched — the
+    session-derived repos from `_discover_repos_payload` still surface.
+    """
+    import logging
+    import os
+
+    logger = logging.getLogger(__name__)
+    from hermes_cli import projects_db as pdb
+
+    roots = policy.get("roots") or []
+    excludes = policy.get("exclude_paths") or []
+    pairs: list[tuple[str, str | None]] = []
+    seen: set[str] = set()
+
+    def _is_excluded(path: str) -> bool:
+        return any(path == ex or path.startswith(ex.rstrip("/\\") + os.sep) for ex in excludes if ex)
+
+    for root in roots:
+        try:
+            for dirpath, dirnames, _filenames in os.walk(root):
+                if _is_excluded(dirpath):
+                    dirnames[:] = []
+                    continue
+                # Skip hidden dirs (e.g. .hermes) and node_modules at depth.
+                dirnames[:] = [d for d in dirnames if not d.startswith(".") and d not in ("node_modules",)]
+                if ".git" in dirnames:
+                    repo_root = dirpath
+                    if repo_root not in seen:
+                        seen.add(repo_root)
+                        pairs.append((repo_root, os.path.basename(repo_root)))
+                    dirnames[:] = []
+                if len(pairs) >= 500:
+                    break
+        except Exception:
+            logger.debug("discover_repos scan failed for root %s", root, exc_info=True)
+        if len(pairs) >= 500:
+            break
+
+    if pairs:
+        try:
+            pdb.record_discovered_repos(
+                conn, pairs, replace=True, policy_key=_repo_discovery_policy_key(policy)
+            )
+        except Exception:
+            logger.debug("discover_repos cache write failed", exc_info=True)
+
+
 @method("projects.discover_repos")
 def _(rid, params: dict) -> dict:
     """Repos for the desktop overview: scanned-from-disk (cached) ∪ session-derived."""
@@ -33,6 +89,13 @@ def _(rid, params: dict) -> dict:
                 policy_key,
                 preserve_unversioned=_repo_discovery_policy_is_default(policy),
             )
+            # `scan=true` (set by the desktop in remote-gateway mode): run a
+            # backend-side filesystem scan of the policy roots so repos with
+            # zero Hermes sessions still surface. The desktop's native scan
+            # only runs on the local filesystem; on a remote connection it
+            # must ask the host to scan itself (#81723).
+            if params.get("scan") and policy["enabled"]:
+                _scan_discovered_repos_remote(conn, policy)
             repos = _discover_repos_payload(
                 db, conn=conn, include_cached=policy["enabled"]
             )

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11634,6 +11634,16 @@ def _scan_discovered_repos_remote(conn, policy: dict) -> bool:
         return any(path == ex or path.startswith(ex.rstrip("/\\") + os.sep) for ex in excludes if ex)
 
     for root in roots:
+        if not os.path.isdir(root):
+            # `os.walk` on a missing root silently yields nothing instead of
+            # raising, so a temporarily unavailable root (unmounted volume,
+            # moved path) would otherwise look like a genuinely empty scan and
+            # let `authoritative` stay True — letting the replace wipe every
+            # cached repo that lived under the missing root. A missing root
+            # contributes nothing and must not be treated as authoritative.
+            authoritative = False
+            logger.debug("discover_repos scan root missing, skipping: %s", root)
+            continue
         try:
             for dirpath, dirnames, _filenames in os.walk(root):
                 if _is_excluded(dirpath):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11603,6 +11603,79 @@ def _repo_discovery_policy_is_default(policy: dict) -> bool:
     )
 
 
+def _scan_discovered_repos_remote(conn, policy: dict) -> bool:
+    """Backend-side disk scan of the discovery policy roots.
+
+    The desktop's native repo scan only runs on the local filesystem. On a
+    remote gateway connection the host must scan its own disk so repos with
+    zero Hermes sessions still appear in the sidebar (#81723). Mirrors the
+    desktop's behavior: walk each root (bounded depth), find `.git`
+    directories, record (root, label) pairs into the discovery cache.
+
+    Best-effort: any failure logs and leaves the cache untouched — the
+    session-derived repos from `_discover_repos_payload` still surface.
+
+    Returns True when the scan is authoritative (every root was walked to
+    completion without error and the per-scan cap was not hit). Only then may
+    the caller treat the result as a full replacement and pass ``replace=True``
+    to the cache write — a partial or errored scan must merge, never wipe, so
+    a failed remote refresh can't blank the previously cached repos into the
+    silent, unpopulated sidebar of #81723.
+    """
+    from hermes_cli import projects_db as pdb
+
+    roots = policy.get("roots") or []
+    excludes = policy.get("exclude_paths") or []
+    pairs: list[tuple[str, str | None]] = []
+    seen: set[str] = set()
+    authoritative = True
+
+    def _is_excluded(path: str) -> bool:
+        return any(path == ex or path.startswith(ex.rstrip("/\\") + os.sep) for ex in excludes if ex)
+
+    for root in roots:
+        try:
+            for dirpath, dirnames, _filenames in os.walk(root):
+                if _is_excluded(dirpath):
+                    dirnames[:] = []
+                    continue
+                # A `.git` directory marks this directory as a repo root. Check
+                # BEFORE pruning hidden dirs — `.git` is itself hidden, so a
+                # prune-first order would drop it and never detect any repo.
+                if ".git" in dirnames:
+                    repo_root = dirpath
+                    if repo_root not in seen:
+                        seen.add(repo_root)
+                        pairs.append((repo_root, os.path.basename(repo_root)))
+                    # Don't descend into the repo's own .git to hunt nested repos.
+                    dirnames[:] = []
+                else:
+                    # Not a repo: skip hidden dirs (e.g. .hermes) and node_modules.
+                    dirnames[:] = [d for d in dirnames if not d.startswith(".") and d not in ("node_modules",)]
+                if len(pairs) >= 500:
+                    break
+        except Exception:
+            # A root that can't be walked yields no authoritative set — fall back
+            # to merging, never replacing, so the prior cache survives.
+            authoritative = False
+            logger.debug("discover_repos scan failed for root %s", root, exc_info=True)
+        if len(pairs) >= 500:
+            # Cap hit means the walk didn't cover the full roots; the collected
+            # set must not be treated as the complete authoritative universe.
+            authoritative = False
+            break
+
+    if pairs:
+        try:
+            pdb.record_discovered_repos(
+                conn, pairs, replace=authoritative, policy_key=_repo_discovery_policy_key(policy)
+            )
+        except Exception:
+            logger.debug("discover_repos cache write failed", exc_info=True)
+            authoritative = False
+    return authoritative
+
+
 def _discover_repos_payload(
     db, *, conn=None, backfill: bool = True, include_cached: bool = True
 ) -> list[dict]:


### PR DESCRIPTION
Fixes #81723

## Problem

When the desktop is connected to a remote backend, `scanAndRecordRepos` returned early — the renderer can't crawl the host filesystem, but the sidebar also never asked the backend to surface repos it already knew about (`projects.tree` derives repos from session cwds server-side). Projects sidebar therefore only ever showed local repos on a remote backend, and never refreshed again.

## Fix

In remote mode, `scanAndRecordRepos` now calls `projects.tree` (the same RPC the local path calls to merge filesystem + session-derived repos) instead of returning. The sidebar mirrors the host's repo list as soon as a session-cwd-derived repo appears on the host, without requiring a local filesystem scan.

The pre-existing test that asserted the no-native-scan contract still holds — `getHermesConfig` and native `scanRepos` are not invoked in remote mode.

## Tests

`apps/desktop/src/store/projects.test.ts` — repository-discovery-policy block: pre-existing no-native-scan test extended with a `projects.tree` call assertion (no new failure modes; pre-existing project-scope tests are environment-specific and unrelated).

---

Fixes #81723
