### PR TITLE
fix(gateway): Telegram UTF-16 semantics, email charset resilience, update-output decode hardening

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -1019,7 +1019,7 @@ class BatchRunner:
             checkpoint_data["completed_prompts"] = sorted(completed_prompts_set)
             self._save_checkpoint(checkpoint_data, lock=checkpoint_lock)
         except Exception as ckpt_err:
-            print(f"âš ï¸  Warning: Failed to save final checkpoint: {ckpt_err}")
+            print(f"⚠️   Warning: Failed to save final checkpoint: {ckpt_err}")
         
         # Calculate success rates
         for tool_name in total_tool_stats:

--- a/batch_runner.py
+++ b/batch_runner.py
@@ -1019,7 +1019,7 @@ class BatchRunner:
             checkpoint_data["completed_prompts"] = sorted(completed_prompts_set)
             self._save_checkpoint(checkpoint_data, lock=checkpoint_lock)
         except Exception as ckpt_err:
-            print(f"⚠️   Warning: Failed to save final checkpoint: {ckpt_err}")
+            print(f"⚠️  Warning: Failed to save final checkpoint: {ckpt_err}")
         
         # Calculate success rates
         for tool_name in total_tool_stats:

--- a/contributors/emails/hermes-agent@users.noreply.local
+++ b/contributors/emails/hermes-agent@users.noreply.local
@@ -1,0 +1,1 @@
+verybigdog

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21335,6 +21335,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             from tools.ansi_strip import strip_ansi
             return strip_ansi(text)
 
+        def _read_output_since(path: Path, offset: int) -> tuple[str, int]:
+            """Read update output defensively; logs may contain invalid UTF-8."""
+            try:
+                data = path.read_bytes()
+            except OSError:
+                return "", offset
+            if len(data) <= offset:
+                return "", len(data)
+            return data[offset:].decode("utf-8", errors="replace"), len(data)
+
         bytes_sent = 0
         last_stream_time = loop.time()
         buffer = ""
@@ -21370,10 +21380,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # Read any remaining output
                 if output_path.exists():
                     try:
-                        content = output_path.read_text(encoding="utf-8")
-                        if len(content) > bytes_sent:
-                            buffer += content[bytes_sent:]
-                            bytes_sent = len(content)
+                        chunk, bytes_sent = _read_output_since(output_path, bytes_sent)
+                        if chunk:
+                            buffer += chunk
                     except OSError:
                         pass
                 await _flush_buffer()
@@ -21411,10 +21420,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Check for new output
             if output_path.exists():
                 try:
-                    content = output_path.read_text(encoding="utf-8")
-                    if len(content) > bytes_sent:
-                        buffer += content[bytes_sent:]
-                        bytes_sent = len(content)
+                    chunk, bytes_sent = _read_output_since(output_path, bytes_sent)
+                    if chunk:
+                        buffer += chunk
                 except OSError:
                     pass
 
@@ -21553,7 +21561,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Read the captured update output
             output = ""
             if output_path.exists():
-                output = output_path.read_text(encoding="utf-8")
+                output = output_path.read_bytes().decode("utf-8", errors="replace")
 
             # Resolve adapter
             platform = Platform(platform_str)

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1258,7 +1258,15 @@ def _restore_stashed_changes(
         if input_fn is not None:
             response = input_fn("Restore local changes now? [Y/n]", "y")
         else:
-            response = input().strip().lower()
+            try:
+                response = input().strip().lower()
+            except (EOFError, UnicodeDecodeError):
+                # Mirror the config-migration prompt's fix: don't let a
+                # terminal-encoding issue or a closed stdin crash the
+                # update mid-restore. Falls through to the existing
+                # skip-restore path below, which already explains how to
+                # restore manually from git stash.
+                response = "n"
         if response not in {"", "y", "yes"}:
             print("Skipped restoring local changes.")
             print("Your changes are still preserved in git stash.")
@@ -1545,7 +1553,7 @@ def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> None:
             response = (
                 input("Add official repo as 'upstream' remote? [Y/n]: ").strip().lower()
             )
-        except (EOFError, KeyboardInterrupt):
+        except (EOFError, KeyboardInterrupt, UnicodeDecodeError):
             print()
             response = "n"
 
@@ -4544,6 +4552,16 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         .lower()
                     )
                 except EOFError:
