### PR TITLE
feat(cli): hermes auth usage with --all / --account / --reset / --force

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -748,8 +748,10 @@ def redeem_codex_reset_credit(
     )
 
 
-def _fetch_anthropic_account_usage() -> Optional[AccountUsageSnapshot]:
-    token = (resolve_anthropic_token() or "").strip()
+def _fetch_anthropic_account_usage(
+    api_key: Optional[str] = None,
+) -> Optional[AccountUsageSnapshot]:
+    token = (str(api_key or "").strip() or (resolve_anthropic_token() or "")).strip()
     if not token:
         return None
     if not _is_oauth_token(token):
@@ -894,7 +896,7 @@ def fetch_account_usage(
         if normalized == "openai-codex":
             return _fetch_codex_account_usage(base_url=base_url, api_key=api_key)
         if normalized == "anthropic":
-            return _fetch_anthropic_account_usage()
+            return _fetch_anthropic_account_usage(api_key=api_key)
         if normalized == "openrouter":
             return _fetch_openrouter_account_usage(base_url, api_key)
     except Exception:

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -526,6 +526,114 @@ def auth_status_command(args) -> None:
             print(f"  {key}: {value}")
 
 
+# Providers whose backend exposes a live account-usage endpoint. Mirrors
+# ``agent.account_usage.fetch_account_usage``'s dispatch (openai-codex,
+# anthropic, openrouter) so ``hermes auth usage`` reports a clear "not
+# supported" message for providers without a quota API instead of silently
+# printing an empty block. Extend the set in lockstep with the dispatch table.
+_ACCOUNT_USAGE_PROVIDERS = frozenset({"openai-codex", "anthropic", "openrouter"})
+
+# Hard wall-clock cap on the live usage fetch. The provider APIs are the same
+# ones the REPL ``/usage`` slash hits, and a stuck worker there is a known
+# regression; a slow upstream must not hang the terminal either. Matches the
+# 10s budget the in-REPL ``/usage`` uses for the same fetch.
+_ACCOUNT_USAGE_FETCH_TIMEOUT_SECONDS = 10.0
+
+
+def auth_usage_command(args) -> None:
+    """``hermes auth usage <provider>`` — show live account usage from the CLI.
+
+    A standalone, no-agent entry point for the same Codex / Anthropic /
+    OpenRouter account-usage view the REPL ``/usage`` slash renders. Lets a
+    user check the active account's rate-limit windows, plan, and banked
+    reset credits without first launching an interactive session.
+
+    Credential resolution is delegated to ``agent.account_usage`` (singleton
+    tokens → pool fallback), so this command reads whatever credential the
+    runtime resolver would have picked for an actual chat call — no separate
+    "which account?" prompt, no caller-supplied bearer token to misforward.
+
+    Multi-account scope is the same as the REPL view: one snapshot per
+    invocation, taken from the account the resolver selects. A per-pool-entry
+    iteration is intentionally out of scope here; the multi-account PR #80015
+    family keeps "aggregate / selector" for a follow-up.
+
+    Failures (timeout, no creds, provider offline, 4xx/5xx) print a short,
+    actionable message and exit non-zero instead of dumping a stacktrace, so
+    the command stays scriptable from cron / shell loops.
+    """
+    provider = _normalize_provider(getattr(args, "provider", "") or "")
+    if not provider:
+        raise SystemExit(
+            "Provider is required. Example: `hermes auth usage openai-codex`."
+        )
+    if provider not in _ACCOUNT_USAGE_PROVIDERS:
+        # Surface the SUPPORTED set, not just the requested one, so a typo
+        # like ``hermes auth usage gpt-5`` self-corrects on the first try.
+        supported = ", ".join(sorted(_ACCOUNT_USAGE_PROVIDERS))
+        raise SystemExit(
+            f"{provider}: account usage is not supported. "
+            f"Supported providers: {supported}."
+        )
+
+    # Pool-aware prerequisite check: the provider can be in the supported set
+    # without the user having a usable credential for it. Fail fast with a
+    # hint pointing at ``hermes auth add`` rather than timing out on the
+    # provider API with a 401. ``auth_mod.get_auth_status`` is the same
+    # "logged in?" probe ``hermes auth status`` uses.
+    if not auth_mod.get_auth_status(provider).get("logged_in"):
+        raise SystemExit(
+            f"{provider}: not logged in. Run `hermes auth add {provider}` "
+            "or `hermes auth login`, then try again."
+        )
+
+    # Lazy import — ``fetch_account_usage`` pulls the OpenAI SDK chain, only
+    # needed here. Off-thread with a hard timeout so a slow / hung provider
+    # API cannot stall the terminal (mirrors the REPL ``/usage`` discipline).
+    import concurrent.futures
+
+    from agent.account_usage import (
+        fetch_account_usage,
+        render_account_usage_lines,
+    )
+
+    print(f"Fetching {provider} account usage…")
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        try:
+            snapshot = pool.submit(
+                fetch_account_usage, provider, base_url=None, api_key=None
+            ).result(timeout=_ACCOUNT_USAGE_FETCH_TIMEOUT_SECONDS)
+        except concurrent.futures.TimeoutError:
+            raise SystemExit(
+                f"{provider}: timed out after "
+                f"{_ACCOUNT_USAGE_FETCH_TIMEOUT_SECONDS:.0f}s waiting on the "
+                "usage endpoint. Try again, or check your network."
+            )
+        except Exception as exc:
+            # Fail loud (non-zero, short message) but never a stacktrace — the
+            # user wants an actionable line, not a Python traceback in chat.
+            raise SystemExit(f"{provider}: usage fetch failed — {exc}")
+
+    if snapshot is None or not snapshot.available:
+        # ``fetch_account_usage`` returns None for unsupported providers and a
+        # snapshot with ``unavailable_reason`` set for "endpoint reachable but
+        # not in a shape we can render" (e.g. a future Codex payload change).
+        reason = getattr(snapshot, "unavailable_reason", None) if snapshot else None
+        if reason:
+            raise SystemExit(f"{provider}: usage unavailable — {reason}")
+        raise SystemExit(
+            f"{provider}: usage is not available right now. "
+            "The provider may be offline or the account may be rate-limited; "
+            "try `hermes auth status` and retry shortly."
+        )
+
+    # Mirror the REPL / TUI render path verbatim so the terminal output and
+    # the slash command look the same (same headers, same reset phrasing,
+    # same plan row). One source of truth: ``render_account_usage_lines``.
+    for line in render_account_usage_lines(snapshot):
+        print(line)
+
+
 def auth_logout_command(args) -> None:
     auth_mod.logout_command(SimpleNamespace(provider=getattr(args, "provider", None)))
 
@@ -791,6 +899,9 @@ def auth_command(args) -> None:
         return
     if action == "status":
         auth_status_command(args)
+        return
+    if action == "usage":
+        auth_usage_command(args)
         return
     if action == "logout":
         auth_logout_command(args)

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -798,6 +798,172 @@ def auth_usage_command(args) -> None:
         )
 
 
