### PR TITLE
fix(read_file): stop misreading truncated multi-byte text as binary

### DIFF
--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -51,6 +51,26 @@ class TestIsLikelyBinary:
         sample = "\x00" * 200 + "a" * 800 + "\x00" * 1000
         assert ops._is_likely_binary("file.xyz", content_sample=sample) is False
 
+    def test_truncated_multibyte_tail_is_not_binary(self, ops):
+        """`head -c 1000` cuts on a byte boundary, so the sample's last char is
+        routinely a half-written multi-byte sequence decoded as U+FFFD. That is
+        our own truncation artifact — a 3-bytes-per-char script would otherwise
+        have ~2 of every 3 files misread as binary and become unreadable."""
+        sample = "가" * 333 + "�"  # 999 bytes of Hangul + a cut char
+        assert ops._is_likely_binary("note.md", content_sample=sample) is False
+
+    def test_replacement_char_survives_when_sample_is_whole_file(self, ops):
+        """A short sample is the entire file, so a trailing U+FFFD there is real
+        corruption rather than truncation — it must still read as binary."""
+        sample = "short note�"
+        assert ops._is_likely_binary("note.md", content_sample=sample) is True
+
+    def test_replacement_char_mid_sample_still_binary(self, ops):
+        """Genuine mojibake carries U+FFFD away from the cut, so the tail
+        exemption must not swallow it."""
+        sample = "title\n�" + "body " * 200
+        assert ops._is_likely_binary("note.md", content_sample=sample) is True
+
 
 # =========================================================================
 # _check_lint edge cases

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -890,7 +890,7 @@ class ShellFileOperations(FileOperations):
     def _is_likely_binary(self, path: str, content_sample: str = None) -> bool:
         """
         Check if a file is likely binary.
-        
+
         Uses extension check (fast) + content analysis (fallback).
         """
         ext = os.path.splitext(path)[1].lower()
@@ -908,11 +908,32 @@ class ShellFileOperations(FileOperations):
             # sample carries the replacement char as binary (read-only) so the
             # agent can't corrupt it. Legitimate UTF-8 text effectively never
             # contains U+FFFD.
-            if "\ufffd" in content_sample[:1000]:
+            # ...except at the tail. The sample comes from `head -c N`, which
+            # cuts on a BYTE boundary, so the last character is routinely a
+            # half-written multi-byte sequence that decodes to U+FFFD. That is
+            # a truncation artifact of our own probe, not evidence about the
+            # file. Left unstripped it misreads dense non-ASCII text as binary:
+            # in a 3-bytes-per-char script (Korean/Japanese/Chinese) roughly
+            # two of every three files land mid-character and become
+            # permanently unreadable. Real mojibake still trips the check
+            # because it carries U+FFFD throughout, not only in the last char.
+            # Only the truncated case earns the exemption: a sample that came
+            # back short is the whole file, so a U+FFFD at its end is real
+            # corruption, not our cut. `head -c 1000` returns exactly 1000
+            # bytes whenever the file is at least that big, and replacing a
+            # 1-2 byte remnant with U+FFFD (3 bytes) can only push the
+            # re-encoded length to >= 1000 \u2014 so that length is the signal.
+            probe = content_sample[:1000]
+            if len(probe.encode("utf-8", "replace")) >= 1000:
+                probe = probe.rstrip("\ufffd")
+            if not probe:
+                # Sample was nothing but replacement chars \u2014 genuinely binary.
                 return True
-            non_printable = sum(1 for c in content_sample[:1000]
+            if "\ufffd" in probe:
+                return True
+            non_printable = sum(1 for c in probe
                                if ord(c) < 32 and c not in '\n\r\t')
-            return non_printable / min(len(content_sample), 1000) > 0.30
+            return non_printable / max(len(probe), 1) > 0.30
         
         return False
     


### PR DESCRIPTION
## Problem

`ShellFileOperations._is_likely_binary()` takes its content sample via `head -c 1000`, which cuts on a **byte** boundary. In a 3-bytes-per-character script (Korean / Japanese / Chinese) the last character of the sample is routinely a half-written multi-byte sequence that decodes to `U+FFFD` under `errors="replace"`. The existing check treats *any* `U+FFFD` in the sample as proof the file is binary — so the truncation artifact of our own probe gets read back as a property of the file.

The effect is that dense non-ASCII text files are misclassified as binary and become unreadable through `read_file`. Roughly two of every three such files land mid-character. Measured on a 1,438-file UTF-8 corpus: **650 (45%) were wrongly rejected**, including ordinary Markdown notes.

## Fix

Exempt only the truncation case. When the re-encoded sample is `>= 1000` bytes — i.e. `head -c 1000` actually cut something — `rstrip` a trailing `U+FFFD` before the check:

- A **short** sample is the whole file, so a trailing `U+FFFD` there is genuine corruption and still classifies as binary.
- **Mid-sample** mojibake still trips the check, because `U+FFFD` then appears away from the cut, not only at the tail.
- Real binaries (null bytes, high non-printable ratio) are unaffected.

## Tests

Adds 3 regression tests in `test_file_operations_edge_cases.py`: truncated multi-byte tail (not binary), whole-file trailing `U+FFFD` (binary), and mid-sample mojibake (binary). Verified against the live method.