### PR TITLE
fix(desktop): surface isolated tool failures in pet state

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -867,6 +867,13 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
 
           if (isActiveEvent) {
             setPetActivity({ toolRunning: false })
+
+            // A tool can fail without ending the turn when the agent recovers
+            // and continues. Surface that failure as a short pet beat too;
+            // otherwise only turn-level errors ever reach the failed state.
+            if (payload?.error) {
+              flashPetActivity({ error: true })
+            }
           }
 
           // A pending clarify blocks the turn, so the first tool.complete after

--- a/apps/desktop/src/app/session/hooks/use-message-stream/pet-tool-failure-event.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/pet-tool-failure-event.test.tsx
@@ -1,0 +1,94 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { $petActivity, $petState, setPetActivity } from '@/store/pet'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useMessageStream } from './index'
+
+const SID = 'session-1'
+const OTHER_SID = 'session-2'
+
+let handleEvent: ((event: RpcEvent) => void) | null = null
+
+function Harness() {
+  const activeSessionIdRef = useRef<string | null>(SID)
+  const sessionStateByRuntimeIdRef = useRef(new Map<string, ClientSessionState>())
+  const queryClientRef = useRef(new QueryClient())
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession: vi.fn(async () => undefined),
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: vi.fn(async () => undefined),
+    refreshSessions: vi.fn(async () => undefined),
+    sessionStateByRuntimeIdRef,
+    updateSessionState: (sessionId, updater) => {
+      const current = sessionStateByRuntimeIdRef.current.get(sessionId) ?? createClientSessionState()
+      const next = updater(current)
+      sessionStateByRuntimeIdRef.current.set(sessionId, next)
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    handleEvent = stream.handleGatewayEvent
+  }, [stream.handleGatewayEvent])
+
+  return null
+}
+
+async function mountStream() {
+  render(<Harness />)
+  await waitFor(() => expect(handleEvent).not.toBeNull())
+}
+
+function emit(type: RpcEvent['type'], payload: RpcEvent['payload'] = {}, sessionId = SID) {
+  act(() => handleEvent!({ payload, session_id: sessionId, type }))
+}
+
+describe('pet tool-failure reaction', () => {
+  beforeEach(() => {
+    handleEvent = null
+    setPetActivity({
+      busy: false,
+      awaitingInput: false,
+      toolRunning: false,
+      reasoning: false,
+      error: false,
+      justCompleted: false,
+      celebrate: false
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    setPetActivity({ error: false, toolRunning: false })
+    vi.restoreAllMocks()
+  })
+
+  it('briefly shows failed when the active session has an isolated tool error', async () => {
+    await mountStream()
+
+    emit('tool.start', { name: 'terminal', tool_id: 'tool-1' })
+    emit('tool.complete', { name: 'terminal', tool_id: 'tool-1', error: 'exit code 1' })
+
+    expect($petActivity.get().error).toBe(true)
+    expect($petState.get()).toBe('failed')
+  })
+
+  it('does not show failed for a successful tool or a background-session failure', async () => {
+    await mountStream()
+
+    emit('tool.complete', { name: 'terminal', tool_id: 'tool-1' })
+    expect($petActivity.get().error).toBe(false)
+
+    emit('tool.complete', { name: 'terminal', tool_id: 'tool-2', error: 'exit code 1' }, OTHER_SID)
+    expect($petActivity.get().error).toBe(false)
+  })
+})


### PR DESCRIPTION
## What does this PR do?

The Desktop pet already reacts when a whole turn fails, but it silently ignores individual tool failures when the agent recovers and continues. This change reuses the existing transient error beat for `tool.complete` events whose payload contains `error`.

The reaction remains scoped to the active session, so a background session cannot hijack the foreground pet.

## Related Issue

Fixes #81907

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Updated `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts` to flash the existing pet error activity for isolated tool failures.
- Added `pet-tool-failure-event.test.tsx` covering active-session failure, successful completion, and background-session failure.

## How to Test

1. Enable a Desktop pet with a `failed` animation.
2. Run a tool that returns an error while the agent continues the turn.
3. Confirm the pet briefly shows `failed`, then returns to its steady activity.
4. Confirm successful tools and failures from background sessions do not trigger the foreground pet.

Automated validation:

- `npm run typecheck`
- `npx eslint src/app/session/hooks/use-message-stream/gateway-event.ts src/app/session/hooks/use-message-stream/pet-tool-failure-event.test.tsx`
- `npx vitest run src/app/session/hooks/use-message-stream/pet-tool-failure-event.test.tsx src/store/pet.test.ts` — 12 tests passed

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing issues and PRs for duplicates
- [x] This PR contains only changes related to the fix
- [x] I ran the relevant TypeScript checks and focused tests
- [x] I added regression tests
- [x] Tested on macOS 26.6

### Documentation & Housekeeping

- [x] Documentation update — N/A
- [x] `cli-config.yaml.example` update — N/A
- [x] Architecture documentation update — N/A
- [x] Cross-platform impact considered — renderer-only behavior with platform-neutral tests
- [x] Tool schema update — N/A

## Screenshots / Logs

N/A — the behavior is a transient sprite-state transition covered by the focused event-handler test.