### PR TITLE
fix(memory/hindsight): preserve extended HINDSIGHT_API_* daemon config through env materialization

### DIFF
--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -142,6 +142,28 @@ Available in `hybrid` and `tools` memory modes:
 | `HINDSIGHT_BUDGET` | Override recall budget |
 | `HINDSIGHT_MODE` | Override mode (`cloud`, `local_embedded`, `local_external`) |
 
+### Extended embedded-daemon configuration (local mode)
+
+In `local_embedded` mode the plugin materializes a profile-scoped env file for
+the embedded daemon (`~/.hindsight/profiles/<profile>.env`). Beyond the base
+LLM keys above, the daemon understands additional `HINDSIGHT_API_*` variables
+for embeddings, reranker, consolidation, and LLM failover strategy. These are
+passed through from your Hermes profile `.env` when present:
+
+- `HINDSIGHT_API_EMBEDDINGS_*` (provider, model, dimensions, API key)
+- `HINDSIGHT_API_RERANKER_*` (provider, model, API key)
+- `HINDSIGHT_API_CONSOLIDATION_*` (LLM provider/model/key, base URL, strategy)
+- `HINDSIGHT_API_LLM_1_*` (failover LLM provider/model/key)
+- `HINDSIGHT_API_LLM_REASONING_EFFORT`, `HINDSIGHT_API_LLM_STRATEGY`
+- `CODEX_HOME` (Codex CLI credential directory, when the daemon uses Codex)
+
+Config keys from `hindsight/config.json` always win; the cloud-mode
+`HINDSIGHT_API_KEY` / `HINDSIGHT_API_URL` are deliberately **not** passed
+through. The process environment is not a source for these extended keys —
+set them in your profile `.env` (`~/.hermes/.env`). (One pre-existing
+exception: `HINDSIGHT_API_LLM_BASE_URL` is also read from the process
+environment by the base builder, so an exported value takes precedence there.)
+
 ## Client Version
 
 Requires `hindsight-client >= 0.6.1`. The plugin auto-upgrades on session start if an older version is detected.

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -37,17 +37,30 @@ import json
 import logging
 import os
 import queue
+from contextlib import contextmanager
 import sys
 import threading
 import time
 
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Dict, List
 
-from agent.secret_scope import get_secret
+from agent.secret_scope import (
+    build_profile_secret_scope,
+    current_secret_scope,
+    get_secret,
+    is_multiplex_active,
+    reset_secret_scope,
+    set_secret_scope,
+)
 
 from agent.memory_provider import MemoryProvider
-from hermes_constants import get_hermes_home
+from hermes_constants import (
+    get_hermes_home,
+    reset_hermes_home_override,
+    set_hermes_home_override,
+)
 from tools.registry import tool_error
 from hermes_cli.config import cfg_get
 
@@ -716,6 +729,11 @@ class HindsightMemoryProvider(MemoryProvider):
         self._agent_workspace = ""
         self._turn_index = 0
         self._client = None
+        self._client_lock = threading.Lock()
+        # Set in initialize() from the hermes_home kwarg; kept as None here so
+        # a pre-initialize _get_client() call fails closed instead of reading
+        # the default profile's secrets.
+        self._profile_home: Path | None = None
         self._timeout = _DEFAULT_TIMEOUT
         self._idle_timeout = _DEFAULT_IDLE_TIMEOUT
         self._prefetch_result = ""
@@ -1098,8 +1116,73 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "port_health_grace_timeout", "description": "Seconds to wait for a slow daemon /health before treating it as stale (raise on busy/low-resource hosts; blank uses the 30s default)", "default": "", "when": {"mode": "local_embedded"}},
         ]
 
+    @contextmanager
+    def _secret_scope_guard(self):
+        """Ensure a profile secret scope (+ home override) is active for the
+        duration of client/daemon setup.
+
+        Background threads (``hindsight-writer``, ``hindsight-daemon-start``)
+        are started with plain ``threading.Thread``, which does NOT
+        ``copy_context()``, so they inherit no per-turn contextvars — under a
+        multiplexing gateway ``get_secret()`` would fail closed with
+        UnscopedSecretError and every auto-retain or daemon start would break.
+        Install the profile scope from the provider's own home for the
+        duration of the block when no scope is already active (normal per-turn
+        calls keep their scope).
+
+        Mirrors gateway/run.py ``_profile_runtime_scope``: home override,
+        secret-source hydration, then the isolated ``.env`` scope. Unlike the
+        gateway's per-turn scope, the writer thread lives for the whole
+        process, so both tokens are always reset in ``finally`` and the scope
+        is built BEFORE any contextvar is installed (a raise in scope building
+        must not leak a stale home override onto a long-lived thread).
+        """
+        if not is_multiplex_active() or current_secret_scope() is not None:
+            yield
+            return
+        if self._profile_home is None:
+            # No profile home captured yet — fail closed rather than silently
+            # substituting the default profile's secrets on a background
+            # thread (get_secret() below raises UnscopedSecretError, which is
+            # the documented contract for this situation).
+            yield
+            return
+        profile_home = self._profile_home
+        try:
+            from hermes_cli.env_loader import hydrate_profile_secret_sources
+            hydrate_profile_secret_sources(profile_home)
+        except Exception:
+            # Hydration is once-per-home, cached and fail-open; never let it
+            # take down client creation.
+            pass
+        scope = build_profile_secret_scope(profile_home)
+        home_token = set_hermes_home_override(str(profile_home))
+        secret_token = set_secret_scope(scope)
+        try:
+            yield
+        finally:
+            reset_secret_scope(secret_token)
+            reset_hermes_home_override(home_token)
+
     def _get_client(self):