+                    response = "n"
+                except UnicodeDecodeError:
+                    # input() can raise this when the terminal encoding can't
+                    # decode the byte sequence (e.g. a non-UTF-8 locale, or an
+                    # embedded terminal). Without this, the exception escapes
+                    # here and crashes the update at this prompt.
+                    print(
+                        "  ⚠ Could not read input (encoding issue). Skipping. "
+                        "Run 'hermes config migrate' manually to configure."
+                    )
                     response = "n"
 
             if response in {"", "y", "yes", "auto"}:

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -216,13 +216,56 @@ def check_email_requirements() -> bool:
     return all([addr, pwd, imap, smtp])
 
 
+_CHARSET_ALIASES = {
+    # Aliases seen in the wild that Python's codec registry doesn't know.
+    # "unknown-8bit" / "x-unknown" are RFC 1428 placeholders some MTAs (QQ
+    # Mail among them) emit when the original charset was lost (#35901).
+    "unknown-8bit": "utf-8",
+    "unknown": "utf-8",
+    "x-unknown": "utf-8",
+    "default": "utf-8",
+    "ansi_x3.110-1983": "latin-1",
+    "cp-850": "cp850",
+    "gb2312": "gb18030",  # superset; avoids failures on GBK extensions
+    "gbk": "gb18030",
+    "ks_c_5601-1987": "cp949",
+}
+
+
+def _safe_decode(payload: bytes, charset: "Optional[str]") -> str:
+    """Decode *payload* without ever raising.
+
+    Unknown or malformed charset labels (``unknown-8bit``, misspelled names,
+    attacker-controlled garbage) previously raised ``LookupError`` from
+    ``bytes.decode`` — ``errors="replace"`` only guards decode errors, not a
+    missing codec — which aborted the whole IMAP fetch and dropped every
+    message in the batch (#35901, #55381, #55383). Fall back through a small
+    alias table, then UTF-8, then latin-1 (which never fails).
+    """
+    label = (charset or "utf-8").strip().strip("\"'").lower() or "utf-8"
+    label = _CHARSET_ALIASES.get(label, label)
+    for candidate in (label, "utf-8"):
+        try:
+            return payload.decode(candidate, errors="replace")
+        except (LookupError, ValueError):
+            continue
+    return payload.decode("latin-1", errors="replace")
+
+
 def _decode_header_value(raw: str) -> str:
-    """Decode an RFC 2047 encoded email header into a plain string."""
-    parts = decode_header(raw)
+    """Decode an RFC 2047 encoded email header into a plain string.
+
+    Never raises: malformed encoded-words or unknown charsets degrade to
+    replacement characters instead of crashing the fetch loop (#55381).
+    """
+    try:
+        parts = decode_header(raw)
+    except Exception:  # malformed RFC 2047 structure
+        return raw
     decoded = []
     for part, charset in parts:
         if isinstance(part, bytes):
-            decoded.append(part.decode(charset or "utf-8", errors="replace"))
+            decoded.append(_safe_decode(part, charset))
         else:
             decoded.append(part)
     return " ".join(decoded)
@@ -240,8 +283,7 @@ def _extract_text_body(msg: email_lib.message.Message) -> str:
             if content_type == "text/plain":
                 payload = part.get_payload(decode=True)
                 if payload:
-                    charset = part.get_content_charset() or "utf-8"
-                    return payload.decode(charset, errors="replace")
+                    return _safe_decode(payload, part.get_content_charset())
         # Fallback: try text/html and strip tags
         for part in msg.walk():
             content_type = part.get_content_type()
@@ -251,15 +293,13 @@ def _extract_text_body(msg: email_lib.message.Message) -> str:
             if content_type == "text/html":
                 payload = part.get_payload(decode=True)
                 if payload:
-                    charset = part.get_content_charset() or "utf-8"
-                    html = payload.decode(charset, errors="replace")
+                    html = _safe_decode(payload, part.get_content_charset())
                     return _strip_html(html)
         return ""
     else:
         payload = msg.get_payload(decode=True)
         if payload:
-            charset = msg.get_content_charset() or "utf-8"
-            text = payload.decode(charset, errors="replace")
+            text = _safe_decode(payload, msg.get_content_charset())
             if msg.get_content_type() == "text/html":
                 return _strip_html(text)
             return text

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8228,7 +8228,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 if offset < 0 or length <= 0:
                     continue
 
-                entity_text = source_text[offset:offset + length].strip()
+                entity_text = TelegramAdapter._telegram_entity_text(source_text, offset, length).strip()
                 if entity_type == "mention":
                     handle = entity_text.lstrip("@").lower()
                     if _is_bot_handle(handle):
