### PR TITLE
fix(terminal): honor pty=true in foreground execution (#81756)

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -15,7 +15,7 @@ class _TestableEnv(BaseEnvironment):
     def __init__(self, cwd="/tmp", timeout=10):
         super().__init__(cwd=cwd, timeout=timeout)
 
-    def _run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None):
+    def _run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None, use_pty=False):
         raise NotImplementedError("Use mock")
 
     def cleanup(self):
@@ -272,7 +272,7 @@ class TestSnapshotFileModes:
             def get_temp_dir(self):
                 return self._temp_dir
 
-            def _run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None):
+            def _run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None, use_pty=False):
                 proc = subprocess.Popen(
                     ["/bin/bash", "-lc", cmd_string],
                     stdout=subprocess.PIPE,
@@ -382,7 +382,7 @@ class TestInitSessionFailure:
 
         calls = []
 
-        def track_run_bash(cmd, *, login=False, timeout=120, stdin_data=None):
+        def track_run_bash(cmd, *, login=False, timeout=120, stdin_data=None, use_pty=False):
             calls.append({"login": login})
             mock = MagicMock()
             mock.poll.return_value = 0

--- a/tests/tools/test_terminal_foreground_pty.py
+++ b/tests/tools/test_terminal_foreground_pty.py
@@ -1,0 +1,352 @@
+"""Foreground PTY support (issue #81756).
+
+``pty=true`` used to be honored only by the background path
+(``process_registry.spawn_local(use_pty=...)``); the foreground path called
+``env.execute()`` with no PTY flag, so interactive CLIs silently ran on
+pipes.  These tests pin the new plumbing:
+
+- ``terminal_tool`` forwards ``pty`` to ``env.execute(use_pty=...)``.
+- ``LocalEnvironment._run_bash`` spawns via ``_spawn_pty_process`` when
+  ``use_pty`` is set (and falls back to pipes when PTY is unavailable).
+- ``_PtyProcessHandle`` adapts a ptyprocess/pywinpty handle to the
+  ``ProcessHandle`` protocol so the shared ``_wait_for_process`` machinery
+  (drain, interrupt, timeout) works unchanged.
+"""
+
+import json
+import os
+import sys
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import tools.environments.base as base_module
+import tools.terminal_tool as terminal_tool_module
+from tools.environments.base import _PtyProcessHandle
+from tools.environments.local import LocalEnvironment
+
+
+# =========================================================================
+# _PtyProcessHandle
+# =========================================================================
+
+
+class _FakePtyProc:
+    """Duck-typed stand-in for ptyprocess.PtyProcess / winpty.PtyProcess."""
+
+    def __init__(self, chunks, exitstatus=0, pid=4242):
+        self._chunks = list(chunks)
+        self.exitstatus = exitstatus
+        self.pid = pid
+        self.alive = True
+
+    def isalive(self):
+        return self.alive
+
+    def read(self, _n):
+        if self._chunks:
+            return self._chunks.pop(0)
+        self.alive = False
+        raise EOFError
+
+    def wait(self):
+        self.alive = False
+        return self.exitstatus
+
+    def terminate(self, force=False):
+        self.alive = False
+
+
+class TestPtyProcessHandle:
+    def test_streams_output_and_exit_code(self):
+        pty = _FakePtyProc([b"caf\xc3", b"\xa9\n", b"done\n"], exitstatus=3)
+        handle = _PtyProcessHandle(pty)
+        out = handle.stdout.read()
+        assert out == "café\ndone\n"
+        assert handle.wait(timeout=5) == 3
+        assert handle.returncode == 3
+        assert handle.poll() == 3
+
+    def test_pid_exposed(self):
+        handle = _PtyProcessHandle(_FakePtyProc([b"x"], pid=777))
+        assert handle.pid == 777
+
+    def test_kill_terminates_pty(self):
+        pty = _FakePtyProc([], pid=888)
+        handle = _PtyProcessHandle(pty)
+        handle.kill()
+        assert pty.alive is False
+
+    def test_poll_none_while_running(self):
+        """poll() must return None while the PTY child is still alive so the
+        shared _wait_for_process poll loop keeps waiting."""
+
+        class _ForeverPty:
+            def __init__(self):
+                self.alive = True
+
+            def isalive(self):
+                return self.alive
+
+            def read(self, _n):
+                return b"x" * 100
+
+            def wait(self):
+                self.alive = False
+                return 0
+
+            def terminate(self, force=False):
+                self.alive = False
+
+        pty = _ForeverPty()
+        handle = _PtyProcessHandle(pty)
+        # Drain the pipe so the reader thread never blocks on a full buffer.
+        drainer = threading.Thread(
+            target=lambda: handle.stdout.read(), daemon=True
+        )
+        drainer.start()
+        try:
+            assert handle.poll() is None
+        finally:
+            handle.kill()
+
+
+def test_spawn_pty_process_uses_configured_shell_and_env(monkeypatch):
+    captured = {}
+
+    class _FakeCls:
+        @classmethod
+        def spawn(cls, argv, cwd=None, env=None, dimensions=(24, 80)):
+            captured["argv"] = argv
+            captured["cwd"] = cwd
+            captured["env"] = env
+            captured["dimensions"] = dimensions
+            return _FakePtyProc([b"hi\n"], pid=999)
+
+    monkeypatch.setattr(base_module.platform, "system", lambda: "Linux")
+    fake_module = SimpleNamespace(PtyProcess=_FakeCls)
+    with patch.dict("sys.modules", {"ptyprocess": fake_module}):
+        handle = base_module._spawn_pty_process(
+            "echo hi",
+            cwd="/tmp",
+            run_env={"PATH": "/usr/bin", "HOME": "/root"},
+            shell="/bin/bash",
+        )
+
+    assert captured["argv"] == ["/bin/bash", "-c", "set +m; echo hi"]
+    assert captured["cwd"] == "/tmp"
+    assert captured["env"]["PYTHONUNBUFFERED"] == "1"
+    assert captured["env"]["HOME"] == "/root"
+    assert isinstance(handle, _PtyProcessHandle)
+
+
+def test_spawn_pty_process_returns_none_when_library_missing(monkeypatch):
+    monkeypatch.setattr(base_module.platform, "system", lambda: "Linux")
+    with patch("builtins.__import__", side_effect=ImportError("no ptyprocess")):
+        assert (
+            base_module._spawn_pty_process(
+                "echo hi", cwd="/tmp", run_env={}, shell="/bin/bash"
+            )
+            is None
+        )
+
+
+# =========================================================================
+# LocalEnvironment._run_bash PTY branch
+# =========================================================================
+
+
+def _make_env(tmp_path):
+    with patch.object(LocalEnvironment, "init_session", autospec=True, return_value=None):
+        env = LocalEnvironment(cwd=str(tmp_path), timeout=10)
+    return env
+
+
+class _PtyProcessHandleStub:
+    """Minimal ProcessHandle-compatible stub with a real stdout pipe."""
+
+    def __init__(self, text="pty-output\n"):
+        read_fd, write_fd = os.pipe()
+        os.write(write_fd, text.encode())
+        os.close(write_fd)
+        self._stdout = os.fdopen(read_fd, "r", encoding="utf-8", errors="replace")
+        self.returncode = 0
+
+    @property
+    def stdout(self):
+        return self._stdout
+
+    def poll(self):
+        return 0
+
+    def wait(self, timeout=None):
+        return 0
+
+    def kill(self):
+        pass
+
+
+def test_local_run_bash_uses_pty_when_requested(tmp_path, monkeypatch):
+    """use_pty=True must route through _spawn_pty_process, not Popen."""
+    env = _make_env(tmp_path)
+
+    with patch("tools.environments.local._find_bash", return_value="/bin/bash"), \
+         patch("tools.environments.base._spawn_pty_process",
+               return_value=_PtyProcessHandleStub()) as spawn_pty, \
+         patch("subprocess.Popen", side_effect=AssertionError("pipe path used for pty")):
+        proc = env._run_bash("echo hi", use_pty=True)
+
+    spawn_pty.assert_called_once()
+    captured_args, captured_kwargs = spawn_pty.call_args
+    assert captured_kwargs["shell"] == "/bin/bash"
+    assert "echo hi" in captured_args[0]
+    assert proc.poll() == 0
+
+
+def test_local_run_bash_falls_back_to_pipes_without_pty_library(tmp_path, monkeypatch):
+    """PTY library missing → pipe path, never an exception (matches the
+    background spawn_local contract)."""
+    env = _make_env(tmp_path)
+    captured = {}
+
+    def fake_popen(args, **kwargs):
+        captured["args"] = args
+        read_fd, write_fd = os.pipe()
+        os.close(write_fd)
+        proc = MagicMock()
+        proc.poll.return_value = 0
+        proc.returncode = 0
+        proc.stdout = os.fdopen(read_fd, "r", encoding="utf-8", errors="replace")
+        return proc
+
+    with patch("tools.environments.local._find_bash", return_value="/bin/bash"), \
+         patch("tools.environments.base._spawn_pty_process", return_value=None), \
+         patch("subprocess.Popen", side_effect=fake_popen):
+        proc = env._run_bash("echo hi", use_pty=True)
+
+    assert captured["args"] == ["/bin/bash", "-c", "echo hi"]
+    assert proc.poll() == 0
+
+
+def test_local_run_bash_pty_skipped_when_stdin_piped(tmp_path, monkeypatch):
+    """stdin_data and PTY are mutually exclusive — the pipe path must win so
+    ``gh auth login --with-token`` (etc.) can still receive piped input."""
+    env = _make_env(tmp_path)
+
+    with patch("tools.environments.local._find_bash", return_value="/bin/bash"), \
+         patch("tools.environments.base._spawn_pty_process") as spawn_pty, \
+         patch("subprocess.Popen") as popen:
+        env._run_bash("gh auth login --with-token", use_pty=True, stdin_data="tok\n")
+
+    spawn_pty.assert_not_called()
+    popen.assert_called_once()
+
+
+def test_local_execute_pty_end_to_end(tmp_path, monkeypatch):
+    """Full execute() with use_pty=True must return captured PTY output
+    through the shared _wait_for_process machinery."""
+    env = _make_env(tmp_path)
+
+    with patch("tools.environments.local._find_bash", return_value="/bin/bash"), \
+         patch("tools.environments.base._spawn_pty_process",
+               return_value=_PtyProcessHandleStub("hello-from-pty\n")), \
+         patch("tools.terminal_tool._interrupt_event", threading.Event()):
+        result = env.execute("echo hello", use_pty=True)
+
+    assert result["returncode"] == 0
+    assert "hello-from-pty" in result["output"]
+
+
+# =========================================================================
+# terminal_tool foreground routing
+# =========================================================================
+
+
+def _base_config(tmp_path):
+    return {
+        "env_type": "local",
+        "docker_image": "",
+        "singularity_image": "",
+        "modal_image": "",
+        "daytona_image": "",
+        "cwd": str(tmp_path),
+        "timeout": 30,
+    }
+
+
+def _run_foreground(command, config, monkeypatch, **kwargs):
+    """Run terminal_tool() foreground against a mocked env; return (result, env)."""
+    import tools.self_repo_guard as self_repo_guard
+
+    monkeypatch.setattr(self_repo_guard, "get_running_source_root", lambda: None)
+    mock_env = MagicMock()
+    mock_env.execute.return_value = {"output": "ok", "returncode": 0}
+    mock_env.cwd = config["cwd"]
+
+    from contextlib import ExitStack
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch("tools.terminal_tool._get_env_config", return_value=config)
+        )
+        stack.enter_context(patch("tools.terminal_tool._start_cleanup_thread"))
+        stack.enter_context(
+            patch("tools.terminal_tool._active_environments", {"default": mock_env})
+        )
+        stack.enter_context(patch("tools.terminal_tool._last_activity", {"default": 0}))
+        stack.enter_context(patch("tools.terminal_tool._session_cwd", {}))
+        stack.enter_context(
+            patch(
+                "tools.terminal_tool._check_all_guards",
+                return_value={"approved": True},
+            )
+        )
+        result = json.loads(terminal_tool_module.terminal_tool(command=command, **kwargs))
+    return result, mock_env
+
+
+def test_foreground_pty_true_is_forwarded_to_env_execute(monkeypatch, tmp_path):
+    """Issue #81756: foreground pty=true must reach env.execute(use_pty=True)."""
+    config = _base_config(tmp_path)
+    result, mock_env = _run_foreground(
+        "python3 -c \"print(input())\"", config, monkeypatch, pty=True
+    )
+
+    assert result["exit_code"] == 0
+    mock_env.execute.assert_called_once()
+    assert mock_env.execute.call_args.kwargs.get("use_pty") is True
+
+
+def test_foreground_pty_false_routes_to_pipes(monkeypatch, tmp_path):
+    config = _base_config(tmp_path)
+    _result, mock_env = _run_foreground(
+        "echo hello", config, monkeypatch, pty=False
+    )
+
+    mock_env.execute.assert_called_once()
+    assert mock_env.execute.call_args.kwargs.get("use_pty") is False
+
+
+def test_foreground_pty_disabled_for_pipe_stdin_command(monkeypatch, tmp_path):
+    """gh auth login --with-token needs piped stdin — PTY must be dropped in
+    foreground exactly like background, with a pty_note explaining why."""
+    config = _base_config(tmp_path)
+    result, mock_env = _run_foreground(
+        "gh auth login --hostname github.com --git-protocol https --with-token",
+        config,
+        monkeypatch,
+        pty=True,
+    )
+
+    assert mock_env.execute.call_args.kwargs.get("use_pty") is False
+    assert "pty_note" in result
+    assert "PTY disabled" in result["pty_note"]
+
+
+def test_foreground_pty_true_without_pty_flag_stays_false(monkeypatch, tmp_path):
+    """The default (no pty arg) must keep the historical pipe behavior."""
+    config = _base_config(tmp_path)
+    _result, mock_env = _run_foreground("echo hello", config, monkeypatch)
+
+    mock_env.execute.assert_called_once()
+    assert mock_env.execute.call_args.kwargs.get("use_pty") is False

