### PR TITLE
fix(gateway): report REJECTED outcome for authorization refusals, suppress success reaction

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2288,6 +2288,11 @@ class ProcessingOutcome(Enum):
     SUCCESS = "success"
     FAILURE = "failure"
     CANCELLED = "cancelled"
+    # The message was deliberately refused before the handler ran (e.g. an
+    # authorization rejection). Unlike FAILURE it is not an error, and unlike
+    # SUCCESS the turn produced no agent work — reactions should be fully
+    # suppressed (no ✅, no ❌) so the message visibly goes unhandled (#81440).
+    REJECTED = "rejected"
 
 
 @dataclass
@@ -2365,6 +2370,12 @@ class MessageEvent:
     # Internal flag — set for synthetic events (e.g. background process
     # completion notifications) that must bypass user authorization checks.
     internal: bool = False
+
+    # Set by gateway.run when the message is refused before the agent runs
+    # (e.g. an authorization rejection). _process_message_background reports
+    # ProcessingOutcome.REJECTED so reaction hooks suppress the final reaction
+    # instead of painting a refusal as success (#81440).
+    rejected: bool = False
 
     # Free-form per-event metadata.  Adapters may set platform-specific
     # signals here (e.g. WhatsApp sets ``whatsapp_from_owner=True`` when
@@ -6716,6 +6727,18 @@ class BasePlatformAdapter(ABC):
 
             # Determine overall success for the processing hook
             processing_ok = delivery_succeeded if delivery_attempted else not bool(response)
