### PR TITLE
fix(tools): invert agent-visible cache paths on every relocated backend

### DIFF
--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -473,6 +473,59 @@ class TestToAgentVisiblePathPerBackend:
         assert to_agent_visible_cache_path("/etc/hosts") == "/etc/hosts"
 
 
+class TestFromAgentVisiblePathPerBackend:
+    """Inverse of TestToAgentVisiblePathPerBackend: agent-visible cache paths
+    must round-trip to the host staging file on every backend that relocates
+    the Hermes cache. Incomplete after #76577 left from_agent docker-only, so
+    modal/ssh inbound vision fell through to a cold-sandbox SourceNotFound."""
+
+    def _staged(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        (hermes_home / "attachments").mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        return str(hermes_home / "attachments" / "drop.zip")
+
+    @pytest.mark.parametrize("backend", ["docker", "modal"])
+    def test_root_hermes_roundtrips(self, tmp_path, monkeypatch, backend):
+        staged = self._staged(tmp_path, monkeypatch)
+        monkeypatch.setenv("TERMINAL_ENV", backend)
+        from tools.credential_files import (
+            from_agent_visible_cache_path,
+            to_agent_visible_cache_path,
+        )
+        visible = to_agent_visible_cache_path(staged)
+        assert visible == "/root/.hermes/attachments/drop.zip"
+        assert from_agent_visible_cache_path(visible) == staged
+
+    @pytest.mark.parametrize("backend", ["ssh", "daytona", "vercel_sandbox"])
+    def test_tilde_hermes_roundtrips(self, tmp_path, monkeypatch, backend):
+        staged = self._staged(tmp_path, monkeypatch)
+        monkeypatch.setenv("TERMINAL_ENV", backend)
+        from tools.credential_files import (
+            from_agent_visible_cache_path,
+            to_agent_visible_cache_path,
+        )
+        visible = to_agent_visible_cache_path(staged)
+        assert visible == "~/.hermes/attachments/drop.zip"
+        assert from_agent_visible_cache_path(visible) == staged
+
+    @pytest.mark.parametrize("backend", ["local", "singularity", ""])
+    def test_untranslated_backends_keep_input(self, tmp_path, monkeypatch, backend):
+        self._staged(tmp_path, monkeypatch)
+        monkeypatch.setenv("TERMINAL_ENV", backend)
+        from tools.credential_files import from_agent_visible_cache_path
+        assert (
+            from_agent_visible_cache_path("/root/.hermes/attachments/drop.zip")
+            == "/root/.hermes/attachments/drop.zip"
+        )
+
+    def test_non_cache_path_passes_through(self, tmp_path, monkeypatch):
+        self._staged(tmp_path, monkeypatch)
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        from tools.credential_files import from_agent_visible_cache_path
+        assert from_agent_visible_cache_path("/etc/hosts") == "/etc/hosts"
+
+
 class TestIterCacheFiles:
     """Tests for iter_cache_files()."""
 

--- a/tests/tools/test_image_source.py
+++ b/tests/tools/test_image_source.py
@@ -117,6 +117,29 @@ class TestNonLocalBackendConfinement:
         assert res.origin == "file"
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "backend,visible",
+        [
+            ("modal", "/root/.hermes/cache/images/inbound.png"),
+            ("ssh", "~/.hermes/cache/images/inbound.png"),
+        ],
+    )
+    async def test_agent_visible_cache_path_host_read_without_sandbox(
+        self, tmp_path, monkeypatch, backend, visible
+    ):
+        """Gateway injects agent-visible cache paths; from_agent must invert them
+        on every relocated backend so vision host-reads without a warm sandbox."""
+        home = tmp_path / "hermes"
+        isrc = _reload(monkeypatch, home)
+        monkeypatch.setenv("TERMINAL_ENV", backend)
+        cached = home / "cache" / "images" / "inbound.png"
+        cached.parent.mkdir(parents=True)
+        cached.write_bytes(PNG)
+        res = await isrc.resolve_image_source(visible, isrc.ResolveContext())
+        assert res.data == PNG
+        assert res.origin == "file"
+
+    @pytest.mark.asyncio
     async def test_desktop_upload_images_dir_host_read(self, tmp_path, monkeypatch):
         """Desktop/clipboard uploads under ``HERMES_HOME/images`` are host-read.
 

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -474,13 +474,21 @@ def from_agent_visible_cache_path(
 ) -> str:
     """Translate a sandbox/container cache path back to its host path.
 
