### PR TITLE
fix(plugins): bootstrap plugin secret sources after discovery

### DIFF
--- a/agent/secret_sources/registry.py
+++ b/agent/secret_sources/registry.py
@@ -51,6 +51,11 @@ logger = logging.getLogger(__name__)
 _SOURCES: Dict[str, SecretSource] = {}
 _BUILTINS_LOADED = False
 
+# Canonical names of the deliberately-closed bundled source set. Callers
+# (e.g. the plugin-discovery re-pull) use this to distinguish plugin sources
+# from in-tree ones without hard-coding a list at each call site.
+BUILTIN_SOURCE_NAMES: frozenset = frozenset({"bitwarden", "onepassword"})
+
 
 @dataclass
 class AppliedVar:

--- a/agent/secret_sources/registry.py
+++ b/agent/secret_sources/registry.py
@@ -47,14 +47,11 @@ from agent.secret_sources.base import (
 logger = logging.getLogger(__name__)
 
 # Ordered registry: name → source instance.  Python dicts preserve
-# insertion order, which doubles as the default apply order.
+# insertion order, which doubles as the default apply order. Origin is
+# recorded beside each source so consumers never infer ownership from names.
 _SOURCES: Dict[str, SecretSource] = {}
+_SOURCE_ORIGINS: Dict[str, str] = {}
 _BUILTINS_LOADED = False
-
-# Canonical names of the deliberately-closed bundled source set. Callers
-# (e.g. the plugin-discovery re-pull) use this to distinguish plugin sources
-# from in-tree ones without hard-coding a list at each call site.
-BUILTIN_SOURCE_NAMES: frozenset = frozenset({"bitwarden", "onepassword"})
 
 
 @dataclass
@@ -99,7 +96,12 @@ class ApplyReport:
 # ---------------------------------------------------------------------------
 
 
-def register_source(source: SecretSource, *, replace: bool = False) -> bool:
+def register_source(
+    source: SecretSource,
+    *,
+    replace: bool = False,
+    builtin: bool = False,
+) -> bool:
     """Register a secret source.  Returns True on success.
 
     Rejections are logged, never raised — a bad plugin must not take
@@ -145,6 +147,7 @@ def register_source(source: SecretSource, *, replace: bool = False) -> bool:
                 )
                 return False
     _SOURCES[name] = source
+    _SOURCE_ORIGINS[name] = "builtin" if builtin else "plugin"
     return True
 
 
@@ -156,6 +159,16 @@ def get_source(name: str) -> Optional[SecretSource]:
 def list_sources() -> List[SecretSource]:
     _ensure_builtin_sources()
     return list(_SOURCES.values())
+
+
+def list_plugin_sources() -> List[SecretSource]:
+    """Return sources registered outside the bundled bootstrap set."""
+    _ensure_builtin_sources()
+    return [
+        source
+        for name, source in _SOURCES.items()
+        if _SOURCE_ORIGINS.get(name) == "plugin"
+    ]
 
 
 def _ensure_builtin_sources() -> None:
@@ -171,21 +184,21 @@ def _ensure_builtin_sources() -> None:
     try:
         from agent.secret_sources.bitwarden import BitwardenSource
 
-        register_source(BitwardenSource())
+        register_source(BitwardenSource(), builtin=True)
     except Exception:  # noqa: BLE001 — never block startup
         logger.warning("Failed to register bundled Bitwarden secret source",
                        exc_info=True)
     try:
         from agent.secret_sources.onepassword import OnePasswordSource
 
-        register_source(OnePasswordSource())
+        register_source(OnePasswordSource(), builtin=True)
     except Exception:  # noqa: BLE001 — never block startup
         logger.warning("Failed to register bundled 1Password secret source",
                        exc_info=True)
     try:
         from agent.secret_sources.command import CommandSource
 
-        register_source(CommandSource())
+        register_source(CommandSource(), builtin=True)
     except Exception:  # noqa: BLE001 — never block startup
         logger.warning("Failed to register bundled command secret source",
                        exc_info=True)
@@ -194,6 +207,7 @@ def _ensure_builtin_sources() -> None:
 def _reset_registry_for_tests() -> None:
     global _BUILTINS_LOADED
     _SOURCES.clear()
+    _SOURCE_ORIGINS.clear()
     _BUILTINS_LOADED = False
 
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -859,15 +859,12 @@ class PluginContext:
         ordering, mapped-vs-bulk precedence, conflict warnings, and
         provenance; the source only fetches.
 
-        NOTE ON TIMING: plugin discovery happens later in startup than
-        the first ``load_hermes_dotenv()`` call, so a plugin-registered
-        source is not consulted by the initial env load of the process
-        that discovers it.  It IS consulted by every subsequently
-        spawned Hermes process (gateway children, cron sessions,
-        subagents), and immediately after a
-        ``reset_secret_source_cache()`` re-pull.  Plugin sources are
-        therefore best for supplying credentials to the running fleet;
-        the bundled sources cover first-process bootstrap.
+        NOTE ON TIMING: ``load_hermes_dotenv()`` usually runs at import
+        *before* plugin discovery.  After discovery completes, the plugin
+        manager re-pulls enabled plugin secret sources (``reset_secret_source_cache``
+        + ``load_hermes_dotenv``) so the first process sees them (#64177).
+        Child processes that load env after plugins still work without that
+        re-pull.  Failed re-pulls never block startup.
 
         Contract requirements (rejected with a warning otherwise):
         inherit from ``SecretSource``, ``api_version`` matching
@@ -1373,9 +1370,63 @@ class PluginManager:
         self._discovered = True
         try:
             self._discover_and_load_inner()
+            # Plugin secret sources register during discover; the initial
+            # load_hermes_dotenv() already ran at import time. Re-pull so the
+            # first process sees plugin backends (tracking #64177).
+            self._refresh_secret_sources_after_discovery()
         except BaseException:
             self._discovered = False
             raise
+
+    def _refresh_secret_sources_after_discovery(self) -> None:
+        """If any non-bundled secret source is enabled, reset cache and re-apply.
+
+        No-op when only built-in sources exist or no secrets config is enabled.
+        Fail-open: never raise into discover_and_load.
+        """
+        try:
+            from agent.secret_sources.registry import list_sources
+            from hermes_cli.env_loader import load_hermes_dotenv, reset_secret_source_cache
+        except Exception:
+            return
+        try:
+            sources = list_sources()
+        except Exception:
+            return
+        builtin = {"bitwarden", "onepassword", "1password"}
+        plugin_names = [
+            getattr(s, "name", "") for s in sources if getattr(s, "name", "") not in builtin
+        ]
+        if not plugin_names:
+            return
+        # Only re-pull when at least one plugin source appears enabled in config.
+        try:
+            from hermes_cli.config import load_config
+
+            cfg = load_config() or {}
+            secrets = cfg.get("secrets") or {}
+        except Exception:
+            secrets = {}
+        enabled_plugin = False
+        for name in plugin_names:
+            section = secrets.get(name)
+            if isinstance(section, dict) and section.get("enabled"):
+                enabled_plugin = True
+                break
+            if section is True:
+                enabled_plugin = True
+                break
+        if not enabled_plugin:
+            return
+        try:
+            reset_secret_source_cache()
+            load_hermes_dotenv()
+            logger.debug(
+                "Re-applied secret sources after plugin discovery for: %s",
+                ", ".join(sorted(plugin_names)),
+            )
+        except Exception as exc:
+            logger.debug("secret source re-apply after discovery failed: %s", exc)
 
     def _discover_and_load_inner(self) -> None:
         """The actual discovery sweep — see :meth:`discover_and_load`."""

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1390,20 +1390,14 @@ class PluginManager:
         Fail-open: never raise into discover_and_load.
         """
         try:
-            from agent.secret_sources.registry import (
-                BUILTIN_SOURCE_NAMES,
-                list_sources,
-            )
+            from agent.secret_sources.registry import list_plugin_sources
             from hermes_cli.env_loader import load_hermes_dotenv, reset_secret_source_cache
         except Exception:
             return
         try:
-            sources = list_sources()
+            plugin_sources = list_plugin_sources()
         except Exception:
             return
-        plugin_sources = [
-            s for s in sources if getattr(s, "name", "") not in BUILTIN_SOURCE_NAMES
-        ]
         if not plugin_sources:
             return
         # Load the secrets config once; hand each source its own section and

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1379,13 +1379,21 @@ class PluginManager:
             raise
 
     def _refresh_secret_sources_after_discovery(self) -> None:
-        """If any non-bundled secret source is enabled, reset cache and re-apply.
+        """If any plugin secret source is enabled, reset cache and re-apply.
 
-        No-op when only built-in sources exist or no secrets config is enabled.
+        Enablement is delegated to each source's ``is_enabled(cfg)`` — the
+        same contract the orchestrator uses (``registry._ordered_enabled_sources``)
+        — so a source with custom activation logic is honored, not just
+        ``secrets.<name>.enabled``.
+
+        No-op when only bundled sources exist or none are enabled.
         Fail-open: never raise into discover_and_load.
         """
         try:
-            from agent.secret_sources.registry import list_sources
+            from agent.secret_sources.registry import (
+                BUILTIN_SOURCE_NAMES,
+                list_sources,
+            )
             from hermes_cli.env_loader import load_hermes_dotenv, reset_secret_source_cache
         except Exception:
             return
@@ -1393,13 +1401,13 @@ class PluginManager:
             sources = list_sources()
         except Exception:
             return
-        builtin = {"bitwarden", "onepassword", "1password"}
-        plugin_names = [
-            getattr(s, "name", "") for s in sources if getattr(s, "name", "") not in builtin
+        plugin_sources = [
+            s for s in sources if getattr(s, "name", "") not in BUILTIN_SOURCE_NAMES
         ]
-        if not plugin_names:
+        if not plugin_sources:
             return
-        # Only re-pull when at least one plugin source appears enabled in config.
+        # Load the secrets config once; hand each source its own section and
+        # let its is_enabled() decide (honours custom activation extensions).
         try:
             from hermes_cli.config import load_config
 
@@ -1407,23 +1415,26 @@ class PluginManager:
             secrets = cfg.get("secrets") or {}
         except Exception:
             secrets = {}
-        enabled_plugin = False
-        for name in plugin_names:
+        enabled_names = []
+        for source in plugin_sources:
+            name = getattr(source, "name", "")
             section = secrets.get(name)
-            if isinstance(section, dict) and section.get("enabled"):
-                enabled_plugin = True
-                break
-            if section is True:
-                enabled_plugin = True
-                break
-        if not enabled_plugin:
+            section = section if isinstance(section, dict) else {}
+            try:
+                if source.is_enabled(section):
+                    enabled_names.append(name)
+            except Exception:
+                # A source whose is_enabled() raises is skipped, mirroring
+                # the orchestrator's defensive posture.
+                continue
+        if not enabled_names:
             return
         try:
             reset_secret_source_cache()
             load_hermes_dotenv()
             logger.debug(
                 "Re-applied secret sources after plugin discovery for: %s",
-                ", ".join(sorted(plugin_names)),
+                ", ".join(sorted(enabled_names)),
             )
         except Exception as exc:
             logger.debug("secret source re-apply after discovery failed: %s", exc)

--- a/tests/hermes_cli/test_secret_source_bootstrap.py
+++ b/tests/hermes_cli/test_secret_source_bootstrap.py
@@ -1,0 +1,84 @@
+"""Tests for plugin secret-source first-process re-pull (#64177)."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from hermes_cli.plugins import PluginManager
+
+
+def test_refresh_secret_sources_noop_without_plugin_sources(monkeypatch):
+    mgr = PluginManager()
+    called = {"reset": 0, "load": 0}
+
+    def _list():
+        return []
+
+    monkeypatch.setattr(
+        "agent.secret_sources.registry.list_sources", _list, raising=False
+    )
+    import agent.secret_sources.registry as reg
+
+    monkeypatch.setattr(reg, "list_sources", _list)
+
+    def _boom_reset():
+        called["reset"] += 1
+
+    def _boom_load(**kwargs):
+        called["load"] += 1
+
+    monkeypatch.setattr(
+        "hermes_cli.env_loader.reset_secret_source_cache", _boom_reset
+    )
+    monkeypatch.setattr("hermes_cli.env_loader.load_hermes_dotenv", _boom_load)
+
+    mgr._refresh_secret_sources_after_discovery()
+    assert called["reset"] == 0
+    assert called["load"] == 0
+
+
+def test_refresh_secret_sources_repulls_when_plugin_enabled(monkeypatch):
+    mgr = PluginManager()
+    called = {"reset": 0, "load": 0}
+
+    class _Src:
+        name = "myvault"
+
+    import agent.secret_sources.registry as reg
+
+    monkeypatch.setattr(reg, "list_sources", lambda: [_Src()])
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"secrets": {"myvault": {"enabled": True}}},
+    )
+
+    def _reset():
+        called["reset"] += 1
+
+    def _load(**kwargs):
+        called["load"] += 1
+
+    monkeypatch.setattr(
+        "hermes_cli.env_loader.reset_secret_source_cache", _reset
+    )
+    monkeypatch.setattr("hermes_cli.env_loader.load_hermes_dotenv", _load)
+
+    mgr._refresh_secret_sources_after_discovery()
+    assert called["reset"] == 1
+    assert called["load"] == 1
+
+
+def test_discover_and_load_invokes_refresh(monkeypatch):
+    mgr = PluginManager()
+    hits = {"n": 0}
+    monkeypatch.setattr(PluginManager, "_discover_and_load_inner", lambda self: None)
+    monkeypatch.setattr(
+        PluginManager,
+        "_refresh_secret_sources_after_discovery",
+        lambda self: hits.__setitem__("n", hits["n"] + 1),
+    )
+    mgr.discover_and_load()
+    assert hits["n"] == 1

