### PR TITLE
feat(api_server): expose session async delegations over HTTP

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -12,6 +12,7 @@ Exposes an HTTP server with endpoints:
 - POST /api/sessions               — create an empty Hermes session
 - GET/PATCH/DELETE /api/sessions/{session_id} — read/update/delete a session
 - GET  /api/sessions/{session_id}/messages — read session message history
+- GET  /api/sessions/{session_id}/delegations — list async delegations for a session
 - POST /api/sessions/{session_id}/fork — branch a session using SessionDB lineage
 - POST /api/sessions/{session_id}/chat[/stream] — chat with a persisted session
 - POST /v1/runs                    — start a run, returns run_id immediately (202)
@@ -2068,6 +2069,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ("PATCH", "/api/sessions/{session_id}", self._handle_patch_session),
             ("DELETE", "/api/sessions/{session_id}", self._handle_delete_session),
             ("GET", "/api/sessions/{session_id}/messages", self._handle_session_messages),
+            ("GET", "/api/sessions/{session_id}/delegations", self._handle_session_delegations),
             ("POST", "/api/sessions/{session_id}/fork", self._handle_fork_session),
             ("POST", "/api/sessions/{session_id}/chat", self._handle_session_chat),
             ("POST", "/api/sessions/{session_id}/chat/stream", self._handle_session_chat_stream),
@@ -3139,6 +3141,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_chat_streaming": True,
                 "session_fork": True,
                 "session_model_lock": True,
+                "session_delegations": True,
                 "admin_config_rw": False,
                 "jobs_admin": False,
                 "memory_write_api": False,
@@ -3170,6 +3173,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_update": {"method": "PATCH", "path": "/api/sessions/{session_id}"},
                 "session_delete": {"method": "DELETE", "path": "/api/sessions/{session_id}"},
                 "session_messages": {"method": "GET", "path": "/api/sessions/{session_id}/messages"},
+                "session_delegations": {
+                    "method": "GET",
+                    "path": "/api/sessions/{session_id}/delegations",
+                },
                 "session_fork": {"method": "POST", "path": "/api/sessions/{session_id}/fork"},
                 "session_chat": {"method": "POST", "path": "/api/sessions/{session_id}/chat"},
                 "session_chat_stream": {"method": "POST", "path": "/api/sessions/{session_id}/chat/stream"},
@@ -3609,6 +3616,101 @@ class APIServerAdapter(BasePlatformAdapter):
                 "order": order or ("latest" if default_page else "oldest"),
                 "returned": len(messages),
             },
+        })
+
+    # Public projection for GET /api/sessions/{id}/delegations — whitelist only.
+    # Deliberately omits free-text blobs like ``context`` / full result payloads
+    # that can be large or credential-bearing (#81754).
+    _DELEGATION_PUBLIC_KEYS = (
+        "delegation_id",
+        "status",
+        "goal",
+        "goals",
+        "is_batch",
+        "role",
+        "model",
+        "toolsets",
+        "dispatched_at",
+        "completed_at",
+        "seconds_since_progress",
+        "children_activity",
+        "in_tool",
+        "stalled_after_quiet_seconds",
+        "stall_threshold_seconds",
+        "stall_in_tool",
+        "origin_session_id",
+        "parent_session_id",
+        "session_key",
+    )
+
+    @classmethod
+    def _project_delegation_for_api(cls, item: Dict[str, Any]) -> Dict[str, Any]:
+        """Project an async-delegation registry row for the public Sessions API."""
+        out: Dict[str, Any] = {}
+        for key in cls._DELEGATION_PUBLIC_KEYS:
+            if key not in item:
+                continue
+            value = item[key]
+            if key == "goal" and isinstance(value, str):
+                value = redact_sensitive_text(value, force=True)
+            elif key == "goals" and isinstance(value, list):
+                value = [
+                    redact_sensitive_text(str(part), force=True)
+                    if isinstance(part, str)
+                    else part
+                    for part in value
+                ]
+            out[key] = value
+        return out
+
+    async def _handle_session_delegations(self, request: "web.Request") -> "web.Response":
+        """GET /api/sessions/{session_id}/delegations — async delegation status.
+
+        Thin projection of ``list_async_delegations_for_session`` for external
+        orchestrators that use ``/v1/runs`` and cannot treat ``run.completed``
+        as "all background children finished" (#81754).
+
+        Query params:
+        - ``include_recent`` (bool, default false): when true, also return
+          recently completed records retained by the registry.
+        - ``active_only`` (bool): when present, overrides ``include_recent``.
+          Default behavior is active-only.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        session_id = request.match_info["session_id"]
+        _, err = await self._get_existing_session_or_404(session_id)
+        if err:
+            return err
+
+        include_recent = _coerce_request_bool(
+            request.query.get("include_recent"), default=False
+        )
+        active_only = not include_recent
+        if "active_only" in request.query:
+            active_only = _coerce_request_bool(
+                request.query.get("active_only"), default=True
+            )
+
+        from tools.async_delegation import list_async_delegations_for_session
+
+        # active_count always reflects live work for this session so clients
+        # polling with include_recent=1 still get a reliable "work remaining"
+        # signal without inventing a second endpoint.
+        active_items = list_async_delegations_for_session(
+            session_id, active_only=True
+        )
+        items = (
+            active_items
+            if active_only
+            else list_async_delegations_for_session(session_id, active_only=False)
+        )
+        return web.json_response({
+            "object": "hermes.session.delegations",
+            "session_id": session_id,
+            "active_count": len(active_items),
+            "delegations": [self._project_delegation_for_api(item) for item in items],
         })
 
     async def _handle_fork_session(self, request: "web.Request") -> "web.Response":

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3641,6 +3641,8 @@ class APIServerAdapter(BasePlatformAdapter):
         "origin_session_id",
         "parent_session_id",
         "session_key",
+        "delivery_state",
+        "delivered_at",
     )
 
     @classmethod
@@ -3675,6 +3677,9 @@ class APIServerAdapter(BasePlatformAdapter):
           recently completed records retained by the registry.
         - ``active_only`` (bool): when present, overrides ``include_recent``.
           Default behavior is active-only.
+
+        Response also includes ``pending_delivery_count`` and ``drain_complete``
+        so orchestrators can wait for wake delivery after subagents finish.
         """
         auth_err = self._check_auth(request)
         if auth_err:
@@ -3693,24 +3698,19 @@ class APIServerAdapter(BasePlatformAdapter):
                 request.query.get("active_only"), default=True
             )
 
-        from tools.async_delegation import list_async_delegations_for_session
+        from tools.async_delegation import snapshot_session_delegations
 
