### PR TITLE
fix(api-server): resolve reasoning for the request's model, not model.default (salvage #78920)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2655,7 +2655,6 @@ class APIServerAdapter(BasePlatformAdapter):
             runtime_kwargs = _resolve_runtime_agent_kwargs()
         except RuntimeError as exc:
             raise _ProviderAuthResolutionError(str(exc)) from exc
-        reasoning_config = GatewayRunner._load_reasoning_config()
         model = _resolve_gateway_model()
 
         # When the primary provider's auth fails (expired token / 429 quota
@@ -2671,8 +2670,6 @@ class APIServerAdapter(BasePlatformAdapter):
             model = runtime_model
 
         request_reasoning_config = _request_reasoning_config(model_options)
-        if request_reasoning_config is not None:
-            reasoning_config = request_reasoning_config
         request_service_tier = _request_service_tier(model_options)
 
         request_model = _clean_request_string(requested_model)
@@ -2875,6 +2872,20 @@ class APIServerAdapter(BasePlatformAdapter):
             None
             if confirmed_runtime_lock
             else GatewayRunner._load_fallback_model()
+        )
+
+        # Resolve reasoning against the model this request will actually
+        # run. Per-model ``agent.reasoning_overrides`` key off that model,
+        # and it is only settled after the precedence chain above (browser
+        # lock -> session /model -> session row -> route -> per-request ->
+        # defaults). Resolving at function entry keyed them off
+        # ``model.default`` instead — the defect e81d18dfb removed from the
+        # native gateway paths. An explicit per-request reasoning parameter
+        # still wins over config.
+        reasoning_config = (
+            request_reasoning_config
+            if request_reasoning_config is not None
+            else GatewayRunner._load_reasoning_config(model)
         )
 
         agent_kwargs = {

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -209,7 +209,7 @@ class TestAdapterInit:
         )
         monkeypatch.setattr(
             "gateway.run.GatewayRunner._load_reasoning_config",
-            staticmethod(lambda: {"enabled": True, "effort": "xhigh"}),
+            staticmethod(lambda model="": {"enabled": True, "effort": "xhigh"}),
         )
         monkeypatch.setattr("gateway.run.GatewayRunner._load_fallback_model", staticmethod(lambda: None))
         monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: set())

--- a/tests/gateway/test_reasoning_config_per_model.py
+++ b/tests/gateway/test_reasoning_config_per_model.py
@@ -82,3 +82,63 @@ class TestGatewaySessionEffectiveModel:
         assert result_default is not None
         assert result_default["effort"] == "low"
 
+
+
+class TestApiServerPerModelReasoning:
+    """The OpenAI-compatible surface must resolve reasoning for the model the
+    request actually runs, not ``model.default``.
+
+    e81d18dfb removed exactly this defect from the native gateway paths
+    ("the gateway resolving reasoning against config model.default instead of
+    the session's effective model"); the API server adapter kept it because it
+    resolved reasoning at function entry, before the model precedence chain.
+    """
+
+    @staticmethod
+    def _cfg():
+        return {
+            "model": {"default": "cheap/model-mini"},
+            "agent": {
+                "reasoning_effort": "low",
+                "reasoning_overrides": {"premium/model-max": "xhigh"},
+            },
+        }
+
+    def _run(self, monkeypatch, effective_model):
+        from unittest.mock import MagicMock, patch
+
+        from gateway.config import PlatformConfig
+        from gateway.platforms.api_server import APIServerAdapter
+
+        monkeypatch.setattr(
+            gateway_run, "_load_gateway_runtime_config", lambda: self._cfg(),
+        )
+        adapter = APIServerAdapter(PlatformConfig())
+
+        with patch("gateway.platforms.api_server.AIOHTTP_AVAILABLE", True), \
+             patch("gateway.run._resolve_runtime_agent_kwargs") as kwargs_mock, \
+             patch("gateway.run._resolve_gateway_model") as model_mock, \
+             patch("gateway.run._load_gateway_config") as cfg_mock, \
+             patch("run_agent.AIAgent") as agent_cls:
+            kwargs_mock.return_value = {
+                "api_key": "k", "base_url": None, "provider": None,
+                "api_mode": None, "command": None, "args": [],
+            }
+            model_mock.return_value = effective_model
+            cfg_mock.return_value = self._cfg()
+            agent_cls.return_value = MagicMock()
+
+            adapter._create_agent()
+
+            return agent_cls.call_args.kwargs
+
+    def test_reasoning_follows_the_requested_model(self, monkeypatch):
+        kwargs = self._run(monkeypatch, "premium/model-max")
+
+        assert kwargs["model"] == "premium/model-max"
+        assert kwargs["reasoning_config"] == {"enabled": True, "effort": "xhigh"}
+
+    def test_model_without_an_override_falls_back_to_global(self, monkeypatch):
+        kwargs = self._run(monkeypatch, "cheap/model-mini")
+
+        assert kwargs["reasoning_config"] == {"enabled": True, "effort": "low"}


### PR DESCRIPTION
## Summary
The OpenAI-compatible API server now resolves per-model reasoning overrides for the request's effective model instead of `model.default`.

Salvage of #78920 by @Drexuxux — cherry-picked onto current main with authorship preserved; applied cleanly, no follow-up fixes needed.

Root cause: `_create_agent` called `GatewayRunner._load_reasoning_config()` with no argument at entry — before the model precedence chain (browser lock → session /model → route → per-request → fallback) settled the effective model — so `agent.reasoning_overrides` keyed off `model.default`. This is the same defect e81d18dfb removed from the native gateway paths; the API adapter kept it.

## Changes
- `gateway/platforms/api_server.py`: reasoning resolution moved to after `fallback_model` settles, passing the effective model; explicit per-request reasoning still wins.
- `tests/gateway/test_reasoning_config_per_model.py`: new test class — per-model override hit + global fallback.
- `tests/gateway/test_api_server.py`: monkeypatched lambda updated for the new arg.

## Validation
| | Before | After |
|---|---|---|
| Request model with a reasoning override | override keyed off `model.default` (missed) | override applied for the request's model |
| Explicit per-request reasoning | wins (unchanged) | wins (unchanged) |
| tests: api_server + toolset + normalize + new file | — | 115/115 pass |

## Infographic

![Reasoning resolved per request model](https://v3b.fal.media/files/b/0aa58a88/_5MYpI8NPuuNzCLfkdWen_WO7XsRR7.png)