--- a/tests/hermes_cli/test_secret_source_bootstrap.py
+++ b/tests/hermes_cli/test_secret_source_bootstrap.py
@@ -2,73 +2,186 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 
+from agent.secret_sources.base import (
+    SECRET_SOURCE_API_VERSION,
+    FetchResult,
+    SecretSource,
+)
 from hermes_cli.plugins import PluginManager
+
+
+class _StubSource(SecretSource):
+    """Minimal spec-compliant plugin source for tests."""
+
+    api_version = SECRET_SOURCE_API_VERSION
+    shape = "bulk"
+
+    def __init__(self, name: str = "myvault", scheme: str | None = None):
+        self.name = name
+        self.scheme = scheme
+
+    def fetch(self, cfg: dict, home_path: Path) -> FetchResult:
+        return FetchResult(secrets={})
+
+
+class _CustomActivationSource(_StubSource):
+    """Ignores ``enabled`` and activates when a custom key is present."""
+
+    def is_enabled(self, cfg: dict) -> bool:
+        return bool(isinstance(cfg, dict) and cfg.get("vault_id"))
 
 
 def test_refresh_secret_sources_noop_without_plugin_sources(monkeypatch):
     mgr = PluginManager()
     called = {"reset": 0, "load": 0}
 
-    def _list():
-        return []
-
-    monkeypatch.setattr(
-        "agent.secret_sources.registry.list_sources", _list, raising=False
-    )
     import agent.secret_sources.registry as reg
 
