### PR TITLE
feat(providers): add Cerebras Inference (wafer-scale silicon)

### DIFF
--- a/plugins/model-providers/cerebras/__init__.py
+++ b/plugins/model-providers/cerebras/__init__.py
@@ -1,0 +1,57 @@
+"""Cerebras Inference provider profile.
+
+Cerebras runs models on their Wafer-Scale Engine (WSE) — a single-chip
+SRAM fabric that holds the entire model on-wafer. This eliminates the
+off-chip HBM bottleneck that limits GPU autoregressive decoding, delivering
+~10-30x faster inference than GPUs on supported models.
+
+Cerebras is OpenAI-compatible at https://api.cerebras.ai/v1, so the
+chat-completions transport works with no custom client.
+
+Their catalog is small and curated (only models that compile cleanly to the
+WSE dataflow architecture). Production models as of late 2026:
+
+- gpt-oss-120b   (production flagship — best TTFT and output speed)
+- llama-3.3-70b
+- llama-4-scout
+- kimi-k2
+- qwen3-32b
+- zai-glm-4.7
+
+Use Cerebras for latency-sensitive and high-throughput workloads
+(voice agents, interactive chat, batch generation) where supported models
+fit. Pair with Fireworks / Together / Baseten for frontier reasoning
+models (Kimi K3, DeepSeek V4 Pro) that exceed single-WSE capacity.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+cerebras = ProviderProfile(
+    name="cerebras",
+    aliases=("cerebras-ai", "cs", "wse"),
+    display_name="Cerebras Inference",
+    description="Cerebras — wafer-scale silicon, ~10x faster than GPUs",
+    signup_url="https://cloud.cerebras.ai/",
+    env_vars=("CEREBRAS_API_KEY",),
+    base_url="https://api.cerebras.ai/v1",
+    auth_type="api_key",
+    # Auxiliary model — fast/cheap chat for side tasks (compression,
+    # session search, vision, title generation). gpt-oss-120b is the
+    # flagship and has the highest sustained throughput on the WSE.
+    default_aux_model="gpt-oss-120b",
+    # Curated safety net shown in /model picker when the live catalog
+    # fetch fails. Cerebras's catalog is small and stable — these are
+    # the production models per inference-docs.cerebras.ai.
+    fallback_models=(
+        "gpt-oss-120b",
+        "llama-3.3-70b",
+        "llama-4-scout",
+        "kimi-k2",
+        "qwen3-32b",
+        "zai-glm-4.7",
+    ),
+)
+
+register_provider(cerebras)

--- a/plugins/model-providers/cerebras/plugin.yaml
+++ b/plugins/model-providers/cerebras/plugin.yaml
@@ -1,0 +1,5 @@
+name: cerebras-provider
+kind: model-provider
+version: 1.0.0
+description: Cerebras Inference — wafer-scale silicon, ~10x faster than GPUs
+author: Milian Solberg + Hermes Agent

--- a/tests/plugins/model_providers/test_cerebras_profile.py
+++ b/tests/plugins/model_providers/test_cerebras_profile.py
@@ -1,0 +1,106 @@
+"""Unit tests for the Cerebras Inference provider profile.
+
+Pins the profile's contract without going live: identity, alias
+registration, and the small curated catalog (Cerebras only hosts models
+that compile cleanly to the WSE dataflow architecture).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def cerebras_profile():
+    """Resolve the registered Cerebras profile through the real discovery path."""
+    # Importing model_tools triggers plugin discovery, registering the profile.
+    import model_tools  # noqa: F401
+    import providers
+
+    profile = providers.get_provider_profile("cerebras")
+    assert profile is not None, "cerebras provider profile must be registered"
+    return profile
+
+
+class TestCerebrasIdentity:
+    def test_core_fields(self, cerebras_profile):
+        p = cerebras_profile
+        assert p.name == "cerebras"
+        assert p.api_mode == "chat_completions"
+        assert p.auth_type == "api_key"
+        assert p.base_url == "https://api.cerebras.ai/v1"
+        assert "CEREBRAS_API_KEY" in p.env_vars
+
+    def test_display_metadata_present(self, cerebras_profile):
+        # Prominence copy is surfaced in the picker; keep it non-empty rather
+        # than pinning exact marketing wording (that's expected to change).
+        assert cerebras_profile.display_name
+        assert cerebras_profile.description
+        assert cerebras_profile.signup_url.startswith("https://")
+
+
+class TestCerebrasHeaders:
+    def test_no_partner_attribution_headers(self, cerebras_profile):
+        # Cerebras doesn't require the OpenRouter-style HTTP-Referer / X-Title
+        # attribution pair, and adding them would risk leaking upstream branding
+        # in Cloudflare request logs.
+        assert "HTTP-Referer" not in cerebras_profile.default_headers
+        assert "X-Title" not in cerebras_profile.default_headers
+
+
+class TestCerebrasAliases:
+    @pytest.mark.parametrize("alias", ["cerebras-ai", "cs", "wse"])
+    def test_alias_resolves_via_registry(self, cerebras_profile, alias):
+        import providers
+
+        resolved = providers.get_provider_profile(alias)
+        assert resolved is not None
+        assert resolved.name == "cerebras"
+
+    def test_aliases_declared_on_profile(self, cerebras_profile):
+        assert "cerebras-ai" in cerebras_profile.aliases
+        assert "cs" in cerebras_profile.aliases
+        assert "wse" in cerebras_profile.aliases
+
+
+class TestCerebrasModelDefaults:
+    """Cerebras's catalog is small and curated — only models that compile
+    cleanly to the WSE dataflow architecture ship. The bundled defaults
+    should reference real production models, not router-only IDs.
+    """
+
+    def test_aux_model_is_curated_catalog_model(self, cerebras_profile):
+        aux = cerebras_profile.default_aux_model
+        assert aux, "expected a non-empty aux model"
+        assert not aux.startswith("accounts/"), aux
+        assert "/routers/" not in aux
+
+    def test_fallback_models_are_curated_catalog_models(self, cerebras_profile):
+        assert cerebras_profile.fallback_models, "expected curated fallbacks"
+        for model in cerebras_profile.fallback_models:
+            assert model, model
+            assert not model.startswith("accounts/"), model
+            assert "/routers/" not in model
+
+    def test_fallback_models_are_short_plain_ids(self, cerebras_profile):
+        # Cerebras's catalog uses short bare model IDs (no org prefix), unlike
+        # OpenRouter / HuggingFace style 'org/model' slugs. Pin this so a
+        # future contributor doesn't accidentally paste a router-style ID.
+        for model in cerebras_profile.fallback_models:
+            assert "/" not in model, (
+                f"Cerebras model IDs should be bare, not slugs: {model!r}"
+            )
+
+
+class TestCerebrasDiscovery:
+    """The profile must be discoverable by both the canonical name and any
+    declared alias. The ``_discover_providers()`` path is the production
+    entry point; smoke-test that it surfaces Cerebras alongside the other
+    bundled providers.
+    """
+
+    def test_profile_appears_in_list_providers(self, cerebras_profile):
+        import providers
+
+        names = {p.name for p in providers.list_providers()}
+        assert "cerebras" in names