@@ -8259,6 +8259,19 @@ class TelegramAdapter(BasePlatformAdapter):
 
         return mentioned_bot_usernames
 
+    @staticmethod
+    def _telegram_entity_text(source_text: str, offset: int, length: int) -> str:
+        """Return a Telegram entity span using UTF-16 code-unit offsets."""
+        if offset < 0 or length <= 0:
+            return ""
+        try:
+            raw = source_text.encode("utf-16-le")
+            start = offset * 2
+            end = (offset + length) * 2
+            return raw[start:end].decode("utf-16-le")
+        except UnicodeDecodeError:
+            return ""
+
     def _message_mentions_bot(self, message: Message) -> bool:
         if not self._bot:
             return False
@@ -8285,7 +8298,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     length = int(getattr(entity, "length", 0))
                     if offset < 0 or length <= 0:
                         continue
-                    if source_text[offset:offset + length].strip().lower() == expected:
+                    if self._telegram_entity_text(source_text, offset, length).strip().lower() == expected:
                         return True
                 elif entity_type == "text_mention":
                     user = getattr(entity, "user", None)
@@ -8305,7 +8318,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     length = int(getattr(entity, "length", 0))
                     if offset < 0 or length <= 0:
                         continue
-                    command_text = source_text[offset:offset + length]
+                    command_text = self._telegram_entity_text(source_text, offset, length)
                     at_index = command_text.find("@")
                     if at_index < 0:
                         continue

--- a/tests/gateway/test_email_charset_fallback.py
+++ b/tests/gateway/test_email_charset_fallback.py
@@ -1,0 +1,103 @@
+"""Email charset robustness: unknown/malformed charsets must never drop mail.
+
+Regression tests for #35901 (QQ Mail ``unknown-8bit`` charset raising
+``LookupError`` and aborting the IMAP fetch), #55381 (malformed RFC 2047
+header crashing ``_decode_header_value``), and #55383 (unknown Content-Type
+charset crashing ``_extract_text_body``). UIDs are marked seen before the
+fetch, so any exception in per-message decoding permanently loses messages —
+decoding must degrade, never raise.
+"""
+
+import email as email_lib
+from email.message import EmailMessage
+
+from plugins.platforms.email.adapter import (
+    _decode_header_value,
+    _extract_text_body,
+    _safe_decode,
+)
+
+
+class TestSafeDecode:
+    def test_unknown_8bit_charset_falls_back(self):
+        # QQ Mail emits the RFC 1428 "unknown-8bit" placeholder (#35901).
+        assert _safe_decode("你好".encode("utf-8"), "unknown-8bit") == "你好"
+
+    def test_garbage_charset_label_never_raises(self):
+        assert _safe_decode(b"Hello", "charset") == "Hello"
+        assert _safe_decode(b"Hello", "not-a-codec-!!") == "Hello"
+
+    def test_none_charset_defaults_to_utf8(self):
+        assert _safe_decode("héllo".encode("utf-8"), None) == "héllo"
+
+    def test_gb2312_label_decodes_gbk_extensions(self):
+        # gb2312-labelled mail routinely contains GBK-only characters.
+        assert _safe_decode("镕".encode("gb18030"), "gb2312") == "镕"
+
+    def test_invalid_bytes_replace_not_raise(self):
+        out = _safe_decode(b"ok \xff\xfe bad", "utf-8")
+        assert "ok" in out and "bad" in out
+
+    def test_latin1_last_resort(self):
+        # A charset whose codec exists but whose bytes are invalid UTF-8
+        # still returns text via errors="replace" — never an exception.
+        assert _safe_decode(b"\x96\x97", "unknown-8bit") != ""
+
+
+class TestDecodeHeaderValue:
+    def test_unknown_8bit_encoded_word(self):
+        assert _decode_header_value("=?unknown-8bit?B?SGVsbG8=?=") == "Hello"
+
+    def test_malformed_charset_in_encoded_word(self):
+        # decode_header parses this fine but "charset" is not a codec —
+        # previously a LookupError aborted the whole fetch batch (#55381).
+        out = _decode_header_value("=?charset?B?SGVsbG8=?=")
+        assert isinstance(out, str)
+        assert out  # degrades, never raises/empties
+
+    def test_plain_header_passthrough(self):
+        assert _decode_header_value("Just a subject") == "Just a subject"
+
+    def test_qq_mail_gbk_subject(self):
+        # =?gbk?B?...?= with GBK bytes; gbk→gb18030 alias covers extensions.
+        import base64
+        encoded = base64.b64encode("你好".encode("gbk")).decode()
+        assert _decode_header_value(f"=?gbk?B?{encoded}?=") == "你好"
+
+
+class TestExtractTextBodyCharsets:
+    def _msg(self, body_bytes: bytes, charset_label: str):
+        raw = (
+            b"From: a@b.c\r\n"
+            b"Subject: t\r\n"
+            b"MIME-Version: 1.0\r\n"
+            b'Content-Type: text/plain; charset="' + charset_label.encode() + b'"\r\n'
+            b"Content-Transfer-Encoding: 8bit\r\n"
+            b"\r\n" + body_bytes
+        )
+        return email_lib.message_from_bytes(raw)
+
+    def test_unknown_charset_body_does_not_raise(self):
+        # LookupError from an unknown Content-Type charset aborted the
+        # fetch and dropped the message (#55383).
+        msg = self._msg("正文内容".encode("utf-8"), "unknown-8bit")
+        assert "正文内容" in _extract_text_body(msg)
+
+    def test_bogus_charset_body_does_not_raise(self):
+        msg = self._msg(b"plain ascii body", "x-mac-cyrillic-fake")
+        assert "plain ascii body" in _extract_text_body(msg)
+
+    def test_multipart_unknown_charset_part(self):
+        outer = EmailMessage()
+        outer["From"] = "a@b.c"
+        outer["Subject"] = "t"
+        outer.make_mixed()
+        raw_part = (
+            b'Content-Type: text/plain; charset="unknown-8bit"\r\n'
+            b"Content-Transfer-Encoding: 8bit\r\n"
+            b"\r\n"
+            b"part body here"
+        )
+        part = email_lib.message_from_bytes(raw_part)
+        outer.attach(part)
+        assert "part body here" in _extract_text_body(outer)

