### PR TITLE
perf(cache): reuse static skill prefixes across webhook events

### DIFF
--- a/agent/prompt_caching.py
+++ b/agent/prompt_caching.py
@@ -14,6 +14,8 @@ import copy
 from dataclasses import dataclass
 from typing import Any, Dict, List
 
+from agent.skill_commands import split_skill_invocation_cache_prefix
+
 
 @dataclass(frozen=True)
 class PromptCachePlan:
@@ -58,6 +60,18 @@ def _apply_cache_marker(msg: dict, cache_marker: dict, native_anthropic: bool = 
         return
 
     if isinstance(content, str):
+        skill_split = split_skill_invocation_cache_prefix(content)
+        if skill_split is not None:
+            stable_prefix, volatile_tail = skill_split
+            msg["content"] = [
+                {
+                    "type": "text",
+                    "text": stable_prefix,
+                    "cache_control": cache_marker,
+                },
+                {"type": "text", "text": volatile_tail},
+            ]
+            return
         msg["content"] = [
             {"type": "text", "text": content, "cache_control": cache_marker}
         ]
@@ -194,6 +208,7 @@ def strip_anthropic_cache_control(
         content = msg.get("content")
         if not isinstance(content, list):
             continue
+        skill_prefix_shape = _is_skill_invocation_cache_split(content)
         if any(isinstance(part, dict) and "cache_control" in part for part in content):
             content = [
                 {k: v for k, v in part.items() if k != "cache_control"}
@@ -211,10 +226,33 @@ def strip_anthropic_cache_control(
         ) and (
             len(content) == 1
             or (msg.get("role") == "system" and len(content) == 2)
+            or skill_prefix_shape
         )
         if decoration_shape:
             msg["content"] = "".join(part["text"] for part in content)
     return api_messages
+
+
+def _is_skill_invocation_cache_split(content: list[Any]) -> bool:
+    """Recognize the exact two-block shape produced for a skill invocation."""
+    if len(content) != 2:
+        return False
+    stable, volatile = content
+    if not isinstance(stable, dict) or not isinstance(volatile, dict):
+        return False
+    if set(stable) != {"type", "text", "cache_control"}:
+        return False
+    if set(volatile) != {"type", "text"}:
+        return False
+    if stable.get("type") != "text" or volatile.get("type") != "text":
+        return False
+    if not isinstance(stable.get("text"), str) or not isinstance(
+        volatile.get("text"), str
+    ):
+        return False
+
+    split = split_skill_invocation_cache_prefix(stable["text"] + volatile["text"])
+    return split == (stable["text"], volatile["text"])
 
 
 def strip_anthropic_tool_cache_control(tools: List[Dict[str, Any]] | None) -> List[Dict[str, Any]]:

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -53,6 +53,7 @@ _RUNTIME_NOTE = "\n\n[Runtime note:"
 _BUNDLE_MARKER = " skill bundle,"
 _BUNDLE_USER_INSTRUCTION = "\nUser instruction: "
 _BUNDLE_FIRST_SKILL_BLOCK = "\n\n[Loaded as part of the "
+_SKILL_CACHE_TAIL_SEPARATOR = "\n\n" + _SINGLE_SKILL_INSTRUCTION
 
 # The skill name sits in the first quoted span of the activation note, for both
 # the single-skill and the bundle header ("work" / "/clean /work").
@@ -68,6 +69,38 @@ SKILL_SCAFFOLD_SQL_LIKE = _SKILL_INVOCATION_PREFIX + "%"
 # the joint (a bundle instruction cut off by the head window); callers cut the
 # description there rather than show the skill body on the far side.
 SKILL_EXCERPT_JOINT = "\x1e"
+
+
+def split_skill_invocation_cache_prefix(content: Any) -> Optional[tuple[str, str]]:
+    """Split a scaffolded skill turn into stable prefix and volatile tail.
+
+    Single-skill builders and cron append the caller's instruction after the
+    loaded skill content. Keeping this parser beside the canonical scaffold
+    markers lets request-local prompt caching place a breakpoint before that
+    volatile instruction without changing the stored message string.
+
+    Returns ``None`` for ordinary messages, bare skill invocations, and bundle
+    layouts whose user instruction precedes the loaded skill blocks.
+    """
+    if (
+        not isinstance(content, str)
+        or not content.startswith(_SKILL_INVOCATION_PREFIX)
+    ):
+        return None
+
+    separator_idx = content.rfind(_SKILL_CACHE_TAIL_SEPARATOR)
+    if separator_idx <= 0:
+        return None
+
+    stable_prefix = content[:separator_idx]
+    if (
+        _SINGLE_SKILL_MARKER not in stable_prefix
+        and _BUNDLE_MARKER not in stable_prefix
+    ):
+        return None
+
+    volatile_tail = content[separator_idx:]
+    return stable_prefix, volatile_tail
 
 
 def extract_user_instruction_from_skill_message(content: Any) -> Optional[str]:

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -717,6 +717,28 @@ class TestConvertMessages:
         assert isinstance(system, list)
         assert system[0]["cache_control"] == {"type": "ephemeral"}
 
+    def test_skill_prefix_cache_marker_survives_user_message_conversion(self):
+        skill_turn = (
+            '[IMPORTANT: The user has invoked the "triage" skill, indicating they want '
+            "you to follow its instructions. The full skill content is loaded below.]\n\n"
+            "Stable triage instructions.\n\n"
+            "The user has provided the following instruction alongside the skill "
+            "invocation: ticket=123"
+        )
+        messages = apply_anthropic_cache_control(
+            [{"role": "user", "content": skill_turn}],
+            native_anthropic=True,
+        )
+
+        _, result = convert_messages_to_anthropic(messages)
+
+        blocks = result[0]["content"]
+        assert len(blocks) == 2
+        assert blocks[0]["cache_control"] == {"type": "ephemeral"}
+        assert "ticket=123" not in blocks[0]["text"]
+        assert "cache_control" not in blocks[1]
+        assert "ticket=123" in blocks[1]["text"]
+
 
     def test_assistant_cache_control_blocks_are_preserved(self):
         messages = apply_anthropic_cache_control([

--- a/tests/agent/test_prompt_caching.py
+++ b/tests/agent/test_prompt_caching.py
@@ -13,6 +13,21 @@ from agent.prompt_caching import (
 
 
 MARKER = {"type": "ephemeral"}
+_SKILL_INSTRUCTION_MARKER = (
+    "The user has provided the following instruction alongside the skill invocation: "
+)
+
+
+def _skill_invocation(instruction: str = "") -> str:
+    stable = (
+        '[IMPORTANT: The user has invoked the "triage" skill, indicating they want '
+        "you to follow its instructions. The full skill content is loaded below.]\n\n"
+        "# Triage\n\n"
+        "Inspect the report carefully and preserve the stable instructions."
+    )
+    if not instruction:
+        return stable
+    return f"{stable}\n\n{_SKILL_INSTRUCTION_MARKER}{instruction}"
 
 
 def _native_marker_indexes(messages):
@@ -164,6 +179,73 @@ class TestPromptCachePlan:
 
         assert "cache_control" in tools[-1]
         assert "cache_control" not in stripped[-1]
+
+
+class TestSkillInvocationPrefixCaching:
+    def test_volatile_tail_does_not_change_marked_skill_prefix(self):
+        first = _skill_invocation("ticket=one timestamp=10:00")
+        second = _skill_invocation("ticket=two timestamp=10:01")
+
+        first_marked = apply_anthropic_cache_control(
+            [{"role": "user", "content": first}]
+        )[0]["content"]
+        second_marked = apply_anthropic_cache_control(
+            [{"role": "user", "content": second}]
+        )[0]["content"]
+
+        assert len(first_marked) == len(second_marked) == 2
+        assert first_marked[0] == second_marked[0]
+        assert first_marked[0]["cache_control"] == MARKER
+        assert "cache_control" not in first_marked[1]
+        assert first_marked[1]["text"] != second_marked[1]["text"]
+        assert "ticket=one" not in first_marked[0]["text"]
+        assert "ticket=one" in first_marked[1]["text"]
+
+    def test_request_plan_keeps_canonical_skill_message_as_string(self):
+        original = _skill_invocation("process delivery 123")
+        messages = [{"role": "user", "content": original}]
+
+        plan = build_prompt_cache_plan(messages, [])
+
+        assert messages == [{"role": "user", "content": original}]
+        assert isinstance(messages[0]["content"], str)
+        assert isinstance(plan.messages[0]["content"], list)
+        assert "cache_control" not in plan.messages[0]["content"][1]
+
+    def test_strip_reconstructs_exact_string_for_non_caching_failover(self):
+        original = _skill_invocation("process delivery 123")
+        marked = apply_anthropic_cache_control(
+            [{"role": "user", "content": original}]
+        )
+
+        strip_anthropic_cache_control(marked)
+
+        assert marked == [{"role": "user", "content": original}]
+
+    def test_instruction_marker_quoted_inside_skill_uses_final_tail(self):
+        quoted = (
+            _skill_invocation()
+            + f"\n\nExample: {_SKILL_INSTRUCTION_MARKER}not a real event"
+            + f"\n\n{_SKILL_INSTRUCTION_MARKER}actual event"
+        )
+
+        content = apply_anthropic_cache_control(
+            [{"role": "user", "content": quoted}]
+        )[0]["content"]
+
+        assert len(content) == 2
+        assert "not a real event" in content[0]["text"]
+        assert "actual event" not in content[0]["text"]
+        assert content[1]["text"].endswith("actual event")
+
+    def test_bare_skill_and_ordinary_user_message_keep_whole_message_layout(self):
+        for original in (_skill_invocation(), "ordinary user request"):
+            content = apply_anthropic_cache_control(
+                [{"role": "user", "content": original}]
+            )[0]["content"]
+            assert content == [
+                {"type": "text", "text": original, "cache_control": MARKER}
+            ]
 
 
 class TestApplyCacheMarker:
@@ -463,7 +545,6 @@ class TestStripAnthropicCacheControl:
         assert isinstance(content, list) and len(content) == 2
         assert content[0] == {"type": "text", "text": "see"}
         assert content[1]["type"] == "image_url"
-
 
 
 

--- a/tests/cron/test_cron_prompt_injection_skill.py
+++ b/tests/cron/test_cron_prompt_injection_skill.py
@@ -134,6 +134,42 @@ class TestScanAssembledCronPrompt:
 
 class TestBuildJobPromptScansSkillContent:
 
+    def test_prompt_cache_isolates_volatile_tail_after_multiple_skills(
+        self, cron_env
+    ):
+        hermes_home, scheduler = cron_env
+        _plant_skill(hermes_home, "triage", "Stable triage guidance.")
+        _plant_skill(hermes_home, "report", "Stable reporting guidance.")
+
+        common = {
+            "id": "job-cache",
+            "name": "cache boundary",
+            "skills": ["triage", "report"],
+        }
+        first = scheduler._build_job_prompt(
+            {**common, "prompt": "ticket=one time=10:00"}
+        )
+        second = scheduler._build_job_prompt(
+            {**common, "prompt": "ticket=two time=10:01"}
+        )
+
+        from agent.prompt_caching import apply_anthropic_cache_control
+
+        first_blocks = apply_anthropic_cache_control(
+            [{"role": "user", "content": first}]
+        )[0]["content"]
+        second_blocks = apply_anthropic_cache_control(
+            [{"role": "user", "content": second}]
+        )[0]["content"]
+
+        assert isinstance(first, str) and isinstance(second, str)
+        assert len(first_blocks) == len(second_blocks) == 2
+        assert first_blocks[0] == second_blocks[0]
+        assert first_blocks[0]["cache_control"] == {"type": "ephemeral"}
+        assert "cache_control" not in first_blocks[1]
+        assert "ticket=one" in first_blocks[1]["text"]
+        assert "ticket=one" not in first_blocks[0]["text"]
+
     def test_builtin_style_github_api_example_is_allowed(self, cron_env):
         hermes_home, scheduler = cron_env
         _plant_skill(
@@ -260,6 +296,36 @@ class TestBuildJobPromptScansSkillContent:
         assert "Bundle member should win." in prompt
         assert "Standalone skill should not win." not in prompt
 
+    def test_prompt_cache_isolates_tail_after_bundle_loaded_by_cron(
+        self, cron_env
+    ):
+        hermes_home, scheduler = cron_env
+        _plant_skill(hermes_home, "bundle-member", "Stable bundled guidance.")
+        _plant_bundle(hermes_home, "article-pipeline", ["bundle-member"])
+
+        common = {
+            "id": "job-bundle-cache",
+            "name": "bundle cache boundary",
+            "skills": ["article-pipeline"],
+        }
+        first = scheduler._build_job_prompt({**common, "prompt": "ticket=one"})
+        second = scheduler._build_job_prompt({**common, "prompt": "ticket=two"})
+
+        from agent.prompt_caching import apply_anthropic_cache_control
+
+        first_blocks = apply_anthropic_cache_control(
+            [{"role": "user", "content": first}]
+        )[0]["content"]
+        second_blocks = apply_anthropic_cache_control(
+            [{"role": "user", "content": second}]
+        )[0]["content"]
+
+        assert len(first_blocks) == len(second_blocks) == 2
+        assert first_blocks[0] == second_blocks[0]
+        assert first_blocks[0]["cache_control"] == {"type": "ephemeral"}
+        assert "ticket=one" not in first_blocks[0]["text"]
+        assert "ticket=one" in first_blocks[1]["text"]
+
 
 # ---------------------------------------------------------------------------
 # Script-output injection — runtime DATA must not be strict-scanned
@@ -346,5 +412,4 @@ class TestScriptOutputNotStrictScanned:
         assert prompt is not None
         assert "\u200b" not in prompt
         assert "item oneitem two" in prompt
-
 


### PR DESCRIPTION
## What does this PR do?

Splits recognized skill-invocation user turns at the stable-skill / volatile-instruction boundary when building an Anthropic prompt-cache request. The stable skill prefix carries the cache breakpoint; webhook or cron event data remains in a trailing unmarked text block, so changing a ticket ID or timestamp no longer invalidates the full skill body.

The split is request-local. Canonical session history remains the original string, ordinary and bare-skill user messages keep their existing layout, and the failover stripper reconstructs the exact original string before a non-caching provider retry.

## Related Issue

Fixes #81867

## Type of Change

- [x] Performance improvement
- [x] Bug fix (non-breaking change)
- [x] Tests

## Changes Made

- Add a canonical scaffold parser beside the existing skill markers for single-skill and cron-appended instruction tails.
- Teach `_apply_cache_marker` to emit `[marked stable prefix, unmarked volatile tail]` only for that recognized shape.
- Teach cache stripping to recognize and byte-exactly flatten the request-local split on provider failover.
- Cover webhook-style volatile changes, multiple cron skills, cron bundles, canonical-history isolation, quoted marker text, ordinary/bare skill messages, and native Anthropic adapter conversion.

## How to Test

```bash
uv run ruff check .
scripts/run_tests.sh \
  tests/agent/test_prompt_caching.py \
  tests/agent/test_anthropic_adapter.py \
  tests/agent/test_moa_aggregator_cache_control.py \
  tests/agent/test_cache_disabled_on_stubs.py \
  tests/run_agent/test_run_agent.py \
  tests/run_agent/test_background_fallback_cache_parity.py \
  tests/run_agent/test_conversation_fallback_state.py \
  tests/run_agent/test_moa_loop_mode.py \
  tests/cron/test_cron_prompt_injection_skill.py \
  tests/agent/test_skill_commands.py \
  tests/agent/test_skill_bundles.py \
  tests/agent/test_memory_skill_scaffolding.py \
  tests/test_session_skill_previews.py \
  tests/openviking_plugin/test_openviking.py
```

Local result: **509 passed, 0 failed**. `ruff check .` and `git diff --check` also pass.

## Coverage Notes

The sibling-path audit covers direct skill construction, multi-skill cron assembly, cron bundle assembly, native Anthropic wire conversion, cache-disabled/provider-failover cleanup, MoA cache planning, memory scaffolding, and session previews. No live Hermes profile, gateway, credential, or provider account was used.

## Checklist

- [x] Read the contributing guide
- [x] Searched open PRs and issue activity for duplicate work immediately before publishing
- [x] Branch rebased onto current `origin/main`
- [x] Public noreply author and committer identity verified
- [x] Added regression coverage at the cache/persistence/provider boundaries
- [x] `gitleaks` publish-range scan passed
- [x] No unrelated changes included

AI assistance was used to help inspect the code paths, draft the implementation, and run validation; all reported commands and checks were executed in an isolated contributor worktree.
