### PR TITLE
fix(file): classify UTF-8 samples before lossy decoding

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 
 from tools.file_operations import (
     _is_write_denied,
+    _decode_utf8_boundary_sample,
     ReadResult,
     WriteResult,
     PatchResult,
@@ -20,6 +21,7 @@ from tools.file_operations import (
     normalize_read_pagination,
     normalize_search_pagination,
 )
+from tools.environments.local import LocalEnvironment
 
 
 # =========================================================================
@@ -258,7 +260,8 @@ def make_real_subprocess_env(cwd: str, include_stderr: bool = False) -> MagicMoc
         completed = subprocess.run(
             command,
             shell=True,
-            text=True,
+            encoding="utf-8",
+            errors="replace",
             capture_output=True,
             input=kwargs.get("stdin_data"),
         )
@@ -304,8 +307,8 @@ class TestShellFileOpsHelpers:
             commands.append(command)
             if command.startswith("wc -c"):
                 return {"output": "5\n", "returncode": 0}
-            if command.startswith("head -c"):
-                return {"output": "hello", "returncode": 0}
+            if "od -An -v -tx1" in command:
+                return {"output": "68 65 6c 6c 6f\n__HERMES_BINARY_SAMPLE_END__\n", "returncode": 0}
             if command.startswith("sed -n"):
                 return {"output": "hello\n", "returncode": 0}
             if command.startswith("wc -l"):
@@ -318,7 +321,7 @@ class TestShellFileOpsHelpers:
 
         assert result.error is None
         assert commands[0] == "wc -c < '/c/Users/alice/notes.txt' 2>/dev/null"
-        assert commands[1] == "head -c 1000 '/c/Users/alice/notes.txt' 2>/dev/null"
+        assert "od -An -v -tx1 -N 1003 '/c/Users/alice/notes.txt'" in commands[1]
         assert commands[2] == "sed -n '1,2000p' '/c/Users/alice/notes.txt'"
         assert commands[3] == "wc -l < '/c/Users/alice/notes.txt'"
 
@@ -345,8 +348,9 @@ class TestShellFileOpsHelpers:
         def side_effect(command, **kwargs):
             if command.startswith("wc -c"):
                 return {"output": "12\n", "returncode": 0}
-            if command.startswith("head -c"):
-                return {"output": "print('ok')\n", "returncode": 0}
+            if "od -An -v -tx1" in command:
+                sample = b"print('ok')\n"
+                return {"output": sample.hex(" ") + "\n__HERMES_BINARY_SAMPLE_END__\n", "returncode": 0}
             if command.startswith("sed -n"):
                 return {"output": leaked, "returncode": 0}
             if command.startswith("wc -l"):
@@ -373,8 +377,8 @@ class TestShellFileOpsHelpers:
         def side_effect(command, **kwargs):
             if command.startswith("wc -c"):
                 return {"output": "6\n", "returncode": 0}
-            if command.startswith("head -c"):
-                return {"output": "alpha\n", "returncode": 0}
+            if "od -An -v -tx1" in command:
+                return {"output": "61 6c 70 68 61 0a\n__HERMES_BINARY_SAMPLE_END__\n", "returncode": 0}
             if command.startswith("cat "):
                 return {"output": leaked, "returncode": 0}
             return {"output": "", "returncode": 0}
@@ -663,13 +667,113 @@ class TestReadNonUtf8IsBinary:
     read→edit→write round-trip would overwrite the original bytes with mojibake.
     """
 
-    def test_replacement_char_sample_flagged_binary(self, tmp_path):
+    def test_invalid_utf8_sample_flagged_binary(self, tmp_path):
         ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
-        # A latin-1 file decoded with errors="replace" yields U+FFFD chars.
-        lossy_sample = "caf\ufffd r\ufffdsum\ufffd\n"
-        assert ops._is_likely_binary("notes.txt", lossy_sample) is True
+        assert ops._is_likely_binary("notes.txt", b"caf\xff r\xe9sum\xe9\n") is True
 
     def test_plain_utf8_text_not_flagged(self, tmp_path):
         ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
         # Proper UTF-8 (including non-ASCII) must still read as text.
-        assert ops._is_likely_binary("notes.txt", "café résumé\nsecond\n") is False
+        assert ops._is_likely_binary(
+            "notes.txt", "café résumé\nsecond\n".encode()
+        ) is False
+
+    @pytest.mark.parametrize(
+        ("character", "bytes_before_boundary"),
+        [
+            ("é", 1),
+            ("”", 1),
+            ("”", 2),
+            ("😀", 1),
+            ("😀", 2),
+            ("😀", 3),
+        ],
+    )
+    def test_multibyte_character_crossing_byte_1000_reads_as_text(
+        self, tmp_path, character, bytes_before_boundary
+    ):
+        encoded = character.encode("utf-8")
+        path = tmp_path / "boundary.txt"
+        padding = 1000 - bytes_before_boundary
+        path.write_bytes(b"a" * padding + encoded + b"\n")
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+
+        result = ops.read_file(str(path))
+
+        assert result.error is None
+        assert result.is_binary is False
+        assert character in result.content
+
+    @pytest.mark.parametrize("reader_name", ["read_file", "read_file_raw"])
+    def test_historical_boundary_file_through_local_environment(
+        self, tmp_path, reader_name
+    ):
+        path = tmp_path / "historical-boundary.md"
+        data = b"a" * 999 + b"\xe2\x80\x9d\n"
+        data += b"x" * (4109 - len(data))
+        assert len(data) == 4109
+        data.decode("utf-8", errors="strict")
+        path.write_bytes(data)
+        ops = ShellFileOperations(LocalEnvironment(cwd=str(tmp_path)))
+
+        result = getattr(ops, reader_name)(str(path))
+
+        assert result.error is None
+        assert result.is_binary is False
+        assert "”" in result.content
+
+    @pytest.mark.parametrize(
+        ("prefix", "start"),
+        [
+            (b"\xc2", 999),
+            (b"\xe2", 999),
+            (b"\xe2\x80", 998),
+            (b"\xf0", 999),
+            (b"\xf0\x9f", 998),
+            (b"\xf0\x9f\x98", 997),
+        ],
+    )
+    def test_boundary_sequence_rejects_illegal_continuation(self, prefix, start):
+        data = b"a" * start + prefix + b"X"
+        assert _decode_utf8_boundary_sample(data) is None
+
+    def test_invalid_byte_starting_after_boundary_is_out_of_scope(self, tmp_path):
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        data = b"a" * 1000 + b"\xff"
+        assert _decode_utf8_boundary_sample(data) == "a" * 1000
+        assert ops._is_likely_binary("notes.txt", data) is False
+
+    def test_literal_replacement_character_reads_as_text(self, tmp_path):
+        path = tmp_path / "literal.txt"
+        path.write_text("valid \ufffd text\n", encoding="utf-8")
+        result = ShellFileOperations(
+            make_real_subprocess_env(str(tmp_path))
+        ).read_file(str(path))
+        assert result.error is None
+        assert result.is_binary is False
+        assert "\ufffd" in result.content
+
+    def test_true_eof_incomplete_utf8_is_binary(self, tmp_path):
+        path = tmp_path / "incomplete.txt"
+        path.write_bytes(b"a" * 999 + b"\xe2")
+        result = ShellFileOperations(
+            make_real_subprocess_env(str(tmp_path))
+        ).read_file(str(path))
+        assert result.is_binary is True
+        assert result.error is not None
+
+    def test_malformed_byte_transport_fails_closed(self, mock_env):
+        def side_effect(command, **kwargs):
+            if command.startswith("wc -c"):
+                return {"output": "5\n", "returncode": 0}
+            if "od -An -v -tx1" in command:
+                return {
+                    "output": "68 65 NOT-HEX\n__HERMES_BINARY_SAMPLE_END__\n",
+                    "returncode": 0,
+                }
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        result = ShellFileOperations(mock_env).read_file("/tmp/test/a.txt")
+        assert result.error is not None
+        assert "malformed hexadecimal" in result.error

--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -26,29 +26,29 @@ class TestIsLikelyBinary:
     def test_binary_extension_returns_true(self, ops):
         """Known binary extensions should short-circuit without content analysis."""
         assert ops._is_likely_binary("image.png") is True
-        assert ops._is_likely_binary("archive.tar.gz", content_sample="hello") is True
+        assert ops._is_likely_binary("archive.tar.gz", content_sample=b"hello") is True
 
     def test_text_content_returns_false(self, ops):
         """Normal printable text should not be classified as binary."""
-        sample = "Hello, world!\nThis is a normal text file.\n"
+        sample = b"Hello, world!\nThis is a normal text file.\n"
         assert ops._is_likely_binary("unknown.xyz", content_sample=sample) is False
 
 
     def test_just_above_threshold(self, ops):
         """301/1000 = 30.1% non-printable → should be binary."""
-        sample = "\x00" * 301 + "a" * 699
+        sample = b"\x00" * 301 + b"a" * 699
         assert ops._is_likely_binary("data.xyz", content_sample=sample) is True
 
     def test_tabs_and_newlines_excluded(self, ops):
         """Tabs, carriage returns, and newlines should not count as non-printable."""
-        sample = "\t" * 400 + "\n" * 300 + "\r" * 200 + "a" * 100
+        sample = b"\t" * 400 + b"\n" * 300 + b"\r" * 200 + b"a" * 100
         assert ops._is_likely_binary("file.txt", content_sample=sample) is False
 
     def test_content_sample_longer_than_1000(self, ops):
         """Only the first 1000 characters should be analysed."""
-        # First 1000 chars: 200 NUL + 800 printable = 20% → not binary
+        # First 1000 bytes: 200 NUL + 800 printable = 20% → not binary
         # Remaining 1000 chars: all NUL → ignored by [:1000] slice
-        sample = "\x00" * 200 + "a" * 800 + "\x00" * 1000
+        sample = b"\x00" * 200 + b"a" * 800 + b"\x00" * 1000
         assert ops._is_likely_binary("file.xyz", content_sample=sample) is False
 
 
@@ -207,8 +207,12 @@ class TestPaginationBounds:
             commands.append(command)
             if command.startswith("wc -c"):
                 return MagicMock(exit_code=0, stdout="12")
-            if command.startswith("head -c"):
-                return MagicMock(exit_code=0, stdout="line1\nline2\n")
+            if "od -An -v -tx1" in command:
+                sample = b"line1\nline2\n"
+                return MagicMock(
+                    exit_code=0,
+                    stdout=sample.hex(" ") + "\n__HERMES_BINARY_SAMPLE_END__\n",
+                )
             if command.startswith("sed -n"):
                 return MagicMock(exit_code=0, stdout="line1\n")
             if command.startswith("wc -l"):

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -26,13 +26,14 @@ Usage:
 """
 
 import base64
+import codecs
 import os
 import re
 import difflib
 import hashlib
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Optional, List, Dict, Any, ClassVar
+from typing import Optional, List, Dict, Any, ClassVar, Tuple
 from pathlib import Path
 from tools.binary_extensions import BINARY_EXTENSIONS
 
@@ -57,6 +58,49 @@ WRITE_DENIED_PREFIXES = build_write_denied_prefixes(_HOME)
 
 _OSC_SEQUENCE_RE = re.compile(r"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)")
 _FENCE_MARKER_RE = re.compile(r"'?\x07?__HERMES_FENCE_[A-Za-z0-9]+__\x07?'?")
+
+_BINARY_SAMPLE_LIMIT = 1000
+_UTF8_BOUNDARY_LOOKAHEAD = 3
+_BINARY_SAMPLE_TRANSPORT_MARKER = "__HERMES_BINARY_SAMPLE_END__"
+
+
+@dataclass(frozen=True)
+class _BinarySampleTransport:
+    """Byte-safe bounded sample returned through the text-only exec API."""
+
+    data: Optional[bytes] = None
+    error: Optional[str] = None
+
+
+def _decode_utf8_boundary_sample(
+    data: bytes,
+    sample_limit: int = _BINARY_SAMPLE_LIMIT,
+) -> Optional[str]:
+    """Strictly decode a UTF-8 prefix while allowing one boundary split.
+
+    Bytes after ``sample_limit`` are consumed only to finish a character that
+    started inside the logical sample.  They are not otherwise classified.
+    """
+    decoder = codecs.getincrementaldecoder("utf-8")(errors="strict")
+    try:
+        text = decoder.decode(data[:sample_limit], final=False)
+    except UnicodeDecodeError:
+        return None
+
+    pending, _ = decoder.getstate()
+    if not pending:
+        return text
+
+    for value in data[sample_limit:sample_limit + _UTF8_BOUNDARY_LOOKAHEAD]:
+        try:
+            text += decoder.decode(bytes((value,)), final=False)
+        except UnicodeDecodeError:
+            return None
+        pending, _ = decoder.getstate()
+        if not pending:
+            return text
+
+    return None
 
 
 def _strip_terminal_fence_leaks(text: str) -> str:
@@ -887,34 +931,85 @@ class ShellFileOperations(FileOperations):
             self._command_cache[cmd] = result.stdout.strip() == 'yes'
         return self._command_cache[cmd]
     
-    def _is_likely_binary(self, path: str, content_sample: str = None) -> bool:
+    def _read_binary_sample(self, path: str, file_size: int) -> _BinarySampleTransport:
+        """Read raw sample bytes as validated ASCII hex across the exec API."""
+        read_limit = _BINARY_SAMPLE_LIMIT + _UTF8_BOUNDARY_LOOKAHEAD
+        escaped = self._escape_shell_arg(path)
+        command = (
+            f"LC_ALL=C od -An -v -tx1 -N {read_limit} {escaped} 2>/dev/null "
+            f"&& printf '\\n{_BINARY_SAMPLE_TRANSPORT_MARKER}\\n'"
+        )
+        result = self._exec(command)
+        if result.exit_code != 0:
+            return _BinarySampleTransport(
+                error=f"byte-sample command failed with exit code {result.exit_code}"
+            )
+
+        output = _strip_terminal_fence_leaks(result.stdout)
+        if output.count(_BINARY_SAMPLE_TRANSPORT_MARKER) != 1:
+            return _BinarySampleTransport(
+                error="byte-sample transport marker missing or duplicated"
+            )
+        payload, trailer = output.split(_BINARY_SAMPLE_TRANSPORT_MARKER, 1)
+        if trailer.strip():
+            return _BinarySampleTransport(
+                error="unexpected data after byte-sample transport marker"
+            )
+        tokens = payload.split()
+        if any(re.fullmatch(r"[0-9A-Fa-f]{2}", token) is None for token in tokens):
+            return _BinarySampleTransport(
+                error="malformed hexadecimal byte-sample transport"
+            )
+        data = bytes(int(token, 16) for token in tokens)
+        expected = min(file_size, read_limit)
+        if len(data) != expected:
+            return _BinarySampleTransport(
+                error=(
+                    "truncated byte-sample transport "
+                    f"(expected {expected} bytes, received {len(data)})"
+                )
+            )
+        return _BinarySampleTransport(data=data)
+
+    def _is_likely_binary(
+        self,
+        path: str,
+        content_sample: Optional[bytes] = None,
+    ) -> bool:
         """
         Check if a file is likely binary.
         
-        Uses extension check (fast) + content analysis (fallback).
+        Uses extension check + strict byte-oriented content analysis.
         """
         ext = os.path.splitext(path)[1].lower()
         if ext in BINARY_EXTENSIONS:
             return True
         
-        # Content analysis: >30% non-printable chars = binary
-        if content_sample:
-            # Undecodable bytes: the terminal env decodes stdout with
-            # errors="replace", so any non-UTF-8 byte arrives here already
-            # turned into U+FFFD. That char is "printable" (ord 65533), so the
-            # non-printable ratio below never catches it — and returning the
-            # lossy text would let a read→edit→write round-trip silently
-            # overwrite the original bytes with mojibake. Treat a file whose
-            # sample carries the replacement char as binary (read-only) so the
-            # agent can't corrupt it. Legitimate UTF-8 text effectively never
-            # contains U+FFFD.
-            if "\ufffd" in content_sample[:1000]:
-                return True
-            non_printable = sum(1 for c in content_sample[:1000]
-                               if ord(c) < 32 and c not in '\n\r\t')
-            return non_printable / min(len(content_sample), 1000) > 0.30
-        
-        return False
+        if content_sample is None:
+            return False
+        text = _decode_utf8_boundary_sample(
+            content_sample,
+            sample_limit=_BINARY_SAMPLE_LIMIT,
+        )
+        if text is None:
+            return True
+        if not text:
+            return False
+        non_printable = sum(
+            1 for char in text if ord(char) < 32 and char not in "\n\r\t"
+        )
+        return non_printable / len(text) > 0.30
+
+    def _inspect_binary_sample(
+        self, path: str, file_size: int
+    ) -> Tuple[Optional[bool], Optional[str]]:
+        if self._is_likely_binary(path):
+            return True, None
+        sample = self._read_binary_sample(path, file_size)
+        if sample.error:
+            return None, sample.error
+        assert sample.data is not None
+        return self._is_likely_binary(path, sample.data), None
     
     def _is_image(self, path: str) -> bool:
         """Check if file is an image we can return as base64."""
@@ -1193,12 +1288,13 @@ class ShellFileOperations(FileOperations):
                 ),
             )
         
