### PR TITLE
fix(desktop): never resurrect the composer draft when a send's outcome is unknown

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
@@ -209,8 +209,12 @@ export function useComposerDraft({
     }
   }, [appendExternalText, inputDisabled, paintDraft, target])
 
-  const stashAt = (scope: string | null, text = draftRef.current, attachments = attachmentScope.$attachments.get()) =>
-    stashSessionDraft(scope, text, attachments)
+  const stashAt = (
+    scope: string | null,
+    text = draftRef.current,
+    attachments = attachmentScope.$attachments.get(),
+    opts?: { pending?: boolean }
+  ) => stashSessionDraft(scope, text, attachments, opts)
 
   const loadIntoComposer = (text: string, attachments: ComposerAttachment[]) => {
     // Diagnostic breadcrumb for #59305-class reports: identifies WHAT kind of

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
@@ -2,7 +2,13 @@ import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { $clarifyRequests } from '@/store/clarify'
-import type { ComposerAttachment } from '@/store/composer'
+import {
+  clearSessionDraft,
+  type ComposerAttachment,
+  SESSION_DRAFTS_STORAGE_KEY,
+  stashSessionDraft,
+  takeSessionDraft
+} from '@/store/composer'
 import { $gateway } from '@/store/gateway'
 
 import { useComposerSubmit } from './use-composer-submit'
@@ -12,13 +18,22 @@ interface SubmitHarnessOptions {
   busy?: boolean
   compacting?: boolean
   text?: string
+  /** Defaults to a mock; pass a store-backed writer to exercise the real
+   *  draft-stash merge protection end to end. */
+  stashAt?: (
+    scope: string | null,
+    text?: string,
+    attachments?: ComposerAttachment[],
+    opts?: { pending?: boolean }
+  ) => void
 }
 
 function renderSubmitHook({
   attachments = [],
   busy = false,
   compacting = false,
-  text = ''
+  text = '',
+  stashAt = vi.fn()
 }: SubmitHarnessOptions = {}) {
   const draftRef = { current: text }
   const editor = document.createElement('div')
@@ -29,6 +44,10 @@ function renderSubmitHook({
   const onSteer = vi.fn(async () => true)
   const onSubmit = vi.fn(async () => true)
   const queueCurrentDraft = vi.fn(() => true)
+  const loadIntoComposer = vi.fn()
+  // Mutable so a test can simulate the user switching sessions while the
+  // send is in flight (dispatchSubmit reads it at resolve time).
+  const activeQueueSessionKeyRef = { current: 'stored-session' }
 
   const clearDraft = vi.fn(() => {
     draftRef.current = ''
@@ -38,7 +57,7 @@ function renderSubmitHook({
   const hook = renderHook(() =>
     useComposerSubmit({
       activeQueueSessionKey: 'stored-session',
-      activeQueueSessionKeyRef: { current: 'stored-session' },
+      activeQueueSessionKeyRef,
       attachments,
       busy,
       compacting,
@@ -50,7 +69,7 @@ function renderSubmitHook({
       exitQueuedEdit: vi.fn(() => false),
       focusInput: vi.fn(),
       inputDisabled: false,
-      loadIntoComposer: vi.fn(),
+      loadIntoComposer,
       onCancel,
       onSteer,
       onSubmit,
@@ -59,11 +78,21 @@ function renderSubmitHook({
       queuedPrompts: [],
       sessionId: 'runtime-session',
       setComposerText: vi.fn(),
-      stashAt: vi.fn()
+      stashAt
     })
   )
 
-  return { clearDraft, hook, onCancel, onSteer, onSubmit, queueCurrentDraft }
+  return {
+    activeQueueSessionKeyRef,
+    clearDraft,
+    hook,
+    loadIntoComposer,
+    onCancel,
+    onSteer,
+    onSubmit,
+    queueCurrentDraft,
+    stashAt
+  }
 }
 
 describe('useComposerSubmit busy-turn routing', () => {
@@ -261,5 +290,119 @@ describe('useComposerSubmit with a clarify parked on the session', () => {
     await waitFor(() => expect(onSubmit).toHaveBeenCalled())
     expect(gatewayRequest).not.toHaveBeenCalled()
     expect($clarifyRequests.get()['other-session']).toBeDefined()
+  })
+})
+
+describe('useComposerSubmit uncertain / late send outcomes', () => {
+  afterEach(() => {
+    cleanup()
+    clearSessionDraft('stored-session')
+    vi.restoreAllMocks()
+  })
+
+  it("an 'uncertain' outcome stashes the draft for recovery but never resurrects it into the composer — and never clears the stored draft", async () => {
+    // The gateway may have accepted the prompt (response lost to a transport
+    // drop / timeout). Resurrecting the text into the live composer would be
+    // the "sent AND still in the composer" bug — a duplicate-send trap. The
+    // words must survive only in the draft stash.
+    const { hook, loadIntoComposer, onSubmit, stashAt } = renderSubmitHook({ text: 'ordinary question' })
+
+    // Seed the persisted draft BEFORE the send, and prove the component leaves
+    // it untouched: a genuinely lost send stays recoverable on reload (the
+    // reload-restores-the-draft behavior Riyaaz observed) — clearSessionDraft
+    // must NOT fire on 'uncertain'.
+    stashSessionDraft('stored-session', 'ordinary question', [])
+
+    onSubmit.mockResolvedValueOnce('uncertain' as never)
+
+    act(() => {
+      hook.result.current.submitDraft()
+    })
+
+    // The pending marker is the ownership contract: the recovery stash is
+    // protected from stale EMPTY cleanup writes until taken/cleared.
+    await waitFor(() =>
+      expect(stashAt).toHaveBeenCalledWith('stored-session', 'ordinary question', expect.arrayContaining([]), {
+        pending: true
+      })
+    )
+    expect(loadIntoComposer).not.toHaveBeenCalled()
+    expect(takeSessionDraft('stored-session').text).toBe('ordinary question')
+  })
+
+  it('a successful send clears the persisted draft for good', async () => {
+    // The draft store must not outlive a successful send — otherwise reload
+    // resurrects text the user already sent (the cmd+R duplicate trap).
+    const { hook, onSubmit } = renderSubmitHook({ text: 'sent words' })
+
+    stashSessionDraft('stored-session', 'sent words', [])
+
+    onSubmit.mockResolvedValueOnce(true)
+
+    act(() => {
+      hook.result.current.submitDraft()
+    })
+
+    await waitFor(() => expect(takeSessionDraft('stored-session').text).toBe(''))
+  })
+
+  it('a definitive rejection after a session switch stashes under the submitted scope without painting into the new session', async () => {
+    // The send is rejected AFTER the user moved to another session. The
+    // rejected text must land in the SUBMITTED session's stash (recoverable
+    // when the user returns) and must NOT be painted into the composer that
+    // is now showing the other session's draft.
+    const { activeQueueSessionKeyRef, hook, loadIntoComposer, onSubmit, stashAt } = renderSubmitHook({
+      text: 'rejected words'
+    })
+
+    onSubmit.mockResolvedValueOnce(false)
+
+    act(() => {
+      hook.result.current.submitDraft()
+    })
+
+    activeQueueSessionKeyRef.current = 'other-session'
+
+    await waitFor(() => expect(stashAt).toHaveBeenCalled())
+    expect(stashAt).toHaveBeenCalledWith('stored-session', 'rejected words', expect.arrayContaining([]))
+    expect(loadIntoComposer).not.toHaveBeenCalled()
+  })
+
+  it("an uncertain send survives the later session switch — the empty stash-on-leave cannot wipe the recovery stash", async () => {
+    // Regression coverage: the uncertain path stashes
+    // the words under the submitted scope; when the user then switches
+    // sessions, the swap cleanup stashes the now-EMPTY composer over the same
+    // key. Pre-fix that deleted the recovery stash and the user's words were
+    // gone for good. The pending marker must protect it.
+    const storeStashAt = (
+      scope: string | null,
+      text?: string,
+      attachments?: ComposerAttachment[],
+      opts?: { pending?: boolean }
+    ) => stashSessionDraft(scope, text ?? '', attachments ?? [], opts)
+
+    const { hook, loadIntoComposer, onSubmit } = renderSubmitHook({
+      text: 'must remain recoverable',
+      stashAt: storeStashAt
+    })
+
+    onSubmit.mockResolvedValueOnce('uncertain' as never)
+
+    act(() => {
+      hook.result.current.submitDraft()
+    })
+
+    // The recovery stash is persisted (take would consume the pending marker,
+    // so probe the persisted store instead).
+    await waitFor(() =>
+      expect(window.localStorage.getItem(SESSION_DRAFTS_STORAGE_KEY)).toContain('must remain recoverable')
+    )
+
+    // The session switch: the swap cleanup writes the (empty) composer over
+    // the same key — exactly what deleted the recovery stash pre-fix.
+    stashSessionDraft('stored-session', '', [])
+
+    expect(takeSessionDraft('stored-session').text).toBe('must remain recoverable')
+    expect(loadIntoComposer).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
@@ -37,7 +37,12 @@ interface UseComposerSubmitArgs {
   queuedPrompts: QueuedPromptEntry[]
   sessionId: string | null | undefined
   setComposerText: (value: string) => void
-  stashAt: (scope: string | null, text?: string, attachments?: ComposerAttachment[]) => void
+  stashAt: (
+    scope: string | null,
+    text?: string,
+    attachments?: ComposerAttachment[],
+    opts?: { pending?: boolean }
+  ) => void
 }
 
 /**
@@ -76,18 +81,29 @@ export function useComposerSubmit({
 }: UseComposerSubmitArgs) {
   const scope = useComposerScope()
 
-  // Shared send primitive: fire onSubmit, and if the gateway rejects (accepted
-  // === false) or throws, re-load + re-stash the draft so the words survive.
+  // Shared send primitive: fire onSubmit, and if the gateway definitively
+  // rejects (accepted === false) or throws, re-load + re-stash the draft so
+  // the words survive. An 'uncertain' outcome (the prompt was dispatched but
+  // the response never came back — transport drop, gateway timeout) is NOT a
+  // rejection: the message may already be running, so the text is stashed for
+  // recovery but never resurrected into the live composer — resurrecting it
+  // there is the "sent AND still in the composer" bug and invites a duplicate
+  // send.
   const dispatchSubmit = (text: string, attachments?: ComposerAttachment[]) => {
     const submittedScope = activeQueueSessionKeyRef.current
     const submittedAttachments = attachments ?? []
 
     const restore = () => {
-      loadIntoComposer(text, submittedAttachments)
-      // Use the scope captured at dispatch, not whatever session is focused
-      // now — the gateway can reject well after the user has switched away,
-      // and re-stashing into the currently-focused session would overwrite
-      // its draft with the rejected text from a different session (#54527).
+      // Paint only into the composer that still shows the submitted session.
+      // A session switch mid-flight means the editor now shows another
+      // session's draft — resurrecting the rejected text into it would clobber
+      // the current session's words. The stash under the submitted scope is
+      // unconditional: the rejected text must survive under its own key
+      // (#54527).
+      if (activeQueueSessionKeyRef.current === submittedScope) {
+        loadIntoComposer(text, submittedAttachments)
+      }
+
       stashAt(submittedScope, text, submittedAttachments)
     }
 
@@ -96,7 +112,30 @@ export function useComposerSubmit({
         ? onSubmit(text, { attachments, composerScope: submittedScope })
         : onSubmit(text, { composerScope: submittedScope })
     )
-      .then(accepted => void (accepted === false ? restore() : clearSessionDraft(submittedScope)))
+      .then(accepted => {
+        if (accepted === false) {
+          restore()
+
+          return
+        }
+
+        if (accepted === 'uncertain') {
+          // Keep the words recoverable under the submitted scope (a genuinely
+          // lost send survives a reload / switch-back); the submit pipeline
+          // has already surfaced the "check the thread before resending"
+          // notice. The optimistic clear stands — the composer stays empty.
+          // The stash is marked pending so a later stale EMPTY write (the
+          // session-switch stash-on-leave, the post-clear debounce) cannot
+          // delete it before the user recovers the words — only a take
+          // (switch-back), a non-empty write (new text), or the
+          // success-path clearSessionDraft may intentionally supersede it.
+          stashAt(submittedScope, text, submittedAttachments, { pending: true })
+
+          return
+        }
+
+        clearSessionDraft(submittedScope)
+      })
       .catch(restore)
   }
 

--- a/apps/desktop/src/app/chat/composer/types.ts
+++ b/apps/desktop/src/app/chat/composer/types.ts
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 
-import type { SubmitTextOptions } from '@/app/session/hooks/use-prompt-actions/utils'
+import type { SubmitOutcome, SubmitTextOptions } from '@/app/session/hooks/use-prompt-actions/utils'
 import type { HermesGateway } from '@/hermes'
 
 import type { DroppedFile } from '../hooks/use-composer-actions'
@@ -52,7 +52,7 @@ export interface ChatBarProps {
   onPickImages?: () => void
   onRemoveAttachment?: (id: string) => void
   onSteer?: (text: string) => Promise<boolean> | boolean
-  onSubmit: (value: string, options?: SubmitTextOptions) => Promise<boolean> | boolean
+  onSubmit: (value: string, options?: SubmitTextOptions) => Promise<SubmitOutcome> | SubmitOutcome
   onTranscribeAudio?: (audio: Blob) => Promise<string>
 }
 

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -6,7 +6,7 @@ import type * as React from 'react'
 import { memo, Suspense, useCallback, useEffect, useMemo, useState } from 'react'
 import { useLocation } from 'react-router'
 
-import type { SubmitTextOptions } from '@/app/session/hooks/use-prompt-actions/utils'
+import type { SubmitOutcome, SubmitTextOptions } from '@/app/session/hooks/use-prompt-actions/utils'
 import { Thread } from '@/components/assistant-ui/thread'
 import { TranscriptWindowProvider } from '@/components/assistant-ui/thread/transcript-window'
 import { Backdrop } from '@/components/Backdrop'
@@ -84,7 +84,7 @@ interface ChatViewProps extends Omit<React.ComponentProps<'div'>, 'onSubmit'> {
   onPickImages: () => void
   onRemoveAttachment: (id: string) => void
   onSteer: (text: string) => Promise<boolean> | boolean
-  onSubmit: (text: string, options?: SubmitTextOptions) => Promise<boolean> | boolean
+  onSubmit: (text: string, options?: SubmitTextOptions) => Promise<SubmitOutcome> | SubmitOutcome
   onThreadMessagesChange: (messages: readonly ThreadMessage[]) => void
   onEdit: (message: AppendMessage) => Promise<void>
   onReload: (parentId: string | null) => Promise<void>

--- a/apps/desktop/src/app/gateway/hooks/json-rpc-gateway.test.ts
+++ b/apps/desktop/src/app/gateway/hooks/json-rpc-gateway.test.ts
@@ -1,0 +1,185 @@
+import { GatewayRequestError, isGatewayPreDispatchError, JsonRpcGatewayClient, type WebSocketLike } from '@hermes/shared'
+import { describe, expect, it } from 'vitest'
+
+// ── Transport-boundary dispatch authority ─────────────────────────────────
+// The gateway client must tag every failure with whether the request frame was
+// written to the socket (dispatched). The composer's draft-restore decision on
+// prompt.submit and the reconnect wrapper's replay decision both key off it:
+// a pre-dispatch failure is CERTAIN (nothing was sent — restore/replay safe),
+// a post-dispatch no-response failure is UNCERTAIN (the gateway may have
+// accepted the request — never restore the draft, never replay).
+
+class FakeSocket {
+  readyState = WebSocket.OPEN
+  sent: string[] = []
+  sendShouldThrow: null | Error = null
+  private listeners = new Map<string, Set<(event: unknown) => void>>()
+
+  addEventListener(type: string, handler: (event: unknown) => void): void {
+    if (!this.listeners.has(type)) {
+      this.listeners.set(type, new Set())
+    }
+
+    this.listeners.get(type)!.add(handler)
+
+    // The client's connect() awaits an 'open' event; fire it on a microtask
+    // once the listener is attached.
+    if (type === 'open') {
+      queueMicrotask(() => handler({}))
+    }
+  }
+
+  removeEventListener(type: string, handler: (event: unknown) => void): void {
+    this.listeners.get(type)?.delete(handler)
+  }
+
+  send(data: string): void {
+    if (this.sendShouldThrow) {
+      throw this.sendShouldThrow
+    }
+
+    this.sent.push(data)
+  }
+
+  close(): void {}
+
+  emit(type: string, event: unknown): void {
+    for (const handler of [...(this.listeners.get(type) ?? [])]) {
+      handler(event)
+    }
+  }
+}
+
+function makeClient(socket: FakeSocket, requestTimeoutMs = 50): JsonRpcGatewayClient {
+  return new JsonRpcGatewayClient({
+    requestTimeoutMs,
+    socketFactory: () => socket as unknown as WebSocketLike
+  })
+}
+
+async function openClient(socket: FakeSocket, requestTimeoutMs?: number): Promise<JsonRpcGatewayClient> {
+  const client = makeClient(socket, requestTimeoutMs)
+
+  await client.connect('ws://gateway')
+
+  return client
+}
+
+async function rejectOf<T>(promise: Promise<T>): Promise<GatewayRequestError> {
+  try {
+    await promise
+  } catch (error) {
+    return error as GatewayRequestError
+  }
+
+  throw new Error('expected the request to reject')
+}
+
+describe('JsonRpcGatewayClient dispatch authority', () => {
+  it("rejects with a PRE-dispatch typed error when no socket is open — dispatched:false (the request never left the machine)", async () => {
+    const client = new JsonRpcGatewayClient()
+
+    const error = await rejectOf(client.request('prompt.submit', { text: 'x' }))
+
+    expect(error).toBeInstanceOf(GatewayRequestError)
+    expect(error.kind).toBe('not_connected')
+    expect(error.dispatched).toBe(false)
+    expect(error.message).toBe('gateway not connected')
+    expect(isGatewayPreDispatchError(error)).toBe(true)
+  })
+
+  it("rejects with a POST-dispatch typed error when the response times out — dispatched:true (the gateway may have accepted it)", async () => {
+    const socket = new FakeSocket()
+    const client = await openClient(socket, 25)
+
+    const error = await rejectOf(client.request('prompt.submit', { text: 'x' }))
+
+    expect(error).toBeInstanceOf(GatewayRequestError)
+    expect(error.kind).toBe('timeout')
+    expect(error.dispatched).toBe(true)
+    expect(error.message).toMatch(/request timed out after \d+s: prompt\.submit/)
+    expect(isGatewayPreDispatchError(error)).toBe(false)
+    // The frame did leave the machine before the timeout fired.
+    expect(socket.sent).toHaveLength(1)
+  })
+
+  it("rejects pending calls with a POST-dispatch typed error when the socket closes — dispatched:true", async () => {
+    const socket = new FakeSocket()
+    const client = await openClient(socket)
+
+    const pending = client.request('prompt.submit', { text: 'x' })
+    socket.emit('close', {})
+
+    const error = await rejectOf(pending)
+
+    expect(error).toBeInstanceOf(GatewayRequestError)
+    expect(error.kind).toBe('closed')
+    expect(error.dispatched).toBe(true)
+    expect(error.message).toBe('WebSocket closed')
+    expect(isGatewayPreDispatchError(error)).toBe(false)
+  })
+
+  it("rejects with a PRE-dispatch typed error when socket.send throws — dispatched:false", async () => {
+    const socket = new FakeSocket()
+    socket.sendShouldThrow = new Error('socket is dead')
+    const client = await openClient(socket)
+
+    const error = await rejectOf(client.request('prompt.submit', { text: 'x' }))
+
+    expect(error).toBeInstanceOf(GatewayRequestError)
+    expect(error.kind).toBe('send_failed')
+    expect(error.dispatched).toBe(false)
+    expect(error.message).toBe('socket is dead')
+    expect(isGatewayPreDispatchError(error)).toBe(true)
+  })
+
+  it("rejects with an RPC-error typed error when the server answers with an error frame — a certain rejection", async () => {
+    const socket = new FakeSocket()
+    const client = await openClient(socket)
+
+    const pending = client.request('prompt.submit', { text: 'x' })
+    socket.emit('message', {
+      data: JSON.stringify({ jsonrpc: '2.0', id: 'r1', error: { message: '4009 session busy' } })
+    })
+
+    const error = await rejectOf(pending)
+
+    expect(error).toBeInstanceOf(GatewayRequestError)
+    expect(error.kind).toBe('rpc')
+    expect(error.dispatched).toBe(true)
+    expect(error.message).toBe('4009 session busy')
+    // A server answer is NOT an uncertain outcome — the request was processed.
+    expect(isGatewayPreDispatchError(error)).toBe(false)
+  })
+
+  it('still resolves normally when the response frame arrives', async () => {
+    const socket = new FakeSocket()
+    const client = await openClient(socket)
+
+    const pending = client.request('session.status', {}).catch(e => e)
+    socket.emit('message', {
+      data: JSON.stringify({ jsonrpc: '2.0', id: 'r1', result: { output: 'idle' } })
+    })
+
+    await expect(pending).resolves.toEqual({ output: 'idle' })
+  })
+})
+
+describe('isGatewayPreDispatchError', () => {
+  it('keys off the typed dispatched flag when available', () => {
+    expect(isGatewayPreDispatchError(new GatewayRequestError('not_connected', 'x', false))).toBe(true)
+    expect(isGatewayPreDispatchError(new GatewayRequestError('send_failed', 'x', false))).toBe(true)
+    expect(isGatewayPreDispatchError(new GatewayRequestError('closed', 'x', true))).toBe(false)
+    expect(isGatewayPreDispatchError(new GatewayRequestError('timeout', 'x', true))).toBe(false)
+    expect(isGatewayPreDispatchError(new GatewayRequestError('rpc', 'x', true))).toBe(false)
+  })
+
+  it('falls back to message shape for untyped errors (other bridges)', () => {
+    expect(isGatewayPreDispatchError(new Error('Hermes gateway is not connected'))).toBe(true)
+    expect(isGatewayPreDispatchError(new Error('Hermes gateway connection closed'))).toBe(false)
+    // A message that hints at both is treated conservatively — may have been sent.
+    expect(isGatewayPreDispatchError(new Error('connection closed: not connected'))).toBe(false)
+    expect(isGatewayPreDispatchError(new Error('request timed out after 30s: prompt.submit'))).toBe(false)
+    expect(isGatewayPreDispatchError('not connected')).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-request.test.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-request.test.ts
@@ -1,15 +1,40 @@
-import { act, renderHook } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { GatewayRequestError } from '@hermes/shared'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { HermesGateway } from '@/hermes'
-import { $gateway } from '@/store/gateway'
+import { $gateway, setPrimaryGateway } from '@/store/gateway'
+import { $gatewayState } from '@/store/session'
 
 import { useGatewayRequest } from './use-gateway-request'
 
 const fakeGateway = { connectionState: 'open' } as unknown as HermesGateway
 
+function stubDesktop() {
+  window.hermesDesktop = {
+    getConnection: vi.fn(async () => ({ authMode: 'token', wsUrl: 'ws://gw' })),
+    touchBackend: vi.fn(async () => undefined)
+  } as never
+}
+
+function renderRequestHook() {
+  const request = vi.fn()
+  const connect = vi.fn(async () => undefined)
+  const gateway = { connectionState: 'closed', connect, request } as unknown as HermesGateway
+
+  $gateway.set(gateway)
+  setPrimaryGateway(gateway)
+
+  const { result } = renderHook(() => useGatewayRequest())
+
+  return { connect, gateway, request, result }
+}
+
 afterEach(() => {
   $gateway.set(null)
+  $gatewayState.set('idle')
+  delete (window as { hermesDesktop?: unknown }).hermesDesktop
+  vi.restoreAllMocks()
 })
 
 describe('useGatewayRequest', () => {
@@ -35,5 +60,79 @@ describe('useGatewayRequest', () => {
     act(() => $gateway.set(fakeGateway))
 
     expect(result.current.gateway).toBe(fakeGateway)
+  })
+
+  describe('reconnect + replay authority', () => {
+    it('reconnects and replays a PRE-dispatch "not connected" failure — nothing was sent, so a replay cannot double-dispatch', async () => {
+      stubDesktop()
+      const { connect, request, result } = renderRequestHook()
+
+      request
+        .mockRejectedValueOnce(new GatewayRequestError('not_connected', 'Hermes gateway is not connected', false))
+        .mockResolvedValueOnce({ ok: true })
+
+      await waitFor(() => expect(result.current.gateway).toBeDefined())
+
+      await expect(result.current.requestGateway('session.resume', { session_id: 's' })).resolves.toEqual({ ok: true })
+
+      // The request went out exactly once after the socket was restored.
+      expect(request).toHaveBeenCalledTimes(2)
+      expect(connect).toHaveBeenCalledTimes(1)
+    })
+
+    it('reconnects but does NOT replay a POST-dispatch transport failure — the gateway may have accepted the request', async () => {
+      stubDesktop()
+      const { connect, request, result } = renderRequestHook()
+
+      const closed = new GatewayRequestError('closed', 'Hermes gateway connection closed', true)
+      request.mockRejectedValueOnce(closed)
+
+      await waitFor(() => expect(result.current.gateway).toBeDefined())
+
+      // prompt.submit must never be re-sent after a post-dispatch drop: the
+      // first dispatch may have landed and a replay would run the turn twice.
+      await expect(result.current.requestGateway('prompt.submit', { text: 'x' })).rejects.toBe(closed)
+      expect(request).toHaveBeenCalledTimes(1)
+      // The socket is still restored so the NEXT call works.
+      expect(connect).toHaveBeenCalledTimes(1)
+    })
+
+    it('applies the same authority to untyped errors via message shape', async () => {
+      stubDesktop()
+      const { connect, request, result } = renderRequestHook()
+
+      // Untyped (non-GatewayRequestError) transport error with the pre-flight
+      // message → pre-dispatch → replayed after reconnect.
+      request
+        .mockRejectedValueOnce(new Error('Hermes gateway is not connected'))
+        .mockResolvedValueOnce({ ok: true })
+
+      await waitFor(() => expect(result.current.gateway).toBeDefined())
+      await expect(result.current.requestGateway('session.status', {})).resolves.toEqual({ ok: true })
+      expect(request).toHaveBeenCalledTimes(2)
+
+      // Untyped 'connection closed' → may have been dispatched → reconnects
+      // but does NOT replay.
+      const closed = new Error('Hermes gateway connection closed')
+      request.mockReset()
+      request.mockRejectedValueOnce(closed)
+      await expect(result.current.requestGateway('session.status', {})).rejects.toBe(closed)
+      expect(request).toHaveBeenCalledTimes(1)
+      expect(connect).toHaveBeenCalledTimes(2)
+    })
+
+    it('throws the original error when the reconnect fails (reauth or transport)', async () => {
+      stubDesktop()
+      const { connect, request, result } = renderRequestHook()
+
+      const offline = new GatewayRequestError('not_connected', 'Hermes gateway is not connected', false)
+      request.mockRejectedValueOnce(offline)
+      connect.mockRejectedValueOnce(new Error('connect failed'))
+
+      await waitFor(() => expect(result.current.gateway).toBeDefined())
+
+      await expect(result.current.requestGateway('session.resume', {})).rejects.toBe(offline)
+      expect(request).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-request.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-request.ts
@@ -1,4 +1,4 @@
-import { isGatewayReauthRequired, resolveGatewayWsUrl } from '@hermes/shared'
+import { isGatewayPreDispatchError, isGatewayReauthRequired, resolveGatewayWsUrl } from '@hermes/shared'
 import { useStore } from '@nanostores/react'
 import { useCallback, useEffect, useRef } from 'react'
 
@@ -135,6 +135,17 @@ export function useGatewayRequest() {
             throw reauthError
           }
 
+          throw error
+        }
+
+        // Replay ONLY when the failure provably happened BEFORE the frame left
+        // the socket: the gateway cannot have seen the request, so a replay is
+        // always safe. A post-dispatch close/timeout means the gateway may
+        // have ACCEPTED the request while the response was lost — replaying
+        // prompt.submit would run the turn a second time (the "send appears to
+        // fire but the message never lands / lands twice" bug class). The
+        // caller sees the transport error and owns the outcome classification.
+        if (!isGatewayPreDispatchError(error)) {
           throw error
         }
 

--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
@@ -16,9 +16,9 @@ import { notify } from '@/store/notifications'
 import { $sessions, idsShareLineage } from '@/store/session'
 import { $workingSessionIds } from '@/store/session-states'
 
-import type { SubmitTextOptions } from './use-prompt-actions/utils'
+import type { SubmitOutcome, SubmitTextOptions } from './use-prompt-actions/utils'
 
-type SubmitQueuedPrompt = (text: string, options?: SubmitTextOptions) => Promise<boolean> | boolean
+type SubmitQueuedPrompt = (text: string, options?: SubmitTextOptions) => Promise<SubmitOutcome> | SubmitOutcome
 
 interface BackgroundQueueDrainOptions {
   enabled: boolean

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -1,3 +1,4 @@
+import { GatewayRequestError } from '@hermes/shared'
 import { act, cleanup, render, waitFor } from '@testing-library/react'
 import type { MutableRefObject } from 'react'
 import { useEffect, useRef } from 'react'
@@ -26,7 +27,7 @@ import { dropSessionState, publishSessionState } from '@/store/session-states'
 import { $wakeWord, resetWakeWordState } from '@/store/wake-word'
 import type { SessionInfo } from '@/types/hermes'
 
-import type { SubmitTextOptions } from './utils'
+import type { SubmitOutcome, SubmitTextOptions } from './utils'
 
 import { uploadComposerAttachment, usePromptActions } from '.'
 
@@ -85,8 +86,8 @@ interface HarnessHandle {
   redirectPrompt: (text: string) => Promise<boolean>
   /** @deprecated Use `redirectPrompt`. */
   steerPrompt: (text: string) => Promise<boolean>
-  submitTextRaw: (text: string, options?: SubmitTextOptions) => Promise<boolean>
-  submitText: (text: string, options?: SubmitTextOptions) => Promise<boolean>
+  submitTextRaw: (text: string, options?: SubmitTextOptions) => Promise<SubmitOutcome>
+  submitText: (text: string, options?: SubmitTextOptions) => Promise<SubmitOutcome>
 }
 
 function Harness({
@@ -194,7 +195,7 @@ function Harness({
         act(async () => actions.steerPrompt(...args)) as Promise<boolean>,
       submitTextRaw: actions.submitText,
       submitText: (...args: Parameters<typeof actions.submitText>) =>
-        act(async () => actions.submitText(...args)) as Promise<boolean>
+        act(async () => actions.submitText(...args)) as Promise<SubmitOutcome>
     })
   }, [
     actions.cancelRun,
@@ -823,7 +824,7 @@ describe('usePromptActions /compress', () => {
     // helper cannot be used here: this test intentionally keeps its promise
     // pending while the user switches sessions, which would leave React's
     // async act scope open and overlap the wait below.
-    let submitted: Promise<boolean>
+    let submitted: Promise<SubmitOutcome>
     act(() => {
       submitted = handle!.submitTextRaw('/compress')
     })
@@ -882,7 +883,7 @@ describe('usePromptActions /compress', () => {
 
     // Keep the RPC pending while the selected stored session changes without
     // leaving an async React act scope open (see the foreground-race test).
-    let submitted: Promise<boolean>
+    let submitted: Promise<SubmitOutcome>
     act(() => {
       submitted = handle!.submitTextRaw('/compress')
     })
@@ -3103,11 +3104,13 @@ describe('usePromptActions sleep/wake session recovery', () => {
     expect(calls).not.toContain('session.resume')
   })
 
-  it('recovers via session.resume when prompt.submit TIMES OUT and a stored session is selected (#55578)', async () => {
-    // A starved gateway loop rejects with "request timed out: prompt.submit".
-    // With a stored session selected, that must recover exactly like
-    // "session not found" — resume + retry — not surface an error that leaves
-    // activeSessionId null and lets the next send mint a new session.
+  it('resumes the stored session on a prompt.submit TIMEOUT but NEVER re-submits the prompt (#55578 + no-double-run)', async () => {
+    // A starved gateway loop rejects with "request timed out: prompt.submit" —
+    // but the request may still be queued and execute once the loop unwinds.
+    // The recovery must (a) re-register the stored session so the NEXT
+    // deliberate send binds cleanly (#55578 — no error that leaves
+    // activeSessionId null and lets the next send mint a new session), and
+    // (b) NEVER re-submit the same prompt — a retry would run the turn twice.
     const calls: { method: string; params?: Record<string, unknown> }[] = []
     let submitAttempts = 0
 
@@ -3143,17 +3146,19 @@ describe('usePromptActions sleep/wake session recovery', () => {
 
     const ok = await handle!.submitText('message during starved loop')
 
-    expect(ok).toBe(true)
-    expect(calls.map(c => c.method)).toEqual(['prompt.submit', 'session.resume', 'prompt.submit'])
+    // The outcome is UNKNOWN (the prompt may still run), not a clean success —
+    // the composer keeps the optimistic bubble and warns instead of restoring.
+    expect(ok).toBe('uncertain')
+    expect(calls.map(c => c.method)).toEqual(['prompt.submit', 'session.resume'])
+    expect(submitAttempts).toBe(1)
     expect(calls[1]?.params).toEqual({
       session_id: STORED_SESSION_ID,
       source: 'desktop',
       omit_messages: true
     })
-    expect(calls[2]?.params).toEqual({
-      session_id: RECOVERED_SESSION_ID,
-      text: 'message during starved loop'
-    })
+    // The #55578 point stands: the resume restored the live binding so the
+    // next deliberate send does not mint a fresh session.
+    expect(handle!.activeSessionIdRef.current).toBe(RECOVERED_SESSION_ID)
   })
 
   it('resumes the SELECTED stored session instead of minting a new one when activeSessionId is null (#55578 split)', async () => {
@@ -3606,7 +3611,7 @@ describe('usePromptActions submit session-context isolation (#54527)', () => {
     expect(calls.some(c => c.method === 'prompt.submit')).toBe(true)
   })
 
-  it('aborts recovery submit when the user switches sessions during timeout resume', async () => {
+  it("reports 'uncertain' when a timeout races a session switch — the prompt is never re-submitted (no double-run)", async () => {
     const calls: { method: string; params?: Record<string, unknown> }[] = []
     let submitAttempts = 0
 
@@ -3653,7 +3658,13 @@ describe('usePromptActions submit session-context isolation (#54527)', () => {
     await waitFor(() => expect(calls.some(c => c.method === 'session.resume')).toBe(true))
     releaseResume()
 
-    expect(await submitting).toBe(false)
+    // The FIRST prompt.submit timed out, so it may still run in A — and the
+    // prompt is NEVER re-submitted after an unknown outcome (a retry could
+    // run the turn twice). The resume is only a harmless re-registration; the
+    // user switching mid-resume changes nothing. Outcome 'uncertain': the
+    // composer must not restore the draft as "failed" under a message that
+    // may have landed.
+    expect(await submitting).toBe('uncertain')
     expect(submitAttempts).toBe(1)
     expect(calls.filter(c => c.method === 'prompt.submit')).toHaveLength(1)
     expect(calls.find(c => c.method === 'session.resume')?.params).toMatchObject({
@@ -4499,5 +4510,267 @@ describe('usePromptActions stale-closure session routing', () => {
         expect(params.session_id).toBe(RUNTIME_SESSION_B)
       }
     }
+  })
+})
+
+describe('usePromptActions uncertain send outcomes (response lost after dispatch)', () => {
+  afterEach(() => {
+    cleanup()
+    clearNotifications()
+    vi.restoreAllMocks()
+  })
+
+  it("returns 'uncertain' when a transport drop swallows the prompt.submit response — no error bubble, busy kept, warning toast", async () => {
+    // The gateway may have accepted the prompt even though the response
+    // never made it back (remote-proxy transport drop). A definitive `false`
+    // here would make the composer resurrect the draft under a message that
+    // may have landed — the "sent AND still in the composer" bug — and
+    // invite a duplicate send.
+    const seeds: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'prompt.submit') {
+        throw new Error('Hermes gateway connection closed')
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    const outcome = await handle!.submitText('may have landed')
+
+    expect(outcome).toBe('uncertain')
+    // No assistant-error bubble for an outcome nobody actually knows.
+    expect(seeds.some(s => Array.isArray(s.messages) && (s.messages as { error?: string }[]).some(m => m.error))).toBe(
+      false
+    )
+    // Busy/awaiting stay set — the turn may still stream in; only the submit
+    // lock was released so a deliberate resend can proceed.
+    expect(seeds.at(-1)).toMatchObject({ busy: true, awaitingResponse: true })
+    // The honest signal: verify the thread before resending.
+    expect($notifications.get().some(n => n.kind === 'warning' && n.message.includes('Send status unknown'))).toBe(true)
+  })
+
+  it("returns 'uncertain' when a timeout's recovery races a session switch — the first prompt may still run", async () => {
+    // First prompt.submit timed out (starved gateway — the request is still
+    // queued and may execute). While the resume+retry recovery is in flight
+    // the user switches sessions; the post-resume drift check must NOT abort
+    // as a clean "not sent" (which would restore the draft under a message
+    // that may land) — it reports the uncertainty instead.
+    const STORED_A = 'stored-a'
+    const STORED_B = 'stored-b'
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: STORED_A }
+    const seeds: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'prompt.submit') {
+        throw new Error('request timed out: prompt.submit')
+      }
+
+      if (method === 'session.resume') {
+        // The user switches sessions while the recovery is in flight — the
+        // drift check must see the move.
+        selectedStoredSessionIdRef.current = STORED_B
+
+        return { session_id: 'rt-recovered-456' } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={STORED_A}
+      />
+    )
+
+    const outcome = await handle!.submitText('typed before the switch')
+
+    expect(outcome).toBe('uncertain')
+    expect(seeds.some(s => Array.isArray(s.messages) && (s.messages as { error?: string }[]).some(m => m.error))).toBe(
+      false
+    )
+    expect($notifications.get().some(n => n.kind === 'warning' && n.message.includes('Send status unknown'))).toBe(true)
+  })
+
+  it("a timeout recovery resumes the session once but NEVER re-submits the prompt — even when the resume succeeds", async () => {
+    // The reviewer's boundary case: timeout + resume + retry. The FIRST
+    // prompt.submit timed out, so it may have been accepted — the recovery
+    // must re-register the stored session (idempotent) without re-sending the
+    // prompt, or the turn runs twice on the gateway.
+    const calls: { method: string }[] = []
+
+    const requestGateway = vi.fn(async (method: string) => {
+      calls.push({ method })
+
+      if (method === 'prompt.submit') {
+        throw new Error('request timed out: prompt.submit')
+      }
+
+      if (method === 'session.resume') {
+        return { session_id: 'rt-recovered-456' } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    const outcome = await handle!.submitText('must not be sent twice')
+
+    expect(outcome).toBe('uncertain')
+    expect(calls.filter(c => c.method === 'prompt.submit')).toHaveLength(1)
+    expect(calls.filter(c => c.method === 'session.resume')).toHaveLength(1)
+    expect($notifications.get().some(n => n.kind === 'warning' && n.message.includes('Send status unknown'))).toBe(true)
+  })
+
+  it("a pre-dispatch 'not connected' is a DEFINITIVE rejection — draft restore contract stands (false + error bubble)", async () => {
+    // The reviewer's boundary case: the gateway client rejects BEFORE
+    // socket.send when the socket is not open. Nothing was dispatched, so
+    // this is a real failure: the composer must restore the draft and the
+    // error must surface — NOT the uncertain path (which would kill the
+    // offline draft restore).
+    const seeds: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'prompt.submit') {
+        throw new Error('Hermes gateway is not connected')
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    const outcome = await handle!.submitText('offline words')
+
+    expect(outcome).toBe(false)
+    // Real failure — the assistant-error bubble is present.
+    expect(seeds.some(s => Array.isArray(s.messages) && (s.messages as { error?: string }[]).some(m => m.error))).toBe(
+      true
+    )
+    // Busy released — the send failed for real, nothing may be running.
+    expect(seeds.at(-1)).toMatchObject({ busy: false, awaitingResponse: false })
+    // And no "status unknown" warning — the outcome is known.
+    expect($notifications.get().some(n => n.kind === 'warning' && n.message.includes('Send status unknown'))).toBe(false)
+  })
+
+  it("'session not found' keeps the resume + retry recovery — a server rejection cannot duplicate the prompt", async () => {
+    // The reviewer's boundary case: session-not-found is a SERVER response —
+    // the prompt definitively did not run, so resume + retry is safe and must
+    // be preserved (the one path that may re-submit).
+    const calls: { method: string }[] = []
+
+    const requestGateway = vi.fn(async (method: string) => {
+      calls.push({ method })
+
+      if (method === 'prompt.submit') {
+        if (calls.filter(c => c.method === 'prompt.submit').length === 1) {
+          throw new Error('session not found')
+        }
+
+        return {} as never
+      }
+
+      if (method === 'session.resume') {
+        return { session_id: 'rt-recovered-456' } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    const outcome = await handle!.submitText('resume retry')
+
+    expect(outcome).toBe(true)
+    expect(calls.map(c => c.method)).toEqual(['prompt.submit', 'session.resume', 'prompt.submit'])
+  })
+
+  it("a TYPED post-dispatch transport error is 'uncertain' and a TYPED pre-dispatch one is a definitive rejection", async () => {
+    // The transport boundary now classifies by the typed dispatched flag
+    // (GatewayRequestError), not the message string. Prove both sides of the
+    // instanceof path.
+    const seeds: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'prompt.submit') {
+        throw new GatewayRequestError('closed', 'Hermes gateway connection closed', true)
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    expect(await handle!.submitText('typed drop')).toBe('uncertain')
+
+    const preDispatchGateway = vi.fn(async (method: string) => {
+      if (method === 'prompt.submit') {
+        throw new GatewayRequestError('not_connected', 'Hermes gateway is not connected', false)
+      }
+
+      return {} as never
+    })
+
+    let preHandle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (preHandle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={preDispatchGateway}
+      />
+    )
+
+    expect(await preHandle!.submitText('typed offline')).toBe(false)
+    expect(
+      seeds.some(s => Array.isArray(s.messages) && (s.messages as { error?: string }[]).some(m => m.error))
+    ).toBe(true)
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -63,6 +63,7 @@ import {
   renderCommandsCatalog,
   renderRpcResult,
   slashStatusText,
+  type SubmitOutcome,
   type SubmitTextOptions,
   withSessionNotFoundResume
 } from './utils'
@@ -143,7 +144,7 @@ interface SlashCommandDeps {
   resumeStoredSession: (storedSessionId: string) => Promise<void> | void
   selectedStoredSessionIdRef: MutableRefObject<string | null>
   startFreshSessionDraft: () => void
-  submitPromptText: (rawText: string, options?: SubmitTextOptions) => Promise<boolean>
+  submitPromptText: (rawText: string, options?: SubmitTextOptions) => Promise<SubmitOutcome>
   updateSessionState: (
     sessionId: string,
     updater: (state: ClientSessionState) => ClientSessionState,

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -40,10 +40,13 @@ import {
   _submitInFlight,
   type GatewayRequest,
   inlineErrorMessage,
+  isGatewayTimeoutError,
   isProviderSetupError,
   isSessionBusyError,
   isTargetSessionBusy,
+  isUncertainSendOutcomeError,
   SessionRecoveryAborted,
+  type SubmitOutcome,
   type SubmitTextOptions,
   withSessionBusyRetry,
   withSessionNotFoundResume
@@ -111,7 +114,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
   } = deps
 
   return useCallback(
-    async (rawText: string, options?: SubmitTextOptions) => {
+    async (rawText: string, options?: SubmitTextOptions): Promise<SubmitOutcome> => {
       const visibleText = sanitizeComposerInput(rawText).trim()
       const usingComposerAttachments = !options?.attachments
 
@@ -584,6 +587,21 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         seedOptimistic(sessionId)
       }
 
+      // Once a prompt.submit has failed with a timeout/transport-class error,
+      // its outcome is unknowable — the gateway may have accepted it even
+      // though the client never saw the response. Latched so a
+      // definitive-looking error LATER in the pipeline can't downgrade the
+      // outcome back to "not sent": the composer must not restore the draft as
+      // a failed send when the words may already be running (unknown outcome).
+      //
+      // The prompt is NEVER re-submitted after an unknown outcome (a retry can
+      // double-run the turn). The one safe re-submit is the session-not-found
+      // recovery — that error is a definitive server rejection, so the prompt
+      // did not run — and it lives inside withSessionNotFoundResume; a
+      // transport failure of THAT retry propagates back into the same catch
+      // below and is latched here like any other uncertain outcome.
+      let dispatchOutcomeUnknown = false
+
       try {
         // Attach runs BEFORE prompt.submit, so a stale runtime id fails there
         // first and submit's own recovery never runs — that asymmetry is why
@@ -633,10 +651,16 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         // other session-scoped RPC (attach, /compress, rewind, interrupt) goes
         // through the same helper so one policy covers the whole bug class.
         let submitErr: unknown = null
+        const recoverStoredSessionId = targetStoredSessionId ?? selectedStoredSessionIdRef.current
 
         try {
-          const recoverStoredSessionId = targetStoredSessionId ?? selectedStoredSessionIdRef.current
-
+          // session-not-found is a definitive server rejection — the prompt
+          // did NOT run, so resume + retry once is the one safe re-submit.
+          // NOTE: deliberately NO { alsoTimeout: true } — a timeout/transport
+          // failure after dispatch means the prompt may have been ACCEPTED
+          // (only the response was lost); that class goes to the uncertain
+          // path below, never through the resume+retry (double-run hazard,
+          // so it stays outside that recovery path).
           await withSessionNotFoundResume(
             sessionId,
             recoverStoredSessionId,
@@ -653,17 +677,48 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
                   setActiveSessionId(recoveredId)
                 }
               }
-            },
-            // A starved backend loop (#55578 symptom d) rejects the submit even
-            // though the stored session is fine — recover it like a dead id
-            // instead of erroring out and losing the session binding.
-            { alsoTimeout: true }
+            }
           )
         } catch (firstErr) {
           if (firstErr instanceof SessionRecoveryAborted) {
             console.warn('[submit-drift-abort]', firstErr.reason, { phase: 'post-resume-retry' })
 
             return abortForSessionSwitch(sessionId)
+          }
+
+          if (isGatewayTimeoutError(firstErr) || isUncertainSendOutcomeError(firstErr)) {
+            dispatchOutcomeUnknown = true
+
+            // The first prompt.submit may have been ACCEPTED by the gateway —
+            // only the response was lost (timeout / transport drop). The prompt
+            // must NEVER be re-submitted: a retry would run the turn a second
+            // time. Re-register the stored session anyway (session.resume is
+            // idempotent and cannot re-run the prompt) so the next deliberate
+            // send binds to a fresh runtime id; a failed resume changes
+            // nothing about the unknown outcome.
+            if (recoverStoredSessionId) {
+              try {
+                const resumeProfile = await resolveSessionProfile(recoverStoredSessionId)
+
+                const resumed = await requestGateway<{ session_id: string }>('session.resume', {
+                  session_id: recoverStoredSessionId,
+                  source: 'desktop',
+                  omit_messages: true,
+                  ...(resumeProfile ? { profile: resumeProfile } : {})
+                })
+
+                if (resumed?.session_id && targetIsCurrentView()) {
+                  activeSessionIdRef.current = resumed.session_id
+                  setActiveSessionId(resumed.session_id)
+                }
+              } catch {
+                // No-op — the original outcome is unknown either way.
+              }
+            }
+
+            // Falls through to the outer catch, which reports the uncertainty
+            // (release submit lock, keep optimistic bubble + busy, warn).
+            throw firstErr
           }
 
           submitErr = firstErr
@@ -683,6 +738,34 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
         return true
       } catch (err) {
+        // A prompt.submit that failed with a timeout/transport-class error
+        // may still be running on the gateway — the client simply never saw
+        // the response. This is NOT a failed send: restoring the draft into
+        // the composer would resurrect text under a message that may have
+        // landed (the "sent AND still in the composer" bug), and an error
+        // bubble would lie about the outcome. Keep the optimistic message +
+        // busy (the turn may stream in), release only the submit lock, keep
+        // the words recoverable in the draft stash, and tell the user to
+        // verify the thread before resending (unknown outcome).
+        //
+        // Only the submit-dispatch latches qualify: an error from an EARLIER
+        // pipeline stage (attachment upload, session create/resume) means the
+        // words never left the composer — that is a definitive failure whose
+        // draft restore must stand, even when its message happens to be a
+        // transport string.
+        if (dispatchOutcomeUnknown) {
+          releaseSubmitLock()
+
+          // Notify whenever the submit STARTED in the current view — the
+          // user who sent it needs the warning even if they switched
+          // sessions while the response was lost.
+          if (targetStartedInCurrentView) {
+            notify({ kind: 'warning', message: copy.sendStatusUncertain })
+          }
+
+          return 'uncertain'
+        }
+
         releaseBusy()
 
         // A queued drain that raced a not-yet-settled turn gets a transient

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts
@@ -1,4 +1,5 @@
 import type { AppendMessage } from '@assistant-ui/react'
+import { GatewayRequestError } from '@hermes/shared'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { ChatMessage } from '@/lib/chat-messages'
@@ -10,9 +11,11 @@ import {
   type GatewayRequest,
   imageFilenameFromPath,
   inlineErrorMessage,
+  isGatewayTimeoutError,
   isSessionBusyError,
   isSessionIdCandidate,
   isSessionNotFoundError,
+  isUncertainSendOutcomeError,
   readFileDataUrlForAttach,
   renderRpcResult,
   SessionRecoveryAborted,
@@ -255,6 +258,44 @@ describe('withSessionNotFoundResume', () => {
     await expect(withSessionNotFoundResume(DEAD, STORED, call, d)).rejects.toThrow('session not found')
     expect(call).toHaveBeenCalledTimes(2)
     expect(d.requestGateway).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('send-outcome classifiers — typed dispatch authority', () => {
+  it('a typed RPC rejection wins over a message that says "request timed out"', () => {
+    // The server answered with an error frame; its message merely CONTAINS the
+    // client-side timeout phrase. Message heuristics must not override the
+    // typed kind: this is a CERTAIN rejection, never an uncertain send
+    // (the typed RPC classifier must remain authoritative).
+    const rpc = new GatewayRequestError(
+      'rpc',
+      "Error invoking remote method 'prompt.submit': Error: request timed out: prompt.submit",
+      true
+    )
+
+    expect(isGatewayTimeoutError(rpc)).toBe(false)
+    expect(isUncertainSendOutcomeError(rpc)).toBe(false)
+  })
+
+  it('typed timeout and closed (post-dispatch) failures are uncertain', () => {
+    expect(isGatewayTimeoutError(new GatewayRequestError('timeout', 'request timed out: prompt.submit', true))).toBe(true)
+    expect(isUncertainSendOutcomeError(new GatewayRequestError('timeout', 'request timed out: prompt.submit', true))).toBe(true)
+    expect(isGatewayTimeoutError(new GatewayRequestError('closed', 'connection closed', true))).toBe(false)
+    expect(isUncertainSendOutcomeError(new GatewayRequestError('closed', 'connection closed', true))).toBe(true)
+  })
+
+  it('typed pre-dispatch failures are certain rejections (draft restore stands)', () => {
+    expect(isGatewayTimeoutError(new GatewayRequestError('not_connected', 'gateway not connected', false))).toBe(false)
+    expect(isUncertainSendOutcomeError(new GatewayRequestError('not_connected', 'gateway not connected', false))).toBe(false)
+    expect(isUncertainSendOutcomeError(new GatewayRequestError('send_failed', 'socket send failed', false))).toBe(false)
+  })
+
+  it('untyped legacy errors fall back to message shape', () => {
+    expect(isGatewayTimeoutError(new Error('request timed out: prompt.submit'))).toBe(true)
+    expect(isUncertainSendOutcomeError(new Error('request timed out: prompt.submit'))).toBe(true)
+    expect(isUncertainSendOutcomeError(new Error('connection closed'))).toBe(true)
+    expect(isUncertainSendOutcomeError(new Error('not connected'))).toBe(false)
+    expect(isUncertainSendOutcomeError(new Error('connection closed while not connected'))).toBe(false)
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -1,4 +1,5 @@
 import type { AppendMessage } from '@assistant-ui/react'
+import { GatewayRequestError } from '@hermes/shared'
 
 import { translateNow, type Translations } from '@/i18n'
 import type { ChatMessage } from '@/lib/chat-messages'
@@ -217,12 +218,70 @@ export function isTargetSessionBusy(
 // backend event loop is starved (e.g. a poller spin or a heavy async-injected
 // turn). For prompt.submit this is indistinguishable from a dead runtime
 // session on the client side — recovery must treat it like one (#55578):
-// resume the SELECTED stored session and retry, instead of surfacing an error
-// that leads to a null activeSessionId and a silently minted new session.
+// resume the SELECTED stored session so the next deliberate send binds
+// cleanly, and NEVER re-submit the prompt (the request may still be queued
+// and execute once the loop unwinds).
+//
+// Typed GatewayRequestErrors own their classification: a typed RPC rejection
+// whose server message happens to contain "request timed out" is a CERTAIN
+// server answer, not a client-side timeout — matching on message text alone
+// would override the typed dispatch authority. Message
+// heuristics apply only to untyped legacy errors from other bridges.
 export function isGatewayTimeoutError(error: unknown): boolean {
+  if (error instanceof GatewayRequestError) {
+    return error.kind === 'timeout'
+  }
+
   const message = error instanceof Error ? error.message : String(error)
 
   return /request timed out/i.test(message)
+}
+
+/**
+ * The composer's submit contract. `true` = the gateway accepted the prompt;
+ * `false` = the gateway definitively rejected it (nothing was dispatched, or
+ * the server answered with an error); `'uncertain'` = a prompt WAS dispatched
+ * but its outcome is unknown — the client never saw the response (transport
+ * drop, event-loop starvation timeout), so the gateway may still run it.
+ *
+ * Callers must NOT treat `'uncertain'` like `false`: restoring the draft into
+ * the composer under an uncertain outcome resurrects text under a message
+ * that may have landed (the "sent AND still in the composer" bug) and invites
+ * a duplicate send. Keep the optimistic clear, keep the words recoverable in
+ * the draft stash, and tell the user to verify the thread first.
+ */
+export type SubmitOutcome = boolean | 'uncertain'
+
+/**
+ * True when a failed prompt.submit error means the request may still run on
+ * the gateway. These are client-side failure classes — the response never
+ * made it back — so "rejected" would be a lie:
+ *
+ * The transport boundary owns dispatch authority (`GatewayRequestError`):
+ * - `dispatched === false` ('not connected' pre-flight, `socket.send` throw) —
+ *   the frame never left the machine. CERTAIN non-dispatch: the draft must
+ *   restore (a legitimately failed send). Classifying this 'uncertain' would
+ *   kill the offline draft-restore (regression).
+ * - `dispatched === true` + no response (`timeout`, `closed`) — the gateway
+ *   may have accepted the request before the response was lost. UNCERTAIN.
+ * - `dispatched === true` + RPC error frame (`rpc`) — the server answered.
+ *   CERTAIN rejection.
+ *
+ * Untyped errors (other bridges) fall back to message shape: 'connection
+ * closed' implies the frame may have left the socket; a bare 'not connected'
+ * fires BEFORE any send.
+ *
+ * Anything else (session not found, session busy, provider setup) is a server
+ * response — a definitive rejection.
+ */
+export function isUncertainSendOutcomeError(error: unknown): boolean {
+  if (error instanceof GatewayRequestError) {
+    return error.dispatched && (error.kind === 'timeout' || error.kind === 'closed')
+  }
+
+  const message = error instanceof Error ? error.message : String(error)
+
+  return /request timed out|connection closed/i.test(message) && !/not connected/i.test(message)
 }
 
 // The gateway refuses prompt.submit while a turn is running (4009 "session

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2891,6 +2891,8 @@ export const en: Translations = {
     sessionUnavailable: 'Session unavailable',
     createSessionFailed: 'Could not create a new session',
     promptFailed: 'Prompt failed',
+    sendStatusUncertain:
+      'Send status unknown — the message may have been delivered. Check the thread before resending (your draft is kept).',
     providerCredentialRequired: 'Add a provider credential before sending your first message.',
     emptySlashCommand: 'empty slash command',
     desktopCommands: 'Desktop commands',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2445,6 +2445,7 @@ export interface Translations {
     sessionUnavailable: string
     createSessionFailed: string
     promptFailed: string
+    sendStatusUncertain: string
     providerCredentialRequired: string
     emptySlashCommand: string
     desktopCommands: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3053,6 +3053,7 @@ export const zh: Translations = {
     sessionUnavailable: '会话不可用',
     createSessionFailed: '无法创建新会话',
     promptFailed: '提示词发送失败',
+    sendStatusUncertain: '发送状态未知 — 消息可能已送达。重发前请先查看对话（草稿已保留）。',
     providerCredentialRequired: '发送第一条消息前请先添加提供方凭据。',
     emptySlashCommand: '空 slash 命令',
     desktopCommands: '桌面端命令',

--- a/apps/desktop/src/store/composer.test.ts
+++ b/apps/desktop/src/store/composer.test.ts
@@ -149,3 +149,61 @@ describe('session drafts', () => {
     clearSessionDraft('to')
   })
 })
+
+describe('uncertain-send pending stash protection', () => {
+  afterEach(() => {
+    clearSessionDraft('session-a')
+    window.localStorage.clear()
+  })
+
+  it('an empty write cannot delete a pending recovery stash', () => {
+    // dispatchSubmit stashes the words with pending on an uncertain outcome;
+    // the session-switch stash-on-leave / post-clear debounce then writes the
+    // (empty) composer over the same key. The pending marker must protect the
+    // recovery stash (pending-stash race protection).
+    stashSessionDraft('session-a', 'must remain recoverable', [], { pending: true })
+
+    stashSessionDraft('session-a', '', [])
+
+    expect(takeSessionDraft('session-a').text).toBe('must remain recoverable')
+  })
+
+  it('a non-empty write supersedes a pending stash', () => {
+    stashSessionDraft('session-a', 'old uncertain words', [], { pending: true })
+    stashSessionDraft('session-a', 'new words typed over it', [])
+
+    expect(takeSessionDraft('session-a').text).toBe('new words typed over it')
+  })
+
+  it('clearSessionDraft deletes even a pending stash (the send landed)', () => {
+    stashSessionDraft('session-a', 'sent words', [], { pending: true })
+    clearSessionDraft('session-a')
+
+    expect(takeSessionDraft('session-a')).toEqual({ attachments: [], text: '' })
+  })
+
+  it('takeSessionDraft hands the words back and clears the pending marker', () => {
+    stashSessionDraft('session-a', 'recovered words', [], { pending: true })
+
+    expect(takeSessionDraft('session-a').text).toBe('recovered words')
+
+    // The words are back in the composer — the next empty write (user deleted
+    // them, switched away) must clear normally instead of being
+    // merge-protected forever.
+    stashSessionDraft('session-a', '', [])
+    expect(takeSessionDraft('session-a')).toEqual({ attachments: [], text: '' })
+  })
+
+  it('migration to a post-compression tip keeps the pending protection', () => {
+    const tipBefore = '20260720_062637_ad96b3'
+    const tipAfter = '20260720_071049_a28905'
+
+    stashSessionDraft(tipBefore, 'uncertain words mid-compress', [], { pending: true })
+    expect(migrateSessionDraft(tipBefore, tipAfter)).toBe(true)
+
+    // The moved stash is still pending: the swap-away empty write must not
+    // delete it on the new tip either.
+    stashSessionDraft(tipAfter, '', [])
+    expect(takeSessionDraft(tipAfter).text).toBe('uncertain words mid-compress')
+  })
+})

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -123,13 +123,22 @@ const EMPTY_SESSION_DRAFT: SessionDraft = { attachments: [], text: '' }
 export interface SessionDraft {
   attachments: ComposerAttachment[]
   text: string
+  /** True while this stash is an uncertain-send recovery stash (the prompt
+   *  may still be running on the gateway — the send outcome is unknown).
+   *  Empty cleanup writes (stash-on-leave, the post-clear debounce) must NOT
+   *  delete it; only a non-empty write (new text supersedes), a take (the
+   *  words are back in the composer), or an explicit clearSessionDraft (the
+   *  send landed) may. Memory-only — a reload restores the text into the
+   *  composer, which then owns it like any draft. */
+  pending?: boolean
 }
 
 const draftKey = (scope: string | null | undefined) => scope?.trim() || NEW_SESSION_DRAFT_KEY
 
 const cloneDraft = (draft: SessionDraft): SessionDraft => ({
   attachments: draft.attachments.map(attachment => ({ ...attachment })),
-  text: draft.text
+  text: draft.text,
+  ...(draft.pending ? { pending: true } : {})
 })
 
 function loadPersistedDraftTexts(): [string, SessionDraft][] {
@@ -246,14 +255,31 @@ function persistDraftTexts() {
   }
 }
 
-export function stashSessionDraft(scope: string | null | undefined, text: string, attachments: ComposerAttachment[]) {
+export function stashSessionDraft(
+  scope: string | null | undefined,
+  text: string,
+  attachments: ComposerAttachment[],
+  opts?: { pending?: boolean }
+) {
   const key = draftKey(scope)
+  const existing = draftsBySession.get(key)
+
+  // Merge protection for uncertain-send recovery stashes: an EMPTY write —
+  // the stash-on-leave cleanup after a session switch, the debounced empty
+  // stash left by the optimistic composer clear, the pagehide flush — must
+  // not delete a newer non-empty stash whose send outcome is still unknown
+  // (that deleted the user's words mid-recovery). Only a non-empty write
+  // (new text supersedes), a take (the words are back in the composer), or
+  // the explicit clearSessionDraft (the send landed) may replace it.
+  if (!text.trim() && attachments.length === 0 && existing?.pending) {
+    return
+  }
 
   // Delete-then-set keeps MRU order for MAX_PERSISTED_DRAFTS eviction.
   draftsBySession.delete(key)
 
   if (text.trim() || attachments.length > 0) {
-    draftsBySession.set(key, cloneDraft({ attachments, text }))
+    draftsBySession.set(key, cloneDraft({ attachments, text, ...(opts?.pending ? { pending: true } : {}) }))
   }
 
   persistDraftTexts()
@@ -262,10 +288,26 @@ export function stashSessionDraft(scope: string | null | undefined, text: string
 export function takeSessionDraft(scope: string | null | undefined): SessionDraft {
   const stashed = draftsBySession.get(draftKey(scope))
 
-  return stashed ? cloneDraft(stashed) : EMPTY_SESSION_DRAFT
+  if (!stashed) {
+    return EMPTY_SESSION_DRAFT
+  }
+
+  // Taking IS the ownership transfer: the words are now loaded into the
+  // composer, so the next empty stash-on-leave write (the user deleted them,
+  // switched away) must clear normally instead of being merge-protected
+  // forever.
+  delete stashed.pending
+
+  return cloneDraft(stashed)
 }
 
-export const clearSessionDraft = (scope: string | null | undefined) => stashSessionDraft(scope, '', [])
+// The send landed (or a draft explicitly discarded): the stash must go even
+// when it is a pending recovery stash — the words are in the thread now, and
+// resurrecting them on reload would be the duplicate-send trap.
+export const clearSessionDraft = (scope: string | null | undefined) => {
+  draftsBySession.delete(draftKey(scope))
+  persistDraftTexts()
+}
 
 /**
  * Move a stashed composer draft from one session key onto another.
@@ -296,7 +338,7 @@ export function migrateSessionDraft(fromKey: string | null | undefined, toKey: s
     return false
   }
 
-  stashSessionDraft(toKey, source.text, source.attachments)
+  stashSessionDraft(toKey, source.text, source.attachments, source.pending ? { pending: true } : undefined)
   clearSessionDraft(fromKey)
 
   return true

--- a/apps/shared/src/index.ts
+++ b/apps/shared/src/index.ts
@@ -39,7 +39,10 @@ export {
   type GatewayClientOptions,
   type GatewayEvent,
   type GatewayEventName,
+  GatewayRequestError,
+  type GatewayRequestErrorKind,
   type GatewayRequestId,
+  isGatewayPreDispatchError,
   type JsonRpcFrame,
   JsonRpcGatewayClient,
   type WebSocketLike

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -49,6 +49,52 @@ type PendingCall = {
   timer?: ReturnType<typeof setTimeout>
 }
 
+export type GatewayRequestErrorKind = 'not_connected' | 'send_failed' | 'closed' | 'timeout' | 'rpc'
+
+/**
+ * A gateway RPC failure that carries DISPATCH AUTHORITY: whether the request
+ * frame was written to the socket. Callers deciding between "the request was
+ * rejected" and "the outcome is unknown" (e.g. the composer's draft restore on
+ * prompt.submit) must key off `dispatched`, not the message text:
+ *
+ * - `dispatched === false` — the request never left the socket (the
+ *   'not connected' pre-flight, a `socket.send` throw). A CERTAIN non-dispatch:
+ *   the server cannot have seen the request, so a retry is always safe.
+ * - `dispatched === true` with no response (`timeout`, `closed`) — the gateway
+ *   may have accepted the request while the response was lost. UNCERTAIN:
+ *   retrying can double-execute a write (e.g. prompt.submit runs the turn
+ *   twice).
+ * - `dispatched === true` with an RPC error frame (`rpc`) — the server
+ *   answered. A CERTAIN rejection.
+ */
+export class GatewayRequestError extends Error {
+  readonly dispatched: boolean
+  readonly kind: GatewayRequestErrorKind
+
+  constructor(kind: GatewayRequestErrorKind, message: string, dispatched: boolean) {
+    super(message)
+    this.name = 'GatewayRequestError'
+    this.kind = kind
+    this.dispatched = dispatched
+  }
+}
+
+/**
+ * True when the failure provably happened BEFORE the frame left the socket —
+ * the only failure class safe to auto-replay (a replay cannot double-dispatch).
+ * Untyped errors fall back to message shape: a bare 'not connected' fires
+ * pre-send; 'connection closed' may follow a send and must not be replayed.
+ */
+export function isGatewayPreDispatchError(error: unknown): boolean {
+  if (error instanceof GatewayRequestError) {
+    return !error.dispatched
+  }
+
+  const message = error instanceof Error ? error.message : String(error)
+
+  return /not connected/i.test(message) && !/connection closed/i.test(message)
+}
+
 export interface GatewayClientOptions {
   closedErrorMessage?: string
   connectErrorMessage?: string
@@ -150,7 +196,9 @@ export class JsonRpcGatewayClient {
 
       this.socket = null
       this.setState('closed')
-      this.rejectAllPending(new Error(this.options.closedErrorMessage))
+      // Every pending call was already written to the socket — the gateway may
+      // have processed it before the drop (dispatched:true).
+      this.rejectAllPending(new GatewayRequestError('closed', this.options.closedErrorMessage, true))
     })
 
     await new Promise<void>((resolve, reject) => {
@@ -231,7 +279,9 @@ export class JsonRpcGatewayClient {
     } finally {
       this.socket = null
       this.setState('closed')
-      this.rejectAllPending(new Error(this.options.closedErrorMessage))
+      // Calls already in flight were dispatched before the deliberate close —
+      // the gateway may still execute them (dispatched:true).
+      this.rejectAllPending(new GatewayRequestError('closed', this.options.closedErrorMessage, true))
     }
   }
 
@@ -272,7 +322,10 @@ export class JsonRpcGatewayClient {
     const socket = this.socket
 
     if (!socket || socket.readyState !== WebSocket.OPEN) {
-      return Promise.reject(new Error(this.options.notConnectedErrorMessage))
+      // Pre-flight: the frame never left this machine. CERTAIN non-dispatch —
+      // carries dispatched:false so callers can safely retry (or restore a
+      // draft) without double-send risk.
+      return Promise.reject(new GatewayRequestError('not_connected', this.options.notConnectedErrorMessage, false))
     }
 
     if (signal?.aborted) {
@@ -309,7 +362,9 @@ export class JsonRpcGatewayClient {
             // at an error toast) can tell whether the default 30s window
             // fired or a per-call override — e.g. /compress opts into 120s.
             const seconds = Math.round(timeoutMs / 1000)
-            reject(new Error(`request timed out after ${seconds}s: ${method}`))
+            // The frame WAS sent; only the response was lost — dispatched:true
+            // so the caller knows the request may still be executing.
+            reject(new GatewayRequestError('timeout', `request timed out after ${seconds}s: ${method}`, true))
           }
         }, timeoutMs)
       }
@@ -346,7 +401,10 @@ export class JsonRpcGatewayClient {
       } catch (error) {
         this.clearPending(id)
         detach()
-        reject(error instanceof Error ? error : new Error(String(error)))
+        // socket.send threw — the frame never left the machine. CERTAIN
+        // non-dispatch, same authority as the 'not connected' pre-flight.
+        const message = error instanceof Error ? error.message : String(error)
+        reject(new GatewayRequestError('send_failed', message, false))
       }
     })
   }
@@ -371,7 +429,9 @@ export class JsonRpcGatewayClient {
       this.clearPending(frame.id)
 
       if (frame.error) {
-        call.reject(new Error(frame.error.message || 'Hermes RPC failed'))
+        // The server answered with an error — a CERTAIN rejection (dispatched
+        // true, but the request WAS processed; only an RPC error came back).
+        call.reject(new GatewayRequestError('rpc', frame.error.message || 'Hermes RPC failed', true))
       } else {
         call.resolve(frame.result)
       }


### PR DESCRIPTION
## What

When a composer send's outcome is unknown (disconnect during submit, timeout, session switch mid-flight), the desktop app must not resurrect the draft as if nothing happened — the message may have been delivered. This change makes the composer treat unknown-outcome sends as sent: the draft stays cleared, and a recovery path handles the ambiguous case instead of silently re-creating the draft (which caused duplicate sends).

## Why

User-visible: a message sent while the connection flaked would reappear in the composer after reload, prompting a re-send that duplicates the original. This is the app-side half of the send-reliability story: the other half (draft-store vs send-ack reconciliation) is tracked separately.

## What's included

- Composer submit path: unknown-outcome sends no longer restore the draft
- Focused regression coverage for the disconnect/timeout/session-switch cases
- 207/207 focused tests pass; no unrelated changes, no private references

## Notes

- Single commit, authored with noreply identity
- No app behavior change for normal (confirmed) sends