### PR TITLE
fix(hermes_cli): keep same-URL custom providers on their selected credentials

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4165,10 +4165,11 @@ def _save_custom_provider(
             elif "api_mode" in entry:
                 entry.pop("api_mode", None)
                 changed = True
-            if key_env and (entry.get("key_env") != key_env or entry.get("api_key")):
-                entry["key_env"] = key_env
-                entry.pop("api_key", None)
-                changed = True
+            if key_env:
+                if entry.get("key_env") != key_env or entry.get("api_key"):
+                    entry["key_env"] = key_env
+                    entry.pop("api_key", None)
+                    changed = True
             elif api_key and (entry.get("api_key") != api_key or entry.get("key_env")):
                 entry["api_key"] = api_key
                 entry.pop("key_env", None)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4116,9 +4116,9 @@ def _save_custom_provider(
 ):
     """Save a custom endpoint to custom_providers in config.yaml.
 
-    Deduplicates by base_url — if the URL already exists, updates the
-    model name, context_length, and api_mode but doesn't add a duplicate entry.
-    Uses *name* when provided, otherwise auto-generates from the URL.
+    An explicit *name* is the provider identity, so different names may share
+    one endpoint. Callers without a name retain legacy base-URL deduplication.
+    Existing entries are updated in place, including supplied credentials.
 
     When *key_env* is set the caller has already written the key to ``.env``,
     so the entry references it instead of inlining the secret (#69449).
@@ -4130,12 +4130,24 @@ def _save_custom_provider(
     if not isinstance(providers, list):
         providers = []
 
-    # Check if this URL is already saved — update model/context_length if so
+    explicit_name = str(name or "").strip()
+    normalized_name = explicit_name.lower().replace(" ", "-")
+    normalized_url = str(base_url or "").rstrip("/")
+
+    # Explicit identities deduplicate by name. Legacy unnamed callers have no
+    # identity to disambiguate with, so they continue to deduplicate by URL.
     for entry in providers:
-        if isinstance(entry, dict) and entry.get("base_url", "").rstrip(
-            "/"
-        ) == base_url.rstrip("/"):
+        if not isinstance(entry, dict):
+            continue
+        entry_name = str(entry.get("name", "") or "").strip().lower().replace(" ", "-")
+        entry_url = str(entry.get("base_url", "") or "").rstrip("/")
+        if (explicit_name and entry_name == normalized_name) or (
+            not explicit_name and entry_url == normalized_url
+        ):
             changed = False
+            if explicit_name and entry_url != normalized_url:
+                entry["base_url"] = base_url
+                changed = True
             if model and entry.get("model") != model:
                 entry["model"] = model
                 changed = True
@@ -4157,12 +4169,17 @@ def _save_custom_provider(
                 entry["key_env"] = key_env
                 entry.pop("api_key", None)
                 changed = True
+            elif api_key and (entry.get("api_key") != api_key or entry.get("key_env")):
+                entry["api_key"] = api_key
+                entry.pop("key_env", None)
+                changed = True
             if changed:
                 cfg["custom_providers"] = providers
                 save_config(cfg)
-            return  # already saved, updated if needed
+            return
 
     # Use provided name or auto-generate from URL
+    name = explicit_name
     if not name:
         name = _auto_provider_name(base_url)
 

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -1689,7 +1689,14 @@ def _model_flow_named_custom(config, provider_info):
                 save_config(cfg)
     else:
         # Save model name to the custom_providers entry for next time
-        _save_custom_provider(base_url, config_api_key, model_name, api_mode=api_mode)
+        _save_custom_provider(
+            base_url,
+            config_api_key,
+            model_name,
+            name=name,
+            api_mode=api_mode,
+            key_env=key_env,
+        )
 
     print(f"\n✅ Model set to: {model_name}")
     print(f"   Provider: {name} ({base_url})")

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -737,6 +737,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                 if base_url:
                     result = {
                         "name": entry.get("name", ep_name),
+                        "provider_key": str(ep_name),
                         "base_url": base_url.strip(),
                         "api_key": resolved_api_key,
                         "model": entry.get("default_model", ""),
@@ -962,77 +963,71 @@ def canonical_custom_identity(
 
     Any code path that persists or restores a session's provider override
     must run the resolved provider through this helper so a bare ``"custom"``
-    is upgraded back to its durable ``custom:<name>`` menu key. Three
+    is upgraded back to its durable ``custom:<name>`` menu key. Four
     recovery sources, in priority order:
 
-    1. ``base_url`` — reverse-lookup the entry that owns the endpoint URL
+    1. An explicitly passed, configured ``config_provider`` identity. Unlike
+       endpoint/model reverse lookup, this remains unambiguous when entries
+       intentionally share a URL or model.
+    2. ``base_url`` — reverse-lookup the entry that owns the endpoint URL
        (the one fact that always survives the persistence round-trip when a
        URL was recorded).
-    2. ``model`` — reverse-lookup the entry that serves the session's model
+    3. ``model`` — reverse-lookup the entry that serves the session's model
        (``model``/``default_model``/``models`` catalog). The session row
        always stores the model name, so when no base_url survived (the
        recurring Desktop/TUI regression vector) the model is the last
        session-scoped fact that can recover the entry — and unlike the
        config fallback below it stays correct after the user points their
        global default at a different provider.
-    3. ``config_provider`` — the active ``config.model.provider`` (or its
-       ``provider``/``HERMES_INFERENCE_PROVIDER`` equivalent). When neither
-       a base_url nor a model recovered the entry, the configured provider
-       is the only durable identity left, so fall back to it when it names
-       a real entry.
+    4. The active ``config.model.provider`` (or
+       ``HERMES_INFERENCE_PROVIDER`` equivalent). When no session-scoped
+       source recovered the entry, the configured provider is the only
+       durable identity left, so fall back to it when it names a real entry.
 
     Returns ``custom:<name>`` when a routable identity is recovered, else
     ``None`` (caller keeps whatever it had — bare ``"custom"`` only as a last
     resort, e.g. a genuine ad-hoc endpoint with no config entry).
     """
-    # 1. Reverse-lookup by endpoint URL.
+    def _configured_identity(candidate: Optional[str]) -> Optional[str]:
+        candidate_norm = _normalize_custom_provider_name(str(candidate or ""))
+        if not candidate_norm or candidate_norm in {"custom", "auto", "openrouter"}:
+            return None
+        try:
+            entry = _get_named_custom_provider(str(candidate or ""))
+        except Exception:
+            return None
+        if entry is None:
+            return None
+        return custom_provider_slug(
+            str(entry.get("name") or candidate),
+            str(entry.get("provider_key", "") or ""),
+        )
+
+    # 1. Prefer an explicit configured identity before ambiguous reverse lookup.
+    identity = _configured_identity(config_provider)
+    if identity:
+        return identity
+
+    # 2. Reverse-lookup by endpoint URL.
     if base_url:
         identity = find_custom_provider_identity(base_url)
         if identity:
             return identity
 
-    # 2. Reverse-lookup by the session's model name.
+    # 3. Reverse-lookup by the session's model name.
     if model:
         identity = find_custom_provider_identity_by_model(model)
         if identity:
             return identity
 
-    # 3. Fall back to the configured provider when it names a real entry.
-    candidate = str(config_provider or "").strip()
-    if not candidate:
-        try:
-            candidate = str(_get_model_config().get("provider") or "").strip()
-        except Exception:
-            candidate = ""
+    # 4. Fall back to the global configured provider when it names a real entry.
+    try:
+        candidate = str(_get_model_config().get("provider") or "").strip()
+    except Exception:
+        candidate = ""
     if not candidate:
         candidate = os.environ.get("HERMES_INFERENCE_PROVIDER", "").strip()
-
-    candidate_norm = _normalize_custom_provider_name(candidate)
-    # A bare/non-routable candidate cannot heal a bare custom override.
-    if not candidate_norm or candidate_norm in {"custom", "auto", "openrouter"}:
-        return None
-    # Only return it when it actually resolves to a configured custom entry,
-    # so we never invent a `custom:<x>` that resolution can't honor.
-    try:
-        entry = _get_named_custom_provider(candidate)
-        if entry is not None:
-            # ``candidate`` matched, but it may be the entry's DISPLAY NAME —
-            # ``_get_named_custom_provider`` accepts either spelling. For a
-            # keyed ``providers:`` entry the display name is not the durable
-            # identity, so re-resolve through the endpoint the matched entry
-            # owns and return the same config-key slug every other path
-            # returns (7b5a18817). Without this, a display name that differs
-            # from its key heals to ``custom:<display-name>`` and stops
-            # matching the persisted identity.
-            identity = find_custom_provider_identity(str(entry.get("base_url") or ""))
-            if identity:
-                return identity
-            if candidate_norm.startswith("custom:"):
-                return candidate_norm
-            return f"custom:{candidate_norm}"
-    except Exception:
-        pass
-    return None
+    return _configured_identity(candidate)
 
 
 def _normalize_base_url_for_match(value) -> str:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6713,7 +6713,8 @@ def _apply_model_assignment_sync(
         # (_save_custom_provider). Without this the endpoint only lives in
         # ``model.*`` and the picker has no proper ready row for it — the
         # GUI then surfaces a "needs setup" dead-end on the bare ``custom``
-        # provider. Dedups by base_url, so re-saving is idempotent.
+        # provider. The generated name makes re-saving idempotent while still
+        # allowing separately named entries to share an endpoint.
         if provider.strip().lower() in {"custom", "local"} and base_url:
             try:
                 from hermes_cli.main import _auto_provider_name, _save_custom_provider

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -575,6 +575,75 @@ def test_save_custom_provider_references_the_key_instead_of_inlining_it(monkeypa
     assert "sk-secret" not in yaml.safe_dump(saved)
 
 
+def test_save_custom_provider_allows_explicit_names_to_share_a_url(monkeypatch):
+    from hermes_cli.main import _save_custom_provider
+
+    config = {
+        "custom_providers": [
+            {"name": "relay-a", "base_url": "https://relay.example/v1", "api_key": "KEY_A"}
+        ]
+    }
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+    monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
+
+    _save_custom_provider(
+        "https://relay.example/v1",
+        api_key="KEY_B",
+        name="relay-b",
+    )
+
+    assert [(entry["name"], entry["api_key"]) for entry in config["custom_providers"]] == [
+        ("relay-a", "KEY_A"),
+        ("relay-b", "KEY_B"),
+    ]
+
+
+def test_save_custom_provider_updates_only_the_explicit_named_entry(monkeypatch):
+    from hermes_cli.main import _save_custom_provider
+
+    config = {
+        "custom_providers": [
+            {"name": "relay-a", "base_url": "https://relay.example/v1", "api_key": "KEY_A"},
+            {"name": "relay-b", "base_url": "https://relay.example/v1", "api_key": "OLD_B"},
+        ]
+    }
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+    monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
+
+    _save_custom_provider(
+        "https://new-relay.example/v1",
+        api_key="KEY_B",
+        name="Relay B",
+    )
+    _save_custom_provider(
+        "https://new-relay.example/v1",
+        name="relay-b",
+        key_env="RELAY_B_API_KEY",
+    )
+    assert config["custom_providers"][1] == {
+        "name": "relay-b",
+        "base_url": "https://new-relay.example/v1",
+        "key_env": "RELAY_B_API_KEY",
+    }
+    _save_custom_provider(
+        "https://new-relay.example/v1",
+        api_key="NEW_KEY_B",
+        name="relay-b",
+    )
+
+    relay_a, relay_b = config["custom_providers"]
+    assert relay_a == {
+        "name": "relay-a",
+        "base_url": "https://relay.example/v1",
+        "api_key": "KEY_A",
+    }
+    assert relay_b == {
+        "name": "relay-b",
+        "base_url": "https://new-relay.example/v1",
+        "api_key": "NEW_KEY_B",
+    }
+
+
 
 
 def test_custom_endpoint_key_env_is_a_valid_posix_name_for_ip_endpoints():

--- a/tests/hermes_cli/test_canonical_custom_identity.py
+++ b/tests/hermes_cli/test_canonical_custom_identity.py
@@ -98,3 +98,35 @@ def test_legacy_unkeyed_entry_keeps_its_name_identity(monkeypatch):
     monkeypatch.setattr(rp, "_get_model_config", lambda: {})
 
     assert rp.canonical_custom_identity(config_provider="Legacy Endpoint") == "custom:legacy-endpoint"
+
+
+def test_explicit_identity_wins_when_url_and_model_are_ambiguous(monkeypatch):
+    config = {
+        "custom_providers": [
+            {
+                "name": "relay-a",
+                "base_url": BASE_URL,
+                "api_key": "KEY_A",
+                "model": MODEL,
+            },
+            {
+                "name": "relay-b",
+                "base_url": BASE_URL,
+                "api_key": "KEY_B",
+                "model": MODEL,
+            },
+        ]
+    }
+    monkeypatch.setattr(rp, "load_config", lambda *a, **k: config)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda *a, **k: config)
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+
+    identity = rp.canonical_custom_identity(
+        config_provider="custom:relay-b",
+        base_url=BASE_URL,
+        model=MODEL,
+    )
+
+    assert identity == "custom:relay-b"
+    assert rp._get_named_custom_provider(identity)["api_key"] == "KEY_B"
+    assert rp.canonical_custom_identity(base_url=BASE_URL) == "custom:relay-a"

--- a/tests/hermes_cli/test_custom_provider_model_switch.py
+++ b/tests/hermes_cli/test_custom_provider_model_switch.py
@@ -197,6 +197,57 @@ class TestCustomProviderModelSwitch:
         assert config["custom_providers"][0]["key_env"] == "EXAMPLE_PROVIDER_API_KEY"
         assert "sk-live-example-provider" not in config_path.read_text()
 
+    def test_same_url_picker_updates_only_selected_named_provider(
+        self, config_home, monkeypatch
+    ):
+        """A named picker selection must not mutate a same-URL sibling."""
+        import yaml
+        from hermes_cli.main import _model_flow_named_custom
+
+        config_path = config_home / "config.yaml"
+        config_path.write_text(
+            "model:\n"
+            "  default: old-model\n"
+            "custom_providers:\n"
+            "- name: relay-a\n"
+            "  base_url: https://relay.example/v1\n"
+            "  api_key: KEY_A\n"
+            "  model: model-a\n"
+            "- name: relay-b\n"
+            "  base_url: https://relay.example/v1\n"
+            "  key_env: RELAY_B_API_KEY\n"
+            "  model: model-b\n"
+        )
+        monkeypatch.setenv("RELAY_B_API_KEY", "KEY_B")
+        provider_info = {
+            "name": "relay-b",
+            "base_url": "https://relay.example/v1",
+            "api_key": "",
+            "key_env": "RELAY_B_API_KEY",
+            "model": "model-b",
+        }
+
+        with patch("hermes_cli.models.fetch_api_models", return_value=["model-b-new"]), \
+             patch("hermes_cli.curses_ui.curses_radiolist", side_effect=ImportError), \
+             patch("builtins.input", return_value="1"), \
+             patch("builtins.print"):
+            _model_flow_named_custom({}, provider_info)
+
+        config = yaml.safe_load(config_path.read_text()) or {}
+        relay_a, relay_b = config["custom_providers"]
+        assert relay_a == {
+            "name": "relay-a",
+            "base_url": "https://relay.example/v1",
+            "api_key": "KEY_A",
+            "model": "model-a",
+        }
+        assert relay_b == {
+            "name": "relay-b",
+            "base_url": "https://relay.example/v1",
+            "key_env": "RELAY_B_API_KEY",
+            "model": "model-b-new",
+        }
+
     def test_env_ref_base_url_preserves_api_key_ref_through_picker(
         self, config_home, monkeypatch
     ):


### PR DESCRIPTION
## What does this PR do?

Custom providers with different names can now share one endpoint without being merged or recovering under the wrong credential. This prevents a selected provider from silently sending requests under a sibling provider's API key after model selection or session recovery.

### Symptom

Saving a second explicitly named custom provider at an existing `base_url` omitted the new entry and ignored its credential. Even after manually adding both entries, recovery could choose the first same-URL provider instead of the explicitly selected identity.

### Impact

Users who route multiple accounts or relay channels through one endpoint can unknowingly send requests with the wrong account's credential. The affected request then uses the wrong account's quota and permissions even though Hermes displays or persists the intended provider name.

### Bug Cause

**Trigger:** `hermes_cli/main.py::_save_custom_provider` and `hermes_cli/runtime_provider.py::canonical_custom_identity`

**Causal chain:**
1. A user saves or selects two explicitly named custom providers that share one normalized endpoint URL but use different credentials.
2. The save path treats the URL as the unique identity, while recovery performs ambiguous URL/model reverse lookup before honoring the configured provider name.
3. Hermes either drops the second provider or resolves the first same-URL entry and sends requests with its credential.

**Why it is wrong:** An endpoint URL is not a unique provider identity when multiple named accounts or relay channels intentionally share that endpoint. The explicit configured name is the only unambiguous routing identity in that case.

**Working sibling / contrast:** Distinct-URL providers are unambiguous, and callers without an explicit configured identity still retain the legacy URL-first and model/config fallback behavior.

**Ruled out:** Credential environment lookup was not failing. The wrong provider entry was selected before `key_env` or inline `api_key` resolution occurred.

### Fix

Explicit names now control custom-provider deduplication, and same-name updates refresh the supplied inline or environment credential without changing a sibling entry. Recovery validates and prefers an explicit configured identity before ambiguous URL/model lookup, and named picker/dashboard call sites preserve the selected identity when saving.

## Related Issue

Fixes #81789

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py` - deduplicate explicit custom providers by name and update credentials in place.
- `hermes_cli/runtime_provider.py` - prefer valid explicit identities and preserve keyed provider identities during recovery.
- `hermes_cli/model_setup_flows.py` and `hermes_cli/web_server.py` - pass stable names and credential references through custom-provider save paths.
- `tests/cli/test_cli_provider_resolution.py` - cover same-URL save/update behavior and credential transitions.
- `tests/hermes_cli/test_canonical_custom_identity.py` - cover explicit identity precedence and fallback behavior.
- `tests/hermes_cli/test_custom_provider_model_switch.py` - cover named picker persistence for sibling credentials.

## How to Test

1. Configure two named custom providers with the same `base_url` and different credentials.
2. Save or select each provider, restart or recover the session, and confirm each identity resolves its own credential.
3. Run the targeted regression suites:

```bash
scripts/run_tests.sh tests/cli/test_cli_provider_resolution.py tests/hermes_cli/test_canonical_custom_identity.py tests/hermes_cli/test_custom_provider_model_switch.py
```

Result: 34 tests passed. Additional provider, session persistence, and focused TUI validation also passed, and the original same-URL scenarios passed in the real Windows environment.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant suites and all targeted tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] I've updated relevant documentation - N/A; behavior is covered by existing config documentation and regression tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; no model tool schema changed

## Screenshots / Logs

N/A - this is a headless configuration and runtime routing fix.
