### PR TITLE
fix(agent): declare skill cache boundaries on the message

### DIFF
--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -341,6 +341,11 @@ def _sanitize_messages_non_ascii(messages: list) -> bool:
     (LANG=C, Chromebooks, minimal containers).  Returns True if any
     non-ASCII content was found and sanitized.
     """
+    from agent.skill_commands import (
+        CACHE_STABLE_PREFIX_LEN_KEY,
+        get_cache_stable_prefix_len,
+    )
+
     found = False
     for msg in messages:
         if not isinstance(msg, dict):
@@ -348,11 +353,41 @@ def _sanitize_messages_non_ascii(messages: list) -> bool:
         # Sanitize content (string)
         content = msg.get("content")
         if isinstance(content, str):
-            sanitized = _strip_non_ascii(content)
+            prefix_len = get_cache_stable_prefix_len(content)
+            if prefix_len is None:
+                existing = msg.get(CACHE_STABLE_PREFIX_LEN_KEY)
+                if isinstance(existing, int):
+                    prefix_len = existing
+            if isinstance(prefix_len, int) and 0 < prefix_len < len(content):
+                # Strip each side independently so the character offset keeps
+                # pointing at the same stable/volatile boundary after chars
+                # before it are deleted.
+                stable = _strip_non_ascii(content[:prefix_len])
+                volatile = _strip_non_ascii(content[prefix_len:])
+                sanitized = stable + volatile
+                if stable and volatile:
+                    msg[CACHE_STABLE_PREFIX_LEN_KEY] = len(stable)
+                else:
+                    msg.pop(CACHE_STABLE_PREFIX_LEN_KEY, None)
+            else:
+                sanitized = _strip_non_ascii(content)
+                msg.pop(CACHE_STABLE_PREFIX_LEN_KEY, None)
             if sanitized != content:
                 msg["content"] = sanitized
                 found = True
         elif isinstance(content, list):
+            declared_len = msg.get(CACHE_STABLE_PREFIX_LEN_KEY)
+            cache_split_shape = (
+                msg.get("role") == "user"
+                and len(content) == 2
+                and isinstance(declared_len, int)
+                and all(
+                    isinstance(part, dict)
+                    and isinstance(part.get("text"), str)
+                    for part in content
+                )
+                and len(content[0]["text"]) == declared_len
+            )
             for part in content:
                 if isinstance(part, dict):
                     text = part.get("text")
@@ -361,6 +396,13 @@ def _sanitize_messages_non_ascii(messages: list) -> bool:
                         if sanitized != text:
                             part["text"] = sanitized
                             found = True
+            if cache_split_shape:
+                stable = content[0]["text"]
+                volatile = content[1]["text"]
+                if stable and volatile:
+                    msg[CACHE_STABLE_PREFIX_LEN_KEY] = len(stable)
+                else:
+                    msg.pop(CACHE_STABLE_PREFIX_LEN_KEY, None)
         # Sanitize name field (can contain non-ASCII in tool results)
         name = msg.get("name")
         if isinstance(name, str):

--- a/agent/prompt_caching.py
+++ b/agent/prompt_caching.py
@@ -14,6 +14,8 @@ import copy
 from dataclasses import dataclass
 from typing import Any, Dict, List
 
+from agent.skill_commands import split_skill_message_for_cache
+
 
 @dataclass(frozen=True)
 class PromptCachePlan:
@@ -58,6 +60,19 @@ def _apply_cache_marker(msg: dict, cache_marker: dict, native_anthropic: bool = 
         return
 
     if isinstance(content, str):
+        if role == "user":
+            skill_parts = split_skill_message_for_cache(content)
+            if skill_parts is not None:
+                stable_prefix, volatile_suffix = skill_parts
+                msg["content"] = [
+                    {
+                        "type": "text",
+                        "text": stable_prefix,
+                        "cache_control": cache_marker,
+                    },
+                    {"type": "text", "text": volatile_suffix},
+                ]
+                return
         msg["content"] = [
             {"type": "text", "text": content, "cache_control": cache_marker}
         ]
@@ -174,8 +189,9 @@ def strip_anthropic_cache_control(
 
     Flattening back to a plain string is restricted to the exact shapes
     :func:`apply_anthropic_cache_control` produces from string content —
-    a single ``{"type": "text"}`` part, or the two-part ``[static, volatile]``
-    system split — so the ``""``-join is provably byte-exact. Organic
+    a single ``{"type": "text"}`` part, the two-part ``[static, volatile]``
+    system split, or a recognized two-part skill invocation split — so the
+    ``""``-join is provably byte-exact. Organic
     multi-part text (merged user turns, imported transcripts) and parts
     carrying extra keys (``citations`` etc.) keep their structure; only
     per-part markers are removed. Marker removal is copy-on-write on the
@@ -194,6 +210,22 @@ def strip_anthropic_cache_control(
         content = msg.get("content")
         if not isinstance(content, list):
             continue
+        skill_split_shape = (
+            msg.get("role") == "user"
+            and len(content) == 2
+            and all(
+                isinstance(part, dict)
+                and part.get("type", "text") == "text"
+                and isinstance(part.get("text"), str)
+                for part in content
+            )
+            and "cache_control" in content[0]
+            and "cache_control" not in content[1]
+            and split_skill_message_for_cache(
+                content[0]["text"] + content[1]["text"]
+            )
+            == (content[0]["text"], content[1]["text"])
+        )
         if any(isinstance(part, dict) and "cache_control" in part for part in content):
             content = [
                 {k: v for k, v in part.items() if k != "cache_control"}
@@ -211,6 +243,7 @@ def strip_anthropic_cache_control(
         ) and (
             len(content) == 1
             or (msg.get("role") == "system" and len(content) == 2)
+            or skill_split_shape
         )
         if decoration_shape:
             msg["content"] = "".join(part["text"] for part in content)

--- a/agent/prompt_caching.py
+++ b/agent/prompt_caching.py
@@ -14,7 +14,11 @@ import copy
 from dataclasses import dataclass
 from typing import Any, Dict, List
 
-from agent.skill_commands import split_skill_message_for_cache
+from agent.skill_commands import (
+    CACHE_STABLE_PREFIX_LEN_KEY,
+    annotate_cache_stable_prefix,
+    with_cache_stable_prefix,
+)
 
 
 @dataclass(frozen=True)
@@ -61,16 +65,18 @@ def _apply_cache_marker(msg: dict, cache_marker: dict, native_anthropic: bool = 
 
     if isinstance(content, str):
         if role == "user":
-            skill_parts = split_skill_message_for_cache(content)
-            if skill_parts is not None:
-                stable_prefix, volatile_suffix = skill_parts
+            # Builder-declared boundary (#81867): prefer the message-local
+            # sidecar, fall back to a ``_CacheBoundedStr`` content attribute.
+            annotate_cache_stable_prefix(msg)
+            prefix_len = msg.get(CACHE_STABLE_PREFIX_LEN_KEY)
+            if isinstance(prefix_len, int) and 0 < prefix_len < len(content):
                 msg["content"] = [
                     {
                         "type": "text",
-                        "text": stable_prefix,
+                        "text": content[:prefix_len],
                         "cache_control": cache_marker,
                     },
-                    {"type": "text", "text": volatile_suffix},
+                    {"type": "text", "text": content[prefix_len:]},
                 ]
                 return
         msg["content"] = [
@@ -190,8 +196,9 @@ def strip_anthropic_cache_control(
     Flattening back to a plain string is restricted to the exact shapes
     :func:`apply_anthropic_cache_control` produces from string content —
     a single ``{"type": "text"}`` part, the two-part ``[static, volatile]``
-    system split, or a recognized two-part skill invocation split — so the
-    ``""``-join is provably byte-exact. Organic
+    system split, or the two-part builder-declared skill split (identified
+    by the message-local ``_cache_stable_prefix_len`` sidecar matching the
+    first part's length) — so the ``""``-join is provably byte-exact. Organic
     multi-part text (merged user turns, imported transcripts) and parts
     carrying extra keys (``citations`` etc.) keep their structure; only
     per-part markers are removed. Marker removal is copy-on-write on the
@@ -210,9 +217,11 @@ def strip_anthropic_cache_control(
         content = msg.get("content")
         if not isinstance(content, list):
             continue
+        declared_len = msg.get(CACHE_STABLE_PREFIX_LEN_KEY)
         skill_split_shape = (
             msg.get("role") == "user"
             and len(content) == 2
+            and isinstance(declared_len, int)
             and all(
                 isinstance(part, dict)
                 and part.get("type", "text") == "text"
@@ -221,10 +230,7 @@ def strip_anthropic_cache_control(
             )
             and "cache_control" in content[0]
             and "cache_control" not in content[1]
-            and split_skill_message_for_cache(
-                content[0]["text"] + content[1]["text"]
-            )
-            == (content[0]["text"], content[1]["text"])
+            and len(content[0]["text"]) == declared_len
         )
         if any(isinstance(part, dict) and "cache_control" in part for part in content):
             content = [
@@ -246,7 +252,15 @@ def strip_anthropic_cache_control(
             or skill_split_shape
         )
         if decoration_shape:
-            msg["content"] = "".join(part["text"] for part in content)
+            # Flatten back to a plain string for the next decorator, but keep
+            # the builder-declared boundary sidecar so a mid-turn failover
+            # redecorate (#72626) can recreate the same split.
+            flat = "".join(part["text"] for part in content)
+            if skill_split_shape:
+                msg["content"] = with_cache_stable_prefix(flat, declared_len)
+                msg[CACHE_STABLE_PREFIX_LEN_KEY] = declared_len
+            else:
+                msg["content"] = flat
     return api_messages
 
 

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -53,6 +53,10 @@ _RUNTIME_NOTE = "\n\n[Runtime note:"
 _BUNDLE_MARKER = " skill bundle,"
 _BUNDLE_USER_INSTRUCTION = "\nUser instruction: "
 _BUNDLE_FIRST_SKILL_BLOCK = "\n\n[Loaded as part of the "
+_CRON_SKIPPED_SKILLS_PREFIX = (
+    "[IMPORTANT: The following skill(s) were listed for this job but could not be found "
+)
+_CRON_EXECUTION_PREFIX = "[IMPORTANT: You are running as a scheduled cron job. "
 
 # The skill name sits in the first quoted span of the activation note, for both
 # the single-skill and the bundle header ("work" / "/clean /work").
@@ -106,20 +110,48 @@ def split_skill_message_for_cache(content: Any) -> Optional[tuple[str, str]]:
 
     Cron's one-or-more-skill prompt uses the same activation and instruction
     markers as the slash-skill builder, so it gets the same boundary without
-    route-specific cache logic. Bundle messages are intentionally excluded:
-    their user instruction currently precedes the loaded skill blocks and is
-    therefore not a stable-prefix layout.
+    changing its canonical text. Ordinary bundle messages are excluded because
+    their user instruction precedes the loaded skill blocks; cron's bundle
+    wrapper is the exception because it appends its own instruction after all
+    stable blocks.
     """