--- a/tests/tools/test_terminal_task_cwd.py
+++ b/tests/tools/test_terminal_task_cwd.py
@@ -40,7 +40,7 @@ def test_foreground_command_uses_registered_task_cwd_for_existing_environment(mo
     result = json.loads(terminal_tool.terminal_tool(command="pwd", task_id=task_id))
 
     assert result["exit_code"] == 0
-    assert calls == [("pwd", {"timeout": 60, "cwd": "/workspace/acp", "bounded_capture": True})]
+    assert calls == [("pwd", {"timeout": 60, "cwd": "/workspace/acp", "bounded_capture": True, "use_pty": False})]
 
 
 def test_explicit_workdir_still_wins_over_registered_task_cwd(monkeypatch):
@@ -73,7 +73,7 @@ def test_explicit_workdir_still_wins_over_registered_task_cwd(monkeypatch):
     )
 
     assert result["exit_code"] == 0
-    assert calls == [{"timeout": 60, "cwd": "/explicit/workdir", "bounded_capture": True}]
+    assert calls == [{"timeout": 60, "cwd": "/explicit/workdir", "bounded_capture": True, "use_pty": False}]
 
 
 def test_explicit_workdir_does_not_persist_into_session_cwd(monkeypatch):

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -10,6 +10,7 @@ import codecs
 import json
 import logging
 import os
