### PR TITLE
docs: explain model refusal attribution

### DIFF
--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -213,6 +213,21 @@ curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
 
 ### Provider & Model Issues
 
+#### The agent says "Hermes policy" or "Hermes guardrails" refused my request
+
+A model cannot reliably identify why it refused a request. If the refusal appears only in the assistant's prose, its claim that a hidden Hermes runtime policy caused it may be a hallucinated explanation or a restriction applied by the selected model or provider.
+
+Hermes enforcement is explicit: a blocked tool action returns a tool error naming the denied command or path, and an approval-required action shows an approval prompt. Hermes does not silently turn those execution controls into a general content-refusal layer. Provider-level controls can still apply when configured, such as Amazon Bedrock Guardrails.
+
+To isolate the source:
+
+1. Run `/status` to confirm the active model and provider.
+2. Check whether the refusal includes an actual Hermes tool error or approval prompt. If it is prose only, do not treat the model's attribution as runtime evidence.
+3. Retry in a fresh session with another configured model or provider. A refusal that changes with the model is model/provider behavior, not a Hermes execution control.
+4. If an explicit tool error appears, use its exact text when reporting the problem.
+
+See [Security](/user-guide/security) for Hermes' documented execution controls and [Providers](/integrations/providers) for provider configuration.
+
 #### `/model` only shows one provider / can't switch providers
 
 **Cause:** `/model` (inside a chat session) can only switch between providers you've **already configured**. If you've only set up OpenRouter, that's all `/model` will show.


### PR DESCRIPTION
## Summary

The FAQ now distinguishes model/provider refusals from explicit Hermes tool enforcement, so users can diagnose claims about hidden “Hermes policy” instead of trusting a model's attribution.

Models can invent explanations for their own refusals; actual Hermes enforcement produces a visible tool error or approval prompt.

## Changes

- `website/docs/reference/faq.md`: add a four-step refusal-source diagnostic under Provider & Model Issues
- Link the diagnostic to the existing security-control and provider documentation

## Validation

- `npm run build` — passed for English and Simplified Chinese; existing unrelated broken-link warnings remain

## Infographic

![Refusal-source diagnostic flow](https://v3b.fal.media/files/b/0aa58b7d/7_kTjF1Dg66UKB1bS5Uc6_7WcAbi9V.png)
