### PR TITLE
feat(desktop): support dual-mode (light/dark) skins

### DIFF
--- a/apps/desktop/src/themes/skin.test.ts
+++ b/apps/desktop/src/themes/skin.test.ts
@@ -47,4 +47,50 @@ describe('skinToDesktopTheme', () => {
 
     expect(theme.colors.destructive).toBe(normalizeHex('#ff5566'))
   })
+
+  it('keeps single-mode behavior when no paired palettes exist', () => {
+    const theme = withColors('solo', { background: '#101020', ui_accent: '#ff33aa' })!
+
+    // One shared object in both slots — the light/dark toggle must not invert it.
+    expect(theme.colors).toBe(theme.darkColors)
+  })
+
+  it('ships distinct light/dark palettes when the skin has paired color blocks', () => {
+    const theme = skinToDesktopTheme({
+      name: 'dual',
+      colors: { background: '#101020', ui_accent: '#ff33aa', banner_text: '#eeeeee' },
+      light_colors: { background: '#fafafa', banner_text: '#111111', ui_accent: '#aa22cc' }
+    })!
+
+    expect(theme.colors).not.toBe(theme.darkColors)
+    // Light slot uses the light_colors background; dark slot keeps the base.
+    expect(luminance(theme.colors.background)).toBeGreaterThan(0.4)
+    expect(luminance(theme.darkColors!.background)).toBeLessThan(0.4)
+    // Both slots keep the authored accent identity, adapted per polarity.
+    expect(theme.colors.primary).not.toBe(theme.darkColors!.primary)
+  })
+
+  it('treats a dark-authored base with only light_colors as dual-mode', () => {
+    const theme = skinToDesktopTheme({
+      name: 'darkfirst',
+      colors: { background: '#0b0b0b', ui_accent: '#ffcc00', banner_text: '#ffffff' },
+      light_colors: { background: '#ffffff', banner_text: '#222222', ui_accent: '#b8860b' }
+    })!
+
+    expect(luminance(theme.colors.background)).toBeGreaterThan(0.4)
+    expect(luminance(theme.darkColors!.background)).toBeLessThan(0.4)
+  })
+
+  it('merges a fills-only paired block over the base palette', () => {
+    const theme = skinToDesktopTheme({
+      name: 'fills',
+      colors: { background: '#0b0b0b', ui_accent: '#ffcc00', banner_text: '#ffffff' },
+      // fills-only light overlay: flips the menu/status fills, keeps the vivid golds
+      light_colors: { completion_menu_bg: '#ffffff', status_bar_bg: '#ffffff' }
+    })!
+
+    // Distinct palettes now, with the overlay's surface in the light slot.
+    expect(theme.colors).not.toBe(theme.darkColors)
+    expect(theme.colors.input).toBe(normalizeHex('#ffffff'))
+  })
 })

--- a/apps/desktop/src/themes/skin.test.ts
+++ b/apps/desktop/src/themes/skin.test.ts
@@ -110,4 +110,30 @@ describe('skinToDesktopTheme', () => {
     // …and the light slot carries the overlay's canvas.
     expect(luminance(theme.colors.background)).toBeGreaterThan(0.4)
   })
+
+  it('mirrors for a light-authored base with only dark_colors', () => {
+    // The inverse of the dark-base case: a light base is the light slot itself,
+    // and the dark_colors overlay lands in the dark slot.
+    const theme = skinToDesktopTheme({
+      name: 'lightfirst',
+      colors: { background: '#fafafa', ui_accent: '#b8860b', banner_text: '#222222' },
+      dark_colors: { background: '#0b0b0b', banner_text: '#ffffff', ui_accent: '#ffcc00' }
+    })!
+
+    expect(theme.colors).not.toBe(theme.darkColors)
+    // Light slot keeps the light base; the dark slot carries the overlay's canvas.
+    expect(luminance(theme.colors.background)).toBeGreaterThan(0.4)
+    expect(luminance(theme.darkColors!.background)).toBeLessThan(0.4)
+  })
+
+  it('treats an empty paired block as single-mode', () => {
+    const theme = skinToDesktopTheme({
+      name: 'emptyoverlay',
+      colors: { background: '#101020', ui_accent: '#ff33aa' },
+      light_colors: {}
+    })!
+
+    // No real tokens in the overlay: keep the single shared palette behavior.
+    expect(theme.colors).toBe(theme.darkColors)
+  })
 })