### PR DESCRIPTION
## feat(providers): add Cerebras Inference (wafer-scale silicon)

Adds a new bundled provider plugin for [Cerebras Inference](https://cloud.cerebras.ai/), an OpenAI-compatible endpoint at `https://api.cerebras.ai/v1`.

Cerebras runs models on their Wafer-Scale Engine — a single-chip SRAM fabric that holds the entire model on-wafer, eliminating the off-chip HBM bottleneck that limits GPU autoregressive decoding. Their public catalog is small and curated (only models that compile cleanly to the WSE dataflow architecture): `gpt-oss-120b`, `llama-3.3-70b`, `llama-4-scout`, `kimi-k2`, `qwen3-32b`, `zai-glm-4.7`.

### What this PR does

- New plugin at `plugins/model-providers/cerebras/` (mirrors the Fireworks / DeepInfra pattern — same OpenAI-compatible shape).
- 6 production models registered as `fallback_models`; `gpt-oss-120b` as `default_aux_model` (highest sustained throughput on the WSE).
- 3 aliases: `cerebras-ai`, `cs`, `wse`.
- 11 unit tests in `tests/plugins/model_providers/test_cerebras_profile.py` pinning the profile's contract (identity, alias resolution, catalog shape, "no router-style IDs in fallbacks" invariant) and exercising the real discovery path through `providers.get_provider_profile()`.

### Verification

- Full provider test suite: **181/181 passing** across 12 files (`scripts/run_tests.sh tests/plugins/model_providers/`).
- Model-switch / setup tests: **44/44 passing** (`tests/hermes_cli/test_model_switch_custom_providers.py`, `test_setup_model_provider.py`, `test_model_provider_persistence.py`).
- Live API verified with a real key against `https://api.cerebras.ai/v1/models` — HTTP 200, production models returned.

### Footprint

Zero core changes. The plugin lives entirely under `plugins/model-providers/cerebras/`. The `ProviderProfile` registration is auto-discovered by the existing `providers._discover_providers()` path on first `get_provider_profile()` call — same pattern as the other 30+ bundled providers. `OPTIONAL_ENV_VARS` is auto-populated from the profile's `env_vars` tuple (`hermes_cli/config.py::_populate_optional_env_vars_from_providers`), so `CEREBRAS_API_KEY` shows up in `hermes setup` and `hermes tools` without a config edit.

### Rebase status

Branch was rebased on `origin/main` (3d7dda4cf) before push — no merge conflicts expected.
