### PR TITLE
fix(desktop): reject slash commands with attachments

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
@@ -59,6 +59,7 @@ function renderSubmitHook({
       queuedPrompts: [],
       sessionId: 'runtime-session',
       setComposerText: vi.fn(),
+      slashAttachmentsUnsupported: 'Remove attachments before running a slash command.',
       stashAt: vi.fn()
     })
   )
@@ -138,6 +139,27 @@ describe('useComposerSubmit busy-turn routing', () => {
     })
 
     expect(queueCurrentDraft).toHaveBeenCalledTimes(1)
+    expect(onSteer).not.toHaveBeenCalled()
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(onCancel).not.toHaveBeenCalled()
+  })
+
+  it('keeps an attachment-bearing slash command in the composer and warns (#81798)', () => {
+    const attachment: ComposerAttachment = { id: 'image', kind: 'image', label: 'diagram.png' }
+
+    const { clearDraft, hook, onCancel, onSteer, onSubmit, queueCurrentDraft } = renderSubmitHook({
+      attachments: [attachment],
+      busy: true,
+      text: '/moa explain this'
+    })
+
+    act(() => {
+      hook.result.current.submitDraft()
+    })
+
+    expect(clearDraft).not.toHaveBeenCalled()
+    expect(queueCurrentDraft).not.toHaveBeenCalled()
+
     expect(onSteer).not.toHaveBeenCalled()
     expect(onSubmit).not.toHaveBeenCalled()
     expect(onCancel).not.toHaveBeenCalled()

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
@@ -6,6 +6,7 @@ import { hasClarifyRequest, skipClarifyRequest } from '@/store/clarify'
 import { clearSessionDraft, type ComposerAttachment } from '@/store/composer'
 import { resetBrowseState } from '@/store/composer-input-history'
 import { enqueueQueuedPrompt, type QueuedPromptEntry } from '@/store/composer-queue'
+import { notify } from '@/store/notifications'
 
 import { cloneAttachments, type QueueEditState } from '../composer-utils'
 import { onComposerSubmitRequest } from '../focus'
@@ -37,6 +38,7 @@ interface UseComposerSubmitArgs {
   queuedPrompts: QueuedPromptEntry[]
   sessionId: string | null | undefined
   setComposerText: (value: string) => void
+  slashAttachmentsUnsupported: string
   stashAt: (scope: string | null, text?: string, attachments?: ComposerAttachment[]) => void
 }
 
@@ -72,6 +74,7 @@ export function useComposerSubmit({
   queuedPrompts,
   sessionId,
   setComposerText,
+  slashAttachmentsUnsupported,
   stashAt
 }: UseComposerSubmitArgs) {
   const scope = useComposerScope()
@@ -145,6 +148,17 @@ export function useComposerSubmit({
     // on the way out so it attaches instead of submitting as inert text.
     const text = pathifyRefs(draftRef.current)
     const payloadPresent = text.trim().length > 0 || attachments.length > 0
+
+    // Attachment refs are prepended to the wire payload, so allowing this
+    // through makes the gateway miss the leading slash and silently treat the
+    // command as ordinary prose (#81798). Keep both draft and attachments
+    // intact and make the unsupported combination explicit.
+    if (attachments.length > 0 && SLASH_COMMAND_RE.test(text.trim())) {
+      notify({ kind: 'warning', message: slashAttachmentsUnsupported })
+      focusInput()
+
+      return
+    }
 
     // A clarify card parked on this session owns the turn: the agent is blocked
     // inside its tool batch waiting on `clarify.respond`, so a follow-up routed

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -335,6 +335,7 @@ export function ChatBar({
     queuedPrompts,
     sessionId,
     setComposerText,
+    slashAttachmentsUnsupported: t.desktop.slashAttachmentsUnsupported,
     stashAt
   })
 

--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -21,7 +21,7 @@ import { triggerHaptic } from '@/lib/haptics'
 import { clearClarifyRequest } from '@/store/clarify'
 import type { ComposerAttachment } from '@/store/composer'
 import { resetSessionBackground } from '@/store/composer-status'
-import { notifyError } from '@/store/notifications'
+import { notify, notifyError } from '@/store/notifications'
 import { clearPreviewArtifacts } from '@/store/preview-status'
 import { clearAllPrompts } from '@/store/prompts'
 import { $connection, $sessions, sessionMatchesStoredId } from '@/store/session'
@@ -238,6 +238,12 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
       const visibleText = rawText.trim()
       const attachments = options?.attachments ?? scope.attachments.$attachments.get()
 
+      if (attachments.length > 0 && SLASH_COMMAND_RE.test(visibleText)) {
+        notify({ kind: 'warning', message: copy.slashAttachmentsUnsupported })
+
+        return false
+      }
+
       listTileSession(visibleText)
 
       if (!attachments.length && SLASH_COMMAND_RE.test(visibleText)) {
@@ -249,7 +255,7 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
 
       return await submitPromptText(rawText, options)
     },
-    [listTileSession, scope.attachments.$attachments, submitPromptText]
+    [copy.slashAttachmentsUnsupported, listTileSession, scope.attachments.$attachments, submitPromptText]
   )
 
   const cancelRun = useCallback(async () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -218,7 +218,32 @@ describe('usePromptActions /title', () => {
 
   afterEach(() => {
     cleanup()
+    clearNotifications()
     vi.restoreAllMocks()
+  })
+
+  it('rejects attachment-bearing slash commands instead of submitting them as prose (#81798)', async () => {
+    const requestGateway = vi.fn(async () => ({}) as never)
+    const attachment: ComposerAttachment = { id: 'image', kind: 'image', label: 'diagram.png' }
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        refreshSessions={vi.fn(async () => undefined)}
+        requestGateway={requestGateway}
+      />
+    )
+
+    const accepted = await handle!.submitText('/moa explain this', { attachments: [attachment] })
+
+    expect(accepted).toBe(false)
+    expect(requestGateway).not.toHaveBeenCalled()
+    expect($notifications.get()).toEqual([
+      expect.objectContaining({
+        kind: 'warning',
+        message: 'Remove attachments before running a slash command.'
+      })
+    ])
   })
 
   it('renames via the session.title RPC (with the runtime id), updates the sidebar store, and refreshes', async () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -595,6 +595,12 @@ export function usePromptActions({
       const visibleText = sanitizeComposerInput(rawText).trim()
       const attachments = options?.attachments ?? $composerAttachments.get()
 
+      if (attachments.length > 0 && SLASH_COMMAND_RE.test(visibleText)) {
+        notify({ kind: 'warning', message: copy.slashAttachmentsUnsupported })
+
+        return false
+      }
+
       if (!attachments.length && SLASH_COMMAND_RE.test(visibleText)) {
         triggerHaptic('selection')
         // Forward the explicit target (background queue drain, tile) — dropping
@@ -606,7 +612,7 @@ export function usePromptActions({
 
       return await submitPromptText(rawText, options)
     },
-    [executeSlashCommand, submitPromptText]
+    [copy.slashAttachmentsUnsupported, executeSlashCommand, submitPromptText]
   )
 
   const transcribeVoiceAudio = useCallback(

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2519,6 +2519,7 @@ export const ar = defineLocale({
     sessionUnavailable: 'الجلسة غير متاحة',
     createSessionFailed: 'فشل إنشاء الجلسة',
     promptFailed: 'فشل إرسال الرسالة',
+    slashAttachmentsUnsupported: 'أزل المرفقات قبل تشغيل أمر بشرطة مائلة.',
     providerCredentialRequired: 'مطلوب اعتماد المزود',
     emptySlashCommand: 'أمر slash فارغ',
     desktopCommands: 'أوامر سطح المكتب',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2889,6 +2889,7 @@ export const en: Translations = {
     sessionUnavailable: 'Session unavailable',
     createSessionFailed: 'Could not create a new session',
     promptFailed: 'Prompt failed',
+    slashAttachmentsUnsupported: 'Remove attachments before running a slash command.',
     providerCredentialRequired: 'Add a provider credential before sending your first message.',
     emptySlashCommand: 'empty slash command',
     desktopCommands: 'Desktop commands',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2728,6 +2728,7 @@ export const ja = defineLocale({
     sessionUnavailable: 'セッションが利用できません',
     createSessionFailed: '新しいセッションを作成できませんでした',
     promptFailed: 'プロンプトに失敗しました',
+    slashAttachmentsUnsupported: 'スラッシュコマンドを実行する前に添付ファイルを削除してください。',
     providerCredentialRequired: '最初のメッセージを送信する前にプロバイダー認証情報を追加してください。',
     emptySlashCommand: '空のスラッシュコマンド',
     desktopCommands: 'デスクトップコマンド',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2444,6 +2444,7 @@ export interface Translations {
     sessionUnavailable: string
     createSessionFailed: string
     promptFailed: string
+    slashAttachmentsUnsupported: string
     providerCredentialRequired: string
     emptySlashCommand: string
     desktopCommands: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2617,6 +2617,7 @@ export const zhHant = defineLocale({
     sessionUnavailable: '工作階段不可用',
     createSessionFailed: '無法建立新工作階段',
     promptFailed: '提示詞傳送失敗',
+    slashAttachmentsUnsupported: '執行斜線指令前請先移除附件。',
     providerCredentialRequired: '傳送第一則訊息前請先新增提供方憑證。',
     emptySlashCommand: '空的斜線指令',
     desktopCommands: '桌面端指令',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3052,6 +3052,7 @@ export const zh: Translations = {
     sessionUnavailable: '会话不可用',
     createSessionFailed: '无法创建新会话',
     promptFailed: '提示词发送失败',
+    slashAttachmentsUnsupported: '运行斜杠命令前请先移除附件。',
     providerCredentialRequired: '发送第一条消息前请先添加提供方凭据。',
     emptySlashCommand: '空 slash 命令',
     desktopCommands: '桌面端命令',


### PR DESCRIPTION
## What does this PR do?

Prevents Hermes Desktop from silently treating slash commands as ordinary model prompts when the composer also contains attachments.

Attachment references are prepended to the submitted wire text, so `/moa`, `/status`, and other commands no longer start the payload. The gateway then misses command detection and sends the text to the active model as prose.

This change rejects that unsupported combination before submission, keeps the draft and attachments intact, and shows a localized warning asking the user to remove attachments first. The guard covers the composer, primary prompt action, and session-tile action paths.

Fixes #81798

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Guard attachment-bearing slash commands before the composer clears or queues the draft.
- Add defensive checks to primary-session and session-tile submission paths.
- Add localized warning copy for English, Chinese, Traditional Chinese, Japanese, and Arabic.
- Add regression coverage proving the command is not submitted, queued, or cleared.

## How to Test

1. Attach an image in Hermes Desktop.
2. Enter `/moa explain this` and submit.
3. Verify the draft and attachment remain in the composer, a warning is shown, and no model turn starts.
4. Remove the attachment and submit again; verify the slash command executes normally.

## Verification

- `vitest run --project ui` on the two affected suites: **115 passed**
- `tsc -p . --noEmit`: passed
- ESLint on changed files: no errors and no new warnings

## Checklist

- [x] I've read the Contributing Guide
- [x] Commit follows Conventional Commits
- [x] Searched existing PRs; no duplicate found
- [x] Change is scoped to this bug
- [x] Added regression tests
- [x] Tested on Windows 11
- [x] Updated all Desktop locales and cross-platform behavior is unchanged