-        # Read a sample to check for binary content
-        sample_cmd = f"head -c 1000 {self._escape_shell_arg(path)} 2>/dev/null"
-        sample_result = self._exec(sample_cmd)
-        sample_output = _strip_terminal_fence_leaks(sample_result.stdout)
-        
-        if self._is_likely_binary(path, sample_output):
+        is_binary, sample_error = self._inspect_binary_sample(path, file_size)
+        if sample_error:
+            return ReadResult(
+                file_size=file_size,
+                error=f"Failed to inspect file safely before reading: {sample_error}",
+            )
+        if is_binary:
             return ReadResult(
                 is_binary=True,
                 file_size=file_size,
@@ -1312,9 +1408,13 @@ class ShellFileOperations(FileOperations):
             file_size = 0
         if self._is_image(path):
             return ReadResult(is_image=True, is_binary=True, file_size=file_size)
-        sample_result = self._exec(f"head -c 1000 {self._escape_shell_arg(path)} 2>/dev/null")
-        sample_output = _strip_terminal_fence_leaks(sample_result.stdout)
-        if self._is_likely_binary(path, sample_output):
+        is_binary, sample_error = self._inspect_binary_sample(path, file_size)
+        if sample_error:
+            return ReadResult(
+                file_size=file_size,
+                error=f"Failed to inspect file safely before reading: {sample_error}",
+            )
+        if is_binary:
             return ReadResult(
                 is_binary=True, file_size=file_size,
                 error="Binary file — cannot display as text."


### PR DESCRIPTION
## Summary

Fix false binary classification when the 1,000-byte content sample splits a valid multibyte UTF-8 sequence.

`ShellFileOperations` currently sends `head -c 1000` output through environment APIs that decode stdout with `errors="replace"`. A valid character beginning before byte 1,000 and ending after it therefore arrives as U+FFFD and is classified as binary.

This change:

- transports a bounded 1,003-byte sample as validated ASCII hex before backend text decoding;
- strictly validates the 1,000-byte logical UTF-8 prefix with up to three completion bytes;
- accepts valid 2-, 3-, and 4-byte characters split at every boundary position;
- treats literal valid U+FFFD as text;
- rejects malformed and incomplete UTF-8 samples;
- preserves existing extension and control-character heuristics;
- consolidates `read_file()` and `read_file_raw()` through the byte-safe sampler;
- fails closed on malformed, truncated, or incomplete sample transport.

`patch_replace()` is intentionally unchanged. Prefix classification does not prove an entire editable file is valid UTF-8, and the existing display-read helper performs lossy terminal-fence cleanup; edit-path hardening requires a separate lossless full-file snapshot design.

The size probe, bounded sample, and final display read remain separate opens. Exact-length validation fails closed on many growth/shrink races, but it cannot detect same-size replacement or mutation after sampling. This PR fixes the byte-boundary classification defect; it does not claim stable-snapshot or full-file edit validation.

## Relationship to existing PRs

Several open PRs address the same symptom, but this implementation differs at the safety boundary:

- #80864 transports only the 1,000-byte prefix and peels trailing bytes until strict decoding succeeds; that cannot prove whether discarded trailing bytes begin a valid character. This PR fetches continuation lookahead and accepts the boundary only when that pending character actually completes.
- #80440 uses a byte transport but falls back to the legacy lossy heuristic when transport fails and introduces an any-NUL rule. This PR fails closed on transport errors and preserves the existing strict `>30%` low-control threshold.
- #76934 performs a bounded raw probe only after replacement-decoded text ends in U+FFFD. This PR never bases classification on replacement-decoded sample bytes: it reconstructs the bounded raw sample first, so literal U+FFFD and every legal split are handled directly.

The regression matrix covers every split position for valid 2-, 3-, and 4-byte UTF-8 characters, malformed continuations at those positions, literal U+FFFD, true-EOF incompleteness, and invalid bytes beginning immediately after the logical boundary.

## Reproduction

A valid 4,109-byte UTF-8 file with `E2` at byte 1,000 and `80 9D` immediately after it:

- current `main`: `is_binary=True` with “Binary file” error;
- this branch: `is_binary=False`, no error, and the closing quote is preserved.

## Verification

```bash
scripts/run_tests.sh tests/tools/test_file*.py tests/tools/test_read_extract.py -q --tb=short
# 346 passed, 0 failed

scripts/run_tests.sh \
  tests/tools/test_file_operations.py \
  tests/tools/test_file_operations_edge_cases.py \
  tests/tools/test_patch_parser.py \
  tests/tools/test_file_ops_cwd_tracking.py \
  -q --tb=short
# 121 passed, 0 failed

ruff check \
  tools/file_operations.py \
  tests/tools/test_file_operations.py \
  tests/tools/test_file_operations_edge_cases.py
# All checks passed

python -m py_compile \
  tools/file_operations.py \
  tests/tools/test_file_operations.py \
  tests/tools/test_file_operations_edge_cases.py

git diff --check
```

The exact `od -An -v -tx1 -N` form was also exercised with GNU coreutils and BusyBox. CI will provide the repository-wide test result.
