### PR TITLE
fix(simplex): reliable inbound image and voice delivery (approved_relays, fresh path)

### DIFF
--- a/contributors/emails/marekp2310@gmail.com
+++ b/contributors/emails/marekp2310@gmail.com
@@ -1,0 +1,2 @@
+v1b3coder
+# simplex inbound media PR #81803

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -52,6 +52,7 @@ import os
 import random
 import re
 import time
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -128,6 +129,13 @@ def _is_image_ext(ext: str) -> bool:
 
 def _is_audio_ext(ext: str) -> bool:
     return ext.lower() in {".mp3", ".wav", ".ogg", ".m4a", ".aac", ".opus"}
+
+
+def _sanitize_filename(name: str) -> str:
+    """Make a peer-supplied file name safe for use in a local path fragment."""
+    name = os.path.basename(name or "").strip()
+    cleaned = re.sub(r"[^A-Za-z0-9._-]", "_", name)
+    return cleaned[:120] or "file"
 
 
 # ---------------------------------------------------------------------------
@@ -415,7 +423,35 @@ class SimplexAdapter(BasePlatformAdapter):
                     "SimpleX: rcvFileDescrReady for fileId=%s — sending /freceive",
                     file_id,
                 )
-                await self._send_fire_and_forget(f"/freceive {file_id}")
+                # approved_relays=on is REQUIRED: without it the daemon
+                # rejects the download with fileNotApproved/unknownServers
+                # and the file never arrives (rcvFileComplete never fires).
+                # All official clients (Python SDK, iOS, Android) send it.
+                #
+                # A fresh NON-EXISTING path is MANDATORY (live-verified on
+                # v7.0.0.11 AND v6.5.6.1): without a path the daemon parks
+                # the transfer at rcvTransfer/rcvFileComplete never fires and
+                # the file never lands; with an EXISTING path (e.g. its own
+                # 0-byte placeholder or a mkstemp file) it answers
+                # CEFileAlreadyExists. Generate with uuid + sanitized
+                # original filename so the extension classifies correctly
+                # (images → PHOTO, audio → VOICE).
+                # The fileName lives in chatItem.chatItem.file (rcvFileTransfer
+                # often omits it) — without it the path ends in "-file" and
+                # voice transcription fails on the extension.
+                chat_item_wrapper = resp.get("chatItem", {}) or {}
+                chat_item_inner = chat_item_wrapper.get("chatItem", {}) or {}
+                chat_item_file = chat_item_inner.get("file") or {}
+                file_name = (
+                    chat_item_file.get("fileName", "") if isinstance(chat_item_file, dict) else ""
+                ) or rcv_file.get("fileName", "")
+                base_name = _sanitize_filename(file_name)
+                fresh_path = f"/tmp/simplex-rcv-{uuid.uuid4().hex}-{base_name}"
+                while os.path.exists(fresh_path):
+                    fresh_path = f"/tmp/simplex-rcv-{uuid.uuid4().hex}-{base_name}"
+                await self._send_fire_and_forget(
+                    f"/freceive {file_id} approved_relays=on {fresh_path}"
+                )
             return
 
         # New messages — simplex-chat sends "newChatItems" with an array
@@ -454,9 +490,12 @@ class SimplexAdapter(BasePlatformAdapter):
                 )
                 if file_path:
                     pending_item_data = pending.get("chatItem", {}) or {}
-                    pending_item_data.setdefault("file", {})["fileSource"] = {
-                        "filePath": file_path
-                    }
+                    pending_file = pending_item_data.setdefault("file", {})
+                    pending_file["fileSource"] = {"filePath": file_path}
+                    # The parked item's fileStatus still says rcvInvitation —
+                    # mark it complete or _handle_chat_item will re-defer it
+                    # forever (the transfer IS done, file is on disk).
+                    pending_file["fileStatus"] = {"type": "rcvComplete"}
                     pending["chatItem"] = pending_item_data
                     try:
                         await self._handle_chat_item(pending)
@@ -568,30 +607,46 @@ class SimplexAdapter(BasePlatformAdapter):
             )
             file_name = file_info.get("fileName", "")
             file_id = file_info.get("fileId")