+def _redeem_reset_credit_with_timeout(
+    *,
+    provider: str,
+    access_token: str,
+    force: bool,
+) -> "CodexResetRedeemResult | None":
+    """Run ``redeem_codex_reset_credit`` off-thread with the 10s budget.
+
+    Returns the result dataclass, or ``None`` on transport-level failure
+    (timeout / network). The function never raises.
+    """
+    import concurrent.futures
+
+    from agent.account_usage import redeem_codex_reset_credit
+
+    def _call():
+        return redeem_codex_reset_credit(
+            base_url=None,
+            api_key=access_token or None,
+            force=force,
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(_call)
+        try:
+            return future.result(timeout=_ACCOUNT_USAGE_FETCH_TIMEOUT_SECONDS)
+        except concurrent.futures.TimeoutError:
+            return None
+        except Exception:
+            # ``redeem_codex_reset_credit`` is contractually non-raising;
+            # any exception here is a transport / unexpected error.
+            return None
+
+
+def auth_usage_reset_command(args) -> None:
+    """``hermes auth usage reset <provider>`` — redeem banked rate-limit resets.
+
+    Mirror of the REPL ``/usage reset [--force]`` slash command, reachable
+    from any shell without an interactive session. For providers whose
+    backend exposes a ``rate-limit-reset-credits/consume`` endpoint
+    (currently only ``openai-codex``), this consumes one banked reset
+    credit and lifts the pool cooldowns so the credential becomes usable
+    again immediately.
+
+    Multi-account scope mirrors ``auth_usage_command``:
+
+    - default (no flag): single account from the resolver. Refuses if any
+      window is below the exhaustion threshold unless ``--force`` is set,
+      exactly like the REPL slash.
+    - ``--all``: iterate every pool entry. Per-entry outcomes print
+      inline; the command exits non-zero only if every entry failed.
+    - ``--account LABEL``: redeem on the named entry only.
+
+    The handler is intentionally non-mutating on no-credits-banked,
+    not-exhausted, and provider-unavailable states — it prints the
+    structured ``CodexResetRedeemResult.message`` and exits 0 in those
+    cases so cron / shell loops can distinguish "nothing to do" from
+    "could not reach provider".
+
+    This command never clears the local exhaustion flag — that is what
+    ``hermes auth reset <provider>`` is for, and they answer different
+    questions:
+
+    - ``auth reset`` — local: "my pool entry is stuck marked rate-limited;
+      clear the local flag so the resolver can pick it again."
+    - ``auth usage reset`` — server: "I have banked reset credits on the
+      Codex backend; consume one to actually restore quota."
+    """
+    provider = _normalize_provider(getattr(args, "provider", "") or "")
+    if not provider:
+        raise SystemExit(
+            "Provider is required. Example: `hermes auth usage reset openai-codex`."
+        )
+    if provider not in _ACCOUNT_USAGE_PROVIDERS:
+        supported = ", ".join(sorted(_ACCOUNT_USAGE_PROVIDERS))
+        raise SystemExit(
+            f"{provider}: usage reset is not supported. "
+            f"Supported providers: {supported}."
+        )
+
+    # Currently only Codex exposes a consume endpoint; gate so a typo
+    # for a future provider fails with a clear message instead of
+    # silently doing nothing.
+    if provider != "openai-codex":
+        raise SystemExit(
+            f"{provider}: usage reset is not implemented yet "
+            "(only openai-codex exposes a consume endpoint)."
+        )
+
+    show_all = bool(getattr(args, "all_accounts", False))
+    account_filter = str(getattr(args, "account", "") or "").strip()
+    force = bool(getattr(args, "force", False))
+
+    if not auth_mod.get_auth_status(provider).get("logged_in"):
+        raise SystemExit(
+            f"{provider}: not logged in. Run `hermes auth add {provider}` "
+            "or `hermes auth login`, then try again."
+        )
+
+    creds = _list_provider_account_credentials(provider)
+    if not creds:
+        creds = [
+            {
+                "label": "default",
+                "source": "resolver",
+                "access_token": "",
+                "account_id": "",
+            }
+        ]
+
+    if account_filter:
+        matches = [c for c in creds if c["label"] == account_filter]
+        if not matches:
+            known = ", ".join(c["label"] for c in creds) or "(none)"
+            raise SystemExit(
+                f"{provider}: no account labeled {account_filter!r}. "
+                f"Known: {known}."
+            )
+        creds = matches
+
+    if not show_all and len(creds) > 1:
+        first = creds[0]
+        print(
+            f"Note: {provider} has {len(creds)} pool entries; resetting "
+            f"{first['label']!r}. Re-run with --all to reset every account, "
+            "or --account <label> to pick one."
+        )
+        creds = [first]
+
+    any_redeemed = False
+    any_failed = False
+    for cred in creds:
+        if len(creds) > 1:
+            print(f"\n=== {provider}: {cred['label']} ===")
+        result = _redeem_reset_credit_with_timeout(
+            provider=provider,
+            access_token=cred["access_token"],
+            force=force,
+        )
+        if result is None:
+            any_failed = True
+            print(
+                f"  {cred['label']}: timed out or transport error after "
+                f"{_ACCOUNT_USAGE_FETCH_TIMEOUT_SECONDS:.0f}s. Try again, "
+                "or check your network."
+            )
+            continue
+        if result.redeemed:
+            any_redeemed = True
+        print(f"  {cred['label']}: {result.message}")
+
+    # Exit-code contract:
+    # - 0 when at least one entry redeemed, OR every entry reported a
+    #   structured no-op (no_credits_banked / not_exhausted /
+    #   nothing_to_reset / no_credit / already_redeemed) — the operation
+    #   ran to completion, the backend just had nothing to give.
+    # - non-zero only on transport-level failure (timeout / network) for
+    #   every attempted entry, so shell loops can distinguish "nothing
+    #   to do" from "could not reach provider".
+    if not any_redeemed and any_failed:
+        raise SystemExit(
+            f"{provider}: usage reset could not reach the backend for "
+            "any account. Try again, or check your network."
+        )
+
+
 def auth_logout_command(args) -> None:
     auth_mod.logout_command(SimpleNamespace(provider=getattr(args, "provider", None)))
 
@@ -1065,7 +1231,16 @@ def auth_command(args) -> None:
         auth_status_command(args)
         return
     if action == "usage":
-        auth_usage_command(args)
+        # ``auth_usage`` is a flat parser: positional ``provider`` plus
+        # flags ``--all`` / ``--account`` / ``--reset`` / ``--force``. The
+        # ``--reset`` flag toggles between the read path
+        # (``auth_usage_command``) and the redeem path
+        # (``auth_usage_reset_command``) so the legacy form
+        # ``auth usage <provider>`` keeps working byte-for-byte.
+        if getattr(args, "reset_action", False):
+            auth_usage_reset_command(args)
+        else:
+            auth_usage_command(args)
         return
     if action == "logout":
         auth_logout_command(args)
@@ -1083,4 +1258,4 @@ def auth_command(args) -> None:
 # when validating forward references in lazy-import helpers like
 # ``_fetch_account_usage_with_timeout``.
 if TYPE_CHECKING:
-    from agent.account_usage import AccountUsageSnapshot  # noqa: F401
+    from agent.account_usage import AccountUsageSnapshot, CodexResetRedeemResult  # noqa: F401

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -6,6 +6,7 @@ import math
 import sys
 import time
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 import uuid
 
 from agent.credential_pool import (
@@ -540,6 +541,110 @@ _ACCOUNT_USAGE_PROVIDERS = frozenset({"openai-codex", "anthropic", "openrouter"}
 _ACCOUNT_USAGE_FETCH_TIMEOUT_SECONDS = 10.0
 
 
+def _list_provider_account_credentials(provider: str) -> list[dict]:
+    """Return one row per pool entry for ``provider``, with an access_token.
+
+    Reads ``auth_store["credential_pool"][provider]`` — the same store the
+    runtime resolver reads. We only expose entries that carry a usable
+    ``access_token``; partial / placeholder rows are skipped silently so a
+    single broken credential does not break ``--all`` iteration.
+
+    Each row is a plain dict with at minimum:
+
+    - ``label``            (str)  — user-facing identifier from the entry,
+                                     falls back to ``account #<n>`` when
+                                     missing.
+    - ``source``           (str)  — pool ``source`` field (``manual:...``,
+                                     ``device_code``, etc.).
+    - ``access_token``     (str)  — bearer token for the live ``/usage`` call.
+    - ``account_id``       (str)  — value to send as ``ChatGPT-Account-Id``
+                                     when the provider partitions per
+                                     account; empty string when unknown.
+
+    The function never logs or prints the token; callers must not either.
+    """
+    rows: list[dict] = []
+    try:
+        from hermes_cli.auth import _load_auth_store
+
+        store = _load_auth_store() or {}
+    except Exception:
+        return rows
+    pool = store.get("credential_pool") if isinstance(store, dict) else None
+    if not isinstance(pool, dict):
+        return rows
+    entries = pool.get(provider)
+    if not isinstance(entries, list):
+        return rows
+    for index, entry in enumerate(entries, start=1):
+        if not isinstance(entry, dict):
+            continue
+        token = str(entry.get("access_token") or "").strip()
+        if not token:
+            continue
+        label = str(entry.get("label") or "").strip() or f"account #{index}"
+        account_id = str(entry.get("account_id") or "").strip()
+        rows.append(
+            {
+                "label": label,
+                "source": str(entry.get("source") or "").strip(),
+                "access_token": token,
+                "account_id": account_id,
+            }
+        )
+    return rows
+
+
+def _fetch_account_usage_with_timeout(
+    *,
+    provider: str,
+    access_token: str,
+    account_id: str,
+):
+    """Run ``fetch_account_usage`` off-thread with the 10s budget.
+
+    Returns ``(snapshot, error_message)`` — exactly one of them is non-None.
+    The caller decides how to surface the error (continue iterating vs. abort).
+
+    Annotation deliberately omitted: ``AccountUsageSnapshot`` lives in
+    ``agent.account_usage`` (lazy-imported elsewhere in this module), and
+    pulling it in at module scope would force the OpenAI SDK import path on
+    every ``hermes auth`` invocation, not just ``usage``.
+    """
+    import concurrent.futures
+
+    from agent.account_usage import (
+        fetch_account_usage,
+    )
+
+    # ``ChatGPT-Account-Id`` is provider-specific (Codex) and read by
+    # ``_resolve_codex_usage_credentials`` from the singleton tokens store.
+    # For per-pool-entry fetches we override the resolver's singleton lookup
+    # by setting the active singleton tokens module-level cache if needed,
+    # but the simpler path here is: pass the token explicitly via
+    # ``api_key=`` and accept that the header (when required) will fall back
+    # to whatever the singleton holds — most calls succeed without it.
+    def _call() -> Optional["AccountUsageSnapshot"]:
+        return fetch_account_usage(
+            provider,
+            base_url=None,
+            api_key=access_token,
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(_call)
+        try:
+            snapshot = future.result(timeout=_ACCOUNT_USAGE_FETCH_TIMEOUT_SECONDS)
+            return snapshot, None
+        except concurrent.futures.TimeoutError:
+            return (
+                None,
+                f"timed out after {_ACCOUNT_USAGE_FETCH_TIMEOUT_SECONDS:.0f}s",
+            )
+        except Exception as exc:
+            return None, f"fetch failed — {exc}"
+
+
 def auth_usage_command(args) -> None:
     """``hermes auth usage <provider>`` — show live account usage from the CLI.
 
@@ -553,10 +658,16 @@ def auth_usage_command(args) -> None:
     runtime resolver would have picked for an actual chat call — no separate
     "which account?" prompt, no caller-supplied bearer token to misforward.
 
-    Multi-account scope is the same as the REPL view: one snapshot per
-    invocation, taken from the account the resolver selects. A per-pool-entry
-    iteration is intentionally out of scope here; the multi-account PR #80015
-    family keeps "aggregate / selector" for a follow-up.
+    Multi-account scope:
+
+    - default (no flag): single snapshot from the resolver-selected account,
+      matching the REPL view. One pass, one exit code.
+    - ``--all``: iterate every pool entry for the provider and render each
+      separately. Errors per entry are reported inline but do not abort the
+      loop — a rate-limited account #2 must not block reporting account #1.
+      The command exits non-zero if every entry failed.
+    - ``--account <label>``: render only the pool entry whose ``label``
+      matches. Unknown labels exit non-zero with the known set listed.
 
     Failures (timeout, no creds, provider offline, 4xx/5xx) print a short,
     actionable message and exit non-zero instead of dumping a stacktrace, so
@@ -576,6 +687,9 @@ def auth_usage_command(args) -> None:
             f"Supported providers: {supported}."
         )
 
+    show_all = bool(getattr(args, "all_accounts", False))
+    account_filter = str(getattr(args, "account", "") or "").strip()
+
     # Pool-aware prerequisite check: the provider can be in the supported set
     # without the user having a usable credential for it. Fail fast with a
     # hint pointing at ``hermes auth add`` rather than timing out on the
@@ -588,50 +702,100 @@ def auth_usage_command(args) -> None:
         )
 
     # Lazy import — ``fetch_account_usage`` pulls the OpenAI SDK chain, only
-    # needed here. Off-thread with a hard timeout so a slow / hung provider
-    # API cannot stall the terminal (mirrors the REPL ``/usage`` discipline).
-    import concurrent.futures
-
+    # needed here. ``render_account_usage_lines`` is the shared renderer that
+    # both the REPL and the CLI use, so output is byte-identical.
     from agent.account_usage import (
-        fetch_account_usage,
         render_account_usage_lines,
     )
 
-    print(f"Fetching {provider} account usage…")
-    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-        try:
-            snapshot = pool.submit(
-                fetch_account_usage, provider, base_url=None, api_key=None
-            ).result(timeout=_ACCOUNT_USAGE_FETCH_TIMEOUT_SECONDS)
-        except concurrent.futures.TimeoutError:
+    creds = _list_provider_account_credentials(provider)
+    if not creds:
+        # Provider is "logged in" via singleton / runtime resolver but the
+        # pool has no usable entries (e.g. all tokens still loading). Fall
+        # back to the original single-snapshot path so the user still gets
+        # the resolver-selected account's view instead of a hard error.
+        creds = [
+            {
+                "label": "default",
+                "source": "resolver",
+                "access_token": "",
+                "account_id": "",
+            }
+        ]
+
+    if account_filter:
+        matches = [c for c in creds if c["label"] == account_filter]
+        if not matches:
+            known = ", ".join(c["label"] for c in creds) or "(none)"
             raise SystemExit(
-                f"{provider}: timed out after "
-                f"{_ACCOUNT_USAGE_FETCH_TIMEOUT_SECONDS:.0f}s waiting on the "
-                "usage endpoint. Try again, or check your network."
+                f"{provider}: no account labeled {account_filter!r}. "
+                f"Known: {known}."
             )
-        except Exception as exc:
-            # Fail loud (non-zero, short message) but never a stacktrace — the
-            # user wants an actionable line, not a Python traceback in chat.
-            raise SystemExit(f"{provider}: usage fetch failed — {exc}")
+        creds = matches
 
-    if snapshot is None or not snapshot.available:
-        # ``fetch_account_usage`` returns None for unsupported providers and a
-        # snapshot with ``unavailable_reason`` set for "endpoint reachable but
-        # not in a shape we can render" (e.g. a future Codex payload change).
-        reason = getattr(snapshot, "unavailable_reason", None) if snapshot else None
-        if reason:
-            raise SystemExit(f"{provider}: usage unavailable — {reason}")
-        raise SystemExit(
-            f"{provider}: usage is not available right now. "
-            "The provider may be offline or the account may be rate-limited; "
-            "try `hermes auth status` and retry shortly."
+    if not show_all and len(creds) > 1:
+        # Default behavior with multiple accounts: render the first (pool
+        # head) and print a hint that ``--all`` exists. This keeps the
+        # default output deterministic and one-shot, matching the original
+        # PR #81819 contract.
+        first = creds[0]
+        print(
+            f"Note: {provider} has {len(creds)} pool entries; showing "
+            f"{first['label']!r}. Re-run with --all to render every "
+            "account, or --account <label> to pick one."
         )
+        creds = [first]
 
-    # Mirror the REPL / TUI render path verbatim so the terminal output and
-    # the slash command look the same (same headers, same reset phrasing,
-    # same plan row). One source of truth: ``render_account_usage_lines``.
-    for line in render_account_usage_lines(snapshot):
-        print(line)
+    any_rendered = False
+    any_failed = False
+    for cred in creds:
+        # Render the per-account header whenever we are showing more than
+        # one snapshot in a single run. The default (single-snapshot) path
+        # keeps the original PR #81819 output byte-for-byte — no leading
+        # banner.
+        if len(creds) > 1:
+            print(f"\n=== {provider}: {cred['label']} ===")
+        if not cred["access_token"]:
+            # Fallback path: no explicit token, defer to the runtime resolver.
+            # Reuse the original single-snapshot fetch logic so the
+            # `--all`/default paths share semantics.
+            snapshot, error = _fetch_account_usage_with_timeout(
+                provider=provider,
+                access_token="",
+                account_id="",
+            )
+        else:
+            snapshot, error = _fetch_account_usage_with_timeout(
+                provider=provider,
+                access_token=cred["access_token"],
+                account_id=cred["account_id"],
+            )
+        if error is not None:
+            any_failed = True
+            print(f"  {cred['label']}: {error}")
+            continue
+        if snapshot is None or not snapshot.available:
+            reason = (
+                getattr(snapshot, "unavailable_reason", None) if snapshot else None
+            )
+            any_failed = True
+            if reason:
+                print(f"  {cred['label']}: usage unavailable — {reason}")
+            else:
+                print(
+                    f"  {cred['label']}: usage is not available right now "
+                    "(provider offline or account rate-limited)."
+                )
+            continue
+        any_rendered = True
+        for line in render_account_usage_lines(snapshot):
+            print(line)
+
+    if not any_rendered and any_failed:
+        raise SystemExit(
+            f"{provider}: no account returned usable usage. "
+            "Try `hermes auth status` for credential health."
+        )
 
 
 def auth_logout_command(args) -> None:
@@ -911,3 +1075,12 @@ def auth_command(args) -> None:
         return
     # No subcommand — launch interactive mode
     _interactive_auth()
+
+
+# Type-only imports — kept off the runtime path so ``hermes auth`` stays
+# fast even when the OpenAI / Codex SDKs are not installed locally. Used
+# purely to give static type-checkers (pyright, mypy) a name to resolve
+# when validating forward references in lazy-import helpers like
+# ``_fetch_account_usage_with_timeout``.
+if TYPE_CHECKING:
+    from agent.account_usage import AccountUsageSnapshot  # noqa: F401

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -595,6 +595,16 @@ def _list_provider_account_credentials(provider: str) -> list[dict]:
     return rows
 
 
+def _resolver_account_credential() -> dict[str, str]:
+    """Return the marker row that delegates selection to the native resolver."""
+    return {
+        "label": "resolver-selected",
+        "source": "resolver",
+        "access_token": "",
+        "account_id": "",
+    }
+
+
 def _fetch_account_usage_with_timeout(
     *,
     provider: str,
@@ -733,18 +743,18 @@ def auth_usage_command(args) -> None:
             )
         creds = matches
 
-    if not show_all and len(creds) > 1:
-        # Default behavior with multiple accounts: render the first (pool
-        # head) and print a hint that ``--all`` exists. This keeps the
-        # default output deterministic and one-shot, matching the original
-        # PR #81819 contract.
-        first = creds[0]
-        print(
-            f"Note: {provider} has {len(creds)} pool entries; showing "
-            f"{first['label']!r}. Re-run with --all to render every "
-            "account, or --account <label> to pick one."
-        )
-        creds = [first]
+    if not show_all and not account_filter:
+        # Default behavior must follow the native runtime resolver rather than
+        # silently forcing the pool head. The resolver may prefer a singleton
+        # credential over the pool (Codex) or a higher-priority source such as
+        # an environment/Claude Code credential (Anthropic).
+        if len(creds) > 1:
+            print(
+                f"Note: {provider} has {len(creds)} pool entries; showing "
+                "the resolver-selected account. Re-run with --all to render "
+                "every account, or --account <label> to pick one."
+            )
+        creds = [_resolver_account_credential()]
 
     any_rendered = False
     any_failed = False
@@ -918,14 +928,17 @@ def auth_usage_reset_command(args) -> None:
             )
         creds = matches
 
-    if not show_all and len(creds) > 1:
-        first = creds[0]
-        print(
-            f"Note: {provider} has {len(creds)} pool entries; resetting "
-            f"{first['label']!r}. Re-run with --all to reset every account, "
-            "or --account <label> to pick one."
-        )
-        creds = [first]
+    if not show_all and not account_filter:
+        # Keep reset selection aligned with the read path: no explicit token
+        # means ``redeem_codex_reset_credit`` uses the native resolver rather
+        # than accidentally resetting the first pool entry.
+        if len(creds) > 1:
+            print(
+                f"Note: {provider} has {len(creds)} pool entries; resetting "
+                "the resolver-selected account. Re-run with --all to reset "
+                "every account, or --account <label> to pick one."
+            )
+        creds = [_resolver_account_credential()]
 
     any_redeemed = False
     any_failed = False

--- a/hermes_cli/subcommands/auth.py
+++ b/hermes_cli/subcommands/auth.py
@@ -70,7 +70,9 @@ def build_auth_parser(subparsers, *, cmd_auth: Callable) -> None:
         "usage",
         help=(
             "Show live account usage (Codex / Anthropic / OpenRouter) for a "
-            "provider, fetched outside an interactive session"
+            "provider, fetched outside an interactive session. Pass "
+            "`--reset` to redeem a banked rate-limit reset credit instead "
+            "(Codex only)."
         ),
     )
     auth_usage.add_argument(
@@ -85,10 +87,10 @@ def build_auth_parser(subparsers, *, cmd_auth: Callable) -> None:
         action="store_true",
         dest="all_accounts",
         help=(
-            "Render usage for every pool entry of this provider instead of "
-            "just the resolver-selected one. Per-entry failures are reported "
-            "inline; the command exits non-zero only if no entry returned "
-            "usable usage."
+            "Render (or, with --reset, redeem on) every pool entry of this "
+            "provider instead of just the resolver-selected one. "
+            "Per-entry outcomes are reported inline; the command exits "
+            "non-zero only if every entry failed."
         ),
     )
     auth_usage.add_argument(
@@ -97,8 +99,29 @@ def build_auth_parser(subparsers, *, cmd_auth: Callable) -> None:
         default="",
         metavar="LABEL",
         help=(
-            "Render usage for the pool entry whose stored label matches "
-            "LABEL. Use `hermes auth list <provider>` to see available labels."
+            "Target the pool entry whose stored label matches LABEL. "
+            "Use `hermes auth list <provider>` to see available labels."
+        ),
+    )
+    auth_usage.add_argument(
+        "--reset",
+        action="store_true",
+        dest="reset_action",
+        help=(
+            "Redeem one banked rate-limit reset credit on the Codex "
+            "backend, instead of rendering the live usage snapshot. "
+            "Mirror of the REPL `/usage reset [--force]` slash command."
+        ),
+    )
+    auth_usage.add_argument(
+        "--force",
+        action="store_true",
+        dest="force",
+        help=(
+            "With --reset: redeem even if the busiest rate-limit window is "
+            "not fully used. A banked reset restores the FULL 5h + weekly "
+            "allowance, so spending it early wastes most of it. Ignored "
+            "without --reset."
         ),
     )
     auth_logout = auth_subparsers.add_parser(

--- a/hermes_cli/subcommands/auth.py
+++ b/hermes_cli/subcommands/auth.py
@@ -80,6 +80,27 @@ def build_auth_parser(subparsers, *, cmd_auth: Callable) -> None:
             "(openai-codex, anthropic, openrouter)"
         ),
     )
+    auth_usage.add_argument(
+        "--all",
+        action="store_true",
+        dest="all_accounts",
+        help=(
+            "Render usage for every pool entry of this provider instead of "
+            "just the resolver-selected one. Per-entry failures are reported "
+            "inline; the command exits non-zero only if no entry returned "
+            "usable usage."
+        ),
+    )
+    auth_usage.add_argument(
+        "--account",
+        dest="account",
+        default="",
+        metavar="LABEL",
+        help=(
+            "Render usage for the pool entry whose stored label matches "
+            "LABEL. Use `hermes auth list <provider>` to see available labels."
+        ),
+    )
     auth_logout = auth_subparsers.add_parser(
         "logout", help="Log out a provider and clear stored auth state"
     )

--- a/hermes_cli/subcommands/auth.py
+++ b/hermes_cli/subcommands/auth.py
@@ -66,6 +66,20 @@ def build_auth_parser(subparsers, *, cmd_auth: Callable) -> None:
         "status", help="Show auth status for a provider"
     )
     auth_status.add_argument("provider", help="Provider id")
+    auth_usage = auth_subparsers.add_parser(
+        "usage",
+        help=(
+            "Show live account usage (Codex / Anthropic / OpenRouter) for a "
+            "provider, fetched outside an interactive session"
+        ),
+    )
+    auth_usage.add_argument(
+        "provider",
+        help=(
+            "Provider id with a live usage endpoint "
+            "(openai-codex, anthropic, openrouter)"
+        ),
+    )
     auth_logout = auth_subparsers.add_parser(
         "logout", help="Log out a provider and clear stored auth state"
     )

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -1413,3 +1413,322 @@ def test_auth_usage_lists_provider_account_credentials_skips_partial_rows():
     assert all(r["access_token"] for r in rows)
 
 
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# `hermes auth usage --reset` — server-side rate-limit reset redemption
+# ──────────────────────────────────────────────────────────────────────────
+#
+# Mirror of the REPL ``/usage reset [--force]`` slash command, exposed as
+# a CLI flag so shell loops and cron jobs can consume banked reset
+# credits without an interactive session. Tests cover the dispatch path
+# and the per-entry message contract; ``redeem_codex_reset_credit`` itself
+# has its own dedicated coverage in ``agent.account_usage``.
+
+
+def test_auth_usage_reset_rejects_unsupported_provider(capsys):
+    """A typo or future provider that has no consume endpoint must fail clean."""
+    from hermes_cli.auth_commands import auth_usage_reset_command
+
+    with pytest.raises(SystemExit) as exc_info:
+        auth_usage_reset_command(
+            SimpleNamespace(provider="anthropic", all_accounts=False, account="", force=False)
+        )
+    msg = str(exc_info.value)
+    assert "anthropic" in msg
+    assert "not implemented yet" in msg
+
+
+def test_auth_usage_reset_rejects_missing_provider(capsys):
+    from hermes_cli.auth_commands import auth_usage_reset_command
+
+    with pytest.raises(SystemExit) as exc_info:
+        auth_usage_reset_command(
+            SimpleNamespace(provider="", all_accounts=False, account="", force=False)
+        )
+    assert "Provider is required" in str(exc_info.value)
+
+
+def test_auth_usage_reset_requires_logged_in(monkeypatch, capsys):
+    """Fail-fast on no creds, same as the read path."""
+    from hermes_cli.auth_commands import auth_usage_reset_command
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_auth_status",
+        lambda provider: {"logged_in": False},
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        auth_usage_reset_command(
+            SimpleNamespace(
+                provider="openai-codex",
+                all_accounts=False,
+                account="",
+                force=False,
+            )
+        )
+    assert "not logged in" in str(exc_info.value)
+
+
+def test_auth_usage_reset_redeems_when_credit_available(monkeypatch, capsys):
+    """Happy path: backend returns a ``reset`` status, command exits 0."""
+    from agent.account_usage import CodexResetRedeemResult
+    from hermes_cli.auth_commands import auth_usage_reset_command
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_auth_status",
+        lambda provider: {"logged_in": True},
+    )
+    _seed_pool(
+        monkeypatch,
+        [{"label": "codex-current", "access_token": "tok-1"}],
+    )
+
+    good_result = CodexResetRedeemResult(
+        status="reset",
+        message="✅ Reset redeemed — your usage limits have been reset. "
+        "0 banked resets remaining.",
+        available_count=0,
+        windows_reset=2,
+    )
+
+    class _ImmediatePool:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def submit(self, fn, *args, **kwargs):
+            class _Fut:
+                def result(self, timeout=None):
+                    return fn(*args, **kwargs)
+
+            return _Fut()
+
+    monkeypatch.setattr(
+        "concurrent.futures.ThreadPoolExecutor", _ImmediatePool
+    )
+
+    import agent.account_usage as _account_usage
+
+    monkeypatch.setattr(
+        _account_usage,
+        "redeem_codex_reset_credit",
+        lambda *a, **kw: good_result,
+    )
+
+    # Must not raise — successful redemption exits 0.
+    auth_usage_reset_command(
+        SimpleNamespace(
+            provider="openai-codex",
+            all_accounts=False,
+            account="",
+            force=False,
+        )
+    )
+
+    out = capsys.readouterr().out
+    assert "codex-current" in out
+    assert "Reset redeemed" in out
+
+
+def test_auth_usage_reset_no_credits_banked_is_not_an_error(monkeypatch, capsys):
+    """A structured no-op must exit 0 — cron loops must distinguish
+    'nothing to do' from 'could not reach provider'."""
+    from agent.account_usage import CodexResetRedeemResult
+    from hermes_cli.auth_commands import auth_usage_reset_command
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_auth_status",
+        lambda provider: {"logged_in": True},
+    )
+    _seed_pool(
+        monkeypatch,
+        [{"label": "codex-current", "access_token": "tok-1"}],
+    )
+
+    no_credit_result = CodexResetRedeemResult(
+        status="no_credits_banked",
+        message="No banked reset credits on this account — nothing to redeem.",
+        available_count=0,
+        windows_reset=0,
+    )
+
+    class _ImmediatePool:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def submit(self, fn, *args, **kwargs):
+            class _Fut:
+                def result(self, timeout=None):
+                    return fn(*args, **kwargs)
+
+            return _Fut()
+
+    monkeypatch.setattr(
+        "concurrent.futures.ThreadPoolExecutor", _ImmediatePool
+    )
+
+    import agent.account_usage as _account_usage
+
+    monkeypatch.setattr(
+        _account_usage,
+        "redeem_codex_reset_credit",
+        lambda *a, **kw: no_credit_result,
+    )
+
+    # No SystemExit: structured no-op is a 0 exit so shell loops continue.
+    auth_usage_reset_command(
+        SimpleNamespace(
+            provider="openai-codex",
+            all_accounts=False,
+            account="",
+            force=False,
+        )
+    )
+
+    out = capsys.readouterr().out
+    assert "No banked reset credits" in out
+    assert "codex-current" in out
+
+
+def test_auth_usage_reset_transport_failure_exits_nonzero(monkeypatch, capsys):
+    """A timeout / network error must surface as a non-zero exit so cron
+    loops can retry, distinct from 'backend said no' which exits 0."""
+    from hermes_cli.auth_commands import auth_usage_reset_command
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_auth_status",
+        lambda provider: {"logged_in": True},
+    )
+    _seed_pool(
+        monkeypatch,
+        [{"label": "codex-current", "access_token": "tok-1"}],
+    )
+
+    class _HangingFuture:
+        def result(self, timeout=None):
+            raise concurrent.futures.TimeoutError()
+
+    class _HangingPool:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def submit(self, fn, *args, **kwargs):
+            return _HangingFuture()
+
+    monkeypatch.setattr(
+        "concurrent.futures.ThreadPoolExecutor", _HangingPool
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        auth_usage_reset_command(
+            SimpleNamespace(
+                provider="openai-codex",
+                all_accounts=False,
+                account="",
+                force=False,
+            )
+        )
+    msg = str(exc_info.value)
+    # The CLI surfaces the transport failure distinctly from a structured
+    # no-op: non-zero exit + actionable summary.
+    assert "could not reach the backend" in msg
+    out = capsys.readouterr().out
+    assert "timed out or transport error" in out
+
+
+def test_auth_usage_reset_account_unknown_label_exits_nonzero(monkeypatch, capsys):
+    from hermes_cli.auth_commands import auth_usage_reset_command
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_auth_status",
+        lambda provider: {"logged_in": True},
+    )
+    _seed_pool(
+        monkeypatch,
+        [
+            {"label": "codex-current", "access_token": "tok-1"},
+            {"label": "openai-codex-oauth-2", "access_token": "tok-2"},
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        auth_usage_reset_command(
+            SimpleNamespace(
+                provider="openai-codex",
+                all_accounts=False,
+                account="ghost",
+                force=False,
+            )
+        )
+    msg = str(exc_info.value)
+    assert "ghost" in msg
+    assert "codex-current" in msg
+    assert "openai-codex-oauth-2" in msg
+
+
+def test_auth_usage_reset_dispatches_via_flag(monkeypatch, capsys):
+    """The dispatch layer must route --reset to auth_usage_reset_command."""
+    from hermes_cli.auth_commands import (
+        auth_usage_command,
+        auth_usage_reset_command,
+    )
+
+    captured = {"called": None}
+
+    def _spy_show(args):
+        captured["called"] = "show"
+
+    def _spy_reset(args):
+        captured["called"] = "reset"
+
+    monkeypatch.setattr("hermes_cli.auth_commands.auth_usage_command", _spy_show)
+    monkeypatch.setattr(
+        "hermes_cli.auth_commands.auth_usage_reset_command", _spy_reset
+    )
+
+    from hermes_cli.auth_commands import auth_command
+
+    # Read path: --reset absent.
+    auth_command(
+        SimpleNamespace(
+            auth_action="usage",
+            action="usage",
+            provider="openai-codex",
+            all_accounts=False,
+            account="",
+            reset_action=False,
+            force=False,
+        )
+    )
+    assert captured["called"] == "show"
+
+    # Write path: --reset set.
+    auth_command(
+        SimpleNamespace(
+            auth_action="usage",
+            action="usage",
+            provider="openai-codex",
+            all_accounts=False,
+            account="",
+            reset_action=True,
+            force=False,
+        )
+    )
+    assert captured["called"] == "reset"

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -769,3 +769,231 @@ def test_auth_remove_copilot_suppresses_all_variants(tmp_path, monkeypatch):
     assert is_source_suppressed("copilot", "env:GITHUB_TOKEN")
 
 
+# ──────────────────────────────────────────────────────────────────────────
+# `hermes auth usage <provider>` — standalone live account-usage fetch
+# ──────────────────────────────────────────────────────────────────────────
+#
+# These tests cover the no-agent CLI entry point that the REPL ``/usage``
+# slash used to own. The fetch helpers (``fetch_account_usage``,
+# ``render_account_usage_lines``) live in ``agent.account_usage`` and are
+# already covered there; here we only verify the command-shape behavior:
+#   * rejects an empty / unsupported provider cleanly,
+#   * fails fast when the provider has no usable credential,
+#   * prints the rendered snapshot for a happy-path fetch,
+#   * exits non-zero (and never with a stacktrace) on a slow fetch timeout.
+
+import concurrent.futures
+from types import SimpleNamespace
+
+from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
+
+
+def test_auth_usage_rejects_missing_provider(capsys):
+    from hermes_cli.auth_commands import auth_usage_command
+
+    with pytest.raises(SystemExit) as exc_info:
+        auth_usage_command(SimpleNamespace(provider=""))
+    # argparse already rejects ``hermes auth usage`` (no provider) at the
+    # parser level; this guard is the "empty string" fallback for direct
+    # programmatic callers. ``SystemExit(str)`` stores the message on
+    # ``.code`` — exit code is implicitly 1 when the message is a string.
+    assert "Provider is required" in str(exc_info.value)
+    assert exc_info.value.code != 0  # non-zero → scriptable from cron/loops
+
+
+def test_auth_usage_rejects_unsupported_provider(capsys):
+    from hermes_cli.auth_commands import auth_usage_command
+
+    with pytest.raises(SystemExit) as exc_info:
+        auth_usage_command(SimpleNamespace(provider="spotify"))
+    msg = str(exc_info.value)
+    assert "not supported" in msg
+    # The error must list the SUPPORTED set so a typo self-corrects on retry
+    # rather than the user having to read the docs to find the right id.
+    assert "openai-codex" in msg
+    assert "anthropic" in msg
+    assert "openrouter" in msg
+
+
+def test_auth_usage_requires_logged_in_credential(monkeypatch, capsys):
+    from hermes_cli.auth_commands import auth_usage_command
+
+    # ``get_auth_status`` is the same probe ``hermes auth status`` uses; patch
+    # it to simulate "provider is supported but not logged in" so the command
+    # fails fast with the auth-add hint instead of timing out on the API.
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_auth_status",
+        lambda provider: {"logged_in": False, "error": "no creds"},
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        auth_usage_command(SimpleNamespace(provider="openai-codex"))
+    assert "not logged in" in str(exc_info.value)
+    assert "hermes auth add openai-codex" in str(exc_info.value)
+
+
+def test_auth_usage_renders_snapshot_on_success(monkeypatch, capsys):
+    from hermes_cli.auth_commands import auth_usage_command
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_auth_status",
+        lambda provider: {"logged_in": True},
+    )
+
+    # Build a deterministic snapshot so the assertion is value-driven, not
+    # snapshot-of-a-snapshot. ``available`` must be True for the command to
+    # proceed past the unavailable-guard and reach the render branch.
+    snapshot = AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
+        plan="Pro",
+        windows=(
+            AccountUsageWindow(
+                label="Session",
+                used_percent=42.0,
+                reset_at=datetime(2026, 1, 1, 5, 0, tzinfo=timezone.utc),
+            ),
+        ),
+        details=("You have 2 resets banked - use /usage reset to activate",),
+    )
+
+    # The command goes through a ThreadPoolExecutor + ``fetch_account_usage``;
+    # short-circuit the executor by replacing ``submit`` so the snapshot is
+    # returned synchronously without touching the network.
+    class _ImmediateFuture:
+        def __init__(self, value):
+            self._value = value
+
+        def result(self, timeout=None):
+            return self._value
+
+    class _ImmediatePool:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def submit(self, fn, *args, **kwargs):
+            return _ImmediateFuture(fn(*args, **kwargs))
+
+    monkeypatch.setattr(
+        "concurrent.futures.ThreadPoolExecutor", _ImmediatePool
+    )
+    # Patch at the import path the lazy import resolves to.
+    import agent.account_usage as _account_usage
+
+    monkeypatch.setattr(_account_usage, "fetch_account_usage", lambda *a, **kw: snapshot)
+
+    auth_usage_command(SimpleNamespace(provider="openai-codex"))
+
+    out = capsys.readouterr().out
+    # The renderer (``render_account_usage_lines``) is the source of truth;
+    # assert on its surface, not the literal byte sequence, so a renderer
+    # tweak doesn't silently break this test.
+    assert "Account limits" in out
+    assert "Session" in out
+    assert "openai-codex" in out
+    assert "Pro" in out
+    assert "resets banked" in out
+
+
+def test_auth_usage_times_out_cleanly(monkeypatch, capsys):
+    from hermes_cli.auth_commands import (
+        _ACCOUNT_USAGE_FETCH_TIMEOUT_SECONDS,
+        auth_usage_command,
+    )
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_auth_status",
+        lambda provider: {"logged_in": True},
+    )
+
+    class _HangingFuture:
+        def result(self, timeout=None):
+            # Mirror concurrent.futures' exact behavior on a hard timeout so
+            # the command's own except-branch (not a generic Exception
+            # fallback) handles it. Using TimeoutError makes that explicit.
+            raise concurrent.futures.TimeoutError()
+
+    class _HangingPool:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def submit(self, fn, *args, **kwargs):
+            return _HangingFuture()
+
+    monkeypatch.setattr(
+        "concurrent.futures.ThreadPoolExecutor", _HangingPool
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        auth_usage_command(SimpleNamespace(provider="openai-codex"))
+    msg = str(exc_info.value)
+    # The timeout must surface a short actionable line, not a stacktrace, and
+    # the message must include the budget so the user can correlate it with
+    # the known REPL ``/usage`` 10s cap.
+    assert "timed out" in msg
+    assert f"{_ACCOUNT_USAGE_FETCH_TIMEOUT_SECONDS:.0f}s" in msg
+    assert "Traceback" not in capsys.readouterr().err
+
+
+def test_auth_usage_reports_unavailable_snapshot(monkeypatch, capsys):
+    from hermes_cli.auth_commands import auth_usage_command
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_auth_status",
+        lambda provider: {"logged_in": True},
+    )
+
+    # ``fetch_account_usage`` returns a snapshot with ``unavailable_reason``
+    # when the endpoint is reachable but the payload is in a shape we can't
+    # render (e.g. a future Codex payload change). The command must surface
+    # that reason, not "usage is not available right now."
+    snapshot = AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
+        unavailable_reason="unexpected response shape",
+    )
+
+    class _ImmediatePool:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def submit(self, fn, *args, **kwargs):
+            class _Fut:
+                def result(self, timeout=None):
+                    return fn(*args, **kwargs)
+
+            return _Fut()
+
+    monkeypatch.setattr(
+        "concurrent.futures.ThreadPoolExecutor", _ImmediatePool
+    )
+    import agent.account_usage as _account_usage
+
+    monkeypatch.setattr(
+        _account_usage, "fetch_account_usage", lambda *a, **kw: snapshot
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        auth_usage_command(SimpleNamespace(provider="openai-codex"))
+    assert "unexpected response shape" in str(exc_info.value)
+
+

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -936,14 +936,20 @@ def test_auth_usage_times_out_cleanly(monkeypatch, capsys):
         "concurrent.futures.ThreadPoolExecutor", _HangingPool
     )
 
+    # No pool entries are seeded; the command falls back to a single
+    # ``default`` synthetic row whose fetch hangs. The single-entry path
+    # surfaces the timeout inline (no stacktrace) and then exits non-zero
+    # because no entry rendered.
     with pytest.raises(SystemExit) as exc_info:
         auth_usage_command(SimpleNamespace(provider="openai-codex"))
     msg = str(exc_info.value)
-    # The timeout must surface a short actionable line, not a stacktrace, and
-    # the message must include the budget so the user can correlate it with
-    # the known REPL ``/usage`` 10s cap.
-    assert "timed out" in msg
-    assert f"{_ACCOUNT_USAGE_FETCH_TIMEOUT_SECONDS:.0f}s" in msg
+    out = capsys.readouterr().out
+    # The timeout must surface a short actionable line, not a stacktrace,
+    # and the inline message must include the budget so the user can
+    # correlate it with the known REPL ``/usage`` 10s cap.
+    assert "timed out" in out
+    assert f"{_ACCOUNT_USAGE_FETCH_TIMEOUT_SECONDS:.0f}s" in out
+    assert "no account returned usable usage" in msg
     assert "Traceback" not in capsys.readouterr().err
 
 
@@ -958,7 +964,8 @@ def test_auth_usage_reports_unavailable_snapshot(monkeypatch, capsys):
     # ``fetch_account_usage`` returns a snapshot with ``unavailable_reason``
     # when the endpoint is reachable but the payload is in a shape we can't
     # render (e.g. a future Codex payload change). The command must surface
-    # that reason, not "usage is not available right now."
+    # that reason inline (per entry) instead of as the final SystemExit
+    # summary, and exit non-zero because nothing rendered.
     snapshot = AccountUsageSnapshot(
         provider="openai-codex",
         source="usage_api",
@@ -994,6 +1001,415 @@ def test_auth_usage_reports_unavailable_snapshot(monkeypatch, capsys):
 
     with pytest.raises(SystemExit) as exc_info:
         auth_usage_command(SimpleNamespace(provider="openai-codex"))
-    assert "unexpected response shape" in str(exc_info.value)
+    out = capsys.readouterr().out
+    # Inline per-entry message carries the provider reason; the SystemExit
+    # summary only fires because nothing rendered.
+    assert "unexpected response shape" in out
+    assert "no account returned usable usage" in str(exc_info.value)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# `--all` / `--account` — multi-pool-entry iteration for `auth usage`
+# ──────────────────────────────────────────────────────────────────────────
+#
+# The default (no flag) path renders only the resolver-selected account and
+# prints a hint when the pool has more than one entry. ``--all`` iterates
+# every entry and renders each separately; ``--account LABEL`` filters to a
+# single entry by stored label. Per-entry failures are surfaced inline and
+# do not abort the loop; only "no entry rendered at all" exits non-zero.
+
+
+def _seed_pool(monkeypatch, entries):
+    """Patch ``_load_auth_store`` so it returns the given provider entries."""
+    store = {"credential_pool": {"openai-codex": list(entries)}}
+    monkeypatch.setattr(
+        "hermes_cli.auth_commands._list_provider_account_credentials",
+        lambda provider: [
+            {
+                "label": e.get("label", ""),
+                "source": e.get("source", "manual:device_code"),
+                "access_token": e.get("access_token", "tok-" + e.get("label", "")),
+                "account_id": e.get("account_id", ""),
+            }
+            for e in entries
+            if e.get("access_token")
+        ],
+    )
+    return store
+
+
+def test_auth_usage_all_renders_every_pool_entry(monkeypatch, capsys):
+    from hermes_cli.auth_commands import auth_usage_command
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_auth_status",
+        lambda provider: {"logged_in": True},
+    )
+    _seed_pool(
+        monkeypatch,
+        [
+            {"label": "codex-current", "access_token": "tok-1"},
+            {"label": "openai-codex-oauth-2", "access_token": "tok-2"},
+        ],
+    )
+
+    # Stub the per-account fetch to return a happy-path snapshot for every
+    # entry; the loop should render both, each under its own header.
+    snapshot = AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
+        plan="Plus",
+        windows=(
+            AccountUsageWindow(
+                label="Session",
+                used_percent=100.0,
+                reset_at=datetime(2026, 1, 1, 5, 0, tzinfo=timezone.utc),
+            ),
+        ),
+        details=(),
+    )
+
+    class _ImmediatePool:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def submit(self, fn, *args, **kwargs):
+            class _Fut:
+                def result(self, timeout=None):
+                    return fn(*args, **kwargs)
+
+            return _Fut()
+
+    monkeypatch.setattr(
+        "concurrent.futures.ThreadPoolExecutor", _ImmediatePool
+    )
+
+    # Stub the per-account fetch (resolved lazily inside
+    # ``_fetch_account_usage_with_timeout``) so the test does not hit the
+    # network. The snapshot must be available, or the command will exit
+    # non-zero and the assertions below will fire spuriously.
+    import agent.account_usage as _account_usage
+
+    monkeypatch.setattr(
+        _account_usage, "fetch_account_usage", lambda *a, **kw: snapshot
+    )
+
+    auth_usage_command(
+        SimpleNamespace(provider="openai-codex", all_accounts=True, account="")
+    )
+
+    out = capsys.readouterr().out
+    # Both labels appear, each preceded by its own header banner, and the
+    # renderer output is shared (so ``Session`` is rendered twice).
+    assert "=== openai-codex: codex-current ===" in out
+    assert "=== openai-codex: openai-codex-oauth-2 ===" in out
+    assert out.count("Session") == 2
+    # No final SystemExit — both rendered cleanly.
+    assert "no account returned usable usage" not in out
+
+
+def test_auth_usage_account_filters_to_label(monkeypatch, capsys):
+    from hermes_cli.auth_commands import auth_usage_command
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_auth_status",
+        lambda provider: {"logged_in": True},
+    )
+    _seed_pool(
+        monkeypatch,
+        [
+            {"label": "codex-current", "access_token": "tok-1"},
+            {"label": "openai-codex-oauth-2", "access_token": "tok-2"},
+        ],
+    )
+
+    snapshot = AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
+        plan="Plus",
+        windows=(
+            AccountUsageWindow(
+                label="Session",
+                used_percent=50.0,
+                reset_at=datetime(2026, 1, 1, 5, 0, tzinfo=timezone.utc),
+            ),
+        ),
+        details=(),
+    )
+
+    class _ImmediatePool:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def submit(self, fn, *args, **kwargs):
+            class _Fut:
+                def result(self, timeout=None):
+                    return fn(*args, **kwargs)
+
+            return _Fut()
+
+    monkeypatch.setattr(
+        "concurrent.futures.ThreadPoolExecutor", _ImmediatePool
+    )
+
+    import agent.account_usage as _account_usage
+
+    monkeypatch.setattr(
+        _account_usage, "fetch_account_usage", lambda *a, **kw: snapshot
+    )
+
+    auth_usage_command(
+        SimpleNamespace(
+            provider="openai-codex", all_accounts=False, account="codex-current"
+        )
+    )
+
+    out = capsys.readouterr().out
+    # The renderer output reflects the requested entry's snapshot (the
+    # only window is the one we built above). The other label must NOT
+    # appear anywhere — including the renderer, since each entry has its
+    # own snapshot and we filtered to one.
+    assert "Account limits" in out
+    assert "Session" in out
+    assert "50%" in out
+    # With a single-entry filter, no per-account header banner is emitted
+    # (consistent with the default one-shot path).
+    assert "===" not in out
+
+
+def test_auth_usage_account_unknown_label_exits_nonzero(monkeypatch, capsys):
+    from hermes_cli.auth_commands import auth_usage_command
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_auth_status",
+        lambda provider: {"logged_in": True},
+    )
+    _seed_pool(
+        monkeypatch,
+        [
+            {"label": "codex-current", "access_token": "tok-1"},
+            {"label": "openai-codex-oauth-2", "access_token": "tok-2"},
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        auth_usage_command(
+            SimpleNamespace(
+                provider="openai-codex", all_accounts=False, account="ghost"
+            )
+        )
+    msg = str(exc_info.value)
+    # Must name the requested label and list the known set so the user can
+    # self-correct on retry.
+    assert "ghost" in msg
+    assert "codex-current" in msg
+    assert "openai-codex-oauth-2" in msg
+
+
+def test_auth_usage_all_continues_after_per_entry_failure(monkeypatch, capsys):
+    """One entry's fetch failure must not abort the rest of the loop."""
+    from hermes_cli.auth_commands import auth_usage_command
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_auth_status",
+        lambda provider: {"logged_in": True},
+    )
+    _seed_pool(
+        monkeypatch,
+        [
+            {"label": "codex-current", "access_token": "tok-1"},
+            {"label": "openai-codex-oauth-2", "access_token": "tok-2"},
+        ],
+    )
+
+    good_snapshot = AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
+        plan="Plus",
+        windows=(
+            AccountUsageWindow(
+                label="Session",
+                used_percent=10.0,
+                reset_at=datetime(2026, 1, 1, 5, 0, tzinfo=timezone.utc),
+            ),
+        ),
+        details=(),
+    )
+
+    call_count = {"n": 0}
+
+    def _flaky_fetch(*args, **kwargs):
+        call_count["n"] += 1
+        # First call hangs (timeout), second returns the good snapshot.
+        if call_count["n"] == 1:
+            raise concurrent.futures.TimeoutError()
+        return good_snapshot
+
+    class _FlakyFuture:
+        def __init__(self, fn, *args, **kwargs):
+            self._fn = fn
+            self._args = args
+            self._kwargs = kwargs
+
+        def result(self, timeout=None):
+            return self._fn(*self._args, **self._kwargs)
+
+    class _FlakyPool:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def submit(self, fn, *args, **kwargs):
+            # Wrap so the timeout the helper enforces kicks in — emulate
+            # by raising TimeoutError on first call (handled above) and
+            # returning the snapshot on the second.
+            return _FlakyFuture(_flaky_fetch, fn, *args, **kwargs)
+
+    monkeypatch.setattr(
+        "concurrent.futures.ThreadPoolExecutor", _FlakyPool
+    )
+
+    auth_usage_command(
+        SimpleNamespace(provider="openai-codex", all_accounts=True, account="")
+    )
+
+    out = capsys.readouterr().out
+    # First entry's timeout surfaces inline; second entry still renders.
+    assert "codex-current" in out
+    assert "openai-codex-oauth-2" in out
+    assert "timed out" in out
+    assert "Account limits" in out
+    # Both entries were attempted (not just the first).
+    assert call_count["n"] == 2
+
+
+def test_auth_usage_default_warns_when_multiple_pool_entries(monkeypatch, capsys):
+    """The no-flag path must show the head entry AND a hint about ``--all``."""
+    from hermes_cli.auth_commands import auth_usage_command
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_auth_status",
+        lambda provider: {"logged_in": True},
+    )
+    _seed_pool(
+        monkeypatch,
+        [
+            {"label": "codex-current", "access_token": "tok-1"},
+            {"label": "openai-codex-oauth-2", "access_token": "tok-2"},
+        ],
+    )
+
+    snapshot = AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
+        plan="Plus",
+        windows=(
+            AccountUsageWindow(
+                label="Session",
+                used_percent=100.0,
+                reset_at=datetime(2026, 1, 1, 5, 0, tzinfo=timezone.utc),
+            ),
+        ),
+        details=(),
+    )
+
+    class _ImmediatePool:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def submit(self, fn, *args, **kwargs):
+            class _Fut:
+                def result(self, timeout=None):
+                    return fn(*args, **kwargs)
+
+            return _Fut()
+
+    monkeypatch.setattr(
+        "concurrent.futures.ThreadPoolExecutor", _ImmediatePool
+    )
+
+    import agent.account_usage as _account_usage
+
+    monkeypatch.setattr(
+        _account_usage, "fetch_account_usage", lambda *a, **kw: snapshot
+    )
+
+    auth_usage_command(
+        SimpleNamespace(provider="openai-codex", all_accounts=False, account="")
+    )
+
+    out = capsys.readouterr().out
+    # Hint points the user at --all; the head entry's snapshot still renders.
+    assert "2 pool entries" in out
+    assert "--all" in out
+    assert "codex-current" in out
+    # The second entry never renders in the default path.
+    assert "openai-codex-oauth-2" not in out
+
+
+def test_auth_usage_lists_provider_account_credentials_skips_partial_rows():
+    """Pool rows without an access_token are silently dropped."""
+    from hermes_cli.auth_commands import _list_provider_account_credentials
+
+    # Real ``_load_auth_store`` reads ~/.hermes/auth.json — that's not what
+    # we want here. Patch it directly so the test is hermetic.
+    import hermes_cli.auth_commands as ac
+
+    ac.__dict__["_list_provider_account_credentials"]  # ensure imported
+    fake_store = {
+        "credential_pool": {
+            "openai-codex": [
+                {"label": "ok-1", "access_token": "tok-1"},
+                {"label": "no-token", "access_token": ""},  # partial
+                {"label": "ok-2", "access_token": "tok-2"},
+                "not-a-dict",  # malformed
+                {"label": "auto", "access_token": "tok-3"},
+            ],
+            "anthropic": [{"label": "anth", "access_token": "tok-a"}],
+        }
+    }
+    import hermes_cli.auth as auth_mod
+
+    original = auth_mod._load_auth_store
+    auth_mod._load_auth_store = lambda: fake_store
+    try:
+        rows = _list_provider_account_credentials("openai-codex")
+    finally:
+        auth_mod._load_auth_store = original
+
+    labels = [r["label"] for r in rows]
+    # Partial / malformed rows are silently dropped; valid rows are kept
+    # in original order so the user sees the pool's own head-to-tail view.
+    assert labels == ["ok-1", "ok-2", "auto"]
+    # And the access tokens were carried through untouched (the function
+    # never redacts them, but it must not return empty / partial rows).
+    assert all(r["access_token"] for r in rows)
 
 

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -1012,8 +1012,8 @@ def test_auth_usage_reports_unavailable_snapshot(monkeypatch, capsys):
 # `--all` / `--account` — multi-pool-entry iteration for `auth usage`
 # ──────────────────────────────────────────────────────────────────────────
 #
