### PR TITLE
fix(anthropic): add api.anthropic.com fallback to OAuth token endpoints

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1120,6 +1120,9 @@ def refresh_anthropic_oauth_pure(refresh_token: str, *, use_json: bool = False) 
     token_endpoints = [
         "https://platform.claude.com/v1/oauth/token",
         "https://console.anthropic.com/v1/oauth/token",
+        # Same fallback rationale as _OAUTH_TOKEN_URLS: reachable where the
+        # other two hosts are category-blocked by corporate content filters.
+        "https://api.anthropic.com/v1/oauth/token",
     ]
     last_error = None
     for endpoint in token_endpoints:
@@ -1467,6 +1470,11 @@ _OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
 _OAUTH_TOKEN_URLS = [
     "https://platform.claude.com/v1/oauth/token",
     "https://console.anthropic.com/v1/oauth/token",
+    # api.anthropic.com serves the same OAuth token endpoint and is the only
+    # host of the three reachable on networks whose content filter blocks
+    # platform.claude.com/console.anthropic.com ("Developer Tools" category)
+    # while allowing the primary API domain.
+    "https://api.anthropic.com/v1/oauth/token",
 ]
 _OAUTH_TOKEN_URL = _OAUTH_TOKEN_URLS[0]
 # User-Agent sent on the OAuth *token endpoint* (login exchange + refresh).

--- a/tests/agent/test_anthropic_oauth_pkce.py
+++ b/tests/agent/test_anthropic_oauth_pkce.py
@@ -215,3 +215,138 @@ def test_callback_state_mismatch_aborts(monkeypatch, tmp_path, caplog):
     assert "url" not in captured_token, (
         "token exchange must NOT happen when state mismatches"
     )
