### PR TITLE
fix(desktop): jump to the prompt turn, not its stuck bubble (#81768)

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/timeline-idle.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline-idle.test.tsx
@@ -133,6 +133,70 @@ describe('ThreadTimeline below the threshold', () => {
   })
 })
 
+describe('ThreadTimeline marker click', () => {
+  // jumpScroll animates over ~170ms via requestAnimationFrame. Drive each
+  // callback synchronously with a far-future timestamp so one step lands the
+  // final scrollTop (p = min(1, Δt/170) = 1 on the first frame).
+  const stubRaf = () => {
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: (now: number) => void) => {
+        callback(performance.now() + 1000)
+
+        return 1
+      })
+    )
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('scrolls the viewport to the clicked prompt turn, measured in-flow (#81768)', () => {
+    messages = transcript(6)
+    stubRaf()
+    // jsdom ships no CSS.escape; the rail's measure effect queries
+    // `[data-message-id="…"]` through it on mount.
+    vi.stubGlobal('CSS', { escape: (value: string) => value })
+
+    const { container } = render(
+      <div data-session-anchor="workspace">
+        <div data-slot="aui_thread-viewport" />
+        <ThreadTimeline />
+      </div>
+    )
+
+    const viewport = container.querySelector<HTMLElement>('[data-slot="aui_thread-viewport"]')!
+    viewport.getBoundingClientRect = () => ({ top: 100 } as DOMRect)
+    Object.defineProperty(viewport, 'scrollTop', { configurable: true, writable: true, value: 400 })
+
+    // Each prompt is a sticky bubble pinned to the viewport top (~4px); its
+    // turn container keeps the in-flow position (1200px into the transcript).
+    // The regression: the old code measured the PINNED bubble (top ≈ 104) and
+    // computed a ~0px jump, so every old marker's click was a silent no-op.
+    for (const message of messages) {
+      const turn = document.createElement('div')
+      const bubble = document.createElement('div')
+      bubble.style.position = 'sticky'
+      bubble.dataset.messageId = message.id
+      turn.appendChild(bubble)
+      viewport.appendChild(turn)
+      turn.getBoundingClientRect = () => ({ top: 1200 } as DOMRect)
+      bubble.getBoundingClientRect = () => ({ top: 104 } as DOMRect)
+    }
+
+    const ticks = container.querySelectorAll('[data-slot="thread-timeline-ticks"] button')
+    expect(ticks).toHaveLength(6)
+
+    fireEvent.click(ticks[0])
+
+    // 400 + 1200 - 100 - 8 = 1492: the turn's in-flow position, offset 8px
+    // above the viewport top — not the bubble's pinned 104px.
+    expect(viewport.scrollTop).toBe(1492)
+  })
+})
+
 describe('ThreadTimeline while a reply streams', () => {
   it('does not re-derive the rail as assistant content grows', () => {
     messages = [...transcript(6), { content: [{ text: 'th', type: 'text' }], id: 'a1', role: 'assistant' }]

--- a/apps/desktop/src/components/assistant-ui/thread/timeline.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline.test.ts
@@ -1,6 +1,6 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { ownViewport } from './timeline'
+import { inFlowAncestor, ownViewport, promptJumpTop } from './timeline'
 
 /**
  * Several chat surfaces are mounted at once — side by side in a split, and
@@ -38,5 +38,93 @@ describe('ownViewport', () => {
     document.body.innerHTML = '<div data-slot="aui_thread-viewport" id="viewport-lone"></div>'
 
     expect(ownViewport(null)?.id).toBe('viewport-lone')
+  })
+})
+
+describe('inFlowAncestor', () => {
+  it('returns the node itself when it is not sticky', () => {
+    const node = document.createElement('div')
+    document.body.appendChild(node)
+
+    expect(inFlowAncestor(node)).toBe(node)
+  })
+
+  it('walks up past a sticky bubble to its in-flow turn container', () => {
+    const turn = document.createElement('div')
+    turn.style.position = 'static'
+    const bubble = document.createElement('div')
+    bubble.style.position = 'sticky'
+    bubble.style.top = '4px'
+    turn.appendChild(bubble)
+    document.body.appendChild(turn)
+
+    expect(inFlowAncestor(bubble)).toBe(turn)
+  })
+
+  it('walks through nested sticky ancestors until an in-flow element is found', () => {
+    const turn = document.createElement('div')
+    turn.style.position = 'static'
+    const mid = document.createElement('div')
+    mid.style.position = 'sticky'
+    const bubble = document.createElement('div')
+    bubble.style.position = 'sticky'
+    mid.appendChild(bubble)
+    turn.appendChild(mid)
+    document.body.appendChild(turn)
+
+    expect(inFlowAncestor(bubble)).toBe(turn)
+  })
+})
+
+describe('promptJumpTop', () => {
+  const setRect = (element: HTMLElement, top: number) => {
+    element.getBoundingClientRect = vi.fn(() => ({ top } as DOMRect))
+  }
+
+  it('targets the prompt turn, offset 8px above the viewport top', () => {
+    const viewport = document.createElement('div')
+    setRect(viewport, 100)
+    Object.defineProperty(viewport, 'scrollTop', { configurable: true, value: 400 })
+    const turn = document.createElement('div')
+    setRect(turn, 50)
+    const bubble = document.createElement('div')
+    bubble.style.position = 'sticky'
+    turn.appendChild(bubble)
+    viewport.appendChild(turn)
+
+    expect(promptJumpTop(viewport, bubble)).toBe(400 + 50 - 100 - 8)
+  })
+
+  it('measures the in-flow ancestor of a sticky prompt, not its pinned rect', () => {
+    const viewport = document.createElement('div')
+    setRect(viewport, 100)
+    Object.defineProperty(viewport, 'scrollTop', { configurable: true, value: 400 })
+    const turn = document.createElement('div')
+    turn.style.position = 'static'
+    // The stuck bubble pins to the viewport top (~4px) even though its turn
+    // sits 1500px below the viewport — the old code computed 400+104-100-8≈396
+    // (a dead ~4px nudge), the fix lands on the turn's real position.
+    const bubble = document.createElement('div')
+    bubble.style.position = 'sticky'
+    setRect(bubble, 104)
+    setRect(turn, 1600)
+    turn.appendChild(bubble)
+    viewport.appendChild(turn)
+
+    expect(promptJumpTop(viewport, bubble)).toBe(400 + 1600 - 100 - 8)
+  })
+
+  it('clamps the target at zero', () => {
+    const viewport = document.createElement('div')
+    setRect(viewport, 100)
+    Object.defineProperty(viewport, 'scrollTop', { configurable: true, value: 0 })
+    const turn = document.createElement('div')
+    setRect(turn, 0)
+    const bubble = document.createElement('div')
+    bubble.style.position = 'sticky'
+    turn.appendChild(bubble)
+    viewport.appendChild(turn)
+
+    expect(promptJumpTop(viewport, bubble)).toBe(0)
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
@@ -110,6 +110,29 @@ function jumpScroll(viewport: HTMLElement, top: number, duration = 170): void {
 export const ownViewport = (root: HTMLElement | null): HTMLElement | null =>
   (root?.closest('[data-session-anchor]') ?? document).querySelector<HTMLElement>(VIEWPORT)
 
+// User prompts are `position: sticky` — once scrolled past, the bubble pins to
+// the viewport top (--sticky-human-top), so its OWN rect reads ~4px for every
+// old prompt and a click on its marker would compute delta ≈ 0: the dead-click
+// #81768. Measure the nearest in-flow ancestor (the turn container) instead.
+export function inFlowAncestor(node: HTMLElement): HTMLElement {
+  let el: HTMLElement | null = node
+
+  while (el && getComputedStyle(el).position === 'sticky') {
+    el = el.parentElement
+  }
+
+  return el ?? node
+}
+
+/** Scroll target (viewport-relative scrollTop) that brings the prompt's turn
+ *  into view — measured from its in-flow position, not its stuck rect. */
+export function promptJumpTop(viewport: HTMLElement, node: HTMLElement): number {
+  const anchor = inFlowAncestor(node)
+  const top = viewport.scrollTop + (anchor.getBoundingClientRect().top - viewport.getBoundingClientRect().top) - 8
+
+  return Math.max(0, top)
+}
+
 function scrollToPrompt(root: HTMLElement | null, id: string) {
   const viewport = ownViewport(root)
   const node = viewport?.querySelector<HTMLElement>(`[data-message-id="${CSS.escape(id)}"]`)
@@ -118,10 +141,8 @@ function scrollToPrompt(root: HTMLElement | null, id: string) {
     return
   }
 
-  const top = viewport.scrollTop + (node.getBoundingClientRect().top - viewport.getBoundingClientRect().top) - 8
-
   triggerHaptic('selection')
-  jumpScroll(viewport, Math.max(0, top))
+  jumpScroll(viewport, promptJumpTop(viewport, node))
 }
 
 /**


### PR DESCRIPTION
Fixes #81768

## Problem

Clicking the right-edge prompt-rail marker did nothing — measured the `data-message-id` element's `getBoundingClientRect()`, but that element is the user prompt bubble with `position: sticky; top: var(--sticky-human-top)` (~4px). Once scrolled past, its rect reads the pinned position for every old prompt, so the computed scroll delta was ≈0.

## Fix

`apps/desktop/src/components/assistant-ui/thread/timeline.tsx` — `scrollToPrompt` now:

- calls `inFlowAncestor()` — walks up past any `position: sticky` ancestors to the nearest in-flow element,
- then `promptJumpTop()` — computes the viewport-relative scroll target from that anchor's rect.

Now the jump lands on the actual turn position, not the pinned sticky bubble.

## Tests

- `apps/desktop/src/components/assistant-ui/thread/timeline.test.ts` and `timeline-idle.test.tsx` — 17 pass. New integration test clicks a marker and asserts the viewport scrolls to the turn's real position (1492, not the dead ~396); confirmed it FAILS without the fix (stash check) and passes with it.
- Thread suite: 113 pass.
- `tsc --noEmit -p tsconfig.json`: clean.

---

Fixes #81768
