### PR TITLE
fix(lsp): preserve push diagnostics and Windows URI identity

### DIFF
--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -54,7 +54,7 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
-from urllib.parse import quote, unquote
+from urllib.parse import quote, unquote, urlsplit
 
 from hermes_cli._subprocess_compat import windows_hide_flags
 
@@ -87,30 +87,49 @@ MAX_CONTENT_MODIFIED_RETRIES = 3
 RETRY_BASE_DELAY = 0.5  # 0.5, 1.0, 2.0 — exponential
 
 
+def _absolute_path(path: str) -> str:
+    """Return an absolute normalized path without changing its case."""
+    return os.path.abspath(os.path.normpath(path))
+
+
+def _path_key(path: str) -> str:
+    """Return a stable key for per-file LSP state."""
+    normalized = _absolute_path(path)
+    return os.path.normcase(normalized) if os.name == "nt" else normalized
+
+
 def file_uri(path: str) -> str:
     """Return ``file://`` URI for an absolute filesystem path.
 
     Mirrors Node's ``pathToFileURL`` — handles spaces, unicode, and
     Windows drive letters (``C:\\foo`` → ``file:///C:/foo``).
     """
-    abs_path = os.path.abspath(path)
+    abs_path = _absolute_path(path)
     if os.name == "nt":
-        # Windows: backslash → forward slash, prepend extra slash so
-        # the drive letter shows up as part of the path component.
+        # Windows: backslash → forward slash. UNC paths already start with
+        # ``//`` and therefore carry their file-URI authority directly.
         abs_path = abs_path.replace("\\", "/")
+        if abs_path.startswith("//"):
+            return "file:" + quote(abs_path, safe="/:")
         if not abs_path.startswith("/"):
             abs_path = "/" + abs_path
     return "file://" + quote(abs_path, safe="/:")
 
 
 def uri_to_path(uri: str) -> str:
-    """Inverse of :func:`file_uri`."""
+    """Inverse of :func:`file_uri`, normalized for stable dictionary keys."""
     if not uri.startswith("file://"):
         return uri
-    raw = uri[len("file://"):]
-    if os.name == "nt" and raw.startswith("/") and len(raw) > 2 and raw[2] == ":":
+    if os.name != "nt":
+        return os.path.normpath(unquote(uri[len("file://"):]))
+
+    parsed = urlsplit(uri)
+    raw = unquote(parsed.path)
+    if parsed.netloc and parsed.netloc.lower() != "localhost":
+        raw = f"//{parsed.netloc}{raw}"
+    elif raw.startswith("/") and len(raw) > 2 and raw[2] == ":":
         raw = raw[1:]  # strip leading slash before drive letter
-    return os.path.normpath(unquote(raw))
+    return _path_key(raw)
 
 
 def _end_position(text: str) -> Dict[str, int]:
@@ -158,6 +177,8 @@ class _DocState:
     pull: List[Dict[str, Any]] = field(default_factory=list)
     push_version: int = -1
     pull_version: int = -1
+    push_counter: int = 0
+    push_time: float = -1.0
     seed_seen: bool = False
 
     def fresh_push(self, version: Optional[int] = None) -> bool:
@@ -231,9 +252,12 @@ class LSPClient:
         }
 
         # Per-document state (version, text, diagnostic stores, and
-        # their freshness tags), keyed by absolute file path (NOT URI).
+        # their freshness tags), keyed by canonical absolute file path.
         # See _DocState for the version-based freshness model.
         self._docs: Dict[str, _DocState] = {}
+        # Push-sequence baselines are tied to the version returned by
+        # ``open_file`` so overlapping edits retain distinct freshness bounds.
+        self._diagnostic_baselines: Dict[tuple[str, int], int] = {}
         # Capability registrations — only diagnostic ones are tracked.
         self._diagnostic_registrations: Dict[str, Dict[str, Any]] = {}
 
@@ -717,13 +741,13 @@ class LSPClient:
         uri = params.get("uri")
         if not isinstance(uri, str):
             return
-        path = uri_to_path(uri)
+        path_key = _path_key(uri_to_path(uri))
         diagnostics = params.get("diagnostics") or []
         if not isinstance(diagnostics, list):
             diagnostics = []
         version = params.get("version")
 
-        doc = self._docs.setdefault(path, _DocState(version=-1))
+        doc = self._docs.setdefault(path_key, _DocState(version=-1))
         if self._seed_first_push and not doc.seed_seen:
             # First push: seed the store WITHOUT a freshness tag.  It
             # arrives before the user-triggered didChange could've
@@ -747,6 +771,8 @@ class LSPClient:
         # decide whether to keep waiting.  ``_push_counter`` is what
         # they actually compare against to detect a fresh event.
         self._push_counter += 1
+        doc.push_counter = self._push_counter
+        doc.push_time = asyncio.get_event_loop().time()
         self._push_event.set()
 
     # ------------------------------------------------------------------
@@ -762,14 +788,16 @@ class LSPClient:
         if not self.is_running:
             raise LSPProtocolError("client not running")
 
-        abs_path = os.path.abspath(path)
+        abs_path = _absolute_path(path)
+        path_key = _path_key(abs_path)
+        diagnostic_counter = self._push_counter
         try:
             text = Path(abs_path).read_text(encoding="utf-8", errors="replace")
         except OSError as e:
             raise LSPProtocolError(f"cannot read {abs_path}: {e}") from e
 
         uri = file_uri(abs_path)
-        doc = self._docs.get(abs_path)
+        doc = self._docs.get(path_key)
 
         if doc is not None and doc.version >= 0:
             # Re-open: bump version, fire didChangeWatchedFiles + didChange.
@@ -804,6 +832,7 @@ class LSPClient:
             # stale by definition (see _DocState).
             doc.version = new_version
             doc.text = text
+            self._diagnostic_baselines[(path_key, new_version)] = diagnostic_counter
             return new_version
 
         # First open: didChangeWatchedFiles CREATED + didOpen.
@@ -813,7 +842,7 @@ class LSPClient:
         )
         # Fresh doc state — anything stashed under this path by a
         # pre-open push (relatedDocuments spillover etc.) is discarded.
-        self._docs[abs_path] = _DocState(version=0, text=text)
+        self._docs[path_key] = _DocState(version=0, text=text)
         await self._send_notification(
             "textDocument/didOpen",
             {
@@ -825,13 +854,14 @@ class LSPClient:
                 }
             },
         )
+        self._diagnostic_baselines[(path_key, 0)] = diagnostic_counter
         return 0
 
     async def save_file(self, path: str) -> None:
         """Send didSave for ``path``.  Some linters re-scan only on save."""
         if not self.is_running:
             return
