### PR TITLE
fix(mcp): stop MCP reconnect after enabled:false

### DIFF
--- a/hermes_cli/mcp_picker.py
+++ b/hermes_cli/mcp_picker.py
@@ -120,9 +120,22 @@ def _enable_disable(name: str, *, enable: bool) -> None:
     server["enabled"] = enable
     cfg["mcp_servers"] = servers
     save_config(cfg)
+    if not enable:
+        try:
+            from tools.mcp_tool import shutdown_mcp_server
+
+            shutdown_mcp_server(name)
+        except Exception:
+            pass
+        print(color(
+            f"  ✓ '{name}' disabled (live connection stopped if this "
+            "process was holding one).",
+            Colors.GREEN,
+        ))
+        return
     print(color(
-        f"  ✓ '{name}' {'enabled' if enable else 'disabled'}. "
-        "Start a new Hermes session for changes to take effect.",
+        f"  ✓ '{name}' enabled. "
+        "Start a new Hermes session (or /reload-mcp) for changes to take effect.",
         Colors.GREEN,
     ))
 

--- a/hermes_cli/web_routers/mcp.py
+++ b/hermes_cli/web_routers/mcp.py
@@ -346,11 +346,13 @@ async def mcp_oauth_callback(
 async def set_mcp_server_enabled(
     name: str, body: MCPEnabledToggle, profile: Optional[str] = None
 ):
-    """Enable or disable an MCP server (takes effect on next session/gateway).
+    """Enable or disable an MCP server.
 
     Toggles the ``enabled`` key on the server's config.yaml entry — the same
     flag the agent reads at startup.  Disabled servers stay in config so they
-    can be re-enabled without re-entering their settings.
+    can be re-enabled without re-entering their settings.  Disabling also
+    stops any live/parked connection in this process immediately so retries
+    do not keep logging after the toggle.
     """
     def _run():
         with _profile_scope(body.profile or profile):
@@ -363,6 +365,17 @@ async def set_mcp_server_enabled(
                     raise HTTPException(status_code=400, detail="Malformed server config")
                 servers[name]["enabled"] = bool(body.enabled)
                 save_config(cfg)
+            if not body.enabled:
+                try:
+                    from tools.mcp_tool import shutdown_mcp_server
+
+                    shutdown_mcp_server(name)
+                except Exception:
+                    _log.debug(
+                        "MCP disable: live shutdown for '%s' skipped",
+                        name,
+                        exc_info=True,
+                    )
         return {"ok": True, "name": name, "enabled": bool(body.enabled)}
 
     return await asyncio.to_thread(_run)

--- a/tests/tools/test_mcp_disabled_no_reconnect.py
+++ b/tests/tools/test_mcp_disabled_no_reconnect.py
@@ -1,0 +1,76 @@
+"""Disabled MCP servers must not stay parked or get reconnect nudges.
+
+Regression: setting ``enabled: false`` only skipped *new* connects, while
+``register_mcp_servers`` still woke session=None cached entries via
+``_signal_reconnect``. A disabled oauth_lab (etc.) kept retrying and
+logging ``failed initial connection ... parking`` WARNINGs.
+"""
+
+from unittest.mock import MagicMock
+
+
+def test_register_does_not_wake_disabled_parked_server(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+
+    woken: list[str] = []
+
+    class _Event:
+        def __init__(self, name):
+            self._name = name
+
+        def set(self):
+            woken.append(self._name)
+
+    class _Parked:
+        session = object()  # flipped to None after disable teardown
+
+        def __init__(self, name):
+            self.name = name
+            self._reconnect_event = _Event(name)
+            self._registered_tool_names: list[str] = []
+            self._shutdown_event = MagicMock()
+
+        def _deregister_tools(self):
+            self._registered_tool_names = []
+
+    monkeypatch.setattr(mcp_tool, "_MCP_AVAILABLE", True)
+    parked = _Parked("oauth_lab")
+    # Parked = cached entry with no live session (the #50170 wake path).
+    parked.session = None
+    monkeypatch.setitem(mcp_tool._servers, "oauth_lab", parked)
+
+    # Avoid scheduling work onto a real MCP loop for this unit test.
+    monkeypatch.setattr(mcp_tool, "_mcp_loop", None)
+
+    try:
+        result = mcp_tool.register_mcp_servers({
+            "oauth_lab": {
+                "url": "http://127.0.0.1:9/mcp",
+                "enabled": False,
+            },
+        })
+        assert result == []
+        assert woken == []
+        assert "oauth_lab" not in mcp_tool._servers
+    finally:
+        mcp_tool._servers.pop("oauth_lab", None)
+        mcp_tool._pending_disable.discard("oauth_lab")
+
+
+def test_shutdown_mcp_server_marks_in_flight_connect_pending(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+
+    monkeypatch.setattr(mcp_tool, "_MCP_AVAILABLE", True)
+    mcp_tool._server_connecting.add("oauth_lab")
+    try:
+        assert mcp_tool.shutdown_mcp_server("oauth_lab") is True
+        assert "oauth_lab" in mcp_tool._pending_disable
+        assert "oauth_lab" not in mcp_tool._server_connecting
+        assert mcp_tool._server_disabled_now("oauth_lab") is True
+    finally:
+        mcp_tool._server_connecting.discard("oauth_lab")
+        mcp_tool._pending_disable.discard("oauth_lab")

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3680,6 +3680,12 @@ _server_connect_errors: Dict[str, str] = {}
 _lazy_server_configs: Dict[str, dict] = {}
 _lazy_server_fingerprints: Dict[str, str] = {}
 _lazy_server_tool_names: Dict[str, List[str]] = {}
+# Names that were disabled while a connect was still in flight (present in
+# ``_server_connecting`` but not yet adopted into ``_servers``). Checked at
+# the end of ``_discover_and_register_server`` so a mid-flight disable does
+# not leave a parked/retrying task behind after the user flipped
+# ``enabled: false``.
+_pending_disable: set[str] = set()
 # Discovery installs a task-local claim before calling ``_connect_server`` so
 # it can retain a recoverable parked task without making standalone probe calls
 # publish failed servers into module-global ownership.
@@ -6510,6 +6516,46 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
         )
     return registered_names
 
+def _server_disabled_now(name: str, fallback_config: Optional[dict] = None) -> bool:
+    """True when ``name`` should not stay connected (config or mid-flight disable)."""
+    with _lock:
+        if name in _pending_disable:
+            return True
+    live = _load_mcp_config().get(name)
+    cfg = live if isinstance(live, dict) else fallback_config
+    if not isinstance(cfg, dict):
+        return False
+    return not _parse_boolish(cfg.get("enabled", True), default=True)
+
+
+async def _drop_disabled_server(
+    name: str, server: Optional["MCPServerTask"]
+) -> None:
+    """Tear down a server that became disabled during/after connect."""
+    if server is not None:
+        await server.shutdown()
+    with _lock:
+        _pending_disable.discard(name)
+        _server_connecting.discard(name)
+        _server_connect_errors.pop(name, None)
+        if _servers.get(name) is server:
+            _servers.pop(name, None)
+        _lazy_server_configs.pop(name, None)
+        _lazy_server_fingerprints.pop(name, None)
+        cached_names = _lazy_server_tool_names.pop(name, None) or []
+        _clear_connect_failure(name)
+    if cached_names:
+        from tools.registry import registry
+
+        for tool_name in cached_names:
+            registry.deregister(tool_name)
+            _forget_mcp_tool_server(tool_name)
+    logger.info(
+        "MCP server '%s': dropped because it is disabled (enabled: false)",
+        name,
+    )
+
+
 async def _discover_and_register_server(name: str, config: dict) -> List[str]:
     """Connect to a single MCP server, discover tools, and register them.
 
@@ -6530,7 +6576,7 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
             _connect_server(name, config),
             timeout=connect_timeout,
         )