--- a/tests/gateway/test_fence_chunker.py
+++ b/tests/gateway/test_fence_chunker.py
@@ -145,3 +145,32 @@ def test_greedy_pack_overflow_callback():
 # ── canonical table-row splitter delegation ──────────────────────────────────
 
 
+
+
+# ── UTF-16 length units at the Telegram limit (#55844) ──────────────────────
+
+
+def test_emoji_heavy_split_respects_utf16_limit():
+    """Telegram's 4096 limit is UTF-16 code units — emoji count as 2.
+
+    Regression for #55844: the fallback splitter must measure chunks with
+    the platform len_fn, not Python codepoints, or emoji-heavy messages
+    ship oversized chunks that Telegram rejects with MESSAGE_TOO_LONG.
+    """
+    limit = 3996  # gateway's safe limit: 4096 - 100 headroom
+    text = "🚀" * 3000  # 3000 codepoints == 6000 UTF-16 units
+    chunks = split_text_fence_aware(
+        text, limit, utf16_len, prefer_paragraphs=False, balance_fences=True
+    )
+    assert len(chunks) > 1
+    assert all(utf16_len(c) <= limit for c in chunks)
+    assert "".join(chunks) == text
+
+
+def test_mixed_emoji_newline_text_utf16_limit():
+    text = "emoji 🎉🎊 line with some more words attached\n" * 400
+    chunks = split_text_fence_aware(
+        text, 500, utf16_len, prefer_paragraphs=False, balance_fences=True
+    )
+    assert all(utf16_len(c) <= 500 for c in chunks)
+    assert all(c for c in chunks)

--- a/tests/gateway/test_telegram_mention_boundaries.py
+++ b/tests/gateway/test_telegram_mention_boundaries.py
@@ -31,6 +31,14 @@ def _mention_entity(text, mention="@hermes_bot"):
     return SimpleNamespace(type="mention", offset=offset, length=len(mention))
 
 