-        abs_path = os.path.abspath(path)
+        abs_path = _absolute_path(path)
         await self._send_notification(
             "textDocument/didSave",
             {"textDocument": {"uri": file_uri(abs_path)}},
@@ -851,8 +881,9 @@ class LSPClient:
         Silently no-ops on errors (server may not support the pull
         endpoint).
         """
-        abs_path = os.path.abspath(path)
-        doc = self._docs.get(abs_path)
+        abs_path = _absolute_path(path)
+        path_key = _path_key(abs_path)
+        doc = self._docs.get(path_key)
         sent_version = doc.version if doc else -1
         try:
             params: Dict[str, Any] = {
@@ -870,7 +901,7 @@ class LSPClient:
             return
         items = result.get("items")
         if isinstance(items, list):
-            doc = self._docs.setdefault(abs_path, _DocState(version=-1))
+            doc = self._docs.setdefault(path_key, _DocState(version=-1))
             doc.pull = items
             doc.pull_version = sent_version
         related = result.get("relatedDocuments")
@@ -880,7 +911,9 @@ class LSPClient:
                     continue
                 sub_items = sub.get("items")
                 if isinstance(sub_items, list):
-                    rel = self._docs.setdefault(uri_to_path(uri), _DocState(version=-1))
+                    rel = self._docs.setdefault(
+                        _path_key(uri_to_path(uri)), _DocState(version=-1)
+                    )
                     rel.pull = sub_items
                     # Same send-anchored tagging: fresh only if that
                     # doc hasn't changed since the request went out.
@@ -916,7 +949,11 @@ class LSPClient:
         else:
             budget = DIAGNOSTICS_FULL_WAIT if mode == "full" else DIAGNOSTICS_DOCUMENT_WAIT
         deadline = asyncio.get_event_loop().time() + budget
-        abs_path = os.path.abspath(path)
+        abs_path = _absolute_path(path)
+        path_key = _path_key(abs_path)
+        baseline = self._diagnostic_baselines.pop(
+            (path_key, version), self._push_counter
+        )
 
         while True:
             if not self._connection_is_open():
@@ -929,23 +966,40 @@ class LSPClient:
 
             # Concurrent: document pull + push wait.
             pull_task = asyncio.create_task(self._pull_document_diagnostics(abs_path))
-            push_task = asyncio.create_task(self._wait_for_fresh_push(abs_path, version, remaining))
-            done, pending = await asyncio.wait(
-                {pull_task, push_task},
-                timeout=remaining,
-                return_when=asyncio.FIRST_COMPLETED,
+            push_task = asyncio.create_task(
+                self._wait_for_fresh_push(path_key, version, remaining, baseline)
             )
-            for t in pending:
-                t.cancel()
-            for t in pending:
-                try:
-                    await t
-                except (asyncio.CancelledError, Exception):  # noqa: BLE001
-                    pass
+            try:
+                done, _ = await asyncio.wait(
+                    {pull_task, push_task},
+                    timeout=remaining,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
 
-            # If we got a fresh push for our version, we're done.
-            doc = self._docs.get(abs_path)
-            if doc and doc.fresh_push(version):
+                # Push-only servers such as typescript-language-server can
+                # reject textDocument/diagnostic immediately. Keep the push
+                # waiter alive instead of issuing unsupported pulls in a loop.
+                doc = self._docs.get(path_key)
+                if (
+                    pull_task in done
+                    and not push_task.done()
+                    and not (doc and doc.fresh_pull(version))
+                ):
+                    remaining = deadline - asyncio.get_event_loop().time()
+                    if remaining > 0:
+                        try:
+                            await asyncio.wait_for(push_task, timeout=remaining)
+                        except asyncio.TimeoutError:
+                            pass
+            finally:
+                for task in (pull_task, push_task):
+                    if not task.done():
+                        task.cancel()
+                await asyncio.gather(pull_task, push_task, return_exceptions=True)
+
+            # If we got a fresh post-edit push for our version, we're done.
+            doc = self._docs.get(path_key)
+            if doc and doc.fresh_push(version) and doc.push_counter > baseline:
                 return True
 
             # Pull may have answered for the current version — that's
@@ -955,42 +1009,59 @@ class LSPClient:
 
             # Loop until budget runs out.
 
-    async def _wait_for_fresh_push(self, path: str, version: int, timeout: float) -> None:
+    async def _wait_for_fresh_push(
+        self, path: str, version: int, timeout: float, baseline: int
+    ) -> None:
         """Wait until a fresh publishDiagnostics arrives for ``path`` at ``version``+."""
         deadline = asyncio.get_event_loop().time() + timeout
-        baseline = self._push_counter
+        observed_counter = self._push_counter
         while True:
             doc = self._docs.get(path)
-            if doc and doc.fresh_push(version):
-                # Debounce — wait a tick in case more diagnostics arrive
-                # immediately after.  TS often emits in pairs.  We
-                # snapshot the counter so we wake on a *new* push, not
-                # on the one that satisfied us a moment ago.
-                debounce_baseline = self._push_counter
-                debounce_deadline = asyncio.get_event_loop().time() + PUSH_DEBOUNCE
-                while self._push_counter == debounce_baseline:
-                    remaining = debounce_deadline - asyncio.get_event_loop().time()
-                    if remaining <= 0:
+            if doc and doc.fresh_push(version) and doc.push_counter > baseline:
+                # TypeScript can publish stale and corrected unversioned
+                # snapshots in quick succession. Debounce quietness for this
+                # path only so unrelated files neither satisfy nor prolong it.
+                while True:
+                    push_counter = doc.push_counter
+                    now = asyncio.get_event_loop().time()
+                    quiet_remaining = min(
+                        PUSH_DEBOUNCE - (now - doc.push_time),
+                        deadline - now,
+                    )
+                    if quiet_remaining <= 0:
                         break
                     self._push_event.clear()
+                    current_doc = self._docs.get(path)
+                    if current_doc is None:
+                        break
+                    if current_doc.push_counter != push_counter:
+                        doc = current_doc
+                        continue
                     try:
-                        await asyncio.wait_for(self._push_event.wait(), timeout=remaining)
+                        await asyncio.wait_for(
+                            self._push_event.wait(), timeout=quiet_remaining
+                        )
                     except asyncio.TimeoutError:
+                        break
+                    doc = self._docs.get(path)
+                    if doc is None:
                         break
                 return
             remaining = deadline - asyncio.get_event_loop().time()
             if remaining <= 0:
                 return
-            if self._push_counter > baseline:
-                # New event arrived but predicate still false — re-check
-                # immediately without waiting again.
-                baseline = self._push_counter
+            if self._push_counter != observed_counter:
+                observed_counter = self._push_counter
                 continue
             self._push_event.clear()
+            if self._push_counter != observed_counter:
+                observed_counter = self._push_counter
+                continue
             try:
                 await asyncio.wait_for(self._push_event.wait(), timeout=min(remaining, 0.5))
             except asyncio.TimeoutError:
                 continue
+            observed_counter = self._push_counter
 
     def diagnostics_for(self, path: str, *, fresh_only: bool = False) -> List[Dict[str, Any]]:
         """Return current merged + deduped diagnostics for one file.
@@ -1005,7 +1076,7 @@ class LSPClient:
         This is what report paths should use: after an edit, "stale
         errors" and "no errors" must not be conflated.
         """
-        doc = self._docs.get(os.path.abspath(path))
+        doc = self._docs.get(_path_key(path))
         if doc is None:
             return []
         if fresh_only:

--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -1068,7 +1068,14 @@ class LSPClient:
         This is what report paths should use: after an edit, "stale
         errors" and "no errors" must not be conflated.
         """
-        doc = self._docs.get(_path_key(path))
+        path_key = _path_key(path)
+        doc = self._docs.get(path_key)
+        if doc is None and not os.path.isabs(path):
+            # ``urlsplit`` cannot distinguish an opaque URI such as
+            # ``untitled:buffer`` from a valid relative POSIX filename such
+            # as ``notes:2026.ts``. Prefer an exact opaque-URI match, then
+            # fall back to the absolute filesystem key used by ``open_file``.
+            doc = self._docs.get(_path_key(_absolute_path(path)))
         if doc is None:
             return []
         if fresh_only:

--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -1105,7 +1105,14 @@ class LSPClient:
         This is what report paths should use: after an edit, "stale
         errors" and "no errors" must not be conflated.
         """
-        doc = self._docs.get(_path_key(path))
+        path_key = _path_key(path)
+        doc = self._docs.get(path_key)
+        if doc is None and not os.path.isabs(path):
+            # ``urlsplit`` cannot distinguish an opaque URI such as
+            # ``untitled:buffer`` from a valid relative POSIX filename such
+            # as ``notes:2026.ts``. Prefer an exact opaque-URI match, then
+            # fall back to the absolute filesystem key used by ``open_file``.
+            doc = self._docs.get(_path_key(_absolute_path(path)))
         if doc is None:
             return []
         if fresh_only:

--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -54,7 +54,7 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
-from urllib.parse import quote, unquote
+from urllib.parse import quote, unquote, urlsplit
 
 from hermes_cli._subprocess_compat import windows_hide_flags
 
@@ -87,30 +87,49 @@ MAX_CONTENT_MODIFIED_RETRIES = 3
 RETRY_BASE_DELAY = 0.5  # 0.5, 1.0, 2.0 — exponential
 
 
+def _absolute_path(path: str) -> str:
+    """Return an absolute normalized path without changing its case."""
+    return os.path.abspath(os.path.normpath(path))
+
+
+def _path_key(path: str) -> str:
+    """Return a stable key for per-file LSP state."""
+    normalized = _absolute_path(path)
+    return os.path.normcase(normalized) if os.name == "nt" else normalized
+
+
 def file_uri(path: str) -> str:
     """Return ``file://`` URI for an absolute filesystem path.
 
     Mirrors Node's ``pathToFileURL`` — handles spaces, unicode, and
     Windows drive letters (``C:\\foo`` → ``file:///C:/foo``).
     """
-    abs_path = os.path.abspath(path)
+    abs_path = _absolute_path(path)
     if os.name == "nt":
-        # Windows: backslash → forward slash, prepend extra slash so
-        # the drive letter shows up as part of the path component.
+        # Windows: backslash → forward slash. UNC paths already start with
+        # ``//`` and therefore carry their file-URI authority directly.
         abs_path = abs_path.replace("\\", "/")
+        if abs_path.startswith("//"):
+            return "file:" + quote(abs_path, safe="/:")
         if not abs_path.startswith("/"):
             abs_path = "/" + abs_path
     return "file://" + quote(abs_path, safe="/:")
 
 
 def uri_to_path(uri: str) -> str:
-    """Inverse of :func:`file_uri`."""
+    """Inverse of :func:`file_uri`, normalized for stable dictionary keys."""
     if not uri.startswith("file://"):
         return uri
-    raw = uri[len("file://"):]
-    if os.name == "nt" and raw.startswith("/") and len(raw) > 2 and raw[2] == ":":
+    if os.name != "nt":
+        return os.path.normpath(unquote(uri[len("file://"):]))
+
+    parsed = urlsplit(uri)
+    raw = unquote(parsed.path)
+    if parsed.netloc and parsed.netloc.lower() != "localhost":
+        raw = f"//{parsed.netloc}{raw}"
+    elif raw.startswith("/") and len(raw) > 2 and raw[2] == ":":
         raw = raw[1:]  # strip leading slash before drive letter
-    return os.path.normpath(unquote(raw))
+    return _path_key(raw)
 
 
 def _end_position(text: str) -> Dict[str, int]:
@@ -158,6 +177,8 @@ class _DocState:
     pull: List[Dict[str, Any]] = field(default_factory=list)
     push_version: int = -1
     pull_version: int = -1
+    push_counter: int = 0
+    push_time: float = -1.0
     seed_seen: bool = False
 
     def fresh_push(self, version: Optional[int] = None) -> bool:
@@ -230,9 +251,12 @@ class LSPClient:
         }
 
         # Per-document state (version, text, diagnostic stores, and
-        # their freshness tags), keyed by absolute file path (NOT URI).
+        # their freshness tags), keyed by canonical absolute file path.
         # See _DocState for the version-based freshness model.
         self._docs: Dict[str, _DocState] = {}
+        # Push-sequence baselines are tied to the version returned by
+        # ``open_file`` so overlapping edits retain distinct freshness bounds.
+        self._diagnostic_baselines: Dict[tuple[str, int], int] = {}
         # Capability registrations — only diagnostic ones are tracked.
         self._diagnostic_registrations: Dict[str, Dict[str, Any]] = {}
 
@@ -684,13 +708,13 @@ class LSPClient:
         uri = params.get("uri")
         if not isinstance(uri, str):
             return
-        path = uri_to_path(uri)
+        path_key = _path_key(uri_to_path(uri))
         diagnostics = params.get("diagnostics") or []
         if not isinstance(diagnostics, list):
             diagnostics = []
         version = params.get("version")
 
-        doc = self._docs.setdefault(path, _DocState(version=-1))
+        doc = self._docs.setdefault(path_key, _DocState(version=-1))
         if self._seed_first_push and not doc.seed_seen:
             # First push: seed the store WITHOUT a freshness tag.  It
             # arrives before the user-triggered didChange could've
@@ -714,6 +738,8 @@ class LSPClient:
         # decide whether to keep waiting.  ``_push_counter`` is what
         # they actually compare against to detect a fresh event.
         self._push_counter += 1
+        doc.push_counter = self._push_counter
+        doc.push_time = asyncio.get_event_loop().time()
         self._push_event.set()
 
     # ------------------------------------------------------------------
@@ -729,14 +755,16 @@ class LSPClient:
         if not self.is_running:
             raise LSPProtocolError("client not running")
 
-        abs_path = os.path.abspath(path)
+        abs_path = _absolute_path(path)
+        path_key = _path_key(abs_path)
+        diagnostic_counter = self._push_counter
         try:
             text = Path(abs_path).read_text(encoding="utf-8", errors="replace")
         except OSError as e:
             raise LSPProtocolError(f"cannot read {abs_path}: {e}") from e
 
         uri = file_uri(abs_path)
-        doc = self._docs.get(abs_path)
+        doc = self._docs.get(path_key)
 
         if doc is not None and doc.version >= 0:
             # Re-open: bump version, fire didChangeWatchedFiles + didChange.
@@ -771,6 +799,7 @@ class LSPClient:
             # stale by definition (see _DocState).
             doc.version = new_version
             doc.text = text
+            self._diagnostic_baselines[(path_key, new_version)] = diagnostic_counter
             return new_version
 
         # First open: didChangeWatchedFiles CREATED + didOpen.
@@ -780,7 +809,7 @@ class LSPClient:
         )
         # Fresh doc state — anything stashed under this path by a
         # pre-open push (relatedDocuments spillover etc.) is discarded.
-        self._docs[abs_path] = _DocState(version=0, text=text)
+        self._docs[path_key] = _DocState(version=0, text=text)
         await self._send_notification(
             "textDocument/didOpen",
             {
@@ -792,13 +821,14 @@ class LSPClient:
                 }
             },
         )
+        self._diagnostic_baselines[(path_key, 0)] = diagnostic_counter
         return 0
 
     async def save_file(self, path: str) -> None:
         """Send didSave for ``path``.  Some linters re-scan only on save."""
         if not self.is_running:
             return
-        abs_path = os.path.abspath(path)
+        abs_path = _absolute_path(path)
         await self._send_notification(
             "textDocument/didSave",
             {"textDocument": {"uri": file_uri(abs_path)}},
@@ -818,8 +848,9 @@ class LSPClient:
         Silently no-ops on errors (server may not support the pull
         endpoint).
         """
-        abs_path = os.path.abspath(path)
-        doc = self._docs.get(abs_path)
+        abs_path = _absolute_path(path)
+        path_key = _path_key(abs_path)
+        doc = self._docs.get(path_key)
         sent_version = doc.version if doc else -1
         try:
             params: Dict[str, Any] = {
@@ -837,7 +868,7 @@ class LSPClient:
             return
         items = result.get("items")
         if isinstance(items, list):
-            doc = self._docs.setdefault(abs_path, _DocState(version=-1))
+            doc = self._docs.setdefault(path_key, _DocState(version=-1))
             doc.pull = items
             doc.pull_version = sent_version
         related = result.get("relatedDocuments")
@@ -847,7 +878,9 @@ class LSPClient:
                     continue
                 sub_items = sub.get("items")
                 if isinstance(sub_items, list):
-                    rel = self._docs.setdefault(uri_to_path(uri), _DocState(version=-1))
+                    rel = self._docs.setdefault(
+                        _path_key(uri_to_path(uri)), _DocState(version=-1)
+                    )
                     rel.pull = sub_items
                     # Same send-anchored tagging: fresh only if that
                     # doc hasn't changed since the request went out.
@@ -883,7 +916,11 @@ class LSPClient:
         else:
             budget = DIAGNOSTICS_FULL_WAIT if mode == "full" else DIAGNOSTICS_DOCUMENT_WAIT
         deadline = asyncio.get_event_loop().time() + budget
-        abs_path = os.path.abspath(path)
+        abs_path = _absolute_path(path)
+        path_key = _path_key(abs_path)
+        baseline = self._diagnostic_baselines.pop(
+            (path_key, version), self._push_counter
+        )
 
         while True:
             remaining = deadline - asyncio.get_event_loop().time()
@@ -892,23 +929,40 @@ class LSPClient:
 
             # Concurrent: document pull + push wait.
             pull_task = asyncio.create_task(self._pull_document_diagnostics(abs_path))
-            push_task = asyncio.create_task(self._wait_for_fresh_push(abs_path, version, remaining))
-            done, pending = await asyncio.wait(
-                {pull_task, push_task},
-                timeout=remaining,
-                return_when=asyncio.FIRST_COMPLETED,
+            push_task = asyncio.create_task(
+                self._wait_for_fresh_push(path_key, version, remaining, baseline)
             )
-            for t in pending:
-                t.cancel()
-            for t in pending:
-                try:
-                    await t
-                except (asyncio.CancelledError, Exception):  # noqa: BLE001
-                    pass
+            try:
+                done, _ = await asyncio.wait(
+                    {pull_task, push_task},
+                    timeout=remaining,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
 
-            # If we got a fresh push for our version, we're done.
-            doc = self._docs.get(abs_path)
-            if doc and doc.fresh_push(version):
+                # Push-only servers such as typescript-language-server can
+                # reject textDocument/diagnostic immediately. Keep the push
+                # waiter alive instead of issuing unsupported pulls in a loop.
+                doc = self._docs.get(path_key)
+                if (
+                    pull_task in done
+                    and not push_task.done()
+                    and not (doc and doc.fresh_pull(version))
+                ):
+                    remaining = deadline - asyncio.get_event_loop().time()
+                    if remaining > 0:
+                        try:
+                            await asyncio.wait_for(push_task, timeout=remaining)
+                        except asyncio.TimeoutError:
+                            pass
+            finally:
+                for task in (pull_task, push_task):
+                    if not task.done():
+                        task.cancel()
+                await asyncio.gather(pull_task, push_task, return_exceptions=True)
+
+            # If we got a fresh post-edit push for our version, we're done.
+            doc = self._docs.get(path_key)
+            if doc and doc.fresh_push(version) and doc.push_counter > baseline:
                 return True
 
             # Pull may have answered for the current version — that's
@@ -918,42 +972,59 @@ class LSPClient:
 
             # Loop until budget runs out.
 
-    async def _wait_for_fresh_push(self, path: str, version: int, timeout: float) -> None:
+    async def _wait_for_fresh_push(
+        self, path: str, version: int, timeout: float, baseline: int
+    ) -> None:
         """Wait until a fresh publishDiagnostics arrives for ``path`` at ``version``+."""
         deadline = asyncio.get_event_loop().time() + timeout
-        baseline = self._push_counter
+        observed_counter = self._push_counter
         while True:
             doc = self._docs.get(path)
-            if doc and doc.fresh_push(version):
-                # Debounce — wait a tick in case more diagnostics arrive
-                # immediately after.  TS often emits in pairs.  We
-                # snapshot the counter so we wake on a *new* push, not
-                # on the one that satisfied us a moment ago.
-                debounce_baseline = self._push_counter
-                debounce_deadline = asyncio.get_event_loop().time() + PUSH_DEBOUNCE
-                while self._push_counter == debounce_baseline:
-                    remaining = debounce_deadline - asyncio.get_event_loop().time()
-                    if remaining <= 0:
+            if doc and doc.fresh_push(version) and doc.push_counter > baseline:
+                # TypeScript can publish stale and corrected unversioned
+                # snapshots in quick succession. Debounce quietness for this
+                # path only so unrelated files neither satisfy nor prolong it.
+                while True:
+                    push_counter = doc.push_counter
+                    now = asyncio.get_event_loop().time()
+                    quiet_remaining = min(
+                        PUSH_DEBOUNCE - (now - doc.push_time),
+                        deadline - now,
+                    )
+                    if quiet_remaining <= 0:
                         break
                     self._push_event.clear()
+                    current_doc = self._docs.get(path)
+                    if current_doc is None:
+                        break
+                    if current_doc.push_counter != push_counter:
+                        doc = current_doc
+                        continue
                     try:
-                        await asyncio.wait_for(self._push_event.wait(), timeout=remaining)
+                        await asyncio.wait_for(
+                            self._push_event.wait(), timeout=quiet_remaining
+                        )
                     except asyncio.TimeoutError:
+                        break
+                    doc = self._docs.get(path)
+                    if doc is None:
                         break
                 return
             remaining = deadline - asyncio.get_event_loop().time()
             if remaining <= 0:
                 return
-            if self._push_counter > baseline:
-                # New event arrived but predicate still false — re-check
-                # immediately without waiting again.
-                baseline = self._push_counter
+            if self._push_counter != observed_counter:
+                observed_counter = self._push_counter
                 continue
             self._push_event.clear()
+            if self._push_counter != observed_counter:
+                observed_counter = self._push_counter
+                continue
             try:
                 await asyncio.wait_for(self._push_event.wait(), timeout=min(remaining, 0.5))
             except asyncio.TimeoutError:
                 continue
+            observed_counter = self._push_counter
 
     def diagnostics_for(self, path: str, *, fresh_only: bool = False) -> List[Dict[str, Any]]:
         """Return current merged + deduped diagnostics for one file.
@@ -968,7 +1039,7 @@ class LSPClient:
         This is what report paths should use: after an edit, "stale
         errors" and "no errors" must not be conflated.
         """
-        doc = self._docs.get(os.path.abspath(path))
+        doc = self._docs.get(_path_key(path))
         if doc is None:
             return []
         if fresh_only:

--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -94,6 +94,17 @@ def _absolute_path(path: str) -> str:
 
 def _path_key(path: str) -> str:
     """Return a stable key for per-file LSP state."""
+    parsed = urlsplit(path)
+    is_windows_drive = (
+        len(parsed.scheme) == 1 and len(path) >= 2 and path[1] == ":"
+    )
+    if parsed.scheme and parsed.scheme.lower() != "file" and not is_windows_drive:
+        # LSP also permits non-file document URIs such as ``untitled:``.
+        # They are opaque identifiers, not local paths: making them absolute
+        # or case-folding them changes their identity.
+        return path
+    if parsed.scheme.lower() == "file":
+        path = uri_to_path(path)
     normalized = _absolute_path(path)
     return os.path.normcase(normalized) if os.name == "nt" else normalized
 
@@ -255,6 +266,9 @@ class LSPClient:
         # their freshness tags), keyed by canonical absolute file path.
         # See _DocState for the version-based freshness model.
         self._docs: Dict[str, _DocState] = {}
+        # Keep document versions and notification ordering atomic when two
+        # file-tool calls touch the same client concurrently.
+        self._document_lock = asyncio.Lock()
         # Push-sequence baselines are tied to the version returned by
         # ``open_file`` so overlapping edits retain distinct freshness bounds.
         self._diagnostic_baselines: Dict[tuple[str, int], int] = {}
@@ -785,12 +799,18 @@ class LSPClient:
         Returns the new document version number that the agent's
         ``wait_for_diagnostics`` should match against.
         """
+        async with self._document_lock:
+            return await self._open_file_locked(path, language_id=language_id)
+
+    async def _open_file_locked(
+        self, path: str, *, language_id: str = "plaintext"
+    ) -> int:
+        """Implement :meth:`open_file` while ``_document_lock`` is held."""
         if not self.is_running:
             raise LSPProtocolError("client not running")
 
         abs_path = _absolute_path(path)
         path_key = _path_key(abs_path)
-        diagnostic_counter = self._push_counter
         try:
             text = Path(abs_path).read_text(encoding="utf-8", errors="replace")
         except OSError as e:
@@ -805,6 +825,7 @@ class LSPClient:
                 "workspace/didChangeWatchedFiles",
                 {"changes": [{"uri": uri, "type": 2}]},  # 2 = CHANGED
             )
+            diagnostic_counter = self._push_counter
             new_version = doc.version + 1
             old_text = doc.text
             content_changes: List[Dict[str, Any]]
@@ -820,6 +841,12 @@ class LSPClient:
                 ]
             else:
                 content_changes = [{"text": text}]
+            # Advance local state before the write can yield to the reader
+            # task. A fast unversioned push received during ``drain()`` must
+            # be tagged with the version carried by this didChange.
+            doc.version = new_version
+            doc.text = text
+            self._diagnostic_baselines[(path_key, new_version)] = diagnostic_counter
             await self._send_notification(
                 "textDocument/didChange",
                 {
@@ -827,12 +854,6 @@ class LSPClient:
                     "contentChanges": content_changes,
                 },
             )
-            # Bumping the version is the whole invalidation story:
-            # every stored result tagged with an older version is now
-            # stale by definition (see _DocState).
-            doc.version = new_version
-            doc.text = text
-            self._diagnostic_baselines[(path_key, new_version)] = diagnostic_counter
             return new_version
 
         # First open: didChangeWatchedFiles CREATED + didOpen.
@@ -840,9 +861,11 @@ class LSPClient:
             "workspace/didChangeWatchedFiles",
             {"changes": [{"uri": uri, "type": 1}]},  # 1 = CREATED
         )
+        diagnostic_counter = self._push_counter
         # Fresh doc state — anything stashed under this path by a
         # pre-open push (relatedDocuments spillover etc.) is discarded.
         self._docs[path_key] = _DocState(version=0, text=text)
+        self._diagnostic_baselines[(path_key, 0)] = diagnostic_counter
         await self._send_notification(
             "textDocument/didOpen",
             {
@@ -854,7 +877,6 @@ class LSPClient:
                 }
             },
         )
-        self._diagnostic_baselines[(path_key, 0)] = diagnostic_counter
         return 0
 
     async def save_file(self, path: str) -> None:

--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -94,6 +94,17 @@ def _absolute_path(path: str) -> str:
 
 def _path_key(path: str) -> str:
     """Return a stable key for per-file LSP state."""
+    parsed = urlsplit(path)
+    is_windows_drive = (
+        len(parsed.scheme) == 1 and len(path) >= 2 and path[1] == ":"
+    )
+    if parsed.scheme and parsed.scheme.lower() != "file" and not is_windows_drive:
+        # LSP also permits non-file document URIs such as ``untitled:``.
+        # They are opaque identifiers, not local paths: making them absolute
+        # or case-folding them changes their identity.
+        return path
+    if parsed.scheme.lower() == "file":
+        path = uri_to_path(path)
     normalized = _absolute_path(path)
     return os.path.normcase(normalized) if os.name == "nt" else normalized
 
@@ -254,6 +265,9 @@ class LSPClient:
         # their freshness tags), keyed by canonical absolute file path.
         # See _DocState for the version-based freshness model.
         self._docs: Dict[str, _DocState] = {}
+        # Keep document versions and notification ordering atomic when two
+        # file-tool calls touch the same client concurrently.
+        self._document_lock = asyncio.Lock()
         # Push-sequence baselines are tied to the version returned by
         # ``open_file`` so overlapping edits retain distinct freshness bounds.
         self._diagnostic_baselines: Dict[tuple[str, int], int] = {}
@@ -752,12 +766,18 @@ class LSPClient:
         Returns the new document version number that the agent's
         ``wait_for_diagnostics`` should match against.
         """
+        async with self._document_lock:
+            return await self._open_file_locked(path, language_id=language_id)
+
+    async def _open_file_locked(
+        self, path: str, *, language_id: str = "plaintext"
+    ) -> int:
+        """Implement :meth:`open_file` while ``_document_lock`` is held."""
         if not self.is_running:
             raise LSPProtocolError("client not running")
 
         abs_path = _absolute_path(path)
         path_key = _path_key(abs_path)
-        diagnostic_counter = self._push_counter
         try:
             text = Path(abs_path).read_text(encoding="utf-8", errors="replace")
         except OSError as e:
@@ -772,6 +792,7 @@ class LSPClient:
                 "workspace/didChangeWatchedFiles",
                 {"changes": [{"uri": uri, "type": 2}]},  # 2 = CHANGED
             )
+            diagnostic_counter = self._push_counter
             new_version = doc.version + 1
             old_text = doc.text
             content_changes: List[Dict[str, Any]]
@@ -787,6 +808,12 @@ class LSPClient:
                 ]
             else:
                 content_changes = [{"text": text}]
+            # Advance local state before the write can yield to the reader
+            # task. A fast unversioned push received during ``drain()`` must
+            # be tagged with the version carried by this didChange.
+            doc.version = new_version
+            doc.text = text
+            self._diagnostic_baselines[(path_key, new_version)] = diagnostic_counter
             await self._send_notification(
                 "textDocument/didChange",
                 {
@@ -794,12 +821,6 @@ class LSPClient:
                     "contentChanges": content_changes,
                 },
             )
-            # Bumping the version is the whole invalidation story:
-            # every stored result tagged with an older version is now
-            # stale by definition (see _DocState).
-            doc.version = new_version
-            doc.text = text
-            self._diagnostic_baselines[(path_key, new_version)] = diagnostic_counter
             return new_version
 
         # First open: didChangeWatchedFiles CREATED + didOpen.
@@ -807,9 +828,11 @@ class LSPClient:
             "workspace/didChangeWatchedFiles",
             {"changes": [{"uri": uri, "type": 1}]},  # 1 = CREATED
         )
+        diagnostic_counter = self._push_counter
         # Fresh doc state — anything stashed under this path by a
         # pre-open push (relatedDocuments spillover etc.) is discarded.
         self._docs[path_key] = _DocState(version=0, text=text)
+        self._diagnostic_baselines[(path_key, 0)] = diagnostic_counter
         await self._send_notification(
             "textDocument/didOpen",
             {
@@ -821,7 +844,6 @@ class LSPClient:
                 }
             },
         )
-        self._diagnostic_baselines[(path_key, 0)] = diagnostic_counter
         return 0
 
     async def save_file(self, path: str) -> None:

--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -441,9 +441,16 @@ class LSPClient:
         except (asyncio.CancelledError, OSError):
             pass
         finally:
-            unexpected_close = not self._stopping and self._state in {"starting", "running"}
+            unexpected_close = not self._stopping and self._state in {
+                "starting",
+                "running",
+            }
             if unexpected_close:
                 self._state = "error"
+            # Diagnostic waiters can be parked on the push event after an
+            # unsupported pull completes. Wake them so transport death is
+            # observed immediately instead of consuming the remaining budget.
+            self._push_event.set()
             # Wake up any pending requests so they can fail fast.
             for fut in list(self._pending.values()):
                 if not fut.done():
@@ -1140,6 +1147,10 @@ class LSPClient:
         observed_counter = self._push_counter
         stabilization_deadline: Optional[float] = None
         while True:
+            if not self._connection_is_open():
+                raise LSPProtocolError(
+                    "server connection closed while waiting for diagnostics"
+                )
             doc = self._docs.get(path)
             if doc is None or doc.version != version:
                 return False
@@ -1149,6 +1160,10 @@ class LSPClient:
                 # unversioned pushes need rolling quiet, bounded from the first
                 # unversioned push in the current settling episode.
                 while True:
+                    if not self._connection_is_open():
+                        raise LSPProtocolError(
+                            "server connection closed while waiting for diagnostics"
+                        )
                     push_counter = doc.push_counter
                     now = asyncio.get_event_loop().time()
                     if doc.push_is_versioned:

--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -21,10 +21,10 @@ Implementation notes:
 - All per-document state lives in one :class:`_DocState` keyed by
   absolute path.  Freshness is tracked with **document versions**,
   not timestamps: every didChange bumps ``version``, and each stored
-  push/pull result is tagged with the version it describes.  A
-  result is fresh iff its tag >= the version being waited on, so a
-  didChange implicitly invalidates everything older — no clearing,
-  no clock comparisons, no race windows.  This is what prevents
+  push/pull result is tagged with the version it describes.  For an
+  open document, a result is fresh iff its tag exactly matches the
+  current version, so a didChange implicitly invalidates everything
+  older — no clearing, no clock comparisons, no race windows.  This prevents
   "ghost diagnostics": a slow server's leftovers from the previous
   edit can never masquerade as a verdict on the current content.
 
@@ -45,6 +45,7 @@ Implementation notes:
   backoff up to 3 times.  This matches Claude Code's
   ``LSPServerInstance.sendRequest``.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -80,6 +81,11 @@ DIAGNOSTICS_DOCUMENT_WAIT = 5.0
 DIAGNOSTICS_FULL_WAIT = 10.0
 DIAGNOSTICS_REQUEST_TIMEOUT = 3.0
 PUSH_DEBOUNCE = 0.15
+# Unversioned pushes cannot identify the edit they describe. Allow a longer
+# per-target quiet period to catch delayed corrections, but never spend more
+# than this fixed stabilization window after the first qualifying push.
+UNVERSIONED_PUSH_DEBOUNCE = 0.30
+UNVERSIONED_PUSH_STABILIZATION = 0.50
 SHUTDOWN_GRACE = 1.0  # seconds between SIGTERM and SIGKILL
 
 # Retry policy for transient ContentModified errors.
@@ -178,15 +184,15 @@ class _DocState:
     each didChange +1).  It doubles as the freshness token: stored
     push/pull results are tagged with the version they describe
     (``push_version`` / ``pull_version``), and a result is *fresh*
