### PR TITLE
fix(stt): normalize command provider audio

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1226,6 +1226,14 @@ stt:
   #   # by the `stt` surface tag — leave `model` blank to take the first
   #   # live result. Pin only when you need a specific Whisper variant.
   #   model: ""
+  # Custom command providers can normalize browser WebM/Opus and other input
+  # formats to 16 kHz mono PCM WAV before substituting {input_path}. This is
+  # opt-in so CLIs that already accept arbitrary containers remain unchanged.
+  # providers:
+  #   custom-asr:
+  #     type: "command"
+  #     command: "custom-asr --input {input_path} --output {output_path}"
+  #     normalize_audio: true  # requires ffmpeg
 
 # Text-to-speech. Only the deepinfra block is documented here — the
 # remaining providers (edge, openai, xai, minimax, mistral, gemini,

--- a/tests/tools/test_transcription_command_providers.py
+++ b/tests/tools/test_transcription_command_providers.py
@@ -19,6 +19,8 @@ identically on Linux, macOS, and Windows (with minor quoting differences).
 from __future__ import annotations
 
 import os
+import shlex
+import subprocess
 import sys
 import wave
 from pathlib import Path
@@ -38,6 +40,7 @@ from tools.transcription_tools import (
     _iter_command_stt_providers,
     _render_command_stt_template,
     _resolve_command_stt_provider_config,
+    _run_ffmpeg_command_stt_normalize,
     _transcribe_command_stt,
     transcribe_audio,
 )
@@ -243,6 +246,139 @@ class TestTranscribeCommandSTT:
         }
         result = _transcribe_command_stt(str(audio), "fake-cli", cfg, {})
         assert result["transcript"] == DEFAULT_COMMAND_STT_LANGUAGE
+
+    def test_normalizes_input_to_temporary_pcm_wav(self, tmp_path):
+        audio = _make_silent_wav(tmp_path / "browser.webm")
+        observed_input = None
+
+        def fake_normalize(_ffmpeg, input_path, output_path):
+            assert input_path == str(audio.resolve())
+            Path(output_path).write_bytes(b"RIFF-normalized")
+
+        def fake_command(command, _timeout, *, env_passthrough):
+            nonlocal observed_input
+            assert env_passthrough == []
+            _executable, input_path, output_path = shlex.split(command)
+            observed_input = Path(input_path)
+            assert observed_input.suffix == ".wav"
+            assert observed_input.read_bytes() == b"RIFF-normalized"
+            Path(output_path).write_text("normalized transcript", encoding="utf-8")
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        cfg = {
+            "type": "command",
+            "command": "probe {input_path} {output_path}",
+            "normalize_audio": True,
+        }
+        with (
+            patch("tools.transcription_tools._find_ffmpeg_binary", return_value="ffmpeg"),
+            patch(
+                "tools.transcription_tools._run_ffmpeg_command_stt_normalize",
+                side_effect=fake_normalize,
+            ),
+            patch("tools.transcription_tools._run_command_stt", side_effect=fake_command),
+        ):
+            result = _transcribe_command_stt(str(audio), "fake-cli", cfg, {})
+
+        assert result["success"] is True
+        assert result["transcript"] == "normalized transcript"
+        assert observed_input is not None
+        assert not observed_input.exists()
+
+    def test_normalization_is_opt_in_and_false_string_stays_raw(self, tmp_path):
+        audio = _make_silent_wav(tmp_path / "browser.webm")
+
+        def fake_command(command, _timeout, *, env_passthrough):
+            _executable, input_path, output_path = shlex.split(command)
+            assert env_passthrough == []
+            assert Path(input_path) == audio.resolve()
+            Path(output_path).write_text("raw transcript", encoding="utf-8")
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        cfg = {
+            "command": "probe {input_path} {output_path}",
+            "normalize_audio": "false",
+        }
+        with (
+            patch(
+                "tools.transcription_tools._find_ffmpeg_binary",
+                side_effect=AssertionError("ffmpeg lookup must remain opt-in"),
+            ),
+            patch("tools.transcription_tools._run_command_stt", side_effect=fake_command),
+        ):
+            result = _transcribe_command_stt(str(audio), "fake-cli", cfg, {})
+
+        assert result["success"] is True
+        assert result["transcript"] == "raw transcript"
+
+    def test_missing_ffmpeg_fails_before_provider_command(self, tmp_path):
+        audio = _make_silent_wav(tmp_path / "browser.webm")
+        cfg = {
+            "command": "probe {input_path} {output_path}",
+            "normalize_audio": True,
+        }
+        with (
+            patch("tools.transcription_tools._find_ffmpeg_binary", return_value=None),
+            patch("tools.transcription_tools._run_command_stt") as command_run,
+        ):
+            result = _transcribe_command_stt(str(audio), "tencent", cfg, {})
+
+        assert result["success"] is False
+        assert "requires ffmpeg" in result["error"]
+        command_run.assert_not_called()
+
+    def test_failed_normalization_fails_before_provider_command(self, tmp_path):
+        audio = _make_silent_wav(tmp_path / "browser.webm")
+        cfg = {
+            "command": "probe {input_path} {output_path}",
+            "normalize_audio": True,
+        }
+        ffmpeg_error = subprocess.CalledProcessError(
+            1,
+            ["ffmpeg"],
+            stderr="invalid input container",
+        )
+        with (
+            patch("tools.transcription_tools._find_ffmpeg_binary", return_value="ffmpeg"),
+            patch(
+                "tools.transcription_tools._run_ffmpeg_command_stt_normalize",
+                side_effect=ffmpeg_error,
+            ),
+            patch("tools.transcription_tools._run_command_stt") as command_run,
+        ):
+            result = _transcribe_command_stt(str(audio), "tencent", cfg, {})
+
+        assert result["success"] is False
+        assert "input normalization failed: invalid input container" in result["error"]
+        command_run.assert_not_called()
+
+
+class TestRunFFmpegCommandSTTNormalize:
+    def test_uses_16khz_mono_pcm_wav_profile(self):
+        with patch("tools.transcription_tools.subprocess.run") as run:
+            _run_ffmpeg_command_stt_normalize(
+                "/usr/bin/ffmpeg",
+                "/tmp/input.webm",
+                "/tmp/output.wav",
+            )
+
+        command = run.call_args.args[0]
+        assert command == [
+            "/usr/bin/ffmpeg",
+            "-y",
+            "-i",
+            "/tmp/input.webm",
+            "-vn",
+            "-ac",
+            "1",
+            "-ar",
+            "16000",
+            "-c:a",
+            "pcm_s16le",
+            "/tmp/output.wav",
+        ]
+        assert run.call_args.kwargs["check"] is True
+        assert run.call_args.kwargs["stdin"] is subprocess.DEVNULL
 
 
 # ---------------------------------------------------------------------------

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -240,6 +240,12 @@ _STT_M4A_ENCODE_ARGS = (
     "-c:a", "aac", "-b:a", "32k", "-movflags", "+faststart",
 )
 
