### PR TITLE
perf(desktop): pause decorative animations when unfocused

### DIFF
--- a/apps/desktop/src/lib/renderer-loop-pause.test.ts
+++ b/apps/desktop/src/lib/renderer-loop-pause.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  installRendererAnimationPauseState,
+  RENDERER_ANIMATIONS_PAUSED_ATTRIBUTE
+} from './renderer-loop-pause'
+
+describe('installRendererAnimationPauseState', () => {
+  afterEach(() => {
+    document.documentElement.removeAttribute(RENDERER_ANIMATIONS_PAUSED_ATTRIBUTE)
+    vi.restoreAllMocks()
+  })
+
+  it('pauses on blur, resumes on focus, and cleans up its root state', () => {
+    let focused = true
+    vi.spyOn(document, 'hasFocus').mockImplementation(() => focused)
+
+    const dispose = installRendererAnimationPauseState()
+    expect(document.documentElement.hasAttribute(RENDERER_ANIMATIONS_PAUSED_ATTRIBUTE)).toBe(false)
+
+    focused = false
+    window.dispatchEvent(new Event('blur'))
+    expect(document.documentElement.hasAttribute(RENDERER_ANIMATIONS_PAUSED_ATTRIBUTE)).toBe(true)
+
+    focused = true
+    window.dispatchEvent(new Event('focus'))
+    expect(document.documentElement.hasAttribute(RENDERER_ANIMATIONS_PAUSED_ATTRIBUTE)).toBe(false)
+
+    focused = false
+    window.dispatchEvent(new Event('blur'))
+    dispose()
+    expect(document.documentElement.hasAttribute(RENDERER_ANIMATIONS_PAUSED_ATTRIBUTE)).toBe(false)
+  })
+})

--- a/apps/desktop/src/lib/renderer-loop-pause.ts
+++ b/apps/desktop/src/lib/renderer-loop-pause.ts
@@ -3,6 +3,8 @@ interface WindowStatePayload {
   isVisible?: boolean
 }
 
+export const RENDERER_ANIMATIONS_PAUSED_ATTRIBUTE = 'data-renderer-animations-paused'
+
 export function createRendererLoopPauseController(onChange: () => void, { pauseWhenUnfocused = true } = {}) {
   let windowPaused = false
   let windowFocused = document.hasFocus()
@@ -46,5 +48,25 @@ export function createRendererLoopPauseController(onChange: () => void, { pauseW
       offWindowState?.()
     },
     isPaused: () => document.visibilityState === 'hidden' || (pauseWhenUnfocused && !windowFocused) || windowPaused
+  }
+}
+
+/**
+ * Mirrors the main window's observability onto :root so continuous decorative
+ * CSS animations can sleep with the JS renderer loops. The caller owns the
+ * returned cleanup; overlay windows intentionally do not install this state.
+ */
+export function installRendererAnimationPauseState(): () => void {
+  const root = document.documentElement
+  let controller: ReturnType<typeof createRendererLoopPauseController>
+
+  const sync = () => root.toggleAttribute(RENDERER_ANIMATIONS_PAUSED_ATTRIBUTE, controller.isPaused())
+
+  controller = createRendererLoopPauseController(sync)
+  sync()
+
+  return () => {
+    controller.dispose()
+    root.removeAttribute(RENDERER_ANIMATIONS_PAUSED_ATTRIBUTE)
   }
 }

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -25,6 +25,7 @@ import { RootTooltipProvider } from './components/ui/tooltip'
 import { I18nProvider } from './i18n'
 import { installClipboardShim } from './lib/clipboard'
 import { queryClient } from './lib/query-client'
+import { installRendererAnimationPauseState } from './lib/renderer-loop-pause'
 import { ThemeProvider } from './themes/context'
 
 installClipboardShim()
