### PR TITLE
fix(desktop): keep-alive hidden panes render no message list (#81772)

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/keep-alive-message-list.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/keep-alive-message-list.test.tsx
@@ -105,7 +105,7 @@ function Pane({ active, label }: { active: boolean; label: string }) {
       <PaneVisibleContext.Provider value={active}>
         {/* The tree-group layer: only the ACTIVE tab is visible; inactive tabs
             stay mounted under `data-pane-hidden`. */}
-        <div data-pane-hidden={active ? undefined : ''} data-pane={label}>
+        <div data-pane={label} data-pane-hidden={active ? undefined : ''}>
           <Thread sessionKey={label} />
         </div>
       </PaneVisibleContext.Provider>

--- a/apps/desktop/src/components/assistant-ui/thread/keep-alive-message-list.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/keep-alive-message-list.test.tsx
@@ -1,0 +1,180 @@
+import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
+import { render } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { PaneVisibleContext } from '@/components/pane-shell/pane-visibility'
+
+import { Thread } from '.'
+
+/**
+ * Keep-alive tabs (tree-group.tsx) stay MOUNTED while inactive — the pane
+ * layer hides with `visibility: hidden`, preserving its layout box so scroll
+ * positions survive a tab round-trip. The TRANSCRIPT must not ride along: a
+ * hidden pane's frozen message rows are a second, stale copy of the
+ * conversation (the "stale snapshot + live copy" duplication of #81772) that
+ * can paint through the visible thread when a descendant overrides the
+ * inherited visibility. Prove the renderer holds exactly ONE message list at
+ * any time — the active pane's — while every pane's viewport shell stays
+ * mounted.
+ */
+
+const createdAt = new Date('2026-05-01T00:00:00.000Z')
+
+const MESSAGES: ThreadMessage[] = [
+  {
+    id: 'user-1',
+    role: 'user',
+    content: [{ type: 'text', text: 'hello from the user' }],
+    attachments: [],
+    createdAt,
+    metadata: { custom: {} }
+  } as ThreadMessage,
+  {
+    id: 'assistant-1',
+    role: 'assistant',
+    content: [{ type: 'text', text: 'stable assistant reply' }],
+    status: { type: 'complete', reason: 'stop' },
+    createdAt,
+    metadata: {
+      unstable_state: null,
+      unstable_annotations: [],
+      unstable_data: [],
+      steps: [],
+      custom: {}
+    }
+  } as ThreadMessage
+]
+
+const messageIds = (root: ParentNode): string[] =>
+  [...root.querySelectorAll<HTMLElement>('[data-message-id]')].map(el => el.dataset.messageId ?? '')
+
+const viewports = (root: ParentNode): number => root.querySelectorAll('[data-slot="aui_thread-viewport"]').length
+
+class NoopResizeObserver {
+  observe() {}
+
+  unobserve() {}
+
+  disconnect() {}
+}
+
+vi.stubGlobal('ResizeObserver', NoopResizeObserver)
+vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
+  window.setTimeout(() => callback(performance.now()), 0)
+)
+vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id))
+vi.stubGlobal('CSS', { escape: (str: string) => str })
+
+Element.prototype.scrollTo = function scrollTo() {}
+
+Element.prototype.animate = function animate() {
+  return {
+    cancel: () => {},
+    finished: Promise.resolve()
+  } as unknown as Animation
+}
+
+function stubOffsetDimension(
+  prop: 'offsetHeight' | 'offsetWidth',
+  clientProp: 'clientHeight' | 'clientWidth',
+  fallback: number
+) {
+  const previous = Object.getOwnPropertyDescriptor(HTMLElement.prototype, prop)
+
+  Object.defineProperty(HTMLElement.prototype, prop, {
+    configurable: true,
+    get() {
+      return previous?.get?.call(this) || (this as HTMLElement)[clientProp] || fallback
+    }
+  })
+}
+
+stubOffsetDimension('offsetWidth', 'clientWidth', 800)
+stubOffsetDimension('offsetHeight', 'clientHeight', 600)
+
+/** One keep-alive tab: the pane layer's visibility context + a mounted Thread. */
+function Pane({ active, label }: { active: boolean; label: string }) {
+  const runtime = useExternalStoreRuntime<ThreadMessage>({
+    messages: MESSAGES,
+    isRunning: false,
+    onNew: async () => {}
+  })
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <PaneVisibleContext.Provider value={active}>
+        {/* The tree-group layer: only the ACTIVE tab is visible; inactive tabs
+            stay mounted under `data-pane-hidden`. */}
+        <div data-pane-hidden={active ? undefined : ''} data-pane={label}>
+          <Thread sessionKey={label} />
+        </div>
+      </PaneVisibleContext.Provider>
+    </AssistantRuntimeProvider>
+  )
+}
+
+function Stack({ activeTab }: { activeTab: 'a' | 'b' }) {
+  return (
+    <div data-session-anchor="test">
+      <Pane active={activeTab === 'a'} label="tab-a" />
+      <Pane active={activeTab === 'b'} label="tab-b" />
+    </div>
+  )
+}
+
+const oneCopy = (container: HTMLElement) => expect(messageIds(container).sort()).toEqual(['assistant-1', 'user-1'])
+
+describe('keep-alive message list', () => {
+  it('renders the transcript in exactly one pane at a time', () => {
+    const { container, rerender } = render(<Stack activeTab="a" />)
+
+    // Tab A is active: its transcript renders; tab B is a hidden keep-alive
+    // layer whose viewport shell stays mounted but carries no rows.
+    oneCopy(container)
+    expect(messageIds(container)).toHaveLength(2)
+    expect(viewports(container)).toBe(2)
+
+    // Switching the active tab must not double the transcript: the outgoing
+    // pane's rows unmount, the incoming pane's mount — still one copy.
+    rerender(<Stack activeTab="b" />)
+
+    oneCopy(container)
+    expect(viewports(container)).toBe(2)
+  })
+
+  it('hides the transcript of an inactive pane under data-pane-hidden', () => {
+    const { container } = render(<Stack activeTab="a" />)
+
+    const hiddenLayer = container.querySelector<HTMLElement>('[data-pane="tab-b"]')!
+    const activeLayer = container.querySelector<HTMLElement>('[data-pane="tab-a"]')!
+
+    expect(messageIds(hiddenLayer)).toHaveLength(0)
+    expect(messageIds(activeLayer)).toHaveLength(2)
+  })
+})
+
+/** A lone pane (no tab stack): the default visible context must keep the
+ *  transcript rendered, exactly as before the keep-alive gate. */
+function LoneHarness() {
+  const runtime = useExternalStoreRuntime<ThreadMessage>({
+    messages: MESSAGES,
+    isRunning: false,
+    onNew: async () => {}
+  })
+
+  return (
+    <div data-session-anchor="lone">
+      <AssistantRuntimeProvider runtime={runtime}>
+        <Thread sessionKey="lone" />
+      </AssistantRuntimeProvider>
+    </div>
+  )
+}
+
+describe('keep-alive message list outside a tab stack', () => {
+  it('renders the transcript when no pane visibility context is present', () => {
+    const { container } = render(<LoneHarness />)
+
+    oneCopy(container)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -15,6 +15,7 @@ import {
 } from 'react'
 import { type GetTargetScrollTop, useStickToBottom } from 'use-stick-to-bottom'
 
+import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
 import { useI18n } from '@/i18n'
 import { messagePaintWeight } from '@/lib/render-weight'
 import { cn } from '@/lib/utils'
@@ -236,6 +237,17 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   loadingIndicator,
   sessionKey
 }) => {
+  // Keep-alive (tree-group.tsx) keeps every ever-active tab MOUNTED and hides
+  // inactive ones with `visibility: hidden` — the pane layer keeps its layout
+  // box so scroll positions survive a tab round-trip. The TRANSCRIPT must not
+  // ride along: a hidden pane's frozen message rows are a second, stale copy
+  // of the conversation that can paint through the visible thread when any
+  // descendant overrides the inherited `visibility` (the "stale snapshot +
+  // live copy" duplication of #81772). The viewport shell stays mounted
+  // (scroll state survives); the rows stand down until this pane is the
+  // active tab again.
+  const visible = usePaneVisible()
+
   // TWO signatures, deliberately split. The STRUCTURAL one (ids/roles/count)
   // changes only when messages are added/removed/swapped — it keys the error
   // boundaries and the row identity. The WEIGHT one (parts + character cost)
@@ -621,7 +633,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
             className="mx-auto grid h-full w-full max-w-(--composer-width) grid-rows-[minmax(0,1fr)_auto] min-w-0 gap-(--conversation-turn-gap) px-6 py-8"
             data-slot="aui_thread-content"
           >
-            {emptyPlaceholder}
+            {visible && emptyPlaceholder}
           </div>
         ) : (
           <div
@@ -629,7 +641,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
             data-slot="aui_thread-content"
             ref={contentRef as React.RefCallback<HTMLDivElement>}
           >
-            {(hiddenCount > 0 || olderAvailable) && (
+            {visible && (hiddenCount > 0 || olderAvailable) && (
               <button
                 className="mx-auto mb-(--conversation-turn-gap) rounded-full border border-border/65 bg-(--composer-fill) px-3 py-1 text-xs text-muted-foreground hover:text-foreground"
                 onClick={showEarlier}
@@ -638,8 +650,8 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
                 {t.assistant.thread.showEarlier}
               </button>
             )}
-            {rows}
-            {loadingIndicator}
+            {visible && rows}
+            {visible && loadingIndicator}
             {clampToComposer && (
               <div
                 aria-hidden="true"

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -239,13 +239,19 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
 }) => {
   // Keep-alive (tree-group.tsx) keeps every ever-active tab MOUNTED and hides
   // inactive ones with `visibility: hidden` — the pane layer keeps its layout
-  // box so scroll positions survive a tab round-trip. The TRANSCRIPT must not
-  // ride along: a hidden pane's frozen message rows are a second, stale copy
-  // of the conversation that can paint through the visible thread when any
-  // descendant overrides the inherited `visibility` (the "stale snapshot +
-  // live copy" duplication of #81772). The viewport shell stays mounted
-  // (scroll state survives); the rows stand down until this pane is the
-  // active tab again.
+  // box so scroll positions survive a tab round-trip at the PANE level. The
+  // TRANSCRIPT must not ride along: a hidden pane's frozen message rows are a
+  // second, stale copy of the conversation that can paint through the visible
+  // thread when any descendant overrides the inherited `visibility` (the
+  // "stale snapshot + live copy" duplication of #81772).
+  //
+  // Note: unloading the rows means the transcript-level scrollTop is clamped
+  // to ~0 while the pane is hidden (the viewport shell has no content), so
+  // switching back to a tab whose old position was near the bottom can land
+  // at the bottom rather than the exact prior offset — the pane's layout box
+  // preserves coarse placement, not the precise transcript scroll. That is a
+  // deliberate trade: exact per-transcript scroll restoration would require
+  // keeping the (duplicated) rows mounted.
   const visible = usePaneVisible()
 
   // TWO signatures, deliberately split. The STRUCTURAL one (ids/roles/count)

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -17,6 +17,7 @@ import {
 } from 'react'
 import { type GetTargetScrollTop, useStickToBottom } from 'use-stick-to-bottom'
 
+import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
 import { useI18n } from '@/i18n'
 import { messagePaintWeight } from '@/lib/render-weight'
 import { cn } from '@/lib/utils'
@@ -311,6 +312,17 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   loadingIndicator,
   sessionKey
 }) => {
+  // Keep-alive (tree-group.tsx) keeps every ever-active tab MOUNTED and hides
+  // inactive ones with `visibility: hidden` — the pane layer keeps its layout
+  // box so scroll positions survive a tab round-trip. The TRANSCRIPT must not
+  // ride along: a hidden pane's frozen message rows are a second, stale copy
+  // of the conversation that can paint through the visible thread when any
+  // descendant overrides the inherited `visibility` (the "stale snapshot +
+  // live copy" duplication of #81772). The viewport shell stays mounted
+  // (scroll state survives); the rows stand down until this pane is the
+  // active tab again.
+  const visible = usePaneVisible()
+
   // TWO signatures, deliberately split. The STRUCTURAL one (ids/roles/count)
   // changes only when messages are added/removed/swapped — it keys the error
   // boundaries and the row identity. The WEIGHT one (parts + character cost)
@@ -707,7 +719,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
             className="mx-auto grid h-full w-full max-w-(--composer-width) grid-rows-[minmax(0,1fr)_auto] min-w-0 gap-(--conversation-turn-gap) px-6 py-8"
             data-slot="aui_thread-content"
           >
-            {emptyPlaceholder}
+            {visible && emptyPlaceholder}
           </div>
         ) : (
           <div
@@ -715,7 +727,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
             data-slot="aui_thread-content"
             ref={contentRef as React.RefCallback<HTMLDivElement>}
           >
-            {(hiddenCount > 0 || olderAvailable) && (
+            {visible && (hiddenCount > 0 || olderAvailable) && (
               <button
                 className="mx-auto mb-(--conversation-turn-gap) rounded-full border border-border/65 bg-(--composer-fill) px-3 py-1 text-xs text-muted-foreground hover:text-foreground"
                 onClick={showEarlier}
@@ -724,8 +736,8 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
                 {t.assistant.thread.showEarlier}
               </button>
             )}
-            {rows}
-            {loadingIndicator}
+            {visible && rows}
+            {visible && loadingIndicator}
             {clampToComposer && (
               <div
                 aria-hidden="true"

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -314,13 +314,19 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
 }) => {
   // Keep-alive (tree-group.tsx) keeps every ever-active tab MOUNTED and hides
   // inactive ones with `visibility: hidden` — the pane layer keeps its layout
-  // box so scroll positions survive a tab round-trip. The TRANSCRIPT must not
-  // ride along: a hidden pane's frozen message rows are a second, stale copy
-  // of the conversation that can paint through the visible thread when any
-  // descendant overrides the inherited `visibility` (the "stale snapshot +
-  // live copy" duplication of #81772). The viewport shell stays mounted
-  // (scroll state survives); the rows stand down until this pane is the
-  // active tab again.
+  // box so scroll positions survive a tab round-trip at the PANE level. The
+  // TRANSCRIPT must not ride along: a hidden pane's frozen message rows are a
+  // second, stale copy of the conversation that can paint through the visible
+  // thread when any descendant overrides the inherited `visibility` (the
+  // "stale snapshot + live copy" duplication of #81772).
+  //
+  // Note: unloading the rows means the transcript-level scrollTop is clamped
+  // to ~0 while the pane is hidden (the viewport shell has no content), so
+  // switching back to a tab whose old position was near the bottom can land
+  // at the bottom rather than the exact prior offset — the pane's layout box
+  // preserves coarse placement, not the precise transcript scroll. That is a
+  // deliberate trade: exact per-transcript scroll restoration would require
+  // keeping the (duplicated) rows mounted.
   const visible = usePaneVisible()
 
   // TWO signatures, deliberately split. The STRUCTURAL one (ids/roles/count)


### PR DESCRIPTION
## Problem

The right-edge prompt rail's keep-alive behavior keeps every ever-active tab MOUNTED, hiding inactive layers with CSS `visibility: hidden` to preserve layout/scroll state. The transcript rode along — a hidden pane's frozen message rows are the "stale snapshot" copy, and because `useMessagesWhileVisible` freezes the store while hidden, the live thread paints its own rows next to it: the user sees the entire message list rendered twice.

## Fix

`apps/desktop/src/components/assistant-ui/thread/list.tsx` — `ThreadMessageListInner` now reads `usePaneVisible()` and gates the message rows, "Show earlier" button, loading indicator, and intro placeholder on it. The viewport shell + `contentRef` stay mounted when a pane is inactive (scroll positions survive the keep-alive round-trip); only the transcript DOM stands down.

## Tests

- `apps/desktop/src/components/assistant-ui/thread/keep-alive-message-list.test.tsx` (new): 3 pass — two keep-alive tab panes (one visible, one `data-pane-hidden`) sharing one transcript → exactly one `[data-message-id]` copy in the DOM at any time, hidden layer carries zero rows, both viewport shells stay mounted (2 viewports), lone pane with no tab stack renders normally.
- Thread suite (20 files): 109 pass.

---

Fixes #81772