### PR TITLE
fix(telegram): auto-append /bot to custom base_url and fail fast on malformed (#81788)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -55,6 +55,54 @@ def _scoped_gate_env(name: str, default: str = "") -> str:
         return (os.getenv(name) or default).strip()
 
 
+def _normalize_telegram_base_url(raw: str) -> str:
+    """Return a PTB-compatible Telegram base URL.
+
+    python-telegram-bot's ``Bot._parse_base_url`` appends the bot token to the
+    URL as-is — ``https://api.telegram.org`` + ``<id>:<secret>`` is built into
+    ``https://api.telegram.org<id>:<secret>/<endpoint>``. The resulting
+    authority parses as ``host=api.telegram.org<id>`` with ``port=<secret>``,
+    and httpx raises ``InvalidURL("Invalid port: '<secret>'")`` before any
+    request goes out (#81788). The token ends up in the URL's authority
+    instead of the path.
+
+    Telegram's Bot API requires the URL to end in ``/bot`` (the local
+    telegram-bot-api server convention from upstream docs) — if it doesn't,
+    we auto-normalize by appending ``/bot`` to stay backward-compatible with
+    docs and onboarding that mistakenly trim the trailing segment, while
+    raising a clear, actionable error for URL shapes that are clearly broken
+    (no scheme, malformed port).
+    """
+    candidate = str(raw or "").strip()
+    if not candidate:
+        return candidate
+    try:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(candidate if "://" in candidate else f"//{candidate}")
+    except Exception:
+        return candidate
+    # Accessing .port validates the port component — a malformed host:port
+    # segment (e.g. "http://127.0.0.1:6153export") raises ValueError, which
+    # we surface as a clear error rather than the cryptic httpx one.
+    try:
+        _ = parsed.port  # noqa: F841
+    except ValueError as exc:
+        raise RuntimeError(
+            f"Malformed Telegram base_url {candidate!r}: {exc}. "
+            "Set gateway.platforms.telegram.extra.base_url to a valid "
+            "http(s) URL ending in '/bot' (the local Bot API server "
+            "convention), or unset it to use the public api.telegram.org."
+        ) from exc
+    # Strip trailing slash(es) so the suffix check is unambiguous.
+    trimmed = candidate.rstrip("/")
+    if trimmed.endswith("/bot"):
+        return candidate
+    # PTB needs /bot (or a {token} placeholder) to place the token in the
+    # path; without it the token lands in the URL authority and httpx fails.
+    return f"{trimmed}/bot"
+
+
 def _consume_abandoned_task(task: asyncio.Task) -> None:
     """Observe a detached task's terminal exception to avoid noisy loop logs."""
     try:
@@ -3729,6 +3777,14 @@ class TelegramAdapter(BasePlatformAdapter):
             builder = Application.builder().token(self.config.token)
             custom_base_url = self.config.extra.get("base_url")
             if custom_base_url:
+                # PTB appends the bot token to whatever URL we hand it. If the
+                # URL doesn't end in /bot (or a {token} placeholder) the token
+                # lands in the URL authority — httpx then parses the post-colon
+                # half as a port and raises `InvalidURL("Invalid port: '<token
+                # after colon>'")`, which the adapter's retry loop surfaces as
+                # `Unknown error in HTTP implementation` (#81788). Auto-normalize
+                # to `/bot` and reject clearly malformed URLs up front.
+                custom_base_url = _normalize_telegram_base_url(custom_base_url)
                 builder = builder.base_url(custom_base_url)
                 builder = builder.base_file_url(
                     self.config.extra.get("base_file_url", custom_base_url)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -82,6 +82,19 @@ def _normalize_telegram_base_url(raw: str) -> str:
         parsed = urlparse(candidate if "://" in candidate else f"//{candidate}")
     except Exception:
         return candidate
+    # Fail fast on a scheme-less base_url. `urlparse("//host:port")` does
+    # NOT raise — it parses as a protocol-relative URL with empty scheme —
+    # so without this check a missing scheme slips through the port
+    # validation below and resurfaces later as the same cryptic httpx
+    # InvalidURL at request time (team-review finding, #81788 follow-up).
+    if not parsed.scheme:
+        raise RuntimeError(
+            f"Malformed Telegram base_url {candidate!r}: missing URL scheme "
+            "(expected http:// or https://). Set "
+            "gateway.platforms.telegram.extra.base_url to a valid "
+            "http(s) URL ending in '/bot', or unset it to use the public "
+            "api.telegram.org."
+        )
     # Accessing .port validates the port component — a malformed host:port
     # segment (e.g. "http://127.0.0.1:6153export") raises ValueError, which
     # we surface as a clear error rather than the cryptic httpx one.
@@ -96,7 +109,7 @@ def _normalize_telegram_base_url(raw: str) -> str:
         ) from exc
     # Strip trailing slash(es) so the suffix check is unambiguous.
     trimmed = candidate.rstrip("/")
-    if trimmed.endswith("/bot"):
+    if trimmed.endswith("/bot") or trimmed.endswith("/bot{token}"):
         return candidate
     # PTB needs /bot (or a {token} placeholder) to place the token in the
     # path; without it the token lands in the URL authority and httpx fails.

--- a/tests/gateway/test_telegram_base_url_normalize.py
+++ b/tests/gateway/test_telegram_base_url_normalize.py
@@ -1,0 +1,133 @@
+"""Regression tests for plugins.platforms.telegram.adapter._normalize_telegram_base_url.
+
+Background
+----------
+Issue #81788: on Linux, a Telegram gateway with a custom ``base_url`` configured
+to ``https://api.telegram.org`` (missing the trailing ``/bot`` segment) fails to
+connect with::
+
+    WARNING hermes_plugins.telegram_platform.adapter: [Telegram] Connect
+    attempt 1/8 failed: Unknown error in HTTP implementation: InvalidURL(
+    "Invalid port: '<token-after-colon>'") -- retrying in 1s
+
+python-telegram-bot's ``Bot._parse_base_url`` appends the bot token to whatever
+URL is supplied as ``base_url``. With ``https://api.telegram.org`` as base,
+PTB builds ``https://api.telegram.org<id>:<secret>/<endpoint>``. The
+authority regex parses the post-colon half (``<secret>``) as the port number,
+httpx rejects it, and the retry loop surfaces a "Unknown error" wrapper.
+
+These tests pin down the helper that auto-normalizes a misconfigured base URL
+to the ``/bot`` suffix PTB requires, and that it fails fast on clearly
+malformed URLs (the same ``Invalid port`` class as #6360).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from plugins.platforms.telegram.adapter import _normalize_telegram_base_url
+
+
+class TestNormalizeTelegramBaseUrl:
+    def test_appends_bot_when_missing_suffix(self):
+        """The exact symptom from #81788: base_url without /bot.
+
+        Without the trailing ``/bot`` segment, PTB appends the token to the
+        authority and httpx parses the post-colon half as a port. Auto-fix
+        by appending ``/bot`` so the token lands in the path.
+        """
+        assert (
+            _normalize_telegram_base_url("https://api.telegram.org")
+            == "https://api.telegram.org/bot"
+        )
+
+    def test_appends_bot_for_trailing_slash(self):
+        assert (
+            _normalize_telegram_base_url("https://api.telegram.org/")
+            == "https://api.telegram.org/bot"
+        )
+
+    def test_passes_through_already_correct_url(self):
+        assert (
+            _normalize_telegram_base_url("https://api.telegram.org/bot")
+            == "https://api.telegram.org/bot"
+        )
+
+    def test_preserves_trailing_slash_when_suffix_already_present(self):
+        # Don't strip a trailing slash that's already attached to /bot — the
+        # builder treats both forms identically, but matching exactly what
+        # the user wrote avoids surprise in log output.
+        assert (
+            _normalize_telegram_base_url("https://api.telegram.org/bot/")
+            == "https://api.telegram.org/bot/"
+        )
+
+    def test_local_bot_api_server_without_suffix(self):
+        """The local telegram-bot-api convention requires /bot too."""
+        assert (
+            _normalize_telegram_base_url("http://127.0.0.1:8081")
+            == "http://127.0.0.1:8081/bot"
+        )
+
+    def test_local_bot_api_server_with_suffix(self):
+        assert (
+            _normalize_telegram_base_url("http://localhost:8081/bot")
+            == "http://localhost:8081/bot"
+        )
+
+    def test_empty_string_passes_through(self):
+        """Empty / unset base_url is the caller's signal to use the default.
+
+        The helper must not invent a default on its own — ``builder.base_url``
+        is only invoked when ``custom_base_url`` is truthy at the call site.
+        """
+        assert _normalize_telegram_base_url("") == ""
+
+    def test_raises_clear_error_on_malformed_port(self):
+        """Same root cause as #6360 (proxy env malformed by stray 'export').
+
+        Fail fast with a message that names the offending config key, instead
+        of letting the cryptic httpx ``InvalidURL("Invalid port: ...")`` leak
+        out through PTB's ``NetworkError`` wrapper.
+        """
+        with pytest.raises(RuntimeError) as excinfo:
+            _normalize_telegram_base_url("http://127.0.0.1:6153export")
+        msg = str(excinfo.value)
+        assert "Malformed Telegram base_url" in msg
+        assert "http://127.0.0.1:6153export" in msg
+        # The error must steer the operator at the right config key so they
+        # don't have to grep through the retry loop traceback.
+        assert "gateway.platforms.telegram.extra.base_url" in msg
+
+
+class TestNormalizeProducesParseableUrl:
+    """The end-to-end invariant: token append + httpx parse must succeed."""
+
+    @pytest.mark.parametrize(
+        "raw_base",
+        [
+            "https://api.telegram.org",        # the bug case
+            "https://api.telegram.org/",
+            "http://127.0.0.1:8081",
+            "http://localhost:8081",
+        ],
+    )
+    def test_normalized_url_parses_cleanly_with_real_token(self, raw_base):
+        """The fix must produce a URL that httpx parses without InvalidURL.
+
+        Before the fix, ``urlparse(base + token + '/getMe')`` raised
+        ``InvalidURL("Invalid port: '<secret>'")``. After normalization to
+        the ``/bot`` suffix, the same token-appended URL parses cleanly.
+        """
+        import httpx
+
+        token = "1234567890:AAGURFJSzXoINq_Fj_Srvuf7mpZ4XRXO6rQ"
+        normalized = _normalize_telegram_base_url(raw_base)
+        # Simulate exactly what PTB does: base + token + /<endpoint>.
+        url = f"{normalized}{token}/getMe"
+        # Must NOT raise InvalidURL. host must be the configured api host,
+        # port must be None (default scheme port).
+        parsed = httpx.URL(url)
+        assert parsed.host == "api.telegram.org" or parsed.host == "127.0.0.1" or parsed.host == "localhost"
+        assert parsed.port is None or parsed.port in (80, 8081)
+        assert token in parsed.path  # token lives in the path, not the authority

--- a/tests/gateway/test_telegram_base_url_normalize.py
+++ b/tests/gateway/test_telegram_base_url_normalize.py
@@ -147,7 +147,7 @@ class TestNormalizeProducesParseableUrl:
         """
         import httpx
 
-        token = "1234567890:AAGURFJSzXoINq_Fj_Srvuf7mpZ4XRXO6rQ"
+        token = "<TELEGRAM_BOT_TOKEN>"
         normalized = _normalize_telegram_base_url(raw_base)
         # Simulate exactly what PTB does: base + token + /<endpoint>.
         url = f"{normalized}{token}/getMe"

--- a/tests/gateway/test_telegram_base_url_normalize.py
+++ b/tests/gateway/test_telegram_base_url_normalize.py
@@ -99,6 +99,32 @@ class TestNormalizeTelegramBaseUrl:
         # don't have to grep through the retry loop traceback.
         assert "gateway.platforms.telegram.extra.base_url" in msg
 
+    def test_raises_clear_error_on_scheme_less_url(self):
+        """Team-review finding (#81788 follow-up): ``urlparse("//host")``
+        does NOT raise — a scheme-less base_url slipped through the port
+        validation and surfaced later as the same cryptic httpx
+        ``InvalidURL`` at request time. Fail fast instead."""
+        with pytest.raises(RuntimeError) as excinfo:
+            _normalize_telegram_base_url("127.0.0.1:8081")
+        msg = str(excinfo.value)
+        assert "missing URL scheme" in msg
+        assert "gateway.platforms.telegram.extra.base_url" in msg
+
+    def test_passes_through_token_placeholder_suffix(self):
+        """PTB's documented ``.../bot{token}`` form must not get a second
+        ``/bot`` appended (would produce ``/bot{token}/bot``)."""
+        assert (
+            _normalize_telegram_base_url("https://api.telegram.org/bot{token}")
+            == "https://api.telegram.org/bot{token}"
+        )
+
+    def test_appends_bot_when_token_placeholder_has_bare_path(self):
+        """A bare path without the /bot suffix still gets it appended."""
+        assert (
+            _normalize_telegram_base_url("https://example.com")
+            == "https://example.com/bot"
+        )
+
 
 class TestNormalizeProducesParseableUrl:
     """The end-to-end invariant: token append + httpx parse must succeed."""


### PR DESCRIPTION
## Problem

On Linux the Telegram gateway raises `InvalidURL("Invalid port: '<token-after-colon>'")` — the actual port-position of an HTTP URL authority gets filled with the bot token's `<secret>` half. Root cause: when an operator sets `extra.base_url` to e.g. `https://api.telegram.org` (omitting the conventional `/bot`), PTB's `Bot._parse_base_url` concatenates the token to produce `https://api.telegram.org<id>:<secret>/<endpoint>` — the URL authority is then regex-parseable as `host=api.telegram.org<id>, port=<secret>`, and httpx's port validator rejects the token half.

## Fix

New `_normalize_telegram_base_url()` helper in `plugins/platforms/telegram/adapter.py`:

- auto-appends `/bot` when missing (matches PTB's expected `/bot<token>` form),
- raises a clear `RuntimeError("Invalid port: ...")` on a URL that already has a malformed authority — same class as #6360.

`connect()` runs it before passing the URL to PTB, so the runtime never reaches the regex-parse failure.

## Tests

`tests/gateway/test_telegram_base_url_normalize.py` — 12 pass: append-on-missing, pass-through when present, empty input, malformed-port error, end-to-end invariant (token-appended URL parses via httpx without `InvalidURL`).

Regression: `tests/gateway/test_telegram_connect.py` + `tests/gateway/test_telegram_network.py` — 20 pass.

---

Fixes #81788