+# Provider-neutral input profile for command STT backends that require a
+# predictable container and sample format (for example Tencent 16k_zh).
+_COMMAND_STT_WAV_ENCODE_ARGS = (
+    "-vn", "-ac", "1", "-ar", "16000", "-c:a", "pcm_s16le",
+)
+
 
 def _run_ffmpeg_stt_encode(
     ffmpeg: str, input_path: str, output_path: str, *, audio_filter: Optional[str] = None
@@ -257,6 +263,32 @@ def _run_ffmpeg_stt_encode(
         command, check=True, capture_output=True, text=True,
         encoding="utf-8", errors="replace", timeout=120,
         stdin=subprocess.DEVNULL, creationflags=windows_hide_flags(),
+    )
+
+
+def _run_ffmpeg_command_stt_normalize(
+    ffmpeg: str,
+    input_path: str,
+    output_path: str,
+) -> None:
+    """Normalize command-provider input to 16 kHz mono PCM WAV."""
+    subprocess.run(
+        [
+            ffmpeg,
+            "-y",
+            "-i",
+            input_path,
+            *_COMMAND_STT_WAV_ENCODE_ARGS,
+            output_path,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=120,
+        stdin=subprocess.DEVNULL,
+        creationflags=windows_hide_flags(),
     )
 
 
@@ -533,6 +565,37 @@ def _get_command_stt_output_format(config: Dict[str, Any]) -> str:
     )
     fmt = str(raw).lower().strip().lstrip(".")
     return fmt if fmt in COMMAND_STT_OUTPUT_FORMATS else DEFAULT_COMMAND_STT_OUTPUT_FORMAT
+
+
+def _normalize_command_stt_input(
+    file_path: Path,
+    work_dir: Path,
+) -> tuple[Optional[Path], Optional[str]]:
+    """Return a normalized PCM WAV path or an actionable conversion error."""
+    ffmpeg = _find_ffmpeg_binary()
+    if not ffmpeg:
+        return None, (
+            "input normalization requires ffmpeg, but ffmpeg was not found"
+        )
+
+    normalized_path = work_dir / f"{file_path.stem or 'audio'}-stt.wav"
+    try:
+        _run_ffmpeg_command_stt_normalize(
+            ffmpeg,
+            str(file_path),
+            str(normalized_path),
+        )
+    except subprocess.TimeoutExpired:
+        return None, "input normalization timed out after 120s"
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or exc.stdout or "no ffmpeg output").strip()
+        return None, f"input normalization failed: {detail}"
+    except OSError as exc:
+        return None, f"input normalization failed: {exc}"
+
+    if not normalized_path.is_file() or normalized_path.stat().st_size == 0:
+        return None, "input normalization failed: ffmpeg produced no audio"
+    return normalized_path, None
 
 
 def _shell_quote_context_stt(command_template: str, position: int) -> Optional[str]:
