### PR TITLE
fix(kanban): explicit --board conflicting with HERMES_KANBAN_DB fails…

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1019,6 +1019,19 @@ def kanban_command(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
             return 1
+        # A pinned process — the dispatcher→worker handoff sets
+        # HERMES_KANBAN_DB — resolves its database before any board scope is
+        # consulted. Scoping here would therefore change the printed header
+        # and NOT the database: the command would read and write the pinned
+        # board while reporting the board that was asked for, with nothing in
+        # the output to reveal it. A dispatched worker ran
+        # `--board life comment <id>` against its own board and reported in
+        # good faith that it had updated a card on `life`. Fail instead.
+        try:
+            kb.kanban_db_path(normed)
+        except kb.BoardPinConflict as exc:
+            print(f"kanban: {exc}", file=sys.stderr)
+            return 2
         board_scope = kb.scoped_current_board(normed)
 
     # Auto-initialize the DB before dispatching any subcommand. init_db

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -562,6 +562,15 @@ def board_exists(board: Optional[str] = None) -> bool:
     return (d / "board.json").exists() or (d / "kanban.db").exists()
 
 
+class BoardPinConflict(RuntimeError):
+    """An explicit board was requested while the process is pinned elsewhere.
+
+    Raised instead of silently honouring the pin, so a cross-board request
+    fails visibly rather than reading or writing the wrong board under the
+    requested board's name.
+    """
+
+
 def kanban_db_path(board: Optional[str] = None) -> Path:
     """Return the path to the ``kanban.db`` for ``board``.
 
@@ -575,10 +584,40 @@ def kanban_db_path(board: Optional[str] = None) -> Path:
        :func:`get_current_board` is used.
     3. Board ``default`` → ``<root>/kanban.db`` (back-compat path).
        Other boards → ``<root>/kanban/boards/<slug>/kanban.db``.
+
+    An EXPLICIT ``board`` that contradicts the override raises
+    :class:`BoardPinConflict` rather than silently returning the override.
+    The override still wins for ``board=None`` — a pinned worker keeps its
+    board — but a caller that named a board is asking a question this
+    function must not answer wrongly. Silently discarding it let a dispatched
+    worker run ``--board life create`` against its own board while the CLI
+    printed "Board: life", so the write went to the wrong board and reported
+    success. Nothing in the output could reveal it.
     """
     override = os.environ.get("HERMES_KANBAN_DB", "").strip()
     if override:
-        return Path(override).expanduser()
+        pinned = Path(override).expanduser()
+        slug = _normalize_board_slug(board)
+        if slug is not None:
+            wanted = (
+                kanban_home() / "kanban.db" if slug == DEFAULT_BOARD
+                else board_dir(slug) / "kanban.db"
+            )
+            try:
+                same = wanted.resolve() == pinned.resolve()
+            except OSError:          # unresolvable path: compare literally
+                same = wanted == pinned
+            if not same:
+                raise BoardPinConflict(
+                    f"board {slug!r} was requested, but this process is pinned "
+                    f"to {pinned} by HERMES_KANBAN_DB. Refusing to read or "
+                    f"write the pinned board under another board's name. "
+                    f"A dispatched worker cannot reach another board; if this "
+                    f"is a deliberate cross-board operation, drop the pin "
+                    f"explicitly (env -u HERMES_KANBAN_DB -u "
+                    f"HERMES_KANBAN_BOARD) so the intent is visible."
+                )
+        return pinned
     slug = _normalize_board_slug(board)
     if slug is None:
         slug = get_current_board()

--- a/tests/hermes_cli/test_kanban_board_pin.py
+++ b/tests/hermes_cli/test_kanban_board_pin.py
@@ -1,0 +1,91 @@
+"""kanban_db_path: an explicit board must never be silently overridden.
+
+The dispatcher pins a worker's kanban context via ``HERMES_KANBAN_DB`` /
+``HERMES_KANBAN_BOARD`` so "workers cannot accidentally see other boards".
+The pin is correct — but it used to beat an *explicit* ``board`` argument
+silently, and the CLI's ``--board`` flag resolves the DB through this
+function before scoping. The combination meant a pinned process running
+
+    hermes kanban --board life create "[attention] ..."
+
+wrote to its own board while the output header printed ``Board: life`` —
+the board that was *requested*, not the one that was read. Nothing in the
+output could reveal the substitution: a dispatched worker filed its
+escalations onto its own board for a full night and truthfully reported,
+run after run, that it had filed them elsewhere.
+
+The fix: an explicit board that contradicts the pin raises
+``BoardPinConflict``. ``board=None`` still honours the pin, so worker
+containment is unchanged.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture()
+def boards(monkeypatch, tmp_path):
+    """Two real board dirs under an isolated HERMES_HOME, pin unset."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    for slug in ("alpha", "beta"):
+        (tmp_path / "kanban" / "boards" / slug).mkdir(parents=True)
+    return tmp_path
+
+
+def _pin_to(monkeypatch, home, slug):
+    pinned = home / "kanban" / "boards" / slug / "kanban.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(pinned))
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", slug)
+    return pinned
+
+
+def test_unpinned_explicit_board_resolves_normally(boards):
+    path = kb.kanban_db_path("alpha")
+    assert path == boards / "kanban" / "boards" / "alpha" / "kanban.db"
+
+
+def test_pinned_with_no_board_keeps_the_pin(boards, monkeypatch):
+    """The dispatcher→worker handoff: containment must be unchanged."""
+    pinned = _pin_to(monkeypatch, boards, "alpha")
+    assert kb.kanban_db_path(None) == pinned
+
+
+def test_pinned_with_matching_board_is_allowed(boards, monkeypatch):
+    """Naming your own board is not a contradiction."""
+    pinned = _pin_to(monkeypatch, boards, "alpha")
+    assert kb.kanban_db_path("alpha") == pinned
+
+
+def test_pinned_with_conflicting_board_raises(boards, monkeypatch):
+    """The silent-mislabel case: must fail, never return the pinned path."""
+    _pin_to(monkeypatch, boards, "alpha")
+    with pytest.raises(kb.BoardPinConflict) as exc:
+        kb.kanban_db_path("beta")
+    # The message must carry what an agent (or human) needs to act on it:
+    # the requested board, the actual pin, and the sanctioned way through.
+    msg = str(exc.value)
+    assert "beta" in msg
+    assert "HERMES_KANBAN_DB" in msg
+    assert "env -u" in msg
+
+
+def test_pinned_default_board_conflict_also_raises(boards, monkeypatch):
+    """`default` resolves to the home-root DB; a pin elsewhere still conflicts."""
+    _pin_to(monkeypatch, boards, "alpha")
+    with pytest.raises(kb.BoardPinConflict):
+        kb.kanban_db_path("default")
+
+
+def test_unresolvable_pin_path_compares_literally(boards, monkeypatch):
+    """A pin pointing at a not-yet-created path must not crash the check."""
+    ghost = boards / "kanban" / "boards" / "alpha" / "kanban.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(ghost))
+    # same board: fine even though the file does not exist yet
+    assert kb.kanban_db_path("alpha") == ghost
+    with pytest.raises(kb.BoardPinConflict):
+        kb.kanban_db_path("beta")

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -98,12 +98,31 @@ class TestPathResolution:
         assert p == fresh_home / "kanban" / "boards" / "atm10-server" / "kanban.db"
 
 
-    def test_env_var_db_override_still_wins(self, fresh_home, tmp_path, monkeypatch):
-        """``HERMES_KANBAN_DB`` pins the file regardless of board= arg."""
+    def test_env_var_db_override_wins_for_unnamed_board(self, fresh_home, tmp_path, monkeypatch):
+        """``HERMES_KANBAN_DB`` pins the file when no board is named.
+
+        This is the dispatcher→worker handoff: a pinned worker that does not
+        name a board stays contained to the board that dispatched it.
+        """
         forced = tmp_path / "custom.db"
         monkeypatch.setenv("HERMES_KANBAN_DB", str(forced))
         assert kb.kanban_db_path() == forced
-        assert kb.kanban_db_path(board="ignored") == forced
+
+    def test_env_var_db_override_conflicts_with_explicit_board(self, fresh_home, tmp_path, monkeypatch):
+        """An EXPLICIT board that contradicts the pin raises, never lies.
+
+        Previously the pin silently won (``board=`` was ignored), and the
+        CLI's ``--board`` resolves the DB through this function before
+        scoping — so a pinned process running ``--board other`` read and
+        wrote the pinned board while printing the requested board's name.
+        A dispatched worker filed cards onto its own board all night while
+        truthfully reporting it had filed them elsewhere. See
+        test_kanban_board_pin.py for the full contract.
+        """
+        forced = tmp_path / "custom.db"
+        monkeypatch.setenv("HERMES_KANBAN_DB", str(forced))
+        with pytest.raises(kb.BoardPinConflict):
+            kb.kanban_db_path(board="ignored")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The bug

      A process pinned via HERMES_KANBAN_DB that explicitly asks for a different board gets the pinned
      board back — silently, and mislabeled:

        HERMES_KANBAN_DB=<boards/alpha/kanban.db> hermes kanban --board beta list
        -> prints "Board: beta", reads and writes board alpha

      Two pieces combine: kanban_db_path() returns the env override before looking at its board
      argument, and the CLI's --board flag resolves the DB through that function before applying its
      board scope — so the scope changes the printed header while the pin chooses the database.
      Nothing in the output reveals the substitution.

      ## How this bites in practice

      The dispatcher pins every worker's env by design ("workers cannot accidentally see other boards"
      — _default_spawn). That containment is good. But in our fleet a dispatched worker whose
      instructions said to file escalation cards on another board ran  --board <other> create  /  --
      board <other> comment  for a full night: every card landed on its own board, while the worker
      truthfully reported filing them elsewhere. The worker's summaries, the CLI output, and the board
      header all agreed on a thing that was not happening. It took a four-layer investigation to find,
      precisely because there is no observable signal.

      ## The change

      • board=None still resolves to the pin — worker containment is unchanged.
      • An EXPLICIT board that contradicts the pin raises BoardPinConflict; the CLI converts it to
      exit 2 with a message naming the requested board, the actual pin, and the sanctioned way to make
      a deliberate cross-board call visible (env -u HERMES_KANBAN_DB -u HERMES_KANBAN_BOARD ...).

      ## This is a deliberate behaviour change

      test_env_var_db_override_still_wins codified the old behaviour ("pins the file regardless of
      board= arg"). I've split it: the unnamed case keeps its assertion; the named case now expects
      the conflict. The argument: a caller that names a board is asking a question this function must
      not answer wrongly — and every downstream consumer (including your own CLI header) trusts the
      answer.

      ## Tests

      Six new tests in tests/hermes_cli/test_kanban_board_pin.py (containment preserved, same-board
      allowed, conflict raises, default-board conflict, unresolvable-path fallback, error-message
      actionability), plus the split described above. Kanban test files pass with an identical failure
      set to clean main in my environment (the pre-existing failures are unrelated write-guard/env
      ones).

      Happy to adjust the exception type/name or fold the check elsewhere if you'd rather keep
      kanban_db_path pure — the substance is only that the contradiction must be loud.