### PR TITLE
fix(auth): seed provider dict credentials with legacy custom providers

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -446,14 +446,13 @@ def _iter_custom_providers(config: Optional[dict] = None):
         config = _load_config_safe()
     if config is None:
         return
-    custom_providers = config.get("custom_providers")
-    if not isinstance(custom_providers, list):
-        # Fall back to the v12+ providers dict via the compatibility layer
-        try:
-            from hermes_cli.config import get_compatible_custom_providers
+    try:
+        from hermes_cli.config import get_compatible_custom_providers
 
-            custom_providers = get_compatible_custom_providers(config)
-        except Exception:
+        custom_providers = get_compatible_custom_providers(config)
+    except Exception:
+        custom_providers = config.get("custom_providers")
+        if not isinstance(custom_providers, list):
             return
     if not custom_providers:
         return

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -24,6 +24,55 @@ def _jwt_with_claims(claims: dict) -> str:
     return f"{_part({'alg': 'none', 'typ': 'JWT'})}.{_part(claims)}.sig"
 
 
+def test_providers_dict_seeds_custom_pool_when_legacy_list_exists(tmp_path, monkeypatch):
+    """The credential pool must consume the merged provider compatibility view."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    (hermes_home / "config.yaml").write_text(
+        """
+model:
+  provider: openai
+  default: some-model
+custom_providers:
+  - name: legacy-endpoint
+    base_url: http://127.0.0.1:9001/v1
+    api_key: legacy-key
+    api_mode: chat_completions
+    model: legacy-model
+providers:
+  newstyle-endpoint:
+    name: newstyle-endpoint
+    api: http://127.0.0.1:9002/v1
+    api_key: newstyle-key
+    default_model: newstyle-model
+    transport: chat_completions
+    models:
+      - newstyle-model
+""".lstrip()
+    )
+
+    from agent.credential_pool import _iter_custom_providers, load_pool
+    from hermes_cli.config import get_compatible_custom_providers, load_config
+
+    cfg = load_config()
+    assert [entry["name"] for entry in get_compatible_custom_providers(cfg)] == [
+        "legacy-endpoint",
+        "newstyle-endpoint",
+    ]
+    assert [name for name, _ in _iter_custom_providers(cfg)] == [
+        "legacy-endpoint",
+        "newstyle-endpoint",
+    ]
+
+    pool = load_pool("custom:newstyle-endpoint")
+    assert pool.has_credentials() is True
+    entry = pool.entries()[0]
+    assert entry.source == "config:newstyle-endpoint"
+    assert entry.runtime_api_key == "newstyle-key"
+    assert entry.runtime_base_url == "http://127.0.0.1:9002/v1"
+
+
 
 
 


### PR DESCRIPTION
Fixes #81126

Credential pool custom-provider discovery treated `custom_providers:` and the newer `providers:` dict as mutually exclusive.

When a migrated config still had any legacy `custom_providers:` list entry, the credential pool never consulted the merged compatibility view, so providers declared only under `providers:` were visible in picker/runtime surfaces but never seeded into `auth.json`.

This change makes credential-pool discovery use `get_compatible_custom_providers()` so both config shapes are considered together. The fallback path still preserves the old direct `custom_providers:` behavior if the compatibility helper cannot be imported.

Added regression coverage for a config containing both:
- a legacy `custom_providers:` entry
- a new-style `providers:` entry

The test verifies that the new-style provider is discovered and its credential is seeded into `custom:<name>`.

Validation:

uv run --extra dev pytest tests/agent/test_credential_pool.py tests/agent/test_credential_pool_routing.py tests/agent/test_credential_pool_key_rotation.py -q

Result: 78 passed