### PR TITLE
feat: support per-child lifecycle reasoning

### DIFF
--- a/agent/subagent_lifecycle.py
+++ b/agent/subagent_lifecycle.py
@@ -53,6 +53,7 @@ class SubagentLaunchRequest:
     context: Optional[str] = None
     role: str = "leaf"
     model: Optional[str] = None
+    reasoning_effort: Optional[str] = None
     allowed_toolsets: Optional[tuple[str, ...]] = None
     blocked_tools: tuple[str, ...] = ()
     working_directory: Optional[str] = None
@@ -74,6 +75,7 @@ class SubagentHandle:
     role: str
     depth: int
     capability: str
+    reasoning_effort: Optional[str] = None
 
     def to_dict(self) -> dict[str, Any]:
         return dataclasses.asdict(self)
@@ -230,6 +232,7 @@ class SubagentLifecycleService:
             if request.allowed_toolsets
             else None,
             model=request.model,
+            override_reasoning_effort=request.reasoning_effort,
             max_iterations=DEFAULT_MAX_ITERATIONS,
             task_count=1,
             parent_agent=parent,
@@ -250,6 +253,7 @@ class SubagentLifecycleService:
             getattr(child, "_delegate_role", request.role),
             int(getattr(child, "_delegate_depth", 1) or 1),
             self._capability(subagent_id, parent_session_id, created),
+            self._reasoning_effort(child),
         )
         record = _Record(handle, SubagentState.PENDING, created, agent=child)
         with _REGISTRY.lock:
@@ -367,6 +371,10 @@ class SubagentLifecycleService:
             or not math.isfinite(handle.created_at)
             or (handle.provider is not None and not isinstance(handle.provider, str))
             or (handle.model is not None and not isinstance(handle.model, str))
+            or (
+                handle.reasoning_effort is not None
+                and handle.reasoning_effort not in {"low", "medium", "high"}
+            )
             or not isinstance(handle.role, str)
             or type(handle.depth) is not int
             or not isinstance(handle.capability, str)
@@ -385,6 +393,14 @@ class SubagentLifecycleService:
             return None
         with _REGISTRY.lock:
             return _REGISTRY.records.get(handle.subagent_id)
+
+    @staticmethod
+    def _reasoning_effort(child: Any) -> Optional[str]:
+        config = getattr(child, "reasoning_config", None)
+        if not isinstance(config, Mapping) or not config.get("enabled"):
+            return None
+        effort = config.get("effort")
+        return str(effort) if effort in {"low", "medium", "high"} else None
 
     @staticmethod
     def _cleanup_locked() -> None:
@@ -503,6 +519,14 @@ class SubagentLifecycleService:
             )
         if request.role not in {"leaf", "orchestrator"}:
             raise SubagentLifecycleError("role must be 'leaf' or 'orchestrator'.")
