### PR TITLE
fix(auth): inherit Nous tool token in named profiles

### DIFF
--- a/tests/tools/test_flux3_video_tool.py
+++ b/tests/tools/test_flux3_video_tool.py
@@ -210,7 +210,7 @@ class TestGating:
 
         # The profile's own store is empty, so this passes only via the
         # global-root fallback — without which the tools would be hidden.
-        assert flux3.peek_nous_access_token() is None
+        assert flux3.peek_nous_access_token() == "root-token"
         assert flux3.check_bfl_requirements() is True
 
     def test_the_credential_probe_never_forces_a_token_refresh(self, monkeypatch):

--- a/tests/tools/test_managed_tool_gateway.py
+++ b/tests/tools/test_managed_tool_gateway.py
@@ -86,14 +86,16 @@ def test_peek_nous_access_token_falls_back_to_global_store_for_named_profile(
     tmp_path, monkeypatch
 ):
     monkeypatch.delenv("TOOL_GATEWAY_USER_TOKEN", raising=False)
-    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    (tmp_path / "auth.json").write_text(json.dumps({
+    root = tmp_path / "root"
+    profile = root / "profiles" / "work"
+    profile.mkdir(parents=True)
+    (root / "auth.json").write_text(json.dumps({
+        "providers": {"nous": {"access_token": "global-nous-token"}}
+    }))
+    (profile / "auth.json").write_text(json.dumps({
         "providers": {"xai-oauth": {"access_token": "profile-token"}}
     }))
-    monkeypatch.setattr(
-        "hermes_cli.auth._load_global_auth_store",
-        lambda: {"providers": {"nous": {"access_token": "global-nous-token"}}},
-    )
+    monkeypatch.setenv("HERMES_HOME", str(profile))
 
     assert managed_tool_gateway.peek_nous_access_token() == "global-nous-token"
 

--- a/tests/tools/test_managed_tool_gateway.py
+++ b/tests/tools/test_managed_tool_gateway.py
@@ -82,6 +82,22 @@ def test_resolve_managed_tool_gateway_is_disabled_without_subscription():
     assert result is None
 
 
+def test_peek_nous_access_token_falls_back_to_global_store_for_named_profile(
+    tmp_path, monkeypatch
+):
+    monkeypatch.delenv("TOOL_GATEWAY_USER_TOKEN", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "auth.json").write_text(json.dumps({
+        "providers": {"xai-oauth": {"access_token": "profile-token"}}
+    }))
+    monkeypatch.setattr(
+        "hermes_cli.auth._load_global_auth_store",
+        lambda: {"providers": {"nous": {"access_token": "global-nous-token"}}},
+    )
+
+    assert managed_tool_gateway.peek_nous_access_token() == "global-nous-token"
+
+
 def test_read_nous_access_token_refreshes_expiring_cached_token(tmp_path, monkeypatch):
     monkeypatch.delenv("TOOL_GATEWAY_USER_TOKEN", raising=False)
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tools/flux3_video_tool.py
+++ b/tools/flux3_video_tool.py
@@ -778,27 +778,11 @@ async def _handle_prompting_guide(args: dict, **kwargs) -> str:
 def _has_nous_credential() -> bool:
     """True when a Nous bearer is on hand, without spending a refresh to learn it.
 
-    Two lookups, because the transport itself has two.
-    ``peek_nous_access_token`` covers the env override and the active store's
-    cached token. A profile that was never logged into separately has neither,
-    and reads the credential from the global-root ``auth.json`` — the same
-    fallback ``resolve_nous_access_token`` takes when the transport refreshes.
-    Probing only the first would hide the tools from a profile whose calls
-    would have gone through perfectly well.
-
-    Neither lookup validates or refreshes the token: an expired credential is
-    the gateway's 401 to report, and that answer already asks for a sign-in.
+    ``peek_nous_access_token`` follows the canonical per-provider profile/global
+    fallback but does not validate or refresh the token. An expired credential
+    is the gateway's 401 to report, and that answer already asks for a sign-in.
     """
-    if peek_nous_access_token():
-        return True
-    try:
-        from hermes_cli.auth import get_provider_auth_state
-
-        state = get_provider_auth_state("nous") or {}
-    except Exception:
-        return False
-    token = state.get("access_token")
-    return isinstance(token, str) and bool(token.strip())
+    return bool(peek_nous_access_token())
 
 
 def check_bfl_requirements() -> bool:
@@ -813,7 +797,7 @@ def check_bfl_requirements() -> bool:
     nothing else: with no credential every call could only ever answer "sign
     in", so the six schemas would be pure cost on every API call.
 
-    Stays a pair of file reads — no portal probe, no OAuth refresh. Behind the
+    Stays a cached file read — no portal probe, no OAuth refresh. Behind the
     registry's 30s cache this still runs on every CLI start, gateway session
     and cron tick.
     """

--- a/tools/managed_tool_gateway.py
+++ b/tools/managed_tool_gateway.py
@@ -33,21 +33,39 @@ def auth_json_path():
     return get_hermes_home() / "auth.json"
 
 
+def _nous_provider_from_store(data: object) -> Optional[dict]:
+    if not isinstance(data, dict):
+        return None
+    providers = data.get("providers", {})
+    if not isinstance(providers, dict) or "nous" not in providers:
+        return None
+    nous_provider = providers.get("nous")
+    if isinstance(nous_provider, dict):
+        return nous_provider
+    return None
+
+
 def _read_nous_provider_state() -> Optional[dict]:
+    """Read Nous OAuth state from the profile, then the shared root fallback."""
     try:
         path = auth_json_path()
-        if not path.is_file():
-            return None
-        data = json.loads(path.read_text(encoding="utf-8"))
-        providers = data.get("providers", {})
-        if not isinstance(providers, dict):
-            return None
-        nous_provider = providers.get("nous", {})
-        if isinstance(nous_provider, dict):
-            return nous_provider
+        if path.is_file():
+            state = _nous_provider_from_store(
+                json.loads(path.read_text(encoding="utf-8"))
+            )
+            if state is not None:
+                return state
     except Exception:
         pass
-    return None
+
+    # Named profiles inherit OAuth providers from the global auth store. Keep
+    # this read-only so a shared rotating refresh token retains one owner.
+    try:
+        from hermes_cli.auth import _load_global_auth_store
+
+        return _nous_provider_from_store(_load_global_auth_store())
+    except Exception:
+        return None
 
 
 def _parse_timestamp(value: object) -> Optional[datetime]:

--- a/tools/managed_tool_gateway.py
+++ b/tools/managed_tool_gateway.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 from datetime import datetime, timezone
@@ -12,7 +11,6 @@ from urllib.parse import urlsplit
 
 logger = logging.getLogger(__name__)
 
-from hermes_constants import get_hermes_home
 from tools.tool_backend_helpers import managed_nous_tools_enabled
 
 _DEFAULT_TOOL_GATEWAY_DOMAIN = "nousresearch.com"
@@ -28,44 +26,23 @@ class ManagedToolGatewayConfig:
     managed_mode: bool
 
 
-def auth_json_path():
-    """Return the Hermes auth store path, respecting HERMES_HOME overrides."""
-    return get_hermes_home() / "auth.json"
-
-
-def _nous_provider_from_store(data: object) -> Optional[dict]:
-    if not isinstance(data, dict):
-        return None
-    providers = data.get("providers", {})
-    if not isinstance(providers, dict) or "nous" not in providers:
-        return None
-    nous_provider = providers.get("nous")
-    if isinstance(nous_provider, dict):
-        return nous_provider
-    return None
-
-
 def _read_nous_provider_state() -> Optional[dict]:
-    """Read Nous OAuth state from the profile, then the shared root fallback."""
+    """Read Nous OAuth state with the canonical profile/global fallback."""
     try:
-        path = auth_json_path()
-        if path.is_file():
-            state = _nous_provider_from_store(
-                json.loads(path.read_text(encoding="utf-8"))
-            )
-            if state is not None:
-                return state
-    except Exception:
-        pass
+        from hermes_cli.auth import get_provider_auth_state
 
-    # Named profiles inherit OAuth providers from the global auth store. Keep
-    # this read-only so a shared rotating refresh token retains one owner.
-    try:
-        from hermes_cli.auth import _load_global_auth_store
-
-        return _nous_provider_from_store(_load_global_auth_store())
+        return get_provider_auth_state("nous")
     except Exception:
         return None
+
+
+def _access_token_from_provider(provider: object) -> Optional[str]:
+    if not isinstance(provider, dict):
+        return None
+    access_token = provider.get("access_token")
+    if isinstance(access_token, str) and access_token.strip():
+        return access_token.strip()
+    return None
 
 
 def _parse_timestamp(value: object) -> Optional[datetime]:
@@ -127,11 +104,7 @@ def peek_nous_access_token() -> Optional[str]:
     if explicit:
         return explicit
 
-    nous_provider = _read_nous_provider_state() or {}
-    access_token = nous_provider.get("access_token")
-    if isinstance(access_token, str) and access_token.strip():
-        return access_token.strip()
-    return None
+    return _access_token_from_provider(_read_nous_provider_state())
 
 
 def read_nous_access_token() -> Optional[str]:
@@ -140,7 +113,7 @@ def read_nous_access_token() -> Optional[str]:
     if explicit:
         return explicit
     nous_provider = _read_nous_provider_state() or {}
-    cached_token = peek_nous_access_token()
+    cached_token = _access_token_from_provider(nous_provider)
 
     if cached_token and not _access_token_is_expiring(
         nous_provider.get("expires_at"),


### PR DESCRIPTION
## Summary

Named profiles can now use Nous-managed tools when Portal OAuth is stored only in the global auth store. Previously, subscription checks inherited the global login while managed-tool availability scans read only the profile-local `auth.json`, so Firecrawl and Browser Use appeared unconfigured despite `use_gateway: true`.

Managed tools now reuse the canonical per-provider auth resolver, preserving profile-local shadowing and global fallback behavior without duplicating auth-store logic. Refresh-aware reads reuse the provider snapshot, and Flux gating relies on the same inherited-token probe instead of repeating the fallback.

## Validation

- Regression test covers a named profile with no local Nous provider and a valid global provider.
- `124 passed` across managed Tool Gateway, browser integration, Nous subscription, profile-auth fallback, and Flux video gating tests.
- Ruff and Python compilation checks pass for the changed files.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![gpt-5.6-sol](https://img.shields.io/badge/gpt--5.6--sol-000000)
