### PR TITLE
fix(agent,gateway): lone-surrogate chokepoints \u2014 sanitize once at model-text exit and outbound assembly

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2404,6 +2404,16 @@ def run_conversation(
                         api_messages,
                         tools_for_api=tools_for_api,
                     )
+                # Outbound-request surrogate chokepoint (#50959): the messages
+                # were scrubbed above, but the rest of the request body —
+                # tool/function descriptions (session_search's ±-heavy text is
+                # the recorded repro), extra_body, system strings routed via
+                # kwargs — can still carry invalid code points that providers
+                # reject with a non-retryable HTTP 400 ("invalid unicode code
+                # point"). One in-place walk here guarantees the entire
+                # payload json.dumps()-safe regardless of which leaf produced
+                # the string. Fast no-op when the payload is clean.
+                _sanitize_structure_surrogates(api_kwargs)
                 if agent._force_ascii_payload:
                     _sanitize_structure_non_ascii(api_kwargs)
                 if agent.api_mode == "codex_responses":

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -26,6 +26,7 @@ import os
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.message_content import flatten_message_text
+from agent.message_sanitization import _sanitize_surrogates
 
 
 def _is_pure_tool_call_tail(msg: dict) -> bool:
@@ -638,6 +639,18 @@ def finalize_turn(
         if msg.get("role") == "assistant" and msg.get("reasoning"):
             last_reasoning = msg["reasoning"]
             break
+
+    # Class-level surrogate chokepoint (#80366, #55143, #55309, #19819):
+    # ``final_response`` is often the RAW SDK content
+    # (``assistant_message.content``), not the sanitized copy stored in
+    # history by ``build_assistant_message``. Any lone UTF-16 surrogate
+    # (U+D800–U+DFFF) in it crashes downstream consumers — oneshot stdout
+    # writes, Telegram's ``utf16_len`` length check, Signal formatting,
+    # JSON envelope encodes — on every provider (Ollama, NVIDIA NIM, …).
+    # Scrub once here, where model text leaves the conversation loop, so
+    # every delivery surface receives valid Unicode.
+    if isinstance(final_response, str):
+        final_response = _sanitize_surrogates(final_response)
 
     # Build result with interrupt info if applicable
     result = {

--- a/contributors/emails/executus.ahli@gmail.com
+++ b/contributors/emails/executus.ahli@gmail.com
@@ -1,0 +1,1 @@
+TheophilusChinomona

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -717,6 +717,19 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
     if _gateway_surface_passes_raw_text(platform):
         return text
 
+    # Lone UTF-16 surrogates (U+D800–U+DFFF) in model output crash chat
+    # surfaces downstream: Telegram's ``utf16_len`` length check and Signal
+    # formatting both ``.encode()`` the reply and raise UnicodeEncodeError
+    # before any send (#55143, #55309). The stored-history copy is already
+    # sanitized by ``build_assistant_message`` and ``finalize_turn`` scrubs
+    # the returned ``final_response``, but this boundary is the last line of
+    # defense for every legacy/plugin delivery path that hands us raw text.
+    # Raw-text/programmatic surfaces above keep passthrough — their JSON
+    # consumers escape surrogates safely.
+    from agent.message_sanitization import _sanitize_surrogates
+
+    text = _sanitize_surrogates(str(text))
+
     # Cancellation metadata, not assistant prose. ACP/TUI already suppress
     # this sentinel; chat surfaces should too (#7921).
     if str(text).strip().startswith(INTERRUPT_WAITING_FOR_MODEL_PREFIX):

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -277,6 +277,15 @@ def run_oneshot(
 
     _write_usage_file(usage_file, result)
 
+    # Model text can contain lone UTF-16 surrogates (invalid in UTF-8). Writing
+    # those to a real stdout TextIO raises UnicodeEncodeError and aborts with
+    # exit 1 after the turn already completed — scrub to U+FFFD first.
+    # See #80366.
+    if response:
+        from agent.message_sanitization import _sanitize_surrogates
+
+        response = _sanitize_surrogates(response)
+
     if response:
         real_stdout.write(response)
         if not response.endswith("\n"):

--- a/tests/agent/test_surrogate_chokepoints.py
+++ b/tests/agent/test_surrogate_chokepoints.py
@@ -1,0 +1,194 @@
+"""Lone-surrogate chokepoint regression tests.
+
+One class of bug, many crash sites: a lone UTF-16 surrogate (U+D800–U+DFFF)
+in model output or a request payload crashes whichever consumer encodes it
+first — oneshot stdout (#80366), Telegram's utf16_len check (#55309), Signal
+formatting (#55143), provider request bodies / tool descriptions (#50959),
+and NIM responses that bypass the Ollama-era sanitize pass (#19819).
+
+The fix is owned at chokepoints, not leaf sites:
+
+* ``finalize_turn`` scrubs ``final_response`` once, where model text leaves
+  the conversation loop (covers oneshot, gateway, API server, subagents).
+* ``_sanitize_gateway_final_response`` scrubs at the gateway delivery
+  boundary for chat surfaces (defense in depth for legacy/plugin paths).
+* ``run_conversation`` walks the fully-built ``api_kwargs`` with
+  ``_sanitize_structure_surrogates`` so tool descriptions and every other
+  request-body leaf are json-encodable before any provider sees them.
+"""
+
+from types import SimpleNamespace
+
+import json
+
+import pytest
+
+from agent.message_sanitization import (
+    _sanitize_structure_surrogates,
+    _sanitize_surrogates,
+)
+from agent.turn_finalizer import finalize_turn
+from tests.agent.test_turn_finalizer_final_response_persistence import FakeAgent
+
+LONE_HIGH = "\ud83d"  # unpaired high surrogate (half of an emoji pair)
+LONE_LOW = "\udce7"  # the exact code point reported in #19819
+
+
+# ---------------------------------------------------------------------------
+# Chokepoint 1: model text leaving the conversation loop (finalize_turn)
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_turn_scrubs_lone_surrogate_from_final_response(monkeypatch):
+    """#80366 / #19819: the returned final_response must be valid Unicode.
+
+    ``final_response`` is often raw SDK content (``assistant_message.content``)
+    — not the sanitized history copy — so without the chokepoint a lone
+    surrogate reaches oneshot stdout / gateway delivery and crashes there.
+    """
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = FakeAgent()
+    dirty = f"answer {LONE_HIGH} and {LONE_LOW} here"
+    messages = [
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "content": dirty},
+    ]
+
+    result = finalize_turn(
+        agent,
+        final_response=dirty,
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="t",
+        turn_id="tid",
+        user_message="q",
+        original_user_message="q",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(final)",
+    )
+
+    final = result["final_response"]
+    # Encodable everywhere a delivery surface needs it to be.
+    final.encode("utf-8")
+    final.encode("utf-16-le")
+    assert "\ufffd" in final
+    assert "answer " in final and " here" in final
+
+
+def test_finalize_turn_leaves_non_string_final_response_alone(monkeypatch):
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = FakeAgent()
+    result = finalize_turn(
+        agent,
+        final_response=None,
+        api_call_count=1,
+        interrupted=True,
+        failed=False,
+        messages=[{"role": "user", "content": "q"}],
+        conversation_history=[],
+        effective_task_id="t",
+        turn_id="tid",
+        user_message="q",
+        original_user_message="q",
+        _should_review_memory=False,
+        _turn_exit_reason="interrupted",
+    )
+    assert result["final_response"] is None
+
+
+# ---------------------------------------------------------------------------
+# Chokepoint 2: gateway delivery boundary (mock platform send)
+# ---------------------------------------------------------------------------
+
+
+def test_gateway_final_response_sanitized_for_chat_surfaces():
+    """#55309 / #55143: chat-surface replies must survive utf16_len/encode."""
+    from gateway.platforms.base import utf16_len
+    from gateway.run import _sanitize_gateway_final_response
+
+    dirty = f"Here is your answer {LONE_HIGH} done"
+    cleaned = _sanitize_gateway_final_response("telegram", dirty)
+
+    # The raw text raises; the sanitized boundary output must not.
+    with pytest.raises(UnicodeEncodeError):
+        utf16_len(dirty)
+    assert utf16_len(cleaned) > 0
+    cleaned.encode("utf-8")
+    assert "\ufffd" in cleaned
+    assert "Here is your answer" in cleaned
+
+
+def test_gateway_raw_text_surfaces_keep_passthrough():
+    """Programmatic surfaces keep raw text — their JSON consumers escape
+    surrogates safely, and byte fidelity matters there."""
+    from gateway.run import _sanitize_gateway_final_response
+
+    dirty = f"raw {LONE_HIGH} text"
+    assert _sanitize_gateway_final_response("local", dirty) == dirty
+
+
+# ---------------------------------------------------------------------------
+# Chokepoint 3: outbound API request assembly (#50959)
+# ---------------------------------------------------------------------------
+
+
+def test_api_kwargs_walk_makes_tool_descriptions_json_safe():
+    """A surrogate anywhere in the request body (tool descriptions included)
+    must be scrubbed by one structure walk so json.dumps cannot fail."""
+    api_kwargs = {
+        "model": "test",
+        "messages": [{"role": "user", "content": "hi"}],
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "session_search",
+                    "description": f"±5 message window {LONE_HIGH} around the match",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "query": {"description": f"nested {LONE_LOW} leaf"},
+                        },
+                    },
+                },
+            }
+        ],
+        "extra_body": {"note": f"deep {LONE_HIGH}"},
+    }
+
+    assert _sanitize_structure_surrogates(api_kwargs) is True
+    encoded = json.dumps(api_kwargs)  # would raise UnicodeEncodeError-class failure before
+    assert "\\ud83d" not in encoded.lower()
+    desc = api_kwargs["tools"][0]["function"]["description"]
+    assert desc.startswith("±5 message window")
+    assert "\ufffd" in desc
+    # Second walk is a no-op on the now-clean payload.
+    assert _sanitize_structure_surrogates(api_kwargs) is False
+
+
+def test_conversation_loop_sanitizes_api_kwargs_after_build():
+    """Wiring pin: the structure walk runs on the fully-built api_kwargs
+    (after _build_api_kwargs, before any transport/provider sees it)."""
+    import inspect
+
+    import agent.conversation_loop as cl
+
+    src = inspect.getsource(cl.run_conversation)
+    build_idx = src.index("api_kwargs = agent._build_api_kwargs(api_messages)")
+    sanitize_idx = src.index("_sanitize_structure_surrogates(api_kwargs)")
+    perform_idx = src.index("def _perform_api_call")
+    assert build_idx < sanitize_idx < perform_idx
+
+
+# ---------------------------------------------------------------------------
+# Helper semantics shared by every chokepoint
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_surrogates_preserves_valid_astral_pairs():
+    """Valid non-BMP text (proper emoji, CJK extension chars) is untouched."""
+    text = "ok 😀 你好 𝕏"
+    assert _sanitize_surrogates(text) == text

