### PR TITLE
fix(gateway): invert agent-visible cache paths for MEDIA delivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1479,6 +1479,13 @@ def validate_media_delivery_path(path: str) -> Optional[str]:
     host's secrets to that same user.
 
     Symlinks are resolved before any containment / denylist check.
+
+    Agent-visible cache paths (``/root/.hermes/cache/...`` under docker/modal,
+    ``~/.hermes/cache/...`` under ssh) are inverted to the host staging file
+    via :func:`tools.credential_files.from_agent_visible_cache_path` *before*
+    ``expanduser`` — inbound attachment notes teach the agent those spellings
+    (:meth:`CachedMedia.context_note`), and without the inverse ``MEDIA:`` /
+    ``send_message`` silently drops the file the model was told to re-send.
     """
     if not path:
         return None
@@ -1489,6 +1496,18 @@ def validate_media_delivery_path(path: str) -> Optional[str]:
     candidate = candidate.lstrip("`\"'").rstrip("`\"',.;:)}]")
     if not candidate:
         return None
+
+    # Inverse of inbound to_agent_visible_cache_path — must run before
+    # expanduser so a literal ``~/.hermes/...`` ssh spelling is not rewritten
+    # against the host home (wrong tree under profiles / non-default
+    # HERMES_HOME). Docker ``/root/.hermes/...`` is unchanged by expanduser;
+    # translating first is still required so resolve() sees the host file.
+    try:
+        from tools.credential_files import from_agent_visible_cache_path
+
+        candidate = from_agent_visible_cache_path(candidate)
+    except Exception:
+        pass
 
     try:
         expanded = Path(os.path.expanduser(candidate))

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -469,6 +469,62 @@ class TestUniversalMediaEgress:
         assert "MEDIA:" not in cleaned
 
 
+class TestMediaDeliveryAgentVisibleCachePath:
+    """Inbound notes teach the agent ``to_agent_visible_cache_path`` spellings;
+    outbound MEDIA must invert them or the file the model was told to re-send
+    is silently skipped as 'unsafe'."""
+
+    def test_docker_agent_visible_cache_path_validates_to_host(
+        self, tmp_path, monkeypatch,
+    ):
+        hermes_home = tmp_path / ".hermes"
+        cached = hermes_home / "cache" / "images" / "photo.png"
+        cached.parent.mkdir(parents=True)
+        cached.write_bytes(b"\x89PNG\r\n\x1a\n")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.delenv("HERMES_MEDIA_DELIVERY_STRICT", raising=False)
+
+        from tools.credential_files import to_agent_visible_cache_path
+
+        visible = to_agent_visible_cache_path(str(cached))
+        assert visible == "/root/.hermes/cache/images/photo.png"
+
+        assert BasePlatformAdapter.validate_media_delivery_path(visible) == str(
+            cached.resolve()
+        )
+
+    def test_filter_keeps_docker_agent_visible_cache_path(
+        self, tmp_path, monkeypatch,
+    ):
+        hermes_home = tmp_path / ".hermes"
+        cached = hermes_home / "cache" / "images" / "photo.png"
+        cached.parent.mkdir(parents=True)
+        cached.write_bytes(b"\x89PNG\r\n\x1a\n")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.delenv("HERMES_MEDIA_DELIVERY_STRICT", raising=False)
+
+        filtered = BasePlatformAdapter.filter_media_delivery_paths([
+            ("/root/.hermes/cache/images/photo.png", False),
+        ])
+        assert filtered == [(str(cached.resolve()), False)]
+
+    def test_non_cache_container_path_still_rejected(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.delenv("HERMES_MEDIA_DELIVERY_STRICT", raising=False)
+
+        assert (
+            BasePlatformAdapter.validate_media_delivery_path(
+                "/root/not-a-hermes-cache/secret.png"
+            )
+            is None
+        )
+
+
 class TestMediaDeliveryPathValidation:
     def _patch_roots(self, monkeypatch, *roots):
         monkeypatch.setattr(


### PR DESCRIPTION

## Summary
- Inbound attachment notes teach the agent `to_agent_visible_cache_path` spellings (`/root/.hermes/cache/...` under docker).
- `validate_media_delivery_path` resolved those strings on the **host** and returned `None`, so `MEDIA:` / `send_message` silently dropped the file the model was told to re-send.
- Invert via `from_agent_visible_cache_path` **before** `expanduser` (same ordering as the vision host-read path).

## Before / After
| Input | Before | After |
|-------|--------|-------|
| host `…/.hermes/cache/images/photo.png` | delivers | delivers |
| agent `/root/.hermes/cache/images/photo.png` (`TERMINAL_ENV=docker`) | `None` / skipped as unsafe | host file delivered |
| `/root/not-a-hermes-cache/secret.png` | rejected | rejected |
