### PR TITLE
fix(terminal): honor foreground PTY requests

### DIFF
--- a/tests/tools/test_managed_browserbase_and_modal.py
+++ b/tests/tools/test_managed_browserbase_and_modal.py
@@ -198,9 +198,13 @@ def _install_fake_tools_package():
             self.backend = backend
             self.detail = detail
 
+    class _DummyPtyUnavailableError(RuntimeError):
+        pass
+
     sys.modules["tools.environments.base"] = types.SimpleNamespace(
         BaseEnvironment=_DummyEnvironment,
         EnvironmentConnectionError=_DummyConnectionError,
+        PtyUnavailableError=_DummyPtyUnavailableError,
     )
     sys.modules["tools.environments.local"] = types.SimpleNamespace(LocalEnvironment=_DummyEnvironment)
     sys.modules["tools.environments.singularity"] = types.SimpleNamespace(

--- a/tests/tools/test_terminal_tool_pty_fallback.py
+++ b/tests/tools/test_terminal_tool_pty_fallback.py
@@ -1,8 +1,15 @@
 import json
+import os
+import threading
+import time
 from types import SimpleNamespace
+
+import pytest
 
 import tools.terminal_tool as terminal_tool_module
 from tools import process_registry as process_registry_module
+from tools.environments.base import PtyUnavailableError
+from tools.environments.local import LocalEnvironment
 
 
 def _base_config(tmp_path):
@@ -56,3 +63,197 @@ def test_terminal_background_keeps_pty_for_regular_interactive_commands(monkeypa
 
     assert captured["use_pty"] is True
     assert "pty_note" not in result
+
+
+def test_terminal_foreground_forwards_pty_to_local_environment(monkeypatch, tmp_path):
+    config = _base_config(tmp_path)
+    captured = {}
+
+    class FakeEnv:
+        env = {}
+        cwd = str(tmp_path)
+
+        def execute(self, command, **kwargs):
+            captured.update(kwargs)
+            return {"output": "ok", "returncode": 0}
+
+    monkeypatch.setattr(terminal_tool_module, "_get_env_config", lambda: config)
+    monkeypatch.setattr(terminal_tool_module, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool_module,
+        "_check_all_guards",
+        lambda *_args, **_kwargs: {"approved": True},
+    )
+    monkeypatch.setitem(terminal_tool_module._active_environments, "default", FakeEnv())
+    monkeypatch.setitem(terminal_tool_module._last_activity, "default", 0.0)
+
+    result = json.loads(
+        terminal_tool_module.terminal_tool(command="tty", pty=True)
+    )
+
+    assert result["exit_code"] == 0
+    assert captured["use_pty"] is True
+
+
+def test_terminal_foreground_reports_when_pipe_stdin_disables_pty(monkeypatch, tmp_path):
+    config = _base_config(tmp_path)
+    captured = {}
+
+    class FakeEnv:
+        env = {}
+        cwd = str(tmp_path)
+
+        def execute(self, command, **kwargs):
+            captured.update(kwargs)
+            return {"output": "ok", "returncode": 0}
+
+    monkeypatch.setattr(terminal_tool_module, "_get_env_config", lambda: config)
+    monkeypatch.setattr(terminal_tool_module, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool_module,
+        "_check_all_guards",
+        lambda *_args, **_kwargs: {"approved": True},
+    )
+    monkeypatch.setitem(terminal_tool_module._active_environments, "default", FakeEnv())
+    monkeypatch.setitem(terminal_tool_module._last_activity, "default", 0.0)
+
+    result = json.loads(
+        terminal_tool_module.terminal_tool(
+            command="gh auth login --with-token",
+            pty=True,
+        )
+    )
+
+    assert result["exit_code"] == 0
+    assert captured["use_pty"] is False
+    assert "expects piped stdin" in result["pty_note"]
+
+
+def test_terminal_foreground_pty_unavailable_fails_without_retry(monkeypatch, tmp_path):
+    config = _base_config(tmp_path)
+
+    class FakeEnv:
+        env = {}
+        cwd = str(tmp_path)
+
+        def execute(self, command, **kwargs):
+            raise PtyUnavailableError("PTY dependency missing")
+
+    monkeypatch.setattr(terminal_tool_module, "_get_env_config", lambda: config)
+    monkeypatch.setattr(terminal_tool_module, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool_module,
+        "_check_all_guards",
+        lambda *_args, **_kwargs: {"approved": True},
+    )
+    monkeypatch.setattr(
+        terminal_tool_module.time,
+        "sleep",
+        lambda _seconds: pytest.fail("PTY availability errors must not retry"),
+    )
+    monkeypatch.setitem(terminal_tool_module._active_environments, "default", FakeEnv())
+    monkeypatch.setitem(terminal_tool_module._last_activity, "default", 0.0)
+
+    result = json.loads(
+        terminal_tool_module.terminal_tool(command="tty", pty=True)
+    )
+
+    assert result == {
+        "output": "",
+        "exit_code": -1,
+        "error": "PTY dependency missing",
+        "status": "unsupported",
+    }
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX tty assertion")
+def test_local_foreground_pty_exposes_a_terminal(tmp_path):
+    pytest.importorskip("ptyprocess")
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=10)
+    try:
+        result = env.execute("tty", timeout=10, use_pty=True)
+    finally:
+        env.cleanup()
+
+    assert result["returncode"] == 0
+    assert result["output"].strip().startswith("/dev/")
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX PTY integration")
+def test_local_foreground_pty_preserves_exit_code_and_cwd(tmp_path):
+    pytest.importorskip("ptyprocess")
+    target = tmp_path / "target"
+    target.mkdir()
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=10)
+    try:
+        result = env.execute(
+            f"cd {target}; printf reached; false",
+            timeout=10,
+            use_pty=True,
+        )
+    finally:
+        env.cleanup()
+
+    assert result["returncode"] == 1
+    assert result["output"].strip() == "reached"
+    assert env.cwd == str(target)
+    assert "__HERMES_CWD_" not in result["output"]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX PTY integration")
+def test_local_foreground_pty_timeout_returns_promptly(tmp_path):
+    pytest.importorskip("ptyprocess")
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=10)
+    started = time.monotonic()
+    try:
+        result = env.execute("sleep 30", timeout=1, use_pty=True)
+    finally:
+        env.cleanup()
+
+    assert result["returncode"] == 124
+    assert "timed out after 1s" in result["output"]
+    assert time.monotonic() - started < 5
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX PTY integration")
+def test_local_foreground_pty_interrupt_reaps_command(tmp_path):
+    pytest.importorskip("ptyprocess")
+    from tools.interrupt import set_interrupt
+
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=10)
+    result = {}
+
+    def run_command():
+        result.update(env.execute("sleep 30", timeout=10, use_pty=True))
+
+    worker = threading.Thread(target=run_command)
+    worker.start()
+    try:
+        time.sleep(0.5)
+        set_interrupt(True, thread_id=worker.ident)
+        worker.join(timeout=5)
+    finally:
+        set_interrupt(False, thread_id=worker.ident)
+        env.cleanup()
+
+    assert not worker.is_alive()
+    assert result["returncode"] == 130
+    assert "Command interrupted" in result["output"]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX PTY integration")
+def test_local_foreground_pty_drains_output_larger_than_pipe_capacity(tmp_path):
+    pytest.importorskip("ptyprocess")
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=10)
+    try:
+        result = env.execute(
+            "printf '%70000s' x",
+            timeout=10,
+            use_pty=True,
+        )
+    finally:
+        env.cleanup()
+
+    assert result["returncode"] == 0
+    assert len(result["output"].rstrip("\r\n")) == 70_000
+    assert result["output"].rstrip().endswith("x")

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -78,6 +78,10 @@ class EnvironmentConnectionError(RuntimeError):
         )
 
 
