### PR TITLE
fix(credential_pool): let two custom providers share one base_url (#81789)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -686,6 +686,11 @@ def init_agent(
                 credential_pool,
                 agent.provider,
                 base_url=agent.base_url,
+                # The REQUESTED identity (``custom:<name>``) disambiguates two
+                # entries sharing one base_url with different api_keys; a bare
+                # base_url reverse-lookup always resolves the first URL owner
+                # (issue #81789).
+                provider_name=agent.requested_provider,
             ):
                 agent._credential_pool = None
         except Exception:

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -980,9 +980,20 @@ def recover_with_credential_pool(
         if current_provider == "custom" and pool_provider.startswith("custom:"):
             try:
                 from agent.credential_pool import get_custom_provider_pool_key
+                # Prefer the agent's REQUESTED identity (``custom:<name>``) —
+                # it resolves the exact entry when two custom providers share
+                # one base_url with different api_keys, while a bare base_url
+                # reverse-lookup always lands on the first URL owner (#81789).
+                _requested = getattr(agent, "requested_provider", "") or ""
                 _agent_base = (getattr(agent, "base_url", "") or "").strip()
                 _custom_match = bool(_agent_base) and (
-                    (get_custom_provider_pool_key(_agent_base) or "").strip().lower()
+                    (
+                        get_custom_provider_pool_key(
+                            _agent_base,
+                            provider_name=_requested or None,
+                        )
+                        or ""
+                    ).strip().lower()
                     == pool_provider
                 )
             except Exception:
@@ -1512,6 +1523,13 @@ def restore_primary_runtime(agent) -> bool:
             pool,
             primary_provider,
             base_url=str((agent._primary_runtime or {}).get("base_url") or ""),
+            # The snapshot's REQUESTED identity (``custom:<name>``) resolves
+            # the exact entry when two custom providers share one base_url
+            # with different api_keys — the base_url reverse-lookup alone
+            # always lands on the first URL owner (issue #81789).
+            provider_name=str(
+                (agent._primary_runtime or {}).get("requested_provider") or ""
+            ),
         ):
             from agent.credential_pool import load_pool
 
@@ -1621,9 +1639,17 @@ def restore_primary_runtime(agent) -> bool:
         ):
             try:
                 from agent.credential_pool import get_custom_provider_pool_key
-
+                # Prefer the snapshot's REQUESTED identity (``custom:<name>``)
+                # — it resolves the exact entry when two custom providers share
+                # one base_url with different api_keys, while a bare base_url
+                # reverse-lookup always lands on the first URL owner (#81789).
+                _requested = str(rt.get("requested_provider") or "").strip()
                 primary_key = (
-                    get_custom_provider_pool_key(str(rt.get("base_url") or "")) or ""
+                    get_custom_provider_pool_key(
+                        str(rt.get("base_url") or ""),
+                        provider_name=_requested or None,
+                    )
+                    or ""
                 ).strip().lower()
                 pool_matches_primary = bool(primary_key) and primary_key == pool_provider
             except Exception:
@@ -1679,8 +1705,18 @@ def restore_primary_runtime(agent) -> bool:
                     try:
                         from agent.credential_pool import get_custom_provider_pool_key
                         primary_base_url = str(rt.get("base_url") or "").strip()