-        """Return the cached Hindsight client (created once, reused)."""
+        """Return the cached Hindsight client (created once, reused).
+
+        Creation happens inside ``_secret_scope_guard`` and is serialized with
+        ``_client_lock``: the daemon-start thread, the retain writer thread,
+        and the prefetch thread can all race ``self._client is None`` on first
+        use, and an unsynchronized double-create would leak an aiohttp
+        session.
+        """
+        if self._client is not None:
+            return self._client
+        with self._client_lock:
+            if self._client is None:
+                with self._secret_scope_guard():
+                    return self._create_client()
+        return self._client
+
+    def _create_client(self):
+        """Create the Hindsight client. Runs inside _secret_scope_guard."""
         if self._client is None:
             if self._mode == "local_embedded":
                 available, reason = _check_local_runtime()
@@ -1454,6 +1537,13 @@ class HindsightMemoryProvider(MemoryProvider):
     def initialize(self, session_id: str, **kwargs) -> None:
         self._session_id = str(session_id or "").strip()
         self._parent_session_id = str(kwargs.get("parent_session_id", "") or "").strip()
+        # Capture the profile home at init time (agent_init passes it; in the
+        # multiplexing gateway initialize runs inside the profile scope, so
+        # get_hermes_home() is the correct fallback). Background threads that
+        # later build the client have no contextvars, so they rely on this.
+        self._profile_home = Path(
+            kwargs.get("hermes_home") or get_hermes_home()
+        )
 
         # Each process lifecycle gets its own document_id. Reusing session_id
         # alone caused overwrites on /resume — the reloaded session starts
@@ -1486,7 +1576,8 @@ class HindsightMemoryProvider(MemoryProvider):
         except Exception:
             pass  # packaging not available or other issue — proceed anyway
 
-        self._config = _load_config()
+        with self._secret_scope_guard():
+            self._config = _load_config()
         self._platform = str(kwargs.get("platform") or "").strip()
         self._user_id = str(kwargs.get("user_id") or "").strip()
         self._user_name = str(kwargs.get("user_name") or "").strip()
@@ -1524,7 +1615,8 @@ class HindsightMemoryProvider(MemoryProvider):
                 )
                 self._mode = "disabled"
                 return
-        self._api_key = self._config.get("apiKey") or self._config.get("api_key") or get_secret("HINDSIGHT_API_KEY", "")
+        with self._secret_scope_guard():
+            self._api_key = self._config.get("apiKey") or self._config.get("api_key") or get_secret("HINDSIGHT_API_KEY", "")
         default_url = _DEFAULT_LOCAL_URL if self._mode in {"local_embedded", "local_external"} else _DEFAULT_API_URL
         self._api_url = self._config.get("api_url") or os.environ.get("HINDSIGHT_API_URL", default_url)
         self._llm_base_url = self._config.get("llm_base_url", "")
@@ -1651,42 +1743,48 @@ class HindsightMemoryProvider(MemoryProvider):
 
             def _start_daemon():
                 import traceback
-                log_dir = get_hermes_home() / "logs"
-                log_dir.mkdir(parents=True, exist_ok=True)
-                log_path = log_dir / "hindsight-embed.log"
-                try:
-                    # Redirect the daemon manager's Rich console to our log file
-                    # instead of stderr. This avoids global fd redirects that
-                    # would capture output from other threads.
-                    import hindsight_embed.daemon_embed_manager as dem
-                    from rich.console import Console
-                    dem.console = Console(file=open(log_path, "a", encoding="utf-8"), force_terminal=False)
+                # This thread has no contextvars (plain threading.Thread), so
+                # install the profile secret scope + home override for the
+                # WHOLE startup sequence — including the log path resolution:
+                # otherwise the daemon log lands in the default profile's
+                # logs/ dir, which makes per-profile failures undiagnosable.
+                with self._secret_scope_guard():
+                    log_dir = get_hermes_home() / "logs"
+                    log_dir.mkdir(parents=True, exist_ok=True)
+                    log_path = log_dir / "hindsight-embed.log"
+                    try:
+                        # Redirect the daemon manager's Rich console to our log file
+                        # instead of stderr. This avoids global fd redirects that
+                        # would capture output from other threads.
+                        import hindsight_embed.daemon_embed_manager as dem
+                        from rich.console import Console
+                        dem.console = Console(file=open(log_path, "a", encoding="utf-8"), force_terminal=False)
 
