### PR TITLE
fix(tests): make test_doctor_journal_modes collectable and green on Windows

### DIFF
--- a/tests/hermes_cli/test_doctor_journal_modes.py
+++ b/tests/hermes_cli/test_doctor_journal_modes.py
@@ -114,7 +114,10 @@ class TestReadJournalMode:
             holder.close()
 
     @pytest.mark.skipif(os.name == "nt", reason="chmod is a no-op on Windows")
-    @pytest.mark.skipif(os.geteuid() == 0, reason="root ignores file permissions")
+    @pytest.mark.skipif(
+        hasattr(os, "geteuid") and os.geteuid() == 0,
+        reason="root ignores file permissions",
+    )
     def test_read_only_directory_is_still_readable(self, tmp_path):
         db = tmp_path / "state.db"
         _make_db(db, journal_mode="WAL")
@@ -185,7 +188,11 @@ class TestReportDatabaseJournalModes:
         assert "state.db is in WAL mode" in out
         assert "projects.db: rollback journal mode" in out
         assert "kanban.db: rollback journal mode" in out
-        assert "kanban/boards/myboard/kanban.db is in WAL mode" in out
+        # doctor names nested databases with str(Path.relative_to(...)), which
+        # uses the platform separator — build the expectation the same way
+        # rather than hardcoding POSIX slashes.
+        board_rel = os.path.join("kanban", "boards", "myboard", "kanban.db")
+        assert f"{board_rel} is in WAL mode" in out
 
     def test_missing_databases_are_skipped(self, tmp_path, capsys):
         doctor._report_database_journal_modes(tmp_path, VULNERABLE)
@@ -209,7 +216,10 @@ class TestReportDatabaseJournalModes:
         assert "state.db: rollback journal mode" in out
 
     @pytest.mark.skipif(os.name == "nt", reason="chmod is a no-op on Windows")
-    @pytest.mark.skipif(os.geteuid() == 0, reason="root ignores file permissions")
+    @pytest.mark.skipif(
+        hasattr(os, "geteuid") and os.geteuid() == 0,
+        reason="root ignores file permissions",
+    )
     def test_unreadable_database_does_not_crash(self, tmp_path, capsys):
         db = tmp_path / "state.db"
         _make_db(db)


### PR DESCRIPTION
## What does this PR do?

`tests/hermes_cli/test_doctor_journal_modes.py` is new in v0.20.0 (`658329708`) and **aborts collection on native Windows**. pytest stops the entire run on a collection error, so no test in the invocation gets to execute:

```
ERROR collecting tests/hermes_cli/test_doctor_journal_modes.py
E   AttributeError: module 'os' has no attribute 'geteuid'
```

## The Windows guard is already there — it just never runs

```python
@pytest.mark.skipif(os.name == "nt", reason="chmod is a no-op on Windows")
@pytest.mark.skipif(os.geteuid() == 0, reason="root ignores file permissions")
def test_read_only_directory_is_still_readable(self, tmp_path):
```

The first decorator is correct and does exactly the right thing. The second one evaluates `os.geteuid()` at **import time**, before pytest looks at either marker — and `os.geteuid` does not exist on Windows. The author's own guard is annulled by the line directly beneath it.

Short-circuiting on `hasattr` fixes it, and it is the form already used for this same pair in `tests/test_hermes_state_readonly_preflight.py:31`:

```python
@pytest.mark.skipif(
    hasattr(os, "geteuid") and os.geteuid() == 0,
    reason="root ignores file permissions",
)
```

POSIX behaviour is byte-identical — `hasattr(os, "geteuid")` is `True` there, so the euid check runs exactly as before.

## One more failure becomes reachable once collection is unblocked

`test_lists_every_managed_database` asserts a POSIX path:

```python
assert "kanban/boards/myboard/kanban.db is in WAL mode" in out
```

`doctor` names nested databases with `str(board_db.relative_to(hermes_home))` (`hermes_cli/doctor.py:114`), which uses the platform separator — so on Windows the output carries backslashes. The product is correct on both platforms; only the expectation was POSIX-only. It is now built with `os.path.join` so it follows whatever separator the host uses.

**No production code is touched.**

## How to test

On native Windows, from PowerShell:

```powershell
python -m pytest tests/hermes_cli/test_doctor_journal_modes.py -q -rs
```

**Before:**
```
ERROR collecting tests/hermes_cli/test_doctor_journal_modes.py
E   AttributeError: module 'os' has no attribute 'geteuid'
Interrupted: 1 error during collection
```

**After:**
```
25 passed, 2 skipped in 1.95s

SKIPPED [1] test_doctor_journal_modes.py:116: chmod is a no-op on Windows
SKIPPED [1] test_doctor_journal_modes.py:218: chmod is a no-op on Windows
```

The two skips carry the author's own reason — now actually firing.

On Linux/macOS nothing changes: both markers evaluate as before and all 27 tests run.

## Scope

I collected all **230 test files added since `v2026.7.30`** on this host. This was the **only** collection error among them, and the bare `skipif(os.geteuid()...)` pattern appears nowhere else under `tests/`.

## Why CI never caught this

All CI jobs run on `ubuntu-latest` (the only other runner in the tree is `ubuntu-24.04-arm` in `docker.yml`). There is no Windows runner, so `os.geteuid` always exists in CI and the import-time evaluation never raises.

## Platforms tested

Native Windows 11 Home, build 26200 · Python 3.11.6 · PowerShell.

## Related

- `658329708` — `feat(doctor): report per-database journal mode with WAL-reset exposure`, which added the file two days ago.
- #74300 — open PR doing Windows skip-marker work across the suite; it does **not** touch this file (it predates it).