### PR TITLE
fix(console): skip the checkpoints prune confirmation the console already took

### DIFF
--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -1249,7 +1249,10 @@ def _apply_confirmed_defaults(args: argparse.Namespace) -> None:
             setattr(args, attr, True)
     if getattr(args, "_console_command", None) == "import":
         setattr(args, "force", True)
-    if getattr(args, "checkpoints_command", None) in {"clear", "clear-legacy"}:
+    # Every checkpoints subcommand the console registers as mutating gates its
+    # own confirmation on --force, so all three belong here. `prune` reaches
+    # _confirm() for its orphan preview, and the console never redirects stdin.
+    if getattr(args, "checkpoints_command", None) in {"prune", "clear", "clear-legacy"}:
         setattr(args, "force", True)
     if getattr(args, "plugins_action", None) == "install":
         if not getattr(args, "enable", False) and not getattr(args, "no_enable", False):

--- a/tests/hermes_cli/test_console_engine.py
+++ b/tests/hermes_cli/test_console_engine.py
@@ -504,3 +504,85 @@ def test_execute_handler_string_exit_returns_error_not_crash(_isolate_hermes_hom
 
     assert result.status == "error"
     assert result.output
+
+
+_ORPHAN_STORE_STATUS = {
+    "projects": [
+        {"hash": "abc123", "workdir": "/gone/v2-project", "exists": False, "commits": 4},
+    ],
+    "pre_v2_projects": [],
+}
+
+
+def _patch_checkpoint_manager(monkeypatch, prune_calls: list) -> None:
+    """Report one orphan project and record the resulting prune call."""
+    import tools.checkpoint_manager as ckpt_mgr
+
+    monkeypatch.setattr(ckpt_mgr, "store_status", lambda *a, **k: _ORPHAN_STORE_STATUS)
+
+    def _fake_prune(**kwargs):
+        prune_calls.append(kwargs)
+        return {
+            "scanned": 1,
+            "deleted_orphan": 1,
+            "deleted_stale": 0,
+            "errors": 0,
+            "bytes_freed": 0,
+        }
+
+    monkeypatch.setattr(ckpt_mgr, "prune_checkpoints", _fake_prune)
+
+
+def test_console_checkpoints_prune_does_not_reprompt_for_orphans(
+    _isolate_hermes_home, monkeypatch
+):
+    """`checkpoints prune` is console-mutating, so the nested prompt must be skipped.
+
+    The console asks for confirmation itself before dispatching any command in the
+    `checkpoints` mutating set, and `_apply_confirmed_defaults` exists to keep the
+    CLI layer from asking a second time. `clear` and `clear-legacy` are force
+    defaulted; `prune` was not, so its orphan confirmation still called `input()`.
+    """
+    prune_calls: list = []
+    _patch_checkpoint_manager(monkeypatch, prune_calls)
+
+    def _unexpected_input(_prompt):
+        raise AssertionError(
+            "input() must not be called: the console already confirmed `checkpoints prune`"
+        )
+
+    monkeypatch.setattr("builtins.input", _unexpected_input)
+
+    result = HermesConsoleEngine().execute("checkpoints prune", confirmed=True)
+
+    assert result.status == "ok"
+    assert len(prune_calls) == 1
+    assert prune_calls[0]["delete_orphans"] is True
+    # No preview was shown, so there is nothing to bind the deletion to — the
+    # documented `--force` case for `orphan_allowlist`.
+    assert prune_calls[0]["orphan_allowlist"] is None
+
+
+def test_console_checkpoints_prune_succeeds_without_a_tty(
+    _isolate_hermes_home, monkeypatch
+):
+    """The dashboard console has no stdin, so an unskipped prompt aborts the command.
+
+    `_capture_output` redirects stdout/stderr but never stdin, so `input()` raises
+    `EOFError`, `_confirm` returns False, and `cmd_prune` returns 1 — which the
+    console surfaces as a failed command for every user with an orphan project.
+    """
+    prune_calls: list = []
+    _patch_checkpoint_manager(monkeypatch, prune_calls)
+
+    def _eof_input(_prompt):
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", _eof_input)
+
+    result = HermesConsoleEngine().execute("checkpoints prune", confirmed=True)
+
+    assert result.status == "ok"
+    assert "Aborted." not in result.output
+    assert len(prune_calls) == 1
+    assert prune_calls[0]["orphan_allowlist"] is None


### PR DESCRIPTION
## What does this PR do?

Hermes Console registers three `checkpoints` subcommands as **mutating** — `prune`, `clear` and `clear-legacy` (`console_engine.py`, the `registered["checkpoints"]` entry) — so the console takes a confirmation from the user before dispatching any of them. `_apply_confirmed_defaults` then exists to stop the CLI layer asking a second time; its docstring says exactly that: *"Skip nested prompts after the console-level confirmation has happened."*

It force-defaults only two of the three:

```python
if getattr(args, "checkpoints_command", None) in {"clear", "clear-legacy"}:
    setattr(args, "force", True)
```

`prune` is missing, even though `cmd_prune` gates its orphan confirmation on the identical shape the other two use (`if delete_orphans and not args.force:` → `_confirm("Delete these orphan projects?")`), and `p_prune` declares the same `-f/--force` flag with the help text *"Skip the orphan-deletion confirmation prompt"*.

**What the user sees.** `_capture_output` redirects stdout and stderr but never stdin, so the unskipped `_confirm()` reaches `input()` with no terminal behind it. `_confirm` catches `EOFError` and returns `False`, `cmd_prune` prints `Aborted.` and returns `1`, and the non-zero exit becomes a `ConsoleCommandError`. **Console `checkpoints prune` fails outright for any user who has at least one orphan checkpoint project — after that user already confirmed at the console level.** Users with no orphans are unaffected, which is why this reads as intermittent.

Secondarily, when the dashboard *is* run in the foreground from a terminal the server inherits that TTY, so the same `input()` call blocks a console worker thread and consumes the operator's keystrokes instead of raising.

## Related Issue

No filed issue — found by reading the mutating-command registration against `_apply_confirmed_defaults`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/console_engine.py` — add `"prune"` to the `checkpoints_command` set that `_apply_confirmed_defaults` force-defaults, so all three console-mutating checkpoints subcommands are neutralized rather than two. Comment records the invariant (every checkpoints subcommand the console marks mutating gates its confirmation on `--force`).
- `tests/hermes_cli/test_console_engine.py` — two regression tests driving the real console dispatch for `checkpoints prune` with a stubbed `tools.checkpoint_manager` reporting one orphan project:
  - `test_console_checkpoints_prune_does_not_reprompt_for_orphans` — `builtins.input` is replaced with a function that fails the test if called.
  - `test_console_checkpoints_prune_succeeds_without_a_tty` — `builtins.input` raises `EOFError`, reproducing the non-TTY dashboard case, and asserts the command does not abort.

### Why forcing the flag is not a weakening of the orphan-allowlist hardening

`cmd_prune` recently gained `orphan_allowlist`, which binds a deletion to exactly the identities shown in the confirmation preview so that a project which becomes orphaned *after* the preview is not swept up in the same run. That guard protects the window where "its workdir disappears **while waiting on `input()`**".

Under the console there is no preview and no `input()` wait, so there is nothing to bind to. That is precisely the case `cmd_prune`'s own comment describes:

> `None` means "no restriction" — used for `--force`, where there is no preview to bind to.

The new tests assert `orphan_allowlist is None` on the resulting `prune_checkpoints` call, so this stays pinned. The console-level confirmation is unchanged — `prune` still requires the user to confirm; only the redundant second prompt goes away.

### Scope

This is one symbol in one dict literal. I checked the adjacent candidates rather than widening:

- `curator`'s three prompts already gate on `getattr(args, "yes", False)` and are neutralized by the blanket `yes=True` above.
- `bundles create` and `pets select` prompt for *data entry*, not confirmation, and have no flag to neutralize — a different concern.
- `backup`/`import`'s force-gated prompt is already handled by the `_console_command == "import"` branch.
- Sweeping `hermes_cli/` for force-gated confirmations, `checkpoints prune` is the only console-mutating command whose nested prompt is not neutralized.

No change to `hermes_cli/checkpoints.py` — the fix belongs at the console boundary that already owns this translation.

## How to Test

Red-before / green-after, both directions run:

```
# with the console_engine.py hunk reverted:
pytest tests/hermes_cli/test_console_engine.py -k checkpoints_prune
# => test_console_checkpoints_prune_does_not_reprompt_for_orphans FAILS:
#      AssertionError: input() must not be called ...
#      (input() is reached with prompt 'Delete these orphan projects? [y/N]: ')
# => test_console_checkpoints_prune_succeeds_without_a_tty FAILS:
#      assert 'error' == 'ok'

# with the fix applied:
pytest tests/hermes_cli/test_console_engine.py tests/hermes_cli/test_checkpoints_prune.py
# => 15 passed
```

Manually: open Hermes Console with at least one checkpoint project whose workdir no longer exists, run `checkpoints prune`, and confirm at the console prompt. Before this change the command reports `Aborted.` / fails; after it, the prune runs.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- ran the focused files listed above, not the full suite -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A <!-- N/A: no user-facing docs describe the console's confirmation forwarding -->
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A <!-- N/A -->
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A <!-- N/A -->
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A <!-- pure argparse-namespace logic, no platform-specific paths; tested on macOS only -->
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A <!-- N/A -->

## Related / Positioning

Searched the open queue for `console_engine`, `_capture_output`, `_apply_confirmed_defaults`, `checkpoints prune console` and `checkpoints_command` — no open PR touches `hermes_cli/console_engine.py`.

The one adjacent PR is **#81499** (*fix(checkpoints): distinguish protected unreachable workdirs*), which changes `hermes_cli/checkpoints.py`, `tools/checkpoint_manager.py` and their tests. It is **file-disjoint** from this PR: it refines *which* workdirs count as orphans inside `cmd_prune`, while this PR fixes whether the console reaches that path at all. The two compose without conflict — this change only sets `args.force`, which #81499 does not touch.

Related merged precedent on the same two files: **#79131** (`fix(console): handle string SystemExit code in _capture_output`), which landed in `_capture_output` itself — the same function whose missing stdin redirection turns this prompt into a hard failure.
