### PR TITLE
fix(windows): base64 clipboard reads + UTF-8 subprocess decodes (PowerShell codepage class)

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -479,13 +479,15 @@ def workspace_fingerprint(cwd: Optional[str] = None) -> str:
     try:
         head = subprocess.run(
             ["git", "rev-parse", "HEAD"],
-            capture_output=True, text=True, timeout=10, cwd=workdir,
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=10, cwd=workdir,
         )
         if head.returncode != 0:
             return ""
         status = subprocess.run(
             ["git", "status", "--porcelain"],
-            capture_output=True, text=True, timeout=30, cwd=workdir,
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=30, cwd=workdir,
         )
         if status.returncode != 0:
             return ""
@@ -509,6 +511,14 @@ def run_gate(gate: GoalGate, *, cwd: Optional[str] = None) -> Tuple[bool, int, s
             shell=True,
             capture_output=True,
             text=True,
+            # A gate runs whatever the operator configured, so its output is
+            # arbitrary bytes. The default text mode decodes with the process
+            # codepage under errors="strict": one byte the codepage can't map
+            # (emoji or CJK from a test runner on a non-UTF-8 Windows console,
+            # or stray binary) kills the reader thread, leaves stdout as None,
+            # and the tail the agent needs to fix the failure arrives empty.
+            encoding="utf-8",
+            errors="replace",
             timeout=max(1, int(gate.timeout_seconds)),
             cwd=cwd or None,
         )

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1341,6 +1341,8 @@ def _repair_cua_driver_autostart_windows(driver_cmd: str, *, verbose: bool) -> b
             [ps, "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", ps_cmd],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=300,
             env=_cua_driver_env(),
         )

--- a/tests/hermes_cli/test_goal_gates.py
+++ b/tests/hermes_cli/test_goal_gates.py
@@ -1,6 +1,7 @@
 """Tests for /goal quality gates (GoalGate, run_gate, GoalManager gate flow)."""
 
 import json
+import sys
 import time
 from unittest.mock import patch
 
@@ -75,6 +76,35 @@ def test_run_gate_timeout():
     assert passed is False
     assert code == -1
     assert "timed out" in out
+
+
+def test_run_gate_keeps_diagnostics_when_a_byte_will_not_decode(tmp_path):
+    """A gate's output tail must survive bytes the decoder rejects.
+
+    A gate runs whatever the operator configured, so its output is arbitrary
+    bytes — a test runner's checkmarks or CJK on a non-UTF-8 Windows console,
+    or stray binary. Decoding strictly means one bad byte kills subprocess's
+    reader thread, stdout comes back None, and the tail lands empty: the agent
+    is told the gate failed with nothing to act on, so it burns every retry and
+    the goal auto-pauses.
+    """
+    script = tmp_path / "gate.py"
+    script.write_text(
+        "import os, sys\n"
+        "os.write(1, b'FAILED: 3 tests broken \\x90\\x8d rerun me\\n')\n"
+        "sys.exit(1)\n",
+        encoding="utf-8",
+    )
+
+    passed, code, out = run_gate(
+        GoalGate(command=f'"{sys.executable}" "{script}"'),
+    )
+
+    assert passed is False
+    assert code == 1
+    assert "FAILED: 3 tests broken" in out, (
+        f"gate diagnostics were lost to a decode failure (tail={out!r})"
+    )
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/tests/tools/test_working_diff.py
+++ b/tests/tools/test_working_diff.py
@@ -10,6 +10,7 @@ import subprocess
 
 import pytest
 
