### PR TITLE
fix(dashboard): retry stalled events feed reconnects

### DIFF
--- a/web/src/components/ChatSidebar.test.tsx
+++ b/web/src/components/ChatSidebar.test.tsx
@@ -3,6 +3,8 @@ import { act, type ReactNode } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { EVENTS_CONNECT_TIMEOUT_MS } from "@/lib/events-reconnect";
+
 const apiMocks = vi.hoisted(() => ({
   buildWsUrl: vi.fn(async () => "ws://localhost/api/events?channel=chat-1"),
   getModelInfo: vi.fn(async () => ({
@@ -113,6 +115,10 @@ async function render(ui: ReactNode) {
 beforeEach(() => {
   FakeWebSocket.instances = [];
   vi.clearAllMocks();
+  apiMocks.buildWsUrl.mockReset();
+  apiMocks.buildWsUrl.mockResolvedValue(
+    "ws://localhost/api/events?channel=chat-1",
+  );
   reloadMocks.maybeReloadForLoopbackWsAuthFailure.mockReturnValue(true);
   vi.stubGlobal("WebSocket", FakeWebSocket);
 });
@@ -180,6 +186,75 @@ describe("ChatSidebar event socket reconnect", () => {
     expect(apiMocks.buildWsUrl).toHaveBeenCalledTimes(2);
   });
 
+  it("keeps retrying when reconnect URL construction fails", async () => {
+    await renderSidebar();
+    apiMocks.buildWsUrl
+      .mockRejectedValueOnce(new Error("ticket endpoint unavailable"))
+      .mockResolvedValue("ws://localhost/api/events?channel=chat-1");
+
+    await act(async () => {
+      FakeWebSocket.instances[0].emit("close", { code: 1006 });
+    });
+
+    await advance(1_000);
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(container.textContent).toContain("reconnecting in 2s");
+
+    await advance(2_000);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    expect(apiMocks.buildWsUrl).toHaveBeenCalledTimes(3);
+  });
+
+  it("times out a stalled URL request and retries", async () => {
+    let resolveStalledRequest!: (url: string) => void;
+    await renderSidebar();
+    apiMocks.buildWsUrl
+      .mockImplementationOnce(
+        () =>
+          new Promise<string>((resolve) => {
+            resolveStalledRequest = resolve;
+          }),
+      )
+      .mockResolvedValue("ws://localhost/api/events?channel=chat-1");
+
+    await act(async () => {
+      FakeWebSocket.instances[0].emit("close", { code: 1006 });
+    });
+
+    await advance(1_000 + EVENTS_CONNECT_TIMEOUT_MS);
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(container.textContent).toContain("reconnecting in 2s");
+
+    // A late ticket response from the timed-out attempt must not create a
+    // superseded socket alongside the scheduled replacement.
+    await act(async () => {
+      resolveStalledRequest("ws://localhost/api/events?channel=stale");
+      await Promise.resolve();
+    });
+    expect(FakeWebSocket.instances).toHaveLength(1);
+
+    await advance(2_000);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    expect(apiMocks.buildWsUrl).toHaveBeenCalledTimes(3);
+  });
+
+  it("times out a stalled WebSocket handshake and retries", async () => {
+    await renderSidebar();
+
+    await act(async () => {
+      FakeWebSocket.instances[0].emit("close", { code: 1006 });
+    });
+    await advance(1_000);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+
+    await advance(EVENTS_CONNECT_TIMEOUT_MS);
+    expect(FakeWebSocket.instances[1].closed).toBe(true);
+    expect(container.textContent).toContain("reconnecting in 2s");
+
+    await advance(2_000);
+    expect(FakeWebSocket.instances).toHaveLength(3);
+  });
+
   it("backs off exponentially across repeated failures", async () => {
     await renderSidebar();
 
@@ -210,7 +285,11 @@ describe("ChatSidebar event socket reconnect", () => {
       FakeWebSocket.instances[0].emit("close", { code: 1006 });
     });
 
-    await advance(30_000);
+    await advance(1_000);
+    await act(async () => {
+      FakeWebSocket.instances[1].emit("open", {});
+    });
+    await advance(29_000);
     expect(FakeWebSocket.instances).toHaveLength(2);
   });
 

--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -36,6 +36,7 @@ import { GatewayClient, type ConnectionState } from "@/lib/gatewayClient";
 import { api, buildWsUrl } from "@/lib/api";
 import { maybeReloadForLoopbackWsAuthFailure } from "@/lib/dashboard-auth-reload";
 import {
+  EVENTS_CONNECT_TIMEOUT_MS,
   EVENTS_DISCONNECTED_MESSAGE,
   EVENTS_MAX_RECONNECT_ATTEMPTS,
   eventsGaveUpMessage,
@@ -256,7 +257,16 @@ export function ChatSidebar({
     let unmounting = false;
     let ws: WebSocket | null = null;
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let connectTimer: ReturnType<typeof setTimeout> | null = null;
+    let connectGeneration = 0;
     let attempt = 0;
+
+    const clearConnectTimer = () => {
+      if (connectTimer) {
+        clearTimeout(connectTimer);
+        connectTimer = null;
+      }
+    };
 
     // The banner is shared with `info.credential_warning` and the JSON-RPC
     // sidecar, and `error` is those messages' only home — the sidecar does
@@ -298,14 +308,49 @@ export function ChatSidebar({
       if (unmounting) {
         return;
       }
-      // Re-minted every attempt: tickets are single-use with a short TTL,
-      // so a reconnect cannot replay the URL from the first connection.
-      const url = await buildWsUrl("/api/events", { channel });
-      if (unmounting) {
+
+      const generation = ++connectGeneration;
+      let socket: WebSocket | null = null;
+
+      // Cover the whole connection attempt, including gated-mode ticket
+      // minting. A failed or hanging pre-socket request otherwise emits no
+      // WebSocket close event and permanently strands the retry loop at its
+      // last "reconnecting in ..." banner.
+      clearConnectTimer();
+      connectTimer = setTimeout(() => {
+        connectTimer = null;
+        if (unmounting || generation !== connectGeneration) {
+          return;
+        }
+
+        // Invalidate any late ticket result or socket event from this attempt
+        // before scheduling its replacement.
+        connectGeneration += 1;
+        if (socket && ws === socket) {
+          ws = null;
+          socket.close();
+        }
+        scheduleReconnect();
+      }, EVENTS_CONNECT_TIMEOUT_MS);
+
+      try {
+        // Re-minted every attempt: tickets are single-use with a short TTL,
+        // so a reconnect cannot replay the URL from the first connection.
+        const url = await buildWsUrl("/api/events", { channel });
+        if (unmounting || generation !== connectGeneration) {
+          return;
+        }
+        socket = new WebSocket(url);
+        ws = socket;
+      } catch {
+        if (unmounting || generation !== connectGeneration) {
+          return;
+        }
+        clearConnectTimer();
+        connectGeneration += 1;
+        scheduleReconnect();
         return;
       }
-      const socket = new WebSocket(url);
-      ws = socket;
 
       // A superseded socket's late close must not schedule a retry on top
       // of the one that replaced it.
@@ -315,6 +360,7 @@ export function ChatSidebar({
         if (!isCurrent()) {
           return;
         }
+        clearConnectTimer();
         attempt = 0;
         clearEventsBanner();
       });
@@ -332,6 +378,7 @@ export function ChatSidebar({
         if (!isCurrent()) {
           return;
         }
+        clearConnectTimer();
         if (maybeReloadForLoopbackWsAuthFailure(ev.code)) {
           return;
         }
@@ -374,6 +421,8 @@ export function ChatSidebar({
 
     return () => {
       unmounting = true;
+      connectGeneration += 1;
+      clearConnectTimer();
       if (reconnectTimer) {
         clearTimeout(reconnectTimer);
         reconnectTimer = null;

--- a/web/src/lib/events-reconnect.ts
+++ b/web/src/lib/events-reconnect.ts
@@ -9,6 +9,8 @@
 export const EVENTS_RECONNECT_BASE_MS = 1_000;
 export const EVENTS_RECONNECT_MAX_MS = 30_000;
 export const EVENTS_MAX_RECONNECT_ATTEMPTS = 15;
+/** Bound ticket minting plus the WebSocket opening handshake. */
+export const EVENTS_CONNECT_TIMEOUT_MS = 15_000;
 
 /** Normal closure — the server said goodbye, don't chase it. */
 const WS_CLOSE_NORMAL = 1000;


### PR DESCRIPTION
## What does this PR do?

Prevents the Dashboard events feed reconnect loop from stalling permanently after it has already displayed `reconnecting in 1s...`.

The existing reconnect path only scheduled another attempt after a WebSocket `close` event. In gated Dashboard mode, every attempt first awaits `buildWsUrl()` to mint a fresh single-use ticket. If that request rejected or never settled, no replacement socket existed to emit `close`, so the retry loop stopped at its previous banner. A WebSocket handshake that emitted neither `open` nor `close` had the same failure mode.

This change gives the complete connection attempt, including ticket minting and the opening handshake, a 15-second deadline. Setup failures and deadline expiry feed back into the existing guarded exponential-backoff scheduler. A generation guard prevents late ticket responses or socket events from creating a superseded connection, and cleanup invalidates the active generation and clears both timers on unmount.

## Related Issue

Discord support report: https://discord.com/channels/1053877538025386074/1535696700121948190

Follow-up to #79524.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `web/src/components/ChatSidebar.tsx`
  - Catch URL/ticket construction failures and reschedule them through the existing reconnect policy.
  - Bound ticket minting plus the WebSocket opening handshake.
  - Invalidate timed-out attempts so late results cannot create competing sockets.
  - Clear the connection deadline on open, close, and unmount.
- `web/src/lib/events-reconnect.ts`
  - Define the events-feed connection-attempt deadline alongside the existing reconnect policy constants.
- `web/src/components/ChatSidebar.test.tsx`
  - Cover rejected URL construction, a stalled URL request with a late result, and a stalled WebSocket handshake.
  - Keep the existing error-plus-close single-scheduler regression explicit under the new handshake deadline.

## How to Test

1. Run `cd web && npx vitest run src/components/ChatSidebar.test.tsx`.
2. Run `cd web && npx tsc -p . --noEmit`.
3. Run `cd web && npx vitest run`.
4. In a gated Dashboard session, interrupt the events-feed ticket request or opening handshake. Confirm the banner advances through backoff attempts instead of remaining at `reconnecting in 1s...` indefinitely.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (not run: this is a web-only TypeScript change; the full Python suite is intentionally left to CI)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no user-facing workflow changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, existing reconnect architecture retained
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — browser timer and WebSocket APIs only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no agent tools changed

## Screenshots / Logs

Validation from the clean worktree:

- Focused `ChatSidebar.test.tsx`: 16 tests passed.
- Full web Vitest suite: 27 files, 194 tests passed.
- Web TypeScript check: clean.
- ESLint on the three changed files: 0 errors and one pre-existing `react-refresh/only-export-components` warning at `ChatSidebar.tsx:104`.
- `git diff --check`: clean.