--- a/apps/desktop/src/themes/skin.test.ts
+++ b/apps/desktop/src/themes/skin.test.ts
@@ -93,4 +93,21 @@ describe('skinToDesktopTheme', () => {
     expect(theme.colors).not.toBe(theme.darkColors)
     expect(theme.colors.input).toBe(normalizeHex('#ffffff'))
   })
+
+  it('buckets a chrome-only base by foreground luminance for polarity', () => {
+    // No background/status_bar_bg: light text must read as a dark-authored base,
+    // so the light_colors overlay lands in the light slot — the toggle works
+    // instead of rendering the same palette in both modes.
+    const theme = skinToDesktopTheme({
+      name: 'chrome',
+      colors: { ui_accent: '#ffcc00', banner_text: '#ffffff' },
+      light_colors: { background: '#fafafa', banner_text: '#111111', ui_accent: '#b8860b' }
+    })!
+
+    expect(theme.colors).not.toBe(theme.darkColors)
+    // Dark slot derives from the light-text chrome base (same bucket as buildPalette)…
+    expect(luminance(theme.darkColors!.background)).toBeLessThan(0.4)
+    // …and the light slot carries the overlay's canvas.
+    expect(luminance(theme.colors.background)).toBeGreaterThan(0.4)
+  })
 })

--- a/apps/desktop/src/themes/skin.ts
+++ b/apps/desktop/src/themes/skin.ts
@@ -40,17 +40,12 @@ const pick = (colors: SkinColors, keys: string[], backdrop: string): string | nu
 const titleCase = (name: string): string => name.charAt(0).toUpperCase() + name.slice(1)
 
 /**
- * Convert a resolved skin into a `DesktopTheme`, or null when it carries no
- * usable colors (so a broken/empty skin never registers junk).
+ * Build one `DesktopThemeColors` palette from a skin color block.
+ *
+ * Extracted from the old single-palette body so a dual-mode skin can derive
+ * its light and dark palettes independently (each with its own polarity).
  */
