### PR TITLE
fix(desktop): start voice TTS from live assistant deltas

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice-stream-subscription.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice-stream-subscription.test.tsx
@@ -1,0 +1,105 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, expect, test, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+  let value: unknown[] = []
+  const listeners = new Set<(next: unknown[], old: unknown[]) => void>()
+
+  const messages = {
+    get: () => value,
+    listen: (listener: (next: unknown[], old: unknown[]) => void) => {
+      listeners.add(listener)
+
+      return () => listeners.delete(listener)
+    },
+    set: (next: unknown[]) => {
+      const old = value
+      value = next
+      listeners.forEach(listener => listener(next, old))
+    },
+    subscribe: (listener: (next: unknown[], old: unknown[]) => void) => {
+      listeners.add(listener)
+      listener(value, value)
+
+      return () => listeners.delete(listener)
+    }
+  }
+
+  const useVoiceConversation = vi.fn(() => ({
+    end: vi.fn(async () => undefined),
+    level: 0,
+    muted: false,
+    start: vi.fn(async () => undefined),
+    status: 'idle' as const,
+    stopTurn: vi.fn(),
+    toggleMute: vi.fn()
+  }))
+
+  return { messages, useVoiceConversation }
+})
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      assistant: { thread: { readAloudFailed: 'read aloud failed' } },
+      notifications: { voice: { sayStopToEnd: (phrase: string) => phrase } },
+      settings: { config: { autosaveFailed: 'autosave failed' } }
+    }
+  })
+}))
+vi.mock('../scope', () => ({ useComposerScope: () => ({ $messages: mocks.messages }) }))
+vi.mock('./use-voice-conversation', () => ({ useVoiceConversation: mocks.useVoiceConversation }))
+vi.mock('./use-voice-recorder', () => ({
+  useVoiceRecorder: () => ({ dictate: vi.fn(), voiceActivityState: null, voiceStatus: 'idle' })
+}))
+vi.mock('./use-auto-speak-replies', () => ({ useAutoSpeakReplies: vi.fn() }))
+vi.mock('@/lib/haptics', () => ({ triggerHaptic: vi.fn() }))
+vi.mock('@/lib/wake-indicator', () => ({
+  clearWakeIndicator: vi.fn(),
+  syncWakeIndicatorWithVoice: vi.fn(() => false)
+}))
+vi.mock('@/store/ambient', () => ({ ownsAmbientCue: vi.fn(async () => true) }))
+vi.mock('@/store/notifications', () => ({ notify: vi.fn(), notifyError: vi.fn() }))
+vi.mock('@/store/wake-word', () => ({
+  resumeWakeAfterVoice: vi.fn(async () => undefined),
+  stopClientCapture: vi.fn(async () => undefined)
+}))
+
+import { useComposerVoice } from './use-composer-voice'
+
+beforeEach(() => {
+  mocks.messages.set([])
+  mocks.useVoiceConversation.mockClear()
+})
+
+test('re-renders the voice loop when an in-progress assistant delta lands', () => {
+  renderHook(() =>
+    useComposerVoice({
+      busy: true,
+      clearDraft: vi.fn(),
+      disabled: false,
+      focusInput: vi.fn(),
+      insertText: vi.fn(),
+      maxRecordingSeconds: 60,
+      onSubmit: vi.fn(async () => true),
+      onTranscribeAudio: vi.fn(async () => ''),
+      sessionId: 'voice-session',
+      target: 'main'
+    })
+  )
+
+  const callsBeforeDelta = mocks.useVoiceConversation.mock.calls.length
+
+  act(() => {
+    mocks.messages.set([
+      {
+        id: 'assistant-stream',
+        pending: true,
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'Natural selection is' }]
+      }
+    ])
+  })
+
+  expect(mocks.useVoiceConversation.mock.calls.length).toBeGreaterThan(callsBeforeDelta)
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice-stream-subscription.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice-stream-subscription.test.tsx
@@ -1,29 +1,9 @@
 import { act, renderHook } from '@testing-library/react'
 import { beforeEach, expect, test, vi } from 'vitest'
 
