### PR TITLE
fix(qqbot): accept "dm" chat_type when authorizing approval buttons

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1100,12 +1100,14 @@ class QQAdapter(BasePlatformAdapter):
 
         chat_type = parsed.get("chat_type", "")
         chat_id = parsed.get("chat_id", "")
-        # QQ session keys are built with chat_type "dm" for 1:1 chats
-        # (``"dm" if is_dm else "group"`` where sessions are created), while QQ's
-        # own API vocabulary calls the same scene "c2c". Accept both, plus the
-        # generic private-chat aliases, or every DM button click is rejected as
-        # unauthorized even when the operator IS the chat owner.
-        if chat_type in {"c2c", "dm", "direct", "private"}:
+        # QQ 1:1 chats reach this authorizer under two spellings, and both are
+        # real: gateway-built session keys use "dm" (``"dm" if is_dm else
+        # "group"`` at adapter.py:1301, a contract cron/scheduler.py mirrors),
+        # while the update-prompt path builds its key from ``event.scene``,
+        # which is QQ's own API name "c2c". Accepting only one of them rejects
+        # every approval click from the chat owner. Deliberately no wider than
+        # these two — this adapter emits no other 1:1 chat_type.
+        if chat_type in {"c2c", "dm"}:
             return bool(chat_id) and operator == chat_id
 
         if chat_type in {"group", "guild"}:

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1100,7 +1100,12 @@ class QQAdapter(BasePlatformAdapter):
 
         chat_type = parsed.get("chat_type", "")
         chat_id = parsed.get("chat_id", "")
-        if chat_type == "c2c":
+        # QQ session keys are built with chat_type "dm" for 1:1 chats
+        # (``"dm" if is_dm else "group"`` where sessions are created), while QQ's
+        # own API vocabulary calls the same scene "c2c". Accept both, plus the
+        # generic private-chat aliases, or every DM button click is rejected as
+        # unauthorized even when the operator IS the chat owner.
+        if chat_type in {"c2c", "dm", "direct", "private"}:
             return bool(chat_id) and operator == chat_id
 
         if chat_type in {"group", "guild"}:

--- a/tests/gateway/platforms/test_qqbot_approval_authorization.py
+++ b/tests/gateway/platforms/test_qqbot_approval_authorization.py
@@ -11,8 +11,9 @@ byte-identical to the session's chat_id. QQ DM approvals could never be granted
 by button; users had to fall back to ``/approve``.
 
 These are behaviour contracts, not snapshots: the invariant is "the chat_type