--- a/tests/hermes_cli/test_oneshot_surrogate.py
+++ b/tests/hermes_cli/test_oneshot_surrogate.py
@@ -1,0 +1,39 @@
+"""Oneshot stdout must survive lone UTF-16 surrogates in model text (#80366)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+def test_oneshot_replaces_lone_surrogate_and_exits_zero():
+    """hermes -z must print U+FFFD and exit 0 when the model returns U+D800."""
+    program = textwrap.dedent(
+        """
+        import hermes_cli.oneshot as oneshot
+
+        dirty = "answer \\ud800 here"
+        oneshot._run_agent = lambda *args, **kwargs: (
+            dirty,
+            {"final_response": dirty, "failed": False, "partial": False, "completed": True},
+        )
+        raise SystemExit(oneshot.run_oneshot("hello"))
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", program],
+        cwd=Path(__file__).resolve().parents[2],
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr.decode("utf-8", errors="replace")
+    # U+FFFD as UTF-8; no raw surrogate bytes
+    assert "\ufffd".encode("utf-8") in result.stdout
+    assert b"answer " in result.stdout
+    assert b" here\n" in result.stdout
+    assert b"Traceback" not in result.stderr

--- a/tests/tools/test_file_write_surrogate_roundtrip.py
+++ b/tests/tools/test_file_write_surrogate_roundtrip.py
@@ -1,0 +1,79 @@
+"""Surrogate-safe stdin piping for the local execution environment (#79178).
+
+These tests exercise the REAL `_pipe_stdin` writer thread against a real
+subprocess — no mocks. They pin the round-trip byte contract (utf-8 +
+surrogateescape is the inverse of the decode that produced the content) and
+the always-close / error-capture guarantees of the writer thread. Later
+tasks in this plan append propagation and write_file tests to this file.
+"""
+import shlex
+import subprocess
+
+import pytest
+
+from tools.environments.base import _pipe_stdin
+
+
+def _cat_to_file_proc(out_path):
+    """A real child that copies its stdin to a file, byte for byte."""
+    return subprocess.Popen(
+        ["bash", "-c", f"cat > {shlex.quote(str(out_path))}"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+
+
+def _wait_or_kill(proc, timeout=5):
+    """wait() with a bounded timeout; kill on timeout so a hung child never
+    leaks into the next test."""
+    try:
+        proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        raise
+
+
+class TestPipeStdinSurrogates:
+    def test_roundtrips_surrogateescape_bytes(self, tmp_path):
+        out = tmp_path / "out.bin"
+        proc = _cat_to_file_proc(out)
+        content = b"\xff\x00\xfe".decode("utf-8", "surrogateescape")
+        try:
+            _pipe_stdin(proc, content)
+            _wait_or_kill(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+        assert proc.returncode == 0
+        assert out.read_bytes() == b"\xff\x00\xfe"
+        assert proc._hermes_stdin_errors == []
+
+    def test_unencodable_surrogate_captures_error_and_closes_stdin(self, tmp_path):
+        out = tmp_path / "out.bin"
+        proc = _cat_to_file_proc(out)
+        try:
+            _pipe_stdin(proc, "\ud800")  # outside the surrogateescape round-trip range
+            _wait_or_kill(proc)  # child MUST exit promptly — stdin closed in finally
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+        assert proc.returncode == 0  # child saw EOF and exited cleanly
+        assert proc._hermes_stdin_errors  # the encode failure was captured
+        assert isinstance(proc._hermes_stdin_errors[0], UnicodeEncodeError)
+
+    def test_normal_content_unchanged(self, tmp_path):
+        out = tmp_path / "out.bin"
+        proc = _cat_to_file_proc(out)
+        try:
+            _pipe_stdin(proc, "hello\nworld\n")
+            _wait_or_kill(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+        assert proc.returncode == 0
+        assert out.read_bytes() == b"hello\nworld\n"
+        assert proc._hermes_stdin_errors == []

--- a/tests/tools/test_file_write_surrogate_roundtrip.py
+++ b/tests/tools/test_file_write_surrogate_roundtrip.py
@@ -8,10 +8,14 @@ tasks in this plan append propagation and write_file tests to this file.
 """
 import shlex
 import subprocess
+import time
+from unittest.mock import MagicMock
 
 import pytest
 
 from tools.environments.base import _pipe_stdin
+from tools.environments.local import LocalEnvironment
+from tools.file_operations import ShellFileOperations
 
 
 def _cat_to_file_proc(out_path):
@@ -77,3 +81,72 @@ class TestPipeStdinSurrogates:
         assert proc.returncode == 0
         assert out.read_bytes() == b"hello\nworld\n"
         assert proc._hermes_stdin_errors == []
+
+
+@pytest.fixture
+def env(tmp_path):
+    """A real LocalEnvironment rooted in a temp directory."""
+    return LocalEnvironment(cwd=str(tmp_path), timeout=15)
+
+
+class TestStdinErrorPropagation:
+    def test_execute_surfaces_stdin_error_without_hanging(self, env):
+        t0 = time.monotonic()
+        result = env.execute("cat > /dev/null", stdin_data="\ud800")
+        elapsed = time.monotonic() - t0
+
+        assert result["returncode"] == 0  # child saw EOF, exited cleanly
+        assert result.get("stdin_error")  # the write failure was surfaced
+        assert "stdin write failed" in result["output"]
+        assert elapsed < 5.0, f"stdin failure path hung for {elapsed:.1f}s"
+
+
+class TestExecStdinErrorMapping:
+    def test_exec_maps_stdin_error_to_failure(self):
+        """Defense-in-depth path (unreachable from write_file after Task 3 —
+        tested with a mock env for exactly that reason)."""
+        env = MagicMock()
+        env.execute.return_value = {
+            "output": "child output\n[stdin write failed: boom]",
+            "returncode": 0,
+            "stdin_error": "boom",
+        }
+        ops = ShellFileOperations(env, cwd="/tmp")
+        result = ops._exec("echo hi", cwd="/tmp", stdin_data="\ud800")
+        assert result.exit_code == 1
+        assert "boom" in result.stdout
+
+
+class TestPipeStdinRemainingBranches:
+    """Review-requested coverage: bytes passthrough + proc.stdin None."""
+
+    def test_bytes_input_passes_through_untouched(self, tmp_path):
+        out = tmp_path / "out.bin"
+        proc = subprocess.Popen(
+            ["bash", "-c", f"cat > {shlex.quote(str(out))}"],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT, text=True,
+            encoding="utf-8", errors="replace",
+        )
+        try:
+            _pipe_stdin(proc, b"\x00\x01\xfe")
+            _wait_or_kill(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+        assert proc.returncode == 0
+        assert out.read_bytes() == b"\x00\x01\xfe"
+        assert proc._hermes_stdin_errors == []
+
+    def test_stdin_none_records_runtime_error(self, tmp_path):
+        proc = subprocess.Popen(
+            ["bash", "-c", "exit 0"],
+            stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT, text=True,
+            encoding="utf-8", errors="replace",
+        )
+        _pipe_stdin(proc, "data")
+        _wait_or_kill(proc)
+        assert proc.returncode == 0
+        assert proc._hermes_stdin_errors
+        assert isinstance(proc._hermes_stdin_errors[0], RuntimeError)

--- a/tests/tools/test_file_write_surrogate_roundtrip.py
+++ b/tests/tools/test_file_write_surrogate_roundtrip.py
@@ -3,8 +3,7 @@
 These tests exercise the REAL `_pipe_stdin` writer thread against a real
 subprocess — no mocks. They pin the round-trip byte contract (utf-8 +
 surrogateescape is the inverse of the decode that produced the content) and
-the always-close / error-capture guarantees of the writer thread. Later
-tasks in this plan append propagation and write_file tests to this file.
+the always-close / error-capture guarantees of the writer thread.
 """
 import shlex
 import subprocess
@@ -89,6 +88,65 @@ def env(tmp_path):
     return LocalEnvironment(cwd=str(tmp_path), timeout=15)
 
 
+@pytest.fixture
+def ops(env, tmp_path):
+    """ShellFileOperations wired to the real local environment."""
+    return ShellFileOperations(env, cwd=str(tmp_path))
+
+
+class TestWriteFileSurrogates:
+    def test_roundtrip_preserves_bytes_count_and_hash(self, ops, tmp_path):
+        p = tmp_path / "surrogate.bin"
+        res = ops.write_file(str(p), b"\xff\x00\xfe".decode("utf-8", "surrogateescape"))
+        assert res.error is None
+        assert res.bytes_written == 3
+        assert res.verified is True
+        assert p.read_bytes() == b"\xff\x00\xfe"
+        assert not list(tmp_path.glob(".hermes-tmp*"))
+
+    def test_roundtrip_mixed_normal_and_surrogate(self, ops, tmp_path):
+        content = "head\n" + b"\xff".decode("utf-8", "surrogateescape") + "\ntail\n"
+        p = tmp_path / "mixed.bin"
+        res = ops.write_file(str(p), content)
+        assert res.error is None
+        assert res.verified is True
+        assert p.read_bytes() == b"head\n\xff\ntail\n"
+
+    @pytest.mark.parametrize("bad", ["\ud800", "\udc7f", "\udd00"])
+    def test_unencodable_surrogate_rejected_before_write(self, ops, tmp_path, bad):
+        p = tmp_path / "reject.bin"
+        res = ops.write_file(str(p), bad)
+        assert res.error and "surrogate" in res.error
+        assert "NOT created or modified" in res.error
+        assert "timed out" not in res.error
+        assert not p.exists()
+
+    def test_rejected_write_leaves_existing_target_unchanged(self, ops, tmp_path):
+        p = tmp_path / "keep.bin"
+        p.write_bytes(b"precious original bytes")
+        res = ops.write_file(str(p), "\ud800")
+        assert res.error and "NOT created or modified" in res.error
+        assert p.read_bytes() == b"precious original bytes"
+
+    def test_patch_replace_funnel_rejects_surrogate_new_string(self, ops, tmp_path):
+        p = tmp_path / "patchme.txt"
+        p.write_text("old\n")
+        # \udc7f is OUTSIDE the surrogateescape round-trip range (U+DC80–U+DCFF)
+        # — unencodable even with surrogateescape — so write_file's early
+        # rejection must catch it through the patch funnel. (An in-range
+        # surrogate like \udcff legitimately round-trips, per the spec.)
+        res = ops.patch_replace(str(p), "old", "new" + "\udc7f")
+        assert res.error and "surrogate" in res.error
+        assert p.read_text() == "old\n"
+
+    def test_normal_content_verified(self, ops, tmp_path):
+        p = tmp_path / "normal.txt"
+        res = ops.write_file(str(p), "hello\nworld\n")
+        assert res.error is None
+        assert res.verified is True
+        assert p.read_bytes() == b"hello\nworld\n"
+
+
 class TestStdinErrorPropagation:
     def test_execute_surfaces_stdin_error_without_hanging(self, env):
         t0 = time.monotonic()
@@ -99,6 +157,12 @@ class TestStdinErrorPropagation:
         assert result.get("stdin_error")  # the write failure was surfaced
         assert "stdin write failed" in result["output"]
         assert elapsed < 5.0, f"stdin failure path hung for {elapsed:.1f}s"
+
+    def test_normal_path_result_has_no_stdin_error_key(self, env):
+        result = env.execute("echo hi")
+        assert "stdin_error" not in result
+        assert result["returncode"] == 0
+        assert "hi" in result["output"]
 
 
 class TestExecStdinErrorMapping:

--- a/tests/tools/test_file_write_surrogate_roundtrip.py
+++ b/tests/tools/test_file_write_surrogate_roundtrip.py
@@ -119,6 +119,10 @@ class TestWriteFileSurrogates:
         assert res.error and "surrogate" in res.error
         assert "NOT created or modified" in res.error
         assert "timed out" not in res.error
+        # Pins the EARLY rejection (char repr in the message) rather than the
+        # post-BOM backstop (whose message contains the codec traceback) —
+        # the early rejection is what guarantees no child ever spawns.
+        assert "codec can't encode" not in res.error
         assert not p.exists()
 
     def test_rejected_write_leaves_existing_target_unchanged(self, ops, tmp_path):

--- a/tests/tools/test_process_registry_write_stdin_surrogates.py
+++ b/tests/tools/test_process_registry_write_stdin_surrogates.py
@@ -1,0 +1,38 @@
+"""Sibling regression test for #79178: background-PTY stdin must round-trip
+surrogateescape content instead of crashing on the strict UTF-8 encode."""
+import shlex
+import time
+
+import pytest
+
+from tools.process_registry import ProcessRegistry
+
+
+def test_write_stdin_pty_surrogateescape_roundtrip(tmp_path):
+    registry = ProcessRegistry()
+    out = tmp_path / "out.bin"
+    script = tmp_path / "read_stdin.py"
+    # readline(): a PTY never delivers EOF, so read one line (canonical mode
+    # delivers it after the newline we send).
+    script.write_text(
+        f"import sys\nopen({str(out)!r}, 'wb').write(sys.stdin.buffer.readline())\n"
+    )
+    session = registry.spawn_local(
+        f"python3 {shlex.quote(str(script))}",
+        cwd=str(tmp_path),
+        use_pty=True,
+    )
+    if session._pty is None:
+        registry.kill_process(session.id)
+        pytest.skip("ptyprocess not available; PTY path not exercised")
+    try:
+        result = registry.write_stdin(
+            session.id, b"\xff".decode("utf-8", "surrogateescape") + "\n"
+        )
+        assert result["status"] == "ok", result
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline and not out.exists():
+            time.sleep(0.05)
+        assert out.read_bytes() == b"\xff\n"
+    finally:
+        registry.kill_process(session.id)

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -307,21 +307,47 @@ def _pipe_stdin(proc: subprocess.Popen, data: str) -> None:
     newline translation entirely on every platform.  No behaviour change
     on POSIX — the byte sequence is identical to what text-mode would
     produce there.
+
+    Encoding uses ``errors="surrogateescape"`` — the exact inverse of the
+    surrogateescape decode, so original bytes are restored.  For
+    surrogate-free strings it is byte-identical to strict UTF-8.
+    Surrogates outside the round-trip range U+DC80–U+DCFF raise and are
+    recorded on ``proc._hermes_stdin_errors`` while stdin is still closed
+    in ``finally`` so the child sees EOF instead of hanging;
+    ``_wait_for_process`` reads the recorded error and surfaces it as
+    ``stdin_error`` on the result.
     """
 
+    errors: list[BaseException] = []
+    proc._hermes_stdin_errors = errors
+
     def _write():
+        if proc.stdin is None:
+            errors.append(RuntimeError("process stdin unavailable"))
+            return
+        # Resolve the target BEFORE encoding: a failed encode must still
+        # reach the finally-close, or the child hangs on EOF forever.
+        target = getattr(proc.stdin, "buffer", proc.stdin)
         try:
-            # proc.stdin is a TextIOWrapper when text=True was set on the
-            # Popen.  Its ``.buffer`` attribute is the raw BufferedWriter
-            # that bypasses newline translation.  When Popen was created
-            # in byte mode, proc.stdin is already a BufferedWriter with
-            # no ``.buffer`` attribute — fall back to .write() directly.
-            raw = data.encode("utf-8") if isinstance(data, str) else data
-            target = getattr(proc.stdin, "buffer", proc.stdin)
-            target.write(raw)
-            target.close()
+            raw = data.encode("utf-8", "surrogateescape") if isinstance(data, str) else data
+            written = target.write(raw)
+            if written != len(raw):
+                # Buffered writers normally complete or raise; a short write
+                # is a real failure and must be surfaced, not swallowed.
+                raise RuntimeError(f"short stdin write: {written} of {len(raw)} bytes")
         except (BrokenPipeError, OSError):
-            pass
+            pass  # child closed stdin early — normal
+        except Exception as exc:
+            # Only reachable with surrogates outside the surrogateescape
+            # round-trip range (e.g. a literal U+D800). Record it so
+            # _wait_for_process can surface it instead of a silent false
+            # success.
+            errors.append(exc)
+        finally:
+            try:
+                target.close()
+            except Exception:
+                pass
 
     threading.Thread(target=_write, daemon=True).start()
 

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -349,7 +349,9 @@ def _pipe_stdin(proc: subprocess.Popen, data: str) -> None:
             except Exception:
                 pass
 
-    threading.Thread(target=_write, daemon=True).start()
+    thread = threading.Thread(target=_write, daemon=True)
+    proc._hermes_stdin_thread = thread
+    thread.start()
 
 
 def _popen_bash(
@@ -1259,7 +1261,22 @@ class BaseEnvironment(ABC):
                 proc.returncode,
             )
 
-        return self._finalize_wait_result(output, output.render(), proc.returncode)
+        # Join the stdin writer thread before reading its error list: a child
+        # that exits without reading stdin can otherwise race ahead of a
+        # recorded encode failure, silently dropping it. The thread cannot
+        # block long after child exit (write raises BrokenPipeError once the
+        # pipe closes); the timeout is a pure safety net.
+        stdin_thread = getattr(proc, "_hermes_stdin_thread", None)
+        if stdin_thread is not None:
+            stdin_thread.join(timeout=5)
+        rendered = output.render()
+        result = self._finalize_wait_result(output, rendered, proc.returncode)
+        stdin_errors = getattr(proc, "_hermes_stdin_errors", None)
+        if stdin_errors:
+            err = str(stdin_errors[0])
+            result["stdin_error"] = err
+            result["output"] = rendered + f"\n[stdin write failed: {err}]"
+        return result
 
     @staticmethod
     def _finalize_wait_result(collector: "_BoundedOutputCollector",

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1502,6 +1502,22 @@ class ShellFileOperations(FileOperations):
         if denied:
             return WriteResult(error=denied)
 
+        # Reject lone surrogates up front with a regex scan (no encode, no
+        # subprocess). surrogateescape-decoded content (U+DC80–U+DCFF)
+        # round-trips through the pipe fine, but surrogates outside that
+        # range cannot be encoded at all — and letting them reach the pipe
+        # would spawn a child that then hangs, or truncates the target via
+        # empty-stdin `cat`. Refuse synchronously before any subprocess.
+        m = re.search(r"[\ud800-\udc7f\udd00-\udfff]", content)
+        if m:
+            return WriteResult(
+                error=(
+                    f"Refusing to write '{path}': content contains a lone "
+                    f"surrogate character ({m.group(0)!r}) that cannot be "
+                    "encoded as UTF-8. The file was NOT created or modified."
+                )
+            )
+
         # ── Fail-closed pre-write syntax gate ───────────────────────────
         # Validate the CANDIDATE content BEFORE any bytes touch disk —
         # previously this only ran as a post-write lint *report* that the
@@ -1626,20 +1642,32 @@ class ShellFileOperations(FileOperations):
         # the atomic swap doesn't silently widen or narrow permissions, and
         # clean the temp up on any failure so we never leak a ``.hermes-tmp``
         # turd next to the user's file.
+        # Encode once for byte count + sha256. surrogateescape is the exact
+        # inverse of the decode that may have produced this content, so these
+        # are the bytes the pipe transmits and the bytes on disk. The early
+        # rejection above guarantees this cannot raise; the try/except is
+        # defense for future callers that bypass it.
+        try:
+            content_bytes = content.encode("utf-8", "surrogateescape")
+        except UnicodeEncodeError as exc:
+            return WriteResult(
+                error=(
+                    f"Refusing to write '{path}': content contains a lone "
+                    f"surrogate character ({exc}) that cannot be encoded as "
+                    "UTF-8. The file was NOT created or modified."
+                )
+            )
         write_result = self._atomic_write(path, content)
 
         if write_result.exit_code != 0:
             return WriteResult(error=f"Failed to write file: {write_result.stdout}")
 
-        # Get bytes written — compute from the content we just wrote
-        # (len of the UTF-8 encoding matches wc -c) instead of spawning a
-        # ``wc -c`` subprocess. ``surrogatepass`` matches the sha256
-        # verification below: content that flowed through a surrogateescape
-        # decode (backend output via patch_replace) may carry lone
-        # surrogates a strict encode would reject.  Encode ONCE and share
-        # the bytes with the sha256 block — a second full encode of a
-        # multi-MB file is measurable.
-        content_bytes = content.encode('utf-8', 'surrogatepass')
+        # Bytes written — computed from the exact bytes we just wrote (len
+        # matches wc -c) instead of spawning a ``wc -c`` subprocess. The
+        # encode happened up front with surrogateescape — the inverse of the
+        # decode that produces surrogate content — so content_bytes == what
+        # rode stdin == what is on disk, and the sha256 below compares like
+        # with like.
         bytes_written = len(content_bytes)
 
         # Post-write content verification (cheap, one shell call): compare

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -875,9 +875,16 @@ class ShellFileOperations(FileOperations):
         # Fall through to init-time self.cwd only if the env doesn't track cwd.
         effective_cwd = cwd or getattr(self.env, 'cwd', None) or self.cwd
         result = self.env.execute(command, cwd=effective_cwd, **kwargs)
+        exit_code = result.get("returncode", 0)
+        # A stdin write failure with an otherwise-clean child exit is still
+        # a failure: the child never received the intended input. write_file
+        # rejects such content up front (Task 3); this mapping is
+        # defense-in-depth for any other stdin caller.
+        if result.get("stdin_error") and exit_code == 0:
+            exit_code = 1
         return ExecuteResult(
             stdout=result.get("output", ""),
-            exit_code=result.get("returncode", 0)
+            exit_code=exit_code
         )
     
     def _has_command(self, cmd: str) -> bool:

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2120,7 +2120,9 @@ class ProcessRegistry:
                 if _IS_WINDOWS:
                     pty_data = data.decode("utf-8") if isinstance(data, bytes) else str(data)
                 else:
-                    pty_data = data.encode("utf-8") if isinstance(data, str) else data
+                    # surrogateescape: a PTY is a byte stream — round-trip the
+                    # original bytes instead of crashing on surrogate content.
+                    pty_data = data.encode("utf-8", "surrogateescape") if isinstance(data, str) else data
                 session._pty.write(pty_data)
                 return {"status": "ok", "bytes_written": len(data)}
             except Exception as e:


### PR DESCRIPTION
## Summary
Lone surrogates in model output crashed one-shot stdout, platform sends (Signal/Telegram), and file writes, and could 400 entire API requests. This lands class-level chokepoints instead of per-platform patches.

## Changes
- Salvaged @TheophilusChinomona's #79240 (surrogateescape-safe _pipe_stdin/write_file/PTY write, stdin_error surfacing) — already a correct choke-point fix for the write path
- Salvaged @rainbowgore's #80374 oneshot stdout scrub (kept as defense-in-depth)
- New: `finalize_turn` scrubs final_response once where model text exits the loop (fixes the raw assistant_message.content path on every provider) + outbound request assembly sanitization

## Validation
| | Result |
|---|---|
| targeted suites | 207 passed |
| repro'd paths | oneshot stdout, platform send, LocalEnvironment write, session_search description |

## Infographic

![surrogate-scrubber](https://v3b.fal.media/files/b/0aa58cd9/OS5U4RIv710qzKtiyjgqa_9roQ7S6a.png)
