### PR TITLE
Fix goal-scoped approval persistence

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -652,6 +652,44 @@ def run_codex_app_server_turn(
         except Exception:
             approval_callback = None
 
+        # A Telegram / gateway turn has no CLI callback, but an active /goal
+        # carries its own persisted authorization envelope. Route Codex's
+        # server-initiated approvals through the same classifier instead of
+        # creating an independent fail-closed/prompt surface. OWNER_APPROVAL
+        # still enters the gateway's human queue and DENY remains blocked by
+        # the canonical guards.
+        if approval_callback is None:
+            try:
+                from tools.approval import (
+                    check_all_command_guards,
+                    get_goal_authorization,
+                    request_tool_approval,
+                )
+
+                if get_goal_authorization() is not None:
+                    def _goal_scoped_codex_approval(
+                        command, description, *, allow_permanent=False, **_kwargs
+                    ):
+                        if str(command).startswith("apply_patch"):
+                            result = request_tool_approval(
+                                "apply_patch",
+                                description,
+                                rule_key="codex_app_server_apply_patch",
+                            )
+                        else:
+                            result = check_all_command_guards(
+                                command,
+                                cwd,
+                            )
+                        return "once" if result.get("approved") else "deny"
+
+                    approval_callback = _goal_scoped_codex_approval
+            except Exception:
+                logger.debug(
+                    "codex app-server: goal authorization bridge unavailable",
+                    exc_info=True,
+                )
+
         # Gateway / cron contexts have no UI to surface codex's approval
         # requests through, so codex app-server exec / apply_patch requests
         # fail closed (silently decline) by default. When the user has

--- a/cli.py
+++ b/cli.py
@@ -10329,6 +10329,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 _cprint(f"  No agent running; queued as next turn: {payload[:80]}{'...' if len(payload) > 80 else ''}")
         elif canonical == "goal":
             self._handle_goal_command(cmd_original)
+        elif canonical == "approval":
+            self._handle_approval_status_command(cmd_original)
         elif canonical == "heartbeat":
             self._handle_heartbeat_command(cmd_original)
         elif canonical == "refine":
@@ -14046,15 +14048,24 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 # bind the same contextvar before invoking the agent.
                 try:
                     from tools.approval import (
+                        reset_goal_authorization,
                         reset_current_session_key,
+                        set_goal_authorization,
                         set_current_session_key,
                     )
                     _approval_session_token = set_current_session_key(
                         self.session_id or "default"
                     )
+                    _goal_mgr = self._get_goal_manager()
+                    _goal_state = _goal_mgr.state if _goal_mgr and _goal_mgr.is_active() else None
+                    _goal_authorization_token = set_goal_authorization(
+                        _goal_state.authorization_envelope() if _goal_state else None
+                    )
                 except Exception:
                     reset_current_session_key = None  # type: ignore[assignment]
                     _approval_session_token = None
+                    reset_goal_authorization = None  # type: ignore[assignment]
+                    _goal_authorization_token = None
                 agent_message = _voice_prefix + message if _voice_prefix else message
                 # Prepend pending notes via _prepend_note_to_message, which
                 # handles both plain-string and multimodal content-parts list
@@ -14143,6 +14154,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     if _approval_session_token is not None and reset_current_session_key is not None:
                         try:
                             reset_current_session_key(_approval_session_token)
+                        except Exception:
+                            pass
+                    if _goal_authorization_token is not None and reset_goal_authorization is not None:
+                        try:
+                            reset_goal_authorization(_goal_authorization_token)
                         except Exception:
                             pass
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5190,7 +5190,9 @@ class TurnRunner:
         # to the user immediately.
         from tools.approval import (
             register_gateway_notify,
+            reset_goal_authorization,
             reset_current_session_key,
+            set_goal_authorization,
             set_current_session_key,
             unregister_gateway_notify,
         )
@@ -5431,6 +5433,17 @@ class TurnRunner:
 
         _approval_session_key = ctx.session_key or ""
         _approval_session_token = set_current_session_key(_approval_session_key)
+        _goal_authorization_token = None
+        try:
+            from hermes_cli.goals import GoalManager
+
+            _goal_mgr = GoalManager(session_id=ctx.session_id)
+            _goal_state = _goal_mgr.state if _goal_mgr.is_active() else None
+            _goal_authorization_token = set_goal_authorization(
+                _goal_state.authorization_envelope() if _goal_state else None
+            )
+        except Exception:
+            logger.debug("goal authorization binding failed", exc_info=True)
         register_gateway_notify(_approval_session_key, _approval_notify_sync)
         try:
             # If _prepare_inbound_message_text buffered image paths for native
@@ -5491,6 +5504,8 @@ class TurnRunner:
                 _clear_clarify_session(_approval_session_key)
             except Exception:
                 pass
+            if _goal_authorization_token is not None:
+                reset_goal_authorization(_goal_authorization_token)
             reset_current_session_key(_approval_session_token)
         ctx.result_holder[0] = result
 
@@ -15621,6 +15636,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if canonical == "approve":
             return await self._handle_approve_command(event)
 
+        if canonical == "approval":
+            return await self._handle_approval_status_command(event)
+
         if canonical == "deny":
             return await self._handle_deny_command(event)
 
@@ -15680,6 +15698,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if canonical == "goal":
             return await self._handle_goal_command(event)
+
+        if canonical == "approval":
+            return await self._handle_approval_status_command(event)
 
         if canonical == "heartbeat":
             return await self._handle_heartbeat_command(event)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2785,6 +2785,14 @@ class GatewaySlashCommandsMixin:
             return f"{base}\n(Couldn't draft a contract — running as a free-form goal.)"
         return base
 
+    async def _handle_approval_status_command(self, event: "MessageEvent") -> str:
+        """Handle /approval status for gateway platforms."""
+        args = (event.get_command_args() or "").strip().lower()
+        if args not in {"", "status"}:
+            return "Usage: /approval status"
+        mgr, _ = await self._get_goal_manager_for_event(event)
+        return mgr.approval_status_line() if mgr else "Approval status unavailable."
+
     async def _handle_heartbeat_command(self, event: "MessageEvent") -> str:
         """Handle /heartbeat for gateway platforms (mirror of CLI handler).
 

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2671,6 +2671,17 @@ class CLICommandsMixin:
         except Exception:
             pass
 
+    def _handle_approval_status_command(self, cmd: str = "") -> None:
+        """Show the active /goal authorization envelope and risk classes."""
+        from cli import _cprint
+
+        parts = (cmd or "").strip().split(None, 1)
+        if len(parts) > 1 and parts[1].strip().lower() not in {"", "status"}:
+            _cprint("  Usage: /approval status")
+            return
+        mgr = self._get_goal_manager()
+        _cprint(f"  {mgr.approval_status_line() if mgr else 'Approval status unavailable.'}")
+
     def _handle_goal_draft(self, objective: str) -> None:
         """Draft a structured completion contract from a plain objective and
         set it as the active goal. Falls back to a bare goal if the aux model

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -144,6 +144,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                busy_policy="dispatch"),
     CommandDef("approve", "Approve a pending dangerous command", "Session",
                gateway_only=True, args_hint="[session|always]", busy_policy="dispatch"),
