### PR TITLE
fix(browser): write camofox screenshots into the mounted cache tree

### DIFF
--- a/tests/tools/test_browser_vision_artifacts.py
+++ b/tests/tools/test_browser_vision_artifacts.py
@@ -1,0 +1,150 @@
+"""browser_vision screenshot cache placement + agent_visible annotation."""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from tools.browser_camofox import camofox_navigate, camofox_vision
+
+
+def _mock_response(status=200, json_data=None):
+    resp = MagicMock()
+    resp.status_code = status
+    resp.json.return_value = json_data or {}
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def test_camofox_vision_writes_under_mounted_cache_screenshots(monkeypatch, tmp_path):
+    """Camofox must use get_hermes_dir(cache/screenshots), not the legacy
+    top-level browser_screenshots dir that Docker does not bind-mount."""
+    from hermes_constants import get_hermes_dir
+    from tools.credential_files import map_cache_path_to_container
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+
+    with (
+        patch("tools.browser_camofox.requests.post") as mock_post,
+        patch("tools.browser_camofox._get_raw") as mock_get_raw,
+        patch("tools.browser_camofox._get") as mock_get,
+        patch("agent.auxiliary_client.call_llm") as mock_llm,
+        patch("tools.browser_camofox.load_config", return_value={}),
+        patch("tools.browser_camofox._camofox_private_page_block", return_value=None),
+    ):
+        mock_post.return_value = _mock_response(
+            json_data={"tabId": "tab-cache", "url": "https://example.com"}
+        )
+        camofox_navigate("https://example.com", task_id="t-cache")
+
+        raw = MagicMock()
+        raw.content = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+        mock_get_raw.return_value = raw
+        mock_get.return_value = {"snapshot": ""}
+        mock_choice = MagicMock()
+        mock_choice.message.content = "ok"
+        mock_llm.return_value = MagicMock(choices=[mock_choice])
+
+        result = json.loads(camofox_vision("what?", annotate=False, task_id="t-cache"))
+
+    path = Path(result["screenshot_path"])
+    expected_dir = get_hermes_dir("cache/screenshots", "browser_screenshots")
+    assert path.parent.resolve() == expected_dir.resolve()
+    assert path.is_file()
+    assert "browser_screenshots" not in path.parts or "cache" in path.parts
+    assert path.parent.name == "screenshots"
+    assert map_cache_path_to_container(str(path)) == (
+        f"/root/.hermes/cache/screenshots/{path.name}"
+    )
+
+
+def test_annotate_browser_vision_adds_agent_visible_under_docker(monkeypatch, tmp_path):
+    from tools import browser_tool
+
+    hermes_home = tmp_path / ".hermes"
+    shot_dir = hermes_home / "cache" / "screenshots"
+    shot_dir.mkdir(parents=True)
+    shot = shot_dir / "browser_screenshot_abc.png"
+    shot.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.setattr(
+        "tools.image_generation_tool._active_terminal_env",
+        lambda task_id: None,
+    )
+
+    raw = json.dumps({
+        "success": True,
+        "analysis": "ok",
+        "screenshot_path": str(shot),
+    })
+    out = json.loads(browser_tool._annotate_browser_vision_result(raw))
+    assert out["screenshot_path"] == str(shot)
+    assert out["agent_visible_screenshot"] == (
+        f"/root/.hermes/cache/screenshots/{shot.name}"
+    )
+
+
+def test_annotate_browser_vision_native_meta_under_ssh(monkeypatch, tmp_path):
+    from tools import browser_tool
+
+    hermes_home = tmp_path / ".hermes"
+    shot_dir = hermes_home / "cache" / "screenshots"
+    shot_dir.mkdir(parents=True)
+    shot = shot_dir / "native.png"
+    shot.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    sync_calls = []
+
+    class FakeSyncManager:
+        def sync(self, *, force=False):
+            sync_calls.append(force)
+
+    env = SimpleNamespace(
+        _remote_home="/home/remotesshuser",
+        _sync_manager=FakeSyncManager(),
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(
+        "tools.image_generation_tool._active_terminal_env",
+        lambda task_id: env,
+    )
+
+    payload = {
+        "type": "multimodal",
+        "meta": {"screenshot_path": str(shot)},
+        "text_summary": f"Screenshot path: {shot}",
+    }
+    out = browser_tool._annotate_browser_vision_result(payload, task_id="t1")
+    assert out["meta"]["agent_visible_screenshot"] == (
+        f"/home/remotesshuser/.hermes/cache/screenshots/{shot.name}"
+    )
+    assert out["meta"]["screenshot_path"] == str(shot)
+    assert sync_calls == [True]
+
+
+def test_annotate_browser_vision_noop_on_local(monkeypatch, tmp_path):
+    from tools import browser_tool
+
+    hermes_home = tmp_path / ".hermes"
+    shot_dir = hermes_home / "cache" / "screenshots"
+    shot_dir.mkdir(parents=True)
+    shot = shot_dir / "local.png"
+    shot.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setattr(
+        "tools.image_generation_tool._active_terminal_env",
+        lambda task_id: None,
+    )
+
+    raw = json.dumps({"success": True, "screenshot_path": str(shot)})
+    out = json.loads(browser_tool._annotate_browser_vision_result(raw))
+    assert out == {"success": True, "screenshot_path": str(shot)}
+    assert "agent_visible_screenshot" not in out

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -854,9 +854,11 @@ def camofox_vision(question: str, annotate: bool = False,
             params={"userId": session["user_id"]},
         )
 
-        # Save screenshot to cache
-        from hermes_constants import get_hermes_home
-        screenshots_dir = get_hermes_home() / "browser_screenshots"
+        # Save screenshot to the same mounted cache tree as browser_tool /
+        # get_cache_directory_mounts (``cache/screenshots``), not the legacy
+        # top-level ``browser_screenshots`` dir which Docker does not bind.
+        from hermes_constants import get_hermes_dir
+        screenshots_dir = get_hermes_dir("cache/screenshots", "browser_screenshots")
         screenshots_dir.mkdir(parents=True, exist_ok=True)
         screenshot_path = str(screenshots_dir / f"browser_screenshot_{uuid.uuid4().hex[:8]}.png")
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -4167,6 +4167,60 @@ def browser_get_images(task_id: Optional[str] = None) -> str:
         return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
 
 
+def _annotate_browser_vision_result(
+    result: Union[str, Dict[str, Any]],
+    task_id: Optional[str] = None,
+) -> Union[str, Dict[str, Any]]:
+    """Annotate browser_vision results with a sandbox-visible screenshot path.
+
+    ``screenshot_path`` stays the host/gateway path for ``MEDIA:`` delivery.
+    Under docker/ssh/modal, ``agent_visible_screenshot`` is the path terminal /
+    file tools can open — same contract as image/tts/video artifact helpers.
+    """
+    is_str = isinstance(result, str)
+    try:
+        payload = json.loads(result) if is_str else result
+    except Exception:
+        return result
+    if not isinstance(payload, dict):
+        return result
+
+    host = payload.get("screenshot_path")
+    meta = payload.get("meta")
+    if not isinstance(host, str) or not host:
+        if isinstance(meta, dict):
+            host = meta.get("screenshot_path")
+        if not isinstance(host, str) or not host:
+            return result
+
+    from tools.image_generation_tool import (
+        _active_terminal_env,
+        _agent_visible_cache_path,
+        _force_artifact_sync,
+        _looks_like_absolute_file_path,
+    )
+
+    if not _looks_like_absolute_file_path(host):
+        return result
+
+    env = _active_terminal_env(task_id)
+    agent_path = _agent_visible_cache_path(host, env)
+    if not agent_path or agent_path == host:
+        return result
+
+    if env is not None:
+        _force_artifact_sync(env)
+
+    if "screenshot_path" in payload:
+        payload.setdefault("host_screenshot_path", host)
+        payload.setdefault("agent_visible_screenshot", agent_path)
+    if isinstance(meta, dict) and meta.get("screenshot_path"):
+        meta.setdefault("host_screenshot_path", host)
+        meta.setdefault("agent_visible_screenshot", agent_path)
+
+    return json.dumps(payload, ensure_ascii=False) if is_str else payload
+
+
 def browser_vision(question: str, annotate: bool = False, task_id: Optional[str] = None) -> Union[str, Dict[str, Any]]:
     """
     Take a screenshot of the current page for visual inspection.
@@ -4179,7 +4233,9 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
     verification challenges, images, complex layouts, etc.).
 
     The screenshot is saved persistently and its file path is returned so it
-    can be shared with users via MEDIA:<path> in the response.
+    can be shared with users via MEDIA:<path> in the response. Under a sandbox
+    terminal backend, results may also include ``agent_visible_screenshot`` for
+    terminal/file follow-up (``screenshot_path`` stays the host/gateway path).
 
     Args:
         question: What you want to know about the page visually
@@ -4192,7 +4248,10 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
     """
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_vision
-        return camofox_vision(question, annotate, task_id)
+        return _annotate_browser_vision_result(
+            camofox_vision(question, annotate, task_id),
+            task_id=task_id,
+        )
 
     import base64
     import uuid as uuid_mod
@@ -4370,7 +4429,7 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
                 f"{native_result.get('text_summary', '')} "
                 f"Screenshot path: {screenshot_path}"
             ).strip()
