### PR TITLE
feat(kanban): add not-before task metadata

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -81,6 +81,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "session_id": t.session_id,
         "workflow_template_id": t.workflow_template_id,
         "current_step_key": t.current_step_key,
+        "not_before": t.not_before,
     }
 
 
@@ -354,6 +355,15 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                "durations (90s, 30m, 2h, 1d). When exceeded, "
                                "the dispatcher SIGTERMs (then SIGKILLs) the worker "
                                "and re-queues the task.")
+    p_create.add_argument(
+        "--not-before",
+        default=None,
+        metavar="ISO8601_UTC",
+        help=(
+            "Optional timezone-aware ISO8601 instant. Numeric offsets are "
+            "accepted and normalized to UTC; metadata only, not enforced."
+        ),
+    )
     p_create.add_argument("--created-by", default="user",
                           help="Author name recorded on the task (default: user)")
     p_create.add_argument("--skill", action="append", default=[], dest="skills",
@@ -1519,6 +1529,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             goal_mode=bool(getattr(args, "goal_mode", False)),
             goal_max_turns=getattr(args, "goal_max_turns", None),
             initial_status=getattr(args, "initial_status", "running"),
+            not_before=getattr(args, "not_before", None),
         )
         task = kb.get_task(conn, task_id)
     if getattr(args, "json", False):

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -71,6 +71,7 @@ new locking.
 from __future__ import annotations
 
 import contextlib
+from datetime import datetime, timezone
 import hashlib
 import json
 import os
