### PR TITLE
fix(agent): tolerate inaccessible remote context cwd

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -2584,13 +2584,23 @@ def build_context_files_prompt(
         )
         project_context = ""
     else:
-        # Priority-based project context: first match wins
-        project_context = (
-            _load_hermes_md(cwd_path, context_length)
-            or _load_agents_md(cwd_path, context_length)
-            or _load_claude_md(cwd_path, context_length)
-            or _load_cursorrules(cwd_path, context_length)
-        )
+        # Priority-based project context: first match wins. Remote backends may
+        # expose a logical cwd that this local process cannot traverse; project
+        # context is optional, so skip it without suppressing SOUL loading.
+        try:
+            project_context = (
+                _load_hermes_md(cwd_path, context_length)
+                or _load_agents_md(cwd_path, context_length)
+                or _load_claude_md(cwd_path, context_length)
+                or _load_cursorrules(cwd_path, context_length)
+            )
+        except OSError as exc:
+            logger.debug(
+                "skipping project-context discovery for inaccessible cwd %s: %s",
+                cwd_path,
+                exc,
+            )
+            project_context = ""
     if project_context:
         sections.append(project_context)
 

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -2249,13 +2249,23 @@ def build_context_files_prompt(
         )
         project_context = ""
     else:
-        # Priority-based project context: first match wins
-        project_context = (
-            _load_hermes_md(cwd_path, context_length)
-            or _load_agents_md(cwd_path, context_length)
-            or _load_claude_md(cwd_path, context_length)
-            or _load_cursorrules(cwd_path, context_length)
-        )
+        # Priority-based project context: first match wins. Remote backends may
+        # expose a logical cwd that this local process cannot traverse; project
+        # context is optional, so skip it without suppressing SOUL loading.
+        try:
+            project_context = (
+                _load_hermes_md(cwd_path, context_length)
+                or _load_agents_md(cwd_path, context_length)
+                or _load_claude_md(cwd_path, context_length)
+                or _load_cursorrules(cwd_path, context_length)
+            )
+        except OSError as exc:
+            logger.debug(
+                "skipping project-context discovery for inaccessible cwd %s: %s",
+                cwd_path,
+                exc,
+            )
+            project_context = ""
     if project_context:
         sections.append(project_context)
 

--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -85,7 +85,17 @@ def resolve_context_cwd() -> Path | None:
     override = _session_cwd_override()
     if override:
         p = Path(override).expanduser()
-        if not p.is_dir():
+        try:
+            is_dir = p.is_dir()
+        except OSError as exc:
+            logger.debug(
+                "could not validate configured working directory locally; "
+                "preserving logical path %s: %s",
+                override,
+                exc,
+            )
+            return p
+        if not is_dir:
             logger.warning("configured working directory does not exist: %s", override)
         else:
             return p
@@ -93,7 +103,16 @@ def resolve_context_cwd() -> Path | None:
     raw = os.environ.get("TERMINAL_CWD", "").strip()
     if raw:
         p = Path(raw).expanduser()
-        if not p.is_dir():
+        try:
+            is_dir = p.is_dir()
+        except OSError as exc:
+            logger.debug(
+                "could not validate TERMINAL_CWD locally; preserving logical path %s: %s",
+                raw,
+                exc,
+            )
+            return p
+        if not is_dir:
             logger.warning("TERMINAL_CWD does not exist: %s", raw)
         else:
             return p

--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -58,16 +58,41 @@ def _session_cwd_override() -> str:
 
 
 def resolve_agent_cwd() -> Path:
+    # A remote backend (ssh/docker/…) can expose a logical cwd this local
+    # process cannot traverse — e.g. an SSH worker home at 0750 owned by
+    # another user. Path.is_dir() raises PermissionError there instead of
+    # returning False, which would propagate out of every caller that builds a
+    # system prompt. Treat an unverifiable configured path as authoritative:
+    # the backend, not this process, is the one that has to resolve it.
     override = _session_cwd_override()
     if override:
         p = Path(override).expanduser()
-        if p.is_dir():
+        try:
+            is_dir = p.is_dir()
+        except OSError as exc:
+            logger.debug(
+                "could not validate configured working directory locally; "
+                "preserving logical path %s: %s",
+                override,
+                exc,
+            )
+            return p
+        if is_dir:
             return p
         logger.warning("configured working directory does not exist: %s", override)
     raw = os.environ.get("TERMINAL_CWD", "").strip()
     if raw:
         p = Path(raw).expanduser()