-    iff its tag has caught up to ``version``.  Bumping the version on
-    didChange therefore invalidates all older results implicitly —
+    iff its tag exactly matches a non-negative ``version``.  Bumping the
+    version on didChange therefore invalidates all older results implicitly —
     no store-clearing, no timestamps.
 
     ``push_version``/``pull_version`` start at -1 = "no data yet".
     Servers that echo a document version in publishDiagnostics get
     exact tagging; those that don't are credited with the current
-    version at receipt time (a push observed after we sent the
-    change describes the changed content or newer).
+    version at receipt time for storage eligibility, while the waiter
+    conservatively settles unversioned snapshots for its bounded budget.
     """
 
     version: int = 0
@@ -195,15 +201,19 @@ class _DocState:
     pull: List[Dict[str, Any]] = field(default_factory=list)
     push_version: int = -1
     pull_version: int = -1
+    push_is_versioned: bool = False
     push_counter: int = 0
     push_time: float = -1.0
     seed_seen: bool = False
+    diagnostic_baseline: int = 0
 
     def fresh_push(self, version: Optional[int] = None) -> bool:
-        return self.push_version >= (self.version if version is None else version)
+        target = self.version if version is None else version
+        return target >= 0 and self.push_version == target
 
     def fresh_pull(self, version: Optional[int] = None) -> bool:
-        return self.pull_version >= (self.version if version is None else version)
+        target = self.version if version is None else version
+        return target >= 0 and self.pull_version == target
 
 
 class LSPClient:
@@ -276,9 +286,6 @@ class LSPClient:
         # Keep document versions and notification ordering atomic when two
         # file-tool calls touch the same client concurrently.
         self._document_lock = asyncio.Lock()
-        # Push-sequence baselines are tied to the version returned by
-        # ``open_file`` so overlapping edits retain distinct freshness bounds.
-        self._diagnostic_baselines: Dict[tuple[str, int], int] = {}
         # Capability registrations — only diagnostic ones are tracked.
         self._diagnostic_registrations: Dict[str, Dict[str, Any]] = {}
 
@@ -288,7 +295,8 @@ class LSPClient:
         self._sync_kind: int = 1  # 1=Full, 2=Incremental
         self._stopping: bool = False
 
-        # Push event for waiters.
+        # Diagnostic-state event for waiters. Pushes and document-version
+        # advances both wake waiters so superseded generations fail promptly.
         self._push_event = asyncio.Event()
         # Monotonic counter incremented on every publishDiagnostics push.
         # Waiters snapshot it on entry and treat any increase as
@@ -425,7 +433,9 @@ class LSPClient:
                 elif kind == "notification":
                     self._dispatch_notification(key, msg)
                 else:
-                    logger.warning("[%s] dropping invalid message: %r", self.server_id, msg)
+                    logger.warning(
+                        "[%s] dropping invalid message: %r", self.server_id, msg
+                    )
         except LSPProtocolError as e:
             logger.warning("[%s] protocol error in reader loop: %s", self.server_id, e)
         except (asyncio.CancelledError, OSError):
@@ -528,7 +538,9 @@ class LSPClient:
         try:
             if self.is_running:
                 try:
-                    await asyncio.wait_for(self._send_request("shutdown", None), timeout=2.0)
+                    await asyncio.wait_for(
+                        self._send_request("shutdown", None), timeout=2.0
+                    )
                 except (asyncio.TimeoutError, LSPRequestError, LSPProtocolError):
                     pass
                 try:
@@ -604,7 +616,9 @@ class LSPClient:
         finally:
             self._pending.pop(req_id, None)
 
-    async def _send_request_with_retry(self, method: str, params: Any, *, timeout: float) -> Any:
+    async def _send_request_with_retry(
+        self, method: str, params: Any, *, timeout: float
+    ) -> Any:
         """Send a request, retrying on ``ContentModified`` (-32801).
 
         Other errors propagate.  The retry policy matches Claude Code's
@@ -613,10 +627,15 @@ class LSPClient:
         """
         for attempt in range(MAX_CONTENT_MODIFIED_RETRIES + 1):
             try:
-                return await asyncio.wait_for(self._send_request(method, params), timeout=timeout)
+                return await asyncio.wait_for(
+                    self._send_request(method, params), timeout=timeout
+                )
             except LSPRequestError as e:
-                if e.code == ERROR_CONTENT_MODIFIED and attempt < MAX_CONTENT_MODIFIED_RETRIES:
-                    await asyncio.sleep(RETRY_BASE_DELAY * (2 ** attempt))
+                if (
+                    e.code == ERROR_CONTENT_MODIFIED
+                    and attempt < MAX_CONTENT_MODIFIED_RETRIES
+                ):
+                    await asyncio.sleep(RETRY_BASE_DELAY * (2**attempt))
                     continue
                 raise
 
@@ -631,7 +650,11 @@ class LSPClient:
             logger.debug("[%s] notify %s failed: %s", self.server_id, method, e)
 
     async def _send_response(self, req_id: Any, result: Any) -> None:
-        if self._proc is None or self._proc.stdin is None or self._proc.stdin.is_closing():
+        if (
+            self._proc is None
+            or self._proc.stdin is None
+            or self._proc.stdin.is_closing()
+        ):
             return
         try:
             self._proc.stdin.write(encode_message(make_response(req_id, result)))
@@ -640,10 +663,16 @@ class LSPClient:
             pass
 
     async def _send_error_response(self, req_id: Any, code: int, message: str) -> None:
-        if self._proc is None or self._proc.stdin is None or self._proc.stdin.is_closing():
+        if (
+            self._proc is None
+            or self._proc.stdin is None
+            or self._proc.stdin.is_closing()
+        ):
             return
         try:
-            self._proc.stdin.write(encode_message(make_error_response(req_id, code, message)))
+            self._proc.stdin.write(
+                encode_message(make_error_response(req_id, code, message))
+            )
             await self._proc.stdin.drain()
         except (BrokenPipeError, ConnectionResetError, OSError):
             pass
@@ -669,12 +698,16 @@ class LSPClient:
         params = msg.get("params")
         handler = self._request_handlers.get(method)
         if handler is None:
-            await self._send_error_response(req_id, ERROR_METHOD_NOT_FOUND, f"method not found: {method}")
+            await self._send_error_response(
+                req_id, ERROR_METHOD_NOT_FOUND, f"method not found: {method}"
+            )
             return
         try:
             result = await handler(params)
         except Exception as e:  # noqa: BLE001 — protocol must not blow up
-            logger.warning("[%s] request handler %s failed: %s", self.server_id, method, e)
+            logger.warning(
+                "[%s] request handler %s failed: %s", self.server_id, method, e
+            )
             await self._send_error_response(req_id, -32000, f"handler failed: {e}")
             return
         await self._send_response(req_id, result)
@@ -686,7 +719,9 @@ class LSPClient:
         try:
             handler(msg.get("params"))
         except Exception as e:  # noqa: BLE001
-            logger.debug("[%s] notification handler %s failed: %s", self.server_id, method, e)
+            logger.debug(
+                "[%s] notification handler %s failed: %s", self.server_id, method, e
+            )
 
     # ------------------------------------------------------------------
     # built-in server-→-client request handlers
@@ -762,30 +797,51 @@ class LSPClient:
         uri = params.get("uri")
         if not isinstance(uri, str):
             return
-        path_key = _path_key(uri_to_path(uri))
-        diagnostics = params.get("diagnostics") or []
+        diagnostics = params.get("diagnostics")
         if not isinstance(diagnostics, list):
-            diagnostics = []
+            return
+        path_key = _path_key(uri_to_path(uri))
         version = params.get("version")
 
         doc = self._docs.setdefault(path_key, _DocState(version=-1))
         if self._seed_first_push and not doc.seed_seen:
-            # First push: seed the store WITHOUT a freshness tag.  It
-            # arrives before the user-triggered didChange could've
-            # produced fresh diagnostics, so it must never satisfy a
-            # waiter — it's baseline data only.
+            # The first syntactically valid publication consumes the one-time
+            # seed slot even when its version cannot describe the current
+            # generation. Otherwise a rejected stale seed could make the next
+            # valid post-edit publication disappear into baseline storage.
             doc.seed_seen = True
-            doc.push = diagnostics
+            if not (
+                isinstance(version, int) and doc.version >= 0 and version != doc.version
+            ):
+                doc.push = diagnostics
             return
-
+        if isinstance(version, int) and doc.version >= 0 and version != doc.version:
+            # Versioned publications are authoritative only for the exact open
+            # generation. Both delayed (stale) and premature (future) pushes
+            # are rejected without touching the store, counters, or waiters.
+            # A never-opened/related path has no generation to compare yet, so
+            # its publication remains available as unscoped (never fresh) data
+            # and will be discarded if the path is subsequently opened.
+            logger.debug(
+                "[%s] dropping diagnostics for %s at version %s; current version is %s",
+                self.server_id,
+                uri,
+                version,
+                doc.version,
+            )
+            return
         doc.seed_seen = True
         doc.push = diagnostics
-        # Tag with the echoed document version when the server provides
-        # one; otherwise credit the current version — a push observed
-        # after we sent the change describes the changed content (or
-        # newer).  Note doc.version is -1 for never-opened paths
-        # (e.g. relatedDocuments spillover), keeping them unfresh.
-        doc.push_version = version if isinstance(version, int) else doc.version
+        # Tag with the echoed document version when the server provides one;
+        # otherwise credit the current version. A push observed after we sent
+        # the change describes the changed content (or newer). Never-opened
+        # paths retain version -1 and therefore cannot be fresh.
+        if isinstance(version, int):
+            doc.push_is_versioned = True
+            doc.push_version = version
+        else:
+            doc.push_is_versioned = False
+            doc.push_version = doc.version
         # Bump the monotonic push counter and wake every waiter.  We
         # keep the Event sticky-set so any wait already in progress
         # resolves; waiters re-check their predicate after waking and
@@ -853,7 +909,11 @@ class LSPClient:
             # be tagged with the version carried by this didChange.
             doc.version = new_version
             doc.text = text
-            self._diagnostic_baselines[(path_key, new_version)] = diagnostic_counter
+            doc.diagnostic_baseline = diagnostic_counter
+            # A waiter belongs to exactly one edit generation. Wake any waiter
+            # for the previous version before the notification write yields so
+            # it can return "no verdict" instead of spanning this didChange.
+            self._push_event.set()
             await self._send_notification(
                 "textDocument/didChange",
                 {
@@ -871,8 +931,9 @@ class LSPClient:
         diagnostic_counter = self._push_counter
         # Fresh doc state — anything stashed under this path by a
         # pre-open push (relatedDocuments spillover etc.) is discarded.
-        self._docs[path_key] = _DocState(version=0, text=text)
-        self._diagnostic_baselines[(path_key, 0)] = diagnostic_counter
+        self._docs[path_key] = _DocState(
+            version=0, text=text, diagnostic_baseline=diagnostic_counter
+        )
         await self._send_notification(
             "textDocument/didOpen",
             {
@@ -900,24 +961,29 @@ class LSPClient:
     # diagnostics: pull + wait
     # ------------------------------------------------------------------
 
-    async def _pull_document_diagnostics(self, path: str) -> None:
+    async def _pull_document_diagnostics(self, path: str, version: int) -> None:
         """Send ``textDocument/diagnostic`` for one file.
 
-        Stores results into the doc's pull store, tagged with the
-        document version captured at request send time.  If a didChange
-        races past the in-flight request, the version bump makes the
-        stored result stale automatically — no explicit invalidation.
-        Silently no-ops on errors (server may not support the pull
-        endpoint).
+        Stores results into the doc's pull store, tagged with the requested
+        document version. The generations of all already-known related
+        documents are snapshotted before sending; a related result is only
+        tagged to an open document if that exact generation is still current.
+        Results for never-opened related URIs may be retained as unscoped data
+        but are never fresh. Silently no-ops on errors (server may not support
+        the pull endpoint).
         """
         abs_path = _absolute_path(path)
         path_key = _path_key(abs_path)
         doc = self._docs.get(path_key)
-        sent_version = doc.version if doc else -1
+        if doc is None or doc.version != version:
+            return
+        sent_version = version
+        related_versions = {
+            related_path: related_doc.version
+            for related_path, related_doc in self._docs.items()
+        }
         try:
-            params: Dict[str, Any] = {
-                "textDocument": {"uri": file_uri(abs_path)}
-            }
+            params: Dict[str, Any] = {"textDocument": {"uri": file_uri(abs_path)}}
             result = await self._send_request_with_retry(
                 "textDocument/diagnostic",
                 params,
@@ -926,11 +992,15 @@ class LSPClient:
         except (LSPRequestError, LSPProtocolError, asyncio.TimeoutError) as e:
             logger.debug("[%s] document diagnostic pull failed: %s", self.server_id, e)
             return
+        # The result is only evidence for the generation that sent it. Do not
+        # let a slow old pull overwrite diagnostics after a newer didChange.
+        doc = self._docs.get(path_key)
+        if doc is None or doc.version != sent_version:
+            return
         if not isinstance(result, dict):
             return
         items = result.get("items")
         if isinstance(items, list):
-            doc = self._docs.setdefault(path_key, _DocState(version=-1))
             doc.pull = items
             doc.pull_version = sent_version
         related = result.get("relatedDocuments")
@@ -940,13 +1010,26 @@ class LSPClient:
                     continue
                 sub_items = sub.get("items")
                 if isinstance(sub_items, list):
-                    rel = self._docs.setdefault(
-                        _path_key(uri_to_path(uri)), _DocState(version=-1)
-                    )
+                    related_path = _path_key(uri_to_path(uri))
+                    sent_related_version = related_versions.get(related_path)
+                    rel = self._docs.get(related_path)
+                    if sent_related_version is not None:
+                        if rel is None or rel.version != sent_related_version:
+                            continue
+                    elif rel is not None and rel.version >= 0:
+                        # The URI became an open document while the request was
+                        # in flight, so the response cannot describe that new
+                        # generation.
+                        continue
+                    if rel is None:
+                        rel = self._docs.setdefault(related_path, _DocState(version=-1))
                     rel.pull = sub_items
-                    # Same send-anchored tagging: fresh only if that
-                    # doc hasn't changed since the request went out.
-                    rel.pull_version = rel.version
+                    rel.pull_version = (
+                        sent_related_version
+                        if sent_related_version is not None
+                        and sent_related_version >= 0
+                        else -1
+                    )
 
     async def wait_for_diagnostics(
         self,
@@ -965,36 +1048,45 @@ class LSPClient:
         loop (slow servers like tsserver on big projects need more
         than the 5s default).
 
-        Returns ``True`` when *fresh* diagnostics arrived (a push at
-        or after our didChange, or a pull answered after it) and
-        ``False`` on timeout.  Callers must treat ``False`` as "no
-        data", NOT as "no errors" — the diagnostic stores may still
-        hold stale entries from the previous edit at that point.
+        Returns ``True`` when *fresh* diagnostics arrived for exactly this
+        edit generation and ``False`` on timeout or when a newer edit
+        supersedes it.  Callers must treat ``False`` as "no data", NOT as
+        "no errors" — the diagnostic stores may still hold stale entries
+        from the previous edit at that point.
         Best-effort — never throws if the server doesn't support pull
         diagnostics; we still get the push side.
         """
         if timeout is not None and timeout > 0:
             budget = timeout
         else:
-            budget = DIAGNOSTICS_FULL_WAIT if mode == "full" else DIAGNOSTICS_DOCUMENT_WAIT
+            budget = (
+                DIAGNOSTICS_FULL_WAIT if mode == "full" else DIAGNOSTICS_DOCUMENT_WAIT
+            )
         deadline = asyncio.get_event_loop().time() + budget
         abs_path = _absolute_path(path)
         path_key = _path_key(abs_path)
-        baseline = self._diagnostic_baselines.pop(
-            (path_key, version), self._push_counter
-        )
+        doc = self._docs.get(path_key)
+        if doc is None or doc.version != version:
+            return False
+        baseline = doc.diagnostic_baseline
 
         while True:
             if not self._connection_is_open():
                 raise LSPProtocolError(
                     "server connection closed while waiting for diagnostics"
                 )
+            doc = self._docs.get(path_key)
+            if doc is None or doc.version != version:
+                return False
             remaining = deadline - asyncio.get_event_loop().time()
             if remaining <= 0:
                 return False
 
-            # Concurrent: document pull + push wait.
-            pull_task = asyncio.create_task(self._pull_document_diagnostics(abs_path))
+            # Concurrent: document pull + push wait. Both tasks are pinned to
+            # the requested generation and reject work once didChange advances.
+            pull_task = asyncio.create_task(
+                self._pull_document_diagnostics(abs_path, version)
+            )
             push_task = asyncio.create_task(
                 self._wait_for_fresh_push(path_key, version, remaining, baseline)
             )
@@ -1012,7 +1104,9 @@ class LSPClient:
                 if (
                     pull_task in done
                     and not push_task.done()
-                    and not (doc and doc.fresh_pull(version))
+                    and not (
+                        doc and doc.version == version and doc.pull_version == version
+                    )
                 ):
                     remaining = deadline - asyncio.get_event_loop().time()
                     if remaining > 0:
@@ -1026,43 +1120,71 @@ class LSPClient:
                         task.cancel()
                 await asyncio.gather(pull_task, push_task, return_exceptions=True)
 
-            # If we got a fresh post-edit push for our version, we're done.
+            # Re-check the generation after both tasks are fully quiesced. This
+            # closes the race where a newer edit lands as one task completes.
             doc = self._docs.get(path_key)
-            if doc and doc.fresh_push(version) and doc.push_counter > baseline:
+            if doc is None or doc.version != version:
+                return False
+            if doc.push_version == version and doc.push_counter > baseline:
                 return True
-
-            # Pull may have answered for the current version — that's
-            # also success.
-            if doc and doc.fresh_pull(version):
+            if doc.pull_version == version:
                 return True
 
             # Loop until budget runs out.
 
     async def _wait_for_fresh_push(
         self, path: str, version: int, timeout: float, baseline: int
-    ) -> None:
-        """Wait until a fresh publishDiagnostics arrives for ``path`` at ``version``+."""
+    ) -> bool:
+        """Settle a push for exactly ``version``; reject superseded waits."""
         deadline = asyncio.get_event_loop().time() + timeout
         observed_counter = self._push_counter
+        stabilization_deadline: Optional[float] = None
         while True:
             doc = self._docs.get(path)
-            if doc and doc.fresh_push(version) and doc.push_counter > baseline:
-                # TypeScript can publish stale and corrected unversioned
-                # snapshots in quick succession. Debounce quietness for this
-                # path only so unrelated files neither satisfy nor prolong it.
+            if doc is None or doc.version != version:
+                return False
+            if doc.push_version == version and doc.push_counter > baseline:
+                # Re-evaluate the latest target publication after every wake.
+                # Versioned pushes prove freshness and use the short debounce;
+                # unversioned pushes need rolling quiet, bounded from the first
+                # unversioned push in the current settling episode.
                 while True:
                     push_counter = doc.push_counter
                     now = asyncio.get_event_loop().time()
