### PR TITLE
fix(memory/hindsight): scope profile secrets for background client/daemon threads

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -37,17 +37,30 @@ import json
 import logging
 import os
 import queue
+from contextlib import contextmanager
 import sys
 import threading
 import time
 
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Dict, List
 
-from agent.secret_scope import get_secret
+from agent.secret_scope import (
+    build_profile_secret_scope,
+    current_secret_scope,
+    get_secret,
+    is_multiplex_active,
+    reset_secret_scope,
+    set_secret_scope,
+)
 
 from agent.memory_provider import MemoryProvider
-from hermes_constants import get_hermes_home
+from hermes_constants import (
+    get_hermes_home,
+    reset_hermes_home_override,
+    set_hermes_home_override,
+)
 from tools.registry import tool_error
 from hermes_cli.config import cfg_get
 
@@ -716,6 +729,11 @@ class HindsightMemoryProvider(MemoryProvider):
         self._agent_workspace = ""
         self._turn_index = 0
         self._client = None
+        self._client_lock = threading.Lock()
+        # Set in initialize() from the hermes_home kwarg; kept as None here so
+        # a pre-initialize _get_client() call fails closed instead of reading
+        # the default profile's secrets.
+        self._profile_home: Path | None = None
         self._timeout = _DEFAULT_TIMEOUT
         self._idle_timeout = _DEFAULT_IDLE_TIMEOUT
         self._prefetch_result = ""
@@ -1098,8 +1116,73 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "port_health_grace_timeout", "description": "Seconds to wait for a slow daemon /health before treating it as stale (raise on busy/low-resource hosts; blank uses the 30s default)", "default": "", "when": {"mode": "local_embedded"}},
         ]
 
+    @contextmanager
+    def _secret_scope_guard(self):
+        """Ensure a profile secret scope (+ home override) is active for the
+        duration of client/daemon setup.
+
+        Background threads (``hindsight-writer``, ``hindsight-daemon-start``)
+        are started with plain ``threading.Thread``, which does NOT
+        ``copy_context()``, so they inherit no per-turn contextvars — under a
+        multiplexing gateway ``get_secret()`` would fail closed with
+        UnscopedSecretError and every auto-retain or daemon start would break.
+        Install the profile scope from the provider's own home for the
+        duration of the block when no scope is already active (normal per-turn
+        calls keep their scope).
+
+        Mirrors gateway/run.py ``_profile_runtime_scope``: home override,
+        secret-source hydration, then the isolated ``.env`` scope. Unlike the
+        gateway's per-turn scope, the writer thread lives for the whole
+        process, so both tokens are always reset in ``finally`` and the scope
+        is built BEFORE any contextvar is installed (a raise in scope building
+        must not leak a stale home override onto a long-lived thread).
+        """
+        if not is_multiplex_active() or current_secret_scope() is not None:
+            yield
+            return
+        if self._profile_home is None:
+            # No profile home captured yet — fail closed rather than silently
+            # substituting the default profile's secrets on a background
+            # thread (get_secret() below raises UnscopedSecretError, which is
+            # the documented contract for this situation).
+            yield
+            return
+        profile_home = self._profile_home
+        try:
+            from hermes_cli.env_loader import hydrate_profile_secret_sources
+            hydrate_profile_secret_sources(profile_home)
+        except Exception:
+            # Hydration is once-per-home, cached and fail-open; never let it
+            # take down client creation.
+            pass
+        scope = build_profile_secret_scope(profile_home)
+        home_token = set_hermes_home_override(str(profile_home))
+        secret_token = set_secret_scope(scope)
+        try:
+            yield
+        finally:
+            reset_secret_scope(secret_token)
+            reset_hermes_home_override(home_token)
+
     def _get_client(self):
