### PR TITLE
fix(desktop): isolate profile context for new chats

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -13,7 +13,7 @@ import contextvars
 from collections import OrderedDict
 from pathlib import Path
 
-from hermes_constants import get_hermes_home, get_skills_dir, is_wsl
+from hermes_constants import get_default_hermes_root, get_hermes_home, get_skills_dir, is_wsl
 from typing import List, Optional
 
 from agent.runtime_cwd import resolve_agent_cwd
@@ -2193,11 +2193,50 @@ def _load_cursorrules(cwd_path: Path, context_length: Optional[int] = None) -> s
     )
 
 
+def _cross_profile_context_owner(cwd_path: Path) -> Optional[str]:
+    """Return the foreign named profile that owns *cwd_path*, if any."""
+
+    def _profile_under(path: Path, profiles_root: Path) -> Optional[str]:
+        try:
+            parts = path.relative_to(profiles_root).parts
+        except ValueError:
+            return None
+        return parts[0] if parts else None
+
+    try:
+        active_home = Path(os.path.abspath(os.path.expanduser(str(get_hermes_home()))))
+        if active_home.parent.name == "profiles":
+            profiles_root = active_home.parent
+            active_profile = active_home.name
+        else:
+            profiles_root = Path(
+                os.path.abspath(
+                    os.path.expanduser(str(get_default_hermes_root() / "profiles"))
+                )
+            )
+            active_profile = "default"
+
+        logical_target = Path(os.path.abspath(os.path.expanduser(str(cwd_path))))
+        candidates = (
+            (logical_target, profiles_root),
+            (cwd_path.resolve(), profiles_root.resolve()),
+        )
+        for target, root in candidates:
+            target_profile = _profile_under(target, root)
+            if target_profile and target_profile != active_profile:
+                return target_profile
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+    return None
+
+
 def build_context_files_prompt(
     cwd: Optional[str] = None,
     skip_soul: bool = False,
     context_length: Optional[int] = None,
     allow_install_tree_fallback: bool = False,
+    allow_cross_profile_context: bool = False,
 ) -> str:
     """Discover and load context files for the system prompt.
 
@@ -2216,6 +2255,10 @@ def build_context_files_prompt(
 
     When *skip_soul* is True, SOUL.md is not included here (it was already
     loaded via ``load_soul_md()`` for the identity slot).
+
+    Named-profile directories owned by another profile are ignored by default.
+    Set *allow_cross_profile_context* only when the caller has an explicit,
+    user-selected reason to treat that directory as project context.
     """
     if cwd is None:
         cwd = os.getcwd()