+            file_status = file_info.get("fileStatus", {}) or {}
+            file_status_type = (
+                file_status.get("type") if isinstance(file_status, dict) else None
+            )
 
-            ext = ""
-            if file_path:
-                ext = Path(file_path).suffix.lower()
-            if not ext and file_name:
-                ext = Path(file_name).suffix.lower()
-
-            # Voice notes typically arrive before the file finishes
-            # downloading. Defer the message until rcvFileComplete fires.
-            if not file_path and _is_audio_ext(ext) and file_id is not None:
+            # Files typically arrive before the transfer finishes
+            # downloading. Defer the message until rcvFileComplete fires,
+            # otherwise the media-less chat item is dispatched as empty text
+            # and the attachment is lost (images/videos/docs, not just voice).
+            # We must NOT send /freceive here: accepting before the file
+            # description is ready (rcvFileDescrReady) parks the transfer as
+            # rcvAccepted and the subsequent descrReady accept then fails
+            # with CEFileAlreadyReceiving — the download never starts.
+            # Accept exactly once, from the rcvFileDescrReady handler, like
+            # the official clients do.
+            if file_id is not None and file_status_type != "rcvComplete":
                 logger.info(
-                    "SimpleX: voice file %d not yet received, accepting transfer",
+                    "SimpleX: file %d not yet received, waiting for rcvFileDescrReady",
                     file_id,
                 )
                 self._pending_file_transfers[file_id] = chat_item
-                # Fire-and-forget: simplex-chat does not return a corrId reply
-                # for /freceive, so awaiting one would block the event loop.
-                await self._send_fire_and_forget(f"/freceive {file_id}")
                 return
 
             if file_path:
-                ext = Path(file_path).suffix.lower() or (
-                    Path(file_name).suffix.lower() if file_name else ""
+                # The daemon stores incoming files under a temp name
+                # (e.g. simplex-rcv-<uuid>.xftp) for encrypted-at-rest
+                # transfers; classify by the original file name first, then
+                # fall back to sniffing the content when the name doesn't
+                # carry a recognizable extension.
+                ext = (
+                    Path(file_name).suffix.lower()
+                    or Path(file_path).suffix.lower()
+                    or ""
                 )
+                if not _is_image_ext(ext) and not _is_audio_ext(ext):
+                    try:
+                        with open(file_path, "rb") as f:
+                            ext = _guess_extension(f.read(16))
+                    except OSError:
+                        pass
                 if _is_image_ext(ext):
                     media_urls.append(file_path)
                     media_types.append(f"image/{ext.lstrip('.')}")

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -388,3 +389,211 @@ def _make_file_chat_item(file_path: str, file_name: str) -> dict:
     }
 
 
