### PR TITLE
fix(relay): heal nemo_relay scope stack after LIFO pop mismatch

### DIFF
--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -24,6 +24,13 @@ RUNTIME_SCHEMA_KEY = "hermes.relay.schema_version"
 RUNTIME_SCHEMA_VERSION = "hermes.relay.runtime.v1"
 RUNTIME_INSTANCE_KEY = "hermes.relay.runtime_instance"
 _PROFILE_KEY_CACHE: dict[str, str] = {}
+# Native ScopeHandle equality is identity-based across Python wrappers; compare
+# by uuid when unwinding nested scopes after a LIFO mismatch.
+_SCOPE_STACK_MISMATCH_MARKERS = (
+    "scope handle is not at the top of the stack",
+    "root scope cannot be removed",
+)
+_MAX_SCOPE_UNWIND_POPS = 64
 
 
 @dataclass
@@ -36,6 +43,9 @@ class RelaySession:
     closing: bool = False
     handle: Any = None
     context: contextvars.Context | None = None
+    # Set when a scope-stack mismatch forced a rebuild. Drain paths may use
+    # this as a signal that waiting for graceful turn completion is futile.
+    scope_stack_healed: bool = False
 
 
 class RelayRuntime:
@@ -313,9 +323,8 @@ class RelayRuntime:
             session.closing = True
             if session.handle is not None:
                 try:
