### PR TITLE
Route complex next moves through Kanban

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1469,6 +1469,8 @@ def init_agent(
         KANBAN_GUIDANCE if "kanban_show" in agent.valid_tool_names else ""
     )
 
+    agent._next_move_routing_enabled = True
+
     # Check tool requirements
     if agent.tools and not agent.quiet_mode:
         requirements = _ra().check_toolset_requirements()

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -191,6 +191,19 @@ SESSION_SEARCH_GUIDANCE = (
     "asking them to repeat themselves."
 )
 
+NEXT_MOVE_GUIDANCE = (
+    "When you propose a next move, keep the normal answer in prose. Only when "
+    "the proposal is an explicit multi-step plan that is complex, durable, "
+    "asynchronous, side-effecting, or must survive a restart, append exactly one "
+    "machine-readable marker in this form: `<!-- hermes-next-move: {JSON} -->`. "
+    "The JSON must contain `proposal: true`, a non-empty `title`, and a `steps` "
+    "array; it may include boolean `durable`, `asynchronous`, `side_effecting`, "
+    "`restart_surviving`, `user_confirmed`, and an `assignee`. Do not emit the "
+    "marker for a one-step suggestion or ordinary chat. The gateway uses this "
+    "explicit evidence to place only qualifying plans on Kanban; never infer a "
+    "plan from keywords."
+)
+
 SKILLS_GUIDANCE = (
     "After completing a complex task (5+ tool calls), fixing a tricky error, "
     "or discovering a non-trivial workflow, save the approach as a "

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -36,6 +36,7 @@ from agent.prompt_builder import (
     HERMES_AGENT_HELP_GUIDANCE,
     KANBAN_GUIDANCE,
     MEMORY_GUIDANCE,
+    NEXT_MOVE_GUIDANCE,
     OPENAI_MODEL_EXECUTION_GUIDANCE,
     PARALLEL_TOOL_CALL_GUIDANCE,
     PLATFORM_HINTS,
@@ -243,6 +244,11 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         tool_guidance.append(KANBAN_GUIDANCE)
     if tool_guidance:
         stable_parts.append(" ".join(tool_guidance))
+
+    # Explicit next-move evidence is parsed by the gateway after a turn. Keep
+    # this in the stable prompt so it does not invalidate the conversation cache.
+    if agent.valid_tool_names and getattr(agent, "_next_move_routing_enabled", False):
+        stable_parts.append(NEXT_MOVE_GUIDANCE)
 
     # Steering only lands inside tool results, so it's only reachable when the
     # agent has tools. Static text → byte-stable prompt (no cache hit).

--- a/gateway/next_move.py
+++ b/gateway/next_move.py
@@ -1,0 +1,97 @@
+"""Route explicit complex next-move proposals to Kanban.
+
+The model-facing marker is deliberately opt-in.  Ordinary prose is never
+classified by keywords, so conversational answers stay in the chat lane.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any, Callable, Dict, Optional, Tuple
+
+_MARKER_RE = re.compile(
+    r"<!--\s*hermes-next-move\s*:\s*(\{.*?\})\s*-->", re.DOTALL | re.IGNORECASE
+)
+
+
+def inspect_next_move(text: Any) -> Tuple[str, Optional[Dict[str, Any]]]:
+    """Return visible text and a validated explicit proposal, if present."""
+    if not isinstance(text, str):
+        return str(text or ""), None
+    match = _MARKER_RE.search(text)
+    if not match:
+        return text, None
+    try:
+        proposal = json.loads(match.group(1))
+    except (TypeError, ValueError):
+        return text, None
+    if not isinstance(proposal, dict) or proposal.get("proposal") is not True:
+        return text, None
+    steps = proposal.get("steps")
+    title = proposal.get("title")
+    if not isinstance(title, str) or not title.strip() or not isinstance(steps, list):
+        return text, None
+    if not all(isinstance(step, str) and step.strip() for step in steps):
+        return text, None
+    visible = (text[: match.start()] + text[match.end() :]).strip()
+    return visible, proposal
+
+
+def is_complex_next_move(proposal: Optional[Dict[str, Any]]) -> bool:
+    """Require explicit plan evidence plus a multi-step/durable threshold."""
+    if not proposal:
+        return False
+    steps = proposal.get("steps")
+    if not isinstance(steps, list) or len(steps) < 2:
+        return False
+    flags = ("durable", "asynchronous", "side_effecting", "restart_surviving")
+    return len(steps) >= 3 or any(proposal.get(flag) is True for flag in flags)
+
+
+def _idempotency_key(proposal: Dict[str, Any], session_id: Optional[str]) -> str:
+    explicit = proposal.get("idempotency_key")
+    if isinstance(explicit, str) and explicit.strip():
+        return explicit.strip()
+    canonical = json.dumps(
+        {"session_id": session_id, "proposal": proposal},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return "next-move:" + hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def route_next_move(
+    text: Any,
+    *,
+    session_id: Optional[str],
+    create_fn: Callable[..., str],
+    assignee: str = "default",
+    recursive: bool = False,
+) -> Dict[str, Any]:
+    """Create one Kanban task for a complex explicit proposal.
+
+    ``create_fn`` is injected so the policy is testable without opening the
+    board.  The caller owns the existing Kanban create/subscribe integration.
+    """
+    visible, proposal = inspect_next_move(text)
+    if recursive or not is_complex_next_move(proposal):
+        return {"text": visible, "created": False, "proposal": proposal}
+    assert proposal is not None
+    task_id = create_fn(
+        title=proposal["title"].strip(),
+        body=json.dumps(
+            {
+                "plan": proposal,
+                "origin_session_id": session_id,
+                "user_confirmed": proposal.get("user_confirmed") is True,
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        assignee=str(proposal.get("assignee") or assignee),
+        session_id=session_id,
+        idempotency_key=_idempotency_key(proposal, session_id),
+    )
+    report = f"\n\nI created Kanban task `{task_id}` for that multi-step plan."
+    return {"text": (visible + report).strip(), "created": True, "task_id": task_id, "proposal": proposal}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5482,6 +5482,42 @@ class TurnRunner:
         # Return final response, or a message if something went wrong
         final_response = result.get("final_response")
 
+        # Inspect the model's explicit next-move evidence after the normal turn.
+        # This keeps chat and delegate_task lanes unchanged: only a structured,
+        # qualifying marker can create a durable Kanban task.
+        if (
+            isinstance(final_response, str)
+            and final_response
+            and not result.get("failed")
+            and not result.get("partial")
+            and not result.get("interrupted")
+            and not os.environ.get("HERMES_KANBAN_TASK")
+        ):
+            try:
+                from gateway.next_move import route_next_move
+                from tools.kanban_tools import _handle_create
+
+                def _create_next_move(**kwargs):
+                    payload = json.loads(_handle_create(kwargs))
+                    if payload.get("error"):
+                        raise RuntimeError(payload["error"])
+                    return str(payload["task_id"])
+
+                routed = route_next_move(
+                    final_response,
+                    session_id=ctx.session_id,
+                    create_fn=_create_next_move,
+                    assignee=os.environ.get("HERMES_PROFILE") or "default",
+                )
+                final_response = routed["text"]
+                result["final_response"] = final_response
+                if routed.get("created"):
+                    result["next_move_task_id"] = routed["task_id"]
+            except Exception:
+                # A routing failure must never turn a successful chat turn into
+                # an error or hide the model's answer.
+                logger.warning("next-move Kanban routing failed", exc_info=True)
+
         # Extract actual token counts from the agent instance used for this run
         _last_prompt_toks = 0
         _input_toks = 0

--- a/tests/gateway/test_next_move.py
+++ b/tests/gateway/test_next_move.py
@@ -1,0 +1,90 @@
+import json
+
+from gateway.next_move import inspect_next_move, is_complex_next_move, route_next_move
+
+
+def marker(**fields):
+    fields.setdefault("proposal", True)
+    return "Suggested next move.\n<!-- hermes-next-move: " + json.dumps(fields) + " -->"
+
+
+def test_simple_suggestion_stays_in_chat():
+    created = []
+    result = route_next_move(
+        marker(title="Read the docs", steps=["Read the docs"]),
+        session_id="s1",
+        create_fn=lambda **kwargs: created.append(kwargs) or "unused",
+    )
+    assert result["created"] is False
+    assert result["text"] == "Suggested next move."
+    assert not created
+
+
+def test_complex_suggestion_creates_one_task_and_reports_origin():
+    calls = []
+
+    def create_fn(**kwargs):
+        calls.append(kwargs)
+        return "t_123"
+
+    result = route_next_move(
+        marker(
+            title="Run the migration",
+            steps=["Back up", "Migrate", "Verify"],
+            durable=True,
+            assignee="builder",
+        ),
+        session_id="discord-session",
+        create_fn=create_fn,
+    )
+    assert result["created"] is True
+    assert "t_123" in result["text"]
+    assert calls[0]["session_id"] == "discord-session"
+    assert calls[0]["assignee"] == "builder"
+    assert calls[0]["idempotency_key"].startswith("next-move:")
+
+
+def test_user_confirmed_execution_is_preserved_in_task_body():
+    calls = []
+    route_next_move(
+        marker(
+            title="Publish report",
+            steps=["Build", "Review", "Publish"],
+            side_effecting=True,
+            user_confirmed=True,
+        ),
+        session_id="s1",
+        create_fn=lambda **kwargs: calls.append(kwargs) or "t_confirmed",
+    )
+    body = json.loads(calls[0]["body"])
+    assert body["user_confirmed"] is True
+
+
+def test_duplicate_proposals_use_same_idempotency_key():
+    keys = []
+    proposal = marker(title="Long plan", steps=["one", "two"], asynchronous=True)
+    for _ in range(2):
+        route_next_move(
+            proposal,
+            session_id="s1",
+            create_fn=lambda **kwargs: keys.append(kwargs["idempotency_key"]) or "t_same",
+        )
+    assert keys[0] == keys[1]
+
+
+def test_recursive_context_is_never_routed():
+    calls = []
+    result = route_next_move(
+        marker(title="Plan", steps=["one", "two", "three"]),
+        session_id="s1",
+        create_fn=lambda **kwargs: calls.append(kwargs) or "t_bad",
+        recursive=True,
+    )
+    assert result["created"] is False
+    assert not calls
+
+
+def test_invalid_or_unmarked_text_is_untouched():
+    text = "Take a look at the next step."
+    assert inspect_next_move(text) == (text, None)
+    assert not is_complex_next_move(None)


### PR DESCRIPTION
## Summary
- detect explicit Hermes next-move markers without classifying ordinary prose
- route complex multi-step proposals to one idempotent Kanban task
- preserve origin session and user confirmation in the task body

## Verification
- `python3 -m pytest -q tests/gateway/test_next_move.py` (6 passed)
- `python3 -m pytest -q tests/gateway/test_next_move.py::test_simple_suggestion_stays_in_chat tests/gateway/test_next_move.py::test_complex_suggestion_creates_one_task_and_reports_origin` (2 passed)
- `hermes gateway list`: default gateway running; builder gateway not running in this profile

Do not merge automatically.