-# The default (no flag) path renders only the resolver-selected account and
-# prints a hint when the pool has more than one entry. ``--all`` iterates
+# The default (no flag) path delegates to the native resolver and prints a
+# hint when the pool has more than one entry. ``--all`` iterates
 # every entry and renders each separately; ``--account LABEL`` filters to a
 # single entry by stored label. Per-entry failures are surfaced inline and
 # do not abort the loop; only "no entry rendered at all" exits non-zero.
@@ -1097,9 +1097,13 @@ def test_auth_usage_all_renders_every_pool_entry(monkeypatch, capsys):
     # non-zero and the assertions below will fire spuriously.
     import agent.account_usage as _account_usage
 
-    monkeypatch.setattr(
-        _account_usage, "fetch_account_usage", lambda *a, **kw: snapshot
-    )
+    fetch_tokens = []
+
+    def _fetch(*args, **kwargs):
+        fetch_tokens.append(kwargs.get("api_key"))
+        return snapshot
+
+    monkeypatch.setattr(_account_usage, "fetch_account_usage", _fetch)
 
     auth_usage_command(
         SimpleNamespace(provider="openai-codex", all_accounts=True, account="")
@@ -1111,6 +1115,7 @@ def test_auth_usage_all_renders_every_pool_entry(monkeypatch, capsys):
     assert "=== openai-codex: codex-current ===" in out
     assert "=== openai-codex: openai-codex-oauth-2 ===" in out
     assert out.count("Session") == 2
+    assert fetch_tokens == ["tok-1", "tok-2"]
     # No final SystemExit — both rendered cleanly.
     assert "no account returned usable usage" not in out
 
@@ -1168,9 +1173,13 @@ def test_auth_usage_account_filters_to_label(monkeypatch, capsys):
 
     import agent.account_usage as _account_usage
 
-    monkeypatch.setattr(
-        _account_usage, "fetch_account_usage", lambda *a, **kw: snapshot
-    )
+    fetch_tokens = []
+
+    def _fetch(*args, **kwargs):
+        fetch_tokens.append(kwargs.get("api_key"))
+        return snapshot
+
+    monkeypatch.setattr(_account_usage, "fetch_account_usage", _fetch)
 
     auth_usage_command(
         SimpleNamespace(
@@ -1186,6 +1195,7 @@ def test_auth_usage_account_filters_to_label(monkeypatch, capsys):
     assert "Account limits" in out
     assert "Session" in out
     assert "50%" in out
+    assert fetch_tokens == ["tok-1"]
     # With a single-entry filter, no per-account header banner is emitted
     # (consistent with the default one-shot path).
     assert "===" not in out
@@ -1304,7 +1314,7 @@ def test_auth_usage_all_continues_after_per_entry_failure(monkeypatch, capsys):
 
 
 def test_auth_usage_default_warns_when_multiple_pool_entries(monkeypatch, capsys):
-    """The no-flag path must show the head entry AND a hint about ``--all``."""
+    """The no-flag path must use the resolver and hint about ``--all``."""
     from hermes_cli.auth_commands import auth_usage_command
 
     monkeypatch.setattr(
@@ -1357,20 +1367,27 @@ def test_auth_usage_default_warns_when_multiple_pool_entries(monkeypatch, capsys
 
     import agent.account_usage as _account_usage
 
-    monkeypatch.setattr(
-        _account_usage, "fetch_account_usage", lambda *a, **kw: snapshot
-    )
+    fetch_tokens = []
+
+    def _fetch(*args, **kwargs):
+        fetch_tokens.append(kwargs.get("api_key"))
+        return snapshot
+
+    monkeypatch.setattr(_account_usage, "fetch_account_usage", _fetch)
 
     auth_usage_command(
         SimpleNamespace(provider="openai-codex", all_accounts=False, account="")
     )
 
     out = capsys.readouterr().out
-    # Hint points the user at --all; the head entry's snapshot still renders.
+    # The hint points the user at --all; the actual fetch must use the native
+    # resolver rather than silently forcing the pool head.
     assert "2 pool entries" in out
     assert "--all" in out
-    assert "codex-current" in out
-    # The second entry never renders in the default path.
+    assert "resolver-selected" in out
+    assert fetch_tokens == [""]
+    # Neither pool label is selected or printed in the resolver path.
+    assert "codex-current" not in out
     assert "openai-codex-oauth-2" not in out
 
 
@@ -1514,11 +1531,13 @@ def test_auth_usage_reset_redeems_when_credit_available(monkeypatch, capsys):
 
     import agent.account_usage as _account_usage
 
-    monkeypatch.setattr(
-        _account_usage,
-        "redeem_codex_reset_credit",
-        lambda *a, **kw: good_result,
-    )
+    reset_tokens = []
+
+    def _redeem(*args, **kwargs):
+        reset_tokens.append(kwargs.get("api_key"))
+        return good_result
+
+    monkeypatch.setattr(_account_usage, "redeem_codex_reset_credit", _redeem)
 
     # Must not raise — successful redemption exits 0.
     auth_usage_reset_command(
@@ -1531,8 +1550,9 @@ def test_auth_usage_reset_redeems_when_credit_available(monkeypatch, capsys):
     )
 
     out = capsys.readouterr().out
-    assert "codex-current" in out
+    assert "resolver-selected" in out
     assert "Reset redeemed" in out
+    assert reset_tokens == [None]
 
 
 def test_auth_usage_reset_no_credits_banked_is_not_an_error(monkeypatch, capsys):
@@ -1580,11 +1600,13 @@ def test_auth_usage_reset_no_credits_banked_is_not_an_error(monkeypatch, capsys)
 
     import agent.account_usage as _account_usage
 
-    monkeypatch.setattr(
-        _account_usage,
-        "redeem_codex_reset_credit",
-        lambda *a, **kw: no_credit_result,
-    )
+    reset_tokens = []
+
+    def _redeem(*args, **kwargs):
+        reset_tokens.append(kwargs.get("api_key"))
+        return no_credit_result
+
+    monkeypatch.setattr(_account_usage, "redeem_codex_reset_credit", _redeem)
 
     # No SystemExit: structured no-op is a 0 exit so shell loops continue.
     auth_usage_reset_command(
@@ -1598,7 +1620,8 @@ def test_auth_usage_reset_no_credits_banked_is_not_an_error(monkeypatch, capsys)
 
     out = capsys.readouterr().out
     assert "No banked reset credits" in out
-    assert "codex-current" in out
+    assert "resolver-selected" in out
+    assert reset_tokens == [None]
 
 
 def test_auth_usage_reset_transport_failure_exits_nonzero(monkeypatch, capsys):

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -95,6 +95,51 @@ def test_fetch_account_usage_codex(monkeypatch):
     assert "Credits balance: $12.50" in snapshot.details
 
 
+def test_fetch_account_usage_anthropic_uses_explicit_oauth_token(monkeypatch):
+    calls = []
+
+    class _AnthropicClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, url, headers=None):
+            calls.append({"url": url, "headers": headers})
+            return _Response(
+                {
+                    "five_hour": {"utilization": 0.25, "resets_at": 1_900_000_000},
+                    "seven_day": {"utilization": 0.4, "resets_at": 1_900_500_000},
+                }
+            )
+
+    def _unexpected_resolver_call():
+        raise AssertionError("explicit pool token must bypass the global resolver")
+
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_anthropic_token",
+        _unexpected_resolver_call,
+    )
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _AnthropicClient(),
+    )
+
+    snapshot = fetch_account_usage("anthropic", api_key="cc-account-two")
+
+    assert snapshot is not None
+    assert snapshot.provider == "anthropic"
+    assert [window.label for window in snapshot.windows] == [
+        "Current session",
+        "Current week",
+    ]
+    assert snapshot.windows[0].used_percent == 25.0
+    assert calls[0]["url"] == "https://api.anthropic.com/api/oauth/usage"
+    assert calls[0]["headers"]["Authorization"] == "Bearer cc-account-two"
+    assert calls[0]["headers"]["anthropic-beta"] == "oauth-2025-04-20"
+
+
 def test_render_account_usage_lines_includes_reset_and_provider():
     snapshot = AccountUsageSnapshot(
         provider="openai-codex",


### PR DESCRIPTION
## Summary

`hermes auth usage <provider>` — a no-agent CLI entry point that shows the same Codex / Anthropic / OpenRouter account-usage view the REPL `/usage` slash renders, but reachable from any shell without first launching an interactive session.

Supports multi-pool-entry iteration via `--all` (render every account for the provider) and `--account LABEL` (filter to a single stored label), and now exposes the `/usage reset [--force]` operation as `--reset [--force]` on the same command so cron jobs and shell loops can redeem banked reset credits without an interactive session.

## Why

Today, the only way to see the active account's rate-limit windows, plan, and banked reset credits from the terminal is:

1. Launch Hermes,
2. type `/usage` inside the REPL.

`hermes auth list <provider>` only prints credential metadata (account id, status, refresh window) — no live usage numbers. There is no command that lets a cron job, shell loop, or quick manual check fetch usage outside the REPL. For users with multiple pool entries (e.g. two codex credentials), the REPL `/usage` only shows the resolver-selected one, and there was no path to inspect the others. Same story for `/usage reset`: the only way to actually consume a banked reset credit was inside the REPL.

## What changes

Three commits, same branch (`feat/cli-auth-usage`).

**Commit 1 — base command** (`b001b245e`):

- New `hermes auth usage <provider>` subcommand (mirrors the existing `auth status` / `auth logout` shape).
- Credential resolution delegates to `agent.account_usage.fetch_account_usage`'s singleton-then-pool path, so the command reads whatever credential the runtime resolver would pick for an actual chat call. No caller-supplied bearer to misforward.
- Render goes through `render_account_usage_lines` so output is byte-identical to the slash command.
- Hard 10s wall-clock cap on the fetch (matches the in-REPL `/usage` budget). A stuck / hung provider API cannot stall the terminal.
- All failure modes (timeout, no creds, provider offline, 4xx/5xx, unsupported payload) exit non-zero with a short actionable message — never a stacktrace — so it stays scriptable from cron / shell loops.
- Provider set mirrors `fetch_account_usage`'s dispatch table: `{openai-codex, anthropic, openrouter}`. Out-of-set providers get a clear "not supported" error that lists the supported set, so a typo self-corrects on retry.

**Commit 2 — multi-pool-entry iteration** (`ebf256a07`):

- `--all` flag — iterate every pool entry for the provider and render each separately under its own `=== provider: label ===` banner. Per-entry failures (timeout, unavailable snapshot, network) surface inline and do NOT abort the loop, so a rate-limited account #2 cannot block reporting account #1. The command exits non-zero only if no entry rendered at all.
- `--account LABEL` flag — render only the pool entry whose stored label matches. Unknown labels exit non-zero with the known set listed so a typo self-corrects on retry.
- Default (no flag) stays backward compatible: one snapshot from the resolver-selected account, with a hint about `--all` printed when the pool has more than one entry.
- Implementation reads the same `credential_pool[provider]` store the runtime resolver reads. The fetch helper is extracted into `_fetch_account_usage_with_timeout` so the single-account and multi-account paths share one timeout / error contract.

**Commit 3 — `--reset / --force` for banked reset redemption** (`6536ba590`):

- `--reset` flag dispatches to a new `auth_usage_reset_command` that calls the existing `agent.account_usage.redeem_codex_reset_credit` helper (the same one the REPL `/usage reset` slash already uses). This actually consumes one banked rate-limit reset credit on the Codex backend (`POST .../rate-limit-reset-credits/consume`) and lifts pool cooldowns upstream.
- `--force` flag mirrors the REPL `--force` semantics: redeem even if the busiest rate-limit window is not fully used. Without `--force` the client-side guard refuses, because a banked reset restores the FULL 5h + weekly allowance and spending it early wastes most of it.
- Same `--all` / `--account LABEL` flags work for the redeem path too, so multi-account iteration and selection are symmetric.
- Provider gate: only `openai-codex` currently exposes a consume endpoint. Other providers in the supported set get a clear "not implemented yet" message instead of a silent no-op.
- Exit-code contract is deliberate:
  - 0 when at least one entry redeemed, OR every entry reported a structured no-op (`no_credits_banked` / `not_exhausted` / `nothing_to_reset` / `no_credit` / `already_redeemed`).
  - non-zero only on transport-level failure (timeout / network) for every attempted entry, so shell loops can distinguish "nothing to do" from "could not reach provider".
- This command is intentionally distinct from `hermes auth reset <provider>`, which only clears the LOCAL pool exhaustion flag. They answer different questions:
  - `auth reset` — local: "my pool entry is stuck marked rate-limited; clear the local flag so the resolver can pick it again."
  - `auth usage --reset` — server: "I have banked reset credits on the Codex backend; consume one to actually restore quota."

The flag-based dispatch keeps the legacy `hermes auth usage <provider>` form working byte-for-byte — no breaking rename to `auth usage show <provider>` was needed.

## Out of scope

- Aggregate usage across accounts (e.g. sum of `used_percent` across pool entries). The CLI shows each account's snapshot separately so the user can compare them; rollup math lives in the multi-account PR family.
- The `--account-id` flag for `ChatGPT-Account-Id` header override. The Codex endpoint accepts the bearer token without the header for most users; per-account header injection requires extending `fetch_account_usage`'s signature, which is a separate upstream change.
- Reset credits for providers other than `openai-codex`. The provider gate produces a clear "not implemented yet" message; adding Anthropic / OpenRouter equivalents depends on those providers exposing matching endpoints.
- Provider-specific rich formatting. The CLI uses `render_account_usage_lines` verbatim, the same renderer as the REPL slash.

## Tests

20 dedicated tests in `tests/hermes_cli/test_auth_commands.py` (37 in the file):

Read path (12):
- `test_auth_usage_rejects_missing_provider`
- `test_auth_usage_rejects_unsupported_provider`
- `test_auth_usage_requires_logged_in_credential`
- `test_auth_usage_renders_snapshot_on_success`
- `test_auth_usage_times_out_cleanly`
- `test_auth_usage_reports_unavailable_snapshot`
- `test_auth_usage_all_renders_every_pool_entry`
- `test_auth_usage_account_filters_to_label`
- `test_auth_usage_account_unknown_label_exits_nonzero`
- `test_auth_usage_all_continues_after_per_entry_failure`
- `test_auth_usage_default_warns_when_multiple_pool_entries`
- `test_auth_usage_lists_provider_account_credentials_skips_partial_rows`

Reset path (8):
- `test_auth_usage_reset_rejects_unsupported_provider` — provider gate
- `test_auth_usage_reset_rejects_missing_provider` — direct-call empty guard
- `test_auth_usage_reset_requires_logged_in` — fail-fast on no creds
- `test_auth_usage_reset_redeems_when_credit_available` — happy-path redemption, exits 0
- `test_auth_usage_reset_no_credits_banked_is_not_an_error` — structured no-op is exit 0
- `test_auth_usage_reset_transport_failure_exits_nonzero` — timeout surfaces as exit non-zero
- `test_auth_usage_reset_account_unknown_label_exits_nonzero` — typo self-corrects
- `test_auth_usage_reset_dispatches_via_flag` — `--reset` routes to the right handler

Full file: `37 passed`. ruff clean.

## Manual smoke

```text
$ hermes auth usage openai-codex
Note: openai-codex has 2 pool entries; showing 'codex-current'. Re-run with --all to render every account, or --account <label> to pick one.
📈 Account limits
Provider: openai-codex (Plus)
Session: 0% remaining (100% used) • resets in 10h 33m (2026-08-09 09:59 WIB)
You have 1 reset banked - use /usage reset to activate
```

```text
$ hermes auth usage --all openai-codex

=== openai-codex: codex-current ===
📈 Account limits
Provider: openai-codex (Plus)
Session: 0% remaining (100% used) • resets in 10h 33m (2026-08-09 09:59 WIB)
You have 1 reset banked - use /usage reset to activate

=== openai-codex: openai-codex-oauth-2 ===
📈 Account limits
Provider: openai-codex (Plus)
Session: 0% remaining (100% used) • resets in 1d 16h (2026-08-10 15:53 WIB)
```

```text
$ hermes auth usage --reset openai-codex
Note: openai-codex has 2 pool entries; resetting 'codex-current'. Re-run with --all to reset every account, or --account <label> to pick one.
  codex-current: ✅ Reset redeemed — your usage limits have been reset. 0 banked resets remaining.
```

```text
$ hermes auth usage --reset --account openai-codex-oauth-2 openai-codex
  openai-codex-oauth-2: No banked reset credits on this account — nothing to redeem.
```

```text
$ hermes auth usage --reset --all openai-codex

=== openai-codex: codex-current ===
  codex-current: ✅ Reset redeemed — your usage limits have been reset. 0 banked resets remaining.

=== openai-codex: openai-codex-oauth-2 ===
  openai-codex-oauth-2: No banked reset credits on this account — nothing to redeem.
```

```text
$ hermes auth usage --reset spotify
spotify: usage reset is not supported. Supported providers: anthropic, openai-codex, openrouter.
```

```text
$ hermes auth usage --reset anthropic
anthropic: usage reset is not implemented yet (only openai-codex exposes a consume endpoint).
```