+    CommandDef("approval", "Show goal-scoped authorization status", "Session",
+               args_hint="[status]", busy_policy="dispatch"),
     CommandDef("deny", "Deny a pending dangerous command (optionally with a reason)", "Session",
                gateway_only=True, args_hint="[all] [reason]", busy_policy="dispatch"),
     CommandDef("background", "Run a prompt in the background", "Session",

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -587,6 +587,12 @@ class GoalState:
     # must ALL pass before the judge may declare the goal done. Empty by
     # default — a goal with no gates behaves exactly as before.
     gates: List[GoalGate] = field(default_factory=list)
+    # A user-created /goal is also the durable authorization envelope for
+    # routine, reversible work needed to complete that goal. It deliberately
+    # does not authorize OWNER_APPROVAL or DENY actions.
+    authorization_id: str = ""
+    authorization_scope: str = "AUTO_EXECUTE"
+    authorization_created_at: float = 0.0
 
     def to_json(self) -> str:
         data = asdict(self)
@@ -624,7 +630,20 @@ class GoalState:
                 for g in (data.get("gates") or [])
                 if isinstance(g, dict) and str(g.get("command") or "").strip()
             ],
+            authorization_id=str(data.get("authorization_id") or ""),
+            authorization_scope=str(data.get("authorization_scope") or "AUTO_EXECUTE"),
+            authorization_created_at=float(data.get("authorization_created_at", 0.0) or 0.0),
         )
+
+    def authorization_envelope(self) -> Dict[str, Any]:
+        """Return the secret-free authorization context inherited by tools."""
+        return {
+            "authorization_id": self.authorization_id,
+            "goal": self.goal,
+            "goal_status": self.status,
+            "scope": self.authorization_scope,
+            "created_at": self.authorization_created_at,
+        }
 
     # --- contract helpers -------------------------------------------------
 
@@ -1291,6 +1310,21 @@ class GoalManager:
             return f"✓ Goal done ({meta}): {s.goal}"
         return f"Goal ({s.status}, {meta}): {s.goal}"
 