+                    if doc.push_is_versioned:
+                        quiet_period = PUSH_DEBOUNCE
+                        stabilization_deadline = None
+                        settle_deadline = deadline
+                    else:
+                        quiet_period = UNVERSIONED_PUSH_DEBOUNCE
+                        if stabilization_deadline is None:
+                            stabilization_deadline = min(
+                                deadline,
+                                doc.push_time + UNVERSIONED_PUSH_STABILIZATION,
+                            )
+                        settle_deadline = stabilization_deadline
                     quiet_remaining = min(
-                        PUSH_DEBOUNCE - (now - doc.push_time),
-                        deadline - now,
+                        quiet_period - (now - doc.push_time),
+                        settle_deadline - now,
                     )
                     if quiet_remaining <= 0:
-                        break
+                        current_doc = self._docs.get(path)
+                        return bool(
+                            current_doc
+                            and current_doc.version == version
+                            and current_doc.push_version == version
+                            and current_doc.push_counter > baseline
+                        )
+
                     self._push_event.clear()
                     current_doc = self._docs.get(path)
-                    if current_doc is None:
-                        break
+                    if (
+                        current_doc is None
+                        or current_doc.version != version
+                        or current_doc.push_version != version
+                        or current_doc.push_counter <= baseline
+                    ):
+                        return False
                     if current_doc.push_counter != push_counter:
                         doc = current_doc
                         continue
@@ -1071,28 +1193,47 @@ class LSPClient:
                             self._push_event.wait(), timeout=quiet_remaining
                         )
                     except asyncio.TimeoutError:
-                        break
-                    doc = self._docs.get(path)
-                    if doc is None:
-                        break
-                return
+                        current_doc = self._docs.get(path)
+                        return bool(
+                            current_doc
+                            and current_doc.version == version
+                            and current_doc.push_version == version
+                            and current_doc.push_counter == push_counter
+                            and current_doc.push_counter > baseline
+                        )
+                    current_doc = self._docs.get(path)
+                    if (
+                        current_doc is None
+                        or current_doc.version != version
+                        or current_doc.push_version != version
+                        or current_doc.push_counter <= baseline
+                    ):
+                        return False
+                    doc = current_doc
             remaining = deadline - asyncio.get_event_loop().time()
             if remaining <= 0:
-                return
+                return False
             if self._push_counter != observed_counter:
                 observed_counter = self._push_counter
                 continue
             self._push_event.clear()
+            current_doc = self._docs.get(path)
+            if current_doc is None or current_doc.version != version:
+                return False
             if self._push_counter != observed_counter:
                 observed_counter = self._push_counter
                 continue
             try:
-                await asyncio.wait_for(self._push_event.wait(), timeout=min(remaining, 0.5))
+                await asyncio.wait_for(
+                    self._push_event.wait(), timeout=min(remaining, 0.5)
+                )
             except asyncio.TimeoutError:
                 continue
             observed_counter = self._push_counter
 
-    def diagnostics_for(self, path: str, *, fresh_only: bool = False) -> List[Dict[str, Any]]:
+    def diagnostics_for(
+        self, path: str, *, fresh_only: bool = False
+    ) -> List[Dict[str, Any]]:
         """Return current merged + deduped diagnostics for one file.
 
         Diagnostics from push and pull stores are concatenated and
@@ -1100,8 +1241,8 @@ class LSPClient:
         key.  Empty list if the server hasn't published anything.
 
         With ``fresh_only=True``, a store only contributes when its
-        version tag has caught up to the document's current version —
-        stale leftovers from the previous edit cycle are excluded.
+        version tag exactly matches an open document's current version;
+        stale leftovers and unscoped never-opened results are excluded.
         This is what report paths should use: after an edit, "stale
         errors" and "no errors" must not be conflated.
         """
@@ -1152,15 +1293,13 @@ def _diagnostic_key(d: Dict[str, Any]) -> str:
     code = d.get("code")
     if code is not None and not isinstance(code, str):
         code = str(code)
-    return "\x00".join(
-        [
-            str(d.get("severity") or 1),
-            str(code or ""),
-            str(d.get("source") or ""),
-            str(d.get("message") or "").strip(),
-            f"{start.get('line', 0)}:{start.get('character', 0)}-{end.get('line', 0)}:{end.get('character', 0)}",
-        ]
-    )
+    return "\x00".join([
+        str(d.get("severity") or 1),
+        str(code or ""),
+        str(d.get("source") or ""),
+        str(d.get("message") or "").strip(),
+        f"{start.get('line', 0)}:{start.get('character', 0)}-{end.get('line', 0)}:{end.get('character', 0)}",
+    ])
 
 
 __all__ = [

--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -96,7 +96,11 @@ def _path_key(path: str) -> str:
     """Return a stable key for per-file LSP state."""
     parsed = urlsplit(path)
     is_windows_drive = (
-        len(parsed.scheme) == 1 and len(path) >= 2 and path[1] == ":"
+        os.name == "nt"
+        and len(path) >= 3
+        and path[0].isalpha()
+        and path[1] == ":"
+        and path[2] in ("/", "\\")
     )
     if parsed.scheme and parsed.scheme.lower() != "file" and not is_windows_drive:
         # LSP also permits non-file document URIs such as ``untitled:``.
@@ -129,13 +133,16 @@ def file_uri(path: str) -> str:
 
 def uri_to_path(uri: str) -> str:
     """Inverse of :func:`file_uri`, normalized for stable dictionary keys."""
-    if not uri.startswith("file://"):
-        return uri
-    if os.name != "nt":
-        return os.path.normpath(unquote(uri[len("file://"):]))
-
     parsed = urlsplit(uri)
+    if parsed.scheme.lower() != "file":
+        return uri
+
     raw = unquote(parsed.path)
+    if os.name != "nt":
+        if parsed.netloc and parsed.netloc.lower() != "localhost":
+            raw = f"//{parsed.netloc}{raw}"
+        return os.path.normpath(raw)
+
     if parsed.netloc and parsed.netloc.lower() != "localhost":
         raw = f"//{parsed.netloc}{raw}"
     elif raw.startswith("/") and len(raw) > 2 and raw[2] == ":":

--- a/tests/agent/lsp/_mock_lsp_server.py
+++ b/tests/agent/lsp/_mock_lsp_server.py
@@ -25,6 +25,9 @@ Behaviour (all behaviours selectable via env var ``MOCK_LSP_SCRIPT``):
   ``didChange`` sleeps ``MOCK_LSP_PUSH_DELAY`` seconds (default 1.0)
   and then pushes EMPTY diagnostics.  Models a server that fixes
   the ghost if you actually wait for it.  Pull endpoint rejects.
+- ``"reject_then_unversioned_push"`` — publishes a versioned result on
+  didOpen, then after didChange rejects the pull request first and sends a
+  delayed unversioned push.  Exercises the real reader-loop race.
 
 The script writes JSON-RPC framed messages to stdout and reads from
 stdin.  No third-party dependencies — uses only stdlib so it runs
@@ -64,6 +67,7 @@ def write_message(obj):
 
 def main():
     script = os.environ.get("MOCK_LSP_SCRIPT", "clean")
+    pending_push = None
 
     while True:
         msg = read_message()
@@ -142,6 +146,29 @@ def main():
                     }
                 )
                 continue
+            if script == "reject_then_unversioned_push":
+                if is_change:
+                    delayed_diag = [
+                        {
+                            **error_diag[0],
+                            "code": "MOCK_UNVERSIONED",
+                            "message": "delayed unversioned diagnostic",
+                        }
+                    ]
+                    pending_push = (uri, delayed_diag)
+                else:
+                    write_message(
+                        {
+                            "jsonrpc": "2.0",
+                            "method": "textDocument/publishDiagnostics",
+                            "params": {
+                                "uri": uri,
+                                "version": version,
+                                "diagnostics": error_diag,
+                            },
+                        }
+                    )
+                continue
             diagnostics = []
             if script == "errors":
                 diagnostics = error_diag
@@ -159,6 +186,26 @@ def main():
             continue
 
         if msg.get("method") == "textDocument/diagnostic":
+            if script == "reject_then_unversioned_push":
+                write_message(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": msg["id"],
+                        "error": {"code": -32601, "message": "method not found"},
+                    }
+                )
+                if pending_push is not None:
+                    uri, diagnostics = pending_push
+                    pending_push = None
+                    time.sleep(float(os.environ.get("MOCK_LSP_PUSH_DELAY", "0.05")))
+                    write_message(
+                        {
+                            "jsonrpc": "2.0",
+                            "method": "textDocument/publishDiagnostics",
+                            "params": {"uri": uri, "diagnostics": diagnostics},
+                        }
+                    )
+                continue
             if script in {"stale", "slow_push"}:
                 # These scripts model push-only servers so the ghost
                 # can't be papered over by the pull channel.

--- a/tests/agent/lsp/_mock_lsp_server.py
+++ b/tests/agent/lsp/_mock_lsp_server.py
@@ -32,11 +32,18 @@ Behaviour (all behaviours selectable via env var ``MOCK_LSP_SCRIPT``):
 - ``"reject_then_unversioned_push"`` — publishes a versioned result on
   didOpen, then after didChange rejects the pull request first and sends a
   delayed unversioned push.  Exercises the real reader-loop race.