-        if p.is_dir():
+        try:
+            is_dir = p.is_dir()
+        except OSError as exc:
+            logger.debug(
+                "could not validate TERMINAL_CWD locally; preserving logical path %s: %s",
+                raw,
+                exc,
+            )
+            return p
+        if is_dir:
             return p
         logger.warning("TERMINAL_CWD does not exist: %s", raw)
     return Path(os.getcwd())
@@ -85,7 +110,17 @@ def resolve_context_cwd() -> Path | None:
     override = _session_cwd_override()
     if override:
         p = Path(override).expanduser()
-        if not p.is_dir():
+        try:
+            is_dir = p.is_dir()
+        except OSError as exc:
+            logger.debug(
+                "could not validate configured working directory locally; "
+                "preserving logical path %s: %s",
+                override,
+                exc,
+            )
+            return p
+        if not is_dir:
             logger.warning("configured working directory does not exist: %s", override)
         else:
             return p
@@ -93,7 +128,16 @@ def resolve_context_cwd() -> Path | None:
     raw = os.environ.get("TERMINAL_CWD", "").strip()
     if raw:
         p = Path(raw).expanduser()
-        if not p.is_dir():
+        try:
+            is_dir = p.is_dir()
+        except OSError as exc:
+            logger.debug(
+                "could not validate TERMINAL_CWD locally; preserving logical path %s: %s",
+                raw,
+                exc,
+            )
+            return p
+        if not is_dir:
             logger.warning("TERMINAL_CWD does not exist: %s", raw)
         else:
             return p

--- a/contributors/emails/hermes-patch@localhost
+++ b/contributors/emails/hermes-patch@localhost
@@ -1,0 +1,2 @@
+RichardHojunJang
+# PR #81805 automated commit authored by local Hermes Patch Applier tooling; PR author is RichardHojunJang

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -5,6 +5,7 @@ import importlib
 import logging
 import os
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -489,6 +490,29 @@ class TestBuildContextFilesPrompt:
         result = build_context_files_prompt(cwd=str(tmp_path))
         assert "Hermes-first context" in result
         assert "Override context" not in result