+            # A refused message (e.g. authorization rejection) is neither a
+            # success nor a failure — the handler deliberately produced no
+            # work. Report REJECTED so reaction hooks fully suppress the
+            # final reaction instead of painting the refusal as ✅ (#81440).
+            if getattr(event, "rejected", False):
+                processing_outcome = ProcessingOutcome.REJECTED
+            else:
+                processing_outcome = (
+                    ProcessingOutcome.SUCCESS
+                    if processing_ok
+                    else ProcessingOutcome.FAILURE
+                )
             # Clean up the per-turn streaming-TTS flag (#60671).
             self._streaming_tts_completed_turns.discard(
                 self._streaming_tts_turn_key(
@@ -6728,7 +6751,7 @@ class BasePlatformAdapter(ABC):
             await self._run_processing_hook(
                 "on_processing_complete",
                 event,
-                ProcessingOutcome.SUCCESS if processing_ok else ProcessingOutcome.FAILURE,
+                processing_outcome,
             )
 
             # The active drain owns debounce state. If a queue-mode timer has

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2048,6 +2048,11 @@ class ProcessingOutcome(Enum):
     SUCCESS = "success"
     FAILURE = "failure"
     CANCELLED = "cancelled"
+    # The message was deliberately refused before the handler ran (e.g. an
+    # authorization rejection). Unlike FAILURE it is not an error, and unlike
+    # SUCCESS the turn produced no agent work — reactions should be fully
+    # suppressed (no ✅, no ❌) so the message visibly goes unhandled (#81440).
+    REJECTED = "rejected"
 
 
 @dataclass
@@ -2125,6 +2130,12 @@ class MessageEvent:
     # Internal flag — set for synthetic events (e.g. background process
     # completion notifications) that must bypass user authorization checks.
     internal: bool = False
+
+    # Set by gateway.run when the message is refused before the agent runs
+    # (e.g. an authorization rejection). _process_message_background reports
+    # ProcessingOutcome.REJECTED so reaction hooks suppress the final reaction
+    # instead of painting a refusal as success (#81440).
+    rejected: bool = False
 
     # Free-form per-event metadata.  Adapters may set platform-specific
     # signals here (e.g. WhatsApp sets ``whatsapp_from_owner=True`` when
@@ -6292,6 +6303,18 @@ class BasePlatformAdapter(ABC):
 
             # Determine overall success for the processing hook
             processing_ok = delivery_succeeded if delivery_attempted else not bool(response)
+            # A refused message (e.g. authorization rejection) is neither a
+            # success nor a failure — the handler deliberately produced no
+            # work. Report REJECTED so reaction hooks fully suppress the
+            # final reaction instead of painting the refusal as ✅ (#81440).
+            if getattr(event, "rejected", False):
+                processing_outcome = ProcessingOutcome.REJECTED
+            else:
+                processing_outcome = (
+                    ProcessingOutcome.SUCCESS
+                    if processing_ok
+                    else ProcessingOutcome.FAILURE
+                )
             # Clean up the per-turn streaming-TTS flag (#60671).
             self._streaming_tts_completed_turns.discard(
                 self._streaming_tts_turn_key(
@@ -6304,7 +6327,7 @@ class BasePlatformAdapter(ABC):
             await self._run_processing_hook(
                 "on_processing_complete",
                 event,
-                ProcessingOutcome.SUCCESS if processing_ok else ProcessingOutcome.FAILURE,
+                processing_outcome,
             )
 
             # The active drain owns debounce state. If a queue-mode timer has

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15987,8 +15987,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # sender). Defer to _is_user_authorized so that path runs.
             if not self._is_user_authorized(source):
                 logger.debug("Ignoring message with no user_id from %s", source.platform.value)
+                event.rejected = True
                 return None
         elif not self._is_user_authorized(source):
+            # Mark the refusal on the event so the processing-complete hook
+            # reports REJECTED (no ✅/❌ reaction) instead of painting the
+            # silent drop as a successful turn (#81440).
+            event.rejected = True
             logger.warning("Unauthorized user: %s (%s) on %s", source.user_id, source.user_name, source.platform.value)
             # In DMs: offer pairing code. In groups: silently ignore.
             if (

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14651,8 +14651,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # sender). Defer to _is_user_authorized so that path runs.
             if not self._is_user_authorized(source):
                 logger.debug("Ignoring message with no user_id from %s", source.platform.value)
+                event.rejected = True
                 return None
         elif not self._is_user_authorized(source):
+            # Mark the refusal on the event so the processing-complete hook
+            # reports REJECTED (no ✅/❌ reaction) instead of painting the
+            # silent drop as a successful turn (#81440).
+            event.rejected = True
             logger.warning("Unauthorized user: %s (%s) on %s", source.user_id, source.user_name, source.platform.value)
             # In DMs: offer pairing code. In groups: silently ignore.
             if (

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3366,6 +3366,9 @@ class DiscordAdapter(BasePlatformAdapter):
                 await self._add_reaction(message, "✅")
             elif outcome == ProcessingOutcome.FAILURE:
                 await self._add_reaction(message, "❌")
+            # REJECTED (e.g. authorization refusal): leave no terminal reaction
+            # so the message visibly goes unhandled instead of reading as a
+            # successful acknowledgment (#81440).
 
     @staticmethod
     def _message_reference_from_ids(message_id, channel) -> "discord.MessageReference":

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3004,6 +3004,9 @@ class DiscordAdapter(BasePlatformAdapter):
                 await self._add_reaction(message, "✅")
             elif outcome == ProcessingOutcome.FAILURE:
                 await self._add_reaction(message, "❌")
+            # REJECTED (e.g. authorization refusal): leave no terminal reaction
+            # so the message visibly goes unhandled instead of reading as a
+            # successful acknowledgment (#81440).
 
     @staticmethod
     def _message_reference_from_ids(message_id, channel) -> "discord.MessageReference":

--- a/tests/gateway/test_discord_reactions.py
+++ b/tests/gateway/test_discord_reactions.py
@@ -111,6 +111,42 @@ async def test_process_message_background_adds_and_swaps_reactions(adapter):
 
 
 @pytest.mark.asyncio
+async def test_rejected_event_suppresses_final_reaction(adapter):
+    """A refused message (event.rejected) must not paint a success reaction.
+
+    Regression for #81440: the authz path returns None with no delivery, which
+    used to compute SUCCESS → ✅. The handler signals rejection via
+    event.rejected so the outcome is REJECTED and no terminal reaction is
+    added (the message visibly goes unhandled).
+    """
+    raw_message = SimpleNamespace(
+        add_reaction=AsyncMock(),
+        remove_reaction=AsyncMock(),
+    )
+
+    async def handler(event):
+        event.rejected = True
+        await asyncio.sleep(0)
+        return None
+
+    async def hold_typing(_chat_id, interval=2.0, metadata=None):
+        await asyncio.Event().wait()
+
+    adapter.set_message_handler(handler)
+    adapter.send = AsyncMock(return_value=SendResult(success=False))
+    adapter._keep_typing = hold_typing
+
+    event = _make_event("7", raw_message)
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    # 👀 in-progress reaction is added and removed...
+    assert raw_message.add_reaction.await_args_list[0].args == ("👀",)
+    assert raw_message.remove_reaction.await_args_list[0].args == ("👀", adapter._client.user)
+    # ...but no terminal ✅ or ❌ reaction is ever added.
+    assert len(raw_message.add_reaction.await_args_list) == 1
+
+
+@pytest.mark.asyncio
 async def test_reactions_disabled_via_env(adapter, monkeypatch):
     """When DISCORD_REACTIONS=false, no reactions should be added."""
     monkeypatch.setenv("DISCORD_REACTIONS", "false")


### PR DESCRIPTION
Rebased onto current `main` (a2b7746), verified the fix is still needed — upstream `ProcessingOutcome` still has only SUCCESS/FAILURE/CANCELLED (no REJECTED) and Discord still paints `✅`/`❌` for refused messages.

**Validation** — `.venv/bin/python -m pytest tests/gateway/test_discord_reactions.py -q` → 3 passed.