+- ``"stale_then_corrected_unversioned_push"`` — publishes a stale unversioned
+  result 10ms after didChange and corrects it around 250ms after didChange.
+  Pull diagnostics are rejected, matching a push-only TypeScript server.
+- ``"versioned_then_stale_corrected_unversioned_push"`` — after didChange,
+  publishes a fresh versioned result, a stale unversioned result 50ms later,
+  and a corrected unversioned result another 250ms later.
 
 The script writes JSON-RPC framed messages to stdout and reads from
 stdin.  No third-party dependencies — uses only stdlib so it runs
 under whatever Python the test process picks up.
 """
+
 from __future__ import annotations
 
 import json
@@ -81,19 +88,20 @@ def main():
         if "id" in msg and msg.get("method") == "initialize":
             if script == "slow":
                 time.sleep(1.0)
-            write_message(
-                {
-                    "jsonrpc": "2.0",
-                    "id": msg["id"],
-                    "result": {
-                        "capabilities": {
-                            "textDocumentSync": 1,  # Full
-                            "diagnosticProvider": {"interFileDependencies": False, "workspaceDiagnostics": False},
+            write_message({
+                "jsonrpc": "2.0",
+                "id": msg["id"],
+                "result": {
+                    "capabilities": {
+                        "textDocumentSync": 1,  # Full
+                        "diagnosticProvider": {
+                            "interFileDependencies": False,
+                            "workspaceDiagnostics": False,
                         },
-                        "serverInfo": {"name": "mock-lsp", "version": "0.1"},
                     },
-                }
-            )
+                    "serverInfo": {"name": "mock-lsp", "version": "0.1"},
+                },
+            })
             if script == "crash":
                 return 0
             continue
@@ -137,26 +145,30 @@ def main():
                 # Ghost scenario: publish an error for the ORIGINAL
                 # content, then never publish again after edits.
                 if not is_change:
-                    write_message(
-                        {
-                            "jsonrpc": "2.0",
-                            "method": "textDocument/publishDiagnostics",
-                            "params": {"uri": uri, "version": version, "diagnostics": error_diag},
-                        }
-                    )
+                    write_message({
+                        "jsonrpc": "2.0",
+                        "method": "textDocument/publishDiagnostics",
+                        "params": {
+                            "uri": uri,
+                            "version": version,
+                            "diagnostics": error_diag,
+                        },
+                    })
                 continue
             if script == "slow_push":
                 diagnostics = error_diag
                 if is_change:
                     time.sleep(float(os.environ.get("MOCK_LSP_PUSH_DELAY", "1.0")))
                     diagnostics = []
-                write_message(
-                    {
-                        "jsonrpc": "2.0",
-                        "method": "textDocument/publishDiagnostics",
-                        "params": {"uri": uri, "version": version, "diagnostics": diagnostics},
-                    }
-                )
+                write_message({
+                    "jsonrpc": "2.0",
+                    "method": "textDocument/publishDiagnostics",
+                    "params": {
+                        "uri": uri,
+                        "version": version,
+                        "diagnostics": diagnostics,
+                    },
+                })
                 continue
             if script == "reject_then_unversioned_push":
                 if is_change:
@@ -169,74 +181,130 @@ def main():
                     ]
                     pending_push = (uri, delayed_diag)
                 else:
-                    write_message(
-                        {
-                            "jsonrpc": "2.0",
-                            "method": "textDocument/publishDiagnostics",
-                            "params": {
-                                "uri": uri,
-                                "version": version,
-                                "diagnostics": error_diag,
-                            },
-                        }
+                    write_message({
+                        "jsonrpc": "2.0",
+                        "method": "textDocument/publishDiagnostics",
+                        "params": {
+                            "uri": uri,
+                            "version": version,
+                            "diagnostics": error_diag,
+                        },
+                    })
+                continue
+            if script == "stale_then_corrected_unversioned_push":
+                if is_change:
+                    time.sleep(float(os.environ.get("MOCK_LSP_STALE_DELAY", "0.01")))
+                    write_message({
+                        "jsonrpc": "2.0",
+                        "method": "textDocument/publishDiagnostics",
+                        "params": {"uri": uri, "diagnostics": error_diag},
+                    })
+                    time.sleep(
+                        float(os.environ.get("MOCK_LSP_CORRECTION_DELAY", "0.24"))
                     )
+                    write_message({
+                        "jsonrpc": "2.0",
+                        "method": "textDocument/publishDiagnostics",
+                        "params": {"uri": uri, "diagnostics": []},
+                    })
+                else:
+                    write_message({
+                        "jsonrpc": "2.0",
+                        "method": "textDocument/publishDiagnostics",
+                        "params": {
+                            "uri": uri,
+                            "version": version,
+                            "diagnostics": error_diag,
+                        },
+                    })
+                continue
+            if script == "versioned_then_stale_corrected_unversioned_push":
+                if is_change:
+                    write_message({
+                        "jsonrpc": "2.0",
+                        "method": "textDocument/publishDiagnostics",
+                        "params": {
+                            "uri": uri,
+                            "version": version,
+                            "diagnostics": [],
+                        },
+                    })
+                    time.sleep(float(os.environ.get("MOCK_LSP_STALE_DELAY", "0.05")))
+                    write_message({
+                        "jsonrpc": "2.0",
+                        "method": "textDocument/publishDiagnostics",
+                        "params": {"uri": uri, "diagnostics": error_diag},
+                    })
+                    time.sleep(
+                        float(os.environ.get("MOCK_LSP_CORRECTION_DELAY", "0.25"))
+                    )
+                    write_message({
+                        "jsonrpc": "2.0",
+                        "method": "textDocument/publishDiagnostics",
+                        "params": {"uri": uri, "diagnostics": []},
+                    })
+                else:
+                    write_message({
+                        "jsonrpc": "2.0",
+                        "method": "textDocument/publishDiagnostics",
+                        "params": {
+                            "uri": uri,
+                            "version": version,
+                            "diagnostics": error_diag,
+                        },
+                    })
                 continue
             diagnostics = []
             if script == "errors":
                 diagnostics = error_diag
-            write_message(
-                {
-                    "jsonrpc": "2.0",
-                    "method": "textDocument/publishDiagnostics",
-                    "params": {
-                        "uri": uri,
-                        "version": version,
-                        "diagnostics": diagnostics,
-                    },
-                }
-            )
+            write_message({
+                "jsonrpc": "2.0",
+                "method": "textDocument/publishDiagnostics",
+                "params": {
+                    "uri": uri,
+                    "version": version,
+                    "diagnostics": diagnostics,
+                },
+            })
             continue
 
         if msg.get("method") == "textDocument/diagnostic":
             if script == "reject_then_unversioned_push":
-                write_message(
-                    {
-                        "jsonrpc": "2.0",
-                        "id": msg["id"],
-                        "error": {"code": -32601, "message": "method not found"},
-                    }
-                )
+                write_message({
+                    "jsonrpc": "2.0",
+                    "id": msg["id"],
+                    "error": {"code": -32601, "message": "method not found"},
+                })
                 if pending_push is not None:
                     uri, diagnostics = pending_push
                     pending_push = None
                     time.sleep(float(os.environ.get("MOCK_LSP_PUSH_DELAY", "0.05")))
-                    write_message(
-                        {
-                            "jsonrpc": "2.0",
-                            "method": "textDocument/publishDiagnostics",
-                            "params": {"uri": uri, "diagnostics": diagnostics},
-                        }
-                    )
+                    write_message({
+                        "jsonrpc": "2.0",
+                        "method": "textDocument/publishDiagnostics",
+                        "params": {"uri": uri, "diagnostics": diagnostics},
+                    })
                 continue
-            if script in {"stale", "slow_push"}:
+            if script in {
+                "stale",
+                "slow_push",
+                "stale_then_corrected_unversioned_push",
+                "versioned_then_stale_corrected_unversioned_push",
+            }:
                 # These scripts model push-only servers so the ghost
                 # can't be papered over by the pull channel.
-                write_message(
-                    {
-                        "jsonrpc": "2.0",
-                        "id": msg["id"],
-                        "error": {"code": -32601, "message": "method not found"},
-                    }
-                )
-                continue
-            # Pull endpoint — return empty.
-            write_message(
-                {
+                write_message({
                     "jsonrpc": "2.0",
                     "id": msg["id"],
-                    "result": {"kind": "full", "items": []},
-                }
-            )
+                    "error": {"code": -32601, "message": "method not found"},
+                })
+                continue
+            # Pull endpoint — return empty.
+            write_message({
+                "jsonrpc": "2.0",
+                "id": msg["id"],
+                "result": {"kind": "full", "items": []},
+            })
             continue
 
         if msg.get("method") == "textDocument/didSave":
@@ -251,13 +319,14 @@ def main():
 
         # Unknown request: respond with method-not-found.
         if "id" in msg:
-            write_message(
-                {
-                    "jsonrpc": "2.0",
-                    "id": msg["id"],
-                    "error": {"code": -32601, "message": f"method not found: {msg.get('method')}"},
-                }
-            )
+            write_message({
+                "jsonrpc": "2.0",
+                "id": msg["id"],
+                "error": {
+                    "code": -32601,
+                    "message": f"method not found: {msg.get('method')}",
+                },
+            })
 
 
 if __name__ == "__main__":

--- a/tests/agent/lsp/_mock_lsp_server.py
+++ b/tests/agent/lsp/_mock_lsp_server.py
@@ -29,6 +29,9 @@ Behaviour (all behaviours selectable via env var ``MOCK_LSP_SCRIPT``):
   process and stdin alive.
 - ``"malformed_frame"`` — writes an invalid frame after ``didOpen``,
   then keeps the process and stdin alive.
+- ``"reject_then_unversioned_push"`` — publishes a versioned result on
+  didOpen, then after didChange rejects the pull request first and sends a
+  delayed unversioned push.  Exercises the real reader-loop race.
 
 The script writes JSON-RPC framed messages to stdout and reads from
 stdin.  No third-party dependencies — uses only stdlib so it runs
@@ -68,6 +71,7 @@ def write_message(obj):
 
 def main():
     script = os.environ.get("MOCK_LSP_SCRIPT", "clean")
+    pending_push = None
 
     while True:
         msg = read_message()
@@ -154,6 +158,29 @@ def main():
                     }
                 )
                 continue
+            if script == "reject_then_unversioned_push":
+                if is_change:
+                    delayed_diag = [
+                        {
+                            **error_diag[0],
+                            "code": "MOCK_UNVERSIONED",
+                            "message": "delayed unversioned diagnostic",
+                        }
+                    ]
+                    pending_push = (uri, delayed_diag)
+                else:
+                    write_message(
+                        {
+                            "jsonrpc": "2.0",
+                            "method": "textDocument/publishDiagnostics",
+                            "params": {
+                                "uri": uri,
+                                "version": version,
+                                "diagnostics": error_diag,
+                            },
+                        }
+                    )
+                continue
             diagnostics = []
             if script == "errors":
                 diagnostics = error_diag
@@ -171,6 +198,26 @@ def main():
             continue
 
         if msg.get("method") == "textDocument/diagnostic":
+            if script == "reject_then_unversioned_push":
+                write_message(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": msg["id"],
+                        "error": {"code": -32601, "message": "method not found"},
+                    }
+                )
+                if pending_push is not None:
+                    uri, diagnostics = pending_push
+                    pending_push = None
+                    time.sleep(float(os.environ.get("MOCK_LSP_PUSH_DELAY", "0.05")))
+                    write_message(
+                        {
+                            "jsonrpc": "2.0",
+                            "method": "textDocument/publishDiagnostics",
+                            "params": {"uri": uri, "diagnostics": diagnostics},
+                        }
+                    )
+                continue
             if script in {"stale", "slow_push"}:
                 # These scripts model push-only servers so the ghost
                 # can't be papered over by the pull channel.

--- a/tests/agent/lsp/_mock_lsp_server.py
+++ b/tests/agent/lsp/_mock_lsp_server.py
@@ -29,6 +29,8 @@ Behaviour (all behaviours selectable via env var ``MOCK_LSP_SCRIPT``):
   process and stdin alive.
 - ``"malformed_frame"`` — writes an invalid frame after ``didOpen``,
   then keeps the process and stdin alive.
+- ``"diagnostic_eof"`` — accepts ``didOpen`` without publishing, then
+  closes stdout when the client requests pull diagnostics.
 - ``"reject_then_unversioned_push"`` — publishes a versioned result on
   didOpen, then after didChange rejects the pull request first and sends a
   delayed unversioned push.  Exercises the real reader-loop race.
@@ -129,6 +131,8 @@ def main():
                 while read_message() is not None:
                     pass
                 return 0
+            if script == "diagnostic_eof":
+                continue
             error_diag = [
                 {
                     "range": {
@@ -269,6 +273,11 @@ def main():
             continue
 
         if msg.get("method") == "textDocument/diagnostic":
+            if script == "diagnostic_eof":
+                os.close(sys.stdout.fileno())
+                while read_message() is not None:
+                    pass
+                return 0
             if script == "reject_then_unversioned_push":
                 write_message({
                     "jsonrpc": "2.0",

--- a/tests/agent/lsp/test_client_e2e.py
+++ b/tests/agent/lsp/test_client_e2e.py
@@ -329,6 +329,20 @@ def test_non_file_diagnostic_uri_preserves_opaque_identity(tmp_path: Path):
     assert client.diagnostics_for(lower_uri) == [lower_diagnostic]
 
 
+def test_relative_path_with_colon_uses_open_document_key(tmp_path: Path):
+    relative_path = "notes:2026.ts"
+    diagnostic = {"message": "relative POSIX path diagnostic"}
+    client = _client(tmp_path, "clean")
+    client._handle_publish_diagnostics(
+        {
+            "uri": file_uri(os.path.abspath(relative_path)),
+            "diagnostics": [diagnostic],
+        }
+    )
+
+    assert client.diagnostics_for(relative_path) == [diagnostic]
+
+
 @pytest.mark.skipif(os.name == "nt", reason="POSIX URI behavior")
 def test_posix_file_uri_round_trip_preserves_case():
     path = "/tmp/MixedCase/File Name.ts"

--- a/tests/agent/lsp/test_client_e2e.py
+++ b/tests/agent/lsp/test_client_e2e.py
@@ -255,6 +255,17 @@ def test_uri_to_path_preserves_non_file_uri():
     assert uri_to_path(uri) == uri
 
 
+def test_non_file_diagnostic_uri_preserves_opaque_identity(tmp_path: Path):
+    uri = "untitled:CaseSensitive-1"
+    diagnostic = {"message": "virtual document diagnostic"}
+    client = _client(tmp_path, "clean")
+
+    client._handle_publish_diagnostics({"uri": uri, "diagnostics": [diagnostic]})
+
+    assert uri in client._docs
+    assert client.diagnostics_for(uri) == [diagnostic]
+
+
 @pytest.mark.skipif(os.name == "nt", reason="POSIX URI behavior")
 def test_posix_file_uri_round_trip_preserves_case():
     path = "/tmp/MixedCase/File Name.ts"
@@ -277,6 +288,54 @@ async def test_edit_baselines_are_tied_to_returned_versions(
 
     assert client._diagnostic_baselines[(key, version_zero)] == 0
     assert client._diagnostic_baselines[(key, version_one)] == 4
+
+
+@pytest.mark.asyncio
+async def test_overlapping_opens_allocate_distinct_versions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    path = tmp_path / "index.ts"
+    path.write_text("const value = 1;\n")
+    client = _client(tmp_path, "clean")
+    await _open_without_server(client, path, monkeypatch)
+
+    async def yield_after_notification(_method: str, _params: object) -> None:
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(client, "_send_notification", yield_after_notification)
+    versions = await asyncio.gather(
+        client.open_file(str(path), language_id="typescript"),
+        client.open_file(str(path), language_id="typescript"),
+    )
+
+    assert versions == [1, 2]
+    key = uri_to_path(file_uri(str(path)))
+    assert (key, 1) in client._diagnostic_baselines
+    assert (key, 2) in client._diagnostic_baselines
+
+
+@pytest.mark.asyncio
+async def test_push_received_during_did_change_is_fresh(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    path = tmp_path / "index.ts"
+    path.write_text("const value = 1;\n")
+    client = _client(tmp_path, "clean")
+    await _open_without_server(client, path, monkeypatch)
+    path.write_text("const value: string = 1;\n")
+    diagnostic = {"message": "Type 'number' is not assignable to type 'string'"}
+
+    async def publish_during_change(method: str, _params: object) -> None:
+        if method == "textDocument/didChange":
+            client._handle_publish_diagnostics(
+                {"uri": file_uri(str(path)), "diagnostics": [diagnostic]}
+            )
+
+    monkeypatch.setattr(client, "_send_notification", publish_during_change)
+    version = await client.open_file(str(path), language_id="typescript")
+
+    assert await client.wait_for_diagnostics(str(path), version, timeout=0.5)
+    assert client.diagnostics_for(str(path), fresh_only=True) == [diagnostic]
 
 
 def test_seed_first_push_is_not_marked_fresh(tmp_path: Path):

--- a/tests/agent/lsp/test_client_e2e.py
+++ b/tests/agent/lsp/test_client_e2e.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import pytest
 
-from agent.lsp.client import LSPClient
+from agent.lsp.client import LSPClient, PUSH_DEBOUNCE, file_uri, uri_to_path
 
 
 MOCK_SERVER = str(Path(__file__).parent / "_mock_lsp_server.py")
@@ -78,3 +78,278 @@ async def test_client_receives_published_errors(tmp_path: Path):
 
 
 
+@pytest.mark.asyncio
+async def test_client_diagnostics_are_deduped(tmp_path: Path):
+    """Repeated identical pushes must not produce duplicate diagnostics."""
+    f = tmp_path / "x.py"
+    f.write_text("")
+    client = _client(tmp_path, "errors")
+    await client.start()
+    try:
+        for _ in range(3):
+            v = await client.open_file(str(f), language_id="python")
+            await client.wait_for_diagnostics(str(f), v, mode="document")
+        diags = client.diagnostics_for(str(f))
+        # Push store overwrites on every notification — should have 1.
+        assert len(diags) == 1
+    finally:
+        await client.shutdown()
+
+
+# Windows path identity and push-only diagnostic regressions.
+
+
+async def _open_without_server(
+    client: LSPClient,
+    path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    language_id: str = "typescript",
+) -> int:
+    class RunningProcess:
+        returncode = None
+
+    async def ignore_notification(_method: str, _params: object) -> None:
+        return None
+
+    client._state = "running"
+    client._proc = RunningProcess()
+    monkeypatch.setattr(client, "_send_notification", ignore_notification)
+    return await client.open_file(str(path), language_id=language_id)
+
+
+@pytest.mark.asyncio
+async def test_wait_keeps_push_waiter_when_pull_is_unsupported(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A fast failed pull must not starve delayed push diagnostics."""
+    path = tmp_path / "x.ts"
+    path.write_text("const value = 1;\n")
+    client = _client(tmp_path, "clean")
+    version = await _open_without_server(client, path, monkeypatch)
+    pull_calls = 0
+
+    async def unsupported_pull(_path: str) -> None:
+        nonlocal pull_calls
+        pull_calls += 1
+
+    async def delayed_push() -> None:
+        await asyncio.sleep(0.01)
+        client._handle_publish_diagnostics(
+            {
+                "uri": file_uri(str(path)),
+                "diagnostics": [{"message": "TS diagnostic"}],
+            }
+        )
+
+    monkeypatch.setattr(client, "_pull_document_diagnostics", unsupported_pull)
+
+    producer = asyncio.create_task(delayed_push())
+    fresh = await client.wait_for_diagnostics(
+        str(path), version, mode="document", timeout=1.0
+    )
+    await producer
+
+    assert fresh is True
+    assert pull_calls == 1
+    assert client.diagnostics_for(str(path)) == [{"message": "TS diagnostic"}]
+
+
+@pytest.mark.asyncio
+async def test_wait_cancellation_stops_preserved_push_task(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    path = tmp_path / "x.ts"
+    path.write_text("const value = 1;\n")
+    client = _client(tmp_path, "clean")
+    version = await _open_without_server(client, path, monkeypatch)
+    push_started = asyncio.Event()
+    push_cancelled = asyncio.Event()
+
+    async def unsupported_pull(_path: str) -> None:
+        return None
+
+    async def blocking_push(
+        _path: str, _version: int, _timeout: float, _baseline: int
+    ) -> None:
+        push_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            push_cancelled.set()
+
+    monkeypatch.setattr(client, "_pull_document_diagnostics", unsupported_pull)
+    monkeypatch.setattr(client, "_wait_for_fresh_push", blocking_push)
+
+    waiter = asyncio.create_task(client.wait_for_diagnostics(str(path), version))
+    await asyncio.wait_for(push_started.wait(), timeout=0.5)
+    waiter.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(waiter, timeout=0.5)
+    await asyncio.wait_for(push_cancelled.wait(), timeout=0.5)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows URI normalization")
+def test_encoded_drive_uri_maps_to_original_native_path(tmp_path: Path):
+    native_path = r"C:\Workspace\Project\src\Index.ts"
+    uri = "file:///c%3A/workspace/project/src/index.ts"
+    diagnostic = {"message": "mapped diagnostic"}
+    client = LSPClient(
+        server_id="typescript",
+        workspace_root=str(tmp_path),
+        command=[sys.executable, MOCK_SERVER],
+    )
+
+    client._handle_publish_diagnostics({"uri": uri, "diagnostics": [diagnostic]})
+
+    assert client.diagnostics_for(native_path) == [diagnostic]
+    assert file_uri(native_path) == "file:///C:/Workspace/Project/src/Index.ts"
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows UNC URI normalization")
+def test_unc_file_uri_round_trip():
+    native_path = r"\\Server\Share\Folder\File.ts"
+    assert file_uri(native_path) == "file://Server/Share/Folder/File.ts"
+    assert uri_to_path("file://server/share/folder/file.ts") == os.path.normcase(
+        os.path.abspath(native_path)
+    )
+
+
+def test_uri_to_path_preserves_non_file_uri():
+    uri = "untitled:Untitled-1"
+    assert uri_to_path(uri) == uri
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX URI behavior")
+def test_posix_file_uri_round_trip_preserves_case():
+    path = "/tmp/MixedCase/File Name.ts"
+    assert uri_to_path(file_uri(path)) == os.path.normpath(os.path.abspath(path))
+
+
+@pytest.mark.asyncio
+async def test_edit_baselines_are_tied_to_returned_versions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    path = tmp_path / "index.ts"
+    path.write_text("const value = 1;\n")
+    client = _client(tmp_path, "clean")
+
+    version_zero = await _open_without_server(client, path, monkeypatch)
+    client._push_counter = 4
+    path.write_text("const value = 2;\n")
+    version_one = await client.open_file(str(path), language_id="typescript")
+    key = uri_to_path(file_uri(str(path)))
+
+    assert client._diagnostic_baselines[(key, version_zero)] == 0
+    assert client._diagnostic_baselines[(key, version_one)] == 4
+
+
+def test_seed_first_push_is_not_marked_fresh(tmp_path: Path):
+    client = LSPClient(
+        server_id="typescript",
+        workspace_root=str(tmp_path),
+        command=[sys.executable, MOCK_SERVER],
+        seed_diagnostics_on_first_push=True,
+    )
+    path = str(tmp_path / "index.ts")
+    uri = file_uri(path)
+    key = uri_to_path(uri)
+
+    client._handle_publish_diagnostics({"uri": uri, "version": 0, "diagnostics": []})
+    doc = client._docs[key]
+    assert doc.push_counter == 0
+    assert doc.push_version == -1
+
+    diagnostic = {"message": "fresh TypeScript error"}
+    client._handle_publish_diagnostics(
+        {"uri": uri, "version": 1, "diagnostics": [diagnostic]}
+    )
+    assert doc.push_counter == 1
+    assert doc.push_version == 1
+    assert client.diagnostics_for(path) == [diagnostic]
+
+
+def test_unversioned_push_drops_stale_version_metadata(tmp_path: Path):
+    client = LSPClient(
+        server_id="typescript",
+        workspace_root=str(tmp_path),
+        command=[sys.executable, MOCK_SERVER],
+    )
+    path = str(tmp_path / "index.ts")
+    uri = file_uri(path)
+    key = uri_to_path(uri)
+
+    client._handle_publish_diagnostics({"uri": uri, "version": 1, "diagnostics": []})
+    assert client._docs[key].push_version == 1
+
+    client._handle_publish_diagnostics({"uri": uri, "diagnostics": []})
+    assert client._docs[key].push_version == -1
+
+
+@pytest.mark.asyncio
+async def test_unversioned_push_freshness_is_scoped_to_target_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    client = _client(tmp_path, "clean")
+    target = tmp_path / "index.ts"
+    other = tmp_path / "other.ts"
+    target.write_text("const value = 1;\n")
+    other.write_text("const other = 1;\n")
+    target_uri = file_uri(str(target))
+    target_key = uri_to_path(target_uri)
+    stale = {"message": "stale TypeScript error"}
+
+    await _open_without_server(client, target, monkeypatch)
+    client._handle_publish_diagnostics({"uri": target_uri, "diagnostics": [stale]})
+    baseline = client._push_counter
+    target.write_text("const value = 2;\n")
+    version = await client.open_file(str(target), language_id="typescript")
+    waiter = asyncio.create_task(
+        client._wait_for_fresh_push(
+            target_key, version=version, timeout=1.0, baseline=baseline
+        )
+    )
+
+    client._handle_publish_diagnostics(
+        {"uri": file_uri(str(other)), "diagnostics": []}
+    )
+    await asyncio.sleep(PUSH_DEBOUNCE + 0.05)
+    assert not waiter.done()
+
+    client._handle_publish_diagnostics({"uri": target_uri, "diagnostics": []})
+    await waiter
+    assert client.diagnostics_for(str(target)) == []
+
+
+@pytest.mark.asyncio
+async def test_unversioned_push_waits_for_post_edit_quiet_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """TypeScript's stale unversioned push must not win over the clean one."""
+    client = _client(tmp_path, "clean")
+    path = tmp_path / "index.ts"
+    path.write_text("const value = 1;\n")
+    uri = file_uri(str(path))
+    key = uri_to_path(uri)
+    stale = {"message": "stale TypeScript error"}
+
+    await _open_without_server(client, path, monkeypatch)
+    client._handle_publish_diagnostics({"uri": uri, "diagnostics": [stale]})
+    baseline = client._push_counter
+    path.write_text("const value = 2;\n")
+    version = await client.open_file(str(path), language_id="typescript")
+
+    async def publish_after_edit() -> None:
+        await asyncio.sleep(0.01)
+        client._handle_publish_diagnostics({"uri": uri, "diagnostics": [stale]})
+        await asyncio.sleep(0.05)
+        client._handle_publish_diagnostics({"uri": uri, "diagnostics": []})
+
+    producer = asyncio.create_task(publish_after_edit())
+    await client._wait_for_fresh_push(
+        key, version=version, timeout=1.0, baseline=baseline
+    )
+    await producer
+
+    assert client.diagnostics_for(str(path)) == []

--- a/tests/agent/lsp/test_client_e2e.py
+++ b/tests/agent/lsp/test_client_e2e.py
@@ -236,6 +236,12 @@ def test_encoded_drive_uri_maps_to_original_native_path(tmp_path: Path):
     )
 
     client._handle_publish_diagnostics({"uri": uri, "diagnostics": [diagnostic]})
+    client._handle_publish_diagnostics(
+        {
+            "uri": "FILE:///c%3A/workspace/project/src/index.ts",
+            "diagnostics": [diagnostic],
+        }
+    )
 
     assert client.diagnostics_for(native_path) == [diagnostic]
     assert file_uri(native_path) == "file:///C:/Workspace/Project/src/Index.ts"
@@ -256,14 +262,23 @@ def test_uri_to_path_preserves_non_file_uri():
 
 
 def test_non_file_diagnostic_uri_preserves_opaque_identity(tmp_path: Path):
-    uri = "untitled:CaseSensitive-1"
-    diagnostic = {"message": "virtual document diagnostic"}
+    upper_uri = "x:CaseSensitive-1"
+    lower_uri = "x:casesensitive-1"
+    upper_diagnostic = {"message": "upper virtual document diagnostic"}
+    lower_diagnostic = {"message": "lower virtual document diagnostic"}
     client = _client(tmp_path, "clean")
 
-    client._handle_publish_diagnostics({"uri": uri, "diagnostics": [diagnostic]})
+    client._handle_publish_diagnostics(
+        {"uri": upper_uri, "diagnostics": [upper_diagnostic]}
+    )
+    client._handle_publish_diagnostics(
+        {"uri": lower_uri, "diagnostics": [lower_diagnostic]}
+    )
 
-    assert uri in client._docs
-    assert client.diagnostics_for(uri) == [diagnostic]
+    assert upper_uri in client._docs
+    assert lower_uri in client._docs
+    assert client.diagnostics_for(upper_uri) == [upper_diagnostic]
+    assert client.diagnostics_for(lower_uri) == [lower_diagnostic]
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX URI behavior")

--- a/tests/agent/lsp/test_client_e2e.py
+++ b/tests/agent/lsp/test_client_e2e.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import pytest
 
-from agent.lsp.client import LSPClient
+from agent.lsp.client import LSPClient, PUSH_DEBOUNCE, file_uri, uri_to_path
 from agent.lsp.protocol import LSPProtocolError
 
 
@@ -124,3 +124,280 @@ async def test_reader_failure_retires_client_and_rejects_later_work(
             )
     finally:
         await client.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_client_diagnostics_are_deduped(tmp_path: Path):
