### PR TITLE
test(file_sync): assert agent-visible cache path equals the sync destination

### DIFF
--- a/contributors/emails/richard.jang@5minlab.com
+++ b/contributors/emails/richard.jang@5minlab.com
@@ -1,0 +1,2 @@
+RichardHojunJang
+# PR #81808 — commit authored under a work git identity (richard.jang@5minlab.com); PR author is RichardHojunJang

--- a/tests/tools/test_file_sync.py
+++ b/tests/tools/test_file_sync.py
@@ -410,3 +410,32 @@ class TestBulkUpload:
         mgr.sync(force=True)
         bulk_upload.assert_called_once()
         assert len(bulk_upload.call_args[0][0]) == 3
+
+
+def test_ssh_agent_path_matches_file_sync_destination(tmp_path, monkeypatch):
+    """The path shown to the agent must equal where file_sync actually puts it.
+
+    ``to_agent_visible_cache_path`` (tools/credential_files.py) and
+    ``iter_sync_files`` (this module) independently decide where a cached file
+    lands on an SSH worker. If they drift, the agent is handed a path that
+    resolves to nothing on the remote side and ``read_file`` fails with a
+    confusing "no such file".
+
+    This asserts the *relationship* between the two rather than freezing a
+    literal string, so a future change to either side that breaks the contract
+    fails here instead of in production.
+    """
+    from tools.credential_files import to_agent_visible_cache_path
+
+    hermes_home = tmp_path / "profiles" / "workbot"
+    doc_dir = hermes_home / "cache" / "documents"
+    doc_dir.mkdir(parents=True)
+    host_path = doc_dir / "report.pdf"
+    host_path.write_bytes(b"%PDF-1.7")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+
+    sync_targets = dict(iter_sync_files("~/.hermes"))
+
+    assert str(host_path) in sync_targets
+    assert to_agent_visible_cache_path(str(host_path)) == sync_targets[str(host_path)]


### PR DESCRIPTION
## Summary

Test-only. Adds one regression test asserting that the cache path Hermes shows
the agent equals the path `file_sync` actually writes to on an SSH worker.

`to_agent_visible_cache_path()` (`tools/credential_files.py`) and
`iter_sync_files()` (`tools/environments/file_sync.py`) independently compute
that destination. Nothing asserts they agree. When they drift, the agent is
handed a path that resolves to nothing on the remote host and `read_file` fails
with a confusing "no such file" — which is exactly the failure #80169 was opened
for.

## Why the existing tests don't cover this

`tests/tools/test_credential_files.py` checks each backend against a literal
string (`== "~/.hermes/attachments/drop.zip"`). That catches a wrong constant in
*one* module, but not the two modules disagreeing.

Demonstrated by injecting a divergence into `iter_sync_files` only
(`/cache/` → `/cached/`, `credential_files.py` untouched):

| | result |
|---|---|
| `tests/tools/test_credential_files.py` (43 literal tests) | **43 passed — miss** |
| this test | **failed — caught** |

Reverted after measuring; no source change ships in this PR.

## Relationship to #80169

I'm closing #80169. Upstream `fe54ab4f9` ("fix(docker): close the cold-container
and multi-backend gaps in attachment delivery") already implements that
behavior, and does it more broadly than my patch did — `ssh` + `daytona` +
`vercel_sandbox` + `modal`, where mine only handled `ssh`. The fix is better
than the one I proposed, so the code half is redundant.

The cross-module invariant is the one piece that had no upstream equivalent, so
it's carried over here on its own rather than being lost with the closed PR.

## Test plan

- [x] `tests/tools/test_file_sync.py`
- [x] `tests/tools/test_credential_files.py`

```
59 passed
```

Verified on `origin/main` @ 3d7dda4cf.
