### PR TITLE
fix(telegram): insert blank line before rich tables lacking one

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -564,8 +564,23 @@ def _rich_normalize_linebreaks(text: str) -> str:
     pos = 0
     for m in _RICH_PROTECTED_REGION_RE.finditer(text):
         prose = text[pos:m.start()]
+        region = m.group(0)
+        # Telegram's GFM parser only recognizes a pipe table when a BLANK line
+        # precedes the header row. Cheap models routinely emit a table directly
+        # after prose (a single \n, no blank line); the hard-break pass above
+        # turns that into '  \n' which is STILL not a blank line, so the table
+        # degrades to escaped pipes. Insert the missing blank line (\n) before
+        # a table unless one already exists. Fenced code blocks don't need it
+        # and are left verbatim.
+        if region.lstrip().startswith("```"):
+            sep = ""
+        elif prose and not prose.endswith("\n\n"):
+            sep = "\n"
+        else:
+            sep = ""
         out.append(re.sub(r'(?<!\n)\n(?!\n)', '  \n', prose))
-        out.append(m.group(0))  # protected region kept verbatim
+        out.append(sep)
+        out.append(region)
         pos = m.end()
     tail = text[pos:]
     out.append(re.sub(r'(?<!\n)\n(?!\n)', '  \n', tail))

--- a/tests/gateway/test_telegram_rich_newlines.py
+++ b/tests/gateway/test_telegram_rich_newlines.py
@@ -76,3 +76,28 @@ class TestRichMessageTableProtection:
         assert "  \n" not in md
         assert md == content
 
+    def test_table_after_prose_gets_blank_line(self, adapter):
+        """A table emitted directly after prose (no blank line) must get one.
+
+        Telegram's GFM parser only recognizes a pipe table when a BLANK line
+        precedes the header row. The hard-break injected into the prose above
+        ('  \\n') is not a blank line, so the normalizer must insert one.
+        """
+        content = "Heading\n| Col A | Col B |\n|-------|-------|\n| 1 | 2 |"
+        md = adapter._rich_message_payload(content)["markdown"]
+        assert md == "Heading  \n\n| Col A | Col B |\n|-------|-------|\n| 1 | 2 |"
+        # table rows keep bare newlines (no hard breaks inside the table)
+        assert "  \n" not in md[len("Heading  \n\n"):]
+
+    def test_table_after_paragraph_break_untouched(self, adapter):
+        """A table already preceded by a blank line must not be altered."""
+        content = "Heading\n\n| Col A | Col B |\n|-------|-------|\n| 1 | 2 |"
+        md = adapter._rich_message_payload(content)["markdown"]
+        assert md == content
+
+    def test_table_at_document_start_untouched(self, adapter):
+        """A table at the start of content needs no blank line."""
+        content = "| Col A | Col B |\n|-------|-------|\n| 1 | 2 |"
+        md = adapter._rich_message_payload(content)["markdown"]
+        assert md == content
+


### PR DESCRIPTION
## What does this PR do?

Fixes pipe tables the agent emits still failing to render as tables on Telegram even when the rich-message path (`sendRichMessage`) is active. The config-path fix in #81596 made the model actually *emit* GFM pipe tables; this fix makes the rich payload valid GFM so Telegram renders them.

## Root cause

Telegram's Bot API 10.1 `sendRichMessage` parses content as GFM, and GFM only recognizes a pipe table when a **blank line** precedes the header row. Cheap models routinely emit a table directly after prose with a single `\n` and no blank line:

```
Heading
| Col A | Col B |
|-------|-------|
```

`_rich_normalize_linebreaks()` (plugins/platforms/telegram/adapter.py) converted the single `\n` in the prose above the table into a Markdown hard break (`  \n`) — which is still **not** a blank line — so Telegram's parser fell back to rendering the table as escaped pipes / a jumble.

## Changes Made

- `plugins/platforms/telegram/adapter.py` — `_rich_normalize_linebreaks()` now inserts a blank line (`\n`) before a table block when the preceding text doesn't already end with a paragraph break (`\n\n`). Fenced code blocks are left verbatim (they don't need it). This is the single choke point: `sendRichMessage` sends, `sendRichMessageDraft` previews, and `editMessageText` rich finalize all route through `_rich_message_payload`.
- `tests/gateway/test_telegram_rich_newlines.py` — regression tests: prose→table gets the missing blank line (and table rows keep bare newlines), paragraph-break→table and document-start tables are untouched.

## How to Test

1. Have `rich_messages: true` at `gateway.platforms.telegram.extra` (see #81596).
2. Ask the model to produce a table immediately after a sentence (no blank line).
3. Before: the table renders as escaped pipes / jumbled text. After: it renders as a proper table — the adapter inserts the blank line Telegram's parser requires.

## Checklist

- [x] Conventional commit (`fix(telegram):`)
- [x] Regression tests for the exact failure shape
- [x] `pytest tests/gateway/test_telegram_rich_newlines.py` passes (7/7)
- [x] No changes outside the adapter and its tests

Note: the local fork-clone venv shows 29 pre-existing failures in `test_telegram_rich_messages.py` / `test_telegram_format.py` that reproduce identically on pristine `main` (venv/environment-related); this change does not affect them.