+import tools.working_diff as working_diff
 from tools.working_diff import collect_working_diff
 
 pytestmark = pytest.mark.skipif(
@@ -57,3 +58,66 @@ def test_unknown_mode_rejected(repo):
     result = collect_working_diff(str(repo), mode="bogus")
     assert result["success"] is False
     assert "bogus" in result["error"]
+
+
+def test_run_decodes_git_output_as_utf8(monkeypatch, repo):
+    """``_run`` must force UTF-8 decoding of git's output.
+
+    Without ``encoding="utf-8"`` (and a lossy ``errors=``), ``subprocess.run``
+    falls back to the platform locale encoding. On Windows that's typically
+    cp932: UTF-8 multibyte output (e.g. a Japanese filename or diff content)
+    then either raises ``UnicodeDecodeError`` or silently decodes as mojibake,
+    depending on the byte sequence. The raise violates the "Never raises on
+    git failure" contract in ``_run``'s docstring.
+    """
+    captured = {}
+    real_run = subprocess.run
+
+    def fake_run(*args, **kwargs):
+        captured.update(kwargs)
+        return real_run(*args, **kwargs)
+
+    monkeypatch.setattr(working_diff.subprocess, "run", fake_run)
+
+    working_diff._run(["status"], str(repo))
+
+    assert captured.get("encoding") == "utf-8"
+    assert captured.get("errors") == "replace"
+
+
+def test_non_ascii_untracked_file_does_not_raise(repo):
+    """A non-ASCII filename + content must decode cleanly, not raise.
+
+    Regression test for the UnicodeDecodeError observed on real Windows
+    machines when git output contains UTF-8 multibyte sequences (Japanese
+    filename/content here) and the platform locale is not UTF-8.
+    """
+    (repo / "日本語ファイル.py").write_text("x = 'こんにちは'\n", encoding="utf-8")
+
+    result = collect_working_diff(str(repo))
+
+    assert result["success"] is True
+    assert any("日本語ファイル.py" in f for f in result["untracked"])
+    assert "こんにちは" in result["diff"]
+
+
+def test_cp932_content_is_lossy_but_never_raises(repo):
+    """Non-UTF-8 blob content degrades to replacement characters, not a crash.
+
+    Git emits blob bytes uninterpreted, so a repo whose files are cp932-encoded
+    decodes lossily under the forced UTF-8 policy. That is the same trade-off
+    checkpoint_manager's ``_run_git`` already makes (utf-8 + errors="replace"
+    on every git call): a readable-but-lossy diff for legacy encodings, never
+    an exception. This test pins the trade-off so it stays a documented choice.
+    """
+    legacy = repo / "legacy.txt"
+    legacy.write_bytes("before=東京\n".encode("cp932"))
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-q", "-m", "legacy")
+    legacy.write_bytes("after=日本語\n".encode("cp932"))
+
+    result = collect_working_diff(str(repo))
+
+    assert result["success"] is True
+    assert "legacy.txt" in result["diff"]
+    assert "\ufffd" in result["diff"]  # lossy by design, matching _run_git

--- a/tools/working_diff.py
+++ b/tools/working_diff.py
@@ -35,6 +35,7 @@ def _run(args: List[str], cwd: str, timeout: int = _GIT_TIMEOUT):
     proc = subprocess.run(
         ["git", "-c", "core.quotePath=false", *args],
         cwd=cwd, capture_output=True, text=True, timeout=timeout,
+        encoding="utf-8", errors="replace",
     )
     return proc.returncode, proc.stdout
 

--- a/ui-tui/src/__tests__/clipboard.test.ts
+++ b/ui-tui/src/__tests__/clipboard.test.ts
@@ -15,25 +15,27 @@ describe('readClipboardText', () => {
   })
 
   it('reads text from PowerShell on Windows', async () => {
-    const run = vi.fn().mockResolvedValue({ stdout: 'from windows\r\n' })
+    const b64 = Buffer.from('from windows\r\n', 'utf8').toString('base64')
+    const run = vi.fn().mockResolvedValue({ stdout: b64 })
 
     await expect(readClipboardText('win32', run)).resolves.toBe('from windows\r\n')
     expect(run).toHaveBeenCalledWith(
       'powershell',
-      ['-NoProfile', '-NonInteractive', '-Command', 'Get-Clipboard -Raw'],
+      ['-NoProfile', '-NonInteractive', '-Command', '[Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes((Get-Clipboard -Raw)))'],
       expect.objectContaining({ encoding: 'utf8', maxBuffer: 4 * 1024 * 1024, windowsHide: true })
     )
   })
 
   it('tries powershell.exe first on WSL', async () => {
-    const run = vi.fn().mockResolvedValue({ stdout: 'from wsl\n' })
+    const b64 = Buffer.from('from wsl\n', 'utf8').toString('base64')
+    const run = vi.fn().mockResolvedValue({ stdout: b64 })
 
     await expect(readClipboardText('linux', run, { WSL_INTEROP: '/tmp/socket' } as NodeJS.ProcessEnv)).resolves.toBe(
       'from wsl\n'
     )
     expect(run).toHaveBeenCalledWith(
       'powershell.exe',
-      ['-NoProfile', '-NonInteractive', '-Command', 'Get-Clipboard -Raw'],
+      ['-NoProfile', '-NonInteractive', '-Command', '[Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes((Get-Clipboard -Raw)))'],
       expect.objectContaining({ encoding: 'utf8', maxBuffer: 4 * 1024 * 1024, windowsHide: true })
     )
   })
@@ -81,6 +83,16 @@ describe('readClipboardText', () => {
       readClipboardText('linux', run, { WAYLAND_DISPLAY: 'wayland-1' } as NodeJS.ProcessEnv)
     ).resolves.toBeNull()
   })