-        # active_count always reflects live work for this session so clients
-        # polling with include_recent=1 still get a reliable "work remaining"
-        # signal without inventing a second endpoint.
-        active_items = list_async_delegations_for_session(
-            session_id, active_only=True
-        )
-        items = (
-            active_items
-            if active_only
-            else list_async_delegations_for_session(session_id, active_only=False)
-        )
+        snapshot = snapshot_session_delegations(session_id, active_only=active_only)
         return web.json_response({
             "object": "hermes.session.delegations",
             "session_id": session_id,
-            "active_count": len(active_items),
-            "delegations": [self._project_delegation_for_api(item) for item in items],
+            "active_count": snapshot["active_count"],
+            "pending_delivery_count": snapshot["pending_delivery_count"],
+            "drain_complete": snapshot["drain_complete"],
+            "delegations": [
+                self._project_delegation_for_api(item)
+                for item in snapshot["delegations"]
+            ],
         })
 
     async def _handle_fork_session(self, request: "web.Request") -> "web.Response":

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -12,6 +12,7 @@ Exposes an HTTP server with endpoints:
 - POST /api/sessions               — create an empty Hermes session
 - GET/PATCH/DELETE /api/sessions/{session_id} — read/update/delete a session
 - GET  /api/sessions/{session_id}/messages — read session message history
+- GET  /api/sessions/{session_id}/delegations — list async delegations for a session
 - POST /api/sessions/{session_id}/fork — branch a session using SessionDB lineage
 - POST /api/sessions/{session_id}/chat[/stream] — chat with a persisted session
 - POST /v1/runs                    — start a run, returns run_id immediately (202)
@@ -2067,6 +2068,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ("PATCH", "/api/sessions/{session_id}", self._handle_patch_session),
             ("DELETE", "/api/sessions/{session_id}", self._handle_delete_session),
             ("GET", "/api/sessions/{session_id}/messages", self._handle_session_messages),
+            ("GET", "/api/sessions/{session_id}/delegations", self._handle_session_delegations),
             ("POST", "/api/sessions/{session_id}/fork", self._handle_fork_session),
             ("POST", "/api/sessions/{session_id}/chat", self._handle_session_chat),
             ("POST", "/api/sessions/{session_id}/chat/stream", self._handle_session_chat_stream),
@@ -3136,6 +3138,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_chat_streaming": True,
                 "session_fork": True,
                 "session_model_lock": True,
+                "session_delegations": True,
                 "admin_config_rw": False,
                 "jobs_admin": False,
                 "memory_write_api": False,
@@ -3166,6 +3169,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_update": {"method": "PATCH", "path": "/api/sessions/{session_id}"},
                 "session_delete": {"method": "DELETE", "path": "/api/sessions/{session_id}"},
                 "session_messages": {"method": "GET", "path": "/api/sessions/{session_id}/messages"},
+                "session_delegations": {
+                    "method": "GET",
+                    "path": "/api/sessions/{session_id}/delegations",
+                },
                 "session_fork": {"method": "POST", "path": "/api/sessions/{session_id}/fork"},
                 "session_chat": {"method": "POST", "path": "/api/sessions/{session_id}/chat"},
                 "session_chat_stream": {"method": "POST", "path": "/api/sessions/{session_id}/chat/stream"},
@@ -3605,6 +3612,101 @@ class APIServerAdapter(BasePlatformAdapter):
                 "order": order or ("latest" if default_page else "oldest"),
                 "returned": len(messages),
             },
+        })
+
+    # Public projection for GET /api/sessions/{id}/delegations — whitelist only.
+    # Deliberately omits free-text blobs like ``context`` / full result payloads
+    # that can be large or credential-bearing (#81754).
+    _DELEGATION_PUBLIC_KEYS = (
+        "delegation_id",
+        "status",
+        "goal",
+        "goals",
+        "is_batch",
+        "role",
+        "model",
+        "toolsets",
+        "dispatched_at",
+        "completed_at",
+        "seconds_since_progress",
+        "children_activity",
+        "in_tool",
+        "stalled_after_quiet_seconds",
+        "stall_threshold_seconds",
+        "stall_in_tool",
+        "origin_session_id",
+        "parent_session_id",
+        "session_key",
+    )
+
+    @classmethod
+    def _project_delegation_for_api(cls, item: Dict[str, Any]) -> Dict[str, Any]:
+        """Project an async-delegation registry row for the public Sessions API."""
+        out: Dict[str, Any] = {}
+        for key in cls._DELEGATION_PUBLIC_KEYS:
+            if key not in item:
+                continue
+            value = item[key]
+            if key == "goal" and isinstance(value, str):
+                value = redact_sensitive_text(value, force=True)
+            elif key == "goals" and isinstance(value, list):
+                value = [
+                    redact_sensitive_text(str(part), force=True)
+                    if isinstance(part, str)
+                    else part
+                    for part in value
+                ]
+            out[key] = value
+        return out
+
+    async def _handle_session_delegations(self, request: "web.Request") -> "web.Response":
+        """GET /api/sessions/{session_id}/delegations — async delegation status.
+
+        Thin projection of ``list_async_delegations_for_session`` for external
+        orchestrators that use ``/v1/runs`` and cannot treat ``run.completed``
+        as "all background children finished" (#81754).
+
+        Query params:
+        - ``include_recent`` (bool, default false): when true, also return
+          recently completed records retained by the registry.
+        - ``active_only`` (bool): when present, overrides ``include_recent``.
+          Default behavior is active-only.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        session_id = request.match_info["session_id"]
+        _, err = await self._get_existing_session_or_404(session_id)
+        if err:
+            return err
+
+        include_recent = _coerce_request_bool(
+            request.query.get("include_recent"), default=False
+        )
+        active_only = not include_recent
+        if "active_only" in request.query:
+            active_only = _coerce_request_bool(
+                request.query.get("active_only"), default=True
+            )
+
+        from tools.async_delegation import list_async_delegations_for_session
+
+        # active_count always reflects live work for this session so clients
+        # polling with include_recent=1 still get a reliable "work remaining"
+        # signal without inventing a second endpoint.
+        active_items = list_async_delegations_for_session(
+            session_id, active_only=True
+        )
+        items = (
+            active_items
+            if active_only
+            else list_async_delegations_for_session(session_id, active_only=False)
+        )
+        return web.json_response({
+            "object": "hermes.session.delegations",
+            "session_id": session_id,
+            "active_count": len(active_items),
+            "delegations": [self._project_delegation_for_api(item) for item in items],
         })
 
     async def _handle_fork_session(self, request: "web.Request") -> "web.Response":

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3637,6 +3637,8 @@ class APIServerAdapter(BasePlatformAdapter):
         "origin_session_id",
         "parent_session_id",
         "session_key",
+        "delivery_state",
+        "delivered_at",
     )
 
     @classmethod
@@ -3671,6 +3673,9 @@ class APIServerAdapter(BasePlatformAdapter):
           recently completed records retained by the registry.
         - ``active_only`` (bool): when present, overrides ``include_recent``.
           Default behavior is active-only.
+
+        Response also includes ``pending_delivery_count`` and ``drain_complete``
+        so orchestrators can wait for wake delivery after subagents finish.
         """
         auth_err = self._check_auth(request)
         if auth_err:
@@ -3689,24 +3694,19 @@ class APIServerAdapter(BasePlatformAdapter):
                 request.query.get("active_only"), default=True
             )
 
-        from tools.async_delegation import list_async_delegations_for_session
+        from tools.async_delegation import snapshot_session_delegations
 
