### PR TITLE
fix(kanban): keep list queries non-mutating

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1576,9 +1576,8 @@ def _cmd_list(args: argparse.Namespace) -> int:
     if args.mine and not assignee:
         assignee = _profile_author()
     with kb.connect_closing() as conn:
-        # Cheap "mini-dispatch": recompute ready so list output reflects
-        # dependencies that may have cleared since the last dispatcher tick.
-        kb.recompute_ready(conn)
+        # Listing is intentionally non-mutating at task/event level. Dependency
+        # promotion belongs to the dispatcher or explicit mutation commands.
         tasks = kb.list_tasks(
             conn,
             assignee=assignee,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3270,6 +3270,16 @@ def create_task(
                         "provider_override": provider_override,
                     },
                 )
+                if initial_status == "blocked":
+                    # A caller that parks a new task in blocked is declaring a
+                    # human gate. Record it so recompute_ready never mistakes
+                    # the status for a transient dependency/circuit-breaker hold.
+                    _append_event(
+                        conn,
+                        task_id,
+                        "blocked",
+                        {"reason": "initial_status=blocked", "source": "create_task"},
+                    )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
             return task_id
         except sqlite3.IntegrityError:

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -76,6 +76,29 @@ def test_worker_block_is_not_auto_promoted_by_recompute_ready(kanban_home: Path)
             assert kb.get_task(conn, tid).status == "blocked"
 
 
+def test_initial_block_is_sticky_until_explicit_unblock(kanban_home: Path) -> None:
+    """Creation directly in blocked is an operator gate, not a transient state."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="planned human gate",
+            initial_status="blocked",
+        )
+        assert [event.kind for event in kb.list_events(conn, tid)] == [
+            "created", "blocked"
+        ]
+        assert kb.recompute_ready(conn) == 0
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "blocked"
+
+        assert kb.unblock_task(conn, tid)
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "ready"
+        assert [event.kind for event in kb.list_events(conn, tid)] == [
+            "created", "blocked", "unblocked"
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -103,6 +103,52 @@ def test_board_override_is_isolated_per_concurrent_call(kanban_home, monkeypatch
     assert beta_titles == ["beta-task"]
 
 
+def test_kanban_list_json_is_read_only_for_explicit_block(kanban_home):
+    """`list` must not silently promote a card held for a human gate.
+
+    A card may be created directly in ``blocked`` state before any worker
+    exists.  Listing is an observation, not a mini-dispatch, so it must leave
+    that explicit hold untouched and create no ``promoted`` event.
+    """
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="operator-held canary",
+            initial_status="blocked",
+        )
+
+    payload = json.loads(kc.run_slash("list --json"))
+    row = next(item for item in payload if item["id"] == task_id)
+    assert row["status"] == "blocked"
+
+    with kb.connect() as conn:
+        persisted = kb.get_task(conn, task_id)
+        assert persisted is not None
+        assert persisted.status == "blocked"
+        assert [event.kind for event in kb.list_events(conn, task_id)] == [
+            "created", "blocked"
+        ]
+
+
+def test_kanban_list_does_not_promote_eligible_dependency(kanban_home):
+    """Only an explicit readiness recompute may promote a todo child."""
+    with kb.connect() as conn:
+        parent_id = kb.create_task(conn, title="parent")
+        child_id = kb.create_task(conn, title="child", parents=[parent_id])
+        conn.execute("UPDATE tasks SET status = 'done' WHERE id = ?", (parent_id,))
+        conn.commit()
+
+    payload = json.loads(kc.run_slash("list --json"))
+    row = next(item for item in payload if item["id"] == child_id)
+    assert row["status"] == "todo"
+
+    with kb.connect() as conn:
+        assert kb.recompute_ready(conn) == 1
+        child = kb.get_task(conn, child_id)
+        assert child is not None
+        assert child.status == "ready"
+
+
 # ---------------------------------------------------------------------------
 # Integration with the COMMAND_REGISTRY
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -111,6 +111,38 @@ def test_list_filters_tasks(monkeypatch, worker_env):
     assert tenant_ids == [c]
 
 
+def test_list_does_not_promote_explicit_block(monkeypatch, worker_env):
+    """Agent-facing list is a query and must preserve a human gate."""
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(
+            conn,
+            title="operator-held list canary",
+            initial_status="blocked",
+        )
+    finally:
+        conn.close()
+
+    payload = json.loads(kt._handle_list({"status": "blocked", "limit": 10}))
+    assert payload["promoted"] == 0
+    assert [task["id"] for task in payload["tasks"]] == [task_id]
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "blocked"
+        assert [event.kind for event in kb.list_events(conn, task_id)] == [
+            "created", "blocked"
+        ]
+    finally:
+        conn.close()
+
+
 def test_complete_happy_path(worker_env):
     from tools import kanban_tools as kt
     out = kt._handle_complete({

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -595,9 +595,9 @@ def _handle_list(args: dict, **kw) -> str:
     try:
         kb, conn = _connect(board=board)
         try:
-            # Match CLI list: dependencies that cleared since the last
-            # dispatcher tick should be visible to orchestrators immediately.
-            promoted = kb.recompute_ready(conn)
+            # List is observational: readiness promotion belongs to dispatch or
+            # an explicit operator mutation, never to a discovery request.
+            promoted = 0
             # Fetch one extra row so model-facing output can report that
             # a bounded listing was truncated without dumping the board.
             rows = kb.list_tasks(

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -747,7 +747,17 @@ hermes kanban gc [--event-retention-days N]            # workspaces + old events
         [--log-retention-days N]
 ```
 
+`list` (CLI, `/kanban list`, and `kanban_list`) is observational at the task/event
+level: it never advances dependency readiness or appends promotion events. A task
+that becomes eligible remains `todo` until a dispatcher tick, a lifecycle mutation
+such as completion, or an explicit `promote` action advances it. Likewise, a task
+created explicitly as `blocked` is a human gate and remains blocked until
+`unblock`. This does **not** make the CLI a physically read-only SQLite client:
+opening a board may still initialise schema state or apply connection pragmas.
+Use a dedicated SQLite read-only wrapper when that stricter guarantee is required.
+
 All commands are also available as a slash command in the interactive CLI and in the messaging gateway (see [`/kanban` slash command](#kanban-slash-command) below).
+
 
 `--max-retries` is a per-task circuit-breaker override for the dispatcher. `--max-retries 1` blocks the task on the first non-successful attempt, while `--max-retries 3` allows two retries and blocks on the third failure. Omit it to use `kanban.failure_limit` from `config.yaml`, then the built-in default.
 


### PR DESCRIPTION
## Summary
- Make CLI, gateway `/kanban list`, and agent `kanban_list` observational at the task/event level.
- Preserve explicitly created `initial_status=blocked` tasks as sticky human gates until `unblock`.
- Keep dependency promotion in dispatcher and lifecycle mutation paths; retain `promoted: 0` in the agent response for compatibility.
- Add regression coverage and document task-level versus physically read-only SQLite semantics.

## Validation
- Reproduced the prior CLI and tool mutation paths in isolated temporary homes.
- Verified the rebased contract: query surfaces preserve blocked gates; `unblock` releases them; `complete_task` still promotes a dependency child.
- `py_compile` and `git diff --check` pass.
- Full pytest is intentionally left to CI: the local Hermes venv does not include `pytest`.

## Scope
- No runtime update, gateway restart, or deployment is included.