-                    client = self._get_client()
-                    profile = self._config.get("profile", "hermes")
+                        client = self._get_client()
+                        profile = self._config.get("profile", "hermes")
 
-                    # Update the profile .env to match our current config so
-                    # the daemon always starts with the right settings.
-                    # If the config changed and the daemon is running, stop it.
-                    profile_env = _embedded_profile_env_path(self._config)
-                    expected_env = _build_embedded_profile_env(self._config)
-                    saved = _load_simple_env(profile_env)
-                    config_changed = saved != expected_env
+                        # Update the profile .env to match our current config so
+                        # the daemon always starts with the right settings.
+                        # If the config changed and the daemon is running, stop it.
+                        profile_env = _embedded_profile_env_path(self._config)
+                        expected_env = _build_embedded_profile_env(self._config)
+                        saved = _load_simple_env(profile_env)
+                        config_changed = saved != expected_env
 
-                    if config_changed:
-                        profile_env = _materialize_embedded_profile_env(self._config)
-                        if client._manager.is_running(profile):
-                            with open(log_path, "a", encoding="utf-8") as f:
-                                f.write("\n=== Config changed, restarting daemon ===\n")
-                            client._manager.stop(profile)
+                        if config_changed:
+                            profile_env = _materialize_embedded_profile_env(self._config)
+                            if client._manager.is_running(profile):
+                                with open(log_path, "a", encoding="utf-8") as f:
+                                    f.write("\n=== Config changed, restarting daemon ===\n")
+                                client._manager.stop(profile)
 
-                    client._ensure_started()
-                    with open(log_path, "a", encoding="utf-8") as f:
-                        f.write("\n=== Daemon started successfully ===\n")
-                except Exception as e:
-                    with open(log_path, "a", encoding="utf-8") as f:
-                        f.write(f"\n=== Daemon startup failed: {e} ===\n")
-                        traceback.print_exc(file=f)
+                        client._ensure_started()
+                        with open(log_path, "a", encoding="utf-8") as f:
+                            f.write("\n=== Daemon started successfully ===\n")
+                    except Exception as e:
+                        with open(log_path, "a", encoding="utf-8") as f:
+                            f.write(f"\n=== Daemon startup failed: {e} ===\n")
+                            traceback.print_exc(file=f)
 
             t = threading.Thread(target=_start_daemon, daemon=True, name="hindsight-daemon-start")
             t.start()

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -37,6 +37,7 @@ import json
 import logging
 import os
 import queue
+import re
 from contextlib import contextmanager
 import sys
 import threading
@@ -71,6 +72,28 @@ _DEFAULT_LOCAL_URL = "http://localhost:8888"
 # Keep in sync with tools/lazy_deps.py ("memory.hindsight") and plugin.yaml.
 _MIN_CLIENT_VERSION = "0.6.1"
 _DEFAULT_TIMEOUT = 120  # seconds — cloud API can take 30-40s per request
+
+# Extended configuration the embedded daemon understands beyond what the base
+# env builder emits (embeddings, reranker, consolidation, LLM failover). Only
+# these keys pass through from the Hermes profile .env into the materialized
+# daemon env. Deliberately NOT a bare "HINDSIGHT_API_" prefix match: that
+# would also copy the cloud-mode HINDSIGHT_API_KEY / HINDSIGHT_API_URL into
+# the daemon env, where the daemon has no use for them.
+_EXTENDED_DAEMON_ENV_PREFIXES = (
+    "HINDSIGHT_API_EMBEDDINGS_",
+    "HINDSIGHT_API_RERANKER_",
+    "HINDSIGHT_API_CONSOLIDATION_",
+)
+_EXTENDED_DAEMON_ENV_EXACT = (
+    "HINDSIGHT_API_LLM_BASE_URL",
+    "HINDSIGHT_API_LLM_REASONING_EFFORT",
+    "HINDSIGHT_API_LLM_STRATEGY",
+    "CODEX_HOME",
+)
+# Failover LLM slots (HINDSIGHT_API_LLM_1_*, _2_, ...). Regex, not a bare
+# "HINDSIGHT_API_LLM_" prefix, so the base-emitted HINDSIGHT_API_LLM_API_KEY /
+# _MODEL / _PROVIDER (which must never be refilled from .env) stay excluded.
+_EXTENDED_DAEMON_LLM_SLOT_RE = re.compile(r"^HINDSIGHT_API_LLM_\d+_")
 _DEFAULT_IDLE_TIMEOUT = 300  # seconds — Hindsight embedded daemon default
 # Mirrors hindsight-integrations/openclaw — Hindsight 0.5.0 added
 # `update_mode='append'` semantics on retain (vectorize-io/hindsight#932).