@@ -883,7 +946,7 @@ def _transcribe_command_stt(
 
     | Placeholder       | Substituted with                                          |
     |-------------------|-----------------------------------------------------------|
-    | ``{input_path}``  | absolute path to the audio file (original location)       |
+    | ``{input_path}``  | absolute path to the original or normalized audio file    |
     | ``{output_path}`` | absolute path the provider should write its transcript to |
     | ``{output_dir}``  | parent dir of ``{output_path}``                           |
     | ``{format}``      | configured output format (``txt`` / ``json`` / ``srt`` / ``vtt``) |
@@ -925,9 +988,27 @@ def _transcribe_command_stt(
 
     try:
         with tempfile.TemporaryDirectory(prefix=f"hermes-cmd-stt-{provider_name}-") as tmpdir:
+            command_audio = audio.resolve()
+            if is_truthy_value(config.get("normalize_audio"), default=False):
+                normalized_audio, normalize_error = _normalize_command_stt_input(
+                    command_audio,
+                    Path(tmpdir),
+                )
+                if normalize_error or normalized_audio is None:
+                    return {
+                        "success": False,
+                        "transcript": "",
+                        "provider": provider_name,
+                        "error": (
+                            f"STT command provider '{provider_name}' "
+                            f"{normalize_error or 'input normalization produced no path'}"
+                        ),
+                    }
+                command_audio = normalized_audio
+
             output_path = Path(tmpdir) / f"transcript.{output_format}"
             placeholders = {
-                "input_path": str(audio.resolve()),
+                "input_path": str(command_audio),
                 "output_path": str(output_path),
                 "output_dir": str(output_path.parent),
                 "format": output_format,


### PR DESCRIPTION
## Summary

- add opt-in `normalize_audio` handling for custom command STT providers
- convert provider input to temporary 16 kHz mono PCM WAV before rendering `{input_path}`
- fail before invoking the provider when ffmpeg is missing or conversion fails, and clean up the normalized file after each call
- document the provider setting in `cli-config.yaml.example`

## Root cause and coverage

Desktop recordings can arrive as 48 kHz WebM/Opus, but `_transcribe_command_stt()` substituted the original path directly. Strict command backends such as Tencent `16k_zh` therefore received an unsupported container. The existing OpenAI retry helper produces AAC/M4A for an API-specific path, so this change uses a separate provider-neutral PCM-WAV profile and leaves that upload path and the built-in local-command path unchanged.

Normalization is disabled by default, preserving existing command providers that already accept arbitrary containers. Regression coverage verifies the exact ffmpeg profile, string/boolean opt-in behavior, placeholder ordering, fail-closed missing/failed ffmpeg handling, provider non-invocation on conversion failure, and temporary-file cleanup.

## Verification

- `tests/tools/test_transcription_command_providers.py`: 24 passed
- command-provider + cloud-trim + adjacent transcription suites: 97 passed; 1 unrelated local-Whisper expectation fails unchanged on exact base `3d7dda4cf421`
- real ffmpeg WebM production-path smoke: provider observed mono, 16 kHz, 16-bit PCM WAV
- `ruff check .`
- Windows footgun check on changed Python files
- Python bytecode compilation
- `uv lock --check`
- contribution publish gate and gitleaks

Closes #81811

Reported by @FreeQueue.