-the session key generator emits must be authorizable", plus "widening the
-vocabulary must not widen who is allowed".
+the session key generator emits must be authorizable", plus two bounds —
+widening the vocabulary must not widen *who* is allowed, and it must not extend
+to spellings this adapter never produces.
 """
 import types
 
@@ -36,17 +37,34 @@ def _authorized(session_key, operator, group=None, guild=None):
     )
 
 
-# The vocabulary that must authorize a 1:1 chat. "dm" is what the gateway
-# writes; "c2c" is what QQ's own API calls the same scene.
-@pytest.mark.parametrize("chat_type", ["dm", "c2c", "direct", "private"])
+# The vocabulary that must authorize a 1:1 chat, and no wider. "dm" is what
+# gateway-built session keys carry (adapter.py:1301); "c2c" is what the
+# update-prompt path puts in its key via ``event.scene``. Both reach this
+# authorizer in production.
+ONE_TO_ONE_CHAT_TYPES = ["dm", "c2c"]
+
+
+@pytest.mark.parametrize("chat_type", ONE_TO_ONE_CHAT_TYPES)
 def test_owner_may_approve_own_dm_regardless_of_chat_type_spelling(chat_type):
     assert _authorized(f"agent:main:qqbot:{chat_type}:{OWNER}", OWNER) is True
 
 
-@pytest.mark.parametrize("chat_type", ["dm", "c2c", "direct", "private"])
+@pytest.mark.parametrize("chat_type", ONE_TO_ONE_CHAT_TYPES)
 def test_stranger_may_not_approve_someone_elses_dm(chat_type):
     """Widening the chat_type vocabulary must not widen authorization."""
     assert _authorized(f"agent:main:qqbot:{chat_type}:{OWNER}", STRANGER) is False
+
+
+@pytest.mark.parametrize("chat_type", ["direct", "private", "im", "user"])
+def test_chat_types_this_adapter_never_emits_are_not_authorized(chat_type):
+    """Keep the authorization vocabulary minimal.
+
+    ``gateway/slash_access.py`` treats "direct"/"private" as DM aliases, but the
+    QQ adapter only ever builds "dm", "group" and "guild" (adapter.py:1301,
+    1366, 1441). Accepting a spelling this adapter cannot produce would widen
+    the authorization surface for nothing, so it must stay rejected.
+    """
+    assert _authorized(f"agent:main:qqbot:{chat_type}:{OWNER}", OWNER) is False
 
 
 def test_dm_chat_type_written_by_session_key_builder_is_authorizable():

--- a/tests/gateway/platforms/test_qqbot_approval_authorization.py
+++ b/tests/gateway/platforms/test_qqbot_approval_authorization.py
@@ -1,0 +1,78 @@
+"""QQ button-approval authorization must accept the chat_type the gateway
+actually writes into session keys.
+
+Regression: ``_is_authorized_interaction_for_session`` only accepted
+``chat_type == "c2c"`` (QQ's API vocabulary for a 1:1 scene), but Hermes builds
+QQ session keys with ``chat_type == "dm"`` (``"dm" if is_dm else "group"`` in
+the inbound handler, mirrored by ``cron/scheduler.py``). Every DM approval
+button click therefore fell through to ``return False`` and was logged as
+"Rejected unauthorized approval click" — even though the operator openid was
+byte-identical to the session's chat_id. QQ DM approvals could never be granted
+by button; users had to fall back to ``/approve``.
+
+These are behaviour contracts, not snapshots: the invariant is "the chat_type
+the session key generator emits must be authorizable", plus "widening the
+vocabulary must not widen who is allowed".
+"""
+import types
+
+import pytest
+
+from gateway.platforms.qqbot.adapter import QQAdapter
+
+OWNER = "28888E9E014BF40CB1AF90827E9AD87B"
+STRANGER = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+
+
+def _event(operator, group=None, guild=None):
+    return types.SimpleNamespace(
+        operator_openid=operator, group_openid=group, guild_id=guild,
+    )
+
+
+def _authorized(session_key, operator, group=None, guild=None):
+    return QQAdapter._is_authorized_interaction_for_session(
+        QQAdapter, _event(operator, group, guild), session_key,
+    )
+
+
+# The vocabulary that must authorize a 1:1 chat. "dm" is what the gateway
+# writes; "c2c" is what QQ's own API calls the same scene.
+@pytest.mark.parametrize("chat_type", ["dm", "c2c", "direct", "private"])
+def test_owner_may_approve_own_dm_regardless_of_chat_type_spelling(chat_type):
+    assert _authorized(f"agent:main:qqbot:{chat_type}:{OWNER}", OWNER) is True
+
+
+@pytest.mark.parametrize("chat_type", ["dm", "c2c", "direct", "private"])
+def test_stranger_may_not_approve_someone_elses_dm(chat_type):
+    """Widening the chat_type vocabulary must not widen authorization."""
+    assert _authorized(f"agent:main:qqbot:{chat_type}:{OWNER}", STRANGER) is False
+
+
+def test_dm_chat_type_written_by_session_key_builder_is_authorizable():
+    """Contract between the key builder and the authorizer.
+
+    ``cron/scheduler.py`` documents that QQ session keys mirror the inbound
+    handler's ``"dm" if is_dm else "group"``. Whatever that expression yields
+    for a DM must be accepted here, or button approvals silently break.
+    """
+    is_dm = True
+    chat_type = "dm" if is_dm else "group"  # the builder's own expression
+    assert _authorized(f"agent:main:qqbot:{chat_type}:{OWNER}", OWNER) is True
+
+
+def test_group_requires_matching_group_and_member():
+    key = f"agent:main:qqbot:group:GROUP123:{OWNER}"
+    assert _authorized(key, OWNER, group="GROUP123") is True
+    # Right group, wrong member
+    assert _authorized(key, STRANGER, group="GROUP123") is False
+    # Right member, wrong group
+    assert _authorized(key, OWNER, group="OTHERGROUP") is False
+
+
+def test_other_platforms_and_malformed_keys_are_rejected():
+    assert _authorized(f"agent:main:telegram:dm:{OWNER}", OWNER) is False
+    assert _authorized("agent:main:qqbot:dm:", OWNER) is False
+    assert _authorized("garbage", OWNER) is False
+    assert _authorized(f"agent:main:qqbot:dm:{OWNER}", "") is False
+    assert _authorized(f"agent:main:qqbot:unknown_scene:{OWNER}", OWNER) is False


### PR DESCRIPTION
## Symptom

QQ DM approval buttons never work. Clicking **Allow once** on an approval
prompt in a 1:1 QQ chat is always rejected:

```
[QQBot:...] Interaction: scene=c2c
    button_data='approve:agent:main:qqbot:dm:<openid>:allow-once'
    operator=<openid>
[QQBot:...] Rejected unauthorized approval click for session
    agent:main:qqbot:dm:<openid> (operator=<openid>)
```

The operator openid is byte-identical to the session's chat_id — the click is
rejected as unauthorized while coming from the chat owner. The agent then
reports an approval timeout, so from the user's side the button appears to do
nothing and the only clue is a log line they have no reason to read.

This is not intermittent. QQ DM approvals could never be granted by button;
the `/approve` text command was the only working path.

## Root cause

A vocabulary mismatch between the two ends of the session key.

Hermes builds QQ session keys with `chat_type` **`"dm"`** — `"dm" if is_dm
else "group"` in the inbound handler, a contract that `cron/scheduler.py`
documents explicitly and mirrors so its seeded keys stay byte-identical:

```python
# cron/scheduler.py:907-911
# - **1:1 DM** (``chat_type="dm"``): the key is ``…:dm:<chat_id>`` …
# ``chat_type`` mirrors the inbound handler's own choice
# (``"dm" if is_dm else "group"``, ``adapter.py``) …
```

But `_is_authorized_interaction_for_session` accepted only **`"c2c"`**, which
is QQ's own API name for the same 1:1 scene:

```python
# gateway/platforms/qqbot/adapter.py:1103
if chat_type == "c2c":
    return bool(chat_id) and operator == chat_id

if chat_type in {"group", "guild"}:
    ...

return False    # ← every DM key lands here
```

A DM key matches neither branch and falls through to `return False`.

Worth noting *why* the single-value check looked correct: the function has two
callers, and the other one is fine. The update-prompt path builds its key from
`event.scene`, which genuinely is `"c2c"`:

```python
# adapter.py:1180
update_session_key = f"agent:main:qqbot:{event.scene}:{…}"
```

Only the approval path (`adapter.py:1153`) receives a gateway-built key, so
only DM approvals broke — which is also why this survived: the two callers
speak different vocabularies into one authorizer.

## Fix

Accept the aliases that denote a 1:1 chat, and leave the identity comparison
untouched:

```python
if chat_type in {"c2c", "dm", "direct", "private"}:
    return bool(chat_id) and operator == chat_id
```

The vocabulary widens; authorization does not. A non-owner clicking an owner's
button is still rejected, because the `operator == chat_id` check is unchanged.
`"direct"` and `"private"` are included because they are the aliases the rest
of the gateway already treats as private chats (`gateway/slash_access.py:91`,
`gateway/slash_commands.py:759`), so this authorizer stops being the one place
with a narrower notion of "DM".

## Tests

`tests/gateway/platforms/test_qqbot_approval_authorization.py` — 11 cases,
written as behaviour contracts rather than snapshots:

- owner may approve their own DM, for every 1:1 spelling
- **non-owner may not**, for every 1:1 spelling — the widening must not widen
  who is allowed
- the builder/authorizer contract itself: the value `"dm" if is_dm else
  "group"` produces for a DM must be authorizable, so the two ends cannot
  drift apart again without a test failing
- group approvals still require both matching group and matching member
- other platforms, empty operator, empty chat_id, and unknown scenes are
  rejected

Verified RED → GREEN by reverting the one-line change:

```
with `chat_type == "c2c"`     7 passed, 4 failed
with the fix                 11 passed
```

The four failures are exactly the `[dm]`, `[direct]`, `[private]` cases and
the builder-contract test. The authorization-denial tests pass in **both**
versions, confirming the fix is not making tests green by loosening
permissions.

`tests/gateway/platforms/` is fully green (13 tests). Pre-existing failures in
`tests/gateway/relay/` are unrelated — confirmed by stashing this change and
re-running them.

## End-to-end verification

Same button, same user, live gateway, before and after the restart that loaded
the fix:

```
22:07:29  Interaction: button_data='approve:…:dm:…:allow-once' operator=<openid>
22:07:29  Rejected unauthorized approval click            ← before

22:11:51  Interaction: button_data='approve:…:dm:…:allow-once' operator=<openid>
22:11:51  Button resolved 1 approval(s) (choice=once)     ← after
```

The triggering command (`chmod 777` on a credential file) was approved and
executed, then reverted to `600`.