@@ -133,6 +134,60 @@ VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 # not dispatcher spawn/crash/timeout failures.
 BLOCK_RECURRENCE_LIMIT = 2
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
+
+_NOT_BEFORE_RE = re.compile(
+    r"^(?P<date>\d{4}-\d{2}-\d{2})T"
+    r"(?P<time>\d{2}:\d{2}:\d{2})"
+    r"(?P<fraction>\.\d+)?"
+    r"(?P<zone>Z|[+-]\d{2}:\d{2})$"
+)
+
+
+def normalize_not_before(value: Optional[str]) -> Optional[str]:
+    """Validate and canonicalise an optional not-before instant.
+
+    Accepted values are explicit timezone-aware ISO8601 date-times with
+    seconds and either ``Z`` or a numeric ``±HH:MM`` offset. Values are stored
+    as UTC with a trailing ``Z``. Fractional-second digits are kept verbatim,
+    including precision beyond Python's microsecond resolution, so
+    normalisation can never move a safety gate earlier than the supplied
+    instant.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(
+            "not_before must be a timezone-aware ISO8601 instant, "
+            "for example 2026-08-08T11:26:00Z"
+        )
+    candidate = value.strip()
+    match = _NOT_BEFORE_RE.fullmatch(candidate)
+    if match is None:
+        raise ValueError(
+            "not_before must be a timezone-aware ISO8601 instant, "
+            "for example 2026-08-08T11:26:00Z"
+        )
+
+    zone = match.group("zone")
+    parse_zone = "+00:00" if zone == "Z" else zone
+    try:
+        aware = datetime.fromisoformat(
+            f"{match.group('date')}T{match.group('time')}{parse_zone}"
+        )
+        if aware.tzinfo is None or aware.utcoffset() is None:
+            raise ValueError("timezone required")
+        utc = aware.astimezone(timezone.utc)
+    except (OverflowError, ValueError) as exc:
+        raise ValueError(
+            "not_before must be a valid timezone-aware ISO8601 instant, "
+            "for example 2026-08-08T11:26:00Z"
+        ) from exc
+
+    fraction = match.group("fraction") or ""
+    return (
+        f"{utc.year:04d}-{utc.month:02d}-{utc.day:02d}T"
+        f"{utc.hour:02d}:{utc.minute:02d}:{utc.second:02d}{fraction}Z"
+    )
 
 
 def normalize_reasoning_effort(effort: Optional[str]) -> Optional[str]:
@@ -993,6 +1048,9 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    # Optional machine-readable scheduling metadata. Stored canonically as an
+    # explicit UTC instant; dispatch enforcement is intentionally separate.
+    not_before: Optional[str] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -1024,6 +1082,7 @@ class Task:
             claim_lock=row["claim_lock"],
             claim_expires=row["claim_expires"],
             tenant=row["tenant"] if "tenant" in keys else None,
+            not_before=row["not_before"] if "not_before" in keys else None,
             result=row["result"] if "result" in keys else None,
             idempotency_key=row["idempotency_key"] if "idempotency_key" in keys else None,
             consecutive_failures=(
@@ -1262,6 +1321,9 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- set the env var. Indexed so per-session list queries stay cheap on
     -- larger boards.
     session_id           TEXT,
+    -- Optional scheduling metadata only. Canonical timezone-aware ISO8601 UTC
+    -- instant; dispatch enforcement is deliberately out of scope here.
+    not_before           TEXT,
     -- Typed block reason set by ``block_task`` (one of VALID_BLOCK_KINDS, or
     -- NULL for legacy/un-typed blocks). Drives routing: ``dependency`` never
     -- sits in ``blocked`` (goes to ``todo`` for parent-gating); the others go
@@ -2458,6 +2520,11 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             conn, "tasks", "session_id", "session_id TEXT"
         )
 
+    if "not_before" not in cols:
+        # Optional machine-readable scheduling metadata. Existing tasks remain
+        # ungated (NULL); dispatch enforcement is intentionally separate.
+        _add_column_if_missing(conn, "tasks", "not_before", "not_before TEXT")
+
     if "block_kind" not in cols:
         # Typed block reason (VALID_BLOCK_KINDS) or NULL for legacy/un-typed
         # blocks. Existing blocked rows get NULL, which is treated as a
@@ -2903,6 +2970,7 @@ def create_task(
     goal_max_turns: Optional[int] = None,
     initial_status: str = "running",
     session_id: Optional[str] = None,
+    not_before: Optional[str] = None,
     board: Optional[str] = None,
     project_id: Optional[str] = None,
     project_source_task_id: Optional[str] = None,
@@ -2949,6 +3017,7 @@ def create_task(
     model_override = (model_override or "").strip() or None
     provider_override = (provider_override or "").strip() or None
     reasoning_effort = normalize_reasoning_effort(reasoning_effort)
+    not_before = normalize_not_before(not_before)
     if provider_override and not model_override:
         raise ValueError("provider_override requires a model_override")
     assignee = _canonical_assignee(assignee)
@@ -3217,8 +3286,8 @@ def create_task(
                         max_runtime_seconds,
                         skills, max_retries, model_override, provider_override,
                         reasoning_effort,
-                        goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        goal_mode, goal_max_turns, session_id, not_before
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -3244,6 +3313,7 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
+                        not_before,
                     ),
                 )
                 for pid in parents:
@@ -3268,6 +3338,7 @@ def create_task(
                         "goal_mode": bool(goal_mode) or None,
                         "model_override": model_override,
                         "provider_override": provider_override,
+                        "not_before": not_before,
                     },
                 )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
@@ -9388,6 +9459,8 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
     lines.append("")
     lines.append(f"Assignee: {task.assignee or '(unassigned)'}")
     lines.append(f"Status:   {task.status}")
+    if task.not_before:
+        lines.append(f"Not before: {task.not_before}")
     if task.tenant:
         lines.append(f"Tenant:   {task.tenant}")
     lines.append(f"Workspace: {task.workspace_kind} @ {task.workspace_path or '(unresolved)'}")

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import argparse
 import concurrent.futures
+import json
 import os
 import sqlite3
 import subprocess
@@ -145,12 +147,16 @@ def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
                 "SELECT name FROM sqlite_master WHERE type = 'index'"
             )
         }
+        legacy_task = kb.get_task(migrated, "legacy")
 
     # Additive columns added by migration:
     assert "session_id" in task_columns
     assert "tenant" in task_columns
     assert "idempotency_key" in task_columns
+    assert "not_before" in task_columns
     assert "run_id" in event_columns
+    assert legacy_task is not None
+    assert legacy_task.not_before is None
     # And their indexes — the regression scope of this test:
     assert "idx_tasks_session_id" in indexes
     assert "idx_tasks_tenant" in indexes
@@ -161,6 +167,111 @@ def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
 # ---------------------------------------------------------------------------
 # Task creation + status inference
 # ---------------------------------------------------------------------------
+
+
+def test_not_before_round_trip_event_and_worker_context(kanban_home):
+    supplied = "2026-08-08T11:26:00.123456789+02:30"
+    canonical = "2026-08-08T08:56:00.123456789Z"
+
+    with kb.connect() as conn:
+        columns = {
+            row["name"] for row in conn.execute("PRAGMA table_info(tasks)")
+        }
+        task_id = kb.create_task(
+            conn,
+            title="wait for the release window",
+            assignee="ops",
+            not_before=supplied,
+        )
+        task = kb.get_task(conn, task_id)
+        created = next(
+            event
+            for event in kb.list_events(conn, task_id)
+            if event.kind == "created"
+        )
+        context = kb.build_worker_context(conn, task_id)
+
+    assert "not_before" in columns
+    assert task is not None
+    assert task.not_before == canonical
+    assert created.payload["not_before"] == canonical
+    assert f"Not before: {canonical}" in context
+
+
+def test_not_before_absent_remains_null_and_out_of_worker_context(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="ordinary task", assignee="ops")
+        task = kb.get_task(conn, task_id)
+        created = next(
+            event
+            for event in kb.list_events(conn, task_id)
+            if event.kind == "created"
+        )
+        context = kb.build_worker_context(conn, task_id)
+
+    assert task is not None
+    assert task.not_before is None
+    assert created.payload["not_before"] is None
+    assert "Not before:" not in context
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "2026-08-08",
+        "2026-08-08T11:26:00",
+        "2026-08-08T11:26:00 UTC",
+        "2026-13-08T11:26:00Z",
+        "not-a-timestamp",
+    ],
+)
+def test_not_before_rejects_empty_date_only_naive_and_malformed_values(
+    kanban_home, value,
+):
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match="timezone-aware ISO8601 instant"):
+            kb.create_task(conn, title="unsafe gate", not_before=value)
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 0
+
+
+def _run_kanban_cli(argv: list[str]) -> int:
+    from hermes_cli import kanban as kanban_cli
+
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers(dest="command")
+    kanban_cli.build_parser(subparsers)
+    args = parser.parse_args(["kanban", *argv])
+    return kanban_cli.kanban_command(args)
+
+
+def test_create_cli_parses_and_serializes_not_before(kanban_home, capsys):
+    value = "2026-08-08T11:26:00.500000Z"
+
+    assert _run_kanban_cli(
+        ["create", "clocked task", "--not-before", value, "--json"]
+    ) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["not_before"] == value
+
+
+def test_create_cli_without_not_before_serializes_null(kanban_home, capsys):
+    assert _run_kanban_cli(["create", "ordinary task", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["not_before"] is None
+
+
+def test_create_cli_refuses_naive_not_before_without_writing(kanban_home, capsys):
+    assert _run_kanban_cli(
+        ["create", "unsafe task", "--not-before", "2026-08-08T11:26:00"]
+    ) == 1
+    captured = capsys.readouterr()
+
+    assert "timezone-aware ISO8601 instant" in captured.err
+    with kb.connect() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 0
 
 
 


### PR DESCRIPTION
## Summary
- add optional `not_before` task metadata with additive legacy migration
- validate explicit timezone-aware ISO8601 instants and normalize to UTC without losing fractional precision
- expose the field in CLI JSON, creation events, and worker context; dispatch remains unchanged

## Verification
- `uv run --frozen --extra dev pytest tests/hermes_cli/test_kanban_db.py -q` (41 passed)
- broader Kanban regression set (97 passed, 1 skipped)
- `uv run --frozen --extra dev ruff check hermes_cli/kanban_db.py hermes_cli/kanban.py tests/hermes_cli/test_kanban_db.py`
- independent exact-SHA review of `38480f21d43e315a6c23f7eedbce306731c1ad8b` against `3d7dda4cf42176d587b459345c56236a26030324`: PASS, no blocking findings