-    except BaseException:
+    except BaseException as exc:
         server = claimed[0] if claimed else None
         task = server._task if server is not None else None
         task_cancelling = (
@@ -6538,6 +6584,13 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
             if task is not None and hasattr(task, "cancelling")
             else 0
         )
+        if _server_disabled_now(name, config):
+            # User disabled mid-flight — do not adopt a parked retry loop,
+            # and do not surface this as a connect failure.
+            await _drop_disabled_server(name, server)
+            if isinstance(exc, (asyncio.CancelledError, KeyboardInterrupt, SystemExit)):
+                raise
+            return []
         if (
             server is not None
             and server._error is not None
@@ -6555,7 +6608,12 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
     finally:
         _connect_server_claim.reset(claim_token)
 
+    if _server_disabled_now(name, config):
+        await _drop_disabled_server(name, server)
+        return []
+
     with _lock:
+        _pending_disable.discard(name)
         _server_connecting.discard(name)
         _server_connect_errors.pop(name, None)
         _servers[name] = server
@@ -6576,11 +6634,104 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
 # Public API
 # ---------------------------------------------------------------------------
 
+def shutdown_mcp_server(name: str) -> bool:
+    """Shut down a single MCP server by name (live, parked, lazy, or connecting).
+
+    Used when the user sets ``enabled: false`` so the process stops retrying
+    immediately instead of waiting for a full ``shutdown_mcp_servers`` /
+    ``/reload-mcp`` cycle. Safe to call when the server is already gone.
+
+    Returns:
+        True if any live/lazy/connecting state was cleared for ``name``.
+    """
+    with _lock:
+        server = _servers.pop(name, None)
+        was_connecting = name in _server_connecting
+        _server_connecting.discard(name)
+        _server_connect_errors.pop(name, None)
+        _clear_connect_failure(name)
+        _lazy_server_configs.pop(name, None)
+        _lazy_server_fingerprints.pop(name, None)
+        cached_names = list(_lazy_server_tool_names.pop(name, None) or [])
+        if was_connecting and server is None:
+            # Connect still in flight — ask discover to drop it on completion.
+            _pending_disable.add(name)
+        else:
+            _pending_disable.discard(name)
+        _parallel_safe_servers.discard(name)
+
+    if cached_names:
+        from tools.registry import registry
+
+        for tool_name in cached_names:
+            registry.deregister(tool_name)
+            _forget_mcp_tool_server(tool_name)
+
+    if server is None:
+        if was_connecting or cached_names:
+            logger.info(
+                "MCP server '%s': disable requested (no live session; "
+                "pending connect will be dropped)",
+                name,
+            )
+            return True
+        return False
+
+    async def _shutdown_one():
+        try:
+            await server.shutdown()
+        except Exception as exc:
+            logger.debug(
+                "Error closing MCP server '%s' on disable: %s", name, exc,
+            )
+
+    with _lock:
+        loop = _mcp_loop
+    if loop is not None and loop.is_running():
+        from agent.async_utils import safe_schedule_threadsafe
+
+        future = safe_schedule_threadsafe(
+            _shutdown_one(),
+            loop,
+            logger=logger,
+            log_message=f"MCP disable shutdown for '{name}': failed to schedule",
+        )
+        if future is not None:
+            try:
+                future.result(timeout=15)
+            except BaseException as exc:
+                logger.debug(
+                    "Error during MCP disable shutdown for '%s': %s", name, exc,
+                )
+    else:
+        # No running loop — best-effort sync teardown of registered tools.
+        try:
+            server._deregister_tools()
+        except Exception:
+            logger.debug(
+                "MCP server '%s': sync tool deregister on disable failed",
+                name,
+                exc_info=True,
+            )
+        server.session = None
+
+    # If a mid-flight connect re-adopted the same name after we popped it,
+    # leave _pending_disable set so _discover_and_register_server drops it.
+    with _lock:
+        if name in _servers and _servers.get(name) is not server:
+            _pending_disable.add(name)
+
+    logger.info("MCP server '%s': shut down (disabled)", name)
+    return True
+
+
 def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
     """Connect to explicit MCP servers and register their tools.
 
     Idempotent for already-connected server names. Servers with
-    ``enabled: false`` are skipped without disconnecting existing sessions.
+    ``enabled: false`` are shut down if still live/parked (so a disable
+    takes effect without waiting for a full ``/reload-mcp``), and are not
+    woken for reconnect.
 
     Args:
         servers: Mapping of ``{server_name: server_config}``.
@@ -6596,6 +6747,18 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
     if not servers:
         logger.debug("No explicit MCP servers provided")
         return []
+
+    # Tear down anything the user has disabled since the last pass. Without
+    # this, a parked oauth_lab (etc.) keeps self-probing / getting woken by
+    # the stale-cache nudge below and keeps logging connection WARNINGs
+    # after ``enabled: false`` was written.
+    disabled_names = [
+        name
+        for name, cfg in servers.items()
+        if not _parse_boolish(cfg.get("enabled", True), default=True)
+    ]
+    for name in disabled_names:
+        shutdown_mcp_server(name)
 
     # Only attempt servers that aren't already connected (or currently
     # connecting) and are enabled.  Checking ``_server_connecting`` prevents
@@ -6625,10 +6788,14 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         # _signal_reconnect — without this nudge a new session silently
         # waits up to _PARKED_RETRY_INTERVAL for the next self-probe
         # (#50170). Wake them now so their tools come back promptly.
+        # Skip disabled servers — shutdown_mcp_server above already reaped
+        # them; never re-signal a disabled parked task.
         stale_cached = [
             _servers[k]
-            for k in servers
-            if k in _servers and getattr(_servers[k], "session", None) is None
+            for k, cfg in servers.items()
+            if k in _servers
+            and getattr(_servers[k], "session", None) is None
+            and _parse_boolish(cfg.get("enabled", True), default=True)
         ]
         _server_connecting.update(new_servers)
         for srv_name in new_servers:
@@ -7286,6 +7453,7 @@ def shutdown_mcp_servers():
         with _lock:
             _server_connect_retry_after.clear()
             _server_connect_failures.clear()
+            _pending_disable.clear()
         _stop_mcp_loop()
         return
 
@@ -7306,6 +7474,7 @@ def shutdown_mcp_servers():
             # stale per-server backoff from before the restart (#50394).
             _server_connect_retry_after.clear()
             _server_connect_failures.clear()
+            _pending_disable.clear()
 
     with _lock:
         loop = _mcp_loop
@@ -7329,6 +7498,7 @@ def shutdown_mcp_servers():
     with _lock:
         _server_connect_retry_after.clear()
         _server_connect_failures.clear()
+        _pending_disable.clear()
 
     _stop_mcp_loop()
 


### PR DESCRIPTION
## What does this PR do?

When an MCP server is set to `enabled: false`, tear down any live/parked/connecting task for that name and do not wake it via the parked-cache `_signal_reconnect` nudge. Previously disable only skipped *new* connects, so a parked server (e.g. oauth_lab after TimeoutError) kept retrying and logging parking WARNINGs.

## Related Issue

Fixes #81830

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py`: add `shutdown_mcp_server`, honor disable in `register_mcp_servers` (shutdown + skip reconnect wake), drop mid-flight connects via `_pending_disable`
- `hermes_cli/mcp_picker.py` / `hermes_cli/web_routers/mcp.py`: call `shutdown_mcp_server` on disable
- `tests/tools/test_mcp_disabled_no_reconnect.py`: regression for no wake + pending mid-flight disable

## How to Test

1. Configure an MCP server that fails connect (parked), observe parking WARNING.
2. Set `enabled: false` (CLI picker, dashboard toggle, or config + rediscovery).
3. Confirm the server is removed from live state and parking/reconnect WARNINGs stop.
4. `python scripts/run_tests_parallel.py tests/tools/test_mcp_disabled_no_reconnect.py -q`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run the focused MCP disable tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) - N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys - N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) - N/A (process-local teardown)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A
