### PR TITLE
fix(desktop): surface compacted session prompts safely

### DIFF
--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -10,6 +10,7 @@ import type { SubmitTextOptions } from '@/app/session/hooks/use-prompt-actions/u
 import { Thread } from '@/components/assistant-ui/thread'
 import { TranscriptWindowProvider } from '@/components/assistant-ui/thread/transcript-window'
 import { Backdrop } from '@/components/Backdrop'
+import { ArchivedTranscript } from '@/components/chat/archived-transcript'
 import { COMPOSER_HEART_CONFIG, HeartField } from '@/components/chat/vibe-hearts'
 import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
 import { $sessionTileDragging, $sessionTileEdgeHover } from '@/components/pane-shell/tree/store'
@@ -542,19 +543,22 @@ export const ChatView = memo(function ChatView({
           data-slot="composer-bounds"
           {...dropHandlers}
         >
-          <Thread
-            clampToComposer={showChatBar}
-            cwd={currentCwd}
-            gateway={gateway}
-            intro={showIntro ? { personality: introPersonality, seed: introSeed } : undefined}
-            loading={threadLoading}
-            onBranchInNewChat={onBranchInNewChat}
-            onCancel={haltRun}
-            onDismissError={onDismissError}
-            onRestoreToMessage={onRestoreToMessage}
-            sessionId={activeSessionId}
-            sessionKey={threadKey}
-          />
+          <ArchivedTranscript profile={activeGatewayProfile} sessionId={activeSessionId} />
+          <div className="min-h-0 flex-1">
+            <Thread
+              clampToComposer={showChatBar}
+              cwd={currentCwd}
+              gateway={gateway}
+              intro={showIntro ? { personality: introPersonality, seed: introSeed } : undefined}
+              loading={threadLoading}
+              onBranchInNewChat={onBranchInNewChat}
+              onCancel={haltRun}
+              onDismissError={onDismissError}
+              onRestoreToMessage={onRestoreToMessage}
+              sessionId={activeSessionId}
+              sessionKey={threadKey}
+            />
+          </div>
           {resumeExhausted && routedSessionId && (
             <div className="absolute inset-0 z-10 grid place-items-center bg-(--ui-chat-surface-background) px-8 py-10">
               <ErrorState

--- a/apps/desktop/src/components/chat/archived-transcript.test.tsx
+++ b/apps/desktop/src/components/chat/archived-transcript.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ArchivedTranscript } from './archived-transcript'
+
+const { getSessionMessages } = vi.hoisted(() => ({ getSessionMessages: vi.fn() }))
+
+vi.mock('@/hermes', () => ({ getSessionMessages }))
+
+describe('ArchivedTranscript', () => {
+  beforeEach(() => {
+    getSessionMessages.mockReset()
+  })
+
+  it('loads compacted history on demand and pages older messages', async () => {
+    getSessionMessages
+      .mockResolvedValueOnce({
+        session_id: 'session-1',
+        messages: [
+          { id: 2, content: 'older visible prompt', role: 'user' },
+          { id: 3, content: 'archived answer', role: 'assistant' }
+        ],
+        pagination: {
+          has_more: true,
+          limit: 100,
+          offset: 0,
+          order: 'latest',
+          returned: 2,
+          scope: 'compacted'
+        }
+      })
+      .mockResolvedValueOnce({
+        session_id: 'session-1',
+        messages: [{ id: 1, content: 'oldest archived prompt', role: 'user' }],
+        pagination: {
+          has_more: false,
+          limit: 100,
+          offset: 2,
+          order: 'latest',
+          returned: 1,
+          scope: 'compacted'
+        }
+      })
+
+    render(<ArchivedTranscript profile="default" sessionId="session-1" />)
+
+    expect(screen.queryByText('older visible prompt')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: /Archived history/ }))
+
+    await waitFor(() => expect(screen.getByText('older visible prompt')).toBeTruthy())
+    expect(getSessionMessages).toHaveBeenCalledWith('session-1', 'default', {
+      limit: 100,
+      offset: 0,
+      order: 'latest',
+      scope: 'compacted'
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load older archived messages' }))
+
+    await waitFor(() => expect(screen.getByText('oldest archived prompt')).toBeTruthy())
+    expect(getSessionMessages).toHaveBeenLastCalledWith('session-1', 'default', {
+      limit: 100,
+      offset: 2,
+      order: 'latest',
+      scope: 'compacted'
+    })
+  })
+})

--- a/apps/desktop/src/components/chat/archived-transcript.tsx
+++ b/apps/desktop/src/components/chat/archived-transcript.tsx
@@ -1,0 +1,197 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { CompactMarkdown } from '@/components/chat/compact-markdown'
+import { Button } from '@/components/ui/button'
+import { getSessionMessages } from '@/hermes'
+import type { SessionMessage } from '@/types/hermes'
+
+const ARCHIVED_PAGE_SIZE = 100
+
+type ArchivedTranscriptProps = {
+  profile?: string | null
+  sessionId?: string | null
+}
+
+function messageText(message: SessionMessage): string {
+  const value = message.content ?? message.text ?? message.context ?? message.name
+
+  if (typeof value === 'string') {
+    return value
+  }
+
+  if (value === null || value === undefined) {
+    return ''
+  }
+
+  if (Array.isArray(value)) {
+    return value
+      .map(item => (typeof item === 'string' ? item : JSON.stringify(item)))
+      .filter(Boolean)
+      .join('\n')
+  }
+
+  if (typeof value === 'object') {
+    const record = value as Record<string, unknown>
+
+    for (const key of ['text', 'content', 'message', 'value']) {
+      if (typeof record[key] === 'string') {
+        return record[key] as string
+      }
+    }
+
+    try {
+      return JSON.stringify(value, null, 2) || ''
+    } catch {
+      return ''
+    }
+  }
+
+  return String(value)
+}
+
+export function ArchivedTranscript({ profile, sessionId }: ArchivedTranscriptProps) {
+  const requestVersion = useRef(0)
+  const sessionKey = `${profile ?? ''}:${sessionId ?? ''}`
+  const previousSessionKey = useRef(sessionKey)
+
+  if (previousSessionKey.current !== sessionKey) {
+    previousSessionKey.current = sessionKey
+    requestVersion.current += 1
+  }
+
+  const [expanded, setExpanded] = useState(false)
+  const [messages, setMessages] = useState<SessionMessage[]>([])
+  const [nextOffset, setNextOffset] = useState(0)
+  const [hasMore, setHasMore] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const loadPage = useCallback(
+    async (offset: number, append: boolean) => {
+      if (!sessionId) {
+        return
+      }
+
+      const version = ++requestVersion.current
+      setLoading(true)
+      setError(null)
+
+      try {
+        const page = await getSessionMessages(sessionId, profile, {
+          limit: ARCHIVED_PAGE_SIZE,
+          offset,
+          order: 'latest',
+          scope: 'compacted'
+        })
+
+        if (version !== requestVersion.current) {
+          return
+        }
+
+        setMessages(previous => (append ? [...page.messages, ...previous] : page.messages))
+        setNextOffset(offset + page.messages.length)
+        setHasMore(page.pagination?.has_more ?? page.messages.length === ARCHIVED_PAGE_SIZE)
+      } catch (cause) {
+        if (version !== requestVersion.current) {
+          return
+        }
+
+        setError(cause instanceof Error ? cause.message : String(cause))
+      } finally {
+        if (version === requestVersion.current) {
+          setLoading(false)
+        }
+      }
+    },
+    [profile, sessionId]
+  )
+
+  useEffect(() => {
+    setExpanded(false)
+    setMessages([])
+    setNextOffset(0)
+    setHasMore(false)
+    setLoading(false)
+    setError(null)
+  }, [profile, sessionId])
+
+  if (!sessionId) {
+    return null
+  }
+
+  const visibleMessages = messages
+    .filter(message => message.display_kind !== 'hidden')
+    .filter(message => message.role === 'user' || message.role === 'assistant')
+    .map(message => ({ message, text: messageText(message) }))
+    .filter(item => item.text.trim())
+
+  const toggleExpanded = () => {
+    const nextExpanded = !expanded
+    setExpanded(nextExpanded)
+
+    if (nextExpanded && messages.length === 0 && !loading) {
+      void loadPage(0, false)
+    }
+  }
+
+  return (
+    <section
+      aria-label="Archived conversation history"
+      className="shrink-0 border-b border-border/60 bg-muted/15"
+      data-testid="archived-transcript"
+    >
+      <Button
+        aria-expanded={expanded}
+        className="flex h-9 w-full items-center justify-between rounded-none px-3 text-xs text-muted-foreground hover:bg-muted/30"
+        onClick={toggleExpanded}
+        variant="ghost"
+      >
+        <span>Archived history</span>
+        <span className="tabular-nums opacity-70">
+          {messages.length}
+          {hasMore ? '+' : ''} {expanded ? '▴' : '▾'}
+        </span>
+      </Button>
+
+      {expanded && (
+        <div className="max-h-72 overflow-y-auto border-t border-border/40 px-3 py-2">
+          {loading && <div className="px-1 py-2 text-xs text-muted-foreground">Loading archived history…</div>}
+          {error && <div className="px-1 py-2 text-xs text-destructive">Could not load archived history: {error}</div>}
+          {!loading && !error && visibleMessages.length === 0 && (
+            <div className="px-1 py-2 text-xs text-muted-foreground">No archived prompts in this session.</div>
+          )}
+
+          <div className="space-y-3">
+            {visibleMessages.map(({ message, text }, index) => (
+              <article
+                className="rounded-md border border-border/50 bg-background/50 px-2.5 py-2"
+                key={message.id ?? message.row_id ?? `archived-${index}`}
+              >
+                <div className="mb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                  {message.role === 'user' ? 'You' : 'Assistant'}
+                </div>
+                {message.role === 'assistant' ? (
+                  <CompactMarkdown text={text} />
+                ) : (
+                  <div className="whitespace-pre-wrap break-words text-xs leading-relaxed text-foreground/90">
+                    {text}
+                  </div>
+                )}
+              </article>
+            ))}
+          </div>
+
+          {hasMore && !loading && (
+            <Button
+              className="mt-3 h-7 w-full text-xs"
+              onClick={() => void loadPage(nextOffset, true)}
+              variant="outline"
+            >
+              Load older archived messages
+            </Button>
+          )}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -659,7 +659,12 @@ export function getSession(id: string, profile?: string | null): Promise<Session
 export function getSessionMessages(
   id: string,
   profile?: string | null,
-  page: { limit?: number; offset?: number; order?: 'latest' | 'oldest' } = {}
+  page: {
+    limit?: number
+    offset?: number
+    order?: 'latest' | 'oldest'
+    scope?: 'compacted' | 'live'
+  } = {}
 ): Promise<SessionMessagesResponse> {
   const query = new URLSearchParams()
 
@@ -677,6 +682,10 @@ export function getSessionMessages(
 
   if (page.order) {
     query.set('order', page.order)
+  }
+
+  if (page.scope) {
+    query.set('scope', page.scope)
   }
 
   const suffix = query.size ? `?${query.toString()}` : ''

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -571,10 +571,12 @@ export interface SessionMessage {
 export interface SessionMessagesResponse {
   messages: SessionMessage[]
   pagination?: {
+    has_more?: boolean
     limit: number
     offset: number
     order: 'latest' | 'oldest'
     returned: number
+    scope?: 'compacted' | 'live'
   }
   session_id: string
 }

--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -605,11 +605,17 @@ async def get_session_messages(
     limit: Optional[int] = Query(None, ge=0),
     offset: int = Query(0, ge=0),
     order: Optional[str] = Query(None),
+    scope: str = Query("live"),
 ):
     if order not in (None, "oldest", "latest"):
         raise HTTPException(
             status_code=400,
             detail="order must be one of: oldest, latest",
+        )
+    if scope not in ("live", "compacted"):
+        raise HTTPException(
+            status_code=400,
+            detail="scope must be one of: live, compacted",
         )
 
     def _read():
@@ -627,28 +633,41 @@ async def get_session_messages(
             default_page = limit is None
             latest_page = order == "latest" or (order is None and default_page)
             _limit = 500 if default_page else min(limit, 500)
-            return sid, _limit, db.get_messages(
+            # Fetch one sentinel row so the Desktop can page a compacted
+            # archive without materializing the full transcript. For latest
+            # pages the sentinel is the oldest row in the selected slice; for
+            # oldest pages it is the newest.
+            page_messages = db.get_messages(
                 sid,
-                limit=_limit,
+                limit=_limit + 1,
                 offset=offset,
                 latest=latest_page,
+                compacted_only=scope == "compacted",
             )
+            has_more = len(page_messages) > _limit
+            if has_more:
+                page_messages = page_messages[1:] if latest_page else page_messages[:-1]
+            return sid, _limit, page_messages, has_more
         finally:
             db.close()
 
     result = await asyncio.to_thread(_read)
     if result is None:
         raise HTTPException(status_code=404, detail="Session not found")
-    sid, _limit, messages = result
+    sid, _limit, messages, has_more = result
+    pagination = {
+        "limit": _limit,
+        "offset": offset,
+        "order": order or ("latest" if limit is None else "oldest"),
+        "returned": len(messages),
+    }
+    if scope == "compacted":
+        pagination.update({"has_more": has_more, "scope": scope})
+
     return {
         "session_id": sid,
         "messages": messages,
-        "pagination": {
-            "limit": _limit,
-            "offset": offset,
-            "order": order or ("latest" if limit is None else "oldest"),
-            "returned": len(messages),
-        },
+        "pagination": pagination,
     }
 
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3491,6 +3491,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """
         def _do(conn):
             system_prompt_hash = self._store_system_prompt(conn, system_prompt)
+            # Default session_key to the session id so every row has a non-NULL
+            # key. The Desktop's history-truncation path (methods_prompt.py) calls
+            # replace_messages(session["session_key"], ...) — a NULL session_key
+            # makes that INSERT violate the messages.session_id FK →
+            # "FOREIGN KEY constraint failed" → "Restore failed" on resume.
+            effective_session_key = session_key or session_id
             conn.execute(
                 """INSERT INTO sessions (
                    id, source, user_id, session_key, chat_id, chat_type, thread_id,
@@ -3523,7 +3529,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     session_id,
                     source,
                     user_id,
-                    session_key,
+                    effective_session_key,
                     chat_id,
                     chat_type,
                     thread_id,
@@ -7657,6 +7663,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         offset: int = 0,
         latest: bool = False,
         after_id: Optional[int] = None,
+        compacted_only: bool = False,
     ) -> List[Dict[str, Any]]:
         """Load messages for a session in insertion order.
 
@@ -7680,10 +7687,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         ``after_id`` enables keyset pagination (``id > after_id``): O(1)
         page seeks on huge transcripts where OFFSET degrades to O(n) per
         page. Ascending order only (incompatible with ``latest``/``offset``).
+
+        ``compacted_only=True`` selects only messages archived by in-place
+        context compaction (``active=0 AND compacted=1``). Rewound rows remain
+        excluded, even when the Desktop requests the archived transcript.
         """
         if after_id is not None and (latest or offset):
             raise ValueError("after_id is incompatible with latest/offset paging")
-        active_clause = "" if include_inactive else " AND active = 1"
+        if compacted_only:
+            active_clause = " AND active = 0 AND compacted = 1"
+        else:
+            active_clause = "" if include_inactive else " AND active = 1"
         keyset_clause = " AND id > ?" if after_id is not None else ""
         sql = (
             "SELECT * FROM messages WHERE session_id = ?"

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1875,6 +1875,57 @@ class TestWebServerEndpoints:
             "msg 499",
         ]
 
+    def test_get_session_messages_compacted_scope_excludes_rewound_rows(self):
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            session_id = "compacted-scope-messages"
+            db.create_session(session_id, source="cli")
+            db.append_messages_batch(
+                session_id,
+                [
+                    {"role": "user", "content": "archived prompt 1"},
+                    {"role": "assistant", "content": "archived answer 1"},
+                    {"role": "user", "content": "archived prompt 2"},
+                ],
+            )
+            db.archive_and_compact(
+                session_id,
+                [
+                    {"role": "assistant", "content": "summary"},
+                    {"role": "user", "content": "live prompt"},
+                ],
+            )
+            live_user = next(
+                message
+                for message in db.get_messages(session_id)
+                if message["role"] == "user"
+            )
+            db.rewind_to_message(session_id, live_user["id"])
+        finally:
+            db.close()
+
+        resp = self.client.get(
+            f"/api/sessions/{session_id}/messages"
+            "?limit=2&order=latest&scope=compacted"
+        )
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["pagination"] == {
+            "limit": 2,
+            "offset": 0,
+            "order": "latest",
+            "returned": 2,
+            "has_more": True,
+            "scope": "compacted",
+        }
+        assert [message["content"] for message in payload["messages"]] == [
+            "archived answer 1",
+            "archived prompt 2",
+        ]
+        assert all(message["content"] != "live prompt" for message in payload["messages"])
+
     def test_export_session_streams_bounded_message_pages(self, monkeypatch):
         from hermes_state import SessionDB
 

--- a/tests/hermes_state/test_compacted_message_scope.py
+++ b/tests/hermes_state/test_compacted_message_scope.py
@@ -1,0 +1,33 @@
+"""Regression tests for the read-only compacted transcript scope."""
+
+from hermes_state import SessionDB
+
+
+def test_compacted_scope_excludes_live_and_rewound_rows(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        session_id = "compacted-scope"
+        db.create_session(session_id, "test")
+        db.append_messages_batch(
+            session_id,
+            [
+                {"role": "user", "content": "archived prompt"},
+                {"role": "assistant", "content": "archived answer"},
+            ],
+        )
+        db.archive_and_compact(
+            session_id,
+            [
+                {"role": "assistant", "content": "compaction summary"},
+                {"role": "user", "content": "live prompt"},
+            ],
+        )
+
+        live_user = db.append_message(session_id, "user", "rewound prompt")
+        db.rewind_to_message(session_id, live_user)
+
+        archived = db.get_messages(session_id, compacted_only=True)
+        assert [row["content"] for row in archived] == ["archived prompt", "archived answer"]
+        assert all(row["active"] == 0 and row["compacted"] == 1 for row in archived)
+    finally:
+        db.close()

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -252,8 +252,12 @@ def _(rid, params: dict) -> dict:
                     # class #80216 fixed for /retry. On an uncompacted session
                     # all rows are active=1, so this is behaviorally identical
                     # to the full replace.
+                    # Fall back to session id when session_key is NULL — CLI-origin
+                    # sessions created before the session_key default fix have no
+                    # key, and replace_messages(None) triggers an FK violation.
+                    truncation_key = session.get("session_key") or sid
                     db.replace_messages(
-                        session["session_key"], truncated, active_only=True
+                        truncation_key, truncated, active_only=True
                     )
                 except Exception as exc:
                     logger.error(


### PR DESCRIPTION
## Summary
- repair NULL `session_key` creation and truncation fallback so history edits do not hit the messages FK
- add a bounded `scope=compacted` transcript API that excludes rewound rows
- add a collapsed, read-only Desktop archive panel with paginated older-history loading

## Verification
- `python3 -m pytest -q tests/hermes_cli/test_web_server.py -k 'get_session_messages' tests/hermes_state/test_compacted_message_scope.py tests/hermes_state/test_replace_messages_archive_siblings.py`
- `npm run typecheck`
- targeted ESLint and Prettier checks
- archive UI Vitest test
- `npm run build`

## Safety
- archived rows are read-only and remain outside the active model transcript
- only `active=0 AND compacted=1` rows are exposed
- rewound rows are excluded