+import platform
 import re
 import select
 import shlex
@@ -20,7 +21,7 @@ import uuid
 from abc import ABC, abstractmethod
 from collections import deque
 from pathlib import Path
-from typing import IO, Callable, Iterable, Protocol
+from typing import IO, Any, Callable, Iterable, Protocol
 
 from hermes_constants import get_hermes_home
 from hermes_cli._subprocess_compat import windows_hide_flags
@@ -466,6 +467,155 @@ class _ThreadedProcessHandle:
         return self._returncode
 
 
+class _PtyProcessHandle:
+    """ProcessHandle adapter for a PTY-spawned foreground process.
+
+    Wraps a ptyprocess (POSIX) / pywinpty (Windows) PtyProcess so the shared
+    ``BaseEnvironment._wait_for_process`` machinery — non-blocking pipe drain,
+    interrupt handling, timeout kill — works unchanged.  A reader thread
+    mirrors the PTY master into an ``os.pipe()``; ``poll()``/``kill()``/
+    ``wait()`` delegate to the PtyProcess handle.
+    """
+
+    def __init__(self, pty_proc: Any):
+        self._pty = pty_proc
+        self._done = threading.Event()
+        self._returncode: int | None = None
+
+        read_fd, write_fd = os.pipe()
+        self._stdout = os.fdopen(read_fd, "r", encoding="utf-8", errors="replace")
+        self._write_fd = write_fd
+
+        def _reader():
+            try:
+                while self._isalive():
+                    try:
+                        chunk = self._pty.read(4096)
+                    except EOFError:
+                        break
+                    except Exception:
+                        break
+                    if not chunk:
+                        break
+                    # ptyprocess returns bytes; pywinpty returns str.
+                    if isinstance(chunk, str):
+                        chunk = chunk.encode("utf-8", errors="replace")
+                    try:
+                        os.write(self._write_fd, chunk)
+                    except OSError:
+                        break
+            finally:
+                try:
+                    self._pty.wait()
+                    self._returncode = (
+                        self._pty.exitstatus
+                        if hasattr(self._pty, "exitstatus")
+                        and self._pty.exitstatus is not None
+                        else -1
+                    )
+                except Exception:
+                    self._returncode = -1
+                try:
+                    os.close(self._write_fd)
+                except OSError:
+                    pass
+                self._done.set()
+
+        t = threading.Thread(target=_reader, daemon=True)
+        t.name = "pty-fg-reader"
+        t.start()
+
+    @property
+    def pid(self) -> int | None:
+        """Return the underlying PTY process PID, if known."""
+        try:
+            return int(self._pty.pid)
+        except Exception:
+            return None
+
+    def _isalive(self) -> bool:
+        try:
+            return bool(self._pty.isalive())
+        except Exception:
+            return False
+
+    @property
+    def stdout(self):
+        return self._stdout
+
+    @property
+    def returncode(self) -> int | None:
+        return self._returncode
+
+    def poll(self) -> int | None:
+        return self._returncode if self._done.is_set() else None
+
+    def kill(self):
+        """Terminate the PTY session (SIGTERM→SIGKILL on POSIX, TerminateProcess
+        on Windows).  The child is the session leader, so this reaches the whole
+        command tree."""
+        try:
+            if self._isalive():
+                self._pty.terminate(force=True)
+        except Exception:
+            pass
+
+    def wait(self, timeout: float | None = None) -> int:
+        self._done.wait(timeout=timeout)
+        return self._returncode
+
+
+def _spawn_pty_process(
+    command: str,
+    cwd: str,
+    run_env: dict,
+    shell: str,
+    login: bool = False,
+    dimensions: tuple[int, int] = (30, 120),
+) -> "_PtyProcessHandle | None":
+    """Spawn *command* under a pseudo-terminal, or None when PTY is unavailable.
+
+    Shared by the foreground terminal path (LocalEnvironment) and the
+    background path (process_registry) so both surfaces honor ``pty=true``
+    with identical semantics.  On POSIX uses ``ptyprocess``; on Windows uses
+    ``pywinpty`` (ConPTY).  Returns None instead of raising so callers can
+    fall back to pipe mode with a warning — same contract as
+    ``process_registry.spawn_local``.
+    """
+    if not run_env:
+        run_env = {}
+    pty_env = dict(run_env)
+    pty_env["PYTHONUNBUFFERED"] = "1"
+    try:
+        if platform.system() == "Windows":
+            from winpty import PtyProcess as _PtyProcessCls
+        else:
+            from ptyprocess import PtyProcess as _PtyProcessCls
+    except ImportError:
+        logger.warning("ptyprocess/winpty not installed, falling back to pipe mode")
+        return None
+
+    # ``set +m`` mirrors the background PTY spawn: disable job control so
+    # job-control messages ("no job control in this shell") never pollute
+    # captured output.
+    argv = (
+        [shell, "-l", "-c", f"set +m; {command}"]
+        if login
+        else [shell, "-c", f"set +m; {command}"]
+    )
+    try:
+        pty_proc = _PtyProcessCls.spawn(
+            argv,
+            cwd=cwd,
+            env=pty_env,
+            dimensions=dimensions,
+        )
+    except Exception as e:
+        logger.warning("PTY spawn failed (%s), falling back to pipe mode", e)
+        return None
+    return _PtyProcessHandle(pty_proc)
+
+
 # ---------------------------------------------------------------------------
 # CWD marker for remote backends
 # ---------------------------------------------------------------------------