+
+  it('preserves CJK text via base64 decoding from PowerShell on WSL', async () => {
+    const cjkText = '你好世界，测试中文 🎉'
+    const b64 = Buffer.from(cjkText, 'utf8').toString('base64')
+    const run = vi.fn().mockResolvedValue({ stdout: b64 })
+
+    await expect(
+      readClipboardText('linux', run, { WSL_INTEROP: '/tmp/socket' } as NodeJS.ProcessEnv)
+    ).resolves.toBe(cjkText)
+  })
 })
 
 describe('isUsableClipboardText', () => {
@@ -109,6 +121,7 @@ describe('writeClipboardText', () => {
 
         return child
       }),
+      unref: vi.fn(),
       stdin: { end: vi.fn() }
     }
 
@@ -129,6 +142,7 @@ describe('writeClipboardText', () => {
 
         return child
       }),
+      unref: vi.fn(),
       stdin
     }
 
@@ -152,6 +166,7 @@ describe('writeClipboardText', () => {
 
         return child
       }),
+      unref: vi.fn(),
       stdin: { end: vi.fn() }
     }
 
@@ -171,6 +186,7 @@ describe('writeClipboardText', () => {
 
         return child
       }),
+      unref: vi.fn(),
       stdin
     }
 
@@ -201,6 +217,7 @@ describe('writeClipboardText', () => {
 
         return child
       }),
+      unref: vi.fn(),
       stdin
     }
 
@@ -226,6 +243,7 @@ describe('writeClipboardText', () => {
 
         return child
       }),
+      unref: vi.fn(),
       stdin
     }
 
@@ -248,6 +266,7 @@ describe('writeClipboardText', () => {
 
         return child
       }),
+      unref: vi.fn(),
       stdin
     }
 
@@ -282,6 +301,7 @@ describe('writeClipboardText', () => {
 
         return child
       }),
+      unref: vi.fn(),
       stdin
     }
 
@@ -319,6 +339,7 @@ describe('writeClipboardText', () => {
 
         return child
       }),
+      unref: vi.fn(),
       stdin
     }
 
@@ -345,6 +366,7 @@ describe('writeClipboardText', () => {
 
         return child
       }),
+      unref: vi.fn(),
       stdin
     }
 