@@ -531,7 +554,25 @@ def _load_simple_env(path) -> dict[str, str]:
     return values
 
 
-def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | None = None) -> dict[str, str]:
+def _is_extended_daemon_env_key(key: str) -> bool:
+    """Return True for keys the embedded daemon consumes beyond the base set.
+
+    Explicit allowlist (prefixes + exact keys + numbered LLM failover slots) —
+    see the module constants.
+    """
+    return (
+        key in _EXTENDED_DAEMON_ENV_EXACT
+        or key.startswith(_EXTENDED_DAEMON_ENV_PREFIXES)
+        or bool(_EXTENDED_DAEMON_LLM_SLOT_RE.match(key))
+    )
+
+
+def _build_embedded_profile_env(
+    config: dict[str, Any],
+    *,
+    llm_api_key: str | None = None,
+    hermes_home: str | Path | None = None,
+) -> dict[str, str]:
     """Build the profile-scoped env file that standalone hindsight-embed consumes."""
     current_key = llm_api_key
     if current_key is None:
@@ -566,6 +607,27 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
         env_values["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] = str(
             _parse_int_setting(idle_timeout, _DEFAULT_IDLE_TIMEOUT)
         )
+
+    # Preserve extended daemon configuration from the Hermes profile .env.
+    # The embedded daemon additionally understands the allowlisted
+    # HINDSIGHT_API_* variables (embeddings, reranker, consolidation, LLM
+    # failover strategy, CODEX_HOME). _materialize_embedded_profile_env()
+    # overwrites the daemon env file whenever the base config changes, so
+    # without this pass-through those extended settings would be silently
+    # dropped on the next restart. Base config keys always win (k not in
+    # env_values) and the daemon env file is deliberately NOT a source — it is
+    # the artifact we write, and reading it back would make settings sticky
+    # after they are removed from the profile .env.
+    try:
+        env_home = Path(hermes_home) if hermes_home else get_hermes_home()
+        for k, v in _load_simple_env(env_home / ".env").items():
+            if _is_extended_daemon_env_key(k) and k not in env_values and v:
+                env_values[k] = v
+    except Exception as exc:
+        logger.warning(
+            "Hindsight extended daemon env pass-through failed: %s", exc, exc_info=True
+        )
+
     return env_values
 
 
@@ -613,11 +675,18 @@ def _validate_profile_env_permissions(profile_env) -> None:
             )
 
 
-def _materialize_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | None = None):
+def _materialize_embedded_profile_env(
+    config: dict[str, Any],
+    *,
+    llm_api_key: str | None = None,
+    hermes_home: str | Path | None = None,
+):
     """Write the profile-scoped env file that standalone hindsight-embed uses."""
     profile_env = _embedded_profile_env_path(config)
     profile_env.parent.mkdir(parents=True, exist_ok=True)
-    env_values = _build_embedded_profile_env(config, llm_api_key=llm_api_key)
+    env_values = _build_embedded_profile_env(
+        config, llm_api_key=llm_api_key, hermes_home=hermes_home
+    )
     content = "".join(f"{key}={value}\n" for key, value in env_values.items())
     try:
         _secure_write_profile_env(profile_env, content)
@@ -1065,6 +1134,7 @@ class HindsightMemoryProvider(MemoryProvider):
             _materialize_embedded_profile_env(
                 materialized_config,
                 llm_api_key=llm_api_key or None,
+                hermes_home=hermes_home,
             )
 
         print(f"\n  ✓ Hindsight memory configured ({mode} mode)")

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1373,3 +1373,164 @@ class TestClientAutoUpgradeRoutesThroughLazyDeps:
         assert len(calls) == 1  # attempted exactly once, init still completed
         assert any("runtime installs are disabled" in r.getMessage()
                    for r in caplog.records)
