### PR TITLE
feat(net): proxy-aware + mirror-fallback fetch helper for cua-driver installer

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -151,6 +151,15 @@ jobs:
         run: |
           ruff check .
 
+      - name: Fetch content_class contract (blocking)
+        # Every production fetch_with_fallback call must explicitly declare
+        # content_class= so the supply-chain decision (may a third-party
+        # mirror supply these bytes?) is visible at the call site. A call
+        # that omits it silently relies on the executed-content default —
+        # exactly the drift that caused the #81883 mirror-fallback finding.
+        run: |
+          python scripts/check_fetch_content_class.py
+
   windows-footguns:
     # Static guardrails on Windows-unsafe Python primitives — os.kill(pid, 0),
     # os.killpg, os.setsid, signal.SIGKILL without getattr fallback,

--- a/DECISION-RECORD.md
+++ b/DECISION-RECORD.md
@@ -1,0 +1,89 @@
+# DECISION-RECORD — DNS 污染检测增强 (PR #81883 迭代)
+
+日期: 2026-08-13
+作者: x7peeps (鲸)
+PR: NousResearch/hermes-agent#81883 (feat/computer-use-net-fallback 分支迭代)
+
+## 1. Background
+
+`net_download.py`（#81883）为 Hermes 的 cua-driver 安装器等场景提供
+proxy-aware + mirror-fallback 的下载策略。在中国大陆网络环境下，除 GitHub
+类域名外，**HuggingFace 系域名（huggingface.co / hf-mirror.com）存在系统性
+DNS 污染**：系统 DNS、公共 DNS、甚至多个 DoH 服务返回的 A 记录都是垃圾 IP
+（实测解析到 Dropbox 162.125.x、Verizon 128.242.x、日本 NTT 160.16.x），
+导致 curl 直连必然失败（`Could not resolve host` / 连接超时）。
+
+现有 mirror fallback 只覆盖 GitHub URL（ghfast.top / gh-proxy.com 前缀包装），
+对 HF 域名返回空列表——HF 生态（模型元数据、weights、安装脚本）在国内
+网络下完全不可下载。
+
+## 2. Existing solutions surveyed
+
+| 方案 | 现状 | 不解决什么 |
+|---|---|---|
+| 显式代理 (HTTPS_PROXY) | 已有 (explicit_proxy) | 用户 Surge 规则对 HF 域名是 DIRECT（被墙超时），代理帮不上 |
+| 系统代理 (scutil --proxy) | 已有 (_macos_system_proxy) | 同上 |
+| GitHub 镜像 (ghfast.top/gh-proxy.com) | 已有 (mirror_candidates) | 只覆盖 github.com / raw.githubusercontent.com，对 HF URL 返回 [] |
+| hf-mirror.com 文件镜像 | 未接入 | 2026 起只镜像 `resolve/` 文件下载；**/api 与 /models 页面 308 跳回原站**，不能做 API 数据源；且其自身域名也被 DNS 污染 |
+| 本机 hosts 手工改 | 用户手工 | 不可自动化、IP 会变、每台机器都要配 |
+
+## 3. Problem decomposition
+
+| 需求 | 显式代理 | 系统代理 | GitHub 镜像 | hosts | **DoH + --resolve** |
+|---|---|---|---|---|---|
+| 覆盖 HF 域名 | ✗ (规则 DIRECT) | ✗ | ✗ | △ (手工) | **✓** |
+| 自动化、零用户配置 | ✓ | ✓ | ✓ | ✗ | **✓** |
+| 供应链安全（内容仍来自官方） | ✓ | ✓ | ✗ (第三方) | ✓ | **✓** |
+| 对 executed 内容安全 | ✓ | ✓ | ✗ | ✓ | **✓** |
+| 国内直连可用 | △ | △ | ✓ | ✓ | **✓** (doh.pub 国内可达) |
+
+## 4. Our approach
+
+在 `curl_download` 失败路径上追加 **DNS 污染 fallback**：
+
+1. 官方 URL 直连失败（保持现有逻辑：proxy → direct）。
+2. 判断是否值得尝试 DoH：目标 host 在已知污染域名集合
+   (`huggingface.co`, `hf-mirror.com`) **或** 失败信息匹配 DNS/连接错误特征
+   （`could not resolve host` / `failed to connect` / `connection refused` …）。
+3. 用腾讯 DNSPod DNS-over-HTTPS（`https://doh.pub/dns-query`，国内直连可达）
+   查询目标域名的 A 记录，拿到真实 IP 列表。
+4. 对每个 IP 用 `curl --resolve <host>:<port>:<ip>` 重试官方 URL。
+
+**明确不做**：
+- 不改动成功路径：直连成功时 DoH 零开销、零查询。
+- 不引入第三方内容源：`--resolve` 只替换"连接的 IP"，**TLS 证书仍校验
+  hostname、请求的 URL 不变**，内容 100% 来自官方服务器。因此对
+  `content_class="executed"` 同样安全——与 mirror fallback（第三方内容）
+  有本质区别，后者维持 opt-in + executed 永久禁用。
+- 不解析失败掩盖原始错误：DoH 查询失败 / IP 重试全失败时返回原始 detail。
+- 不注入代理到 DoH 查询：doh.pub 国内直连稳定，避免代理规则干扰 DNS 解析。
+
+## 5. Decision rationale
+
+- **为什么 DoH 而不是 hosts / 其他 DNS**：DoH 是标准协议（RFC 8484），
+  doh.pub 是国内可直连的权威解析服务，返回未污染 A 记录；hosts 无法自动化
+  且 IP 漂移。实测 doh.pub 对 huggingface.co 返回 CloudFront 真实 IP
+  （3.164.110.x），对 hf-mirror.com 返回其真实地址。
+- **为什么 DNSPod 而不是 Cloudflare/Google DoH**：后者在国内被墙
+  （实测 cloudflare-dns.com / dns.google 连接超时），doh.pub 直连 200。
+- **为什么失败才触发**：保持"直连成功零影响"的基线；DoH 查询只在官方
+  失败后发生，代价可控（5s 超时兜底）。
+- **为什么 --resolve 而非 --resolve-as / SNI 直连**：`--resolve` 是 curl
+  原生、跨平台、同时适用于 http/https；只影响本命令的目标解析。
+
+## 6. Capability matrix
+
+| 维度 | 现有 (proxy + mirror) | + DNS 污染 fallback |
+|---|---|---|
+| GitHub 下载韧性 | ✓ (mirror) | ✓ (不变) |
+| HF / 任意域名下载韧性 | ✗ (CN 下必失败) | ✓ (DoH 真实 IP 直连) |
+| executed 内容安全 | ✓ (mirror 禁用) | ✓ (等价官方直连) |
+| 用户配置负担 | 零 | 零（自动） |
+| 失败信息可诊断性 | detail | detail + 是否尝试 DoH fallback 的说明 |
+
+## 7. Tests
+
+- `resolve_dns_doh` 单测：解析 A 记录 / 过滤非 A / curl 失败返回 [] / 超时返回 [] / 非法 JSON 返回 [] / 不注入代理。
+- `curl_download` DNS fallback：直连失败 → DoH 成功 → `--resolve` 重试成功；
+  直连成功不触发 DoH；非污染域名 + 非 DNS 错误不触发；DoH 失败保留原始错误；`dns_fallback=False` 完全禁用。
+- `fetch_with_fallback` 集成：official 失败 → DNS fallback 成功（在 mirror 之前）。

--- a/SECURITY-AUDIT.md
+++ b/SECURITY-AUDIT.md
@@ -1,0 +1,62 @@
+# SECURITY-AUDIT — DNS 污染 fallback (PR #81883 迭代)
+
+日期: 2026-08-13
+审计人: x7peeps (鲸)
+审计对象: `hermes_cli/net_download.py` 新增的 `resolve_dns_doh` /
+`curl_download(dns_fallback=True)` 路径
+
+## 审计结论
+
+**DNS 污染 fallback 不引入新的攻击面。** 它只替换"连接的目标 IP"，
+请求的 URL、TLS hostname 校验、内容源全部保持官方不变。供应链安全
+等价于官方直连。以下为逐项证据链。
+
+## 1. 威胁模型
+
+| 威胁 | 分析 |
+|---|---|
+| 第三方内容注入（供应链攻击） | **不适用**。fallback 连接的是官方服务器（DoH 返回的真实 A 记录），URL 不变，TLS 证书仍校验 hostname。与 mirror fallback（第三方前缀包装）本质不同。 |
+| DoH 响应伪造 | DNSPod DoH 走 HTTPS（TLS 加密），响应无法被中间人改写。即便 DoH 返回恶意 IP，TLS 证书校验仍会失败（证书不含目标 hostname），连接被 curl 拒绝。**纵深防御：--resolve 只改 IP，不改 TLS 校验。** |
+| 数据外泄 | DoH 查询内容（域名）经 TLS 加密；查询目标是公开域名，非敏感信息。 |
+| 错误掩盖 | DoH 失败时返回**原始错误 detail**（不替换、不吞掉），fallback 尝试信息附加在 detail 中。 |
+| 重试放大 / 循环 | 每个 IP 至多重试一次，IP 列表上限 4；整体在 `fetch_with_fallback` 内有限。DoH 查询 5s 超时兜底。 |
+
+## 2. 安全契约（与 #81883 一致）
+
+- **`content_class="executed"`（默认）**：mirror 永久禁用（现有逻辑）。
+  DNS fallback **不触碰此契约**——它不属于"第三方镜像"，而是"官方 IP 直连"，
+  对 executed 内容同样允许（等价官方）。
+- **`content_class="data"`**：mirror 保持 opt-in；DNS fallback 默认开启
+  （对数据内容无额外风险）。
+- **直连成功路径零影响**：DoH 查询只在官方失败后触发，且
+  `dns_fallback=False` 可完全禁用（调用方可按需关闭）。
+
+## 3. 代码级审计点
+
+| 审计点 | 结论 |
+|---|---|
+| 无 `shell=True`，全部 argv 列表 | ✓ 与现有代码一致 |
+| `--resolve` 仅限本命令，不修改系统 DNS/hosts | ✓ 无持久化副作用 |
+| DoH 查询不注入代理 env | ✓ 避免代理规则污染 DNS 解析 |
+| IP 白名单过滤（正则 `\d+\.\d+\.\d+\.\d+`，type=1 A 记录） | ✓ 拒绝非 IPv4/恶意 JSON 字段 |
+| 失败返回原始 detail | ✓ 不掩盖根因 |
+| 端口推导（https→443 / http→80 / 显式端口） | ✓ 防 `--resolve` 格式错误 |
+
+## 4. 验证记录（2026-08-13 本机实测）
+
+| 场景 | 结果 |
+|---|---|
+| `doh.pub/dns-query?name=huggingface.co` | 200，返回 CloudFront 真实 IP（3.164.110.x），**证明系统 DNS 确实被污染**（系统解析返回 Verizon 128.242.x） |
+| `doh.pub/dns-query?name=hf-mirror.com` | 200，返回 160.16.86.14（其真实边缘地址） |
+| `curl --resolve hf-mirror.com:443:<cloudflare-ip>` 直连 | 可达（308/200），**证明 --resolve 方案有效** |
+| `curl --resolve huggingface.co:443:<cloudfront-ip>` 直连 | 000（IP 被墙），**证明 fallback 失败时正确保留错误**，不会假装成功 |
+| `curl -x http://127.0.0.1:6152`（Surge 代理）访问 HF | 超时（规则 DIRECT），**证明代理无法替代 DoH fallback** |
+
+## 5. 测试覆盖（tests/hermes_cli/test_net_download.py 新增）
+
+- DoH 解析成功/失败/超时/非法 JSON/非 A 记录过滤
+- 直连成功不触发 DoH（回归保护）
+- 直连失败 → DoH → `--resolve` 重试成功（核心路径）
+- 非污染域名 + 非 DNS 错误不触发（防误触发）
+- DoH 失败保留原始错误（不掩盖）
+- `dns_fallback=False` 完全禁用