-            return native_result
+            return _annotate_browser_vision_result(native_result, task_id=task_id)
 
         vision_prompt = (
             f"You are analyzing a screenshot of a web browser.\n\n"
@@ -4456,7 +4515,10 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
         # Include annotation data if annotated screenshot was taken
         if annotate and result.get("data", {}).get("annotations"):
             response_data["annotations"] = result["data"]["annotations"]
-        return json.dumps(response_data, ensure_ascii=False)
+        return _annotate_browser_vision_result(
+            json.dumps(response_data, ensure_ascii=False),
+            task_id=task_id,
+        )
 
     except Exception as e:
         # Keep the screenshot if it was captured successfully — the failure is
@@ -4469,7 +4531,10 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
             error_info["screenshot_path"] = str(screenshot_path)
             error_info["note"] = "Screenshot was captured but vision analysis failed. You can still share it via MEDIA:<path>."
         _copy_fallback_warning(error_info, result if 'result' in locals() else {})
-        return json.dumps(error_info, ensure_ascii=False)
+        return _annotate_browser_vision_result(
+            json.dumps(error_info, ensure_ascii=False),
+            task_id=task_id,
+        )
 
 
 def _cleanup_old_screenshots(screenshots_dir, max_age_hours=24):


### PR DESCRIPTION
## Summary
- Camofox `browser_vision` wrote PNGs under the legacy top-level `browser_screenshots/` directory.
- Docker bind-mounts `cache/screenshots` (via `get_cache_directory_mounts`), so sandbox follow-up on the returned path missed the file even though the tool reported success — and `map_cache_path_to_container` returned `None` for the camofox path.
- Align camofox with `browser_tool`'s `get_hermes_dir("cache/screenshots", …)` layout.
- Annotate `agent_visible_screenshot` (keep `screenshot_path` as the host/gateway path) using the same helpers as image/tts/video artifacts.

## Before / After
| Backend | Write dir | Sandbox follow-up |
|---------|-----------|-------------------|
| camofox + docker (before) | `…/browser_screenshots/` (unmounted) | not-found / unmappable |
| camofox + docker (after) | `…/cache/screenshots/` + `agent_visible_screenshot=/root/.hermes/cache/screenshots/…` | works |
| local | host path | unchanged (no annotation) |