-    monkeypatch.setattr(reg, "list_sources", _list)
-
-    def _boom_reset():
-        called["reset"] += 1
-
-    def _boom_load(**kwargs):
-        called["load"] += 1
-
+    monkeypatch.setattr(reg, "list_sources", lambda: [])
     monkeypatch.setattr(
-        "hermes_cli.env_loader.reset_secret_source_cache", _boom_reset
+        "hermes_cli.env_loader.reset_secret_source_cache",
+        lambda: called.__setitem__("reset", called["reset"] + 1),
     )
-    monkeypatch.setattr("hermes_cli.env_loader.load_hermes_dotenv", _boom_load)
+    monkeypatch.setattr(
+        "hermes_cli.env_loader.load_hermes_dotenv",
+        lambda **kw: called.__setitem__("load", called["load"] + 1),
+    )
 
     mgr._refresh_secret_sources_after_discovery()
-    assert called["reset"] == 0
-    assert called["load"] == 0
+    assert called == {"reset": 0, "load": 0}
+
+
+def test_refresh_secret_sources_noop_when_only_builtins(monkeypatch):
+    """Bundled sources must never trigger a re-pull."""
+    mgr = PluginManager()
+    called = {"reset": 0, "load": 0}
+
+    import agent.secret_sources.registry as reg
+
+    monkeypatch.setattr(
+        reg, "list_sources", lambda: [_StubSource(name="bitwarden")]
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"secrets": {"bitwarden": {"enabled": True}}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.env_loader.reset_secret_source_cache",
+        lambda: called.__setitem__("reset", called["reset"] + 1),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.env_loader.load_hermes_dotenv",
+        lambda **kw: called.__setitem__("load", called["load"] + 1),
+    )
+
+    mgr._refresh_secret_sources_after_discovery()
+    assert called == {"reset": 0, "load": 0}
 
 
 def test_refresh_secret_sources_repulls_when_plugin_enabled(monkeypatch):
     mgr = PluginManager()
     called = {"reset": 0, "load": 0}
 