@@ -2223,7 +2266,8 @@ def build_context_files_prompt(
     else:
         cwd_is_fallback = False
 
-    cwd_path = Path(cwd).resolve()
+    cwd_path_raw = Path(cwd)
+    cwd_path = cwd_path_raw.resolve()
     sections = []
 
     # Never let a FALLBACK-picked directory inside the Hermes install/source
@@ -2236,7 +2280,16 @@ def build_context_files_prompt(
     # their launch dir IS the user's shell cwd (developing Hermes in-tree).
     from agent.runtime_cwd import _is_install_tree
 
-    if (
+    foreign_profile = _cross_profile_context_owner(cwd_path_raw)
+    if foreign_profile and not allow_cross_profile_context:
+        logger.warning(
+            "skipping project-context discovery: working directory %s belongs "
+            "to another Hermes profile (%s)",
+            cwd_path,
+            foreign_profile,
+        )
+        project_context = ""
+    elif (
         cwd_is_fallback
         and not allow_install_tree_fallback
         and _is_install_tree(cwd_path)

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -16,8 +16,10 @@ from pathlib import Path
 from typing import Optional
 
 from hermes_constants import (
-    get_hermes_home, get_skills_dir, is_wsl, reset_hermes_home_override, set_hermes_home_override,
+    get_default_hermes_root, get_hermes_home, get_skills_dir, is_wsl,
+    reset_hermes_home_override, set_hermes_home_override,
 )
+from typing import List, Optional
 
 from agent.runtime_cwd import resolve_agent_cwd
 from agent.skill_utils import (
@@ -1569,25 +1571,108 @@ def _load_cursorrules(cwd_path: Path, context_length: Optional[int] = None) -> s
                              read_path=str(cwd_path / ".cursorrules"))
 
 
+def _cross_profile_context_owner(cwd_path: Path) -> Optional[str]:
+    """Return the foreign named profile that owns *cwd_path*, if any."""
+
+    def _profile_under(path: Path, profiles_root: Path) -> Optional[str]:
+        try:
+            parts = path.relative_to(profiles_root).parts
+        except ValueError:
+            return None
+        return parts[0] if parts else None
+
+    try:
+        active_home = Path(os.path.abspath(os.path.expanduser(str(get_hermes_home()))))
+        if active_home.parent.name == "profiles":
+            profiles_root = active_home.parent
+            active_profile = active_home.name
+        else:
+            profiles_root = Path(
+                os.path.abspath(
+                    os.path.expanduser(str(get_default_hermes_root() / "profiles"))
+                )
+            )
+            active_profile = "default"
+
+        logical_target = Path(os.path.abspath(os.path.expanduser(str(cwd_path))))
+        candidates = (
+            (logical_target, profiles_root),
+            (cwd_path.resolve(), profiles_root.resolve()),
+        )
+        for target, root in candidates:
+            target_profile = _profile_under(target, root)
+            if target_profile and target_profile != active_profile:
+                return target_profile
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+    return None
+
+
 def build_context_files_prompt(
-    cwd: Optional[str] = None, skip_soul: bool = False, context_length: Optional[int] = None,
-    allow_install_tree_fallback: bool = False, home_override: "Path | None" = None,
+    cwd: Optional[str] = None,
+    skip_soul: bool = False,
+    context_length: Optional[int] = None,
+    allow_install_tree_fallback: bool = False,
+    allow_cross_profile_context: bool = False,
+    home_override: "Path | None" = None,
 ) -> str:
     """Discover and load context files for the system prompt (each capped, see ``_get_context_file_max_chars``).
 
-    Only ONE project context type loads, first found wins: .hermes.md/HERMES.md (walk to git root) →
-    AGENTS.md chain (git root → cwd) → CLAUDE.md (cwd) → .cursorrules + .cursor/rules/*.mdc (cwd). SOUL.md
-    from HERMES_HOME is independent and always included unless *skip_soul* (already the identity slot).
+    Priority (first found wins — only ONE project context type is loaded):
+      1. .hermes.md / HERMES.md  (walk to git root)
+      2. AGENTS.md / agents.md   (merged chain: git root → cwd)
+      3. CLAUDE.md / claude.md   (cwd only)
+      4. .cursorrules / .cursor/rules/*.mdc  (cwd only)
+
+    SOUL.md from HERMES_HOME is independent and always included when present.
+
+    Each context source is capped before injection. The cap defaults to the
+    model's context window (scaled — see ``_dynamic_context_file_max_chars``)
+    when *context_length* is provided, falling back to 20,000 chars otherwise.
+    An explicit ``context_file_max_chars`` in config.yaml always wins.
+
+    When *skip_soul* is True, SOUL.md is not included here (it was already
+    loaded via ``load_soul_md()`` for the identity slot).
+
+    Named-profile directories owned by another profile are ignored by default.
+    Set *allow_cross_profile_context* only when the caller has an explicit,
+    user-selected reason to treat that directory as project context.
     """
-    cwd_path = Path(cwd if cwd is not None else os.getcwd()).resolve()
-    # A FALLBACK-picked cwd inside the Hermes install tree must not gain system-prompt authority (the desktop
-    # default would load this repo's contributor AGENTS.md). An explicit cwd is honored verbatim.
-    # An explicitly configured cwd is honored verbatim — the Hermes tree is a legitimate workspace when the
-    # user deliberately points a session at it — and CLI-style surfaces pass
-    # allow_install_tree_fallback=True because their launch dir IS the user's shell cwd (developing Hermes
-    # in-tree). See #64590.
+    if cwd is None:
+        cwd = os.getcwd()
+        cwd_is_fallback = True
+    else:
+        cwd_is_fallback = False
+
+    cwd_path_raw = Path(cwd)
+    cwd_path = cwd_path_raw.resolve()
+    sections = []
+
+    # Never let a FALLBACK-picked directory inside the Hermes install/source
+    # tree gain system-prompt authority. A backend that self-spawns into that
+    # tree (the desktop app default) would otherwise load this repo's
+    # contributor AGENTS.md as authoritative project context (#64590). An
+    # explicitly configured cwd is honored verbatim — the Hermes tree is a
+    # legitimate workspace when the user deliberately points a session at it —
+    # and CLI-style surfaces pass allow_install_tree_fallback=True because
+    # their launch dir IS the user's shell cwd (developing Hermes in-tree).
     from agent.runtime_cwd import _is_install_tree
-    if cwd is None and not allow_install_tree_fallback and _is_install_tree(cwd_path):
+
+    foreign_profile = _cross_profile_context_owner(cwd_path_raw)
+    if foreign_profile and not allow_cross_profile_context:
+        logger.warning(
+            "skipping project-context discovery: working directory %s belongs "
+            "to another Hermes profile (%s)",
+            cwd_path,
+            foreign_profile,
+        )
+        sections = []
+    elif (
+        cwd_is_fallback
+        and not allow_install_tree_fallback
+        and _is_install_tree(cwd_path)
+    ):
         logger.warning(
             "skipping project-context discovery: working-directory resolution fell back to the Hermes "
             "install tree (%s) — set terminal.cwd to your project directory", cwd_path,

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -49,7 +49,7 @@ from agent.prompt_builder import (
     drain_truncation_warnings,
 )
 from agent.runtime_cwd import resolve_context_cwd
-from hermes_constants import get_hermes_home
+from hermes_constants import get_default_hermes_root, get_hermes_home
 from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
@@ -406,10 +406,12 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         active_profile = _resolve_active_profile_name()
     except Exception:
         active_profile = "default"
+    active_home = get_hermes_home()
+    default_home = get_default_hermes_root()
     if active_profile == "default":
         post_workspace_parts.append(
             "Active Hermes profile: default. Other profiles (if any) live "
-            "under " + str(get_hermes_home()) + "/profiles/<name>/. Each profile has its own "
+            f"under {default_home}/profiles/<name>/. Each profile has its own "
             "skills/, plugins/, cron/, and memories/ that affect a different "
             "session than this one. Do not modify another profile's "
             "skills/plugins/cron/memories unless the user explicitly directs "
@@ -418,9 +420,9 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     else:
         post_workspace_parts.append(
             f"Active Hermes profile: {active_profile}. This session reads "
-            f"and writes {get_hermes_home()}/profiles/{active_profile}/. The default "
-            f"profile's data lives at {get_hermes_home()}/skills/, {get_hermes_home()}/plugins/, "
-            f"{get_hermes_home()}/cron/, {get_hermes_home()}/memories/ — those belong to a "
+            f"and writes {active_home}/. The default profile's data lives at "
+            f"{default_home}/skills/, {default_home}/plugins/, "
+            f"{default_home}/cron/, {default_home}/memories/ — those belong to a "
             f"different session run from a different shell. Do NOT modify "
             f"another profile's skills/plugins/cron/memories unless the user "
             f"explicitly directs you to. The cross-profile write guard will "
@@ -499,7 +501,9 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         context_files_prompt = _r.build_context_files_prompt(
             cwd=resolve_context_cwd(), skip_soul=_soul_loaded,
             context_length=_ctx_len,
-            allow_install_tree_fallback=agent.platform in ("cli", "tui"))
+            allow_install_tree_fallback=agent.platform in ("cli", "tui"),
+            allow_cross_profile_context=agent.platform in ("cli", "tui"),
+        )
         if context_files_prompt:
             context_parts.append(context_files_prompt)
 

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -376,7 +376,9 @@ def _active_profile_line(agent: Any) -> str:
         f"{default_root}/cron/, {default_root}/memories/ — those belong to a "
         f"different session run from a different shell. Do NOT modify "
         f"another profile's skills/plugins/cron/memories unless the user "
-        f"explicitly directs you to."
+        f"explicitly directs you to. The cross-profile write guard will "
+        f"refuse such writes by default; pass cross_profile=True only "
+        f"after explicit direction."
     )
 
 
@@ -593,7 +595,9 @@ def _context_files_part(agent: Any, ctx_len: Optional[int], soul_loaded: bool) -
     launch_artifact = getattr(agent, "_context_cwd_is_launch_artifact", False)
     return [_pb.build_context_files_prompt(
         cwd=None if launch_artifact else resolve_context_cwd(), skip_soul=soul_loaded, context_length=ctx_len,
-        allow_install_tree_fallback=agent.platform in ("cli", "tui"), home_override=_agent_home(agent))]
+        allow_install_tree_fallback=agent.platform in ("cli", "tui"),
+        allow_cross_profile_context=agent.platform in ("cli", "tui"),
+        home_override=_agent_home(agent))]
 
 
 def _join_tier(parts: List[Optional[str]]) -> str:

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -8,7 +8,7 @@ import { noteActiveTreeGroup, revealTreePane } from '@/components/pane-shell/tre
 import { getAllSessionMessages, getLatestSessionMessages, getSession, type SessionInfo } from '@/hermes'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { clearSessionDraft, stashSessionDraft, takeSessionDraft } from '@/store/composer'
-import { $activeGatewayProfile, $newChatProfile, ensureGatewayProfile } from '@/store/profile'
+import { $activeGatewayProfile, $gatewaySwapTarget, $newChatProfile, ensureGatewayProfile } from '@/store/profile'
 import { $projectScope, $projectTree, ALL_PROJECTS } from '@/store/projects'
 import {
   $activeSessionId,
@@ -464,6 +464,7 @@ describe('createBackendSessionForSend profile routing', () => {
   afterEach(() => {
     cleanup()
     $newChatProfile.set(null)
+    $gatewaySwapTarget.set(null)
     $activeGatewayProfile.set('default')
     $projectScope.set(ALL_PROJECTS)
     $projectTree.set([])
@@ -487,6 +488,19 @@ describe('createBackendSessionForSend profile routing', () => {
     })
 
     expect(params).toMatchObject({ profile: 'coder' })
+  })
+
+  it('keeps the pending profile switch as the new-chat target', async () => {
+    // Cmd+N clears the per-profile quick-create selection. If a profile switch
+    // is still opening its gateway, the visible intent is the pending target,
+    // not the previous live gateway profile.
+    const params = await createWith(() => {
+      $activeGatewayProfile.set('private-xiaomi')
+      $gatewaySwapTarget.set('rebel-soul')
+      $newChatProfile.set(null)
+    })
+
+    expect(params).toMatchObject({ profile: 'rebel-soul' })
   })
 
   it('honours an explicit per-profile "+" selection', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -24,7 +24,7 @@ import { $clarifyRequests, clearClarifyRequest, setClarifyRequest } from '@/stor
 import { clearSessionDraft, stashSessionDraft, takeSessionDraft } from '@/store/composer'
 import { requestGatewayForAgent, requestGatewayForProfile } from '@/store/gateway'
 import { $pinnedSessionIds } from '@/store/layout'
-import { $activeGatewayProfile, $newChatProfile, $newChatRoute, $profiles, ensureGatewayProfile } from '@/store/profile'
+import { $activeGatewayProfile, $gatewaySwapTarget, $newChatProfile, ensureGatewayProfile } from '@/store/profile'
 import { $projectScope, $projectTree, ALL_PROJECTS } from '@/store/projects'
 import {
   $activeSessionId,
@@ -726,7 +726,7 @@ describe('createBackendSessionForSend profile routing', () => {
   afterEach(() => {
     cleanup()
     $newChatProfile.set(null)
-    $newChatRoute.set(null)
+    $gatewaySwapTarget.set(null)
     $activeGatewayProfile.set('default')
     $projectScope.set(ALL_PROJECTS)
     $projectTree.set([])
@@ -751,6 +751,19 @@ describe('createBackendSessionForSend profile routing', () => {
     })
 
     expect(params).toMatchObject({ profile: 'coder' })
+  })
+
+  it('keeps the pending profile switch as the new-chat target', async () => {
+    // Cmd+N clears the per-profile quick-create selection. If a profile switch
+    // is still opening its gateway, the visible intent is the pending target,
+    // not the previous live gateway profile.
+    const params = await createWith(() => {
+      $activeGatewayProfile.set('private-xiaomi')
+      $gatewaySwapTarget.set('rebel-soul')
+      $newChatProfile.set(null)
+    })
+
+    expect(params).toMatchObject({ profile: 'rebel-soul' })
   })
 
   it('honours an explicit per-profile "+" selection', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -13,7 +13,13 @@ import { migrateSessionDraft } from '@/store/composer'
 import { clearQueuedPrompts, migrateQueuedPrompts } from '@/store/composer-queue'
 import { $pinnedSessionIds } from '@/store/layout'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
-import { $activeGatewayProfile, $newChatProfile, ensureGatewayProfile, normalizeProfileKey } from '@/store/profile'
+import {
+  $activeGatewayProfile,
+  $gatewaySwapTarget,
+  $newChatProfile,
+  ensureGatewayProfile,
+  normalizeProfileKey
+} from '@/store/profile'
 import {
   beginSessionMutation,
   endSessionMutation,
@@ -170,7 +176,12 @@ async function desktopSessionCreateParams(cwd: string): Promise<Record<string, u
     provider: $currentProvider.get().trim()
   }
 
-  const profile = $newChatProfile.get() ?? normalizeProfileKey($activeGatewayProfile.get())
+  // A pending gateway swap is still the user's visible profile intent. Cmd+N
+  // deliberately clears a stale per-profile quick-create selection, but must
+  // not route the new session back through the previous live backend while
+  // that explicit profile switch is still opening (#79003 class).
+  const profile = $newChatProfile.get() ?? $gatewaySwapTarget.get() ?? normalizeProfileKey($activeGatewayProfile.get())
+
   await ensureGatewayProfile(profile)
 
   return {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -308,7 +308,11 @@ async function desktopSessionCreateParams(
     provider: isManualSelection ? $currentProvider.get().trim() : ''
   }
 
-  const profile = capturedRoute?.profile || $newChatProfile.get() || normalizeProfileKey($activeGatewayProfile.get())
+  // A pending gateway swap is still the user's visible profile intent. Cmd+N
+  // deliberately clears a stale per-profile quick-create selection, but must
+  // not route the new session back through the previous live backend while
+  // that explicit profile switch is still opening (#79003 class).
+  const profile = capturedRoute?.profile || $newChatProfile.get() ?? $gatewaySwapTarget.get() ?? normalizeProfileKey($activeGatewayProfile.get())
 
   if (capturedRoute) {
     await ensureGatewayAgent(capturedRoute.connectionId, profile)

--- a/plugins/web/jina_reader/__init__.py
+++ b/plugins/web/jina_reader/__init__.py
@@ -1,0 +1,9 @@
+"""Jina Reader plugin — bundled, auto-loaded."""
+from __future__ import annotations
+
+from plugins.web.jina_reader.provider import JinaReaderWebSearchProvider
+
+
+def register(ctx) -> None:
+    """Register the Jina Reader extract provider."""
+    ctx.register_web_search_provider(JinaReaderWebSearchProvider())

--- a/plugins/web/jina_reader/plugin.yaml
+++ b/plugins/web/jina_reader/plugin.yaml
@@ -1,0 +1,7 @@
+name: web-jina-reader
+version: 1.0.0
+description: "Jina Reader raw Markdown extraction for public URLs; no key required for basic usage."
+author: NousResearch
+kind: backend
+provides_web_providers:
+  - jina-reader

--- a/plugins/web/jina_reader/provider.py
+++ b/plugins/web/jina_reader/provider.py
@@ -1,0 +1,147 @@
+"""Jina Reader web-content extraction provider.
+
+The reader is intentionally extract-only. It sends public, SSRF-screened URLs to
+Jina's raw Markdown reader; `tools.web_tools.web_extract_tool` performs the
+SSRF/credential-like URL screening before dispatching here.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Dict, List
+
+from agent.web_search_provider import WebSearchProvider, get_provider_env
+
+logger = logging.getLogger(__name__)
+
+_READER_PREFIX = "https://r.jina.ai/http://"
+_TITLE_RE = re.compile(r"^Title:\s*(.+?)\s*$", re.MULTILINE)
+
+
+def _reader_url(url: str) -> str:
+    """Keep the source URL's scheme explicit for Jina Reader."""
+    return f"{_READER_PREFIX}{url}"
+
+
+def _title_from_markdown(text: str) -> str:
+    match = _TITLE_RE.search(text or "")
+    return match.group(1).strip() if match else ""
+
+
+class JinaReaderWebSearchProvider(WebSearchProvider):
+    """Public Jina Reader provider for raw Markdown extraction."""
+
+    @property
+    def name(self) -> str:
+        return "jina-reader"
+
+    @property
+    def display_name(self) -> str:
+        return "Jina Reader"
+
+    def is_available(self) -> bool:
+        # Basic Reader usage is unauthenticated. A JINA_API_KEY, if present,
+        # only raises limits; never make a network request during discovery.
+        return True
+
+    def supports_search(self) -> bool:
+        return False
+
+    def supports_extract(self) -> bool:
+        return True
+
+    def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
+        import httpx
+
+        headers = {
+            "Accept": "text/markdown",
+            "X-Return-Format": "markdown",
+            "User-Agent": "Hermes-Agent/1.0 (+https://hermes-agent.nousresearch.com)",
+        }
+        api_key = get_provider_env("JINA_API_KEY")
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+
+        results: List[Dict[str, Any]] = []
+        for url in urls:
+            try:
+                response = httpx.get(
+                    _reader_url(url),
+                    headers=headers,
+                    timeout=60,
+                    follow_redirects=True,
+                )
+                response.raise_for_status()
+                raw = response.text
+                title = _title_from_markdown(raw)
+                metadata: Dict[str, Any] = {
+                    "sourceURL": url,
+                    "title": title,
+                    "status_code": response.status_code,
+                    "source_provider": self.name,
+                }
+                cache_hint = response.headers.get("x-cache-warning") or response.headers.get("x-cache")
+                if cache_hint:
+                    metadata["cache_warning"] = str(cache_hint)[:300]
+                results.append(
+                    {
+                        "url": url,
+                        "title": title,
+                        "content": raw,
+                        "raw_content": raw,
+                        "metadata": metadata,
+                        "source_provider": self.name,
+                    }
+                )
+            except httpx.HTTPStatusError as exc:
+                status = getattr(exc.response, "status_code", None)
+                logger.warning("Jina Reader HTTP error for %s: %s", url, exc)
+                results.append(
+                    {
+                        "url": url,
+                        "title": "",
+                        "content": "",
+                        "raw_content": "",
+                        "error": f"Jina Reader returned HTTP {status}",
+                        "metadata": {"sourceURL": url, "status_code": status, "source_provider": self.name},
+                    }
+                )
+            except httpx.RequestError as exc:
+                logger.warning("Jina Reader request error for %s: %s", url, exc)
+                results.append(
+                    {
+                        "url": url,
+                        "title": "",
+                        "content": "",
+                        "raw_content": "",
+                        "error": f"Could not reach Jina Reader: {exc}",
+                        "metadata": {"sourceURL": url, "source_provider": self.name},
+                    }
+                )
+            except Exception as exc:  # pragma: no cover - defensive boundary
+                logger.warning("Jina Reader unexpected error for %s: %s", url, exc)
+                results.append(
+                    {
+                        "url": url,
+                        "title": "",
+                        "content": "",
+                        "raw_content": "",
+                        "error": f"Jina Reader extraction failed: {exc}",
+                        "metadata": {"sourceURL": url, "source_provider": self.name},
+                    }
+                )
+        return results
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Jina Reader",
+            "badge": "free",
+            "tag": "Raw Markdown extraction; public URLs only, no key required for basic usage.",
+            "env_vars": [
+                {
+                    "key": "JINA_API_KEY",
+                    "prompt": "Optional Jina Reader API key",
+                    "url": "https://jina.ai/reader/",
+                }
+            ],
+        }

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -36,6 +36,7 @@ from agent.prompt_builder import (
     WSL_ENVIRONMENT_HINT,
 )
 from hermes_cli.nous_subscription import NousFeatureState, NousSubscriptionFeatures
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 
 
 # =========================================================================
@@ -528,6 +529,92 @@ class TestBuildContextFilesPrompt:
         result = build_context_files_prompt(cwd=None, skip_soul=True)
         assert "Never give up" not in result
         assert result == ""
+
+    def test_skips_agents_md_from_another_profile(self, monkeypatch, tmp_path):
+        root = tmp_path / "hermes"
+        active_home = root / "profiles" / "rebel-soul"
+        foreign_workspace = root / "profiles" / "private-xiaomi" / "workspace"
+        active_home.mkdir(parents=True)
+        foreign_workspace.mkdir(parents=True)
+        (foreign_workspace / "AGENTS.md").write_text(
+            "PRIVATE XIAOMI IDENTITY", encoding="utf-8"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(active_home))
+
+        result = build_context_files_prompt(cwd=str(foreign_workspace), skip_soul=True)
+
+        assert "PRIVATE XIAOMI IDENTITY" not in result
+        assert result == ""
+
+    def test_skips_foreign_profile_under_context_home_override_root(
+        self, monkeypatch, tmp_path
+    ):
+        launch_root = tmp_path / "launch-root"
+        scoped_root = tmp_path / "scoped-root"
+        active_home = scoped_root / "profiles" / "rebel-soul"
+        foreign_workspace = scoped_root / "profiles" / "private-xiaomi" / "workspace"
+        launch_root.mkdir()
+        active_home.mkdir(parents=True)
+        foreign_workspace.mkdir(parents=True)
+        (foreign_workspace / "AGENTS.md").write_text(
+            "CONTEXT OVERRIDE FOREIGN IDENTITY", encoding="utf-8"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(launch_root))
+        token = set_hermes_home_override(active_home)
+        try:
+            result = build_context_files_prompt(
+                cwd=str(foreign_workspace), skip_soul=True
+            )
+        finally:
+            reset_hermes_home_override(token)
+
+        assert "CONTEXT OVERRIDE FOREIGN IDENTITY" not in result
+        assert result == ""
+
+    def test_skips_logical_foreign_profile_when_profile_dir_is_symlinked(
+        self, monkeypatch, tmp_path
+    ):
+        root = tmp_path / "hermes"
+        active_home = root / "profiles" / "rebel-soul"
+        external_profile = tmp_path / "external-private-xiaomi"
+        external_workspace = external_profile / "workspace"
+        foreign_link = root / "profiles" / "private-xiaomi"
+        active_home.mkdir(parents=True)
+        external_workspace.mkdir(parents=True)
+        (external_workspace / "AGENTS.md").write_text(
+            "SYMLINKED FOREIGN IDENTITY", encoding="utf-8"
+        )
+        try:
+            foreign_link.symlink_to(external_profile, target_is_directory=True)
+        except OSError as exc:
+            pytest.skip(f"directory symlinks unavailable: {exc}")
+        monkeypatch.setenv("HERMES_HOME", str(active_home))
+
+        result = build_context_files_prompt(
+            cwd=str(foreign_link / "workspace"), skip_soul=True
+        )
+
+        assert "SYMLINKED FOREIGN IDENTITY" not in result
+        assert result == ""
+
+    def test_allows_explicit_cross_profile_context(self, monkeypatch, tmp_path):
+        root = tmp_path / "hermes"
+        active_home = root / "profiles" / "rebel-soul"
+        foreign_workspace = root / "profiles" / "private-xiaomi" / "workspace"
+        active_home.mkdir(parents=True)
+        foreign_workspace.mkdir(parents=True)
+        (foreign_workspace / "AGENTS.md").write_text(
+            "EXPLICIT SHARED WORKSPACE", encoding="utf-8"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(active_home))
+
+        result = build_context_files_prompt(
+            cwd=str(foreign_workspace),
+            skip_soul=True,
+            allow_cross_profile_context=True,
+        )
+
+        assert "EXPLICIT SHARED WORKSPACE" in result
 
 
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -36,6 +36,8 @@ from agent.prompt_builder import (
     PLATFORM_HINTS,
     WSL_ENVIRONMENT_HINT,
 )
+from hermes_cli.nous_subscription import NousFeatureState, NousSubscriptionFeatures
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 
 
 @pytest.fixture(autouse=True)
@@ -518,6 +520,92 @@ class TestBuildContextFilesPrompt:
         result = build_context_files_prompt(cwd=None, skip_soul=True)
         assert "Never give up" not in result
         assert result == ""
+
+    def test_skips_agents_md_from_another_profile(self, monkeypatch, tmp_path):
+        root = tmp_path / "hermes"
+        active_home = root / "profiles" / "rebel-soul"
+        foreign_workspace = root / "profiles" / "private-xiaomi" / "workspace"
+        active_home.mkdir(parents=True)
+        foreign_workspace.mkdir(parents=True)
+        (foreign_workspace / "AGENTS.md").write_text(
+            "PRIVATE XIAOMI IDENTITY", encoding="utf-8"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(active_home))
+
+        result = build_context_files_prompt(cwd=str(foreign_workspace), skip_soul=True)
+
+        assert "PRIVATE XIAOMI IDENTITY" not in result
+        assert result == ""
+
+    def test_skips_foreign_profile_under_context_home_override_root(
+        self, monkeypatch, tmp_path
+    ):
+        launch_root = tmp_path / "launch-root"
+        scoped_root = tmp_path / "scoped-root"
+        active_home = scoped_root / "profiles" / "rebel-soul"
+        foreign_workspace = scoped_root / "profiles" / "private-xiaomi" / "workspace"
+        launch_root.mkdir()
+        active_home.mkdir(parents=True)
+        foreign_workspace.mkdir(parents=True)
+        (foreign_workspace / "AGENTS.md").write_text(
+            "CONTEXT OVERRIDE FOREIGN IDENTITY", encoding="utf-8"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(launch_root))
+        token = set_hermes_home_override(active_home)
+        try:
+            result = build_context_files_prompt(
+                cwd=str(foreign_workspace), skip_soul=True
+            )
+        finally:
+            reset_hermes_home_override(token)
+
+        assert "CONTEXT OVERRIDE FOREIGN IDENTITY" not in result
+        assert result == ""
+
+    def test_skips_logical_foreign_profile_when_profile_dir_is_symlinked(
+        self, monkeypatch, tmp_path
+    ):
+        root = tmp_path / "hermes"
+        active_home = root / "profiles" / "rebel-soul"
+        external_profile = tmp_path / "external-private-xiaomi"
+        external_workspace = external_profile / "workspace"
+        foreign_link = root / "profiles" / "private-xiaomi"
+        active_home.mkdir(parents=True)
+        external_workspace.mkdir(parents=True)
+        (external_workspace / "AGENTS.md").write_text(
+            "SYMLINKED FOREIGN IDENTITY", encoding="utf-8"
+        )
+        try:
+            foreign_link.symlink_to(external_profile, target_is_directory=True)
+        except OSError as exc:
+            pytest.skip(f"directory symlinks unavailable: {exc}")
+        monkeypatch.setenv("HERMES_HOME", str(active_home))
+
+        result = build_context_files_prompt(
+            cwd=str(foreign_link / "workspace"), skip_soul=True
+        )
+
+        assert "SYMLINKED FOREIGN IDENTITY" not in result
+        assert result == ""
+
+    def test_allows_explicit_cross_profile_context(self, monkeypatch, tmp_path):
+        root = tmp_path / "hermes"
+        active_home = root / "profiles" / "rebel-soul"
+        foreign_workspace = root / "profiles" / "private-xiaomi" / "workspace"
+        active_home.mkdir(parents=True)
+        foreign_workspace.mkdir(parents=True)
+        (foreign_workspace / "AGENTS.md").write_text(
+            "EXPLICIT SHARED WORKSPACE", encoding="utf-8"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(active_home))
+
+        result = build_context_files_prompt(
+            cwd=str(foreign_workspace),
+            skip_soul=True,
+            allow_cross_profile_context=True,
+        )
+
+        assert "EXPLICIT SHARED WORKSPACE" in result
 
 
 

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -34,10 +34,14 @@ def _captured_context_cwd(agent):
     captured = {}
 
     def fake_context_files(
-        cwd=None, skip_soul=False, context_length=None,
+        cwd=None,
+        skip_soul=False,
+        context_length=None,
         allow_install_tree_fallback=False,
+        allow_cross_profile_context=False,
     ):
         captured["cwd"] = cwd
+        captured["allow_cross_profile_context"] = allow_cross_profile_context
         return ""
 
     with (
@@ -50,6 +54,23 @@ def _captured_context_cwd(agent):
     return captured["cwd"]
 
 
+def _captured_cross_profile_context_flag(agent):
+    captured = {}
+
+    def fake_context_files(**kwargs):
+        captured.update(kwargs)
+        return ""
+
+    with (
+        patch("run_agent.load_soul_md", return_value=""),
+        patch("run_agent.build_nous_subscription_prompt", return_value=""),
+        patch("run_agent.build_environment_hints", return_value=""),
+        patch("run_agent.build_context_files_prompt", side_effect=fake_context_files),
+    ):
+        build_system_prompt_parts(agent)
+    return captured.get("allow_cross_profile_context", False)
+
+
 class TestContextFileCwd:
     def test_none_when_terminal_cwd_unset(self, monkeypatch):
         # Unset → None, so discovery falls back to the launch dir inside
@@ -60,6 +81,12 @@ class TestContextFileCwd:
     def test_configured_dir_when_terminal_cwd_set(self, monkeypatch, tmp_path):
         monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
         assert _captured_context_cwd(_make_agent()) == tmp_path
+
+    def test_cross_profile_context_opt_in_is_cli_only(self):
+        assert _captured_cross_profile_context_flag(_make_agent(platform="cli")) is True
+        assert _captured_cross_profile_context_flag(_make_agent(platform="tui")) is True
+        assert _captured_cross_profile_context_flag(_make_agent(platform="desktop")) is False
+        assert _captured_cross_profile_context_flag(_make_agent(platform="telegram")) is False
 
 
 def _stable_prompt(agent):
@@ -80,6 +107,20 @@ def _prompt_parts(agent):
         patch("run_agent.build_context_files_prompt", return_value=""),
     ):
         return build_system_prompt_parts(agent)
+
+
+def test_named_profile_hint_uses_current_and_default_homes(monkeypatch, tmp_path):
+    root = tmp_path / "hermes"
+    profile_home = root / "profiles" / "rebel-soul"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    with patch("agent.file_safety._resolve_active_profile_name", return_value="rebel-soul"):
+        stable = _stable_prompt(_make_agent())
+
+    assert f"This session reads and writes {profile_home}/." in stable
+    assert f"The default profile's data lives at {root}/skills/" in stable
+    assert str(profile_home / "profiles" / "rebel-soul") not in stable
 
 
 def _init_code_repo(path):
@@ -142,6 +183,7 @@ def test_coding_prompt_preserves_legacy_workspace_order(monkeypatch):
     monkeypatch.setattr(system_prompt, "HERMES_AGENT_HELP_GUIDANCE", "HELP")
     monkeypatch.setattr(system_prompt, "STEER_CHANNEL_NOTE", "STEER")
     monkeypatch.setattr(system_prompt, "get_hermes_home", lambda: Path("/hermes"))
+    monkeypatch.setattr(system_prompt, "get_default_hermes_root", lambda: Path("/hermes"))
 
     expected_profile = (
         "Active Hermes profile: default. Other profiles (if any) live "

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -41,9 +41,12 @@ def _captured_context_cwd(agent):
 
     def fake_context_files(
         cwd=None, skip_soul=False, context_length=None,
-        allow_install_tree_fallback=False, home_override=None,
+        allow_install_tree_fallback=False,
+        allow_cross_profile_context=False,
+        home_override=None,
     ):
         captured["cwd"] = cwd
+        captured["allow_cross_profile_context"] = allow_cross_profile_context
         return ""
 
     with (
@@ -53,6 +56,23 @@ def _captured_context_cwd(agent):
     ):
         build_system_prompt_parts(agent)
     return captured["cwd"]
+
+
+def _captured_cross_profile_context_flag(agent):
+    captured = {}
+
+    def fake_context_files(**kwargs):
+        captured.update(kwargs)
+        return ""
+
+    with (
+        patch("run_agent.load_soul_md", return_value=""),
+        patch("run_agent.build_nous_subscription_prompt", return_value=""),
+        patch("run_agent.build_environment_hints", return_value=""),
+        patch("run_agent.build_context_files_prompt", side_effect=fake_context_files),
+    ):
+        build_system_prompt_parts(agent)
+    return captured.get("allow_cross_profile_context", False)
 
 
 class TestContextFileCwd:
@@ -110,6 +130,12 @@ class TestContextFileCwd:
 
         assert "chosen workspace instructions" in context
 
+    def test_cross_profile_context_opt_in_is_cli_only(self):
+        assert _captured_cross_profile_context_flag(_make_agent(platform="cli")) is True
+        assert _captured_cross_profile_context_flag(_make_agent(platform="tui")) is True
+        assert _captured_cross_profile_context_flag(_make_agent(platform="desktop")) is False
+        assert _captured_cross_profile_context_flag(_make_agent(platform="telegram")) is False
+
 
 def _stable_prompt(agent):
     with (
@@ -127,6 +153,20 @@ def _prompt_parts(agent):
         patch("agent.prompt_builder.build_context_files_prompt", return_value=""),
     ):
         return build_system_prompt_parts(agent)
+
+
+def test_named_profile_hint_uses_current_and_default_homes(monkeypatch, tmp_path):
+    root = tmp_path / "hermes"
+    profile_home = root / "profiles" / "rebel-soul"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    with patch("agent.file_safety._resolve_active_profile_name", return_value="rebel-soul"):
+        stable = _stable_prompt(_make_agent())
+
+    assert f"This session reads and writes {profile_home}/." in stable
+    assert f"The default profile's data lives at {root}/skills/" in stable
+    assert str(profile_home / "profiles" / "rebel-soul") not in stable
 
 
 def _init_code_repo(path):
@@ -382,6 +422,7 @@ def test_coding_prompt_orders_shared_context_before_workspace(monkeypatch):
     monkeypatch.setattr(system_prompt, "HERMES_AGENT_HELP_GUIDANCE_NO_SKILLS", "HELP")
     monkeypatch.setattr(system_prompt, "STEER_CHANNEL_NOTE", "STEER")
     monkeypatch.setattr(system_prompt, "get_hermes_home", lambda: Path("/hermes"))
+    monkeypatch.setattr(system_prompt, "get_default_hermes_root", lambda: Path("/hermes"))
 
     # Production renders this as str(get_hermes_home()) + "/profiles/<name>/",
     # and str(Path("/hermes")) is platform-dependent (backslash on Windows) —


### PR DESCRIPTION
## What does this PR do?

Prevents a new Hermes Desktop chat from binding to the previous profile while an explicit profile switch is still opening its gateway.

The race was:

1. `selectProfile("rebel-soul")` starts an asynchronous gateway swap while the old profile is still live.
2. `Cmd+N` intentionally clears `$newChatProfile`.
3. `session.create` falls back to the still-live old `$activeGatewayProfile`, so the new session receives the old profile's `HERMES_HOME` and cwd.

The fix resolves the new-chat profile in this order: explicit per-profile target, pending gateway-swap target, then active gateway profile.

It also adds defense in depth around prompt identity:

- non-interactive surfaces skip project context files discovered under another named profile's home, including context-local profile overrides plus logical or symlink-resolved foreign paths;
- CLI/TUI keep an explicit opt-in because their cwd is directly user-selected;
- named-profile prompt hints now show the actual current profile home and the real default Hermes root instead of duplicating `/profiles/<name>`.

This is distinct from the adjacent stale-cwd fixes in #79453 and #61653. Those PRs address inherited/project cwd selection; this PR fixes the profile-target race and adds a core prompt-context boundary.

## Related Issue

Related to #79003, #79406, #54990, and #52589.

Complements #79453 and #61653; does not supersede their stale-cwd fixes.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-session-actions/index.ts`
  - preserve `$gatewaySwapTarget` as the new-chat target before falling back to `$activeGatewayProfile`;
  - add a regression test for `private-xiaomi → pending rebel-soul → Cmd+N → session.create`.
- `agent/prompt_builder.py`
  - classify cwd paths under another named profile;
  - skip their `.hermes.md` / `AGENTS.md` / `CLAUDE.md` / cursor context by default;
  - retain an explicit cross-profile context opt-in.
- `agent/system_prompt.py`
  - allow the opt-in only for CLI/TUI interactive cwd surfaces;
  - render current/default profile paths from their correct roots.
- Add behavior tests for the guard, opt-in policy, and profile-path marker.

## How to Test

1. Run the Desktop regression and full check:

   ```bash
   cd apps/desktop
   npm run test:ui -- src/app/session/hooks/use-session-actions.test.tsx
   npm run check
   ```

2. Run the affected Python tests:

   ```bash
   scripts/run_tests.sh \
     tests/agent/test_prompt_builder.py \
     tests/agent/test_system_prompt.py \
     tests/tools/test_cross_profile_guard.py
   ```

3. Run formatting, lint, and cross-platform checks:

   ```bash
   uvx ruff check agent/prompt_builder.py agent/system_prompt.py \
     tests/agent/test_prompt_builder.py tests/agent/test_system_prompt.py
   python scripts/check-windows-footguns.py
   ```

Observed locally:

- Desktop focused regression: 42 passed.
- Desktop full `npm run check`: passed, including Linux packaging.
- Affected Python union: 95 passed.
- Full Python wrapper: 19 failures in 4 unrelated files; the exact same 19 failure IDs reproduce on a clean worktree at the base SHA. No new Python failures were introduced.
- TypeScript typecheck, ESLint, Prettier, Ruff, and `git diff --check`: passed.
- CI-equivalent Windows footgun scan (`python scripts/check-windows-footguns.py --all`): passed across 936 production Python files.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run the full Python suite with zero failures (see baseline-identical failures documented above)
- [x] I've added tests for my changes
- [x] I've tested on Ubuntu 24.04, Linux 7.0.0-28-generic x86_64

### Documentation & Housekeeping

- [x] Relevant documentation/docstrings updated, or N/A
- [x] `cli-config.yaml.example` update: N/A, no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update: N/A, no workflow changed
- [x] Cross-platform impact considered
- [x] Tool descriptions/schemas update: N/A, no tool schema changed

## Screenshots / Logs

The regression is state/routing based and covered by executable tests; no UI screenshot is required.