-                    self.run_in_session(
+                    self.pop_scope_resilient(
                         session,
-                        self.relay.scope.pop,
                         session.handle,
                         output={},
                         metadata={
@@ -323,9 +332,14 @@ class RelayRuntime:
                             RUNTIME_INSTANCE_KEY: self.runtime_id,
                         },
                         allow_closing=True,
+                        rebuild_on_failure=False,
                     )
                 except Exception as exc:
+                    # Closing abandons the native stack with the session
+                    # object; a failed pop must not block registry cleanup.
                     failures.append(f"session scope close failed: {exc}")
+                session.handle = None
+                session.context = None
         try:
             self.relay.subscribers.flush()
         except Exception as exc:
@@ -340,6 +354,211 @@ class RelayRuntime:
                 "Hermes Relay session %s closed with errors: %s",
                 session_id,
                 "; ".join(failures),
+            )
+
+    def pop_scope_resilient(
+        self,
+        session: RelaySession,
+        handle: Any,
+        *,
+        output: Any = None,
+        metadata: dict[str, Any] | None = None,
+        allow_closing: bool = False,
+        rebuild_on_failure: bool = True,
+        reason: str = "scope_pop",
+    ) -> bool:
+        """Pop ``handle``, unwinding nested orphans on LIFO mismatch.
+
+        NeMo Relay scopes are strictly stack-ordered. Interrupted compaction,
+        shared-metrics task scopes, or logical-LLM children left above a turn
+        make ``scope.pop(turn_handle)`` raise::
+
+            RuntimeError: invalid argument: scope handle is not at the top of the stack
+
+        Catching that without healing leaves the session stack corrupted so
+        every future ``end_turn`` / ``close_session`` logs the same error.
+        This helper first tries a direct pop, then abandons nested scopes
+        until ``handle`` is top (matched by uuid), then pops it. If the stack
+        is still unusable, optionally rebuild a fresh session root so later
+        turns start clean.
+        """
+        if handle is None:
+            return True
+        meta = metadata or {
+            RUNTIME_SCHEMA_KEY: RUNTIME_SCHEMA_VERSION,
+            RUNTIME_INSTANCE_KEY: self.runtime_id,
+        }
+        try:
+            self.run_in_session(
+                session,
+                self.relay.scope.pop,
+                handle,
+                output=output,
+                metadata=meta,
+                allow_closing=allow_closing,
+            )
+            return True
+        except Exception as exc:
+            if not _is_scope_stack_mismatch(exc):
+                raise
+            logger.warning(
+                "Hermes Relay scope pop mismatched for session %s (%s); "
+                "unwinding nested scopes",
+                session.session_id,
+                reason,
+                exc_info=True,
+            )
+
+        target_uuid = _scope_handle_uuid(handle)
+        session_uuid = _scope_handle_uuid(session.handle)
+        abandoned = 0
+        get_handle = getattr(self.relay.scope, "get_handle", None)
+        if not callable(get_handle):
+            if rebuild_on_failure and not session.closing:
+                self.rebuild_session_scope(session, reason=reason)
+                return False
+            raise RuntimeError(
+                f"Hermes Relay could not pop scope during {reason} for session "
+                f"{session.session_id} (no get_handle to unwind)"
+            )
+        for _ in range(_MAX_SCOPE_UNWIND_POPS):
+            try:
+                top = self.run_in_session(
+                    session,
+                    get_handle,
+                    allow_closing=allow_closing,
+                )
+            except Exception:
+                break
+            top_uuid = _scope_handle_uuid(top)
+            top_name = str(getattr(top, "name", "") or "")
+            if not top_uuid:
+                break
+            if target_uuid and top_uuid == target_uuid:
+                try:
+                    self.run_in_session(
+                        session,
+                        self.relay.scope.pop,
+                        handle,
+                        output=output,
+                        metadata=meta,
+                        allow_closing=allow_closing,
+                    )
+                    return True
+                except Exception as exc:
+                    if not _is_scope_stack_mismatch(exc):
+                        raise
+                    break
+            if session_uuid and top_uuid == session_uuid:
+                # Target is already gone; session root is current top.
+                return False
+            if top_name == "root":
+                break
+            try:
+                self.run_in_session(
+                    session,
+                    self.relay.scope.pop,
+                    top,
+                    output={"outcome": "abandoned", "reason": reason},
+                    metadata={
+                        **meta,
+                        "hermes.relay.abandoned_scope": True,
+                    },
+                    allow_closing=allow_closing,
+                )
+                abandoned += 1
+            except Exception as exc:
+                if _is_scope_stack_mismatch(exc) and "root scope" in str(exc).lower():
+                    break
+                logger.warning(
+                    "Hermes Relay nested scope abandon failed for session %s",
+                    session.session_id,
+                    exc_info=True,
+                )
+                break
+
+        if abandoned:
+            logger.warning(
+                "Hermes Relay abandoned %d nested scope(s) on session %s during %s",
+                abandoned,
+                session.session_id,
+                reason,
+            )
+
+        if rebuild_on_failure and not session.closing:
+            self.rebuild_session_scope(session, reason=reason)
+            return False
+        raise RuntimeError(
+            f"Hermes Relay could not pop scope during {reason} for session "
+            f"{session.session_id}"
+        )
+
+    def rebuild_session_scope(
+        self,
+        session: RelaySession,
+        *,
+        reason: str,
+    ) -> None:
+        """Replace a corrupted per-session scope stack with a fresh root.
+
+        The previous Context/ScopeStack is abandoned (not shared with other
+        sessions). Callers that still hold child handles on the old stack must
+        treat those handles as invalid after this returns.
+        """
+        with session.lock:
+            if session.closing:
+                return
+            parent_session_id = session.parent_session_id
+            session_id = session.session_id
+
+        # Resolve parent outside session.lock so we never nest
+        # session.lock -> _sessions_lock (ensure_session takes the opposite order).
+        parent_handle = None
+        if parent_session_id:
+            with self._sessions_lock:
+                parent_handle = self._subagent_parent_handles.get(session_id)
+            if parent_handle is None:
+                parent = self.get_session(parent_session_id)
+                if parent is not None:
+                    parent_handle = parent.handle
+
+        scope_metadata = {
+            RUNTIME_SCHEMA_KEY: RUNTIME_SCHEMA_VERSION,
+            RUNTIME_INSTANCE_KEY: self.runtime_id,
+            "hermes.relay.rebuilt": True,
+            "hermes.relay.rebuild_reason": reason,
+        }
+        if parent_session_id:
+            scope_metadata["nemo_relay_scope_role"] = "subagent"
+        context = contextvars.Context()
+        try:
+            new_handle = context.run(
+                self.relay.scope.push,
+                SESSION_SCOPE,
+                self.relay.ScopeType.Agent,
+                handle=parent_handle,
+                input={},
+                metadata=scope_metadata,
+            )
+        except Exception:
+            logger.warning(
+                "Hermes Relay session %s rebuild failed after %s",
+                session_id,
+                reason,
+                exc_info=True,
+            )
+            raise
+
+        with session.lock:
+            if session.closing:
+                return
+            session.handle = new_handle
+            session.context = context
+            session.scope_stack_healed = True
+            logger.warning(
+                "Hermes Relay rebuilt scope stack for session %s after %s",
+                session_id,
+                reason,
             )
 
     def shutdown(self) -> None:
@@ -657,20 +876,26 @@ class RelaySessionCoordinator:
                     self._finish_logical_calls(turn, outcome=outcome)
                     if turn.handle is not None:
                         try:
