### PR TITLE
fix(tools): byte-accurate UTF-8 sampling in read_file/read_file_raw (…

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import base64
 import pytest
 import subprocess
 from pathlib import Path
@@ -305,7 +306,10 @@ class TestShellFileOpsHelpers:
             if command.startswith("wc -c"):
                 return {"output": "5\n", "returncode": 0}
             if command.startswith("head -c"):
-                return {"output": "hello", "returncode": 0}
+                # Byte-accurate sampling contract (#76886): the sampler
+                # pipeline is `head -c 1000 ... | base64` and the env
+                # returns base64 of the raw sample bytes.
+                return {"output": base64.encodebytes(b"hello").decode(), "returncode": 0}
             if command.startswith("sed -n"):
                 return {"output": "hello\n", "returncode": 0}
             if command.startswith("wc -l"):
@@ -318,7 +322,7 @@ class TestShellFileOpsHelpers:
 
         assert result.error is None
         assert commands[0] == "wc -c < '/c/Users/alice/notes.txt' 2>/dev/null"
-        assert commands[1] == "head -c 1000 '/c/Users/alice/notes.txt' 2>/dev/null"
+        assert commands[1] == "head -c 1000 '/c/Users/alice/notes.txt' 2>/dev/null | base64"
         assert commands[2] == "sed -n '1,2000p' '/c/Users/alice/notes.txt'"
         assert commands[3] == "wc -l < '/c/Users/alice/notes.txt'"
 
@@ -346,7 +350,12 @@ class TestShellFileOpsHelpers:
             if command.startswith("wc -c"):
                 return {"output": "12\n", "returncode": 0}
             if command.startswith("head -c"):
-                return {"output": "print('ok')\n", "returncode": 0}
+                # Byte-accurate sampling contract (#76886): base64 of the
+                # raw sample bytes (here: "print('ok')\n").
+                return {
+                    "output": base64.encodebytes(b"print('ok')\n").decode(),
+                    "returncode": 0,
+                }
             if command.startswith("sed -n"):
                 return {"output": leaked, "returncode": 0}
             if command.startswith("wc -l"):
@@ -374,7 +383,12 @@ class TestShellFileOpsHelpers:
             if command.startswith("wc -c"):
                 return {"output": "6\n", "returncode": 0}
             if command.startswith("head -c"):
-                return {"output": "alpha\n", "returncode": 0}
+                # Byte-accurate sampling contract (#76886): base64 of the
+                # raw sample bytes (here: "alpha\n").
+                return {
+                    "output": base64.encodebytes(b"alpha\n").decode(),
+                    "returncode": 0,
+                }
             if command.startswith("cat "):
                 return {"output": leaked, "returncode": 0}
             return {"output": "", "returncode": 0}

--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -3,7 +3,13 @@
 Covers:
 - ``_is_likely_binary()`` content-analysis branch (dead-code removal regression guard)
 - ``_check_lint()`` robustness against file paths containing curly braces
+- ``_sample_utf8_text()`` byte-accurate UTF-8 sampling (#76886 — read_file
+  misclassifying valid CJK/Korean/Thai/Cyrillic text as binary when the
+  1000-byte sample boundary cuts a multibyte char)
 """
+
+import base64
+import subprocess
 
 import pytest
 from unittest.mock import MagicMock, patch
@@ -208,7 +214,12 @@ class TestPaginationBounds:
             if command.startswith("wc -c"):
                 return MagicMock(exit_code=0, stdout="12")
             if command.startswith("head -c"):
-                return MagicMock(exit_code=0, stdout="line1\nline2\n")
+                # read_file now samples via `head -c 1000 ... | base64`
+                # (byte-accurate UTF-8 sampling, #76886).
+                return MagicMock(
+                    exit_code=0,
+                    stdout=base64.encodebytes(b"line1\nline2\n").decode(),
+                )
             if command.startswith("sed -n"):
                 return MagicMock(exit_code=0, stdout="line1\n")
             if command.startswith("wc -l"):
@@ -310,3 +321,146 @@ class TestSearchContextParsing:
         assert result.matches[0].path == "dir/file-12-name.py"
         assert result.matches[0].line_number == 8
         assert result.matches[0].content == "context here"
+
+
+# =========================================================================
+# _sample_utf8_text — byte-accurate UTF-8 sampling (#76886)
+# =========================================================================
+
+
+def _make_real_shell_env(cwd: str) -> MagicMock:
+    """Mock env whose execute() runs the command in a real shell.
+
+    Uses ``sh`` explicitly so the ``head | base64`` pipeline in
+    ``_sample_utf8_text`` exercises real coreutils on both POSIX and
+    Windows (git-bash) hosts.
+
+    Faithful to the real Hermes terminal env: subprocess stdout is
+    decoded as UTF-8 with ``errors="replace"`` (NOT the locale codec),
+    because the #76886 bug only manifests when the sample crosses that
+    lossy decode boundary. A locale-decode harness (e.g. cp1252) would
+    turn the cut bytes into mojibake without U+FFFD and silently miss
+    the regression.
+    """
+    env = MagicMock()
+    env.cwd = cwd
+
+    def execute(command, **kwargs):
+        completed = subprocess.run(
+            ["sh", "-c", command],
+            capture_output=True,
+            input=kwargs.get("stdin_data"),
+        )
+        return {
+            "output": completed.stdout.decode("utf-8", errors="replace"),
+            "returncode": completed.returncode,
+        }
+
+    env.execute = execute
+    return env
+
+
+def _b64_sample(raw: bytes) -> str:
+    """Encode raw sample bytes exactly as the shell pipeline returns them:
+    ``head -c 1000 file | base64`` (base64 may wrap lines at 76 cols)."""
+    return base64.encodebytes(raw).decode()
+
+
+class TestSampleUtf8Text:
+    """Unit tests for the byte-accurate UTF-8 sampler."""
+
+    def _ops_with_sample(self, raw: bytes, exit_code: int = 0) -> ShellFileOperations:
+        env = MagicMock()
+        env.cwd = "/tmp"
+        env.execute.return_value = {
+            "output": _b64_sample(raw),
+            "returncode": exit_code,
+        }
+        return ShellFileOperations(env)
+
+    def test_clean_utf8_text_passes_through(self):
+        raw = "plain ascii text\n".encode() * 50  # 800 bytes, all ASCII
+        ops = self._ops_with_sample(raw)
+        sample = ops._sample_utf8_text("/tmp/f.txt", file_size=len(raw))
+        assert sample is not None
+        assert "\ufffd" not in sample
+        assert sample == raw.decode("utf-8")
+
+    def test_boundary_cut_multibyte_char_is_text_not_binary(self):
+        # 998 ASCII bytes + a 3-byte CJK char that starts at byte 998:
+        # ``head -c 1000`` keeps bytes 0..999, i.e. the first 2 bytes of
+        # the CJK char. The old lossy decode produced a synthetic U+FFFD
+        # and flagged the file binary (the #76886 regression).
+        raw = b"a" * 998 + "中".encode("utf-8")[:2]
+        assert len(raw) == 1000  # exactly the sample window
+        ops = self._ops_with_sample(raw)
+        sample = ops._sample_utf8_text("/tmp/f.txt", file_size=len(raw) + 10)
+        assert sample is not None
+        assert sample == "a" * 998
+        assert "\ufffd" not in sample
+
+    def test_genuine_mid_stream_invalid_bytes_still_binary(self):
+        raw = b"ok" + b"\xff\xfe\x00\x01" + b"tail" * 100
+        ops = self._ops_with_sample(raw)
+        sample = ops._sample_utf8_text("/tmp/f.bin", file_size=len(raw) + 10)
+        assert sample is None  # mid-stream corruption -> binary
+
+    def test_small_file_ending_mid_char_is_binary(self):
+        # File smaller than the sample window that genuinely ends with an
+        # incomplete sequence: that is true truncation, not a boundary
+        # artifact — the mojibake round-trip guard must keep it binary.
+        raw = b"abc" + "中".encode("utf-8")[:2]  # 5 bytes, incomplete tail
+        ops = self._ops_with_sample(raw)
+        sample = ops._sample_utf8_text("/tmp/f.txt", file_size=len(raw))
+        assert sample is None
+
+    def test_exec_failure_falls_back_to_empty_sample(self):
+        env = MagicMock()
+        env.cwd = "/tmp"
+        env.execute.return_value = {"output": "", "returncode": 1}
+        ops = ShellFileOperations(env)
+        assert ops._sample_utf8_text("/tmp/f.txt", file_size=10) == ""
+
+
+class TestReadFileUtf8BoundaryE2E:
+    """End-to-end: read_file/read_file_raw must not reject CJK text whose
+    1000-byte boundary cuts a multibyte char (regression for #76886)."""
+
+    def test_read_file_cjk_boundary_cut_not_binary(self, tmp_path):
+        # 998 ASCII bytes, then CJK: byte 999 is the first byte of a
+        # 3-byte char, so head -c 1000 cuts it mid-sequence.
+        body = b"a" * 998 + "中文测试\n".encode("utf-8") * 20
+        p = tmp_path / "cjk_notes.md"
+        p.write_bytes(body)
+
+        ops = ShellFileOperations(_make_real_shell_env(str(tmp_path)))
+        result = ops.read_file(str(p))
+
+        assert result.is_binary is False
+        assert result.error is None
+        assert "中文测试" in result.content
+
+    def test_read_file_raw_cjk_boundary_cut_not_binary(self, tmp_path):
+        body = b"a" * 998 + "中文测试\n".encode("utf-8") * 20
+        p = tmp_path / "cjk_notes.md"
+        p.write_bytes(body)
+
+        ops = ShellFileOperations(_make_real_shell_env(str(tmp_path)))
+        result = ops.read_file_raw(str(p))
+
+        assert result.is_binary is False
+        assert result.error is None
+        assert "中文测试" in result.content
+
+    def test_read_file_genuine_binary_still_rejected(self, tmp_path):
+        # Invalid UTF-8 mid-stream (not a boundary artifact) must remain
+        # binary after the fix.
+        body = b"a" * 998 + b"\xff\xfe\x00\x01" + b"b" * 200
+        p = tmp_path / "junk.dat"
+        p.write_bytes(body)
+
+        ops = ShellFileOperations(_make_real_shell_env(str(tmp_path)))
+        result = ops.read_file(str(p))
+
+        assert result.is_binary is True
+

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -887,6 +887,57 @@ class ShellFileOperations(FileOperations):
             self._command_cache[cmd] = result.stdout.strip() == 'yes'
         return self._command_cache[cmd]
     
+    def _sample_utf8_text(self, path: str, file_size: int) -> Optional[str]:
+        """Return a lossless UTF-8 text sample of the file's first 1000 bytes.
+
+        The terminal env decodes command stdout with ``errors="replace"``,
+        so a raw byte sample can never cross that boundary intact: a
+        1000-byte cut landing inside a multibyte char would arrive here as
+        a synthetic U+FFFD and make valid UTF-8 text look binary (see
+        #76886 — CJK/Korean/Thai/Cyrillic notes misclassified at 20-30%).
+
+        Route the sample through ``base64`` (pure ASCII, survives the lossy
+        decode), then strict-decode the real bytes in Python:
+
+        - Decodes cleanly          -> genuinely valid UTF-8 text
+        - ``unexpected end of data`` AND file is larger than the window
+          -> the cut landed mid-char: trim the incomplete trailing
+             sequence (<=3 bytes) and return the valid prefix
+        - Any other failure        -> genuinely invalid bytes mid-stream,
+             or a small file that itself ends mid-char (true truncation):
+             return None so the caller treats it as binary
+
+        Returns ``""`` if the sample command itself failed (read proceeds,
+        matching pre-existing behavior); ``None`` means "binary".
+        """
+        sample_result = self._exec(
+            f"head -c 1000 {self._escape_shell_arg(path)} 2>/dev/null | base64"
+        )
+        if sample_result.exit_code != 0:
+            return ""
+        compact = "".join(_strip_terminal_fence_leaks(sample_result.stdout).split())
+        try:
+            raw = base64.b64decode(compact, validate=True)
+        except (ValueError, base64.binascii.Error):
+            return None
+        try:
+            return raw.decode("utf-8", errors="strict")
+        except UnicodeDecodeError as e:
+            if e.reason != "unexpected end of data":
+                return None
+            # Trailing incomplete sequence. If the whole file fits inside
+            # the sample window, the file itself is truncated/corrupt —
+            # keep it binary (the mojibake round-trip guard). Otherwise it
+            # is a sampling artifact: trim the partial char and proceed.
+            if file_size <= 1000:
+                return None
+            for cut in range(1, 4):
+                try:
+                    return raw[:-cut].decode("utf-8", errors="strict")
+                except UnicodeDecodeError:
+                    continue
+            return None
+
     def _is_likely_binary(self, path: str, content_sample: str = None) -> bool:
         """
         Check if a file is likely binary.
@@ -1193,12 +1244,12 @@ class ShellFileOperations(FileOperations):
                 ),
             )
         
-        # Read a sample to check for binary content
-        sample_cmd = f"head -c 1000 {self._escape_shell_arg(path)} 2>/dev/null"
-        sample_result = self._exec(sample_cmd)
-        sample_output = _strip_terminal_fence_leaks(sample_result.stdout)
+        # Read a byte-accurate sample (base64 round-trip avoids the
+        # terminal's lossy errors="replace" decode) and check for binary
+        # content. None = genuinely invalid UTF-8 -> binary.
+        sample_output = self._sample_utf8_text(path, file_size)
         
-        if self._is_likely_binary(path, sample_output):
+        if sample_output is None or self._is_likely_binary(path, sample_output):
             return ReadResult(
                 is_binary=True,
                 file_size=file_size,
@@ -1312,9 +1363,8 @@ class ShellFileOperations(FileOperations):
             file_size = 0
         if self._is_image(path):
             return ReadResult(is_image=True, is_binary=True, file_size=file_size)
-        sample_result = self._exec(f"head -c 1000 {self._escape_shell_arg(path)} 2>/dev/null")
-        sample_output = _strip_terminal_fence_leaks(sample_result.stdout)
-        if self._is_likely_binary(path, sample_output):
+        sample_output = self._sample_utf8_text(path, file_size)
+        if sample_output is None or self._is_likely_binary(path, sample_output):
             return ReadResult(
                 is_binary=True, file_size=file_size,
                 error="Binary file — cannot display as text."


### PR DESCRIPTION
…#76886)

read_file/read_file_raw sample the first 1000 bytes via `head -c 1000`. The terminal env decodes command stdout with errors="replace", so a sample cut landing inside a multibyte char arrives as a synthetic U+FFFD the file never contained. _is_likely_binary then rejects the whole file as binary — valid CJK/Korean/Thai/Cyrillic notes get misclassified at measured rates of 20-30% (see #76886), and to the agent the failure is indistinguishable from a missing file.

Sample through base64 (pure ASCII, survives the lossy decode), then strict-decode the real bytes in Python:
- clean decode          -> text
- unexpected end of data + file larger than the window -> boundary
  artifact: trim the incomplete trailing sequence (<=3 bytes) and
  return the valid prefix
- anything else (invalid byte mid-stream, or a small file that
  itself ends mid-char) -> None -> binary (guard preserved)

Fixes the whole bug class across both sibling call paths; the existing U+FFFD/non-printable ratio checks in _is_likely_binary are untouched.

Regression tests: unit tests for _sample_utf8_text (clean pass-through, boundary cut, mid-stream corruption, truncated small file, exec failure) plus real-shell E2E for read_file/read_file_raw with a CJK file whose 1000-byte boundary cuts a 3-byte char. RED against the old code (both E2E CJK tests fail with is_binary=True), GREEN with the fix.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