-    class _Src:
-        name = "myvault"
-
     import agent.secret_sources.registry as reg
 
-    monkeypatch.setattr(reg, "list_sources", lambda: [_Src()])
-
+    monkeypatch.setattr(reg, "list_sources", lambda: [_StubSource()])
     monkeypatch.setattr(
         "hermes_cli.config.load_config",
         lambda: {"secrets": {"myvault": {"enabled": True}}},
     )
-
-    def _reset():
-        called["reset"] += 1
-
-    def _load(**kwargs):
-        called["load"] += 1
-
     monkeypatch.setattr(
-        "hermes_cli.env_loader.reset_secret_source_cache", _reset
+        "hermes_cli.env_loader.reset_secret_source_cache",
+        lambda: called.__setitem__("reset", called["reset"] + 1),
     )
-    monkeypatch.setattr("hermes_cli.env_loader.load_hermes_dotenv", _load)
+    monkeypatch.setattr(
+        "hermes_cli.env_loader.load_hermes_dotenv",
+        lambda **kw: called.__setitem__("load", called["load"] + 1),
+    )
 
     mgr._refresh_secret_sources_after_discovery()
-    assert called["reset"] == 1
-    assert called["load"] == 1
+    assert called == {"reset": 1, "load": 1}
+
+
+def test_refresh_respects_custom_is_enabled(monkeypatch):
+    """A source with custom activation (no ``enabled`` key) is re-pulled."""
+    mgr = PluginManager()
+    called = {"reset": 0, "load": 0}
+
+    import agent.secret_sources.registry as reg
+
+    monkeypatch.setattr(reg, "list_sources", lambda: [_CustomActivationSource()])
+    # No `enabled` key at all — only the source's custom contract decides.
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"secrets": {"myvault": {"vault_id": "abc123"}}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.env_loader.reset_secret_source_cache",
+        lambda: called.__setitem__("reset", called["reset"] + 1),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.env_loader.load_hermes_dotenv",
+        lambda **kw: called.__setitem__("load", called["load"] + 1),
+    )
+
+    mgr._refresh_secret_sources_after_discovery()
+    assert called == {"reset": 1, "load": 1}
+
+
+def test_refresh_skips_custom_source_when_not_activated(monkeypatch):
+    mgr = PluginManager()
+    called = {"reset": 0, "load": 0}
+
+    import agent.secret_sources.registry as reg
+
+    monkeypatch.setattr(reg, "list_sources", lambda: [_CustomActivationSource()])
+    # `enabled: true` but the custom contract ignores it and requires vault_id.
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"secrets": {"myvault": {"enabled": True}}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.env_loader.reset_secret_source_cache",
+        lambda: called.__setitem__("reset", called["reset"] + 1),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.env_loader.load_hermes_dotenv",
+        lambda **kw: called.__setitem__("load", called["load"] + 1),
+    )
+
+    mgr._refresh_secret_sources_after_discovery()
+    assert called == {"reset": 0, "load": 0}
+
+
+def test_refresh_skips_source_whose_is_enabled_raises(monkeypatch):
+    mgr = PluginManager()
+    called = {"reset": 0, "load": 0}
+
+    class _Boom(_StubSource):
+        def is_enabled(self, cfg: dict) -> bool:
+            raise RuntimeError("boom")
+
+    import agent.secret_sources.registry as reg
+
+    monkeypatch.setattr(reg, "list_sources", lambda: [_Boom()])
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"secrets": {"myvault": {"enabled": True}}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.env_loader.reset_secret_source_cache",
+        lambda: called.__setitem__("reset", called["reset"] + 1),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.env_loader.load_hermes_dotenv",
+        lambda **kw: called.__setitem__("load", called["load"] + 1),
+    )
+
+    mgr._refresh_secret_sources_after_discovery()
+    assert called == {"reset": 0, "load": 0}
 
 
 def test_discover_and_load_invokes_refresh(monkeypatch):