+
+
+# ---------------------------------------------------------------------------
+# Inbound media: fresh-path /freceive, defer-without-accept, completion
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rcv_file_descr_ready_sends_freceive_with_fresh_path():
+    """rcvFileDescrReady must trigger /freceive with approved_relays=on AND
+    a fresh non-existing path (uuid-prefixed, original filename preserved).
+
+    Without a path the daemon parks the transfer at rcvTransfer and
+    rcvFileComplete never fires; with an existing path it answers
+    CEFileAlreadyExists. The uuid prefix guarantees the path does not exist
+    (regression for the v7 media stall)."""
+    from gateway.config import PlatformConfig
+
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+    sent_cmds = []
+
+    async def _fake_send_fire_and_forget(cmd):
+        sent_cmds.append(cmd)
+
+    adapter._send_fire_and_forget = _fake_send_fire_and_forget
+
+    resp = {
+        "type": "rcvFileDescrReady",
+        "rcvFileTransfer": {"fileId": 777, "fileName": "holiday.jpg"},
+    }
+    await adapter._handle_event(resp)
+
+    assert len(sent_cmds) == 1
+    cmd = sent_cmds[0]
+    assert cmd.startswith("/freceive 777 approved_relays=on /tmp/simplex-rcv-")
+    assert cmd.endswith("-holiday.jpg")
+    path = cmd.split()[-1]
+    # The path must not exist at accept time (fresh-path requirement).
+    assert not os.path.exists(path)
+    # Sanitization: weird file names must keep only safe chars.
+    resp["rcvFileTransfer"]["fileName"] = "../../evil name!.png"
+    await adapter._handle_event(resp)
+    path2 = sent_cmds[1].split()[-1]
+    assert path2.endswith("-evil_name_.png")
+    assert "/../" not in path2
+    assert path2.startswith("/tmp/simplex-rcv-")
+
+    # Voice: the daemon carries fileName in chatItem.chatItem.file, not in
+    # rcvFileTransfer — the fresh path must still end with the .m4a name or
+    # voice transcription fails on the extension.
+    resp = {
+        "type": "rcvFileDescrReady",
+        "rcvFileTransfer": {"fileId": 888},
+        "chatItem": {
+            "chatItem": {
+                "file": {"fileId": 888, "fileName": "voice_note.m4a"},
+            }
+        },
+    }
+    await adapter._handle_event(resp)
+    path3 = sent_cmds[2].split()[-1]
+    assert path3.endswith("-voice_note.m4a"), path3
+
+
+@pytest.mark.asyncio
+async def test_deferred_file_is_parked_no_freceive():
+    """A deferred inbound file must be parked in _pending_file_transfers
+    WITHOUT sending /freceive.
+
+    Accepting before the file description is ready (rcvFileDescrReady) parks
+    the transfer as rcvAccepted and the subsequent descrReady accept then
+    fails with CEFileAlreadyReceiving — the download never starts. Accept
+    exactly once, from the rcvFileDescrReady handler, like the official
+    clients do."""
+    from gateway.config import PlatformConfig
+
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+    dispatched = []
+
+    async def _capture(event):
+        dispatched.append(event)
+
+    adapter.handle_message = _capture
+
+    sent_cmds = []
+
+    async def _fake_send_fire_and_forget(cmd):
+        sent_cmds.append(cmd)
+
+    adapter._send_fire_and_forget = _fake_send_fire_and_forget
+
+    item = {
+        "chatInfo": {
+            "type": "direct",
+            "contact": {"contactId": 42, "localDisplayName": "tester"},
+        },
+        "chatItem": {
+            "chatDir": {"type": "directRcv"},
+            "meta": {"itemTs": "2026-01-01T00:00:00Z"},
+            "content": {
+                "type": "rcvMsgContent",
+                "msgContent": {"type": "image", "text": ""},
+            },
+            "file": {
+                "fileId": 99,
+                "fileName": "pic.jpg",
+                "fileSource": {},
+            },
+        },
+    }
+    await adapter._handle_chat_item(item)
+
+    assert dispatched == []
+    assert 99 in adapter._pending_file_transfers
+    assert sent_cmds == [], "deferred file must not send /freceive"
+
+
+@pytest.mark.asyncio
+async def test_rcv_file_complete_marks_status_complete_and_dispatches(tmp_path):
+    """rcvFileComplete must mark the parked item's fileStatus as rcvComplete
+    before re-dispatching — otherwise _handle_chat_item re-defers it forever
+    and the media never reaches the agent."""
+    from gateway.config import PlatformConfig
+    from gateway.platforms.base import MessageType
+
+    p = tmp_path / "simplex-rcv-deadbeef-holiday.jpg"
+    p.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 32)
+
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+    dispatched = []
+
+    async def _capture(event):
+        dispatched.append(event)
+
+    adapter.handle_message = _capture
+
+    # Parked item first (fileStatus rcvInvitation, no path).
+    parked = {
+        "chatInfo": {
+            "type": "direct",
+            "contact": {"contactId": 42, "localDisplayName": "tester"},
+        },
+        "chatItem": {
+            "chatDir": {"type": "directRcv"},
+            "meta": {"itemTs": "2026-01-01T00:00:00Z"},
+            "content": {
+                "type": "rcvMsgContent",
+                "msgContent": {"type": "image", "text": ""},
+            },
+            "file": {
+                "fileId": 777,
+                "fileName": "holiday.jpg",
+                "fileStatus": {"type": "rcvInvitation"},
+                "fileSource": {},
+            },
+        },
+    }
+    adapter._pending_file_transfers[777] = parked
+
+    resp = {
+        "type": "rcvFileComplete",
+        "chatItem": {
+            "chatItem": {
+                "file": {
+                    "fileId": 777,
+                    "fileName": "holiday.jpg",
+                    "fileSource": {"filePath": str(p)},
+                }
+            }
+        },
+    }
+    await adapter._handle_event(resp)
+
+    assert dispatched, "rcvFileComplete must dispatch the deferred media"
+    assert dispatched[0].message_type == MessageType.PHOTO
+
+
+@pytest.mark.asyncio
+async def test_classify_temp_xftp_as_image(tmp_path):
+    """An inbound file stored under the daemon's temp name (.xftp) whose
+    content is a JPEG must classify as image/jpeg — the extension of the
+    temp path is not meaningful, content sniffing decides (regression for
+    simplex-rcv-*.xftp attachments)."""
+    from gateway.config import PlatformConfig
+    from gateway.platforms.base import MessageType
+
+    p = tmp_path / "simplex-rcv-deadbeef.xftp"
+    p.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 32)
+
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+    dispatched = []
+
+    async def _capture(event):
+        dispatched.append(event)
+
+    adapter.handle_message = _capture
+
+    item = _make_file_chat_item(str(p), "IMG_1234.jpg")
+    item["chatItem"]["file"]["fileStatus"] = {"type": "rcvComplete"}
+    await adapter._handle_chat_item(item)
+
+    assert dispatched, "_handle_chat_item did not dispatch any event"
+    assert dispatched[0].message_type == MessageType.PHOTO
+    assert dispatched[0].media_types == ["image/jpg"]