@@ -606,10 +756,17 @@ class BaseEnvironment(ABC):
         login: bool = False,
         timeout: int = 120,
         stdin_data: str | None = None,
+        use_pty: bool = False,
     ) -> ProcessHandle:
         """Spawn a bash process to run *cmd_string*.
 
-        Returns a ProcessHandle (subprocess.Popen or _ThreadedProcessHandle).
+        ``use_pty=True`` requests a pseudo-terminal for the child (interactive
+        CLIs, line-buffered output).  Only the local backend honors it; remote
+        backends accept and ignore the flag so the foreground ``execute`` path
+        can thread it unconditionally.
+
+        Returns a ProcessHandle (subprocess.Popen, _ThreadedProcessHandle, or
+        _PtyProcessHandle).
         Must be overridden by every backend.
         """
         raise NotImplementedError(f"{type(self).__name__} must implement _run_bash()")
@@ -1322,6 +1479,7 @@ class BaseEnvironment(ABC):
         stdin_data: str | None = None,
         rewrite_compound_background: bool = True,
         bounded_capture: bool = False,
+        use_pty: bool = False,
     ) -> dict:
         """Execute a command, return {"output": str, "returncode": int}.
 
@@ -1333,6 +1491,13 @@ class BaseEnvironment(ABC):
         full-fidelity consumers — file operations ``cat`` reads that feed
         the patch engine, code-execution RPC reads, log reads — MUST leave
         it False: truncating those corrupts data, not just display.
+
+        ``use_pty=True`` runs the command under a pseudo-terminal so
+        interactive CLIs and line-buffered output behave as they would in a
+        real terminal.  Only the local backend implements it; remote backends
+        ignore the flag (their transports have no PTY concept).  When the
+        platform's PTY library is unavailable the local backend falls back to
+        pipe mode rather than failing the command.
         """
         self._before_execute()
 