+        if request.reasoning_effort is not None and request.reasoning_effort not in {
+            "low",
+            "medium",
+            "high",
+        }:
+            raise SubagentLifecycleError(
+                "reasoning_effort must be 'low', 'medium', or 'high'."
+            )
         if request.timeout_seconds is not None:
             raise SubagentLifecycleError(
                 "Per-launch timeout is not supported; configure delegation timeout explicitly."

--- a/tests/agent/test_subagent_lifecycle.py
+++ b/tests/agent/test_subagent_lifecycle.py
@@ -17,12 +17,13 @@ from agent.subagent_lifecycle import (
 
 
 class FakeChild:
-    def __init__(self, ident="sa-test"):
+    def __init__(self, ident="sa-test", reasoning_config=None):
         self._subagent_id = ident
         self._delegate_role = "leaf"
         self._delegate_depth = 1
         self.provider = "test"
         self.model = "test-model"
+        self.reasoning_config = reasoning_config
         self.interrupted = False
         self.interrupt_kind = None
 
@@ -80,6 +81,44 @@ def test_cancel_is_cooperative_and_forged_handle_is_unknown(lifecycle):
     other_parent = SimpleNamespace(session_id="different-parent")
     other_service = SubagentLifecycleService(lambda: other_parent)
     assert other_service.status(handle).state is SubagentState.UNKNOWN
+
+
+def test_public_lifecycle_applies_and_attributes_exact_reasoning(monkeypatch):
+    parent = SimpleNamespace(session_id="parent-reasoning", enabled_toolsets=["file"])
+    captured = {}
+
+    def build(**kwargs):
+        captured.update(kwargs)
+        return FakeChild(
+            "sa-reasoning",
+            reasoning_config={
+                "enabled": True,
+                "effort": kwargs["override_reasoning_effort"],
+            },
+        )
+
+    monkeypatch.setattr("tools.delegate_tool._build_child_agent", build)
+    monkeypatch.setattr(
+        "tools.delegate_tool._run_single_child",
+        lambda *_args, **_kwargs: {
+            "status": "completed",
+            "summary": "ok",
+            "api_calls": 1,
+            "duration_seconds": 0.01,
+        },
+    )
+    service = SubagentLifecycleService(lambda: parent)
+    handle = service.launch(
+        SubagentLaunchRequest(goal="reason", reasoning_effort="high")
+    )
+    assert captured["override_reasoning_effort"] == "high"
+    assert handle.reasoning_effort == "high"
+    assert service.wait(handle, timeout_seconds=1).state is SubagentState.SUCCEEDED
+
+
+def test_public_lifecycle_rejects_unknown_reasoning(lifecycle):
+    with pytest.raises(SubagentLifecycleError, match="reasoning_effort"):
+        lifecycle.launch(SubagentLaunchRequest(goal="x", reasoning_effort="extreme"))
 
 
 def test_cancel_uses_explicit_hard_interrupt(lifecycle):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1217,6 +1217,29 @@ class TestDelegationReasoningEffort(unittest.TestCase):
         call_kwargs = MockAgent.call_args[1]
         self.assertEqual(call_kwargs["reasoning_config"], {"enabled": True, "effort": "low"})
 
+    @patch("tools.delegate_tool._load_config")
+    @patch("run_agent.AIAgent")
+    def test_public_lifecycle_override_beats_delegation_config(self, MockAgent, mock_cfg):
+        """An explicit public lifecycle effort is exact for this child only."""
+        mock_cfg.return_value = {"max_iterations": 50, "reasoning_effort": "low"}
+        MockAgent.return_value = MagicMock()
+        parent = _make_mock_parent()
+        parent.reasoning_config = {"enabled": True, "effort": "xhigh"}
+
+        _build_child_agent(
+            task_index=0,
+            goal="test",
+            context=None,
+            toolsets=None,
+            model=None,
+            max_iterations=50,
+            parent_agent=parent,
+            task_count=1,
+            override_reasoning_effort="high",
+        )
+        call_kwargs = MockAgent.call_args[1]
+        self.assertEqual(call_kwargs["reasoning_config"], {"enabled": True, "effort": "high"})
+
 # =========================================================================
 # Dispatch helper, progress events, concurrency
 # =========================================================================

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1318,6 +1318,9 @@ def _build_child_agent(
     override_api_mode: Optional[str] = None,
     override_request_overrides: Optional[Dict[str, Any]] = None,
     override_max_tokens: Optional[int] = None,
+    # Public lifecycle callers may request an exact per-child effort without
+    # changing global delegation config. None preserves existing inheritance.
+    override_reasoning_effort: Optional[str] = None,
     # ACP transport overrides from trusted delegation config.
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
@@ -1545,7 +1548,8 @@ def _build_child_agent(
         effective_provider = "copilot-acp"
         effective_api_mode = "chat_completions"
 
-    # Resolve reasoning config: delegation override > parent inherit
+    # Resolve reasoning config: explicit public-lifecycle override >
+    # delegation config > parent inherit.
     parent_reasoning = getattr(parent_agent, "reasoning_config", None)
     child_reasoning = parent_reasoning
     try:
@@ -1553,19 +1557,24 @@ def _build_child_agent(
         # False (``reasoning_effort: false``) to "" and inherit the parent
         # instead of disabling thinking for children.
         delegation_effort = delegation_cfg.get("reasoning_effort")
-        if delegation_effort or delegation_effort is False:
+        selected_effort = (
+            override_reasoning_effort
+            if override_reasoning_effort is not None
+            else delegation_effort
+        )
+        if selected_effort or selected_effort is False:
             from hermes_constants import parse_reasoning_effort
 
-            parsed = parse_reasoning_effort(delegation_effort)
+            parsed = parse_reasoning_effort(selected_effort)
             if parsed is not None:
                 child_reasoning = parsed
             else:
                 logger.warning(
-                    "Unknown delegation.reasoning_effort '%s', inheriting parent level",
-                    delegation_effort,
+                    "Unknown child reasoning effort '%s', inheriting parent level",
+                    selected_effort,
                 )
     except Exception as exc:
-        logger.debug("Could not load delegation reasoning_effort: %s", exc)
+        logger.debug("Could not load child reasoning effort: %s", exc)
 
     # Inherit the parent's fallback provider chain so subagents can recover
     # from rate-limits and credential exhaustion exactly like the top-level


### PR DESCRIPTION
## Summary

Extend the public subagent lifecycle contract with an optional per-child `reasoning_effort` override and expose the actual child effort on `SubagentHandle`.

This lets lifecycle integrations request and then verify an exact child reasoning level without mutating global delegation configuration. Existing callers preserve current inheritance behavior because the new request field defaults to `None`.

## Changes

- add `reasoning_effort` to `SubagentLaunchRequest`;
- pass it through `_build_child_agent` with precedence over delegation config;
- add observed `reasoning_effort` to `SubagentHandle`;
- validate allowed values (`low`, `medium`, `high`);
- retain backward-compatible serialization/deserialization;
- test request forwarding, precedence, attribution, and invalid input.

## Verification

- `pytest tests/agent/test_subagent_lifecycle.py tests/tools/test_delegate.py -q` — 70 passed
- `ruff check agent/subagent_lifecycle.py tools/delegate_tool.py tests/agent/test_subagent_lifecycle.py tests/tools/test_delegate.py` — passed
- `git diff --check` — passed
