### PR TITLE
fix(install): reject npm 11.10-11.16 on Windows desktop bootstrap

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -388,7 +388,10 @@ $NodeVersion = "22"
 # when install.ps1 is piped straight from the web).  Get-NpmRange prefers the
 # manifest whenever it does exist, so a drifted constant self-corrects on any
 # run against an existing checkout.
-$NpmRange = ">=12.0.0"
+# Keep in sync with root package.json engines.npm. npm 11.10-11.16 honor
+# min-release-age but ignore min-release-age-exclude (see .npmrc), so that
+# band is excluded. Node 22's bundled npm 10.x satisfies the left arm.
+$NpmRange = "<11.10.0 || >=11.17.0"
 
 # Stage-protocol version.  Bumped only for genuinely breaking changes to the
 # manifest schema, stage-name set semantics, or stdout JSON shape.  Adding a
@@ -818,12 +821,12 @@ function Get-NpmRange {
 
 # Upgrade the Hermes-managed Node tree's bundled npm into $NpmRange.
 #
-# The nodejs.org zip ships whatever npm that Node major bundles -- Node 26.5.1
-# bundles npm 11.17.0, one minor below the root package.json's own
-# `engines.npm` floor of >=12.  The repo .npmrc sets `engine-strict=true`, so
-# that is fatal rather than a warning and a brand-new install dies at the first
-# `npm ci` with EBADENGINE.  Provision the right npm here instead of reacting
-# to the failure later.
+# The nodejs.org zip ships whatever npm that Node major bundles.  Node 24.x
+# currently ships npm 11.16.x, which sits inside the engines.npm exclusion
+# band.  The repo .npmrc sets `engine-strict=true`, so that is fatal rather
+# than a warning and a brand-new install dies at the first `npm ci` with
+# EBADENGINE.  Provision the right npm here instead of reacting to the
+# failure later.
 #
 # Three details are load-bearing, mirroring _nb_ensure_bundled_npm_range in
 # scripts/lib/node-bootstrap.sh and upgrade_managed_npm in
@@ -844,18 +847,22 @@ function Update-ManagedNpm {
 
     $range = Get-NpmRange
 
-    # Skip the network round-trip when the bundled npm already satisfies the
-    # range.  Only the ">=N" shape we actually author is parsed; anything more
-    # exotic falls through to letting npm itself decide.
-    if ($range -match '^>=(\d+)') {
-        $want = [int]$Matches[1]
-        try {
-            $have = (& $npmCmd --version 2>$null)
-            if ($have -match '^(\d+)') {
-                if ([int]$Matches[1] -ge $want) { return $true }
+    # Skip the network round-trip when the bundled npm already works with this
+    # repo's .npmrc / engines.npm.  Test-NpmSupportsNpmrc covers the compound
+    # range we author; a plain ">=N" floor is still enforced numerically.
+    try {
+        $have = (& $npmCmd --version 2>$null)
+        if (Test-NpmSupportsNpmrc $have) {
+            if ($range -match '^>=(\d+)') {
+                $want = [int]$Matches[1]
+                if ($have -match '^(\d+)' -and [int]$Matches[1] -ge $want) {
+                    return $true
+                }
+            } else {
+                return $true
             }
-        } catch { }
-    }
+        }
+    } catch { }
 
     Write-Info "Upgrading bundled npm to satisfy $range ..."
 
@@ -1437,18 +1444,79 @@ function Test-NodeVersionOk {
     return ($v.Major -gt 22)
 }
 
+# Mirror of install.sh's npm_supports_npmrc.  npm 11.10.0-11.16.x honor
+# `min-release-age` but ignore `min-release-age-exclude`, both of which
+# `.npmrc` sets.  That combination applies the 14-day age gate to packages
+# we deliberately exempted, so every install fails ETARGET (or EBADENGINE
+# under engine-strict) on a freshly published dependency.  Returns $true
+# when the npm is usable with this repo.
+function Test-NpmSupportsNpmrc {
+    param([string]$Version)
+    if (-not $Version) { return $false }
+    try {
+        $v = [version]($Version -replace '^v', '' -replace '-.*$', '')
+    } catch {
+        return $false
+    }
+    # The bad band is 11.10.0 through 11.16.x.
+    if ($v.Major -eq 11 -and $v.Minor -ge 10 -and $v.Minor -le 16) {
+        return $false
+    }
+    return $true
+}
+
+# Resolve a runnable npm and return its --version string, or $null.
+# Prefer npm.cmd so PowerShell execution policy cannot reject npm.ps1.
+function Get-NpmVersion {
+    $npmCmd = Get-Command npm.cmd -ErrorAction SilentlyContinue
+    if (-not $npmCmd) {
+        $npmCmd = Get-Command npm -ErrorAction SilentlyContinue
+    }
+    if (-not $npmCmd) { return $null }
+
+    $prevEAP = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = "Continue"
+        $ver = & $npmCmd.Source --version 2>$null
+        if ($LASTEXITCODE -ne 0) { return $null }
+        $ver = [string]$ver
+        if ([string]::IsNullOrWhiteSpace($ver)) { return $null }
+        return $ver.Trim()
+    } catch {
+        return $null
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
+}
+
 function Test-Node {
     Write-Info "Checking Node.js (for browser tools)..."
 
+    # The system toolchain is only usable when BOTH halves work: a Node new
+    # enough for the desktop build AND an npm that can read our .npmrc.  A
+    # bad-band npm (see Test-NpmSupportsNpmrc) fails `npm ci` with EBADENGINE
+    # under engine-strict -- the exact Windows desktop-install failure when
+    # Node 24.x ships with npm 11.16.x.  Fall through to Hermes-managed Node
+    # (which bundles a good npm, then Update-ManagedNpm keeps it in range).
     if (Get-Command node -ErrorAction SilentlyContinue) {
         $version = node --version
         if (Test-NodeVersionOk $version) {
             Ensure-NodeExeOnPath | Out-Null
-            Write-Success "Node.js $version found"
-            $script:HasNode = $true
-            return $true
+            $npmVersion = Get-NpmVersion
+            if ($npmVersion -and (Test-NpmSupportsNpmrc $npmVersion)) {
+                Write-Success "Node.js $version found"
+                $script:HasNode = $true
+                return $true
+            }
+            if ($npmVersion) {
+                Write-Warn "npm $npmVersion cannot honor this repo's .npmrc (npm 11.10-11.16 ignore"
+                Write-Warn "min-release-age-exclude) -- installing Hermes-managed Node $NodeVersion instead..."
+            } else {
+                Write-Warn "Node.js $version has no usable npm on PATH -- installing Hermes-managed Node $NodeVersion instead..."
+            }
+        } else {
+            Write-Warn "Node.js $version is too old (Hermes requires Node >=26)"
         }
-        Write-Warn "Node.js $version is too old (Hermes requires Node >=26)"
     }
 
     # Prefer a Hermes-managed Node from a previous run over a too-old system one.

--- a/tests/test_install_ps1_npm_band.py
+++ b/tests/test_install_ps1_npm_band.py
@@ -1,0 +1,124 @@
+"""Windows installer must reject npm 11.10-11.16 the same way install.sh does.
+
+Node 24.x currently ships with npm 11.16.x.  That band honors
+``min-release-age`` but ignores ``min-release-age-exclude`` (both set in
+``.npmrc``), so ``engine-strict=true`` turns the mismatch into a hard
+``EBADENGINE`` during the desktop ``npm ci`` stage.  POSIX ``install.sh``
+already falls through to Hermes-managed Node via ``npm_supports_npmrc``;
+``install.ps1`` must mirror that gate.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+PACKAGE_JSON = REPO_ROOT / "package.json"
+
+
+def _install_ps1() -> str:
+    return INSTALL_PS1.read_text(encoding="utf-8")
+
+
+def _root_npm_range() -> str:
+    return json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))["engines"]["npm"]
+
+
+def _npm_supports_npmrc(version: str) -> bool:
+    """Python mirror of install.ps1's Test-NpmSupportsNpmrc / install.sh's helper."""
+    ver = version.lstrip("v").split("-", 1)[0]
+    parts = ver.split(".")
+    try:
+        major = int(parts[0])
+        minor = int(parts[1]) if len(parts) > 1 else 0
+    except ValueError:
+        return False
+    if major == 11 and 10 <= minor <= 16:
+        return False
+    return True
+
+
+class TestNpmRangeConstant:
+    def test_fallback_npm_range_matches_package_json(self) -> None:
+        text = _install_ps1()
+        match = re.search(
+            r'\$NpmRange\s*=\s*"([^"]+)"',
+            text,
+        )
+        assert match is not None, "install.ps1 must define $NpmRange"
+        assert match.group(1) == _root_npm_range(), (
+            "install.ps1 $NpmRange must stay in sync with package.json "
+            "engines.npm — Test-Node runs before the repo is cloned, so the "
+            "constant is the only range Update-ManagedNpm can see on a fresh "
+            "install."
+        )
+
+
+class TestNpmSupportsNpmrcContract:
+    @pytest.mark.parametrize("bad_npm", ["11.10.0", "11.12.1", "11.16.0"])
+    def test_python_mirror_rejects_bad_band(self, bad_npm: str) -> None:
+        assert not _npm_supports_npmrc(bad_npm)
+
+    @pytest.mark.parametrize("good_npm", ["10.9.8", "11.9.9", "11.17.0", "12.0.2"])
+    def test_python_mirror_accepts_good_versions(self, good_npm: str) -> None:
+        assert _npm_supports_npmrc(good_npm)
+
+    def test_helper_function_is_wired_into_test_node(self) -> None:
+        text = _install_ps1()
+        assert "function Test-NpmSupportsNpmrc" in text
+        assert "function Get-NpmVersion" in text
+        # System Node success path must require a usable npm, not Node alone.
+        assert re.search(
+            r"function Test-Node \{[\s\S]{0,1200}?Get-NpmVersion[\s\S]{0,400}?Test-NpmSupportsNpmrc",
+            text,
+        ), "Test-Node must probe npm version and reject the 11.10-11.16 band"
+        assert "cannot honor this repo's .npmrc" in text
+
+
+@pytest.mark.skipif(
+    shutil.which("pwsh") is None and shutil.which("powershell") is None,
+    reason="PowerShell not available to execute Test-NpmSupportsNpmrc",
+)
+class TestNpmSupportsNpmrcRuntime:
+    """Execute the real PowerShell helper when a host is available."""
+
+    @staticmethod
+    def _powershell() -> str:
+        return shutil.which("pwsh") or shutil.which("powershell") or "pwsh"
+
+    def _eval(self, version: str) -> bool:
+        # Dot-source only the helper by extracting it into a tiny script, so
+        # we do not run the full installer entrypoint.
+        text = _install_ps1()
+        match = re.search(
+            r"(function Test-NpmSupportsNpmrc \{[\s\S]*?\n\})\n\nfunction Get-NpmVersion",
+            text,
+        )
+        assert match is not None, "could not extract Test-NpmSupportsNpmrc"
+        script = (
+            match.group(1)
+            + f"; if (Test-NpmSupportsNpmrc '{version}') {{ 'yes' }} else {{ 'no' }}"
+        )
+        result = subprocess.run(
+            [self._powershell(), "-NoProfile", "-NonInteractive", "-Command", script],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        return result.stdout.strip().splitlines()[-1].strip() == "yes"
+
+    @pytest.mark.parametrize("bad_npm", ["11.10.0", "11.16.0"])
+    def test_runtime_rejects_bad_band(self, bad_npm: str) -> None:
+        assert self._eval(bad_npm) is False
+
+    @pytest.mark.parametrize("good_npm", ["10.9.8", "11.17.0"])
+    def test_runtime_accepts_good_versions(self, good_npm: str) -> None:
+        assert self._eval(good_npm) is True


### PR DESCRIPTION
## Summary
- Windows desktop install fails with `EBADENGINE` when system Node 24.x ships npm `11.16.x` (inside the engines.npm exclusion band).
- `install.sh` already rejects that band via `npm_supports_npmrc` and falls through to Hermes-managed Node; `install.ps1` only checked the Node version, so it accepted a broken toolchain and died at the desktop `npm ci` stage.
- Port the same gate to `Test-Node`, refresh the stale `$NpmRange` fallback to match `package.json`, and teach `Update-ManagedNpm` to skip upgrades when npm is already outside the bad band.

## Test plan
- [x] `scripts/run_tests.sh tests/test_install_ps1_npm_band.py tests/test_install_ps1_node_path_for_npm.py tests/test_engines_satisfiable.py -q`
- [ ] On Windows 11 with system Node 24.x / npm 11.16.x, rerun the desktop installer and confirm it installs Hermes-managed Node instead of failing at `desktop workspace npm install`
- [ ] Confirm a system toolchain with npm 10.x or >=11.17 still reports `Node.js ... found` and continues