+    def test_permission_denied_project_discovery_still_loads_soul(
+        self, monkeypatch, tmp_path
+    ):
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        (hermes_home / "SOUL.md").write_text(
+            "REMOTE_CWD_SOUL_MARKER", encoding="utf-8"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        remote_cwd = Path("/home/red-worker/workspace")
+        denied_git = remote_cwd / ".git"
+        original_exists = Path.exists
+
+        def deny_remote_git(path):
+            if path == denied_git:
+                raise PermissionError(13, "Permission denied", str(path))
+            return original_exists(path)
+
+        monkeypatch.setattr(Path, "exists", deny_remote_git)
+
+        result = build_context_files_prompt(cwd=str(remote_cwd))
+
+        assert "REMOTE_CWD_SOUL_MARKER" in result
 
     def test_skips_agents_md_in_install_tree_on_fallback(self, monkeypatch, tmp_path):
         # A backend that FALLS BACK into the install tree (cwd=None → getcwd,

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -5,6 +5,7 @@ import importlib
 import logging
 import os
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -514,6 +515,30 @@ class TestBuildContextFilesPrompt:
         from agent.prompt_builder import _load_agents_md
 
         assert _load_agents_md(sub) == ""
+
+    def test_permission_denied_project_discovery_still_loads_soul(
+        self, monkeypatch, tmp_path
+    ):
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        (hermes_home / "SOUL.md").write_text(
+            "REMOTE_CWD_SOUL_MARKER", encoding="utf-8"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        remote_cwd = Path("/home/red-worker/workspace")
+        denied_git = remote_cwd / ".git"
+        original_exists = Path.exists
+
+        def deny_remote_git(path):
+            if path == denied_git:
+                raise PermissionError(13, "Permission denied", str(path))
+            return original_exists(path)
+
+        monkeypatch.setattr(Path, "exists", deny_remote_git)
+
+        result = build_context_files_prompt(cwd=str(remote_cwd))
+
+        assert "REMOTE_CWD_SOUL_MARKER" in result
 
     def test_skips_agents_md_in_install_tree_on_fallback(self, monkeypatch, tmp_path):
         # A backend that FALLS BACK into the install tree (cwd=None → getcwd,

--- a/tests/agent/test_runtime_cwd.py
+++ b/tests/agent/test_runtime_cwd.py
@@ -43,8 +43,21 @@ class TestResolveContextCwd:
         monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
         assert resolve_context_cwd() == tmp_path
 
+    def test_preserves_opaque_terminal_cwd_when_local_validation_is_denied(
+        self, monkeypatch
+    ):
+        remote_cwd = Path("/home/red-worker/workspace")
+        monkeypatch.setenv("TERMINAL_CWD", str(remote_cwd))
+        original_is_dir = Path.is_dir
 
+        def deny_remote_cwd(path):
+            if path == remote_cwd:
+                raise PermissionError(13, "Permission denied", str(path))
+            return original_is_dir(path)
 
+        monkeypatch.setattr(Path, "is_dir", deny_remote_cwd)
+
+        assert resolve_context_cwd() == remote_cwd
 
     def test_expands_leading_tilde(self, monkeypatch):
         monkeypatch.setenv("TERMINAL_CWD", "~")
@@ -67,6 +80,24 @@ class TestSessionCwdOverride:
         finally:
             rt._SESSION_CWD.reset(token)
 
+    def test_preserves_opaque_session_cwd_when_local_validation_is_denied(
+        self, monkeypatch, tmp_path
+    ):
+        remote_cwd = Path("/home/red-worker/workspace")
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        original_is_dir = Path.is_dir
+
+        def deny_remote_cwd(path):
+            if path == remote_cwd:
+                raise PermissionError(13, "Permission denied", str(path))
+            return original_is_dir(path)
+
+        monkeypatch.setattr(Path, "is_dir", deny_remote_cwd)
+        token = set_session_cwd(str(remote_cwd))
+        try:
+            assert resolve_context_cwd() == remote_cwd
+        finally:
+            rt._SESSION_CWD.reset(token)
 
     def test_clear_session_cwd_restores_terminal_cwd(self, monkeypatch, tmp_path):
         other = tmp_path / "other"

--- a/tests/agent/test_runtime_cwd.py
+++ b/tests/agent/test_runtime_cwd.py
@@ -43,12 +43,65 @@ class TestResolveContextCwd:
         monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
         assert resolve_context_cwd() == tmp_path
 
+    def test_preserves_opaque_terminal_cwd_when_local_validation_is_denied(
+        self, monkeypatch
+    ):
+        remote_cwd = Path("/home/red-worker/workspace")
+        monkeypatch.setenv("TERMINAL_CWD", str(remote_cwd))
+        original_is_dir = Path.is_dir
 
+        def deny_remote_cwd(path):
+            if path == remote_cwd:
+                raise PermissionError(13, "Permission denied", str(path))
+            return original_is_dir(path)
 
+        monkeypatch.setattr(Path, "is_dir", deny_remote_cwd)
+
+        assert resolve_context_cwd() == remote_cwd
 
     def test_expands_leading_tilde(self, monkeypatch):
         monkeypatch.setenv("TERMINAL_CWD", "~")
         assert resolve_context_cwd() == Path(os.path.expanduser("~"))
+
+
+class TestAgentCwdWithDeniedValidation:
+    """resolve_agent_cwd feeds the system prompt on every turn, so an
+    unreadable-but-configured remote cwd must not propagate PermissionError."""
+
+    def test_preserves_opaque_terminal_cwd_when_local_validation_is_denied(
+        self, monkeypatch
+    ):
+        remote_cwd = Path("/home/red-worker/workspace")
+        monkeypatch.setenv("TERMINAL_CWD", str(remote_cwd))
+        original_is_dir = Path.is_dir
+
+        def deny_remote_cwd(path):
+            if path == remote_cwd:
+                raise PermissionError(13, "Permission denied", str(path))
+            return original_is_dir(path)
+
+        monkeypatch.setattr(Path, "is_dir", deny_remote_cwd)
+
+        assert resolve_agent_cwd() == remote_cwd
+
+    def test_preserves_opaque_session_cwd_when_local_validation_is_denied(
+        self, monkeypatch
+    ):
+        remote_cwd = Path("/home/red-worker/workspace")
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        original_is_dir = Path.is_dir
+
+        def deny_remote_cwd(path):
+            if path == remote_cwd:
+                raise PermissionError(13, "Permission denied", str(path))
+            return original_is_dir(path)
+
+        monkeypatch.setattr(Path, "is_dir", deny_remote_cwd)
+        token = set_session_cwd(str(remote_cwd))
+        try:
+            assert resolve_agent_cwd() == remote_cwd
+        finally:
+            rt._SESSION_CWD.reset(token)
 
 
 
@@ -67,6 +120,24 @@ class TestSessionCwdOverride:
         finally:
             rt._SESSION_CWD.reset(token)
 
+    def test_preserves_opaque_session_cwd_when_local_validation_is_denied(
+        self, monkeypatch, tmp_path
+    ):
+        remote_cwd = Path("/home/red-worker/workspace")
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        original_is_dir = Path.is_dir
+
+        def deny_remote_cwd(path):
+            if path == remote_cwd:
+                raise PermissionError(13, "Permission denied", str(path))
+            return original_is_dir(path)
+
+        monkeypatch.setattr(Path, "is_dir", deny_remote_cwd)
+        token = set_session_cwd(str(remote_cwd))
+        try:
+            assert resolve_context_cwd() == remote_cwd
+        finally:
+            rt._SESSION_CWD.reset(token)
 
     def test_clear_session_cwd_restores_terminal_cwd(self, monkeypatch, tmp_path):
         other = tmp_path / "other"


### PR DESCRIPTION
## Summary

With a remote terminal backend, the configured cwd is a path on the *backend*,
not on the host running Hermes. When the local gateway process cannot traverse
it, `Path.is_dir()` / project-context discovery raise `PermissionError` instead
of returning `False`, and that propagates out of system-prompt construction —
every turn fails before the model is ever called.

Concrete case: an SSH backend whose worker home is `0750` and owned by another
user (`TERMINAL_CWD=/home/red-worker/workspace`). The gateway user cannot stat
it, so the agent could not answer at all — including losing `SOUL.md`, which has
nothing to do with the unreadable directory.

Reproduced on current `main` (3d7dda4cf):

```
resolve_agent_cwd:   PermissionError: [Errno 13] Permission denied: '/home/red-worker/workspace'
resolve_context_cwd: PermissionError: [Errno 13] Permission denied: '/home/red-worker/workspace'
```

## Approach

Treat an unverifiable *configured* path as authoritative rather than fatal — the
backend, not this process, is the thing that has to resolve it:

- `agent/runtime_cwd.py` — guard the four `is_dir()` probes in
  `resolve_agent_cwd` / `resolve_context_cwd`. On `OSError`, keep the logical
  path instead of raising or silently rewriting it to the launch dir.
- `agent/prompt_builder.py` — project-context discovery is *optional*, so an
  inaccessible cwd skips it and logs at debug. `SOUL.md` loading is unaffected;
  identity must not depend on whether a remote workspace happens to be readable
  locally.

Security note: this does not widen discovery. An unreadable path yields *no*
project context — it never falls back to walking parents, so a `.hermes.md`
planted in `/tmp` or `$HOME` still cannot be picked up.

## Relationship to #17100

@iws17's #17100 fixes the same class of bug from the other end — `OSError`
guards inside `prompt_builder`'s `_find_git_root` / `_find_hermes_md` helpers.
That work is good and I'd rather it land than duplicate it.

The two are complementary, not competing:

| | #17100 | this PR |
|---|---|---|
| `prompt_builder` internal helpers | ✅ | partially (top-level guard) |
| `agent/runtime_cwd.py` | ❌ untouched | ✅ all four `is_dir()` probes |
| `SOUL.md` preserved on denial | not asserted | ✅ explicit test |

`runtime_cwd.py` is the gap that matters most here: `resolve_agent_cwd` feeds the
system prompt on every turn and is reached from `conversation_loop`,
`codex_runtime`, and `coding_context`. #17100 does not touch that file, so the
crash above still reproduces with it applied.

Happy to rebase this onto #17100, split out just the `runtime_cwd` half, or close
this in favor of a combined patch — maintainer's call.

## Test plan

- [x] `tests/agent/test_runtime_cwd.py` — new `TestAgentCwdWithDeniedValidation`
      covering both `TERMINAL_CWD` and session-override arms
- [x] `tests/agent/test_prompt_builder.py` — asserts `SOUL.md` still loads when
      project discovery is denied

```
72 passed
```

Behavior probe before/after on the reproduction above: `PermissionError` →
`FIXED` (both resolvers return the logical path).

Verified on `origin/main` @ 3d7dda4cf.