-const mocks = vi.hoisted(() => {
-  let value: unknown[] = []
-  const listeners = new Set<(next: unknown[], old: unknown[]) => void>()
-
-  const messages = {
-    get: () => value,
-    listen: (listener: (next: unknown[], old: unknown[]) => void) => {
-      listeners.add(listener)
-
-      return () => listeners.delete(listener)
-    },
-    set: (next: unknown[]) => {
-      const old = value
-      value = next
-      listeners.forEach(listener => listener(next, old))
-    },
-    subscribe: (listener: (next: unknown[], old: unknown[]) => void) => {
-      listeners.add(listener)
-      listener(value, value)
-
-      return () => listeners.delete(listener)
-    }
-  }
+const mocks = await vi.hoisted(async () => {
+  const { atom } = await import('nanostores')
+  const messages = atom<unknown[]>([])
 
   const useVoiceConversation = vi.fn(() => ({
     end: vi.fn(async () => undefined),
@@ -72,7 +52,7 @@ beforeEach(() => {
   mocks.useVoiceConversation.mockClear()
 })
 
-test('re-renders the voice loop when an in-progress assistant delta lands', () => {
+test('re-renders once when an in-progress assistant reply first becomes speakable', () => {
   renderHook(() =>
     useComposerVoice({
       busy: true,
@@ -101,5 +81,19 @@ test('re-renders the voice loop when an in-progress assistant delta lands', () =
     ])
   })
 
-  expect(mocks.useVoiceConversation.mock.calls.length).toBeGreaterThan(callsBeforeDelta)
+  const callsAfterFirstDelta = mocks.useVoiceConversation.mock.calls.length
+  expect(callsAfterFirstDelta).toBeGreaterThan(callsBeforeDelta)
+
+  act(() => {
+    mocks.messages.set([
+      {
+        id: 'assistant-stream',
+        pending: true,
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'Natural selection is the differential survival.' }]
+      }
+    ])
+  })
+
+  expect(mocks.useVoiceConversation).toHaveBeenCalledTimes(callsAfterFirstDelta)
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
@@ -61,6 +61,11 @@ export function useComposerVoice({
   const { t } = useI18n()
   // A tile's composer speaks ITS transcript, not the primary chat's.
   const { $messages } = useComposerScope()
+  // Voice conversation speech is driven by in-progress assistant deltas. Keep
+  // this hook subscribed so its speech effect runs before busy flips false;
+  // pendingTurnResponse still reads $messages.get() so the 150 ms feeder sees
+  // every later delta instead of a stale render-time snapshot.
+  useStore($messages)
   const [voiceConversationActive, setVoiceConversationActive] = useState(false)
   const lastSpokenIdRef = useRef<string | null>(null)
   const ownsWakeIndicatorRef = useRef(false)

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
@@ -1,5 +1,6 @@
 import { useStore } from '@nanostores/react'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { computed } from 'nanostores'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { useI18n } from '@/i18n'
 import { chatMessageText, collectUnspokenTurnSpeech } from '@/lib/chat-messages'
@@ -61,11 +62,25 @@ export function useComposerVoice({
   const { t } = useI18n()
   // A tile's composer speaks ITS transcript, not the primary chat's.
   const { $messages } = useComposerScope()
-  // Voice conversation speech is driven by in-progress assistant deltas. Keep
-  // this hook subscribed so its speech effect runs before busy flips false;
-  // pendingTurnResponse still reads $messages.get() so the 150 ms feeder sees
-  // every later delta instead of a stale render-time snapshot.
-  useStore($messages)
+
+  // Wake the voice loop once when a pending reply first becomes speakable,
+  // without re-rendering the composer for every streamed token. The live
+  // speech feeder still reads $messages.get() every 150 ms for later deltas.
+  const $pendingVoiceReplyId = useMemo(
+    () =>
+      computed($messages, messages => {
+        const last = messages.findLast(message => message.role === 'assistant' && !message.hidden)
+
+        if (!last?.pending || !chatMessageText(last).trim()) {
+          return null
+        }
+
+        return last.id
+      }),
+    [$messages]
+  )
+
+  useStore($pendingVoiceReplyId)
   const [voiceConversationActive, setVoiceConversationActive] = useState(false)
   const lastSpokenIdRef = useRef<string | null>(null)
   const ownsWakeIndicatorRef = useRef(false)


### PR DESCRIPTION
## Summary

- subscribe the composer voice hook to its scoped assistant message store
- wake the live-speech effect on the first in-progress assistant text delta instead of waiting for another state change at turn completion
- keep the existing live `.get()` selector so the 150 ms feeder sees later deltas rather than a stale snapshot
- add a behavioral regression test that publishes a pending assistant delta while `busy` remains true

## Root cause

Desktop already has a per-reply `startSpeechStream()` path and a live feeder. However, `useComposerVoice()` only read `$messages.get()`; it did not subscribe to `$messages`. During a normal model turn, the hook therefore did not rerender as assistant text streamed. The speech session typically opened only when `busy` changed at turn completion, making most or all reply text render before TTS began.

This change adds the missing scoped-message subscription. It does not alter provider selection, sentence buffering, Markdown sanitization, barge-in, or final fallback behavior.

## Reproduction

1. Start a Desktop voice conversation with a streaming TTS provider.
2. Ask for a multi-sentence model-generated explanation.
3. Observe assistant text stream into the bubble.
4. Before this patch, `speak-stream` begins only after the model turn completes.
5. With this patch, the first pending assistant text delta rerenders the voice loop, allowing the existing safe-sentence streamer to overlap speech with generation.

## Verification

- `vitest`: 12 focused composer/voice-conversation tests passed
- changed-file ESLint passed with zero warnings
- Desktop TypeScript typecheck passed
- production Desktop renderer/Electron build passed

Refs #38386