### PR TITLE
fix(kanban): terminate timed-out workers before retry

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -74,6 +74,11 @@ def _record_kanban_budget_exhausted(
         from hermes_cli import kanban_db as _kb
         _conn = _kb.connect()
         try:
+            _run_id_raw = os.environ.get("HERMES_KANBAN_RUN_ID", "")
+            try:
+                _expected_run_id = int(_run_id_raw) if _run_id_raw else None
+            except ValueError:
+                _expected_run_id = None
             _kb._record_task_failure(
                 _conn,
                 kanban_task,
@@ -90,6 +95,8 @@ def _record_kanban_budget_exhausted(
                     "budget_used": api_call_count,
                     "budget_max": max_iterations,
                 },
+                expected_run_id=_expected_run_id,
+                expected_claim_lock=os.environ.get("HERMES_KANBAN_CLAIM_LOCK"),
             )
         finally:
             try:

--- a/contributors/emails/royce.personalassistant@gmail.com
+++ b/contributors/emails/royce.personalassistant@gmail.com
@@ -1,0 +1,2 @@
+roycepersonalassistant
+# PR #80020

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7982,6 +7982,12 @@ DEFAULT_LOG_BACKUP_COUNT = 1
 # and call kanban_block/kanban_complete before max_runtime_seconds kills it.
 KANBAN_TERMINAL_TIMEOUT_GRACE_SECONDS = 30
 
+# A worker that timed itself out may still be unwinding after releasing its
+# task lease. Remote PIDs and local PIDs without a start-time fingerprint
+# cannot be safely signalled, so quarantine their retry briefly instead of
+# either risking an immediate concurrent writer or stranding the task forever.
+TERMINAL_TIMEOUT_UNVERIFIED_GUARD_SECONDS = 300
+
 # ---------------------------------------------------------------------------
 # Respawn guard constants
 # ---------------------------------------------------------------------------
@@ -8464,13 +8470,14 @@ def _terminate_terminal_timeout_worker_before_respawn(
 
     Returns a respawn-guard reason when the original worker cannot be proven
     gone. Host-local workers are fingerprinted and terminated before retry;
-    remote claimers fail closed because their PID cannot be interpreted from
-    this host's process namespace. A dead worker, a recycled host-local PID,
-    or a timeout run produced by the dispatcher's max-runtime path falls
-    through to the normal claim path.
+    remote claimers and unverifiable local PIDs fail closed during a bounded
+    quarantine because they cannot be safely signalled. A dead worker, a
+    recycled host-local PID, an expired quarantine, or a timeout run produced
+    by the dispatcher's max-runtime path falls through to the normal claim
+    path.
     """
     row = conn.execute(
-        "SELECT outcome, metadata FROM task_runs "
+        "SELECT outcome, metadata, ended_at FROM task_runs "
         "WHERE task_id = ? AND ended_at IS NOT NULL "
         "ORDER BY id DESC LIMIT 1",
         (task_id,),
@@ -8498,22 +8505,30 @@ def _terminate_terminal_timeout_worker_before_respawn(
     if not claimer:
         return None
 
+    quarantine_expired = (
+        int(time.time()) - int(row["ended_at"])
+        >= TERMINAL_TIMEOUT_UNVERIFIED_GUARD_SECONDS
+    )
+
     # Claim locks are host-qualified (``host:pid``). A numeric PID from a
     # different host has no meaning in this process namespace: probing it could
     # mistake an unrelated local process for the timed-out remote worker, while
     # allowing the retry could create the same concurrent-writer race remotely.
-    # Keep the task ready and let the originating host prove/terminate its own
-    # worker before any claimant starts a replacement.
+    # Keep the task ready long enough for the originating host to finish
+    # unwinding. After the bounded quarantine, availability wins: a host that
+    # never returns must not strand the task forever.
     host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
     if not str(claimer).startswith(host_prefix):
-        return "timed_out_worker_remote_unverified"
+        if not quarantine_expired:
+            return "timed_out_worker_remote_unverified"
+        return None
 
     expected_started_at = identity.get("process_started_at")
     if expected_started_at is None:
         # Without the start fingerprint, a live numeric PID may already have
         # been recycled. Fail closed instead of signalling an unproven process
         # or starting a concurrent retry beside the original worker.
-        if _pid_alive(pid):
+        if _pid_alive(pid) and not quarantine_expired:
             return "timed_out_worker_identity_unverified"
         return None
 
@@ -8521,7 +8536,7 @@ def _terminate_terminal_timeout_worker_before_respawn(
     if current_started_at is None:
         # A missing current fingerprint normally means the original PID is
         # already gone. If it still appears alive, keep the retry gated.
-        if _pid_alive(pid):
+        if _pid_alive(pid) and not quarantine_expired:
             return "timed_out_worker_identity_unverified"
         return None
     if int(current_started_at) != int(expected_started_at):

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4626,6 +4626,11 @@ def claim_task(
     Returns the claimed ``Task`` on success, ``None`` if the task was
     already claimed (or is not in ``ready`` status).
     """
+    # Enforce terminal-timeout teardown at the claim boundary, not only in
+    # auto-dispatch. Interactive/control-plane claimers use this same API and
+    # must not start a second writer while the previous worker is still alive.
+    if _terminate_terminal_timeout_worker_before_respawn(conn, task_id) is not None:
+        return None
     now = int(time.time())
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
@@ -8061,9 +8066,11 @@ class DispatchResult:
     respawn_guarded: list[tuple[str, str]] = field(default_factory=list)
     """Tasks skipped by the respawn guard, as ``(task_id, reason)`` pairs.
 
-    Reasons: ``"blocker_auth"`` (quota/auth error — also auto-blocked),
-    ``"recent_success"`` (completed run within guard window),
-    ``"active_pr"`` (GitHub PR URL in a recent comment)."""
+    Reasons include ``"blocker_auth"`` (quota/auth error — also
+    auto-blocked), ``"recent_success"`` (completed run within guard window),
+    ``"active_pr"`` (GitHub PR URL in a recent comment), and
+    ``"timed_out_worker_*"`` (a terminal timeout's host worker has not been
+    safely reaped yet)."""
     rate_limited: list[str] = field(default_factory=list)
     """Task ids whose workers bailed on a provider rate-limit / quota wall
     (EX_TEMPFAIL sentinel exit) and were released back to ``ready`` WITHOUT
@@ -8326,6 +8333,219 @@ def _worker_survived_termination(termination: dict) -> bool:
         and termination.get("host_local")
         and not termination.get("terminated")
     )
+
+
+def _worker_process_start_time(pid: int) -> Optional[int]:
+    """Return the PID-reuse fingerprint used by gateway process guards."""
+    try:
+        from gateway.status import get_process_start_time
+        return get_process_start_time(int(pid))
+    except Exception:
+        return None
+
+
+def _terminate_identified_worker(
+    pid: int,
+    claimer: str,
+    expected_started_at: int,
+) -> dict[str, Any]:
+    """Terminate one proven host-local process without crossing PID reuse.
+
+    Recheck the process-start fingerprint before every signal and throughout
+    the grace period so a recycled PID cannot receive this worker's SIGKILL.
+    """
+    import signal
+
+    host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
+    result: dict[str, Any] = {
+        "pid": int(pid),
+        "claimer": str(claimer),
+        "host_local": str(claimer).startswith(host_prefix),
+        "termination_attempted": False,
+        "terminated": False,
+    }
+    if not result["host_local"]:
+        return result
+
+    def same_live_process() -> Optional[bool]:
+        if not _pid_alive(pid):
+            return False
+        current_started_at = _worker_process_start_time(pid)
+        if current_started_at is None:
+            return None
+        return int(current_started_at) == int(expected_started_at)
+
+    identity = same_live_process()
+    if identity is False:
+        result["terminated"] = True
+        return result
+    if identity is None:
+        result["identity_unverified"] = True
+        return result
+
+    result["termination_attempted"] = True
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        result["terminated"] = True
+        return result
+    except (PermissionError, OSError) as exc:
+        result["termination_error"] = type(exc).__name__
+        return result
+
+    for _ in range(10):
+        time.sleep(0.5)
+        identity = same_live_process()
+        if identity is False:
+            result["terminated"] = True
+            return result
+        if identity is None:
+            result["identity_unverified"] = True
+            return result
+
+    # Revalidate immediately before escalation. A process that now has a
+    # different start fingerprint is a recycled PID, not our worker.
+    identity = same_live_process()
+    if identity is False:
+        result["terminated"] = True
+        return result
+    if identity is None:
+        result["identity_unverified"] = True
+        return result
+    try:
+        # Windows has no SIGKILL; Python maps SIGTERM to TerminateProcess there.
+        force_signal = getattr(signal, "SIGKILL", signal.SIGTERM)
+        os.kill(pid, force_signal)
+    except ProcessLookupError:
+        result["terminated"] = True
+        return result
+    except (PermissionError, OSError) as exc:
+        result["termination_error"] = type(exc).__name__
+        return result
+
+    for _ in range(4):
+        time.sleep(0.25)
+        identity = same_live_process()
+        if identity is False:
+            result["terminated"] = True
+            return result
+        if identity is None:
+            result["identity_unverified"] = True
+            return result
+    return result
+
+
+def _terminal_timeout_worker_identity(row: sqlite3.Row) -> Optional[dict[str, Any]]:
+    """Capture enough identity to reap a worker after it closes its own run.
+
+    Iteration-budget exhaustion is recorded from inside the worker process.
+    That transaction must release the task lease, but the Python process can
+    remain alive briefly (or hang during shutdown).  Persisting the PID,
+    claimer, and process start fingerprint on the closed run lets the next
+    dispatcher tick prove it is still looking at the same host-local process
+    before signalling it.
+    """
+    pid = row["worker_pid"]
+    claimer = row["claim_lock"]
+    if not pid or int(pid) <= 0 or not claimer:
+        return None
+    return {
+        "pid": int(pid),
+        "claimer": str(claimer),
+        "process_started_at": _worker_process_start_time(int(pid)),
+    }
+
+
+def _terminate_terminal_timeout_worker_before_respawn(
+    conn: sqlite3.Connection,
+    task_id: str,
+) -> Optional[str]:
+    """Reap a live worker from the latest terminal timeout before retrying.
+
+    Returns a respawn-guard reason when the original worker cannot be proven
+    gone. Host-local workers are fingerprinted and terminated before retry;
+    remote claimers fail closed because their PID cannot be interpreted from
+    this host's process namespace. A dead worker, a recycled host-local PID,
+    or a timeout run produced by the dispatcher's max-runtime path falls
+    through to the normal claim path.
+    """
+    row = conn.execute(
+        "SELECT outcome, metadata FROM task_runs "
+        "WHERE task_id = ? AND ended_at IS NOT NULL "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    if row is None or not row["metadata"]:
+        return None
+    try:
+        metadata = json.loads(row["metadata"])
+    except (TypeError, ValueError):
+        return None
+    is_timeout_run = row["outcome"] == "timed_out" or (
+        row["outcome"] == "gave_up"
+        and metadata.get("trigger_outcome") == "timed_out"
+    )
+    if not is_timeout_run:
+        return None
+    identity = metadata.get("terminal_worker")
+    if not isinstance(identity, dict):
+        return None
+    try:
+        pid = int(identity["pid"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    claimer = identity.get("claimer")
+    if not claimer:
+        return None
+
+    # Claim locks are host-qualified (``host:pid``). A numeric PID from a
+    # different host has no meaning in this process namespace: probing it could
+    # mistake an unrelated local process for the timed-out remote worker, while
+    # allowing the retry could create the same concurrent-writer race remotely.
+    # Keep the task ready and let the originating host prove/terminate its own
+    # worker before any claimant starts a replacement.
+    host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
+    if not str(claimer).startswith(host_prefix):
+        return "timed_out_worker_remote_unverified"
+
+    expected_started_at = identity.get("process_started_at")
+    if expected_started_at is None:
+        # Without the start fingerprint, a live numeric PID may already have
+        # been recycled. Fail closed instead of signalling an unproven process
+        # or starting a concurrent retry beside the original worker.
+        if _pid_alive(pid):
+            return "timed_out_worker_identity_unverified"
+        return None
+
+    current_started_at = _worker_process_start_time(pid)
+    if current_started_at is None:
+        # A missing current fingerprint normally means the original PID is
+        # already gone. If it still appears alive, keep the retry gated.
+        if _pid_alive(pid):
+            return "timed_out_worker_identity_unverified"
+        return None
+    if int(current_started_at) != int(expected_started_at):
+        # PID was recycled after the timed-out worker exited. Never signal
+        # the new process; the old writer is already gone.
+        return None
+
+    termination = _terminate_identified_worker(
+        pid,
+        str(claimer),
+        int(expected_started_at),
+    )
+    if termination.get("identity_unverified"):
+        return "timed_out_worker_identity_unverified"
+    if _worker_survived_termination(termination):
+        return "timed_out_worker_alive"
+    if (
+        termination.get("host_local")
+        and not termination.get("termination_attempted")
+        and not termination.get("terminated")
+        and _pid_alive(pid)
+    ):
+        return "timed_out_worker_termination_unavailable"
+    return None
 
 
 def _defer_reclaim_for_live_worker(
@@ -9160,6 +9380,8 @@ def _record_task_failure(
     release_claim: bool = False,
     end_run: bool = False,
     event_payload_extra: Optional[dict] = None,
+    expected_run_id: Optional[int] = None,
+    expected_claim_lock: Optional[str] = None,
 ) -> bool:
     """Record a non-success outcome (spawn_failed / crashed / timed_out)
     and maybe trip the circuit breaker.
@@ -9174,10 +9396,12 @@ def _record_task_failure(
 
     Modes:
 
-    * ``release_claim=True, end_run=True`` — spawn-failure path.
-      Caller has a running task with an open run; this transitions
-      it back to its source phase (or ``blocked`` when the breaker trips),
-      releases the claim, and closes the run with ``outcome=<outcome>``.
+    * ``release_claim=True, end_run=True`` — active-run terminal path.
+      Spawn failures and worker-side iteration timeouts use this mode. Caller
+      has a running task with an open run; this restores its source phase (or
+      ``blocked`` when the breaker trips), releases the claim, and closes the
+      run with ``outcome=<outcome>``. Worker-side timeouts also persist the
+      host process identity so dispatch can reap it before retry.
 
     * ``release_claim=False, end_run=False`` — timeout/crash path.
       Caller has ALREADY restored the task's source phase and closed the
@@ -9209,10 +9433,21 @@ def _record_task_failure(
     blocked = False
     with write_txn(conn):
         row = conn.execute(
-            "SELECT consecutive_failures, status, max_retries, current_run_id "
+            "SELECT consecutive_failures, status, max_retries, "
+            "worker_pid, claim_lock, current_run_id "
             "FROM tasks WHERE id = ?", (task_id,),
         ).fetchone()
         if row is None:
+            return False
+        if (
+            expected_run_id is not None
+            and row["current_run_id"] != int(expected_run_id)
+        ):
+            return False
+        if (
+            expected_claim_lock is not None
+            and row["claim_lock"] != expected_claim_lock
+        ):
             return False
         retry_status = (
             _retry_status_for_run(conn, task_id, row["current_run_id"])
@@ -9220,6 +9455,12 @@ def _record_task_failure(
             else ("review" if row["status"] == "review" else "ready")
         )
         failures = int(row["consecutive_failures"]) + 1
+        failure_payload_extra = dict(event_payload_extra or {})
+        terminal_worker = None
+        if outcome == "timed_out" and release_claim and end_run:
+            terminal_worker = _terminal_timeout_worker_identity(row)
+            if terminal_worker is not None:
+                failure_payload_extra["terminal_worker"] = terminal_worker
 
         # Per-task override wins over both caller-supplied and default
         # thresholds. None (the common case) falls through.
@@ -9256,18 +9497,21 @@ def _record_task_failure(
                 )
             run_id = None
             if end_run:
-                # Only the spawn path has an open run to close.
+                # Active-run terminal paths still have an open run to close.
+                run_metadata: dict[str, Any] = {
+                    "failures": failures,
+                    "trigger_outcome": outcome,
+                    "effective_limit": effective_limit,
+                    "limit_source": limit_source,
+                    "retry_status": retry_status,
+                }
+                if terminal_worker is not None:
+                    run_metadata["terminal_worker"] = terminal_worker
                 run_id = _end_run(
                     conn, task_id,
                     outcome="gave_up", status="gave_up",
                     error=error[:500],
-                    metadata={
-                        "failures": failures,
-                        "trigger_outcome": outcome,
-                        "effective_limit": effective_limit,
-                        "limit_source": limit_source,
-                        "retry_status": retry_status,
-                    },
+                    metadata=run_metadata,
                 )
             payload = {
                 "failures": failures,
@@ -9277,8 +9521,8 @@ def _record_task_failure(
                 "trigger_outcome": outcome,
                 "retry_status": retry_status,
             }
-            if event_payload_extra:
-                payload.update(event_payload_extra)
+            if failure_payload_extra:
+                payload.update(failure_payload_extra)
             _append_event(
                 conn, task_id, "gave_up", payload, run_id=run_id,
             )
@@ -9302,23 +9546,29 @@ def _record_task_failure(
                     (failures, error[:500], task_id),
                 )
             if end_run:
-                # Spawn path: close the open run with outcome.
+                # Active-run terminal path: close the open run with outcome.
+                run_metadata: dict[str, Any] = {
+                    "failures": failures,
+                    "retry_status": retry_status,
+                }
+                if terminal_worker is not None:
+                    run_metadata["terminal_worker"] = terminal_worker
                 run_id = _end_run(
                     conn, task_id,
                     outcome=outcome, status=outcome,
                     error=error[:500],
-                    metadata={
-                        "failures": failures,
-                        "retry_status": retry_status,
-                    },
+                    metadata=run_metadata,
                 )
+                event_payload = {
+                    "error": error[:500],
+                    "failures": failures,
+                    "retry_status": retry_status,
+                }
+                if failure_payload_extra:
+                    event_payload.update(failure_payload_extra)
                 _append_event(
                     conn, task_id, outcome,
-                    {
-                        "error": error[:500],
-                        "failures": failures,
-                        "retry_status": retry_status,
-                    },
+                    event_payload,
                     run_id=run_id,
                 )
             # Timeout/crash path's caller already emitted its own event.
@@ -10194,6 +10444,23 @@ def _dispatch_once_locked(
                     (row["id"], row_assignee, current)
                 )
                 continue
+        # A worker can terminally time itself out while its host process is
+        # still unwinding. Reap that exact process (PID + start fingerprint)
+        # before claiming the retry, otherwise two attempts can write the same
+        # workspace concurrently.
+        timeout_worker_guard = None
+        if not dry_run:
+            timeout_worker_guard = _terminate_terminal_timeout_worker_before_respawn(
+                conn, row["id"],
+            )
+        if timeout_worker_guard is not None:
+            result.respawn_guarded.append((row["id"], timeout_worker_guard))
+            with write_txn(conn):
+                _append_event(
+                    conn, row["id"], "respawn_guarded",
+                    {"reason": timeout_worker_guard},
+                )
+            continue
         # Respawn guard: refuse to re-spawn when useful work is already
         # in-flight/recent, or when the last failure is a deterministic
         # blocker (quota / auth). The guard defers the spawn this tick so

--- a/tests/agent/test_turn_finalizer_iteration_limit_exit.py
+++ b/tests/agent/test_turn_finalizer_iteration_limit_exit.py
@@ -168,6 +168,8 @@ def test_pending_response_does_not_mask_later_terminal_exit(
 def test_pending_response_records_kanban_timeout(monkeypatch):
     monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
     monkeypatch.setenv("HERMES_KANBAN_TASK", "task-123")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "17")
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", "host:claim-17")
     record = MagicMock(name="record_task_failure")
     conn = SimpleNamespace(close=lambda: None)
     monkeypatch.setattr("hermes_cli.kanban_db.connect", lambda: conn)
@@ -193,6 +195,8 @@ def test_pending_response_records_kanban_timeout(monkeypatch):
         release_claim=True,
         end_run=True,
         event_payload_extra={"budget_used": 60, "budget_max": 60},
+        expected_run_id=17,
+        expected_claim_lock="host:claim-17",
     )
 
 

--- a/tests/hermes_cli/test_kanban_terminal_timeout_teardown.py
+++ b/tests/hermes_cli/test_kanban_terminal_timeout_teardown.py
@@ -23,6 +23,7 @@ def kanban_home(tmp_path, monkeypatch):
     return home
 
 
+@pytest.mark.live_system_guard_bypass
 def test_terminal_timeout_kills_previous_worker_before_retry_spawn(kanban_home):
     """A worker-side timeout must not release a live writer into a retry race."""
     previous_worker = subprocess.Popen(
@@ -130,6 +131,7 @@ def test_terminal_timeout_without_process_fingerprint_fails_closed(
         conn.close()
 
 
+@pytest.mark.live_system_guard_bypass
 def test_direct_claim_reaps_terminal_timeout_worker_first(kanban_home):
     """Manual/control-plane claims must use the same teardown boundary."""
     previous_worker = subprocess.Popen(
@@ -208,6 +210,7 @@ def test_stale_timeout_report_cannot_close_a_newer_run(kanban_home):
         conn.close()
 
 
+@pytest.mark.live_system_guard_bypass
 def test_unblocked_gave_up_timeout_reaps_worker_before_claim(kanban_home):
     """A breaker outcome must retain the timeout teardown requirement."""
     previous_worker = subprocess.Popen(

--- a/tests/hermes_cli/test_kanban_terminal_timeout_teardown.py
+++ b/tests/hermes_cli/test_kanban_terminal_timeout_teardown.py
@@ -1,0 +1,360 @@
+"""Regression coverage for terminal timeout worker teardown ordering."""
+
+from __future__ import annotations
+
+import signal
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda _profile: True)
+    kb.init_db()
+    return home
+
+
+def test_terminal_timeout_kills_previous_worker_before_retry_spawn(kanban_home):
+    """A worker-side timeout must not release a live writer into a retry race."""
+    previous_worker = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)"]
+    )
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="timeout retry", assignee="developer")
+        assert kb.claim_task(conn, task_id) is not None
+        first_run = kb.latest_run(conn, task_id)
+        assert first_run is not None
+        kb._set_worker_pid(conn, task_id, previous_worker.pid)
+
+        kb._record_task_failure(
+            conn,
+            task_id,
+            error="Iteration budget exhausted (90/90)",
+            outcome="timed_out",
+            release_claim=True,
+            end_run=True,
+            event_payload_extra={"budget_used": 90, "budget_max": 90},
+        )
+
+        task = kb.get_task(conn, task_id)
+        closed_run = kb.get_run(conn, first_run.id)
+        assert task is not None
+        assert closed_run is not None
+        assert task.status == "ready"
+        assert task.claim_lock is None
+        assert task.current_run_id is None
+        assert closed_run.outcome == "timed_out"
+        assert closed_run.ended_at is not None
+
+        alive_at_spawn = []
+
+        def spawn_retry(_task, _workspace):
+            alive_at_spawn.append(previous_worker.poll() is None)
+            return None
+
+        result = kb.dispatch_once(conn, spawn_fn=spawn_retry)
+
+        assert result.spawned and result.spawned[0][0] == task_id
+        assert alive_at_spawn == [False]
+        previous_worker.wait(timeout=5)
+        retry_run = kb.latest_run(conn, task_id)
+        assert retry_run is not None
+        assert retry_run.id != first_run.id
+        assert retry_run.ended_at is None
+    finally:
+        conn.close()
+        if previous_worker.poll() is None:
+            previous_worker.terminate()
+            previous_worker.wait(timeout=5)
+
+
+def test_terminal_timeout_without_process_fingerprint_fails_closed(
+    kanban_home, monkeypatch
+):
+    """An unverifiable live PID must block retry rather than risk overlap."""
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="timeout retry", assignee="developer")
+        assert kb.claim_task(conn, task_id) is not None
+        kb._set_worker_pid(conn, task_id, 424242)
+        monkeypatch.setattr(kb, "_worker_process_start_time", lambda _pid: None)
+
+        kb._record_task_failure(
+            conn,
+            task_id,
+            error="Iteration budget exhausted (90/90)",
+            outcome="timed_out",
+            release_claim=True,
+            end_run=True,
+        )
+
+        monkeypatch.setattr(kb, "_pid_alive", lambda _pid: True)
+        termination_calls = []
+
+        def terminate_worker(pid, claimer):
+            termination_calls.append((pid, claimer))
+            return {
+                "host_local": True,
+                "termination_attempted": True,
+                "terminated": True,
+            }
+
+        monkeypatch.setattr(kb, "_terminate_reclaimed_worker", terminate_worker)
+        spawn_calls = []
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda task, _workspace: spawn_calls.append(task.id),
+        )
+
+        assert spawn_calls == []
+        assert termination_calls == []
+        assert result.respawn_guarded == [
+            (task_id, "timed_out_worker_identity_unverified")
+        ]
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "ready"
+        assert task.claim_lock is None
+        assert task.current_run_id is None
+    finally:
+        conn.close()
+
+
+def test_direct_claim_reaps_terminal_timeout_worker_first(kanban_home):
+    """Manual/control-plane claims must use the same teardown boundary."""
+    previous_worker = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)"]
+    )
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="direct timeout retry")
+        assert kb.claim_task(conn, task_id) is not None
+        kb._set_worker_pid(conn, task_id, previous_worker.pid)
+        kb._record_task_failure(
+            conn,
+            task_id,
+            error="Iteration budget exhausted (90/90)",
+            outcome="timed_out",
+            release_claim=True,
+            end_run=True,
+        )
+
+        retry = kb.claim_task(conn, task_id)
+
+        assert retry is not None
+        assert previous_worker.poll() is not None
+    finally:
+        conn.close()
+        if previous_worker.poll() is None:
+            previous_worker.terminate()
+            previous_worker.wait(timeout=5)
+
+
+def test_stale_timeout_report_cannot_close_a_newer_run(kanban_home):
+    """A delayed finalizer must be bound to its original run and claim."""
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="stale finalizer")
+        first_claim = kb.claim_task(conn, task_id)
+        assert first_claim is not None
+        first_run = kb.latest_run(conn, task_id)
+        assert first_run is not None
+        first_claim_lock = first_claim.claim_lock
+        assert first_claim_lock is not None
+
+        kb._record_task_failure(
+            conn,
+            task_id,
+            error="first attempt ended",
+            outcome="crashed",
+            release_claim=True,
+            end_run=True,
+        )
+        second_claim = kb.claim_task(conn, task_id)
+        assert second_claim is not None
+        second_run = kb.latest_run(conn, task_id)
+        assert second_run is not None
+
+        kb._record_task_failure(
+            conn,
+            task_id,
+            error="late timeout from first attempt",
+            outcome="timed_out",
+            release_claim=True,
+            end_run=True,
+            expected_run_id=first_run.id,
+            expected_claim_lock=first_claim_lock,
+        )
+
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "running"
+        assert task.current_run_id == second_run.id
+        assert task.claim_lock == second_claim.claim_lock
+        active_run = kb.get_run(conn, second_run.id)
+        assert active_run is not None
+        assert active_run.ended_at is None
+    finally:
+        conn.close()
+
+
+def test_unblocked_gave_up_timeout_reaps_worker_before_claim(kanban_home):
+    """A breaker outcome must retain the timeout teardown requirement."""
+    previous_worker = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)"]
+    )
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(
+            conn,
+            title="gave-up timeout retry",
+            max_retries=1,
+        )
+        assert kb.claim_task(conn, task_id) is not None
+        kb._set_worker_pid(conn, task_id, previous_worker.pid)
+        blocked = kb._record_task_failure(
+            conn,
+            task_id,
+            error="Iteration budget exhausted (90/90)",
+            outcome="timed_out",
+            release_claim=True,
+            end_run=True,
+        )
+        assert blocked is True
+        assert kb.unblock_task(conn, task_id) is True
+
+        retry = kb.claim_task(conn, task_id)
+
+        assert retry is not None
+        assert previous_worker.poll() is not None
+    finally:
+        conn.close()
+        if previous_worker.poll() is None:
+            previous_worker.terminate()
+            previous_worker.wait(timeout=5)
+
+
+def test_pid_reuse_after_sigterm_never_receives_sigkill(kanban_home, monkeypatch):
+    """Revalidate the process fingerprint throughout the termination grace."""
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="pid reuse")
+        assert kb.claim_task(conn, task_id) is not None
+        kb._set_worker_pid(conn, task_id, 424242)
+        monkeypatch.setattr(kb, "_worker_process_start_time", lambda _pid: 100)
+        kb._record_task_failure(
+            conn,
+            task_id,
+            error="Iteration budget exhausted (90/90)",
+            outcome="timed_out",
+            release_claim=True,
+            end_run=True,
+        )
+
+        process_starts = iter([100, 100, 200])
+        monkeypatch.setattr(
+            kb,
+            "_worker_process_start_time",
+            lambda _pid: next(process_starts),
+        )
+        monkeypatch.setattr(kb, "_pid_alive", lambda _pid: True)
+        monkeypatch.setattr(kb.time, "sleep", lambda _seconds: None)
+        signals = []
+        monkeypatch.setattr(kb.os, "kill", lambda pid, sig: signals.append((pid, sig)))
+
+        retry = kb.claim_task(conn, task_id)
+
+        assert retry is not None
+        assert signals == [(424242, signal.SIGTERM)]
+        assert all(sig != signal.SIGKILL for _, sig in signals)
+    finally:
+        conn.close()
+
+
+def test_timeout_escalation_uses_sigterm_when_sigkill_is_unavailable(
+    kanban_home, monkeypatch
+):
+    """Windows-style signal modules must still terminate before retry."""
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="portable escalation")
+        assert kb.claim_task(conn, task_id) is not None
+        kb._set_worker_pid(conn, task_id, 424242)
+        monkeypatch.setattr(kb, "_worker_process_start_time", lambda _pid: 100)
+        kb._record_task_failure(
+            conn,
+            task_id,
+            error="Iteration budget exhausted (90/90)",
+            outcome="timed_out",
+            release_claim=True,
+            end_run=True,
+        )
+
+        alive = {"value": True}
+        signals = []
+
+        def signal_worker(pid, sig):
+            signals.append((pid, sig))
+            if len(signals) == 2:
+                alive["value"] = False
+
+        monkeypatch.setattr(kb, "_pid_alive", lambda _pid: alive["value"])
+        monkeypatch.setattr(kb.time, "sleep", lambda _seconds: None)
+        monkeypatch.setattr(kb.os, "kill", signal_worker)
+        monkeypatch.delattr(signal, "SIGKILL", raising=False)
+
+        retry = kb.claim_task(conn, task_id)
+
+        assert retry is not None
+        assert signals == [
+            (424242, signal.SIGTERM),
+            (424242, signal.SIGTERM),
+        ]
+    finally:
+        conn.close()
+
+
+def test_remote_timeout_worker_fails_closed_at_claim_boundary(
+    kanban_home, monkeypatch
+):
+    """Never infer remote worker death from this host's PID namespace."""
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="remote timeout")
+        first_claim = kb.claim_task(conn, task_id, claimer="remote-host:claim")
+        assert first_claim is not None
+        kb._set_worker_pid(conn, task_id, 424242)
+        monkeypatch.setattr(kb, "_worker_process_start_time", lambda _pid: 100)
+        kb._record_task_failure(
+            conn,
+            task_id,
+            error="Iteration budget exhausted (90/90)",
+            outcome="timed_out",
+            release_claim=True,
+            end_run=True,
+        )
+
+        monkeypatch.setattr(kb, "_pid_alive", lambda _pid: True)
+        signals = []
+        monkeypatch.setattr(kb.os, "kill", lambda pid, sig: signals.append((pid, sig)))
+
+        retry = kb.claim_task(conn, task_id)
+
+        assert retry is None
+        assert signals == []
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "ready"
+        assert task.claim_lock is None
+    finally:
+        conn.close()

--- a/tests/hermes_cli/test_kanban_terminal_timeout_teardown.py
+++ b/tests/hermes_cli/test_kanban_terminal_timeout_teardown.py
@@ -361,3 +361,68 @@ def test_remote_timeout_worker_fails_closed_at_claim_boundary(
         assert task.claim_lock is None
     finally:
         conn.close()
+
+
+def test_remote_timeout_worker_guard_expires(kanban_home, monkeypatch):
+    """An offline worker host must not strand a ready task forever."""
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="stale remote timeout")
+        assert kb.claim_task(conn, task_id, claimer="remote-host:claim") is not None
+        kb._set_worker_pid(conn, task_id, 424242)
+        monkeypatch.setattr(kb, "_worker_process_start_time", lambda _pid: 100)
+        kb._record_task_failure(
+            conn,
+            task_id,
+            error="Iteration budget exhausted (90/90)",
+            outcome="timed_out",
+            release_claim=True,
+            end_run=True,
+        )
+        conn.execute(
+            "UPDATE task_runs SET ended_at = ended_at - ? WHERE task_id = ?",
+            (kb.TERMINAL_TIMEOUT_UNVERIFIED_GUARD_SECONDS + 1, task_id),
+        )
+        conn.commit()
+
+        monkeypatch.setattr(kb, "_pid_alive", lambda _pid: True)
+        signals = []
+        monkeypatch.setattr(kb.os, "kill", lambda pid, sig: signals.append((pid, sig)))
+
+        retry = kb.claim_task(conn, task_id)
+
+        assert retry is not None
+        assert signals == []
+    finally:
+        conn.close()
+
+
+def test_local_unverifiable_timeout_worker_guard_expires(kanban_home, monkeypatch):
+    """A missing local PID fingerprint also uses the bounded quarantine."""
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="stale unverifiable timeout")
+        assert kb.claim_task(conn, task_id) is not None
+        kb._set_worker_pid(conn, task_id, 424242)
+        monkeypatch.setattr(kb, "_worker_process_start_time", lambda _pid: None)
+        kb._record_task_failure(
+            conn,
+            task_id,
+            error="Iteration budget exhausted (90/90)",
+            outcome="timed_out",
+            release_claim=True,
+            end_run=True,
+        )
+        conn.execute(
+            "UPDATE task_runs SET ended_at = ended_at - ? WHERE task_id = ?",
+            (kb.TERMINAL_TIMEOUT_UNVERIFIED_GUARD_SECONDS + 1, task_id),
+        )
+        conn.commit()
+
+        monkeypatch.setattr(kb, "_pid_alive", lambda _pid: True)
+
+        retry = kb.claim_task(conn, task_id)
+
+        assert retry is not None
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary
- rebuild the valid core of #80020 on current upstream main
- terminate the identified timed-out worker before dispatcher or direct-claim retry
- preserve terminal timeout disposition across unblock/retry paths
- adapt the real-signal integration tests to current upstream's explicit live-system guard marker
- retain contributor attribution

## Validation
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_terminal_timeout_teardown.py tests/agent/test_turn_finalizer_iteration_limit_exit.py -q` (13 passed)
- `ruff check agent/turn_finalizer.py hermes_cli/kanban_db.py tests/agent/test_turn_finalizer_iteration_limit_exit.py tests/hermes_cli/test_kanban_terminal_timeout_teardown.py`

Supersedes #80020.