+    """Repeated identical pushes must not produce duplicate diagnostics."""
+    f = tmp_path / "x.py"
+    f.write_text("")
+    client = _client(tmp_path, "errors")
+    await client.start()
+    try:
+        for _ in range(3):
+            v = await client.open_file(str(f), language_id="python")
+            await client.wait_for_diagnostics(str(f), v, mode="document")
+        diags = client.diagnostics_for(str(f))
+        # Push store overwrites on every notification — should have 1.
+        assert len(diags) == 1
+    finally:
+        await client.shutdown()
+
+
+# Windows path identity and push-only diagnostic regressions.
+
+
+async def _open_without_server(
+    client: LSPClient,
+    path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    language_id: str = "typescript",
+) -> int:
+    class RunningProcess:
+        returncode = None
+
+    async def ignore_notification(_method: str, _params: object) -> None:
+        return None
+
+    client._state = "running"
+    client._proc = RunningProcess()
+    monkeypatch.setattr(client, "_send_notification", ignore_notification)
+    return await client.open_file(str(path), language_id=language_id)
+
+
+@pytest.mark.asyncio
+async def test_wait_keeps_push_waiter_when_pull_is_unsupported(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A fast failed pull must not starve delayed push diagnostics."""
+    path = tmp_path / "x.ts"
+    path.write_text("const value = 1;\n")
+    client = _client(tmp_path, "clean")
+    version = await _open_without_server(client, path, monkeypatch)
+    pull_calls = 0
+
+    async def unsupported_pull(_path: str) -> None:
+        nonlocal pull_calls
+        pull_calls += 1
+
+    async def delayed_push() -> None:
+        await asyncio.sleep(0.01)
+        client._handle_publish_diagnostics(
+            {
+                "uri": file_uri(str(path)),
+                "diagnostics": [{"message": "TS diagnostic"}],
+            }
+        )
+
+    monkeypatch.setattr(client, "_pull_document_diagnostics", unsupported_pull)
+
+    producer = asyncio.create_task(delayed_push())
+    fresh = await client.wait_for_diagnostics(
+        str(path), version, mode="document", timeout=1.0
+    )
+    await producer
+
+    assert fresh is True
+    assert pull_calls == 1
+    assert client.diagnostics_for(str(path)) == [{"message": "TS diagnostic"}]
+
+
+@pytest.mark.asyncio
+async def test_wait_cancellation_stops_preserved_push_task(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    path = tmp_path / "x.ts"
+    path.write_text("const value = 1;\n")
+    client = _client(tmp_path, "clean")
+    version = await _open_without_server(client, path, monkeypatch)
+    push_started = asyncio.Event()
+    push_cancelled = asyncio.Event()
+
+    async def unsupported_pull(_path: str) -> None:
+        return None
+
+    async def blocking_push(
+        _path: str, _version: int, _timeout: float, _baseline: int
+    ) -> None:
+        push_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            push_cancelled.set()
+
+    monkeypatch.setattr(client, "_pull_document_diagnostics", unsupported_pull)
+    monkeypatch.setattr(client, "_wait_for_fresh_push", blocking_push)
+
+    waiter = asyncio.create_task(client.wait_for_diagnostics(str(path), version))
+    await asyncio.wait_for(push_started.wait(), timeout=0.5)
+    waiter.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(waiter, timeout=0.5)
+    await asyncio.wait_for(push_cancelled.wait(), timeout=0.5)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows URI normalization")
+def test_encoded_drive_uri_maps_to_original_native_path(tmp_path: Path):
+    native_path = r"C:\Workspace\Project\src\Index.ts"
+    uri = "file:///c%3A/workspace/project/src/index.ts"
+    diagnostic = {"message": "mapped diagnostic"}
+    client = LSPClient(
+        server_id="typescript",
+        workspace_root=str(tmp_path),
+        command=[sys.executable, MOCK_SERVER],
+    )
+
+    client._handle_publish_diagnostics({"uri": uri, "diagnostics": [diagnostic]})
+
+    assert client.diagnostics_for(native_path) == [diagnostic]
+    assert file_uri(native_path) == "file:///C:/Workspace/Project/src/Index.ts"
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows UNC URI normalization")
+def test_unc_file_uri_round_trip():
+    native_path = r"\\Server\Share\Folder\File.ts"
+    assert file_uri(native_path) == "file://Server/Share/Folder/File.ts"
+    assert uri_to_path("file://server/share/folder/file.ts") == os.path.normcase(
+        os.path.abspath(native_path)
+    )
+
+
+def test_uri_to_path_preserves_non_file_uri():
+    uri = "untitled:Untitled-1"
+    assert uri_to_path(uri) == uri
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX URI behavior")
+def test_posix_file_uri_round_trip_preserves_case():
+    path = "/tmp/MixedCase/File Name.ts"
+    assert uri_to_path(file_uri(path)) == os.path.normpath(os.path.abspath(path))
+
+
+@pytest.mark.asyncio
+async def test_edit_baselines_are_tied_to_returned_versions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    path = tmp_path / "index.ts"
+    path.write_text("const value = 1;\n")
+    client = _client(tmp_path, "clean")
+
+    version_zero = await _open_without_server(client, path, monkeypatch)
+    client._push_counter = 4
+    path.write_text("const value = 2;\n")
+    version_one = await client.open_file(str(path), language_id="typescript")
+    key = uri_to_path(file_uri(str(path)))
+
+    assert client._diagnostic_baselines[(key, version_zero)] == 0
+    assert client._diagnostic_baselines[(key, version_one)] == 4
+
+
+def test_seed_first_push_is_not_marked_fresh(tmp_path: Path):
+    client = LSPClient(
+        server_id="typescript",
+        workspace_root=str(tmp_path),
+        command=[sys.executable, MOCK_SERVER],
+        seed_diagnostics_on_first_push=True,
+    )
+    path = str(tmp_path / "index.ts")
+    uri = file_uri(path)
+    key = uri_to_path(uri)
+
+    client._handle_publish_diagnostics({"uri": uri, "version": 0, "diagnostics": []})
+    doc = client._docs[key]
+    assert doc.push_counter == 0
+    assert doc.push_version == -1
+
+    diagnostic = {"message": "fresh TypeScript error"}
+    client._handle_publish_diagnostics(
+        {"uri": uri, "version": 1, "diagnostics": [diagnostic]}
+    )
+    assert doc.push_counter == 1
+    assert doc.push_version == 1
+    assert client.diagnostics_for(path) == [diagnostic]
+
+
+def test_unversioned_push_drops_stale_version_metadata(tmp_path: Path):
+    client = LSPClient(
+        server_id="typescript",
+        workspace_root=str(tmp_path),
+        command=[sys.executable, MOCK_SERVER],
+    )
+    path = str(tmp_path / "index.ts")
+    uri = file_uri(path)
+    key = uri_to_path(uri)
+
+    client._handle_publish_diagnostics({"uri": uri, "version": 1, "diagnostics": []})
+    assert client._docs[key].push_version == 1
+
+    client._handle_publish_diagnostics({"uri": uri, "diagnostics": []})
+    assert client._docs[key].push_version == -1
+
+
+@pytest.mark.asyncio
+async def test_unversioned_push_freshness_is_scoped_to_target_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    client = _client(tmp_path, "clean")
+    target = tmp_path / "index.ts"
+    other = tmp_path / "other.ts"
+    target.write_text("const value = 1;\n")
+    other.write_text("const other = 1;\n")
+    target_uri = file_uri(str(target))
+    target_key = uri_to_path(target_uri)
+    stale = {"message": "stale TypeScript error"}
+
+    await _open_without_server(client, target, monkeypatch)
+    client._handle_publish_diagnostics({"uri": target_uri, "diagnostics": [stale]})
+    baseline = client._push_counter
+    target.write_text("const value = 2;\n")
+    version = await client.open_file(str(target), language_id="typescript")
+    waiter = asyncio.create_task(
+        client._wait_for_fresh_push(
+            target_key, version=version, timeout=1.0, baseline=baseline
+        )
+    )
+
+    client._handle_publish_diagnostics(
+        {"uri": file_uri(str(other)), "diagnostics": []}
+    )
+    await asyncio.sleep(PUSH_DEBOUNCE + 0.05)
+    assert not waiter.done()
+
+    client._handle_publish_diagnostics({"uri": target_uri, "diagnostics": []})
+    await waiter
+    assert client.diagnostics_for(str(target)) == []
+
+
+@pytest.mark.asyncio
+async def test_unversioned_push_waits_for_post_edit_quiet_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """TypeScript's stale unversioned push must not win over the clean one."""
+    client = _client(tmp_path, "clean")
+    path = tmp_path / "index.ts"
+    path.write_text("const value = 1;\n")
+    uri = file_uri(str(path))
+    key = uri_to_path(uri)
+    stale = {"message": "stale TypeScript error"}
+
+    await _open_without_server(client, path, monkeypatch)
+    client._handle_publish_diagnostics({"uri": uri, "diagnostics": [stale]})
+    baseline = client._push_counter
+    path.write_text("const value = 2;\n")
+    version = await client.open_file(str(path), language_id="typescript")
+
+    async def publish_after_edit() -> None:
+        await asyncio.sleep(0.01)
+        client._handle_publish_diagnostics({"uri": uri, "diagnostics": [stale]})
+        await asyncio.sleep(0.05)
+        client._handle_publish_diagnostics({"uri": uri, "diagnostics": []})
+
+    producer = asyncio.create_task(publish_after_edit())
+    await client._wait_for_fresh_push(
+        key, version=version, timeout=1.0, baseline=baseline
+    )
+    await producer
+
+    assert client.diagnostics_for(str(path)) == []

--- a/tests/agent/lsp/test_client_e2e.py
+++ b/tests/agent/lsp/test_client_e2e.py
@@ -284,6 +284,12 @@ def test_encoded_drive_uri_maps_to_original_native_path(tmp_path: Path):
     )
 
     client._handle_publish_diagnostics({"uri": uri, "diagnostics": [diagnostic]})
+    client._handle_publish_diagnostics(
+        {
+            "uri": "FILE:///c%3A/workspace/project/src/index.ts",
+            "diagnostics": [diagnostic],
+        }
+    )
 
     assert client.diagnostics_for(native_path) == [diagnostic]
     assert file_uri(native_path) == "file:///C:/Workspace/Project/src/Index.ts"
@@ -304,14 +310,23 @@ def test_uri_to_path_preserves_non_file_uri():
 
 
 def test_non_file_diagnostic_uri_preserves_opaque_identity(tmp_path: Path):
-    uri = "untitled:CaseSensitive-1"
-    diagnostic = {"message": "virtual document diagnostic"}
+    upper_uri = "x:CaseSensitive-1"
+    lower_uri = "x:casesensitive-1"
+    upper_diagnostic = {"message": "upper virtual document diagnostic"}
+    lower_diagnostic = {"message": "lower virtual document diagnostic"}
     client = _client(tmp_path, "clean")
 
-    client._handle_publish_diagnostics({"uri": uri, "diagnostics": [diagnostic]})
+    client._handle_publish_diagnostics(
+        {"uri": upper_uri, "diagnostics": [upper_diagnostic]}
+    )
+    client._handle_publish_diagnostics(
+        {"uri": lower_uri, "diagnostics": [lower_diagnostic]}
+    )
 
-    assert uri in client._docs
-    assert client.diagnostics_for(uri) == [diagnostic]
+    assert upper_uri in client._docs
+    assert lower_uri in client._docs
+    assert client.diagnostics_for(upper_uri) == [upper_diagnostic]
+    assert client.diagnostics_for(lower_uri) == [lower_diagnostic]
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX URI behavior")

--- a/tests/agent/lsp/test_client_e2e.py
+++ b/tests/agent/lsp/test_client_e2e.py
@@ -281,6 +281,20 @@ def test_non_file_diagnostic_uri_preserves_opaque_identity(tmp_path: Path):
     assert client.diagnostics_for(lower_uri) == [lower_diagnostic]
 
 
+def test_relative_path_with_colon_uses_open_document_key(tmp_path: Path):
+    relative_path = "notes:2026.ts"
+    diagnostic = {"message": "relative POSIX path diagnostic"}
+    client = _client(tmp_path, "clean")
+    client._handle_publish_diagnostics(
+        {
+            "uri": file_uri(os.path.abspath(relative_path)),
+            "diagnostics": [diagnostic],
+        }
+    )
+
+    assert client.diagnostics_for(relative_path) == [diagnostic]
+
+
 @pytest.mark.skipif(os.name == "nt", reason="POSIX URI behavior")
 def test_posix_file_uri_round_trip_preserves_case():
     path = "/tmp/MixedCase/File Name.ts"