+def _telegram_mention_entity(text, mention="@hermes_bot", entity_type="mention"):
+    """Build an entity with Telegram UTF-16 code-unit offset/length values."""
+    start = text.index(mention)
+    offset = len(text[:start].encode("utf-16-le")) // 2
+    length = len(mention.encode("utf-16-le")) // 2
+    return SimpleNamespace(type=entity_type, offset=offset, length=length)
+
+
 def _text_mention_entity(offset, length, user_id):
     """Build a TEXT_MENTION entity (used when the target user has no public @handle)."""
     return SimpleNamespace(
@@ -62,6 +70,12 @@ class TestRealMentionsAreDetected:
         msg = _message(text=text, entities=[_mention_entity(text)])
         assert adapter._message_mentions_bot(msg) is True
 
+
+    def test_mention_after_non_bmp_characters_uses_telegram_offsets(self):
+        adapter = _make_adapter()
+        text = "\U0001f680\U0001f680 @hermes_bot hello"
+        msg = _message(text=text, entities=[_telegram_mention_entity(text)])
+        assert adapter._message_mentions_bot(msg) is True
 
     def test_text_mention_entity_targets_bot(self):
         """TEXT_MENTION is Telegram's entity type for @FirstName -> user without a public handle."""
@@ -119,3 +133,28 @@ class TestCaseInsensitivity:
         msg = _message(text=text, entities=[_mention_entity(text, mention="@HERMES_BOT")])
         assert adapter._message_mentions_bot(msg) is True
 
+    def test_mixed_case_mention(self):
+        adapter = _make_adapter()
+        text = "hi @Hermes_Bot"
+        msg = _message(text=text, entities=[_mention_entity(text, mention="@Hermes_Bot")])
+        assert adapter._message_mentions_bot(msg) is True
+
+
+class TestTelegramUtf16EntityOffsets:
+    def test_extracts_bot_mention_username_after_non_bmp_characters(self):
+        text = "\U0001f9ea\U0001f9ea @hermes_bot please"
+        msg = _message(text=text, entities=[_telegram_mention_entity(text)])
+        assert TelegramAdapter._extract_bot_mention_usernames(msg) == {"hermes_bot"}
+
+    def test_bot_command_suffix_after_non_bmp_characters_mentions_bot(self):
+        adapter = _make_adapter()
+        text = "\U0001f9ea\U0001f9ea /new@hermes_bot"
+        entity = _telegram_mention_entity(text, mention="/new@hermes_bot", entity_type="bot_command")
+        msg = _message(text=text, entities=[entity])
+        assert adapter._message_mentions_bot(msg) is True
+
+    def test_extracts_bot_command_target_after_non_bmp_characters(self):
+        text = "\U0001f9ea\U0001f9ea /new@hermes_bot"
+        entity = _telegram_mention_entity(text, mention="/new@hermes_bot", entity_type="bot_command")
+        msg = _message(text=text, entities=[entity])
+        assert TelegramAdapter._extract_bot_mention_usernames(msg) == {"hermes_bot"}

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -34,6 +34,7 @@ def _make_runner():
     runner = object.__new__(GatewayRunner)
     runner.adapters = {}
     runner._voice_mode = {}
+    runner._update_prompt_pending = {}
     return runner
 
 
@@ -414,6 +415,83 @@ class TestSendUpdateNotification:
         # The marker stays in its canonical pending location (claim restored).
         assert not (hermes_home / ".update_pending.claimed.json").exists()
 
+    @pytest.mark.asyncio
+    async def test_deferred_notification_delivers_after_reconnect(self, tmp_path):
+        """A deferred completion is delivered once the platform reconnects.
+
+        Regression for the late-reconnect /update bug: the update finishes while
+        the target platform is offline, the markers survive the deferral, and
+        the next call (after the adapter is registered) delivers the result and
+        cleans up — exactly once.
+        """
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+
+        pending = {"platform": "discord", "chat_id": "111", "user_id": "222"}
+        pending_path = hermes_home / ".update_pending.json"
+        output_path = hermes_home / ".update_output.txt"
+        exit_code_path = hermes_home / ".update_exit_code"
+        pending_path.write_text(json.dumps(pending))
+        output_path.write_text("✓ Update complete!")
+        exit_code_path.write_text("0")
+
+        # First pass: target platform (discord) is still offline → defer.
+        with patch("gateway.run._hermes_home", hermes_home):
+            first = await runner._send_update_notification()
+
+        assert first is False
+        assert pending_path.exists()
+
+        # Platform reconnects: the reconnect watcher adds the adapter back.
+        mock_adapter = AsyncMock()
+        runner.adapters = {Platform.DISCORD: mock_adapter}
+
+        with patch("gateway.run._hermes_home", hermes_home):
+            second = await runner._send_update_notification()
+
+        assert second is True
+        mock_adapter.send.assert_called_once()
+        sent_text = mock_adapter.send.call_args[0][1]
+        assert "Update complete" in sent_text
+        # Now everything is cleaned up — no duplicate deliveries possible.
+        assert not pending_path.exists()
+        assert not output_path.exists()
+        assert not exit_code_path.exists()
+        assert not (hermes_home / ".update_pending.claimed.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_completion_notification_tolerates_invalid_utf8_output(self, tmp_path):
+        """Completion-only update notifications must not crash on bad bytes."""
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+
+        pending = {"platform": "discord", "chat_id": "111", "user_id": "222"}
+        pending_path = hermes_home / ".update_pending.json"
+        output_path = hermes_home / ".update_output.txt"
+        exit_code_path = hermes_home / ".update_exit_code"
+        pending_path.write_text(json.dumps(pending))
+        output_path.write_bytes(b"ok before\ninvalid byte: \x96\ncontinued after\n")
+        exit_code_path.write_text("0")
+
+        mock_adapter = AsyncMock()
+        runner.adapters = {Platform.DISCORD: mock_adapter}
+
+        with patch("gateway.run._hermes_home", hermes_home):
+            delivered = await runner._send_update_notification()
+
+        assert delivered is True
+        mock_adapter.send.assert_called_once()
+        sent_text = mock_adapter.send.call_args[0][1]
+        assert "ok before" in sent_text
+        assert "invalid byte" in sent_text
+        assert "continued after" in sent_text
+        assert "Hermes update finished" in sent_text
+        assert not pending_path.exists()
+        assert not output_path.exists()
+        assert not exit_code_path.exists()
+
 
 # ---------------------------------------------------------------------------
 # /update in help and known_commands
@@ -432,3 +510,32 @@ class TestUpdateInHelp:
         import inspect
         source = inspect.getsource(GatewayRunner._handle_message)
         assert '"update"' in source
+
+class TestWatchUpdateProgress:
+    @pytest.mark.asyncio
+    async def test_invalid_utf8_update_output_does_not_crash_watcher(self, tmp_path):
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+
+        (hermes_home / ".update_pending.json").write_text(json.dumps({
+            "platform": "telegram",
+            "chat_id": "67890",
+            "user_id": "12345",
+        }))
+        (hermes_home / ".update_output.txt").write_bytes(
+            b"ok before\n\xe2\x9c invalid-continuation: \x96\ncontinued after\n"
+        )
+        (hermes_home / ".update_exit_code").write_text("0")
+
+        mock_adapter = AsyncMock()
+        runner.adapters = {Platform.TELEGRAM: mock_adapter}
+
+        with patch("gateway.run._hermes_home", hermes_home):
+            await runner._watch_update_progress(poll_interval=0.01, stream_interval=0.01, timeout=1.0)
+
+        sent = "\n".join(call.args[1] for call in mock_adapter.send.call_args_list)
+        assert "ok before" in sent
+        assert "continued after" in sent
+        assert "Hermes update finished" in sent
+        assert not (hermes_home / ".update_pending.json").exists()

--- a/tests/hermes_cli/test_update_yes_flag.py
+++ b/tests/hermes_cli/test_update_yes_flag.py
@@ -181,9 +181,7 @@ class TestUnicodeDecodeErrorInUpdatePrompts:
 
         out = capsys.readouterr().out
         assert "hermes config migrate" in out
-        assert mock_migrate.call_count == 0 or (
-            mock_migrate.call_args and mock_migrate.call_args.kwargs.get("interactive") is not True
-        )
+        mock_migrate.assert_not_called()
 
     def test_stash_restore_unicode_decode_error_falls_through_to_skip(self, tmp_path, capsys):
         from hermes_cli.update_cmd import _restore_stashed_changes

--- a/tests/hermes_cli/test_update_yes_flag.py
+++ b/tests/hermes_cli/test_update_yes_flag.py
@@ -135,3 +135,99 @@ class TestUpdateYesConfigMigration:
 class TestUpdateYesStashRestore:
     """--yes auto-restores the pre-update autostash without prompting."""
 
+
+
+class TestUnicodeDecodeErrorInUpdatePrompts:
+    """Regression tests (review of #68497): input() can raise
+    UnicodeDecodeError when the terminal encoding can't decode the byte
+    sequence (e.g. a non-UTF-8 locale, or an embedded terminal). Three
+    interactive update prompts call input() directly -- the config-
+    migration prompt, the stash-restore prompt, and the upstream-remote
+    prompt -- and each must fail safe (skip, don't crash) rather than let
+    the exception escape and crash `hermes update` mid-flight.
+    """
+
+    @patch("hermes_cli.config.migrate_config")
+    @patch("hermes_cli.config.check_config_version", return_value=(1, 2))
+    @patch("hermes_cli.config.get_missing_config_fields", return_value=[])
+    @patch("hermes_cli.config.get_missing_env_vars", return_value=["NEW_KEY"])
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_unicode_decode_error_in_tty_skips_and_prints_hint(
+        self,
+        mock_run,
+        _mock_which,
+        _mock_missing_env,
+        _mock_missing_cfg,
+        _mock_version,
+        mock_migrate,
+        capsys,
+    ):
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="1"
+        )
+        mock_migrate.return_value = {"env_added": [], "config_added": []}
+        args = SimpleNamespace(yes=False)
+
+        import sys as _sys
+
+        with patch(
+            "builtins.input",
+            side_effect=UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid byte"),
+        ), patch.object(_sys.stdin, "isatty", return_value=True), patch.object(
+            _sys.stdout, "isatty", return_value=True
+        ):
+            cmd_update(args)  # must not raise
+
+        out = capsys.readouterr().out
+        assert "hermes config migrate" in out
+        assert mock_migrate.call_count == 0 or (
+            mock_migrate.call_args and mock_migrate.call_args.kwargs.get("interactive") is not True
+        )
+
+    def test_stash_restore_unicode_decode_error_falls_through_to_skip(self, tmp_path, capsys):
+        from hermes_cli.update_cmd import _restore_stashed_changes
+
+        with patch(
+            "builtins.input",
+            side_effect=UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid byte"),
+        ):
+            result = _restore_stashed_changes(
+                ["git"], tmp_path, "stash@{0}", prompt_user=True, input_fn=None,
+            )  # must not raise
+
+        assert result is False
+        out = capsys.readouterr().out
+        assert "Skipped restoring local changes" in out
+        assert "git stash apply stash@{0}" in out
+
+    def test_stash_restore_eof_error_still_falls_through_to_skip(self, tmp_path):
+        """Sanity: this fix must not regress the pre-existing EOFError case,
+        which the raw input() path had no guard for at all before this fix."""
+        from hermes_cli.update_cmd import _restore_stashed_changes
+
+        with patch("builtins.input", side_effect=EOFError()):
+            result = _restore_stashed_changes(
+                ["git"], tmp_path, "stash@{0}", prompt_user=True, input_fn=None,
+            )  # must not raise
+
+        assert result is False
+
+    def test_upstream_remote_prompt_unicode_decode_error_falls_through_to_skip(
+        self, tmp_path
+    ):
+        from hermes_cli.update_cmd import _sync_with_upstream_if_needed
+
+        with patch(
+            "hermes_cli.update_cmd._has_upstream_remote", return_value=False
+        ), patch(
+            "hermes_cli.update_cmd._should_skip_upstream_prompt", return_value=False
+        ), patch(
+            "hermes_cli.update_cmd._add_upstream_remote"
+        ) as mock_add, patch(
+            "builtins.input",
+            side_effect=UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid byte"),
+        ):
+            _sync_with_upstream_if_needed(["git"], tmp_path)  # must not raise
+
+        mock_add.assert_not_called()


### PR DESCRIPTION
## Summary
Platform text-encoding singles, each premise-verified on main: Telegram entity offsets sliced with codepoint indices (UTF-16 per API spec), email fetches crashed and dropped messages on malformed RFC2047 headers / unknown charsets, update watcher output crashed on invalid bytes.

## Changes
- Salvaged @zapabob #55507: `_telegram_entity_text()` UTF-16-aware slicing (3 sites in adapter.py)
- Salvaged @verybigdog #49748 (update watcher read_text tolerance, 3 sites) + @ygd58 #74631 (interactive update prompts)
- Salvaged @Kailigithub #32982 (batch_runner mojibake emoji — older than dupe #66680)
- Fixed directly (issues, no PR): email charset fallback chain + RFC2047 resilience (#35901, #55381, #55383) — a message is never dropped for undecodable headers/bodies

## Validation
| | Result |
|---|---|
| targeted suites | 123 passed |

## Infographic

![message-integrity](https://v3b.fal.media/files/b/0aa58cf4/BqKXiTSUz1QYurssQV9jG_2sLWWRk1.png)
