### PR TITLE
fix(desktop): restart stale native OAuth attempts

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -177,6 +177,11 @@ release-path changes.
 
 Boot logs land in `HERMES_HOME/logs/desktop.log` (includes backend output and recent Python tracebacks) — check it first if the app reports a boot failure.
 
+If an old Google sign-in tab shows a `400`, do not refresh it. That tab belongs
+to an expired or replaced one-time PKCE attempt. Return to Desktop and choose
+**Restart sign-in**; Hermes closes the prior local callback listener and opens
+one fresh attempt with a new callback port, verifier/challenge, and state.
+
 **macOS / Linux:**
 
 ```bash

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -150,9 +150,13 @@ import {
   resolveLoginStrategy,
   tokenNeedsRefresh
 } from './native-oauth'
-import { runNativeLogin } from './native-oauth-login'
+import {
+  canUseEmbeddedLoginFallback,
+  NativeLoginCoordinator,
+  recoveryActionForNativeLoginFailure
+} from './native-oauth-login'
 import { loadNativeTokenSet, type NativeTokenStoreIo, persistNativeTokenSet } from './native-token-store'
-import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
+import { bindAbortSignal, serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
 import { createKeepAwake } from './power-save'
 import { FirstRunSetupResetError, runPrimaryBackendStartup } from './primary-backend-startup'
 import { rehomePrimaryConnection } from './primary-connection-rehome'
@@ -4259,6 +4263,8 @@ function fetchJson(url, token, options: any = {}) {
       return
     }
 
+    let detachAbort = () => undefined
+
     const req = client.request(
       parsed,
       {
@@ -4277,13 +4283,22 @@ function fetchJson(url, token, options: any = {}) {
       },
       res => {
         const chunks = []
-        res.on('error', reject)
+        res.on('error', error => {
+          detachAbort()
+          reject(error)
+        })
         res.on('data', chunk => chunks.push(chunk))
         res.on('end', () => {
+          detachAbort()
           const text = Buffer.concat(chunks).toString('utf8')
 
           if ((res.statusCode || 500) >= 400) {
-            reject(new Error(`${res.statusCode}: ${text || res.statusMessage}`))
+            const error = new Error(`${res.statusCode}: ${text || res.statusMessage}`) as Error & {
+              statusCode?: number
+            }
+
+            error.statusCode = res.statusCode
+            reject(error)
 
             return
           }
@@ -4321,9 +4336,15 @@ function fetchJson(url, token, options: any = {}) {
       }
     )
 
-    req.on('error', reject)
+    req.on('error', error => {
+      detachAbort()
+      reject(error)
+    })
     req.setTimeout(timeoutMs, () => {
       req.destroy(new Error(`Timed out connecting to Hermes backend after ${timeoutMs}ms`))
+    })
+    detachAbort = bindAbortSignal(options.signal, () => {
+      req.destroy(new Error('Hermes backend request was cancelled.'))
     })
 
     if (body) {
@@ -6288,6 +6309,7 @@ function fetchJsonViaOauthSession(url, options: any = {}) {
 // In-memory cache of decrypted native tokens, keyed by normalized base URL.
 // Backed by the encrypted on-disk store so it survives restarts.
 const _nativeTokens = new Map<string, NativeTokenSet>()
+const _nativeLoginCoordinator = new NativeLoginCoordinator()
 
 function _nativeTokenStorePath() {
   // Co-located with the connection config under userData; one JSON file mapping
@@ -10194,7 +10216,7 @@ ipcMain.handle('hermes:connection-config:oauth-login', async (_event, rawUrl) =>
 
   if (strategy === 'native') {
     try {
-      const tokens = await runNativeLogin(baseUrl, {
+      const tokens = await _nativeLoginCoordinator.start(baseUrl, {
         openExternal: url => shell.openExternal(url),
         postJson: (url, body, opts) => postJsonNoAuth(url, body, opts),
         rememberLog
@@ -10207,13 +10229,27 @@ ipcMain.handle('hermes:connection-config:oauth-login', async (_event, rawUrl) =>
 
       return { ok: true, baseUrl, connected: true }
     } catch (error) {
-      rememberLog(
-        `[native-oauth] native login failed (${
-          error instanceof Error ? error.message : String(error)
-        }); falling back to embedded flow`
-      )
+      const recovery = recoveryActionForNativeLoginFailure(error)
+
+      if (recovery === 'ignore') {
+        return { ok: false, baseUrl, connected: false, superseded: true }
+      }
+
+      if (recovery === 'restart') {
+        rememberLog('[native-oauth] native login ended; waiting for an explicit restart')
+
+        return { ok: false, baseUrl, connected: false, restartSignIn: true }
+      }
+
+      if (!canUseEmbeddedLoginFallback(error)) {
+        rememberLog('[native-oauth] native login ended without opening another sign-in surface')
+
+        return { ok: false, baseUrl, connected: false }
+      }
+
+      rememberLog('[native-oauth] native login unavailable; using embedded compatibility flow')
       // Fall through to the embedded flow so a native-flow hiccup (blocked
-      // loopback, user closed the browser) still lets the user sign in.
+      // loopback or system-browser launch failure) still lets the user sign in.
     }
   }
 
@@ -10233,6 +10269,11 @@ ipcMain.handle('hermes:connection-config:oauth-login', async (_event, rawUrl) =>
 })
 ipcMain.handle('hermes:connection-config:oauth-logout', async (_event, rawUrl) => {
   const baseUrl = rawUrl ? normalizeRemoteBaseUrl(rawUrl) : ''
+
+  if (baseUrl) {
+    _nativeLoginCoordinator.cancel(baseUrl)
+  }
+
   await clearOauthSession(baseUrl || undefined)
 
   // Also drop any native (RFC 8252) bearer tokens for this gateway so a

--- a/apps/desktop/electron/native-oauth-login.test.ts
+++ b/apps/desktop/electron/native-oauth-login.test.ts
@@ -10,14 +10,21 @@
 import assert from 'node:assert/strict'
 import { EventEmitter } from 'node:events'
 
-import { test } from 'vitest'
+import { test, vi } from 'vitest'
 
-import { runNativeLogin } from './native-oauth-login'
+import {
+  canUseEmbeddedLoginFallback,
+  classifyNativeLoginFailure,
+  NativeLoginCoordinator,
+  NativeLoginError,
+  recoveryActionForNativeLoginFailure,
+  runNativeLogin
+} from './native-oauth-login'
 
 // A fake http.Server: captures the request handler, lets the test drive a
 // synthetic browser callback, and records listen/close lifecycle.
 function makeFakeServerFactory(port = 51234) {
-  const state: any = { handler: null, listening: false, closed: false, openedUrl: null }
+  const state: any = { closeCount: 0, handler: null, listening: false, closed: false, openedUrl: null }
 
   const createServer: any = (handler: any) => {
     state.handler = handler
@@ -32,6 +39,7 @@ function makeFakeServerFactory(port = 51234) {
 
     server.close = () => {
       state.closed = true
+      state.closeCount += 1
     }
 
     state.server = server
@@ -102,6 +110,262 @@ test('runNativeLogin completes the loopback round trip and returns tokens', asyn
   assert.equal(state.closed, true)
 })
 
+test('starting again cancels the prior gateway attempt and rejects its stale callback', async () => {
+  const coordinator = new NativeLoginCoordinator()
+  const first = makeFakeServerFactory(51234)
+  const second = makeFakeServerFactory(51235)
+  const openedUrls: string[] = []
+  let firstTokenPosts = 0
+
+  const firstPromise = coordinator.start('https://gw.example.com', {
+    openExternal: async url => {
+      openedUrls.push(url)
+    },
+    postJson: async () => {
+      firstTokenPosts += 1
+
+      return { access_token: 'stale-token' }
+    },
+    createServer: first.createServer,
+    timeoutMs: 5_000
+  })
+
+  await new Promise(r => setTimeout(r, 5))
+  const firstAuthorize = new URL(openedUrls[0])
+
+  const secondPromise = coordinator.start('https://gw.example.com', {
+    openExternal: async url => {
+      openedUrls.push(url)
+    },
+    postJson: async () => ({ access_token: 'fresh-token' }),
+    createServer: second.createServer,
+    timeoutMs: 5_000
+  })
+
+  // Replacement is synchronous: the old listener is closed before the new
+  // attempt can open a browser or receive a callback.
+  assert.equal(first.state.closed, true)
+  await assert.rejects(firstPromise, (error: any) => error?.code === 'superseded')
+
+  await new Promise(r => setTimeout(r, 5))
+  const secondAuthorize = new URL(openedUrls[1])
+
+  assert.notEqual(secondAuthorize.searchParams.get('state'), firstAuthorize.searchParams.get('state'))
+  assert.notEqual(secondAuthorize.searchParams.get('code_challenge'), firstAuthorize.searchParams.get('code_challenge'))
+  assert.notEqual(secondAuthorize.searchParams.get('redirect_uri'), firstAuthorize.searchParams.get('redirect_uri'))
+
+  // Even if a fake drives the now-closed old handler, stale state cannot be
+  // redeemed or affect the fresh attempt.
+  first.state.hitCallback(`code=old-code&state=${encodeURIComponent(firstAuthorize.searchParams.get('state') || '')}`)
+  assert.equal(firstTokenPosts, 0)
+
+  second.state.hitCallback(`code=new-code&state=${encodeURIComponent(secondAuthorize.searchParams.get('state') || '')}`)
+  assert.equal((await secondPromise).accessToken, 'fresh-token')
+  assert.equal(second.state.closed, true)
+})
+
+test('replacement before bind prevents the cancelled attempt from opening a tab', async () => {
+  const coordinator = new NativeLoginCoordinator()
+  const firstState: any = { closeCount: 0, listenCallback: null }
+
+  const firstCreateServer: any = (_handler: any) => {
+    const server: any = new EventEmitter()
+
+    server.listen = (_port: number, _host: string, callback: () => void) => {
+      firstState.listenCallback = callback
+    }
+
+    server.address = () => ({ address: '127.0.0.1', family: 'IPv4', port: 51234 })
+
+    server.close = () => {
+      firstState.closeCount += 1
+    }
+
+    return server
+  }
+
+  let staleTabs = 0
+
+  const firstPromise = coordinator.start('https://gw.example.com', {
+    openExternal: async () => {
+      staleTabs += 1
+    },
+    postJson: async () => ({ access_token: 'stale-token' }),
+    createServer: firstCreateServer,
+    timeoutMs: 5_000
+  })
+
+  const second = makeFakeServerFactory(51235)
+
+  const secondPromise = coordinator.start('https://gw.example.com', {
+    openExternal: async () => undefined,
+    postJson: async () => ({ access_token: 'fresh-token' }),
+    createServer: second.createServer,
+    timeoutMs: 5_000
+  })
+
+  await assert.rejects(firstPromise, (error: any) => error?.code === 'superseded')
+  firstState.listenCallback()
+  await new Promise(r => setTimeout(r, 0))
+  assert.equal(staleTabs, 0)
+  assert.equal(firstState.closeCount, 1)
+
+  coordinator.cancel('https://gw.example.com')
+  await assert.rejects(secondPromise, (error: any) => error?.code === 'cancelled')
+})
+
+test('explicit cancellation closes once and leaves no timeout work behind', async () => {
+  vi.useFakeTimers()
+
+  try {
+    const coordinator = new NativeLoginCoordinator()
+    const { createServer, state } = makeFakeServerFactory()
+    let tokenPosts = 0
+
+    const promise = coordinator.start('https://gw.example.com', {
+      openExternal: async () => undefined,
+      postJson: async () => {
+        tokenPosts += 1
+
+        return { access_token: 'should-not-exist' }
+      },
+      createServer,
+      timeoutMs: 5_000
+    })
+
+    assert.equal(coordinator.cancel('https://gw.example.com'), true)
+    assert.equal(state.closed, true)
+    await assert.rejects(promise, (error: any) => error?.code === 'cancelled')
+
+    await vi.advanceTimersByTimeAsync(5_001)
+    assert.equal(state.closeCount, 1)
+    assert.equal(tokenPosts, 0)
+    assert.equal(vi.getTimerCount(), 0)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+test('replacement aborts an in-flight token exchange and ignores its late result', async () => {
+  const coordinator = new NativeLoginCoordinator()
+  const first = makeFakeServerFactory(51234)
+  const second = makeFakeServerFactory(51235)
+  let firstAuthorizeUrl = ''
+  let exchangeSignal: AbortSignal | undefined
+  let resolveExchange: ((body: any) => void) | undefined
+
+  const firstPromise = coordinator.start('https://gw.example.com', {
+    openExternal: async url => {
+      firstAuthorizeUrl = url
+    },
+    postJson: async (_url, _body, opts: any) => {
+      exchangeSignal = opts?.signal
+
+      return new Promise(resolve => {
+        resolveExchange = resolve
+      })
+    },
+    createServer: first.createServer,
+    timeoutMs: 5_000
+  })
+
+  await new Promise(r => setTimeout(r, 5))
+  const firstState = new URL(firstAuthorizeUrl).searchParams.get('state') || ''
+  first.state.hitCallback(`code=first-code&state=${encodeURIComponent(firstState)}`)
+  await new Promise(r => setTimeout(r, 0))
+
+  const secondPromise = coordinator.start('https://gw.example.com', {
+    openExternal: async () => undefined,
+    postJson: async () => ({ access_token: 'fresh-token' }),
+    createServer: second.createServer,
+    timeoutMs: 5_000
+  })
+
+  assert.equal(exchangeSignal?.aborted, true)
+  await assert.rejects(firstPromise, (error: any) => error?.code === 'superseded')
+  resolveExchange?.({ access_token: 'late-stale-token' })
+
+  await new Promise(r => setTimeout(r, 0))
+  assert.equal(first.state.closeCount, 1)
+
+  coordinator.cancel('https://gw.example.com')
+  await assert.rejects(secondPromise, (error: any) => error?.code === 'cancelled')
+})
+
+test('only the gateway stale-code contract is classified as a stale attempt', () => {
+  const stale: any = new Error('400: {"detail":"Invalid or expired authorization code."}')
+  stale.statusCode = 400
+
+  assert.equal(classifyNativeLoginFailure(stale), 'stale_attempt')
+  assert.equal(classifyNativeLoginFailure(new Error('400: invalid_grant from Google OAuth')), null)
+  assert.equal(classifyNativeLoginFailure(new Error('Google returned a 400 stale request')), null)
+  assert.equal(
+    classifyNativeLoginFailure(
+      Object.assign(new Error('401: Invalid or expired authorization code.'), { statusCode: 401 })
+    ),
+    null
+  )
+})
+
+test('embedded compatibility fallback is limited to local native startup failures', async () => {
+  const callbackFailure = new Error('Google OAuth returned an arbitrary 400 response')
+  const { createServer, state } = makeFakeServerFactory()
+  let authorizeUrl = ''
+
+  const promise = runNativeLogin('https://gw.example.com', {
+    openExternal: async url => {
+      authorizeUrl = url
+    },
+    postJson: async () => {
+      throw callbackFailure
+    },
+    createServer,
+    timeoutMs: 5_000
+  })
+
+  await new Promise(r => setTimeout(r, 5))
+  const callbackState = new URL(authorizeUrl).searchParams.get('state') || ''
+  state.hitCallback(`code=failed-code&state=${encodeURIComponent(callbackState)}`)
+
+  const error = await promise.catch(reason => reason)
+
+  assert.equal(classifyNativeLoginFailure(error), null)
+  assert.equal(canUseEmbeddedLoginFallback(error), false)
+  assert.equal(canUseEmbeddedLoginFallback(new Error('Could not bind native login listener')), false)
+})
+
+test('a listener failure after browser launch cannot open an embedded second attempt', async () => {
+  const { createServer, state } = makeFakeServerFactory()
+  let opened = false
+
+  const promise = runNativeLogin('https://gw.example.com', {
+    openExternal: async () => {
+      opened = true
+    },
+    postJson: async () => ({ access_token: 'unused' }),
+    createServer,
+    timeoutMs: 5_000
+  })
+
+  await new Promise(r => setTimeout(r, 5))
+  assert.equal(opened, true)
+  state.server.emit('error', new Error('listener failed'))
+
+  const error = await promise.catch(reason => reason)
+  assert.equal(canUseEmbeddedLoginFallback(error), false)
+  assert.equal(state.closeCount, 1)
+})
+
+test('recovery is user-driven only for bounded stale-attempt failures', () => {
+  for (const code of ['cancelled', 'stale_attempt', 'state_mismatch', 'timeout'] as const) {
+    assert.equal(recoveryActionForNativeLoginFailure(new NativeLoginError(code, code)), 'restart')
+  }
+
+  assert.equal(recoveryActionForNativeLoginFailure(new NativeLoginError('superseded', 'superseded')), 'ignore')
+  assert.equal(recoveryActionForNativeLoginFailure(new Error('Google OAuth returned 400')), null)
+  assert.equal(recoveryActionForNativeLoginFailure(new Error('network offline')), null)
+})
+
 test('runNativeLogin rejects on a state mismatch (CSRF) without redeeming', async () => {
   const { createServer, state } = makeFakeServerFactory()
   let tokenPostCalled = false
@@ -121,7 +385,12 @@ test('runNativeLogin rejects on a state mismatch (CSRF) without redeeming', asyn
   // Wrong state — must not redeem the code.
   state.hitCallback('code=evil&state=not-the-real-state')
 
-  await assert.rejects(promise, /state mismatch/i)
+  await assert.rejects(promise, (error: any) => {
+    assert.match(error?.message || '', /state mismatch/i)
+    assert.equal(error?.code, 'state_mismatch')
+
+    return true
+  })
   assert.equal(tokenPostCalled, false)
   assert.equal(state.closed, true)
 })
@@ -139,11 +408,17 @@ test('runNativeLogin surfaces a gateway error param', async () => {
   await new Promise(r => setTimeout(r, 5))
   state.hitCallback('error=access_denied&error_description=user_declined')
 
-  await assert.rejects(promise, /access_denied/i)
+  await assert.rejects(promise, (error: any) => {
+    assert.match(error?.message || '', /access_denied/i)
+    assert.equal(error?.code, 'cancelled')
+
+    return true
+  })
+  assert.equal(state.closeCount, 1)
 })
 
 test('runNativeLogin times out when no callback arrives', async () => {
-  const { createServer } = makeFakeServerFactory()
+  const { createServer, state } = makeFakeServerFactory()
 
   await assert.rejects(
     runNativeLogin('https://gw.example.com', {
@@ -152,8 +427,39 @@ test('runNativeLogin times out when no callback arrives', async () => {
       createServer,
       timeoutMs: 20
     }),
-    /timed out/i
+    (error: any) => {
+      assert.match(error?.message || '', /timed out/i)
+      assert.equal(error?.code, 'timeout')
+
+      return true
+    }
   )
+  assert.equal(state.closeCount, 1)
+})
+
+test('runNativeLogin classifies the gateway expired-code contract and cleans up', async () => {
+  const { createServer, state } = makeFakeServerFactory()
+  let authorizeUrl = ''
+
+  const promise = runNativeLogin('https://gw.example.com', {
+    openExternal: async url => {
+      authorizeUrl = url
+    },
+    postJson: async () => {
+      const error: any = new Error('400: {"detail":"Invalid or expired authorization code."}')
+      error.statusCode = 400
+      throw error
+    },
+    createServer,
+    timeoutMs: 5_000
+  })
+
+  await new Promise(r => setTimeout(r, 5))
+  const callbackState = new URL(authorizeUrl).searchParams.get('state') || ''
+  state.hitCallback(`code=expired-code&state=${encodeURIComponent(callbackState)}`)
+
+  await assert.rejects(promise, (error: any) => error?.code === 'stale_attempt')
+  assert.equal(state.closeCount, 1)
 })
 
 test('runNativeLogin fails if the browser cannot be opened', async () => {
@@ -168,6 +474,11 @@ test('runNativeLogin fails if the browser cannot be opened', async () => {
       createServer,
       timeoutMs: 5_000
     }),
-    /could not open the system browser/i
+    (error: any) => {
+      assert.match(error?.message || '', /could not open the system browser/i)
+      assert.equal(canUseEmbeddedLoginFallback(error), true)
+
+      return true
+    }
   )
 })

--- a/apps/desktop/electron/native-oauth-login.ts
+++ b/apps/desktop/electron/native-oauth-login.ts
@@ -56,14 +56,92 @@ export interface NativeLoginDeps {
   /** Open a URL in the user's system browser (shell.openExternal). */
   openExternal: (url: string) => Promise<void>
   /** POST JSON and resolve the parsed body (electron.net-backed in prod). */
-  postJson: (url: string, body: unknown, opts?: { timeoutMs?: number }) => Promise<any>
+  postJson: (url: string, body: unknown, opts?: { signal?: AbortSignal; timeoutMs?: number }) => Promise<any>
   /** http.createServer, injectable for tests. */
   createServer?: typeof http.createServer
   /** Clock + timeout, injectable for tests. */
   now?: () => number
   timeoutMs?: number
+  /** Abort the attempt and synchronously release its local resources. */
+  signal?: AbortSignal
   /** Optional logger for boot diagnostics. */
   rememberLog?: (line: string) => void
+}
+
+export type NativeLoginFailureCode = 'cancelled' | 'stale_attempt' | 'state_mismatch' | 'superseded' | 'timeout'
+
+export class NativeLoginError extends Error {
+  readonly code: NativeLoginFailureCode
+
+  constructor(code: NativeLoginFailureCode, message: string) {
+    super(message)
+    this.name = 'NativeLoginError'
+    this.code = code
+  }
+}
+
+class NativeLoginUnavailableError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'NativeLoginUnavailableError'
+  }
+}
+
+const STALE_AUTHORIZATION_CODE_DETAIL = 'Invalid or expired authorization code.'
+
+/** Recognize only errors that are safe to turn into native-login recovery. */
+export function classifyNativeLoginFailure(error: unknown): NativeLoginFailureCode | null {
+  if (error instanceof NativeLoginError) {
+    return error.code
+  }
+
+  if (!error || typeof error !== 'object' || (error as any).statusCode !== 400) {
+    return null
+  }
+
+  const message = error instanceof Error ? error.message : String(error)
+  const body = message.replace(/^400:\s*/, '')
+
+  try {
+    const parsed = JSON.parse(body)
+
+    return parsed?.detail === STALE_AUTHORIZATION_CODE_DETAIL ? 'stale_attempt' : null
+  } catch {
+    return null
+  }
+}
+
+export function recoveryActionForNativeLoginFailure(error: unknown): 'ignore' | 'restart' | null {
+  const failure = classifyNativeLoginFailure(error)
+
+  if (failure === 'superseded') {
+    return 'ignore'
+  }
+
+  if (failure === 'cancelled' || failure === 'stale_attempt' || failure === 'state_mismatch' || failure === 'timeout') {
+    return 'restart'
+  }
+
+  return null
+}
+
+/** Only local startup failures may use the intentionally supported embedded flow. */
+export function canUseEmbeddedLoginFallback(error: unknown): boolean {
+  return error instanceof NativeLoginUnavailableError
+}
+
+function classifyLoopbackError(error: unknown): Error {
+  const message = error instanceof Error ? error.message : String(error)
+
+  if (message.startsWith('Loopback callback state mismatch')) {
+    return new NativeLoginError('state_mismatch', message)
+  }
+
+  if (message.startsWith('Gateway rejected native login: access_denied')) {
+    return new NativeLoginError('cancelled', message)
+  }
+
+  return error instanceof Error ? error : new Error(message)
 }
 
 /**
@@ -89,7 +167,10 @@ export async function runNativeLogin(
 
   return new Promise<NativeTokenSet>((resolve, reject) => {
     let settled = false
+    let processingCallback = false
+    let browserLaunchStarted = false
     let timer: NodeJS.Timeout | null = null
+    let listenerClosed = false
 
     const server = createServer((req, res) => {
       // Only the callback path carries the code; any other path (favicon,
@@ -101,7 +182,7 @@ export async function runNativeLogin(
       res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
       res.end(DONE_HTML)
 
-      if (settled) {
+      if (settled || processingCallback) {
         return
       }
 
@@ -116,26 +197,48 @@ export async function runNativeLogin(
           const tokenBody = await deps.postJson(
             nativeTokenUrl(baseUrl),
             { code, code_verifier: verifier },
-            { timeoutMs: 15_000 }
+            { signal: deps.signal, timeoutMs: 15_000 }
           )
 
           return parseTokenResponse(tokenBody)
         })
       } catch (error) {
-        fail(error instanceof Error ? error : new Error(String(error)))
+        fail(classifyLoopbackError(error))
       }
     })
 
-    const cleanup = () => {
+    const closeListener = () => {
       if (timer) {
         clearTimeout(timer)
+        timer = null
       }
+
+      if (listenerClosed) {
+        return
+      }
+
+      listenerClosed = true
 
       try {
         server.close()
       } catch {
         // already closed
       }
+    }
+
+    const cleanup = () => {
+      closeListener()
+      deps.signal?.removeEventListener('abort', cancel)
+    }
+
+    function cancel() {
+      const reason = deps.signal?.reason
+
+      fail(
+        reason instanceof NativeLoginError
+          ? reason
+          : new NativeLoginError('superseded', 'Native sign-in was replaced by a newer attempt.')
+      )
     }
 
     const fail = (error: Error) => {
@@ -149,32 +252,72 @@ export async function runNativeLogin(
     }
 
     const finishWith = (produce: () => Promise<NativeTokenSet>) => {
-      if (settled) {
+      if (settled || processingCallback) {
         return
       }
 
-      settled = true
-      // Keep the listener up just long enough to have answered the browser,
-      // then redeem the code out-of-band.
+      processingCallback = true
+      // The browser response is complete. Close the one-shot listener before
+      // redeeming so replacement can never leave an old callback port alive.
+      closeListener()
       produce()
         .then(tokens => {
+          if (settled) {
+            return
+          }
+
+          settled = true
           cleanup()
           resolve(tokens)
         })
         .catch(error => {
+          if (settled) {
+            return
+          }
+
+          settled = true
           cleanup()
-          reject(error instanceof Error ? error : new Error(String(error)))
+          const failure = classifyNativeLoginFailure(error)
+          reject(
+            failure === 'stale_attempt'
+              ? new NativeLoginError(failure, 'Native sign-in expired before its authorization code could be redeemed.')
+              : error instanceof Error
+                ? error
+                : new Error(String(error))
+          )
         })
     }
 
-    server.on('error', err => fail(err instanceof Error ? err : new Error(String(err))))
+    server.on('error', err => {
+      const message = err instanceof Error ? err.message : String(err)
+
+      fail(
+        browserLaunchStarted
+          ? err instanceof Error
+            ? err
+            : new Error(message)
+          : new NativeLoginUnavailableError(`Could not start the loopback listener for native sign-in: ${message}`)
+      )
+    })
+
+    deps.signal?.addEventListener('abort', cancel, { once: true })
+
+    if (deps.signal?.aborted) {
+      cancel()
+
+      return
+    }
 
     // Bind an ephemeral loopback port, then open the browser.
     server.listen(0, '127.0.0.1', () => {
+      if (settled) {
+        return
+      }
+
       const addr = server.address() as AddressInfo | null
 
       if (!addr || typeof addr === 'string') {
-        fail(new Error('Failed to bind loopback listener for native login'))
+        fail(new NativeLoginUnavailableError('Failed to bind loopback listener for native login'))
 
         return
       }
@@ -189,19 +332,15 @@ export async function runNativeLogin(
       })
 
       timer = setTimeout(() => {
-        fail(
-          new Error(
-            'Native sign-in timed out. The browser window may not have completed ' +
-              'sign-in; open Settings → Gateway and try again.'
-          )
-        )
+        fail(new NativeLoginError('timeout', 'Native sign-in timed out. Return to Hermes and select Restart sign-in.'))
       }, timeoutMs)
 
       log(`[native-oauth] loopback listening on 127.0.0.1:${addr.port}; opening system browser`)
 
+      browserLaunchStarted = true
       deps.openExternal(authorizeUrl).catch(error => {
         fail(
-          new Error(
+          new NativeLoginUnavailableError(
             `Could not open the system browser for native sign-in: ${
               error instanceof Error ? error.message : String(error)
             }`
@@ -210,6 +349,50 @@ export async function runNativeLogin(
       })
     })
   })
+}
+
+interface ActiveNativeLogin {
+  controller: AbortController
+  promise: Promise<NativeTokenSet>
+}
+
+/** Owns the single live native-login attempt for each normalized gateway. */
+export class NativeLoginCoordinator {
+  private readonly active = new Map<string, ActiveNativeLogin>()
+
+  start(baseUrl: string, deps: NativeLoginDeps, opts: { provider?: string } = {}): Promise<NativeTokenSet> {
+    this.active
+      .get(baseUrl)
+      ?.controller.abort(new NativeLoginError('superseded', 'Native sign-in was replaced by a newer attempt.'))
+
+    const controller = new AbortController()
+    const promise = runNativeLogin(baseUrl, { ...deps, signal: controller.signal }, opts)
+    const attempt = { controller, promise }
+    this.active.set(baseUrl, attempt)
+
+    void promise
+      .finally(() => {
+        if (this.active.get(baseUrl) === attempt) {
+          this.active.delete(baseUrl)
+        }
+      })
+      .catch(() => undefined)
+
+    return promise
+  }
+
+  cancel(baseUrl: string): boolean {
+    const attempt = this.active.get(baseUrl)
+
+    if (!attempt) {
+      return false
+    }
+
+    this.active.delete(baseUrl)
+    attempt.controller.abort(new NativeLoginError('cancelled', 'Native sign-in was cancelled.'))
+
+    return true
+  }
 }
 
 export { DEFAULT_LOGIN_TIMEOUT_MS }

--- a/apps/desktop/electron/oauth-net-request.test.ts
+++ b/apps/desktop/electron/oauth-net-request.test.ts
@@ -8,7 +8,7 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
+import { bindAbortSignal, serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
 
 test('serializeJsonBody returns undefined for absent bodies', () => {
   assert.equal(serializeJsonBody(undefined), undefined)
@@ -36,4 +36,27 @@ test('setJsonRequestHeaders does not set Electron-restricted Content-Length', ()
     headers.some(([name]) => name.toLowerCase() === 'content-length'),
     false
   )
+})
+
+test('bindAbortSignal aborts once and detaches cleanly', () => {
+  const controller = new AbortController()
+  let aborts = 0
+
+  const detach = bindAbortSignal(controller.signal, () => {
+    aborts += 1
+  })
+
+  controller.abort()
+  controller.abort()
+  assert.equal(aborts, 1)
+
+  detach()
+  assert.equal(aborts, 1)
+
+  const alreadyAborted = new AbortController()
+  alreadyAborted.abort()
+  bindAbortSignal(alreadyAborted.signal, () => {
+    aborts += 1
+  })
+  assert.equal(aborts, 2)
 })

--- a/apps/desktop/electron/oauth-net-request.ts
+++ b/apps/desktop/electron/oauth-net-request.ts
@@ -14,4 +14,20 @@ function setJsonRequestHeaders(request) {
   request.setHeader('Content-Type', 'application/json')
 }
 
-export { serializeJsonBody, setJsonRequestHeaders }
+function bindAbortSignal(signal, abort) {
+  if (!signal) {
+    return () => undefined
+  }
+
+  if (signal.aborted) {
+    abort()
+
+    return () => undefined
+  }
+
+  signal.addEventListener('abort', abort, { once: true })
+
+  return () => signal.removeEventListener('abort', abort)
+}
+
+export { bindAbortSignal, serializeJsonBody, setJsonRequestHeaders }

--- a/apps/desktop/src/app/settings/gateway-settings.test.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.test.tsx
@@ -6,6 +6,8 @@ import type { ProfileInfo } from '@/types/hermes'
 
 const getConnectionConfig = vi.fn()
 const saveConnectionConfig = vi.fn()
+const probeConnectionConfig = vi.fn()
+const oauthLoginConnectionConfig = vi.fn()
 const profiles = atom<ProfileInfo[]>([])
 
 vi.mock('@/store/profile', () => ({
@@ -49,7 +51,7 @@ beforeEach(() => {
   saveConnectionConfig.mockResolvedValue(localConnection)
   Object.defineProperty(window, 'hermesDesktop', {
     configurable: true,
-    value: { getConnectionConfig, saveConnectionConfig }
+    value: { getConnectionConfig, oauthLoginConnectionConfig, probeConnectionConfig, saveConnectionConfig }
   })
 })
 
@@ -117,5 +119,44 @@ describe('GatewaySettings', () => {
         })
       )
     )
+  })
+
+  it('changes the OAuth action to Restart sign-in after a stale native attempt', async () => {
+    const remote = {
+      ...localConnection,
+      mode: 'remote',
+      remoteAuthMode: 'oauth',
+      remoteUrl: 'https://gateway.example.com/hermes'
+    }
+
+    getConnectionConfig.mockResolvedValue(remote)
+    saveConnectionConfig.mockResolvedValue(remote)
+    probeConnectionConfig.mockResolvedValue({
+      authMode: 'oauth',
+      baseUrl: remote.remoteUrl,
+      error: null,
+      providers: [{ displayName: 'Google', name: 'nous' }],
+      reachable: true,
+      version: '0.17.0'
+    })
+    oauthLoginConnectionConfig.mockResolvedValue({
+      baseUrl: remote.remoteUrl,
+      connected: false,
+      ok: false,
+      restartSignIn: true
+    })
+    const { GatewaySettings } = await import('./gateway-settings')
+
+    render(<GatewaySettings />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Sign in with Google' }))
+
+    expect(await screen.findByRole('button', { name: 'Restart sign-in' })).toBeTruthy()
+    expect(oauthLoginConnectionConfig).toHaveBeenCalledWith(remote.remoteUrl)
+
+    fireEvent.change(screen.getByDisplayValue(remote.remoteUrl), {
+      target: { value: 'https://other-gateway.example.com' }
+    })
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Restart sign-in' })).toBeNull())
+    expect(await screen.findByRole('button', { name: 'Sign in with Google' })).toBeTruthy()
   })
 })

--- a/apps/desktop/src/app/settings/gateway-settings.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.tsx
@@ -212,6 +212,7 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
   // its public /api/status) whether it gates with OAuth or a static session
   // token, so we can show the right control (login button vs token box).
   const [probeStatus, setProbeStatus] = useState<ProbeStatus>('idle')
+  const [needsSignInRestart, setNeedsSignInRestart] = useState(false)
   const [probe, setProbe] = useState<DesktopConnectionProbeResult | null>(null)
   const probeSeq = useRef(0)
 
@@ -415,9 +416,11 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
     signingSeq.current += 1
     cloudConnectSeq.current += 1
     setLastTest(null)
+    setNeedsSignInRestart(false)
   }, [
     scope,
     state.mode,
+    state.remoteUrl,
     state.sshHost,
     state.sshUser,
     state.sshPort,
@@ -533,6 +536,7 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
     }
 
     setSigningIn(true)
+    setNeedsSignInRestart(false)
 
     try {
       // Save (don't apply/restart) so the login window has a URL to use and the
@@ -556,15 +560,20 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
         return
       }
 
+      if (result.superseded) {
+        return
+      }
+
       if (result.connected) {
         const refreshed = await window.hermesDesktop.getConnectionConfig(scope)
         acceptSavedConfig(refreshed)
         notify({ kind: 'success', title: g.signedIn, message: g.connectedTo(providerLabel) })
       } else {
+        setNeedsSignInRestart(Boolean(result.restartSignIn))
         notify({
           kind: 'warning',
           title: t.boot.failure.signInIncompleteTitle,
-          message: t.boot.failure.signInIncompleteMessage
+          message: result.restartSignIn ? t.install.restartSignInHint : t.boot.failure.signInIncompleteMessage
         })
       }
     } catch (err) {
@@ -1296,7 +1305,11 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
                 ) : (
                   <Button disabled={signingIn || state.envOverride || !trimmedUrl} onClick={() => void signIn()}>
                     {signingIn ? <Loader2 className="animate-spin" /> : <LogIn />}
-                    {isPasswordProvider ? g.signIn : g.signInWith(providerLabel)}
+                    {needsSignInRestart
+                      ? t.install.restartSignIn
+                      : isPasswordProvider
+                        ? g.signIn
+                        : g.signInWith(providerLabel)}
                   </Button>
                 )
               }

--- a/apps/desktop/src/components/boot-failure-overlay.test.tsx
+++ b/apps/desktop/src/components/boot-failure-overlay.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $desktopBoot } from '@/store/boot'
 import { $desktopOnboarding } from '@/store/onboarding'
@@ -96,6 +96,52 @@ describe('BootFailureOverlay', () => {
       expect(screen.getByRole('button', { name: /use local gateway/i })).toBeTruthy()
     } finally {
       restore()
+    }
+  })
+
+  it('offers Restart sign-in when native reauthentication reports a stale attempt', async () => {
+    $desktopBoot.set({ ...$desktopBoot.get(), error: 'Gateway sign-in required' })
+    const original = window.hermesDesktop
+
+    const remoteOauth = {
+      ...remoteToken,
+      remoteAuthMode: 'oauth',
+      remoteTokenSet: false
+    }
+
+    const oauthLoginConnectionConfig = vi.fn().mockResolvedValue({
+      baseUrl: remoteOauth.remoteUrl,
+      connected: false,
+      ok: false,
+      restartSignIn: true
+    })
+
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: {
+        getConnectionConfig: async () => remoteOauth,
+        getRecentLogs: async () => ({ lines: [] }),
+        oauthLoginConnectionConfig,
+        oauthLogoutConnectionConfig: vi.fn().mockResolvedValue({ connected: false, ok: true }),
+        probeConnectionConfig: vi.fn().mockResolvedValue({
+          authMode: 'oauth',
+          baseUrl: remoteOauth.remoteUrl,
+          error: null,
+          providers: [{ displayName: 'Google', name: 'nous' }],
+          reachable: true,
+          version: '0.17.0'
+        })
+      }
+    })
+
+    try {
+      render(<BootFailureOverlay />)
+      fireEvent.click(await screen.findByRole('button', { name: 'Sign out & sign in' }))
+
+      expect(await screen.findByRole('button', { name: 'Restart sign-in' })).toBeTruthy()
+      expect(oauthLoginConnectionConfig).toHaveBeenCalledWith(remoteOauth.remoteUrl)
+    } finally {
+      Object.defineProperty(window, 'hermesDesktop', { configurable: true, value: original })
     }
   })
 })

--- a/apps/desktop/src/components/boot-failure-overlay.tsx
+++ b/apps/desktop/src/components/boot-failure-overlay.tsx
@@ -50,6 +50,7 @@ export function BootFailureOverlay() {
   const [logs, setLogs] = useState<string[]>([])
   const [showLogs, setShowLogs] = useState(false)
   const [remoteReauth, setRemoteReauth] = useState<RemoteReauth | null>(null)
+  const [needsSignInRestart, setNeedsSignInRestart] = useState(false)
   const [connectionConfig, setConnectionConfig] = useState<DesktopConnectionConfig | null>(null)
   // A remote/cloud backend that failed to boot is fixable from gateway settings,
   // so the escape hatch earns emphasis (local failures keep it as a quiet ghost).
@@ -84,6 +85,7 @@ export function BootFailureOverlay() {
       setRemoteReauth(null)
       setConnectionConfig(null)
       setRemoteFailure(false)
+      setNeedsSignInRestart(false)
       setView('recovery')
 
       return
@@ -174,10 +176,15 @@ export function BootFailureOverlay() {
     }
 
     setBusy('signin')
+    setNeedsSignInRestart(false)
 
     try {
-      await window.hermesDesktop?.oauthLogoutConnectionConfig?.()
+      await window.hermesDesktop?.oauthLogoutConnectionConfig?.(remoteReauth.url)
       const result = await window.hermesDesktop?.oauthLoginConnectionConfig(remoteReauth.url)
+
+      if (result?.superseded) {
+        return
+      }
 
       if (result?.connected) {
         notify({ kind: 'success', title: t.boot.failure.signedInTitle, message: t.boot.failure.signedInMessage })
@@ -186,10 +193,12 @@ export function BootFailureOverlay() {
         return
       }
 
+      setNeedsSignInRestart(Boolean(result?.restartSignIn))
+
       notify({
         kind: 'warning',
         title: t.boot.failure.signInIncompleteTitle,
-        message: t.boot.failure.signInIncompleteMessage
+        message: result?.restartSignIn ? t.install.restartSignInHint : t.boot.failure.signInIncompleteMessage
       })
     } catch (err) {
       notifyError(err, t.boot.failure.signInFailed)
@@ -252,7 +261,7 @@ export function BootFailureOverlay() {
     actions = [
       {
         key: 'signin',
-        label: copy.signOutAndSignIn,
+        label: needsSignInRestart ? t.install.restartSignIn : copy.signOutAndSignIn,
         onClick: () => void signInRemote(),
         icon: <LogIn />,
         busy: 'signin'
@@ -260,7 +269,7 @@ export function BootFailureOverlay() {
       { ...settingsAction, variant: 'secondary' },
       localAction
     ]
-    hint = copy.remoteSignInHint(label)
+    hint = needsSignInRestart ? t.install.restartSignInHint : copy.remoteSignInHint(label)
   } else if (remoteFailure) {
     actions = [settingsAction, { ...retryAction, variant: 'secondary' }, localAction]
     hint = copy.remoteFailureHint

--- a/apps/desktop/src/components/desktop-install-overlay.test.tsx
+++ b/apps/desktop/src/components/desktop-install-overlay.test.tsx
@@ -516,6 +516,57 @@ describe('DesktopInstallOverlay first-run setup', () => {
     })
   })
 
+  it('offers one explicit fresh PKCE restart after a stale native sign-in', async () => {
+    const desktop = installDesktopMock(
+      bootstrapState({
+        setupChoice: { platform: 'linux', activeRoot: '/home/me/.hermes/hermes-agent' }
+      })
+    )
+
+    desktop.probeConnectionConfig.mockResolvedValue({
+      authMode: 'oauth',
+      baseUrl: 'https://gateway.example.com/hermes',
+      error: null,
+      providers: [{ displayName: 'Google', name: 'nous' }],
+      reachable: true,
+      version: '0.17.0'
+    })
+    desktop.oauthLoginConnectionConfig
+      .mockResolvedValueOnce({
+        baseUrl: 'https://gateway.example.com/hermes',
+        connected: false,
+        ok: false,
+        restartSignIn: true
+      })
+      .mockResolvedValueOnce({
+        baseUrl: 'https://gateway.example.com/hermes',
+        connected: true,
+        ok: true
+      })
+
+    render(<DesktopInstallOverlay />)
+    fireEvent.click(await screen.findByText('Connect to existing Hermes'))
+    fireEvent.change(await screen.findByPlaceholderText('https://gateway.example.com/hermes'), {
+      target: { value: 'https://gateway.example.com/hermes' }
+    })
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 550))
+    })
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Sign in with Google' }))
+    const restart = await screen.findByRole('button', { name: 'Restart sign-in' })
+    expect(
+      screen.getByText(
+        "That browser attempt is no longer valid. Don't refresh the old Google 400 tab — Restart sign-in creates fresh PKCE state."
+      )
+    ).toBeTruthy()
+
+    fireEvent.click(restart)
+    await waitFor(() => expect(desktop.oauthLoginConnectionConfig).toHaveBeenCalledTimes(2))
+    expect(await screen.findByText('Browser sign-in completed.')).toBeTruthy()
+  })
+
   it('offers remote connection from the unsupported packaged install screen', async () => {
     const desktop = installDesktopMock(
       bootstrapState({

--- a/apps/desktop/src/components/first-run-remote-form.tsx
+++ b/apps/desktop/src/components/first-run-remote-form.tsx
@@ -29,6 +29,7 @@ export function FirstRunRemoteForm({ onBack }: FirstRunRemoteFormProps) {
   const [probe, setProbe] = useState<DesktopConnectionProbeResult | null>(null)
   const [oauthConnected, setOauthConnected] = useState(false)
   const [signingIn, setSigningIn] = useState(false)
+  const [needsSignInRestart, setNeedsSignInRestart] = useState(false)
   const [testing, setTesting] = useState(false)
   const [applying, setApplying] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -44,6 +45,7 @@ export function FirstRunRemoteForm({ onBack }: FirstRunRemoteFormProps) {
     setTesting(false)
     setError(null)
     setSuccess(null)
+    setNeedsSignInRestart(false)
     setLastTestedPayloadKey(null)
   }, [])
 
@@ -135,10 +137,16 @@ export function FirstRunRemoteForm({ onBack }: FirstRunRemoteFormProps) {
       // its OAuth cookies; config is persisted once the user applies.
       const result = await window.hermesDesktop.oauthLoginConnectionConfig(trimmedUrl)
       invalidateTest()
+
+      if (result.superseded) {
+        return
+      }
+
       setOauthConnected(Boolean(result.connected))
 
       if (!result.connected) {
-        setError(copy.signInIncomplete)
+        setNeedsSignInRestart(Boolean(result.restartSignIn))
+        setError(result.restartSignIn ? copy.restartSignInHint : copy.signInIncomplete)
       }
     } catch (err) {
       setError(errorMessage(err))
@@ -280,7 +288,11 @@ export function FirstRunRemoteForm({ onBack }: FirstRunRemoteFormProps) {
                 ) : (
                   <Button disabled={signingIn || applying} onClick={() => void signIn()} size="sm">
                     {signingIn ? <Loader2 className="size-4 animate-spin" /> : <LogIn className="size-4" />}
-                    {isPasswordProvider ? copy.signIn : copy.signInWith(providerLabel)}
+                    {needsSignInRestart
+                      ? copy.restartSignIn
+                      : isPasswordProvider
+                        ? copy.signIn
+                        : copy.signInWith(providerLabel)}
                   </Button>
                 )}
               </div>

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -641,6 +641,8 @@ export interface DesktopOauthLoginResult {
   ok: boolean
   baseUrl: string
   connected: boolean
+  restartSignIn?: boolean
+  superseded?: boolean
 }
 
 export interface DesktopOauthLogoutResult {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2272,6 +2272,9 @@ export const en: Translations = {
     connected: 'Connected',
     signIn: 'Sign in',
     signInWith: provider => `Sign in with ${provider}`,
+    restartSignIn: 'Restart sign-in',
+    restartSignInHint:
+      "That browser attempt is no longer valid. Don't refresh the old Google 400 tab — Restart sign-in creates fresh PKCE state.",
     enterUrlFirst: 'Enter a gateway URL first.',
     signInIncomplete: 'The sign-in window closed before authentication completed.',
     tokenTitle: 'Session token',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2107,6 +2107,9 @@ export const ja = defineLocale({
     connected: '接続済み',
     signIn: 'サインイン',
     signInWith: provider => `${provider} でサインイン`,
+    restartSignIn: 'サインインを再開',
+    restartSignInHint:
+      'このブラウザーの試行は無効です。古い Google の 400 タブは更新しないでください。「サインインを再開」で新しい PKCE 状態が作成されます。',
     enterUrlFirst: '先にゲートウェイ URL を入力してください。',
     signInIncomplete: '認証が完了する前にサインインウィンドウが閉じられました。',
     tokenTitle: 'セッショントークン',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1894,6 +1894,8 @@ export interface Translations {
     connected: string
     signIn: string
     signInWith: (provider: string) => string
+    restartSignIn: string
+    restartSignInHint: string
     enterUrlFirst: string
     signInIncomplete: string
     tokenTitle: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2040,6 +2040,9 @@ export const zhHant = defineLocale({
     connected: '已連線',
     signIn: '登入',
     signInWith: provider => `使用 ${provider} 登入`,
+    restartSignIn: '重新開始登入',
+    restartSignInHint:
+      '此瀏覽器登入嘗試已失效。請勿重新整理舊的 Google 400 分頁；「重新開始登入」會建立新的 PKCE 狀態。',
     enterUrlFirst: '請先輸入閘道 URL。',
     signInIncomplete: '驗證完成前登入視窗已關閉。',
     tokenTitle: '工作階段權杖',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2461,6 +2461,8 @@ export const zh: Translations = {
     connected: '已连接',
     signIn: '登录',
     signInWith: provider => `使用 ${provider} 登录`,
+    restartSignIn: '重新开始登录',
+    restartSignInHint: '此浏览器登录尝试已失效。请勿刷新旧的 Google 400 标签页；“重新开始登录”会创建新的 PKCE 状态。',
     enterUrlFirst: '请先输入网关 URL。',
     signInIncomplete: '认证完成前登录窗口已关闭。',
     tokenTitle: '会话令牌',

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -315,14 +315,20 @@ async def auth_native_authorize(
         raise HTTPException(status_code=400, detail="code_challenge required")
     _validate_loopback_redirect_uri(redirect_uri)
 
-    # Resolve the provider. With exactly one session provider registered
-    # (the common hosted case) an empty ``provider`` selects it, mirroring
-    # the auto-SSO convenience so the desktop needn't hardcode the name.
+    # Resolve the provider. With exactly one brokerable OAuth provider
+    # registered, an empty ``provider`` selects it. Password providers are
+    # deliberately excluded from this count: mixed deployments commonly
+    # expose both a password fallback and one OAuth provider, while the desktop
+    # intentionally omits the provider name from its native-PKCE URL.
     p = get_provider(provider) if provider else None
     if p is None and not provider:
-        sess_providers = list_session_providers()
-        if len(sess_providers) == 1:
-            p = sess_providers[0]
+        brokerable_providers = [
+            candidate
+            for candidate in list_session_providers()
+            if not getattr(candidate, "supports_password", False)
+        ]
+        if len(brokerable_providers) == 1:
+            p = brokerable_providers[0]
     if p is None:
         raise HTTPException(
             status_code=404, detail=f"Unknown provider: {provider!r}"

--- a/tests/hermes_cli/test_dashboard_auth_native_flow.py
+++ b/tests/hermes_cli/test_dashboard_auth_native_flow.py
@@ -181,6 +181,29 @@ def test_native_authorize_rejects_non_loopback_redirect(gated_client):
     assert "loopback" in r.json()["detail"].lower()
 
 
+def test_native_authorize_auto_selects_only_oauth_provider_with_password_fallback(
+    gated_client,
+):
+    class PasswordFallback(StubAuthProvider):
+        name = "password-fallback"
+        supports_password = True
+
+    register_provider(PasswordFallback())
+    _verifier, challenge = _make_pkce()
+    r = gated_client.get(
+        "/auth/native/authorize",
+        params={
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "redirect_uri": "http://127.0.0.1:53999/callback",
+            "state": "desktop-state",
+        },
+    )
+
+    assert r.status_code == 302, r.text
+    assert "code=stub_code" in r.headers["location"]
+
+
 # ---------------------------------------------------------------------------
 # Cookieless bearer auth of a gated route — the core deliverable
 # ---------------------------------------------------------------------------

--- a/website/docs/guides/desktop-native-signin.md
+++ b/website/docs/guides/desktop-native-signin.md
@@ -78,9 +78,16 @@ an `auth_flows` array:
 | `["cookie"]` | Gateway supports only the legacy flow → the app uses the embedded webview |
 | *(field absent)* | Older gateway → the app uses the embedded webview |
 
-If native sign-in is advertised but fails for a local reason — e.g. a security
-tool blocks the loopback listener, or you close the browser tab — the app
-**falls back to the embedded flow automatically** so you can still sign in.
+If native sign-in cannot start locally — for example, a security tool blocks
+the loopback listener or the system browser cannot open — the app can still use
+the embedded compatibility flow. Once a native attempt has started, Hermes
+does not silently retry it or open repeated tabs. A timeout, cancellation,
+callback-state mismatch, or an expired one-time gateway code ends that attempt
+and shows **Restart sign-in**.
+
+Restarting closes the previous loopback listener and creates a new callback
+port, PKCE verifier/challenge, and `state` before opening one new browser tab.
+The old attempt stays invalid and cannot complete the new one.
 
 ## Token lifecycle
 
@@ -94,6 +101,18 @@ tool blocks the loopback listener, or you close the browser tab — the app
   sign-in.
 - **Sign out**: clears both the native tokens (keychain) and any legacy session
   cookie for that gateway.
+
+## Troubleshooting a Google 400 page
+
+If an older Google sign-in tab shows a `400` after the Desktop attempt timed
+out, was cancelled, or was restarted, **do not refresh that tab**. Its
+one-time OAuth and PKCE state belongs to an attempt Hermes has already closed,
+so refreshing cannot make it valid again.
+
+Return to Hermes Desktop and select **Restart sign-in**. Desktop closes any
+remaining local listener for that gateway and opens one fresh attempt with a
+new PKCE verifier/challenge, callback port, and `state`. Complete sign-in only
+in the newly opened tab.
 
 ## For gateway operators
 


### PR DESCRIPTION
## Summary

- enforce one active native PKCE attempt per normalized gateway and synchronously abort the prior listener, timer, and token request
- classify only the gateway expired-code contract as stale; surface explicit Restart sign-in recovery for timeout, cancellation, state mismatch, and stale code
- preserve embedded fallback only for local native startup failures, avoiding automatic retries and repeated sign-in surfaces after browser launch
- add Desktop recovery UI/copy across onboarding, Gateway Settings, boot recovery, locales, and native sign-in docs
- preserve the pinned sole-provider native OAuth selection fix as the first commit because it was not present on current upstream main

## Security invariants

- every restart creates a new callback port, verifier/challenge, and state
- stale callbacks cannot redeem or affect the replacement attempt
- state and PKCE validation remain strict; no verifier reuse or insecure fallback
- normal logs contain no authorization URL, state, code, or verifier
- arbitrary Google/OAuth failures are not broadly classified as stale

## Tests

- targeted Electron auth: 150 passed
- targeted recovery UI: 60 passed
- full Desktop Vitest: 4,554 passed, 2 skipped
- Electron/platform suite: 961 passed, 2 skipped
- Desktop typecheck: passed
- Desktop lint: passed (0 errors; existing warnings only)
- git diff --check: passed
- Desktop build: renderer and Electron bundles passed; final native dependency staging is blocked on this host because electron-rebuild cannot find make for get-windows/node-pty
- pinned Python auth test wrapper: unavailable because no pytest-enabled repository virtualenv is installed

## TDD coverage

Behavior-first RED/GREEN cycles cover concurrent replacement, pre-bind cancellation, explicit cancellation, in-flight token abort, timeout cleanup, state mismatch, user cancellation, exact stale-code classification, fresh PKCE material, successful callback, and listener/timer/request leak prevention.