-    if not isinstance(content, str) or not content.startswith(_SKILL_INVOCATION_PREFIX):
+    if not isinstance(content, str):
         return None
-    if _SINGLE_SKILL_MARKER not in content:
+
+    activation_index = content.find(_SKILL_INVOCATION_PREFIX)
+    starts_with_single_skill = activation_index == 0
+    starts_with_cron_skip_notice = (
+        content.startswith(_CRON_SKIPPED_SKILLS_PREFIX)
+        and activation_index > 0
+    )
+    if not starts_with_single_skill and not starts_with_cron_skip_notice:
         return None
+
+    activation_end = content.find("\n\n", activation_index)
+    if activation_end < 0:
+        activation_end = len(content)
+    activation_note = content[activation_index:activation_end]
+    is_single_skill_scaffold = _SINGLE_SKILL_MARKER in activation_note
+    is_bundle_scaffold = (
+        activation_index == 0 and _BUNDLE_MARKER in activation_note
+    )
 
     instruction_boundary = f"\n\n{_SINGLE_SKILL_INSTRUCTION}"
     boundary_index = content.rfind(instruction_boundary)
     if boundary_index >= 0:
         split_index = boundary_index + len(instruction_boundary)
+        suffix = content[split_index:]
+        # A normal bundle keeps its instruction before the skill blocks and
+        # must retain the ordinary one-block cache policy. Cron is the one
+        # bundle caller that appends a second, outer instruction after all
+        # stable blocks; its suffix always begins with the execution hint.
+        if not is_single_skill_scaffold and not (
+            is_bundle_scaffold and suffix.startswith(_CRON_EXECUTION_PREFIX)
+        ):
+            return None
     else:
+        if not is_single_skill_scaffold:
+            return None
         boundary_index = content.rfind(_RUNTIME_NOTE)
         if boundary_index < 0:
             return None

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -97,6 +97,40 @@ def extract_user_instruction_from_skill_message(content: Any) -> Optional[str]:
     return None
 
 
