### PR TITLE
fix(gateway): auto-append MEDIA for video_generate JSON results

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1505,6 +1505,7 @@ _AUTO_APPEND_MEDIA_TOOL_NAMES = {
     "text_to_speech",
     "text_to_speech_tool",
     "image_generate",
+    "video_generate",
     "bfl_flux3_get_result",
 }
 
@@ -1557,10 +1558,22 @@ def _strip_auto_continue_noise(content: Any) -> Any:
 
 # Tools in this set return their deliverable artifact as a JSON payload with a
 # local-file path field rather than a literal ``MEDIA:`` tag (e.g. image_generate
-# returns ``{"success": true, "image": "/abs/path.png"}``). The auto-append path
+# returns ``{"success": true, "image": "/abs/path.png"}``, video_generate returns
+# ``{"success": true, "video": "/abs/path.mp4"}``). The auto-append path
 # extracts the path from these fields so delivery is deterministic and does not
 # depend on the model restating the path in its final reply.
-_JSON_MEDIA_TOOL_PATH_FIELDS = ("host_image", "image", "agent_visible_image")
+_JSON_MEDIA_TOOL_NAMES = {
+    "image_generate",
+    "video_generate",
+}
+_JSON_MEDIA_TOOL_PATH_FIELDS = (
+    "host_image",
+    "image",
+    "agent_visible_image",
+    "host_video",
+    "video",
+    "agent_visible_video",
+)
 
 
 # Extension-anchored MEDIA: matcher for tool results. Mirrors the dispatch-site