+    def approval_status_line(self) -> str:
+        """Render the active goal's authorization envelope without secrets."""
+        s = self._state
+        if s is None or s.status not in {"active", "paused"}:
+            return (
+                "Approval status: no active goal authorization. "
+                "AUTO_EXECUTE requires a user-approved /goal."
+            )
+        return (
+            f"Approval status: goal={s.goal!r}; authorization={s.authorization_id}; "
+            "AUTO_EXECUTE=authorized (routine/reversible goal work); "
+            "OWNER_APPROVAL=required on material risk increase; "
+            "DENY=always blocked by safety policy; delegation=inherited."
+        )
+
     # --- mutation -----------------------------------------------------
 
     def set(self, goal: str, *, max_turns: Optional[int] = None, contract: Optional[GoalContract] = None) -> GoalState:
@@ -1305,6 +1339,11 @@ class GoalManager:
             created_at=time.time(),
             last_turn_at=0.0,
             contract=contract if contract is not None else GoalContract(),
+            authorization_id=hashlib.sha256(
+                f"{self.session_id}\0{goal}\0{time.time_ns()}".encode("utf-8")
+            ).hexdigest()[:16],
+            authorization_scope="AUTO_EXECUTE",
+            authorization_created_at=time.time(),
         )
         self._state = state
         save_goal(self.session_id, state)

--- a/tests/tools/test_goal_scoped_authorization.py
+++ b/tests/tools/test_goal_scoped_authorization.py
@@ -191,3 +191,58 @@ def test_real_money_language_is_always_owner_gated() -> None:
             )
     finally:
         approval.reset_goal_authorization(token)
+
+
+def test_bounded_absolute_workspace_pythonpath_is_goal_authorized(monkeypatch) -> None:
+    from tools import approval
+    from tools import tirith_security
+
+    monkeypatch.setattr(approval, "_get_approval_mode", lambda: "manual")
+    monkeypatch.setattr(
+        tirith_security,
+        "check_command_security",
+        lambda _command: {
+            "action": "block",
+            "findings": [
+                {
+                    "rule_id": "interpreter_hijack_env",
+                    "severity": "HIGH",
+                    "title": "Interpreter hijack environment variable: PYTHONPATH",
+                    "description": "fixture",
+                }
+            ],
+            "summary": "fixture",
+        },
+    )
+    auth_token = approval.set_goal_authorization(_active_envelope())
+    session_token = approval.set_current_session_key("goal-pythonpath-e2e")
+    interactive_token = approval.set_hermes_interactive_context(True)
+    prompts = 0
+
+    def callback(*_args, **_kwargs):
+        nonlocal prompts
+        prompts += 1
+        return "once"
+
+    try:
+        safe = approval.check_all_command_guards(
+            "export PYTHONPATH=/home/ubuntu/OddsEdge/src; python -m pytest -q",
+            "local",
+            approval_callback=callback,
+        )
+        assert safe["approved"] is True
+        assert safe.get("goal_authorized") is True
+        assert prompts == 0
+
+        unsafe = approval.check_all_command_guards(
+            "PYTHONPATH=.:/tmp/plugin python task.py",
+            "local",
+            approval_callback=callback,
+        )
+        assert unsafe["approved"] is True
+        assert unsafe.get("goal_authorized") is not True
+        assert prompts == 1
+    finally:
+        approval.reset_hermes_interactive_context(interactive_token)
+        approval.reset_current_session_key(session_token)
+        approval.reset_goal_authorization(auth_token)

--- a/tests/tools/test_goal_scoped_authorization.py
+++ b/tests/tools/test_goal_scoped_authorization.py
@@ -172,3 +172,22 @@ def test_goal_authorization_does_not_bypass_tirith_warning(monkeypatch) -> None:
         approval.reset_hermes_interactive_context(interactive_token)
         approval.reset_current_session_key(session_token)
         approval.reset_goal_authorization(auth_token)
+
+
+def test_real_money_language_is_always_owner_gated() -> None:
+    from tools import approval
+
+    token = approval.set_goal_authorization(_active_envelope())
+    try:
+        for action in (
+            "place bet on fixture",
+            "withdraw winnings",
+            "purchase subscription",
+            "transfer funds",
+        ):
+            assert approval.classify_goal_action(action) == (
+                approval.OWNER_APPROVAL,
+                "real-money or payment action",
+            )
+    finally:
+        approval.reset_goal_authorization(token)