+
+
+class TestSecretScopeGuard:
+    """Background writer/daemon threads run without contextvars under a
+    multiplexing gateway. get_secret() then fails closed with
+    UnscopedSecretError; _secret_scope_guard must install the provider's
+    profile scope so client creation and daemon startup resolve the right key.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_multiplex(self):
+        from agent.secret_scope import set_multiplex_active
+        set_multiplex_active(True)
+        try:
+            yield
+        finally:
+            set_multiplex_active(False)
+
+    def _provider(self, tmp_path):
+        from agent.secret_scope import current_secret_scope
+        # Scope must be empty at the start of each test (fresh context).
+        assert current_secret_scope() is None
+        provider = HindsightMemoryProvider()
+        provider._profile_home = tmp_path
+        return provider
+
+    def test_guard_installs_profile_scope_for_secret_reads(self, tmp_path):
+        from agent import secret_scope as ss
+        tmp_path.joinpath(".env").write_text(
+            "HINDSIGHT_LLM_API_KEY=test-llm-key\nHINDSIGHT_API_KEY=test-api-key\n"
+        )
+        provider = self._provider(tmp_path)
+
+        # Baseline: fail closed without the guard.
+        with pytest.raises(ss.UnscopedSecretError):
+            ss.get_secret("HINDSIGHT_LLM_API_KEY", "")
+
+        with provider._secret_scope_guard():
+            assert ss.get_secret("HINDSIGHT_LLM_API_KEY", "") == "test-llm-key"
+            assert ss.get_secret("HINDSIGHT_API_KEY", "") == "test-api-key"
+            # Home override is active too, so daemon-env fills resolve the
+            # provider's own profile .env, not the default home.
+            from hermes_constants import get_hermes_home
+            assert str(get_hermes_home()) == str(tmp_path)
+
+        assert ss.current_secret_scope() is None
+
+    def test_guard_is_reentrant_and_keeps_existing_scope(self, tmp_path):
+        from agent import secret_scope as ss
+        tmp_path.joinpath(".env").write_text("HINDSIGHT_LLM_API_KEY=k\n")
+        provider = self._provider(tmp_path)
+
+        with provider._secret_scope_guard():
+            outer = ss.current_secret_scope()
+            with provider._secret_scope_guard():
+                assert ss.current_secret_scope() is outer
+            assert ss.current_secret_scope() is outer
+
+    def test_guard_noop_when_multiplex_off(self, tmp_path, monkeypatch):
+        from agent import secret_scope as ss
+        from agent.secret_scope import set_multiplex_active
+        set_multiplex_active(False)
+        tmp_path.joinpath(".env").write_text("HINDSIGHT_LLM_API_KEY=k\n")
+        provider = self._provider(tmp_path)
+
+        with provider._secret_scope_guard():
+            # Multiplex off => get_secret falls back to os.environ; guard must
+            # not have installed any scope.
+            assert ss.current_secret_scope() is None
+
+    def test_get_client_creates_within_scope_and_caches(self, tmp_path):
+        from agent import secret_scope as ss
+        tmp_path.joinpath(".env").write_text("HINDSIGHT_LLM_API_KEY=test-llm-key\n")
+        provider = self._provider(tmp_path)
+        provider._client = None
+
+        calls = {}
+
+        def fake_unscoped(self):
+            scope = ss.current_secret_scope()
+            calls["scope_active"] = scope is not None
+            calls["key"] = (scope or {}).get("HINDSIGHT_LLM_API_KEY")
+            self._client = "FAKE_CLIENT"  # real creation sets self._client
+            return "FAKE_CLIENT"
+
+        provider._create_client = fake_unscoped.__get__(provider, HindsightMemoryProvider)
+
+        assert provider._get_client() == "FAKE_CLIENT"
+        assert calls["scope_active"] is True
+        assert calls["key"] == "test-llm-key"
+        # Cached: second call must not re-enter unscoped creation.
+        provider._create_client = None
+        assert provider._get_client() == "FAKE_CLIENT"
+
+    def test_background_thread_resolves_secrets_through_guard(self, tmp_path):
+        """Regression for the actual bug: a plain threading.Thread (no
+        copy_context) like hindsight-writer must still resolve profile secrets
+        when it builds the client under a multiplexing gateway."""
+        import threading
+        from agent import secret_scope as ss
+        tmp_path.joinpath(".env").write_text("HINDSIGHT_LLM_API_KEY=thread-key\n")
+        provider = self._provider(tmp_path)
+        provider._client = None
+
+        result = {}
+
+        def fake_unscoped(self):
+            scope = ss.current_secret_scope()
+            result["scope_active"] = scope is not None
+            result["key"] = (scope or {}).get("HINDSIGHT_LLM_API_KEY")
+            self._client = "THREAD_CLIENT"
+            return "THREAD_CLIENT"
+
+        provider._create_client = fake_unscoped.__get__(provider, HindsightMemoryProvider)
+
+        thread = threading.Thread(target=provider._get_client, name="hindsight-writer")
+        thread.start()
+        thread.join(timeout=10)
+        assert not thread.is_alive()
+        assert result["scope_active"] is True
+        assert result["key"] == "thread-key"
+        assert provider._client == "THREAD_CLIENT"
+        # Main thread context stayed untouched — no leak from the worker.
+        assert ss.current_secret_scope() is None
+
+    def test_guard_restores_contextvars_on_exception(self, tmp_path):
+        from agent import secret_scope as ss
+        from hermes_constants import get_hermes_home_override
+        tmp_path.joinpath(".env").write_text("HINDSIGHT_LLM_API_KEY=k\n")
+        provider = self._provider(tmp_path)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            with provider._secret_scope_guard():
+                raise RuntimeError("boom")
+
+        assert ss.current_secret_scope() is None
+        assert get_hermes_home_override() is None
+
+    def test_guard_fails_closed_when_profile_home_missing(self, tmp_path):
+        from agent import secret_scope as ss
+        provider = HindsightMemoryProvider()
+        provider._profile_home = None  # pre-initialize state
+
+        # Guard must NOT install the default profile's secrets: get_secret
+        # keeps failing closed so a wrong-key client can never be built.
+        with provider._secret_scope_guard():
+            assert ss.current_secret_scope() is None
+            with pytest.raises(ss.UnscopedSecretError):
+                ss.get_secret("HINDSIGHT_LLM_API_KEY", "")
+
+    def test_initialize_captures_profile_home_from_kwarg(self, tmp_path, monkeypatch):
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps({"mode": "cloud", "apiKey": "x"}))
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
+        provider = HindsightMemoryProvider()
+        provider.initialize(session_id="s", hermes_home=str(tmp_path), platform="cli")
+        assert provider._profile_home == tmp_path
+

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -50,6 +50,12 @@ def _clean_env(tmp_path, monkeypatch):
         "HINDSIGHT_RETAIN_USER_PREFIX", "HINDSIGHT_RETAIN_ASSISTANT_PREFIX",
     ):
         monkeypatch.delenv(key, raising=False)
+    # The extended daemon env pass-through reads HINDSIGHT_API_* / CODEX_HOME
+    # from the profile .env; strip any process-level copies so host state
+    # cannot leak into the built daemon env during tests.
+    for key in list(os.environ):
+        if key.startswith("HINDSIGHT_API_") or key == "CODEX_HOME":
+            monkeypatch.delenv(key, raising=False)
 
     # On Windows pathlib.Path.home() resolves USERPROFILE/HOMEDRIVE+HOMEPATH,
     # not the POSIX HOME alias that these tests historically monkeypatched.
@@ -1533,4 +1539,156 @@ class TestSecretScopeGuard:
         provider = HindsightMemoryProvider()
         provider.initialize(session_id="s", hermes_home=str(tmp_path), platform="cli")
         assert provider._profile_home == tmp_path
+
+
+class TestExtendedDaemonEnvPreservation:
+    """The embedded daemon understands more HINDSIGHT_API_* variables than the
+    base env builder emits (embeddings, reranker, consolidation, LLM failover
+    strategy, CODEX_HOME). Those are configured in the Hermes profile .env and
+    must survive env materialization instead of being silently dropped on the
+    next config change/restart."""
+
+    CONFIG = {
+        "mode": "local_embedded",
+        "profile": "hermes",
+        "llm_provider": "openai-codex",
+        "llm_model": "gpt-test",
+    }
+
+    def _build(self, tmp_path, monkeypatch, config=None, hermes_home=None):
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
+        return _build_embedded_profile_env(
+            config or dict(self.CONFIG),
+            hermes_home=hermes_home or tmp_path,
+        )
+
+    def test_extended_config_preserved_from_profile_env(self, tmp_path, monkeypatch):
+        tmp_path.joinpath(".env").write_text(
+            "HINDSIGHT_API_EMBEDDINGS_PROVIDER=openai\n"
+            "HINDSIGHT_API_EMBEDDINGS_MODEL=text-embedding-3-large\n"
+            "HINDSIGHT_API_RERANKER_PROVIDER=openrouter\n"
+            "HINDSIGHT_API_LLM_STRATEGY={\"mode\":\"failover\"}\n"
+            "CODEX_HOME=/home/user/.codex\n"
+        )
+        env = self._build(tmp_path, monkeypatch)
+        assert env["HINDSIGHT_API_EMBEDDINGS_PROVIDER"] == "openai"
+        assert env["HINDSIGHT_API_EMBEDDINGS_MODEL"] == "text-embedding-3-large"
+        assert env["HINDSIGHT_API_RERANKER_PROVIDER"] == "openrouter"
+        assert json.loads(env["HINDSIGHT_API_LLM_STRATEGY"]) == {"mode": "failover"}
+        assert env["CODEX_HOME"] == "/home/user/.codex"
+
+    def test_cloud_keys_not_copied(self, tmp_path, monkeypatch):
+        # The bare HINDSIGHT_API_ prefix would also match the cloud-mode
+        # HINDSIGHT_API_KEY / HINDSIGHT_API_URL; the allowlist must exclude
+        # them (they are meaningless to the embedded daemon, and one is a
+        # secret).
+        tmp_path.joinpath(".env").write_text(
+            "HINDSIGHT_API_KEY=cloud-key\n"
+            "HINDSIGHT_API_URL=https://api.hindsight.vectorize.io\n"
+            "HINDSIGHT_API_EMBEDDINGS_PROVIDER=openai\n"
+        )
+        env = self._build(tmp_path, monkeypatch)
+        assert "HINDSIGHT_API_KEY" not in env
+        assert "HINDSIGHT_API_URL" not in env
+        assert env["HINDSIGHT_API_EMBEDDINGS_PROVIDER"] == "openai"
+
+    def test_empty_base_key_not_refilled_from_env(self, tmp_path, monkeypatch):
+        # B2: the base builder authoritatively emits HINDSIGHT_API_LLM_API_KEY
+        # (possibly ""). A leftover value in the profile .env must never
+        # resurrect it — otherwise a rotated/removed key could never be
+        # cleared from the materialized daemon env.
+        tmp_path.joinpath(".env").write_text("HINDSIGHT_API_LLM_API_KEY=stale\n")
+        env = self._build(tmp_path, monkeypatch)
+        assert env["HINDSIGHT_API_LLM_API_KEY"] == ""
+
+    def test_daemon_env_file_not_a_source(self, tmp_path, monkeypatch):
+        # The materialized daemon env file is the artifact we WRITE; it must
+        # never be read back, or removed settings would stay sticky forever.
+        env_path = Path.home() / ".hindsight" / "profiles" / "hermes.env"
+        env_path.parent.mkdir(parents=True, exist_ok=True)
+        env_path.write_text("HINDSIGHT_API_RERANKER_PROVIDER=stale\n")
+        env = self._build(tmp_path, monkeypatch)
+        assert "HINDSIGHT_API_RERANKER_PROVIDER" not in env
+
+    def test_base_keys_win_over_env(self, tmp_path, monkeypatch):
+        # config.json provider mapping (openrouter -> "openai" wire format)
+        # must not be overridden by a stale value in the profile .env.
+        tmp_path.joinpath(".env").write_text(
+            "HINDSIGHT_API_LLM_PROVIDER=deepseek\nHINDSIGHT_API_LLM_MODEL=stale-model\n"
+        )
+        config = dict(self.CONFIG, llm_provider="openrouter", llm_model="gpt-real")
+        env = self._build(tmp_path, monkeypatch, config=config)
+        assert env["HINDSIGHT_API_LLM_PROVIDER"] == "openai"
+        assert env["HINDSIGHT_API_LLM_MODEL"] == "gpt-real"
+
+    def test_explicit_llm_api_key_wins_over_env(self, tmp_path, monkeypatch):
+        tmp_path.joinpath(".env").write_text("HINDSIGHT_API_LLM_API_KEY=wrong\n")
+        config = dict(self.CONFIG, llmApiKey="right")
+        env = self._build(tmp_path, monkeypatch, config=config)
+        assert env["HINDSIGHT_API_LLM_API_KEY"] == "right"
+
+    def test_explicit_hermes_home_wins(self, tmp_path, monkeypatch):
+        # post_setup passes its explicit hermes_home; the pass-through must
+        # read THAT profile's .env, not the ambient home.
+        other_home = tmp_path / "other-profile"
+        other_home.mkdir()
+        other_home.joinpath(".env").write_text(
+            "HINDSIGHT_API_EMBEDDINGS_PROVIDER=other-openai\n"
+        )
+        env = self._build(tmp_path, monkeypatch, hermes_home=other_home)
+        assert env["HINDSIGHT_API_EMBEDDINGS_PROVIDER"] == "other-openai"
+
+    def test_empty_values_not_filled(self, tmp_path, monkeypatch):
+        # Empty values are truthiness-dropped: a blank extended key must not
+        # clobber anything nor appear in the built env.
+        tmp_path.joinpath(".env").write_text(
+            "HINDSIGHT_API_EMBEDDINGS_PROVIDER=\n"
+        )
+        env = self._build(tmp_path, monkeypatch)
+        assert "HINDSIGHT_API_EMBEDDINGS_PROVIDER" not in env
+
+    def test_process_env_not_a_source(self, tmp_path, monkeypatch):
+        # Deliberate: launch-env HINDSIGHT_API_* must not leak into the daemon
+        # env (would silently attach one profile's config to another's daemon).
+        monkeypatch.setenv("HINDSIGHT_API_RERANKER_PROVIDER", "process-value")
+        monkeypatch.setenv("HINDSIGHT_API_LLM_API_KEY", "process-key")
+        env = self._build(tmp_path, monkeypatch)
+        assert "HINDSIGHT_API_RERANKER_PROVIDER" not in env
+        # The base builder always emits the LLM key slot; it must stay EMPTY,
+        # never filled from the process env.
+        assert env.get("HINDSIGHT_API_LLM_API_KEY", "") == ""
+
+    def test_failover_slots_and_base_url_passthrough(self, tmp_path, monkeypatch):
+        # Numbered failover slots (LLM_1_/LLM_2_) and the allowlisted
+        # LLM_BASE_URL pass through; the base-emitted LLM_API_KEY / _MODEL /
+        # _PROVIDER never do.
+        tmp_path.joinpath(".env").write_text(
+            "HINDSIGHT_API_LLM_1_PROVIDER=openrouter\n"
+            "HINDSIGHT_API_LLM_2_PROVIDER=deepseek\n"
+            "HINDSIGHT_API_LLM_BASE_URL=https://example.com/api\n"
+            "HINDSIGHT_API_LLM_API_KEY=should-not-pass\n"
+            "HINDSIGHT_API_LLM_MODEL=should-not-pass\n"
+        )
+        env = self._build(tmp_path, monkeypatch)
+        assert env["HINDSIGHT_API_LLM_1_PROVIDER"] == "openrouter"
+        assert env["HINDSIGHT_API_LLM_2_PROVIDER"] == "deepseek"
+        assert env["HINDSIGHT_API_LLM_BASE_URL"] == "https://example.com/api"
+        assert env.get("HINDSIGHT_API_LLM_API_KEY", "") == ""
+        assert env["HINDSIGHT_API_LLM_MODEL"] == "gpt-test"
+
+    def test_non_hindsight_keys_not_leaked(self, tmp_path, monkeypatch):
+        tmp_path.joinpath(".env").write_text(
+            "MY_PRIVATE_SECRET=shhh\nGITHUB_TOKEN=ghp_x\n"
+        )
+        env = self._build(tmp_path, monkeypatch)
+        assert "MY_PRIVATE_SECRET" not in env
+        assert "GITHUB_TOKEN" not in env
+
+    def test_missing_profile_env_is_harmless(self, tmp_path, monkeypatch):
+        # No .env at all: base builder must still return the base keys.
+        env = self._build(tmp_path, monkeypatch)
+        assert env["HINDSIGHT_API_LLM_PROVIDER"] == "openai-codex"
+        assert env["HINDSIGHT_API_LOG_LEVEL"] == "info"
 


### PR DESCRIPTION
## Problem

In `local_embedded` mode the plugin materializes a profile-scoped env file for the embedded daemon (`~/.hindsight/profiles/<profile>.env`) from `_build_embedded_profile_env()`. The base builder only emits the core LLM keys, but the daemon understands many more `HINDSIGHT_API_*` variables (embeddings, reranker, consolidation, LLM failover strategy, `CODEX_HOME`). Users configure those in the Hermes profile `.env`.

`_materialize_embedded_profile_env()` overwrites the daemon env file whenever the base config changes, so without a pass-through those extended settings get **silently dropped on the next restart** — the daemon quietly loses its embeddings/reranker/consolidation/failover configuration.

## Fix

`_build_embedded_profile_env()` now layers the extended configuration from the Hermes profile `.env` (`get_hermes_home()/.env`) into the built env:

- **Explicit allowlist** (`_EXTENDED_DAEMON_ENV_PREFIXES` / `_EXTENDED_DAEMON_ENV_EXACT` / numbered `HINDSIGHT_API_LLM_\d+_` failover slots) — NOT a bare `HINDSIGHT_API_` prefix match, which would also copy the cloud-mode `HINDSIGHT_API_KEY` / `HINDSIGHT_API_URL` into the daemon env.
- **Base config always wins**: `k not in env_values`, so the base-emitted `HINDSIGHT_API_LLM_API_KEY` (even when empty) is never refilled from `.env` — a rotated/removed key can actually be cleared.
- **Daemon env file is NOT a source**: it is the artifact we write; reading it back would make removed settings sticky forever.
- **`hermes_home` threading**: `_build_embedded_profile_env` / `_materialize_embedded_profile_env` accept an explicit `hermes_home`; `post_setup` passes it (the daemon-start path resolves it correctly inside the profile secret-scope guard from #81816).
- **Process env is not a source** for these keys (launch-env values must not attach to a different profile's daemon env); documented exception: `HINDSIGHT_API_LLM_BASE_URL` is pre-read from the process env by the base builder.
- Logging via `logger.warning` on pass-through failure; README documents the pass-through and exclusions.

Bonus: this also ends a spurious daemon-restart loop — before, any extra key in the daemon env file made `saved != expected_env` permanently true, rewriting the file and restarting the daemon on every session start.

## Tests

`TestExtendedDaemonEnvPreservation` (12 tests): extended-key pass-through, cloud-key exclusion, empty-base-key non-refill, daemon-env-file-not-a-source, base-wins precedence, explicit `hermes_home`, empty-value dropping, process-env non-source, failover slots + base-url pass-through, secret non-leak, missing-`.env` harmlessness. `_clean_env` fixture now strips `HINDSIGHT_API_*`/`CODEX_HOME` from the process env so host state cannot leak into tests. All 90 hindsight-related tests pass.

## Related

- Depends on #81816 (secret-scope guard): the daemon-start thread resolves `get_hermes_home()` inside the guard, which is what makes the `.env` pass-through profile-correct under multiplexing.
- Tracking issue: #81815 (shared daemon env file across Hermes profiles).