@@ -1366,7 +1531,8 @@ class BaseEnvironment(ABC):
         login = not self._snapshot_ready and not self._prefer_nonlogin
 
         proc = self._run_bash(
-            wrapped, login=login, timeout=effective_timeout, stdin_data=effective_stdin
+            wrapped, login=login, timeout=effective_timeout,
+            stdin_data=effective_stdin, use_pty=use_pty,
         )
         result = self._wait_for_process(
             proc, timeout=effective_timeout, bounded_capture=bounded_capture

--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -218,7 +218,8 @@ class DaytonaEnvironment(BaseEnvironment):
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
-                  stdin_data: str | None = None):
+                  stdin_data: str | None = None,
+                  use_pty: bool = False):
         """Return a _ThreadedProcessHandle wrapping a blocking Daytona SDK call."""
         sandbox = self._sandbox
         lock = self._lock

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -1595,7 +1595,8 @@ class DockerEnvironment(BaseEnvironment):
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
-                  stdin_data: str | None = None) -> subprocess.Popen:
+                  stdin_data: str | None = None,
+                  use_pty: bool = False) -> subprocess.Popen:
         """Spawn a bash process inside the Docker container."""
         assert self._container_id, "Container not started"
         cmd = [self._docker_exe, "exec"]

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1485,7 +1485,8 @@ class LocalEnvironment(BaseEnvironment):
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
-                  stdin_data: str | None = None) -> subprocess.Popen:
+                  stdin_data: str | None = None,
+                  use_pty: bool = False):
         bash = _find_bash()
         # For login-shell invocations (used by init_session to build the
         # environment snapshot), prepend sources for the user's bashrc /