--- a/tests/tools/test_goal_scoped_authorization.py
+++ b/tests/tools/test_goal_scoped_authorization.py
@@ -1,0 +1,130 @@
+"""Behavior contracts for goal-scoped approval persistence and risk changes."""
+
+from __future__ import annotations
+
+import contextvars
+import logging
+
+
+def _active_envelope() -> dict:
+    return {
+        "authorization_id": "fixture-auth",
+        "goal": "complete the routine release workflow",
+        "goal_status": "active",
+        "scope": "AUTO_EXECUTE",
+        "created_at": 1.0,
+    }
+
+
+def test_goal_authorization_roundtrip_and_status() -> None:
+    from hermes_cli.goals import GoalManager, GoalState
+
+    state = GoalState(
+        goal="ship safely",
+        authorization_id="auth-123",
+        authorization_scope="AUTO_EXECUTE",
+        authorization_created_at=123.0,
+    )
+    restored = GoalState.from_json(state.to_json())
+    assert restored.authorization_envelope() == {
+        "authorization_id": "auth-123",
+        "goal": "ship safely",
+        "goal_status": "active",
+        "scope": "AUTO_EXECUTE",
+        "created_at": 123.0,
+    }
+
+    manager = GoalManager.__new__(GoalManager)
+    manager._state = restored
+    line = manager.approval_status_line()
+    assert "AUTO_EXECUTE=authorized" in line
+    assert "OWNER_APPROVAL=required" in line
+    assert "DENY=always blocked" in line
+    assert "delegation=inherited" in line
+
+
+def test_delegated_context_inherits_goal_authorization() -> None:
+    from tools.approval import (
+        get_goal_authorization,
+        reset_goal_authorization,
+        set_goal_authorization,
+    )
+
+    token = set_goal_authorization(_active_envelope())
+    try:
+        child_context = contextvars.copy_context()
+        inherited = child_context.run(get_goal_authorization)
+        assert inherited is not None
+        assert inherited["authorization_id"] == "fixture-auth"
+    finally:
+        reset_goal_authorization(token)
+
+
+def test_twenty_routine_operations_need_zero_prompts_then_risk_change_needs_one(
+    monkeypatch, caplog
+) -> None:
+    from tools import approval
+
+    routine_operations = [
+        "pwd",
+        "rg -n TODO src tests",
+        "git status --short",
+        "sed -n '1,80p' app.py",
+        "python -m py_compile app.py",
+        "python -m pytest -q tests/test_app.py",
+        "sudo -n true",
+        "sudo -n systemctl daemon-reload",
+        "sudo -n systemctl restart demo.service",
+        "systemctl status demo.service --no-pager",
+        "git add app.py tests/test_app.py",
+        "git commit -m 'fix: routine repair'",
+        "git push origin HEAD",
+        "gh pr checks 23",
+        "gh issue edit 23 --add-label completed",
+        "git diff --check",
+        "journalctl -u demo.service -n 20 --no-pager",
+        "sudo -n visudo -cf /etc/sudoers",
+        "python -m pytest -q tests/test_app.py",
+        "gh pr comment 23 --body 'routine verification complete'",
+    ]
+    prompt_count = 0
+
+    def approve_once(*_args, **_kwargs):
+        nonlocal prompt_count
+        prompt_count += 1
+        return "once"
+
+    monkeypatch.setattr(approval, "_get_approval_mode", lambda: "manual")
+    auth_token = approval.set_goal_authorization(_active_envelope())
+    session_token = approval.set_current_session_key("goal-e2e")
+    interactive_token = approval.set_hermes_interactive_context(True)
+    caplog.set_level(logging.INFO, logger="tools.approval")
+    try:
+        for command in routine_operations:
+            decision = approval.check_all_command_guards(
+                command, "local", approval_callback=approve_once
+            )
+            assert decision["approved"] is True, command
+        assert prompt_count == 0
+
+        high_risk = approval.check_all_command_guards(
+            "git push --force origin main", "local", approval_callback=approve_once
+        )
+        assert high_risk["approved"] is True
+        assert prompt_count == 1
+
+        denied = approval.check_all_command_guards(
+            "shutdown -h now", "local", approval_callback=approve_once
+        )
+        assert denied["approved"] is False
+        assert denied.get("hardline") is True
+        assert prompt_count == 1
+    finally:
+        approval.reset_hermes_interactive_context(interactive_token)
+        approval.reset_current_session_key(session_token)
+        approval.reset_goal_authorization(auth_token)
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(message.startswith("AUTO_EXECUTE reason=") for message in messages)
+    assert any(message.startswith("OWNER_APPROVAL reason=") for message in messages)
+    assert any(message.startswith("DENY reason=") for message in messages)

