### PR TITLE
fix(auth): make explicit pool reset authoritative

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -168,6 +168,7 @@ _EXTRA_KEYS = frozenset({
     # with the entry so a restart doesn't downgrade a billing bench back to a
     # 60s transient cooldown.
     "failure_reason",
+    "status_cleared_at",
 })
 
 
@@ -2284,6 +2285,7 @@ class CredentialPool:
         with self._lock:
             count = 0
             new_entries = []
+            cleared_at = time.time()
             for entry in self._entries:
                 if entry.last_status or entry.last_status_at or entry.last_error_code:
                     new_entries.append(
@@ -2295,6 +2297,7 @@ class CredentialPool:
                             last_error_reason=None,
                             last_error_message=None,
                             last_error_reset_at=None,
+                            extra={**entry.extra, "status_cleared_at": cleared_at},
                         )
                     )
                     count += 1

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1618,7 +1618,37 @@ def _merge_disk_cooldown_state(
             _parse_absolute_timestamp,
         )
 
+        # An explicit `hermes auth reset` persists a clear marker. It is
+        # authoritative over cooldown snapshots created before the reset, but
+        # never over a provider failure observed afterward. This also prevents
+        # a stale long-running process from resurrecting the old cooldown.
+        entry_clear_at = (
+            _parse_absolute_timestamp(entry.get("status_cleared_at")) or 0.0
+        )
+        disk_clear_at = (
+            _parse_absolute_timestamp(disk_entry.get("status_cleared_at")) or 0.0
+        )
+        disk_status_at = (
+            _parse_absolute_timestamp(disk_entry.get("last_status_at")) or 0.0
+        )
+        entry_status_at = (
+            _parse_absolute_timestamp(entry.get("last_status_at")) or 0.0
+        )
         disk_status = disk_entry.get("last_status")
+        if (
+            disk_status in (STATUS_DEAD, STATUS_EXHAUSTED)
+            and entry_clear_at > disk_status_at
+        ):
+            return entry
+        if disk_clear_at >= entry_status_at and entry.get("last_status"):
+            cleared_entry = dict(entry)
+            for status_field in _POOL_STATUS_FIELDS:
+                cleared_entry[status_field] = None
+            cleared_entry["status_cleared_at"] = disk_entry.get("status_cleared_at")
+            return cleared_entry
+        if disk_clear_at > entry_clear_at:
+            entry = {**entry, "status_cleared_at": disk_entry.get("status_cleared_at")}
+
         if disk_status not in (STATUS_DEAD, STATUS_EXHAUSTED):
             return entry
         # A token change means the caller re-authed/refreshed this entry and

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -288,3 +288,50 @@ def test_write_pool_never_merges_cooldown_onto_reauthed_entry(classic_env):
     assert persisted["access_token"] == "sk-new"
     assert persisted.get("last_status") != "exhausted"
     assert persisted.get("last_error_code") is None
+
+
+def test_explicit_pool_reset_beats_old_cooldown_but_not_new_failure(classic_env):
+    """Reset is authoritative over old state, without masking later failures."""
+    from agent.credential_pool import load_pool
+    from hermes_cli.auth import write_credential_pool
+
+    old_status_at = time.time() - 60
+    original = _pool_entry(
+        auth_type="oauth",
+        source="manual:device_code",
+        last_status="exhausted",
+        last_status_at=old_status_at,
+        last_error_code=None,
+        last_error_reason=None,
+        last_error_message=None,
+        last_error_reset_at=None,
+    )
+    _write(classic_env / "auth.json", _make_auth_store(pool={
+        "openai-codex": [original],
+    }))
+
+    pool = load_pool("openai-codex")
+    assert pool.reset_statuses() == 1
+    reset_entry = json.loads((classic_env / "auth.json").read_text())[
+        "credential_pool"
+    ]["openai-codex"][0]
+    assert reset_entry["last_status"] is None
+    cleared_at = reset_entry["status_cleared_at"]
+    assert cleared_at > old_status_at
+
+    # A stale process cannot resurrect the pre-reset cooldown.
+    write_credential_pool("openai-codex", [original])
+    after_stale = json.loads((classic_env / "auth.json").read_text())[
+        "credential_pool"
+    ]["openai-codex"][0]
+    assert after_stale["last_status"] is None
+    assert after_stale["status_cleared_at"] == cleared_at
+
+    # A genuinely newer provider failure remains authoritative.
+    newer = {**original, "last_status_at": cleared_at + 1, "last_error_code": 429}
+    write_credential_pool("openai-codex", [newer])
+    after_new_failure = json.loads((classic_env / "auth.json").read_text())[
+        "credential_pool"
+    ]["openai-codex"][0]
+    assert after_new_failure["last_status"] == "exhausted"
+    assert after_new_failure["last_error_code"] == 429


### PR DESCRIPTION
## What changed

- persists an explicit credential-pool reset marker
- prevents stale writers or older on-disk cooldown state from resurrecting a reset status
- preserves newer provider failures as authoritative
- adds regression coverage for reset persistence and stale-writer behavior

## Root cause

`hermes auth reset` cleared exhaustion in memory, but the disk cooldown merge interpreted the cleared timestamp as older and restored the prior exhausted state. The command reported success even though the credential remained unusable.

## Validation

- 83 focused credential/auth tests passed on current upstream `main`
- `git diff --check` passed
- live Hermes reset behavior was verified before OAuth relinking