-    Inverse of :func:`to_agent_visible_cache_path`. Returns the input unchanged
-    when the active backend is not Docker, or when the path is not under any
+    Inverse of :func:`to_agent_visible_cache_path`. Uses the same per-backend
+    base selection so a path the gateway rendered for modal/ssh/daytona/
+    vercel_sandbox round-trips to the host staging file (the media-resolver
+    host-read fast path). Returns the input unchanged when the active backend
+    does not translate cache paths, or when the path is not under any
     auto-mounted cache directory — the caller then treats a still-container
     path as "no host file" and falls back to an in-container read.
     """
-    if os.environ.get("TERMINAL_ENV", "local") != "docker":
-        return container_path
+    backend = (os.environ.get("TERMINAL_ENV") or "local").strip().lower()
+    if backend in ("docker", "modal"):
+        pass  # /root/.hermes default
+    elif backend in ("ssh", "daytona", "vercel_sandbox"):
+        container_base = "~/.hermes"
+    else:
+        return container_path  # local, singularity, unknown: already a host path
 
     path = Path(container_path)
     for mount in get_cache_directory_mounts(container_base=container_base):

--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -120,7 +120,21 @@ async def resolve_image_source(
     # Everything else is a filesystem path — including bare relative names
     # like "pic.png" (accepted on main; a path-shape gate here regressed them).
     candidate = s[len("file://"):] if s.lower().startswith("file://") else s
-    p = Path(os.path.expanduser(candidate))
+    # Inverse-translate agent-visible cache paths BEFORE expanduser. Under
+    # ssh/daytona/vercel_sandbox the gateway injects a literal ``~/.hermes/...``
+    # remote-shell spelling; expanduser would rewrite that tilde against the
+    # *host* home, which (a) destroys the marker from_agent_visible_cache_path
+    # matches on and (b) points at the wrong tree when HERMES_HOME is a
+    # profile or other non-default location. Docker/modal ``/root/.hermes/...``
+    # paths are unchanged by expanduser; translating first is a no-op there
+    # when the inverse already ran, and still correct when it hasn't.
+    from tools.credential_files import from_agent_visible_cache_path
+
+    translated = from_agent_visible_cache_path(candidate)
+    if translated != candidate:
+        p = Path(translated)
+    else:
+        p = Path(os.path.expanduser(candidate))
     # Confinement decision (see module docstring). Under a non-local backend
     # a path is host-readable ONLY if it lands in a media cache (after
     # translating a container-visible cache path back to its host mount);


### PR DESCRIPTION
## Summary
- `to_agent_visible_cache_path` already relocates the Hermes cache for modal/ssh/daytona/vercel_sandbox, but `from_agent_visible_cache_path` stayed docker-only — so inbound vision/video on those backends missed the host-read fast path and failed closed when no warm sandbox existed.
- Translate agent-visible cache paths **before** `expanduser` so literal `~/.hermes/...` SSH spellings are not rewritten to the host home (wrong tree under profiles / non-default `HERMES_HOME`).

## Before / After
| Backend | Agent-visible path | Before | After |
|---------|--------------------|--------|-------|
| docker | `/root/.hermes/cache/images/x.png` | host-read OK | host-read OK |
| modal | `/root/.hermes/cache/images/x.png` | `SourceNotFound` (cold sandbox) | host-read OK |
| ssh | `~/.hermes/cache/images/x.png` | expanduser → wrong home → miss | host-read OK |
           