### PR TITLE
fix(skills): fail closed protected discovery and retrieval

### DIFF
--- a/agent/skill_bundles.py
+++ b/agent/skill_bundles.py
@@ -313,6 +313,19 @@ def build_bundle_invocation_message(
             continue
         loaded_skill, skill_dir, skill_name = loaded
 
+        from agent.skill_governance import (
+            SkillGovernanceRejectedError,
+            evaluate_skill_selection_fail_closed,
+        )
+
+        decision = evaluate_skill_selection_fail_closed(
+            skill_name,
+            mode="explicit",
+            historical_intent=False,
+        )
+        if decision is not None and not decision.allowed:
+            raise SkillGovernanceRejectedError(decision)
+
         # Per-platform / global disabled gate. Checked against the loaded
         # skill's canonical name (identifiers may be paths or aliases).
         if skill_name in disabled_names or identifier in disabled_names:

--- a/agent/skill_bundles.py
+++ b/agent/skill_bundles.py
@@ -205,6 +205,79 @@ def get_skill_bundles() -> Dict[str, Dict[str, Any]]:
     return _bundles_cache
 
 
+def get_discoverable_skill_bundles() -> Dict[str, Dict[str, Any]]:
+    """Return bundle entries safe to advertise in help/completion surfaces.
+
+    Discovery is stricter than explicit dispatch: for protected task classes,
+    or when governance evaluation cannot be trusted, hide any bundle whose
+    loadable members would be denied at invocation time.
+
+    Unprotected task classes preserve the historical behavior and keep the full
+    bundle list even if governance evaluation is unavailable.
+    """
+    bundles = get_skill_bundles()
+    if not bundles:
+        return bundles
+
+    try:
+        from agent.skill_governance import evaluate_skill_selection_fail_closed
+    except Exception:
+        evaluate_skill_selection_fail_closed = None
+
+    if evaluate_skill_selection_fail_closed is None:
+        try:
+            from agent.skill_governance import probe_protected_task_class
+
+            if probe_protected_task_class().protected_task:
+                return {}
+        except Exception:
+            return {}
+        return bundles
+
+    try:
+        from agent.skill_commands import _load_skill_payload
+    except Exception:
+        try:
+            from agent.skill_governance import probe_protected_task_class
+
+            if probe_protected_task_class().protected_task:
+                return {}
+        except Exception:
+            return {}
+        return bundles
+
+    visible: Dict[str, Dict[str, Any]] = {}
+    for cmd_key, info in bundles.items():
+        bundle_skills = info.get("skills") or []
+        seen: set[str] = set()
+        blocked = False
+        for skill_id in bundle_skills:
+            identifier = str(skill_id or "").strip()
+            if not identifier or identifier in seen:
+                continue
+            seen.add(identifier)
+
+            loaded = _load_skill_payload(identifier)
+            if not loaded:
+                # Missing members are skipped at invocation time too.
+                continue
+
+            _loaded_skill, _skill_dir, skill_name = loaded
+            decision = evaluate_skill_selection_fail_closed(
+                skill_name,
+                mode="explicit",
+                historical_intent=False,
+                emit_log=False,
+            )
+            if decision is not None and not decision.allowed:
+                blocked = True
+                break
+
+        if not blocked:
+            visible[cmd_key] = info
+    return visible
+
+
 def resolve_bundle_command_key(command: str) -> Optional[str]:
     """Resolve a user-typed command to its canonical bundle slash key.
 

--- a/agent/skill_bundles.py
+++ b/agent/skill_bundles.py
@@ -323,6 +323,12 @@ def list_bundles() -> List[Dict[str, Any]]:
     return sorted(bundles.values(), key=lambda b: b["slug"])
 
 
+def list_discoverable_bundles() -> List[Dict[str, Any]]:
+    """Return governance-filtered bundle info dicts for display surfaces."""
+    bundles = get_discoverable_skill_bundles()
+    return sorted(bundles.values(), key=lambda b: b["slug"])
+
+
 def build_bundle_invocation_message(
     cmd_key: str,
     user_instruction: str = "",

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -11,7 +11,7 @@ import re
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from hermes_constants import display_hermes_home, get_config_path
+from hermes_constants import display_hermes_home
 from agent.skill_preprocessing import (
     expand_inline_shell as _expand_inline_shell,
     load_skills_config as _load_skills_config,
@@ -68,32 +68,6 @@ SKILL_SCAFFOLD_SQL_LIKE = _SKILL_INVOCATION_PREFIX + "%"
 # the joint (a bundle instruction cut off by the head window); callers cut the
 # description there rather than show the skill body on the far side.
 SKILL_EXCERPT_JOINT = "\x1e"
-
-
-def _protected_task_class_configured_fallback() -> bool:
-    """Best-effort config-only fallback when skill_governance can't import."""
-    try:
-        from agent.skill_utils import yaml_load
-
-        config_path = get_config_path()
-        if not config_path.exists():
-            return False
-        raw = yaml_load(config_path.read_text(encoding="utf-8"))
-        if not isinstance(raw, dict):
-            return False
-        skills_cfg = raw.get("skills") if isinstance(raw.get("skills"), dict) else {}
-        gov_cfg = skills_cfg.get("governance") if isinstance(skills_cfg.get("governance"), dict) else {}
-        task_class = str(gov_cfg.get("task_class") or "").strip().lower()
-        if not task_class:
-            return False
-        protected = gov_cfg.get("protected_task_classes") or []
-        if isinstance(protected, str):
-            protected = [protected]
-        protected_names = {str(item or "").strip().lower() for item in protected if str(item or "").strip()}
-        return task_class in protected_names
-    except Exception:
-        logger.debug("Failed to inspect protected skill governance fallback", exc_info=True)
-        return False
 
 
 def extract_user_instruction_from_skill_message(content: Any) -> Optional[str]:
@@ -825,12 +799,12 @@ def build_preloaded_skills_prompt(
     try:
         from agent.skill_governance import (
             evaluate_skill_selection_fail_closed,
-            is_protected_task_class_configured,
+            probe_protected_task_class,
         )
-        _protected_task = is_protected_task_class_configured()
+        _protected_task = probe_protected_task_class().protected_task
     except Exception:
         evaluate_skill_selection_fail_closed = None
-        _protected_task = _protected_task_class_configured_fallback()
+        _protected_task = True
 
     seen: set[str] = set()
     for raw_identifier in skill_identifiers:

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -482,6 +482,51 @@ def get_skill_commands() -> Dict[str, Dict[str, Any]]:
     return _skill_commands
 
 
+def get_discoverable_skill_commands() -> Dict[str, Dict[str, Any]]:
+    """Return skill commands safe to advertise in help/completion surfaces.
+
+    Discovery is stricter than explicit dispatch: when governance marks the
+    current task class protected, or governance evaluation cannot be trusted,
+    skills that would be blocked at invocation time are hidden entirely.
+
+    Unprotected task classes preserve the historical behavior and keep the full
+    scan-time command list even if governance evaluation is unavailable.
+    """
+    commands = get_skill_commands()
+    if not commands:
+        return commands
+
+    try:
+        from agent.skill_governance import evaluate_skill_selection_fail_closed
+    except Exception:
+        evaluate_skill_selection_fail_closed = None
+
+    if evaluate_skill_selection_fail_closed is None:
+        try:
+            from agent.skill_governance import probe_protected_task_class
+
+            if probe_protected_task_class().protected_task:
+                return {}
+        except Exception:
+            return {}
+        return commands
+
+    visible: Dict[str, Dict[str, Any]] = {}
+    for cmd_key, info in commands.items():
+        skill_name = str((info or {}).get("name") or cmd_key.lstrip("/") or "").strip()
+        if not skill_name:
+            continue
+        decision = evaluate_skill_selection_fail_closed(
+            skill_name,
+            mode="explicit",
+            historical_intent=False,
+            emit_log=False,
+        )
+        if decision is None or decision.allowed:
+            visible[cmd_key] = info
+    return visible
+
+
 def reload_skills() -> Dict[str, Any]:
     """Re-scan the skills directory and return a diff of what changed.
 

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -762,12 +762,20 @@ def build_preloaded_skills_prompt(
     prompt_parts: list[str] = []
     loaded_names: list[str] = []
     missing: list[str] = []
+    rejected: set[str] = set()
 
     try:
         from agent.skill_utils import get_disabled_skill_names
         disabled_names = get_disabled_skill_names()
     except Exception:
         disabled_names = set()
+    try:
+        from agent.skill_governance import evaluate_skill_selection, governance_context
+
+        _governance_context = governance_context(mode="preload")
+    except Exception:
+        evaluate_skill_selection = None
+        _governance_context = None
 
     seen: set[str] = set()
     for raw_identifier in skill_identifiers:
@@ -786,6 +794,13 @@ def build_preloaded_skills_prompt(
         if skill_name in disabled_names or identifier in disabled_names:
             missing.append(identifier)
             continue
+
+        if evaluate_skill_selection is not None and _governance_context is not None:
+            decision = evaluate_skill_selection(skill_name, context=_governance_context)
+            if not decision.allowed:
+                rejected.add(identifier)
+                missing.append(identifier)
+                continue
 
         # Track active usage for Curator lifecycle management (#17782)
         try:
@@ -808,5 +823,11 @@ def build_preloaded_skills_prompt(
             )
         )
         loaded_names.append(skill_name)
+
+    if rejected:
+        logger.warning(
+            "Skill preload rejected by governance: %s",
+            sorted(rejected),
+        )
 
     return "\n\n".join(prompt_parts), loaded_names, missing

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -11,7 +11,7 @@ import re
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from hermes_constants import display_hermes_home
+from hermes_constants import display_hermes_home, get_config_path
 from agent.skill_preprocessing import (
     expand_inline_shell as _expand_inline_shell,
     load_skills_config as _load_skills_config,
@@ -68,6 +68,32 @@ SKILL_SCAFFOLD_SQL_LIKE = _SKILL_INVOCATION_PREFIX + "%"
 # the joint (a bundle instruction cut off by the head window); callers cut the
 # description there rather than show the skill body on the far side.
 SKILL_EXCERPT_JOINT = "\x1e"
+
+
+def _protected_task_class_configured_fallback() -> bool:
+    """Best-effort config-only fallback when skill_governance can't import."""
+    try:
+        from agent.skill_utils import yaml_load
+
+        config_path = get_config_path()
+        if not config_path.exists():
+            return False
+        raw = yaml_load(config_path.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            return False
+        skills_cfg = raw.get("skills") if isinstance(raw.get("skills"), dict) else {}
+        gov_cfg = skills_cfg.get("governance") if isinstance(skills_cfg.get("governance"), dict) else {}
+        task_class = str(gov_cfg.get("task_class") or "").strip().lower()
+        if not task_class:
+            return False
+        protected = gov_cfg.get("protected_task_classes") or []
+        if isinstance(protected, str):
+            protected = [protected]
+        protected_names = {str(item or "").strip().lower() for item in protected if str(item or "").strip()}
+        return task_class in protected_names
+    except Exception:
+        logger.debug("Failed to inspect protected skill governance fallback", exc_info=True)
+        return False
 
 
 def extract_user_instruction_from_skill_message(content: Any) -> Optional[str]:
@@ -795,13 +821,16 @@ def build_preloaded_skills_prompt(
         disabled_names = get_disabled_skill_names()
     except Exception:
         disabled_names = set()
+    _protected_task = False
     try:
-        from agent.skill_governance import evaluate_skill_selection, governance_context
-
-        _governance_context = governance_context(mode="preload")
+        from agent.skill_governance import (
+            evaluate_skill_selection_fail_closed,
+            is_protected_task_class_configured,
+        )
+        _protected_task = is_protected_task_class_configured()
     except Exception:
-        evaluate_skill_selection = None
-        _governance_context = None
+        evaluate_skill_selection_fail_closed = None
+        _protected_task = _protected_task_class_configured_fallback()
 
     seen: set[str] = set()
     for raw_identifier in skill_identifiers:
@@ -821,12 +850,19 @@ def build_preloaded_skills_prompt(
             missing.append(identifier)
             continue
 
-        if evaluate_skill_selection is not None and _governance_context is not None:
-            decision = evaluate_skill_selection(skill_name, context=_governance_context)
-            if not decision.allowed:
+        if evaluate_skill_selection_fail_closed is not None:
+            decision = evaluate_skill_selection_fail_closed(
+                skill_name,
+                mode="preload",
+            )
+            if decision is not None and not decision.allowed:
                 rejected.add(identifier)
                 missing.append(identifier)
                 continue
+        elif _protected_task:
+            rejected.add(identifier)
+            missing.append(identifier)
+            continue
 
         # Track active usage for Curator lifecycle management (#17782)
         try:

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -592,6 +592,19 @@ def build_skill_invocation_message(
 
     loaded_skill, skill_dir, skill_name = loaded
 
+    from agent.skill_governance import (
+        SkillGovernanceRejectedError,
+        evaluate_skill_selection_fail_closed,
+    )
+
+    decision = evaluate_skill_selection_fail_closed(
+        skill_name,
+        mode="explicit",
+        historical_intent=False,
+    )
+    if decision is not None and not decision.allowed:
+        raise SkillGovernanceRejectedError(decision)
+
     # Track active usage for Curator lifecycle management (#17782)
     try:
         from tools.skill_usage import bump_use
@@ -699,6 +712,19 @@ def build_stacked_skill_invocation_message(
             missing.append(cmd_key.lstrip("/"))
             continue
         loaded_skill, skill_dir, skill_name = loaded
+
+        from agent.skill_governance import (
+            SkillGovernanceRejectedError,
+            evaluate_skill_selection_fail_closed,
+        )
+
+        decision = evaluate_skill_selection_fail_closed(
+            skill_name,
+            mode="explicit",
+            historical_intent=False,
+        )
+        if decision is not None and not decision.allowed:
+            raise SkillGovernanceRejectedError(decision)
 
         # Track active usage for Curator lifecycle management (#17782)
         try:

--- a/agent/skill_governance.py
+++ b/agent/skill_governance.py
@@ -72,6 +72,14 @@ class SkillGovernanceDecision:
     registry_path: str = ""
 
 
+class SkillGovernanceRejectedError(RuntimeError):
+    """Raised when an explicit skill load is denied by governance."""
+
+    def __init__(self, decision: SkillGovernanceDecision, message: str | None = None):
+        self.decision = decision
+        super().__init__(message or format_skill_governance_denial(decision))
+
+
 _CONFIG_CACHE: tuple[tuple[str, int], GovernanceConfig] | None = None
 _REGISTRY_CACHE: tuple[tuple[str, int], dict[str, SkillRegistryEntry]] | None = None
 
@@ -279,6 +287,57 @@ def evaluate_skill_selection(
     return decision
 
 
+def evaluate_skill_selection_fail_closed(
+    skill_name: str,
+    *,
+    mode: GovernanceMode | str,
+    historical_intent: bool = False,
+    emit_log: bool = True,
+) -> SkillGovernanceDecision | None:
+    """Evaluate selection, denying on evaluation failure for protected tasks."""
+    try:
+        context = governance_context(
+            mode=mode,
+            historical_intent=historical_intent,
+        )
+        return evaluate_skill_selection(
+            skill_name,
+            context=context,
+            emit_log=emit_log,
+        )
+    except Exception as exc:
+        cfg = _load_governance_config()
+        protected = bool(cfg.task_class) and (
+            _normalize_name(cfg.task_class) in cfg.protected_task_classes
+        )
+        if not protected:
+            logger.debug(
+                "Skill governance evaluation unavailable for %s",
+                skill_name,
+                exc_info=True,
+            )
+            return None
+        try:
+            resolved_mode = mode if isinstance(mode, GovernanceMode) else GovernanceMode(str(mode))
+        except Exception:
+            resolved_mode = GovernanceMode.EXPLICIT
+        decision = SkillGovernanceDecision(
+            requested_name=skill_name,
+            canonical_name=skill_name,
+            classification=GovernanceClassification.UNKNOWN,
+            allowed=False,
+            reason=f"skill governance evaluation failed: {exc}",
+            mode=resolved_mode,
+            task_class=cfg.task_class,
+            protected_task=True,
+            historical_intent=bool(historical_intent),
+            registry_path=str(cfg.registry_path or ""),
+        )
+        if emit_log:
+            log_skill_governance_decision(decision)
+        return decision
+
+
 def evaluate_skill_selections(
     skill_names: Iterable[str],
     *,
@@ -356,7 +415,7 @@ def rank_skill_search_results(
         _normalize_name(context.task_class) in cfg.protected_task_classes
     )
 
-    decorated: list[tuple[int, int, Any]] = []
+    decorated: list[tuple[tuple[int, int, str, str, str, str], int, Any]] = []
     for idx, result in enumerate(results):
         name = str(getattr(result, "name", "") or "")
         identifier = str(getattr(result, "identifier", "") or "")
@@ -380,10 +439,7 @@ def rank_skill_search_results(
             )
         decorated.append(
             (
-                -_classification_rank(
-                    decision.classification,
-                    protected_task=protected,
-                ),
+                governance_sort_tuple(result, context=context),
                 idx,
                 result,
             )
@@ -396,9 +452,11 @@ def governance_sort_tuple(
     result: Any,
     *,
     context: GovernanceContext,
-) -> tuple[int, int]:
+) -> tuple[int, int, str, str, str, str]:
     name = str(getattr(result, "name", "") or "")
     identifier = str(getattr(result, "identifier", "") or "")
+    source = str(getattr(result, "source", "") or "")
+    trust_level = str(getattr(result, "trust_level", "") or "")
     decision = evaluate_skill_selection(
         name or identifier,
         context=context,
@@ -410,4 +468,16 @@ def governance_sort_tuple(
             protected_task=decision.protected_task,
         ),
         0 if decision.allowed else 1,
+        _normalize_name(name),
+        _normalize_name(identifier),
+        _normalize_name(source),
+        _normalize_name(trust_level),
+    )
+
+
+def format_skill_governance_denial(decision: SkillGovernanceDecision) -> str:
+    task_class = decision.task_class or "protected task"
+    return (
+        f'The "{decision.canonical_name}" skill is blocked by governance for '
+        f'"{task_class}": {decision.reason}'
     )

--- a/agent/skill_governance.py
+++ b/agent/skill_governance.py
@@ -554,6 +554,8 @@ def rank_skill_search_results(
                     "protected_task": decision.protected_task,
                 }
             )
+        if protected and not decision.allowed:
+            continue
         decorated.append(
             (
                 governance_sort_tuple(result, context=context),

--- a/agent/skill_governance.py
+++ b/agent/skill_governance.py
@@ -215,6 +215,20 @@ def governance_context(
     )
 
 
+def is_protected_task_class_configured(
+    *,
+    task_class: str | None = None,
+) -> bool:
+    """Return whether the configured task class is currently protected.
+
+    This helper is safe to use from fail-closed call sites that need to decide
+    whether governance/setup failures must deny skill loading.
+    """
+    cfg = _load_governance_config()
+    resolved_task = _normalize_name(task_class) or cfg.task_class
+    return bool(resolved_task) and (resolved_task in cfg.protected_task_classes)
+
+
 def _lookup_entry(skill_name: str) -> tuple[SkillRegistryEntry | None, str | None, str]:
     entries, registry_path = _load_registry_entries()
     lookup = _normalize_name(skill_name)
@@ -254,14 +268,11 @@ def evaluate_skill_selection(
     context: GovernanceContext,
     emit_log: bool = True,
 ) -> SkillGovernanceDecision:
-    cfg = _load_governance_config()
     entry, matched_alias, registry_path = _lookup_entry(skill_name)
     classification = (
         entry.classification if entry is not None else GovernanceClassification.UNKNOWN
     )
-    protected = bool(context.task_class) and (
-        _normalize_name(context.task_class) in cfg.protected_task_classes
-    )
+    protected = is_protected_task_class_configured(task_class=context.task_class)
     allowed, reason = _decision_reason(
         classification=classification,
         protected_task=protected,
@@ -307,9 +318,7 @@ def evaluate_skill_selection_fail_closed(
         )
     except Exception as exc:
         cfg = _load_governance_config()
-        protected = bool(cfg.task_class) and (
-            _normalize_name(cfg.task_class) in cfg.protected_task_classes
-        )
+        protected = is_protected_task_class_configured(task_class=cfg.task_class)
         if not protected:
             logger.debug(
                 "Skill governance evaluation unavailable for %s",
@@ -411,9 +420,7 @@ def rank_skill_search_results(
     cfg = _load_governance_config()
     if not cfg.retrieval_ranking or not results:
         return results
-    protected = bool(context.task_class) and (
-        _normalize_name(context.task_class) in cfg.protected_task_classes
-    )
+    protected = is_protected_task_class_configured(task_class=context.task_class)
 
     decorated: list[tuple[tuple[int, int, str, str, str, str], int, Any]] = []
     for idx, result in enumerate(results):

--- a/agent/skill_governance.py
+++ b/agent/skill_governance.py
@@ -1,0 +1,413 @@
+"""Config-driven provenance-aware skill governance.
+
+This module is intentionally lightweight enough to be imported by skill
+selection, gateway, and search paths.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+from hermes_constants import get_config_path, get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+
+class GovernanceClassification(str, Enum):
+    CURRENT = "CURRENT"
+    COMPATIBILITY_ONLY = "COMPATIBILITY_ONLY"
+    STALE = "STALE"
+    CONFLICTING = "CONFLICTING"
+    UNKNOWN = "UNKNOWN"
+
+
+class GovernanceMode(str, Enum):
+    AUTO = "auto"
+    PRELOAD = "preload"
+    EXPLICIT = "explicit"
+    RETRIEVAL = "retrieval"
+
+
+@dataclass(frozen=True)
+class GovernanceConfig:
+    registry_path: str = ""
+    task_class: str = ""
+    protected_task_classes: tuple[str, ...] = ()
+    retrieval_ranking: bool = True
+
+
+@dataclass(frozen=True)
+class SkillRegistryEntry:
+    name: str
+    classification: GovernanceClassification
+    aliases: tuple[str, ...] = ()
+    provenance: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class GovernanceContext:
+    mode: GovernanceMode
+    task_class: str = ""
+    historical_intent: bool = False
+
+
+@dataclass(frozen=True)
+class SkillGovernanceDecision:
+    requested_name: str
+    canonical_name: str
+    classification: GovernanceClassification
+    allowed: bool
+    reason: str
+    mode: GovernanceMode
+    task_class: str
+    protected_task: bool
+    historical_intent: bool
+    matched_alias: str | None = None
+    provenance: dict[str, Any] = field(default_factory=dict)
+    registry_path: str = ""
+
+
+_CONFIG_CACHE: tuple[tuple[str, int], GovernanceConfig] | None = None
+_REGISTRY_CACHE: tuple[tuple[str, int], dict[str, SkillRegistryEntry]] | None = None
+
+
+def _normalize_name(value: str) -> str:
+    return str(value or "").strip().lower()
+
+
+def _safe_mtime(path: Path) -> int:
+    try:
+        return int(path.stat().st_mtime_ns)
+    except OSError:
+        return -1
+
+
+def _load_yaml_file(path: Path) -> dict[str, Any]:
+    try:
+        from agent.skill_utils import yaml_load
+
+        raw = yaml_load(path.read_text(encoding="utf-8"))
+        return raw if isinstance(raw, dict) else {}
+    except Exception:
+        logger.debug("Failed to load YAML file %s", path, exc_info=True)
+        return {}
+
+
+def _load_governance_config() -> GovernanceConfig:
+    global _CONFIG_CACHE
+    config_path = get_config_path()
+    cache_key = (str(config_path), _safe_mtime(config_path))
+    if _CONFIG_CACHE and _CONFIG_CACHE[0] == cache_key:
+        return _CONFIG_CACHE[1]
+
+    raw = _load_yaml_file(config_path) if config_path.exists() else {}
+    skills_cfg = raw.get("skills") if isinstance(raw.get("skills"), dict) else {}
+    gov = skills_cfg.get("governance") if isinstance(skills_cfg.get("governance"), dict) else {}
+    protected = gov.get("protected_task_classes")
+    if isinstance(protected, str):
+        protected = [protected]
+    protected_norm = tuple(
+        cls for cls in (_normalize_name(v) for v in (protected or [])) if cls
+    )
+    cfg = GovernanceConfig(
+        registry_path=str(gov.get("registry_path") or "").strip(),
+        task_class=_normalize_name(gov.get("task_class") or ""),
+        protected_task_classes=protected_norm,
+        retrieval_ranking=bool(gov.get("retrieval_ranking", True)),
+    )
+    _CONFIG_CACHE = (cache_key, cfg)
+    return cfg
+
+
+def _resolve_registry_path(config: GovernanceConfig) -> Path | None:
+    raw = config.registry_path.strip()
+    if not raw:
+        return None
+    candidate = Path(raw).expanduser()
+    if not candidate.is_absolute():
+        candidate = (get_hermes_home() / candidate).resolve()
+    return candidate
+
+
+def _parse_classification(value: Any) -> GovernanceClassification:
+    normalized = str(value or "").strip().upper()
+    try:
+        return GovernanceClassification(normalized)
+    except ValueError:
+        return GovernanceClassification.UNKNOWN
+
+
+def _parse_registry_entry(item: dict[str, Any]) -> SkillRegistryEntry | None:
+    name = str(item.get("name") or "").strip()
+    if not name:
+        return None
+    aliases = item.get("aliases") or []
+    if isinstance(aliases, str):
+        aliases = [aliases]
+    parsed_aliases = tuple(
+        alias for alias in (str(v).strip() for v in aliases) if alias
+    )
+    provenance = item.get("provenance")
+    if not isinstance(provenance, dict):
+        provenance = {}
+    return SkillRegistryEntry(
+        name=name,
+        classification=_parse_classification(item.get("classification")),
+        aliases=parsed_aliases,
+        provenance=copy.deepcopy(provenance),
+    )
+
+
+def _load_registry_entries() -> tuple[dict[str, SkillRegistryEntry], str]:
+    global _REGISTRY_CACHE
+    cfg = _load_governance_config()
+    path = _resolve_registry_path(cfg)
+    if path is None:
+        return {}, ""
+    cache_key = (str(path), _safe_mtime(path))
+    if _REGISTRY_CACHE and _REGISTRY_CACHE[0] == cache_key:
+        return _REGISTRY_CACHE[1], str(path)
+
+    raw = _load_yaml_file(path) if path.exists() else {}
+    items = raw.get("skills") or raw.get("entries") or []
+    if not isinstance(items, list):
+        items = []
+    entries: dict[str, SkillRegistryEntry] = {}
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        parsed = _parse_registry_entry(item)
+        if parsed is None:
+            continue
+        for key in {_normalize_name(parsed.name), *(_normalize_name(a) for a in parsed.aliases)}:
+            if key:
+                entries[key] = parsed
+    _REGISTRY_CACHE = (cache_key, entries)
+    return entries, str(path)
+
+
+def governance_context(
+    *,
+    mode: GovernanceMode | str,
+    task_class: str | None = None,
+    historical_intent: bool = False,
+) -> GovernanceContext:
+    cfg = _load_governance_config()
+    resolved_mode = mode if isinstance(mode, GovernanceMode) else GovernanceMode(str(mode))
+    resolved_task = _normalize_name(task_class) or cfg.task_class
+    return GovernanceContext(
+        mode=resolved_mode,
+        task_class=resolved_task,
+        historical_intent=bool(historical_intent),
+    )
+
+
+def _lookup_entry(skill_name: str) -> tuple[SkillRegistryEntry | None, str | None, str]:
+    entries, registry_path = _load_registry_entries()
+    lookup = _normalize_name(skill_name)
+    entry = entries.get(lookup)
+    if entry is None:
+        return None, None, registry_path
+    matched_alias = None
+    if lookup != _normalize_name(entry.name):
+        matched_alias = skill_name
+    return entry, matched_alias, registry_path
+
+
+def _decision_reason(
+    *,
+    classification: GovernanceClassification,
+    protected_task: bool,
+    historical_intent: bool,
+) -> tuple[bool, str]:
+    if not protected_task:
+        return True, "unprotected task class"
+    if classification == GovernanceClassification.CURRENT:
+        return True, "current registry entry"
+    if classification == GovernanceClassification.COMPATIBILITY_ONLY:
+        if historical_intent:
+            return True, "compatibility-only entry allowed by historical intent"
+        return False, "compatibility-only entry requires explicit historical intent"
+    if classification == GovernanceClassification.STALE:
+        return False, "stale registry entry blocked for protected task class"
+    if classification == GovernanceClassification.CONFLICTING:
+        return False, "conflicting registry entry blocked for protected task class"
+    return False, "unknown registry entry blocked for protected task class"
+
+
+def evaluate_skill_selection(
+    skill_name: str,
+    *,
+    context: GovernanceContext,
+    emit_log: bool = True,
+) -> SkillGovernanceDecision:
+    cfg = _load_governance_config()
+    entry, matched_alias, registry_path = _lookup_entry(skill_name)
+    classification = (
+        entry.classification if entry is not None else GovernanceClassification.UNKNOWN
+    )
+    protected = bool(context.task_class) and (
+        _normalize_name(context.task_class) in cfg.protected_task_classes
+    )
+    allowed, reason = _decision_reason(
+        classification=classification,
+        protected_task=protected,
+        historical_intent=context.historical_intent,
+    )
+    canonical_name = entry.name if entry is not None else skill_name
+    decision = SkillGovernanceDecision(
+        requested_name=skill_name,
+        canonical_name=canonical_name,
+        classification=classification,
+        allowed=allowed,
+        reason=reason,
+        mode=context.mode,
+        task_class=context.task_class,
+        protected_task=protected,
+        historical_intent=context.historical_intent,
+        matched_alias=matched_alias,
+        provenance=copy.deepcopy(entry.provenance if entry is not None else {}),
+        registry_path=registry_path,
+    )
+    if emit_log:
+        log_skill_governance_decision(decision)
+    return decision
+
+
+def evaluate_skill_selections(
+    skill_names: Iterable[str],
+    *,
+    context: GovernanceContext,
+) -> list[SkillGovernanceDecision]:
+    return [
+        evaluate_skill_selection(skill_name, context=context)
+        for skill_name in skill_names
+        if str(skill_name or "").strip()
+    ]
+
+
+def log_skill_governance_decision(decision: SkillGovernanceDecision) -> None:
+    payload = {
+        "skill": decision.requested_name,
+        "canonical_name": decision.canonical_name,
+        "classification": decision.classification.value,
+        "allowed": decision.allowed,
+        "mode": decision.mode.value,
+        "task_class": decision.task_class or "",
+        "protected_task": decision.protected_task,
+        "historical_intent": decision.historical_intent,
+        "registry_path": decision.registry_path,
+        "reason": decision.reason,
+    }
+    if decision.allowed:
+        logger.info("skill_governance allow: %s", payload)
+    else:
+        logger.warning("skill_governance reject: %s", payload)
+
+
+def filter_allowed_skill_names(
+    skill_names: Iterable[str],
+    *,
+    context: GovernanceContext,
+) -> tuple[list[str], list[SkillGovernanceDecision]]:
+    decisions = evaluate_skill_selections(skill_names, context=context)
+    allowed = [decision.requested_name for decision in decisions if decision.allowed]
+    return allowed, decisions
+
+
+def _classification_rank(
+    classification: GovernanceClassification,
+    *,
+    protected_task: bool,
+) -> int:
+    if protected_task:
+        ranks = {
+            GovernanceClassification.CURRENT: 40,
+            GovernanceClassification.COMPATIBILITY_ONLY: 25,
+            GovernanceClassification.UNKNOWN: 10,
+            GovernanceClassification.STALE: -10,
+            GovernanceClassification.CONFLICTING: -20,
+        }
+    else:
+        ranks = {
+            GovernanceClassification.CURRENT: 20,
+            GovernanceClassification.COMPATIBILITY_ONLY: 16,
+            GovernanceClassification.UNKNOWN: 10,
+            GovernanceClassification.STALE: 6,
+            GovernanceClassification.CONFLICTING: 0,
+        }
+    return ranks.get(classification, 0)
+
+
+def rank_skill_search_results(
+    results: list[Any],
+    *,
+    context: GovernanceContext,
+) -> list[Any]:
+    cfg = _load_governance_config()
+    if not cfg.retrieval_ranking or not results:
+        return results
+    protected = bool(context.task_class) and (
+        _normalize_name(context.task_class) in cfg.protected_task_classes
+    )
+
+    decorated: list[tuple[int, int, Any]] = []
+    for idx, result in enumerate(results):
+        name = str(getattr(result, "name", "") or "")
+        identifier = str(getattr(result, "identifier", "") or "")
+        target = name or identifier
+        decision = evaluate_skill_selection(
+            target,
+            context=context,
+            emit_log=False,
+        )
+        extra = getattr(result, "extra", None)
+        if isinstance(extra, dict):
+            extra.setdefault("governance", {})
+            extra["governance"].update(
+                {
+                    "classification": decision.classification.value,
+                    "allowed": decision.allowed,
+                    "reason": decision.reason,
+                    "task_class": decision.task_class,
+                    "protected_task": decision.protected_task,
+                }
+            )
+        decorated.append(
+            (
+                -_classification_rank(
+                    decision.classification,
+                    protected_task=protected,
+                ),
+                idx,
+                result,
+            )
+        )
+    decorated.sort(key=lambda item: (item[0], item[1]))
+    return [item[2] for item in decorated]
+
+
+def governance_sort_tuple(
+    result: Any,
+    *,
+    context: GovernanceContext,
+) -> tuple[int, int]:
+    name = str(getattr(result, "name", "") or "")
+    identifier = str(getattr(result, "identifier", "") or "")
+    decision = evaluate_skill_selection(
+        name or identifier,
+        context=context,
+        emit_log=False,
+    )
+    return (
+        -_classification_rank(
+            decision.classification,
+            protected_task=decision.protected_task,
+        ),
+        0 if decision.allowed else 1,
+    )

--- a/agent/skill_governance.py
+++ b/agent/skill_governance.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any, Iterable, Optional
 
 from hermes_constants import get_config_path, get_hermes_home
+from utils import fast_safe_load
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +58,14 @@ class GovernanceContext:
 
 
 @dataclass(frozen=True)
+class ProtectedTaskProbe:
+    safe: bool
+    protected_task: bool
+    task_class: str = ""
+    reason: str = ""
+
+
+@dataclass(frozen=True)
 class SkillGovernanceDecision:
     requested_name: str
     canonical_name: str
@@ -84,6 +93,10 @@ _CONFIG_CACHE: tuple[tuple[str, int], GovernanceConfig] | None = None
 _REGISTRY_CACHE: tuple[tuple[str, int], dict[str, SkillRegistryEntry]] | None = None
 
 
+class GovernanceConfigError(RuntimeError):
+    """Raised when skill governance config cannot be read or trusted."""
+
+
 def _normalize_name(value: str) -> str:
     return str(value or "").strip().lower()
 
@@ -95,15 +108,125 @@ def _safe_mtime(path: Path) -> int:
         return -1
 
 
+def _read_yaml_mapping(path: Path) -> dict[str, Any]:
+    try:
+        raw = fast_safe_load(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise GovernanceConfigError(f"failed to parse {path}: {exc}") from exc
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise GovernanceConfigError(f"{path} must contain a YAML mapping")
+    return raw
+
+
+def _parse_governance_config(raw: dict[str, Any]) -> GovernanceConfig:
+    skills_raw = raw.get("skills")
+    if skills_raw is None:
+        skills_cfg: dict[str, Any] = {}
+    elif isinstance(skills_raw, dict):
+        skills_cfg = skills_raw
+    else:
+        raise GovernanceConfigError("skills config must be a mapping")
+
+    gov_raw = skills_cfg.get("governance")
+    if gov_raw is None:
+        gov: dict[str, Any] = {}
+    elif isinstance(gov_raw, dict):
+        gov = gov_raw
+    else:
+        raise GovernanceConfigError("skills.governance must be a mapping")
+
+    registry_path = gov.get("registry_path")
+    if registry_path is None:
+        registry_path = ""
+    elif not isinstance(registry_path, str):
+        raise GovernanceConfigError("skills.governance.registry_path must be a string")
+
+    task_class = gov.get("task_class")
+    if task_class is None:
+        normalized_task_class = ""
+    elif isinstance(task_class, str):
+        normalized_task_class = _normalize_name(task_class)
+    else:
+        raise GovernanceConfigError("skills.governance.task_class must be a string")
+
+    protected = gov.get("protected_task_classes")
+    if protected is None:
+        protected_values: list[Any] = []
+    elif isinstance(protected, str):
+        protected_values = [protected]
+    elif isinstance(protected, list):
+        protected_values = protected
+    else:
+        raise GovernanceConfigError(
+            "skills.governance.protected_task_classes must be a string or list"
+        )
+
+    protected_norm: list[str] = []
+    for item in protected_values:
+        if not isinstance(item, str):
+            raise GovernanceConfigError(
+                "skills.governance.protected_task_classes entries must be strings"
+            )
+        normalized = _normalize_name(item)
+        if normalized:
+            protected_norm.append(normalized)
+
+    retrieval_ranking = gov.get("retrieval_ranking", True)
+    if not isinstance(retrieval_ranking, bool):
+        raise GovernanceConfigError(
+            "skills.governance.retrieval_ranking must be a boolean"
+        )
+
+    return GovernanceConfig(
+        registry_path=registry_path.strip(),
+        task_class=normalized_task_class,
+        protected_task_classes=tuple(protected_norm),
+        retrieval_ranking=retrieval_ranking,
+    )
+
+
+def probe_protected_task_class(
+    *,
+    task_class: str | None = None,
+) -> ProtectedTaskProbe:
+    """Conservatively report whether governance failures must deny skill use."""
+    config_path = get_config_path()
+    if not config_path.exists():
+        return ProtectedTaskProbe(
+            safe=True,
+            protected_task=False,
+            task_class=_normalize_name(task_class or ""),
+            reason="missing config",
+        )
+    try:
+        raw = _read_yaml_mapping(config_path)
+        cfg = _parse_governance_config(raw)
+    except GovernanceConfigError as exc:
+        logger.warning("Protected-task governance probe failed", exc_info=True)
+        return ProtectedTaskProbe(
+            safe=False,
+            protected_task=True,
+            task_class=_normalize_name(task_class or ""),
+            reason=str(exc),
+        )
+
+    resolved_task = _normalize_name(task_class) or cfg.task_class
+    return ProtectedTaskProbe(
+        safe=True,
+        protected_task=bool(resolved_task) and (resolved_task in cfg.protected_task_classes),
+        task_class=resolved_task,
+        reason="ok",
+    )
+
+
 def _load_yaml_file(path: Path) -> dict[str, Any]:
     try:
-        from agent.skill_utils import yaml_load
-
-        raw = yaml_load(path.read_text(encoding="utf-8"))
-        return raw if isinstance(raw, dict) else {}
-    except Exception:
+        return _read_yaml_mapping(path)
+    except GovernanceConfigError:
         logger.debug("Failed to load YAML file %s", path, exc_info=True)
-        return {}
+        raise
 
 
 def _load_governance_config() -> GovernanceConfig:
@@ -113,21 +236,8 @@ def _load_governance_config() -> GovernanceConfig:
     if _CONFIG_CACHE and _CONFIG_CACHE[0] == cache_key:
         return _CONFIG_CACHE[1]
 
-    raw = _load_yaml_file(config_path) if config_path.exists() else {}
-    skills_cfg = raw.get("skills") if isinstance(raw.get("skills"), dict) else {}
-    gov = skills_cfg.get("governance") if isinstance(skills_cfg.get("governance"), dict) else {}
-    protected = gov.get("protected_task_classes")
-    if isinstance(protected, str):
-        protected = [protected]
-    protected_norm = tuple(
-        cls for cls in (_normalize_name(v) for v in (protected or [])) if cls
-    )
-    cfg = GovernanceConfig(
-        registry_path=str(gov.get("registry_path") or "").strip(),
-        task_class=_normalize_name(gov.get("task_class") or ""),
-        protected_task_classes=protected_norm,
-        retrieval_ranking=bool(gov.get("retrieval_ranking", True)),
-    )
+    raw = _read_yaml_mapping(config_path) if config_path.exists() else {}
+    cfg = _parse_governance_config(raw)
     _CONFIG_CACHE = (cache_key, cfg)
     return cfg
 
@@ -224,9 +334,10 @@ def is_protected_task_class_configured(
     This helper is safe to use from fail-closed call sites that need to decide
     whether governance/setup failures must deny skill loading.
     """
-    cfg = _load_governance_config()
-    resolved_task = _normalize_name(task_class) or cfg.task_class
-    return bool(resolved_task) and (resolved_task in cfg.protected_task_classes)
+    probe = probe_protected_task_class(task_class=task_class)
+    if not probe.safe:
+        raise GovernanceConfigError(probe.reason)
+    return probe.protected_task
 
 
 def _lookup_entry(skill_name: str) -> tuple[SkillRegistryEntry | None, str | None, str]:
@@ -317,9 +428,8 @@ def evaluate_skill_selection_fail_closed(
             emit_log=emit_log,
         )
     except Exception as exc:
-        cfg = _load_governance_config()
-        protected = is_protected_task_class_configured(task_class=cfg.task_class)
-        if not protected:
+        probe = probe_protected_task_class()
+        if probe.safe and not probe.protected_task:
             logger.debug(
                 "Skill governance evaluation unavailable for %s",
                 skill_name,
@@ -337,10 +447,10 @@ def evaluate_skill_selection_fail_closed(
             allowed=False,
             reason=f"skill governance evaluation failed: {exc}",
             mode=resolved_mode,
-            task_class=cfg.task_class,
+            task_class=probe.task_class,
             protected_task=True,
             historical_intent=bool(historical_intent),
-            registry_path=str(cfg.registry_path or ""),
+            registry_path="",
         )
         if emit_log:
             log_skill_governance_decision(decision)

--- a/cli.py
+++ b/cli.py
@@ -10359,6 +10359,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             base_cmd = cmd_lower.split()[0]
             skill_commands = _ensure_skill_commands()
             skill_bundles = get_skill_bundles()
+            discoverable_skill_bundles = get_discoverable_skill_bundles()
             quick_commands = self.config.get("quick_commands", {})
             if base_cmd.lstrip("/") in quick_commands:
                 qcmd = quick_commands[base_cmd.lstrip("/")]
@@ -10497,7 +10498,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 # that execution-time resolution agrees with tab-completion.
                 from hermes_cli.commands import COMMANDS
                 typed_base = cmd_lower.split()[0]
-                all_known = set(COMMANDS) | set(skill_commands) | set(skill_bundles)
+                all_known = set(COMMANDS) | set(skill_commands) | set(discoverable_skill_bundles)
                 matches = [c for c in all_known if c.startswith(typed_base)]
                 if len(matches) > 1:
                     # Prefer an exact match (typed the full command name)

--- a/cli.py
+++ b/cli.py
@@ -4058,6 +4058,12 @@ def get_skill_bundles() -> dict:
     return _skill_bundles
 
 
+def get_discoverable_skill_bundles() -> dict:
+    from agent.skill_bundles import get_discoverable_skill_bundles as _impl
+
+    return _impl()
+
+
 def build_bundle_invocation_message(*args, **kwargs):
     from agent.skill_bundles import build_bundle_invocation_message as _impl
 
@@ -7719,7 +7725,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     f"    [bold {_accent_hex()}]{cmd:<22}[/] [dim]-[/] {_escape(info['description'])}"
                 )
 
-        _bundles_now = get_skill_bundles()
+        _bundles_now = get_discoverable_skill_bundles()
         if _bundles_now:
             _cprint(f"\n  ▣ {_BOLD}Skill Bundles{_RST} ({len(_bundles_now)} installed):")
             for cmd, info in sorted(_bundles_now.items()):
@@ -16308,7 +16314,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         _completer = SlashCommandCompleter(
             skill_commands_provider=lambda: get_skill_commands(),
             command_filter=cli_ref._command_available,
-            skill_bundles_provider=lambda: get_skill_bundles(),
+            skill_bundles_provider=lambda: get_discoverable_skill_bundles(),
         )
         input_area = TextArea(
             height=Dimension(min=1, max=8, preferred=1),

--- a/cli.py
+++ b/cli.py
@@ -10425,14 +10425,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         _cprint(f"\033[1;31mPlugin command error: {e}{_RST}")
             # Skill bundles take precedence over individual skills — /<bundle>
             # loads multiple skills at once. Rescans cheaply when files change.
-            elif base_cmd in skill_bundles:
+            elif base_cmd in discoverable_skill_bundles:
                 user_instruction = cmd_original[len(base_cmd):].strip()
                 bundle_result = build_bundle_invocation_message(
                     base_cmd, user_instruction, task_id=self.session_id
                 )
                 if bundle_result:
                     msg, loaded_names, missing = bundle_result
-                    bundle_info = skill_bundles[base_cmd]
+                    bundle_info = discoverable_skill_bundles[base_cmd]
                     print(
                         f"\n⚡ Loading bundle: {bundle_info['name']} "
                         f"({len(loaded_names)} skills)"

--- a/cli.py
+++ b/cli.py
@@ -4027,9 +4027,9 @@ _skill_bundles = None
 def _ensure_skill_commands() -> dict:
     global _skill_commands
     if _skill_commands is None:
-        from agent.skill_commands import scan_skill_commands
+        from agent.skill_commands import get_discoverable_skill_commands
 
-        _skill_commands = scan_skill_commands()
+        _skill_commands = get_discoverable_skill_commands()
     return _skill_commands
 
 

--- a/docs/skills-governance.md
+++ b/docs/skills-governance.md
@@ -1,0 +1,91 @@
+# Skill Governance
+
+Hermes can apply provenance-aware governance to skill selection and skill search ranking.
+
+The configuration lives under `skills.governance` in `config.yaml`:
+
+```yaml
+skills:
+  governance:
+    registry_path: governance/skills-registry.yaml
+    task_class: ardyn_engineering
+    protected_task_classes:
+      - ardyn_engineering
+    retrieval_ranking: true
+```
+
+Fields:
+
+- `registry_path`: path to a machine-readable registry file. Relative paths resolve against `HERMES_HOME`.
+- `task_class`: optional ambient task-class tag used by preload, automatic selection, and retrieval ranking.
+- `protected_task_classes`: task classes that fail closed for non-current skills.
+- `retrieval_ranking`: when true, supported skills-hub retrieval surfaces rank results with governance classification awareness.
+
+## Registry Schema
+
+The registry is YAML (or JSON with the same shape):
+
+```yaml
+version: 1
+skills:
+  - name: ModernCurrent
+    classification: CURRENT
+    aliases: [modern-current]
+    provenance:
+      source: qualified-registry
+      lineage: current-v3
+  - name: ToolTrust
+    classification: COMPATIBILITY_ONLY
+    aliases: [tooltrust]
+    provenance:
+      source: legacy-catalog
+      lineage: tooltrust-v1
+  - name: PREMP
+    classification: STALE
+    aliases: [premp]
+    provenance:
+      source: legacy-catalog
+      lineage: premp-v1
+```
+
+Supported `classification` values:
+
+- `CURRENT`
+- `COMPATIBILITY_ONLY`
+- `STALE`
+- `CONFLICTING`
+- `UNKNOWN`
+
+## Decision Rules
+
+For protected task classes:
+
+- `CURRENT`: allowed
+- `COMPATIBILITY_ONLY`: allowed only with explicit historical intent
+- `UNKNOWN`: rejected
+- `STALE`: rejected
+- `CONFLICTING`: rejected
+
+For unprotected task classes, selection remains permissive and the classification is still exposed for logs and ranking.
+
+Current integrations:
+
+- CLI/TUI skill preload (`--skills`, startup preload path)
+- Gateway automatic channel/topic skill bindings
+- Skills-hub retrieval ordering
+
+## Deterministic Tests
+
+Targeted tests for the governance facility:
+
+```bash
+pytest tests/agent/test_skill_governance.py
+pytest tests/agent/test_skill_commands.py tests/gateway/test_slack_channel_skills.py
+```
+
+The governance test fixture uses a temporary `HERMES_HOME` and proves:
+
+- `ToolTrust` (`COMPATIBILITY_ONLY`) is rejected from protected automatic/preload selection unless historical intent is explicit
+- `PREMP` (`STALE`) is rejected
+- an unregistered skill is treated as `UNKNOWN` and rejected
+- `ModernCurrent` (`CURRENT`) is accepted

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2555,53 +2555,18 @@ def resolve_channel_prompt(
     return None
 
 
-def _normalize_governance_name(value: str) -> str:
-    return str(value or "").strip().lower()
-
-
-def _auto_binding_governance_protected() -> bool:
-    """Return True when channel/topic auto-bindings must fail closed."""
-    try:
-        from agent.skill_utils import yaml_load
-        from hermes_constants import get_config_path
-
-        config_path = get_config_path()
-        if not config_path.exists():
-            return False
-        raw = yaml_load(config_path.read_text(encoding="utf-8"))
-        if not isinstance(raw, dict):
-            return False
-        skills_cfg = raw.get("skills") if isinstance(raw.get("skills"), dict) else {}
-        gov_cfg = (
-            skills_cfg.get("governance")
-            if isinstance(skills_cfg.get("governance"), dict)
-            else {}
-        )
-        task_class = _normalize_governance_name(gov_cfg.get("task_class") or "")
-        if not task_class:
-            return False
-        protected = gov_cfg.get("protected_task_classes") or []
-        if isinstance(protected, str):
-            protected = [protected]
-        protected_names = {
-            name
-            for name in (_normalize_governance_name(item) for item in protected)
-            if name
-        }
-        return task_class in protected_names
-    except Exception:
-        logger.debug("Failed to inspect governance config for auto-bindings", exc_info=True)
-        return False
-
-
 def _filter_auto_bound_skills(skill_names: list[str]) -> list[str]:
     """Apply governance filtering to automatic channel/topic skill bindings."""
     if not skill_names:
         return []
 
-    protected_task = _auto_binding_governance_protected()
+    protected_task = True
     try:
-        from agent.skill_governance import evaluate_skill_selection_fail_closed
+        from agent.skill_governance import (
+            evaluate_skill_selection_fail_closed,
+            probe_protected_task_class,
+        )
+        protected_task = probe_protected_task_class().protected_task
     except Exception:
         if protected_task:
             logger.warning(

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2579,6 +2579,14 @@ def resolve_channel_skills(
     Returns a deduplicated list of skill names (order preserved), or None if
     no match is found.
     """
+    try:
+        from agent.skill_governance import filter_allowed_skill_names, governance_context
+
+        _governance_context = governance_context(mode="auto")
+    except Exception:
+        filter_allowed_skill_names = None
+        _governance_context = None
+
     bindings = config_extra.get("channel_skill_bindings") or []
     if not isinstance(bindings, list) or not bindings:
         return None
@@ -2597,7 +2605,17 @@ def resolve_channel_skills(
             skills = entry.get("skills") or entry.get("skill")
             if isinstance(skills, str):
                 s = skills.strip()
-                return [s] if s else None
+                resolved = [s] if s else None
+                if (
+                    resolved
+                    and filter_allowed_skill_names is not None
+                    and _governance_context is not None
+                ):
+                    resolved, _decisions = filter_allowed_skill_names(
+                        resolved,
+                        context=_governance_context,
+                    )
+                return resolved or None
             if isinstance(skills, list) and skills:
                 seen: list[str] = []
                 for name in skills:
@@ -2606,6 +2624,15 @@ def resolve_channel_skills(
                     nm = name.strip()
                     if nm and nm not in seen:
                         seen.append(nm)
+                if (
+                    seen
+                    and filter_allowed_skill_names is not None
+                    and _governance_context is not None
+                ):
+                    seen, _decisions = filter_allowed_skill_names(
+                        seen,
+                        context=_governance_context,
+                    )
                 return seen or None
     return None
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2555,6 +2555,84 @@ def resolve_channel_prompt(
     return None
 
 
+def _normalize_governance_name(value: str) -> str:
+    return str(value or "").strip().lower()
+
+
+def _auto_binding_governance_protected() -> bool:
+    """Return True when channel/topic auto-bindings must fail closed."""
+    try:
+        from agent.skill_utils import yaml_load
+        from hermes_constants import get_config_path
+
+        config_path = get_config_path()
+        if not config_path.exists():
+            return False
+        raw = yaml_load(config_path.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            return False
+        skills_cfg = raw.get("skills") if isinstance(raw.get("skills"), dict) else {}
+        gov_cfg = (
+            skills_cfg.get("governance")
+            if isinstance(skills_cfg.get("governance"), dict)
+            else {}
+        )
+        task_class = _normalize_governance_name(gov_cfg.get("task_class") or "")
+        if not task_class:
+            return False
+        protected = gov_cfg.get("protected_task_classes") or []
+        if isinstance(protected, str):
+            protected = [protected]
+        protected_names = {
+            name
+            for name in (_normalize_governance_name(item) for item in protected)
+            if name
+        }
+        return task_class in protected_names
+    except Exception:
+        logger.debug("Failed to inspect governance config for auto-bindings", exc_info=True)
+        return False
+
+
+def _filter_auto_bound_skills(skill_names: list[str]) -> list[str]:
+    """Apply governance filtering to automatic channel/topic skill bindings."""
+    if not skill_names:
+        return []
+
+    protected_task = _auto_binding_governance_protected()
+    try:
+        from agent.skill_governance import evaluate_skill_selection_fail_closed
+    except Exception:
+        if protected_task:
+            logger.warning(
+                "Auto-bound skill governance unavailable for protected task class; denying %s",
+                skill_names,
+            )
+            return []
+        return skill_names
+
+    allowed: list[str] = []
+    for skill_name in skill_names:
+        try:
+            decision = evaluate_skill_selection_fail_closed(
+                skill_name,
+                mode="auto",
+            )
+        except Exception:
+            if protected_task:
+                logger.warning(
+                    "Auto-bound skill governance evaluation failed for protected task class; denying %s",
+                    skill_name,
+                    exc_info=True,
+                )
+                continue
+            allowed.append(skill_name)
+            continue
+        if decision is None or decision.allowed:
+            allowed.append(skill_name)
+    return allowed
+
+
 def resolve_channel_skills(
     config_extra: dict,
     channel_id: str,
@@ -2579,14 +2657,6 @@ def resolve_channel_skills(
     Returns a deduplicated list of skill names (order preserved), or None if
     no match is found.
     """
-    try:
-        from agent.skill_governance import filter_allowed_skill_names, governance_context
-
-        _governance_context = governance_context(mode="auto")
-    except Exception:
-        filter_allowed_skill_names = None
-        _governance_context = None
-
     bindings = config_extra.get("channel_skill_bindings") or []
     if not isinstance(bindings, list) or not bindings:
         return None
@@ -2605,16 +2675,7 @@ def resolve_channel_skills(
             skills = entry.get("skills") or entry.get("skill")
             if isinstance(skills, str):
                 s = skills.strip()
-                resolved = [s] if s else None
-                if (
-                    resolved
-                    and filter_allowed_skill_names is not None
-                    and _governance_context is not None
-                ):
-                    resolved, _decisions = filter_allowed_skill_names(
-                        resolved,
-                        context=_governance_context,
-                    )
+                resolved = _filter_auto_bound_skills([s]) if s else None
                 return resolved or None
             if isinstance(skills, list) and skills:
                 seen: list[str] = []
@@ -2624,15 +2685,8 @@ def resolve_channel_skills(
                     nm = name.strip()
                     if nm and nm not in seen:
                         seen.append(nm)
-                if (
-                    seen
-                    and filter_allowed_skill_names is not None
-                    and _governance_context is not None
-                ):
-                    seen, _decisions = filter_allowed_skill_names(
-                        seen,
-                        context=_governance_context,
-                    )
+                if seen:
+                    seen = _filter_auto_bound_skills(seen)
                 return seen or None
     return None
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -62,7 +62,6 @@ from agent.i18n import t
 from agent.interrupt_compat import request_hard_interrupt
 from hermes_cli.config import cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
-from hermes_constants import get_config_path
 
 # --- Agent cache tuning ---------------------------------------------------
 # Bounds the per-session AIAgent cache to prevent unbounded growth in
@@ -119,32 +118,6 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r")",
     re.IGNORECASE | re.DOTALL,
 )
-
-
-def _protected_skill_governance_configured_fallback() -> bool:
-    """Best-effort config-only fallback when skill governance can't import."""
-    try:
-        from agent.skill_utils import yaml_load
-
-        config_path = get_config_path()
-        if not config_path.exists():
-            return False
-        raw = yaml_load(config_path.read_text(encoding="utf-8"))
-        if not isinstance(raw, dict):
-            return False
-        skills_cfg = raw.get("skills") if isinstance(raw.get("skills"), dict) else {}
-        gov_cfg = skills_cfg.get("governance") if isinstance(skills_cfg.get("governance"), dict) else {}
-        task_class = str(gov_cfg.get("task_class") or "").strip().lower()
-        if not task_class:
-            return False
-        protected = gov_cfg.get("protected_task_classes") or []
-        if isinstance(protected, str):
-            protected = [protected]
-        protected_names = {str(item or "").strip().lower() for item in protected if str(item or "").strip()}
-        return task_class in protected_names
-    except Exception:
-        logger.debug("Failed to inspect protected skill governance fallback", exc_info=True)
-        return False
 
 
 def _record_hygiene_cooldown(gateway, session_id: str, cooldown_seconds: float) -> None:
@@ -15389,12 +15362,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Skill bundles take precedence over individual skill commands —
             # /<bundle> loads multiple skills at once. Mirrors CLI dispatch.
             _bundle_handled = False
+            _skill_governance_rejected = ()
             try:
                 from agent.skill_bundles import (
                     build_bundle_invocation_message,
                     resolve_bundle_command_key,
                 )
                 from agent.skill_governance import SkillGovernanceRejectedError
+                _skill_governance_rejected = (SkillGovernanceRejectedError,)
                 bundle_key = resolve_bundle_command_key(command)
                 if bundle_key is not None:
                     user_instruction = event.get_command_args().strip()
@@ -15418,7 +15393,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 bundle_key, ", ".join(missing),
                             )
                         # Fall through to normal message processing with bundle content
-            except SkillGovernanceRejectedError as exc:
+            except _skill_governance_rejected as exc:
                 return str(exc)
             except Exception as exc:
                 logger.warning("Bundle dispatch failed: %s", exc)
@@ -15433,9 +15408,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 from agent.skill_governance import (
                     SkillGovernanceRejectedError,
-                    is_protected_task_class_configured,
+                    probe_protected_task_class,
                 )
-                _protected_skill_governance = is_protected_task_class_configured()
+                _protected_skill_governance = probe_protected_task_class().protected_task
                 skill_cmds = get_skill_commands()
                 cmd_key = resolve_skill_command_key(command)
                 if cmd_key is not None:
@@ -15538,7 +15513,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return str(exc)
             except Exception as e:
                 logger.debug("Skill command check failed", exc_info=True)
-                if _protected_skill_governance or _protected_skill_governance_configured_fallback():
+                if _protected_skill_governance:
                     return (
                         f'The "/{command}" skill command was denied because skill governance '
                         f"could not be evaluated for the protected task class: {e}"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15367,6 +15367,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     build_bundle_invocation_message,
                     resolve_bundle_command_key,
                 )
+                from agent.skill_governance import SkillGovernanceRejectedError
                 bundle_key = resolve_bundle_command_key(command)
                 if bundle_key is not None:
                     user_instruction = event.get_command_args().strip()
@@ -15390,6 +15391,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 bundle_key, ", ".join(missing),
                             )
                         # Fall through to normal message processing with bundle content
+            except SkillGovernanceRejectedError as exc:
+                return str(exc)
             except Exception as exc:
                 logger.warning("Bundle dispatch failed: %s", exc)
 
@@ -15400,6 +15403,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     build_skill_invocation_message,
                     resolve_skill_command_key,
                 )
+                from agent.skill_governance import SkillGovernanceRejectedError
                 skill_cmds = get_skill_commands()
                 cmd_key = resolve_skill_command_key(command)
                 if cmd_key is not None:
@@ -15498,6 +15502,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             f"or resend without the leading slash to send "
                             f"as a regular message."
                         )
+            except SkillGovernanceRejectedError as exc:
+                return str(exc)
             except Exception as e:
                 logger.debug("Skill command check failed (non-fatal): %s", e)
         

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -62,6 +62,7 @@ from agent.i18n import t
 from agent.interrupt_compat import request_hard_interrupt
 from hermes_cli.config import cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
+from hermes_constants import get_config_path
 
 # --- Agent cache tuning ---------------------------------------------------
 # Bounds the per-session AIAgent cache to prevent unbounded growth in
@@ -118,6 +119,32 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r")",
     re.IGNORECASE | re.DOTALL,
 )
+
+
+def _protected_skill_governance_configured_fallback() -> bool:
+    """Best-effort config-only fallback when skill governance can't import."""
+    try:
+        from agent.skill_utils import yaml_load
+
+        config_path = get_config_path()
+        if not config_path.exists():
+            return False
+        raw = yaml_load(config_path.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            return False
+        skills_cfg = raw.get("skills") if isinstance(raw.get("skills"), dict) else {}
+        gov_cfg = skills_cfg.get("governance") if isinstance(skills_cfg.get("governance"), dict) else {}
+        task_class = str(gov_cfg.get("task_class") or "").strip().lower()
+        if not task_class:
+            return False
+        protected = gov_cfg.get("protected_task_classes") or []
+        if isinstance(protected, str):
+            protected = [protected]
+        protected_names = {str(item or "").strip().lower() for item in protected if str(item or "").strip()}
+        return task_class in protected_names
+    except Exception:
+        logger.debug("Failed to inspect protected skill governance fallback", exc_info=True)
+        return False
 
 
 def _record_hygiene_cooldown(gateway, session_id: str, cooldown_seconds: float) -> None:
@@ -15397,13 +15424,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.warning("Bundle dispatch failed: %s", exc)
 
         if command and not locals().get("_bundle_handled", False):
+            _protected_skill_governance = False
             try:
                 from agent.skill_commands import (
                     get_skill_commands,
                     build_skill_invocation_message,
                     resolve_skill_command_key,
                 )
-                from agent.skill_governance import SkillGovernanceRejectedError
+                from agent.skill_governance import (
+                    SkillGovernanceRejectedError,
+                    is_protected_task_class_configured,
+                )
+                _protected_skill_governance = is_protected_task_class_configured()
                 skill_cmds = get_skill_commands()
                 cmd_key = resolve_skill_command_key(command)
                 if cmd_key is not None:
@@ -15505,7 +15537,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except SkillGovernanceRejectedError as exc:
                 return str(exc)
             except Exception as e:
-                logger.debug("Skill command check failed (non-fatal): %s", e)
+                logger.debug("Skill command check failed", exc_info=True)
+                if _protected_skill_governance or _protected_skill_governance_configured_fallback():
+                    return (
+                        f'The "/{command}" skill command was denied because skill governance '
+                        f"could not be evaluated for the protected task class: {e}"
+                    )
         
         # Pending exec approvals are handled by /approve and /deny commands above.
         # No bare text matching — "yes" in normal conversation must not trigger

--- a/hermes_cli/bundles.py
+++ b/hermes_cli/bundles.py
@@ -24,7 +24,7 @@ from agent.skill_bundles import (
     _bundles_dir,
     delete_bundle,
     get_bundle,
-    list_bundles,
+    list_discoverable_bundles,
     reload_bundles,
     save_bundle,
     scan_bundles,
@@ -40,7 +40,7 @@ def _console() -> Console:
 
 def _cmd_list(args) -> None:
     c = _console()
-    bundles = list_bundles()
+    bundles = list_discoverable_bundles()
     if not bundles:
         c.print(
             f"[dim]No bundles installed yet. Create one with:\n"

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -918,7 +918,7 @@ def _collect_gateway_skill_entries(
 
     skill_triples: list[tuple[str, str, str]] = []
     try:
-        from agent.skill_commands import get_skill_commands
+        from agent.skill_commands import get_discoverable_skill_commands
         from tools.skills_tool import SKILLS_DIR
         from agent.skill_utils import get_external_skills_dirs
         _skills_dir = str(SKILLS_DIR.resolve())
@@ -933,7 +933,7 @@ def _collect_gateway_skill_entries(
         _allowed_prefixes.extend(
             str(d).rstrip("/") + "/" for d in get_external_skills_dirs()
         )
-        skill_cmds = get_skill_commands()
+        skill_cmds = get_discoverable_skill_commands()
         for cmd_key in sorted(skill_cmds):
             info = skill_cmds[cmd_key]
             skill_path = info.get("skill_md_path", "")
@@ -1099,7 +1099,7 @@ def discord_skill_commands_by_category(
     hidden = 0
 
     try:
-        from agent.skill_commands import get_skill_commands
+        from agent.skill_commands import get_discoverable_skill_commands
         from agent.skill_utils import get_external_skills_dirs
         from tools.skills_tool import SKILLS_DIR
 
@@ -1117,7 +1117,7 @@ def discord_skill_commands_by_category(
                     continue
         except Exception:
             pass
-        skill_cmds = get_skill_commands()
+        skill_cmds = get_discoverable_skill_commands()
 
         for cmd_key in sorted(skill_cmds):
             info = skill_cmds[cmd_key]

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1790,6 +1790,23 @@ DEFAULT_CONFIG = {
     # always goes to ~/.hermes/skills/.
     "skills": {
         "external_dirs": [],   # e.g. ["~/.agents/skills", "/shared/team-skills"]
+        "governance": {
+            # Optional machine-readable registry describing the provenance
+            # status of skills. Relative paths resolve against HERMES_HOME.
+            # When unset, governance classification falls back to UNKNOWN.
+            "registry_path": "",
+            # Optional ambient task class used by automatic skill selection,
+            # preload filtering, and retrieval ranking.
+            "task_class": "",
+            # Task classes that must fail closed for non-current skills.
+            # CURRENT is allowed. COMPATIBILITY_ONLY additionally requires
+            # explicit historical intent from the caller. UNKNOWN / STALE /
+            # CONFLICTING are rejected.
+            "protected_task_classes": [],
+            # Apply governance classification to supported retrieval ranking
+            # surfaces (currently skills-hub search ordering).
+            "retrieval_ranking": True,
+        },
         # Substitute ${HERMES_SKILL_DIR} and ${HERMES_SESSION_ID} in SKILL.md
         # content with the absolute skill directory and the active session id
         # before the agent sees it.  Lets skill authors reference bundled

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -41,6 +41,42 @@ def _display_source(r) -> str:
     return r.source
 
 
+def _rank_retrieval_results(
+    results,
+    *,
+    fallback_key=None,
+):
+    """Governance-aware retrieval ordering with protected-task fail-closed.
+
+    Retrieval may fall back to the pre-governance ordering only when the active
+    config parsed safely and does not mark the current task class protected.
+    """
+    ranked = list(results or [])
+    if not ranked:
+        return ranked
+
+    try:
+        from agent.skill_governance import governance_context, rank_skill_search_results
+
+        return rank_skill_search_results(
+            ranked,
+            context=governance_context(mode="retrieval"),
+        )
+    except Exception:
+        probe = None
+        try:
+            from agent.skill_governance import probe_protected_task_class
+
+            probe = probe_protected_task_class()
+        except Exception:
+            probe = None
+        if probe is None or not probe.safe or probe.protected_task:
+            return []
+        if fallback_key is not None:
+            ranked.sort(key=fallback_key)
+        return ranked
+
+
 # ---------------------------------------------------------------------------
 # Shared do_* functions
 # ---------------------------------------------------------------------------
@@ -402,22 +438,18 @@ def do_browse(page: int = 1, page_size: int = 20, source: str = "all",
             seen[r.identifier] = r
     deduped = list(seen.values())
 
-    try:
-        from agent.skill_governance import governance_context, governance_sort_tuple
+    deduped = _rank_retrieval_results(
+        deduped,
+        fallback_key=lambda r: (
+            -_TRUST_RANK.get(r.trust_level, 0),
+            r.source != "official",
+            r.name.lower(),
+        ),
+    )
 
-        _governance_context = governance_context(mode="retrieval")
-        deduped.sort(key=lambda r: (
-            *governance_sort_tuple(r, context=_governance_context),
-            -_TRUST_RANK.get(r.trust_level, 0),
-            r.source != "official",
-            r.name.lower(),
-        ))
-    except Exception:
-        deduped.sort(key=lambda r: (
-            -_TRUST_RANK.get(r.trust_level, 0),
-            r.source != "official",
-            r.name.lower(),
-        ))
+    if not deduped:
+        c.print("[dim]No skills found in the Skills Hub.[/]\n")
+        return
 
     # Paginate
     total = len(deduped)

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -402,12 +402,22 @@ def do_browse(page: int = 1, page_size: int = 20, source: str = "all",
             seen[r.identifier] = r
     deduped = list(seen.values())
 
-    # Sort: official first, then by trust level (desc), then alphabetically
-    deduped.sort(key=lambda r: (
-        -_TRUST_RANK.get(r.trust_level, 0),
-        r.source != "official",
-        r.name.lower(),
-    ))
+    try:
+        from agent.skill_governance import governance_context, governance_sort_tuple
+
+        _governance_context = governance_context(mode="retrieval")
+        deduped.sort(key=lambda r: (
+            *governance_sort_tuple(r, context=_governance_context),
+            -_TRUST_RANK.get(r.trust_level, 0),
+            r.source != "official",
+            r.name.lower(),
+        ))
+    except Exception:
+        deduped.sort(key=lambda r: (
+            -_TRUST_RANK.get(r.trust_level, 0),
+            r.source != "official",
+            r.name.lower(),
+        ))
 
     # Paginate
     total = len(deduped)
@@ -877,7 +887,20 @@ def browse_skills(page: int = 1, page_size: int = 20, source: str = "all") -> di
         if r.identifier not in seen or rank > _TRUST_RANK.get(seen[r.identifier].trust_level, 0):
             seen[r.identifier] = r
     deduped = list(seen.values())
-    deduped.sort(key=lambda r: (-_TRUST_RANK.get(r.trust_level, 0), r.source != "official", r.name.lower()))
+    try:
+        from agent.skill_governance import governance_context, governance_sort_tuple
+
+        _governance_context = governance_context(mode="retrieval")
+        deduped.sort(
+            key=lambda r: (
+                *governance_sort_tuple(r, context=_governance_context),
+                -_TRUST_RANK.get(r.trust_level, 0),
+                r.source != "official",
+                r.name.lower(),
+            )
+        )
+    except Exception:
+        deduped.sort(key=lambda r: (-_TRUST_RANK.get(r.trust_level, 0), r.source != "official", r.name.lower()))
     total = len(deduped)
     total_pages = max(1, (total + page_size - 1) // page_size)
     page = max(1, min(page, total_pages))

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -918,21 +918,16 @@ def browse_skills(page: int = 1, page_size: int = 20, source: str = "all") -> di
         rank = _TRUST_RANK.get(r.trust_level, 0)
         if r.identifier not in seen or rank > _TRUST_RANK.get(seen[r.identifier].trust_level, 0):
             seen[r.identifier] = r
-    deduped = list(seen.values())
-    try:
-        from agent.skill_governance import governance_context, governance_sort_tuple
-
-        _governance_context = governance_context(mode="retrieval")
-        deduped.sort(
-            key=lambda r: (
-                *governance_sort_tuple(r, context=_governance_context),
-                -_TRUST_RANK.get(r.trust_level, 0),
-                r.source != "official",
-                r.name.lower(),
-            )
-        )
-    except Exception:
-        deduped.sort(key=lambda r: (-_TRUST_RANK.get(r.trust_level, 0), r.source != "official", r.name.lower()))
+    deduped = _rank_retrieval_results(
+        list(seen.values()),
+        fallback_key=lambda r: (
+            -_TRUST_RANK.get(r.trust_level, 0),
+            r.source != "official",
+            r.name.lower(),
+        ),
+    )
+    if not deduped:
+        return {"items": [], "page": 1, "total_pages": 1, "total": 0}
     total = len(deduped)
     total_pages = max(1, (total + page_size - 1) // page_size)
     page = max(1, min(page, total_pages))

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -302,7 +302,14 @@ def do_search(query: str, source: str = "all", limit: int = 10,
     if as_json:
         # Avoid Rich status spinner contaminating stdout — JSON consumers
         # expect a clean parseable stream.
-        results = unified_search(query, sources, source_filter=source, limit=limit)
+        results = _rank_retrieval_results(
+            unified_search(query, sources, source_filter=source, limit=limit),
+            fallback_key=lambda r: (
+                {"builtin": 2, "trusted": 1, "community": 0}.get(r.trust_level, 0) * -1,
+                r.source != "official",
+                r.name.lower(),
+            ),
+        )
         payload = [
             {
                 "name": r.name,
@@ -318,7 +325,14 @@ def do_search(query: str, source: str = "all", limit: int = 10,
 
     c.print(f"\n[bold]Searching for:[/] {query}")
     with c.status("[bold]Searching registries..."):
-        results = unified_search(query, sources, source_filter=source, limit=limit)
+        results = _rank_retrieval_results(
+            unified_search(query, sources, source_filter=source, limit=limit),
+            fallback_key=lambda r: (
+                {"builtin": 2, "trusted": 1, "community": 0}.get(r.trust_level, 0) * -1,
+                r.source != "official",
+                r.name.lower(),
+            ),
+        )
 
     if not results:
         c.print("[dim]No skills found matching your query.[/]\n")

--- a/hermes_cli/slash_exec.py
+++ b/hermes_cli/slash_exec.py
@@ -109,14 +109,14 @@ def _exec_profile(ctx: CommandContext) -> CommandReply:
 def _exec_bundles(ctx: CommandContext) -> CommandReply:
     """Core /bundles data — installed skill bundles listing."""
     try:
-        from agent.skill_bundles import _bundles_dir, list_bundles
+        from agent.skill_bundles import _bundles_dir, list_discoverable_bundles
     except Exception as exc:  # pragma: no cover - env-specific
         return CommandReply(
             f"Bundles subsystem unavailable: {exc}",
             data={"error": str(exc)},
         )
 
-    bundles = list_bundles()
+    bundles = list_discoverable_bundles()
     bundles_dir = str(_bundles_dir())
     if not bundles:
         return CommandReply(
@@ -150,8 +150,9 @@ def _exec_help(ctx: CommandContext) -> CommandReply:
         *gateway_help_lines(),
     ]
     try:
-        from agent.skill_commands import get_skill_commands
-        skill_cmds = get_skill_commands()
+        from agent.skill_commands import get_discoverable_skill_commands
+
+        skill_cmds = get_discoverable_skill_commands()
         if skill_cmds:
             lines.append(t("gateway.help.skill_header", count=len(skill_cmds)))
             # Show first 10, then point to /commands for the rest
@@ -186,8 +187,9 @@ def _exec_commands(ctx: CommandContext) -> CommandReply:
     # Build combined entry list: built-in commands + skill commands
     entries = list(gateway_help_lines())
     try:
-        from agent.skill_commands import get_skill_commands
-        skill_cmds = get_skill_commands()
+        from agent.skill_commands import get_discoverable_skill_commands
+
+        skill_cmds = get_discoverable_skill_commands()
         if skill_cmds:
             entries.append("")
             entries.append(t("gateway.commands.skill_header"))

--- a/hermes_cli/web_routers/skills.py
+++ b/hermes_cli/web_routers/skills.py
@@ -119,6 +119,7 @@ async def list_skills_hub_sources(profile: Optional[str] = None):
     """
 
     def _run():
+        from hermes_cli.skills_hub import _rank_retrieval_results
         from tools.skills_hub import create_source_router
 
         with _config_profile_scope(profile):
@@ -147,9 +148,8 @@ async def list_skills_hub_sources(profile: Optional[str] = None):
                 # Empty-query search on the index returns featured/popular skills.
                 if index_available:
                     try:
-                        featured = [
-                            _skill_meta_to_payload(m) for m in src.search("", limit=12)
-                        ]
+                        ranked_featured = _rank_retrieval_results(src.search("", limit=12))
+                        featured = [_skill_meta_to_payload(m) for m in ranked_featured]
                     except Exception:
                         featured = []
             out.append(entry)
@@ -196,6 +196,7 @@ async def search_skills_hub(
         return {"results": [], "source_counts": {}, "timed_out": [], "installed": {}}
 
     def _run():
+        from hermes_cli.skills_hub import _rank_retrieval_results
         from tools.skills_hub import create_source_router, parallel_search_sources
 
         with _config_profile_scope(profile):
@@ -213,7 +214,14 @@ async def search_skills_hub(
                 seen[r.identifier] = r
             elif _rank.get(r.trust_level, 0) > _rank.get(seen[r.identifier].trust_level, 0):
                 seen[r.identifier] = r
-        deduped = list(seen.values())[:capped]
+        deduped = _rank_retrieval_results(
+            list(seen.values()),
+            fallback_key=lambda r: (
+                -_rank.get(r.trust_level, 0),
+                r.source != "official",
+                r.name.lower(),
+            ),
+        )[:capped]
 
         return {
             "results": [_skill_meta_to_payload(m) for m in deduped],

--- a/tests/agent/test_skill_bundles.py
+++ b/tests/agent/test_skill_bundles.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 
 import pytest
+from agent.skill_governance import SkillGovernanceRejectedError
 
 from agent.skill_bundles import (
     _slugify,
@@ -17,6 +18,25 @@ from agent.skill_bundles import (
     save_bundle,
     scan_bundles,
 )
+
+
+def _configure_protected_governance(home: Path, registry_entries: str) -> None:
+    (home / "governance").mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        """\
+skills:
+  governance:
+    registry_path: governance/skills-registry.yaml
+    task_class: ardyn_engineering
+    protected_task_classes:
+      - ardyn_engineering
+""",
+        encoding="utf-8",
+    )
+    (home / "governance" / "skills-registry.yaml").write_text(
+        "version: 1\nskills:\n" + registry_entries,
+        encoding="utf-8",
+    )
 
 
 def _make_bundle_yaml(
@@ -227,6 +247,29 @@ class TestBuildBundleInvocationMessage:
         msg2, loaded2, _ = result2
         assert set(loaded2) == {"skill-a", "skill-b"}
         assert "SECRET DISABLED CONTENT." in msg2
+
+    def test_bundle_denies_when_member_is_governance_blocked(
+        self, bundles_env, monkeypatch
+    ):
+        bundles_dir, skills_dir = bundles_env
+        home = bundles_dir.parent / "home"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        _configure_protected_governance(
+            home,
+            """\
+  - name: skill-a
+    classification: CURRENT
+  - name: skill-b
+    classification: COMPATIBILITY_ONLY
+""",
+        )
+        _make_skill(skills_dir, "skill-a", body="safe")
+        _make_skill(skills_dir, "skill-b", body="blocked")
+        _make_bundle_yaml(bundles_dir, "combo", ["skill-a", "skill-b"])
+        scan_bundles()
+
+        with pytest.raises(SkillGovernanceRejectedError, match="skill-b"):
+            build_bundle_invocation_message("/combo")
 
 
 

--- a/tests/agent/test_skill_bundles.py
+++ b/tests/agent/test_skill_bundles.py
@@ -10,6 +10,7 @@ from agent.skill_bundles import (
     _slugify,
     build_bundle_invocation_message,
     delete_bundle,
+    get_discoverable_skill_bundles,
     get_bundle,
     get_skill_bundles,
     list_bundles,
@@ -145,6 +146,52 @@ class TestGetSkillBundles:
         result = get_skill_bundles()
         assert "/a" in result
         assert "/b" in result
+
+
+class TestDiscoverableSkillBundles:
+    def test_hides_bundle_with_governance_blocked_member(self, bundles_env, monkeypatch):
+        bundles_dir, skills_dir = bundles_env
+        home = bundles_dir.parent / "home"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        _configure_protected_governance(
+            home,
+            """\
+  - name: skill-a
+    classification: CURRENT
+  - name: skill-b
+    classification: COMPATIBILITY_ONLY
+""",
+        )
+        _make_skill(skills_dir, "skill-a", body="safe")
+        _make_skill(skills_dir, "skill-b", body="blocked")
+        _make_bundle_yaml(bundles_dir, "combo", ["skill-a", "skill-b"])
+
+        assert get_discoverable_skill_bundles() == {}
+
+    def test_fail_closes_when_governance_config_is_malformed(self, bundles_env, monkeypatch):
+        bundles_dir, skills_dir = bundles_env
+        home = bundles_dir.parent / "home"
+        home.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        (home / "config.yaml").write_text(
+            "skills:\n  governance: []\n",
+            encoding="utf-8",
+        )
+        _make_skill(skills_dir, "skill-a", body="safe")
+        _make_bundle_yaml(bundles_dir, "combo", ["skill-a"])
+
+        assert get_discoverable_skill_bundles() == {}
+
+    def test_preserves_unprotected_behavior(self, bundles_env, monkeypatch):
+        bundles_dir, skills_dir = bundles_env
+        home = bundles_dir.parent / "home"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        _make_skill(skills_dir, "skill-a", body="safe")
+        _make_bundle_yaml(bundles_dir, "combo", ["skill-a"])
+
+        visible = get_discoverable_skill_bundles()
+
+        assert list(visible) == ["/combo"]
 
 
 class TestResolveBundleCommandKey:

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -465,7 +465,71 @@ class TestBuildPreloadedSkillsPrompt:
         assert loaded == []
         assert missing == ["protected-skill"]
 
-    def test_unprotected_preload_keeps_loading_when_governance_import_fails(self, tmp_path, monkeypatch):
+    def test_protected_preload_denies_when_skill_utils_import_fails_and_governance_eval_errors(
+        self, tmp_path, monkeypatch
+    ):
+        home = tmp_path / "home"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        _configure_protected_governance(
+            home,
+            """\
+  - name: protected-skill
+    classification: CURRENT
+""",
+        )
+
+        real_import = builtins.__import__
+
+        def _deny_imports(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "agent.skill_utils":
+                raise ImportError(f"simulated import failure: {name}")
+            return real_import(name, globals, locals, fromlist, level)
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path / "nonexistent"):
+            monkeypatch.setattr(
+                "agent.skill_commands._load_skill_payload",
+                lambda identifier, task_id=None: (
+                    {"content": "must not load", "name": identifier},
+                    None,
+                    identifier,
+                ),
+            )
+            monkeypatch.setattr(
+                "agent.skill_governance.evaluate_skill_selection",
+                lambda *args, **kwargs: (_ for _ in ()).throw(
+                    RuntimeError("simulated governance evaluation failure")
+                ),
+            )
+            monkeypatch.setattr(builtins, "__import__", _deny_imports)
+            prompt, loaded, missing = build_preloaded_skills_prompt(["protected-skill"])
+
+        assert prompt == ""
+        assert loaded == []
+        assert missing == ["protected-skill"]
+
+    def test_protected_preload_denies_when_config_cannot_be_parsed(
+        self, tmp_path, monkeypatch
+    ):
+        home = tmp_path / "home"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        (home / "config.yaml").parent.mkdir(parents=True, exist_ok=True)
+        (home / "config.yaml").write_text("skills: [\n", encoding="utf-8")
+        monkeypatch.setattr(
+            "agent.skill_commands._load_skill_payload",
+            lambda identifier, task_id=None: (
+                {"content": "must not load", "name": identifier},
+                None,
+                identifier,
+            ),
+        )
+
+        prompt, loaded, missing = build_preloaded_skills_prompt(["protected-skill"])
+
+        assert prompt == ""
+        assert loaded == []
+        assert missing == ["protected-skill"]
+
+    def test_unprotected_preload_keeps_loading_when_config_is_unprotected(self, tmp_path, monkeypatch):
         home = tmp_path / "home"
         skills_dir = tmp_path / "skills"
         skills_dir.mkdir()
@@ -490,15 +554,7 @@ skills:
         )
         _make_skill(skills_dir, "unprotected-skill", body="still loads")
 
-        real_import = builtins.__import__
-
-        def _deny_governance_import(name, globals=None, locals=None, fromlist=(), level=0):
-            if name == "agent.skill_governance":
-                raise ImportError("simulated governance import failure")
-            return real_import(name, globals, locals, fromlist, level)
-
         with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
-            monkeypatch.setattr(builtins, "__import__", _deny_governance_import)
             prompt, loaded, missing = build_preloaded_skills_prompt(["unprotected-skill"])
 
         assert loaded == ["unprotected-skill"]

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 
 import tools.skills_tool as skills_tool_module
+from agent.skill_governance import SkillGovernanceRejectedError
 from agent.skill_commands import (
     build_preloaded_skills_prompt,
     build_skill_invocation_message,
@@ -50,6 +51,25 @@ def _symlink_category(skills_dir: Path, linked_root: Path, category: str) -> Pat
     return external_category
 
 
+def _configure_protected_governance(home: Path, registry_entries: str) -> None:
+    (home / "governance").mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        """\
+skills:
+  governance:
+    registry_path: governance/skills-registry.yaml
+    task_class: ardyn_engineering
+    protected_task_classes:
+      - ardyn_engineering
+""",
+        encoding="utf-8",
+    )
+    (home / "governance" / "skills-registry.yaml").write_text(
+        "version: 1\nskills:\n" + registry_entries,
+        encoding="utf-8",
+    )
+
+
 class TestScanSkillCommands:
 
 
@@ -81,6 +101,48 @@ class TestScanSkillCommands:
         assert "/impeccable" in result
         assert message is not None
         assert "Apply impeccable design craft." in message
+
+    def test_explicit_skill_invocation_denies_compatibility_only_without_historical_intent(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _configure_protected_governance(
+            tmp_path,
+            """\
+  - name: ToolTrust
+    classification: COMPATIBILITY_ONLY
+""",
+        )
+        _make_skill(tmp_path, "ToolTrust", body="blocked legacy content")
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            scan_skill_commands()
+            with pytest.raises(SkillGovernanceRejectedError, match="historical intent"):
+                build_skill_invocation_message("/tooltrust", "do it")
+
+    def test_explicit_skill_invocation_fails_closed_when_governance_eval_errors(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _configure_protected_governance(
+            tmp_path,
+            """\
+  - name: ToolTrust
+    classification: CURRENT
+""",
+        )
+        _make_skill(tmp_path, "ToolTrust", body="should not load")
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch(
+                "agent.skill_governance.governance_context",
+                side_effect=RuntimeError("registry unreadable"),
+            ),
+        ):
+            scan_skill_commands()
+            with pytest.raises(SkillGovernanceRejectedError, match="evaluation failed"):
+                build_skill_invocation_message("/tooltrust", "do it")
 
     def test_get_skill_commands_rescans_when_platform_scope_changes(self, tmp_path):
         """Platform-specific disabled-skill caches must not leak across platforms.
@@ -690,3 +752,28 @@ class TestStackedSkillCommands:
         assert loaded == ["skill-a"]
         assert missing == ["gone"]
         assert "Skills missing (skipped): gone" in msg
+
+    def test_stacked_message_denies_when_any_member_is_governance_blocked(
+        self, tmp_path, monkeypatch
+    ):
+        from agent.skill_commands import build_stacked_skill_invocation_message
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        _configure_protected_governance(
+            tmp_path / "home",
+            """\
+  - name: skill-a
+    classification: CURRENT
+  - name: skill-b
+    classification: COMPATIBILITY_ONLY
+""",
+        )
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            self._setup_three_skills(tmp_path)
+            scan_skill_commands()
+            with pytest.raises(SkillGovernanceRejectedError, match="skill-b"):
+                build_stacked_skill_invocation_message(
+                    ["/skill-a", "/skill-b"],
+                    "go",
+                )

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -12,6 +12,7 @@ from agent.skill_governance import SkillGovernanceRejectedError
 from agent.skill_commands import (
     build_preloaded_skills_prompt,
     build_skill_invocation_message,
+    get_discoverable_skill_commands,
     resolve_skill_command_key,
     scan_skill_commands,
 )
@@ -144,6 +145,62 @@ class TestScanSkillCommands:
             scan_skill_commands()
             with pytest.raises(SkillGovernanceRejectedError, match="evaluation failed"):
                 build_skill_invocation_message("/tooltrust", "do it")
+
+    def test_discoverable_skill_commands_hide_governance_blocked_skills_when_protected(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _configure_protected_governance(
+            tmp_path,
+            """\
+  - name: ToolTrust
+    classification: COMPATIBILITY_ONLY
+  - name: SafeSkill
+    classification: CURRENT
+""",
+        )
+        _make_skill(tmp_path, "ToolTrust", body="blocked legacy content")
+        _make_skill(tmp_path, "SafeSkill", body="allowed content")
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            scan_skill_commands()
+            commands = get_discoverable_skill_commands()
+
+        assert "/safeskill" in commands
+        assert "/tooltrust" not in commands
+
+    def test_discoverable_skill_commands_fail_closed_when_config_unreadable(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "skills:\n  governance: []\n",
+            encoding="utf-8",
+        )
+        _make_skill(tmp_path, "ToolTrust", body="blocked legacy content")
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            scan_skill_commands()
+            commands = get_discoverable_skill_commands()
+
+        assert commands == {}
+
+    def test_discoverable_skill_commands_preserve_unprotected_behavior_on_eval_failure(
+        self, tmp_path, monkeypatch
+    ):
+        _make_skill(tmp_path, "ToolTrust", body="still visible when unprotected")
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch(
+                "agent.skill_governance.governance_context",
+                side_effect=RuntimeError("registry unreadable"),
+            ),
+        ):
+            scan_skill_commands()
+            commands = get_discoverable_skill_commands()
+
+        assert "/tooltrust" in commands
 
     def test_get_skill_commands_rescans_when_platform_scope_changes(self, tmp_path):
         """Platform-specific disabled-skill caches must not leak across platforms.

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -1,5 +1,6 @@
 """Tests for agent/skill_commands.py — skill slash command scanning and platform filtering."""
 
+import builtins
 import os
 from pathlib import Path
 from unittest.mock import patch
@@ -434,6 +435,75 @@ class TestBuildPreloadedSkillsPrompt:
         assert missing == ["disabled-skill"]
         assert "SECRET DISABLED CONTENT." not in prompt
         assert "enabled-skill" in prompt
+
+    def test_protected_preload_denies_all_when_governance_import_fails(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        _configure_protected_governance(
+            home,
+            """\
+  - name: protected-skill
+    classification: CURRENT
+""",
+        )
+        _make_skill(skills_dir, "protected-skill", body="must not load")
+
+        real_import = builtins.__import__
+
+        def _deny_governance_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "agent.skill_governance":
+                raise ImportError("simulated governance import failure")
+            return real_import(name, globals, locals, fromlist, level)
+
+        with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
+            monkeypatch.setattr(builtins, "__import__", _deny_governance_import)
+            prompt, loaded, missing = build_preloaded_skills_prompt(["protected-skill"])
+
+        assert prompt == ""
+        assert loaded == []
+        assert missing == ["protected-skill"]
+
+    def test_unprotected_preload_keeps_loading_when_governance_import_fails(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        _configure_protected_governance(
+            home,
+            """\
+  - name: unprotected-skill
+    classification: CURRENT
+""",
+        )
+        (home / "config.yaml").write_text(
+            """\
+skills:
+  governance:
+    registry_path: governance/skills-registry.yaml
+    task_class: general_ops
+    protected_task_classes:
+      - ardyn_engineering
+""",
+            encoding="utf-8",
+        )
+        _make_skill(skills_dir, "unprotected-skill", body="still loads")
+
+        real_import = builtins.__import__
+
+        def _deny_governance_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "agent.skill_governance":
+                raise ImportError("simulated governance import failure")
+            return real_import(name, globals, locals, fromlist, level)
+
+        with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
+            monkeypatch.setattr(builtins, "__import__", _deny_governance_import)
+            prompt, loaded, missing = build_preloaded_skills_prompt(["unprotected-skill"])
+
+        assert loaded == ["unprotected-skill"]
+        assert missing == []
+        assert "still loads" in prompt
 
 
 

--- a/tests/agent/test_skill_governance.py
+++ b/tests/agent/test_skill_governance.py
@@ -168,7 +168,7 @@ def test_auto_mode_filter_keeps_only_current_entries_for_protected_task_class(tm
     ]
 
 
-def test_retrieval_ranking_prefers_current_entries_for_protected_task_class(tmp_path, monkeypatch):
+def test_retrieval_ranking_filters_denied_entries_for_protected_task_class(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     _configure_governance(tmp_path)
 
@@ -200,6 +200,44 @@ def test_retrieval_ranking_prefers_current_entries_for_protected_task_class(tmp_
             ),
         ],
         context=governance_context(mode="retrieval"),
+    )
+
+    assert [item.name for item in ranked] == ["ModernCurrent"]
+    assert ranked[0].extra["governance"]["classification"] == "CURRENT"
+
+
+def test_retrieval_ranking_preserves_unprotected_results(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _configure_governance(tmp_path)
+
+    ranked = rank_skill_search_results(
+        [
+            _SearchResult(
+                name="PREMP",
+                description="Legacy stale entry",
+                source="github",
+                identifier="github/premp",
+                trust_level="trusted",
+                extra={},
+            ),
+            _SearchResult(
+                name="ModernCurrent",
+                description="Qualified current entry",
+                source="official",
+                identifier="official/modern-current",
+                trust_level="builtin",
+                extra={},
+            ),
+            _SearchResult(
+                name="ToolTrust",
+                description="Compatibility-only legacy entry",
+                source="github",
+                identifier="github/tooltrust",
+                trust_level="trusted",
+                extra={},
+            ),
+        ],
+        context=governance_context(mode="retrieval", task_class="general"),
     )
 
     assert [item.name for item in ranked] == ["ModernCurrent", "ToolTrust", "PREMP"]

--- a/tests/agent/test_skill_governance.py
+++ b/tests/agent/test_skill_governance.py
@@ -9,6 +9,7 @@ from agent.skill_governance import (
     evaluate_skill_selection,
     filter_allowed_skill_names,
     governance_context,
+    probe_protected_task_class,
     rank_skill_search_results,
 )
 
@@ -205,3 +206,36 @@ def test_retrieval_ranking_prefers_current_entries_for_protected_task_class(tmp_
     assert ranked[0].extra["governance"]["classification"] == "CURRENT"
     assert ranked[1].extra["governance"]["classification"] == "COMPATIBILITY_ONLY"
     assert ranked[2].extra["governance"]["classification"] == "STALE"
+
+
+def test_protected_task_probe_is_self_contained_when_skill_utils_import_fails(
+    tmp_path, monkeypatch
+):
+    import builtins
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _configure_governance(tmp_path)
+    real_import = builtins.__import__
+
+    def _deny_skill_utils(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "agent.skill_utils":
+            raise ImportError("simulated skill_utils import failure")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _deny_skill_utils)
+
+    probe = probe_protected_task_class()
+
+    assert probe.safe is True
+    assert probe.protected_task is True
+    assert probe.task_class == "ardyn_engineering"
+
+
+def test_protected_task_probe_fails_closed_on_config_parse_error(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text("skills: [\n", encoding="utf-8")
+
+    probe = probe_protected_task_class()
+
+    assert probe.safe is False
+    assert probe.protected_task is True

--- a/tests/agent/test_skill_governance.py
+++ b/tests/agent/test_skill_governance.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from agent.skill_commands import build_preloaded_skills_prompt
+from agent.skill_governance import (
+    GovernanceClassification,
+    evaluate_skill_selection,
+    filter_allowed_skill_names,
+    governance_context,
+    rank_skill_search_results,
+)
+
+
+@dataclass
+class _SearchResult:
+    name: str
+    description: str
+    source: str
+    identifier: str
+    trust_level: str
+    extra: dict = field(default_factory=dict)
+
+
+def _write_skill(skills_dir: Path, name: str) -> None:
+    skill_dir = skills_dir / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"""\
+---
+name: {name}
+description: Test skill for {name}
+---
+
+# {name}
+
+Use the {name} workflow.
+""",
+        encoding="utf-8",
+    )
+
+
+def _configure_governance(home: Path) -> None:
+    (home / "governance").mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        """\
+skills:
+  governance:
+    registry_path: governance/skills-registry.yaml
+    task_class: ardyn_engineering
+    protected_task_classes:
+      - ardyn_engineering
+    retrieval_ranking: true
+""",
+        encoding="utf-8",
+    )
+    (home / "governance" / "skills-registry.yaml").write_text(
+        """\
+version: 1
+skills:
+  - name: ToolTrust
+    classification: COMPATIBILITY_ONLY
+    aliases: [tooltrust]
+    provenance:
+      source: legacy-catalog
+      lineage: tooltrust-v1
+  - name: PREMP
+    classification: STALE
+    aliases: [premp]
+    provenance:
+      source: legacy-catalog
+      lineage: premp-v1
+  - name: ModernCurrent
+    classification: CURRENT
+    aliases: [modern-current]
+    provenance:
+      source: qualified-registry
+      lineage: current-v3
+  - name: ConflictCase
+    classification: CONFLICTING
+    aliases: [conflict-case]
+    provenance:
+      source: competing-registry
+      lineage: conflict-v2
+""",
+        encoding="utf-8",
+    )
+
+
+def test_protected_governance_api_rejects_unknown_and_legacy_auto_selection(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _configure_governance(tmp_path)
+
+    auto_ctx = governance_context(mode="auto")
+    tooltrust = evaluate_skill_selection("ToolTrust", context=auto_ctx)
+    premp = evaluate_skill_selection("PREMP", context=auto_ctx)
+    unknown = evaluate_skill_selection("UnregisteredSkill", context=auto_ctx)
+    current = evaluate_skill_selection("ModernCurrent", context=auto_ctx)
+
+    assert tooltrust.allowed is False
+    assert tooltrust.classification == GovernanceClassification.COMPATIBILITY_ONLY
+    assert "historical intent" in tooltrust.reason
+
+    assert premp.allowed is False
+    assert premp.classification == GovernanceClassification.STALE
+
+    assert unknown.allowed is False
+    assert unknown.classification == GovernanceClassification.UNKNOWN
+
+    assert current.allowed is True
+    assert current.classification == GovernanceClassification.CURRENT
+
+
+def test_compatibility_entry_requires_explicit_historical_intent(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _configure_governance(tmp_path)
+
+    blocked = evaluate_skill_selection(
+        "ToolTrust",
+        context=governance_context(mode="explicit", historical_intent=False),
+    )
+    allowed = evaluate_skill_selection(
+        "ToolTrust",
+        context=governance_context(mode="explicit", historical_intent=True),
+    )
+
+    assert blocked.allowed is False
+    assert allowed.allowed is True
+    assert allowed.reason == "compatibility-only entry allowed by historical intent"
+
+
+def test_preloaded_skills_fail_closed_for_protected_task_class(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _configure_governance(tmp_path)
+    skills_dir = tmp_path / "skills"
+    _write_skill(skills_dir, "ToolTrust")
+    _write_skill(skills_dir, "PREMP")
+    _write_skill(skills_dir, "ModernCurrent")
+
+    prompt, loaded_names, missing = build_preloaded_skills_prompt(
+        ["ToolTrust", "PREMP", "ModernCurrent"]
+    )
+
+    assert loaded_names == ["ModernCurrent"]
+    assert set(missing) == {"ToolTrust", "PREMP"}
+    assert "ModernCurrent" in prompt
+    assert "ToolTrust" not in prompt
+    assert "PREMP" not in prompt
+
+
+def test_auto_mode_filter_keeps_only_current_entries_for_protected_task_class(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _configure_governance(tmp_path)
+
+    resolved, decisions = filter_allowed_skill_names(
+        ["ToolTrust", "PREMP", "ModernCurrent", "ConflictCase"],
+        context=governance_context(mode="auto"),
+    )
+
+    assert resolved == ["ModernCurrent"]
+    assert [decision.classification for decision in decisions] == [
+        GovernanceClassification.COMPATIBILITY_ONLY,
+        GovernanceClassification.STALE,
+        GovernanceClassification.CURRENT,
+        GovernanceClassification.CONFLICTING,
+    ]
+
+
+def test_retrieval_ranking_prefers_current_entries_for_protected_task_class(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _configure_governance(tmp_path)
+
+    ranked = rank_skill_search_results(
+        [
+            _SearchResult(
+                name="PREMP",
+                description="Legacy stale entry",
+                source="github",
+                identifier="github/premp",
+                trust_level="trusted",
+                extra={},
+            ),
+            _SearchResult(
+                name="ModernCurrent",
+                description="Qualified current entry",
+                source="official",
+                identifier="official/modern-current",
+                trust_level="builtin",
+                extra={},
+            ),
+            _SearchResult(
+                name="ToolTrust",
+                description="Compatibility-only legacy entry",
+                source="github",
+                identifier="github/tooltrust",
+                trust_level="trusted",
+                extra={},
+            ),
+        ],
+        context=governance_context(mode="retrieval"),
+    )
+
+    assert [item.name for item in ranked] == ["ModernCurrent", "ToolTrust", "PREMP"]
+    assert ranked[0].extra["governance"]["classification"] == "CURRENT"
+    assert ranked[1].extra["governance"]["classification"] == "COMPATIBILITY_ONLY"
+    assert ranked[2].extra["governance"]["classification"] == "STALE"

--- a/tests/cli/test_cli_prefix_matching.py
+++ b/tests/cli/test_cli_prefix_matching.py
@@ -119,30 +119,25 @@ class TestSlashCommandPrefixMatching:
         assert "Unknown command" in combined
         assert "research-pack" not in combined
 
-    def test_exact_blocked_bundle_invocation_path_remains_preserved(self):
-        """Typing the full bundle name still reaches explicit bundle invocation."""
+    def test_exact_blocked_bundle_is_not_selected_for_invocation(self):
+        """Typing the full blocked bundle name must not select or load it."""
         cli_obj = _make_cli()
         import cli as cli_mod
+        printed = []
 
         with (
             patch.object(cli_mod, "_skill_commands", {}),
             patch.object(cli_mod, "get_skill_bundles", return_value={"/research-pack": {"name": "Research Pack"}}),
             patch.object(cli_mod, "get_discoverable_skill_bundles", return_value={}),
-            patch.object(
-                cli_mod,
-                "build_bundle_invocation_message",
-                return_value=("bundle payload", ["alpha"], []),
-            ) as mock_build,
-            patch("builtins.print"),
+            patch.object(cli_mod, "_cprint", side_effect=lambda text: printed.append(str(text))),
+            patch.object(cli_mod, "build_bundle_invocation_message") as mock_build,
         ):
             cli_obj.process_command("/research-pack investigate")
 
-        mock_build.assert_called_once_with(
-            "/research-pack",
-            "investigate",
-            task_id=None,
-        )
-        cli_obj._pending_input.put.assert_called_once_with("bundle payload")
+        combined = " ".join(printed)
+        assert "Unknown command" in combined
+        mock_build.assert_not_called()
+        cli_obj._pending_input.put.assert_not_called()
 
     def test_prefix_matching_preserves_unprotected_bundle_behavior(self):
         """/research-p should still expand to a visible bundle when unprotected."""
@@ -167,3 +162,28 @@ class TestSlashCommandPrefixMatching:
             "investigate",
             task_id=None,
         )
+
+    def test_exact_unprotected_bundle_invocation_still_loads(self):
+        """Typing the full visible bundle name should still load it."""
+        cli_obj = _make_cli()
+        import cli as cli_mod
+
+        with (
+            patch.object(cli_mod, "_skill_commands", {}),
+            patch.object(cli_mod, "get_skill_bundles", return_value={"/research-pack": {"name": "Research Pack"}}),
+            patch.object(cli_mod, "get_discoverable_skill_bundles", return_value={"/research-pack": {"name": "Research Pack"}}),
+            patch.object(
+                cli_mod,
+                "build_bundle_invocation_message",
+                return_value=("bundle payload", ["alpha"], []),
+            ) as mock_build,
+            patch("builtins.print"),
+        ):
+            cli_obj.process_command("/research-pack investigate")
+
+        mock_build.assert_called_once_with(
+            "/research-pack",
+            "investigate",
+            task_id=None,
+        )
+        cli_obj._pending_input.put.assert_called_once_with("bundle payload")

--- a/tests/cli/test_cli_prefix_matching.py
+++ b/tests/cli/test_cli_prefix_matching.py
@@ -100,3 +100,70 @@ class TestSlashCommandPrefixMatching:
         mock_help.assert_called_once()
         printed = " ".join(str(c) for c in cli_obj.console.print.call_args_list)
         assert "Ambiguous" not in printed
+
+    def test_prefix_matching_ignores_blocked_bundles_for_selection(self):
+        """/research-p should not select a blocked bundle under protected governance."""
+        cli_obj = _make_cli()
+        printed = []
+        import cli as cli_mod
+
+        with (
+            patch.object(cli_mod, "_skill_commands", {}),
+            patch.object(cli_mod, "get_skill_bundles", return_value={"/research-pack": {"name": "Research Pack"}}),
+            patch.object(cli_mod, "get_discoverable_skill_bundles", return_value={}),
+            patch.object(cli_mod, "_cprint", side_effect=lambda text: printed.append(str(text))),
+        ):
+            cli_obj.process_command("/research-p")
+
+        combined = " ".join(printed)
+        assert "Unknown command" in combined
+        assert "research-pack" not in combined
+
+    def test_exact_blocked_bundle_invocation_path_remains_preserved(self):
+        """Typing the full bundle name still reaches explicit bundle invocation."""
+        cli_obj = _make_cli()
+        import cli as cli_mod
+
+        with (
+            patch.object(cli_mod, "_skill_commands", {}),
+            patch.object(cli_mod, "get_skill_bundles", return_value={"/research-pack": {"name": "Research Pack"}}),
+            patch.object(cli_mod, "get_discoverable_skill_bundles", return_value={}),
+            patch.object(
+                cli_mod,
+                "build_bundle_invocation_message",
+                return_value=("bundle payload", ["alpha"], []),
+            ) as mock_build,
+            patch("builtins.print"),
+        ):
+            cli_obj.process_command("/research-pack investigate")
+
+        mock_build.assert_called_once_with(
+            "/research-pack",
+            "investigate",
+            task_id=None,
+        )
+        cli_obj._pending_input.put.assert_called_once_with("bundle payload")
+
+    def test_prefix_matching_preserves_unprotected_bundle_behavior(self):
+        """/research-p should still expand to a visible bundle when unprotected."""
+        cli_obj = _make_cli()
+        import cli as cli_mod
+
+        with (
+            patch.object(cli_mod, "_skill_commands", {}),
+            patch.object(cli_mod, "get_skill_bundles", return_value={"/research-pack": {"name": "Research Pack"}}),
+            patch.object(cli_mod, "get_discoverable_skill_bundles", return_value={"/research-pack": {"name": "Research Pack"}}),
+            patch.object(
+                cli_mod,
+                "build_bundle_invocation_message",
+                return_value=("bundle payload", ["alpha"], []),
+            ) as mock_build,
+            patch("builtins.print"),
+        ):
+            cli_obj.process_command("/research-p investigate")
+
+        mock_build.assert_called_once_with(
+            "/research-pack",
+            "investigate",
+            task_id=None,
+        )

--- a/tests/cli/test_skill_discovery_governance.py
+++ b/tests/cli/test_skill_discovery_governance.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 from prompt_toolkit.document import Document
 
-
 def _make_skill(skills_dir: Path, name: str, body: str = "Do the thing.") -> None:
     skill_dir = skills_dir / name
     skill_dir.mkdir(parents=True, exist_ok=True)
@@ -193,3 +192,70 @@ def test_show_help_keeps_bundles_visible_when_unprotected(monkeypatch, tmp_path)
 
     output = "\n".join(printed)
     assert "/safe-pack" in output
+
+
+def test_slash_exec_help_and_commands_hide_governance_blocked_skills(monkeypatch, tmp_path):
+    from hermes_cli.slash_exec import CommandContext, execute_command
+
+    home = tmp_path / "home"
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    _configure_protected_governance(home)
+    _make_skill(skills_dir, "ToolTrust", body="blocked")
+    _make_skill(skills_dir, "SafeSkill", body="allowed")
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr("tools.skills_tool.SKILLS_DIR", skills_dir)
+
+    help_reply = execute_command("help", CommandContext(surface="gateway"))
+    commands_reply = execute_command(
+        "commands",
+        CommandContext(surface="gateway", options={"page_size": 200}),
+    )
+
+    assert "/safeskill" in help_reply.text
+    assert "/tooltrust" not in help_reply.text
+    assert "/safeskill" in commands_reply.text
+    assert "/tooltrust" not in commands_reply.text
+
+
+def test_slash_exec_bundles_hide_bundles_when_governance_config_is_malformed(monkeypatch, tmp_path):
+    from hermes_cli.slash_exec import CommandContext, execute_command
+
+    home = tmp_path / "home"
+    skills_dir = tmp_path / "skills"
+    bundles_dir = tmp_path / "bundles"
+    home.mkdir()
+    skills_dir.mkdir()
+    (home / "config.yaml").write_text("skills:\n  governance: []\n", encoding="utf-8")
+    _make_skill(skills_dir, "SafeSkill", body="allowed")
+    _make_bundle(bundles_dir, "safe-pack", ["SafeSkill"])
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_BUNDLES_DIR", str(bundles_dir))
+    monkeypatch.setattr("tools.skills_tool.SKILLS_DIR", skills_dir)
+
+    reply = execute_command("bundles", CommandContext(surface="gateway"))
+
+    assert "/safe-pack" not in reply.text
+    assert reply.data["bundles"] == []
+
+
+def test_slash_exec_bundles_preserve_unprotected_behavior(monkeypatch, tmp_path):
+    from hermes_cli.slash_exec import CommandContext, execute_command
+
+    home = tmp_path / "home"
+    skills_dir = tmp_path / "skills"
+    bundles_dir = tmp_path / "bundles"
+    skills_dir.mkdir()
+    _make_skill(skills_dir, "SafeSkill", body="allowed")
+    _make_bundle(bundles_dir, "safe-pack", ["SafeSkill"])
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_BUNDLES_DIR", str(bundles_dir))
+    monkeypatch.setattr("tools.skills_tool.SKILLS_DIR", skills_dir)
+
+    reply = execute_command("bundles", CommandContext(surface="gateway"))
+
+    assert "/safe-pack" in reply.text
+    assert [info["slug"] for info in reply.data["bundles"]] == ["safe-pack"]

--- a/tests/cli/test_skill_discovery_governance.py
+++ b/tests/cli/test_skill_discovery_governance.py
@@ -21,6 +21,17 @@ description: Description for {name}.
     )
 
 
+def _make_bundle(bundles_dir: Path, slug: str, skills: list[str]) -> None:
+    bundles_dir.mkdir(parents=True, exist_ok=True)
+    (bundles_dir / f"{slug}.yaml").write_text(
+        "name: {slug}\nskills:\n{skills}\n".format(
+            slug=slug,
+            skills="\n".join(f"  - {skill}" for skill in skills),
+        ),
+        encoding="utf-8",
+    )
+
+
 def _configure_protected_governance(home: Path) -> None:
     (home / "governance").mkdir(parents=True, exist_ok=True)
     (home / "config.yaml").write_text(
@@ -114,3 +125,71 @@ def test_cli_completer_hides_governance_blocked_skills(monkeypatch, tmp_path):
 
     assert "safeskill" in texts
     assert "tooltrust" not in texts
+
+
+def test_show_help_hides_bundles_when_governance_config_is_malformed(monkeypatch, tmp_path):
+    import agent.skill_bundles as skill_bundles_mod
+    import cli as cli_mod
+
+    home = tmp_path / "home"
+    skills_dir = tmp_path / "skills"
+    bundles_dir = tmp_path / "bundles"
+    home.mkdir()
+    skills_dir.mkdir()
+    (home / "config.yaml").write_text("skills:\n  governance: []\n", encoding="utf-8")
+    _make_skill(skills_dir, "SafeSkill", body="allowed")
+    _make_bundle(bundles_dir, "safe-pack", ["SafeSkill"])
+
+    printed: list[str] = []
+
+    class _FakeChatConsole:
+        def print(self, *args, **kwargs):
+            printed.append(" ".join(str(arg) for arg in args))
+
+    cli_obj = _make_cli()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_BUNDLES_DIR", str(bundles_dir))
+    monkeypatch.setattr("tools.skills_tool.SKILLS_DIR", skills_dir)
+    monkeypatch.setattr(cli_mod, "_skill_bundles", None)
+    monkeypatch.setattr(skill_bundles_mod, "_bundles_cache", {})
+    monkeypatch.setattr(skill_bundles_mod, "_bundles_cache_mtime", None)
+    monkeypatch.setattr(cli_mod, "ChatConsole", _FakeChatConsole)
+    monkeypatch.setattr(cli_mod, "_cprint", lambda text: printed.append(str(text)))
+
+    cli_obj.show_help()
+
+    output = "\n".join(printed)
+    assert "/safe-pack" not in output
+
+
+def test_show_help_keeps_bundles_visible_when_unprotected(monkeypatch, tmp_path):
+    import agent.skill_bundles as skill_bundles_mod
+    import cli as cli_mod
+
+    home = tmp_path / "home"
+    skills_dir = tmp_path / "skills"
+    bundles_dir = tmp_path / "bundles"
+    skills_dir.mkdir()
+    _make_skill(skills_dir, "SafeSkill", body="allowed")
+    _make_bundle(bundles_dir, "safe-pack", ["SafeSkill"])
+
+    printed: list[str] = []
+
+    class _FakeChatConsole:
+        def print(self, *args, **kwargs):
+            printed.append(" ".join(str(arg) for arg in args))
+
+    cli_obj = _make_cli()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_BUNDLES_DIR", str(bundles_dir))
+    monkeypatch.setattr("tools.skills_tool.SKILLS_DIR", skills_dir)
+    monkeypatch.setattr(cli_mod, "_skill_bundles", None)
+    monkeypatch.setattr(skill_bundles_mod, "_bundles_cache", {})
+    monkeypatch.setattr(skill_bundles_mod, "_bundles_cache_mtime", None)
+    monkeypatch.setattr(cli_mod, "ChatConsole", _FakeChatConsole)
+    monkeypatch.setattr(cli_mod, "_cprint", lambda text: printed.append(str(text)))
+
+    cli_obj.show_help()
+
+    output = "\n".join(printed)
+    assert "/safe-pack" in output

--- a/tests/cli/test_skill_discovery_governance.py
+++ b/tests/cli/test_skill_discovery_governance.py
@@ -1,0 +1,116 @@
+from pathlib import Path
+
+from prompt_toolkit.document import Document
+
+
+def _make_skill(skills_dir: Path, name: str, body: str = "Do the thing.") -> None:
+    skill_dir = skills_dir / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"""\
+---
+name: {name}
+description: Description for {name}.
+---
+
+# {name}
+
+{body}
+""",
+        encoding="utf-8",
+    )
+
+
+def _configure_protected_governance(home: Path) -> None:
+    (home / "governance").mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        """\
+skills:
+  governance:
+    registry_path: governance/skills-registry.yaml
+    task_class: ardyn_engineering
+    protected_task_classes:
+      - ardyn_engineering
+""",
+        encoding="utf-8",
+    )
+    (home / "governance" / "skills-registry.yaml").write_text(
+        """\
+version: 1
+skills:
+  - name: ToolTrust
+    classification: COMPATIBILITY_ONLY
+  - name: SafeSkill
+    classification: CURRENT
+""",
+        encoding="utf-8",
+    )
+
+
+def _make_cli():
+    import cli as cli_mod
+
+    obj = object.__new__(cli_mod.HermesCLI)
+    obj.config = {}
+    return obj
+
+
+def test_show_help_hides_governance_blocked_skills(monkeypatch, tmp_path):
+    import agent.skill_commands as skill_commands_mod
+    import cli as cli_mod
+
+    home = tmp_path / "home"
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    _configure_protected_governance(home)
+    _make_skill(skills_dir, "ToolTrust", body="blocked")
+    _make_skill(skills_dir, "SafeSkill", body="allowed")
+
+    printed: list[str] = []
+
+    class _FakeChatConsole:
+        def print(self, *args, **kwargs):
+            printed.append(" ".join(str(arg) for arg in args))
+
+    cli_obj = _make_cli()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr("tools.skills_tool.SKILLS_DIR", skills_dir)
+    monkeypatch.setattr(cli_mod, "_skill_commands", None)
+    monkeypatch.setattr(skill_commands_mod, "_skill_commands", {})
+    monkeypatch.setattr(skill_commands_mod, "_skill_commands_platform", None)
+    monkeypatch.setattr(cli_mod, "ChatConsole", _FakeChatConsole)
+    monkeypatch.setattr(cli_mod, "_cprint", lambda text: printed.append(str(text)))
+
+    cli_obj.show_help()
+
+    output = "\n".join(printed)
+    assert "/safeskill" in output
+    assert "/tooltrust" not in output
+
+
+def test_cli_completer_hides_governance_blocked_skills(monkeypatch, tmp_path):
+    import agent.skill_commands as skill_commands_mod
+    import cli as cli_mod
+    from hermes_cli.commands import SlashCommandCompleter
+
+    home = tmp_path / "home"
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    _configure_protected_governance(home)
+    _make_skill(skills_dir, "ToolTrust", body="blocked")
+    _make_skill(skills_dir, "SafeSkill", body="allowed")
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr("tools.skills_tool.SKILLS_DIR", skills_dir)
+    monkeypatch.setattr(cli_mod, "_skill_commands", None)
+    monkeypatch.setattr(skill_commands_mod, "_skill_commands", {})
+    monkeypatch.setattr(skill_commands_mod, "_skill_commands_platform", None)
+
+    completer = SlashCommandCompleter(
+        skill_commands_provider=lambda: cli_mod.get_skill_commands(),
+    )
+    completions = list(completer.get_completions(Document("/s"), None))
+    texts = {item.text for item in completions}
+
+    assert "safeskill" in texts
+    assert "tooltrust" not in texts

--- a/tests/cli/test_skill_discovery_governance.py
+++ b/tests/cli/test_skill_discovery_governance.py
@@ -65,6 +65,15 @@ def _make_cli():
     return obj
 
 
+def _reset_skill_discovery_caches(monkeypatch) -> None:
+    import agent.skill_commands as skill_commands_mod
+
+    # Clear scan-time discovery state so each test re-resolves the patched
+    # skills dir instead of inheriting a prior governance test's command map.
+    monkeypatch.setattr(skill_commands_mod, "_skill_commands", {})
+    monkeypatch.setattr(skill_commands_mod, "_skill_commands_platform", None)
+
+
 def test_show_help_hides_governance_blocked_skills(monkeypatch, tmp_path):
     import agent.skill_commands as skill_commands_mod
     import cli as cli_mod
@@ -195,6 +204,7 @@ def test_show_help_keeps_bundles_visible_when_unprotected(monkeypatch, tmp_path)
 
 
 def test_slash_exec_help_and_commands_hide_governance_blocked_skills(monkeypatch, tmp_path):
+    import agent.skill_commands as skill_commands_mod
     from hermes_cli.slash_exec import CommandContext, execute_command
 
     home = tmp_path / "home"
@@ -206,6 +216,8 @@ def test_slash_exec_help_and_commands_hide_governance_blocked_skills(monkeypatch
 
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setattr("tools.skills_tool.SKILLS_DIR", skills_dir)
+    _reset_skill_discovery_caches(monkeypatch)
+    assert skill_commands_mod._skill_commands == {}
 
     help_reply = execute_command("help", CommandContext(surface="gateway"))
     commands_reply = execute_command(

--- a/tests/gateway/test_slack_channel_skills.py
+++ b/tests/gateway/test_slack_channel_skills.py
@@ -1,4 +1,7 @@
 """Tests for Slack channel_skill_bindings auto-skill resolution."""
+import builtins
+
+from pathlib import Path
 from unittest.mock import MagicMock
 
 
@@ -14,6 +17,30 @@ def _make_adapter(extra=None):
 def _resolve(adapter, channel_id, parent_id=None):
     from gateway.platforms.base import resolve_channel_skills
     return resolve_channel_skills(adapter.config.extra, channel_id, parent_id)
+
+
+def _write_governance_config(home: Path, *, task_class: str = "", protected: list[str] | None = None) -> None:
+    (home / "governance").mkdir(parents=True, exist_ok=True)
+    protected_entries = protected or []
+    protected_block = "".join(f"      - {name}\n" for name in protected_entries)
+    protected_yaml = protected_block or "      []\n"
+    (home / "config.yaml").write_text(
+        f"""\
+skills:
+  governance:
+    registry_path: governance/skills-registry.yaml
+    task_class: {task_class}
+    protected_task_classes:
+{protected_yaml}""",
+        encoding="utf-8",
+    )
+
+
+def _write_registry(home: Path, entries: str) -> None:
+    (home / "governance" / "skills-registry.yaml").write_text(
+        f"version: 1\nskills:\n{entries}",
+        encoding="utf-8",
+    )
 
 
 class TestSlackResolveChannelSkills:
@@ -52,6 +79,81 @@ class TestSlackResolveChannelSkills:
             ]
         })
         assert _resolve(adapter, "D0ABC") is None
+
+    def test_protected_binding_denied_when_governance_import_unavailable(self, monkeypatch, tmp_path):
+        adapter = _make_adapter({
+            "channel_skill_bindings": [
+                {"id": "D0ATH9TQ0G6", "skills": ["legacy-skill"]},
+            ]
+        })
+        home = tmp_path / "home"
+        _write_governance_config(
+            home,
+            task_class="ardyn_engineering",
+            protected=["ardyn_engineering"],
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        real_import = builtins.__import__
+
+        def _deny_governance_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "agent.skill_governance":
+                raise ImportError("simulated governance import failure")
+            return real_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.setattr(builtins, "__import__", _deny_governance_import)
+
+        assert _resolve(adapter, "D0ATH9TQ0G6") is None
+
+    def test_protected_binding_keeps_current_and_drops_non_current(self, monkeypatch, tmp_path):
+        adapter = _make_adapter({
+            "channel_skill_bindings": [
+                {"id": "D0ATH9TQ0G6", "skills": ["ToolTrust", "ModernCurrent", "PREMP"]},
+            ]
+        })
+        home = tmp_path / "home"
+        _write_governance_config(
+            home,
+            task_class="ardyn_engineering",
+            protected=["ardyn_engineering"],
+        )
+        _write_registry(
+            home,
+            """\
+  - name: ToolTrust
+    classification: COMPATIBILITY_ONLY
+  - name: ModernCurrent
+    classification: CURRENT
+  - name: PREMP
+    classification: STALE
+""",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        assert _resolve(adapter, "D0ATH9TQ0G6") == ["ModernCurrent"]
+
+    def test_unprotected_binding_keeps_compatibility_skill(self, monkeypatch, tmp_path):
+        adapter = _make_adapter({
+            "channel_skill_bindings": [
+                {"id": "D0ATH9TQ0G6", "skills": ["ToolTrust"]},
+            ]
+        })
+        home = tmp_path / "home"
+        _write_governance_config(
+            home,
+            task_class="general_ops",
+            protected=["ardyn_engineering"],
+        )
+        _write_registry(
+            home,
+            """\
+  - name: ToolTrust
+    classification: COMPATIBILITY_ONLY
+""",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        assert _resolve(adapter, "D0ATH9TQ0G6") == ["ToolTrust"]
 
 
 class TestSlackMessageEventAutoSkill:

--- a/tests/gateway/test_slack_channel_skills.py
+++ b/tests/gateway/test_slack_channel_skills.py
@@ -80,7 +80,7 @@ class TestSlackResolveChannelSkills:
         })
         assert _resolve(adapter, "D0ABC") is None
 
-    def test_protected_binding_denied_when_governance_import_unavailable(self, monkeypatch, tmp_path):
+    def test_protected_binding_denied_when_skill_utils_import_fails_and_governance_eval_errors(self, monkeypatch, tmp_path):
         adapter = _make_adapter({
             "channel_skill_bindings": [
                 {"id": "D0ATH9TQ0G6", "skills": ["legacy-skill"]},
@@ -97,11 +97,30 @@ class TestSlackResolveChannelSkills:
         real_import = builtins.__import__
 
         def _deny_governance_import(name, globals=None, locals=None, fromlist=(), level=0):
-            if name == "agent.skill_governance":
-                raise ImportError("simulated governance import failure")
+            if name == "agent.skill_utils":
+                raise ImportError(f"simulated import failure: {name}")
             return real_import(name, globals, locals, fromlist, level)
 
+        monkeypatch.setattr(
+            "agent.skill_governance.evaluate_skill_selection",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                RuntimeError("simulated governance evaluation failure")
+            ),
+        )
         monkeypatch.setattr(builtins, "__import__", _deny_governance_import)
+
+        assert _resolve(adapter, "D0ATH9TQ0G6") is None
+
+    def test_protected_binding_denied_when_config_cannot_be_parsed(self, monkeypatch, tmp_path):
+        adapter = _make_adapter({
+            "channel_skill_bindings": [
+                {"id": "D0ATH9TQ0G6", "skills": ["legacy-skill"]},
+            ]
+        })
+        home = tmp_path / "home"
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "config.yaml").write_text("skills: [\n", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(home))
 
         assert _resolve(adapter, "D0ATH9TQ0G6") is None
 

--- a/tests/gateway/test_stacked_skill_platform_disabled.py
+++ b/tests/gateway/test_stacked_skill_platform_disabled.py
@@ -12,6 +12,8 @@ for a given platform still had its full SKILL.md content injected into the
 agent's context for that turn if it was stacked behind an allowed one.
 """
 
+import asyncio
+
 from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -93,6 +95,30 @@ def _make_skill(skills_dir, name, body="content"):
     )
 
 
+def _configure_protected_governance(home):
+    (home / "governance").mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        """\
+skills:
+  governance:
+    registry_path: governance/skills-registry.yaml
+    task_class: ardyn_engineering
+    protected_task_classes:
+      - ardyn_engineering
+""",
+        encoding="utf-8",
+    )
+    (home / "governance" / "skills-registry.yaml").write_text(
+        """\
+version: 1
+skills:
+  - name: ToolTrust
+    classification: COMPATIBILITY_ONLY
+""",
+        encoding="utf-8",
+    )
+
+
 @pytest.fixture
 def skills_env(tmp_path, monkeypatch):
     skills_dir = tmp_path / "skills"
@@ -135,3 +161,28 @@ async def test_stacked_second_skill_disabled_for_platform_is_blocked(monkeypatch
     assert "disabled for telegram" in result
 
 
+def test_gateway_skill_dispatch_denies_governance_blocked_skill(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+    import tools.skills_tool as skills_tool_module
+    import agent.skill_commands as skill_commands_mod
+
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    _make_skill(skills_dir, "ToolTrust", body="blocked legacy content")
+    home = tmp_path / "home"
+    _configure_protected_governance(home)
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool_module, "SKILLS_DIR", skills_dir)
+    skill_commands_mod._skill_commands = {}
+    skill_commands_mod._skill_commands_platform = None
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    runner = _make_runner()
+    result = asyncio.run(runner._handle_message(_make_event("/tooltrust do something")))
+
+    assert result is not None
+    assert "ToolTrust" in result
+    assert "historical intent" in result

--- a/tests/gateway/test_stacked_skill_platform_disabled.py
+++ b/tests/gateway/test_stacked_skill_platform_disabled.py
@@ -13,6 +13,7 @@ agent's context for that turn if it was stacked behind an allowed one.
 """
 
 import asyncio
+import builtins
 from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -225,6 +226,65 @@ def test_gateway_skill_dispatch_denies_protected_setup_failure(monkeypatch, tmp_
     assert result is not None
     assert '"/tooltrust"' in result
     assert "denied" in result.lower()
+    assert "protected task class" in result
+
+
+def test_gateway_skill_dispatch_denies_when_skill_utils_import_fails_and_governance_eval_errors(
+    monkeypatch, tmp_path
+):
+    import gateway.run as gateway_run
+
+    home = tmp_path / "home"
+    _configure_protected_governance(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+    real_import = builtins.__import__
+
+    def _deny_imports(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "agent.skill_utils":
+            raise ImportError(f"simulated import failure: {name}")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(
+        "agent.skill_governance.evaluate_skill_selection",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            RuntimeError("simulated governance evaluation failure")
+        ),
+    )
+    monkeypatch.setattr(builtins, "__import__", _deny_imports)
+
+    runner = _make_runner()
+    result = asyncio.run(runner._handle_message(_make_event("/tooltrust do something")))
+
+    assert result is not None
+    assert '"/tooltrust"' in result
+    assert "protected task class" in result
+
+
+def test_gateway_skill_dispatch_denies_when_config_cannot_be_parsed(
+    monkeypatch, tmp_path
+):
+    import gateway.run as gateway_run
+
+    home = tmp_path / "home"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("skills: [\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+    monkeypatch.setattr(
+        "agent.skill_commands.get_skill_commands",
+        lambda: (_ for _ in ()).throw(RuntimeError("simulated setup failure")),
+    )
+
+    runner = _make_runner()
+    result = asyncio.run(runner._handle_message(_make_event("/tooltrust do something")))
+
+    assert result is not None
+    assert '"/tooltrust"' in result
     assert "protected task class" in result
 
 

--- a/tests/gateway/test_stacked_skill_platform_disabled.py
+++ b/tests/gateway/test_stacked_skill_platform_disabled.py
@@ -13,7 +13,6 @@ agent's context for that turn if it was stacked behind an allowed one.
 """
 
 import asyncio
-
 from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -87,6 +86,25 @@ def _make_runner():
     return runner
 
 
+def _enable_normal_message_flow(runner):
+    state = SimpleNamespace(
+        turn=SimpleNamespace(lease=None, agent=None, started_ts=None),
+        conversation=SimpleNamespace(model_override=None, one_turn_restore=None),
+        persistent=SimpleNamespace(native_image_paths=[]),
+    )
+    runner._external_drain_active = False
+    runner._claim_active_session_slot = lambda *_args, **_kwargs: (None, None)
+    runner._session_state = lambda _key: state
+    runner._persist_active_agents = lambda: None
+    runner._begin_session_run_generation = lambda _key: 1
+    runner._restore_moa_one_shot = lambda *_args, **_kwargs: None
+    runner._restore_pending_one_turn_model_override = lambda *_args, **_kwargs: None
+    runner._release_turn_lease = lambda *_args, **_kwargs: None
+    runner._handle_message_with_agent = AsyncMock(
+        return_value={"final_response": "agent ok", "messages": []}
+    )
+
+
 def _make_skill(skills_dir, name, body="content"):
     sd = skills_dir / name
     sd.mkdir(parents=True, exist_ok=True)
@@ -131,8 +149,7 @@ def skills_env(tmp_path, monkeypatch):
     return skills_dir
 
 
-@pytest.mark.asyncio
-async def test_stacked_second_skill_disabled_for_platform_is_blocked(monkeypatch, skills_env):
+def test_stacked_second_skill_disabled_for_platform_is_blocked(monkeypatch, skills_env):
     """The whole stacked invocation is rejected when a NON-leading stacked
     skill is disabled for the message's platform — it must not silently load
     that skill's content just because only the first skill was checked."""
@@ -152,8 +169,8 @@ async def test_stacked_second_skill_disabled_for_platform_is_blocked(monkeypatch
     )
 
     runner = _make_runner()
-    result = await runner._handle_message(
-        _make_event("/allowed-skill /disabled-skill do something")
+    result = asyncio.run(
+        runner._handle_message(_make_event("/allowed-skill /disabled-skill do something"))
     )
 
     assert result is not None
@@ -186,3 +203,60 @@ def test_gateway_skill_dispatch_denies_governance_blocked_skill(monkeypatch, tmp
     assert result is not None
     assert "ToolTrust" in result
     assert "historical intent" in result
+
+
+def test_gateway_skill_dispatch_denies_protected_setup_failure(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+
+    home = tmp_path / "home"
+    _configure_protected_governance(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+    monkeypatch.setattr(
+        "agent.skill_commands.get_skill_commands",
+        lambda: (_ for _ in ()).throw(RuntimeError("simulated governance setup failure")),
+    )
+
+    runner = _make_runner()
+    result = asyncio.run(runner._handle_message(_make_event("/tooltrust do something")))
+
+    assert result is not None
+    assert '"/tooltrust"' in result
+    assert "denied" in result.lower()
+    assert "protected task class" in result
+
+
+def test_gateway_skill_dispatch_keeps_unprotected_behavior_on_setup_failure(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+
+    home = tmp_path / "home"
+    _configure_protected_governance(home)
+    (home / "config.yaml").write_text(
+        """\
+skills:
+  governance:
+    registry_path: governance/skills-registry.yaml
+    task_class: general_ops
+    protected_task_classes:
+      - ardyn_engineering
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+    monkeypatch.setattr(
+        "agent.skill_commands.get_skill_commands",
+        lambda: (_ for _ in ()).throw(RuntimeError("simulated governance setup failure")),
+    )
+
+    runner = _make_runner()
+    _enable_normal_message_flow(runner)
+    result = asyncio.run(runner._handle_message(_make_event("/tooltrust do something")))
+
+    assert isinstance(result, dict)
+    assert result["final_response"] == "agent ok"
+    runner._handle_message_with_agent.assert_awaited_once()

--- a/tests/hermes_cli/test_bundles.py
+++ b/tests/hermes_cli/test_bundles.py
@@ -1,6 +1,7 @@
 """Tests for hermes_cli/bundles.py — the `hermes bundles` CLI subcommand."""
 
 import argparse
+from pathlib import Path
 
 import pytest
 
@@ -13,12 +14,50 @@ from hermes_cli.bundles import (
 @pytest.fixture
 def bundles_env(tmp_path, monkeypatch):
     bundles_dir = tmp_path / "skill-bundles"
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
     monkeypatch.setenv("HERMES_BUNDLES_DIR", str(bundles_dir))
+    monkeypatch.setattr("tools.skills_tool.SKILLS_DIR", skills_dir)
     # Reset module-level cache between tests.
     import agent.skill_bundles as mod
     mod._bundles_cache = {}
     mod._bundles_cache_mtime = None
-    return bundles_dir
+    return bundles_dir, skills_dir
+
+
+def _make_skill(skills_dir: Path, name: str) -> None:
+    skill_dir = skills_dir / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: Description for {name}\n---\n\n# {name}\n",
+        encoding="utf-8",
+    )
+
+
+def _configure_protected_governance(home: Path) -> None:
+    (home / "governance").mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        """\
+skills:
+  governance:
+    registry_path: governance/skills-registry.yaml
+    task_class: ardyn_engineering
+    protected_task_classes:
+      - ardyn_engineering
+""",
+        encoding="utf-8",
+    )
+    (home / "governance" / "skills-registry.yaml").write_text(
+        """\
+version: 1
+skills:
+  - name: SafeSkill
+    classification: CURRENT
+  - name: ToolTrust
+    classification: COMPATIBILITY_ONLY
+""",
+        encoding="utf-8",
+    )
 
 
 def _parse(argv):
@@ -47,4 +86,50 @@ class TestBundlesCli:
         with pytest.raises(SystemExit):
             bundles_command(_parse(["create", "empty"]))
 
+    def test_list_hides_blocked_bundle_when_governance_protected(self, bundles_env, capsys, monkeypatch):
+        bundles_dir, skills_dir = bundles_env
+        home = bundles_dir.parent / "home"
+        _configure_protected_governance(home)
+        _make_skill(skills_dir, "SafeSkill")
+        _make_skill(skills_dir, "ToolTrust")
+        bundles_command(_parse(["create", "safe-pack", "--skill", "SafeSkill"]))
+        capsys.readouterr()
+        bundles_command(_parse(["create", "blocked-pack", "--skill", "ToolTrust"]))
+        capsys.readouterr()
+
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        bundles_command(_parse(["list"]))
+
+        out = capsys.readouterr().out
+        assert "/safe-pack" in out
+        assert "/blocked-pack" not in out
+
+    def test_list_hides_bundles_when_governance_config_is_malformed(self, bundles_env, capsys, monkeypatch):
+        bundles_dir, skills_dir = bundles_env
+        home = bundles_dir.parent / "home"
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "config.yaml").write_text("skills:\n  governance: []\n", encoding="utf-8")
+        _make_skill(skills_dir, "SafeSkill")
+        bundles_command(_parse(["create", "safe-pack", "--skill", "SafeSkill"]))
+        capsys.readouterr()
+
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        bundles_command(_parse(["list"]))
+
+        out = capsys.readouterr().out
+        assert "/safe-pack" not in out
+        assert "No bundles installed yet" in out
+
+    def test_list_preserves_unprotected_behavior(self, bundles_env, capsys, monkeypatch):
+        bundles_dir, skills_dir = bundles_env
+        home = bundles_dir.parent / "home"
+        _make_skill(skills_dir, "SafeSkill")
+        bundles_command(_parse(["create", "safe-pack", "--skill", "SafeSkill"]))
+        capsys.readouterr()
+
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        bundles_command(_parse(["list"]))
+
+        out = capsys.readouterr().out
+        assert "/safe-pack" in out
 

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -610,7 +610,7 @@ class TestDiscordSkillCmdKeyDispatch:
             },
         }
 
-        with patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds), \
+        with patch("agent.skill_commands.get_discoverable_skill_commands", return_value=fake_cmds), \
              patch("tools.skills_tool.SKILLS_DIR", fake_skills_dir), \
              patch("agent.skill_utils.get_external_skills_dirs", return_value=[]):
             entries, hidden = discord_skill_commands(
@@ -685,7 +685,7 @@ class TestTelegramMenuCommands:
         }
 
         with (
-            patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds),
+            patch("agent.skill_commands.get_discoverable_skill_commands", return_value=fake_cmds),
             patch("tools.skills_tool.SKILLS_DIR", local_dir),
             patch(
                 "agent.skill_utils.get_external_skills_dirs",
@@ -726,7 +726,7 @@ class TestTelegramMenuCommands:
             },
         }
         with (
-            patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds),
+            patch("agent.skill_commands.get_discoverable_skill_commands", return_value=fake_cmds),
             patch("tools.skills_tool.SKILLS_DIR", tmp_path / "skills"),
         ):
             (tmp_path / "skills").mkdir(exist_ok=True)
@@ -759,7 +759,7 @@ class TestTelegramMenuCommands:
             },
         }
         with (
-            patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds),
+            patch("agent.skill_commands.get_discoverable_skill_commands", return_value=fake_cmds),
             patch("tools.skills_tool.SKILLS_DIR", tmp_path / "skills"),
         ):
             (tmp_path / "skills").mkdir(exist_ok=True)
@@ -770,6 +770,43 @@ class TestTelegramMenuCommands:
         assert "valid_skill" in menu_names
         # No empty string in menu names
         assert "" not in menu_names
+
+    def test_hides_skills_when_discoverable_set_is_empty(self, tmp_path, monkeypatch):
+        from unittest.mock import patch
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "skills").mkdir(exist_ok=True)
+        with (
+            patch("agent.skill_commands.get_discoverable_skill_commands", return_value={}),
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path / "skills"),
+        ):
+            menu, _ = telegram_menu_commands(max_commands=100)
+
+        menu_names = {n for n, _ in menu}
+        assert "my_cool_skill" not in menu_names
+
+    def test_preserves_unprotected_behavior_via_discoverable_set(self, tmp_path, monkeypatch):
+        from unittest.mock import patch
+
+        fake_skills_dir = str(tmp_path / "skills")
+        fake_cmds = {
+            "/my-cool-skill": {
+                "name": "my-cool-skill",
+                "description": "A cool skill",
+                "skill_md_path": f"{fake_skills_dir}/my-cool-skill/SKILL.md",
+                "skill_dir": f"{fake_skills_dir}/my-cool-skill",
+            },
+        }
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        with (
+            patch("agent.skill_commands.get_discoverable_skill_commands", return_value=fake_cmds),
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path / "skills"),
+        ):
+            (tmp_path / "skills").mkdir(exist_ok=True)
+            menu, _ = telegram_menu_commands(max_commands=100)
+
+        menu_names = {n for n, _ in menu}
+        assert "my_cool_skill" in menu_names
 
 
 # ---------------------------------------------------------------------------
@@ -810,7 +847,7 @@ class TestDiscordSkillCommands:
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         (tmp_path / "skills").mkdir(exist_ok=True)
         with (
-            patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds),
+            patch("agent.skill_commands.get_discoverable_skill_commands", return_value=fake_cmds),
             patch("tools.skills_tool.SKILLS_DIR", tmp_path / "skills"),
         ):
             entries, _ = discord_skill_commands(
@@ -836,7 +873,7 @@ class TestDiscordSkillCommands:
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         (tmp_path / "skills").mkdir(exist_ok=True)
         with (
-            patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds),
+            patch("agent.skill_commands.get_discoverable_skill_commands", return_value=fake_cmds),
             patch("tools.skills_tool.SKILLS_DIR", tmp_path / "skills"),
         ):
             entries, hidden = discord_skill_commands(
@@ -845,6 +882,49 @@ class TestDiscordSkillCommands:
 
         assert len(entries) == 5
         assert hidden == 15
+
+    def test_hides_skills_when_discoverable_set_is_empty(self, tmp_path, monkeypatch):
+        """Gateway discovery must respect fail-closed governance filtering."""
+        from unittest.mock import patch
+
+        fake_skills_dir = tmp_path / "skills"
+        fake_skills_dir.mkdir(exist_ok=True)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        with (
+            patch("agent.skill_commands.get_discoverable_skill_commands", return_value={}),
+            patch("tools.skills_tool.SKILLS_DIR", fake_skills_dir),
+        ):
+            entries, hidden = discord_skill_commands(
+                max_slots=50, reserved_names=set(),
+            )
+
+        assert entries == []
+        assert hidden == 0
+
+    def test_preserves_unprotected_behavior_via_discoverable_set(self, tmp_path, monkeypatch):
+        from unittest.mock import patch
+
+        fake_skills_dir = tmp_path / "skills"
+        fake_skills_dir.mkdir(exist_ok=True)
+        fake_cmds = {
+            "/my-cool-skill": {
+                "name": "my-cool-skill",
+                "description": "A cool skill",
+                "skill_md_path": f"{fake_skills_dir}/my-cool-skill/SKILL.md",
+                "skill_dir": f"{fake_skills_dir}/my-cool-skill",
+            },
+        }
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        with (
+            patch("agent.skill_commands.get_discoverable_skill_commands", return_value=fake_cmds),
+            patch("tools.skills_tool.SKILLS_DIR", fake_skills_dir),
+        ):
+            entries, hidden = discord_skill_commands(
+                max_slots=50, reserved_names=set(),
+            )
+
+        assert [name for name, _desc, _key in entries] == ["my-cool-skill"]
+        assert hidden == 0
 
 
 
@@ -897,7 +977,7 @@ class TestDiscordSkillCommandsByCategory:
 
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         with (
-            patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds),
+            patch("agent.skill_commands.get_discoverable_skill_commands", return_value=fake_cmds),
             patch("tools.skills_tool.SKILLS_DIR", tmp_path / "skills"),
         ):
             categories, uncategorized, hidden = discord_skill_commands_by_category(
@@ -954,7 +1034,7 @@ class TestDiscordSkillCommandsByCategory:
         }
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         with (
-            patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds),
+            patch("agent.skill_commands.get_discoverable_skill_commands", return_value=fake_cmds),
             patch("tools.skills_tool.SKILLS_DIR", local_skills_dir),
             patch(
                 "agent.skill_utils.get_external_skills_dirs",

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -7,6 +7,8 @@ contract and the CLI-config parity (servers/keys written via the API are
 visible to the CLI data layer), not specific catalog values.
 """
 
+from pathlib import Path
+
 import pytest
 
 
@@ -25,6 +27,31 @@ def _client():
     # touches it.
     hermes_state.DEFAULT_DB_PATH = get_hermes_home() / "state.db"
     return client, _SESSION_HEADER_NAME
+
+
+def _write_governance_config(
+    home: Path,
+    *,
+    task_class: str = "",
+    protected: list[str] | None = None,
+) -> None:
+    (home / "governance").mkdir(parents=True, exist_ok=True)
+    lines = [
+        "skills:",
+        "  governance:",
+        "    registry_path: governance/skills-registry.yaml",
+        f"    task_class: {task_class}",
+        "    protected_task_classes:",
+    ]
+    if protected:
+        lines.extend(f"      - {item}" for item in protected)
+    else:
+        lines.append("      []")
+    (home / "config.yaml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    (home / "governance" / "skills-registry.yaml").write_text(
+        "skills: []\n",
+        encoding="utf-8",
+    )
 
 
 class TestMcpEndpoints:
@@ -556,6 +583,62 @@ class TestSkillsHubSearchEndpoint:
     def _setup(self, _isolate_hermes_home):
         self.client, _ = _client()
 
+    def test_search_fail_closes_when_protected_governance_ranking_fails(
+        self, monkeypatch, _isolate_hermes_home
+    ):
+        from hermes_constants import get_hermes_home
+
+        _write_governance_config(
+            get_hermes_home(),
+            task_class="medical",
+            protected=["medical"],
+        )
+
+        result = _FakeMeta("github/owner/current-skill", trust_level="community")
+        monkeypatch.setattr("tools.skills_hub.create_source_router", lambda: [])
+        monkeypatch.setattr(
+            "tools.skills_hub.parallel_search_sources",
+            lambda *_a, **_k: ([result], {"github": 1}, []),
+        )
+        monkeypatch.setattr(
+            "agent.skill_governance.rank_skill_search_results",
+            lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("simulated ranking failure")),
+        )
+
+        r = self.client.get("/api/skills/hub/search?q=current")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["results"] == []
+        assert body["source_counts"] == {"github": 1}
+
+    def test_search_keeps_fallback_order_when_unprotected_governance_ranking_fails(
+        self, monkeypatch, _isolate_hermes_home
+    ):
+        from hermes_constants import get_hermes_home
+
+        _write_governance_config(
+            get_hermes_home(),
+            task_class="general",
+            protected=["medical"],
+        )
+
+        community = _FakeMeta("github/owner/zulu", trust_level="community")
+        trusted = _FakeMeta("github/owner/alpha", trust_level="trusted")
+        monkeypatch.setattr("tools.skills_hub.create_source_router", lambda: [])
+        monkeypatch.setattr(
+            "tools.skills_hub.parallel_search_sources",
+            lambda *_a, **_k: ([community, trusted], {"github": 2}, []),
+        )
+        monkeypatch.setattr(
+            "agent.skill_governance.rank_skill_search_results",
+            lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("simulated ranking failure")),
+        )
+
+        r = self.client.get("/api/skills/hub/search?q=skill")
+        assert r.status_code == 200
+        body = r.json()
+        assert [item["name"] for item in body["results"]] == ["alpha", "zulu"]
+
 
 class _FakeMeta:
     """Minimal SkillMeta stand-in for monkeypatched source search."""
@@ -633,6 +716,37 @@ class TestSkillsHubSourcesEndpoint:
         assert len(body["featured"]) == 1
         assert body["featured"][0]["trust_level"] == "trusted"
         assert isinstance(body["installed"], dict)
+
+    def test_sources_featured_fail_closes_when_protected_governance_ranking_fails(
+        self, monkeypatch, _isolate_hermes_home
+    ):
+        from hermes_constants import get_hermes_home
+
+        _write_governance_config(
+            get_hermes_home(),
+            task_class="medical",
+            protected=["medical"],
+        )
+
+        class _Src:
+            is_available = True
+
+            def source_id(self):
+                return "hermes-index"
+
+            def search(self, q, limit=10):
+                return [_FakeMeta("hermes-index/current-skill", "trusted", source="hermes-index")]
+
+        monkeypatch.setattr("tools.skills_hub.create_source_router", lambda: [_Src()])
+        monkeypatch.setattr(
+            "agent.skill_governance.rank_skill_search_results",
+            lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("simulated ranking failure")),
+        )
+
+        r = self.client.get("/api/skills/hub/sources")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["featured"] == []
 
 
 class TestSkillsHubPreviewEndpoint:

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -340,6 +340,88 @@ def test_do_search_json_flag_emits_full_identifiers(capsys):
     assert "Searching for:" not in sink.getvalue()
 
 
+def test_do_search_filters_governance_blocked_results_when_protected(monkeypatch, tmp_path):
+    from hermes_cli.skills_hub import do_search
+
+    home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _write_governance_config(home, task_class="medical", protected=["medical"])
+    (home / "governance" / "skills-registry.yaml").write_text(
+        """\
+version: 1
+skills:
+  - name: blocked
+    classification: COMPATIBILITY_ONLY
+  - name: allowed
+    classification: CURRENT
+""",
+        encoding="utf-8",
+    )
+
+    blocked = type("R", (), {
+        "name": "blocked",
+        "description": "Blocked",
+        "source": "github",
+        "trust_level": "trusted",
+        "identifier": "github/blocked",
+        "extra": {},
+    })()
+    allowed = type("R", (), {
+        "name": "allowed",
+        "description": "Allowed",
+        "source": "github",
+        "trust_level": "trusted",
+        "identifier": "github/allowed",
+        "extra": {},
+    })()
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None, width=120)
+
+    monkeypatch.setattr("tools.skills_hub.GitHubAuth", lambda: object())
+    monkeypatch.setattr("tools.skills_hub.create_source_router", lambda *_a, **_k: [])
+    monkeypatch.setattr(
+        "tools.skills_hub.unified_search",
+        lambda *_a, **_k: [blocked, allowed],
+    )
+
+    do_search("skill", console=console)
+
+    rendered = sink.getvalue()
+    assert "allowed" in rendered
+    assert "blocked" not in rendered
+
+
+def test_do_search_keeps_results_when_unprotected_governance_eval_fails(monkeypatch, tmp_path):
+    from hermes_cli.skills_hub import do_search
+
+    home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    result = type("R", (), {
+        "name": "visible",
+        "description": "Visible",
+        "source": "github",
+        "trust_level": "trusted",
+        "identifier": "github/visible",
+        "extra": {},
+    })()
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None, width=120)
+
+    monkeypatch.setattr("tools.skills_hub.GitHubAuth", lambda: object())
+    monkeypatch.setattr("tools.skills_hub.create_source_router", lambda *_a, **_k: [])
+    monkeypatch.setattr("tools.skills_hub.unified_search", lambda *_a, **_k: [result])
+    monkeypatch.setattr(
+        "agent.skill_governance.rank_skill_search_results",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("simulated ranking failure")),
+    )
+
+    do_search("skill", console=console)
+
+    rendered = sink.getvalue()
+    assert "No skills found matching your query." not in rendered
+    assert "visible" in rendered
+
+
 def test_do_browse_fail_closes_when_protected_governance_ranking_fails(monkeypatch, tmp_path):
     from hermes_cli.skills_hub import do_browse
 

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -1,4 +1,5 @@
 from io import StringIO
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -96,6 +97,31 @@ def _capture_update(monkeypatch, results) -> tuple[str, list[tuple[str, str, boo
 
     do_update(console=console)
     return sink.getvalue(), installs
+
+
+def _write_governance_config(
+    home: Path,
+    *,
+    task_class: str = "",
+    protected: list[str] | None = None,
+) -> None:
+    (home / "governance").mkdir(parents=True, exist_ok=True)
+    lines = [
+        "skills:",
+        "  governance:",
+        "    registry_path: governance/skills-registry.yaml",
+        f"    task_class: {task_class}",
+        "    protected_task_classes:",
+    ]
+    if protected:
+        lines.extend(f"      - {item}" for item in protected)
+    else:
+        lines.append("      []")
+    (home / "config.yaml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    (home / "governance" / "skills-registry.yaml").write_text(
+        "skills: []\n",
+        encoding="utf-8",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -313,3 +339,96 @@ def test_do_search_json_flag_emits_full_identifiers(capsys):
     # Table render must be suppressed — sink should be empty (no "Searching for:" header).
     assert "Searching for:" not in sink.getvalue()
 
+
+def test_do_browse_fail_closes_when_protected_governance_ranking_fails(monkeypatch, tmp_path):
+    from hermes_cli.skills_hub import do_browse
+
+    home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _write_governance_config(home, task_class="medical", protected=["medical"])
+
+    result = type(
+        "R",
+        (),
+        {
+            "name": "current-skill",
+            "description": "Alpha",
+            "source": "community",
+            "identifier": "repo/current-skill",
+            "trust_level": "community",
+            "extra": {},
+        },
+    )()
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+
+    monkeypatch.setattr("tools.skills_hub.GitHubAuth", lambda: object())
+    monkeypatch.setattr("tools.skills_hub.create_source_router", lambda *_a, **_k: [])
+    monkeypatch.setattr(
+        "tools.skills_hub.parallel_search_sources",
+        lambda *_a, **_k: ([result], {"community": 1}, []),
+    )
+    monkeypatch.setattr(
+        "agent.skill_governance.rank_skill_search_results",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("simulated ranking failure")),
+    )
+
+    do_browse(console=console)
+
+    rendered = sink.getvalue()
+    assert "No skills found in the Skills Hub." in rendered
+    assert "current-skill" not in rendered
+
+
+def test_do_browse_keeps_fallback_order_when_unprotected_governance_ranking_fails(
+    monkeypatch, tmp_path
+):
+    from hermes_cli.skills_hub import do_browse
+
+    home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _write_governance_config(home, task_class="general", protected=["medical"])
+
+    trusted = type(
+        "R",
+        (),
+        {
+            "name": "alpha",
+            "description": "Trusted",
+            "source": "community",
+            "identifier": "repo/alpha",
+            "trust_level": "trusted",
+            "extra": {},
+        },
+    )()
+    community = type(
+        "R",
+        (),
+        {
+            "name": "zulu",
+            "description": "Community",
+            "source": "community",
+            "identifier": "repo/zulu",
+            "trust_level": "community",
+            "extra": {},
+        },
+    )()
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None, width=120)
+
+    monkeypatch.setattr("tools.skills_hub.GitHubAuth", lambda: object())
+    monkeypatch.setattr("tools.skills_hub.create_source_router", lambda *_a, **_k: [])
+    monkeypatch.setattr(
+        "tools.skills_hub.parallel_search_sources",
+        lambda *_a, **_k: ([community, trusted], {"community": 2}, []),
+    )
+    monkeypatch.setattr(
+        "agent.skill_governance.rank_skill_search_results",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("simulated ranking failure")),
+    )
+
+    do_browse(console=console)
+
+    rendered = sink.getvalue()
+    assert "No skills found in the Skills Hub." not in rendered
+    assert rendered.index("alpha") < rendered.index("zulu")

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -432,3 +432,128 @@ def test_do_browse_keeps_fallback_order_when_unprotected_governance_ranking_fail
     rendered = sink.getvalue()
     assert "No skills found in the Skills Hub." not in rendered
     assert rendered.index("alpha") < rendered.index("zulu")
+
+
+def test_browse_skills_fail_closes_when_protected_governance_ranking_fails(
+    monkeypatch, tmp_path
+):
+    from hermes_cli.skills_hub import browse_skills
+
+    home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _write_governance_config(home, task_class="medical", protected=["medical"])
+
+    result = type(
+        "R",
+        (),
+        {
+            "name": "current-skill",
+            "description": "Alpha",
+            "source": "community",
+            "identifier": "repo/current-skill",
+            "trust_level": "community",
+            "extra": {},
+        },
+    )()
+
+    monkeypatch.setattr("tools.skills_hub.GitHubAuth", lambda: object())
+    monkeypatch.setattr("tools.skills_hub.create_source_router", lambda *_a, **_k: [])
+    monkeypatch.setattr(
+        "tools.skills_hub.parallel_search_sources",
+        lambda *_a, **_k: ([result], {"community": 1}, []),
+    )
+    monkeypatch.setattr(
+        "agent.skill_governance.rank_skill_search_results",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("simulated ranking failure")),
+    )
+
+    payload = browse_skills()
+
+    assert payload == {"items": [], "page": 1, "total_pages": 1, "total": 0}
+
+
+def test_browse_skills_fail_closes_when_config_is_unreadable(monkeypatch, tmp_path):
+    from hermes_cli.skills_hub import browse_skills
+
+    home = tmp_path / "home"
+    home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    (home / "config.yaml").write_text("skills: [\n", encoding="utf-8")
+
+    result = type(
+        "R",
+        (),
+        {
+            "name": "current-skill",
+            "description": "Alpha",
+            "source": "community",
+            "identifier": "repo/current-skill",
+            "trust_level": "community",
+            "extra": {},
+        },
+    )()
+
+    monkeypatch.setattr("tools.skills_hub.GitHubAuth", lambda: object())
+    monkeypatch.setattr("tools.skills_hub.create_source_router", lambda *_a, **_k: [])
+    monkeypatch.setattr(
+        "tools.skills_hub.parallel_search_sources",
+        lambda *_a, **_k: ([result], {"community": 1}, []),
+    )
+    monkeypatch.setattr(
+        "agent.skill_governance.rank_skill_search_results",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("simulated ranking failure")),
+    )
+
+    payload = browse_skills()
+
+    assert payload == {"items": [], "page": 1, "total_pages": 1, "total": 0}
+
+
+def test_browse_skills_keeps_fallback_order_when_unprotected_governance_ranking_fails(
+    monkeypatch, tmp_path
+):
+    from hermes_cli.skills_hub import browse_skills
+
+    home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _write_governance_config(home, task_class="general", protected=["medical"])
+
+    trusted = type(
+        "R",
+        (),
+        {
+            "name": "alpha",
+            "description": "Trusted",
+            "source": "community",
+            "identifier": "repo/alpha",
+            "trust_level": "trusted",
+            "extra": {},
+        },
+    )()
+    community = type(
+        "R",
+        (),
+        {
+            "name": "zulu",
+            "description": "Community",
+            "source": "community",
+            "identifier": "repo/zulu",
+            "trust_level": "community",
+            "extra": {},
+        },
+    )()
+
+    monkeypatch.setattr("tools.skills_hub.GitHubAuth", lambda: object())
+    monkeypatch.setattr("tools.skills_hub.create_source_router", lambda *_a, **_k: [])
+    monkeypatch.setattr(
+        "tools.skills_hub.parallel_search_sources",
+        lambda *_a, **_k: ([community, trusted], {"community": 2}, []),
+    )
+    monkeypatch.setattr(
+        "agent.skill_governance.rank_skill_search_results",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("simulated ranking failure")),
+    )
+
+    payload = browse_skills()
+
+    assert [item["name"] for item in payload["items"]] == ["alpha", "zulu"]

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8361,6 +8361,45 @@ skills:
     assert "/tooltrust" not in resp["result"]["skills"]
 
 
+def test_skills_manage_browse_fail_closes_when_config_is_unreadable(
+    monkeypatch, tmp_path
+):
+    home = tmp_path / "home"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("skills: [\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    result = types.SimpleNamespace(
+        name="current-skill",
+        description="Alpha",
+        source="community",
+        identifier="repo/current-skill",
+        trust_level="community",
+        extra={},
+    )
+
+    monkeypatch.setattr("tools.skills_hub.GitHubAuth", lambda: object())
+    monkeypatch.setattr("tools.skills_hub.create_source_router", lambda *_a, **_k: [])
+    monkeypatch.setattr(
+        "tools.skills_hub.parallel_search_sources",
+        lambda *_a, **_k: ([result], {"community": 1}, []),
+    )
+    monkeypatch.setattr(
+        "agent.skill_governance.rank_skill_search_results",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("simulated ranking failure")),
+    )
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "skills.manage",
+            "params": {"action": "browse", "page": 1, "page_size": 20},
+        }
+    )
+
+    assert resp["result"] == {"items": [], "page": 1, "total_pages": 1, "total": 0}
+
+
 def test_session_status_reads_live_gateway_agent(monkeypatch):
     agent = types.SimpleNamespace(
         model="live-model",

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -6499,6 +6499,78 @@ skills:
     assert "tooltrust" not in texts
 
 
+def test_complete_slash_hides_bundles_when_governance_config_is_malformed(
+    monkeypatch, tmp_path
+):
+    import agent.skill_bundles as skill_bundles_mod
+    import agent.skill_commands as skill_commands_mod
+    import tools.skills_tool as skills_tool_module
+
+    home = tmp_path / "home"
+    skills_dir = tmp_path / "skills"
+    bundles_dir = tmp_path / "bundles"
+    home.mkdir()
+    skills_dir.mkdir()
+    (home / "config.yaml").write_text("skills:\n  governance: []\n", encoding="utf-8")
+    (skills_dir / "SafeSkill").mkdir(parents=True, exist_ok=True)
+    (skills_dir / "SafeSkill" / "SKILL.md").write_text(
+        "---\nname: SafeSkill\ndescription: allowed\n---\n\n# SafeSkill\n\nAllowed.\n",
+        encoding="utf-8",
+    )
+    bundles_dir.mkdir(parents=True, exist_ok=True)
+    (bundles_dir / "safe-pack.yaml").write_text(
+        "name: safe-pack\nskills:\n  - SafeSkill\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_BUNDLES_DIR", str(bundles_dir))
+    monkeypatch.setattr(skills_tool_module, "SKILLS_DIR", skills_dir)
+    skill_commands_mod._skill_commands = {}
+    skill_commands_mod._skill_commands_platform = None
+    skill_bundles_mod._bundles_cache = {}
+    skill_bundles_mod._bundles_cache_mtime = None
+
+    items = _slash_completions("/safe")
+    texts = {item["text"].strip() for item in items if item["kind"] == "skill"}
+
+    assert "safe-pack" not in texts
+
+
+def test_complete_slash_keeps_bundles_visible_when_unprotected(monkeypatch, tmp_path):
+    import agent.skill_bundles as skill_bundles_mod
+    import agent.skill_commands as skill_commands_mod
+    import tools.skills_tool as skills_tool_module
+
+    home = tmp_path / "home"
+    skills_dir = tmp_path / "skills"
+    bundles_dir = tmp_path / "bundles"
+    skills_dir.mkdir()
+    (skills_dir / "SafeSkill").mkdir(parents=True, exist_ok=True)
+    (skills_dir / "SafeSkill" / "SKILL.md").write_text(
+        "---\nname: SafeSkill\ndescription: allowed\n---\n\n# SafeSkill\n\nAllowed.\n",
+        encoding="utf-8",
+    )
+    bundles_dir.mkdir(parents=True, exist_ok=True)
+    (bundles_dir / "safe-pack.yaml").write_text(
+        "name: safe-pack\nskills:\n  - SafeSkill\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_BUNDLES_DIR", str(bundles_dir))
+    monkeypatch.setattr(skills_tool_module, "SKILLS_DIR", skills_dir)
+    skill_commands_mod._skill_commands = {}
+    skill_commands_mod._skill_commands_platform = None
+    skill_bundles_mod._bundles_cache = {}
+    skill_bundles_mod._bundles_cache_mtime = None
+
+    items = _slash_completions("/safe")
+    texts = {item["text"].strip() for item in items if item["kind"] == "skill"}
+
+    assert "safe-pack" in texts
+
+
 def test_config_set_reasoning_updates_live_session_and_agent(tmp_path, monkeypatch):
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
     (tmp_path / "config.yaml").write_text("agent:\n  reasoning_effort: medium\n", encoding="utf-8")

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -6383,7 +6383,7 @@ def _slash_skill_fixtures(monkeypatch):
         ),
     )
     monkeypatch.setattr(
-        "agent.skill_commands.get_skill_commands",
+        "agent.skill_commands.get_discoverable_skill_commands",
         lambda: {
             "/work": {"description": "Fresh worktree"},
             "/research": {"description": "Look it up"},
@@ -6452,6 +6452,51 @@ def test_complete_slash_leaves_argument_stages_alone(monkeypatch):
     items = _slash_completions("/details c")
 
     assert [item["text"] for item in items] == ["collapsed", "cycle"]
+
+
+def test_complete_slash_hides_governance_blocked_skills_when_protected(
+    monkeypatch, tmp_path
+):
+    import agent.skill_commands as skill_commands_mod
+    import tools.skills_tool as skills_tool_module
+
+    home = tmp_path / "home"
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    _configure_protected_governance(home)
+    (home / "governance" / "skills-registry.yaml").write_text(
+        """\
+version: 1
+skills:
+  - name: ToolTrust
+    classification: COMPATIBILITY_ONLY
+  - name: SafeSkill
+    classification: CURRENT
+""",
+        encoding="utf-8",
+    )
+    (skills_dir / "ToolTrust").mkdir(parents=True, exist_ok=True)
+    (skills_dir / "ToolTrust" / "SKILL.md").write_text(
+        "---\nname: ToolTrust\ndescription: blocked\n---\n\n# ToolTrust\n\nBlocked.\n",
+        encoding="utf-8",
+    )
+    (skills_dir / "SafeSkill").mkdir(parents=True, exist_ok=True)
+    (skills_dir / "SafeSkill" / "SKILL.md").write_text(
+        "---\nname: SafeSkill\ndescription: allowed\n---\n\n# SafeSkill\n\nAllowed.\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool_module, "SKILLS_DIR", skills_dir)
+    skill_commands_mod._skill_commands = {}
+    skill_commands_mod._skill_commands_platform = None
+    monkeypatch.setattr("agent.skill_bundles.get_skill_bundles", lambda: {})
+
+    items = _slash_completions("/s")
+    texts = {item["text"].strip() for item in items if item["kind"] == "skill"}
+
+    assert "safeskill" in texts
+    assert "tooltrust" not in texts
 
 
 def test_config_set_reasoning_updates_live_session_and_agent(tmp_path, monkeypatch):
@@ -8160,7 +8205,7 @@ def test_commands_catalog_ranks_skill_commands_by_recorded_usage(monkeypatch):
         ),
     )
     monkeypatch.setattr(
-        "agent.skill_commands.scan_skill_commands",
+        "agent.skill_commands.get_discoverable_skill_commands",
         lambda: {
             "/research": {"name": "research", "description": "Look it up"},
             "/research-paper-writing": {
@@ -8267,6 +8312,53 @@ def test_commands_catalog_filters_gateway_only_commands_and_keeps_status_visible
     assert "/approve" not in canon
     assert "/deny" not in canon
     assert "/set-home" not in canon
+
+
+def test_commands_catalog_hides_governance_blocked_skills_when_protected(
+    monkeypatch, tmp_path
+):
+    import agent.skill_commands as skill_commands_mod
+    import tools.skills_tool as skills_tool_module
+
+    home = tmp_path / "home"
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    _configure_protected_governance(home)
+    (home / "governance" / "skills-registry.yaml").write_text(
+        """\
+version: 1
+skills:
+  - name: ToolTrust
+    classification: COMPATIBILITY_ONLY
+  - name: SafeSkill
+    classification: CURRENT
+""",
+        encoding="utf-8",
+    )
+    (skills_dir / "ToolTrust").mkdir(parents=True, exist_ok=True)
+    (skills_dir / "ToolTrust" / "SKILL.md").write_text(
+        "---\nname: ToolTrust\ndescription: blocked\n---\n\n# ToolTrust\n\nBlocked.\n",
+        encoding="utf-8",
+    )
+    (skills_dir / "SafeSkill").mkdir(parents=True, exist_ok=True)
+    (skills_dir / "SafeSkill" / "SKILL.md").write_text(
+        "---\nname: SafeSkill\ndescription: allowed\n---\n\n# SafeSkill\n\nAllowed.\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool_module, "SKILLS_DIR", skills_dir)
+    skill_commands_mod._skill_commands = {}
+    skill_commands_mod._skill_commands_platform = None
+
+    resp = server.handle_request(
+        {"id": "1", "method": "commands.catalog", "params": {}}
+    )
+
+    pairs = dict(resp["result"]["pairs"])
+    assert "/safeskill" in pairs
+    assert "/tooltrust" not in pairs
+    assert "/tooltrust" not in resp["result"]["skills"]
 
 
 def test_session_status_reads_live_gateway_agent(monkeypatch):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3589,6 +3589,30 @@ def _session(agent=None, **extra):
     }
 
 
+def _configure_protected_governance(home: Path) -> None:
+    (home / "governance").mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        """\
+skills:
+  governance:
+    registry_path: governance/skills-registry.yaml
+    task_class: ardyn_engineering
+    protected_task_classes:
+      - ardyn_engineering
+""",
+        encoding="utf-8",
+    )
+    (home / "governance" / "skills-registry.yaml").write_text(
+        """\
+version: 1
+skills:
+  - name: ToolTrust
+    classification: COMPATIBILITY_ONLY
+""",
+        encoding="utf-8",
+    )
+
+
 def test_session_close_commits_memory_and_fires_finalize_hook(monkeypatch):
     calls = {"hooks": []}
 
@@ -8357,6 +8381,42 @@ def test_command_dispatch_exec_nonzero_surfaces_error(monkeypatch):
 
     assert "error" in resp
     assert "failed" in resp["error"]["message"]
+
+
+def test_command_dispatch_skill_denies_governance_blocked_skill(monkeypatch, tmp_path):
+    import agent.skill_commands as skill_commands_mod
+    import tools.skills_tool as skills_tool_module
+
+    home = tmp_path / "home"
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    _configure_protected_governance(home)
+    (skills_dir / "ToolTrust").mkdir(parents=True, exist_ok=True)
+    (skills_dir / "ToolTrust" / "SKILL.md").write_text(
+        "---\nname: ToolTrust\ndescription: blocked\n---\n\n# ToolTrust\n\nBlocked.\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool_module, "SKILLS_DIR", skills_dir)
+    skill_commands_mod._skill_commands = {}
+    skill_commands_mod._skill_commands_platform = None
+
+    server._sessions["sid"] = _session()
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "command.dispatch",
+                "params": {"name": "tooltrust", "arg": "do it", "session_id": "sid"},
+            }
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert "error" in resp
+    assert "ToolTrust" in resp["error"]["message"]
+    assert "historical intent" in resp["error"]["message"]
 
 
 def test_plugins_list_surfaces_loader_error(monkeypatch):

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -31,6 +31,33 @@ from tools.skills_hub import (
 )
 
 
+def _configure_protected_governance(home):
+    (home / "governance").mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        """\
+skills:
+  governance:
+    registry_path: governance/skills-registry.yaml
+    task_class: ardyn_engineering
+    protected_task_classes:
+      - ardyn_engineering
+    retrieval_ranking: true
+""",
+        encoding="utf-8",
+    )
+    (home / "governance" / "skills-registry.yaml").write_text(
+        """\
+version: 1
+skills:
+  - name: alpha-current
+    classification: CURRENT
+  - name: zulu-current
+    classification: CURRENT
+""",
+        encoding="utf-8",
+    )
+
+
 # ---------------------------------------------------------------------------
 # GitHubSource._parse_frontmatter_quick
 # ---------------------------------------------------------------------------
@@ -597,6 +624,32 @@ class TestUnifiedSearchDedup:
         ])
         results = unified_search("query", [failing, ok])
         assert len(results) == 1
+
+    def test_governance_sort_is_deterministic_within_equal_class(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        _configure_protected_governance(home)
+
+        alpha = SkillMeta(
+            name="alpha-current",
+            description="Alpha",
+            source="b",
+            identifier="repo/alpha-current",
+            trust_level="community",
+        )
+        zulu = SkillMeta(
+            name="zulu-current",
+            description="Zulu",
+            source="a",
+            identifier="repo/zulu-current",
+            trust_level="community",
+        )
+        src_a = self._make_source("a", [zulu])
+        src_b = self._make_source("b", [alpha])
+
+        results = unified_search("skill", [src_a, src_b])
+
+        assert [result.name for result in results] == ["alpha-current", "zulu-current"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1,5 +1,6 @@
 """Tests for tools/skills_hub.py — source adapters, lock file, taps, dedup logic."""
 
+import builtins
 import json
 import time
 from typing import List, Optional
@@ -650,6 +651,50 @@ class TestUnifiedSearchDedup:
         results = unified_search("skill", [src_a, src_b])
 
         assert [result.name for result in results] == ["alpha-current", "zulu-current"]
+
+    def test_protected_governance_import_failure_returns_no_results(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        _configure_protected_governance(home)
+
+        result = SkillMeta(
+            name="alpha-current",
+            description="Alpha",
+            source="a",
+            identifier="repo/alpha-current",
+            trust_level="community",
+        )
+        src = self._make_source("a", [result])
+        real_import = builtins.__import__
+
+        def _deny_governance_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "agent.skill_governance":
+                raise ImportError("simulated governance import failure")
+            return real_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.setattr(builtins, "__import__", _deny_governance_import)
+
+        assert unified_search("skill", [src]) == []
+
+    def test_protected_governance_eval_failure_returns_no_results(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        _configure_protected_governance(home)
+
+        result = SkillMeta(
+            name="alpha-current",
+            description="Alpha",
+            source="a",
+            identifier="repo/alpha-current",
+            trust_level="community",
+        )
+        src = self._make_source("a", [result])
+        monkeypatch.setattr(
+            "agent.skill_governance.rank_skill_search_results",
+            lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("simulated ranking failure")),
+        )
+
+        assert unified_search("skill", [src]) == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -56,6 +56,25 @@ def _symlink_category(skills_dir: Path, linked_root: Path, category: str) -> Pat
     return external_category
 
 
+def _configure_protected_governance(home: Path, registry_entries: str) -> None:
+    (home / "governance").mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        """\
+skills:
+  governance:
+    registry_path: governance/skills-registry.yaml
+    task_class: ardyn_engineering
+    protected_task_classes:
+      - ardyn_engineering
+""",
+        encoding="utf-8",
+    )
+    (home / "governance" / "skills-registry.yaml").write_text(
+        "version: 1\nskills:\n" + registry_entries,
+        encoding="utf-8",
+    )
+
+
 # ---------------------------------------------------------------------------
 # _parse_frontmatter
 # ---------------------------------------------------------------------------
@@ -295,6 +314,56 @@ class TestSkillsList:
         assert result["categories"] == ["linked"]
         assert result["skills"][0]["name"] == "knowledge-brain"
 
+    def test_hides_governance_blocked_skills_when_protected(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        _configure_protected_governance(
+            home,
+            """\
+  - name: blocked-skill
+    classification: COMPATIBILITY_ONLY
+  - name: allowed-skill
+    classification: CURRENT
+""",
+        )
+        skills_dir = home / "skills"
+        with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
+            _make_skill(skills_dir, "blocked-skill")
+            _make_skill(skills_dir, "allowed-skill")
+            result = json.loads(skills_list())
+
+        assert [skill["name"] for skill in result["skills"]] == ["allowed-skill"]
+
+    def test_fail_closes_when_governance_config_is_malformed(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        home.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        (home / "config.yaml").write_text("skills:\n  governance: []\n", encoding="utf-8")
+        skills_dir = home / "skills"
+        with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
+            _make_skill(skills_dir, "visible-if-unprotected")
+            result = json.loads(skills_list())
+
+        assert result["skills"] == []
+
+    def test_preserves_unprotected_behavior_when_governance_eval_fails(
+        self, tmp_path, monkeypatch
+    ):
+        home = tmp_path / "home"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        skills_dir = home / "skills"
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", skills_dir),
+            patch(
+                "agent.skill_governance.governance_context",
+                side_effect=RuntimeError("registry unreadable"),
+            ),
+        ):
+            _make_skill(skills_dir, "still-visible")
+            result = json.loads(skills_list())
+
+        assert [skill["name"] for skill in result["skills"]] == ["still-visible"]
+
 
 # ---------------------------------------------------------------------------
 # skill_view
@@ -408,6 +477,56 @@ class TestSkillView:
         result = json.loads(raw)
         assert result["success"] is True
         assert result["name"] == "knowledge-brain"
+
+    def test_view_denies_governance_blocked_skill_when_protected(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        _configure_protected_governance(
+            home,
+            """\
+  - name: blocked-skill
+    classification: COMPATIBILITY_ONLY
+""",
+        )
+        skills_dir = home / "skills"
+        with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
+            _make_skill(skills_dir, "blocked-skill", body="blocked content")
+            result = json.loads(skill_view("blocked-skill"))
+
+        assert result["success"] is False
+        assert "blocked by skill governance" in result["error"].lower()
+
+    def test_view_fails_closed_when_governance_config_is_malformed(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        home.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        (home / "config.yaml").write_text("skills:\n  governance: []\n", encoding="utf-8")
+        skills_dir = home / "skills"
+        with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
+            _make_skill(skills_dir, "blocked-by-error", body="content")
+            result = json.loads(skill_view("blocked-by-error"))
+
+        assert result["success"] is False
+        assert "blocked by skill governance" in result["error"].lower()
+
+    def test_view_preserves_unprotected_behavior_when_governance_eval_fails(
+        self, tmp_path, monkeypatch
+    ):
+        home = tmp_path / "home"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        skills_dir = home / "skills"
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", skills_dir),
+            patch(
+                "agent.skill_governance.governance_context",
+                side_effect=RuntimeError("registry unreadable"),
+            ),
+        ):
+            _make_skill(skills_dir, "still-loads", body="visible content")
+            result = json.loads(skill_view("still-loads"))
+
+        assert result["success"] is True
+        assert "visible content" in result["content"]
 
 
 class TestSkillViewSecureSetupOnLoad:

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -4429,13 +4429,30 @@ def unified_search(query: str, sources: List[SkillSource],
             seen[r.identifier] = r
     deduped = list(seen.values())
     try:
-        from agent.skill_governance import governance_context, rank_skill_search_results
+        from agent.skill_governance import (
+            governance_context,
+            probe_protected_task_class,
+            rank_skill_search_results,
+        )
 
         deduped = rank_skill_search_results(
             deduped,
             context=governance_context(mode="retrieval"),
         )
     except Exception:
+        probe = None
+        try:
+            from agent.skill_governance import probe_protected_task_class
+
+            probe = probe_protected_task_class()
+        except Exception:
+            probe = None
+        if probe is None or probe.protected_task:
+            logger.warning(
+                "Governance-aware ranking unavailable for protected task class; returning no skills",
+                exc_info=True,
+            )
+            return []
         logger.debug("Governance-aware ranking unavailable", exc_info=True)
 
     return deduped[:limit]

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -4428,5 +4428,14 @@ def unified_search(query: str, sources: List[SkillSource],
         elif _TRUST_RANK.get(r.trust_level, 0) > _TRUST_RANK.get(seen[r.identifier].trust_level, 0):
             seen[r.identifier] = r
     deduped = list(seen.values())
+    try:
+        from agent.skill_governance import governance_context, rank_skill_search_results
+
+        deduped = rank_skill_search_results(
+            deduped,
+            context=governance_context(mode="retrieval"),
+        )
+    except Exception:
+        logger.debug("Governance-aware ranking unavailable", exc_info=True)
 
     return deduped[:limit]

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -783,6 +783,36 @@ def _sort_skills(skills: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return sorted(skills, key=lambda s: (s.get("category") or "", s["name"]))
 
 
+def _is_skill_visible_under_governance(
+    skill_name: str,
+    *,
+    mode: str,
+) -> bool:
+    """Return whether a skill should stay visible on a governed surface."""
+    try:
+        from agent.skill_governance import evaluate_skill_selection_fail_closed
+
+        decision = evaluate_skill_selection_fail_closed(
+            skill_name,
+            mode=mode,
+            emit_log=False,
+        )
+        return decision is None or decision.allowed
+    except Exception:
+        logger.debug(
+            "Skill governance visibility check failed for %s",
+            skill_name,
+            exc_info=True,
+        )
+    try:
+        from agent.skill_governance import probe_protected_task_class
+
+        probe = probe_protected_task_class()
+    except Exception:
+        return False
+    return probe.safe and not probe.protected_task
+
+
 def skills_list(category: str = None, task_id: str = None) -> str:
     """
     List all available skills (progressive disclosure tier 1 - minimal metadata).
@@ -829,6 +859,12 @@ def skills_list(category: str = None, task_id: str = None) -> str:
         if category:
             all_skills = [s for s in all_skills if s.get("category") == category]
 
+        all_skills = [
+            s
+            for s in all_skills
+            if _is_skill_visible_under_governance(s.get("name", ""), mode="auto")
+        ]
+
         # Sort by category then name
         all_skills = _sort_skills(all_skills)
 
@@ -865,6 +901,19 @@ def _serve_plugin_skill(
 ) -> str:
     """Read a plugin-provided skill, apply guards, return JSON."""
     from hermes_cli.plugins import _get_disabled_plugins, get_plugin_manager
+
+    qualified_name = f"{namespace}:{bare}"
+    if preprocess and not _is_skill_visible_under_governance(qualified_name, mode="explicit"):
+        return json.dumps(
+            {
+                "success": False,
+                "error": (
+                    f"Skill '{qualified_name}' is blocked by skill governance "
+                    "for the active task class."
+                ),
+            },
+            ensure_ascii=False,
+        )
 
     if namespace in _get_disabled_plugins():
         return json.dumps(
@@ -1285,6 +1334,19 @@ def skill_view(
                     "error": (
                         f"Skill '{resolved_name}' is disabled. "
                         "Enable it with `hermes skills` or inspect the files directly on disk."
+                    ),
+                },
+                ensure_ascii=False,
+            )
+        if preprocess and not _is_skill_visible_under_governance(
+            resolved_name, mode="explicit"
+        ):
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": (
+                        f"Skill '{resolved_name}' is blocked by skill governance "
+                        "for the active task class."
                     ),
                 },
                 ensure_ascii=False,

--- a/tui_gateway/methods_complete.py
+++ b/tui_gateway/methods_complete.py
@@ -226,11 +226,11 @@ def _(rid, params: dict) -> dict:
         from prompt_toolkit.document import Document
         from prompt_toolkit.formatted_text import to_plain_text
 
-        from agent.skill_commands import get_skill_commands
+        from agent.skill_commands import get_discoverable_skill_commands
         from agent.skill_bundles import get_skill_bundles
 
         completer = SlashCommandCompleter(
-            skill_commands_provider=lambda: get_skill_commands(),
+            skill_commands_provider=lambda: get_discoverable_skill_commands(),
             skill_bundles_provider=lambda: get_skill_bundles(),
         )
         doc = Document(text, len(text))
@@ -240,7 +240,7 @@ def _(rid, params: dict) -> dict:
         # uses — no sniffing the ⚡/▣ meta glyphs, which are display text.
         skill_names = {
             key.lstrip("/").lower()
-            for key in (*get_skill_commands(), *get_skill_bundles())
+            for key in (*get_discoverable_skill_commands(), *get_skill_bundles())
         }
         items = [
             {

--- a/tui_gateway/methods_complete.py
+++ b/tui_gateway/methods_complete.py
@@ -227,11 +227,11 @@ def _(rid, params: dict) -> dict:
         from prompt_toolkit.formatted_text import to_plain_text
 
         from agent.skill_commands import get_discoverable_skill_commands
-        from agent.skill_bundles import get_skill_bundles
+        from agent.skill_bundles import get_discoverable_skill_bundles
 
         completer = SlashCommandCompleter(
             skill_commands_provider=lambda: get_discoverable_skill_commands(),
-            skill_bundles_provider=lambda: get_skill_bundles(),
+            skill_bundles_provider=lambda: get_discoverable_skill_bundles(),
         )
         doc = Document(text, len(text))
         # Skill commands and bundles are the only completions offered for an
@@ -240,7 +240,7 @@ def _(rid, params: dict) -> dict:
         # uses — no sniffing the ⚡/▣ meta glyphs, which are display text.
         skill_names = {
             key.lstrip("/").lower()
-            for key in (*get_discoverable_skill_commands(), *get_skill_bundles())
+            for key in (*get_discoverable_skill_commands(), *get_discoverable_skill_bundles())
         }
         items = [
             {

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -331,7 +331,7 @@ def _(rid, params: dict) -> dict:
         skill_count = 0
         skills: dict[str, dict] = {}
         try:
-            from agent.skill_commands import scan_skill_commands
+            from agent.skill_commands import get_discoverable_skill_commands
 
             # Usage + origin per skill command. Surfaces here rather than in a
             # second RPC because every consumer that renders the catalog also
@@ -339,7 +339,7 @@ def _(rid, params: dict) -> dict:
             # loaded once per catalog build.
             usage, origin_of = _skill_usage_lookup()
 
-            for k, info in sorted(scan_skill_commands().items()):
+            for k, info in sorted(get_discoverable_skill_commands().items()):
                 d = str(info.get("description", "Skill"))
                 all_pairs.append([k, d[:120] + ("…" if len(d) > 120 else "")])
                 name = str(info.get("name") or k.lstrip("/"))

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -511,12 +511,15 @@ def _(rid, params: dict) -> dict:
 
     if bundle_key is not None:
         try:
+            from agent.skill_governance import SkillGovernanceRejectedError
             bundle_result = build_bundle_invocation_message(
                 bundle_key,
                 arg,
                 task_id=session.get("session_key", "") if session else "",
                 platform=_resolve_session_platform(),
             )
+        except SkillGovernanceRejectedError as exc:
+            return _err(rid, 4018, str(exc))
         except Exception as exc:
             return _err(rid, 4018, f"bundle dispatch failed: {exc}")
 
@@ -546,6 +549,7 @@ def _(rid, params: dict) -> dict:
             scan_skill_commands,
             build_skill_invocation_message,
         )
+        from agent.skill_governance import SkillGovernanceRejectedError
 
         cmds = scan_skill_commands()
         key = f"/{name}"
@@ -565,6 +569,8 @@ def _(rid, params: dict) -> dict:
                         "display": _skill_scaffold_projection(msg),
                     },
                 )
+    except SkillGovernanceRejectedError as exc:
+        return _err(rid, 4018, str(exc))
     except Exception:
         pass
 


### PR DESCRIPTION
## AP-003: fail-closed protected skill governance across discovery and retrieval

### Accepted candidate
- **Exact head SHA:** `a85075137569bb0e997549ed661ef17442096e5e`
- **Fork head:** `Kylewilson04:fix/ap-003-skill-governance-fail-closed`
- **Qualification:** HERMES-QUAL-03A / AP-003 — **ACCEPTED**

### Remediated fail-open surfaces
This candidate makes protected skill discovery and retrieval fail closed when governance configuration is absent, malformed, or otherwise cannot be evaluated. The remediation covers:

- CLI discovery, including exact/prefix bundle selection;
- `skills_list` and `skill_view` protected retrieval filtering;
- skills-hub search/ranking/browse;
- preload, direct, stacked, and bundle dispatch;
- channel/topic auto-binding;
- dashboard and TUI retrieval/autocomplete paths.

The central retrieval visibility guard is applied in `tools/skills_tool.py`; protected ranking in `agent/skill_governance.py` returns no results when governance evaluation fails.

### Verification evidence
- Focused protected retrieval qualification: **67 passed**
- Governance/discovery acceptance: **193 passed**
- Independent whole-surface audit: **PASS**
- Broader relevant regression: **720 passed; 1 unrelated nondeterministic concurrency failure**

The unrelated result is `tests/test_tui_gateway_server.py::test_write_json_serializes_concurrent_writes`. It passed **10/10** independently on both this candidate and the unchanged production baseline. The candidate does not modify `write_json`, `_real_stdout`, or that test's concurrency logic.

### Production boundary
No production Hermes installation, configuration, credential, gateway, session/memory, cron, or routing change occurred. The production baseline remains `6564f319a647b47de391cab2f608660323804a2b`.

### Review request
Please review this exact, qualification-sealed commit. Local AP-003 acceptance does **not** authorize production installation. Any review-driven code change or upstream-base relineage requires isolated requalification and a successor acceptance record before activation.

Evidence package: `HERMES-QUAL-03/03-ap-003/` (including acceptance record, final integrity ledger, audit output, and fork publication transcript).