-        """Return the cached Hindsight client (created once, reused)."""
+        """Return the cached Hindsight client (created once, reused).
+
+        Creation happens inside ``_secret_scope_guard`` and is serialized with
+        ``_client_lock``: the daemon-start thread, the retain writer thread,
+        and the prefetch thread can all race ``self._client is None`` on first
+        use, and an unsynchronized double-create would leak an aiohttp
+        session.
+        """
+        if self._client is not None:
+            return self._client
+        with self._client_lock:
+            if self._client is None:
+                with self._secret_scope_guard():
+                    return self._create_client()
+        return self._client
+
+    def _create_client(self):
+        """Create the Hindsight client. Runs inside _secret_scope_guard."""
         if self._client is None:
             if self._mode == "local_embedded":
                 available, reason = _check_local_runtime()
@@ -1454,6 +1537,13 @@ class HindsightMemoryProvider(MemoryProvider):
     def initialize(self, session_id: str, **kwargs) -> None:
         self._session_id = str(session_id or "").strip()
         self._parent_session_id = str(kwargs.get("parent_session_id", "") or "").strip()
+        # Capture the profile home at init time (agent_init passes it; in the
+        # multiplexing gateway initialize runs inside the profile scope, so
+        # get_hermes_home() is the correct fallback). Background threads that
+        # later build the client have no contextvars, so they rely on this.
+        self._profile_home = Path(
+            kwargs.get("hermes_home") or get_hermes_home()
+        )
 
         # Each process lifecycle gets its own document_id. Reusing session_id
         # alone caused overwrites on /resume — the reloaded session starts
@@ -1486,7 +1576,8 @@ class HindsightMemoryProvider(MemoryProvider):
         except Exception:
             pass  # packaging not available or other issue — proceed anyway
 
-        self._config = _load_config()
+        with self._secret_scope_guard():
+            self._config = _load_config()
         self._platform = str(kwargs.get("platform") or "").strip()
         self._user_id = str(kwargs.get("user_id") or "").strip()
         self._user_name = str(kwargs.get("user_name") or "").strip()
@@ -1524,7 +1615,8 @@ class HindsightMemoryProvider(MemoryProvider):
                 )
                 self._mode = "disabled"
                 return
-        self._api_key = self._config.get("apiKey") or self._config.get("api_key") or get_secret("HINDSIGHT_API_KEY", "")
+        with self._secret_scope_guard():
+            self._api_key = self._config.get("apiKey") or self._config.get("api_key") or get_secret("HINDSIGHT_API_KEY", "")
         default_url = _DEFAULT_LOCAL_URL if self._mode in {"local_embedded", "local_external"} else _DEFAULT_API_URL
         self._api_url = self._config.get("api_url") or os.environ.get("HINDSIGHT_API_URL", default_url)
         self._llm_base_url = self._config.get("llm_base_url", "")
@@ -1651,42 +1743,48 @@ class HindsightMemoryProvider(MemoryProvider):
 
             def _start_daemon():
                 import traceback
-                log_dir = get_hermes_home() / "logs"
-                log_dir.mkdir(parents=True, exist_ok=True)
-                log_path = log_dir / "hindsight-embed.log"
-                try:
-                    # Redirect the daemon manager's Rich console to our log file
-                    # instead of stderr. This avoids global fd redirects that
-                    # would capture output from other threads.
-                    import hindsight_embed.daemon_embed_manager as dem
-                    from rich.console import Console
-                    dem.console = Console(file=open(log_path, "a", encoding="utf-8"), force_terminal=False)
+                # This thread has no contextvars (plain threading.Thread), so
+                # install the profile secret scope + home override for the
+                # WHOLE startup sequence — including the log path resolution:
+                # otherwise the daemon log lands in the default profile's
+                # logs/ dir, which makes per-profile failures undiagnosable.
+                with self._secret_scope_guard():
+                    log_dir = get_hermes_home() / "logs"
+                    log_dir.mkdir(parents=True, exist_ok=True)
+                    log_path = log_dir / "hindsight-embed.log"
+                    try:
+                        # Redirect the daemon manager's Rich console to our log file
+                        # instead of stderr. This avoids global fd redirects that
+                        # would capture output from other threads.
+                        import hindsight_embed.daemon_embed_manager as dem
+                        from rich.console import Console
+                        dem.console = Console(file=open(log_path, "a", encoding="utf-8"), force_terminal=False)
 
