### PR TITLE
feat(dashboard): add Kubrick guided workflow

### DIFF
--- a/plugins/kubrick-guide/dashboard/dist/index.js
+++ b/plugins/kubrick-guide/dashboard/dist/index.js
@@ -1,0 +1,216 @@
+(function () {
+  "use strict";
+
+  const SDK = window.__HERMES_PLUGIN_SDK__;
+  const REGISTRY = window.__HERMES_PLUGINS__;
+  if (!SDK || !REGISTRY) return;
+
+  const React = SDK.React;
+  const h = React.createElement;
+
+  const JOBS = [
+    { id: "design", title: "Design a cinematic system", detail: "Turn project evidence into a governed visual design specification.", output: "design specification", mode: "design" },
+    { id: "script", title: "Develop or diagnose a scene", detail: "Engineer dramatic pressure, observable change, motif behavior, and residue.", output: "scene or script packet", mode: "script" },
+    { id: "image", title: "Build an image prompt", detail: "Translate a frame into visible constraints and provider-ready syntax.", output: "image prompt packet", mode: "image" },
+    { id: "storyboard", title: "Plan a storyboard or video", detail: "Propagate ownership, geometry, recurrence, and residue across shots.", output: "storyboard and video packets", mode: "storyboard" },
+    { id: "qa", title: "Review generated visuals", detail: "Compare expected state to observed frames and propose corrections.", output: "visual QA and correction packet", mode: "visual QA" },
+    { id: "continuity", title: "Maintain motif continuity", detail: "Start or update a proposed project ledger without silently changing canon.", output: "motif ledger proposal", mode: "ledger" },
+  ];
+
+  const PROVIDERS = [
+    ["none", "Neutral / decide later"],
+    ["generic", "Generic image model"],
+    ["grok-imagine", "Grok Imagine"],
+    ["flux", "Flux"],
+    ["sd3", "Stable Diffusion 3"],
+    ["midjourney", "Midjourney"],
+  ];
+
+  function valueOrUnknown(value) {
+    const clean = String(value || "").trim();
+    return clean || "Not supplied. Ask before inventing.";
+  }
+
+  function buildPrompt(state) {
+    const job = JOBS.find(function (item) { return item.id === state.job; }) || JOBS[0];
+    const lines = [
+      "Use the Kubrick skill for this " + job.mode + " task.",
+      "",
+      "PROJECT",
+      "Title: " + valueOrUnknown(state.title),
+      "Format: " + valueOrUnknown(state.format),
+      "Audience experience: " + valueOrUnknown(state.audience),
+      "",
+      "DRAMATIC ENGINE",
+      "Current pressure or imbalance: " + valueOrUnknown(state.pressure),
+      "What must visibly change: " + valueOrUnknown(state.change),
+      "What is literally on screen: " + valueOrUnknown(state.visible),
+      "Motifs, materials, objects, or recurring forms: " + valueOrUnknown(state.motifs),
+      "Constraints and exclusions: " + valueOrUnknown(state.constraints),
+      "",
+      "PRODUCTION REQUEST",
+      "Produce: " + job.output + ".",
+      "Scope: " + state.scope + ".",
+      "Provider target: " + state.provider + ".",
+      "Evidence mode: " + state.evidence + ".",
+      "",
+      "KUBRICK OPERATING RULES",
+      "- Observed form first. Dramatic function first.",
+      "- Keep named esoteric or archetypal systems latent unless I explicitly request them.",
+      "- Express meaning as enforceable cinematic constraints: geometry, behavior, rhythm, material state, light, sound, convergence, and residue.",
+      "- Separate private symbolic architecture from audience-facing prompts.",
+      "- Do not invent missing project facts. Ask focused questions or mark the result NOT_COMPUTABLE.",
+      "- Treat local ledgers, corrections, and pattern changes as PROPOSED. Never silently rewrite canon.",
+      "- Preserve provider-neutral intent before applying provider syntax.",
+    ];
+    if (state.includeCommands) {
+      lines.push("- Include the exact `python scripts/kubrick.py do ...` command when a deterministic CLI run would help.");
+    }
+    lines.push("", "Start by identifying any missing inputs that block a trustworthy result. Otherwise produce the requested packet and a short next-step checklist.");
+    return lines.join("\n");
+  }
+
+  function Field(props) {
+    const Tag = props.multiline ? "textarea" : "input";
+    return h("label", { className: "kg-field" },
+      h("span", { className: "kg-label" }, props.label, props.required ? h("b", null, " required") : null),
+      props.help ? h("span", { className: "kg-help" }, props.help) : null,
+      h(Tag, {
+        value: props.value,
+        placeholder: props.placeholder || "",
+        rows: props.multiline ? (props.rows || 4) : undefined,
+        onChange: function (event) { props.onChange(event.target.value); },
+      })
+    );
+  }
+
+  function SelectField(props) {
+    return h("label", { className: "kg-field" },
+      h("span", { className: "kg-label" }, props.label),
+      props.help ? h("span", { className: "kg-help" }, props.help) : null,
+      h("select", { value: props.value, onChange: function (event) { props.onChange(event.target.value); } },
+        props.options.map(function (option) {
+          const pair = Array.isArray(option) ? option : [option, option];
+          return h("option", { key: pair[0], value: pair[0] }, pair[1]);
+        })
+      )
+    );
+  }
+
+  function navigate(path) {
+    window.history.pushState({}, "", path);
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  }
+
+  function KubrickGuide() {
+    const useState = React.useState;
+    const [step, setStep] = useState(0);
+    const [copied, setCopied] = useState(false);
+    const [state, setState] = useState({
+      job: "design",
+      title: "",
+      format: "",
+      audience: "",
+      pressure: "",
+      change: "",
+      visible: "",
+      motifs: "",
+      constraints: "",
+      scope: "single frame",
+      provider: "none",
+      evidence: "Use only supplied and workspace evidence; ask before external research",
+      includeCommands: false,
+    });
+
+    function update(key, value) {
+      setState(function (current) { return Object.assign({}, current, { [key]: value }); });
+      setCopied(false);
+    }
+
+    const prompt = buildPrompt(state);
+    const canContinue = step !== 1 || (state.pressure.trim() && state.change.trim() && state.visible.trim());
+
+    async function copyPrompt(openChat) {
+      try {
+        await navigator.clipboard.writeText(prompt);
+        setCopied(true);
+        if (openChat) navigate("/chat");
+      } catch (_) {
+        setCopied(false);
+      }
+    }
+
+    return h("div", { className: "kg-shell" },
+      h("header", { className: "kg-hero" },
+        h("div", { className: "kg-kicker" }, "HERMES CINEMATIC WORKFLOW"),
+        h("h1", null, "Build with Kubrick"),
+        h("p", null, "Shape a trustworthy cinematic brief, then hand it to Hermes Chat. The wizard keeps symbolic architecture private, visible constraints explicit, and canon changes proposed."),
+        h("div", { className: "kg-install" },
+          h("span", null, "Need the skill?"),
+          h("code", null, "hermes skills install Zero-State-LLC/Kubrick/skills/kubrick"),
+          h("button", { onClick: function () { navigator.clipboard.writeText("hermes skills install Zero-State-LLC/Kubrick/skills/kubrick"); } }, "Copy")
+        )
+      ),
+      h("nav", { className: "kg-progress", "aria-label": "Wizard progress" },
+        ["Choose job", "Describe change", "Set production", "Review"].map(function (label, index) {
+          return h("button", { key: label, className: index === step ? "active" : index < step ? "done" : "", onClick: function () { if (index <= step) setStep(index); } },
+            h("span", null, index + 1), label
+          );
+        })
+      ),
+      h("main", { className: "kg-panel" },
+        step === 0 && h(React.Fragment, null,
+          h("div", { className: "kg-heading" }, h("h2", null, "What are you making?"), h("p", null, "Choose the smallest Kubrick surface that matches the outcome.")),
+          h("div", { className: "kg-job-grid" }, JOBS.map(function (job) {
+            return h("button", { key: job.id, className: "kg-job " + (state.job === job.id ? "selected" : ""), onClick: function () { update("job", job.id); } },
+              h("strong", null, job.title), h("span", null, job.detail), h("small", null, "Produces " + job.output)
+            );
+          }))
+        ),
+        step === 1 && h(React.Fragment, null,
+          h("div", { className: "kg-heading" }, h("h2", null, "Describe observable change"), h("p", null, "Kubrick needs dramatic pressure and visible evidence, not symbol names alone.")),
+          h("div", { className: "kg-form two" },
+            h(Field, { label: "Project title", value: state.title, onChange: function (v) { update("title", v); }, placeholder: "The Glass Station" }),
+            h(Field, { label: "Format", value: state.format, onChange: function (v) { update("format", v); }, placeholder: "Feature film, commercial, storyboard…" }),
+            h(Field, { label: "Current pressure or imbalance", required: true, multiline: true, value: state.pressure, onChange: function (v) { update("pressure", v); }, placeholder: "A junior scientist must present evidence while her director controls the room." }),
+            h(Field, { label: "What must visibly change", required: true, multiline: true, value: state.change, onChange: function (v) { update("change", v); }, placeholder: "Authority transfers without dialogue; the room begins orienting toward her." }),
+            h(Field, { label: "What is literally on screen", required: true, multiline: true, value: state.visible, onChange: function (v) { update("visible", v); }, placeholder: "Conference table, access badge, projection glass, seven observers…" }),
+            h(Field, { label: "Audience experience", multiline: true, value: state.audience, onChange: function (v) { update("audience", v); }, placeholder: "Controlled unease resolving into earned recognition." }),
+            h(Field, { label: "Motifs and recurring forms", multiline: true, value: state.motifs, onChange: function (v) { update("motifs", v); }, placeholder: "Cracked badge, reflected grid, migrating pool of light…" }),
+            h(Field, { label: "Constraints and exclusions", multiline: true, value: state.constraints, onChange: function (v) { update("constraints", v); }, placeholder: "No occult labels, no glowing runes, no generic teal-orange spectacle." })
+          ),
+          !canContinue && h("p", { className: "kg-warning" }, "Add the pressure, visible change, and on-screen evidence before continuing.")
+        ),
+        step === 2 && h(React.Fragment, null,
+          h("div", { className: "kg-heading" }, h("h2", null, "Set the production contract"), h("p", null, "Kubrick preserves neutral intent before provider adaptation and fails closed when evidence is weak.")),
+          h("div", { className: "kg-form" },
+            h(SelectField, { label: "Scope", value: state.scope, onChange: function (v) { update("scope", v); }, options: [["single frame", "Single frame"], ["single scene", "Single scene"], ["multi-shot sequence", "Multi-shot sequence"], ["whole project system", "Whole project system"]] }),
+            h(SelectField, { label: "Provider", value: state.provider, onChange: function (v) { update("provider", v); }, options: PROVIDERS, help: "Provider selection changes syntax, not the cinematic intent." }),
+            h(SelectField, { label: "Evidence mode", value: state.evidence, onChange: function (v) { update("evidence", v); }, options: ["Use only supplied and workspace evidence; ask before external research", "Public research is allowed when it improves the result", "Stay fully offline and use only what I provide"] }),
+            h("label", { className: "kg-check" }, h("input", { type: "checkbox", checked: state.includeCommands, onChange: function (event) { update("includeCommands", event.target.checked); } }), h("span", null, h("strong", null, "Include deterministic CLI commands"), " Useful for repeatable compile, ledger, adapter, or QA runs."))
+          ),
+          h("aside", { className: "kg-rule-card" }, h("strong", null, "What stays governed"), h("ul", null,
+            h("li", null, "Audience prompts show observable form, not hidden labels."),
+            h("li", null, "Local ledger and learning changes remain PROPOSED."),
+            h("li", null, "Missing evidence triggers questions or NOT_COMPUTABLE."),
+            h("li", null, "Provider adapters preserve the neutral packet.")))
+        ),
+        step === 3 && h(React.Fragment, null,
+          h("div", { className: "kg-heading" }, h("h2", null, "Review the Hermes prompt"), h("p", null, "Copy it into Chat. Hermes can then load Kubrick and use the appropriate production surface.")),
+          h("pre", { className: "kg-prompt" }, prompt),
+          h("div", { className: "kg-actions review" },
+            h("button", { className: "kg-secondary", onClick: function () { copyPrompt(false); } }, copied ? "Copied" : "Copy prompt"),
+            h("button", { className: "kg-primary", onClick: function () { copyPrompt(true); } }, "Copy and open Chat")
+          ),
+          h("p", { className: "kg-footnote" }, "Clipboard blocked? Select the prompt above and copy it manually. The wizard never sends content outside Hermes on its own.")
+        )
+      ),
+      step < 3 && h("footer", { className: "kg-actions" },
+        h("button", { className: "kg-secondary", disabled: step === 0, onClick: function () { setStep(Math.max(0, step - 1)); } }, "Back"),
+        h("button", { className: "kg-primary", disabled: !canContinue, onClick: function () { setStep(Math.min(3, step + 1)); } }, step === 2 ? "Review prompt" : "Continue")
+      )
+    );
+  }
+
+  REGISTRY.register("kubrick-guide", KubrickGuide);
+})();