--- a/ui-tui/src/lib/clipboard.ts
+++ b/ui-tui/src/lib/clipboard.ts
@@ -3,7 +3,14 @@ import { promisify } from 'node:util'
 
 const execFileAsync = promisify(execFile)
 const CLIPBOARD_MAX_BUFFER = 4 * 1024 * 1024
-const POWERSHELL_ARGS = ['-NoProfile', '-NonInteractive', '-Command', 'Get-Clipboard -Raw'] as const
+// PowerShell read: base64-encode the clipboard content to avoid ANSI codepage
+// corruption (same problem as the write path — see comment at line 94).
+const POWERSHELL_READ_ARGS = [
+  '-NoProfile',
+  '-NonInteractive',
+  '-Command',
+  '[Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes((Get-Clipboard -Raw)))'
+] as const
 
 type ClipboardRun = typeof execFileAsync
 
@@ -33,19 +40,19 @@ export function isUsableClipboardText(text: null | string): text is string {
 function readClipboardCommands(
   platform: NodeJS.Platform,
   env: NodeJS.ProcessEnv
-): Array<{ args: readonly string[]; cmd: string }> {
+): Array<{ args: readonly string[]; cmd: string; base64?: boolean }> {
   if (platform === 'darwin') {
     return [{ cmd: 'pbpaste', args: [] }]
   }
 
   if (platform === 'win32') {
-    return [{ cmd: 'powershell', args: POWERSHELL_ARGS }]
+    return [{ cmd: 'powershell', args: POWERSHELL_READ_ARGS, base64: true }]
   }
 
-  const attempts: Array<{ args: readonly string[]; cmd: string }> = []
+  const attempts: Array<{ args: readonly string[]; cmd: string; base64?: boolean }> = []
 
   if (env.WSL_INTEROP || env.WSL_DISTRO_NAME) {
-    attempts.push({ cmd: 'powershell.exe', args: POWERSHELL_ARGS })
+    attempts.push({ cmd: 'powershell.exe', args: POWERSHELL_READ_ARGS, base64: true })
   }
 
   if (env.WAYLAND_DISPLAY) {
@@ -81,6 +88,10 @@ export async function readClipboardText(
       })
 
       if (typeof result.stdout === 'string') {
+        if (attempt.base64) {
+          return Buffer.from(result.stdout.trim(), 'base64').toString('utf8')
+        }
+
         return result.stdout
       }
     } catch {
@@ -159,6 +170,7 @@ export async function writeClipboardText(
             windowsHide: true
           })
 
+          child.unref()
           child.once('error', () => resolve(false))
           child.once('close', (code: number | null) => resolve(code === 0))
           child.stdin?.end(text)
@@ -171,6 +183,7 @@ export async function writeClipboardText(
             windowsHide: true
           })
 
+          child.unref()
           child.once('error', () => resolve(false))
           child.once('close', (code: number | null) => resolve(code === 0))
         }


### PR DESCRIPTION
## Summary
PowerShell codepage cluster: clipboard reads mangled emoji/CJK to `??` because Get-Clipboard output crossed the console codepage; several Windows subprocess captures decoded with locale defaults and could crash.

## Changes
- Salvaged @annguyenNous's base64 clipboard strategy (#37212): `[Convert]::ToBase64String` over raw clipboard bytes sidesteps the codepage entirely; covers TUI + desktop composer paste paths (same readClipboardText)
- Salvaged @Sora-bluesky's working_diff git decode fix (#72642, /diff UnicodeDecodeError) and @Drexuxux's goals quality-gate decode (#80236), standardized on utf-8 + errors='replace'
- Widened: remaining text-mode subprocess captures in touched modules

## Validation
| | Result |
|---|---|
| clipboard vitest (CJK/emoji) | green |
| working_diff + goal gates pytest | green |
| #57434 | already fixed on main (c89481db5e) |

## Infographic

![clipboard-quest](https://v3b.fal.media/files/b/0aa58cd9/PHWiciyS6NgYqKokdqjx__vwsIuiR1.png)