@@ -1500,6 +1501,27 @@ class LocalEnvironment(BaseEnvironment):
         args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
         run_env = _make_run_env(self.env)
 
+        # PTY mode: interactive CLIs and line-buffered output need a real
+        # pseudo-terminal (issue #81756 — foreground pty=true used to be
+        # silently ignored).  stdin cannot be piped through a PTY, so the
+        # pipe-stdin path and PTY mode are mutually exclusive; callers with
+        # stdin_data get the pipe path below.
+        if use_pty and stdin_data is None:
+            from tools.environments.base import _spawn_pty_process
+
+            pty_proc = _spawn_pty_process(
+                cmd_string,
+                cwd=_resolve_safe_cwd(self.cwd),
+                run_env=run_env,
+                shell=bash,
+                login=login,
+            )
+            if pty_proc is not None:
+                return pty_proc
+            # PTY unavailable → fall through to the pipe path (same contract
+            # as process_registry.spawn_local: warn and degrade, never fail).
+
+        _popen_cwd = _resolve_safe_cwd(self.cwd)
         # Recover when the cwd has been deleted out from under us — usually by
         # a previous tool call that ran ``rm -rf`` on its own working dir
         # (issue #17558).  Popen would otherwise raise FileNotFoundError on
@@ -1510,22 +1532,19 @@ class LocalEnvironment(BaseEnvironment):
         # POSIX paths (``/c/Users/...``) to native form so a perfectly valid
         # ``pwd -P`` result from bash isn't mistakenly treated as "missing"
         # and spammed as a warning on every command.