--- a/plugins/kubrick-guide/dashboard/dist/style.css
+++ b/plugins/kubrick-guide/dashboard/dist/style.css
@@ -1,0 +1,107 @@
+.kg-shell {
+  --kg-ink: hsl(var(--foreground));
+  --kg-muted: hsl(var(--muted-foreground));
+  --kg-line: hsl(var(--border));
+  --kg-panel: hsl(var(--card));
+  --kg-accent: #c8a96a;
+  --kg-deep: #171510;
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 24px;
+  color: var(--kg-ink);
+}
+
+.kg-hero {
+  position: relative;
+  overflow: hidden;
+  padding: 38px;
+  border: 1px solid color-mix(in srgb, var(--kg-accent) 50%, var(--kg-line));
+  border-radius: 18px;
+  color: #f8f3e8;
+  background:
+    radial-gradient(circle at 83% 20%, rgba(200, 169, 106, .18), transparent 28%),
+    linear-gradient(135deg, #12110e, #252017 58%, #11100d);
+  box-shadow: 0 24px 70px rgba(0, 0, 0, .18);
+}
+
+.kg-hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: .16;
+  background: repeating-linear-gradient(90deg, transparent 0 78px, #c8a96a 79px 80px);
+}
+
+.kg-hero > * { position: relative; z-index: 1; }
+.kg-kicker { font: 700 11px/1.2 ui-monospace, monospace; letter-spacing: .18em; color: var(--kg-accent); }
+.kg-hero h1 { margin: 10px 0 8px; font-family: Georgia, serif; font-size: clamp(36px, 6vw, 64px); font-weight: 500; letter-spacing: -.035em; }
+.kg-hero > p { max-width: 760px; margin: 0; color: rgba(248, 243, 232, .75); font-size: 16px; line-height: 1.65; }
+
+.kg-install { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-top: 24px; padding-top: 20px; border-top: 1px solid rgba(255,255,255,.12); font-size: 12px; }
+.kg-install span { color: rgba(255,255,255,.62); }
+.kg-install code { flex: 0 1 auto; padding: 7px 10px; border-radius: 7px; background: rgba(255,255,255,.08); color: #f5e4bd; }
+.kg-install button { border: 0; background: transparent; color: var(--kg-accent); cursor: pointer; font-weight: 700; }
+
+.kg-progress { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; margin: 18px 0; }
+.kg-progress button { display: flex; align-items: center; gap: 9px; min-width: 0; padding: 11px 12px; border: 1px solid var(--kg-line); border-radius: 10px; background: transparent; color: var(--kg-muted); text-align: left; font-size: 12px; cursor: default; }
+.kg-progress button.done { cursor: pointer; color: var(--kg-ink); }
+.kg-progress button.active { border-color: color-mix(in srgb, var(--kg-accent) 70%, var(--kg-line)); background: color-mix(in srgb, var(--kg-accent) 9%, transparent); color: var(--kg-ink); }
+.kg-progress button span { display: grid; place-items: center; width: 23px; height: 23px; flex: 0 0 23px; border-radius: 50%; background: hsl(var(--muted)); font: 700 11px/1 ui-monospace, monospace; }
+.kg-progress button.active span, .kg-progress button.done span { background: var(--kg-accent); color: var(--kg-deep); }
+
+.kg-panel { min-height: 430px; padding: 28px; border: 1px solid var(--kg-line); border-radius: 16px; background: var(--kg-panel); }
+.kg-heading { margin-bottom: 24px; }
+.kg-heading h2 { margin: 0 0 5px; font-family: Georgia, serif; font-size: 28px; font-weight: 500; }
+.kg-heading p { margin: 0; color: var(--kg-muted); line-height: 1.55; }
+
+.kg-job-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+.kg-job { min-height: 154px; display: flex; flex-direction: column; align-items: flex-start; padding: 18px; border: 1px solid var(--kg-line); border-radius: 12px; background: hsl(var(--background)); color: var(--kg-ink); text-align: left; cursor: pointer; transition: transform .15s ease, border-color .15s ease, background .15s ease; }
+.kg-job:hover { transform: translateY(-2px); border-color: color-mix(in srgb, var(--kg-accent) 55%, var(--kg-line)); }
+.kg-job.selected { border-color: var(--kg-accent); background: color-mix(in srgb, var(--kg-accent) 8%, hsl(var(--background))); box-shadow: inset 3px 0 var(--kg-accent); }
+.kg-job strong { font-size: 15px; }
+.kg-job span { margin: 8px 0 14px; color: var(--kg-muted); font-size: 13px; line-height: 1.45; }
+.kg-job small { margin-top: auto; color: color-mix(in srgb, var(--kg-accent) 78%, var(--kg-ink)); font-size: 11px; text-transform: uppercase; letter-spacing: .06em; }
+
+.kg-form { display: grid; gap: 16px; }
+.kg-form.two { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.kg-field { display: flex; flex-direction: column; gap: 6px; }
+.kg-label { font-size: 13px; font-weight: 700; }
+.kg-label b { margin-left: 5px; color: #b97866; font-size: 10px; text-transform: uppercase; }
+.kg-help { color: var(--kg-muted); font-size: 11px; }
+.kg-field input, .kg-field textarea, .kg-field select { width: 100%; border: 1px solid var(--kg-line); border-radius: 9px; padding: 10px 12px; background: hsl(var(--background)); color: var(--kg-ink); font: inherit; outline: none; }
+.kg-field textarea { resize: vertical; min-height: 104px; line-height: 1.45; }
+.kg-field input:focus, .kg-field textarea:focus, .kg-field select:focus { border-color: var(--kg-accent); box-shadow: 0 0 0 3px color-mix(in srgb, var(--kg-accent) 14%, transparent); }
+.kg-check { display: flex; align-items: flex-start; gap: 10px; padding: 14px; border: 1px solid var(--kg-line); border-radius: 10px; cursor: pointer; }
+.kg-check input { margin-top: 3px; accent-color: var(--kg-accent); }
+.kg-check span { color: var(--kg-muted); font-size: 13px; line-height: 1.5; }
+.kg-check strong { color: var(--kg-ink); }
+.kg-warning { margin: 16px 0 0; padding: 11px 13px; border-left: 3px solid #b97866; background: color-mix(in srgb, #b97866 10%, transparent); color: var(--kg-ink); font-size: 12px; }
+
+.kg-rule-card { margin-top: 20px; padding: 18px 20px; border-radius: 12px; background: var(--kg-deep); color: #f5f0e5; }
+.kg-rule-card > strong { color: var(--kg-accent); font-family: Georgia, serif; font-size: 18px; font-weight: 500; }
+.kg-rule-card ul { display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px 28px; margin: 12px 0 0; padding-left: 18px; color: rgba(245,240,229,.72); font-size: 12px; line-height: 1.5; }
+.kg-prompt { max-height: 480px; overflow: auto; margin: 0; padding: 20px; border: 1px solid var(--kg-line); border-radius: 12px; white-space: pre-wrap; background: #14130f; color: #eee5d4; font: 12px/1.62 ui-monospace, SFMono-Regular, Menlo, monospace; }
+.kg-footnote { margin: 11px 0 0; color: var(--kg-muted); font-size: 11px; }
+
+.kg-actions { display: flex; justify-content: space-between; gap: 10px; margin-top: 16px; }
+.kg-actions.review { justify-content: flex-end; }
+.kg-actions button { min-width: 108px; padding: 10px 16px; border-radius: 9px; font-weight: 700; cursor: pointer; }
+.kg-actions button:disabled { opacity: .4; cursor: not-allowed; }
+.kg-primary { border: 1px solid var(--kg-accent); background: var(--kg-accent); color: var(--kg-deep); }
+.kg-secondary { border: 1px solid var(--kg-line); background: hsl(var(--background)); color: var(--kg-ink); }
+
+@media (max-width: 820px) {
+  .kg-shell { padding: 14px; }
+  .kg-hero { padding: 28px 22px; }
+  .kg-progress { grid-template-columns: repeat(2, 1fr); }
+  .kg-job-grid, .kg-form.two, .kg-rule-card ul { grid-template-columns: 1fr; }
+  .kg-panel { padding: 20px; }
+}
+
+@media (max-width: 480px) {
+  .kg-progress button { font-size: 0; }
+  .kg-progress button span { font-size: 11px; }
+  .kg-actions { position: sticky; bottom: 8px; padding: 8px; border: 1px solid var(--kg-line); border-radius: 12px; background: color-mix(in srgb, hsl(var(--background)) 92%, transparent); backdrop-filter: blur(12px); }
+  .kg-actions button { flex: 1; min-width: 0; }
+}

--- a/plugins/kubrick-guide/dashboard/manifest.json
+++ b/plugins/kubrick-guide/dashboard/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "kubrick-guide",
+  "label": "Kubrick",
+  "description": "Guided cinematic brief builder for the Kubrick Hermes skill",
+  "icon": "Eye",
+  "version": "1.0.0",
+  "tab": {
+    "path": "/kubrick",
+    "position": "after:skills"
+  },
+  "entry": "dist/index.js",
+  "css": "dist/style.css"
+}

--- a/tests/plugins/test_kubrick_guide_plugin.py
+++ b/tests/plugins/test_kubrick_guide_plugin.py
@@ -1,0 +1,56 @@
+"""Contract tests for the bundled Kubrick dashboard guide."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DASHBOARD = ROOT / "plugins" / "kubrick-guide" / "dashboard"
+
+
+def test_kubrick_guide_manifest_and_assets_are_complete():
+    manifest = json.loads((DASHBOARD / "manifest.json").read_text(encoding="utf-8"))
+
+    assert manifest["name"] == "kubrick-guide"
+    assert manifest["label"] == "Kubrick"
+    assert manifest["tab"] == {"path": "/kubrick", "position": "after:skills"}
+    assert manifest["icon"] == "Eye"
+
+    for asset_key in ("entry", "css"):
+        asset = DASHBOARD / manifest[asset_key]
+        assert asset.is_file(), f"missing {asset_key}: {asset}"
+        assert asset.stat().st_size > 0
+
+
+def test_kubrick_guide_preserves_governance_and_chat_handoff_contract():
+    bundle = (DASHBOARD / "dist" / "index.js").read_text(encoding="utf-8")
+
+    required_phrases = (
+        'REGISTRY.register("kubrick-guide", KubrickGuide)',
+        "Observed form first. Dramatic function first.",
+        "NOT_COMPUTABLE",
+        "PROPOSED",
+        "provider-neutral intent",
+        'navigate("/chat")',
+        "Copy and open Chat",
+        "Current pressure or imbalance",
+        "What must visibly change",
+        "What is literally on screen",
+    )
+    for phrase in required_phrases:
+        assert phrase in bundle
+
+    assert "__HERMES_SESSION_TOKEN__" not in bundle
+    assert "fetch(" not in bundle
+
+
+def test_kubrick_guide_covers_first_class_production_surfaces():
+    bundle = (DASHBOARD / "dist" / "index.js").read_text(encoding="utf-8")
+
+    for job in ("design", "script", "image", "storyboard", "qa", "continuity"):
+        assert f'id: "{job}"' in bundle
+
+    for provider in ("generic", "grok-imagine", "flux", "sd3", "midjourney"):
+        assert f'["{provider}"' in bundle


### PR DESCRIPTION
## Summary

Adds a first-class `/kubrick` dashboard wizard that helps operators shape cinematic briefs before handing them to Hermes Chat.

## What it includes

- six guided Kubrick workflows: design, script, image, storyboard/video, visual QA, and motif continuity
- required dramatic-pressure, visible-change, and on-screen-evidence inputs
- scope, provider, evidence-mode, and deterministic CLI options
- governed prompt generation that preserves provider-neutral intent, keeps hidden symbolic architecture private, and marks local canon changes as `PROPOSED`
- clipboard handoff into `/chat` with a manual-copy fallback
- responsive dashboard styling and contract/security tests

## Validation

- `npm --prefix web run build`
- `uv run --extra dev pytest -q tests/plugins/test_kubrick_guide_plugin.py tests/plugins/test_plugin_dashboard_auth_contract.py tests/hermes_cli/test_plugin_runtime_disable_gate.py` — 12 passed
- independent dashboard manifest/runtime suite — 10 passed
- live `hermes dashboard` browser acceptance:
  - `/kubrick` visible in sidebar
  - required-field gating works
  - Grok Imagine/provider, governance, and CLI options appear in generated prompt
  - clipboard content exactly matches review prompt
  - successful navigation to `/chat`
  - clipboard-denied manual-copy path stays on review
  - 390px viewport has no horizontal overflow
  - no browser console or page errors

## Notes

The dashboard wizard does not execute Kubrick itself or grant additional authority. It prepares a prompt for Hermes Chat and points users to the standalone skill install path.