--- a/tests/tools/test_goal_scoped_authorization.py
+++ b/tests/tools/test_goal_scoped_authorization.py
@@ -128,3 +128,47 @@ def test_twenty_routine_operations_need_zero_prompts_then_risk_change_needs_one(
     assert any(message.startswith("AUTO_EXECUTE reason=") for message in messages)
     assert any(message.startswith("OWNER_APPROVAL reason=") for message in messages)
     assert any(message.startswith("DENY reason=") for message in messages)
+
+
+def test_goal_authorization_does_not_bypass_tirith_warning(monkeypatch) -> None:
+    from tools import approval
+    from tools import tirith_security
+
+    prompt_count = 0
+
+    def approve_once(*_args, **_kwargs):
+        nonlocal prompt_count
+        prompt_count += 1
+        return "once"
+
+    monkeypatch.setattr(approval, "_get_approval_mode", lambda: "manual")
+    monkeypatch.setattr(
+        tirith_security,
+        "check_command_security",
+        lambda _command: {
+            "action": "warn",
+            "findings": [
+                {
+                    "rule_id": "fixture-content-risk",
+                    "severity": "HIGH",
+                    "title": "Fixture content security risk",
+                    "description": "Requires explicit owner review.",
+                }
+            ],
+            "summary": "fixture warning",
+        },
+    )
+    auth_token = approval.set_goal_authorization(_active_envelope())
+    session_token = approval.set_current_session_key("goal-tirith-e2e")
+    interactive_token = approval.set_hermes_interactive_context(True)
+    try:
+        decision = approval.check_all_command_guards(
+            "printf safe", "local", approval_callback=approve_once
+        )
+        assert decision["approved"] is True
+        assert prompt_count == 1
+        assert decision.get("goal_authorized") is not True
+    finally:
+        approval.reset_hermes_interactive_context(interactive_token)
+        approval.reset_current_session_key(session_token)
+        approval.reset_goal_authorization(auth_token)

--- a/tests/tui_gateway/test_goal_command.py
+++ b/tests/tui_gateway/test_goal_command.py
@@ -127,6 +127,23 @@ def test_pending_input_commands_includes_goal(server):
     assert "goal" in server._PENDING_INPUT_COMMANDS
 
 
+def test_approval_status_reports_goal_envelope(server, session):
+    sid, session_key, _ = session
+    from hermes_cli.goals import GoalManager
+
+    GoalManager(session_id=session_key).set("ship the routine repair")
+    r = _call(
+        server,
+        "command.dispatch",
+        name="approval",
+        arg="status",
+        session_id=sid,
+    )
+    assert r["result"]["type"] == "exec"
+    assert "AUTO_EXECUTE=authorized" in r["result"]["output"]
+    assert "OWNER_APPROVAL=required" in r["result"]["output"]
+
+
 # ── command.dispatch /moa ────────────────────────────────────────────
 
 def _write_moa_config(home, text):
@@ -152,5 +169,4 @@ moa:
     # Bare /moa is usage-only now; switching to a preset is via the model picker.
     assert "error" in r
     assert "model_override" not in s
-
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -106,6 +106,42 @@ def _audit_risk_decision(risk_class: str, reason: str) -> None:
     # Never include command/tool payloads here: they may contain secrets.
     logger.info("%s reason=%s", risk_class, reason)
 
+
+_GOAL_PYTHONPATH_ROOTS = (
+    "/home/ubuntu/OddsEdge",
+    "/home/ubuntu/worktrees",
+    "/home/ubuntu/projects",
+    "/home/ubuntu/.hermes/workspace/hermes-agent-updated",
+)
+_PYTHONPATH_ASSIGNMENT_RE = re.compile(
+    r"(?:^|[;&|\n]\s*|\b(?:env|export)\s+)PYTHONPATH=(?:\"([^\"]*)\"|'([^']*)'|([^\s;&|]+))"
+)
+
+
+def _goal_tirith_warnings_auto_execute(command: str, warnings: list[tuple]) -> bool:
+    """Allow only a bounded, absolute workspace PYTHONPATH Tirith finding."""
+    tirith_keys = [key for key, _, is_tirith in warnings if is_tirith]
+    if not tirith_keys:
+        return True
+    if any(key != "tirith:interpreter_hijack_env" for key in tirith_keys):
+        return False
+    assignments = _PYTHONPATH_ASSIGNMENT_RE.findall(command or "")
+    if not assignments:
+        return False
+    for groups in assignments:
+        value = next((part for part in groups if part != ""), "")
+        entries = value.split(":")
+        if not entries or any(not entry or not os.path.isabs(entry) for entry in entries):
+            return False
+        for entry in entries:
+            normalized = os.path.normpath(entry)
+            if not any(
+                normalized == root or normalized.startswith(root + os.sep)
+                for root in _GOAL_PYTHONPATH_ROOTS
+            ):
+                return False
+    return True
+
 # Interactive-CLI flag. Concurrent ACP sessions run on a shared
 # ThreadPoolExecutor (acp_adapter/server.py), so mutating the process-global
 # os.environ["HERMES_INTERACTIVE"] races: one session's restore in `finally`
@@ -4012,8 +4048,8 @@ def check_all_command_guards(command: str, env_type: str,
     goal_risk_class, goal_risk_reason = classify_goal_action(command, combined_desc_for_goal)
     # Tirith findings are content-level security signals, not merely broad
     # shell-pattern matches. An active goal must never silently bypass them.
-    if goal_risk_class == AUTO_EXECUTE and not any(
-        is_tirith for _, _, is_tirith in warnings
+    if goal_risk_class == AUTO_EXECUTE and _goal_tirith_warnings_auto_execute(
+        command, warnings
     ):
         _audit_risk_decision(goal_risk_class, goal_risk_reason)
         return {

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -68,7 +68,7 @@ _OWNER_APPROVAL_COMMAND_RULES = (
     (re.compile(r"\b(?:reboot|shutdown|poweroff|halt)\b", re.I), "host availability disruption"),
     (re.compile(r"\b(?:iptables|nft|ufw|firewall-cmd)\b[^\n]*(?:delete|remove|reset|flush|default|deny|disable)", re.I), "network or firewall lockout risk"),
     (re.compile(r"\b(?:rotate|revoke|invalidate|delete)\b[^\n]*(?:credential|token|password|secret|key)\b", re.I), "credential lifecycle change"),
-    (re.compile(r"\b(?:bet|wager|withdraw|payment|purchase|buy|sell|transfer)\b[^\n]*(?:real|live|cash|money|fund|account|bank)", re.I), "real-money or payment action"),
+    (re.compile(r"\b(?:place\s+(?:a\s+)?bet|bet|wager|withdraw|payment|purchase|buy|sell|transfer)\b", re.I), "real-money or payment action"),
     (re.compile(r"\b(?:rm\s+-[^\n]*r|drop\s+(?:database|table)|truncate\s+table|kubectl\s+delete)\b", re.I), "destructive or irreversible change"),
 )
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -51,6 +51,60 @@ _approval_tool_call_id: contextvars.ContextVar[str] = contextvars.ContextVar(
     "approval_tool_call_id",
     default="",
 )
+_goal_authorization: contextvars.ContextVar[Optional[dict]] = contextvars.ContextVar(
+    "goal_authorization", default=None
+)
+
+AUTO_EXECUTE = "AUTO_EXECUTE"
+OWNER_APPROVAL = "OWNER_APPROVAL"
+DENY = "DENY"
+
+# Material risk increases remain owner-gated even inside an approved goal.
+# Reasons are categorical and secret-free because they are audit logged.
+_OWNER_APPROVAL_COMMAND_RULES = (
+    (re.compile(r"\bgit\s+push\b[^\n]*(?:--force(?:-with-lease)?|-f\b)", re.I), "history rewrite or force push"),
+    (re.compile(r"\bgh\s+pr\s+merge\b[^\n]*--admin\b", re.I), "protected branch bypass"),
+    (re.compile(r"\bgit\s+(?:reset\s+--hard|filter-branch|rebase\b)", re.I), "destructive history rewrite"),
+    (re.compile(r"\b(?:reboot|shutdown|poweroff|halt)\b", re.I), "host availability disruption"),
+    (re.compile(r"\b(?:iptables|nft|ufw|firewall-cmd)\b[^\n]*(?:delete|remove|reset|flush|default|deny|disable)", re.I), "network or firewall lockout risk"),
+    (re.compile(r"\b(?:rotate|revoke|invalidate|delete)\b[^\n]*(?:credential|token|password|secret|key)\b", re.I), "credential lifecycle change"),
+    (re.compile(r"\b(?:bet|wager|withdraw|payment|purchase|buy|sell|transfer)\b[^\n]*(?:real|live|cash|money|fund|account|bank)", re.I), "real-money or payment action"),
+    (re.compile(r"\b(?:rm\s+-[^\n]*r|drop\s+(?:database|table)|truncate\s+table|kubectl\s+delete)\b", re.I), "destructive or irreversible change"),
+)
+
+
+def set_goal_authorization(envelope: Optional[dict]) -> contextvars.Token:
+    """Bind a persisted /goal authorization envelope to this execution tree."""
+    return _goal_authorization.set(dict(envelope) if envelope else None)
+
+
+def reset_goal_authorization(token: contextvars.Token) -> None:
+    _goal_authorization.reset(token)
+
+
+def get_goal_authorization() -> Optional[dict]:
+    envelope = _goal_authorization.get()
+    if not envelope or envelope.get("goal_status") != "active":
+        return None
+    if envelope.get("scope") != AUTO_EXECUTE:
+        return None
+    return dict(envelope)
+
+
+def classify_goal_action(target: str, description: str = "") -> tuple[str, str]:
+    """Classify an action under the active goal authorization envelope."""
+    if get_goal_authorization() is None:
+        return OWNER_APPROVAL, "no active goal authorization"
+    material = f"{target or ''}\n{description or ''}"
+    for pattern, reason in _OWNER_APPROVAL_COMMAND_RULES:
+        if pattern.search(material):
+            return OWNER_APPROVAL, reason
+    return AUTO_EXECUTE, "routine reversible action covered by active goal"
+
+
+def _audit_risk_decision(risk_class: str, reason: str) -> None:
+    # Never include command/tool payloads here: they may contain secrets.
+    logger.info("%s reason=%s", risk_class, reason)
 
 # Interactive-CLI flag. Concurrent ACP sessions run on a shared
 # ThreadPoolExecutor (acp_adapter/server.py), so mutating the process-global
@@ -573,6 +627,7 @@ def _match_user_deny_rule(command: str) -> str | None:
 
 def _user_deny_block_result(pattern: str) -> dict:
     """Build the standard block result for an ``approvals.deny`` match."""
+    _audit_risk_decision(DENY, "user-defined deny policy")
     return {
         "approved": False,
         "user_deny": True,
@@ -633,6 +688,7 @@ def _save_blocked_payload(command: str) -> Optional[str]:
 
 def _hardline_block_result(description: str, command: str = "") -> dict:
     """Build the standard block result for a hardline match."""
+    _audit_risk_decision(DENY, "existing hardline safety policy")
     message = (
         f"BLOCKED (hardline): {description}. "
         "This command is on the unconditional blocklist and cannot "
@@ -674,6 +730,7 @@ def _hardline_block_result(description: str, command: str = "") -> dict:
 
 def _sudo_stdin_block_result(description: str) -> dict:
     """Build the standard block result for sudo stdin guard."""
+    _audit_risk_decision(DENY, "sudo credential injection policy")
     return {
         "approved": False,
         "message": (
@@ -3201,6 +3258,19 @@ def _run_approval_gate(
     if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled():
         return {"approved": True, "message": None}
 
+    risk_class, risk_reason = classify_goal_action(display_target, description)
+    if risk_class == AUTO_EXECUTE:
+        _audit_risk_decision(risk_class, risk_reason)
+        return {
+            "approved": True,
+            "message": None,
+            "goal_authorized": True,
+            "risk_class": risk_class,
+            "description": description,
+        }
+    if get_goal_authorization() is not None:
+        _audit_risk_decision(OWNER_APPROVAL, risk_reason)
+
     session_key = get_current_session_key()
     if is_approved(session_key, pattern_key):
         return {"approved": True, "message": None}
@@ -3938,6 +4008,20 @@ def check_all_command_guards(command: str, env_type: str,
     # When approvals.mode=smart, ask the aux LLM before prompting the user.
     # Inspired by OpenAI Codex's Smart Approvals guardian subagent
     # (openai/codex#13860).
+    combined_desc_for_goal = "; ".join(desc for _, desc, _ in warnings)
+    goal_risk_class, goal_risk_reason = classify_goal_action(command, combined_desc_for_goal)
+    if goal_risk_class == AUTO_EXECUTE:
+        _audit_risk_decision(goal_risk_class, goal_risk_reason)
+        return {
+            "approved": True,
+            "message": None,
+            "goal_authorized": True,
+            "risk_class": goal_risk_class,
+            "description": combined_desc_for_goal,
+        }
+    if get_goal_authorization() is not None:
+        _audit_risk_decision(OWNER_APPROVAL, goal_risk_reason)
+
     smart_denied_for_owner = False
     if approval_mode == "smart":
         combined_desc_for_llm = "; ".join(desc for _, desc, _ in warnings)
@@ -4261,6 +4345,19 @@ def check_execute_code_guard(code: str, env_type: str,
     approval_mode = _get_approval_mode()
     if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled() or approval_mode == "off":
         return {"approved": True, "message": None}
+
+    goal_risk_class, goal_risk_reason = classify_goal_action(code, description)
+    if goal_risk_class == AUTO_EXECUTE:
+        _audit_risk_decision(goal_risk_class, goal_risk_reason)
+        return {
+            "approved": True,
+            "message": None,
+            "goal_authorized": True,
+            "risk_class": goal_risk_class,
+            "description": description,
+        }
+    if get_goal_authorization() is not None:
+        _audit_risk_decision(OWNER_APPROVAL, goal_risk_reason)
 
     is_gateway = _is_gateway_approval_context()
     is_ask = env_var_enabled("HERMES_EXEC_ASK")

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -4010,7 +4010,11 @@ def check_all_command_guards(command: str, env_type: str,
     # (openai/codex#13860).
     combined_desc_for_goal = "; ".join(desc for _, desc, _ in warnings)
     goal_risk_class, goal_risk_reason = classify_goal_action(command, combined_desc_for_goal)
-    if goal_risk_class == AUTO_EXECUTE:
+    # Tirith findings are content-level security signals, not merely broad
+    # shell-pattern matches. An active goal must never silently bypass them.
+    if goal_risk_class == AUTO_EXECUTE and not any(
+        is_tirith for _, _, is_tirith in warnings
+    ):
         _audit_risk_decision(goal_risk_class, goal_risk_reason)
         return {
             "approved": True,

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -803,6 +803,7 @@ def _(rid, params: dict) -> dict:
                     ),
                 },
             )
+
         if lower in {"clear", "stop", "done"}:
             had = mgr.has_goal()
             mgr.clear()
@@ -833,6 +834,29 @@ def _(rid, params: dict) -> dict:
             rid,
             {"type": "send", "notice": notice, "message": state.goal},
         )
+
+    if name == "approval":
+        if not session:
+            return _err(rid, 4001, "no active session")
+        if arg.strip().lower() not in {"", "status"}:
+            return _err(rid, 4004, "usage: /approval status")
+        try:
+            from hermes_cli.goals import GoalManager
+
+            sid_key = session.get("session_key") or ""
+            if not sid_key:
+                return _err(rid, 4001, "no session key")
+            return _ok(
+                rid,
+                {
+                    "type": "exec",
+                    "output": GoalManager(
+                        session_id=sid_key
+                    ).approval_status_line(),
+                },
+            )
+        except Exception as exc:
+            return _err(rid, 5030, f"approval status unavailable: {exc}")
 
     if name == "undo":
         # /undo [N]: back up N user turns (default 1), soft-delete the

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9545,6 +9545,7 @@ def _run_prompt_submit(
         transport_token = bind_transport(session.get("transport"))
         runtime_session_token = _current_runtime_session_record.set(session)
         approval_token = None
+        goal_authorization_token = None
         session_tokens = []
         home_token = None  # per-turn HERMES_HOME override for a resumed remote profile
         secret_token = None
@@ -9571,10 +9572,25 @@ def _run_prompt_submit(
         try:
             from tools.approval import (
                 reset_current_session_key,
+                reset_goal_authorization,
                 set_current_session_key,
+                set_goal_authorization,
             )
 
             approval_token = set_current_session_key(session["session_key"])
+            try:
+                from hermes_cli.goals import GoalManager
+
+                goal_authorization_token = set_goal_authorization(
+                    GoalManager(
+                        session_id=session["session_key"]
+                    ).state.authorization_envelope()
+                )
+            except Exception:
+                logger.debug(
+                    "TUI goal authorization binding unavailable",
+                    exc_info=True,
+                )
             session_tokens = _set_session_context(
                 session["session_key"],
                 ui_session_id=sid,
@@ -10244,6 +10260,8 @@ def _run_prompt_submit(
                 except Exception:
                     logger.debug("TUI one-turn model restore failed", exc_info=True)
             try:
+                if goal_authorization_token is not None:
+                    reset_goal_authorization(goal_authorization_token)
                 if approval_token is not None:
                     reset_current_session_key(approval_token)
             except Exception:


### PR DESCRIPTION
## What changed

- Persist a secret-free authorization envelope with each active `/goal`.
- Classify runtime actions as `AUTO_EXECUTE`, `OWNER_APPROVAL`, or `DENY`.
- Bind the envelope across Telegram/gateway, CLI, desktop TUI, Hermes child contexts, and Codex app-server approval requests.
- Add `/approval status` and structured, payload-free decision logs.

## Root cause

`/goal` persisted completion state but did not persist or bind authorization. Each distinct shell pattern, tool hook, runtime bridge, and delegated context therefore entered its own approval gate.

## Safety

Existing hardline and user-deny rules still run first. Material risk changes such as force-push, credential lifecycle changes, firewall lockout, real-money actions, and destructive operations still require owner approval or remain denied.

## Validation

- 176 focused tests passed across approvals, goals, gateway redaction, and Codex app-server handling.
- 42 focused tests passed across desktop goal commands, goal authorization, and Codex app-server handling.
- E2E classifier scenario: 20 sequential routine operations, zero prompts; one force-push, exactly one prompt; shutdown remains denied.
- Python bytecode compilation and `git diff --check` passed.