-        safe_cwd = _resolve_safe_cwd(self.cwd)
-        if safe_cwd != self.cwd:
+        if _popen_cwd != self.cwd:
             # MSYS → Windows translation alone shouldn't surface as a warning
             # (it's a benign normalization, not a recovery). Only warn when
             # the directory really doesn't exist on disk.
             normalized = _msys_to_windows_path(self.cwd) if _IS_WINDOWS else self.cwd
-            if safe_cwd != normalized:
+            if _popen_cwd != normalized:
                 logger.warning(
                     "LocalEnvironment cwd %r is missing on disk; "
                     "falling back to %r so terminal commands keep working.",
                     self.cwd,
-                    safe_cwd,
+                    _popen_cwd,
                 )
-            self.cwd = safe_cwd
-
-        _popen_cwd = self.cwd
+            self.cwd = _popen_cwd
 
         _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
 

--- a/tools/environments/modal.py
+++ b/tools/environments/modal.py
@@ -407,7 +407,8 @@ class ModalEnvironment(BaseEnvironment):
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
-                  stdin_data: str | None = None):
+                  stdin_data: str | None = None,
+                  use_pty: bool = False):
         """Return a _ThreadedProcessHandle wrapping an async Modal sandbox exec."""
         sandbox = self._sandbox
         worker = self._worker

--- a/tools/environments/modal_utils.py
+++ b/tools/environments/modal_utils.py
@@ -81,6 +81,7 @@ class BaseModalExecutionEnvironment(BaseEnvironment):
         stdin_data: str | None = None,
         rewrite_compound_background: bool = True,
         bounded_capture: bool = False,
+        use_pty: bool = False,
     ) -> dict:
         # Managed/remote modal transports execute commands via explicit transport
         # and do not rely on shell background rewriters. Keep parameter for
@@ -91,6 +92,10 @@ class BaseModalExecutionEnvironment(BaseEnvironment):
         # remote function's result in one payload, so streaming-time bounding
         # does not apply; the terminal tool's final truncation still caps it.
         _ = bounded_capture
