### PR TITLE
perf(desktop): keep built-in theme fonts local

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -393,10 +393,10 @@
     /* Key caps always use the native UI face — never theme typography overrides. */
     --dt-font-kbd: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', system-ui, sans-serif;
     /* Menlo/Monaco first — Apple's native monospace faces — so code/diff read
-       in the system mono on macOS, with SF Mono and bundled Courier Prime as
+       in the system mono on macOS, with SF Mono and bundled JetBrains Mono as
        fallbacks. */
     --dt-font-mono:
-      Menlo, Monaco, 'SF Mono', 'Courier Prime', monospace, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
+      Menlo, Monaco, 'SF Mono', 'JetBrains Mono', monospace, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
       'Noto Color Emoji', emoji;
     --dt-base-size: 1rem;
     --dt-line-height: 1.5;

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -400,10 +400,10 @@
     /* Key caps always use the native UI face — never theme typography overrides. */
     --dt-font-kbd: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', system-ui, sans-serif;
     /* Menlo/Monaco first — Apple's native monospace faces — so code/diff read
-       in the system mono on macOS, with SF Mono and bundled Courier Prime as
+       in the system mono on macOS, with SF Mono and bundled JetBrains Mono as
        fallbacks. */
     --dt-font-mono:
-      Menlo, Monaco, 'SF Mono', 'Courier Prime', monospace, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
+      Menlo, Monaco, 'SF Mono', 'JetBrains Mono', monospace, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
       'Noto Color Emoji', emoji;
     --dt-base-size: 1rem;
     --dt-line-height: 1.5;

--- a/apps/desktop/src/themes/presets.test.ts
+++ b/apps/desktop/src/themes/presets.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, it } from 'vitest'
 
-import { BUILTIN_THEME_LIST, DEFAULT_TYPOGRAPHY, EMOJI_FALLBACK } from './presets'
+import { BUILTIN_THEME_LIST, DEFAULT_TYPOGRAPHY, EMOJI_FALLBACK, midnightTheme, nousTheme } from './presets'
+
+describe('bundled theme fonts', () => {
+  it('keeps the default Nous mono stack local', () => {
+    expect(nousTheme.typography?.fontMono).toContain('JetBrains Mono')
+    expect(nousTheme.typography?.fontUrl).toBeUndefined()
+  })
+
+  it('does not fetch the already-bundled JetBrains Mono face', () => {
+    expect(midnightTheme.typography?.fontMono).toContain('JetBrains Mono')
+    expect(midnightTheme.typography?.fontUrl).toBeUndefined()
+  })
+})
 
 // #40364: none of the UI text/mono fonts carry emoji glyphs, so every font
 // stack must end with a color-emoji fallback or emoji render as tofu on

--- a/apps/desktop/src/themes/presets.ts
+++ b/apps/desktop/src/themes/presets.ts
@@ -15,7 +15,7 @@ const SYSTEM_SANS =
   '"Segoe WPC", "Segoe UI", -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro Display", system-ui, sans-serif, ' +
   EMOJI_FALLBACK
 
-const SYSTEM_MONO = 'Menlo, Monaco, "SF Mono", "Courier Prime", monospace, ' + EMOJI_FALLBACK
+const SYSTEM_MONO = 'Menlo, Monaco, "SF Mono", "JetBrains Mono", monospace, ' + EMOJI_FALLBACK
 
 export const DEFAULT_TYPOGRAPHY: DesktopThemeTypography = { fontSans: SYSTEM_SANS, fontMono: SYSTEM_MONO }
 
@@ -91,8 +91,9 @@ export const nousTheme: DesktopTheme = {
   },
   typography: {
     fontSans: SYSTEM_SANS,
-    fontMono: SYSTEM_MONO,
-    fontUrl: 'https://fonts.googleapis.com/css2?family=Courier+Prime:wght@400;700&display=swap'
+    // Native mono faces win on macOS; bundled JetBrains Mono keeps the same
+    // stack fully local on platforms where those faces are unavailable.
+    fontMono: SYSTEM_MONO
   }
 }
 
@@ -128,8 +129,9 @@ export const midnightTheme: DesktopTheme = {
     userBubbleBorder: '#242466'
   },
   typography: {
-    fontMono: `"JetBrains Mono", ${SYSTEM_MONO}`,
-    fontUrl: 'https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap'
+    // JetBrains Mono is bundled in styles.css; a Google Fonts link here made
+    // every Midnight startup perform redundant third-party requests.
+    fontMono: `"JetBrains Mono", ${SYSTEM_MONO}`
   }
 }
 


### PR DESCRIPTION
## Summary

Keep the built-in Nous and Midnight theme font stacks fully local.

- Midnight now uses the JetBrains Mono WOFF2 faces already shipped in the Desktop bundle instead of requesting the same family from Google Fonts.
- The default Nous stack uses native monospace faces first and bundled JetBrains Mono as its cross-platform fallback, removing an unused Courier Prime request.
- Ember retains its IBM Plex Mono URL because that remote face is an explicit theme choice rather than an unused fallback.

## Root cause

Midnight declared a Google Fonts stylesheet for JetBrains Mono even though regular, bold, and italic faces are bundled by `styles.css`. There was also a less obvious inheritance issue: typography is merged with the Nous defaults, so removing only Midnight's URL made it inherit the Nous Courier Prime URL. On macOS that stylesheet was fetched even though Menlo, earlier in the stack, was the rendered face.

## Measured impact

Runtime verification used Chromium performance resource entries on the packaged macOS arm64 app with Midnight active.

| Startup resource | Before | After |
|---|---:|---:|
| Google Fonts requests | 2 | **0** |
| Active external font stylesheets | 1 | **0** |

The post-change renderer reported the local JetBrains Mono stack and no `fonts.googleapis.com` or `fonts.gstatic.com` resources.

This is primarily a startup/network/privacy cleanup; no battery-life percentage is claimed.

## Validation

- 12 theme preset tests passed
- Desktop typecheck passed
- Desktop lint passed
- `git diff --check` passed
- Packaged and runtime-verified on macOS arm64