### PR DESCRIPTION
## Problem

Inbound media on SimpleX is broken in two ways:

1. **Files never download on daemon v7** — the adapter sends `/freceive <fileId>` without `approved_relays=on`. The v7 daemon rejects this with `chatCmdError → fileNotApproved → unknownServers` (XFTP relay hosts are not pre-approved), so `rcvFileComplete` never fires and the attachment is silently lost. All official SimpleX clients (Python SDK, iOS, Android) always accept with `userApprovedRelays=True`.
2. **Downloaded files land in a broken location** — the daemon stores encrypted-at-rest transfers under a temp name (e.g. `simplex-rcv-<uuid>.xftp`); without an explicit target path the file is written to the default folder with no useful extension, so extension-based media classification mislabels voice notes/images as `DOCUMENT` (or the transfer stalls at `rcvTransfer` 100% with a 0-byte placeholder due to a path collision).

Additionally, when a voice message arrives, `fileName` is read from `rcvFileTransfer.fileName` which is often **empty** — the name actually lives in `chatItem.chatItem.file.fileName`. An empty name means the received file ends up with no extension, and voice transcription (Whisper) rejects it with `Unsupported format: .`

## Fix

- Send `/freceive <fileId> approved_relays=on <fresh_path>` from the `rcvFileDescrReady` handler — exactly once (the previous code could double-accept, which the daemon rejects with `CEFileAlreadyReceiving`).
- Generate a **fresh, non-existent path** `/tmp/simplex-rcv-<uuid>-<sanitized original filename>` (loop on `os.path.exists`) so the daemon writes real bytes to a file with the correct extension; never reuse an existing path (daemon answers `fileAlreadyExists`).
- Read `fileName` from `chatItem.chatItem.file` first, fall back to `rcvFileTransfer.fileName`.
- In the `rcvFileComplete` handler, also overwrite the parked item's `fileStatus` to `rcvComplete` before re-dispatching — otherwise the item is deferred forever (`waiting for rcvFileDescrReady` loop) and the message never reaches the agent.

## Verification

- Defer-then-receive flow verified live against daemon v7.0.0.11 AND v6.5.6.1: image (218 KB JPEG) and voice (`.m4a`) both arrive, land on disk with correct names, and reach the agent with `PHOTO`/`VOICE` message types.
- New unit tests: 20/20 pass (4 new inbound-media tests + 16 existing).