@@ -82,3 +195,37 @@ def test_discover_and_load_invokes_refresh(monkeypatch):
     )
     mgr.discover_and_load()
     assert hits["n"] == 1
+
+
+def test_real_plugin_source_discovery_applies_dotenv(monkeypatch, tmp_path):
+    """End-to-end: a real plugin source registered via discovery triggers a
+    re-pull that flows through the registry's is_enabled contract."""
+    import agent.secret_sources.registry as reg
+
+    reg._reset_registry_for_tests()
+
+    # Register a real plugin source the way PluginContext.register_secret_source
+    # would (lands in registry.register_source).
+    plugin_source = _StubSource(name="tmpvault", scheme="tmpvault")
+    assert reg.register_source(plugin_source) is True
+    assert any(getattr(s, "name", "") == "tmpvault" for s in reg.list_sources())
+
+    applied = {"reset": 0, "load": 0}
+    monkeypatch.setattr(
+        "hermes_cli.env_loader.reset_secret_source_cache",
+        lambda: applied.__setitem__("reset", applied["reset"] + 1),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.env_loader.load_hermes_dotenv",
+        lambda **kw: applied.__setitem__("load", applied["load"] + 1),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"secrets": {"tmpvault": {"enabled": True}}},
+    )
+
+    mgr = PluginManager()
+    mgr._refresh_secret_sources_after_discovery()
+
+    assert applied == {"reset": 1, "load": 1}
+    reg._reset_registry_for_tests()