+class PtyUnavailableError(RuntimeError):
+    """Raised when an execution backend cannot provide a requested PTY."""
+
+
 class _BoundedOutputCollector:
     """Retain a bounded 40/60 head-tail window of streamed text.
 
@@ -613,6 +617,24 @@ class BaseEnvironment(ABC):
         Must be overridden by every backend.
         """
         raise NotImplementedError(f"{type(self).__name__} must implement _run_bash()")
+
+    def _run_bash_pty(
+        self,
+        cmd_string: str,
+        *,
+        login: bool = False,
+        timeout: int = 120,
+        stdin_data: str | None = None,
+    ) -> ProcessHandle:
+        """Spawn a foreground command behind a pseudo-terminal.
+
+        PTY execution is intentionally opt-in. Backends must override this
+        hook before advertising support so a requested PTY can never degrade
+        silently to ordinary pipes.
+        """
+        raise PtyUnavailableError(
+            f"Foreground PTY execution is not supported by {type(self).__name__}."
+        )
 
     @abstractmethod
     def cleanup(self):
@@ -1322,6 +1344,7 @@ class BaseEnvironment(ABC):
         stdin_data: str | None = None,
         rewrite_compound_background: bool = True,
         bounded_capture: bool = False,
+        use_pty: bool = False,
     ) -> dict:
         """Execute a command, return {"output": str, "returncode": int}.
 
@@ -1365,7 +1388,8 @@ class BaseEnvironment(ABC):
         # unless login itself is broken — then non-login is the only path.
         login = not self._snapshot_ready and not self._prefer_nonlogin
 
-        proc = self._run_bash(
+        runner = self._run_bash_pty if use_pty else self._run_bash
+        proc = runner(
             wrapped, login=login, timeout=effective_timeout, stdin_data=effective_stdin
         )
         result = self._wait_for_process(

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -78,6 +78,10 @@ class EnvironmentConnectionError(RuntimeError):
         )
 
 
+class PtyUnavailableError(RuntimeError):
+    """Raised when an execution backend cannot provide a requested PTY."""
+
+
 class _BoundedOutputCollector:
     """Retain a bounded 40/60 head-tail window of streamed text.
 