@@ -1628,10 +1641,11 @@ def _collect_auto_append_media_tags(
             continue
         content = str(msg.get("content") or "")
         tool_name = tool_name_by_call_id.get(call_id)
-        # JSON-payload tools (image_generate) return a local-file path in a
-        # known field rather than a MEDIA: tag. Extract it so delivery is
-        # deterministic even when the model omits the path from its reply.
-        if tool_name == "image_generate" and "MEDIA:" not in content:
+        # JSON-payload tools (image_generate / video_generate) return a
+        # local-file path in a known field rather than a MEDIA: tag. Extract
+        # it so delivery is deterministic even when the model omits the path
+        # from its reply.
+        if tool_name in _JSON_MEDIA_TOOL_NAMES and "MEDIA:" not in content:
             try:
                 payload = json.loads(content)
             except Exception:
@@ -1664,8 +1678,10 @@ def _collect_history_media_paths(agent_history: List[Dict[str, Any]]) -> set:
     is not re-sent on later turns. Covers three delivery shapes:
       * ``MEDIA:<path>`` text tags in tool results,
       * ``MEDIA:<path>`` text tags in assistant messages (model-generated tags),
-      * ``image_generate`` JSON-payload paths (``host_image`` / ``image`` /
-        ``agent_visible_image``), which carry no MEDIA: tag.
+      * JSON-payload paths from ``image_generate`` / ``video_generate``
+        (``host_image`` / ``image`` / ``agent_visible_image`` /
+        ``host_video`` / ``video`` / ``agent_visible_video``), which carry
+        no MEDIA: tag.
 
     Missing the JSON-payload shape caused #46627; missing the assistant-message
     shape caused repeated delivery when the model echoed a previous MEDIA tag.
@@ -1707,7 +1723,7 @@ def _collect_history_media_paths(agent_history: List[Dict[str, Any]]) -> set:
             _add_text_media_paths(content)
             continue
         cid = str(msg.get("tool_call_id") or msg.get("call_id") or "")
-        if tool_name_by_call_id.get(cid) == "image_generate":
+        if tool_name_by_call_id.get(cid) in _JSON_MEDIA_TOOL_NAMES:
             try:
                 payload = json.loads(content)
             except Exception:

--- a/tests/gateway/test_media_extraction.py
+++ b/tests/gateway/test_media_extraction.py
@@ -11,6 +11,7 @@ make_image tool several turns earlier must not leak onto a later
 text-only reply, even when the path-based dedup set fails to capture it.
 """
 
+import json
 import re
 from unittest.mock import MagicMock
 
@@ -268,6 +269,127 @@ caption
             history, history_offset=9999, history_media_paths=history_paths
         )
         assert tags == [], f"generated image re-emitted after compression: {tags}"
+
+    def test_video_generate_json_auto_appends_local_path(self):
+        """Sibling of image_generate/#46627: local-file video_generate JSON
+        has no MEDIA: tag, so the gateway must auto-append or the user gets
+        text with no video attachment."""
+        from gateway.run import _collect_auto_append_media_tags
+
+        path = "/home/u/.hermes/cache/videos/clip.mp4"
+        messages = [
+            {"role": "user", "content": "make a clip"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "v1", "function": {"name": "video_generate"}}
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "v1",
+                "content": json.dumps({"success": True, "video": path}),
+            },
+            {"role": "assistant", "content": "Here is your clip."},
+        ]
+        tags, voice = _collect_auto_append_media_tags(messages, history_offset=0)
+        assert tags == [f"MEDIA:{path}"]
+        assert voice is False
+
+    def test_video_generate_prefers_host_video_over_agent_visible(self):
+        from gateway.run import _collect_auto_append_media_tags
+
+        host = "/home/u/.hermes/cache/videos/host.mp4"
+        agent = "/root/.hermes/cache/videos/host.mp4"
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "v1", "function": {"name": "video_generate"}}
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "v1",
+                "content": json.dumps({
+                    "success": True,
+                    "video": host,
+                    "host_video": host,
+                    "agent_visible_video": agent,
+                }),
+            },
+            {"role": "assistant", "content": "done"},
+        ]
+        tags, _ = _collect_auto_append_media_tags(messages, history_offset=0)
+        assert tags == [f"MEDIA:{host}"]
+
+    def test_video_generate_https_url_not_auto_appended(self):
+        from gateway.run import _collect_auto_append_media_tags
+
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "v1", "function": {"name": "video_generate"}}
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "v1",
+                "content": json.dumps({
+                    "success": True,
+                    "video": "https://cdn.example/clip.mp4",
+                }),
+            },
+            {"role": "assistant", "content": "Here is the URL."},
+        ]
+        tags, _ = _collect_auto_append_media_tags(messages, history_offset=0)
+        assert tags == []
+
+    def test_collect_history_media_paths_includes_video_generate_json(self):
+        from gateway.run import _collect_history_media_paths
+
+        history = [
+            {"role": "user", "content": "make a clip"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "c", "function": {"name": "video_generate"}}
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "c",
+                "content": '{"success": true, "video": "/tmp/gen/clip.mp4"}',
+            },
+        ]
+        paths = _collect_history_media_paths(history)
+        assert "/tmp/gen/clip.mp4" in paths
+
+    def test_video_generate_not_reemitted_after_compression(self):
+        from gateway.run import (
+            _collect_auto_append_media_tags,
+            _collect_history_media_paths,
+        )
+
+        history = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "c", "function": {"name": "video_generate"}}
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "c",
+                "content": '{"success": true, "video": "/tmp/gen/clip.mp4"}',
+            },
+        ]
+        history_paths = _collect_history_media_paths(history)
+        tags, _ = _collect_auto_append_media_tags(
+            history, history_offset=9999, history_media_paths=history_paths
+        )
+        assert tags == [], f"generated video re-emitted after compression: {tags}"
 
 
     def test_media_tags_not_extracted_from_history(self):


### PR DESCRIPTION
## Summary
- `image_generate` local-file JSON is already allowlisted + field-extracted so gateway delivery does not depend on the model restating `MEDIA:` (#46627).
- `video_generate` returns the same shape (`{"success": true, "video": "/…/cache/videos/….mp4"}`) but was omitted from the allowlist/JSON extractor — DeepInfra / OpenAI-compatible local clips arrived as text-only replies.
- Mirror the image path: allowlist `video_generate`, extract `host_video` / `video` / `agent_visible_video`, and include those paths in history dedup so compression does not re-emit.

## Before / After
| Tool result | Reply has no MEDIA | Before | After |
|-------------|--------------------|--------|-------|
| `image_generate` local path | auto-append | delivers | delivers |
| `video_generate` local `.mp4` | auto-append | text only | `MEDIA:` delivered |
| `video_generate` `https://…` | — | no append | no append (unchanged) |