-        # active_count always reflects live work for this session so clients
-        # polling with include_recent=1 still get a reliable "work remaining"
-        # signal without inventing a second endpoint.
-        active_items = list_async_delegations_for_session(
-            session_id, active_only=True
-        )
-        items = (
-            active_items
-            if active_only
-            else list_async_delegations_for_session(session_id, active_only=False)
-        )
+        snapshot = snapshot_session_delegations(session_id, active_only=active_only)
         return web.json_response({
             "object": "hermes.session.delegations",
             "session_id": session_id,
-            "active_count": len(active_items),
-            "delegations": [self._project_delegation_for_api(item) for item in items],
+            "active_count": snapshot["active_count"],
+            "pending_delivery_count": snapshot["pending_delivery_count"],
+            "drain_complete": snapshot["drain_complete"],
+            "delegations": [
+                self._project_delegation_for_api(item)
+                for item in snapshot["delegations"]
+            ],
         })
 
     async def _handle_fork_session(self, request: "web.Request") -> "web.Response":

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -47,6 +47,10 @@ def _create_session_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_patch("/api/sessions/{session_id}", adapter._handle_patch_session)
     app.router.add_delete("/api/sessions/{session_id}", adapter._handle_delete_session)
     app.router.add_get("/api/sessions/{session_id}/messages", adapter._handle_session_messages)
+    app.router.add_get(
+        "/api/sessions/{session_id}/delegations",
+        adapter._handle_session_delegations,
+    )
     app.router.add_post("/api/sessions/{session_id}/fork", adapter._handle_fork_session)
     app.router.add_post("/api/sessions/{session_id}/chat", adapter._handle_session_chat)
     app.router.add_post("/api/sessions/{session_id}/chat/stream", adapter._handle_session_chat_stream)
@@ -67,11 +71,16 @@ async def test_capabilities_advertises_session_control_surface(adapter):
     assert features["session_chat_streaming"] is True
     assert features["session_fork"] is True
     assert features["run_steer"] is True
+    assert features["session_delegations"] is True
     assert features["admin_config_rw"] is False
     assert features["memory_write_api"] is False
     assert features["skills_api"] is True
     assert features["realtime_voice"] is False
     assert data["endpoints"]["sessions"] == {"method": "GET", "path": "/api/sessions"}
+    assert data["endpoints"]["session_delegations"] == {
+        "method": "GET",
+        "path": "/api/sessions/{session_id}/delegations",
+    }
     assert data["endpoints"]["session_chat_stream"] == {
         "method": "POST",
         "path": "/api/sessions/{session_id}/chat/stream",
@@ -833,3 +842,109 @@ async def test_patch_session_still_rejects_unknown_fields(adapter, session_db):
         resp = await cli.patch(f"/api/sessions/{session_id}", json={"nonsense": 1})
         assert resp.status == 400, await resp.text()
         assert (await resp.json())["error"]["code"] == "unsupported_session_field"
+
+
+@pytest.mark.asyncio
+async def test_session_delegations_lists_active_for_origin_session(
+    adapter, session_db, monkeypatch
+):
+    """/v1/runs orchestrators poll this after run.completed (#81754).
+
+    api_server background dispatch stamps origin_session_id with the raw
+    session id while session_key is often the per-run approval key — the
+    endpoint must match on origin_session_id.
+    """
+    import threading
+    import time
+
+    from tools import async_delegation as ad
+
+    monkeypatch.setattr(ad, "_STALE_CHECK_INTERVAL", 60.0)
+    ad._reset_for_tests()
+    session_id = session_db.create_session("deleg-origin-session", "api_server")
+    gate = threading.Event()
+
+    try:
+        res = ad.dispatch_async_delegation(
+            goal="bg for api orchestrator",
+            context="secret-context-must-not-leak",
+            toolsets=["terminal"],
+            role="leaf",
+            model="m",
+            session_key="run_approval_key_not_session",
+            parent_session_id=None,
+            origin_session_id=session_id,
+            max_async_children=1,
+            runner=lambda: {} if gate.wait(timeout=10) else {},
+        )
+        assert res["status"] == "dispatched"
+
+        # Foreign session must not appear in this listing.
+        ad.dispatch_async_delegation(
+            goal="other session work",
+            context=None,
+            toolsets=None,
+            role="leaf",
+            model="m",
+            session_key="other",
+            origin_session_id="someone-else",
+            max_async_children=2,
+            runner=lambda: {"status": "completed"},
+        )
+
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            missing = await cli.get("/api/sessions/does-not-exist/delegations")
+            assert missing.status == 404
+
+            resp = await cli.get(f"/api/sessions/{session_id}/delegations")
+            assert resp.status == 200, await resp.text()
+            payload = await resp.json()
+
+            recent = await cli.get(
+                f"/api/sessions/{session_id}/delegations?include_recent=1"
+            )
+            assert recent.status == 200
+            recent_payload = await recent.json()
+
+        assert payload["object"] == "hermes.session.delegations"
+        assert payload["session_id"] == session_id
+        assert payload["active_count"] == 1
+        assert len(payload["delegations"]) == 1
+        row = payload["delegations"][0]
+        assert row["delegation_id"] == res["delegation_id"]
+        assert row["status"] == "running"
+        assert row["goal"] == "bg for api orchestrator"
+        assert row["origin_session_id"] == session_id
+        assert "context" not in row
+        assert "interrupt_fn" not in row
+        assert "progress_fn" not in row
+        # Still active — include_recent does not change active_count.
+        assert recent_payload["active_count"] == 1
+        assert any(
+            d["delegation_id"] == res["delegation_id"]
+            for d in recent_payload["delegations"]
+        )
+    finally:
+        gate.set()
+        deadline = time.monotonic() + 2.0
+        while ad.active_count() and time.monotonic() < deadline:
+            time.sleep(0.02)
+        ad._reset_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_session_delegations_requires_auth(auth_adapter, session_db):
+    session_id = session_db.create_session("deleg-auth-session", "api_server")
+    app = _create_session_app(auth_adapter)
+    async with TestClient(TestServer(app)) as cli:
+        unauth = await cli.get(f"/api/sessions/{session_id}/delegations")
+        assert unauth.status == 401
+        ok = await cli.get(
+            f"/api/sessions/{session_id}/delegations",
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        assert ok.status == 200
+        payload = await ok.json()
+        assert payload["active_count"] == 0
+        assert payload["delegations"] == []

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import threading
+import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -11,6 +12,7 @@ from aiohttp.test_utils import TestClient, TestServer
 from gateway.config import PlatformConfig
 from gateway.platforms.api_server import APIServerAdapter
 from hermes_state import SessionDB
+from tools.process_registry import process_registry
 
 
 @pytest.fixture
@@ -33,7 +35,9 @@ def adapter(session_db):
 
 @pytest.fixture
 def auth_adapter(session_db):
-    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={"key": "sk-test"}))
+    adapter = APIServerAdapter(
+        PlatformConfig(enabled=True, extra={"key": "sk-test-81754-long-key"})
+    )
     adapter._session_db = session_db
     return adapter
 
