### PR TITLE
fix(image-gen): gate xAI Image 2 API capabilities

### DIFF
--- a/plugins/image_gen/xai/__init__.py
+++ b/plugins/image_gen/xai/__init__.py
@@ -1,13 +1,21 @@
 """xAI image generation backend.
 
-Exposes xAI's ``grok-imagine-image`` model as an
+Exposes xAI's ``grok-imagine-image`` / ``grok-imagine-image-quality`` models as an
 :class:`ImageGenProvider` implementation.
 
-Features:
+Features (API-available today):
 - Text-to-image generation
+- Image edit + multi-image edit (≤3 total sources — plugin/API limit)
 - Multiple aspect ratios (1:1, 16:9, 9:16, etc.)
 - Multiple resolutions (1K, 2K)
-- Base64 output saved to cache
+- Base64 / URL output saved to cache
+
+**Imagine Image 2.0:** xAI's announcement describes consumer Quality Mode and
+states **API access is coming soon**
+(https://x.ai/news/grok-imagine-image-2). Do **not** raise multi-ref to 5 or add
+Magic Wand / Segmentation / Smart Resize tool routes until docs.x.ai documents
+them. ``grok-imagine-image-quality`` is the closest existing API stand-in for
+Quality Mode.
 
 Selection precedence (first hit wins):
 1. ``XAI_IMAGE_MODEL`` env var
@@ -53,14 +61,25 @@ _MODELS: Dict[str, Dict[str, Any]] = {
     "grok-imagine-image": {
         "display": "Grok Imagine Image",
         "speed": "~5-10s",
-        "strengths": "Fast, high-quality",
+        "strengths": "Fast stills; API live. Not Image 2.0 consumer product.",
     },
     "grok-imagine-image-quality": {
         "display": "Grok Imagine Image (Quality)",
         "speed": "~10-20s",
-        "strengths": "Higher fidelity / detail; slower than the standard model.",
+        # Closest API stand-in for consumer "Quality Mode" / Image 2.0 until
+        # xAI ships a dedicated Image 2.0 model id on the API.
+        "strengths": (
+            "Higher fidelity / detail; preferred for production stills. "
+            "Image 2.0 consumer tools (wand/segment/5-ref) are not on API yet."
+        ),
     },
 }
+
+# xAI's Image 2.0 announcement describes multi-ref up to 5; the live API/plugin
+# stay at 3 until xAI documents API availability and a higher limit:
+# https://x.ai/news/grok-imagine-image-2
+MAX_SOURCE_IMAGES = 3
+MAX_REFERENCE_IMAGES = max(0, MAX_SOURCE_IMAGES - 1)
 
 DEFAULT_MODEL = "grok-imagine-image"
 
@@ -203,12 +222,15 @@ class XAIImageGenProvider(ImageGenProvider):
         }
 
     def capabilities(self) -> Dict[str, Any]:
-        # xAI's /v1/images/edits supports image editing via grok-imagine-image
-        # -quality, including up to 3 total source images.
+        # xAI /v1/images/edits (quality model). Cap is API-documented 3 sources —
+        # Image 2.0 consumer multi-ref (5) is not available on API yet (2026-08-08).
         return {
             "modalities": ["text", "image"],
-            "max_reference_images": 2,
-            "max_source_images": 3,
+            "max_reference_images": MAX_REFERENCE_IMAGES,
+            "max_source_images": MAX_SOURCE_IMAGES,
+            # Surface honesty for tool-description builders / agents.
+            "imagine_image_2_api": "coming_soon",
+            "imagine_image_2_source": "https://x.ai/news/grok-imagine-image-2",
         }
 
     def generate(
@@ -251,9 +273,13 @@ class XAIImageGenProvider(ImageGenProvider):
         refs = normalize_reference_images(reference_image_urls)
         if refs:
             source_images.extend(refs)
-        if len(source_images) > 3:
+        if len(source_images) > MAX_SOURCE_IMAGES:
             return error_response(
-                error="xAI image editing supports at most 3 source images",
+                error=(
+                    f"xAI image editing supports at most {MAX_SOURCE_IMAGES} source "
+                    "images on the current API. Image 2.0 consumer multi-ref (up to 5) "
+                    "is not API-available yet — see https://x.ai/news/grok-imagine-image-2"
+                ),
                 error_type="too_many_references",
                 provider=provider_name,
                 model="grok-imagine-image-quality",

--- a/plugins/image_gen/xai/plugin.yaml
+++ b/plugins/image_gen/xai/plugin.yaml
@@ -1,6 +1,10 @@
 name: xai
-version: 1.0.0
-description: "xAI image generation backend (grok-imagine-image). Text-to-image."
+version: 1.1.0
+description: >
+  xAI Grok Imagine image backend (grok-imagine-image + quality). Text-to-image and
+  multi-image edit (≤3 sources). xAI says Imagine Image 2.0 API access is "coming
+  soon" at https://x.ai/news/grok-imagine-image-2; do not expose wand/segment/5-ref
+  until xAI documents API availability.
 author: Julien Talbot
 kind: backend
 requires_env:

--- a/tests/plugins/image_gen/test_xai_provider.py
+++ b/tests/plugins/image_gen/test_xai_provider.py
@@ -83,11 +83,24 @@ class TestXAIImageGenProvider:
         assert schema["post_setup"] == "xai_grok"
 
     def test_capabilities_expose_total_source_image_limit(self):
+        from plugins.image_gen.xai import (
+            MAX_REFERENCE_IMAGES,
+            MAX_SOURCE_IMAGES,
+            XAIImageGenProvider,
+        )
+
+        caps = XAIImageGenProvider().capabilities()
+        assert MAX_SOURCE_IMAGES > 0
+        assert MAX_REFERENCE_IMAGES == MAX_SOURCE_IMAGES - 1
+        assert caps["max_reference_images"] == MAX_REFERENCE_IMAGES
+        assert caps["max_source_images"] == MAX_SOURCE_IMAGES
+
+    def test_capabilities_gate_unreleased_imagine_image_2_api(self):
         from plugins.image_gen.xai import XAIImageGenProvider
 
         caps = XAIImageGenProvider().capabilities()
-        assert caps["max_reference_images"] == 2
-        assert caps["max_source_images"] == 3
+        assert caps["imagine_image_2_api"] == "coming_soon"
+        assert caps["imagine_image_2_source"] == "https://x.ai/news/grok-imagine-image-2"
 
 
 # ---------------------------------------------------------------------------
@@ -259,6 +272,27 @@ class TestGenerate:
             f"resolution must be the literal '1k' or '2k', got {payload['resolution']!r}"
         )
 
+    def test_image_edit_rejects_more_sources_than_the_current_api_supports(self):
+        from plugins.image_gen.xai import MAX_SOURCE_IMAGES, XAIImageGenProvider
+
+        sources = [
+            f"https://example.com/source-{index}.png"
+            for index in range(MAX_SOURCE_IMAGES + 1)
+        ]
+        with patch("plugins.image_gen.xai.requests.post") as mock_post:
+            result = XAIImageGenProvider().generate(
+                prompt="combine these images",
+                image_url=sources[0],
+                reference_image_urls=sources[1:],
+            )
+
+        assert result["success"] is False
+        assert result["error_type"] == "too_many_references"
+        assert f"at most {MAX_SOURCE_IMAGES} source images" in result["error"]
+        assert "not API-available" in result["error"]
+        assert "https://x.ai/news/grok-imagine-image-2" in result["error"]
+        mock_post.assert_not_called()
+
     def test_image_edit_rejects_bare_file_id_input(self):
         from plugins.image_gen.xai import XAIImageGenProvider
 
@@ -402,5 +436,3 @@ class TestXAIImageFieldReadGuard:
 
         with pytest.raises(ValueError, match="credential store"):
             _xai_image_field(str(auth_json))
-
-


### PR DESCRIPTION
## What does this PR do?

Keeps the xAI image provider aligned with the API surface available today while explicitly marking Imagine Image 2 consumer features as unavailable through the API. This prevents agents and tool-description consumers from treating the announced five-reference and editing tools as live API capabilities.

Official status source: https://x.ai/news/grok-imagine-image-2

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)
- [x] 📝 Documentation update

## Changes Made

- Define shared source/reference limits and use them for capability metadata and runtime validation.
- Advertise the Imagine Image 2 API gate as `coming_soon` with its official source URL.
- Reject over-limit edit requests before any network call with an actionable error.
- Clarify plugin metadata without claiming the consumer Image 2.0 tools exist in the API.

## How to Test

1. `scripts/run_tests.sh tests/plugins/image_gen/test_xai_provider.py -q`
2. `scripts/run_tests.sh tests/plugins/image_gen/ -q`
3. Parse `plugins/image_gen/xai/plugin.yaml` with PyYAML.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing open PRs for duplicates
- [x] My PR contains only related changes
- [x] All relevant image-provider tests pass (130 tests)
- [x] I've added tests for the changes
- [x] Tested on Linux

### Documentation & Housekeeping

- [x] Updated relevant docstrings and plugin metadata
- [x] `cli-config.yaml.example`: N/A (no config keys changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A (no architecture/workflow change)
- [x] Considered cross-platform impact; provider logic remains platform-neutral
- [x] Updated capability metadata and runtime error behavior

## Screenshots / Logs

Focused provider file: 25 passed. Full image-provider directory: 130 passed.