+                        # Prefer the snapshot's REQUESTED identity
+                        # (``custom:<name>``) — it resolves the exact entry
+                        # when two custom providers share one gateway base_url
+                        # with different api_keys; the bare URL reverse-lookup
+                        # always lands on the first URL owner (#81789).
+                        _requested = str(rt.get("requested_provider") or "").strip()
                         primary_key = (
-                            get_custom_provider_pool_key(primary_base_url) or ""
+                            get_custom_provider_pool_key(
+                                primary_base_url,
+                                provider_name=_requested or None,
+                            )
+                            or ""
                         ).strip().lower()
                         entry_matches_primary = bool(primary_key) and primary_key == entry_provider
                     except Exception:

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -484,6 +484,10 @@ def get_custom_provider_pool_key(base_url: Optional[str], provider_name: Optiona
     # base_url always resolve to the first one's credentials.
     if provider_name:
         normalized_name = _normalize_custom_pool_name(provider_name)
+        # Callers may pass the full menu slug (``custom:<name>``) or the raw
+        # entry name — both must match the entry's own normalized name.
+        if normalized_name.startswith(f"{CUSTOM_POOL_PREFIX}"):
+            normalized_name = normalized_name[len(CUSTOM_POOL_PREFIX):]
         for norm_name, entry in _iter_custom_providers():
             if norm_name == normalized_name:
                 return f"{CUSTOM_POOL_PREFIX}{norm_name}"
@@ -539,12 +543,15 @@ def credential_pool_matches_provider(
     provider: Optional[str],
     *,
     base_url: Optional[str] = None,
+    provider_name: Optional[str] = None,
 ) -> bool:
     """Return whether a pool belongs to the requested runtime provider.
 
     Named custom endpoints intentionally use two identities: the live agent is
     ``custom`` while its pool is keyed ``custom:<name>``. Accept that pair only
-    when the runtime base URL resolves to the exact same custom pool key.
+    when the requested identity (``provider_name`` first — it disambiguates
+    two entries sharing one base_url with different api_keys, issue #81789 —
+    then the runtime base URL) resolves to the exact same custom pool key.
     Empty string identities fail closed. Legacy pool adapters without a
     ``provider`` attribute remain compatible; production pools are scoped.
     """
@@ -566,7 +573,9 @@ def credential_pool_matches_provider(
     if provider_norm != "custom" or not pool_provider.startswith(CUSTOM_POOL_PREFIX):
         return False
     try:
-        matched_pool = get_custom_provider_pool_key(base_url or "")
+        matched_pool = get_custom_provider_pool_key(
+            base_url or "", provider_name=provider_name
+        )
     except Exception:
         return False
     return str(matched_pool or "").strip().lower() == pool_provider

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4110,15 +4110,75 @@ def _custom_provider_base_url_config_value(provider_info, resolved_base_url=""):
     return str(resolved_base_url or "").strip()
 
 
+def _apply_custom_provider_update(
+    entry: dict,
+    *,
+    base_url: str,
+    api_key: str,
+    model: str,
+    context_length,
+    api_mode: str,
+    key_env: str,
+) -> bool:
+    """Apply caller-supplied fields onto an existing custom_providers entry.
+
+    Returns True when anything changed. Refreshes the inline ``api_key`` when
+    the caller supplied a new one — the old base_url dedup silently ignored a
+    new key, so a second channel key for one relay endpoint was never saved
+    (issue #81789). ``key_env`` still wins over an inline key: once a
+    credential lives in ``.env``, the plaintext ``api_key`` is dropped.
+    """
+    changed = False
+    if str(entry.get("base_url", "") or "").rstrip("/") != base_url.rstrip("/"):
+        entry["base_url"] = base_url
+        changed = True
+    if model and entry.get("model") != model:
+        entry["model"] = model
+        changed = True
+    if model and context_length:
+        models_cfg = entry.get("models", {})
+        if not isinstance(models_cfg, dict):
+            models_cfg = {}
+        if models_cfg.get(model, {}).get("context_length") != context_length:
+            models_cfg[model] = {"context_length": context_length}
+            entry["models"] = models_cfg
+            changed = True
+    if api_mode:
+        if entry.get("api_mode") != api_mode:
+            entry["api_mode"] = api_mode
+            changed = True
+    elif "api_mode" in entry:
+        entry.pop("api_mode", None)
+        changed = True
+    if key_env:
+        if entry.get("key_env") != key_env or entry.get("api_key"):
+            entry["key_env"] = key_env
+            entry.pop("api_key", None)
+            changed = True
+    elif (
+        api_key
+        and not entry.get("key_env")
+        and not str(api_key).startswith("${")
+        and entry.get("api_key") != api_key
+    ):
+        entry["api_key"] = api_key
+        changed = True
+    return changed
+
+
 def _save_custom_provider(
     base_url, api_key="", model="", context_length=None, name=None, api_mode=None,
     key_env=""
 ):
     """Save a custom endpoint to custom_providers in config.yaml.
 
-    Deduplicates by base_url — if the URL already exists, updates the
-    model name, context_length, and api_mode but doesn't add a duplicate entry.
-    Uses *name* when provided, otherwise auto-generates from the URL.
+    Deduplicates by explicit *name* first — two custom providers may
+    legitimately share one base_url with different api_keys (multi-channel /
+    multi-region relay endpoints, issue #81789), so a distinct name is a NEW
+    entry, never an update of the first URL owner. Same name (or a legacy
+    no-name call hitting an existing URL) updates the entry in place and
+    refreshes ``api_key`` when a new one was supplied. Uses *name* when
+    provided, otherwise auto-generates from the URL.
 
     When *key_env* is set the caller has already written the key to ``.env``,
     so the entry references it instead of inlining the secret (#69449).
@@ -4130,37 +4190,49 @@ def _save_custom_provider(
     if not isinstance(providers, list):
         providers = []
 
-    # Check if this URL is already saved — update model/context_length if so
-    for entry in providers:
-        if isinstance(entry, dict) and entry.get("base_url", "").rstrip(
-            "/"
-        ) == base_url.rstrip("/"):
-            changed = False
-            if model and entry.get("model") != model:
-                entry["model"] = model
-                changed = True
-            if model and context_length:
-                models_cfg = entry.get("models", {})
-                if not isinstance(models_cfg, dict):
-                    models_cfg = {}
-                models_cfg[model] = {"context_length": context_length}
-                entry["models"] = models_cfg
-                changed = True
-            if api_mode:
-                if entry.get("api_mode") != api_mode:
-                    entry["api_mode"] = api_mode
-                    changed = True
-            elif "api_mode" in entry:
-                entry.pop("api_mode", None)
-                changed = True
-            if key_env and (entry.get("key_env") != key_env or entry.get("api_key")):
-                entry["key_env"] = key_env
-                entry.pop("api_key", None)
-                changed = True
-            if changed:
-                cfg["custom_providers"] = providers
-                save_config(cfg)
-            return  # already saved, updated if needed
+    # Dedup by explicit name first (same normalized name → update in place).
+    # A DIFFERENT explicit name with the same base_url is a legitimate new
+    # entry (multi-channel / multi-region relay endpoints, issue #81789) — it
+    # must never fall through to the legacy URL dedup below.
+    if name:
+        name_key = name.strip().lower().replace(" ", "-")
+        for entry in providers:
+            if (
+                isinstance(entry, dict)
+                and str(entry.get("name", "") or "")
+                .strip().lower().replace(" ", "-") == name_key
+            ):
+                if _apply_custom_provider_update(
+                    entry,
+                    base_url=base_url,
+                    api_key=api_key,
+                    model=model,
+                    context_length=context_length,
+                    api_mode=api_mode,
+                    key_env=key_env,
+                ):
+                    cfg["custom_providers"] = providers
+                    save_config(cfg)
+                return  # already saved, updated if needed
+    else:
+        # Legacy: no explicit name — keep the base_url dedup (first entry
+        # owning the URL wins), now also refreshing api_key on update.
+        for entry in providers:
+            if isinstance(entry, dict) and entry.get("base_url", "").rstrip(
+                "/"
+            ) == base_url.rstrip("/"):
+                if _apply_custom_provider_update(
+                    entry,
+                    base_url=base_url,
+                    api_key=api_key,
+                    model=model,
+                    context_length=context_length,
+                    api_mode=api_mode,
+                    key_env=key_env,
+                ):
+                    cfg["custom_providers"] = providers
+                    save_config(cfg)
+                return  # already saved, updated if needed
 
     # Use provided name or auto-generate from URL
     if not name:

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -1688,8 +1688,18 @@ def _model_flow_named_custom(config, provider_info):
                 cfg["providers"] = providers_cfg
                 save_config(cfg)
     else:
-        # Save model name to the custom_providers entry for next time
-        _save_custom_provider(base_url, config_api_key, model_name, api_mode=api_mode)
+        # Save model name to the custom_providers entry for next time.
+        # Pass the entry's own name so the update lands on THIS entry even
+        # when another custom provider shares the same base_url with a
+        # different api_key (issue #81789) — a no-name call would update
+        # the first URL owner instead.
+        _save_custom_provider(
+            base_url,
+            config_api_key,
+            model_name,
+            api_mode=api_mode,
+            name=name,
+        )
 
     print(f"\n✅ Model set to: {model_name}")
     print(f"   Provider: {name} ({base_url})")

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -951,6 +951,7 @@ def canonical_custom_identity(
     base_url: Optional[str] = None,
     config_provider: Optional[str] = None,
     model: Optional[str] = None,
+    requested_provider: Optional[str] = None,
 ) -> Optional[str]:
     """Recover a routable ``custom:<name>`` identity for a bare custom provider.
 
@@ -962,20 +963,28 @@ def canonical_custom_identity(
 
     Any code path that persists or restores a session's provider override
     must run the resolved provider through this helper so a bare ``"custom"``
-    is upgraded back to its durable ``custom:<name>`` menu key. Three
-    recovery sources, in priority order:
+    is upgraded back to its durable ``custom:<name>`` menu key. Recovery
+    sources, in priority order:
 
-    1. ``base_url`` — reverse-lookup the entry that owns the endpoint URL
+    1. ``requested_provider`` — the identity the session was explicitly
+       switched to (e.g. a ``custom:<name>`` from a /model switch or a
+       persisted override). This is the most precise fact: when two custom
+       providers share one base_url with different api_keys, the base_url
+       reverse-lookup cannot disambiguate them (it always returns the first
+       URL owner), while the requested name resolves exactly (issue #81789).
+       Only accepted when it names a real configured entry.
+    2. ``base_url`` — reverse-lookup the entry that owns the endpoint URL
        (the one fact that always survives the persistence round-trip when a
-       URL was recorded).
-    2. ``model`` — reverse-lookup the entry that serves the session's model
+       URL was recorded). Ambiguous when multiple entries share the URL, so
+       it sits below the explicit name.
+    3. ``model`` — reverse-lookup the entry that serves the session's model
        (``model``/``default_model``/``models`` catalog). The session row
        always stores the model name, so when no base_url survived (the
        recurring Desktop/TUI regression vector) the model is the last
        session-scoped fact that can recover the entry — and unlike the
        config fallback below it stays correct after the user points their
        global default at a different provider.
-    3. ``config_provider`` — the active ``config.model.provider`` (or its
+    4. ``config_provider`` — the active ``config.model.provider`` (or its
        ``provider``/``HERMES_INFERENCE_PROVIDER`` equivalent). When neither
        a base_url nor a model recovered the entry, the configured provider
        is the only durable identity left, so fall back to it when it names
@@ -985,6 +994,49 @@ def canonical_custom_identity(
     ``None`` (caller keeps whatever it had — bare ``"custom"`` only as a last
     resort, e.g. a genuine ad-hoc endpoint with no config entry).
     """
+    # 0. Explicitly-requested identity wins: it disambiguates multiple
+    # entries that share one base_url (different api_keys per channel/tenant),
+    # which no URL reverse-lookup can do. The requested name maps to ITS OWN
+    # entry's durable slug — never through the URL, which would return the
+    # first URL owner again (issue #81789).
+    if requested_provider:
+        requested_norm = _normalize_custom_provider_name(requested_provider)
+        if requested_norm and requested_norm not in {"custom", "auto"}:
+            try:
+                config = load_config()
+            except Exception:
+                config = None
+            if isinstance(config, dict):
+                providers = config.get("providers")
+                if isinstance(providers, dict):
+                    from hermes_cli.config import is_provider_enabled
+
+                    for ep_name, entry in providers.items():
+                        if not isinstance(entry, dict):
+                            continue
+                        if not is_provider_enabled(entry):
+                            continue
+                        if requested_norm in custom_provider_aliases(
+                            str(entry.get("name") or ep_name), str(ep_name)
+                        ):
+                            return custom_provider_slug(str(ep_name), str(ep_name))
+                try:
+                    custom_providers = get_compatible_custom_providers(config)
+                except Exception:
+                    custom_providers = None
+                for entry in custom_providers or []:
+                    if not isinstance(entry, dict):
+                        continue
+                    name = entry.get("name")
+                    if not isinstance(name, str) or not name.strip():
+                        continue
+                    if requested_norm in custom_provider_aliases(
+                        name, str(entry.get("provider_key", "") or "")
+                    ):
+                        return custom_provider_slug(
+                            name, str(entry.get("provider_key", "") or "")
+                        )
+
     # 1. Reverse-lookup by endpoint URL.
     if base_url:
         identity = find_custom_provider_identity(base_url)
@@ -1920,6 +1972,11 @@ def resolve_runtime_provider(
                     or getattr(entry, "base_url", None)
                     or ""
                 ),
+                # The REQUESTED identity (``custom:<name>``) disambiguates two
+                # entries sharing one base_url with different api_keys — a
+                # bare base_url reverse-lookup always resolves the first URL
+                # owner (issue #81789).
+                provider_name=requested_provider,
             )
         ):
             return _resolve_runtime_from_pool_entry(

--- a/tests/agent/test_credential_pool_provider_boundary.py
+++ b/tests/agent/test_credential_pool_provider_boundary.py
@@ -3,7 +3,10 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from agent.credential_pool import credential_pool_matches_provider
+from agent.credential_pool import (
+    credential_pool_matches_provider,
+    get_custom_provider_pool_key,
+)
 from hermes_cli import runtime_provider as rp
 
 
@@ -24,6 +27,83 @@ def test_custom_pool_match_is_scoped_by_endpoint():
         assert not credential_pool_matches_provider(
             "custom:other", "custom", base_url="https://lab.example/v1"
         )
+
+
+def test_pool_key_name_wins_over_shared_base_url(monkeypatch):
+    """Two providers sharing one base_url with different api_keys (issue
+    #81789) must resolve to their own pool keys when the name is given."""
+    config = {
+        "custom_providers": [
+            {
+                "name": "slomerex-grok",
+                "base_url": "https://relay.example/v1",
+                "api_key": "keyA",
+            },
+            {
+                "name": "slomerex-alt",
+                "base_url": "https://relay.example/v1",
+                "api_key": "keyB",
+            },
+        ]
+    }
+    monkeypatch.setattr(
+        "agent.credential_pool._load_config_safe", lambda: config
+    )
+
+    assert (
+        get_custom_provider_pool_key("https://relay.example/v1", provider_name="slomerex-alt")
+        == "custom:slomerex-alt"
+    )
+    assert (
+        get_custom_provider_pool_key("https://relay.example/v1", provider_name="custom:slomerex-grok")
+        == "custom:slomerex-grok"
+    )
+    # Slug form and raw name both match.
+    assert (
+        get_custom_provider_pool_key("https://relay.example/v1", provider_name="custom:slomerex-alt")
+        == "custom:slomerex-alt"
+    )
+    # Bare base_url keeps the legacy first-owner behavior.
+    assert (
+        get_custom_provider_pool_key("https://relay.example/v1")
+        == "custom:slomerex-grok"
+    )
+
+
+def test_pool_match_prefers_requested_name_over_shared_url(monkeypatch):
+    """credential_pool_matches_provider must use the requested identity so the
+    second provider's pool is accepted even though its URL is owned first by
+    the other entry."""
+    config = {
+        "custom_providers": [
+            {
+                "name": "slomerex-grok",
+                "base_url": "https://relay.example/v1",
+                "api_key": "keyA",
+            },
+            {
+                "name": "slomerex-alt",
+                "base_url": "https://relay.example/v1",
+                "api_key": "keyB",
+            },
+        ]
+    }
+    monkeypatch.setattr(
+        "agent.credential_pool._load_config_safe", lambda: config
+    )
+
+    assert credential_pool_matches_provider(
+        "custom:slomerex-alt",
+        "custom",
+        base_url="https://relay.example/v1",
+        provider_name="custom:slomerex-alt",
+    )
+    # Without the name the URL lookup resolves the first owner → mismatch.
+    assert not credential_pool_matches_provider(
+        "custom:slomerex-alt",
+        "custom",
+        base_url="https://relay.example/v1",
+    )
 
 
 def test_runtime_ignores_pool_loaded_for_different_provider(monkeypatch):

--- a/tests/agent/test_custom_pool_mismatch_guard.py
+++ b/tests/agent/test_custom_pool_mismatch_guard.py
@@ -28,6 +28,7 @@ def _agent(provider, base_url, pool_provider):
     agent = MagicMock()
     agent.provider = provider
     agent.base_url = base_url
+    agent.requested_provider = ""
     pool = MagicMock()
     pool.provider = pool_provider
     agent._credential_pool = pool
@@ -66,6 +67,61 @@ class TestCustomPoolMismatchGuard:
             has_retried_429=False,
             classified_reason=FailoverReason.auth,
         )
+        assert recovered is False
+        assert not pool.method_calls
+
+    def test_second_provider_sharing_base_url_guard_passes_with_name(self):
+        """Two custom providers sharing one base_url with different api_keys
+        (issue #81789): the pool of the SECOND entry must pass the guard when
+        the agent carries its requested identity, even though a bare base_url
+        lookup resolves the first URL owner."""
+        agent, pool = _agent(
+            "custom", "https://relay.example/v1", "custom:slomerex-alt"
+        )
+        agent.requested_provider = "custom:slomerex-alt"
+        # Drive the auth-recovery path past the entitlement check to the
+        # rotation branch (this test is about the guard, not refresh logic).
+        agent._is_entitlement_failure = lambda *a, **k: False
+        agent.api_key = "sk-keyB"
+        pool.try_refresh_matching = lambda **kw: None
+        pool.mark_exhausted_and_rotate = lambda **kw: MagicMock(id="next-entry")
+        with patch(
+            "agent.credential_pool.get_custom_provider_pool_key",
+            side_effect=lambda url, provider_name=None: (
+                "custom:slomerex-alt" if provider_name else "custom:slomerex-grok"
+            ),
+        ) as lookup:
+            recovered, _ = recover_with_credential_pool(
+                agent,
+                status_code=401,
+                has_retried_429=False,
+                classified_reason=FailoverReason.auth,
+            )
+        assert recovered is True
+        # Recovery actually ran: the failed credential was rotated and the
+        # agent swapped onto the new entry (not blocked by the guard).
+        agent._swap_credential.assert_called_once()
+        # The guard must have consulted the requested identity, not just URL.
+        kwargs = lookup.call_args
+        assert kwargs.kwargs.get("provider_name") == "custom:slomerex-alt"
+
+    def test_second_provider_sharing_base_url_without_name_still_guarded(self):
+        """Without the requested identity the base_url-only lookup resolves
+        the first URL owner, so the second pool stays guarded (no mutation)."""
+        agent, pool = _agent(
+            "custom", "https://relay.example/v1", "custom:slomerex-alt"
+        )
+        agent.requested_provider = ""
+        with patch(
+            "agent.credential_pool.get_custom_provider_pool_key",
+            return_value="custom:slomerex-grok",
+        ):
+            recovered, _ = recover_with_credential_pool(
+                agent,
+                status_code=401,
+                has_retried_429=False,
+                classified_reason=FailoverReason.auth,
+            )
         assert recovered is False
         assert not pool.method_calls
 

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -575,6 +575,77 @@ def test_save_custom_provider_references_the_key_instead_of_inlining_it(monkeypa
     assert "sk-secret" not in yaml.safe_dump(saved)
 
 
+# ---------------------------------------------------------------------------
+# _save_custom_provider — same base_url, different api_key (issue #81789)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def custom_provider_save(monkeypatch, tmp_path):
+    """Stateful load/save around _save_custom_provider for multi-entry tests."""
+    import yaml
+    from hermes_cli.main import _save_custom_provider
+
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.dump({}))
+    state = {"cfg": None}
+
+    def _load():
+        if state["cfg"] is not None:
+            return state["cfg"]
+        return yaml.safe_load(cfg_path.read_text()) or {}
+
+    def _save(cfg):
+        state["cfg"] = cfg
+        cfg_path.write_text(yaml.safe_dump(cfg))
+
+    monkeypatch.setattr("hermes_cli.config.load_config", _load)
+    monkeypatch.setattr("hermes_cli.config.save_config", _save)
+    return _save_custom_provider, state
+
+
+def test_same_base_url_distinct_names_create_two_entries(custom_provider_save):
+    """Two providers sharing one base_url with different api_keys must coexist.
+
+    Regression for issue #81789: the old base_url dedup silently merged the
+    second entry into the first (and never refreshed its api_key), so a
+    multi-channel relay endpoint could only ever hold one credential.
+    """
+    _save, state = custom_provider_save
+
+    _save("https://api.slomerex.xyz/v1", api_key="keyA", name="slomerex-grok")
+    _save("https://api.slomerex.xyz/v1", api_key="keyB", name="slomerex-alt")
+
+    entries = state["cfg"]["custom_providers"]
+    assert len(entries) == 2
+    by_name = {e["name"]: e.get("api_key") for e in entries}
+    assert by_name == {"slomerex-grok": "keyA", "slomerex-alt": "keyB"}
+
+
+def test_same_name_updates_in_place_and_refreshes_api_key(custom_provider_save):
+    """Re-saving under the same name updates that entry — including api_key."""
+    _save, state = custom_provider_save
+
+    _save("https://api.slomerex.xyz/v1", api_key="keyA", name="slomerex-grok")
+    _save("https://api.slomerex.xyz/v1", api_key="keyB", name="slomerex-grok", model="grok-4")
+
+    entries = state["cfg"]["custom_providers"]
+    assert len(entries) == 1
+    assert entries[0]["api_key"] == "keyB"
+    assert entries[0]["model"] == "grok-4"
+
+
+def test_no_name_same_url_updates_first_owner_and_refreshes_key(custom_provider_save):
+    """Legacy no-name call still dedups by base_url — but now refreshes api_key."""
+    _save, state = custom_provider_save
+
+    _save("https://api.slomerex.xyz/v1", api_key="keyA", name="slomerex-grok")
+    _save("https://api.slomerex.xyz/v1", api_key="keyB")
+
+    entries = state["cfg"]["custom_providers"]
+    assert len(entries) == 1
+    assert entries[0]["api_key"] == "keyB"
+
+
 
 
 def test_custom_endpoint_key_env_is_a_valid_posix_name_for_ip_endpoints():

--- a/tests/hermes_cli/test_canonical_custom_identity.py
+++ b/tests/hermes_cli/test_canonical_custom_identity.py
@@ -98,3 +98,103 @@ def test_legacy_unkeyed_entry_keeps_its_name_identity(monkeypatch):
     monkeypatch.setattr(rp, "_get_model_config", lambda: {})
 
     assert rp.canonical_custom_identity(config_provider="Legacy Endpoint") == "custom:legacy-endpoint"
+
+
+# --- Issue #81789: two providers sharing one base_url, different api_keys ----
+#
+# The base_url reverse-lookup cannot disambiguate same-URL entries (it always
+# returns the FIRST URL owner), so recovery must prefer the explicitly
+# requested provider identity over the URL.
+
+SHARED_URL = "https://relay.example.invalid/v1"
+
+SHARED_URL_CONFIG = {
+    "custom_providers": [
+        {
+            "name": "slomerex-grok",
+            "base_url": SHARED_URL,
+            "api_key": "keyA",
+            "api_mode": "chat_completions",
+        },
+        {
+            "name": "slomerex-alt",
+            "base_url": SHARED_URL,
+            "api_key": "keyB",
+            "api_mode": "chat_completions",
+        },
+    ]
+}
+
+
+@pytest.fixture
+def shared_url_config(monkeypatch):
+    monkeypatch.setattr(rp, "load_config", lambda *a, **k: SHARED_URL_CONFIG)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda *a, **k: SHARED_URL_CONFIG)
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    return SHARED_URL_CONFIG
+
+
+def test_requested_identity_disambiguates_shared_base_url(shared_url_config):
+    """The explicitly requested provider must win over the first URL owner."""
+    assert (
+        rp.canonical_custom_identity(
+            requested_provider="slomerex-alt", base_url=SHARED_URL
+        )
+        == "custom:slomerex-alt"
+    )
+    assert (
+        rp.canonical_custom_identity(
+            requested_provider="slomerex-grok", base_url=SHARED_URL
+        )
+        == "custom:slomerex-grok"
+    )
+
+
+def test_requested_identity_wins_even_when_url_matches_first_entry(shared_url_config):
+    """The base_url alone would heal to the FIRST owner — the name must win."""
+    assert (
+        rp.canonical_custom_identity(
+            requested_provider="custom:slomerex-alt", base_url=SHARED_URL
+        )
+        == "custom:slomerex-alt"
+    )
+
+
+def test_bare_url_still_heals_to_first_url_owner(shared_url_config):
+    """Without a name the URL reverse-lookup keeps its legacy first-match
+    behavior (callers that only have a base_url cannot do better)."""
+    assert rp.canonical_custom_identity(base_url=SHARED_URL) == "custom:slomerex-grok"
+
+
+def test_unconfigured_requested_identity_falls_through_to_url(shared_url_config):
+    """A requested name that matches no entry must not mint a fake identity."""
+    assert (
+        rp.canonical_custom_identity(
+            requested_provider="not-a-real-entry", base_url=SHARED_URL
+        )
+        == "custom:slomerex-grok"
+    )
+
+
+def test_requested_identity_heals_keyed_providers_dict(monkeypatch):
+    """Keyed ``providers:`` entries keep their config-key slug, not the
+    display name, when recovered by the requested identity."""
+    config = {
+        "providers": {
+            "slomerex-alt": {
+                "name": "Slomerex Alt Display",
+                "api": SHARED_URL,
+                "api_key": "keyB",
+            }
+        }
+    }
+    monkeypatch.setattr(rp, "load_config", lambda *a, **k: config)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda *a, **k: config)
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+
+    assert (
+        rp.canonical_custom_identity(
+            requested_provider="Slomerex Alt Display", base_url=SHARED_URL
+        )
+        == "custom:slomerex-alt"
+    )

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -12091,6 +12091,7 @@ def test_model_options_preserves_canonical_custom_row_after_agent_init(monkeypat
         "custom:local-ollama"
     ]
     canonical.assert_called_once_with(
+        requested_provider="",
         base_url="http://127.0.0.1:11434/v1",
         config_provider="custom:local-ollama",
         model="qwen3.6:35b-65k",

--- a/tests/tui_gateway/test_custom_provider_session_persistence.py
+++ b/tests/tui_gateway/test_custom_provider_session_persistence.py
@@ -167,8 +167,106 @@ class TestResumeRoundTrip:
 
         kwargs = _make_agent_with_override(override, monkeypatch, LEGACY_LIST_CONFIG)
 
-        assert kwargs["base_url"] == MIMO_URL
-        assert kwargs["api_key"] == MIMO_KEY
+
+# --- Issue #81789: two providers sharing one base_url, different api_keys ----
+
+SHARED_URL = "https://relay.example.invalid/v1"
+
+SHARED_URL_CONFIG = {
+    "custom_providers": [
+        {
+            "name": "slomerex-grok",
+            "base_url": SHARED_URL,
+            "api_key": "keyA",
+            "api_mode": "chat_completions",
+        },
+        {
+            "name": "slomerex-alt",
+            "base_url": SHARED_URL,
+            "api_key": "keyB",
+            "api_mode": "chat_completions",
+        },
+    ]
+}
+
+
+def _shared_url_agent(name="slomerex-alt"):
+    agent = types.SimpleNamespace(
+        model="grok-4",
+        provider="custom",
+        requested_provider=f"custom:{name}",
+        base_url=SHARED_URL,
+        api_mode="chat_completions",
+        reasoning_config=None,
+        service_tier=None,
+    )
+    return agent
+
+
+class TestSharedBaseUrlRecovery:
+    def test_persist_keeps_the_requested_identity_not_the_first_url_owner(
+        self, monkeypatch
+    ):
+        """_runtime_model_config must persist custom:slomerex-alt (the
+        requested identity), not heal through the URL to custom:slomerex-grok
+        (the first URL owner)."""
+        monkeypatch.setattr(rp, "load_config", lambda: SHARED_URL_CONFIG)
+
+        from tui_gateway.server import _runtime_model_config
+
+        config = _runtime_model_config(_shared_url_agent("slomerex-alt"))
+
+        assert config["provider"] == "custom:slomerex-alt"
+        assert config["base_url"] == SHARED_URL
+
+    def test_round_trip_restores_the_second_entries_key(self, monkeypatch):
+        """persist → stored-overrides → _make_agent must resolve keyB, the
+        second entry's credential, not keyA of the first URL owner."""
+        monkeypatch.setattr(rp, "load_config", lambda: SHARED_URL_CONFIG)
+
+        from tui_gateway.server import (
+            _runtime_model_config,
+            _stored_session_runtime_overrides,
+        )
+
+        model_config = _runtime_model_config(_shared_url_agent("slomerex-alt"))
+        row = {
+            "model": "grok-4",
+            "model_config": json.dumps(model_config),
+        }
+        overrides = _stored_session_runtime_overrides(row)
+        assert overrides["model_override"]["provider"] == "custom:slomerex-alt"
+
+        kwargs = _make_agent_with_override(
+            overrides["model_override"], monkeypatch, SHARED_URL_CONFIG
+        )
+
+        assert kwargs["base_url"] == SHARED_URL
+        assert kwargs["api_key"] == "keyB"
+
+    def test_first_entry_still_recovers_its_own_key(self, monkeypatch):
+        """The first URL owner keeps resolving its own credential too."""
+        monkeypatch.setattr(rp, "load_config", lambda: SHARED_URL_CONFIG)
+
+        from tui_gateway.server import (
+            _runtime_model_config,
+            _stored_session_runtime_overrides,
+        )
+
+        model_config = _runtime_model_config(_shared_url_agent("slomerex-grok"))
+        row = {
+            "model": "grok-4",
+            "model_config": json.dumps(model_config),
+        }
+        overrides = _stored_session_runtime_overrides(row)
+        assert overrides["model_override"]["provider"] == "custom:slomerex-grok"
+
+        kwargs = _make_agent_with_override(
+            overrides["model_override"], monkeypatch, SHARED_URL_CONFIG
+        )
+
+        assert kwargs["base_url"] == SHARED_URL
+        assert kwargs["api_key"] == "keyA"
 
 
 # --- Regression: bare "custom" WITHOUT a base_url (GH #44022 / #47714) ------

--- a/tests/tui_gateway/test_custom_provider_session_persistence.py
+++ b/tests/tui_gateway/test_custom_provider_session_persistence.py
@@ -167,6 +167,14 @@ class TestResumeRoundTrip:
 
         kwargs = _make_agent_with_override(override, monkeypatch, LEGACY_LIST_CONFIG)
 
+        # The rebuild must recover the entry identity from the stored
+        # base_url — restoring these assertions (they were dropped when the
+        # #81789 change landed, leaving an empty test body; #44022/#47714
+        # guard). `requested_provider="custom"` is in the exclusion set, so
+        # the base_url heal path is what must carry the recovery.
+        assert kwargs["base_url"] == MIMO_URL
+        assert kwargs["api_key"] == MIMO_KEY
+
 
 # --- Issue #81789: two providers sharing one base_url, different api_keys ----
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2769,14 +2769,16 @@ def _ensure_session_db_row(session: dict) -> None:
     # (the very first DB write for a fresh desktop session, before the agent is
     # built) is the origin of the recurring "No LLM provider configured" rows:
     # on the next resume bare "custom" routes to OpenRouter with no key. Recover
-    # the durable ``custom:<name>`` identity from the override's base_url, else
-    # the configured provider, so a routable identity is persisted from the
-    # start (matches _runtime_model_config's normalization).
+    # the durable ``custom:<name>`` identity from the override's provider (when
+    # it already names a real entry), else its base_url, else the configured
+    # provider, so a routable identity is persisted from the start (matches
+    # _runtime_model_config's normalization).
     if str(model_config.get("provider") or "").strip().lower() == "custom":
         try:
             from hermes_cli.runtime_provider import canonical_custom_identity
 
             healed = canonical_custom_identity(
+                requested_provider=override.get("requested_provider"),
                 base_url=model_config.get("base_url") or None,
                 model=model_config.get("model") or row_model or None,
             )
@@ -3751,7 +3753,13 @@ def _stored_session_runtime_overrides(row: dict | None) -> dict:
             from hermes_cli.runtime_provider import canonical_custom_identity
 
             healed = canonical_custom_identity(
-                base_url=base_url or None, model=model or None
+                # The persisted provider (``custom:<name>`` when the row was
+                # written by a fixed build) is the most precise identity — it
+                # disambiguates two entries sharing one base_url with different
+                # api_keys, which the URL reverse-lookup cannot (issue #81789).
+                requested_provider=provider or None,
+                base_url=base_url or None,
+                model=model or None,
             )
         except Exception:
             logger.debug(
@@ -3804,12 +3812,14 @@ def _runtime_model_config(agent, existing: dict | None = None) -> dict:
             # later resume/rebuild cannot re-resolve the entry's credentials
             # (the api_key is deliberately never persisted; see
             # _stored_session_runtime_overrides). Recover the canonical
-            # ``custom:<name>`` menu key from the endpoint URL when present,
-            # else from the configured provider — this second fallback is the
-            # fix for sessions built WITHOUT a base_url on the override (the
-            # recurring Desktop/TUI "No LLM provider configured" regression:
-            # bare "custom" with no base_url was persisted verbatim and routed
-            # to OpenRouter with no key on the next resume).
+            # ``custom:<name>`` menu key from the agent's REQUESTED identity
+            # first (it disambiguates two entries sharing one base_url with
+            # different api_keys — issue #81789), else the endpoint URL when
+            # present, else the configured provider — these later fallbacks
+            # are the fix for sessions built WITHOUT a base_url on the
+            # override (the recurring Desktop/TUI "No LLM provider configured"
+            # regression: bare "custom" with no base_url was persisted verbatim
+            # and routed to OpenRouter with no key on the next resume).
             try:
                 from hermes_cli.runtime_provider import (
                     canonical_custom_identity,
@@ -3817,7 +3827,11 @@ def _runtime_model_config(agent, existing: dict | None = None) -> dict:
 
                 provider = (
                     canonical_custom_identity(
-                        base_url=base_url, model=model or None
+                        requested_provider=getattr(
+                            agent, "requested_provider", ""
+                        ),
+                        base_url=base_url,
+                        model=model or None,
                     )
                     or provider
                 )
@@ -6566,6 +6580,13 @@ def _make_agent(
         acp_command=runtime.get("command"),
         acp_args=runtime.get("args"),
         credential_pool=runtime.get("credential_pool"),
+        # Carry the REQUESTED identity (e.g. ``custom:<name>``) onto the
+        # agent so _runtime_model_config / recovery can disambiguate two
+        # custom providers that share one base_url with different api_keys
+        # (issue #81789). Without this the resolved "custom" is the only
+        # identity the agent keeps, and the next persist/recover round-trip
+        # resolves the first URL owner's key.
+        requested_provider=runtime.get("requested_provider"),
         quiet_mode=True,
         # verbose_logging controls DEBUG-level agent logging; it is intentionally
         # independent of tool_progress_mode (which only controls per-tool
@@ -12399,6 +12420,7 @@ def _model_picker_context(agent):
 
             provider = (
                 canonical_custom_identity(
+                    requested_provider=getattr(agent, "requested_provider", ""),
                     base_url=base_url or None,
                     config_provider=ctx.current_provider,
                     model=(getattr(agent, "model", "") if agent else "")


### PR DESCRIPTION
## Problem

`get_custom_provider_pool_key` deduped on `base_url` alone, so a second custom provider with the same base URL but a different api_key (multi-tenant / multi-region endpoint behind one proxy) was unreachable — recovery always picked the first entry.

## Fix

`credential_pool_matches_provider` and `get_custom_provider_pool_key` now accept `provider_name`. When supplied, name matches first (exact), base_url remains the fallback. Threads through `agent_init`, `agent_runtime_helpers`, `runtime_provider`, `main.py`, `model_setup_flows`, and `tui_gateway/server.py` so the requested identity survives the whole provider-resolution pipeline.

Preserves the #81126 fix: malformed / placeholder legacy entries still keep their raw-iteration path; same-name collisions keep the legacy entry.

## Tests

- `tests/agent/test_credential_pool.py` — 58 pass (multi-tenant disambiguation: requested name picks the right pool key).
- `tests/agent/test_credential_pool_provider_boundary.py` — 5 pass.
- `tests/agent/test_custom_pool_mismatch_guard.py` — 4 pass.
- `tests/cli/test_cli_provider_resolution.py` — 15 pass.
- `tests/hermes_cli/test_canonical_custom_identity.py` — 11 pass.
- `tests/tui_gateway/test_custom_provider_session_persistence.py` — session persistence keeps requested identity; both entries round-trip to their own keys.

Total: 93 passed, 0 failed across 5 files; plus tui_gateway session-persistence suite.

---

Fixes #81789