### PR TITLE
fix(providers): defer tool-result images to user-role message for Con…

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -6641,6 +6641,12 @@ def run_conversation(
 
                 agent._execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count)
 
+                # Providers that reject image parts inside tool-role messages
+                # (e.g. Console Go) get the deferred native-vision image parts
+                # as a user-role message now that the whole tool batch is
+                # appended (role alternation: tool..tool, user).
+                agent._append_pending_tool_images_as_user_message(messages)
+
                 if getattr(agent, "_incremental_persistence_failed", False):
                     # A tool result could not be made canonical. Do not send
                     # the in-memory result back to the model or project any

--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -141,6 +141,11 @@ opencode_go = OpenCodeGoProfile(
     env_vars=("OPENCODE_GO_API_KEY",),
     base_url="https://opencode.ai/zen/go/v1",
     default_aux_model="glm-5",
+    # Console Go accepts multimodal USER messages (verified 2026-08-08) but
+    # rejects image_url parts inside tool-role messages with HTTP 400
+    # ("Upstream request failed: [400] Provider returned error"). Hermes
+    # defers those image parts to a follow-up user-role message instead.
+    supports_vision_tool_messages=False,
 )
 
 register_provider(opencode_zen)

--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -146,6 +146,7 @@ opencode_go = OpenCodeGoProfile(
     # ("Upstream request failed: [400] Provider returned error"). Hermes
     # defers those image parts to a follow-up user-role message instead.
     supports_vision_tool_messages=False,
+    supports_vision_user_messages=True,
 )
 
 register_provider(opencode_zen)

--- a/providers/base.py
+++ b/providers/base.py
@@ -72,6 +72,14 @@ class ProviderProfile:
     # (e.g. Xiaomi MiMo, which returns 400 "text is not set").
     supports_vision_tool_messages: bool = True
 
+    # True when the provider's API accepts multimodal USER messages
+    # (text + image parts) even though it rejects image_url parts inside
+    # tool-role messages (see ``supports_vision_tool_messages``).  Set on
+    # providers like opencode-go / Console Go: image parts must then be
+    # deferred to a follow-up user-role message instead of downgraded to
+    # a text summary, so vision-capable models keep native pixels.
+    supports_vision_user_messages: bool = False
+
     # True only when this provider's Chat Completions endpoint explicitly
     # documents ``prompt_cache_key`` as an accepted request body field.  This
     # is deliberately opt-in: many OpenAI-compatible endpoints reject unknown

--- a/run_agent.py
+++ b/run_agent.py
@@ -6680,6 +6680,26 @@ class AIAgent:
             pass
         return True  # default: assume compatible
 
+    def _provider_supports_vision_user_messages(self) -> bool:
+        """Return True if the active provider accepts multimodal USER messages.
+
+        Some providers (e.g. opencode-go / Console Go) reject ``image_url``
+        parts inside tool-role messages but accept them in user-role
+        messages.  When True, deferred image parts are appended as a
+        user-role message after the tool batch instead of downgrading the
+        whole tool result to a text summary.  This checks the provider
+        profile's ``supports_vision_user_messages`` field.
+        """
+        try:
+            from providers import get_provider_profile
+            provider = (getattr(self, "provider", "") or "").strip()
+            profile = get_provider_profile(provider)
+            if profile is not None:
+                return getattr(profile, "supports_vision_user_messages", False)
+        except Exception:
+            pass
+        return False  # default: assume no multimodal user-message support
+
     def _preprocess_anthropic_content(self, content: Any, role: str) -> Any:
         if not self._content_has_image_parts(content):
             return content
@@ -6836,12 +6856,18 @@ class AIAgent:
                 # image parts to a follow-up user-role message (appended by
                 # _append_pending_tool_images_as_user_message after the whole
                 # tool batch), so a vision-capable model still sees the
-                # pixels natively.
+                # pixels natively. Providers that do not declare multimodal
+                # user-message support (e.g. Xiaomi MiMo) keep the safe
+                # text-summary downgrade.
                 image_parts = [
                     p for p in content
-                    if isinstance(p, dict) and p.get("type") == "image_url"
+                    if isinstance(p, dict) and p.get("type") in {"image_url", "input_image"}
                 ]
-                if image_parts and self._model_supports_vision():
+                if (
+                    image_parts
+                    and self._model_supports_vision()
+                    and self._provider_supports_vision_user_messages()
+                ):
                     pending = list(
                         getattr(self, "_pending_tool_image_parts", None) or []
                     )