@@ -655,6 +659,24 @@ class BaseEnvironment(ABC):
         Must be overridden by every backend.
         """
         raise NotImplementedError(f"{type(self).__name__} must implement _run_bash()")
+
+    def _run_bash_pty(
+        self,
+        cmd_string: str,
+        *,
+        login: bool = False,
+        timeout: int = 120,
+        stdin_data: str | None = None,
+    ) -> ProcessHandle:
+        """Spawn a foreground command behind a pseudo-terminal.
+
+        PTY execution is intentionally opt-in. Backends must override this
+        hook before advertising support so a requested PTY can never degrade
+        silently to ordinary pipes.
+        """
+        raise PtyUnavailableError(
+            f"Foreground PTY execution is not supported by {type(self).__name__}."
+        )
 
     @abstractmethod
     def cleanup(self):
@@ -1404,6 +1426,7 @@ class BaseEnvironment(ABC):
         stdin_data: str | None = None,
         rewrite_compound_background: bool = True,
         bounded_capture: bool = False,
+        use_pty: bool = False,
     ) -> dict:
         """Execute a command, return {"output": str, "returncode": int}.
 
@@ -1447,7 +1470,8 @@ class BaseEnvironment(ABC):
         # unless login itself is broken — then non-login is the only path.
         login = not self._snapshot_ready and not self._prefer_nonlogin
 
