### PR TITLE
fix(file_operations): handle UTF-8 truncation artifact in binary detection

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -328,8 +328,38 @@ class TestShellFileOpsHelpers:
         assert file_ops._is_likely_binary("code.py") is False
         assert file_ops._is_likely_binary("readme.md") is False
 
+    def test_is_likely_binary_utf8_truncation_artifact(self, file_ops):
+        """Single trailing U+FFFD from head -c N splitting a multi-byte char
+        must NOT be treated as binary.  This is a regression test for the
+        false-positive that caused UTF-8 text files (e.g. CJK .md notes) to
+        be misclassified as binary when the 1000-byte sample boundary landed
+        inside a multi-byte character."""
+        text_with_trailing_fffd = "你好世界\n" * 100 + "\ufffd"
+        assert file_ops._is_likely_binary("notes.md", text_with_trailing_fffd) is False
 
-    def test_cwd_fallback_to_slash(self):
+    def test_is_likely_binary_multiple_fffd_is_binary(self, file_ops):
+        """Multiple U+FFFD scattered throughout the sample indicates real
+        binary/non-UTF-8 content and should still be caught."""
+        binary_like = "hello\ufffdworld\ufffdtest"
+        assert file_ops._is_likely_binary("data.bin", binary_like) is True
+
+    def test_is_likely_binary_fffd_mid_sample_is_binary(self, file_ops):
+        """A single U+FFFD in the middle of the sample (not at the truncation
+        boundary) should still be treated as binary."""
+        mid_fffd = "hello world" * 20 + "\ufffd" + "more text" * 20
+        assert file_ops._is_likely_binary("data.bin", mid_fffd) is True
+
+    def test_is_likely_binary_clean_utf8_text(self, file_ops):
+        """Clean UTF-8 text without any FFFD should not be binary."""
+        clean_text = "你好世界\n" * 100
+        assert file_ops._is_likely_binary("notes.md", clean_text) is False
+
+    def test_is_likely_binary_clean_ascii_text(self, file_ops):
+        """Clean ASCII text should not be binary."""
+        clean_text = "hello world\n" * 100
+        assert file_ops._is_likely_binary("notes.txt", clean_text) is False
+
+    def test_cwd_fallback_to_slash(self, mock_env):
         env = MagicMock(spec=[])  # no cwd attribute
         ops = ShellFileOperations(env)
         assert ops.cwd == "/"

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -903,8 +903,22 @@ class ShellFileOperations(FileOperations):
             # sample carries the replacement char as binary (read-only) so the
             # agent can't corrupt it. Legitimate UTF-8 text effectively never
             # contains U+FFFD.
-            if "\ufffd" in content_sample[:1000]:
-                return True
+            #
+            # HOWEVER: head -c N truncates at byte boundary, which can split
+            # a multi-byte UTF-8 character, producing a single trailing U+FFFD
+            # even for perfectly valid text files. We must distinguish this
+            # truncation artifact from real binary content. Strategy: count
+            # U+FFFD occurrences; if only one and it is at the very end of the
+            # sample (within last 3 chars, enough to cover a 4-byte UTF-8 char
+            # split), treat it as a truncation artifact and ignore it.
+            check_sample = content_sample[:1000]
+            fffd_indices = [i for i, c in enumerate(check_sample) if c == "\ufffd"]
+            if fffd_indices:
+                sample_len = len(check_sample)
+                # More than one FFFD, or FFFD not near the end → real binary
+                if len(fffd_indices) > 1 or fffd_indices[-1] < sample_len - 3:
+                    return True
+                # Single trailing FFFD → truncation artifact, skip the check
             non_printable = sum(1 for c in content_sample[:1000]
                                if ord(c) < 32 and c not in '\n\r\t')
             return non_printable / min(len(content_sample), 1000) > 0.30


### PR DESCRIPTION
## Bug Description

UTF-8 text files (especially CJK/emoji content) were being misclassified as binary and blocked from reading via `read_file`. The agent would report:

```
Binary file - cannot display as text. Use appropriate tools to handle this file type.
```

This affected `.md` files, `.txt` files, and any other text file whose content caused the `head -c 1000` sample to end mid-character in a multi-byte UTF-8 sequence.

## Root Cause

`_is_likely_binary()` uses `head -c 1000` to sample the first 1000 bytes of a file, then checks for `U+FFFD` (replacement character) as an indicator of non-UTF-8/binary content. However, `head -c N` truncates at a **byte boundary**, which can split a multi-byte UTF-8 character. The terminal environment decodes stdout with `errors="replace"`, so the split byte becomes a `U+FFFD` — even though the file is perfectly valid UTF-8 text.

The original check treated **any** `U+FFFD` as binary:

```python
if "\ufffd" in content_sample[:1000]:
    return True
```

For CJK text (3 bytes/char) or emoji (4 bytes/char), it is statistically very likely that a 1000-byte boundary will land inside a character, producing exactly one trailing `U+FFFD`.

## Fix

Distinguish truncation artifacts from real binary content:

- **Single trailing `U+FFFD`** (within last 3 chars of sample) → truncation artifact, **ignore**
- **Multiple `U+FFFD`** or **`U+FFFD` not near the end** → real binary/non-UTF-8 content, **block**

The 3-char threshold covers the worst case (a 4-byte UTF-8 character split, leaving up to 3 trailing bytes that decode to 1 `U+FFFD` plus the preceding valid characters).

## How to Verify

1. Create a UTF-8 file with CJK/emoji content: `echo "你好世界🌙" > test.md`
2. Repeat enough to exceed 1000 bytes
3. Run `read_file` — should now succeed instead of reporting binary

## Test Plan

- [x] Added 5 regression tests:
  - `test_is_likely_binary_utf8_truncation_artifact` — single trailing FFFD should NOT be binary
  - `test_is_likely_binary_multiple_fffd_is_binary` — multiple FFFD should still be caught
  - `test_is_likely_binary_fffd_mid_sample_is_binary` — mid-sample FFFD should still be caught
  - `test_is_likely_binary_clean_utf8_text` — clean UTF-8 should pass
  - `test_is_likely_binary_clean_ascii_text` — clean ASCII should pass
- [x] Existing tests still pass (no behavior change for non-FFFD paths)
- [x] Manual verification against real CJK `.md` files confirms fix

## Risk Assessment

**Low** — The change only relaxes the binary detection for a very specific false-positive case (single trailing `U+FFFD`). Real binary content (multiple `U+FFFD` or mid-sample `U+FFFD`) is still correctly blocked. The non-printable ratio check remains unchanged as a secondary guard.