+        # use_pty: accepted for signature parity; remote transports have no
+        # PTY concept, so the flag is ignored (foreground pty=true is honored
+        # only by the local backend — issue #81756).
+        _ = use_pty
         self._before_execute()
         prepared = self._prepare_modal_exec(
             command,

--- a/tools/environments/singularity.py
+++ b/tools/environments/singularity.py
@@ -234,7 +234,8 @@ class SingularityEnvironment(BaseEnvironment):
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
-                  stdin_data: str | None = None) -> subprocess.Popen:
+                  stdin_data: str | None = None,
+                  use_pty: bool = False) -> subprocess.Popen:
         """Spawn a bash process inside the Singularity instance."""
         if not self._instance_started:
             raise RuntimeError("Singularity instance not started")

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -393,7 +393,8 @@ class SSHEnvironment(BaseEnvironment):
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
-                  stdin_data: str | None = None) -> subprocess.Popen:
+                  stdin_data: str | None = None,
+                  use_pty: bool = False) -> subprocess.Popen:
         """Spawn an SSH process that runs bash on the remote host."""
         cmd = self._build_ssh_command()
         if login:

--- a/tools/environments/vercel_sandbox.py
+++ b/tools/environments/vercel_sandbox.py
@@ -601,6 +601,7 @@ class VercelSandboxEnvironment(BaseEnvironment):
         login: bool = False,
         timeout: int = 120,
         stdin_data: str | None = None,
+        use_pty: bool = False,
     ):
         """Run a bash command in the Vercel sandbox.
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3079,6 +3079,12 @@ def terminal_tool(
                         # Internal env.execute() consumers (file ops cat
                         # reads, RPC reads) intentionally stay unbounded.
                         "bounded_capture": True,
+                        # Foreground pty=true was silently ignored before
+                        # #81756: the execute path never carried the flag, so
+                        # interactive CLIs ran on pipes. LocalEnvironment now
+                        # honors it (ptyprocess/pywinpty); remote backends
+                        # accept and ignore it.
+                        "use_pty": effective_pty,
                     }
                     result = env.execute(command, **execute_kwargs)
                 except Exception as e:
@@ -3305,6 +3311,8 @@ def terminal_tool(
                 result_dict["sudo_auth_failed"] = True
             if sudo_cache_cleared:
                 result_dict["sudo_cache_cleared"] = True
+            if pty_disabled_reason:
+                result_dict["pty_note"] = pty_disabled_reason
 
             return json.dumps(result_dict, ensure_ascii=False)
 


### PR DESCRIPTION
## Problem

`pty=true` was silently ignored in the foreground execution path: `terminal_tool()`'s foreground call to `env.execute(command, **execute_kwargs)` passed no PTY flag, while only the background `spawn_local(use_pty=...)` honored `pty=true`. Operators got piped (line-buffered, no signal forwarding) output for foreground commands even with `pty=true`.

## Fix

`tools/terminal_tool.py` foreground now passes `use_pty=effective_pty` to `env.execute`; `pty_note` surfaced on the foreground result when PTY is dropped for pipe-stdin commands (matches the background contract).

`tools/environments/base.py` — new `_PtyProcessHandle` (pipe-backed stdout + poll/wait/kill/pid over `ptyprocess`/`pywinpty`) and `_spawn_pty_process()` (shared helper; sets `set +m`, exports `PYTHONUNBUFFERED`). `use_pty` threaded through `execute()` → `_run_bash()`.

`tools/environments/local.py` — `_run_bash` spawns via PTY when `use_pty and stdin_data is None`; falls back to pipes with a warning when the PTY library is unavailable (same contract as `spawn_local`).

`docker/ssh/modal/singularity/daytona/vercel_sandbox/modal_utils` accept-and-ignore `use_pty` for signature parity.

Cross-platform: POSIX uses `ptyprocess`; Windows uses `pywinpty` (ConPTY) — verified live on Windows (`sys.stdout.isatty()` returned True through the PTY, exit 0).

## Tests

`tests/tools/test_terminal_foreground_pty.py` (new) — 14 pass: foreground pty=true/false routing, `--with-token` PTY-drop + `pty_note`, `_PtyProcessHandle` behavior, local `_run_bash` PTY branch/fallback/stdin-exclusion, end-to-end `execute(use_pty=True)`.

Related suites: 64 pass. 6 pre-existing Windows failures (`test_terminal_cwd_echo`, `test_local_background_child_hang`) confirmed identical via stash on clean tree.

---

Fixes #81756