@@ -50,6 +51,11 @@ if (winParam === 'overlay') {
 } else if (winParam === 'wake') {
   void import('./app/wake-indicator/wake-indicator-root').then(({ mountWakeIndicator }) => mountWakeIndicator())
 } else {
+  // CSS animations do not inherit Chromium's JS-loop pause policy. Mirror the
+  // main window's focus/visibility state to :root so decorative infinite
+  // animations stop producing frames when nobody can see them.
+  installRendererAnimationPauseState()
+
   createRoot(document.getElementById('root')!).render(
     <StrictMode>
       <RootErrorBoundary>

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -25,6 +25,7 @@ import { RootTooltipProvider } from './components/ui/tooltip'
 import { I18nProvider } from './i18n'
 import { installClipboardShim } from './lib/clipboard'
 import { queryClient } from './lib/query-client'
+import { installRendererAnimationPauseState } from './lib/renderer-loop-pause'
 import { ThemeProvider } from './themes/context'
 
 installClipboardShim()
@@ -46,6 +47,11 @@ if (winParam === 'overlay') {
 } else if (winParam === 'wake') {
   void import('./app/wake-indicator/wake-indicator-root').then(({ mountWakeIndicator }) => mountWakeIndicator())
 } else {
+  // CSS animations do not inherit Chromium's JS-loop pause policy. Mirror the
+  // main window's focus/visibility state to :root so decorative infinite
+  // animations stop producing frames when nobody can see them.
+  installRendererAnimationPauseState()
+
   createRoot(document.getElementById('root')!).render(
     <StrictMode>
       <RootErrorBoundary>

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -28,6 +28,27 @@
   }
 }
 
+/* Continuous decorative animations otherwise keep Chromium's renderer awake
+   behind another app. main.tsx owns this attribute only for the primary
+   window; wake/pet overlays retain their purpose-built visibility behavior. */
+:root[data-renderer-animations-paused] :is(
+    .shimmer,
+    .quest-glow,
+    .pet-egg,
+    .pet-egg__glow,
+    .pet-egg-shadow,
+    .pet-wobble,
+    .progress-slide,
+    .kanban-arc
+  ),
+:root[data-renderer-animations-paused] .arc-border::before,
+:root[data-renderer-animations-paused]
+  [data-slot='aui_assistant-message-content']
+  .aui-md
+  [data-slot='code-card'][data-streaming='true'] {
+  animation-play-state: paused !important;
+}
+
 /* Sidebar sections: tall viewports give each its own scroller; compact ones
    (this variant) flatten everything into one shared scroll. See ChatSidebar. */
 @custom-variant compact (@media (max-height: 768px));

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -21,6 +21,27 @@
   }
 }
 
+/* Continuous decorative animations otherwise keep Chromium's renderer awake
+   behind another app. main.tsx owns this attribute only for the primary
+   window; wake/pet overlays retain their purpose-built visibility behavior. */
+:root[data-renderer-animations-paused] :is(
+    .shimmer,
+    .quest-glow,
+    .pet-egg,
+    .pet-egg__glow,
+    .pet-egg-shadow,
+    .pet-wobble,
+    .progress-slide,
+    .kanban-arc
+  ),
+:root[data-renderer-animations-paused] .arc-border::before,
+:root[data-renderer-animations-paused]
+  [data-slot='aui_assistant-message-content']
+  .aui-md
+  [data-slot='code-card'][data-streaming='true'] {
+  animation-play-state: paused !important;
+}
+
 /* Sidebar sections: tall viewports give each its own scroller; compact ones
    (this variant) flatten everything into one shared scroll. See ChatSidebar. */
 @custom-variant compact (@media (max-height: 768px));


### PR DESCRIPTION
## Summary

Pause continuous decorative CSS animations when the primary Desktop window is hidden, minimized, or not focused, and resume them immediately when the window becomes observable again.

The main window now mirrors the existing renderer-loop pause policy onto a root attribute. The stylesheet uses that state to pause infinite borders, shimmers, glow effects, progress indicators, and equivalent decorative animations. Wake/pet overlay windows intentionally do not install this global state and retain their purpose-built lifecycle behavior.

## Root cause

The Desktop already pauses several JavaScript-driven renderer loops, but CSS animations do not inherit that policy. On macOS, a window behind another application can remain `visible`, so infinite `background-position` animations continued producing renderer work for pixels the user could not see.

In the reproduced session, the gateway reported zero active agents and there were no HTTP requests during the profile, but multiple `arc-border` and shimmer animations remained in the `running` state.

## Measured impact

Test system: MacBook Air M2 (2022), battery power. Same selected session, Hermes visible behind another app.

| Metric | Before | After | Difference |
|---|---:|---:|---:|
| Renderer task duration over 12 s | 2,172 ms | 832 ms | **-61.7%** |
| Renderer CPU, short `ps` sample average | 27.54% | 2.25% | **-91.8%** |
| Renderer CPU median | 27.3% | 0.0% | — |
| GPU while unfocused | 0% | 0% | unchanged |

The process samples are short and include occasional session-update bursts, so the CPU percentage describes this reproduction rather than a universal battery-life estimate. The profiler task-duration comparison is the more controlled result.

In a final normal launch without DevTools, 11 of 12 renderer samples were between 0% and 0.7%; one isolated session refresh reached 68.6%.

## Behavior and safety

- The state is installed only for the primary window.
- Animations resume on focus/visibility restoration without resetting application state.
- No gateway, streaming, or React state ingestion is paused.
- Reduced-motion behavior remains unchanged.

## Validation

- Targeted renderer pause-state test passed
- Desktop typecheck passed
- Desktop lint passed
- `git diff --check` passed
- Packaged and runtime-verified on macOS arm64