@@ -6849,7 +6875,7 @@ class AIAgent:
                     self._pending_tool_image_parts = pending
                     text_parts = [
                         p for p in content
-                        if not (isinstance(p, dict) and p.get("type") == "image_url")
+                        if not (isinstance(p, dict) and p.get("type") in {"image_url", "input_image"})
                     ]
                     if text_parts:
                         return text_parts

--- a/run_agent.py
+++ b/run_agent.py
@@ -6820,15 +6820,39 @@ class AIAgent:
 
         if self._model_supports_vision():
             # Vision-capable on paper — but if the provider rejects list-type
-            # tool content (e.g. Xiaomi MiMo's 400 "text is not set"), or if
-            # we've already learned this lesson in-session, short-circuit to
+            # tool content (e.g. Xiaomi MiMo's 400 "text is not set", Console
+            # Go's 400 on image_url in tool-role messages), or if we've
+            # already learned this lesson in-session, short-circuit to
             # a text summary so we don't burn a round-trip relearning it.
             if not self._provider_supports_vision_tool_messages():
                 logger.debug(
                     "Tool %s: provider %s does not accept list-type tool "
-                    "content — sending text summary",
+                    "content — deferring image parts to a user-role message",
                     tool_name, getattr(self, "provider", ""),
                 )
+                # Providers like Console Go (opencode-go) accept multimodal
+                # USER messages but reject image_url parts inside tool-role
+                # messages. Keep the text for the tool message and defer the
+                # image parts to a follow-up user-role message (appended by
+                # _append_pending_tool_images_as_user_message after the whole
+                # tool batch), so a vision-capable model still sees the
+                # pixels natively.
+                image_parts = [
+                    p for p in content
+                    if isinstance(p, dict) and p.get("type") == "image_url"
+                ]
+                if image_parts and self._model_supports_vision():
+                    pending = list(
+                        getattr(self, "_pending_tool_image_parts", None) or []
+                    )
+                    pending.extend(image_parts)
+                    self._pending_tool_image_parts = pending
+                    text_parts = [
+                        p for p in content
+                        if not (isinstance(p, dict) and p.get("type") == "image_url")
+                    ]
+                    if text_parts:
+                        return text_parts
                 return _multimodal_text_summary(result)
             key = (
                 (getattr(self, "provider", "") or "").strip().lower(),
@@ -6864,6 +6888,29 @@ class AIAgent:
             self.model,
         )
         return summary
