### PR TITLE
fix(mcp): make n8n catalog install portable

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -27,16 +27,23 @@ See references/mcp-catalog.md (this repo's skill) for the manifest schema.
 
 from __future__ import annotations
 
+import os
 import re
+import shlex
 import shutil
 import subprocess
+import sys
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any, Dict, List, Optional
 
 import yaml
 
-from hermes_constants import get_hermes_home, get_optional_mcps_dir
+from hermes_constants import (
+    get_hermes_home,
+    get_optional_mcps_dir,
+    venv_python_path,
+)
 from hermes_cli._subprocess_compat import noninteractive_git_env
 from hermes_cli.colors import Colors, color
 from hermes_cli.config import (
@@ -51,6 +58,8 @@ _MANIFEST_VERSION = 1
 
 # Substituted at install time inside `transport.command` / `transport.args`.
 _INSTALL_DIR_VAR = "${INSTALL_DIR}"
+_PYTHON_VAR = "${PYTHON}"
+_VENV_PYTHON_VAR = "${VENV_PYTHON}"
 
 
 # ─── Data classes ────────────────────────────────────────────────────────────
@@ -388,13 +397,78 @@ def _install_root() -> Path:
     return root
 
 
+def _runtime_os_name() -> str:
+    return os.name
+
+
+def _runtime_python_executable() -> str:
+    return sys.executable
+
+
+def _venv_python_path(install_dir: Path, *, os_name: str) -> str:
+    path = venv_python_path(install_dir / ".venv", windows=os_name == "nt")
+    return str(PureWindowsPath(str(path))) if os_name == "nt" else str(path)
+
+
+def _shell_quote(value: str, *, os_name: str) -> str:
+    if os_name == "nt":
+        return subprocess.list2cmdline([value])
+    return shlex.quote(value)
+
+
+def _expand_catalog_vars(
+    value: str,
+    install_dir: Optional[Path],
+    *,
+    for_shell: bool = False,
+    os_name: Optional[str] = None,
+    python_executable: Optional[str] = None,
+) -> str:
+    """Expand trusted catalog path variables for this runtime.
+
+    Bootstrap commands run through a shell and therefore receive quoted
+    substitutions. Transport command/args are persisted as raw argv values.
+    User environment placeholders are deliberately left untouched for the MCP
+    runtime's existing `${ENV_VAR}` expansion.
+    """
+    resolved_os = os_name or _runtime_os_name()
+    needs_install = _INSTALL_DIR_VAR in value or _VENV_PYTHON_VAR in value
+    if needs_install and install_dir is None:
+        variable = (
+            _VENV_PYTHON_VAR if _VENV_PYTHON_VAR in value else _INSTALL_DIR_VAR
+        )
+        raise CatalogError(
+            f"manifest references {variable} but no install block exists"
+        )
+
+    replacements = {
+        _PYTHON_VAR: python_executable or _runtime_python_executable(),
+    }
+    if install_dir is not None:
+        replacements[_INSTALL_DIR_VAR] = str(install_dir)
+        replacements[_VENV_PYTHON_VAR] = _venv_python_path(
+            install_dir, os_name=resolved_os
+        )
+
+    expanded = value
+    for variable, replacement in replacements.items():
+        rendered = (
+            _shell_quote(replacement, os_name=resolved_os)
+            if for_shell
+            else replacement
+        )
+        expanded = expanded.replace(variable, rendered)
+    return expanded
+
+
 def _run_bootstrap(cwd: Path, commands: List[str]) -> None:
     """Execute bootstrap commands in *cwd*. Raise CatalogError on first failure.
 
     Each command runs through the shell (so `&&` etc. work). The output is
     streamed to the user's terminal for visibility.
     """
-    for cmd in commands:
+    for raw_cmd in commands:
+        cmd = _expand_catalog_vars(raw_cmd, cwd, for_shell=True)
         print(color(f"  $ {cmd}", Colors.DIM))
         proc = subprocess.run(cmd, cwd=str(cwd), shell=True)
         if proc.returncode != 0:
@@ -471,13 +545,7 @@ def _do_git_install(entry: CatalogEntry) -> Path:
 
 
 def _expand_install_dir(value: str, install_dir: Optional[Path]) -> str:
-    if _INSTALL_DIR_VAR not in value:
-        return value
-    if install_dir is None:
-        raise CatalogError(
-            f"manifest references {_INSTALL_DIR_VAR} but no install block exists"
-        )
-    return value.replace(_INSTALL_DIR_VAR, str(install_dir))
+    return _expand_catalog_vars(value, install_dir)
 
 
 def _prompt_env_vars(specs: List[EnvVarSpec]) -> Dict[str, str]:

--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -27,16 +27,23 @@ See references/mcp-catalog.md (this repo's skill) for the manifest schema.
 
 from __future__ import annotations
 
+import os
 import re
+import shlex
 import shutil
 import subprocess
+import sys
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any, Dict, List, Optional
 
 import yaml
 
-from hermes_constants import get_hermes_home, get_optional_mcps_dir
+from hermes_constants import (
+    get_hermes_home,
+    get_optional_mcps_dir,
+    venv_python_path,
+)
 from hermes_cli._subprocess_compat import noninteractive_git_env
 from hermes_cli.colors import Colors, color
 from hermes_cli.config import (
@@ -51,6 +58,8 @@ _MANIFEST_VERSION = 1
 
 # Substituted at install time inside `transport.command` / `transport.args`.
 _INSTALL_DIR_VAR = "${INSTALL_DIR}"
+_PYTHON_VAR = "${PYTHON}"
+_VENV_PYTHON_VAR = "${VENV_PYTHON}"
 
 
 # ─── Data classes ────────────────────────────────────────────────────────────
@@ -465,13 +474,78 @@ def _install_root() -> Path:
     return root
 
 
+def _runtime_os_name() -> str:
+    return os.name
+
+
+def _runtime_python_executable() -> str:
+    return sys.executable
+
+
+def _venv_python_path(install_dir: Path, *, os_name: str) -> str:
+    path = venv_python_path(install_dir / ".venv", windows=os_name == "nt")
+    return str(PureWindowsPath(str(path))) if os_name == "nt" else str(path)
+
+
+def _shell_quote(value: str, *, os_name: str) -> str:
+    if os_name == "nt":
+        return subprocess.list2cmdline([value])
+    return shlex.quote(value)
+
+
+def _expand_catalog_vars(
+    value: str,
+    install_dir: Optional[Path],
+    *,
+    for_shell: bool = False,
+    os_name: Optional[str] = None,
+    python_executable: Optional[str] = None,
+) -> str:
+    """Expand trusted catalog path variables for this runtime.
+
+    Bootstrap commands run through a shell and therefore receive quoted
+    substitutions. Transport command/args are persisted as raw argv values.
+    User environment placeholders are deliberately left untouched for the MCP
+    runtime's existing `${ENV_VAR}` expansion.
+    """
+    resolved_os = os_name or _runtime_os_name()
+    needs_install = _INSTALL_DIR_VAR in value or _VENV_PYTHON_VAR in value
+    if needs_install and install_dir is None:
+        variable = (
+            _VENV_PYTHON_VAR if _VENV_PYTHON_VAR in value else _INSTALL_DIR_VAR
+        )
+        raise CatalogError(
+            f"manifest references {variable} but no install block exists"
+        )
+
+    replacements = {
+        _PYTHON_VAR: python_executable or _runtime_python_executable(),
+    }
+    if install_dir is not None:
+        replacements[_INSTALL_DIR_VAR] = str(install_dir)
+        replacements[_VENV_PYTHON_VAR] = _venv_python_path(
+            install_dir, os_name=resolved_os
+        )
+
+    expanded = value
+    for variable, replacement in replacements.items():
+        rendered = (
+            _shell_quote(replacement, os_name=resolved_os)
+            if for_shell
+            else replacement
+        )
+        expanded = expanded.replace(variable, rendered)
+    return expanded
+
+
 def _run_bootstrap(cwd: Path, commands: List[str]) -> None:
     """Execute bootstrap commands in *cwd*. Raise CatalogError on first failure.
 
     Each command runs through the shell (so `&&` etc. work). The output is
     streamed to the user's terminal for visibility.
     """
-    for cmd in commands:
+    for raw_cmd in commands:
+        cmd = _expand_catalog_vars(raw_cmd, cwd, for_shell=True)
         print(color(f"  $ {cmd}", Colors.DIM))
         proc = subprocess.run(cmd, cwd=str(cwd), shell=True)
         if proc.returncode != 0:
@@ -548,13 +622,7 @@ def _do_git_install(entry: CatalogEntry) -> Path:
 
 
 def _expand_install_dir(value: str, install_dir: Optional[Path]) -> str:
-    if _INSTALL_DIR_VAR not in value:
-        return value
-    if install_dir is None:
-        raise CatalogError(
-            f"manifest references {_INSTALL_DIR_VAR} but no install block exists"
-        )
-    return value.replace(_INSTALL_DIR_VAR, str(install_dir))
+    return _expand_catalog_vars(value, install_dir)
 
 
 def _prompt_env_vars(specs: List[EnvVarSpec]) -> Dict[str, str]:

--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -34,7 +34,7 @@ import shutil
 import subprocess
 import sys
 from dataclasses import dataclass, field
-from pathlib import Path, PureWindowsPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, Dict, List, Optional
 
 import yaml
@@ -42,7 +42,6 @@ import yaml
 from hermes_constants import (
     get_hermes_home,
     get_optional_mcps_dir,
-    venv_python_path,
 )
 from hermes_cli._subprocess_compat import noninteractive_git_env
 from hermes_cli.colors import Colors, color
@@ -483,8 +482,19 @@ def _runtime_python_executable() -> str:
 
 
 def _venv_python_path(install_dir: Path, *, os_name: str) -> str:
-    path = venv_python_path(install_dir / ".venv", windows=os_name == "nt")
-    return str(PureWindowsPath(str(path))) if os_name == "nt" else str(path)
+    if os_name == "nt":
+        return str(PureWindowsPath(str(install_dir)) / ".venv" / "Scripts" / "python.exe")
+    return str(PurePosixPath(str(install_dir).replace("\\", "/")) / ".venv" / "bin" / "python")
+
+
+def _install_dir_value(install_dir: Path) -> str:
+    """Render install paths for manifest args without host-OS separators.
+
+    Transport arguments are raw argv values and accept forward slashes on every
+    supported host. Keeping them POSIX-shaped also lets path-expansion tests
+    simulate another runtime OS from Windows or POSIX hosts.
+    """
+    return str(PurePosixPath(str(install_dir).replace("\\", "/")))
 
 
 def _shell_quote(value: str, *, os_name: str) -> str:
@@ -522,7 +532,7 @@ def _expand_catalog_vars(
         _PYTHON_VAR: python_executable or _runtime_python_executable(),
     }
     if install_dir is not None:
-        replacements[_INSTALL_DIR_VAR] = str(install_dir)
+        replacements[_INSTALL_DIR_VAR] = _install_dir_value(install_dir)
         replacements[_VENV_PYTHON_VAR] = _venv_python_path(
             install_dir, os_name=resolved_os
         )

--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -41,6 +41,7 @@ import yaml
 from hermes_constants import (
     get_hermes_home,
     get_optional_mcps_dir,
+    venv_python_path,
 )
 from hermes_cli._subprocess_compat import noninteractive_git_env
 from hermes_cli.colors import Colors, color
@@ -481,9 +482,10 @@ def _runtime_python_executable() -> str:
 
 
 def _venv_python_path(install_dir: Path, *, os_name: str) -> str:
+    path = venv_python_path(install_dir / ".venv", windows=os_name == "nt")
     if os_name == "nt":
-        return str(PureWindowsPath(str(install_dir)) / ".venv" / "Scripts" / "python.exe")
-    return str(PurePosixPath(str(install_dir).replace("\\", "/")) / ".venv" / "bin" / "python")
+        return str(PureWindowsPath(str(path)))
+    return str(PurePosixPath(str(path).replace("\\", "/")))
 
 
 def _install_dir_value(install_dir: Path, *, os_name: str) -> str:
@@ -497,17 +499,9 @@ def _expand_catalog_vars(
     value: str,
     install_dir: Optional[Path],
     *,
-    for_shell: bool = False,
     os_name: Optional[str] = None,
-    python_executable: Optional[str] = None,
 ) -> str:
-    """Expand trusted catalog path variables for this runtime.
-
-    Bootstrap commands run through a shell and therefore receive quoted
-    substitutions. Transport command/args are persisted as raw argv values.
-    User environment placeholders are deliberately left untouched for the MCP
-    runtime's existing `${ENV_VAR}` expansion.
-    """
+    """Expand trusted catalog variables into raw transport argv values."""
     resolved_os = os_name or _runtime_os_name()
     needs_install = _INSTALL_DIR_VAR in value or _VENV_PYTHON_VAR in value
     if needs_install and install_dir is None:
@@ -519,7 +513,7 @@ def _expand_catalog_vars(
         )
 
     replacements = {
-        _PYTHON_VAR: python_executable or _runtime_python_executable(),
+        _PYTHON_VAR: _runtime_python_executable(),
     }
     if install_dir is not None:
         replacements[_INSTALL_DIR_VAR] = _install_dir_value(

--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -29,7 +29,6 @@ from __future__ import annotations
 
 import os
 import re
-import shlex
 import shutil
 import subprocess
 import sys
@@ -487,20 +486,11 @@ def _venv_python_path(install_dir: Path, *, os_name: str) -> str:
     return str(PurePosixPath(str(install_dir).replace("\\", "/")) / ".venv" / "bin" / "python")
 
 
-def _install_dir_value(install_dir: Path) -> str:
-    """Render install paths for manifest args without host-OS separators.
-
-    Transport arguments are raw argv values and accept forward slashes on every
-    supported host. Keeping them POSIX-shaped also lets path-expansion tests
-    simulate another runtime OS from Windows or POSIX hosts.
-    """
-    return str(PurePosixPath(str(install_dir).replace("\\", "/")))
-
-
-def _shell_quote(value: str, *, os_name: str) -> str:
+def _install_dir_value(install_dir: Path, *, os_name: str) -> str:
+    """Render a catalog install directory with the target runtime's syntax."""
     if os_name == "nt":
-        return subprocess.list2cmdline([value])
-    return shlex.quote(value)
+        return str(PureWindowsPath(str(install_dir)))
+    return str(PurePosixPath(str(install_dir).replace("\\", "/")))
 
 
 def _expand_catalog_vars(
@@ -532,20 +522,62 @@ def _expand_catalog_vars(
         _PYTHON_VAR: python_executable or _runtime_python_executable(),
     }
     if install_dir is not None:
-        replacements[_INSTALL_DIR_VAR] = _install_dir_value(install_dir)
+        replacements[_INSTALL_DIR_VAR] = _install_dir_value(
+            install_dir, os_name=resolved_os
+        )
         replacements[_VENV_PYTHON_VAR] = _venv_python_path(
             install_dir, os_name=resolved_os
         )
 
     expanded = value
-    for variable, replacement in replacements.items():
-        rendered = (
-            _shell_quote(replacement, os_name=resolved_os)
-            if for_shell
-            else replacement
+    if resolved_os == "nt" and _INSTALL_DIR_VAR in value:
+        expanded = expanded.replace(
+            f"{_INSTALL_DIR_VAR}/", f"{replacements[_INSTALL_DIR_VAR]}\\"
         )
-        expanded = expanded.replace(variable, rendered)
+    for variable, replacement in replacements.items():
+        expanded = expanded.replace(variable, replacement)
     return expanded
+
+
+_BOOTSTRAP_PYTHON_ENV = "HERMES_MCP_BOOTSTRAP_PYTHON"
+_BOOTSTRAP_INSTALL_DIR_ENV = "HERMES_MCP_BOOTSTRAP_INSTALL_DIR"
+_BOOTSTRAP_VENV_PYTHON_ENV = "HERMES_MCP_BOOTSTRAP_VENV_PYTHON"
+
+
+def _expand_bootstrap_vars(
+    value: str, install_dir: Path, *, os_name: str
+) -> tuple[str, Dict[str, str]]:
+    """Prepare a bootstrap command without interpolating paths into its shell.
+
+    Catalog bootstrap steps intentionally support shell operators such as
+    ``&&``. User-controlled install paths must therefore travel through child
+    environment variables instead of command text: this prevents cmd.exe and
+    POSIX shells from interpreting path characters such as ``&`` or ``%``.
+    """
+    env = {
+        _BOOTSTRAP_PYTHON_ENV: _runtime_python_executable(),
+        _BOOTSTRAP_INSTALL_DIR_ENV: _install_dir_value(install_dir, os_name=os_name),
+        _BOOTSTRAP_VENV_PYTHON_ENV: _venv_python_path(
+            install_dir, os_name=os_name
+        ),
+    }
+    if os_name == "nt":
+        references = {
+            _PYTHON_VAR: f'"%{_BOOTSTRAP_PYTHON_ENV}%"',
+            _INSTALL_DIR_VAR: f'"%{_BOOTSTRAP_INSTALL_DIR_ENV}%"',
+            _VENV_PYTHON_VAR: f'"%{_BOOTSTRAP_VENV_PYTHON_ENV}%"',
+        }
+    else:
+        references = {
+            _PYTHON_VAR: f'"${_BOOTSTRAP_PYTHON_ENV}"',
+            _INSTALL_DIR_VAR: f'"${_BOOTSTRAP_INSTALL_DIR_ENV}"',
+            _VENV_PYTHON_VAR: f'"${_BOOTSTRAP_VENV_PYTHON_ENV}"',
+        }
+
+    expanded = value
+    for variable, reference in references.items():
+        expanded = expanded.replace(variable, reference)
+    return expanded, env
 
 
 def _run_bootstrap(cwd: Path, commands: List[str]) -> None:
@@ -554,10 +586,16 @@ def _run_bootstrap(cwd: Path, commands: List[str]) -> None:
     Each command runs through the shell (so `&&` etc. work). The output is
     streamed to the user's terminal for visibility.
     """
+    os_name = _runtime_os_name()
     for raw_cmd in commands:
-        cmd = _expand_catalog_vars(raw_cmd, cwd, for_shell=True)
+        cmd, bootstrap_env = _expand_bootstrap_vars(raw_cmd, cwd, os_name=os_name)
         print(color(f"  $ {cmd}", Colors.DIM))
-        proc = subprocess.run(cmd, cwd=str(cwd), shell=True)
+        proc = subprocess.run(
+            cmd,
+            cwd=str(cwd),
+            shell=True,
+            env={**os.environ, **bootstrap_env},
+        )
         if proc.returncode != 0:
             raise CatalogError(
                 f"bootstrap step failed (exit {proc.returncode}): {cmd}"

--- a/optional-mcps/n8n/manifest.yaml
+++ b/optional-mcps/n8n/manifest.yaml
@@ -17,7 +17,9 @@ transport:
   # with the path the catalog cloned the repo into. The catalog never
   # auto-updates: the user re-runs `hermes mcp install official/n8n` to
   # refresh.
-  command: "${INSTALL_DIR}/.venv/bin/python"
+  # Catalog-owned placeholders resolve to OS-correct absolute paths:
+  # .venv/bin/python on POSIX, .venv/Scripts/python.exe on Windows.
+  command: "${VENV_PYTHON}"
   args:
     - "${INSTALL_DIR}/server.py"
 
@@ -35,8 +37,10 @@ install:
   ref: 7a9ae00795593aa1fdb4e61ecd640e8bfd0c3841
   # Bootstrap commands run inside the cloned directory after clone.
   bootstrap:
-    - "python3 -m venv .venv"
-    - ".venv/bin/pip install -r requirements.txt"
+    - "${PYTHON} -m venv .venv"
+    # The pinned source declares mcp>=1.0.0, which now floats to incompatible
+    # mcp 2.x. Its FastMCP + postponed-annotation code is verified with 1.4.1.
+    - '${VENV_PYTHON} -m pip install "mcp==1.4.1" "pydantic>=2.7,<2.10" -r requirements.txt'
 
 # Authentication. Three shapes:
 #   type: api_key  — prompt for env vars, write to ~/.hermes/.env

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -179,6 +179,118 @@ class TestManifestParsing:
             _parse_manifest(path)
 
 
+class TestCatalogPathVariables:
+    def test_posix_bootstrap_paths_are_shell_quoted(self):
+        from hermes_cli.mcp_catalog import _expand_catalog_vars
+
+        install_dir = Path("/tmp/MCP installs/n8n")
+        command = _expand_catalog_vars(
+            "${PYTHON} -m venv .venv && ${VENV_PYTHON} -m pip --version",
+            install_dir,
+            for_shell=True,
+            os_name="posix",
+            python_executable="/opt/Hermes Python/bin/python",
+        )
+
+        assert command == (
+            "'/opt/Hermes Python/bin/python' -m venv .venv && "
+            "'/tmp/MCP installs/n8n/.venv/bin/python' -m pip --version"
+        )
+
+    def test_windows_transport_path_uses_scripts_python(self):
+        from hermes_cli.mcp_catalog import _expand_catalog_vars
+
+        command = _expand_catalog_vars(
+            "${VENV_PYTHON}",
+            Path("C:/MCP installs/n8n"),
+            os_name="nt",
+        )
+
+        assert command == (
+            r"C:\MCP installs\n8n\.venv\Scripts\python.exe"
+        )
+
+    def test_windows_bootstrap_paths_are_cmd_quoted(self):
+        from hermes_cli.mcp_catalog import _expand_catalog_vars
+
+        command = _expand_catalog_vars(
+            "${PYTHON} -m venv .venv && ${VENV_PYTHON} -m pip --version",
+            Path("C:/MCP installs/n8n"),
+            for_shell=True,
+            os_name="nt",
+            python_executable=r"C:\Program Files\Python\python.exe",
+        )
+
+        assert command == (
+            '"C:\\Program Files\\Python\\python.exe" -m venv .venv && '
+            '"C:\\MCP installs\\n8n\\.venv\\Scripts\\python.exe" '
+            "-m pip --version"
+        )
+
+    @pytest.mark.parametrize("variable", ["${INSTALL_DIR}", "${VENV_PYTHON}"])
+    def test_install_scoped_variable_requires_install_block(self, variable):
+        from hermes_cli.mcp_catalog import CatalogError, _expand_catalog_vars
+
+        with pytest.raises(CatalogError, match="no install block"):
+            _expand_catalog_vars(variable, None)
+
+    def test_n8n_server_config_uses_windows_venv_interpreter(
+        self, monkeypatch
+    ):
+        monkeypatch.delenv("HERMES_OPTIONAL_MCPS", raising=False)
+        from hermes_cli import mcp_catalog
+
+        entry = mcp_catalog._parse_manifest(
+            mcp_catalog._catalog_root() / "n8n" / "manifest.yaml"
+        )
+        monkeypatch.setattr(mcp_catalog, "_runtime_os_name", lambda: "nt")
+
+        cfg = mcp_catalog._build_server_config(
+            entry, Path("C:/MCP installs/n8n")
+        )
+
+        assert cfg["command"] == (
+            r"C:\MCP installs\n8n\.venv\Scripts\python.exe"
+        )
+        assert cfg["args"] == ["C:/MCP installs/n8n/server.py"]
+
+    def test_bootstrap_expands_runtime_paths_before_shell_execution(
+        self, monkeypatch
+    ):
+        from types import SimpleNamespace
+
+        from hermes_cli import mcp_catalog
+
+        calls = []
+
+        def fake_run(command, **kwargs):
+            calls.append((command, kwargs))
+            return SimpleNamespace(returncode=0)
+
+        monkeypatch.setattr(mcp_catalog, "_runtime_os_name", lambda: "posix")
+        monkeypatch.setattr(
+            mcp_catalog,
+            "_runtime_python_executable",
+            lambda: "/opt/Hermes Python/bin/python",
+        )
+        monkeypatch.setattr(mcp_catalog.subprocess, "run", fake_run)
+
+        cwd = Path("/tmp/MCP installs/n8n")
+        mcp_catalog._run_bootstrap(
+            cwd,
+            [
+                "${PYTHON} -m venv .venv",
+                "${VENV_PYTHON} -m pip --version",
+            ],
+        )
+
+        assert [call[0] for call in calls] == [
+            "'/opt/Hermes Python/bin/python' -m venv .venv",
+            "'/tmp/MCP installs/n8n/.venv/bin/python' -m pip --version",
+        ]
+        assert all(call[1] == {"cwd": str(cwd), "shell": True} for call in calls)
+
+
 
 
 
@@ -636,3 +748,18 @@ class TestShippedCatalog:
                     )
 
         assert not problems, "unpinned catalog entries:\n" + "\n".join(problems)
+
+    def test_n8n_uses_portable_pinned_python_bootstrap(self, monkeypatch):
+        monkeypatch.delenv("HERMES_OPTIONAL_MCPS", raising=False)
+        from hermes_cli.mcp_catalog import _catalog_root, _parse_manifest
+
+        entry = _parse_manifest(_catalog_root() / "n8n" / "manifest.yaml")
+
+        assert entry.transport.command == "${VENV_PYTHON}"
+        assert entry.install is not None
+        bootstrap = entry.install.bootstrap
+        assert bootstrap[0] == "${PYTHON} -m venv .venv"
+        assert "mcp==1.4.1" in bootstrap[1]
+        assert "pydantic>=2.7,<2.10" in bootstrap[1]
+        assert "python3" not in "\n".join(bootstrap)
+        assert ".venv/bin" not in "\n".join(bootstrap)

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -223,21 +223,22 @@ class TestManifestParsing:
 
 
 class TestCatalogPathVariables:
-    def test_posix_bootstrap_paths_are_shell_quoted(self):
-        from hermes_cli.mcp_catalog import _expand_catalog_vars
+    def test_posix_bootstrap_paths_use_quoted_child_environment_variables(self):
+        from hermes_cli.mcp_catalog import _expand_bootstrap_vars
 
         install_dir = Path("/tmp/MCP installs/n8n")
-        command = _expand_catalog_vars(
+        command, env = _expand_bootstrap_vars(
             "${PYTHON} -m venv .venv && ${VENV_PYTHON} -m pip --version",
             install_dir,
-            for_shell=True,
             os_name="posix",
-            python_executable="/opt/Hermes Python/bin/python",
         )
 
         assert command == (
-            "'/opt/Hermes Python/bin/python' -m venv .venv && "
-            "'/tmp/MCP installs/n8n/.venv/bin/python' -m pip --version"
+            '"$HERMES_MCP_BOOTSTRAP_PYTHON" -m venv .venv && '
+            '"$HERMES_MCP_BOOTSTRAP_VENV_PYTHON" -m pip --version'
+        )
+        assert env["HERMES_MCP_BOOTSTRAP_VENV_PYTHON"] == (
+            "/tmp/MCP installs/n8n/.venv/bin/python"
         )
 
     def test_windows_transport_path_uses_scripts_python(self):
@@ -253,21 +254,36 @@ class TestCatalogPathVariables:
             r"C:\MCP installs\n8n\.venv\Scripts\python.exe"
         )
 
-    def test_windows_bootstrap_paths_are_cmd_quoted(self):
-        from hermes_cli.mcp_catalog import _expand_catalog_vars
+    def test_windows_bootstrap_paths_use_child_environment_variables(self):
+        from hermes_cli.mcp_catalog import _expand_bootstrap_vars
 
-        command = _expand_catalog_vars(
+        command, env = _expand_bootstrap_vars(
             "${PYTHON} -m venv .venv && ${VENV_PYTHON} -m pip --version",
             Path("C:/MCP installs/n8n"),
-            for_shell=True,
             os_name="nt",
-            python_executable=r"C:\Program Files\Python\python.exe",
         )
 
         assert command == (
-            '"C:\\Program Files\\Python\\python.exe" -m venv .venv && '
-            '"C:\\MCP installs\\n8n\\.venv\\Scripts\\python.exe" '
+            '"%HERMES_MCP_BOOTSTRAP_PYTHON%" -m venv .venv && '
+            '"%HERMES_MCP_BOOTSTRAP_VENV_PYTHON%" '
             "-m pip --version"
+        )
+        assert env["HERMES_MCP_BOOTSTRAP_VENV_PYTHON"] == (
+            r"C:\MCP installs\n8n\.venv\Scripts\python.exe"
+        )
+
+    def test_windows_bootstrap_escapes_percent_in_install_path(self):
+        from hermes_cli.mcp_catalog import _expand_bootstrap_vars
+
+        command, env = _expand_bootstrap_vars(
+            "${VENV_PYTHON} -m pip --version",
+            Path(r"C:/MCP&%TEMP%/n8n"),
+            os_name="nt",
+        )
+
+        assert command == '"%HERMES_MCP_BOOTSTRAP_VENV_PYTHON%" -m pip --version'
+        assert env["HERMES_MCP_BOOTSTRAP_VENV_PYTHON"] == (
+            r"C:\MCP&%TEMP%\n8n\.venv\Scripts\python.exe"
         )
 
     @pytest.mark.parametrize("variable", ["${INSTALL_DIR}", "${VENV_PYTHON}"])
@@ -295,7 +311,7 @@ class TestCatalogPathVariables:
         assert cfg["command"] == (
             r"C:\MCP installs\n8n\.venv\Scripts\python.exe"
         )
-        assert cfg["args"] == ["C:/MCP installs/n8n/server.py"]
+        assert cfg["args"] == [r"C:\MCP installs\n8n\server.py"]
 
     def test_bootstrap_expands_runtime_paths_before_shell_execution(
         self, monkeypatch
@@ -328,10 +344,16 @@ class TestCatalogPathVariables:
         )
 
         assert [call[0] for call in calls] == [
-            "'/opt/Hermes Python/bin/python' -m venv .venv",
-            "'/tmp/MCP installs/n8n/.venv/bin/python' -m pip --version",
+            '"$HERMES_MCP_BOOTSTRAP_PYTHON" -m venv .venv',
+            '"$HERMES_MCP_BOOTSTRAP_VENV_PYTHON" -m pip --version',
         ]
-        assert all(call[1] == {"cwd": str(cwd), "shell": True} for call in calls)
+        assert all(call[1]["cwd"] == str(cwd) for call in calls)
+        assert all(call[1]["shell"] is True for call in calls)
+        assert all(
+            call[1]["env"]["HERMES_MCP_BOOTSTRAP_VENV_PYTHON"]
+            == "/tmp/MCP installs/n8n/.venv/bin/python"
+            for call in calls
+        )
 
 
 

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -222,6 +222,118 @@ class TestManifestParsing:
             _parse_manifest(path)
 
 
+class TestCatalogPathVariables:
+    def test_posix_bootstrap_paths_are_shell_quoted(self):
+        from hermes_cli.mcp_catalog import _expand_catalog_vars
+
+        install_dir = Path("/tmp/MCP installs/n8n")
+        command = _expand_catalog_vars(
+            "${PYTHON} -m venv .venv && ${VENV_PYTHON} -m pip --version",
+            install_dir,
+            for_shell=True,
+            os_name="posix",
+            python_executable="/opt/Hermes Python/bin/python",
+        )
+
+        assert command == (
+            "'/opt/Hermes Python/bin/python' -m venv .venv && "
+            "'/tmp/MCP installs/n8n/.venv/bin/python' -m pip --version"
+        )
+
+    def test_windows_transport_path_uses_scripts_python(self):
+        from hermes_cli.mcp_catalog import _expand_catalog_vars
+
+        command = _expand_catalog_vars(
+            "${VENV_PYTHON}",
+            Path("C:/MCP installs/n8n"),
+            os_name="nt",
+        )
+
+        assert command == (
+            r"C:\MCP installs\n8n\.venv\Scripts\python.exe"
+        )
+
+    def test_windows_bootstrap_paths_are_cmd_quoted(self):
+        from hermes_cli.mcp_catalog import _expand_catalog_vars
+
+        command = _expand_catalog_vars(
+            "${PYTHON} -m venv .venv && ${VENV_PYTHON} -m pip --version",
+            Path("C:/MCP installs/n8n"),
+            for_shell=True,
+            os_name="nt",
+            python_executable=r"C:\Program Files\Python\python.exe",
+        )
+
+        assert command == (
+            '"C:\\Program Files\\Python\\python.exe" -m venv .venv && '
+            '"C:\\MCP installs\\n8n\\.venv\\Scripts\\python.exe" '
+            "-m pip --version"
+        )
+
+    @pytest.mark.parametrize("variable", ["${INSTALL_DIR}", "${VENV_PYTHON}"])
+    def test_install_scoped_variable_requires_install_block(self, variable):
+        from hermes_cli.mcp_catalog import CatalogError, _expand_catalog_vars
+
+        with pytest.raises(CatalogError, match="no install block"):
+            _expand_catalog_vars(variable, None)
+
+    def test_n8n_server_config_uses_windows_venv_interpreter(
+        self, monkeypatch
+    ):
+        monkeypatch.delenv("HERMES_OPTIONAL_MCPS", raising=False)
+        from hermes_cli import mcp_catalog
+
+        entry = mcp_catalog._parse_manifest(
+            mcp_catalog._catalog_root() / "n8n" / "manifest.yaml"
+        )
+        monkeypatch.setattr(mcp_catalog, "_runtime_os_name", lambda: "nt")
+
+        cfg = mcp_catalog._build_server_config(
+            entry, Path("C:/MCP installs/n8n")
+        )
+
+        assert cfg["command"] == (
+            r"C:\MCP installs\n8n\.venv\Scripts\python.exe"
+        )
+        assert cfg["args"] == ["C:/MCP installs/n8n/server.py"]
+
+    def test_bootstrap_expands_runtime_paths_before_shell_execution(
+        self, monkeypatch
+    ):
+        from types import SimpleNamespace
+
+        from hermes_cli import mcp_catalog
+
+        calls = []
+
+        def fake_run(command, **kwargs):
+            calls.append((command, kwargs))
+            return SimpleNamespace(returncode=0)
+
+        monkeypatch.setattr(mcp_catalog, "_runtime_os_name", lambda: "posix")
+        monkeypatch.setattr(
+            mcp_catalog,
+            "_runtime_python_executable",
+            lambda: "/opt/Hermes Python/bin/python",
+        )
+        monkeypatch.setattr(mcp_catalog.subprocess, "run", fake_run)
+
+        cwd = Path("/tmp/MCP installs/n8n")
+        mcp_catalog._run_bootstrap(
+            cwd,
+            [
+                "${PYTHON} -m venv .venv",
+                "${VENV_PYTHON} -m pip --version",
+            ],
+        )
+
+        assert [call[0] for call in calls] == [
+            "'/opt/Hermes Python/bin/python' -m venv .venv",
+            "'/tmp/MCP installs/n8n/.venv/bin/python' -m pip --version",
+        ]
+        assert all(call[1] == {"cwd": str(cwd), "shell": True} for call in calls)
+
+
 
 
 
@@ -897,3 +1009,18 @@ class TestShippedCatalog:
                     )
 
         assert not problems, "unpinned catalog entries:\n" + "\n".join(problems)
+
+    def test_n8n_uses_portable_pinned_python_bootstrap(self, monkeypatch):
+        monkeypatch.delenv("HERMES_OPTIONAL_MCPS", raising=False)
+        from hermes_cli.mcp_catalog import _catalog_root, _parse_manifest
+
+        entry = _parse_manifest(_catalog_root() / "n8n" / "manifest.yaml")
+
+        assert entry.transport.command == "${VENV_PYTHON}"
+        assert entry.install is not None
+        bootstrap = entry.install.bootstrap
+        assert bootstrap[0] == "${PYTHON} -m venv .venv"
+        assert "mcp==1.4.1" in bootstrap[1]
+        assert "pydantic>=2.7,<2.10" in bootstrap[1]
+        assert "python3" not in "\n".join(bootstrap)
+        assert ".venv/bin" not in "\n".join(bootstrap)

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -7,6 +7,7 @@ launch an MCP is mocked.
 
 from __future__ import annotations
 
+import os
 import re
 from pathlib import Path
 from unittest.mock import patch
@@ -272,7 +273,7 @@ class TestCatalogPathVariables:
             r"C:\MCP installs\n8n\.venv\Scripts\python.exe"
         )
 
-    def test_windows_bootstrap_escapes_percent_in_install_path(self):
+    def test_windows_bootstrap_keeps_path_metacharacters_out_of_command(self):
         from hermes_cli.mcp_catalog import _expand_bootstrap_vars
 
         command, env = _expand_bootstrap_vars(
@@ -281,7 +282,11 @@ class TestCatalogPathVariables:
             os_name="nt",
         )
 
-        assert command == '"%HERMES_MCP_BOOTSTRAP_VENV_PYTHON%" -m pip --version'
+        assert command == (
+            '"%HERMES_MCP_BOOTSTRAP_VENV_PYTHON%" -m pip --version'
+        )
+        assert "&" not in command
+        assert "%TEMP%" not in command
         assert env["HERMES_MCP_BOOTSTRAP_VENV_PYTHON"] == (
             r"C:\MCP&%TEMP%\n8n\.venv\Scripts\python.exe"
         )
@@ -355,11 +360,23 @@ class TestCatalogPathVariables:
             for call in calls
         )
 
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX shell regression")
+    def test_bootstrap_does_not_reparse_install_dir_metacharacters(self, tmp_path):
+        from hermes_cli.mcp_catalog import _run_bootstrap
 
+        cwd = tmp_path / "MCP & $(touch INJECTED) $HOME"
+        cwd.mkdir()
 
+        _run_bootstrap(
+            cwd,
+            [
+                '${PYTHON} -c "from pathlib import Path; import sys; '
+                "Path(sys.argv[1], 'ok').write_text('ok')\" ${INSTALL_DIR}"
+            ],
+        )
 
-
-
+        assert (cwd / "ok").read_text() == "ok"
+        assert not (cwd / "INJECTED").exists()
 
     def test_tools_default_excluded_parsed(self, catalog_dir):
         body = _basic_manifest(
@@ -385,7 +402,6 @@ class TestCatalogPathVariables:
         from hermes_cli.mcp_catalog import list_catalog
 
         assert list_catalog() == []
-
 
 # ---------------------------------------------------------------------------
 # Install flow

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -164,6 +164,15 @@ Note this is distinct from `${INSTALL_DIR}` in catalog manifests, which is
 substituted at install-time with the path the catalog cloned the entry's
 repo into.
 
+Git-installed catalog entries may also use two catalog-owned Python
+placeholders. `${PYTHON}` resolves to the interpreter running Hermes, while
+`${VENV_PYTHON}` resolves to `.venv/bin/python` on POSIX and
+`.venv/Scripts/python.exe` on Windows. In `install.bootstrap` commands these
+values are shell-quoted automatically; in `transport.command` and
+`transport.args` they are stored as raw argv values. This keeps one reviewed
+manifest portable across operating systems and install paths containing
+spaces.
+
 ### Updating tool selection later
 
 ```bash

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -171,6 +171,15 @@ Note this is distinct from `${INSTALL_DIR}` in catalog manifests, which is
 substituted at install-time with the path the catalog cloned the entry's
 repo into.
 
+Git-installed catalog entries may also use two catalog-owned Python
+placeholders. `${PYTHON}` resolves to the interpreter running Hermes, while
+`${VENV_PYTHON}` resolves to `.venv/bin/python` on POSIX and
+`.venv/Scripts/python.exe` on Windows. In `install.bootstrap` commands these
+values are shell-quoted automatically; in `transport.command` and
+`transport.args` they are stored as raw argv values. This keeps one reviewed
+manifest portable across operating systems and install paths containing
+spaces.
+
 ### Updating tool selection later
 
 ```bash


### PR DESCRIPTION
## Summary

- add catalog-owned `${PYTHON}` and `${VENV_PYTHON}` placeholders, with OS-correct POSIX/Windows rendering
- shell-quote bootstrap substitutions while preserving raw argv values in persisted transport config
- update the n8n catalog entry to use the portable interpreter paths and constrain its compatible `mcp`/`pydantic` stack
- document the manifest placeholders and cover Windows paths, paths containing spaces, bootstrap execution, and the shipped n8n contract

## Root cause and scope

The n8n manifest hardcoded `python3` and `.venv/bin/...`, so bootstrap and transport could not work on native Windows. Its pinned upstream source also declares `mcp>=1.0.0`, which now admits incompatible releases. The fix lives at the catalog expansion boundary so future git-installed entries can use the same portable interpreter contract without duplicating platform-specific manifests.

Unknown `${ENV_VAR}` placeholders remain untouched for the existing MCP runtime expansion. `${INSTALL_DIR}` behavior is preserved.

## MCP catalog security review notes

- Persisted transport is local stdio only: `${VENV_PYTHON}` executes the pinned clone's `server.py`; no shell or network payload is stored in `transport.command` / `transport.args`.
- The git source remains pinned to full SHA `7a9ae00795593aa1fdb4e61ecd640e8bfd0c3841` (2026-05-23).
- Bootstrap is limited to creating `.venv` and installing the source requirements with the verified `mcp==1.4.1` / `pydantic>=2.7,<2.10` constraints.
- The existing credential contract is unchanged and matches the pinned source: non-secret `N8N_BASE_URL` plus secret `N8N_API_KEY`.
- Default tools remain read-mostly; mutating activate/deactivate and container-log tools are still opt-in.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_update_zip_two_phase.py tests/hermes_cli/test_mcp_catalog.py tests/hermes_cli/test_noninteractive_git.py tests/hermes_cli/test_mcp_config.py tests/hermes_cli/test_mcp_startup.py tests/hermes_cli/test_mcp_tools_config.py tests/hermes_cli/test_mcp_security.py tests/hermes_cli/test_mcp_add_command_dest.py tests/hermes_cli/test_mcp_reload_confirm_gate.py` (`106 passed`)
- `uv run ruff check .`
- `uv run ty check hermes_cli/mcp_catalog.py`
- isolated `mcp==1.4.1` + `pydantic>=2.7,<2.10` postponed-annotation FastMCP registration smoke test
- `ascii-guard lint --exclude-code-blocks docs` (`397 files`, `0 errors`)
- `npm run build:fast` (Docusaurus production build passed)

The Windows execution path is exercised through platform-simulated unit tests. I inspected the pinned upstream requirements and server imports through GitHub, but did not clone or execute the third-party n8n server.

Closes #81898