-                    client = self._get_client()
-                    profile = self._config.get("profile", "hermes")
+                        client = self._get_client()
+                        profile = self._config.get("profile", "hermes")
 
-                    # Update the profile .env to match our current config so
-                    # the daemon always starts with the right settings.
-                    # If the config changed and the daemon is running, stop it.
-                    profile_env = _embedded_profile_env_path(self._config)
-                    expected_env = _build_embedded_profile_env(self._config)
-                    saved = _load_simple_env(profile_env)
-                    config_changed = saved != expected_env
+                        # Update the profile .env to match our current config so
+                        # the daemon always starts with the right settings.
+                        # If the config changed and the daemon is running, stop it.
+                        profile_env = _embedded_profile_env_path(self._config)
+                        expected_env = _build_embedded_profile_env(self._config)
+                        saved = _load_simple_env(profile_env)
+                        config_changed = saved != expected_env
 
-                    if config_changed:
-                        profile_env = _materialize_embedded_profile_env(self._config)
-                        if client._manager.is_running(profile):
-                            with open(log_path, "a", encoding="utf-8") as f:
-                                f.write("\n=== Config changed, restarting daemon ===\n")
-                            client._manager.stop(profile)
+                        if config_changed:
+                            profile_env = _materialize_embedded_profile_env(self._config)
+                            if client._manager.is_running(profile):
+                                with open(log_path, "a", encoding="utf-8") as f:
+                                    f.write("\n=== Config changed, restarting daemon ===\n")
+                                client._manager.stop(profile)
 
-                    client._ensure_started()
-                    with open(log_path, "a", encoding="utf-8") as f:
-                        f.write("\n=== Daemon started successfully ===\n")
-                except Exception as e:
-                    with open(log_path, "a", encoding="utf-8") as f:
-                        f.write(f"\n=== Daemon startup failed: {e} ===\n")
-                        traceback.print_exc(file=f)
+                        client._ensure_started()
+                        with open(log_path, "a", encoding="utf-8") as f:
+                            f.write("\n=== Daemon started successfully ===\n")
+                    except Exception as e:
+                        with open(log_path, "a", encoding="utf-8") as f:
+                            f.write(f"\n=== Daemon startup failed: {e} ===\n")
+                            traceback.print_exc(file=f)
 
             t = threading.Thread(target=_start_daemon, daemon=True, name="hindsight-daemon-start")
             t.start()

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1373,3 +1373,164 @@ class TestClientAutoUpgradeRoutesThroughLazyDeps:
         assert len(calls) == 1  # attempted exactly once, init still completed
         assert any("runtime installs are disabled" in r.getMessage()
                    for r in caplog.records)
