### PR TITLE
test(lsp): don't hardcode /usr/bin/npm in the install-target filter

### DIFF
--- a/tests/agent/lsp/test_install_and_lint_fixes.py
+++ b/tests/agent/lsp/test_install_and_lint_fixes.py
@@ -45,16 +45,19 @@ def test_install_npm_works_without_extras(tmp_path, monkeypatch):
     from agent.lsp import install as install_mod
 
     monkeypatch.setattr(install_mod.subprocess, "run", fake_run)
-    monkeypatch.setattr(install_mod.shutil, "which", lambda c: "/usr/bin/npm" if c == "npm" else None)
+    # _install_npm resolves npm via find_node_executable, not shutil.which;
+    # on Windows that scans PATH directly (finding e.g. C:\...\npm.cmd), so
+    # mock the resolver itself to keep the command deterministic everywhere.
+    monkeypatch.setattr(install_mod, "find_node_executable", lambda _cmd: "/usr/bin/npm")
 
     install_mod._install_npm("pyright", "pyright-langserver")
 
     cmd = captured["cmd"]
+    assert cmd[0] == "/usr/bin/npm"
     assert "pyright" in cmd
     # Should not blow up when extra_pkgs is omitted/None
-    install_targets = [c for c in cmd if not c.startswith("-") and c not in {
+    install_targets = [c for c in cmd[1:] if not c.startswith("-") and c not in {
         "install", "--prefix", str(install_mod.hermes_lsp_bin_dir().parent),
-        "/usr/bin/npm",
     }]
     assert install_targets == ["pyright"]
 


### PR DESCRIPTION
## What does this PR do?

Fixes a Windows-only failure in `tests/agent/lsp/test_install_and_lint_fixes.py::test_install_npm_works_without_extras`.

The test mocks `shutil.which` so npm resolves to `/usr/bin/npm`, but `_install_npm` actually resolves npm via `find_node_executable` (`agent/lsp/install.py`). On Windows that resolver scans `PATH` directly and never consults `shutil.which`, so on any Windows machine with a real npm the constructed command starts with an absolute launcher path like `C:\...\npm.cmd`. The install-target filter only excluded the literal `/usr/bin/npm`, so the resolved npm path leaked in as an unexpected install target:

```
AssertionError: assert ['D:\\Users\\...\\npm.cmd', 'pyright'] == ['pyright']
```

The fix mocks `find_node_executable` itself — the resolver `_install_npm` actually uses — so the constructed command is deterministic on every platform, pins `cmd[0]`, and filters install targets from `cmd[1:]` instead of matching a hardcoded npm path.

Related: #77896 makes the same `shutil.which` → `find_node_executable` mock swap, but as one line inside a larger runtime change to Windows npm launcher provenance. This PR is the minimal test-only fix so the suite passes on Windows independently of that PR's fate; if #77896 lands first, the overlap is a single line.

## Related Issue

No tracking issue exists — searched PRs and issues for "test lsp npm windows", `"/usr/bin/npm"`, and the test name; nothing covers this test failure (closest is #77896, discussed above).

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/agent/lsp/test_install_and_lint_fixes.py` (`test_install_npm_works_without_extras`): mock `agent.lsp.install.find_node_executable` instead of `shutil.which`; assert `cmd[0] == "/usr/bin/npm"`; build `install_targets` from `cmd[1:]` and drop the hardcoded `/usr/bin/npm` entry from the exclusion set.

## How to Test

1. On Windows with node/npm on `PATH`, run `python -m pytest tests/agent/lsp/test_install_and_lint_fixes.py::test_install_npm_works_without_extras` on `main` → fails with the `AssertionError` above.
2. Re-run on this branch → passes.
3. Whole file: `python -m pytest tests/agent/lsp/test_install_and_lint_fixes.py -q` → `5 passed`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`test(lsp): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (one test, +6/−3)
- [ ] I've run `pytest tests/ -q` and all tests pass — partial: on Windows I ran this file (5/5 passed on the PR branch) and all of `tests/agent/lsp/` (59 passed, 1 failed: `test_workspace.py::test_normalize_path_expands_tilde`, which is pre-existing and unrelated — it fails identically on a clean tree without this change, HOME vs USERPROFILE tilde expansion; happy to file it separately)
- [x] I've added tests for my changes (the change is itself test code)
- [x] I've tested on my platform: Windows 11 (Python 3.11.15, pytest 9.1.1); with the resolver mocked, the test is hermetic on POSIX too

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (test-only change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — this *is* a Windows-compatibility fix; POSIX behavior unchanged
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before (Windows, `main`):

```
FAILED tests/agent/lsp/test_install_and_lint_fixes.py::test_install_npm_works_without_extras
AssertionError: assert ['D:\\Users\\qasims\\node-v22.21.1-win-x64\\npm.cmd', 'pyright'] == ['pyright']
```

After (this branch, same machine):

```
5 passed in 11.72s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)