### PR TITLE
fix(desktop): clean up residual preview status entry when closing preview tab

### DIFF
--- a/apps/desktop/src/store/preview-status.test.ts
+++ b/apps/desktop/src/store/preview-status.test.ts
@@ -4,6 +4,7 @@ import {
   $previewStatusBySession,
   clearPreviewArtifacts,
   dismissPreviewArtifact,
+  dismissPreviewArtifactFromAllSessions,
   recordPreviewArtifact
 } from './preview-status'
 
@@ -38,4 +39,16 @@ describe('recordPreviewArtifact', () => {
     clearPreviewArtifacts('s1')
     expect($previewStatusBySession.get().s1).toBeUndefined()
   })
+
+  it('dismissPreviewArtifactFromAllSessions removes matching targets from all sessions', () => {
+    recordPreviewArtifact('s1', '/a/index.html', '/work')
+    recordPreviewArtifact('s2', '/a/index.html', '/work')
+    recordPreviewArtifact('s2', '/a/other.html', '/work')
+
+    dismissPreviewArtifactFromAllSessions('/a/index.html')
+
+    expect($previewStatusBySession.get().s1).toBeUndefined()
+    expect($previewStatusBySession.get().s2.map(i => i.id)).toEqual(['/a/other.html'])
+  })
 })
+

--- a/apps/desktop/src/store/preview-status.ts
+++ b/apps/desktop/src/store/preview-status.ts
@@ -69,11 +69,38 @@ export function dismissPreviewArtifact(sid: string, id: string) {
   if (list) {
     writePreviews(
       sid,
-      list.filter(item => item.id !== id)
+      list.filter(item => item.id !== id && item.target !== id)
     )
+  }
+}
+
+export function dismissPreviewArtifactFromAllSessions(targetOrId: string) {
+  if (!targetOrId) {
+    return
+  }
+
+  const current = $previewStatusBySession.get()
+  const next: Record<string, PreviewArtifact[]> = {}
+  let changed = false
+
+  for (const [sid, items] of Object.entries(current)) {
+    const filtered = items.filter(item => item.id !== targetOrId && item.target !== targetOrId)
+
+    if (filtered.length !== items.length) {
+      changed = true
+    }
+
+    if (filtered.length > 0) {
+      next[sid] = filtered
+    }
+  }
+
+  if (changed) {
+    $previewStatusBySession.set(next)
   }
 }
 
 export function clearPreviewArtifacts(sid: string) {
   writePreviews(sid, [])
 }
+

--- a/apps/desktop/src/store/preview.test.ts
+++ b/apps/desktop/src/store/preview.test.ts
@@ -119,12 +119,26 @@ describe('preview store', () => {
     expect($previewTabs.get()).toHaveLength(0)
   })
 
-  it('closes by the raw source the composer rows were handed', () => {
+  it('closes by the raw source the composer rows were handed and clears status artifact', () => {
+    const { $previewStatusBySession, recordPreviewArtifact } = require('./preview-status')
+    recordPreviewArtifact('s1', 'http://localhost:5174', '/work')
     openPreview(urlTarget('http://localhost:5174'), 'tool-result')
 
     expect(closePreviewForSource('http://localhost:5174')).toBe(true)
     expect($previewTabs.get()).toHaveLength(0)
+    expect($previewStatusBySession.get().s1).toBeUndefined()
     expect(closePreviewForSource('http://localhost:5174')).toBe(false)
+  })
+
+  it('dismisses status artifacts across sessions when closeRightRailTab is called directly', () => {
+    const { $previewStatusBySession, recordPreviewArtifact } = require('./preview-status')
+    recordPreviewArtifact('s1', '/work/demo.html', '/work')
+    openPreview(fileTarget('/work/demo.html'), 'tool-result')
+
+    closeRightRailTab(previewTabId(fileTarget('/work/demo.html')))
+
+    expect($previewTabs.get()).toHaveLength(0)
+    expect($previewStatusBySession.get().s1).toBeUndefined()
   })
 
   it('persists file and url tabs but never artifacts, whose content is memory-only', () => {

--- a/apps/desktop/src/store/preview.ts
+++ b/apps/desktop/src/store/preview.ts
@@ -4,6 +4,7 @@ import { persistentAtom } from '@/lib/persisted'
 import { normalize } from '@/lib/text'
 
 import { $rightRailActiveTabId, type RightRailTabId, selectRightRailTab } from './layout'
+import { $previewStatusBySession, dismissPreviewArtifactFromAllSessions } from './preview-status'
 
 /**
  * PREVIEW RAIL — one list of tabs, one way in.
@@ -234,6 +235,7 @@ export function closeRightRailTab(tabId: string) {
     return
   }
 
+  const tabToClose = current[index]
   const next = current.filter(tab => tab.id !== tabId)
 
   $previewTabs.set(next)
@@ -245,10 +247,20 @@ export function closeRightRailTab(tabId: string) {
   if (next.length === 0) {
     selectRightRailTab(null)
   }
+
+  if (tabToClose?.target) {
+    const targets = [tabToClose.target.source, tabToClose.target.url, tabToClose.target.path].filter(Boolean) as string[]
+
+    for (const target of targets) {
+      dismissPreviewArtifactFromAllSessions(target)
+    }
+  }
 }
 
 /** Close the tab showing `source`, if one is open. Returns whether it closed. */
 export function closePreviewForSource(source: string): boolean {
+  dismissPreviewArtifactFromAllSessions(source)
+
   const tab = $previewTabs.get().find(item => item.target.source === source)
 
   if (!tab) {
@@ -273,6 +285,7 @@ export function closeArtifactPreviewTabs() {
 /** Close every tab so the rail's panes leave the tree. */
 export function closeRightRail() {
   $previewTabs.set([])
+  $previewStatusBySession.set({})
   selectRightRailTab(null)
 }
 


### PR DESCRIPTION
### Summary
Fixes #81856: Closing a preview tab via the ✕ button on the tab strip left behind an unremovable residual status entry in the UI.

### Root Cause
When opening a preview (e.g. via `open_preview` or from tool output completions), the target is recorded into `$previewStatusBySession` (`apps/desktop/src/store/preview-status.ts`) and rendered in the composer status stack. 

When a user closed the preview tab, `closeRightRailTab()` evicted the tab from `$previewTabs` and the layout tree, but did not dismiss the corresponding status artifact entry in `$previewStatusBySession`.

### Fix
- Added `dismissPreviewArtifactFromAllSessions()` in `preview-status.ts` to evict matching status artifact entries across all sessions.
- Updated `closeRightRailTab()`, `closePreviewForSource()`, and `closeRightRail()` in `preview.ts` to automatically trigger status artifact dismissal upon tab close.
- Added unit tests in `preview.test.ts` and `preview-status.test.ts` verifying status artifact cleanup on tab closure.

### Test Plan
- Ran unit tests in `preview.test.ts` and `preview-status.test.ts`.
- Verified `pytest tests/tools/test_open_preview_tool.py`.