-export function skinToDesktopTheme(skin: HermesSkin): DesktopTheme | null {
-  const name = (skin.name ?? '').trim()
-  const colors = skin.colors
-
-  if (!name || !colors || typeof colors !== 'object') {
-    return null
-  }
-
+function buildPalette(colors: SkinColors): DesktopThemeColors {
   // Background is the backdrop every other token flattens alpha over. Skins are
   // terminal-first so most only tint chrome — `status_bar_bg` is the closest
   // thing to an app surface; `background` is the explicit opt-in for GUI authors.
@@ -76,7 +71,7 @@ export function skinToDesktopTheme(skin: HermesSkin): DesktopTheme | null {
 
   const destructive = pick(colors, ['ui_error'], background) ?? '#e25563'
 
-  const palette: DesktopThemeColors = {
+  return {
     background,
     foreground,
     card: mix(background, foreground, dark ? 0.04 : 0.025),
@@ -104,14 +99,63 @@ export function skinToDesktopTheme(skin: HermesSkin): DesktopTheme | null {
     userBubble: mix(background, accent, dark ? 0.18 : 0.12),
     userBubbleBorder: border
   }
+}
+
+/** True when a paired palette block carries at least one real token. */
+const hasTokens = (block: SkinColors | undefined): boolean => !!block && Object.keys(block).length > 0
+
+/**
+ * Convert a resolved skin into a `DesktopTheme`, or null when it carries no
+ * usable colors (so a broken/empty skin never registers junk).
+ *
+ * A skin may ship a base `colors` block plus hand-tuned `light_colors` /
+ * `dark_colors` overlays (the TUI's paired-palette contract). When paired
+ * blocks exist, the base palette's polarity decides which overlay belongs to
+ * which mode, and the desktop produces genuinely distinct `colors` (light)
+ * and `darkColors` (dark) — so the light/dark toggle works. Without paired
+ * blocks the skin is single-mode: both slots get the same palette, exactly
+ * as before.
+ */
+export function skinToDesktopTheme(skin: HermesSkin): DesktopTheme | null {
+  const name = (skin.name ?? '').trim()
+  const colors = skin.colors
+
+  if (!name || !colors || typeof colors !== 'object') {
+    return null
+  }
+
+  const hasLight = hasTokens(skin.light_colors)
+  const hasDark = hasTokens(skin.dark_colors)
+
+  // Single-mode skin (no paired palettes): identical palette in both slots —
+  // the light/dark toggle must not invert it. Kept as one shared object so
+  // callers comparing by reference see the same palette as before.
+  if (!hasLight && !hasDark) {
+    const palette = buildPalette(colors)
+
+    return {
+      name,
+      label: titleCase(name),
+      description: 'Hermes skin',
+      colors: palette,
+      darkColors: palette
+    }
+  }
+
+  // Dual-mode: the base palette's authored background decides polarity (mirror
+  // of the TUI's `skinIsLight`). The opposite mode is the base merged with the
+  // matching hand-tuned overlay; the authored mode is the base itself.
+  const seededBg = pick(colors, ['background', 'status_bar_bg'], '#000000')
+  const baseDark = seededBg ? luminance(seededBg) < 0.4 : false
+
+  const lightSource = baseDark ? { ...colors, ...(skin.light_colors ?? {}) } : colors
+  const darkSource = baseDark ? colors : { ...colors, ...(skin.dark_colors ?? {}) }
 
   return {
     name,
     label: titleCase(name),
     description: 'Hermes skin',
-    // Single palette in both slots: a skin is one-mode, so the light/dark toggle
-    // shouldn't invert it. renderedModeFor still paints `.dark` from luminance.
-    colors: palette,
-    darkColors: palette
+    colors: buildPalette(lightSource),
+    darkColors: buildPalette(darkSource)
   }
 }

--- a/apps/desktop/src/themes/skin.ts
+++ b/apps/desktop/src/themes/skin.ts
@@ -145,8 +145,16 @@ export function skinToDesktopTheme(skin: HermesSkin): DesktopTheme | null {
   // Dual-mode: the base palette's authored background decides polarity (mirror
   // of the TUI's `skinIsLight`). The opposite mode is the base merged with the
   // matching hand-tuned overlay; the authored mode is the base itself.
+  //
+  // A chrome-only base (no `background`/`status_bar_bg`) must fall back to the
+  // SAME foreground-luminance bucket `buildPalette` uses, or the polarity seed
+  // disagrees with the palette it derives: light text ⇒ dark canvas ⇒ the
+  // light_colors overlay belongs in the light slot.
   const seededBg = pick(colors, ['background', 'status_bar_bg'], '#000000')
-  const baseDark = seededBg ? luminance(seededBg) < 0.4 : false
+  const foregroundSeed = pick(colors, ['ui_text', 'banner_text', 'status_bar_text'], seededBg ?? '#000000')
+  const baseDark = seededBg
+    ? luminance(seededBg) < 0.4
+    : (foregroundSeed ? luminance(foregroundSeed) > 0.5 : false)
 
   const lightSource = baseDark ? { ...colors, ...(skin.light_colors ?? {}) } : colors
   const darkSource = baseDark ? colors : { ...colors, ...(skin.dark_colors ?? {}) }

--- a/website/docs/user-guide/features/skins.md
+++ b/website/docs/user-guide/features/skins.md
@@ -212,6 +212,36 @@ branding:
 tool_prefix: "▏"
 ```
 
+### Dual light/dark palettes
+
+A skin can ship **paired palettes** so the light/dark toggle works on every surface — the Hermes desktop app included. Author the base `colors:` block for one polarity, then add an overlay block for the other:
+
+```yaml
+name: teal-ocean
+description: Teal canvas with a warm coral accent — dual-mode
+
+colors:
+  background: "#02181A"        # dark base (Abyss)
+  ui_accent: "#F6A278"         # coral on dark
+  banner_text: "#C8F5F2"
+
+# Light overlay: same keys as `colors`, hand-tuned for light surfaces.
+# The base palette's background decides polarity — dark base + light_colors,
+# or light base + dark_colors.
+light_colors:
+  background: "#F2FAF8"        # light canvas (Shallows)
+  ui_accent: "#B22E12"         # deeper coral on light
+  banner_text: "#051C1C"
+```
+
+Semantics:
+
+- The base `colors:` block is authored for one polarity; its `background` (when set) decides which.
+- `light_colors:` / `dark_colors:` are **overlays** merged over the base — partial blocks work (e.g. flip only the fills), full blocks override every key they list.
+- Without any paired block, a skin is single-mode and renders the same palette in both light and dark — exactly as before.
+- The **desktop app** maps the pair onto its `colors`/`darkColors` slots, so a dual-mode skin appears in Settings → Appearance with a working Light/Dark/System toggle. The TUI picks the block matching the terminal's detected polarity.
+- These keys were already supported by the skin engine, TUI, and the `skin` RPC payload; this also documents the desktop's support.
+
 ## Hermes Mod — Visual Skin Editor
 
 [Hermes Mod](https://github.com/cocktailpeanut/hermes-mod) is a community-built web UI for creating and managing skins visually. Instead of writing YAML by hand, you get a point-and-click editor with live preview.


### PR DESCRIPTION
## What

The desktop skin converter (`skinToDesktopTheme`) stamped a single palette into both the `colors` and `darkColors` slots, so a skin authored with the paired `light_colors`/`dark_colors` blocks — already supported by the skin engine, the `skin` RPC payload, and the TUI — rendered identically in both light and dark mode on the desktop.

This refactors the single-palette body into `buildPalette(colors)` and adds a dual-mode path: when a skin ships paired palettes, the base `colors` block decides polarity (mirror of the TUI's `skinIsLight`) and the matching overlay is merged over the base for the opposite mode. Skins **without** paired blocks keep the exact previous behavior (one shared palette object in both slots).

## Why

A user-authored YAML skin is currently single-mode on the desktop: no matter what you put in the file, the Light/Dark toggle has no effect, forcing console injection into `localStorage` (`hermes-desktop-user-themes-v1`) to get a dual-mode theme. With this change, one YAML file in `~/.hermes/skins/` drives a working Light/Dark/System toggle in Settings → Appearance — the same paired-palette contract the TUI already honors.

## Changes

- `apps/desktop/src/themes/skin.ts` — extract `buildPalette()`, add dual-mode merge path. A chrome-only base (no `background`/`status_bar_bg`) seeds polarity from the same foreground-luminance bucket `buildPalette` uses, so the `light_colors` overlay lands in the right slot (fix from AI triage, d241bd8)
- `apps/desktop/src/themes/skin.test.ts` — tests: single-mode preserved (same shared object), dual-mode distinct palettes, dark-base + light overlay, light-base + dark overlay, fills-only overlay merge, chrome-only polarity bucket, empty-overlay single-mode fallback
- `website/docs/user-guide/features/skins.md` — document dual light/dark palettes

## Verification

- `vitest run src/themes/skin.test.ts` — 13/13 pass (7 new)
- `tsc --noEmit -p tsconfig.json` — clean
- Full `src/themes/` suite — 70/70 pass
- End-to-end: the exact `resolve_skin()` RPC payload (name/colors/light_colors/dark_colors) converts to distinct light/dark `DesktopTheme` palettes
- Python engine resolves the new `teal-ocean.yaml` sample skin with base + 21-key light overlay

## Related

Refs #68364 (Desktop Skin: Official Open Customization & Agent-Assisted Skin Builder)