--- a/tests/agent/lsp/test_client_e2e.py
+++ b/tests/agent/lsp/test_client_e2e.py
@@ -204,6 +204,40 @@ async def test_wait_keeps_push_waiter_when_pull_is_unsupported(
 
 
 @pytest.mark.asyncio
+async def test_protocol_rejected_pull_accepts_delayed_unversioned_push(
+    tmp_path: Path,
+):
+    """Exercise rejection-first ordering through the real subprocess reader."""
+    path = tmp_path / "x.ts"
+    path.write_text("const value = 1;\n")
+    client = _client(tmp_path, "reject_then_unversioned_push")
+    assert client._env is not None
+    client._env["MOCK_LSP_PUSH_DELAY"] = "0.05"
+    await client.start()
+    try:
+        version_zero = await client.open_file(str(path), language_id="typescript")
+        assert await client.wait_for_diagnostics(
+            str(path), version_zero, mode="document", timeout=1.0
+        )
+        key = uri_to_path(file_uri(str(path)))
+        assert client._docs[key].push_version == version_zero
+
+        path.write_text("const value = 2;\n")
+        version_one = await client.open_file(str(path), language_id="typescript")
+        assert await client.wait_for_diagnostics(
+            str(path), version_one, mode="document", timeout=1.0
+        )
+
+        assert client._docs[key].push_version == version_one
+        diagnostics = client.diagnostics_for(str(path), fresh_only=True)
+        assert [diagnostic["code"] for diagnostic in diagnostics] == [
+            "MOCK_UNVERSIONED"
+        ]
+    finally:
+        await client.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_wait_cancellation_stops_preserved_push_task(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/agent/lsp/test_client_e2e.py
+++ b/tests/agent/lsp/test_client_e2e.py
@@ -137,6 +137,23 @@ async def test_reader_failure_retires_client_and_rejects_later_work(
 
 
 @pytest.mark.asyncio
+async def test_transport_death_interrupts_preserved_push_wait(tmp_path: Path):
+    path = tmp_path / "x.py"
+    path.write_text("print('hi')\n")
+    client = _client(tmp_path, "diagnostic_eof")
+    await client.start()
+    try:
+        version = await client.open_file(str(path), language_id="python")
+        with pytest.raises(LSPProtocolError):
+            await asyncio.wait_for(
+                client.wait_for_diagnostics(str(path), version, timeout=3.0),
+                timeout=0.5,
+            )
+    finally:
+        await client.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_client_diagnostics_are_deduped(tmp_path: Path):
     """Repeated identical pushes must not produce duplicate diagnostics."""
     f = tmp_path / "x.py"

--- a/tests/agent/lsp/test_client_e2e.py
+++ b/tests/agent/lsp/test_client_e2e.py
@@ -303,6 +303,17 @@ def test_uri_to_path_preserves_non_file_uri():
     assert uri_to_path(uri) == uri
 
 
+def test_non_file_diagnostic_uri_preserves_opaque_identity(tmp_path: Path):
+    uri = "untitled:CaseSensitive-1"
+    diagnostic = {"message": "virtual document diagnostic"}
+    client = _client(tmp_path, "clean")
+
+    client._handle_publish_diagnostics({"uri": uri, "diagnostics": [diagnostic]})
+
+    assert uri in client._docs
+    assert client.diagnostics_for(uri) == [diagnostic]
+
+
 @pytest.mark.skipif(os.name == "nt", reason="POSIX URI behavior")
 def test_posix_file_uri_round_trip_preserves_case():
     path = "/tmp/MixedCase/File Name.ts"
@@ -325,6 +336,54 @@ async def test_edit_baselines_are_tied_to_returned_versions(
 
     assert client._diagnostic_baselines[(key, version_zero)] == 0
     assert client._diagnostic_baselines[(key, version_one)] == 4
+
+
+@pytest.mark.asyncio
+async def test_overlapping_opens_allocate_distinct_versions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    path = tmp_path / "index.ts"
+    path.write_text("const value = 1;\n")
+    client = _client(tmp_path, "clean")
+    await _open_without_server(client, path, monkeypatch)
+
+    async def yield_after_notification(_method: str, _params: object) -> None:
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(client, "_send_notification", yield_after_notification)
+    versions = await asyncio.gather(
+        client.open_file(str(path), language_id="typescript"),
+        client.open_file(str(path), language_id="typescript"),
+    )
+
+    assert versions == [1, 2]
+    key = uri_to_path(file_uri(str(path)))
+    assert (key, 1) in client._diagnostic_baselines
+    assert (key, 2) in client._diagnostic_baselines
+
+
+@pytest.mark.asyncio
+async def test_push_received_during_did_change_is_fresh(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    path = tmp_path / "index.ts"
+    path.write_text("const value = 1;\n")
+    client = _client(tmp_path, "clean")
+    await _open_without_server(client, path, monkeypatch)
+    path.write_text("const value: string = 1;\n")
+    diagnostic = {"message": "Type 'number' is not assignable to type 'string'"}
+
+    async def publish_during_change(method: str, _params: object) -> None:
+        if method == "textDocument/didChange":
+            client._handle_publish_diagnostics(
+                {"uri": file_uri(str(path)), "diagnostics": [diagnostic]}
+            )
+
+    monkeypatch.setattr(client, "_send_notification", publish_during_change)
+    version = await client.open_file(str(path), language_id="typescript")
+
+    assert await client.wait_for_diagnostics(str(path), version, timeout=0.5)
+    assert client.diagnostics_for(str(path), fresh_only=True) == [diagnostic]
 
 
 def test_seed_first_push_is_not_marked_fresh(tmp_path: Path):

--- a/tests/agent/lsp/test_client_e2e.py
+++ b/tests/agent/lsp/test_client_e2e.py
@@ -156,6 +156,40 @@ async def test_wait_keeps_push_waiter_when_pull_is_unsupported(
 
 
 @pytest.mark.asyncio
+async def test_protocol_rejected_pull_accepts_delayed_unversioned_push(
+    tmp_path: Path,
+):
+    """Exercise rejection-first ordering through the real subprocess reader."""
+    path = tmp_path / "x.ts"
+    path.write_text("const value = 1;\n")
+    client = _client(tmp_path, "reject_then_unversioned_push")
+    assert client._env is not None
+    client._env["MOCK_LSP_PUSH_DELAY"] = "0.05"
+    await client.start()
+    try:
+        version_zero = await client.open_file(str(path), language_id="typescript")
+        assert await client.wait_for_diagnostics(
+            str(path), version_zero, mode="document", timeout=1.0
+        )
+        key = uri_to_path(file_uri(str(path)))
+        assert client._docs[key].push_version == version_zero
+
+        path.write_text("const value = 2;\n")
+        version_one = await client.open_file(str(path), language_id="typescript")
+        assert await client.wait_for_diagnostics(
+            str(path), version_one, mode="document", timeout=1.0
+        )
+
+        assert client._docs[key].push_version == version_one
+        diagnostics = client.diagnostics_for(str(path), fresh_only=True)
+        assert [diagnostic["code"] for diagnostic in diagnostics] == [
+            "MOCK_UNVERSIONED"
+        ]
+    finally:
+        await client.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_wait_cancellation_stops_preserved_push_task(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/agent/lsp/test_client_e2e.py
+++ b/tests/agent/lsp/test_client_e2e.py
@@ -5,6 +5,7 @@ it through real LSP traffic, and asserts diagnostic flow.  This is
 the closest thing we have to integration coverage without requiring
 pyright/gopls/etc. to be installed in CI.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -14,11 +15,20 @@ from pathlib import Path
 
 import pytest
 
-from agent.lsp.client import LSPClient, PUSH_DEBOUNCE, file_uri, uri_to_path
+from agent.lsp.client import (
+    LSPClient,
+    PUSH_DEBOUNCE,
+    UNVERSIONED_PUSH_DEBOUNCE,
+    UNVERSIONED_PUSH_STABILIZATION,
+    file_uri,
+    uri_to_path,
+)
 from agent.lsp.protocol import LSPProtocolError
 
 
 MOCK_SERVER = str(Path(__file__).parent / "_mock_lsp_server.py")
+EARLY_TIMING_SLACK = 0.10
+NO_FULL_WAIT_CEILING = 3.0
 
 
 def _client(workspace: Path, script: str = "clean") -> LSPClient:
@@ -161,7 +171,8 @@ async def _open_without_server(
         return None
 
     client._state = "running"
-    client._proc = RunningProcess()
+    monkeypatch.setattr(client, "_proc", RunningProcess())
+    monkeypatch.setattr(client, "_connection_is_open", lambda: True)
     monkeypatch.setattr(client, "_send_notification", ignore_notification)
     return await client.open_file(str(path), language_id=language_id)
 
@@ -177,18 +188,16 @@ async def test_wait_keeps_push_waiter_when_pull_is_unsupported(
     version = await _open_without_server(client, path, monkeypatch)
     pull_calls = 0
 
-    async def unsupported_pull(_path: str) -> None:
+    async def unsupported_pull(_path: str, _version: int) -> None:
         nonlocal pull_calls
         pull_calls += 1
 
     async def delayed_push() -> None:
         await asyncio.sleep(0.01)
-        client._handle_publish_diagnostics(
-            {
-                "uri": file_uri(str(path)),
-                "diagnostics": [{"message": "TS diagnostic"}],
-            }
-        )
+        client._handle_publish_diagnostics({
+            "uri": file_uri(str(path)),
+            "diagnostics": [{"message": "TS diagnostic"}],
+        })
 
     monkeypatch.setattr(client, "_pull_document_diagnostics", unsupported_pull)
 
@@ -248,7 +257,7 @@ async def test_wait_cancellation_stops_preserved_push_task(
     push_started = asyncio.Event()
     push_cancelled = asyncio.Event()
 
-    async def unsupported_pull(_path: str) -> None:
+    async def unsupported_pull(_path: str, _version: int) -> None:
         return None
 
     async def blocking_push(
@@ -264,15 +273,15 @@ async def test_wait_cancellation_stops_preserved_push_task(
     monkeypatch.setattr(client, "_wait_for_fresh_push", blocking_push)
 
     waiter = asyncio.create_task(client.wait_for_diagnostics(str(path), version))
-    await asyncio.wait_for(push_started.wait(), timeout=0.5)
+    await asyncio.wait_for(push_started.wait(), timeout=1.5)
     waiter.cancel()
 
     with pytest.raises(asyncio.CancelledError):
-        await asyncio.wait_for(waiter, timeout=0.5)
-    await asyncio.wait_for(push_cancelled.wait(), timeout=0.5)
+        await asyncio.wait_for(waiter, timeout=1.5)
+    await asyncio.wait_for(push_cancelled.wait(), timeout=1.5)
 
 
-@pytest.mark.skipif(os.name != "nt", reason="Windows URI normalization")
+@pytest.mark.windows_only
 def test_encoded_drive_uri_maps_to_original_native_path(tmp_path: Path):
     native_path = r"C:\Workspace\Project\src\Index.ts"
     uri = "file:///c%3A/workspace/project/src/index.ts"
@@ -284,18 +293,16 @@ def test_encoded_drive_uri_maps_to_original_native_path(tmp_path: Path):
     )
 
     client._handle_publish_diagnostics({"uri": uri, "diagnostics": [diagnostic]})
-    client._handle_publish_diagnostics(
-        {
-            "uri": "FILE:///c%3A/workspace/project/src/index.ts",
-            "diagnostics": [diagnostic],
-        }
-    )
+    client._handle_publish_diagnostics({
+        "uri": "FILE:///c%3A/workspace/project/src/index.ts",
+        "diagnostics": [diagnostic],
+    })
 
     assert client.diagnostics_for(native_path) == [diagnostic]
     assert file_uri(native_path) == "file:///C:/Workspace/Project/src/Index.ts"
 
 
-@pytest.mark.skipif(os.name != "nt", reason="Windows UNC URI normalization")
+@pytest.mark.windows_only
 def test_unc_file_uri_round_trip():
     native_path = r"\\Server\Share\Folder\File.ts"
     assert file_uri(native_path) == "file://Server/Share/Folder/File.ts"
@@ -316,12 +323,14 @@ def test_non_file_diagnostic_uri_preserves_opaque_identity(tmp_path: Path):
     lower_diagnostic = {"message": "lower virtual document diagnostic"}
     client = _client(tmp_path, "clean")
 
-    client._handle_publish_diagnostics(
-        {"uri": upper_uri, "diagnostics": [upper_diagnostic]}
-    )
-    client._handle_publish_diagnostics(
-        {"uri": lower_uri, "diagnostics": [lower_diagnostic]}
-    )
+    client._handle_publish_diagnostics({
+        "uri": upper_uri,
+        "diagnostics": [upper_diagnostic],
+    })
+    client._handle_publish_diagnostics({
+        "uri": lower_uri,
+        "diagnostics": [lower_diagnostic],
+    })
 
     assert upper_uri in client._docs
     assert lower_uri in client._docs
@@ -333,38 +342,47 @@ def test_relative_path_with_colon_uses_open_document_key(tmp_path: Path):
     relative_path = "notes:2026.ts"
     diagnostic = {"message": "relative POSIX path diagnostic"}
     client = _client(tmp_path, "clean")
-    client._handle_publish_diagnostics(
-        {
-            "uri": file_uri(os.path.abspath(relative_path)),
-            "diagnostics": [diagnostic],
-        }
-    )
+    client._handle_publish_diagnostics({
+        "uri": file_uri(os.path.abspath(relative_path)),
+        "diagnostics": [diagnostic],
+    })
 
     assert client.diagnostics_for(relative_path) == [diagnostic]
 
 
-@pytest.mark.skipif(os.name == "nt", reason="POSIX URI behavior")
-def test_posix_file_uri_round_trip_preserves_case():
+def _assert_posix_file_uri_round_trip_preserves_case() -> None:
     path = "/tmp/MixedCase/File Name.ts"
     assert uri_to_path(file_uri(path)) == os.path.normpath(os.path.abspath(path))
 
 
+@pytest.mark.linux_only
+def test_posix_file_uri_round_trip_preserves_case_on_linux():
+    _assert_posix_file_uri_round_trip_preserves_case()
+
+
+@pytest.mark.macos_only
+def test_posix_file_uri_round_trip_preserves_case_on_macos():
+    _assert_posix_file_uri_round_trip_preserves_case()
+
+
 @pytest.mark.asyncio
-async def test_edit_baselines_are_tied_to_returned_versions(
+async def test_edit_baseline_tracks_current_generation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
     path = tmp_path / "index.ts"
     path.write_text("const value = 1;\n")
     client = _client(tmp_path, "clean")
 
-    version_zero = await _open_without_server(client, path, monkeypatch)
+    await _open_without_server(client, path, monkeypatch)
+    key = uri_to_path(file_uri(str(path)))
+    assert client._docs[key].diagnostic_baseline == 0
+
     client._push_counter = 4
     path.write_text("const value = 2;\n")
     version_one = await client.open_file(str(path), language_id="typescript")
-    key = uri_to_path(file_uri(str(path)))
 
-    assert client._diagnostic_baselines[(key, version_zero)] == 0
-    assert client._diagnostic_baselines[(key, version_one)] == 4
+    assert client._docs[key].version == version_one
+    assert client._docs[key].diagnostic_baseline == 4
 
 
 @pytest.mark.asyncio
@@ -387,8 +405,206 @@ async def test_overlapping_opens_allocate_distinct_versions(
 
     assert versions == [1, 2]
     key = uri_to_path(file_uri(str(path)))
-    assert (key, 1) in client._diagnostic_baselines
-    assert (key, 2) in client._diagnostic_baselines
+    assert client._docs[key].version == 2
+
+
+@pytest.mark.asyncio
+async def test_superseded_wait_returns_false_without_a_clean_verdict(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    path = tmp_path / "index.ts"
+    path.write_text("const value = 0;\n")
+    client = _client(tmp_path, "clean")
+    version_zero = await _open_without_server(client, path, monkeypatch)
+
+    async def unsupported_pull(*_args: object) -> None:
+        return None
+
+    monkeypatch.setattr(client, "_pull_document_diagnostics", unsupported_pull)
+    old_wait = asyncio.create_task(
+        client.wait_for_diagnostics(str(path), version_zero, timeout=1.0)
+    )
+    await asyncio.sleep(0)
+
+    path.write_text("const value = 1;\n")
+    version_one = await client.open_file(str(path), language_id="typescript")
+
+    assert version_one == version_zero + 1
+    assert await asyncio.wait_for(old_wait, timeout=1.5) is False
+    assert client.diagnostics_for(str(path), fresh_only=True) == []
+
+
+@pytest.mark.asyncio
+async def test_superseded_pull_cannot_overwrite_latest_generation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    path = tmp_path / "index.ts"
+    path.write_text("const value = 0;\n")
+    client = _client(tmp_path, "clean")
+    version_zero = await _open_without_server(client, path, monkeypatch)
+    old_pull_started = asyncio.Event()
+    release_old_pull = asyncio.Event()
+    old_diagnostic = {"message": "old pull result"}
+    latest_diagnostic = {"message": "latest pull result"}
+    pull_calls = 0
+
+    async def staged_request(
+        _method: str, _params: object, *, timeout: float
+    ) -> object:
+        nonlocal pull_calls
+        pull_calls += 1
+        if pull_calls == 1:
+            old_pull_started.set()
+            try:
+                await release_old_pull.wait()
+            except asyncio.CancelledError:
+                # Model a response already committed by the server/transport.
+                await release_old_pull.wait()
+            return {"items": [old_diagnostic]}
+        return {"items": [latest_diagnostic]}
+
+    monkeypatch.setattr(client, "_send_request_with_retry", staged_request)
+    old_wait = asyncio.create_task(
+        client.wait_for_diagnostics(str(path), version_zero, timeout=2.0)
+    )
+    await asyncio.wait_for(old_pull_started.wait(), timeout=1.5)
+
+    path.write_text("const value = 1;\n")
+    version_one = await client.open_file(str(path), language_id="typescript")
+    latest_wait = asyncio.create_task(
+        client.wait_for_diagnostics(str(path), version_one, timeout=1.5)
+    )
+    assert await latest_wait is True
+    assert client.diagnostics_for(str(path), fresh_only=True) == [latest_diagnostic]
+
+    release_old_pull.set()
+    assert await asyncio.wait_for(old_wait, timeout=1.5) is False
+    assert client.diagnostics_for(str(path), fresh_only=True) == [latest_diagnostic]
+
+
+@pytest.mark.asyncio
+async def test_related_pull_result_is_discarded_when_related_generation_advances(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    primary = tmp_path / "primary.ts"
+    related = tmp_path / "related.ts"
+    primary.write_text("export const primary = 0;\n")
+    related.write_text("export const related = 0;\n")
+    client = _client(tmp_path, "clean")
+    primary_version = await _open_without_server(client, primary, monkeypatch)
+    await client.open_file(str(related), language_id="typescript")
+    pull_started = asyncio.Event()
+    release_pull = asyncio.Event()
+    stale_related = {"message": "stale related pull result"}
+    current_related = {"message": "current related push result"}
+
+    async def delayed_request(
+        _method: str, _params: object, *, timeout: float
+    ) -> object:
+        pull_started.set()
+        await release_pull.wait()
+        return {
+            "kind": "full",
+            "items": [],
+            "relatedDocuments": {
+                file_uri(str(related)): {"kind": "full", "items": [stale_related]}
+            },
+        }
+
+    monkeypatch.setattr(client, "_send_request_with_retry", delayed_request)
+    pull = asyncio.create_task(
+        client._pull_document_diagnostics(str(primary), primary_version)
+    )
+    await asyncio.wait_for(pull_started.wait(), timeout=1.5)
+
+    related.write_text("export const related = 1;\n")
+    related_version = await client.open_file(str(related), language_id="typescript")
+    client._handle_publish_diagnostics({
+        "uri": file_uri(str(related)),
+        "version": related_version,
+        "diagnostics": [current_related],
+    })
+    release_pull.set()
+    await pull
+
+    related_doc = client._docs[uri_to_path(file_uri(str(related)))]
+    assert related_doc.pull == []
+    assert related_doc.pull_version == -1
+    assert client.diagnostics_for(str(related)) == [current_related]
+    assert client.diagnostics_for(str(related), fresh_only=True) == [current_related]
+
+
+@pytest.mark.asyncio
+async def test_never_opened_related_pull_is_stored_but_not_fresh(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    primary = tmp_path / "primary.ts"
+    related = tmp_path / "related.ts"
+    primary.write_text("export const primary = 0;\n")
+    client = _client(tmp_path, "clean")
+    primary_version = await _open_without_server(client, primary, monkeypatch)
+    related_diagnostic = {"message": "never-opened related pull result"}
+
+    async def related_result(
+        _method: str, _params: object, *, timeout: float
+    ) -> object:
+        return {
+            "kind": "full",
+            "items": [],
+            "relatedDocuments": {
+                file_uri(str(related)): {
+                    "kind": "full",
+                    "items": [related_diagnostic],
+                }
+            },
+        }
+
+    monkeypatch.setattr(client, "_send_request_with_retry", related_result)
+    await client._pull_document_diagnostics(str(primary), primary_version)
+
+    assert client.diagnostics_for(str(related)) == [related_diagnostic]
+    assert client.diagnostics_for(str(related), fresh_only=True) == []
+
+
+@pytest.mark.asyncio
+async def test_overlapping_waits_settle_only_the_latest_edit_generation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    path = tmp_path / "index.ts"
+    path.write_text("const value = 0;\n")
+    client = _client(tmp_path, "clean")
+    version_zero = await _open_without_server(client, path, monkeypatch)
+    uri = file_uri(str(path))
+    stale = {"message": "stale TypeScript error"}
+    quiet_period = 0.60
+
+    async def unsupported_pull(*_args: object) -> None:
+        return None
+
+    monkeypatch.setattr(client, "_pull_document_diagnostics", unsupported_pull)
+    monkeypatch.setattr("agent.lsp.client.UNVERSIONED_PUSH_DEBOUNCE", quiet_period)
+    monkeypatch.setattr("agent.lsp.client.UNVERSIONED_PUSH_STABILIZATION", 2.0)
+
+    old_wait = asyncio.create_task(
+        client.wait_for_diagnostics(str(path), version_zero, timeout=2.0)
+    )
+    await asyncio.sleep(0)
+    path.write_text("const value = 1;\n")
+    version_one = await client.open_file(str(path), language_id="typescript")
+    latest_wait = asyncio.create_task(
+        client.wait_for_diagnostics(str(path), version_one, timeout=2.0)
+    )
+    await asyncio.sleep(0)
+
+    client._handle_publish_diagnostics({"uri": uri, "diagnostics": [stale]})
+    await asyncio.sleep(0.40)
+    client._handle_publish_diagnostics({"uri": uri, "diagnostics": []})
+    await asyncio.sleep(0.35)
+
+    assert await old_wait is False
+    assert not latest_wait.done(), "the latest target push must reset quiet settling"
+    assert await asyncio.wait_for(latest_wait, timeout=1.5) is True
+    assert client.diagnostics_for(str(path), fresh_only=True) == []
 
 
 @pytest.mark.asyncio
@@ -404,15 +620,106 @@ async def test_push_received_during_did_change_is_fresh(
 
     async def publish_during_change(method: str, _params: object) -> None:
         if method == "textDocument/didChange":
-            client._handle_publish_diagnostics(
-                {"uri": file_uri(str(path)), "diagnostics": [diagnostic]}
-            )
+            client._handle_publish_diagnostics({
+                "uri": file_uri(str(path)),
+                "diagnostics": [diagnostic],
+            })
 
     monkeypatch.setattr(client, "_send_notification", publish_during_change)
     version = await client.open_file(str(path), language_id="typescript")
 
-    assert await client.wait_for_diagnostics(str(path), version, timeout=0.5)
+    assert await client.wait_for_diagnostics(str(path), version, timeout=1.5)
     assert client.diagnostics_for(str(path), fresh_only=True) == [diagnostic]
+
+
+@pytest.mark.parametrize("version_offset", [-1, 1])
+@pytest.mark.asyncio
+async def test_mismatched_versioned_push_does_not_replace_open_document_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    version_offset: int,
+):
+    path = tmp_path / "index.ts"
+    path.write_text("const value = 0;\n")
+    client = _client(tmp_path, "clean")
+    await _open_without_server(client, path, monkeypatch)
+    path.write_text("const value = 1;\n")
+    version = await client.open_file(str(path), language_id="typescript")
+    current = {"message": "current generation diagnostic"}
+    mismatched = {"message": "mismatched generation diagnostic"}
+    uri = file_uri(str(path))
+
+    client._handle_publish_diagnostics({
+        "uri": uri,
+        "version": version,
+        "diagnostics": [current],
+    })
+    counter = client._push_counter
+    client._handle_publish_diagnostics({
+        "uri": uri,
+        "version": version + version_offset,
+        "diagnostics": [mismatched],
+    })
+
+    doc = client._docs[uri_to_path(uri)]
+    assert doc.push == [current]
+    assert doc.push_version == version
+    assert doc.push_counter == counter
+    assert client._push_counter == counter
+    assert client.diagnostics_for(str(path)) == [current]
+    assert client.diagnostics_for(str(path), fresh_only=True) == [current]
+
+
+@pytest.mark.parametrize("version_offset", [-1, 1])
+@pytest.mark.asyncio
+async def test_mismatched_versioned_push_cannot_satisfy_current_wait(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    version_offset: int,
+):
+    path = tmp_path / "index.ts"
+    path.write_text("const value = 0;\n")
+    client = _client(tmp_path, "clean")
+    await _open_without_server(client, path, monkeypatch)
+    previous = {"message": "previous generation diagnostic"}
+    client._handle_publish_diagnostics({
+        "uri": file_uri(str(path)),
+        "version": 0,
+        "diagnostics": [previous],
+    })
+    path.write_text("const value = 1;\n")
+    version = await client.open_file(str(path), language_id="typescript")
+
+    async def unsupported_pull(_path: str, _version: int) -> None:
+        return None
+
+    monkeypatch.setattr(client, "_pull_document_diagnostics", unsupported_pull)
+    client._handle_publish_diagnostics({
+        "uri": file_uri(str(path)),
+        "version": version + version_offset,
+        "diagnostics": [{"message": "mismatched generation diagnostic"}],
+    })
+
+    assert not await client.wait_for_diagnostics(str(path), version, timeout=0.05)
+    assert client.diagnostics_for(str(path)) == [previous]
+    assert client.diagnostics_for(str(path), fresh_only=True) == []
+
+
+def test_versioned_push_for_never_opened_path_is_stored_but_not_fresh(
+    tmp_path: Path,
+):
+    client = _client(tmp_path, "clean")
+    path = tmp_path / "related.ts"
+    diagnostic = {"message": "never-opened versioned push"}
+
+    client._handle_publish_diagnostics({
+        "uri": file_uri(str(path)),
+        "version": 7,
+        "diagnostics": [diagnostic],
+    })
+
+    assert client.diagnostics_for(str(path)) == [diagnostic]
+    assert client.diagnostics_for(str(path), fresh_only=True) == []
 
 
 def test_seed_first_push_is_not_marked_fresh(tmp_path: Path):
@@ -426,18 +733,68 @@ def test_seed_first_push_is_not_marked_fresh(tmp_path: Path):
     uri = file_uri(path)
     key = uri_to_path(uri)
 
+    client._handle_publish_diagnostics({"uri": uri, "diagnostics": "invalid"})
+    assert key not in client._docs
+
     client._handle_publish_diagnostics({"uri": uri, "version": 0, "diagnostics": []})
     doc = client._docs[key]
     assert doc.push_counter == 0
     assert doc.push_version == -1
 
     diagnostic = {"message": "fresh TypeScript error"}
-    client._handle_publish_diagnostics(
-        {"uri": uri, "version": 1, "diagnostics": [diagnostic]}
-    )
+    client._handle_publish_diagnostics({
+        "uri": uri,
+        "version": 1,
+        "diagnostics": [diagnostic],
+    })
     assert doc.push_counter == 1
     assert doc.push_version == 1
     assert client.diagnostics_for(path) == [diagnostic]
+
+
+@pytest.mark.asyncio
+async def test_stale_versioned_seed_does_not_swallow_current_generation_push(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    path = tmp_path / "index.ts"
+    path.write_text("const value = 0;\n")
+    client = LSPClient(
+        server_id="typescript",
+        workspace_root=str(tmp_path),
+        command=[sys.executable, MOCK_SERVER],
+        seed_diagnostics_on_first_push=True,
+    )
+    await _open_without_server(client, path, monkeypatch)
+    path.write_text("const value = 1;\n")
+    version = await client.open_file(str(path), language_id="typescript")
+    uri = file_uri(str(path))
+    key = uri_to_path(uri)
+    diagnostic = {"message": "current generation diagnostic"}
+
+    async def unsupported_pull(*_args: object) -> None:
+        return None
+
+    monkeypatch.setattr(client, "_pull_document_diagnostics", unsupported_pull)
+    waiter = asyncio.create_task(
+        client.wait_for_diagnostics(str(path), version, timeout=1.0)
+    )
+    await asyncio.sleep(0)
+    client._handle_publish_diagnostics({
+        "uri": uri,
+        "version": version - 1,
+        "diagnostics": [{"message": "stale generation diagnostic"}],
+    })
+    client._handle_publish_diagnostics({
+        "uri": uri,
+        "version": version,
+        "diagnostics": [diagnostic],
+    })
+
+    assert await waiter is True
+    doc = client._docs[key]
+    assert doc.seed_seen is True
+    assert doc.push_counter == 1
+    assert client.diagnostics_for(str(path), fresh_only=True) == [diagnostic]
 
 
 def test_unversioned_push_drops_stale_version_metadata(tmp_path: Path):
@@ -458,7 +815,7 @@ def test_unversioned_push_drops_stale_version_metadata(tmp_path: Path):
 
 
 @pytest.mark.asyncio
-async def test_unversioned_push_freshness_is_scoped_to_target_path(
+async def test_unversioned_push_uses_rolling_target_path_quiet_period(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
     client = _client(tmp_path, "clean")
@@ -469,57 +826,231 @@ async def test_unversioned_push_freshness_is_scoped_to_target_path(
     target_uri = file_uri(str(target))
     target_key = uri_to_path(target_uri)
     stale = {"message": "stale TypeScript error"}
+    quiet_period = 0.60
 
     await _open_without_server(client, target, monkeypatch)
     client._handle_publish_diagnostics({"uri": target_uri, "diagnostics": [stale]})
     baseline = client._push_counter
     target.write_text("const value = 2;\n")
     version = await client.open_file(str(target), language_id="typescript")
+    monkeypatch.setattr("agent.lsp.client.UNVERSIONED_PUSH_DEBOUNCE", quiet_period)
+    monkeypatch.setattr("agent.lsp.client.UNVERSIONED_PUSH_STABILIZATION", 2.0)
     waiter = asyncio.create_task(
         client._wait_for_fresh_push(
-            target_key, version=version, timeout=1.0, baseline=baseline
+            target_key, version=version, timeout=2.0, baseline=baseline
         )
     )
 
-    client._handle_publish_diagnostics(
-        {"uri": file_uri(str(other)), "diagnostics": []}
-    )
-    await asyncio.sleep(PUSH_DEBOUNCE + 0.05)
+    client._handle_publish_diagnostics({"uri": file_uri(str(other)), "diagnostics": []})
+    await asyncio.sleep(0.05)
     assert not waiter.done()
 
+    client._handle_publish_diagnostics({"uri": target_uri, "diagnostics": [stale]})
+    await asyncio.sleep(0.40)
     client._handle_publish_diagnostics({"uri": target_uri, "diagnostics": []})
-    await waiter
+    await asyncio.sleep(0.35)
+    assert not waiter.done(), "the latest target push must reset quiet settling"
+
+    client._handle_publish_diagnostics({"uri": file_uri(str(other)), "diagnostics": []})
+    await asyncio.wait_for(waiter, timeout=1.5)
     assert client.diagnostics_for(str(target)) == []
 
 
 @pytest.mark.asyncio
-async def test_unversioned_push_waits_for_post_edit_quiet_snapshot(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+async def test_unversioned_push_waits_for_slower_corrected_snapshot(
+    tmp_path: Path,
 ):
-    """TypeScript's stale unversioned push must not win over the clean one."""
-    client = _client(tmp_path, "clean")
+    """A stale unversioned push must not win over a correction 250ms later."""
     path = tmp_path / "index.ts"
     path.write_text("const value = 1;\n")
-    uri = file_uri(str(path))
-    key = uri_to_path(uri)
-    stale = {"message": "stale TypeScript error"}
+    client = _client(tmp_path, "stale_then_corrected_unversioned_push")
+    await client.start()
+    try:
+        version_zero = await client.open_file(str(path), language_id="typescript")
+        assert await client.wait_for_diagnostics(str(path), version_zero, timeout=1.5)
+        assert client.diagnostics_for(str(path), fresh_only=True)
 
-    await _open_without_server(client, path, monkeypatch)
-    client._handle_publish_diagnostics({"uri": uri, "diagnostics": [stale]})
+        path.write_text("const value = 2;\n")
+        version_one = await client.open_file(str(path), language_id="typescript")
+        wait_started = asyncio.get_running_loop().time()
+        assert await client.wait_for_diagnostics(str(path), version_one, timeout=5.0)
+        elapsed = asyncio.get_running_loop().time() - wait_started
+        assert elapsed < NO_FULL_WAIT_CEILING
+        assert client.diagnostics_for(str(path), fresh_only=True) == []
+    finally:
+        await client.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_versioned_push_reclassifies_when_unversioned_correction_follows(
+    tmp_path: Path,
+):
+    """The latest target push must select the active settling policy."""
+    path = tmp_path / "index.ts"
+    path.write_text("const value = 1;\n")
+    client = _client(tmp_path, "versioned_then_stale_corrected_unversioned_push")
+    await client.start()
+    try:
+        version_zero = await client.open_file(str(path), language_id="typescript")
+        assert await client.wait_for_diagnostics(str(path), version_zero, timeout=1.5)
+        assert client.diagnostics_for(str(path), fresh_only=True)
+
+        path.write_text("const value = 2;\n")
+        version_one = await client.open_file(str(path), language_id="typescript")
+        assert await client.wait_for_diagnostics(str(path), version_one, timeout=2.0)
+        assert client.diagnostics_for(str(path), fresh_only=True) == []
+    finally:
+        await client.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_stable_unversioned_push_does_not_spend_large_caller_budget(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    path = tmp_path / "index.ts"
+    path.write_text("const value = 1;\n")
+    client = _client(tmp_path, "clean")
+    version = await _open_without_server(client, path, monkeypatch)
+    target_uri = file_uri(str(path))
+    target_key = uri_to_path(target_uri)
     baseline = client._push_counter
-    path.write_text("const value = 2;\n")
-    version = await client.open_file(str(path), language_id="typescript")
 
-    async def publish_after_edit() -> None:
-        await asyncio.sleep(0.01)
-        client._handle_publish_diagnostics({"uri": uri, "diagnostics": [stale]})
-        await asyncio.sleep(0.05)
-        client._handle_publish_diagnostics({"uri": uri, "diagnostics": []})
-
-    producer = asyncio.create_task(publish_after_edit())
-    await client._wait_for_fresh_push(
-        key, version=version, timeout=1.0, baseline=baseline
+    waiter = asyncio.create_task(
+        client._wait_for_fresh_push(
+            target_key, version=version, timeout=5.0, baseline=baseline
+        )
     )
-    await producer
+    await asyncio.sleep(0.01)
+    client._handle_publish_diagnostics({"uri": target_uri, "diagnostics": []})
+    push_time = asyncio.get_running_loop().time()
+    await asyncio.wait_for(waiter, timeout=NO_FULL_WAIT_CEILING)
 
-    assert client.diagnostics_for(str(path)) == []
+    elapsed_after_push = asyncio.get_running_loop().time() - push_time
+    assert elapsed_after_push >= UNVERSIONED_PUSH_DEBOUNCE - EARLY_TIMING_SLACK
+
+
+@pytest.mark.asyncio
+async def test_versioned_push_keeps_shorter_debounce(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    path = tmp_path / "index.ts"
+    path.write_text("const value = 1;\n")
+    client = _client(tmp_path, "clean")
+    version = await _open_without_server(client, path, monkeypatch)
+    target_uri = file_uri(str(path))
+    target_key = uri_to_path(target_uri)
+    baseline = client._push_counter
+
+    waiter = asyncio.create_task(
+        client._wait_for_fresh_push(
+            target_key, version=version, timeout=2.0, baseline=baseline
+        )
+    )
+    await asyncio.sleep(0.01)
+    client._handle_publish_diagnostics({
+        "uri": target_uri,
+        "version": version,
+        "diagnostics": [],
+    })
+    push_time = asyncio.get_running_loop().time()
+    await asyncio.wait_for(waiter, timeout=1.5)
+
+    elapsed_after_push = asyncio.get_running_loop().time() - push_time
+    assert elapsed_after_push >= PUSH_DEBOUNCE - EARLY_TIMING_SLACK
+
+
+@pytest.mark.asyncio
+async def test_unversioned_push_reclassifies_when_fresh_versioned_push_follows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    path = tmp_path / "index.ts"
+    path.write_text("const value = 1;\n")
+    client = _client(tmp_path, "clean")
+    version = await _open_without_server(client, path, monkeypatch)
+    target_uri = file_uri(str(path))
+    target_key = uri_to_path(target_uri)
+    baseline = client._push_counter
+
+    waiter = asyncio.create_task(
+        client._wait_for_fresh_push(
+            target_key, version=version, timeout=2.0, baseline=baseline
+        )
+    )
+    client._handle_publish_diagnostics({
+        "uri": target_uri,
+        "diagnostics": [{"message": "unversioned result"}],
+    })
+    await asyncio.sleep(0.05)
+    assert not waiter.done()
+    client._handle_publish_diagnostics({
+        "uri": target_uri,
+        "version": version,
+        "diagnostics": [],
+    })
+    versioned_push_time = asyncio.get_running_loop().time()
+    await asyncio.wait_for(waiter, timeout=1.5)
+
+    elapsed_after_versioned_push = (
+        asyncio.get_running_loop().time() - versioned_push_time
+    )
+    assert elapsed_after_versioned_push >= PUSH_DEBOUNCE - EARLY_TIMING_SLACK
+    assert client.diagnostics_for(str(path), fresh_only=True) == []
+
+
+@pytest.mark.asyncio
+async def test_same_version_wait_can_be_repeated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    path = tmp_path / "index.ts"
+    path.write_text("const value = 1;\n")
+    client = _client(tmp_path, "clean")
+    version = await _open_without_server(client, path, monkeypatch)
+    diagnostic = {"message": "versioned result"}
+
+    async def unsupported_pull(_path: str, _version: int) -> None:
+        return None
+
+    monkeypatch.setattr(client, "_pull_document_diagnostics", unsupported_pull)
+    client._handle_publish_diagnostics({
+        "uri": file_uri(str(path)),
+        "version": version,
+        "diagnostics": [diagnostic],
+    })
+
+    assert await client.wait_for_diagnostics(str(path), version, timeout=1.0)
+    assert await client.wait_for_diagnostics(str(path), version, timeout=1.0)
+    assert client.diagnostics_for(str(path), fresh_only=True) == [diagnostic]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_wait_preserves_same_version_baseline_for_retry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    path = tmp_path / "index.ts"
+    path.write_text("const value = 1;\n")
+    client = _client(tmp_path, "clean")
+    version = await _open_without_server(client, path, monkeypatch)
+    pull_started = asyncio.Event()
+
+    async def blocking_pull(_path: str, _version: int) -> None:
+        pull_started.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(client, "_pull_document_diagnostics", blocking_pull)
+    first_wait = asyncio.create_task(
+        client.wait_for_diagnostics(str(path), version, timeout=1.0)
+    )
+    await asyncio.wait_for(pull_started.wait(), timeout=1.0)
+    first_wait.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first_wait
+
+    diagnostic = {"message": "result received after cancellation"}
+    client._handle_publish_diagnostics({
+        "uri": file_uri(str(path)),
+        "version": version,
+        "diagnostics": [diagnostic],
+    })
+
+    assert await client.wait_for_diagnostics(str(path), version, timeout=1.0)
+    assert client.diagnostics_for(str(path), fresh_only=True) == [diagnostic]

--- a/tests/agent/lsp/test_stale_diagnostics.py
+++ b/tests/agent/lsp/test_stale_diagnostics.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 import pytest
 
-from agent.lsp.client import LSPClient
+from agent.lsp.client import LSPClient, file_uri, uri_to_path
 
 
 MOCK_SERVER = str(Path(__file__).parent / "_mock_lsp_server.py")
@@ -75,6 +75,29 @@ async def test_slow_push_is_waited_for(tmp_path: Path):
 
 
 
+@pytest.mark.asyncio
+async def test_stale_pull_result_dropped_when_change_races(tmp_path: Path):
+    """A pull answered for pre-edit content must not read as fresh after
+    a didChange raced past it (version-tag anchoring)."""
+    f = tmp_path / "x.py"
+    f.write_text("bad code\n")
+
+    client = _client(tmp_path, "clean")
+    await client.start()
+    try:
+        v0 = await client.open_file(str(f), language_id="python")
+        await client.wait_for_diagnostics(str(f), v0, mode="document", timeout=2.0)
+        doc = client._docs[uri_to_path(file_uri(str(f)))]
+        assert doc.fresh_pull()
+
+        # Simulate an edit racing in: the version bump invalidates the
+        # stored pull without any explicit clearing.
+        f.write_text("good code\n")
+        await client.open_file(str(f), language_id="python")
+        assert not doc.fresh_pull()
+        assert client.diagnostics_for(str(f), fresh_only=True) == []
+    finally:
+        await client.shutdown()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/lsp/test_stale_diagnostics.py
+++ b/tests/agent/lsp/test_stale_diagnostics.py
@@ -17,6 +17,7 @@ The contract under test:
 - A slow-but-eventually-correct server ("slow_push") is waited on,
   honouring the configured ``lsp.wait_timeout``.
 """
+
 from __future__ import annotations
 
 import os
@@ -46,10 +47,6 @@ def _client(workspace: Path, script: str, **env_extra: str) -> LSPClient:
     )
 
 
-
-
-
-
 @pytest.mark.asyncio
 async def test_slow_push_is_waited_for(tmp_path: Path):
     """A server that re-checks slowly (but within budget) gets waited on,
@@ -61,18 +58,20 @@ async def test_slow_push_is_waited_for(tmp_path: Path):
     await client.start()
     try:
         v0 = await client.open_file(str(f), language_id="python")
-        assert await client.wait_for_diagnostics(str(f), v0, mode="document", timeout=2.0)
+        assert await client.wait_for_diagnostics(
+            str(f), v0, mode="document", timeout=2.0
+        )
         assert len(client.diagnostics_for(str(f), fresh_only=True)) == 1
 
         f.write_text("good code\n")
         v1 = await client.open_file(str(f), language_id="python")
-        fresh = await client.wait_for_diagnostics(str(f), v1, mode="document", timeout=5.0)
+        fresh = await client.wait_for_diagnostics(
+            str(f), v1, mode="document", timeout=5.0
+        )
         assert fresh is True, "slow push within budget must satisfy the wait"
         assert client.diagnostics_for(str(f), fresh_only=True) == []
     finally:
         await client.shutdown()
-
-
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Repairs LSP diagnostic freshness and Windows document identity as one coherent client-side state machine.

Push-only servers such as `typescript-language-server` commonly reject `textDocument/diagnostic` and publish diagnostics asynchronously without document versions. The previous client could cancel the push waiter when pull failed, return stale snapshots before a slower correction, let unrelated or superseded generations satisfy a wait, or tag delayed pull results as current. Windows URI spellings could also diverge from the native path used by file tools, leaving correctly published diagnostics invisible at lookup time.

This PR fixes those boundaries without changing launcher installation:

- preserve a push waiter after an unsupported pull response;
- canonicalize Windows drive, percent-encoded, UNC, and case-insensitive `file:` identities while preserving opaque URI and filesystem I/O identity;
- serialize document edits and advance generation state before notification writes can yield;
- bind every wait, push, pull, and related-document result to an exact document generation;
- reject stale and future versioned publications without overwriting current stores;
- make superseded waits return `False` as “no verdict,” never as a clean result;
- keep current-generation retry/cancellation baselines in O(1) per-document state;
- handle TypeScript's one-time seed publication without swallowing the first valid post-edit result;
- settle unversioned publications with a target-scoped rolling quiet period (`0.30s`) and fixed stabilization cap (`0.50s`), independent of the caller's larger timeout;
- re-evaluate the policy after every versioned↔unversioned transition;
- prevent unrelated files from satisfying or prolonging a target wait;
- cancel and await child pull/push tasks cleanly.

This PR contains no installer or launcher-selection changes and remains independent of #63896.

## Related Issue

Companion diagnostic/identity split from #63896 after maintainer triage.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes incorrect behavior)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `agent/lsp/client.py`: exact-generation diagnostic state, push/pull coordination, bounded unversioned settling, URI identity, serialized edits, seed handling, and O(1) baselines.
- `tests/agent/lsp/_mock_lsp_server.py`: real reader-loop scenarios for rejection-first, delayed correction, version transitions, and stale generations.
- `tests/agent/lsp/test_client_e2e.py`: URI, concurrency, overlap, cancellation, seed, push/pull, related-document, and timing regressions.
- `tests/agent/lsp/test_stale_diagnostics.py`: stale-store and service-level no-data behavior.

The large test surface is intentional: the production bug class spans asynchronous push/pull ordering, document generations, cancellation, URI aliases, related documents, and unversioned TypeScript publications. Independent specification and code-quality reviews completed with no remaining critical, important, or minor findings.

## How to Test

Verified on native Windows 11, Python 3.11.15, at pushed head `e8e87f3e8c2c84df49b212ec3281026bf7988f4a`, rebased onto `main` `044acf2bf700b8452e903f035406091146eb0245`:

1. Changed diagnostic suites:

   ```text
   38 passed, 2 OS-lane skips
   ```

   The same result passed repeatedly during race/seed review.

2. Complete LSP directory:

   ```text
   94 passed, 2 skipped, 2 failed
   ```

   Both failures reproduce on exact current-main Windows baselines and are outside the four changed files:
   - `test_install_npm_works_without_extras`
   - `test_normalize_path_expands_tilde`

3. Real language servers through the exact pushed client:

   ```text
   Pyright 1.1.411
     running: true
     broken edit: fresh, 3 semantic diagnostics
     corrected edit: fresh, 0 diagnostics

   TypeScript LS 5.3.0 + TypeScript 6.0.3
     seed publication observed before measurement
     running: true
     broken edit: fresh, 2 semantic diagnostics
     corrected edit: fresh, 0 diagnostics
   ```

4. Static and repository gates:

   ```text
   Ruff check: passed
   Ruff format check: passed
   ty check agent/lsp/client.py: passed
   compileall: passed
   git diff --check: clean
   rebase range-diff: all six commits semantically equivalent
   independent spec review: PASS
   independent code-quality review: APPROVED
   ```

Fresh CI, Docker, and Nix workflows were dispatched from the new head and currently show `action_required`, awaiting maintainer approval to start. No remote CI success is being claimed yet.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched and compared related/overlapping PRs
- [x] My PR contains only diagnostic/identity changes and their regression tests
- [ ] I've run `pytest tests/ -q` and all tests pass (the two exact-main Windows failures are documented above)
- [x] I've added regression tests that fail on the prior behavior
- [x] I've tested on native Windows 11 with real Pyright and TypeScript servers

### Documentation & Housekeeping

- [x] Relevant docstrings and state contracts are updated
- [x] `cli-config.yaml.example` changes are N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are N/A
- [x] Cross-platform impact and Linux/macOS/Windows OS lanes were considered
- [x] Tool description/schema changes are N/A

## Screenshots / Logs

The PR discussion records the refreshed head and concise verified results. Full race, baseline-comparison, and real-server evidence is available from the author if maintainers want a specific trace.
