### PR TITLE
fix(sessions): raise /api/sessions page-size cap 100->200

### DIFF
--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -52,10 +52,9 @@ _strip_session_list_rows = late("_strip_session_list_rows")
 
 @list_router.get("/api/sessions")
 def get_sessions(
-    # ``le=100`` caps the page size (idea from #39200): an unbounded limit
-    # lets one request drag every session row (plus correlated-subquery
-    # preview work) out of SQLite in a single hit.
-    limit: int = Query(20, ge=0, le=100),
+    # ``le=200`` caps the page size (idea from #39200, raised from 100:
+    # desktop callers send limit=200; the gateway api_server already allows 200)
+    limit: int = Query(20, ge=0, le=200),
     offset: int = Query(0, ge=0),
     min_messages: int = 0,
     archived: str = "exclude",


### PR DESCRIPTION
Desktop clients request `limit=200`; the gateway api_server already allows 200. The `le=100` cap (idea from #39200) makes those requests fail with a 422, so raise the cap to match the server policy.

Small, self-contained change to `hermes_cli/web_routers/sessions.py`.