--- a/tests/hermes_cli/test_secret_source_bootstrap.py
+++ b/tests/hermes_cli/test_secret_source_bootstrap.py
@@ -1,9 +1,8 @@
 """Tests for plugin secret-source first-process re-pull (#64177)."""
 from __future__ import annotations
 
+import os
 from pathlib import Path
-
-import pytest
 
 from agent.secret_sources.base import (
     SECRET_SOURCE_API_VERSION,
@@ -40,7 +39,7 @@ def test_refresh_secret_sources_noop_without_plugin_sources(monkeypatch):
 
     import agent.secret_sources.registry as reg
 
-    monkeypatch.setattr(reg, "list_sources", lambda: [])
+    monkeypatch.setattr(reg, "list_plugin_sources", lambda: [])
     monkeypatch.setattr(
         "hermes_cli.env_loader.reset_secret_source_cache",
         lambda: called.__setitem__("reset", called["reset"] + 1),
@@ -61,9 +60,8 @@ def test_refresh_secret_sources_noop_when_only_builtins(monkeypatch):
 
     import agent.secret_sources.registry as reg
 
-    monkeypatch.setattr(
-        reg, "list_sources", lambda: [_StubSource(name="bitwarden")]
-    )
+    reg._reset_registry_for_tests()
+    assert reg.list_plugin_sources() == []
     monkeypatch.setattr(
         "hermes_cli.config.load_config",
         lambda: {"secrets": {"bitwarden": {"enabled": True}}},
@@ -87,7 +85,7 @@ def test_refresh_secret_sources_repulls_when_plugin_enabled(monkeypatch):
 
     import agent.secret_sources.registry as reg
 
-    monkeypatch.setattr(reg, "list_sources", lambda: [_StubSource()])
+    monkeypatch.setattr(reg, "list_plugin_sources", lambda: [_StubSource()])
     monkeypatch.setattr(
         "hermes_cli.config.load_config",
         lambda: {"secrets": {"myvault": {"enabled": True}}},
@@ -112,7 +110,9 @@ def test_refresh_respects_custom_is_enabled(monkeypatch):
 
     import agent.secret_sources.registry as reg
 
-    monkeypatch.setattr(reg, "list_sources", lambda: [_CustomActivationSource()])
+    monkeypatch.setattr(
+        reg, "list_plugin_sources", lambda: [_CustomActivationSource()]
+    )
     # No `enabled` key at all — only the source's custom contract decides.
     monkeypatch.setattr(
         "hermes_cli.config.load_config",
@@ -137,7 +137,9 @@ def test_refresh_skips_custom_source_when_not_activated(monkeypatch):
 
     import agent.secret_sources.registry as reg
 
-    monkeypatch.setattr(reg, "list_sources", lambda: [_CustomActivationSource()])
+    monkeypatch.setattr(
+        reg, "list_plugin_sources", lambda: [_CustomActivationSource()]
+    )
     # `enabled: true` but the custom contract ignores it and requires vault_id.
     monkeypatch.setattr(
         "hermes_cli.config.load_config",
@@ -166,7 +168,7 @@ def test_refresh_skips_source_whose_is_enabled_raises(monkeypatch):
 
     import agent.secret_sources.registry as reg
 
-    monkeypatch.setattr(reg, "list_sources", lambda: [_Boom()])
+    monkeypatch.setattr(reg, "list_plugin_sources", lambda: [_Boom()])
     monkeypatch.setattr(
         "hermes_cli.config.load_config",
         lambda: {"secrets": {"myvault": {"enabled": True}}},
@@ -198,34 +200,57 @@ def test_discover_and_load_invokes_refresh(monkeypatch):
 
 
 def test_real_plugin_source_discovery_applies_dotenv(monkeypatch, tmp_path):
-    """End-to-end: a real plugin source registered via discovery triggers a
-    re-pull that flows through the registry's is_enabled contract."""
+    """A cold process discovers a real plugin and applies its credential."""
     import agent.secret_sources.registry as reg
+    from hermes_cli import env_loader
 
     reg._reset_registry_for_tests()
-
-    # Register a real plugin source the way PluginContext.register_secret_source
-    # would (lands in registry.register_source).
-    plugin_source = _StubSource(name="tmpvault", scheme="tmpvault")
-    assert reg.register_source(plugin_source) is True
-    assert any(getattr(s, "name", "") == "tmpvault" for s in reg.list_sources())
-
-    applied = {"reset": 0, "load": 0}
-    monkeypatch.setattr(
-        "hermes_cli.env_loader.reset_secret_source_cache",
-        lambda: applied.__setitem__("reset", applied["reset"] + 1),
+    env_loader.reset_secret_source_cache()
+    home = tmp_path / ".hermes"
+    plugin_dir = home / "plugins" / "fixture-secret-source"
+    plugin_dir.mkdir(parents=True)
+    (home / "config.yaml").write_text(
+        "plugins:\n"
+        "  enabled: [fixture-secret-source]\n"
+        "secrets:\n"
+        "  fixturevault:\n"
+        "    enabled: true\n",
+        encoding="utf-8",
     )
-    monkeypatch.setattr(
-        "hermes_cli.env_loader.load_hermes_dotenv",
-        lambda **kw: applied.__setitem__("load", applied["load"] + 1),
+    (plugin_dir / "plugin.yaml").write_text(
+        "name: fixture-secret-source\nversion: 0.1.0\n",
+        encoding="utf-8",
     )
-    monkeypatch.setattr(
-        "hermes_cli.config.load_config",
-        lambda: {"secrets": {"tmpvault": {"enabled": True}}},
+    (plugin_dir / "__init__.py").write_text(
+        "from pathlib import Path\n"
+        "from agent.secret_sources.base import (\n"
+        "    SECRET_SOURCE_API_VERSION, FetchResult, SecretSource,\n"
+        ")\n\n"
+        "class FixtureVault(SecretSource):\n"
+        "    name = 'fixturevault'\n"
+        "    label = 'Fixture vault'\n"
+        "    api_version = SECRET_SOURCE_API_VERSION\n"
+        "    shape = 'bulk'\n\n"
+        "    def fetch(self, cfg: dict, home_path: Path) -> FetchResult:\n"
+        "        return FetchResult(secrets={\n"
+        "            'HERMES_TEST_PLUGIN_BOOTSTRAP': 'from-plugin',\n"
+        "        })\n\n"
+        "def register(ctx):\n"
+        "    ctx.register_secret_source(FixtureVault())\n",
+        encoding="utf-8",
     )
 
-    mgr = PluginManager()
-    mgr._refresh_secret_sources_after_discovery()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_TEST_PLUGIN_BOOTSTRAP", raising=False)
 
-    assert applied == {"reset": 1, "load": 1}
-    reg._reset_registry_for_tests()
+    try:
+        PluginManager().discover_and_load()
+
+        assert os.environ["HERMES_TEST_PLUGIN_BOOTSTRAP"] == "from-plugin"
+        assert [source.name for source in reg.list_plugin_sources()] == [
+            "fixturevault"
+        ]
+    finally:
+        os.environ.pop("HERMES_TEST_PLUGIN_BOOTSTRAP", None)
+        reg._reset_registry_for_tests()
+        env_loader.reset_secret_source_cache()

--- a/website/docs/developer-guide/secret-source-plugin.md
+++ b/website/docs/developer-guide/secret-source-plugin.md
@@ -12,6 +12,20 @@ Secret sources resolve provider credentials from an external secret manager (a v
 The bundled set is deliberately closed, same policy as [memory providers](/developer-guide/memory-provider-plugin): PRs adding new vault backends under `agent/secret_sources/` are closed with a pointer to this guide. Publish your backend as a standalone plugin repo and share it in the Nous Research Discord (`#plugins-skills-and-skins`).
 :::
 
+## First-process bootstrap timing
+
+`load_hermes_dotenv()` often runs at import time **before** plugins register.
+Hermes then re-pulls secrets after plugin discovery when any **enabled**
+plugin secret source is configured (`secrets.<name>.enabled: true`). That
+closes the "replace Bitwarden with my vault" first-process gap (#64177).
+
+- Re-pull is idempotent and fail-open (never blocks startup).
+- Sources only supply env vars through the orchestrator; there is **no**
+  plugin API to dump other plugins' or the user's entire secret store beyond
+  what your source's own config allows.
+- Reading `os.environ` after load is possible for any in-process code — the
+  trust boundary remains "enabled plugins run with agent privilege".
+
 ## What the framework owns vs. what you own
 
 The orchestrator (`agent.secret_sources.registry.apply_all`) owns everything security- and precedence-sensitive, so a backend cannot get it wrong:

--- a/website/docs/developer-guide/secret-source-plugin.md
+++ b/website/docs/developer-guide/secret-source-plugin.md
@@ -141,7 +141,7 @@ def register(ctx):
 Registration is rejected (with a log warning, never a crash) for: non-`SecretSource` instances, invalid/duplicate names, a `scheme` another source owns, wrong `api_version`, or a `shape` outside `mapped`/`bulk`.
 
 :::note Timing
-Plugin discovery runs later in startup than the first `load_hermes_dotenv()` call, so a plugin source is not consulted by the very first env load of the process that discovers it. It IS consulted by every subsequently spawned Hermes process (gateway children, cron sessions, subagents). Bundled sources cover first-process bootstrap.
+Plugin discovery runs later in startup than the first `load_hermes_dotenv()` call. Immediately after discovery, Hermes re-pulls enabled plugin secret sources (`reset_secret_source_cache()` + `load_hermes_dotenv()`), so the discovering process *does* pick them up — see [First-process bootstrap timing](#first-process-bootstrap-timing) above (#64177). The re-pull is fail-open and skipped when no plugin source is enabled. Any code that read `os.environ` *before* discovery completes (i.e. at pure import time) still sees only the initial load; bundled sources remain the safest choice for the earliest bootstrap. Every subsequently spawned Hermes process (gateway children, cron sessions, subagents) also consults plugin sources on its own initial load.
 :::
 
 ## Users configure it like any other source

--- a/website/docs/developer-guide/secret-source-plugin.md
+++ b/website/docs/developer-guide/secret-source-plugin.md
@@ -16,8 +16,10 @@ The bundled set is deliberately closed, same policy as [memory providers](/devel
 
 `load_hermes_dotenv()` often runs at import time **before** plugins register.
 Hermes then re-pulls secrets after plugin discovery when any **enabled**
-plugin secret source is configured (`secrets.<name>.enabled: true`). That
-closes the "replace Bitwarden with my vault" first-process gap (#64177).
+plugin secret source is configured. Enablement uses the source's
+`is_enabled(cfg)` contract; the standard form is
+`secrets.<name>.enabled: true`, while custom activation remains supported.
+That closes the "replace Bitwarden with my vault" first-process gap (#64177).
 
 - Re-pull is idempotent and fail-open (never blocks startup).
 - Sources only supply env vars through the orchestrator; there is **no**
@@ -141,7 +143,7 @@ def register(ctx):
 Registration is rejected (with a log warning, never a crash) for: non-`SecretSource` instances, invalid/duplicate names, a `scheme` another source owns, wrong `api_version`, or a `shape` outside `mapped`/`bulk`.
 
 :::note Timing
-Plugin discovery runs later in startup than the first `load_hermes_dotenv()` call. Immediately after discovery, Hermes re-pulls enabled plugin secret sources (`reset_secret_source_cache()` + `load_hermes_dotenv()`), so the discovering process *does* pick them up — see [First-process bootstrap timing](#first-process-bootstrap-timing) above (#64177). The re-pull is fail-open and skipped when no plugin source is enabled. Any code that read `os.environ` *before* discovery completes (i.e. at pure import time) still sees only the initial load; bundled sources remain the safest choice for the earliest bootstrap. Every subsequently spawned Hermes process (gateway children, cron sessions, subagents) also consults plugin sources on its own initial load.
+Plugin discovery runs later in startup than the first `load_hermes_dotenv()` call. Immediately after discovery, Hermes re-pulls enabled plugin secret sources (`reset_secret_source_cache()` + `load_hermes_dotenv()`), so the discovering process *does* pick them up — see [First-process bootstrap timing](#first-process-bootstrap-timing) above (#64177). The re-pull is fail-open and skipped when no plugin source is enabled. Any code that reads `os.environ` during the plugin module's import or `register(ctx)` still runs before the re-pull and cannot depend on credentials supplied by that same source; keep credentialed work inside `fetch()`. Gateway, cron, and subagent processes perform the same discovery/re-pull sequence.
 :::
 
 ## Users configure it like any other source


### PR DESCRIPTION
## Summary

Plugin-provided secret sources now hydrate credentials in the first Hermes process that discovers them, without requiring a restart or child process.

The initial env load precedes plugin registration, so the source was previously invisible until a later process. Discovery now performs one fail-open re-pull when an enabled plugin source is present.

## Changes

- Re-apply enabled plugin secret sources after discovery.
- Record bundled-vs-plugin origin in the source registry instead of maintaining a fragile name list.
- Preserve each source's custom `is_enabled(cfg)` contract.
- Add a real temporary-plugin cold-process E2E test.
- Document bootstrap timing and the import-time limitation.
- Preserve @Bartok9's commits from #64189 and add the current-main ownership fix on top.

## Validation

| Check | Result |
|---|---|
| Secret-source and env-loader tests | 73 passed |
| Cold-process plugin E2E | Credential hydrated in discovering process |
| Ruff | Passed |
| Docusaurus build | Local dependency absent; CI owns installed-dependency build |

Fixes #64177.

## Infographic

![Plugin secret bootstrap lifecycle](https://v3b.fal.media/files/b/0aa58cdc/QMN4ub-c5BlCxWVCYSbnV_6BpBhAcV.png)