--- a/SECURITY-BASELINE.md
+++ b/SECURITY-BASELINE.md
@@ -1,0 +1,48 @@
+# SECURITY-BASELINE — net_download DNS 污染 fallback
+
+日期: 2026-08-13
+维护者: x7peeps (鲸)
+适用范围: `hermes_cli/net_download.py`
+
+## 默认配置基线（测试基准）
+
+| 项 | 默认值 | 说明 |
+|---|---|---|
+| `curl_download(dns_fallback=...)` | `True` | 官方失败后自动 DoH 解析 + `--resolve` 重试 |
+| `fetch_with_fallback(dns_fallback=...)` | `True` | 透传给 `curl_download`，在 mirror 之前尝试 |
+| `resolve_dns_doh(timeout=...)` | `5` | DoH 查询超时；失败返回 `[]`（绝不抛异常） |
+| DoH 端点 | `https://doh.pub/dns-query` | 腾讯 DNSPod，国内直连可达 |
+| 已知污染域名 | `huggingface.co`, `hf-mirror.com` | 失败必触发 DoH fallback |
+| 其他域名触发条件 | stderr 含 DNS/连接特征 | `could not resolve host` / `failed to connect` / `connection refused` / `no route to host` / `name or service not known` / `temporary failure in name resolution` |
+| IP 重试上限 | 4 个 | 顺序尝试，全失败则返回原始错误 |
+| `content_class="executed"` | mirror 永久禁用 | **DNS fallback 不受此限制**（等价官方直连，非第三方） |
+
+## 安全不变式（每次改动必须保持）
+
+1. **内容源不变**：fallback 只换 IP，URL / TLS hostname 校验不变 → 字节
+   100% 来自官方服务器。任何"引入第三方内容源"的改动都是违规。
+2. **成功路径零查询**：直连成功时不得发起 DoH 查询（0 开销、0 延迟）。
+3. **失败不掩盖**：DoH 失败 / IP 全失败 → 返回原始 `detail`，可附加
+   fallback 尝试信息但不得替换根因。
+4. **无持久化副作用**：`--resolve` 仅作用于单次 curl，不写 hosts、
+   不改系统 DNS、不缓存 IP（IP 漂移风险通过每次实时查询规避）。
+5. **有限重试**：IP 上限 4、DoH 5s 超时、整体受 `fetch_with_fallback`
+   调用边界约束，无死循环路径。
+
+## 回归验证命令
+
+```bash
+# worktree 无 venv，用主仓库 venv 解释器（pytest 以当前目录为 rootdir）
+~/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/hermes_cli/test_net_download.py -x -q
+
+# 全量相关单测（防 CI 环境探针问题）
+~/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/hermes_cli/test_net_download.py tests/tools/test_cua_installer.py -q
+```
+
+## 兜底保护
+
+- **DoH 端点不可达（非 CN 网络）**：`resolve_dns_doh` 返回 `[]` →
+  fallback 静默跳过，行为退回纯 proxy + mirror 的现状。**非 CN 用户零影响。**
+- **已知污染域名但 IP 全被墙**（如 huggingface.co CloudFront）：
+  fallback 失败 → 返回原始错误；不会假装成功或产生误导性成功。
+- **调用方需要完全禁用**：`dns_fallback=False`（如内网环境禁止出站 DoH）。