-        proc = self._run_bash(
+        runner = self._run_bash_pty if use_pty else self._run_bash
+        proc = runner(
             wrapped, login=login, timeout=effective_timeout, stdin_data=effective_stdin
         )
         result = self._wait_for_process(

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -10,12 +10,13 @@ import signal
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 from collections.abc import Mapping
 from pathlib import Path
 
 from hermes_constants import get_process_hermes_home
-from tools.environments.base import BaseEnvironment, _pipe_stdin
+from tools.environments.base import BaseEnvironment, PtyUnavailableError, _pipe_stdin
 from hermes_cli._subprocess_compat import windows_hide_flags
 
 _IS_WINDOWS = platform.system() == "Windows"
@@ -1705,6 +1706,120 @@ def _prepend_shell_init(cmd_string: str, files: list[str]) -> str:
     return prelude + cmd_string
 
 
+class _ForegroundPtyProcessHandle:
+    """Adapt a platform PTY bridge to BaseEnvironment's process contract."""
+
+    def __init__(self, bridge, proc):
+        self._bridge = bridge
+        self._proc = proc
+        self.pid = int(bridge.pid)
+        self._returncode = None
+        self._status_lock = threading.Lock()
+        self._done = threading.Event()
+
+        read_fd, write_fd = os.pipe()
+        self._stdout = os.fdopen(read_fd, "rb", buffering=0)
+        self._write_fd = write_fd
+        self._reader_thread = threading.Thread(
+            target=self._pump_output,
+            daemon=True,
+            name=f"foreground-pty-reader-{self.pid}",
+        )
+        self._reader_thread.start()
+
+    @property
+    def stdout(self):
+        return self._stdout
+
+    @property
+    def returncode(self):
+        return self._returncode
+
+    def _resolved_returncode(self) -> int | None:
+        exit_status = getattr(self._proc, "exitstatus", None)
+        if exit_status is not None:
+            return int(exit_status)
+        signal_status = getattr(self._proc, "signalstatus", None)
+        if signal_status is not None:
+            return -int(signal_status)
+        return None
+
+    def poll(self):
+        with self._status_lock:
+            if self._returncode is not None:
+                return self._returncode
+            try:
+                alive = bool(self._proc.isalive())
+            except Exception:
+                alive = not self._done.is_set()
+            if alive:
+                return None
+            self._returncode = self._resolved_returncode()
+            if self._returncode is None and self._done.is_set():
+                self._returncode = 1
+            return self._returncode
+
+    def _write_output(self, data: bytes) -> bool:
+        view = memoryview(data)
+        while view:
+            try:
+                written = os.write(self._write_fd, view)
+            except (BrokenPipeError, OSError):
+                return False
+            if written <= 0:
+                return False
+            view = view[written:]
+        return True
+
+    def _pump_output(self) -> None:
+        idle_after_exit = 0
+        try:
+            while True:
+                data = self._bridge.read(timeout=0.1)
+                if data is None:
+                    break
+                if data:
+                    idle_after_exit = 0
+                    if not self._write_output(data):
+                        break
+                    continue
+                if self.poll() is not None:
+                    idle_after_exit += 1
+                    if idle_after_exit >= 3:
+                        break
+        finally:
+            # Resolve the natural status before close() changes bridge state.
+            self.poll()
+            try:
+                self._bridge.close()
+            except Exception:
+                pass
+            self._done.set()
+            with self._status_lock:
+                if self._returncode is None:
+                    self._returncode = self._resolved_returncode()
+                if self._returncode is None:
+                    self._returncode = 1
+            try:
+                os.close(self._write_fd)
+            except OSError:
+                pass
+
+    def kill(self):
+        try:
+            self._bridge.close()
+        finally:
+            self._done.set()
+
+    def wait(self, timeout: float | None = None) -> int:
+        if timeout is None:
+            self._done.wait()
+        elif not self._done.wait(timeout=timeout):
+            raise subprocess.TimeoutExpired("foreground PTY", timeout)
+        returncode = self.poll()
+        return 1 if returncode is None else returncode
+
+
 class LocalEnvironment(BaseEnvironment):
     """Run commands directly on the host machine.
 
@@ -1777,9 +1892,13 @@ class LocalEnvironment(BaseEnvironment):
         """Rewrite native/mixed Windows paths before quoting for Git Bash."""
         return _quote_bash_path(path)
 
-    def _run_bash(self, cmd_string: str, *, login: bool = False,
-                  timeout: int = 120,
-                  stdin_data: str | None = None) -> subprocess.Popen:
+    def _prepare_bash_spawn(
+        self,
+        cmd_string: str,
+        *,
+        login: bool,
+    ) -> tuple[list[str], dict[str, str], str]:
+        """Build one local bash invocation for pipe or PTY execution."""
         bash = _find_bash()
         # For login-shell invocations (used by init_session to build the
         # environment snapshot), prepend sources for the user's bashrc /
@@ -1819,7 +1938,15 @@ class LocalEnvironment(BaseEnvironment):
                 )
             self.cwd = safe_cwd
 
-        _popen_cwd = self.cwd
+        return args, run_env, self.cwd
+
+    def _run_bash(self, cmd_string: str, *, login: bool = False,
+                  timeout: int = 120,
+                  stdin_data: str | None = None) -> subprocess.Popen:
+        args, run_env, _popen_cwd = self._prepare_bash_spawn(
+            cmd_string,
+            login=login,
+        )
 
         _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
 
@@ -1846,6 +1973,63 @@ class LocalEnvironment(BaseEnvironment):
             _pipe_stdin(proc, stdin_data)
 
         return proc
+
+    def _run_bash_pty(
+        self,
+        cmd_string: str,
+        *,
+        login: bool = False,
+        timeout: int = 120,
+        stdin_data: str | None = None,
+    ) -> _ForegroundPtyProcessHandle:
+        if stdin_data is not None:
+            raise PtyUnavailableError(
+                "Foreground PTY execution cannot also consume piped stdin."
+            )
+
+        args, run_env, spawn_cwd = self._prepare_bash_spawn(
+            cmd_string,
+            login=login,
+        )
+        if not run_env.get("TERM"):
+            run_env["TERM"] = "xterm-256color"
+
+        try:
+            if _IS_WINDOWS:
+                from hermes_cli.win_pty_bridge import WinPtyBridge
+                from winpty import PtyProcess  # type: ignore
+
+                proc = PtyProcess.spawn(
+                    args,
+                    cwd=spawn_cwd,
+                    env=run_env,
+                    dimensions=(30, 120),
+                )
+                bridge = WinPtyBridge(proc)
+            else:
+                from hermes_cli.pty_bridge import PtyBridge
+                from ptyprocess import PtyProcess
+
+                proc = PtyProcess.spawn(
+                    args,
+                    cwd=spawn_cwd,
+                    env=run_env,
+                    echo=False,
+                    dimensions=(30, 120),
+                )
+                bridge = PtyBridge(proc)
+        except ImportError as exc:
+            package = "pywinpty" if _IS_WINDOWS else "ptyprocess"
+            raise PtyUnavailableError(
+                f"Foreground PTY execution requires the declared {package} dependency. "
+                "Repair the Hermes installation with `hermes update`."
+            ) from exc
+        except Exception as exc:
+            raise PtyUnavailableError(
+                f"Could not start foreground PTY execution: {exc}"
+            ) from exc
+
+        return _ForegroundPtyProcessHandle(bridge, proc)
 
     def _kill_process(self, proc):
         """Kill the entire process group (all children)."""

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -10,11 +10,12 @@ import signal
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 from collections.abc import Mapping
 from pathlib import Path
 
-from tools.environments.base import BaseEnvironment, _pipe_stdin
+from tools.environments.base import BaseEnvironment, PtyUnavailableError, _pipe_stdin
 from hermes_cli._subprocess_compat import windows_hide_flags
 
 _IS_WINDOWS = platform.system() == "Windows"
@@ -1411,6 +1412,120 @@ def _prepend_shell_init(cmd_string: str, files: list[str]) -> str:
     return prelude + cmd_string
 
 
+class _ForegroundPtyProcessHandle:
+    """Adapt a platform PTY bridge to BaseEnvironment's process contract."""
+
+    def __init__(self, bridge, proc):
+        self._bridge = bridge
+        self._proc = proc
+        self.pid = int(bridge.pid)
+        self._returncode = None
+        self._status_lock = threading.Lock()
+        self._done = threading.Event()
+
+        read_fd, write_fd = os.pipe()
+        self._stdout = os.fdopen(read_fd, "rb", buffering=0)
+        self._write_fd = write_fd
+        self._reader_thread = threading.Thread(
+            target=self._pump_output,
+            daemon=True,
+            name=f"foreground-pty-reader-{self.pid}",
+        )
+        self._reader_thread.start()
+
+    @property
+    def stdout(self):
+        return self._stdout
+
+    @property
+    def returncode(self):
+        return self._returncode
+
+    def _resolved_returncode(self) -> int | None:
+        exit_status = getattr(self._proc, "exitstatus", None)
+        if exit_status is not None:
+            return int(exit_status)
+        signal_status = getattr(self._proc, "signalstatus", None)
+        if signal_status is not None:
+            return -int(signal_status)
+        return None
+
+    def poll(self):
+        with self._status_lock:
+            if self._returncode is not None:
+                return self._returncode
+            try:
+                alive = bool(self._proc.isalive())
+            except Exception:
+                alive = not self._done.is_set()
+            if alive:
+                return None
+            self._returncode = self._resolved_returncode()
+            if self._returncode is None and self._done.is_set():
+                self._returncode = 1
+            return self._returncode
+
+    def _write_output(self, data: bytes) -> bool:
+        view = memoryview(data)
+        while view:
+            try:
+                written = os.write(self._write_fd, view)
+            except (BrokenPipeError, OSError):
+                return False
+            if written <= 0:
+                return False
+            view = view[written:]
+        return True
+
+    def _pump_output(self) -> None:
+        idle_after_exit = 0
+        try:
+            while True:
+                data = self._bridge.read(timeout=0.1)
+                if data is None:
+                    break
+                if data:
+                    idle_after_exit = 0
+                    if not self._write_output(data):
+                        break
+                    continue
+                if self.poll() is not None:
+                    idle_after_exit += 1
+                    if idle_after_exit >= 3:
+                        break
+        finally:
+            # Resolve the natural status before close() changes bridge state.
+            self.poll()
+            try:
+                self._bridge.close()
+            except Exception:
+                pass
+            self._done.set()
+            with self._status_lock:
+                if self._returncode is None:
+                    self._returncode = self._resolved_returncode()
+                if self._returncode is None:
+                    self._returncode = 1
+            try:
+                os.close(self._write_fd)
+            except OSError:
+                pass
+
+    def kill(self):
+        try:
+            self._bridge.close()
+        finally:
+            self._done.set()
+
+    def wait(self, timeout: float | None = None) -> int:
+        if timeout is None:
+            self._done.wait()
+        elif not self._done.wait(timeout=timeout):
+            raise subprocess.TimeoutExpired("foreground PTY", timeout)
+        returncode = self.poll()
+        return 1 if returncode is None else returncode
+
+
 class LocalEnvironment(BaseEnvironment):
     """Run commands directly on the host machine.
 
@@ -1483,9 +1598,13 @@ class LocalEnvironment(BaseEnvironment):
         """Rewrite native/mixed Windows paths before quoting for Git Bash."""
         return _quote_bash_path(path)
 
-    def _run_bash(self, cmd_string: str, *, login: bool = False,
-                  timeout: int = 120,
-                  stdin_data: str | None = None) -> subprocess.Popen:
+    def _prepare_bash_spawn(
+        self,
+        cmd_string: str,
+        *,
+        login: bool,
+    ) -> tuple[list[str], dict[str, str], str]:
+        """Build one local bash invocation for pipe or PTY execution."""
         bash = _find_bash()
         # For login-shell invocations (used by init_session to build the
         # environment snapshot), prepend sources for the user's bashrc /
@@ -1525,7 +1644,15 @@ class LocalEnvironment(BaseEnvironment):
                 )
             self.cwd = safe_cwd
 
-        _popen_cwd = self.cwd
+        return args, run_env, self.cwd
+
+    def _run_bash(self, cmd_string: str, *, login: bool = False,
+                  timeout: int = 120,
+                  stdin_data: str | None = None) -> subprocess.Popen:
+        args, run_env, _popen_cwd = self._prepare_bash_spawn(
+            cmd_string,
+            login=login,
+        )
 
         _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
 
@@ -1552,6 +1679,63 @@ class LocalEnvironment(BaseEnvironment):
             _pipe_stdin(proc, stdin_data)
 
         return proc
+
+    def _run_bash_pty(
+        self,
+        cmd_string: str,
+        *,
+        login: bool = False,
+        timeout: int = 120,
+        stdin_data: str | None = None,
+    ) -> _ForegroundPtyProcessHandle:
+        if stdin_data is not None:
+            raise PtyUnavailableError(
+                "Foreground PTY execution cannot also consume piped stdin."
+            )
+
+        args, run_env, spawn_cwd = self._prepare_bash_spawn(
+            cmd_string,
+            login=login,
+        )
+        if not run_env.get("TERM"):
+            run_env["TERM"] = "xterm-256color"
+
+        try:
+            if _IS_WINDOWS:
+                from hermes_cli.win_pty_bridge import WinPtyBridge
+                from winpty import PtyProcess  # type: ignore
+
+                proc = PtyProcess.spawn(
+                    args,
+                    cwd=spawn_cwd,
+                    env=run_env,
+                    dimensions=(30, 120),
+                )
+                bridge = WinPtyBridge(proc)
+            else:
+                from hermes_cli.pty_bridge import PtyBridge
+                from ptyprocess import PtyProcess
+
+                proc = PtyProcess.spawn(
+                    args,
+                    cwd=spawn_cwd,
+                    env=run_env,
+                    echo=False,
+                    dimensions=(30, 120),
+                )
+                bridge = PtyBridge(proc)
+        except ImportError as exc:
+            package = "pywinpty" if _IS_WINDOWS else "ptyprocess"
+            raise PtyUnavailableError(
+                f"Foreground PTY execution requires the declared {package} dependency. "
+                "Repair the Hermes installation with `hermes update`."
+            ) from exc
+        except Exception as exc:
+            raise PtyUnavailableError(
+                f"Could not start foreground PTY execution: {exc}"
+            ) from exc
+
+        return _ForegroundPtyProcessHandle(bridge, proc)
 
     def _kill_process(self, proc):
         """Kill the entire process group (all children)."""

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1062,7 +1062,7 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
 
 
 # Environment classes now live in tools/environments/
-from tools.environments.base import EnvironmentConnectionError
+from tools.environments.base import EnvironmentConnectionError, PtyUnavailableError
 from tools.environments.local import LocalEnvironment as _LocalEnvironment
 from tools.environments.singularity import SingularityEnvironment as _SingularityEnvironment
 from tools.environments.ssh import SSHEnvironment as _SSHEnvironment
@@ -3080,7 +3080,16 @@ def terminal_tool(
                         # reads, RPC reads) intentionally stay unbounded.
                         "bounded_capture": True,
                     }
+                    if pty and env_type == "local":
+                        execute_kwargs["use_pty"] = effective_pty
                     result = env.execute(command, **execute_kwargs)
+                except PtyUnavailableError as e:
+                    return json.dumps({
+                        "output": "",
+                        "exit_code": -1,
+                        "error": _redact_terminal_error_text(str(e)),
+                        "status": "unsupported",
+                    }, ensure_ascii=False)
                 except Exception as e:
                     error_str = str(e).lower()
                     if "timeout" in error_str:
@@ -3224,6 +3233,8 @@ def terminal_tool(
                 "exit_code": returncode,
                 "error": None,
             }
+            if pty_disabled_reason:
+                result_dict["pty_note"] = pty_disabled_reason
             # cwd echo: when the command changed the session's working
             # directory (cd, pushd, ...), tell the model where it ended up.
             # Production mining shows 60% of terminal calls carry a

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1063,7 +1063,7 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
 
 
 # Environment classes now live in tools/environments/
-from tools.environments.base import EnvironmentConnectionError
+from tools.environments.base import EnvironmentConnectionError, PtyUnavailableError
 from tools.environments.local import LocalEnvironment as _LocalEnvironment
 from tools.environments.singularity import SingularityEnvironment as _SingularityEnvironment
 from tools.environments.ssh import SSHEnvironment as _SSHEnvironment
@@ -3356,7 +3356,16 @@ def terminal_tool(
                         # reads, RPC reads) intentionally stay unbounded.
                         "bounded_capture": True,
                     }
+                    if pty and env_type == "local":
+                        execute_kwargs["use_pty"] = effective_pty
                     result = env.execute(command, **execute_kwargs)
+                except PtyUnavailableError as e:
+                    return json.dumps({
+                        "output": "",
+                        "exit_code": -1,
+                        "error": _redact_terminal_error_text(str(e)),
+                        "status": "unsupported",
+                    }, ensure_ascii=False)
                 except Exception as e:
                     error_str = str(e).lower()
                     if "timeout" in error_str:
@@ -3520,6 +3529,8 @@ def terminal_tool(
                 "exit_code": returncode,
                 "error": None,
             }
+            if pty_disabled_reason:
+                result_dict["pty_note"] = pty_disabled_reason
             # cwd echo: when the command changed the session's working
             # directory (cd, pushd, ...), tell the model where it ended up.
             # Production mining shows 60% of terminal calls carry a


### PR DESCRIPTION
## What does this PR do?

Makes `terminal(..., pty=true)` use a real pseudo-terminal in foreground local execution instead of silently running through ordinary pipes.

The new foreground adapter feeds the existing bounded-output/timeout/interrupt machinery through a pipe while the child itself runs behind the existing POSIX or Windows PTY bridge. That preserves output limits, CWD tracking, exit codes, process-group cleanup, and cross-platform dependency handling. PTY setup failures are returned immediately as `status: unsupported` rather than retried and silently downgraded.

The `ptyprocess`/`pywinpty` dependencies are already declared on current main, so this PR does not change dependencies.

## Related Issue

Fixes #81756

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Security fix
- [ ] Documentation update
- [x] Tests
- [ ] Refactor
- [ ] New skill

## Changes Made

- `tools/terminal_tool.py`: forward foreground local PTY requests and surface PTY-disable/unavailable reasons.
- `tools/environments/base.py`: add an opt-in foreground PTY execution hook without changing other backends.
- `tools/environments/local.py`: run foreground commands through `ptyprocess`/`pywinpty` while preserving the normal process-handle contract.
- `tests/tools/test_terminal_tool_pty_fallback.py`: cover real TTY allocation, CWD and exit status, timeout, interrupt cleanup, output larger than pipe capacity, and unavailable/disabled PTY behavior.

## How to Test

1. Before this change, run `terminal(command="tty", pty=true)` on the local backend: output is `not a tty`, exit code 1.
2. With this change, run the same call: output is a `/dev/ttys...` path, exit code 0.
3. Run `uv run --frozen pytest -q tests/tools/test_terminal_tool_pty_fallback.py`.
4. Run the terminal/environment regression set listed below.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit follows Conventional Commits.
- [x] I searched existing PRs and claimed the issue before editing.
- [x] My PR contains only changes related to this fix.
- [ ] I've run the complete `pytest tests/ -q` suite (focused and sibling suites run locally; full suite delegated to CI).
- [x] I've added tests for the change.
- [x] Tested on macOS 26.5.

### Documentation & Housekeeping

- [x] Documentation update: N/A; the tool already documents `pty=true`.
- [x] `cli-config.yaml.example`: N/A.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A.
- [x] Cross-platform impact considered: the adapter uses Hermes' existing POSIX and Windows PTY bridges and declared platform dependencies; Windows behavior remains covered by bridge tests and CI.
- [x] Tool descriptions/schemas: N/A; they already advertise PTY mode.

## Verification

```text
10 passed in 6.86s  (foreground/background PTY tests)
110 passed, 11 skipped in 20.57s  (terminal/environment/PTY regression set)
ruff: all changed files passed
py_compile: passed
uv lock --check: passed
git diff --check: passed
gitleaks: no leaks found
```