+
+
+class TestSecretScopeGuard:
+    """Background writer/daemon threads run without contextvars under a
+    multiplexing gateway. get_secret() then fails closed with
+    UnscopedSecretError; _secret_scope_guard must install the provider's
+    profile scope so client creation and daemon startup resolve the right key.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_multiplex(self):
+        from agent.secret_scope import set_multiplex_active
+        set_multiplex_active(True)
+        try:
+            yield
+        finally:
+            set_multiplex_active(False)
+
+    def _provider(self, tmp_path):
+        from agent.secret_scope import current_secret_scope
+        # Scope must be empty at the start of each test (fresh context).
+        assert current_secret_scope() is None
+        provider = HindsightMemoryProvider()
+        provider._profile_home = tmp_path
+        return provider
+
+    def test_guard_installs_profile_scope_for_secret_reads(self, tmp_path):
+        from agent import secret_scope as ss
+        tmp_path.joinpath(".env").write_text(
+            "HINDSIGHT_LLM_API_KEY=test-llm-key\nHINDSIGHT_API_KEY=test-api-key\n"
+        )
+        provider = self._provider(tmp_path)
+
+        # Baseline: fail closed without the guard.
+        with pytest.raises(ss.UnscopedSecretError):
+            ss.get_secret("HINDSIGHT_LLM_API_KEY", "")
+
+        with provider._secret_scope_guard():
+            assert ss.get_secret("HINDSIGHT_LLM_API_KEY", "") == "test-llm-key"
+            assert ss.get_secret("HINDSIGHT_API_KEY", "") == "test-api-key"
+            # Home override is active too, so daemon-env fills resolve the
+            # provider's own profile .env, not the default home.
+            from hermes_constants import get_hermes_home
+            assert str(get_hermes_home()) == str(tmp_path)
+
+        assert ss.current_secret_scope() is None
+
+    def test_guard_is_reentrant_and_keeps_existing_scope(self, tmp_path):
+        from agent import secret_scope as ss
+        tmp_path.joinpath(".env").write_text("HINDSIGHT_LLM_API_KEY=k\n")
+        provider = self._provider(tmp_path)
+
+        with provider._secret_scope_guard():
+            outer = ss.current_secret_scope()
+            with provider._secret_scope_guard():
+                assert ss.current_secret_scope() is outer
+            assert ss.current_secret_scope() is outer
+
+    def test_guard_noop_when_multiplex_off(self, tmp_path, monkeypatch):
+        from agent import secret_scope as ss
+        from agent.secret_scope import set_multiplex_active
+        set_multiplex_active(False)
+        tmp_path.joinpath(".env").write_text("HINDSIGHT_LLM_API_KEY=k\n")
+        provider = self._provider(tmp_path)
+
+        with provider._secret_scope_guard():
+            # Multiplex off => get_secret falls back to os.environ; guard must
+            # not have installed any scope.
+            assert ss.current_secret_scope() is None
+
+    def test_get_client_creates_within_scope_and_caches(self, tmp_path):
+        from agent import secret_scope as ss
+        tmp_path.joinpath(".env").write_text("HINDSIGHT_LLM_API_KEY=test-llm-key\n")
+        provider = self._provider(tmp_path)
+        provider._client = None
+
+        calls = {}
+
+        def fake_unscoped(self):
+            scope = ss.current_secret_scope()
+            calls["scope_active"] = scope is not None
+            calls["key"] = (scope or {}).get("HINDSIGHT_LLM_API_KEY")
+            self._client = "FAKE_CLIENT"  # real creation sets self._client
+            return "FAKE_CLIENT"
+
+        provider._create_client = fake_unscoped.__get__(provider, HindsightMemoryProvider)
+
+        assert provider._get_client() == "FAKE_CLIENT"
+        assert calls["scope_active"] is True
+        assert calls["key"] == "test-llm-key"
+        # Cached: second call must not re-enter unscoped creation.
+        provider._create_client = None
+        assert provider._get_client() == "FAKE_CLIENT"
+
+    def test_background_thread_resolves_secrets_through_guard(self, tmp_path):
+        """Regression for the actual bug: a plain threading.Thread (no
+        copy_context) like hindsight-writer must still resolve profile secrets
+        when it builds the client under a multiplexing gateway."""
+        import threading
+        from agent import secret_scope as ss
+        tmp_path.joinpath(".env").write_text("HINDSIGHT_LLM_API_KEY=thread-key\n")
+        provider = self._provider(tmp_path)
+        provider._client = None
+
+        result = {}
+
+        def fake_unscoped(self):
+            scope = ss.current_secret_scope()
+            result["scope_active"] = scope is not None
+            result["key"] = (scope or {}).get("HINDSIGHT_LLM_API_KEY")
+            self._client = "THREAD_CLIENT"
+            return "THREAD_CLIENT"
+
+        provider._create_client = fake_unscoped.__get__(provider, HindsightMemoryProvider)
+
+        thread = threading.Thread(target=provider._get_client, name="hindsight-writer")
+        thread.start()
+        thread.join(timeout=10)
+        assert not thread.is_alive()
+        assert result["scope_active"] is True
+        assert result["key"] == "thread-key"
+        assert provider._client == "THREAD_CLIENT"
+        # Main thread context stayed untouched — no leak from the worker.
+        assert ss.current_secret_scope() is None
+
+    def test_guard_restores_contextvars_on_exception(self, tmp_path):
+        from agent import secret_scope as ss
+        from hermes_constants import get_hermes_home_override
+        tmp_path.joinpath(".env").write_text("HINDSIGHT_LLM_API_KEY=k\n")
+        provider = self._provider(tmp_path)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            with provider._secret_scope_guard():
+                raise RuntimeError("boom")
+
+        assert ss.current_secret_scope() is None
+        assert get_hermes_home_override() is None
+
+    def test_guard_fails_closed_when_profile_home_missing(self, tmp_path):
+        from agent import secret_scope as ss
+        provider = HindsightMemoryProvider()
+        provider._profile_home = None  # pre-initialize state
+
+        # Guard must NOT install the default profile's secrets: get_secret
+        # keeps failing closed so a wrong-key client can never be built.
+        with provider._secret_scope_guard():
+            assert ss.current_secret_scope() is None
+            with pytest.raises(ss.UnscopedSecretError):
+                ss.get_secret("HINDSIGHT_LLM_API_KEY", "")
+
+    def test_initialize_captures_profile_home_from_kwarg(self, tmp_path, monkeypatch):
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps({"mode": "cloud", "apiKey": "x"}))
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
+        provider = HindsightMemoryProvider()
+        provider.initialize(session_id="s", hermes_home=str(tmp_path), platform="cli")
+        assert provider._profile_home == tmp_path
+


### PR DESCRIPTION
## Problem

Under a multiplexing gateway (`gateway.multiplex_profiles: true`), the Hindsight memory plugin's background threads fail closed on every secret read:

- `hindsight-writer` (retain queue, `_ensure_writer`) is a plain `threading.Thread` — no `copy_context()` — so it has **no per-turn contextvars**.
- `hindsight-daemon-start` (embedded daemon, `initialize`) is the same.
- `agent.secret_scope.get_secret()` **fails closed** with `UnscopedSecretError` when multiplexing is active and no profile secret scope is installed.

Result (observed in production): every auto-retain logs
`Hindsight retain failed: get_secret("HINDSIGHT_LLM_API_KEY") called with no profile secret scope active...`
and the embedded daemon startup throws the same — so automatic memory learning silently never happens in a multiplexed gateway.

## Fix

Add `HindsightMemoryProvider._secret_scope_guard()` — a context manager that mirrors `gateway/run.py` `_profile_runtime_scope` (home override → `hydrate_profile_secret_sources` → isolated `.env` scope) and installs the provider's own profile scope around:

- client creation (`_get_client`, now serialized with a `threading.Lock` — the daemon, writer and prefetch threads can all race first creation and would otherwise leak an aiohttp session),
- the embedded daemon startup sequence (whole `_start_daemon` body, including log-path resolution),
- the initialize-time API-key read and `_load_config()`.

Guarantees:
- **fail-closed**: if `_profile_home` was never captured (pre-initialize), the guard installs nothing and `get_secret` keeps raising `UnscopedSecretError` — it never silently substitutes the default profile's secrets.
- **no leak**: tokens are reset in `finally`; scope is built before any contextvar is installed, so a raise cannot leak a stale home override onto the long-lived writer thread.
- **reentrant**: nested guards keep the existing scope.
- **no-op when multiplexing is off**: single-profile behavior unchanged.

## Tests

`TestSecretScopeGuard` (9 tests): scope install + fail-closed baseline, reentrancy, no-op when multiplex off, `_get_client` creates within scope and caches, real background-thread resolution (regression for the bug shape), exception safety, fail-closed when `_profile_home` is missing, `initialize()` capturing `hermes_home`.

All 78 hindsight-related tests pass.

## Related

- Tracking issue for a pre-existing collision this PR makes reachable: #81815 (shared `~/.hindsight/profiles/<name>.env` + daemon across Hermes profiles).