-                            lease.host.run_in_session(
+                            lease.host.pop_scope_resilient(
                                 lease.session,
-                                lease.host.relay.scope.pop,
                                 turn.handle,
                                 output={"outcome": outcome},
                                 metadata={
                                     RUNTIME_SCHEMA_KEY: RUNTIME_SCHEMA_VERSION,
                                     RUNTIME_INSTANCE_KEY: lease.host.runtime_id,
                                 },
+                                reason="turn_finalization",
                             )
                         except Exception:
                             logger.warning(
                                 "Hermes Relay turn finalization failed", exc_info=True
                             )
+                        finally:
+                            # Handles on a rebuilt stack are invalid; clear so
+                            # a double end_turn cannot re-pop a stale uuid.
+                            turn.handle = None
+                            with turn.logical_llm_lock:
+                                turn.logical_llm_calls.clear()
             finally:
                 try:
                     # Delegated agents own one turn. Close their conversation
@@ -741,15 +966,18 @@ class RelaySessionCoordinator:
         for index in range(len(logical_calls) - 1, -1, -1):
             request_id, logical_handle = logical_calls[index]
             try:
-                lease.host.run_in_session(
+                lease.host.pop_scope_resilient(
                     lease.session,
-                    lease.host.relay.scope.pop,
                     logical_handle,
                     output={"outcome": outcome},
                     metadata={
                         RUNTIME_SCHEMA_KEY: RUNTIME_SCHEMA_VERSION,
                         RUNTIME_INSTANCE_KEY: lease.host.runtime_id,
                     },
+                    # Leave rebuild to turn finalization so one heal covers
+                    # the whole orphaned prefix above the turn handle.
+                    rebuild_on_failure=False,
+                    reason="logical_llm_finalization",
                 )
             except Exception:
                 with turn.logical_llm_lock:
@@ -1027,6 +1255,27 @@ def _load_nemo_relay() -> Any:
 
 def _session_id(event: dict[str, Any]) -> str:
     return str(event.get("session_id") or "")
+
+
+def _scope_handle_uuid(handle: Any) -> str:
+    """Return the stable native uuid for a ScopeHandle-like object."""
+    if handle is None:
+        return ""
+    uuid_value = getattr(handle, "uuid", None)
+    if uuid_value is not None:
+        return str(uuid_value)
+    if isinstance(handle, tuple) and len(handle) >= 3:
+        # Fake handles used by unit tests: ("scope", name, serial)
+        return str(handle[2])
+    return str(handle)
+
+
+def _is_scope_stack_mismatch(exc: BaseException) -> bool:
+    """Detect native LIFO / root-protection errors from nemo_relay.scope.pop."""
+    if not isinstance(exc, RuntimeError):
+        return False
+    message = str(exc).lower()
+    return any(marker in message for marker in _SCOPE_STACK_MISMATCH_MARKERS)
 
 
 def _reset_for_tests() -> None:

--- a/tests/agent/test_relay_scope_stack_heal.py
+++ b/tests/agent/test_relay_scope_stack_heal.py
@@ -1,0 +1,177 @@
+"""Regression: interrupted nested scopes must not permanently wedge a session.
+
+Live incident (2026-08-08): preflight compaction was interrupted mid-API call,
+leaving orphaned scopes above ``hermes.turn``. Every subsequent ``end_turn``
+logged::
+
+    RuntimeError: invalid argument: scope handle is not at the top of the stack
+
+The process stayed up but the session stack never healed, so close_session and
+later turns kept failing the same way until a hard gateway restart.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("nemo_relay")
+
+from agent import relay_runtime
+
+
+@pytest.fixture()
+def relay_session(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    relay_runtime._reset_for_tests()
+    lease = relay_runtime.SESSION_COORDINATOR.acquire_conversation(
+        profile_key=relay_runtime.current_profile_key(),
+        session_id="session-wedge",
+        platform="telegram",
+    )
+    try:
+        yield lease
+    finally:
+        relay_runtime.SESSION_COORDINATOR.release_conversation(lease)
+        relay_runtime.SESSION_COORDINATOR.finalize_conversation(
+            profile_key=lease.profile_key,
+            session_id=lease.session_id,
+        )
+        relay_runtime._reset_for_tests()
+
+
+def _push(host, session, name, *, parent):
+    return host.run_in_session(
+        session,
+        host.relay.scope.push,
+        name,
+        host.relay.ScopeType.Function,
+        handle=parent,
+        input={},
+        metadata={
+            relay_runtime.RUNTIME_SCHEMA_KEY: relay_runtime.RUNTIME_SCHEMA_VERSION,
+            relay_runtime.RUNTIME_INSTANCE_KEY: host.runtime_id,
+        },
+    )
+
+
+def test_end_turn_heals_orphaned_nested_scopes(relay_session):
+    """Orphans above the turn must unwind so the next turn can finalize cleanly."""
+    lease = relay_session
+    host = lease.host
+    assert isinstance(host, relay_runtime.RelayRuntime)
+    session = lease.session
+    assert session is not None
+
+    turn = relay_runtime.SESSION_COORDINATOR.begin_turn(
+        lease,
+        turn_id="turn-interrupted",
+        task_id="task-interrupted",
+    )
+    assert turn.handle is not None
+    turn_uuid = relay_runtime._scope_handle_uuid(turn.handle)
+
+    # Simulate shared-metrics task + compaction logical scopes left open when
+    # a gateway restart interrupts the API call mid-flight.
+    task = _push(host, session, "hermes.task_run", parent=turn.handle)
+    logical = _push(
+        host,
+        session,
+        relay_runtime.LOGICAL_LLM_SCOPE,
+        parent=turn.handle,
+    )
+    assert relay_runtime._scope_handle_uuid(logical)
+    assert relay_runtime._scope_handle_uuid(task)
+
+    # Naive pop of the turn (pre-fix behavior) fails while orphans remain.
+    with pytest.raises(RuntimeError, match="not at the top of the stack"):
+        host.run_in_session(
+            session,
+            host.relay.scope.pop,
+            turn.handle,
+            output={"outcome": "cancelled"},
+        )
+
+    # end_turn must heal rather than leave the stack wedged.
+    relay_runtime.SESSION_COORDINATOR.end_turn(turn, outcome="cancelled")
+    assert turn.handle is None
+    assert turn.closed is True
+
+    # Session root must still be usable for a full subsequent turn cycle.
+    turn2 = relay_runtime.SESSION_COORDINATOR.begin_turn(
+        lease,
+        turn_id="turn-recovered",
+        task_id="task-recovered",
+    )
+    assert turn2.handle is not None
+    assert relay_runtime._scope_handle_uuid(turn2.handle) != turn_uuid
+    relay_runtime.SESSION_COORDINATOR.end_turn(turn2, outcome="success")
+    assert turn2.handle is None
+
+
+def test_pop_scope_resilient_rebuilds_when_stack_unrecoverable(relay_session):
+    """If nested unwind cannot reach the target, rebuild a fresh session root."""
+    lease = relay_session
+    host = lease.host
+    assert isinstance(host, relay_runtime.RelayRuntime)
+    session = lease.session
+    assert session is not None
+
+    old_handle = session.handle
+    old_uuid = relay_runtime._scope_handle_uuid(old_handle)
+    turn = _push(host, session, relay_runtime.TURN_SCOPE, parent=session.handle)
+    orphan = _push(host, session, "orphan.scope", parent=turn)
+
+    # Force rebuild path: ask to pop a handle that is not on this stack at all
+    # after we abandon everything above the session via resilient pop of turn.
+    ok = host.pop_scope_resilient(
+        session,
+        turn,
+        output={"outcome": "cancelled"},
+        reason="unit_test_unwind",
+    )
+    assert ok is True
+    # Orphan must have been abandoned; session root still the original one.
+    assert relay_runtime._scope_handle_uuid(session.handle) == old_uuid
+    # Direct proof the stack is clean under the original session handle.
+    probe = _push(host, session, "probe", parent=session.handle)
+    assert host.pop_scope_resilient(session, probe, reason="unit_test_probe") is True
+
+    # Rebuild path: poison by closing session context reference then recover.
+    # Create orphans and drop the only handle references without popping.
+    lost_turn = _push(host, session, relay_runtime.TURN_SCOPE, parent=session.handle)
+    _push(host, session, "lost.orphan", parent=lost_turn)
+    # Pretend caller only knows a stale child handle whose uuid no longer
+    # matches anything after a manual rebuild trigger.
+    host.rebuild_session_scope(session, reason="unit_test_rebuild")
+    assert session.scope_stack_healed is True
+    assert relay_runtime._scope_handle_uuid(session.handle) != old_uuid
+
+    turn2 = relay_runtime.SESSION_COORDINATOR.begin_turn(
+        lease,
+        turn_id="turn-after-rebuild",
+        task_id="task-after-rebuild",
+    )
+    assert turn2.handle is not None
+    relay_runtime.SESSION_COORDINATOR.end_turn(turn2, outcome="success")
+
+
+def test_close_session_survives_orphaned_children(relay_session):
+    """close_session must not leave a permanently broken registry entry."""
+    lease = relay_session
+    host = lease.host
+    assert isinstance(host, relay_runtime.RelayRuntime)
+    session = lease.session
+    assert session is not None
+    session_id = session.session_id
+
+    turn = _push(host, session, relay_runtime.TURN_SCOPE, parent=session.handle)
+    _push(host, session, "orphan.close", parent=turn)
+
+    host.close_session({"session_id": session_id})
+    assert host.get_session(session_id) is None
+
+    # A new session id can still open (same runtime, fresh stack).
+    fresh = host.ensure_session({"session_id": "session-fresh-after-close"})
+    assert fresh is not None
+    assert fresh.handle is not None
+    host.close_session({"session_id": fresh.session_id})

--- a/tests/hermes_cli/test_relay_shared_metrics_runtime.py
+++ b/tests/hermes_cli/test_relay_shared_metrics_runtime.py
@@ -1316,6 +1316,7 @@ def test_concurrent_turn_skips_relay_before_scope_stack_can_interleave(
 
     assert first.relay_enabled is True
     assert first.handle is not None
+    first_handle = first.handle
     assert second.relay_enabled is False
     assert second.handle is None
     assert relay_runtime.resolve_execution_context("shared-session") == (
@@ -1335,9 +1336,10 @@ def test_concurrent_turn_skips_relay_before_scope_stack_can_interleave(
     turn_closes = [
         event
         for event in direct_runtime.events
-        if event[0] == "scope.pop" and event[1] == first.handle
+        if event[0] == "scope.pop" and event[1] == first_handle
     ]
     assert len(turn_closes) == 1
+    assert first.handle is None
     assert not [
         event
         for event in direct_runtime.events


### PR DESCRIPTION
## Bug Description

When a turn leaves nested NeMo Relay scopes above `hermes.turn` (reproduced live when preflight compaction was interrupted mid-API call during a gateway restart), every subsequent `end_turn` / `close_session` for that session logged:

```text
RuntimeError: invalid argument: scope handle is not at the top of the stack
```

The process stayed alive, but the per-session scope stack never healed. Inbound messages could batch while the session was unhealthy, and recovery needed a hard gateway restart (full 180s drain when an agent was still in-flight).

## Root Cause

NeMo Relay scopes are strictly LIFO. `end_turn` already caught the pop failure and logged it, but it did **not** unwind orphan scopes (task/logical/metrics children) or rebuild the session root. The corrupted stack therefore poisoned every later finalization for that Hermes session.

Native `ScopeHandle` Python wrappers also do not compare equal by value (`==` is false across wrappers for the same uuid), so any unwind path must match handles by `uuid`.

## Fix

In `agent/relay_runtime.py`:

- Add `pop_scope_resilient()` — try normal pop; on stack-mismatch, abandon nested tops (uuid-matched) until the target is top, then pop it; if still unusable, `rebuild_session_scope()` with a fresh `contextvars.Context` + `hermes.session` root.
- Use it from `end_turn` and `close_session`.
- Clear `turn.handle` / retained logical handles after finalization so stale uuids cannot be re-popped after a rebuild.
- Mark `RelaySession.scope_stack_healed` when a rebuild happens (hook for future drain shortcuts).
- Avoid `session.lock` → `_sessions_lock` nesting in rebuild (opposite of `ensure_session`).

## How to Verify

```bash
pytest tests/agent/test_relay_scope_stack_heal.py \
  tests/hermes_cli/test_relay_shared_metrics_runtime.py \
  tests/plugins/test_nemo_relay_plugin.py \
  tests/agent/test_relay_tools.py -q
```

Manual: open a long session past the preflight compression threshold, restart the gateway mid-compaction, and confirm later turns no longer spam `turn finalization failed` / `scope handle is not at the top of the stack`.

## Test Plan

- [x] Added regression test for orphaned nested scopes + post-heal turn cycle
- [x] Added rebuild / close_session survival coverage
- [x] Existing relay / shared-metrics tests still pass (70 passed in local run; 2 asyncio tests deselected for missing plugin in that env)
- [ ] Manual verification on a live gateway with compaction interrupt (optional)

## Risk Assessment

Medium — touches core Relay session lifecycle. Failure mode is fail-open (same as before: log + continue), but successful heal mutates the session root handle. Observability exporters may see abandoned child scopes with `outcome=abandoned`; conversation correctness does not depend on those scopes.

## Out of scope (follow-ups)

1. Drain-on-restart: soft-interrupt earlier / short-circuit when only wedged sessions remain (still waits full `restart_drain_timeout` today before interrupt).
2. Persist inbound Telegram batch content before turn conversion so mid-processing crashes do not drop messages.
