### PR TITLE
fix(cron): classify extensionless Python wrappers before shell walk

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -105,6 +105,10 @@ def contains_gateway_lifecycle_command(text: str) -> bool:
 
 _SHELL_EXECUTABLES = frozenset({"sh", "bash", "dash", "ksh", "zsh"})
 _SHELL_OPTIONS_WITH_VALUES = frozenset({"-O", "+O", "-o", "+o"})
+_PYTHON_SHEBANG_PATTERN = re.compile(
+    r"^#![^\n]*\bpython(?:\d+(?:\.\d+)*)?\b",
+    re.IGNORECASE,
+)
 _MAX_REFERENCED_SCRIPT_BYTES = 1024 * 1024
 _MAX_REFERENCED_SCRIPT_DEPTH = 8
 _CONTROL_CHARS = frozenset(";&|()")
@@ -501,6 +505,11 @@ def _sanitize_remote_script_text(text: Optional[str]) -> tuple[Optional[str], bo
     return text, False
 
 
+def _is_python_shebang_script(text: str) -> bool:
+    """Return True when an executable script declares a Python interpreter."""
+    return bool(_PYTHON_SHEBANG_PATTERN.search(text))
+
+
 def _contains_unsafe_gateway_action(
     command: str,
     *,
@@ -549,6 +558,14 @@ def _contains_unsafe_gateway_action(
             if unsafe:
                 return True
         if not script_text:
+            continue
+        # Executable Python scripts without a .py suffix are common CLI
+        # wrappers. Apply the full direct scan, but do not tokenize Python as
+        # POSIX shell and reinterpret syntax such as Path("/tmp") as an
+        # executable reference. Shell scripts still take the recursive path.
+        if _is_python_shebang_script(script_text):
+            if _direct_lifecycle_scan(script_text):
+                return True
             continue
         # Relative references inside a script resolve against that script's
         # directory, not the original command's cwd.

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -419,6 +419,65 @@ class TestTerminalToolGatewayLifecycleGuard:
 
         assert result["exit_code"] == 1
 
+    @pytest.mark.parametrize(
+        "arguments",
+        [
+            "--repo example/project pr review --help",
+            (
+                "--repo example/project pr review 42 --approve "
+                f"--match-head-commit {'a' * 40} "
+                "--asl-receipt /tmp/review-receipt.json"
+            ),
+        ],
+    )
+    def test_allows_extensionless_python_github_review_wrapper(
+        self, tmp_path, arguments
+    ):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        wrapper = tmp_path / "asl-gh-admin"
+        wrapper.write_text(
+            "#!/usr/bin/env python3\n"
+            "from pathlib import Path\n"
+            f"CONTROL_ROOT = Path({str(tmp_path)!r})\n"
+            'IDENTITY_ROOT = CONTROL_ROOT / "github-identities"\n'
+            "print(IDENTITY_ROOT)\n",
+            encoding="utf-8",
+        )
+        wrapper.chmod(0o700)
+
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            f"{wrapper} {arguments}",
+            cwd=str(tmp_path),
+        )
+
+        assert result is False
+
+    def test_blocks_extensionless_python_wrapper_with_literal_lifecycle(
+        self, tmp_path
+    ):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        wrapper = tmp_path / "unsafe-python-wrapper"
+        wrapper.write_text(
+            "#!/usr/bin/env python3\n"
+            "import os\n"
+            "os.system('hermes gateway restart')\n",
+            encoding="utf-8",
+        )
+        wrapper.chmod(0o700)
+
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            str(wrapper),
+            cwd=str(tmp_path),
+        )
+
+        assert result is True
+
     def test_launchctl_submit_parser_handles_shell_quoting(self, monkeypatch):
         import tools.terminal_tool as tt
 


### PR DESCRIPTION
## Summary

- Detect executable Python wrappers by their shebang before the referenced-script shell walk.
- Keep the complete direct lifecycle scan for Python source, so literal gateway lifecycle and `launchctl submit|bootstrap` commands remain blocked.
- Add regression coverage for both a harmless extensionless GitHub review wrapper and an extensionless Python wrapper containing a real lifecycle command.

## Root cause

The referenced-script guard reads an invoked extensionless wrapper and recursively tokenizes its contents as POSIX shell. For Python source, syntax such as `Path("/existing/directory")` is then misread as another executable script path. Because the referenced path is a directory, the regular-file check correctly fails closed, but the final verdict is a false positive before the harmless wrapper can launch.

This is the extensionless-shebang form of the same interpreter mismatch already avoided for `.py` cron scripts. The fix is based on interpreter intent, not a command basename allowlist.

## Safety properties

- Real shell scripts still follow the existing recursive referenced-script path unchanged.
- Python wrappers still run `_direct_lifecycle_scan()` over their full source.
- A literal `hermes gateway restart|stop` in an extensionless Python wrapper remains blocked.
- Existing direct, shell payload, nested wrapper, non-regular-file fail-closed, and binary-path coverage remains green.

## Verification

Base: `upstream/main@3d7dda4cf42176d587b459345c56236a26030324`

RED before the production change:

```text
2 failed, 1 passed
```

Exact HEAD `21bec59d5b21ecc33a175939fd3dd1d717958b74`:

```text
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/hermes_cli/test_gateway_restart_loop.py -q
121 passed

ruff check cron/lifecycle_guard.py tests/hermes_cli/test_gateway_restart_loop.py
All checks passed!

ty check cron/lifecycle_guard.py tests/hermes_cli/test_gateway_restart_loop.py
All checks passed!

detect-secrets 1.5.0
results: {}
```

Additional adjacent gateway-service matrix:

```text
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh \
  tests/hermes_cli/test_gateway_restart_loop.py \
  tests/hermes_cli/test_gateway_service.py -q
198 passed
```