+def split_skill_message_for_cache(content: Any) -> Optional[tuple[str, str]]:
+    """Split stable single-skill scaffolding from its volatile invocation tail.
+
+    The returned boundary is used only while decorating an outgoing provider
+    request. The canonical conversation message remains a string, preserving
+    persistence, transcript rendering, and memory-provider behavior.
+
+    Cron's one-or-more-skill prompt uses the same activation and instruction
+    markers as the slash-skill builder, so it gets the same boundary without
+    route-specific cache logic. Bundle messages are intentionally excluded:
+    their user instruction currently precedes the loaded skill blocks and is
+    therefore not a stable-prefix layout.
+    """
+    if not isinstance(content, str) or not content.startswith(_SKILL_INVOCATION_PREFIX):
+        return None
+    if _SINGLE_SKILL_MARKER not in content:
+        return None
+
+    instruction_boundary = f"\n\n{_SINGLE_SKILL_INSTRUCTION}"
+    boundary_index = content.rfind(instruction_boundary)
+    if boundary_index >= 0:
+        split_index = boundary_index + len(instruction_boundary)
+    else:
+        boundary_index = content.rfind(_RUNTIME_NOTE)
+        if boundary_index < 0:
+            return None
+        split_index = boundary_index + len(_RUNTIME_NOTE)
+
+    prefix, suffix = content[:split_index], content[split_index:]
+    if not prefix or not suffix:
+        return None
+    return prefix, suffix
+
+
 def describe_skill_invocation(content: Any, separator: str = " — ") -> Optional[str]:
     """Render a slash-skill-expanded turn the way the user typed it.
 

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -132,9 +132,7 @@ def split_skill_message_for_cache(content: Any) -> Optional[tuple[str, str]]:
         activation_end = len(content)
     activation_note = content[activation_index:activation_end]
     is_single_skill_scaffold = _SINGLE_SKILL_MARKER in activation_note
-    is_bundle_scaffold = (
-        activation_index == 0 and _BUNDLE_MARKER in activation_note
-    )
+    is_bundle_scaffold = _BUNDLE_MARKER in activation_note
 
     instruction_boundary = f"\n\n{_SINGLE_SKILL_INSTRUCTION}"
     boundary_index = content.rfind(instruction_boundary)
@@ -146,7 +144,9 @@ def split_skill_message_for_cache(content: Any) -> Optional[tuple[str, str]]:
         # bundle caller that appends a second, outer instruction after all
         # stable blocks; its suffix always begins with the execution hint.
         if not is_single_skill_scaffold and not (
-            is_bundle_scaffold and suffix.startswith(_CRON_EXECUTION_PREFIX)
+            is_bundle_scaffold
+            and 0 <= content.rfind(_BUNDLE_FIRST_SKILL_BLOCK) < boundary_index
+            and suffix.startswith(_CRON_EXECUTION_PREFIX)
         ):
             return None
     else:

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -53,10 +53,6 @@ _RUNTIME_NOTE = "\n\n[Runtime note:"
 _BUNDLE_MARKER = " skill bundle,"
 _BUNDLE_USER_INSTRUCTION = "\nUser instruction: "
 _BUNDLE_FIRST_SKILL_BLOCK = "\n\n[Loaded as part of the "
-_CRON_SKIPPED_SKILLS_PREFIX = (
-    "[IMPORTANT: The following skill(s) were listed for this job but could not be found "
-)
-_CRON_EXECUTION_PREFIX = "[IMPORTANT: You are running as a scheduled cron job. "
 
 # The skill name sits in the first quoted span of the activation note, for both
 # the single-skill and the bundle header ("work" / "/clean /work").
@@ -72,6 +68,90 @@ SKILL_SCAFFOLD_SQL_LIKE = _SKILL_INVOCATION_PREFIX + "%"
 # the joint (a bundle instruction cut off by the head window); callers cut the
 # description there rather than show the skill body on the far side.
 SKILL_EXCERPT_JOINT = "\x1e"
+
+# Message-local sidecar (#81867): builders declare the exact stable/volatile
+# byte boundary at construction time. The cache planner reads this key (or the
+# matching attribute on a ``_CacheBoundedStr`` content value) to mark only the
+# scaffold. Underscore-prefixed so transports strip it before the provider
+# wire — same convention as other Hermes-internal message sidecars.
+CACHE_STABLE_PREFIX_LEN_KEY = "_cache_stable_prefix_len"
+
+
+class _CacheBoundedStr(str):
+    """str subclass carrying a builder-declared Anthropic cache boundary.
+
+    Plain ``str`` is a deepcopy atomic, but subclasses go through
+    ``__newobj__`` — so ``__getnewargs__`` must round-trip the boundary.
+    Structural send-path clones share immutable string leaves and therefore
+    keep the same object. JSON / SessionDB serialization collapses to a plain
+    ``str``, after which the message falls back to whole-block caching —
+    never worse than main.
+    """
+
+    __slots__ = (CACHE_STABLE_PREFIX_LEN_KEY,)
+
+    def __new__(cls, value: str, cache_stable_prefix_len: int):
+        obj = str.__new__(cls, value)
+        object.__setattr__(obj, CACHE_STABLE_PREFIX_LEN_KEY, cache_stable_prefix_len)
+        return obj
+
+    def __getnewargs__(self):
+        return (str.__str__(self), getattr(self, CACHE_STABLE_PREFIX_LEN_KEY))
+
+
+def get_cache_stable_prefix_len(content: Any) -> Optional[int]:
+    """Return a builder-declared stable-prefix length, or ``None``."""
+    length = getattr(content, CACHE_STABLE_PREFIX_LEN_KEY, None)
+    if isinstance(length, int) and length > 0:
+        return length
+    return None
+
+
+def with_cache_stable_prefix(content: str, prefix_len: Optional[int]) -> str:
+    """Attach a proper-prefix cache boundary to ``content`` when valid."""
+    if (
+        isinstance(content, str)
+        and isinstance(prefix_len, int)
+        and 0 < prefix_len < len(content)
+    ):
+        return _CacheBoundedStr(content, prefix_len)
+    return content
+
+
+def annotate_cache_stable_prefix(message: dict, prefix_len: Optional[int] = None) -> dict:
+    """Lift a builder-declared boundary onto a message dict (in place).
+
+    Resolution order for the boundary length:
+    1. Explicit ``prefix_len`` argument
+    2. ``_CacheBoundedStr`` attribute on ``content``
+    3. Existing message-local ``_cache_stable_prefix_len`` sidecar
+
+    (3) matters on the send path: memory/plugin injection may replace
+    ``content`` with a longer plain ``str`` via ``api_content`` while leaving
+    the dict key intact. Dropping a still-valid sidecar there would silently
+    revert to whole-block caching (#81867).
+
+    Invalid / missing boundaries leave the message unmarked so the ordinary
+    one-block cache policy applies.
+    """
+    if not isinstance(message, dict):
+        return message
+    content = message.get("content")
+    if prefix_len is None:
+        prefix_len = get_cache_stable_prefix_len(content)
+    if prefix_len is None:
+        existing = message.get(CACHE_STABLE_PREFIX_LEN_KEY)
+        if isinstance(existing, int):
+            prefix_len = existing
+    if (
+        isinstance(content, str)
+        and isinstance(prefix_len, int)
+        and 0 < prefix_len < len(content)
+    ):
+        message[CACHE_STABLE_PREFIX_LEN_KEY] = prefix_len
+    else:
+        message.pop(CACHE_STABLE_PREFIX_LEN_KEY, None)
+    return message
 
 
 def extract_user_instruction_from_skill_message(content: Any) -> Optional[str]:
@@ -99,68 +179,6 @@ def extract_user_instruction_from_skill_message(content: Any) -> Optional[str]:
         return _extract_single_skill_user_instruction(content)
 
     return None
-
-
-def split_skill_message_for_cache(content: Any) -> Optional[tuple[str, str]]:
-    """Split stable single-skill scaffolding from its volatile invocation tail.
-
-    The returned boundary is used only while decorating an outgoing provider
-    request. The canonical conversation message remains a string, preserving
-    persistence, transcript rendering, and memory-provider behavior.
-
-    Cron's one-or-more-skill prompt uses the same activation and instruction
-    markers as the slash-skill builder, so it gets the same boundary without
-    changing its canonical text. Ordinary bundle messages are excluded because
-    their user instruction precedes the loaded skill blocks; cron's bundle
-    wrapper is the exception because it appends its own instruction after all
-    stable blocks.
-    """
-    if not isinstance(content, str):
-        return None
-
-    activation_index = content.find(_SKILL_INVOCATION_PREFIX)
-    starts_with_single_skill = activation_index == 0
-    starts_with_cron_skip_notice = (
-        content.startswith(_CRON_SKIPPED_SKILLS_PREFIX)
-        and activation_index > 0
-    )
-    if not starts_with_single_skill and not starts_with_cron_skip_notice:
-        return None
-
-    activation_end = content.find("\n\n", activation_index)
-    if activation_end < 0:
-        activation_end = len(content)
-    activation_note = content[activation_index:activation_end]
-    is_single_skill_scaffold = _SINGLE_SKILL_MARKER in activation_note
-    is_bundle_scaffold = _BUNDLE_MARKER in activation_note
-
-    instruction_boundary = f"\n\n{_SINGLE_SKILL_INSTRUCTION}"
-    boundary_index = content.rfind(instruction_boundary)
-    if boundary_index >= 0:
-        split_index = boundary_index + len(instruction_boundary)
-        suffix = content[split_index:]
-        # A normal bundle keeps its instruction before the skill blocks and
-        # must retain the ordinary one-block cache policy. Cron is the one
-        # bundle caller that appends a second, outer instruction after all
-        # stable blocks; its suffix always begins with the execution hint.
-        if not is_single_skill_scaffold and not (
-            is_bundle_scaffold
-            and 0 <= content.rfind(_BUNDLE_FIRST_SKILL_BLOCK) < boundary_index
-            and suffix.startswith(_CRON_EXECUTION_PREFIX)
-        ):
-            return None
-    else:
-        if not is_single_skill_scaffold:
-            return None
-        boundary_index = content.rfind(_RUNTIME_NOTE)
-        if boundary_index < 0:
-            return None
-        split_index = boundary_index + len(_RUNTIME_NOTE)
-
-    prefix, suffix = content[:split_index], content[split_index:]
-    if not prefix or not suffix:
-        return None
-    return prefix, suffix
 
 
 def describe_skill_invocation(content: Any, separator: str = " — ") -> Optional[str]:
@@ -426,15 +444,23 @@ def _build_skill_message(
             f"(e.g. `node {skill_dir}/scripts/foo.js`)."
         )
 
+    stable_prefix = None
     if user_instruction:
         parts.append("")
-        parts.append(f"The user has provided the following instruction alongside the skill invocation: {user_instruction}")
+        # Everything through the static instruction prose is a stable scaffold;
+        # the caller-supplied instruction (webhook payload, ticket IDs,
+        # timestamps) and any runtime note ride in the volatile tail (#81867).
+        stable_prefix = "\n".join(parts) + "\n" + _SINGLE_SKILL_INSTRUCTION
+        parts.append(f"{_SINGLE_SKILL_INSTRUCTION}{user_instruction}")
 
     if runtime_note:
         parts.append("")
         parts.append(f"[Runtime note: {runtime_note}]")
 
-    return "\n".join(parts)
+    message = "\n".join(parts)
+    if stable_prefix is not None:
+        return with_cache_stable_prefix(message, len(stable_prefix))
+    return message
 
 
 def scan_skill_commands() -> Dict[str, Dict[str, Any]]:

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -109,15 +109,31 @@ def substitute_api_content(api_msg: Dict[str, Any]) -> Optional[str]:
 
 
 def drop_stale_api_content(msg: Dict[str, Any]) -> None:
-    """Drop the ``api_content`` sidecar from a message whose content was rewritten.
+    """Drop request-local sidecars from a message whose content was rewritten.
 
     Called from every content-rewrite path (historical image strip,
     merge-summary-into-tail, consecutive-user repair merge, stale-confirmation
-    redaction). Replaying the pre-rewrite sidecar would resend exactly what
-    the rewrite removed, so it must be dropped — the cost is one cache
-    boundary miss, never wrong content.
+    redaction). Replaying the pre-rewrite ``api_content`` sidecar would
+    resend exactly what the rewrite removed, so it must be dropped — the
+    cost is one cache boundary miss, never wrong content.
+
+    The builder-declared skill-cache boundary (#81867) is cleared for the
+    same reason: a prepend/replace rewrite invalidates the old offset, and
+    keeping ``_cache_stable_prefix_len`` would place ``cache_control`` on
+    the wrong cut. Falls back to whole-message caching.
     """
+    from agent.skill_commands import (
+        CACHE_STABLE_PREFIX_LEN_KEY,
+        get_cache_stable_prefix_len,
+    )
+
     msg.pop("api_content", None)
+    msg.pop(CACHE_STABLE_PREFIX_LEN_KEY, None)
+    content = msg.get("content")
+    # Collapse ``_CacheBoundedStr`` so a stale attribute cannot re-annotate
+    # after the dict sidecar was cleared.
+    if get_cache_stable_prefix_len(content) is not None:
+        msg["content"] = str(content)
 
 
 def extract_api_content_sidecar(msg: Mapping[str, Any]) -> Optional[str]:
@@ -439,9 +455,20 @@ def build_turn_context(
     except Exception:
         logger.debug("between-turns MCP tool refresh skipped", exc_info=True)
 
-    # Sanitize surrogate characters from user input.
+    # Sanitize surrogate characters from user input. Preserve a builder-declared
+    # cache boundary (#81867) across the rewrite — ``sanitize_surrogates`` returns
+    # a plain ``str`` when it replaces lone surrogates.
+    from agent.skill_commands import (
+        annotate_cache_stable_prefix,
+        get_cache_stable_prefix_len,
+        with_cache_stable_prefix,
+    )
+
+    _user_cache_boundary = get_cache_stable_prefix_len(user_message)
     if isinstance(user_message, str):
         user_message = sanitize_surrogates(user_message)
+        if _user_cache_boundary is not None:
+            user_message = with_cache_stable_prefix(user_message, _user_cache_boundary)
     if isinstance(persist_user_message, str):
         persist_user_message = sanitize_surrogates(persist_user_message)
 
@@ -541,6 +568,10 @@ def build_turn_context(
         user_msg = {"role": "user", "content": user_message}
         if isinstance(pending_cli_message, dict):
             agent._pending_cli_user_message = None
+
+    # Lift the builder-declared cache boundary onto the message dict so it
+    # survives later content rewrites (sanitize, api_content stamp, etc.).
+    annotate_cache_stable_prefix(user_msg)
 
     # Hydrate todo store from conversation history.
     if conversation_history and not agent._todo_store.has_items():

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2813,9 +2813,31 @@ def _build_job_prompt(
         )
         parts.insert(0, notice)
 
+    stable_prefix = None
     if prompt:
-        parts.extend(["", f"The user has provided the following instruction alongside the skill invocation: {prompt}"])
-    return _scan_assembled_cron_prompt("\n".join(parts), job, has_skills=True)
+        from agent.skill_commands import (
+            _SINGLE_SKILL_INSTRUCTION,
+            with_cache_stable_prefix,
+        )
+
+        parts.append("")
+        # Skill blocks (and any skipped-skill notice) above are stable per job
+        # config; the appended instruction carries the volatile per-run data
+        # (cron hint + prompt + script output + run context). Declare that
+        # boundary for the Anthropic cache planner (#81867).
+        stable_prefix = "\n".join(parts) + "\n" + _SINGLE_SKILL_INSTRUCTION
+        parts.append(f"{_SINGLE_SKILL_INSTRUCTION}{prompt}")
+    assembled = _scan_assembled_cron_prompt("\n".join(parts), job, has_skills=True)
+    if (
+        stable_prefix
+        and len(assembled) > len(stable_prefix)
+        and assembled.startswith(stable_prefix)
+    ):
+        # Guarded because the injection scanner may sanitize (mutate) the
+        # assembled bytes; a mismatch simply falls back to whole-message
+        # caching.
+        return with_cache_stable_prefix(assembled, len(stable_prefix))
+    return assembled
 
 
 def _scan_assembled_cron_prompt(

--- a/tests/agent/test_prompt_caching.py
+++ b/tests/agent/test_prompt_caching.py
@@ -15,6 +15,16 @@ from agent.prompt_caching import (
 MARKER = {"type": "ephemeral"}
 
 
+def _skill_invocation(instruction: str) -> str:
+    return (
+        '[IMPORTANT: The user has invoked the "airtable" skill, indicating they want '
+        "you to follow its instructions. The full skill content is loaded below.]\n\n"
+        "# Airtable\n\nA stable skill body.\n\n"
+        "The user has provided the following instruction alongside the skill invocation: "
+        f"{instruction}"
+    )
+
+
 def _native_marker_indexes(messages):
     return {
         index
@@ -192,6 +202,20 @@ class TestApplyCacheMarker:
         assert msg["content"][0]["type"] == "text"
         assert msg["content"][0]["text"] == "Hello"
         assert msg["content"][0]["cache_control"] == MARKER
+
+    def test_skill_invocation_marks_only_the_stable_scaffold_prefix(self):
+        first = {"role": "user", "content": _skill_invocation("ticket=A/time=1")}
+        second = {"role": "user", "content": _skill_invocation("ticket=B/time=2")}
+
+        _apply_cache_marker(first, MARKER)
+        _apply_cache_marker(second, MARKER)
+
+        assert len(first["content"]) == len(second["content"]) == 2
+        assert first["content"][0] == second["content"][0]
+        assert first["content"][0]["cache_control"] == MARKER
+        assert "cache_control" not in first["content"][1]
+        assert first["content"][1]["text"] == "ticket=A/time=1"
+        assert second["content"][1]["text"] == "ticket=B/time=2"
 
 
 
@@ -463,6 +487,32 @@ class TestStripAnthropicCacheControl:
         assert isinstance(content, list) and len(content) == 2
         assert content[0] == {"type": "text", "text": "see"}
         assert content[1]["type"] == "image_url"
+
+    def test_skill_prefix_split_round_trips_and_redecorates_identically(self):
+        import copy
+
+        original = [
+            {"role": "system", "content": "stable system\nvolatile session"},
+            {"role": "user", "content": _skill_invocation("ticket=A/time=1")},
+        ]
+        first_plan = build_prompt_cache_plan(
+            original,
+            tools=None,
+            native_anthropic=True,
+            static_system_prefix="stable system",
+        )
+        first_wire = copy.deepcopy(first_plan.messages)
+
+        stripped = strip_anthropic_cache_control(first_plan.messages)
+        assert stripped == original
+
+        second_plan = build_prompt_cache_plan(
+            stripped,
+            tools=None,
+            native_anthropic=True,
+            static_system_prefix="stable system",
+        )
+        assert second_plan.messages == first_wire
 
 
 

--- a/tests/agent/test_prompt_caching.py
+++ b/tests/agent/test_prompt_caching.py
@@ -10,18 +10,31 @@ from agent.prompt_caching import (
     strip_anthropic_cache_control,
     strip_anthropic_tool_cache_control,
 )
+from agent.skill_commands import (
+    CACHE_STABLE_PREFIX_LEN_KEY,
+    _SINGLE_SKILL_INSTRUCTION,
+    annotate_cache_stable_prefix,
+    with_cache_stable_prefix,
+)
 
 
 MARKER = {"type": "ephemeral"}
 
 
 def _skill_invocation(instruction: str) -> str:
-    return (
+    """Webhook-style skill turn with a builder-declared cache boundary."""
+    stable = (
         '[IMPORTANT: The user has invoked the "airtable" skill, indicating they want '
         "you to follow its instructions. The full skill content is loaded below.]\n\n"
         "# Airtable\n\nA stable skill body.\n\n"
-        "The user has provided the following instruction alongside the skill invocation: "
-        f"{instruction}"
+        f"{_SINGLE_SKILL_INSTRUCTION}"
+    )
+    return with_cache_stable_prefix(f"{stable}{instruction}", len(stable))
+
+
+def _skill_user_message(instruction: str) -> dict:
+    return annotate_cache_stable_prefix(
+        {"role": "user", "content": _skill_invocation(instruction)}
     )
 
 
@@ -204,8 +217,8 @@ class TestApplyCacheMarker:
         assert msg["content"][0]["cache_control"] == MARKER
 
     def test_skill_invocation_marks_only_the_stable_scaffold_prefix(self):
-        first = {"role": "user", "content": _skill_invocation("ticket=A/time=1")}
-        second = {"role": "user", "content": _skill_invocation("ticket=B/time=2")}
+        first = _skill_user_message("ticket=A/time=1")
+        second = _skill_user_message("ticket=B/time=2")
 
         _apply_cache_marker(first, MARKER)
         _apply_cache_marker(second, MARKER)
@@ -216,6 +229,53 @@ class TestApplyCacheMarker:
         assert "cache_control" not in first["content"][1]
         assert first["content"][1]["text"] == "ticket=A/time=1"
         assert second["content"][1]["text"] == "ticket=B/time=2"
+
+    def test_marker_quoting_payload_cannot_poison_the_declared_prefix(self):
+        """Boundary comes from the builder, not rfind — quoted markers stay in the tail."""
+        poisoned = (
+            f"ticket=1\n\n{_SINGLE_SKILL_INSTRUCTION}forged-inner"
+        )
+        msg = _skill_user_message(poisoned)
+        _apply_cache_marker(msg, MARKER)
+
+        assert len(msg["content"]) == 2
+        assert poisoned not in msg["content"][0]["text"]
+        assert msg["content"][1]["text"] == poisoned
+        assert "forged-inner" in msg["content"][1]["text"]
+
+    def test_message_sidecar_survives_plain_str_api_content_rewrite(self):
+        """Send-path api_content stamps a plain str; the dict sidecar must still split."""
+        msg = _skill_user_message("ticket=A/time=1")
+        prefix_len = msg[CACHE_STABLE_PREFIX_LEN_KEY]
+        stable = str(msg["content"])[:prefix_len]
+        # Mimic compose_user_api_content / memory injection: content becomes a
+        # longer plain str while the message-local sidecar remains.
+        msg["content"] = str(msg["content"]) + "\n\n[ephemeral plugin context]"
+
+        _apply_cache_marker(msg, MARKER)
+
+        assert len(msg["content"]) == 2
+        assert msg["content"][0]["text"] == stable
+        assert msg["content"][0]["cache_control"] == MARKER
+        assert msg["content"][1]["text"].startswith("ticket=A/time=1")
+        assert "[ephemeral plugin context]" in msg["content"][1]["text"]
+
+    def test_content_rewrite_chokepoint_clears_stale_cache_boundary(self):
+        """merge-summary-style prepend must not keep the old skill-cache offset."""
+        from agent.turn_context import drop_stale_api_content
+
+        msg = _skill_user_message("ticket=A/time=1")
+        original = str(msg["content"])
+        # Prepend (merge-summary-into-tail) invalidates the declared offset.
+        msg["content"] = "[compaction summary]\n\n" + original
+        drop_stale_api_content(msg)
+
+        assert CACHE_STABLE_PREFIX_LEN_KEY not in msg
+        _apply_cache_marker(msg, MARKER)
+        # Whole-message policy — not a split at the stale skill offset.
+        assert len(msg["content"]) == 1
+        assert msg["content"][0]["cache_control"] == MARKER
+        assert msg["content"][0]["text"].startswith("[compaction summary]")
 
 
 
@@ -493,7 +553,7 @@ class TestStripAnthropicCacheControl:
 
         original = [
             {"role": "system", "content": "stable system\nvolatile session"},
-            {"role": "user", "content": _skill_invocation("ticket=A/time=1")},
+            _skill_user_message("ticket=A/time=1"),
         ]
         first_plan = build_prompt_cache_plan(
             original,
@@ -504,7 +564,10 @@ class TestStripAnthropicCacheControl:
         first_wire = copy.deepcopy(first_plan.messages)
 
         stripped = strip_anthropic_cache_control(first_plan.messages)
-        assert stripped == original
+        assert stripped[0] == original[0]
+        assert stripped[1]["role"] == "user"
+        assert str(stripped[1]["content"]) == str(original[1]["content"])
+        assert stripped[1][CACHE_STABLE_PREFIX_LEN_KEY] == original[1][CACHE_STABLE_PREFIX_LEN_KEY]
 
         second_plan = build_prompt_cache_plan(
             stripped,

--- a/tests/agent/test_skill_invocation_description.py
+++ b/tests/agent/test_skill_invocation_description.py
@@ -89,6 +89,22 @@ class TestDescribeSkillInvocation:
         assert first_split[1] == "ticket=A/time=1"
         assert second_split[1] == "ticket=B/time=2"
 
+    def test_ordinary_bundle_keeps_one_block_when_body_quotes_single_skill_markers(self, skills):
+        skill_md = skills / "work" / "SKILL.md"
+        skill_md.write_text(
+            skill_md.read_text()
+            + "\nThe full skill content is loaded below.]\n\n"
+            + "The user has provided the following instruction alongside the skill invocation: quoted\n"
+        )
+
+        result = skill_bundles.build_bundle_invocation_message(
+            "/demo", user_instruction="real bundle instruction"
+        )
+
+        assert result is not None
+        message, _, _ = result
+        assert split_skill_message_for_cache(message) is None
+
 
 
 

--- a/tests/agent/test_skill_invocation_description.py
+++ b/tests/agent/test_skill_invocation_description.py
@@ -19,6 +19,7 @@ from agent.skill_commands import (
     SKILL_EXCERPT_JOINT,
     SKILL_SCAFFOLD_SQL_LIKE,
     describe_skill_invocation,
+    split_skill_message_for_cache,
 )
 
 SKILL_BODY = "Kick off a task in a fresh isolated git worktree instead of the current checkout."
@@ -71,6 +72,22 @@ class TestDescribeSkillInvocation:
             "/work", user_instruction="fix the title leak"
         )
         assert describe_skill_invocation(message) == "/work — fix the title leak"
+
+    def test_builder_exposes_a_stable_cache_prefix_before_the_instruction(self, skills):
+        first = skill_commands.build_skill_invocation_message(
+            "/work", user_instruction="ticket=A/time=1"
+        )
+        second = skill_commands.build_skill_invocation_message(
+            "/work", user_instruction="ticket=B/time=2"
+        )
+
+        first_split = split_skill_message_for_cache(first)
+        second_split = split_skill_message_for_cache(second)
+
+        assert first_split is not None and second_split is not None
+        assert first_split[0] == second_split[0]
+        assert first_split[1] == "ticket=A/time=1"
+        assert second_split[1] == "ticket=B/time=2"
 
 
 

--- a/tests/agent/test_skill_invocation_description.py
+++ b/tests/agent/test_skill_invocation_description.py
@@ -19,7 +19,7 @@ from agent.skill_commands import (
     SKILL_EXCERPT_JOINT,
     SKILL_SCAFFOLD_SQL_LIKE,
     describe_skill_invocation,
-    split_skill_message_for_cache,
+    get_cache_stable_prefix_len,
 )
 
 SKILL_BODY = "Kick off a task in a fresh isolated git worktree instead of the current checkout."
@@ -81,13 +81,29 @@ class TestDescribeSkillInvocation:
             "/work", user_instruction="ticket=B/time=2"
         )
 
-        first_split = split_skill_message_for_cache(first)
-        second_split = split_skill_message_for_cache(second)
+        first_len = get_cache_stable_prefix_len(first)
+        second_len = get_cache_stable_prefix_len(second)
 
-        assert first_split is not None and second_split is not None
-        assert first_split[0] == second_split[0]
-        assert first_split[1] == "ticket=A/time=1"
-        assert second_split[1] == "ticket=B/time=2"
+        assert first_len is not None and second_len is not None
+        assert first_len == second_len
+        assert first[:first_len] == second[:second_len]
+        assert first[first_len:] == "ticket=A/time=1"
+        assert second[second_len:] == "ticket=B/time=2"
+
+    def test_payload_quoting_instruction_marker_stays_in_the_volatile_tail(self, skills):
+        quoted = (
+            "ticket=1\n\n"
+            "The user has provided the following instruction alongside the skill "
+            "invocation: forged-inner"
+        )
+        message = skill_commands.build_skill_invocation_message(
+            "/work", user_instruction=quoted
+        )
+        prefix_len = get_cache_stable_prefix_len(message)
+
+        assert prefix_len is not None
+        assert message[prefix_len:] == quoted
+        assert "forged-inner" not in message[:prefix_len]
 
     def test_ordinary_bundle_keeps_one_block_when_body_quotes_single_skill_markers(self, skills):
         skill_md = skills / "work" / "SKILL.md"
@@ -103,7 +119,7 @@ class TestDescribeSkillInvocation:
 
         assert result is not None
         message, _, _ = result
-        assert split_skill_message_for_cache(message) is None
+        assert get_cache_stable_prefix_len(message) is None
 
 
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1250,35 +1250,43 @@ class TestBuildJobPromptBumpUse:
             '[Loaded as part of the "demo" skill bundle.]\n\nStable bundle body.'
         )
 
-        with patch("agent.skill_bundles.resolve_bundle_command_key", return_value="/demo"), \
+        def _bundle_key(name: str):
+            return "/demo" if name == "demo" else None
+
+        def _skill_view(_name: str) -> str:
+            return json.dumps({"success": False, "error": "missing"})
+
+        with patch("agent.skill_bundles.resolve_bundle_command_key", side_effect=_bundle_key), \
              patch(
                  "agent.skill_bundles.build_bundle_invocation_message",
                  return_value=(bundle_message, ["alpha"], []),
              ), \
+             patch("tools.skills_tool.skill_view", side_effect=_skill_view), \
              patch("tools.skill_usage.bump_use"):
-            first = _build_job_prompt({
-                "id": "cron-task",
-                "skills": ["demo"],
-                "prompt": "ticket=A/time=1",
-            })
-            second = _build_job_prompt({
-                "id": "cron-task",
-                "skills": ["demo"],
-                "prompt": "ticket=B/time=2",
-            })
+            for configured_skills in (["demo"], ["missing", "demo"]):
+                first = _build_job_prompt({
+                    "id": "cron-task",
+                    "skills": configured_skills,
+                    "prompt": "ticket=A/time=1",
+                })
+                second = _build_job_prompt({
+                    "id": "cron-task",
+                    "skills": configured_skills,
+                    "prompt": "ticket=B/time=2",
+                })
 
-        first_wire = apply_anthropic_cache_control(
-            [{"role": "user", "content": first}], native_anthropic=True
-        )[0]["content"]
-        second_wire = apply_anthropic_cache_control(
-            [{"role": "user", "content": second}], native_anthropic=True
-        )[0]["content"]
+                first_wire = apply_anthropic_cache_control(
+                    [{"role": "user", "content": first}], native_anthropic=True
+                )[0]["content"]
+                second_wire = apply_anthropic_cache_control(
+                    [{"role": "user", "content": second}], native_anthropic=True
+                )[0]["content"]
 
-        assert first_wire[0] == second_wire[0]
-        assert first_wire[0]["cache_control"] == {"type": "ephemeral"}
-        assert "cache_control" not in first_wire[1]
-        assert first_wire[1]["text"].endswith("ticket=A/time=1")
-        assert second_wire[1]["text"].endswith("ticket=B/time=2")
+                assert first_wire[0] == second_wire[0]
+                assert first_wire[0]["cache_control"] == {"type": "ephemeral"}
+                assert "cache_control" not in first_wire[1]
+                assert first_wire[1]["text"].endswith("ticket=A/time=1")
+                assert second_wire[1]["text"].endswith("ticket=B/time=2")
 
     def test_missing_skill_notice_remains_in_the_cacheable_prefix(self):
         from agent.prompt_caching import apply_anthropic_cache_control

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1207,6 +1207,39 @@ class TestBuildJobPromptBumpUse:
             for call in mock_bump.call_args_list
         )
 
+    def test_skill_prompt_keeps_run_data_outside_the_cacheable_prefix(self):
+        from agent.prompt_caching import apply_anthropic_cache_control
+
+        def _skill_view(name: str) -> str:
+            return json.dumps({"success": True, "content": f"Stable content for {name}."})
+
+        with patch("tools.skills_tool.skill_view", side_effect=_skill_view), \
+             patch("tools.skill_usage.bump_use"):
+            first = _build_job_prompt({
+                "id": "cron-task",
+                "skills": ["alpha", "beta"],
+                "prompt": "ticket=A/time=1",
+            })
+            second = _build_job_prompt({
+                "id": "cron-task",
+                "skills": ["alpha", "beta"],
+                "prompt": "ticket=B/time=2",
+            })
+
+        first_wire = apply_anthropic_cache_control(
+            [{"role": "user", "content": first}],
+            native_anthropic=True,
+        )[0]["content"]
+        second_wire = apply_anthropic_cache_control(
+            [{"role": "user", "content": second}],
+            native_anthropic=True,
+        )[0]["content"]
+
+        assert first_wire[0] == second_wire[0]
+        assert first_wire[0]["cache_control"] == {"type": "ephemeral"}
+        assert first_wire[1]["text"].endswith("ticket=A/time=1")
+        assert second_wire[1]["text"].endswith("ticket=B/time=2")
+
 
 class TestSendMediaViaAdapter:
     """Unit tests for _send_media_via_adapter — routes files to typed adapter methods."""

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1240,6 +1240,82 @@ class TestBuildJobPromptBumpUse:
         assert first_wire[1]["text"].endswith("ticket=A/time=1")
         assert second_wire[1]["text"].endswith("ticket=B/time=2")
 
+    def test_bundle_only_prompt_keeps_run_data_outside_the_cacheable_prefix(self):
+        from agent.prompt_caching import apply_anthropic_cache_control
+
+        bundle_message = (
+            '[IMPORTANT: The user has invoked the "demo" skill bundle, loading 1 skills '
+            "together. Treat every skill below as active guidance for this turn.]\n\n"
+            "Bundle: demo\nSkills loaded: alpha\n\n"
+            '[Loaded as part of the "demo" skill bundle.]\n\nStable bundle body.'
+        )
+
+        with patch("agent.skill_bundles.resolve_bundle_command_key", return_value="/demo"), \
+             patch(
+                 "agent.skill_bundles.build_bundle_invocation_message",
+                 return_value=(bundle_message, ["alpha"], []),
+             ), \
+             patch("tools.skill_usage.bump_use"):
+            first = _build_job_prompt({
+                "id": "cron-task",
+                "skills": ["demo"],
+                "prompt": "ticket=A/time=1",
+            })
+            second = _build_job_prompt({
+                "id": "cron-task",
+                "skills": ["demo"],
+                "prompt": "ticket=B/time=2",
+            })
+
+        first_wire = apply_anthropic_cache_control(
+            [{"role": "user", "content": first}], native_anthropic=True
+        )[0]["content"]
+        second_wire = apply_anthropic_cache_control(
+            [{"role": "user", "content": second}], native_anthropic=True
+        )[0]["content"]
+
+        assert first_wire[0] == second_wire[0]
+        assert first_wire[0]["cache_control"] == {"type": "ephemeral"}
+        assert "cache_control" not in first_wire[1]
+        assert first_wire[1]["text"].endswith("ticket=A/time=1")
+        assert second_wire[1]["text"].endswith("ticket=B/time=2")
+
+    def test_missing_skill_notice_remains_in_the_cacheable_prefix(self):
+        from agent.prompt_caching import apply_anthropic_cache_control
+
+        def _skill_view(name: str) -> str:
+            if name == "missing":
+                return json.dumps({"success": False, "error": "missing"})
+            return json.dumps({"success": True, "content": "Stable alpha body."})
+
+        with patch("agent.skill_bundles.resolve_bundle_command_key", return_value=None), \
+             patch("tools.skills_tool.skill_view", side_effect=_skill_view), \
+             patch("tools.skill_usage.bump_use"):
+            first = _build_job_prompt({
+                "id": "cron-task",
+                "skills": ["missing", "alpha"],
+                "prompt": "ticket=A/time=1",
+            })
+            second = _build_job_prompt({
+                "id": "cron-task",
+                "skills": ["missing", "alpha"],
+                "prompt": "ticket=B/time=2",
+            })
+
+        first_wire = apply_anthropic_cache_control(
+            [{"role": "user", "content": first}], native_anthropic=True
+        )[0]["content"]
+        second_wire = apply_anthropic_cache_control(
+            [{"role": "user", "content": second}], native_anthropic=True
+        )[0]["content"]
+
+        assert first_wire[0] == second_wire[0]
+        assert first_wire[0]["cache_control"] == {"type": "ephemeral"}
+        assert "missing" in first_wire[0]["text"]
+        assert "cache_control" not in first_wire[1]
+        assert first_wire[1]["text"].endswith("ticket=A/time=1")
+        assert second_wire[1]["text"].endswith("ticket=B/time=2")
+
 
 class TestSendMediaViaAdapter:
     """Unit tests for _send_media_via_adapter — routes files to typed adapter methods."""

--- a/tests/run_agent/test_unicode_ascii_codec.py
+++ b/tests/run_agent/test_unicode_ascii_codec.py
@@ -35,6 +35,56 @@ class TestSanitizeMessagesNonAscii:
         assert _sanitize_messages_non_ascii(messages) is False
         assert messages[0]["content"] == "hello"
 
+    def test_rebases_cache_boundary_after_stripping_stable_prefix(self):
+        from agent.prompt_caching import _apply_cache_marker
+        from agent.skill_commands import (
+            CACHE_STABLE_PREFIX_LEN_KEY,
+            annotate_cache_stable_prefix,
+            with_cache_stable_prefix,
+        )
+
+        stable = "stable café\n"
+        ticket = "ticket=A/time=1"
+        message = annotate_cache_stable_prefix({
+            "role": "user",
+            "content": with_cache_stable_prefix(
+                stable + ticket,
+                len(stable),
+            ),
+        })
+
+        assert _sanitize_messages_non_ascii([message]) is True
+        _apply_cache_marker(message, {"type": "ephemeral"})
+
+        assert message[CACHE_STABLE_PREFIX_LEN_KEY] == len("stable caf\n")
+        assert message["content"][0]["text"] == "stable caf\n"
+        assert message["content"][1]["text"] == ticket
+
+    def test_rebases_already_decorated_cache_boundary(self):
+        from agent.prompt_caching import _apply_cache_marker
+        from agent.skill_commands import (
+            CACHE_STABLE_PREFIX_LEN_KEY,
+            annotate_cache_stable_prefix,
+            with_cache_stable_prefix,
+        )
+
+        stable = "stable café\n"
+        ticket = "ticket=A/time=1"
+        message = annotate_cache_stable_prefix({
+            "role": "user",
+            "content": with_cache_stable_prefix(
+                stable + ticket,
+                len(stable),
+            ),
+        })
+        _apply_cache_marker(message, {"type": "ephemeral"})
+
+        assert _sanitize_messages_non_ascii([message]) is True
+
+        assert message[CACHE_STABLE_PREFIX_LEN_KEY] == len("stable caf\n")
+        assert message["content"][0]["text"] == "stable caf\n"
+        assert message["content"][1]["text"] == ticket
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Repeated webhook and cron skill invocations force Anthropic to rewrite the entire expanded skill message when only the per-run ticket, timestamp, or instruction changes. This change keeps the canonical conversation string byte-identical while request-locally marking only a builder-declared stable skill scaffold prefix and leaving the volatile invocation tail unmarked.

Builders attach the exact stable/volatile boundary at construction time via a message-local `_cache_stable_prefix_len` sidecar (also carried on a `_CacheBoundedStr` content value through the Event.text -> run_conversation path). The cache planner splits on that declared length; it does not re-parse instruction marker strings with `rfind`, so a helpdesk payload that quotes the marker cannot poison the cached prefix.

### Symptom

Two skill-triggered turns within the cache TTL can contain the same large skill body and differ only in a short invocation-specific tail, yet each Anthropic request marks the whole user message as one cache block. The second request therefore cannot reuse the stable skill prefix at an internal cache breakpoint.

### Impact

Webhook and scheduled jobs that repeatedly invoke large skills incur avoidable cache writes for stable content. The reported production route ran hundreds of times per day and attributed approximately 58% of account spend to these cache writes. This PR makes that stable content reusable without changing stored transcripts, ordinary user messages, or the session system prompt. It does not claim a measured post-merge billing reduction.

### Bug Cause

**Trigger:** `agent/prompt_caching.py::_apply_cache_marker` receives a user string built by `agent/skill_commands.py::_build_skill_message` or the cron skill prompt builder.

**Causal chain:**

1. A webhook or scheduled job combines a stable expanded skill body with a volatile per-invocation instruction.
2. `_apply_cache_marker` wraps that complete user string in one marked text block.
3. The volatile tail becomes part of the cache key, so the next invocation cannot reuse the otherwise identical stable prefix.

**Why it is wrong:** The boundary known at construction time was discarded when parts were joined into one string, and recovering it by searching for instruction markers is unsafe when the volatile payload quotes those markers.

**Working sibling / contrast:** System messages already split a stable prefix from a session-specific suffix via `static_system_prefix`. Ordinary user messages and ordinary bundle invocations (instruction before skill blocks) correctly retain the one-block policy. Cron appends its instruction after all stable blocks and declares the same boundary.

**Ruled out:** This is not TTL expiry or system-prompt mutation. The reported calls were 25 seconds apart, and the real-environment reproduction held the system bytes constant while only the user tail changed.

### Fix

- Builders declare the stable prefix length when appending a user/cron instruction (`_CacheBoundedStr` + `_cache_stable_prefix_len`).
- `turn_context` preserves the boundary across surrogate sanitization, lifts it onto the message dict, and clears it in `drop_stale_api_content` when content is rewritten (merge-summary prepend, etc.).
- `_apply_cache_marker` / cache stripping use the declared length only; failover redecorate keeps the sidecar.
- Message-local sidecar survives send-path `api_content` plain-str rewrites; invalid/missing boundaries fall back to whole-message caching (including SessionDB resume).

## Related Issue

Fixes #81867

## Type of Change

- [x] Bug fix
- [x] Performance improvement
- [x] Tests

## Changes Made

- `agent/skill_commands.py` - builder-declared cache boundary helpers and single-skill scaffold registration.
- `agent/prompt_caching.py` - decorate/strip using the message-local sidecar.
- `agent/turn_context.py` - lift, sanitize-preserve, and drop-stale clearing of the boundary.
- `cron/scheduler.py` - declare the boundary for cron skill prompts (scanner-mutation guarded).
- `tests/agent/test_prompt_caching.py` - stable-prefix reuse, marker-quoting, api_content survival, drop-stale clearing, strip/redecorate.
- `tests/agent/test_skill_invocation_description.py` - real-builder boundary and quoting coverage.
- `tests/cron/test_scheduler.py` - single-skill, multi-skill, bundle-only, missing-skill cron variants.

## How to Test

1. Manual: Build two real webhook-style `/airtable` skill messages with the same installed skill and different ticket/time tails, decorate both for native Anthropic, and verify the first marked blocks are identical, the second blocks are unmarked and distinct, and stripping restores each original string exactly. Repeat with a payload that quotes the instruction marker, and with the cron prompt builder.
2. Automated:

```bash
scripts/run_tests.sh \
  tests/agent/test_prompt_caching.py \
  tests/agent/test_skill_invocation_description.py \
  tests/cron/test_scheduler.py
```

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on relevant tests and all tests pass
- [x] I've added regression tests for the fix
- [x] I've tested on Windows 10
