### PR TITLE
fix(desktop): don't yank the viewport to bottom on every run start

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -431,8 +431,17 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   useEffect(() => onThreadEditOpen(beginEditHold), [beginEditHold])
   useEffect(() => onThreadEditClose(endEditHold), [endEditHold])
   useEffect(() => () => endEditHold(), [endEditHold])
-  // New run → snap to the latest turn.
-  useAuiEvent('thread.runStart', () => void scrollToBottom())
+  // New run → snap to the latest turn, but ONLY if the user is already at (or
+  // near) the bottom. A run start while the user is reading earlier content must
+  // not yank the viewport away from them mid-read (regression: unconditional
+  // scrollToBottom on every runStart interrupted reading of long answers).
+  useAuiEvent('thread.runStart', () => {
+    const el = scrollRef.current
+
+    if (el && el.scrollHeight - el.scrollTop - el.clientHeight < 64) {
+      scrollToBottom()
+    }
+  })
 
   // Reset the cap and pin to bottom on mount + every session switch (messages
   // swap in place on a long-lived runtime, so sessionKey is the only signal).


### PR DESCRIPTION
## Problem

When a follow-up question is sent while the user is still reading an earlier (long) answer, `thread.runStart` unconditionally called `scrollToBottom()`, snapping the viewport to the bottom of the thread and interrupting their reading position. The user then has to scroll back to find where they were.

## Fix

Only snap to the latest turn when the viewport is already at (or near) the bottom (64px threshold). If the user has scrolled up into history, a new run leaves the position alone — the existing stick-to-bottom behavior still follows new content when the user is at the bottom.

## Verification

- `npm run typecheck` clean, `npm run lint` 0 errors
- Related UI tests pass (thread list + scroll-to-bottom button suites)
- Manual: Windows 11, Hermes desktop 0.20.0 — reading a long answer mid-way, sending a follow-up no longer moves the viewport; at the bottom, streaming still follows as before