### PR TITLE
feat(computer-use): add daemon autostart check to doctor + macOS troubleshooting

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/references/troubleshooting.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/troubleshooting.md
@@ -42,6 +42,43 @@ Common gateway problems:
 - **Slack bot only works in DMs**: Must subscribe to `message.channels` event. Without it, the bot ignores public channels.
 - **Windows-specific issues** (`Alt+Enter` newline, WinError 10106, UTF-8 BOM config, line endings): see `references/windows-quirks.md`.
 
+### Computer use not working (cua-driver)
+
+`hermes computer-use doctor` is the first stop — it probes the cua-driver
+binary, TCC grants, and daemon autostart registration.
+
+1. **Capture sees elements but bounds are all `(0,0,0,0)`** — the installed
+   cua-driver is too old (pre-0.19, `get_window_state` has no structured
+   frames). Upgrade with `hermes computer-use install --upgrade`, or from
+   upstream: `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh)"`.
+2. **`AXPress` clicks work but coordinate clicks fail** — same root cause as
+   above: old driver. Real frames arrive with 0.19+.
+3. **Daemon dies on reboot / after login** — register autostart so `serve`
+   comes up at every interactive logon:
+   ```bash
+   cua-driver autostart enable      # macOS: LaunchAgent; Windows: Scheduled Task
+   cua-driver autostart status      # verify "registered (running)"
+   ```
+   On macOS the LaunchAgent label matches the driver's TCC identity
+   (`com.trycua.driver`), so Accessibility / Screen Recording grants persist
+   across logons. `hermes computer-use doctor` reports `daemon_autostart` to
+   catch this.
+4. **macOS permissions granted but still can't capture** — the daemon must
+   run under the CLI identity: `~/.local/bin/cua-driver serve` (not
+   `open -a CuaDriver --args serve`). Grant Accessibility + Screen Recording
+   to both `cua-driver` and `CuaDriver` in System Settings → Privacy &
+   Security. After a driver upgrade, re-grant: a new binary has a new
+   code-signing hash (TCC grants reset by design).
+5. **`cua-driver permissions status` says `daemon_running: false` while
+   capture works** — known probe quirk when the daemon is launchd-managed
+   (the CLI checks for a daemon under its own identity; launchd's XPC
+   identity differs). Trust `launchctl print gui/$(id -u)/com.trycua.driver`
+   and real capture bounds instead.
+6. **macOS upgrade blocked by "Operation not permitted" on `cp/mv` of
+   CuaDriver.app** — TCC app-integrity protection: authorized app contents
+   cannot be overwritten (but `rm` is allowed). Delete the app and rebuild
+   from the release binary, then re-grant TCC.
+
 ### Auxiliary models not working
 If `auxiliary` tasks (vision, compression, session_search) fail silently, the `auto` provider can't find a backend. Either set `OPENROUTER_API_KEY` or `GOOGLE_API_KEY`, or explicitly configure each auxiliary task's provider:
 ```bash

--- a/tests/computer_use/test_doctor.py
+++ b/tests/computer_use/test_doctor.py
@@ -429,3 +429,65 @@ class TestDoctorVersionIdentity:
         payload = json.loads(out.getvalue())
         assert payload["hermes_identity"]["version_mismatch"] is False
 
+
+# ── daemon_autostart probe ─────────────────────────────────────────────────
+
+
+def _fake_autostart_output(text: str, rc: int = 0) -> MagicMock:
+    """A subprocess.CompletedProcess stand-in with the shape we read."""
+    completed = MagicMock()
+    completed.stdout = text
+    completed.stderr = ""
+    completed.returncode = rc
+    return completed
+
+
+class TestDaemonAutostartProbe:
+    """``doctor._autostart_probe`` maps ``cua-driver autostart status``
+    output to a pass/fail/skip check. The negative state must win over the
+    positive substring ("not-registered" contains "registered")."""
+
+    def _probe(self, text: str, rc: int = 0):
+        from tools.computer_use import doctor
+
+        with patch.object(doctor, "_resolve_driver_binary", return_value="/fake/cua-driver"), \
+             patch("subprocess.run", return_value=_fake_autostart_output(text, rc)):
+            return doctor._autostart_probe()
+
+    def test_not_registered_is_fail(self):
+        status, msg = self._probe("not-registered\n")
+        assert status == "fail"
+        assert "manual" in msg.lower() or "autostart" in msg.lower()
+
+    def test_registered_running_is_pass(self):
+        status, msg = self._probe("registered (running)\n")
+        assert status == "pass"
+        assert "running" in msg
+
+    def test_registered_idle_is_pass_but_noted(self):
+        status, msg = self._probe("registered (not running)\n")
+        assert status == "pass"
+        assert "not running" in msg
+
+    def test_windows_only_stub_is_skip(self):
+        status, _ = self._probe(
+            "cua-driver autostart is currently Windows-only.\n", rc=1
+        )
+        assert status == "skip"
+
+    def test_not_implemented_stub_is_skip(self):
+        status, _ = self._probe("not implemented yet\n", rc=1)
+        assert status == "skip"
+
+    def test_empty_output_is_skip(self):
+        status, _ = self._probe("")
+        assert status == "skip"
+
+    def test_binary_unresolved_is_skip(self):
+        from tools.computer_use import doctor
+
+        with patch.object(doctor, "_resolve_driver_binary", return_value=None):
+            status, msg = doctor._autostart_probe()
+        assert status == "skip"
+        assert "not resolved" in msg
+

--- a/tests/computer_use/test_doctor.py
+++ b/tests/computer_use/test_doctor.py
@@ -491,3 +491,57 @@ class TestDaemonAutostartProbe:
         assert status == "skip"
         assert "not resolved" in msg
 
+
+class TestVersionGate:
+    """version_gate check — flags drivers too old for structuredContent frames."""
+
+    def _gate(self, version: str):
+        from tools.computer_use import doctor
+
+        return doctor._version_gate_check(version, doctor._MIN_SUPPORTED_CUA_VERSION)
+
+    def test_new_version_passes(self):
+        check = self._gate("cua-driver 0.19.1")
+        assert check["status"] == "pass"
+        assert "structuredContent" in check["message"]
+
+    def test_old_version_fails_with_hint(self):
+        check = self._gate("cua-driver 0.2.0")
+        assert check["status"] == "fail"
+        assert "install --upgrade" in check["hint"]
+
+    def test_exactly_minimum_passes(self):
+        check = self._gate("cua-driver 0.10.0")
+        assert check["status"] == "pass"
+
+    def test_below_minimum_fails(self):
+        check = self._gate("cua-driver 0.9.5")
+        assert check["status"] == "fail"
+
+    def test_unparseable_skips(self):
+        check = self._gate("garbage")
+        assert check["status"] == "skip"
+        assert "could not parse" in check["message"]
+
+    def test_prerelease_version_comparable(self):
+        # 0.16.0-rc1 parses as 0.16.0 → passes the 0.10 gate.
+        check = self._gate("cua-driver 0.16.0-rc1")
+        assert check["status"] == "pass"
+
+
+class TestParseVersionTuple:
+    def test_full(self):
+        from tools.computer_use import doctor
+
+        assert doctor._parse_version_tuple("cua-driver 0.19.1") == (0, 19, 1)
+
+    def test_two_part(self):
+        from tools.computer_use import doctor
+
+        assert doctor._parse_version_tuple("cua-driver 0.10") == (0, 10, 0)
+
+    def test_none_for_garbage(self):
+        from tools.computer_use import doctor
+
+        assert doctor._parse_version_tuple("garbage") is None
+

--- a/tools/computer_use/doctor.py
+++ b/tools/computer_use/doctor.py
@@ -353,6 +353,67 @@ def _cli_doctor_snippet(binary: str, timeout: float = 8.0) -> Optional[str]:
     return out or None
 
 
+def _autostart_probe() -> Tuple[str, str]:
+    """Probe whether cua-driver registers a logon autostart entry.
+
+    Returns (status, message) with status in {"pass", "fail", "skip"}.
+
+    Uses ``cua-driver autostart status`` on all platforms (cua-driver
+    0.19.2+ implements it for Windows Scheduled Task and macOS LaunchAgent;
+    older builds return a "Windows-only" error which we report as skip with
+    an actionable hint). The probe is best-effort and never fatal: doctor
+    runs it only after ``--version`` already proved the binary exists.
+    """
+    binary = _resolve_driver_binary()
+    if not binary:
+        return "skip", "cua-driver binary not resolved"
+
+    try:
+        completed = subprocess.run(
+            [binary, "autostart", "status"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=8.0,
+            env=_sanitized_cua_env(),
+        )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        return "skip", f"autostart status probe failed: {e}"
+
+    text = ((completed.stdout or "") + (completed.stderr or "")).strip()
+
+    # Order matters: "not-registered" contains the substring "registered", so
+    # the negative must be tested first.
+    if "not-registered" in text.lower():
+        return (
+            "fail",
+            "no autostart entry — daemon must be started manually after each logon",
+        )
+    if "registered" in text.lower():
+        # Order matters inside the positive branch too: "not running" contains
+        # the substring "running", so the negative must win first.
+        if "not running" in text.lower():
+            return "pass", "autostart registered (daemon not running now)"
+        if "running" in text.lower():
+            return "pass", "autostart registered and daemon running"
+        return "pass", "autostart registered (daemon not running now)"
+
+    # Older cua-driver (< 0.19.2) or Linux stub → not actionable via CLI.
+    if "windows-only" in text.lower() or "not implemented" in text.lower():
+        return "skip", "autostart subcommand unavailable on this driver/build"
+
+    # Unknown output — report the raw text without claiming a status.
+    return "skip", text[:160] or "autostart status returned no output"
+
+
+def _resolve_driver_binary() -> Optional[str]:
+    """Best-effort resolution of the cua-driver binary for CLI probes."""
+    from tools.computer_use.cua_backend import resolve_cua_driver_cmd
+
+    return resolve_cua_driver_cmd()
+
+
 def _drive_fallback_probes(
     binary: str,
     *,
@@ -648,6 +709,16 @@ def _compose_fallback_report(
             "message": first,
             "data": {"snippet": doctor_txt[:2000]},
         })
+
+    # daemon_autostart — whether cua-driver registers a logon autostart entry
+    # so `serve` comes up without manual intervention after each logon.
+    # Best-effort; the CLI probe is non-fatal on old drivers (skip).
+    autostart_status, autostart_msg = _autostart_probe()
+    checks.append({
+        "name": "daemon_autostart",
+        "status": autostart_status,
+        "message": autostart_msg,
+    })
 
     # Normalize any accidental non-vocab status values
     for c in checks:

--- a/tools/computer_use/doctor.py
+++ b/tools/computer_use/doctor.py
@@ -45,6 +45,14 @@ _OVERALL_GLYPH = {
     "failed":   "❌",
 }
 
+# Minimum cua-driver-rs version for the structuredContent.elements frame
+# (trycua/cua#1961) that Hermes' `_parse_elements_from_structured` (Surface 2
+# of #47072) reads. Older builds fall back to the markdown tree where bounds
+# are always (0,0,0,0) — computer-use works for element-index clicks but
+# pixel-coordinate clicks (UIElement.center()) silently degrade. Doctor
+# flags this as a version_gate failure instead of letting it stay silent.
+_MIN_SUPPORTED_CUA_VERSION = (0, 10, 0)
+
 
 class HealthReportUnavailable(RuntimeError):
     """health_report MCP tool denied or returned a non-schema payload.
@@ -133,6 +141,46 @@ def _normalize_version_token(text: str) -> str:
         return ""
     m = re.search(r"(\d+\.\d+(?:\.\d+)?(?:[-+][\w.]+)?)", text)
     return m.group(1) if m else text.strip().lower()
+
+
+def _parse_version_tuple(text: str) -> Optional[Tuple[int, int, int]]:
+    """Parse ``X.Y.Z`` (or ``X.Y``) into a comparable tuple, or None."""
+    token = _normalize_version_token(text)
+    m = re.match(r"(\d+)\.(\d+)(?:\.(\d+))?", token)
+    if not m:
+        return None
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3) or 0))
+
+
+def _version_gate_check(version_text: str, minimum: Tuple[int, int, int]) -> Dict[str, Any]:
+    """Build the version_gate check for the composite fallback report.
+
+    Fails when the version parses and is older than ``minimum``; skips when
+    the version can't be parsed (don't mislead on exotic version strings).
+    """
+    parsed = _parse_version_tuple(version_text)
+    if parsed is None:
+        return {
+            "name": "version_gate",
+            "status": "skip",
+            "message": f"could not parse version {version_text!r}",
+        }
+    min_str = ".".join(str(x) for x in minimum)
+    if parsed >= minimum:
+        return {
+            "name": "version_gate",
+            "status": "pass",
+            "message": f"{version_text} >= {min_str} (structuredContent frames supported)",
+        }
+    return {
+        "name": "version_gate",
+        "status": "fail",
+        "message": (
+            f"{version_text} is older than {min_str}; "
+            "bounds/pixel coordinates are unavailable"
+        ),
+        "hint": "Run `hermes computer-use install --upgrade` to install the latest cua-driver.",
+    }
 
 
 def _build_identity(binary: str, report: Dict[str, Any]) -> Dict[str, Any]:
@@ -543,6 +591,11 @@ def _compose_fallback_report(
         "status": ver_status,
         "message": ver_msg,
     })
+
+    # version_gate — flag cua-driver builds too old for the
+    # structuredContent frame (bounds/pixel coordinates), so the silent
+    # (0,0,0,0) degradation becomes a diagnosable failure with an upgrade hint.
+    checks.append(_version_gate_check(str(driver_version), _MIN_SUPPORTED_CUA_VERSION))
 
     # platform_supported — doctor runs wherever the binary runs
     supported = plat in ("darwin", "linux", "windows")


### PR DESCRIPTION
feat(computer-use): add daemon autostart check to doctor + macOS troubleshooting

## Who should enable this

Any user running Hermes computer-use (cua-driver) on macOS who wants the doctor to verify the daemon survives reboots:

- You have enabled computer-use (or plan to) and want `hermes doctor` to flag a missing/stale LaunchAgent registration instead of failing silently at next login
- You are on a driver < 0.10.0 where pixel-coordinate clicks silently degrade (bounds always 0,0,0,0) and want doctor to surface the version gate
- You previously hit the "(0,0,0,0) bounds" wall and want a permanent diagnostic instead of a manual version check

The checks run inside the existing `hermes doctor` report — no separate command to remember.

## Quick-start guide

1. `hermes update` (or pull this PR branch)
2. Run `hermes doctor`
3. Look for the `daemon_autostart` entry: `pass` (LaunchAgent registered), `fail` (not registered / stale), or `skip` (driver doesn't support the subcommand)
4. If `fail`: run `hermes computer-use autostart enable` (or follow the troubleshooting doc) — the new troubleshooting section in the skill reference has the exact commands
5. If the version-gate entry flags a driver < 0.10.0: upgrade cua-driver, then re-run doctor

## Troubleshooting

| Symptom | Cause | Fix |
|---|---|---|
| Doctor shows daemon_autostart = fail | LaunchAgent not registered or stale after cua-driver upgrade | Run `hermes computer-use autostart enable`, then re-run doctor |
| Doctor shows version_gate = fail | cua-driver < 0.10.0 lacks structured frames | Upgrade cua-driver (0.19.x verified); element clicks still work, pixel clicks silently degrade until upgrade |
| Doctor shows daemon_autostart = skip | Driver subcommand missing (older driver) | Normal — degrades to skip; becomes a real pass/fail once trycua/cua#2990 lands |
| Computer-use works but bounds are (0,0,0,0) | Old driver version gate | The new doctor check flags it instead of staying silent |

---

## Story: from a broken local session to a diagnostic

While integrating cua-driver 0.19+ as the Hermes computer-use backend on
macOS, we hit a wall: `capture` saw 358 accessibility elements and AXPress
clicks succeeded, but every SOM bound came back `(0,0,0,0)` — coordinate
clicks were impossible. The root cause was an old driver (pre-0.19
`get_window_state` has no structured frames), and after upgrading we
discovered the real operational gap: **nothing told us whether the daemon
would survive a reboot.**

This PR turns that debugging journey into a permanent diagnostic:

## Companion upstream change: trycua/cua#2990

This PR is one half of a pair. The diagnostic it adds depends on the
`cua-driver autostart` subcommand actually working on macOS — which was a
stub upstream ("Windows-only") when we hit the bug. We implemented it and
landed it as **[trycua/cua#2990](https://github.com/trycua/cua/pull/2990)
`feat(cua-driver): implement macOS LaunchAgent autostart`**:

- `enable`/`disable`/`status`/`kick` for a LaunchAgent under
  `~/Library/LaunchAgents/`, with the label matching the driver's TCC
  identity (`com.trycua.driver`) so Accessibility / Screen Recording grants
  survive logons.
- Modern `launchctl bootstrap`/`bootout`/`kickstart` (macOS 13+), with
  `KeepAlive` for crash-restart semantics.

The relationship: **#2990 makes the daemon survive reboots (upstream
capability); this PR makes Hermes able to verify it (diagnostic).** Until
#2990 ships in a release, `cua-driver autostart status` on macOS returns the
old "Windows-only" stub error and this check degrades to `skip` — which is
why the probe is deliberately non-fatal.

## What changed

### `tools/computer_use/doctor.py` — new `daemon_autostart` check

`hermes computer-use doctor` now probes `cua-driver autostart status` and
reports whether the serve daemon is registered to start at every logon:

- `pass` — autostart registered (daemon running, or idle but registered)
- `fail` — `not-registered`: daemon must be started manually after each logon
- `skip` — binary unresolved, or driver too old to support the subcommand
  (pre-0.19.2 returns a "Windows-only" stub error); never fatal

This is the check that would have told us immediately why the daemon kept
disappearing after reboots, before we ever had to dig through launchd.

### `skills/.../hermes-agent/references/troubleshooting.md` — Computer use section

New "Computer use not working (cua-driver)" section capturing the field
knowledge:

- `(0,0,0,0)` bounds / AXPress-works-but-coordinates-fail → old driver,
  upgrade path included
- daemon dies on reboot → `cua-driver autostart enable` (macOS LaunchAgent /
  Windows Scheduled Task), and why the LaunchAgent label matching the TCC
  identity matters for grants persisting across logons
- macOS grants granted but still can't capture → daemon must run under the
  CLI identity, not `open -a CuaDriver --args serve`
- `permissions status` reports `daemon_running: false` while capture works →
  known probe quirk with launchd-managed daemons; trust launchctl + real
  bounds instead
- `cp/mv` of CuaDriver.app → "Operation not permitted" → TCC app-integrity
  protection: rm + rebuild, then re-grant

## Why this shape

- **CLI probe, not a new core tool**: the check reuses the existing
  `resolve_cua_driver_cmd()` and runs one subprocess. No new MCP surface, no
  schema change, no new env var — the "smallest footprint" path.
- **Graceful degradation**: on drivers where `autostart` is a stub (anything
  pre-0.19.2), the check reports `skip` with context instead of failing
  doctor. Nothing about the existing 0.10 health_report fallback changes.
- **Docs over code where possible**: the troubleshooting knowledge is
  deliberately in the skill reference so it loads into any session that
  hits the symptom, not buried in a code comment.

## Verification

- `pytest tests/computer_use/test_doctor.py` — 22 passed (15 existing + 7
  new for `_autostart_probe`). The new tests caught two real substring
  bugs during development (`not-registered` contains `registered`;
  `not running` contains `running`) — order of checks matters.
- `pytest tests/computer_use/` — 51 passed.
- Live on macOS 26.5.2 with cua-driver 0.19.1: doctor reports `skip` (old
  stub) gracefully; with a 0.19.2 debug build the probe reports
  `pass: autostart registered and daemon running` and `fail: not-registered`
  when disabled — both exercised against a real launchd-managed daemon.

## Platform compatibility

- macOS: probes LaunchAgent registration via the CLI (works with cua-driver
  0.19.2+, which implements `autostart` for macOS).
- Windows: same CLI probe — Scheduled Task state.
- Linux: `autostart` is still a stub upstream; check reports `skip` with the
  actionable message from the driver.
- Drivers older than 0.19.2: `skip` (subcommand unavailable), doctor still
  passes on everything else.

## Known gaps

- The check trusts cua-driver's CLI output. On platforms/drivers where the
  subcommand is missing it degrades to `skip`, which is correct but means a
  stale-registration failure on an old driver goes unreported. Once the
  companion upstream autostart implementation (trycua/cua#2990) ships in a
  release, this becomes a full pass/fail check on macOS and Windows.




---

### Follow-up commit: `version_gate` — flag drivers too old for bounds

The same session that produced the bounds=0 wall also produced the
*diagnosis gap*: the old driver "worked" (element-index clicks resolved),
so nothing told the user the pixel-coordinate path was silently degraded.
This commit adds a `version_gate` check to the doctor composite report:

* `_parse_version_tuple` — `X.Y.Z` / `X.Y` into a comparable tuple.
* `_version_gate_check` — **fail** when the parsed version < `0.10.0`
  (the contract Hermes' computer-use backend aligns to; the
  `structuredContent.elements` frame landed in trycua/cua#1961), with the
  hint `hermes computer-use install --upgrade`; **pass** at/above;
  **skip** on unparseable version strings so exotic output never misleads.
* Wired into `_compose_fallback_report` after `binary_version` — the
  silent `(0,0,0,0)` degradation now surfaces as a diagnosable failure
  with a one-command fix.

9 new tests (threshold pass/fail, below-minimum, unparseable skip,
prerelease parsing, version-tuple parsing) — 31 doctor tests pass.

