### PR TITLE
fix(personality): preserve manual system prompts (#81791)

### DIFF
--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1339,22 +1339,34 @@ class CLICommandsMixin:
             # Set personality
             personality_name = parts[1].strip().lower()
             
+            # ``system_prompt`` is also used to carry the manual prompt and
+            # other startup overlays.  Snapshot it before the first personality
+            # change, then compose the selected personality on top instead of
+            # replacing or persisting the user's manual prompt.
+            if not hasattr(self, "_personality_base_prompt"):
+                self._personality_base_prompt = self.system_prompt or ""
+
             if personality_name in {"none", "default", "neutral"}:
-                self.system_prompt = ""
+                self.system_prompt = self._personality_base_prompt
                 self.agent = None  # Force re-init
-                if save_config_value("agent.system_prompt", ""):
+                if save_config_value("display.personality", ""):
                     print("(^_^)b Personality cleared (saved to config)")
                 else:
                     print("(^_^) Personality cleared (session only)")
                 print("  No personality overlay — using base agent behavior.")
             elif personality_name in self.personalities:
-                self.system_prompt = self._resolve_personality_prompt(self.personalities[personality_name])
+                personality_prompt = self._resolve_personality_prompt(
+                    self.personalities[personality_name]
+                )
+                self.system_prompt = "\n\n".join(
+                    part for part in (self._personality_base_prompt, personality_prompt) if part
+                )
                 self.agent = None  # Force re-init
-                if save_config_value("agent.system_prompt", self.system_prompt):
+                if save_config_value("display.personality", personality_name):
                     print(f"(^_^)b Personality set to '{personality_name}' (saved to config)")
                 else:
                     print(f"(^_^) Personality set to '{personality_name}' (session only)")
-                print(f"  \"{self.system_prompt[:60]}{'...' if len(self.system_prompt) > 60 else ''}\"")
+                print(f"  \"{personality_prompt[:60]}{'...' if len(personality_prompt) > 60 else ''}\"")
             else:
                 print(f"(._.) Unknown personality: {personality_name}")
                 print(f"  Available: none, {', '.join(self.personalities.keys())}")

--- a/tests/cli/test_personality_none.py
+++ b/tests/cli/test_personality_none.py
@@ -26,7 +26,9 @@ class TestCLIPersonalityNone:
         cli = self._make_cli()
         with patch("cli.save_config_value", return_value=True):
             cli._handle_personality_command("/personality neutral")
-        assert cli.system_prompt == ""
+        # Clearing the overlay restores the manual/base prompt rather than
+        # deleting it.
+        assert cli.system_prompt == "You are kawaii~"
 
 
 
@@ -133,11 +135,14 @@ class TestPersonalityDictFormat:
             cli._handle_personality_command("/personality coder")
         assert "Style: use code examples" in cli.system_prompt
 
-    def test_string_personality_still_works(self):
+    def test_personality_preserves_manual_prompt_and_persists_selection(self):
         cli = self._make_cli({"helper": "You are helpful."})
-        with patch("cli.save_config_value", return_value=True):
+        cli.system_prompt = "Be concise."
+        with patch("cli.save_config_value", return_value=True) as save:
             cli._handle_personality_command("/personality helper")
-        assert cli.system_prompt == "You are helpful."
+        assert "Be concise." in cli.system_prompt
+        assert "You are helpful." in cli.system_prompt
+        save.assert_called_once_with("display.personality", "helper")
 
     def test_resolve_prompt_dict_no_tone_no_style(self):
         from cli import HermesCLI

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7450,7 +7450,8 @@ def test_config_set_personality_preserves_history_and_returns_info(monkeypatch):
         server, "_session_info", lambda agent, *a: {"model": getattr(agent, "model", "?")}
     )
     monkeypatch.setattr(server, "_emit", lambda *args: emits.append(args))
-    monkeypatch.setattr(server, "_write_config_key", lambda path, value: None)
+    writes = []
+    monkeypatch.setattr(server, "_write_config_key", lambda path, value: writes.append((path, value)))
 
     resp = server.handle_request(
         {
@@ -7472,6 +7473,8 @@ def test_config_set_personality_preserves_history_and_returns_info(monkeypatch):
     # Agent's system prompt was updated in-place; cached prompt untouched
     assert agent.ephemeral_system_prompt == "You are helpful."
     assert agent._cached_system_prompt == "old"
+    assert ("display.personality", "helpful") in writes
+    assert all(path != "agent.system_prompt" for path, _ in writes)
     assert ("session.info", "sid", {"model": "?"}) in emits
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11325,8 +11325,10 @@ def _(rid, params: dict) -> dict:
             elif key == "personality":
                 sid_key = params.get("session_id", "")
                 pname, new_prompt = _validate_personality(str(value or ""), cfg)
+                # Personality text is an in-session overlay.  Keep the
+                # user-owned global system prompt intact so changing a
+                # personality cannot destroy manual configuration.
                 _write_config_key("display.personality", pname)
-                _write_config_key("agent.system_prompt", new_prompt)
                 nv = str(value or "none")
                 history_reset, info = _apply_personality_to_session(
                     sid_key, session, new_prompt, pname


### PR DESCRIPTION
## Summary
- keep `agent.system_prompt` as the user-owned manual prompt when selecting a personality
- apply personality text only as an in-session overlay and persist the selection in `display.personality`
- add regression coverage for the TUI Gateway and CLI paths

Closes #81791

## Tests
- `./venv/bin/pytest -q tests/test_tui_gateway_server.py::test_config_set_personality_preserves_history_and_returns_info tests/cli/test_personality_none.py` (10 passed)
- `python3 -m py_compile tui_gateway/server.py hermes_cli/cli_commands_mixin.py`
- `git diff --check`