+
+    def _append_pending_tool_images_as_user_message(self, messages: list) -> None:
+        """Append deferred native-vision image parts as a user-role message.
+
+        Providers like Console Go (opencode-go) accept multimodal user
+        messages but reject ``image_url`` parts inside tool-role messages
+        (HTTP 400). ``_tool_result_content_for_active_model`` collects those
+        parts in ``self._pending_tool_image_parts``; call this once after
+        tool execution finished so the user message is appended after ALL
+        tool messages of the batch (OpenAI role alternation: tool..tool, user).
+        """
+        pending = getattr(self, "_pending_tool_image_parts", None)
+        if not pending:
+            return
+        self._pending_tool_image_parts = None
+        text = (
+            "Native image(s) from the preceding tool result — use your "
+            "built-in vision to inspect them and answer accordingly."
+        )
+        messages.append({
+            "role": "user",
+            "content": [{"type": "text", "text": text}] + pending,
+        })
 
     def _try_shrink_image_parts_in_messages(
         self,

--- a/tests/run_agent/test_console_go_tool_image_deferral.py
+++ b/tests/run_agent/test_console_go_tool_image_deferral.py
@@ -1,0 +1,140 @@
+"""Tests for the Console Go native-vision deferral (PR #81955).
+
+Providers like opencode-go / Console Go accept multimodal USER messages
+but reject ``image_url`` parts inside tool-role messages with HTTP 400
+("Upstream request failed: [400] Provider returned error"). When the
+provider profile declares ``supports_vision_tool_messages=False`` and the
+active model is vision-capable, ``_tool_result_content_for_active_model``
+must:
+
+* keep the text parts in the tool message,
+* defer the image parts to ``self._pending_tool_image_parts``,
+* and ``_append_pending_tool_images_as_user_message`` must append them as
+  a user-role message after the whole tool batch (role alternation
+  ``tool..tool -> user``).
+
+These tests pin that contract, including the ``input_image`` part type
+(Responses-style) which ``_content_has_image_parts`` recognises too.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from run_agent import AIAgent
+
+
+def _make_agent(*, vision: bool = True, tool_messages: bool = False, user_messages: bool = True):
+    agent = MagicMock(spec=AIAgent)
+    agent.provider = "opencode-go"
+    agent.model = "mimo-v2.5"
+    agent._model_supports_vision = lambda: vision
+    agent._provider_supports_vision_tool_messages = lambda: tool_messages
+    agent._provider_supports_vision_user_messages = lambda: user_messages
+    agent._pending_tool_image_parts = None
+    agent._no_list_tool_content_models = None
+    # staticmethod — bind it so the code path under test uses the real impl
+    agent._content_has_image_parts = lambda content: AIAgent._content_has_image_parts(content)
+    return agent
+
+
+def _tool_result(text="The image shows a red stop sign.", part_type="image_url"):
+    return {
+        "_multimodal": True,
+        "content": [
+            {"type": "text", "text": text},
+            {"type": part_type, "image_url": {"url": "data:image/png;base64,AAAA"}},
+        ],
+        "text_summary": text,
+    }
+
+
+class TestToolResultContentForActiveModel:
+    def test_text_kept_and_image_deferred(self):
+        agent = _make_agent()
+        result = _tool_result()
+        content = AIAgent._tool_result_content_for_active_model(
+            agent, "vision_analyze", result
+        )
+        assert content == [{"type": "text", "text": "The image shows a red stop sign."}]
+        assert agent._pending_tool_image_parts == [
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}
+        ]
+
+    def test_input_image_parts_are_deferred_too(self):
+        """Responses-style ``input_image`` parts must be deferred as well."""
+        agent = _make_agent()
+        result = _tool_result(part_type="input_image")
+        content = AIAgent._tool_result_content_for_active_model(
+            agent, "vision_analyze", result
+        )
+        assert content == [{"type": "text", "text": "The image shows a red stop sign."}]
+        assert len(agent._pending_tool_image_parts) == 1
+        assert agent._pending_tool_image_parts[0]["type"] == "input_image"
+
+    def test_image_only_content_falls_back_to_text_summary(self):
+        agent = _make_agent()
+        result = {
+            "_multimodal": True,
+            "content": [
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}
+            ],
+            "text_summary": "summary text",
+        }
+        content = AIAgent._tool_result_content_for_active_model(
+            agent, "vision_analyze", result
+        )
+        assert isinstance(content, str)
+        assert content == "summary text"
+        assert agent._pending_tool_image_parts  # image deferred anyway
+
+    def test_provider_accepting_tool_images_passes_content_through(self):
+        agent = _make_agent(tool_messages=True)
+        result = _tool_result()
+        content = AIAgent._tool_result_content_for_active_model(
+            agent, "vision_analyze", result
+        )
+        assert content is result["content"]
+        assert agent._pending_tool_image_parts is None
+
+    def test_no_user_multimodal_support_keeps_text_summary_downgrade(self):
+        """Xiaomi-style providers (no multimodal user messages) keep the
+        safe text-summary downgrade and defer nothing."""
+        agent = _make_agent(user_messages=False)
+        result = _tool_result()
+        content = AIAgent._tool_result_content_for_active_model(
+            agent, "vision_analyze", result
+        )
+        assert isinstance(content, str)
+        assert "red stop sign" in content
+        assert agent._pending_tool_image_parts is None
+
+    def test_non_vision_model_gets_text_summary_without_deferral(self):
+        agent = _make_agent(vision=False)
+        result = _tool_result()
+        content = AIAgent._tool_result_content_for_active_model(
+            agent, "vision_analyze", result
+        )
+        assert isinstance(content, str)
+        assert agent._pending_tool_image_parts is None
+
+
+class TestAppendPendingToolImagesAsUserMessage:
+    def test_appends_user_message_and_clears_pending(self):
+        agent = _make_agent()
+        image_part = {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}
+        agent._pending_tool_image_parts = [image_part]
+        messages: list = []
+        AIAgent._append_pending_tool_images_as_user_message(agent, messages)
+        assert len(messages) == 1
+        msg = messages[0]
+        assert msg["role"] == "user"
+        assert msg["content"][0]["type"] == "text"
+        assert msg["content"][1] is image_part
+        assert agent._pending_tool_image_parts is None
+
+    def test_no_pending_is_noop(self):
+        agent = _make_agent()
+        messages: list = [{"role": "user", "content": "hi"}]
+        AIAgent._append_pending_tool_images_as_user_message(agent, messages)
+        assert len(messages) == 1

--- a/tests/run_agent/test_vision_tool_messages.py
+++ b/tests/run_agent/test_vision_tool_messages.py
@@ -40,6 +40,7 @@ def _make_agent(provider="openrouter", model="gpt-4o"):
     agent._content_has_image_parts = _real_content_has_image_parts
     agent._model_supports_vision = lambda: AIAgent._model_supports_vision(agent)
     agent._provider_supports_vision_tool_messages = lambda: AIAgent._provider_supports_vision_tool_messages(agent)
+    agent._provider_supports_vision_user_messages = lambda: AIAgent._provider_supports_vision_user_messages(agent)
     agent._tool_result_content_for_active_model = (
         lambda name, result: AIAgent._tool_result_content_for_active_model(agent, name, result)
     )


### PR DESCRIPTION
**DISCLAIMER: This PR is purely AI generated (DeepSeek V4 Flash).**

## Problem

`vision_analyze` — and every other tool returning native image parts — crashes with an HTTP 400 (`Upstream request failed: [400] Provider returned error`) for vision-capable models running through the **opencode-go / Console Go** gateway. The provider rejects `image_url` parts inside **tool-role** messages, even though it accepts multimodal **user** messages.

In practice this killed Kanban worker tasks that hit native vision on this provider: the worker died as `protocol_violation` with no actionable error surfaced.

## Root cause

- `run_agent._tool_result_content_for_active_model` embeds image parts directly in the tool-role message for vision-capable models (the "native vision fast path").
- `_provider_supports_vision_tool_messages()` defaults to `True`; the `opencode-go` profile never declared otherwise → raw `image_url` parts were sent inside tool messages → Console Go HTTP 400.
- The existing workaround (`_multimodal_text_summary`) downgrades the image to a text summary, silently defeating native vision.

## Fix

1. **`plugins/model-providers/opencode-zen/__init__.py`** — declare `supports_vision_tool_messages=False` for `opencode-go` (Console Go rejects image parts in tool-role messages, verified 2026-08-08) **and** `supports_vision_user_messages=True` (it accepts multimodal user messages).
2. **`providers/base.py`** — new `ProviderProfile.supports_vision_user_messages` field (default `False`). It distinguishes "rejects image parts in tool messages, accepts multimodal user messages" (Console Go → defer) from "rejects list-type tool content entirely" (Xiaomi MiMo → keep text-summary downgrade). Behavior for all existing providers is unchanged.
3. **`run_agent.py`** — when the provider is in the deferral category and the model is vision-capable:
   - keep the text parts in the tool message,
   - defer the `image_url` / `input_image` parts to `self._pending_tool_image_parts`,
   - `_append_pending_tool_images_as_user_message()` appends them as a **user-role message after the whole tool batch** (preserving strict role alternation `tool..tool → user`).
4. **`agent/conversation_loop.py`** — call the append right after tool execution completes.

Why this approach: vision-capable models keep native pixels (no quality loss vs. text summary) without violating role alternation; providers that can't take multimodal user messages keep the safe, battle-tested text-summary path.

## Verification

- **E2E (real provider):** `mimo-v2.5` via Console Go + `vision_analyze` on a screenshot → the model returns pixel-level details (hex colors). Before this PR: HTTP 400 on every call.
- **Tests:** new `tests/run_agent/test_console_go_tool_image_deferral.py` (8 tests) covering the deferral contract including `input_image` parts, the Xiaomi-style fallback, and the pass-through path. All affected suites green (32 tests) — existing Xiaomi/vision-tool behavior is unchanged and still pinned by its tests.

## How to test

1. Configure the `opencode-go` provider with `OPENCODE_GO_API_KEY` and a vision-capable model (e.g. `mimo-v2.5`), `image_input_mode: native`.
2. Attach a screenshot and ask, e.g. `Describe the exact colors in this screenshot` (triggers `vision_analyze`).
3. Expected: the model answers with pixel-level detail. Before this PR: `HTTP 400 Upstream request failed: [400] Provider returned error`.
4. Regression: `pytest tests/run_agent/test_console_go_tool_image_deferral.py tests/run_agent/test_vision_tool_messages.py tests/run_agent/test_multimodal_tool_content_recovery.py -q` → all green.

## Checklist

### Code

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] Conventional commit (`fix(providers): ...`)
- [x] Searched existing PRs — no duplicate
- [x] PR contains only changes related to this fix
- [x] `pytest` on the affected suites passes
- [x] Tests added for the fix (new deferral-contract tests + fixture binding in the existing vision-tool-messages test)

### Documentation & Housekeeping

- [x] Tool descriptions/schemas unchanged (no tool-layer behavior change)
- [x] `cli-config.yaml.example` — N/A (no new config keys)
- [x] Cross-platform — pure Python, no platform-specific code
- [x] I've read the Contributing Guide

## Related issue

No GitHub issue — reported from a real deployment (Kanban workers dying as `protocol_violation` on Console Go 400s; provider ping + model override were already correct, the 400 was the root cause).