+
+
+def test_login_token_exchange_falls_back_to_api_anthropic_host(monkeypatch, tmp_path):
+    """When ``platform.claude.com`` and ``console.anthropic.com`` both fail,
+    the login exchange must fall back to ``api.anthropic.com``.
+
+    Corporate content filters (Zscaler and similar) category-block the first
+    two hosts ("Developer Tools") while allowing the primary API domain.
+    Without the fallback, login on such networks dies with a confusing
+    ``HTTP Error 404`` from the console host after the filter 403s platform.
+    """
+    import urllib.error
+    import urllib.request
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    captured_url: Dict[str, str] = {}
+    _patch_oauth_flow(
+        monkeypatch,
+        callback_code="placeholder",
+        capture_auth_url=captured_url,
+    )
+
+    import builtins
+
+    def fake_input(*_a, **_kw):
+        qs = parse_qs(urlparse(captured_url.get("url", "")).query)
+        state = qs.get("state", [""])[0]
+        return f"auth-code#{state}"
+
+    monkeypatch.setattr(builtins, "input", fake_input)
+
+    attempts: list[str] = []
+
+    class _Resp:
+        def __init__(self, body: bytes) -> None:
+            self._body = body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def read(self):
+            return self._body
+
+    def selective_urlopen(req, *_a, **_kw):
+        url = req.full_url
+        attempts.append(url)
+        if "api.anthropic.com" not in url:
+            raise urllib.error.HTTPError(url, 403, "Forbidden", None, None)
+        return _Resp(
+            json.dumps(
+                {
+                    "access_token": "sk-ant-test-access",
+                    "refresh_token": "sk-ant-test-refresh",
+                    "expires_in": 3600,
+                }
+            ).encode()
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", selective_urlopen)
+
+    from agent.anthropic_adapter import run_hermes_oauth_login_pure
+
+    result = run_hermes_oauth_login_pure()
+
+    assert result is not None, (
+        "login must succeed via the api.anthropic.com fallback when the "
+        "first two token hosts are blocked by a content filter"
+    )
+    assert attempts[-1] == "https://api.anthropic.com/v1/oauth/token", (
+        f"final attempt should be the api.anthropic.com fallback, got {attempts}"
+    )
+    assert attempts[0] == "https://platform.claude.com/v1/oauth/token", (
+        "platform.claude.com must stay the first-choice host"
+    )
+
+
+def test_refresh_falls_back_to_api_anthropic_host(monkeypatch):
+    """The refresh path mirrors the login fallback: blocked platform/console
+    hosts must not kill a refresh that ``api.anthropic.com`` can serve."""
+    import urllib.error
+    import urllib.request
+
+    attempts: list[str] = []
+
+    class _Resp:
+        def __init__(self, body: bytes) -> None:
+            self._body = body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def read(self):
+            return self._body
+
+    def selective_urlopen(req, *_a, **_kw):
+        url = req.full_url
+        attempts.append(url)
+        if "api.anthropic.com" not in url:
+            raise urllib.error.HTTPError(url, 403, "Forbidden", None, None)
+        return _Resp(
+            json.dumps(
+                {
+                    "access_token": "sk-ant-refreshed",
+                    "refresh_token": "sk-ant-next-refresh",
+                    "expires_in": 3600,
+                }
+            ).encode()
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", selective_urlopen)
+
+    from agent.anthropic_adapter import refresh_anthropic_oauth_pure
+
+    result = refresh_anthropic_oauth_pure("sk-ant-old-refresh")
+
+    assert result["access_token"] == "sk-ant-refreshed"
+    assert attempts[-1] == "https://api.anthropic.com/v1/oauth/token", (
+        f"refresh must fall back to api.anthropic.com, got {attempts}"
+    )
+
+
+def test_oauth_token_url_order_contract():
+    """Order contract: platform first (fast path for unfiltered networks),
+    console second (legacy), api.anthropic.com strictly last (fallback)."""
+    from agent.anthropic_adapter import _OAUTH_TOKEN_URLS
+
+    assert _OAUTH_TOKEN_URLS[0] == "https://platform.claude.com/v1/oauth/token"
+    assert _OAUTH_TOKEN_URLS[-1] == "https://api.anthropic.com/v1/oauth/token"


### PR DESCRIPTION
## What does this PR do?

Makes Anthropic OAuth login (and token refresh) work on networks whose content filter blocks `platform.claude.com` / `console.anthropic.com` but allows the primary API domain.

Both current token-endpoint hosts are category-blocked ("Developer Tools") by common corporate filters (Zscaler and similar). On such networks the login exchange fails today with a confusing `Token exchange failed: HTTP Error 404: Not Found` — the filter 403s `platform.claude.com`, then the loop falls back to `console.anthropic.com`, whose genuine 404 masks the real cause. `api.anthropic.com` serves the identical `/v1/oauth/token` endpoint and is reachable on those networks (it has to be, for API traffic to work at all).

This appends `https://api.anthropic.com/v1/oauth/token` as a **last** fallback in both endpoint lists. Order is unchanged for unfiltered networks; the existing loop already continues past failures, so the fast path is untouched.

## Related Issue

No existing issue found (searched `"oauth/token" fallback`, `platform.claude.com blocked` — nearest hits are the UA-prefix and 429-burn issues, different problem). Happy to file one if you want the paper trail.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/anthropic_adapter.py` — append `api.anthropic.com` to `_OAUTH_TOKEN_URLS` (login exchange) and to the hardcoded endpoint list in `refresh_anthropic_oauth_pure` (refresh path), with a comment explaining why.
- `tests/agent/test_anthropic_oauth_pkce.py` — behavioral tests: login falls back to `api.anthropic.com` when the first two hosts fail; refresh does the same; order contract (`platform` first, `api` strictly last).

## How to Test

1. `pytest tests/agent/test_anthropic_oauth_pkce.py -q` → 6 passed in 1.81s (3 pre-existing + 3 new).
2. Manual, on an affected network: `hermes auth add anthropic --type oauth` currently dies with `HTTP Error 404`; with this patch the exchange completes via the fallback host. Probe evidence that the fallback host serves the real endpoint: `POST https://api.anthropic.com/v1/oauth/token` with an invalid grant returns `{"error": "invalid_grant", "error_description": "Invalid 'code' in request."}` while `platform.claude.com` returns the filter's 403.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] Full `pytest tests/ -q` not run on this machine — the touched test file passes 6/6; CI should cover the rest
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (real device login completed through the fallback on a Zscaler-filtered corporate network)

### Documentation & Housekeeping

- [x] Relevant documentation — N/A (behavior-preserving fallback; rationale documented in code comments)
- [x] `cli-config.yaml.example` — N/A (no config keys changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered (pure-Python URL list, no platform-specific code)
- [x] Tool descriptions/schemas — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)