@@ -894,7 +898,9 @@ async def test_session_delegations_lists_active_for_origin_session(
 
         app = _create_session_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            missing = await cli.get("/api/sessions/does-not-exist/delegations")
+            missing = await cli.get(
+                f"/api/sessions/missing-deleg-{uuid.uuid4().hex}/delegations"
+            )
             assert missing.status == 404
 
             resp = await cli.get(f"/api/sessions/{session_id}/delegations")
@@ -910,6 +916,8 @@ async def test_session_delegations_lists_active_for_origin_session(
         assert payload["object"] == "hermes.session.delegations"
         assert payload["session_id"] == session_id
         assert payload["active_count"] == 1
+        assert payload["pending_delivery_count"] == 0
+        assert payload["drain_complete"] is False
         assert len(payload["delegations"]) == 1
         row = payload["delegations"][0]
         assert row["delegation_id"] == res["delegation_id"]
@@ -934,6 +942,86 @@ async def test_session_delegations_lists_active_for_origin_session(
 
 
 @pytest.mark.asyncio
+async def test_session_delegations_pending_delivery_blocks_drain_complete(
+    adapter, session_db, monkeypatch,
+):
+    """Completed subagent with undelivered wake must not report drain_complete."""
+    import time
+
+    from tools import async_delegation as ad
+
+    monkeypatch.setattr(ad, "_STALE_CHECK_INTERVAL", 60.0)
+    ad._reset_for_tests()
+    session_id = session_db.create_session("deleg-drain-session", "api_server")
+
+    res = ad.dispatch_async_delegation(
+        goal="fast bg",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="m",
+        session_key="run_key",
+        origin_session_id=session_id,
+        max_async_children=1,
+        runner=lambda: {"status": "completed", "summary": "done"},
+    )
+    assert res["status"] == "dispatched"
+
+    deadline = time.monotonic() + 5.0
+    while ad.active_count() and time.monotonic() < deadline:
+        time.sleep(0.02)
+    evt = None
+    while time.monotonic() < deadline:
+        if not process_registry.completion_queue.empty():
+            evt = process_registry.completion_queue.get_nowait()
+            if evt.get("delegation_id") == res["delegation_id"]:
+                break
+        time.sleep(0.02)
+    assert evt is not None
+
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.get(f"/api/sessions/{session_id}/delegations")
+        payload = await resp.json()
+        recent = await cli.get(
+            f"/api/sessions/{session_id}/delegations?include_recent=1"
+        )
+        recent_payload = await recent.json()
+
+    assert payload["active_count"] == 0
+    assert payload["pending_delivery_count"] == 1
+    assert payload["drain_complete"] is False
+    assert recent_payload["active_count"] == 0
+    assert recent_payload["pending_delivery_count"] == 1
+    row = next(
+        d for d in recent_payload["delegations"]
+        if d["delegation_id"] == res["delegation_id"]
+    )
+    assert row["status"] == "completed"
+    assert row["delivery_state"] == "pending"
+    assert "delivered_at" not in row
+
+    assert ad.mark_completion_delivered(res["delegation_id"])
+
+    async with TestClient(TestServer(app)) as cli:
+        done = await cli.get(f"/api/sessions/{session_id}/delegations")
+        done_payload = await done.json()
+        done_recent = await cli.get(
+            f"/api/sessions/{session_id}/delegations?include_recent=1"
+        )
+        done_recent_payload = await done_recent.json()
+
+    assert done_payload["pending_delivery_count"] == 0
+    assert done_payload["drain_complete"] is True
+    delivered_row = next(
+        d for d in done_recent_payload["delegations"]
+        if d["delegation_id"] == res["delegation_id"]
+    )
+    assert delivered_row["delivery_state"] == "delivered"
+    assert isinstance(delivered_row["delivered_at"], float)
+
+
+@pytest.mark.asyncio
 async def test_session_delegations_requires_auth(auth_adapter, session_db):
     session_id = session_db.create_session("deleg-auth-session", "api_server")
     app = _create_session_app(auth_adapter)
@@ -942,9 +1030,11 @@ async def test_session_delegations_requires_auth(auth_adapter, session_db):
         assert unauth.status == 401
         ok = await cli.get(
             f"/api/sessions/{session_id}/delegations",
-            headers={"Authorization": "Bearer sk-test"},
+            headers={"Authorization": "Bearer sk-test-81754-long-key"},
         )
         assert ok.status == 200
         payload = await ok.json()
         assert payload["active_count"] == 0
+        assert payload["pending_delivery_count"] == 0
+        assert payload["drain_complete"] is True
         assert payload["delegations"] == []

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -45,6 +45,10 @@ def _create_session_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_patch("/api/sessions/{session_id}", adapter._handle_patch_session)
     app.router.add_delete("/api/sessions/{session_id}", adapter._handle_delete_session)
     app.router.add_get("/api/sessions/{session_id}/messages", adapter._handle_session_messages)
+    app.router.add_get(
+        "/api/sessions/{session_id}/delegations",
+        adapter._handle_session_delegations,
+    )
     app.router.add_post("/api/sessions/{session_id}/fork", adapter._handle_fork_session)
     app.router.add_post("/api/sessions/{session_id}/chat", adapter._handle_session_chat)
     app.router.add_post("/api/sessions/{session_id}/chat/stream", adapter._handle_session_chat_stream)
@@ -64,11 +68,16 @@ async def test_capabilities_advertises_session_control_surface(adapter):
     assert features["session_chat"] is True
     assert features["session_chat_streaming"] is True
     assert features["session_fork"] is True
+    assert features["session_delegations"] is True
     assert features["admin_config_rw"] is False
     assert features["memory_write_api"] is False
     assert features["skills_api"] is True
     assert features["realtime_voice"] is False
     assert data["endpoints"]["sessions"] == {"method": "GET", "path": "/api/sessions"}
+    assert data["endpoints"]["session_delegations"] == {
+        "method": "GET",
+        "path": "/api/sessions/{session_id}/delegations",
+    }
     assert data["endpoints"]["session_chat_stream"] == {
         "method": "POST",
         "path": "/api/sessions/{session_id}/chat/stream",
@@ -695,3 +704,109 @@ async def test_patch_session_still_rejects_unknown_fields(adapter, session_db):
         resp = await cli.patch(f"/api/sessions/{session_id}", json={"nonsense": 1})
         assert resp.status == 400, await resp.text()
         assert (await resp.json())["error"]["code"] == "unsupported_session_field"
+
+
+@pytest.mark.asyncio
+async def test_session_delegations_lists_active_for_origin_session(
+    adapter, session_db, monkeypatch
+):
+    """/v1/runs orchestrators poll this after run.completed (#81754).
+
+    api_server background dispatch stamps origin_session_id with the raw
+    session id while session_key is often the per-run approval key — the
+    endpoint must match on origin_session_id.
+    """
+    import threading
+    import time
+
+    from tools import async_delegation as ad
+
+    monkeypatch.setattr(ad, "_STALE_CHECK_INTERVAL", 60.0)
+    ad._reset_for_tests()
+    session_id = session_db.create_session("deleg-origin-session", "api_server")
+    gate = threading.Event()
+
+    try:
+        res = ad.dispatch_async_delegation(
+            goal="bg for api orchestrator",
+            context="secret-context-must-not-leak",
+            toolsets=["terminal"],
+            role="leaf",
+            model="m",
+            session_key="run_approval_key_not_session",
+            parent_session_id=None,
+            origin_session_id=session_id,
+            max_async_children=1,
+            runner=lambda: {} if gate.wait(timeout=10) else {},
+        )
+        assert res["status"] == "dispatched"
+
+        # Foreign session must not appear in this listing.
+        ad.dispatch_async_delegation(
+            goal="other session work",
+            context=None,
+            toolsets=None,
+            role="leaf",
+            model="m",
+            session_key="other",
+            origin_session_id="someone-else",
+            max_async_children=2,
+            runner=lambda: {"status": "completed"},
+        )
+
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            missing = await cli.get("/api/sessions/does-not-exist/delegations")
+            assert missing.status == 404
+
+            resp = await cli.get(f"/api/sessions/{session_id}/delegations")
+            assert resp.status == 200, await resp.text()
+            payload = await resp.json()
+
+            recent = await cli.get(
+                f"/api/sessions/{session_id}/delegations?include_recent=1"
+            )
+            assert recent.status == 200
+            recent_payload = await recent.json()
+
+        assert payload["object"] == "hermes.session.delegations"
+        assert payload["session_id"] == session_id
+        assert payload["active_count"] == 1
+        assert len(payload["delegations"]) == 1
+        row = payload["delegations"][0]
+        assert row["delegation_id"] == res["delegation_id"]
+        assert row["status"] == "running"
+        assert row["goal"] == "bg for api orchestrator"
+        assert row["origin_session_id"] == session_id
+        assert "context" not in row
+        assert "interrupt_fn" not in row
+        assert "progress_fn" not in row
+        # Still active — include_recent does not change active_count.
+        assert recent_payload["active_count"] == 1
+        assert any(
+            d["delegation_id"] == res["delegation_id"]
+            for d in recent_payload["delegations"]
+        )
+    finally:
+        gate.set()
+        deadline = time.monotonic() + 2.0
+        while ad.active_count() and time.monotonic() < deadline:
+            time.sleep(0.02)
+        ad._reset_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_session_delegations_requires_auth(auth_adapter, session_db):
+    session_id = session_db.create_session("deleg-auth-session", "api_server")
+    app = _create_session_app(auth_adapter)
+    async with TestClient(TestServer(app)) as cli:
+        unauth = await cli.get(f"/api/sessions/{session_id}/delegations")
+        assert unauth.status == 401
+        ok = await cli.get(
+            f"/api/sessions/{session_id}/delegations",
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        assert ok.status == 200
+        payload = await ok.json()
+        assert payload["active_count"] == 0
+        assert payload["delegations"] == []

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -1,5 +1,6 @@
 """Focused tests for API server session-control endpoints."""
 
+import uuid
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -9,6 +10,7 @@ from aiohttp.test_utils import TestClient, TestServer
 from gateway.config import PlatformConfig
 from gateway.platforms.api_server import APIServerAdapter
 from hermes_state import SessionDB
+from tools.process_registry import process_registry
 
 
 @pytest.fixture
@@ -31,7 +33,9 @@ def adapter(session_db):
 
 @pytest.fixture
 def auth_adapter(session_db):
-    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={"key": "sk-test"}))
+    adapter = APIServerAdapter(
+        PlatformConfig(enabled=True, extra={"key": "sk-test-81754-long-key"})
+    )
     adapter._session_db = session_db
     return adapter
 
@@ -756,7 +760,9 @@ async def test_session_delegations_lists_active_for_origin_session(
 
         app = _create_session_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            missing = await cli.get("/api/sessions/does-not-exist/delegations")
+            missing = await cli.get(
+                f"/api/sessions/missing-deleg-{uuid.uuid4().hex}/delegations"
+            )
             assert missing.status == 404
 
             resp = await cli.get(f"/api/sessions/{session_id}/delegations")
@@ -772,6 +778,8 @@ async def test_session_delegations_lists_active_for_origin_session(
         assert payload["object"] == "hermes.session.delegations"
         assert payload["session_id"] == session_id
         assert payload["active_count"] == 1
+        assert payload["pending_delivery_count"] == 0
+        assert payload["drain_complete"] is False
         assert len(payload["delegations"]) == 1
         row = payload["delegations"][0]
         assert row["delegation_id"] == res["delegation_id"]
@@ -796,6 +804,86 @@ async def test_session_delegations_lists_active_for_origin_session(
 
 
 @pytest.mark.asyncio
+async def test_session_delegations_pending_delivery_blocks_drain_complete(
+    adapter, session_db, monkeypatch,
+):
+    """Completed subagent with undelivered wake must not report drain_complete."""
+    import time
+
+    from tools import async_delegation as ad
+
+    monkeypatch.setattr(ad, "_STALE_CHECK_INTERVAL", 60.0)
+    ad._reset_for_tests()
+    session_id = session_db.create_session("deleg-drain-session", "api_server")
+
+    res = ad.dispatch_async_delegation(
+        goal="fast bg",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="m",
+        session_key="run_key",
+        origin_session_id=session_id,
+        max_async_children=1,
+        runner=lambda: {"status": "completed", "summary": "done"},
+    )
+    assert res["status"] == "dispatched"
+
+    deadline = time.monotonic() + 5.0
+    while ad.active_count() and time.monotonic() < deadline:
+        time.sleep(0.02)
+    evt = None
+    while time.monotonic() < deadline:
+        if not process_registry.completion_queue.empty():
+            evt = process_registry.completion_queue.get_nowait()
+            if evt.get("delegation_id") == res["delegation_id"]:
+                break
+        time.sleep(0.02)
+    assert evt is not None
+
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.get(f"/api/sessions/{session_id}/delegations")
+        payload = await resp.json()
+        recent = await cli.get(
+            f"/api/sessions/{session_id}/delegations?include_recent=1"
+        )
+        recent_payload = await recent.json()
+
+    assert payload["active_count"] == 0
+    assert payload["pending_delivery_count"] == 1
+    assert payload["drain_complete"] is False
+    assert recent_payload["active_count"] == 0
+    assert recent_payload["pending_delivery_count"] == 1
+    row = next(
+        d for d in recent_payload["delegations"]
+        if d["delegation_id"] == res["delegation_id"]
+    )
+    assert row["status"] == "completed"
+    assert row["delivery_state"] == "pending"
+    assert "delivered_at" not in row
+
+    assert ad.mark_completion_delivered(res["delegation_id"])
+
+    async with TestClient(TestServer(app)) as cli:
+        done = await cli.get(f"/api/sessions/{session_id}/delegations")
+        done_payload = await done.json()
+        done_recent = await cli.get(
+            f"/api/sessions/{session_id}/delegations?include_recent=1"
+        )
+        done_recent_payload = await done_recent.json()
+
+    assert done_payload["pending_delivery_count"] == 0
+    assert done_payload["drain_complete"] is True
+    delivered_row = next(
+        d for d in done_recent_payload["delegations"]
+        if d["delegation_id"] == res["delegation_id"]
+    )
+    assert delivered_row["delivery_state"] == "delivered"
+    assert isinstance(delivered_row["delivered_at"], float)
+
+
+@pytest.mark.asyncio
 async def test_session_delegations_requires_auth(auth_adapter, session_db):
     session_id = session_db.create_session("deleg-auth-session", "api_server")
     app = _create_session_app(auth_adapter)
@@ -804,9 +892,11 @@ async def test_session_delegations_requires_auth(auth_adapter, session_db):
         assert unauth.status == 401
         ok = await cli.get(
             f"/api/sessions/{session_id}/delegations",
-            headers={"Authorization": "Bearer sk-test"},
+            headers={"Authorization": "Bearer sk-test-81754-long-key"},
         )
         assert ok.status == 200
         payload = await ok.json()
         assert payload["active_count"] == 0
+        assert payload["pending_delivery_count"] == 0
+        assert payload["drain_complete"] is True
         assert payload["delegations"] == []

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -473,6 +473,42 @@ def test_list_async_delegations_exposes_live_activity(monkeypatch):
         gate.set()
 
 
+def test_list_async_delegations_for_session_matches_origin_and_filters(monkeypatch):
+    """Session filter must match origin_session_id even when session_key differs
+    (api_server /v1/runs approval key vs raw session id) (#81754)."""
+    monkeypatch.setattr(ad, "_STALE_CHECK_INTERVAL", 60.0)
+    gate = threading.Event()
+    try:
+        mine = ad.dispatch_async_delegation(
+            goal="mine",
+            context=None,
+            toolsets=None,
+            role="leaf",
+            model="m",
+            session_key="run_abc",
+            origin_session_id="sess-raw",
+            max_async_children=2,
+            runner=lambda: {} if gate.wait(timeout=10) else {},
+        )
+        ad.dispatch_async_delegation(
+            goal="theirs",
+            context=None,
+            toolsets=None,
+            role="leaf",
+            model="m",
+            session_key="other",
+            origin_session_id="other-sess",
+            max_async_children=2,
+            runner=lambda: {"status": "completed"},
+        )
+        active = ad.list_async_delegations_for_session("sess-raw")
+        assert [d["delegation_id"] for d in active] == [mine["delegation_id"]]
+        assert ad.list_async_delegations_for_session("") == []
+        assert ad.list_async_delegations_for_session("run_abc")  # session_key match
+    finally:
+        gate.set()
+
+
 def test_in_tool_stall_uses_higher_threshold(monkeypatch):
     """A frozen child inside a tool gets the in-tool ceiling, not the idle one."""
     _fast_stale_monitor(monkeypatch, idle=0.1, in_tool=10.0, grace=0.1)

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -97,6 +97,83 @@ def test_active_for_session_counts_every_live_delegation_state():
     assert ad.active_for_session("") == 0
 
 
+def test_count_pending_deliveries_for_session():
+    session_id = "sess-pending-count"
+    foreign_id = "sess-foreign-count"
+    res = ad.dispatch_async_delegation(
+        goal="owner work",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="m",
+        session_key="run-key",
+        origin_session_id=session_id,
+        max_async_children=1,
+        runner=lambda: {"status": "completed"},
+    )
+    ad.dispatch_async_delegation(
+        goal="foreign work",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="m",
+        session_key="other-run",
+        origin_session_id=foreign_id,
+        max_async_children=2,
+        runner=lambda: {"status": "completed"},
+    )
+    deadline = time.monotonic() + 5.0
+    while ad.active_count() and time.monotonic() < deadline:
+        time.sleep(0.02)
+    assert _drain_for(res["delegation_id"]) is not None
+
+    assert ad.count_pending_deliveries_for_session(session_id) == 1
+    assert ad.count_pending_deliveries_for_session(foreign_id) == 1
+    assert ad.count_pending_deliveries_for_session("nobody") == 0
+
+    ad.mark_completion_delivered(res["delegation_id"])
+    assert ad.count_pending_deliveries_for_session(session_id) == 0
+
+
+def test_snapshot_session_delegations_pending_delivery_blocks_drain():
+    session_id = "sess-snapshot-drain"
+    res = ad.dispatch_async_delegation(
+        goal="snapshot drain",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="m",
+        session_key="run-key",
+        origin_session_id=session_id,
+        max_async_children=1,
+        runner=lambda: {"status": "completed", "summary": "ok"},
+    )
+    deadline = time.monotonic() + 5.0
+    while ad.active_count() and time.monotonic() < deadline:
+        time.sleep(0.02)
+    assert _drain_for(res["delegation_id"]) is not None
+
+    snap = ad.snapshot_session_delegations(session_id, active_only=False)
+    assert snap["active_count"] == 0
+    assert snap["pending_delivery_count"] == 1
+    assert snap["drain_complete"] is False
+    row = next(
+        d for d in snap["delegations"] if d["delegation_id"] == res["delegation_id"]
+    )
+    assert row["status"] == "completed"
+    assert row["delivery_state"] == "pending"
+
+    ad.mark_completion_delivered(res["delegation_id"])
+    done = ad.snapshot_session_delegations(session_id, active_only=False)
+    assert done["pending_delivery_count"] == 0
+    assert done["drain_complete"] is True
+    delivered = next(
+        d for d in done["delegations"] if d["delegation_id"] == res["delegation_id"]
+    )
+    assert delivered["delivery_state"] == "delivered"
+    assert isinstance(delivered["delivered_at"], float)
+
+
 def test_dispatch_returns_immediately_without_blocking():
     gate = threading.Event()
 

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -1538,6 +1538,131 @@ def list_async_delegations_for_session(
     return out
 
 
+def _delegation_matches_session_id(
+    session_id: str,
+    *,
+    origin_session_id: str = "",
+    session_key: str = "",
+    parent_session_id: Optional[str] = None,
+) -> bool:
+    """True when a delegation row belongs to ``session_id`` (#81754 matching)."""
+    sid = (session_id or "").strip()
+    if not sid:
+        return False
+    return (
+        str(origin_session_id or "") == sid
+        or str(session_key or "") == sid
+        or str(parent_session_id or "") == sid
+    )
+
+
+def count_pending_deliveries_for_session(session_id: str) -> int:
+    """Count terminal delegations whose wake completion is not yet delivered.
+
+    Rows stay ``delivery_state='pending'`` from batch/subagent completion until
+    the gateway injects the wake turn and acknowledges delivery. External
+    orchestrators use this with ``active_count`` to avoid treating the session
+    as fully drained while a parent wake turn is still in flight.
+    """
+    sid = (session_id or "").strip()
+    if not sid:
+        return 0
+    with _DB_LOCK, _transaction() as conn:
+        row = conn.execute(
+            """SELECT COUNT(*) FROM async_delegations
+               WHERE state NOT IN ('running', 'finalizing')
+                 AND delivery_state = 'pending'
+                 AND (origin_session_id = ? OR origin_session = ? OR parent_session_id = ?)""",
+            (sid, sid, sid),
+        ).fetchone()
+    return int(row[0] or 0)
+
+
+def list_durable_delegations_for_session(session_id: str) -> List[Dict[str, Any]]:
+    """Read-only snapshot of durable async_delegations rows for one session."""
+    sid = (session_id or "").strip()
+    if not sid:
+        return []
+    with _DB_LOCK, _transaction() as conn:
+        rows = conn.execute(
+            """SELECT delegation_id, origin_session, origin_session_id, parent_session_id,
+                      state, dispatched_at, completed_at, delivery_state, delivered_at, task_json
+               FROM async_delegations
+               WHERE origin_session_id = ? OR origin_session = ? OR parent_session_id = ?
+               ORDER BY dispatched_at ASC, delegation_id ASC""",
+            (sid, sid, sid),
+        ).fetchall()
+    out: List[Dict[str, Any]] = []
+    for row in rows:
+        task = json.loads(row[9] or "{}") if row[9] else {}
+        item: Dict[str, Any] = {
+            "delegation_id": row[0],
+            "session_key": row[1] or "",
+            "origin_session_id": row[2] or "",
+            "parent_session_id": row[3],
+            "status": row[4],
+            "dispatched_at": row[5],
+            "completed_at": row[6],
+            "delivery_state": row[7],
+            "delivered_at": row[8],
+        }
+        for key in ("goal", "goals", "role", "model", "toolsets", "is_batch"):
+            if key in task:
+                item[key] = task[key]
+        out.append(item)
+    return out
+
+
+def snapshot_session_delegations(
+    session_id: str,
+    *,
+    active_only: bool = True,
+) -> Dict[str, Any]:
+    """Merged in-memory registry + durable delivery state for the Sessions API."""
+    active_items = list_async_delegations_for_session(session_id, active_only=True)
+    memory_items = (
+        active_items
+        if active_only
+        else list_async_delegations_for_session(session_id, active_only=False)
+    )
+    durable_by_id = {
+        row["delegation_id"]: row
+        for row in list_durable_delegations_for_session(session_id)
+    }
+    merged: Dict[str, Dict[str, Any]] = {}
+    for item in memory_items:
+        delegation_id = item.get("delegation_id")
+        if not delegation_id:
+            continue
+        merged[delegation_id] = dict(item)
+        durable = durable_by_id.get(delegation_id)
+        if durable is not None:
+            merged[delegation_id]["delivery_state"] = durable.get("delivery_state")
+            if durable.get("delivered_at") is not None:
+                merged[delegation_id]["delivered_at"] = durable.get("delivered_at")
+
+    if not active_only:
+        for delegation_id, durable in durable_by_id.items():
+            if delegation_id in merged:
+                continue
+            if durable.get("status") in _LIVE_STATUSES:
+                continue
+            merged[delegation_id] = dict(durable)
+
+    delegations = sorted(
+        merged.values(),
+        key=lambda row: (row.get("dispatched_at") or 0, row.get("delegation_id") or ""),
+    )
+    pending_delivery_count = count_pending_deliveries_for_session(session_id)
+    active_count = len(active_items)
+    return {
+        "active_count": active_count,
+        "pending_delivery_count": pending_delivery_count,
+        "drain_complete": active_count == 0 and pending_delivery_count == 0,
+        "delegations": delegations,
+    }
+
+
 def interrupt_all(reason: str = "shutdown") -> int:
     """Signal every running async delegation to stop. Returns how many.
 

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -689,7 +689,7 @@ def has_live_for_session(
         return False
     with _records_lock:
         return any(
-            r.get("status") in {"running", "stalling", "finalizing"}
+            r.get("status") in _LIVE_STATUSES
             and _matches_session_selectors(
                 r,
                 session_key=session_key,
@@ -1437,6 +1437,11 @@ def _children_activity_from_token(token: Any, now: float) -> Optional[List]:
     return out
 
 
+# Statuses treated as still-in-flight work for session observability /
+# keepalive (matches ``has_live_for_session``).
+_LIVE_STATUSES = frozenset({"running", "stalling", "finalizing"})
+
+
 def list_async_delegations() -> List[Dict[str, Any]]:
     """Snapshot of async delegations (running + recently completed).
 
@@ -1497,6 +1502,40 @@ def list_async_delegations() -> List[Dict[str, Any]]:
             item["children_activity"] = activity
         item["in_tool"] = bool(in_tool)
     return items
+
+
+def list_async_delegations_for_session(
+    session_id: str,
+    *,
+    active_only: bool = True,
+) -> List[Dict[str, Any]]:
+    """Snapshot of async delegations owned by a session id (#81754).
+
+    Matches records where any of ``origin_session_id``, ``session_key``, or
+    ``parent_session_id`` equals ``session_id``. That covers api_server
+    ``/v1/runs`` (``origin_session_id`` is the raw session id while
+    ``session_key`` is often the per-run approval key) and session-chat
+    paths (``session_key`` equals the session id).
+
+    When ``active_only`` is true (default), only live statuses are returned
+    (``running`` / ``stalling`` / ``finalizing``).
+    """
+    sid = (session_id or "").strip()
+    if not sid:
+        return []
+    items = list_async_delegations()
+    out: List[Dict[str, Any]] = []
+    for item in items:
+        if not (
+            str(item.get("origin_session_id") or "") == sid
+            or str(item.get("session_key") or "") == sid
+            or str(item.get("parent_session_id") or "") == sid
+        ):
+            continue
+        if active_only and item.get("status") not in _LIVE_STATUSES:
+            continue
+        out.append(item)
+    return out
 
 
 def interrupt_all(reason: str = "shutdown") -> int:

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -485,6 +485,8 @@ curl http://localhost:8642/api/sessions/$ID/delegations \
   "object": "hermes.session.delegations",
   "session_id": "my-session",
   "active_count": 1,
+  "pending_delivery_count": 0,
+  "drain_complete": false,
   "delegations": [
     {
       "delegation_id": "deleg_...",
@@ -499,15 +501,30 @@ curl http://localhost:8642/api/sessions/$ID/delegations \
 
 Defaults to **active-only** (`running` / `stalling` / `finalizing`). Pass
 `?include_recent=1` (or `?active_only=false`) to also include recently
-completed records retained by the registry. `active_count` always reflects
-live work for the session, even when recent completions are included.
+completed records retained by the registry or durable store. `active_count`
+always reflects live work for the session, even when recent completions are
+included.
+
+**Delivery drain fields** (for external orchestrators such as SCLAW):
+
+| Field | Meaning |
+|-------|---------|
+| `active_count` | Live subagent/batch units still running in the registry |
+| `pending_delivery_count` | Terminal delegations whose wake completion is not yet `delivered` |
+| `drain_complete` | `active_count == 0` and `pending_delivery_count == 0` |
+| `delivery_state` | Per delegation: `pending`, `delivered`, or `dropped` (when included) |
+| `delivered_at` | Timestamp when wake injection completed (when `delivered`) |
+
+A subagent can finish (`active_count` drops to 0) while the parent session is
+still processing the wake turn (`pending_delivery_count > 0`). Poll until
+`drain_complete` is true before treating the session as fully drained.
 
 This does **not** change `run.completed` semantics: a run still completes when
 the parent turn ends. Typical orchestrator flow:
 
 1. Wait for `run.completed` on the original run
-2. Poll `GET /api/sessions/{session_id}/delegations` until `active_count == 0`
-3. Optionally read session messages / the wake turn for the child result
+2. Poll `GET /api/sessions/{session_id}/delegations` until `drain_complete == true`
+3. Read session messages for the consolidated child results
 
 ```bash
 # fork a session and run one turn

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -388,6 +388,12 @@ redaction before leaving the process. Per-tool child events
 are high-volume UI noise; use the per-child live transcript files for
 play-by-play.
 
+Detached `delegate_task(background=true)` children may outlive the parent run:
+`run.completed` means the parent turn finished, not that every background
+subagent is done. Poll `GET /api/sessions/{session_id}/delegations` (see
+Sessions API below) for session-scoped async-delegation status after the run
+terminates.
+
 Unconsumed event buffers expire after five minutes so a detached client cannot
 grow memory indefinitely. This expires transport state only: a run that is
 still executing remains visible to status polling, approval, stop control, and
@@ -453,11 +459,55 @@ External UIs can manage Hermes sessions over REST without standing up the dashbo
 | `PATCH` | `/api/sessions/{id}` | Update title or `end_reason` |
 | `DELETE` | `/api/sessions/{id}` | Delete a session |
 | `GET` | `/api/sessions/{id}/messages` | Message history for a session |
+| `GET` | `/api/sessions/{id}/delegations` | Active (or recent) async `delegate_task` background work for a session |
 | `POST` | `/api/sessions/{id}/fork` | Branch the session via `SessionDB` lineage (matches CLI `/branch` semantics) |
 | `POST` | `/api/sessions/{id}/chat` | Run one synchronous agent turn |
 | `POST` | `/api/sessions/{id}/chat/stream` | SSE wrapper over a single turn — emits `assistant.delta`, `tool.started`, `tool.completed`, `run.completed` events |
 
 `/v1/capabilities` advertises the full surface via `session_*` feature flags and `endpoints.session_*` entries so external UIs can detect support and fall back safely. Inline images are supported in `chat` and `chat/stream` payloads (multimodal-aware path).
+
+### GET /api/sessions/\{id\}/delegations
+
+External orchestrators that drive Hermes through `POST /v1/runs` often treat
+`run.completed` as "the job is finished". That is true for the **parent turn**,
+but `delegate_task(background=true)` children can keep running after the parent
+run reaches a terminal state; their results re-enter the session later as a
+wake turn. This endpoint projects the in-process async-delegation registry for
+one session so clients can poll until background work drains.
+
+```bash
+curl http://localhost:8642/api/sessions/$ID/delegations \
+  -H "Authorization: Bearer $API_SERVER_KEY"
+```
+
+```json
+{
+  "object": "hermes.session.delegations",
+  "session_id": "my-session",
+  "active_count": 1,
+  "delegations": [
+    {
+      "delegation_id": "deleg_...",
+      "status": "running",
+      "goal": "...",
+      "dispatched_at": 0,
+      "seconds_since_progress": 12.3
+    }
+  ]
+}
+```
+
+Defaults to **active-only** (`running` / `stalling` / `finalizing`). Pass
+`?include_recent=1` (or `?active_only=false`) to also include recently
+completed records retained by the registry. `active_count` always reflects
+live work for the session, even when recent completions are included.
+
+This does **not** change `run.completed` semantics: a run still completes when
+the parent turn ends. Typical orchestrator flow:
+
+1. Wait for `run.completed` on the original run
+2. Poll `GET /api/sessions/{session_id}/delegations` until `active_count == 0`
+3. Optionally read session messages / the wake turn for the child result
 
 ```bash
 # fork a session and run one turn


### PR DESCRIPTION
External /v1/runs orchestrators treat run.completed as job-done, but background delegate_task children can outlive the parent turn. Add GET /api/sessions/{id}/delegations as a thin projection of the async registry so clients can poll until session work actually drains. Closes #81754

## What does this PR do?
External runtimes that drive Hermes via `POST /v1/runs` + SSE often treat
`run.completed` as "the job is finished". That is correct for the **parent
turn**, but `delegate_task(background=true)` children can keep running after
the parent run terminates; their results re-enter the session later as a wake
turn.
This PR adds `GET /api/sessions/{session_id}/delegations` so orchestrators
can poll until session async work is **fully drained** — without redefining
`run.completed` semantics.
### Two drain phases (why both signals matter)
| Phase | Signal | Meaning |
|-------|--------|---------|
| Subagent live work | `active_count` | In-memory registry: `running` / `stalling` / `finalizing` |
| Wake delivery | `pending_delivery_count` | Terminal delegations with `delivery_state='pending'` in durable SQLite |
| Fully drained | `drain_complete` | `active_count == 0 && pending_delivery_count == 0` |
**Production note:** A subagent can finish (`active_count → 0`) while the
parent session is still processing the wake turn (`pending_delivery_count > 0`).
Polling only `active_count == 0` is insufficient for external orchestrators
that finalize after background work; they should poll until `drain_complete`.
This is a **read-only API projection** of existing durable `delivery_state`
rows. It does **not** change wake injection, `gateway/run.py`, or agent turn
semantics.


## Related Issue

Fixes #81754

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

### Core (initial)
- `tools/async_delegation.py`: `list_async_delegations_for_session()` — match
  `origin_session_id` / `session_key` / `parent_session_id`; default active-only
- `gateway/platforms/api_server.py`:
  - `GET /api/sessions/{session_id}/delegations`
  - advertise under `/v1/capabilities` (`session_delegations`)
  - whitelist projection + secret redaction on `goal`/`goals` (no `context` / callables)
 
### Drain extension (follow-up in same PR)
- `tools/async_delegation.py`:
  - `count_pending_deliveries_for_session()`
  - `list_durable_delegations_for_session()`
  - `snapshot_session_delegations()` — merge in-memory registry + durable delivery state
- `gateway/platforms/api_server.py`: response adds `pending_delivery_count`,
  `drain_complete`; per-delegation `delivery_state` / `delivered_at`
- `website/docs/user-guide/features/api-server.md`: document drain fields and
  orchestrator polling guidance (`drain_complete`, not `active_count` alone)
- Tests: pending-delivery blocks `drain_complete`; durable snapshot unit tests

### Example response (wake still pending)
```json
{
  "object": "hermes.session.delegations",
  "session_id": "…",
  "active_count": 0,
  "pending_delivery_count": 1,
  "drain_complete": false,
  "delegations": []
}
```
## How to Test

1. pytest tests/gateway/test_session_api.py -k session_delegations -v
2. pytest tests/tools/test_async_delegation.py -k "pending or snapshot_session" -v
3. Manual:

    - Create/use a stable session_id
    - POST /v1/runs that triggers delegate_task(background=true) (ideally 2 batches)
    - Wait for parent run.completed
    - Poll GET /api/sessions/{session_id}/delegations?include_recent=1 until drain_complete == true (not just active_count == 0)
    - Confirm session messages contain wake / batch-complete content after drain

4. Confirm GET /v1/capabilities includes endpoints.session_delegations and features.session_delegations: true

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform:macOS (darwin)

### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — API-only change; covered by unit/integration tests above.