--- a/hermes_cli/net_download.py
+++ b/hermes_cli/net_download.py
@@ -1,0 +1,234 @@
+"""Network-fetch helpers with proxy detection and mirror fallback.
+
+Hermes occasionally needs to fetch small files from the internet (the
+cua-driver install script, release tarballs, model metadata, …). On many
+machines those fetches sit behind a corporate/NAT proxy, and on others the
+official endpoints (raw.githubusercontent.com, objects.githubusercontent.com)
+are slow or blocked — China-mainland networks being the common case.
+
+This module gives every such fetch the same resilient strategy:
+
+1. **Explicit proxy** — the caller's environment (``HTTPS_PROXY`` /
+   ``HTTP_PROXY``) wins when set.
+2. **System proxy** — on macOS, fall back to the system-configured HTTP(S)
+   proxy (Surge, Clash, …) read via ``scutil --proxy``, so a proxy that the
+   user turned on in System Settings actually reaches the child curl without
+   them having to export anything.
+3. **Direct** — no proxy detected: try the official URL as-is.
+4. **Mirror fallback** — if the official URL fails (DNS/TLS/HTTP error),
+   retry through community GitHub mirrors (``ghfast.top``,
+   ``gh-proxy.com``) that prefix-wrap the original URL. Mirrors are only
+   tried after the official path fails, so users with working direct access
+   are never redirected.
+
+Design notes:
+
+* No ``shell=True`` anywhere; every subprocess call is an argv list.
+* Proxy env is injected into the *child* env, never mutated on the parent.
+* Mirrors are opt-in by default via ``allow_mirrors`` — installers that
+  must not be redirected (e.g. anything checksum-pinned) can disable them.
+* All functions are pure-ish and take an explicit ``env`` so tests can
+  inject a fake environment and a fake ``curl`` via ``curl_cmd``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import platform
+import re
+import subprocess
+import sys
+from typing import Dict, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Community GitHub mirrors used as fallbacks. Each is a prefix wrapper:
+# https://ghfast.top/https://github.com/…  (also works for
+# https://raw.githubusercontent.com/… and release-assets URLs).
+_DEFAULT_MIRRORS: Tuple[str, ...] = (
+    "https://ghfast.top/",
+    "https://gh-proxy.com/",
+)
+
+_PROXY_ENV_KEYS = ("HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "ALL_PROXY", "all_proxy")
+
+
+def _env_value(env: Dict[str, str], key: str) -> str:
+    return env.get(key, "").strip()
+
+
+def explicit_proxy(env: Optional[Dict[str, str]] = None) -> Optional[str]:
+    """Return the caller's explicit proxy URL, or ``None``.
+
+    ``HTTPS_PROXY`` (case-insensitive) wins over ``HTTP_PROXY``; either is
+    accepted because the endpoints we fetch are HTTPS anyway and many users
+    only set one. ``ALL_PROXY`` is the last resort.
+    """
+    env = env if env is not None else dict(os.environ)
+    for key in ("HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "ALL_PROXY", "all_proxy"):
+        value = _env_value(env, key)
+        if value:
+            return value
+    return None
+
+
+def _macos_system_proxy() -> Optional[str]:
+    """Read the macOS system HTTP(S) proxy via ``scutil --proxy``.
+
+    Returns the HTTPS proxy (or HTTP proxy as a fallback) as
+    ``http://host:port``. Returns ``None`` when the proxy is disabled or
+    ``scutil`` is unavailable (non-macOS, container, missing tool).
+    """
+    if platform.system() != "Darwin":
+        return None
+    try:
+        result = subprocess.run(
+            ["scutil", "--proxy"],
+            capture_output=True, text=True, timeout=5,
+            check=False,
+        )
+        if result.returncode != 0:
+            return None
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    # Collect key → value pairs first, then assemble host+port. The key
+    # order in `scutil --proxy` output is not guaranteed, so a port may
+    # precede its host line.
+    values: Dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if ":" not in line:
+            continue
+        key, _, raw = line.partition(":")
+        values[key.strip()] = raw.strip()
+    if values.get("HTTPSEnable") == "1" and values.get("HTTPSProxy"):
+        return _normalize_proxy_url(f"{values['HTTPSProxy']}:{values.get('HTTPSPort', '')}" if values.get("HTTPSPort") else values["HTTPSProxy"])
+    if values.get("HTTPEnable") == "1" and values.get("HTTPProxy"):
+        return _normalize_proxy_url(f"{values['HTTPProxy']}:{values.get('HTTPPort', '')}" if values.get("HTTPPort") else values["HTTPProxy"])
+    return None
+
+
+def _normalize_proxy_url(raw: str) -> str:
+    """Prefix ``http://`` when a proxy host is bare (``127.0.0.1:6152``)."""
+    raw = raw.strip()
+    if not raw:
+        return raw
+    if re.match(r"^https?://", raw, re.IGNORECASE):
+        return raw
+    return f"http://{raw}"
+
+
+def detect_proxy(env: Optional[Dict[str, str]] = None) -> Optional[str]:
+    """Resolve the effective proxy for a fetch.
+
+    Priority: explicit env var → macOS system proxy → ``None``.
+    """
+    env = env if env is not None else dict(os.environ)
+    explicit = explicit_proxy(env)
+    if explicit:
+        return explicit
+    return _macos_system_proxy()
+
+
+def proxy_env_for(env: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+    """Return a copy of ``env`` with the detected proxy injected.
+
+    Never mutates the caller's dict. When no proxy is found the copy is
+    returned unchanged (so child processes still inherit whatever the
+    parent shell exported).
+    """
+    base = dict(env) if env is not None else dict(os.environ)
+    proxy = detect_proxy(base)
+    if proxy:
+        base.setdefault("HTTPS_PROXY", proxy)
+        base.setdefault("HTTP_PROXY", proxy)
+    return base
+
+
+def mirror_candidates(url: str, mirrors: Sequence[str] = _DEFAULT_MIRRORS) -> List[str]:
+    """Return mirror-wrapped copies of a GitHub URL.
+
+    ``ghfast.top``/``gh-proxy.com`` prefix-wrap any github.com /
+    raw.githubusercontent.com URL. Non-GitHub URLs return ``[]``.
+    """
+    if not re.match(r"^https://(github\.com|raw\.githubusercontent\.com|objects\.githubusercontent\.com|release-assets\.githubusercontent\.com)/", url):
+        return []
+    return [f"{mirror.rstrip('/')}/{url}" for mirror in mirrors]
+
+
+def curl_download(
+    url: str,
+    dest: str,
+    *,
+    timeout: int = 120,
+    env: Optional[Dict[str, str]] = None,
+    curl_cmd: Optional[str] = None,
+    extra_args: Sequence[str] = (),
+) -> Tuple[bool, str]:
+    """Download ``url`` to ``dest`` with curl.
+
+    Returns ``(ok, detail)`` where ``detail`` is the error text on failure.
+    Proxy is resolved from ``env`` (explicit env var or macOS system proxy)
+    and injected into the child environment — a proxy the user enabled in
+    System Settings reaches the fetch without any manual export.
+    """
+    import shutil
+
+    curl = curl_cmd or shutil.which("curl")
+    if not curl:
+        return False, "curl not found on PATH"
+    child_env = proxy_env_for(env)
+    # --connect-timeout fails fast when the host is unreachable (blocked
+    # DNS/TLS), so a down official endpoint doesn't burn the full
+    # --max-time before the mirror fallback kicks in.
+    args = [curl, "-fsSL", "--connect-timeout", "10", "--max-time", str(timeout), "-o", dest, url]
+    if extra_args:
+        args = args[:1] + list(extra_args) + args[1:]
+    try:
+        result = subprocess.run(
+            args,
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=timeout + 10,
+            env=child_env,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, f"{exc}"
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        return False, detail[:300] or f"curl exit {result.returncode}"
+    if not os.path.exists(dest) or os.path.getsize(dest) == 0:
+        return False, "empty or missing output file"
+    return True, ""
+
+
+def fetch_with_fallback(
+    url: str,
+    dest: str,
+    *,
+    timeout: int = 120,
+    env: Optional[Dict[str, str]] = None,
+    allow_mirrors: bool = True,
+    curl_cmd: Optional[str] = None,
+) -> Tuple[bool, str]:
+    """Download with the proxy-aware official-then-mirror strategy.
+
+    Tries the official URL first (with proxy), then each mirror candidate
+    in order. Returns ``(True, '')`` on success or ``(False, detail)`` with
+    a summary of every attempt.
+    """
+    attempts: List[Tuple[str, str]] = []
+    ok, detail = curl_download(url, dest, timeout=timeout, env=env, curl_cmd=curl_cmd)
+    if ok:
+        return True, ""
+    attempts.append((url, detail))
+
+    if allow_mirrors:
+        for mirror_url in mirror_candidates(url):
+            ok, detail = curl_download(mirror_url, dest, timeout=timeout, env=env, curl_cmd=curl_cmd)
+            if ok:
+                logger.info("fetch_with_fallback: official URL failed; mirror succeeded: %s", mirror_url)
+                return True, ""
+            attempts.append((mirror_url, detail))
+    summary = "; ".join(f"{u}: {d}" for u, d in attempts)
+    return False, summary

--- a/hermes_cli/net_download.py
+++ b/hermes_cli/net_download.py
@@ -25,8 +25,10 @@ Design notes:
 
 * No ``shell=True`` anywhere; every subprocess call is an argv list.
 * Proxy env is injected into the *child* env, never mutated on the parent.
-* Mirrors are opt-in by default via ``allow_mirrors`` — installers that
-  must not be redirected (e.g. anything checksum-pinned) can disable them.
+* Mirrors are opt-in by default via ``allow_mirrors`` — callers that
+  download content which will later be executed (install scripts, pinned
+  binaries) must never let a third-party mirror supply it unless they
+  explicitly opt in; the default keeps mirrors off.
 * All functions are pure-ish and take an explicit ``env`` so tests can
   inject a fake environment and a fake ``curl`` via ``curl_cmd``.
 """
@@ -208,7 +210,7 @@ def fetch_with_fallback(
     *,
     timeout: int = 120,
     env: Optional[Dict[str, str]] = None,
-    allow_mirrors: bool = True,
+    allow_mirrors: bool = False,
     curl_cmd: Optional[str] = None,
 ) -> Tuple[bool, str]:
     """Download with the proxy-aware official-then-mirror strategy.

--- a/hermes_cli/net_download.py
+++ b/hermes_cli/net_download.py
@@ -29,6 +29,21 @@ Design notes:
   download content which will later be executed (install scripts, pinned
   binaries) must never let a third-party mirror supply it unless they
   explicitly opt in; the default keeps mirrors off.
+
+Content-class contract
+^^^^^^^^^^^^^^^^^^^^^^
+
+Every fetch declares the *class* of the content it transports via
+``content_class``. The class decides whether mirrors may ever be tried —
+**independently of what the caller happens to pass** — so a future call site
+cannot accidentally re-enable mirrors for executed content:
+
+* ``content_class="executed"`` (default) — bytes that will be executed or
+  imported (shell scripts, binaries, wheels). Mirrors are **always disabled**;
+  passing ``allow_mirrors=True`` logs a warning and is ignored.
+* ``content_class="data"`` — non-executed payloads (model weights, metadata).
+  Mirrors remain opt-in via ``allow_mirrors=True``; the default stays off.
+
 * All functions are pure-ish and take an explicit ``env`` so tests can
   inject a fake environment and a fake ``curl`` via ``curl_cmd``.
 """
@@ -210,15 +225,32 @@ def fetch_with_fallback(
     *,
     timeout: int = 120,
     env: Optional[Dict[str, str]] = None,
-    allow_mirrors: bool = False,
+    content_class: str = "executed",
+    allow_mirrors: Optional[bool] = None,
     curl_cmd: Optional[str] = None,
 ) -> Tuple[bool, str]:
     """Download with the proxy-aware official-then-mirror strategy.
 
+    ``content_class`` is the security contract (see module docstring):
+    ``"executed"`` (default) permanently disables mirrors — a third-party
+    mirror must never supply bytes that will be executed or imported, so an
+    accidental ``allow_mirrors=True`` is warned about and ignored. ``"data"``
+    keeps mirrors strictly opt-in via ``allow_mirrors=True``.
+
     Tries the official URL first (with proxy), then each mirror candidate
-    in order. Returns ``(True, '')`` on success or ``(False, detail)`` with
-    a summary of every attempt.
+    in order (only when the content class + allow_mirrors permit). Returns
+    ``(True, '')`` on success or ``(False, detail)`` with a summary of every
+    attempt.
     """
+    if content_class == "executed" and allow_mirrors:
+        logger.warning(
+            "fetch_with_fallback: allow_mirrors=True ignored for content_class='executed' "
+            "(supply-chain safety: mirrors must never supply executed content)"
+        )
+        allow_mirrors = False
+    if allow_mirrors is None:
+        allow_mirrors = False
+
     attempts: List[Tuple[str, str]] = []
     ok, detail = curl_download(url, dest, timeout=timeout, env=env, curl_cmd=curl_cmd)
     if ok:

--- a/hermes_cli/net_download.py
+++ b/hermes_cli/net_download.py
@@ -20,6 +20,17 @@ This module gives every such fetch the same resilient strategy:
    ``gh-proxy.com``) that prefix-wrap the original URL. Mirrors are only
    tried after the official path fails, so users with working direct access
    are never redirected.
+5. **DNS-pollution fallback** — on some networks (China mainland being the
+   common case) the system DNS returns poisoned A records for hosts such as
+   ``huggingface.co`` / ``hf-mirror.com``, so the official URL fails with a
+   DNS/connect error even though the site itself is reachable. When a fetch
+   fails that way, we re-resolve the host through the DNSPod DNS-over-HTTPS
+   endpoint (``doh.pub``, reachable directly from CN) and retry the **same
+   official URL** with ``curl --resolve <host>:<port>:<ip>``. This only swaps
+   the resolved IP — the URL, TLS hostname check and content source stay
+   official, so it is supply-chain-safe for executed content too (unlike
+   mirrors, which are third-party and stay opt-in/disabled for executed
+   content).
 
 Design notes:
 
@@ -50,10 +61,12 @@ cannot accidentally re-enable mirrors for executed content:
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import platform
 import re
+import shutil
 import subprocess
 import sys
 from typing import Dict, List, Optional, Sequence, Tuple
@@ -69,6 +82,34 @@ _DEFAULT_MIRRORS: Tuple[str, ...] = (
 )
 
 _PROXY_ENV_KEYS = ("HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "ALL_PROXY", "all_proxy")
+
+# DNS-over-HTTPS endpoint used by the DNS-pollution fallback. DNSPod is
+# reachable directly from mainland China (unlike Cloudflare/Google DoH),
+# so it works even when every public resolver is returning poisoned
+# answers for the target host.
+_DOH_ENDPOINT = "https://doh.pub/dns-query"
+_DOH_ACCEPT_HEADER = "accept: application/dns-json"
+
+# Hosts whose A records are commonly poisoned on CN networks. A failed
+# fetch for one of these always triggers the DoH fallback, without
+# needing to pattern-match the error text.
+_POLLUTED_HOSTS: Tuple[str, ...] = ("huggingface.co", "hf-mirror.com")
+
+# Substrings in curl's stderr that indicate a DNS/connect-layer failure —
+# the only failure classes the DoH fallback can plausibly fix. HTTP-level
+# errors (404, 403, …) never trigger it, so a real server error is not
+# masked by an extra resolution round-trip.
+_DNS_ERROR_MARKERS: Tuple[str, ...] = (
+    "could not resolve host",
+    "failed to connect",
+    "connection refused",
+    "no route to host",
+    "name or service not known",
+    "temporary failure in name resolution",
+)
+
+# Upper bound on IPs tried during one DoH fallback.
+_MAX_DOH_IPS = 4
 
 
 def _env_value(env: Dict[str, str], key: str) -> str:
@@ -174,6 +215,164 @@ def mirror_candidates(url: str, mirrors: Sequence[str] = _DEFAULT_MIRRORS) -> Li
     return [f"{mirror.rstrip('/')}/{url}" for mirror in mirrors]
 
 
+def _host_from_url(url: str) -> Optional[str]:
+    """Return the host of an http(s) URL, or ``None`` when unparsable."""
+    match = re.match(r"^https?://([^/:]+)", url)
+    return match.group(1) if match else None
+
+
+def _port_from_url(url: str) -> str:
+    """Return the port to use in ``--resolve`` for ``url``."""
+    match = re.match(r"^https?://[^/:]+:(\d+)", url)
+    if match:
+        return match.group(1)
+    return "443" if url.startswith("https") else "80"
+
+
+def _is_pollution_candidate(host: str) -> bool:
+    """True for hosts whose DNS answers are commonly poisoned on CN networks."""
+    return host in _POLLUTED_HOSTS
+
+
+def _looks_like_dns_or_connect_error(detail: str) -> bool:
+    """True when a curl failure looks like a DNS/connect-layer problem.
+
+    The DoH fallback can only fix resolution/connectivity failures; an
+    HTTP-level error (404/403) is a real server response and must not be
+    retried through a different resolver.
+    """
+    low = detail.lower()
+    return any(marker in low for marker in _DNS_ERROR_MARKERS)
+
+
+def _should_try_doh_fallback(url: str, detail: str) -> bool:
+    """Decide whether a failed fetch is worth a DoH re-resolution.
+
+    Known-polluted hosts always qualify; other hosts only when the error
+    text indicates a DNS/connect-layer failure.
+    """
+    host = _host_from_url(url)
+    if not host:
+        return False
+    if _is_pollution_candidate(host):
+        return True
+    return _looks_like_dns_or_connect_error(detail)
+
+
+def _is_valid_ipv4(data: str) -> bool:
+    """True only for syntactically *and* numerically valid IPv4 addresses.
+
+    A pure format regex (``\\d{1,3}(\\.\\d{1,3}){3}``) would accept
+    ``999.999.999.999``; the numeric range check rejects out-of-range
+    octets so a poisoned/malformed answer can never be used for ``--resolve``.
+    """
+    if not re.match(r"^\d{1,3}(\.\d{1,3}){3}$", data):
+        return False
+    return all(0 <= int(part) <= 255 for part in data.split("."))
+
+
+def resolve_dns_doh(
+    host: str,
+    *,
+    timeout: int = 5,
+    env: Optional[Dict[str, str]] = None,
+    curl_cmd: Optional[str] = None,
+) -> List[str]:
+    """Resolve ``host`` A records via DNSPod DNS-over-HTTPS.
+
+    Returns a list of IPv4 addresses (``[]`` on any failure — curl missing,
+    non-zero exit, timeout, unparsable JSON, no A records). The query is
+    intentionally sent **without** proxy injection: ``doh.pub`` is reachable
+    directly from mainland China, and a proxy rule must never be able to
+    intercept the resolution that exists to bypass poisoned answers.
+    """
+    curl = curl_cmd or shutil.which("curl")
+    if not curl or not host:
+        return []
+    args = [
+        curl, "-fsSL",
+        "--connect-timeout", "5",
+        "--max-time", str(timeout),
+        "-H", _DOH_ACCEPT_HEADER,
+        f"{_DOH_ENDPOINT}?name={host}&type=A",
+    ]
+    child_env = dict(env) if env is not None else dict(os.environ)
+    try:
+        result = subprocess.run(
+            args,
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=timeout + 5,
+            env=child_env,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return []
+    if result.returncode != 0:
+        return []
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except ValueError:
+        return []
+    ips: List[str] = []
+    for answer in payload.get("Answer", []) or []:
+        data = answer.get("data", "") if isinstance(answer, dict) else ""
+        # Only valid IPv4 A records; ignore AAAA / CNAME / malformed
+        # (including out-of-range octets like 999.x.x.x).
+        if answer.get("type") == 1 and _is_valid_ipv4(data):
+            ips.append(data)
+    return ips
+
+
+def _retry_with_doh_resolve(
+    url: str,
+    dest: str,
+    *,
+    timeout: int,
+    env: Dict[str, str],
+    curl: str,
+    extra_args: Sequence[str],
+) -> Tuple[bool, str]:
+    """Retry ``url`` through ``--resolve`` with DoH-obtained real IPs.
+
+    Returns ``(True, '')`` when one of the IPs connects and the download
+    lands; ``(False, '')`` when nothing could be attempted or every IP
+    failed. The caller keeps its original failure detail when we return
+    ``False`` so a failed fallback never hides the root cause.
+    """
+    host = _host_from_url(url)
+    if not host:
+        return False, ""
+    port = _port_from_url(url)
+    ips = resolve_dns_doh(host, timeout=5, env=env, curl_cmd=curl)
+    if not ips:
+        return False, ""
+    for ip in ips[:_MAX_DOH_IPS]:
+        args = [
+            curl, "-fsSL",
+            "--connect-timeout", "10",
+            "--max-time", str(timeout),
+            "--resolve", f"{host}:{port}:{ip}",
+            "-o", dest,
+            url,
+        ]
+        if extra_args:
+            args = args[:1] + list(extra_args) + args[1:]
+        try:
+            result = subprocess.run(
+                args,
+                capture_output=True, text=True, encoding="utf-8", errors="replace",
+                timeout=timeout + 10,
+                env=env,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            continue
+        if result.returncode == 0 and os.path.exists(dest) and os.path.getsize(dest) > 0:
+            logger.info(
+                "curl_download: DNS-pollution fallback succeeded for %s via %s", host, ip
+            )
+            return True, ""
+    return False, ""
+
+
 def curl_download(
     url: str,
     dest: str,
@@ -182,6 +381,7 @@ def curl_download(
     env: Optional[Dict[str, str]] = None,
     curl_cmd: Optional[str] = None,
     extra_args: Sequence[str] = (),
+    dns_fallback: bool = True,
 ) -> Tuple[bool, str]:
     """Download ``url`` to ``dest`` with curl.
 
@@ -189,9 +389,14 @@ def curl_download(
     Proxy is resolved from ``env`` (explicit env var or macOS system proxy)
     and injected into the child environment — a proxy the user enabled in
     System Settings reaches the fetch without any manual export.
-    """
-    import shutil
 
+    When ``dns_fallback`` is enabled (default) and the direct attempt fails
+    with a DNS/connect-layer error (or targets a known DNS-polluted host),
+    the host is re-resolved through DNSPod DoH and the same official URL is
+    retried with ``--resolve``. The fallback never changes the URL or the
+    TLS identity — it only swaps the resolved IP — so the fetched bytes are
+    still from the official server.
+    """
     curl = curl_cmd or shutil.which("curl")
     if not curl:
         return False, "curl not found on PATH"
@@ -213,6 +418,15 @@ def curl_download(
         return False, f"{exc}"
     if result.returncode != 0:
         detail = (result.stderr or result.stdout or "").strip()
+        if dns_fallback and _should_try_doh_fallback(url, detail):
+            ok, _ = _retry_with_doh_resolve(
+                url, dest, timeout=timeout, env=child_env,
+                curl=curl, extra_args=extra_args,
+            )
+            if ok:
+                return True, ""
+            # DoH resolution or every IP failed — keep the original error
+            # so the root cause is never masked by the fallback.
         return False, detail[:300] or f"curl exit {result.returncode}"
     if not os.path.exists(dest) or os.path.getsize(dest) == 0:
         return False, "empty or missing output file"
@@ -228,6 +442,7 @@ def fetch_with_fallback(
     content_class: str = "executed",
     allow_mirrors: Optional[bool] = None,
     curl_cmd: Optional[str] = None,
+    dns_fallback: bool = True,
 ) -> Tuple[bool, str]:
     """Download with the proxy-aware official-then-mirror strategy.
 
@@ -237,8 +452,10 @@ def fetch_with_fallback(
     accidental ``allow_mirrors=True`` is warned about and ignored. ``"data"``
     keeps mirrors strictly opt-in via ``allow_mirrors=True``.
 
-    Tries the official URL first (with proxy), then each mirror candidate
-    in order (only when the content class + allow_mirrors permit). Returns
+    Tries the official URL first (with proxy), then a DNS-pollution
+    ``--resolve`` retry when the failure looks like poisoned DNS (both
+    inside :func:`curl_download`), then each mirror candidate in order
+    (only when the content class + allow_mirrors permit). Returns
     ``(True, '')`` on success or ``(False, detail)`` with a summary of every
     attempt.
     """
@@ -252,14 +469,16 @@ def fetch_with_fallback(
         allow_mirrors = False
 
     attempts: List[Tuple[str, str]] = []
-    ok, detail = curl_download(url, dest, timeout=timeout, env=env, curl_cmd=curl_cmd)
+    ok, detail = curl_download(url, dest, timeout=timeout, env=env, curl_cmd=curl_cmd,
+                               dns_fallback=dns_fallback)
     if ok:
         return True, ""
     attempts.append((url, detail))
 
     if allow_mirrors:
         for mirror_url in mirror_candidates(url):
-            ok, detail = curl_download(mirror_url, dest, timeout=timeout, env=env, curl_cmd=curl_cmd)
+            ok, detail = curl_download(mirror_url, dest, timeout=timeout, env=env, curl_cmd=curl_cmd,
+                                       dns_fallback=dns_fallback)
             if ok:
                 logger.info("fetch_with_fallback: official URL failed; mirror succeeded: %s", mirror_url)
                 return True, ""

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1521,6 +1521,7 @@ def _run_cua_driver_installer(
     system = _plat.system()
     is_windows = system == "Windows"
     is_linux = system == "Linux"
+    fetch_env: Optional[Dict[str, str]] = None  # set by the POSIX script-download path below
 
     if is_windows:
         # Mirror the one-liner printed by cua_driver_install_hint().
@@ -1553,28 +1554,53 @@ def _run_cua_driver_installer(
         manual_hint = f'/bin/bash -c "$(curl -fsSL {install_url})"'
         fd, script_path = _tempfile.mkstemp(prefix="cua-driver-install-", suffix=".sh")
         os.close(fd)
+        # Fetch with the proxy-aware official-then-mirror strategy so the
+        # install script downloads on proxied/blocked networks too. The
+        # installer env (telemetry policy + detected proxy) is built once
+        # here and reused when executing the script below, so the script's
+        # own internal curl (which fetches the release tarball from GitHub)
+        # also goes through the proxy.
         try:
-            dl = subprocess.run(
-                ["curl", "-fsSL", "-o", script_path, install_url],
-                capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=120,
-            )
-        except (subprocess.TimeoutExpired, OSError) as e:
-            _print_warning(f"    cua-driver installer download failed: {e}")
+            from hermes_cli.net_download import fetch_with_fallback, proxy_env_for
+        except ImportError:  # pragma: no cover - defensive; net_download is local
+            fetch_with_fallback = None
+            proxy_env_for = None
+        fetch_env = proxy_env_for(_cua_driver_env()) if proxy_env_for else _cua_driver_env()
+        if fetch_with_fallback is not None:
+            ok, detail = fetch_with_fallback(install_url, script_path, timeout=120, env=fetch_env)
+            if not ok:
+                _print_warning(
+                    "    cua-driver installer download failed (official + mirrors): "
+                    f"{detail[:300]}"
+                )
+                try:
+                    os.remove(script_path)
+                except OSError:
+                    pass
+                return False
+        else:  # pragma: no cover - defensive fallback to the old behaviour
             try:
-                os.remove(script_path)
-            except OSError:
-                pass
-            return False
-        if dl.returncode != 0:
-            _print_warning(
-                "    cua-driver installer download failed: "
-                f"{(dl.stderr or '').strip()[:200]}"
-            )
-            try:
-                os.remove(script_path)
-            except OSError:
-                pass
-            return False
+                dl = subprocess.run(
+                    ["curl", "-fsSL", "-o", script_path, install_url],
+                    capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=120,
+                )
+            except (subprocess.TimeoutExpired, OSError) as e:
+                _print_warning(f"    cua-driver installer download failed: {e}")
+                try:
+                    os.remove(script_path)
+                except OSError:
+                    pass
+                return False
+            if dl.returncode != 0:
+                _print_warning(
+                    "    cua-driver installer download failed: "
+                    f"{(dl.stderr or '').strip()[:200]}"
+                )
+                try:
+                    os.remove(script_path)
+                except OSError:
+                    pass
+                return False
         install_cmd = ["/bin/bash", script_path]
     use_shell = False
 
@@ -1585,7 +1611,17 @@ def _run_cua_driver_installer(
             _print_info(f"→ {label} cua-driver (Computer Use)...")
     driver_cmd = _cua_driver_cmd()
 
-    installer_env = _cua_driver_env()
+    # Reuse the proxy-aware env built during the script download (or build it
+    # here on the Windows path where no script was fetched): the upstream
+    # installer's own curl fetches the release tarball from GitHub, which must
+    # also go through the detected proxy / mirrors.
+    if "fetch_env" not in locals() or fetch_env is None:  # Windows / fallback
+        try:
+            from hermes_cli.net_download import proxy_env_for
+        except ImportError:  # pragma: no cover
+            proxy_env_for = None
+        fetch_env = proxy_env_for(_cua_driver_env()) if proxy_env_for else _cua_driver_env()
+    installer_env = dict(fetch_env)
     if pin_version:
         # Both upstream installers (install.sh and install.ps1) honour
         # CUA_DRIVER_RS_VERSION over their baked default.

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1560,6 +1560,12 @@ def _run_cua_driver_installer(
         # here and reused when executing the script below, so the script's
         # own internal curl (which fetches the release tarball from GitHub)
         # also goes through the proxy.
+        #
+        # Security: this script is executed via /bin/bash below, so it must
+        # NEVER be supplied by a third-party mirror. `allow_mirrors=False`
+        # keeps the fetch official-only (explicit proxy → system proxy →
+        # direct), matching the documented "mirrors opt-in by default"
+        # contract. Mirror fallback is for non-executed payloads that opt in.
         try:
             from hermes_cli.net_download import fetch_with_fallback, proxy_env_for
         except ImportError:  # pragma: no cover - defensive; net_download is local
@@ -1567,10 +1573,13 @@ def _run_cua_driver_installer(
             proxy_env_for = None
         fetch_env = proxy_env_for(_cua_driver_env()) if proxy_env_for else _cua_driver_env()
         if fetch_with_fallback is not None:
-            ok, detail = fetch_with_fallback(install_url, script_path, timeout=120, env=fetch_env)
+            ok, detail = fetch_with_fallback(
+                install_url, script_path, timeout=120, env=fetch_env, allow_mirrors=False,
+            )
             if not ok:
                 _print_warning(
-                    "    cua-driver installer download failed (official + mirrors): "
+                    "    cua-driver installer download failed (official URL only; "
+                    "mirrors are disabled for executed scripts): "
                     f"{detail[:300]}"
                 )
                 try:

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1585,6 +1585,28 @@ def _run_cua_driver_installer(
                     "mirrors are disabled for executed scripts): "
                     f"{detail[:300]}"
                 )
+                # Actionable failure UX: the user must be able to reproduce
+                # and fix the network problem in seconds, not guess.
+                _print_info(
+                    "    Retry manually: curl -fsSL --connect-timeout 10 --max-time 120 "
+                    f"'{install_url}' -o /tmp/cua-driver-install.sh"
+                )
+                if fetch_env:
+                    _proxy = (
+                        fetch_env.get("HTTPS_PROXY")
+                        or fetch_env.get("HTTP_PROXY")
+                        or fetch_env.get("ALL_PROXY")
+                    )
+                    if _proxy:
+                        _print_info(f"    Proxy in use: {_proxy} — verify it is up and allow GitHub")
+                    else:
+                        _print_info(
+                            "    No proxy detected — check your network/proxy and retry; "
+                            "on macOS enable it in System Settings or export HTTPS_PROXY"
+                        )
+                _print_info(
+                    "    Docs: https://github.com/trycua/cua/blob/main/libs/cua-driver/README.md"
+                )
                 try:
                     os.remove(script_path)
                 except OSError:

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1562,10 +1562,12 @@ def _run_cua_driver_installer(
         # also goes through the proxy.
         #
         # Security: this script is executed via /bin/bash below, so it must
-        # NEVER be supplied by a third-party mirror. `allow_mirrors=False`
-        # keeps the fetch official-only (explicit proxy → system proxy →
-        # direct), matching the documented "mirrors opt-in by default"
-        # contract. Mirror fallback is for non-executed payloads that opt in.
+        # NEVER be supplied by a third-party mirror. `content_class="executed"`
+        # (the default) permanently disables mirrors at the API level — even
+        # an accidental allow_mirrors=True is ignored — keeping the fetch
+        # official-only (explicit proxy → system proxy → direct), matching the
+        # documented "mirrors opt-in by default" contract. Mirror fallback is
+        # for non-executed payloads that opt in.
         try:
             from hermes_cli.net_download import fetch_with_fallback, proxy_env_for
         except ImportError:  # pragma: no cover - defensive; net_download is local
@@ -1574,7 +1576,8 @@ def _run_cua_driver_installer(
         fetch_env = proxy_env_for(_cua_driver_env()) if proxy_env_for else _cua_driver_env()
         if fetch_with_fallback is not None:
             ok, detail = fetch_with_fallback(
-                install_url, script_path, timeout=120, env=fetch_env, allow_mirrors=False,
+                install_url, script_path, timeout=120, env=fetch_env,
+                content_class="executed", allow_mirrors=False,
             )
             if not ok:
                 _print_warning(

--- a/scripts/check_fetch_content_class.py
+++ b/scripts/check_fetch_content_class.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Blocking supply-chain contract check: every production call to
+``fetch_with_fallback`` must explicitly declare ``content_class=``.
+
+Rationale (#81883 audit): the security property of a fetch — whether a
+third-party mirror may ever supply the bytes — is decided by
+``content_class``. The default is ``"executed"`` (mirrors permanently
+disabled), which is safe, but the whole point of the API is that the
+*contract is visible at the call site*. A call that omits
+``content_class`` silently relies on the default; the next person reading
+the code can't tell whether executed content was meant. Requiring the
+explicit keyword makes the supply-chain decision auditable in a grep.
+
+Test files are exempt (they deliberately exercise defaults and both
+classes); production code under hermes_cli/ is not.
+
+Exit 0 when every production call declares content_class, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+SCAN_DIRS = ("hermes_cli",)
+EXEMPT = {"tests", "test_"}
+
+
+def _iter_python_files() -> list[pathlib.Path]:
+    files: list[pathlib.Path] = []
+    for base in SCAN_DIRS:
+        base_dir = ROOT / base
+        if not base_dir.is_dir():
+            continue
+        for path in sorted(base_dir.rglob("*.py")):
+            parts = path.parts
+            if any(part in EXEMPT for part in parts):
+                continue
+            files.append(path)
+    return files
+
+
+def _calls_without_content_class(path: pathlib.Path) -> list[tuple[int, str]]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (SyntaxError, UnicodeDecodeError):
+        # Let the normal lint/tests catch syntax problems; don't fail here.
+        return []
+
+    hits: list[tuple[int, str]] = []
+
+    class Visitor(ast.NodeVisitor):
+        def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
+            self.generic_visit(node)
+            func = node.func
+            if not (isinstance(func, ast.Name) and func.id == "fetch_with_fallback"):
+                return
+            kw_names = {kw.arg for kw in node.keywords if kw.arg is not None}
+            if "content_class" not in kw_names:
+                hits.append((node.lineno, ast.unparse(node)[:120]))
+
+    Visitor().visit(tree)
+    return hits
+
+
+def main() -> int:
+    problems: list[tuple[str, int, str]] = []
+    for path in _iter_python_files():
+        for lineno, snippet in _calls_without_content_class(path):
+            problems.append((str(path.relative_to(ROOT)), lineno, snippet))
+
+    if not problems:
+        print("fetch_with_fallback content_class contract: OK")
+        return 0
+
+    print("fetch_with_fallback calls missing explicit content_class= :")
+    for path, lineno, snippet in problems:
+        print(f"  {path}:{lineno}: {snippet}")
+    print("Add content_class='executed' (or 'data' for non-executed payloads).")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/hermes_cli/test_install_cua_driver.py
+++ b/tests/hermes_cli/test_install_cua_driver.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import json
 import sys
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -109,6 +109,42 @@ class TestCuaDriverRuntimeContract:
         assert "serve --approve-capability-manifest" in state["reason"]
 
 
+def _downloading_run(cmd, **kwargs):
+    """Fake ``subprocess.run`` that actually writes the curl download target.
+
+    ``curl_download`` (hermes_cli/net_download.py) now verifies the output
+    file is non-empty after a successful exit; a mock that only returns
+    ``returncode=0`` without writing the file makes every POSIX install
+    appear to fail ("empty or missing output file"). This helper scans the
+    argv for ``-o <dest>`` and writes a byte so the size check passes.
+    """
+    m = MagicMock(returncode=0, stderr="", stdout="")
+    if isinstance(cmd, list):
+        try:
+            i = cmd.index("-o")
+            dest = cmd[i + 1]
+            with open(dest, "w", encoding="utf-8") as fh:
+                fh.write("#!/bin/sh\necho ok\n")
+        except (ValueError, IndexError, OSError):
+            pass
+    return m
+
+
+def _which_side_effect(name):
+    """Fake ``shutil.which`` that distinguishes curl from cua-driver.
+
+    The POSIX install path now looks up curl via ``shutil.which("curl")``
+    (hermes_cli/net_download.py) in addition to the cua-driver binary; a
+    blanket ``return_value`` mock would make the download argv start with
+    the cua-driver path, breaking ``dl_cmd[0] == \"curl\"`` assertions.
+    """
+    if name == "curl":
+        return "/usr/bin/curl"
+    if name == "cua-driver":
+        return "/usr/local/bin/cua-driver"
+    return None
+
+
 class TestInstallCuaDriverUpgrade:
     # ``install_cua_driver`` supports macOS, Windows AND Linux. For everything
     # below except the two unsupported-platform cases, the Linux host takes a
@@ -185,16 +221,14 @@ class TestInstallCuaDriverUpgrade:
         fake_proc.returncode = 0
         fake_proc.communicate.return_value = ("", None)
 
-        with patch(
-                 "subprocess.run",
-                 return_value=MagicMock(returncode=0, stderr=""),
-             ), \
+        with patch("platform.system", return_value="Linux"), \
+             patch("subprocess.run", side_effect=_downloading_run), \
              patch("subprocess.Popen", return_value=fake_proc), \
              patch.object(
-                 tools_config.shutil,
-                 "which",
-                 return_value="/usr/local/bin/cua-driver",
-             ), \
+                tools_config.shutil,
+                "which",
+                side_effect=_which_side_effect,
+            ), \
              patch.object(tools_config, "_clear_stale_cua_install_lock"), \
              patch.object(tools_config, "_print_info") as info:
             assert tools_config._run_cua_driver_installer(
@@ -218,16 +252,14 @@ class TestInstallCuaDriverUpgrade:
         fake_proc.returncode = 0
         fake_proc.communicate.return_value = ("", None)
 
-        with patch(
-                 "subprocess.run",
-                 return_value=MagicMock(returncode=0, stderr=""),
-             ), \
+        with patch("platform.system", return_value="Linux"), \
+             patch("subprocess.run", side_effect=_downloading_run), \
              patch("subprocess.Popen", return_value=fake_proc), \
              patch.object(
-                 tools_config.shutil,
-                 "which",
-                 return_value="/usr/local/bin/cua-driver",
-             ), \
+                tools_config.shutil,
+                "which",
+                side_effect=_which_side_effect,
+            ), \
              patch.object(tools_config, "_clear_stale_cua_install_lock"), \
              patch.object(tools_config, "_print_info") as info:
             assert tools_config._run_cua_driver_installer(
@@ -885,7 +917,9 @@ class TestInstallerTimeoutKillsProcessGroup:
             killed["pgid"] = pgid
             killed["sig"] = sig
 
-        with patch("subprocess.run", return_value=MagicMock(returncode=0, stderr="")), \
+        with patch("platform.system", return_value="Linux"), \
+             patch.object(signal, "SIGKILL", sigkill, create=True), \
+             patch("subprocess.run", side_effect=_downloading_run), \
              patch("subprocess.Popen", return_value=fake_proc), \
              patch.object(
                  tools_config.os, "getpgid", return_value=99999, create=True
@@ -925,7 +959,8 @@ class TestInstallerTimeoutKillsProcessGroup:
             captured.update(kwargs)
             return fake_proc
 
-        with patch("subprocess.run", return_value=MagicMock(returncode=0, stderr="")), \
+        with patch("platform.system", return_value="Linux"), \
+             patch("subprocess.run", side_effect=_downloading_run), \
              patch("subprocess.Popen", side_effect=fake_popen), \
              patch.object(tools_config, "_clear_stale_cua_install_lock"), \
              patch.object(tools_config, "_print_warning"), \
@@ -1025,6 +1060,15 @@ class TestInstallerNoShell:
             m = MagicMock()
             m.returncode = download_rc
             m.stderr = "curl: (6) could not resolve" if download_rc else ""
+            # curl_download verifies a non-empty output file; write the
+            # download target so the size check passes on success.
+            if not download_rc and isinstance(cmd, list):
+                try:
+                    i = cmd.index("-o")
+                    with open(cmd[i + 1], "w", encoding="utf-8") as fh:
+                        fh.write("#!/bin/sh\necho ok\n")
+                except (ValueError, IndexError, OSError):
+                    pass
             return m
 
         def fake_popen(cmd, **kw):
@@ -1033,7 +1077,7 @@ class TestInstallerNoShell:
 
         with patch("subprocess.run", side_effect=fake_run), \
              patch("subprocess.Popen", side_effect=fake_popen), \
-             patch.object(tools_config.shutil, "which", return_value="/usr/local/bin/cua-driver"), \
+             patch.object(tools_config.shutil, "which", side_effect=_which_side_effect), \
              patch.object(tools_config, "_clear_stale_cua_install_lock"), \
              patch.object(tools_config, "_print_warning"), \
              patch.object(tools_config, "_print_info"), \
@@ -1047,9 +1091,12 @@ class TestInstallerNoShell:
         run_calls = [c for c in calls if c[0] == "run"]
         popen_calls = [c for c in calls if c[0] == "popen"]
         assert len(run_calls) == 1 and len(popen_calls) == 1
-        # Download: plain argv curl, no shell.
+        # Download: plain argv curl, no shell. The curl binary is resolved
+        # via shutil.which (net_download.curl_download), so assert the
+        # basename rather than a hardcoded argv[0] == "curl".
         dl_cmd = run_calls[0][1]
-        assert isinstance(dl_cmd, list) and dl_cmd[0] == "curl"
+        assert isinstance(dl_cmd, list)
+        assert os.path.basename(dl_cmd[0]) == "curl"
         # Exec: argv list ["/bin/bash", <mkstemp path>], shell=False.
         exec_cmd, exec_kw = popen_calls[0][1], popen_calls[0][2]
         assert isinstance(exec_cmd, list) and exec_cmd[0] == "/bin/bash"
@@ -1074,6 +1121,13 @@ class TestInstallerNoShell:
 
         def fake_run(cmd, **kw):
             m = MagicMock(); m.returncode = 0; m.stderr = ""
+            if isinstance(cmd, list):
+                try:
+                    i = cmd.index("-o")
+                    with open(cmd[i + 1], "w", encoding="utf-8") as fh:
+                        fh.write("#!/bin/sh\necho ok\n")
+                except (ValueError, IndexError, OSError):
+                    pass
             return m
 
         def fake_popen(cmd, **kw):
@@ -1082,7 +1136,7 @@ class TestInstallerNoShell:
 
         with patch("subprocess.run", side_effect=fake_run), \
              patch("subprocess.Popen", side_effect=fake_popen), \
-             patch.object(tools_config.shutil, "which", return_value="/usr/local/bin/cua-driver"), \
+             patch.object(tools_config.shutil, "which", side_effect=_which_side_effect), \
              patch.object(tools_config, "_clear_stale_cua_install_lock"), \
              patch.object(tools_config, "_print_warning"), \
              patch.object(tools_config, "_print_info"), \
@@ -1199,6 +1253,13 @@ class TestRunInstallerPinEnv:
 
         def fake_run(cmd, **kw):
             m = MagicMock(); m.returncode = 0; m.stderr = ""
+            if isinstance(cmd, list):
+                try:
+                    i = cmd.index("-o")
+                    with open(cmd[i + 1], "w", encoding="utf-8") as fh:
+                        fh.write("#!/bin/sh\necho ok\n")
+                except (ValueError, IndexError, OSError):
+                    pass
             return m
 
         with patch("subprocess.run", side_effect=fake_run), \

--- a/tests/hermes_cli/test_install_cua_driver.py
+++ b/tests/hermes_cli/test_install_cua_driver.py
@@ -22,6 +22,7 @@ cleanly on missing-arch assets, and the upgrade path uses
 from __future__ import annotations
 
 import json
+import os
 import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch

--- a/tests/hermes_cli/test_net_download.py
+++ b/tests/hermes_cli/test_net_download.py
@@ -1,0 +1,208 @@
+"""Tests for hermes_cli.net_download — proxy detection + mirror fallback."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from hermes_cli.net_download import (
+    _macos_system_proxy,
+    curl_download,
+    detect_proxy,
+    explicit_proxy,
+    fetch_with_fallback,
+    mirror_candidates,
+    proxy_env_for,
+)
+
+
+class TestExplicitProxy:
+    def test_https_proxy_wins(self):
+        env = {"HTTPS_PROXY": "http://proxy:8080", "HTTP_PROXY": "http://proxy:8081"}
+        assert explicit_proxy(env) == "http://proxy:8080"
+
+    def test_http_proxy_fallback(self):
+        assert explicit_proxy({"HTTP_PROXY": "http://proxy:8081"}) == "http://proxy:8081"
+
+    def test_case_insensitive(self):
+        assert explicit_proxy({"https_proxy": "http://proxy:8080"}) == "http://proxy:8080"
+
+    def test_all_proxy_last_resort(self):
+        assert explicit_proxy({"ALL_PROXY": "socks5://127.0.0.1:1080"}) == "socks5://127.0.0.1:1080"
+
+    def test_empty(self):
+        assert explicit_proxy({}) is None
+
+
+class TestDetectProxy:
+    def test_explicit_beats_system(self, monkeypatch):
+        env = {"HTTPS_PROXY": "http://user-proxy:3128"}
+        monkeypatch.setattr("hermes_cli.net_download._macos_system_proxy", lambda: "http://127.0.0.1:6152")
+        assert detect_proxy(env) == "http://user-proxy:3128"
+
+    def test_system_proxy_used_when_no_explicit(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.net_download._macos_system_proxy", lambda: "http://127.0.0.1:6152")
+        assert detect_proxy({}) == "http://127.0.0.1:6152"
+
+    def test_no_proxy(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.net_download._macos_system_proxy", lambda: None)
+        assert detect_proxy({}) is None
+
+
+class TestMacOSSystemProxy:
+    def _fake_run(self, output, returncode=0):
+        def fake_run(args, **kwargs):
+            return type("R", (), {"returncode": returncode, "stdout": output})()
+        return fake_run
+
+    def test_parses_https_proxy_with_port(self, monkeypatch):
+        out = (
+            "HTTPEnable : 1\n"
+            "HTTPProxy : 127.0.0.1\n"
+            "HTTPPort : 6152\n"
+            "HTTPSEnable : 1\n"
+            "HTTPSProxy : 127.0.0.1\n"
+            "HTTPSPort : 6152\n"
+        )
+        monkeypatch.setattr("hermes_cli.net_download.subprocess.run", self._fake_run(out))
+        assert _macos_system_proxy() == "http://127.0.0.1:6152"
+
+    def test_port_before_host_still_works(self, monkeypatch):
+        # Port keys may appear before their host keys in scutil output.
+        out = (
+            "HTTPSEnable : 1\n"
+            "HTTPSPort : 6152\n"
+            "HTTPSProxy : 10.0.0.1\n"
+        )
+        monkeypatch.setattr("hermes_cli.net_download.subprocess.run", self._fake_run(out))
+        assert _macos_system_proxy() == "http://10.0.0.1:6152"
+
+    def test_disabled_proxy_returns_none(self, monkeypatch):
+        out = "HTTPSEnable : 0\nHTTPSProxy : 127.0.0.1\nHTTPSPort : 6152\n"
+        monkeypatch.setattr("hermes_cli.net_download.subprocess.run", self._fake_run(out))
+        assert _macos_system_proxy() is None
+
+    def test_non_darwin_returns_none(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.net_download.platform.system", lambda: "Linux")
+        assert _macos_system_proxy() is None
+
+
+class TestProxyEnvFor:
+    def test_injects_proxy_without_mutating(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.net_download._macos_system_proxy", lambda: "http://127.0.0.1:6152")
+        base = {"FOO": "bar"}
+        out = proxy_env_for(base)
+        assert base == {"FOO": "bar"}  # not mutated
+        assert out["HTTPS_PROXY"] == "http://127.0.0.1:6152"
+        assert out["HTTP_PROXY"] == "http://127.0.0.1:6152"
+        assert out["FOO"] == "bar"
+
+    def test_no_proxy_returns_unchanged(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.net_download._macos_system_proxy", lambda: None)
+        assert proxy_env_for({"FOO": "bar"}) == {"FOO": "bar"}
+
+
+class TestMirrorCandidates:
+    RAW = "https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh"
+
+    def test_github_urls_get_mirrors(self):
+        urls = mirror_candidates(self.RAW)
+        assert urls[0].startswith("https://ghfast.top/")
+        assert urls[1].startswith("https://gh-proxy.com/")
+        assert self.RAW in urls[0]
+
+    def test_non_github_urls_empty(self):
+        assert mirror_candidates("https://example.com/x.sh") == []
+        assert mirror_candidates("https://pypi.org/simple/") == []
+
+
+class TestCurlDownload:
+    def _fake_curl_script(self, tmp_path, fail_urls=(), output="fake-content"):
+        """Create a fake `curl` executable.
+
+        Fails (exit 1) for URLs in ``fail_urls``, otherwise writes
+        ``output`` to the ``-o`` destination.
+        """
+        script = tmp_path / "fake-curl"
+        script.write_text(
+            "#!/bin/sh\n"
+            "url=''\n"
+            "dest=''\n"
+            "prev=''\n"
+            "for a in \"$@\"; do\n"
+            "  if [ \"$prev\" = \"-o\" ]; then\n"
+            "    dest=\"$a\"\n"
+            "    prev=''\n"
+            "  fi\n"
+            "  case \"$a\" in\n"
+            "    -o) prev='-o' ;;\n"
+            "    http*) url=\"$a\" ;;\n"
+            "  esac\n"
+            "done\n"
+            "case \"$url\" in\n"
+            + "".join(f"    {u!r}) exit 1 ;;\n" for u in fail_urls)
+            + "esac\n"
+            "printf '%s' '" + output + "' > \"$dest\"\n"
+            "exit 0\n"
+        )
+        script.chmod(0o755)
+        return str(script)
+
+    def test_success(self, tmp_path):
+        dest = tmp_path / "out.sh"
+        ok, detail = curl_download(
+            "https://raw.githubusercontent.com/x/y/main/z.sh",
+            str(dest),
+            curl_cmd=self._fake_curl_script(tmp_path),
+        )
+        assert ok is True
+        assert detail == ""
+        assert dest.read_text() == "fake-content"
+
+    def test_failure_returns_detail(self, tmp_path):
+        dest = tmp_path / "out.sh"
+        ok, detail = curl_download(
+            "https://raw.githubusercontent.com/x/y/main/z.sh",
+            str(dest),
+            curl_cmd=self._fake_curl_script(tmp_path, fail_urls=("https://raw.githubusercontent.com/x/y/main/z.sh",)),
+        )
+        assert ok is False
+        assert "exit 1" in detail
+
+
+class TestFetchWithFallback:
+    def test_official_success_no_mirror_attempted(self, tmp_path):
+        dest = tmp_path / "out.sh"
+        ok, _ = fetch_with_fallback(
+            "https://raw.githubusercontent.com/x/y/main/z.sh",
+            str(dest),
+            curl_cmd=TestCurlDownload()._fake_curl_script(tmp_path),
+        )
+        assert ok is True
+
+    def test_official_fails_mirror_succeeds(self, tmp_path):
+        dest = tmp_path / "out.sh"
+        url = "https://raw.githubusercontent.com/x/y/main/z.sh"
+        curl = TestCurlDownload()._fake_curl_script(
+            tmp_path, fail_urls=(url,), output="mirror-content"
+        )
+        ok, detail = fetch_with_fallback(url, str(dest), curl_cmd=curl)
+        assert ok is True
+        assert dest.read_text() == "mirror-content"
+
+    def test_all_fail_returns_summary(self, tmp_path):
+        dest = tmp_path / "out.sh"
+        url = "https://raw.githubusercontent.com/x/y/main/z.sh"
+        mirror1 = f"https://ghfast.top/{url}"
+        mirror2 = f"https://gh-proxy.com/{url}"
+        curl = TestCurlDownload()._fake_curl_script(
+            tmp_path, fail_urls=(url, mirror1, mirror2), output="x"
+        )
+        ok, detail = fetch_with_fallback(url, str(dest), curl_cmd=curl)
+        assert ok is False
+        assert url in detail
+        assert mirror1 in detail

--- a/tests/hermes_cli/test_net_download.py
+++ b/tests/hermes_cli/test_net_download.py
@@ -184,17 +184,39 @@ class TestFetchWithFallback:
         )
         assert ok is True
 
-    def test_official_fails_mirror_succeeds(self, tmp_path):
+    def test_official_fails_mirror_succeeds_when_opted_in(self, tmp_path):
         dest = tmp_path / "out.sh"
         url = "https://raw.githubusercontent.com/x/y/main/z.sh"
         curl = TestCurlDownload()._fake_curl_script(
             tmp_path, fail_urls=(url,), output="mirror-content"
         )
-        ok, detail = fetch_with_fallback(url, str(dest), curl_cmd=curl)
+        # Mirrors are opt-in: the mirror path only runs when the caller
+        # explicitly passes allow_mirrors=True.
+        ok, detail = fetch_with_fallback(url, str(dest), curl_cmd=curl, allow_mirrors=True)
         assert ok is True
         assert dest.read_text() == "mirror-content"
 
-    def test_all_fail_returns_summary(self, tmp_path):
+    def test_official_fails_no_mirror_by_default(self, tmp_path):
+        """Security contract: executed-content fetches must not fall back to
+        third-party mirrors unless the caller opts in. The default keeps
+        mirrors off, so an official-URL failure is a hard failure."""
+        dest = tmp_path / "out.sh"
+        url = "https://raw.githubusercontent.com/x/y/main/z.sh"
+        mirror1 = f"https://ghfast.top/{url}"
+        mirror2 = f"https://gh-proxy.com/{url}"
+        curl = TestCurlDownload()._fake_curl_script(
+            tmp_path, fail_urls=(url, mirror1, mirror2), output="mirror-content"
+        )
+        ok, detail = fetch_with_fallback(url, str(dest), curl_cmd=curl)
+        assert ok is False
+        assert url in detail
+        # Mirrors must NOT be attempted (and therefore must not appear in the
+        # failure summary) with the default allow_mirrors=False.
+        assert mirror1 not in detail
+        assert mirror2 not in detail
+        assert not dest.exists() or dest.read_text() == ""
+
+    def test_all_fail_returns_summary_when_opted_in(self, tmp_path):
         dest = tmp_path / "out.sh"
         url = "https://raw.githubusercontent.com/x/y/main/z.sh"
         mirror1 = f"https://ghfast.top/{url}"
@@ -202,7 +224,8 @@ class TestFetchWithFallback:
         curl = TestCurlDownload()._fake_curl_script(
             tmp_path, fail_urls=(url, mirror1, mirror2), output="x"
         )
-        ok, detail = fetch_with_fallback(url, str(dest), curl_cmd=curl)
+        ok, detail = fetch_with_fallback(url, str(dest), curl_cmd=curl, allow_mirrors=True)
         assert ok is False
         assert url in detail
         assert mirror1 in detail
+        assert mirror2 in detail

--- a/tests/hermes_cli/test_net_download.py
+++ b/tests/hermes_cli/test_net_download.py
@@ -17,6 +17,7 @@ from hermes_cli.net_download import (
     fetch_with_fallback,
     mirror_candidates,
     proxy_env_for,
+    resolve_dns_doh,
 )
 
 
@@ -300,3 +301,296 @@ class TestFetchWithFallback:
         assert ok is False
         assert url in detail
         assert mirror1 not in detail
+
+
+class TestResolveDnsDoh:
+    """DNS-over-HTTPS resolution (DNSPod doh.pub)."""
+
+    def _fake_run(self, output, returncode=0):
+        def fake_run(args, **kwargs):
+            return type("R", (), {"returncode": returncode, "stdout": output})()
+        return fake_run
+
+    def test_parses_a_records(self, monkeypatch):
+        out = (
+            '{"Status":0,"Answer":['
+            '{"name":"example.com.","type":1,"TTL":60,"data":"93.184.216.34"},'
+            '{"name":"example.com.","type":1,"TTL":60,"data":"93.184.216.35"}]}'
+        )
+        monkeypatch.setattr("hermes_cli.net_download.subprocess.run", self._fake_run(out))
+        assert resolve_dns_doh("example.com", curl_cmd="curl") == [
+            "93.184.216.34", "93.184.216.35",
+        ]
+
+    def test_filters_non_a_records_and_malformed(self, monkeypatch):
+        out = (
+            '{"Answer":['
+            '{"type":1,"data":"93.184.216.34"},'
+            '{"type":28,"data":"2606:2800:220:1:248:1893:25c8:1946"},'
+            '{"type":5,"data":"evil.example.net"},'
+            '{"type":1,"data":"not-an-ip"},'
+            '{"type":1,"data":"999.999.999.999"}]}'
+        )
+        monkeypatch.setattr("hermes_cli.net_download.subprocess.run", self._fake_run(out))
+        assert resolve_dns_doh("example.com", curl_cmd="curl") == ["93.184.216.34"]
+
+    def test_returns_empty_on_curl_failure(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.net_download.subprocess.run", self._fake_run("", returncode=7)
+        )
+        assert resolve_dns_doh("example.com", curl_cmd="curl") == []
+
+    def test_returns_empty_on_timeout(self, monkeypatch):
+        def boom(args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd=args, timeout=5)
+        monkeypatch.setattr("hermes_cli.net_download.subprocess.run", boom)
+        assert resolve_dns_doh("example.com", curl_cmd="curl") == []
+
+    def test_returns_empty_on_invalid_json(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.net_download.subprocess.run", self._fake_run("not json")
+        )
+        assert resolve_dns_doh("example.com", curl_cmd="curl") == []
+
+    def test_missing_curl_returns_empty(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.net_download.shutil.which", lambda name: None)
+        assert resolve_dns_doh("example.com") == []
+
+    def test_doh_query_does_not_use_proxy(self, monkeypatch):
+        """The DoH query must not be routed through a proxy — the whole
+        point is to bypass poisoned resolution, and doh.pub is reachable
+        directly from CN. The child env must not gain a proxy either."""
+        captured = {}
+
+        def fake_run(args, **kwargs):
+            captured["args"] = args
+            captured["env"] = kwargs.get("env")
+            return type("R", (), {"returncode": 0, "stdout": '{"Answer":[]}'})()
+
+        monkeypatch.setattr("hermes_cli.net_download.subprocess.run", fake_run)
+        resolve_dns_doh(
+            "example.com", curl_cmd="curl",
+            env={"HTTPS_PROXY": "http://proxy:8080", "FOO": "bar"},
+        )
+        assert "-x" not in captured["args"]
+        assert any("doh.pub" in a for a in captured["args"])
+        assert any("application/dns-json" in a for a in captured["args"])
+        # env 未被修改（无代理注入），调用方 dict 原样透传
+        assert captured["env"] == {"HTTPS_PROXY": "http://proxy:8080", "FOO": "bar"}
+
+
+class TestCurlDownloadDnsFallback:
+    """DNS-pollution fallback inside curl_download."""
+
+    def _fake_curl_dns(self, tmp_path, doh_ips=("93.184.216.34",), output="dns-content"):
+        """fake curl that models a poisoned-DNS network:
+
+        - doh.pub URL          -> prints the DNS JSON with ``doh_ips``
+        - URL with --resolve   -> writes ``output`` to dest (fallback wins)
+        - anything else        -> exit 1 with a DNS error on stderr
+        """
+        script = tmp_path / "fake-curl-dns"
+        answers = ",".join(
+            f'{{"name":"h","type":1,"TTL":60,"data":"{ip}"}}' for ip in doh_ips
+        )
+        script.write_text(
+            "#!/bin/sh\n"
+            "url=''; dest=''; is_resolve=''; prev=''\n"
+            "for a in \"$@\"; do\n"
+            "  if [ \"$prev\" = \"-o\" ]; then dest=\"$a\"; prev=''; fi\n"
+            "  case \"$a\" in\n"
+            "    --resolve) is_resolve='1' ;;\n"
+            "    -o) prev='-o' ;;\n"
+            "    http*) url=\"$a\" ;;\n"
+            "  esac\n"
+            "done\n"
+            "case \"$url\" in\n"
+            "  *doh.pub*)\n"
+            f"    printf '%s' '{{\"Status\":0,\"Answer\":[{answers}]}}'\n"
+            "    exit 0 ;;\n"
+            "esac\n"
+            "if [ -n \"$is_resolve\" ]; then\n"
+            f"  printf '%s' '{output}' > \"$dest\"\n"
+            "  exit 0\n"
+            "fi\n"
+            "echo 'Could not resolve host: example.com' >&2\n"
+            "exit 1\n"
+        )
+        script.chmod(0o755)
+        return str(script)
+
+    def test_dns_fallback_retries_with_resolve(self, tmp_path):
+        """Core path: direct fetch fails (poisoned DNS), DoH returns the
+        real IP, and the retry with --resolve lands the file."""
+        dest = tmp_path / "out.sh"
+        url = "https://huggingface.co/api/models"  # known-polluted host
+        ok, detail = curl_download(url, str(dest), curl_cmd=self._fake_curl_dns(tmp_path))
+        assert ok is True
+        assert dest.read_text() == "dns-content"
+
+    def test_first_ip_fails_second_succeeds(self, tmp_path):
+        """The fallback tries each DoH IP in order until one connects."""
+        dest = tmp_path / "out.sh"
+        url = "https://huggingface.co/api/models"
+        # 两个 IP：fake curl 对第一个 --resolve 失败、第二个成功
+        script = tmp_path / "fake-curl-multi"
+        script.write_text(
+            "#!/bin/sh\n"
+            "url=''; dest=''; resolve_ip=''; prev=''\n"
+            "for a in \"$@\"; do\n"
+            "  if [ \"$prev\" = \"-o\" ]; then dest=\"$a\"; prev=''; fi\n"
+            "  case \"$a\" in\n"
+            "    --resolve) resolve_ip='pending' ;;\n"
+            "    -o) prev='-o' ;;\n"
+            "    http*) url=\"$a\" ;;\n"
+            "  esac\n"
+            "  case \"$a\" in\n"
+            "    *:93.184.216.34) resolve_ip='10.0.0.1' ;;\n"
+            "    *:93.184.216.35) resolve_ip='10.0.0.2' ;;\n"
+            "  esac\n"
+            "done\n"
+            "case \"$url\" in\n"
+            "  *doh.pub*)\n"
+            "    printf '%s' '{\"Status\":0,\"Answer\":[{\"name\":\"h\",\"type\":1,\"TTL\":60,\"data\":\"93.184.216.34\"},{\"name\":\"h\",\"type\":1,\"TTL\":60,\"data\":\"93.184.216.35\"}]}'\n"
+            "    exit 0 ;;\n"
+            "esac\n"
+            "if [ \"$resolve_ip\" = '10.0.0.1' ]; then\n"
+            "  echo 'Connection refused' >&2\n"
+            "  exit 1\n"
+            "fi\n"
+            "if [ \"$resolve_ip\" = '10.0.0.2' ]; then\n"
+            "  printf 'second-ip-wins' > \"$dest\"\n"
+            "  exit 0\n"
+            "fi\n"
+            "echo 'Could not resolve host' >&2\n"
+            "exit 1\n"
+        )
+        script.chmod(0o755)
+        ok, detail = curl_download(url, str(dest), curl_cmd=str(script))
+        assert ok is True
+        assert dest.read_text() == "second-ip-wins"
+
+    def test_no_doh_query_on_success(self, tmp_path, monkeypatch):
+        """Regression guard: a working direct fetch must never trigger DoH."""
+        calls = []
+
+        def spy(*args, **kwargs):
+            calls.append(args)
+            return []
+
+        monkeypatch.setattr("hermes_cli.net_download.resolve_dns_doh", spy)
+        script = tmp_path / "ok-curl"
+        script.write_text(
+            "#!/bin/sh\nurl=''; dest=''; prev=''\n"
+            "for a in \"$@\"; do\n"
+            "  if [ \"$prev\" = \"-o\" ]; then dest=\"$a\"; prev=''; fi\n"
+            "  case \"$a\" in\n"
+            "    -o) prev='-o' ;;\n"
+            "    http*) url=\"$a\" ;;\n"
+            "  esac\n"
+            "done\n"
+            "printf 'ok' > \"$dest\"\n"
+            "exit 0\n"
+        )
+        script.chmod(0o755)
+        dest = tmp_path / "out.sh"
+        ok, detail = curl_download(
+            "https://raw.githubusercontent.com/x/y/main/z.sh",
+            str(dest), curl_cmd=str(script),
+        )
+        assert ok is True
+        assert calls == []
+
+    def test_http_error_does_not_trigger_doh(self, tmp_path, monkeypatch):
+        """A 404/403 (real server response) on a non-polluted host must not
+        be retried through a different resolver."""
+        calls = []
+
+        def spy(*args, **kwargs):
+            calls.append(args)
+            return []
+
+        monkeypatch.setattr("hermes_cli.net_download.resolve_dns_doh", spy)
+        script = tmp_path / "fail-curl"
+        script.write_text("#!/bin/sh\necho '404 Not Found' >&2\nexit 1\n")
+        script.chmod(0o755)
+        dest = tmp_path / "out.sh"
+        ok, detail = curl_download(
+            "https://example.com/foo.sh", str(dest), curl_cmd=str(script)
+        )
+        assert ok is False
+        assert calls == []
+        assert "404" in detail
+
+    def test_doh_failure_preserves_original_error(self, tmp_path, monkeypatch):
+        """When DoH itself fails, the original curl error must survive —
+        the fallback never masks the root cause."""
+        monkeypatch.setattr(
+            "hermes_cli.net_download.resolve_dns_doh",
+            lambda *a, **k: [],
+        )
+        script = tmp_path / "fail-curl"
+        script.write_text(
+            "#!/bin/sh\necho 'Could not resolve host: huggingface.co' >&2\nexit 1\n"
+        )
+        script.chmod(0o755)
+        dest = tmp_path / "out.sh"
+        ok, detail = curl_download(
+            "https://huggingface.co/api/models", str(dest), curl_cmd=str(script)
+        )
+        assert ok is False
+        assert "Could not resolve host" in detail
+
+    def test_dns_fallback_disabled(self, tmp_path, monkeypatch):
+        """dns_fallback=False must skip DoH entirely."""
+        calls = []
+
+        def spy(*args, **kwargs):
+            calls.append(args)
+            return []
+
+        monkeypatch.setattr("hermes_cli.net_download.resolve_dns_doh", spy)
+        script = tmp_path / "fail-curl"
+        script.write_text(
+            "#!/bin/sh\necho 'Could not resolve host: huggingface.co' >&2\nexit 1\n"
+        )
+        script.chmod(0o755)
+        dest = tmp_path / "out.sh"
+        ok, detail = curl_download(
+            "https://huggingface.co/api/models", str(dest),
+            curl_cmd=str(script), dns_fallback=False,
+        )
+        assert ok is False
+        assert calls == []
+
+
+class TestFetchWithFallbackDns:
+    """DNS fallback integrated with the official-then-mirror flow."""
+
+    def test_dns_fallback_succeeds_before_mirror(self, tmp_path):
+        """Official fails (poisoned DNS) → DoH fallback wins → mirrors are
+        never attempted, even when opted in."""
+        dest = tmp_path / "out.sh"
+        url = "https://huggingface.co/api/models"
+        curl = TestCurlDownloadDnsFallback()._fake_curl_dns(tmp_path)
+        ok, detail = fetch_with_fallback(
+            url, str(dest), curl_cmd=curl,
+            content_class="data", allow_mirrors=True,
+        )
+        assert ok is True
+        assert dest.read_text() == "dns-content"
+
+    def test_dns_fallback_disabled_uses_mirror_when_opted_in(self, tmp_path):
+        """dns_fallback=False + data/mirror opt-in → mirror still rescues."""
+        dest = tmp_path / "out.bin"
+        url = "https://raw.githubusercontent.com/x/y/main/weights.bin"
+        mirror1 = f"https://ghfast.top/{url}"
+        curl = TestCurlDownload()._fake_curl_script(
+            tmp_path, fail_urls=(url,), output="mirror-bytes"
+        )
+        ok, detail = fetch_with_fallback(
+            url, str(dest), curl_cmd=curl,
+            content_class="data", allow_mirrors=True, dns_fallback=False,
+        )
+        assert ok is True
+        assert dest.read_text() == "mirror-bytes"

--- a/tests/hermes_cli/test_net_download.py
+++ b/tests/hermes_cli/test_net_download.py
@@ -202,8 +202,12 @@ class TestFetchWithFallback:
             tmp_path, fail_urls=(url,), output="mirror-content"
         )
         # Mirrors are opt-in: the mirror path only runs when the caller
-        # explicitly passes allow_mirrors=True.
-        ok, detail = fetch_with_fallback(url, str(dest), curl_cmd=curl, allow_mirrors=True)
+        # explicitly passes allow_mirrors=True (and only for non-executed
+        # data-class content — executed content can never use mirrors).
+        ok, detail = fetch_with_fallback(
+            url, str(dest), curl_cmd=curl,
+            content_class="data", allow_mirrors=True,
+        )
         assert ok is True
         assert dest.read_text() == "mirror-content"
 
@@ -235,8 +239,64 @@ class TestFetchWithFallback:
         curl = TestCurlDownload()._fake_curl_script(
             tmp_path, fail_urls=(url, mirror1, mirror2), output="x"
         )
-        ok, detail = fetch_with_fallback(url, str(dest), curl_cmd=curl, allow_mirrors=True)
+        ok, detail = fetch_with_fallback(
+            url, str(dest), curl_cmd=curl,
+            content_class="data", allow_mirrors=True,
+        )
         assert ok is False
         assert url in detail
         assert mirror1 in detail
         assert mirror2 in detail
+
+    def test_executed_class_ignores_allow_mirrors_true(self, tmp_path):
+        """Security contract: content_class='executed' (the default) must
+        permanently disable mirrors at the API level — even a caller that
+        mistakenly passes allow_mirrors=True must not be able to route
+        executed-content bytes through a third-party mirror."""
+        dest = tmp_path / "out.sh"
+        url = "https://raw.githubusercontent.com/x/y/main/z.sh"
+        mirror1 = f"https://ghfast.top/{url}"
+        mirror2 = f"https://gh-proxy.com/{url}"
+        curl = TestCurlDownload()._fake_curl_script(
+            tmp_path, fail_urls=(url, mirror1, mirror2), output="mirror-content"
+        )
+        # Explicitly asking for mirrors on executed content is ignored:
+        ok, detail = fetch_with_fallback(
+            url, str(dest), curl_cmd=curl,
+            content_class="executed", allow_mirrors=True,
+        )
+        assert ok is False
+        assert url in detail
+        assert mirror1 not in detail
+        assert mirror2 not in detail
+        assert not dest.exists() or dest.read_text() == ""
+
+    def test_data_class_opt_in_mirror(self, tmp_path):
+        """content_class='data' keeps mirrors opt-in: allow_mirrors=True
+        works for non-executed payloads (model weights, metadata)."""
+        dest = tmp_path / "out.bin"
+        url = "https://raw.githubusercontent.com/x/y/main/weights.bin"
+        curl = TestCurlDownload()._fake_curl_script(
+            tmp_path, fail_urls=(url,), output="data-bytes"
+        )
+        ok, detail = fetch_with_fallback(
+            url, str(dest), curl_cmd=curl,
+            content_class="data", allow_mirrors=True,
+        )
+        assert ok is True
+        assert dest.read_text() == "data-bytes"
+
+    def test_data_class_default_no_mirror(self, tmp_path):
+        """Even data content defaults to mirrors off (allow_mirrors=None)."""
+        dest = tmp_path / "out.bin"
+        url = "https://raw.githubusercontent.com/x/y/main/weights.bin"
+        mirror1 = f"https://ghfast.top/{url}"
+        curl = TestCurlDownload()._fake_curl_script(
+            tmp_path, fail_urls=(url, mirror1), output="data-bytes"
+        )
+        ok, detail = fetch_with_fallback(
+            url, str(dest), curl_cmd=curl, content_class="data",
+        )
+        assert ok is False
+        assert url in detail
+        assert mirror1 not in detail

--- a/tests/hermes_cli/test_net_download.py
+++ b/tests/hermes_cli/test_net_download.py
@@ -54,6 +54,17 @@ class TestDetectProxy:
 
 
 class TestMacOSSystemProxy:
+    @pytest.fixture(autouse=True)
+    def _darwin(self, monkeypatch):
+        """Simulate a macOS host for all proxy-parsing tests.
+
+        `_macos_system_proxy` early-returns None when `platform.system()`
+        is not "Darwin", so on Linux CI runners the parsing assertions must
+        force Darwin or they fail before touching subprocess at all.
+        (test_non_darwin_returns_none deliberately overrides this fixture.)
+        """
+        monkeypatch.setattr("hermes_cli.net_download.platform.system", lambda: "Darwin")
+
     def _fake_run(self, output, returncode=0):
         def fake_run(args, **kwargs):
             return type("R", (), {"returncode": returncode, "stdout": output})()


### PR DESCRIPTION
feat(net): proxy-aware + mirror-fallback fetch helper for cua-driver installer

## Who should enable this

Any user installing/upgrading Hermes computer-use (cua-driver), especially:

- Users with a system proxy enabled (Surge/Clash configured in macOS System Settings) who never exported proxy env vars
- Users on networks where GitHub is slow/blocked (GFW, corporate firewalls)
- Users hitting \"installer download failed\" with no path forward

The fix takes effect with the code — no config change needed. Users with healthy direct access keep the official-URL-first behavior.

## Platform compatibility

| Platform | Compatibility |
|---|---|
| macOS | ✅ Target platform (new system-proxy detection via `scutil --proxy`) |
| Linux | ✅ Compatible (existing env-var proxy contract; no system-proxy detection) |
| Windows | ✅ Compatible (irm path unchanged + detected proxy env passed through) |

## Quick-start guide

1. `hermes update` (or pull this PR branch)
2. (macOS) Enable proxy in System Settings, then run `hermes computer-use install --upgrade`
3. Installer automatically: detects system proxy → injects into child curl → fetches the install script from the official URL (mirrors are disabled for executed content)
4. Verify: install log shows success; `cua-driver` version updated

## Troubleshooting

| Symptom | Cause | Fix |
|---|---|---|
| \"installer download failed\" with no detail | Old single-URL single-attempt | Upgrade; log shows per-attempt results |
| GitHub direct timeout | raw.githubusercontent.com blocked/throttled | Install fails fast with per-attempt detail — mirrors are **disabled for executed scripts** (supply-chain safety); use a working proxy/direct route |
| System proxy not honored | Old version reads env vars only | macOS: auto-reads System Settings proxy after upgrade |
| Executed script via mirror | Security concern (supply chain) | Mirrors off by default (`allow_mirrors=False`); the install script never uses a third-party mirror — official URL only |

---

## Story: an installer that can't install on half the world's networks

While bringing Hermes computer-use (cua-driver 0.19+) up on macOS we hit a wall
that had nothing to do with the driver: `hermes computer-use install --upgrade`
fetches `install.sh` from `raw.githubusercontent.com` and the release tarball
from `github.com`. On a machine with a System-Settings proxy (Surge/Clash) and
on networks where GitHub is slow or blocked, that fetch hangs for the full curl
timeout and fails — **the installer never runs, the driver stays stale, and the
only symptom is a terse "installer download failed" line with no way forward.**

The root cause is that Hermes' download code is proxy-blind:

1. It never reads the macOS **system** proxy (`scutil --proxy`) — only env vars
   the user happened to export. A proxy turned on in System Settings never
   reaches the child `curl`.
2. There is **no mirror fallback** — one URL, one attempt, one failure mode.

## What this PR does

### New module `hermes_cli/net_download.py` (reusable fetch helper)

| Function | Behavior |
|---|---|
| `detect_proxy()` | Explicit `HTTPS_PROXY`/`HTTP_PROXY` env vars win; on macOS fall back to the **system proxy** via `scutil --proxy` (Surge/Clash in System Settings now reach child curl with zero manual export). Parses scutil robustly — key order is not guaranteed, a port may precede its host line. |
| `curl_download()` | argv-list curl (no `shell=True`), `--connect-timeout 10` + `--max-time`; proxy injected into the **child** env only, parent env never mutated. |
| `mirror_candidates()` / `fetch_with_fallback()` | Official URL first (through the proxy), then — only when the caller opts in with `allow_mirrors=True` — community GitHub mirrors (`ghfast.top`, `gh-proxy.com`) prefix-wrapping the same URL. Default is `allow_mirrors=False`, so executed/pinned content never falls back to third-party mirrors. Fails fast on unreachable hosts so a down official endpoint costs seconds, not the full timeout. |

### Wired into `_run_cua_driver_installer` (`hermes_cli/tools_config.py`)

- `install.sh` is now fetched with `fetch_with_fallback`.
- The proxy-aware env is **reused when executing the installer**, so the
  script's own internal curl (which pulls the release tarball from GitHub)
  also goes through the detected proxy.
- Windows keeps the `irm` path but still receives the detected proxy env.

## Design decisions

- **Proxy first, mirror never for executed content.** Explicit env → system
  proxy → official direct. Mirror fallback exists in the helper but is
  opt-in (`allow_mirrors=True`) and is **never** used for the install script,
  which is executed via `/bin/bash` — a third-party mirror must not supply
  executable code. Users behind proxies/GFW get a working install through
  the detected proxy.
- **System-proxy detection is macOS-only** and read-only (`scutil --proxy`);
  on Linux/Windows the existing env-var contract stands.
- Mirrors are opt-in by default via `allow_mirrors` (default `False`); the
  install-script fetch passes `allow_mirrors=False` explicitly, and nothing
  in this PR redirects executed or pinned content.

## Comparison

| | Before | After |
|---|---|---|
| System proxy (Surge/Clash) | Ignored — install fails | Detected + injected automatically |
| `raw.githubusercontent.com` blocked (with proxy) | 30s hang → fail, no path forward | ~0.9s → official URL succeeds through the detected proxy |
| `raw.githubusercontent.com` blocked (no proxy) | 30s hang → fail, no path forward | Fail fast with per-attempt detail; mirrors stay disabled for the executed script |
| Error message | "installer download failed" | Per-attempt detail (official URL; mirrors disabled for executed content) |
| Windows | Unchanged irm path | Unchanged + proxy env |

## Security review

- No `shell=True` anywhere; every subprocess call is an argv list.
- Proxy env is injected into child processes only; the caller's environment
  is never mutated.
- Download-to-tempfile pattern preserved (mkstemp, 0600), avoiding the
  previous fixed-/tmp and command-substitution surface — unchanged from the
  existing installer code.
- Mirror URLs are fixed, hard-coded community prefixes; no user-controlled
  URL rewriting.
- **Executed content never uses mirrors.** The install script (run via
  `/bin/bash`) is fetched with `allow_mirrors=False`; `fetch_with_fallback`
  defaults to mirrors-off (`allow_mirrors=False`), so any future fetch of
  executed/pinned content inherits the safe default unless it explicitly opts
  in — closing the supply-chain gap where a mirror response could replace an
  executable script.

## Self-test

```
22 passed in 3.24s          # tests/hermes_cli/test_net_download.py
45 passed, 2 skipped        # tests/hermes_cli/test_install_cua_driver.py
```

Coverage: env proxy precedence, case-insensitivity, system-proxy parsing
(port-before-host, disabled proxy, non-Darwin), child-env injection without
mutation, mirror URL construction (GitHub vs non-GitHub), curl success/failure,
official→mirror fallback when opted in, and the **mirrors-off-by-default
security contract** (`test_official_fails_no_mirror_by_default`).

E2E on a Surge-enabled Mac where `raw.githubusercontent.com` is blocked:

```
detected proxy: http://127.0.0.1:6152
fetch_with_fallback(install.sh): ok=True, 0.9s   (before: 31s timeout + failure)
```





---

## DNS-Pollution Fallback — 2026-08-13 iteration

### Background (why this exists)

The original PR made cua-driver installs work behind proxies and GitHub mirrors. Real-world observation on a China-mainland network: **the system resolver returns poisoned A records for `huggingface.co` / `hf-mirror.com`** — measured values include Dropbox (162.125.x), Verizon (128.242.x) and NTT (160.16.x) IPs. Direct fetches fail with `Could not resolve host` / connect errors even though the sites are reachable. Neither existing strategy helps: Surge proxy rules send HF domains DIRECT (wall timeout), and `mirror_candidates()` only wraps `github.com` URLs, so HF fetches (model metadata, weights, install scripts) are hopeless.

### Approach — DoH re-resolution + `--resolve` retry

When a direct fetch fails with a DNS/connect-layer error (or targets a known-polluted host), we re-resolve the host through **DNSPod DNS-over-HTTPS** (`doh.pub` — reachable directly from mainland China, unlike Cloudflare/Google DoH) and retry the **same official URL** with `curl --resolve <host>:<port>:<ip>`.

Key property: this only swaps the *resolved IP*. URL, TLS hostname check and content source stay **official** — so unlike mirrors (third-party bytes, opt-in + permanently disabled for `content_class="executed"`), the DNS fallback is supply-chain-safe for executed content too.

### Design (files changed)

| File | Change |
|---|---|
| `hermes_cli/net_download.py` | `resolve_dns_doh()` (strict IPv4 A-record filter — format **and** numeric range, rejects `999.x.x.x`; no proxy injection); `_should_try_doh_fallback()` (polluted-host set OR DNS/connect error markers); `_retry_with_doh_resolve()` (per-IP retry, max 4); `curl_download(dns_fallback=True)` + `fetch_with_fallback(dns_fallback=True)` pass-through |
| `tests/hermes_cli/test_net_download.py` | +14 tests (40 total) |
| `DECISION-RECORD.md` / `SECURITY-AUDIT.md` / `SECURITY-BASELINE.md` | Decision record, threat-model audit, security baseline contract |

### Safety invariants (see SECURITY-AUDIT.md)

1. **Content source unchanged** — only the IP changes; TLS cert still validates the hostname. A malicious DoH answer cannot inject third-party bytes (TLS fails).
2. **Zero cost on success** — DoH is only queried after a failed direct attempt.
3. **Never masks root cause** — DoH failure / all-IP failure returns the original curl detail.
4. **Bounded retries** — ≤4 IPs, 5s DoH timeout, `dns_fallback=False` fully disables.
5. **Non-CN zero impact** — if `doh.pub` is unreachable, `resolve_dns_doh()` returns `[]` and behavior is unchanged.

### Verification (real execution)

```bash
# 1. DoH returns REAL IPs while system DNS is poisoned:
$ resolve_dns_doh("huggingface.co")
['52.222.136.92', '52.222.136.38', ...]   # CloudFront (real)
$ dig +short huggingface.co
128.242.240.253                            # Verizon (poisoned)

# 2. Real-world failure path (CloudFront IPs wall-blocked on this network):
ok=False, detail="curl: (28) SSL connection timeout"   # original error preserved, no fake success

# 3. Tests (mock end-to-end poisoned-DNS network):
$ python -m pytest tests/hermes_cli/test_net_download.py -q
40 passed
$ ruff check hermes_cli/net_download.py tests/hermes_cli/test_net_download.py
All checks passed!
```

### Who should enable this

Anyone on networks with DNS pollution (China mainland) who fetches HuggingFace-hosted files (model metadata, weights, installers) through Hermes. Users on healthy networks see zero change — the fallback only activates after a direct failure.

### Platform compatibility

| Platform | DoH fallback | Notes |
|---|---|---|
| macOS | ✅ | curl built-in `--resolve`; doh.pub reachable |
| Linux | ✅ | Same curl flags |
| Windows | ✅ | curl.exe supports `--resolve`; `shutil.which("curl")` finds bundled curl |

### Quick-start

No configuration. `curl_download()` / `fetch_with_fallback()` enable DNS fallback by default; pass `dns_fallback=False` to disable (e.g. restricted networks that block outbound DoH).

### Troubleshooting

| Symptom | Cause | Fix |
|---|---|---|
| Fetch fails with `Could not resolve host` but site is up | DNS poisoning | Automatic — DoH fallback re-resolves real IPs and retries |
| Fallback also fails (`SSL connection timeout`) | IP range wall-blocked (e.g. CloudFront) | Original error preserved; use a mirror or proxy channel outside Hermes |
| `doh.pub` unreachable (non-CN network) | DoH endpoint blocked | `resolve_dns_doh()` returns `[]`; behavior unchanged |
| Want to disable entirely | Restricted network policy | `dns_fallback=False` |
