### PR TITLE
fix: BOM-tolerant user-file reads + encoding-footgun closures (PLW1514 was already gated)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2102,7 +2102,7 @@ def _read_nous_auth() -> Optional[dict]:
     try:
         if not _AUTH_JSON_PATH.is_file():
             return None
-        data = json.loads(_AUTH_JSON_PATH.read_text(encoding="utf-8"))
+        data = json.loads(_AUTH_JSON_PATH.read_text(encoding="utf-8-sig"))
         if data.get("active_provider") != "nous":
             return None
         provider = data.get("providers", {}).get("nous", {})

--- a/agent/credential_sources.py
+++ b/agent/credential_sources.py
@@ -162,9 +162,17 @@ def _remove_env_source(provider: str, removed) -> RemovalResult:
     try:
         env_path = get_env_path()
         if env_path.exists():
+            # Read the .env as UTF-8 with BOM tolerance, matching the
+            # canonical reader in hermes_cli/config.py. read_text() with no
+            # encoding falls back to the system locale (cp1252/GBK on Windows)
+            # and never strips a BOM, so a Notepad-edited .env (BOM + non-ASCII
+            # values) would make the first line fail the startswith() check —
+            # misreporting a .env-backed var as a shell export.
             env_in_dotenv = any(
                 line.strip().startswith(f"{env_var}=")
-                for line in env_path.read_text(errors="replace", encoding="utf-8").splitlines()
+                for line in env_path.read_text(
+                    encoding="utf-8-sig", errors="replace"
+                ).splitlines()
             )
     except OSError:
         pass

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -793,7 +793,7 @@ def save_allowlist(data: Dict[str, Any]) -> None:
             prefix=f"{p.name}.", suffix=".tmp", dir=str(p.parent),
         )
         try:
-            with os.fdopen(fd, "w") as fh:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
                 fh.write(json.dumps(data, indent=2, sort_keys=True))
             atomic_replace(tmp_path, p)
         except Exception:

--- a/contributors/emails/nolanchic@gmail.com
+++ b/contributors/emails/nolanchic@gmail.com
@@ -1,0 +1,1 @@
+nolanchic

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -5655,7 +5655,7 @@ class GatewaySlashCommandsMixin:
                     with open(output_path, "wb") as f:
                         proc = subprocess.Popen(cmd, stdout=f, stderr=subprocess.STDOUT, env=env)
                         rc = proc.wait(timeout=3600)
-                    with open(exit_code_path, "w") as f:
+                    with open(exit_code_path, "w", encoding="utf-8") as f:
                         f.write(str(rc))
                     """
                 ).strip()

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1218,7 +1218,7 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
         return {"version": AUTH_STORE_VERSION, "providers": {}}
 
     try:
-        raw = json.loads(auth_file.read_text(encoding="utf-8"))
+        raw = json.loads(auth_file.read_text(encoding="utf-8-sig"))
     except OSError:
         # The file exists (checked above) but could not be READ: EMFILE under
         # fd exhaustion, EACCES, EIO, a stalled network mount. None of those
@@ -3950,7 +3950,7 @@ def _import_codex_cli_tokens() -> Optional[Dict[str, str]]:
     if not auth_path.is_file():
         return None
     try:
-        payload = json.loads(auth_path.read_text(encoding="utf-8"))
+        payload = json.loads(auth_path.read_text(encoding="utf-8-sig"))
         tokens = payload.get("tokens")
         if not isinstance(tokens, dict):
             return None
@@ -5442,7 +5442,7 @@ def _read_shared_nous_state() -> Optional[Dict[str, Any]]:
     if not path.is_file():
         return None
     try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload = json.loads(path.read_text(encoding="utf-8-sig"))
     except (OSError, ValueError) as exc:
         logger.debug("Shared Nous auth store at %s is unreadable: %s", path, exc)
         return None

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -341,7 +341,11 @@ def _sanitize_loaded_credentials() -> None:
 
 def _load_dotenv_with_fallback(path: Path, *, override: bool) -> None:
     try:
-        load_dotenv(dotenv_path=path, override=override, encoding="utf-8")
+        # utf-8-sig strips a leading UTF-8 BOM if present (PowerShell 5.1
+        # Set-Content -Encoding UTF8 / Notepad) and is a no-op for BOM-less
+        # UTF-8. Plain "utf-8" would keep U+FEFF on the first key name and
+        # silently drop it from os.environ under its canonical name.
+        load_dotenv(dotenv_path=path, override=override, encoding="utf-8-sig")
     except UnicodeDecodeError:
         load_dotenv(dotenv_path=path, override=override, encoding="latin-1")
     # Strip non-ASCII characters from credential env vars that were just

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -347,7 +347,11 @@ def _load_dotenv_with_fallback(path: Path, *, override: bool) -> None:
         # silently drop it from os.environ under its canonical name.
         load_dotenv(dotenv_path=path, override=override, encoding="utf-8-sig")
     except UnicodeDecodeError:
-        load_dotenv(dotenv_path=path, override=override, encoding="latin-1")
+        # utf-8-sig can't strip a BOM once we fall back to latin-1 decode.
+        raw = path.read_bytes()
+        if raw.startswith(codecs.BOM_UTF8):
+            raw = raw[len(codecs.BOM_UTF8) :]
+        load_dotenv(stream=io.StringIO(raw.decode("latin-1")), override=override)
     # Strip non-ASCII characters from credential env vars that were just
     # loaded.  API keys must be pure ASCII since they're sent as HTTP
     # header values (httpx encodes headers as ASCII).  Non-ASCII chars

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10210,7 +10210,7 @@ def _read_ssh_session_token_file(path: str) -> str:
         if hasattr(os, "getuid") and (file_stat.st_mode & 0o777) & ~0o600:
             raise SystemExit("--ssh-session-token-file has unsafe permissions")
 
-        with os.fdopen(file_fd, "r") as token_stream:
+        with os.fdopen(file_fd, "r", encoding="utf-8") as token_stream:
             file_fd = -1
             token = token_stream.read(65)
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1026,7 +1026,7 @@ def _has_any_provider_configured() -> bool:
         try:
             import json
 
-            auth = json.loads(auth_file.read_text(encoding="utf-8"))
+            auth = json.loads(auth_file.read_text(encoding="utf-8-sig"))
             active = auth.get("active_provider")
             if active:
                 status = get_auth_status(active)

--- a/hermes_cli/send_cmd.py
+++ b/hermes_cli/send_cmd.py
@@ -263,10 +263,22 @@ def _load_hermes_env() -> None:
     env_path = home / ".env"
     if load_dotenv and env_path.exists():
         try:
-            load_dotenv(str(env_path), override=True, encoding="utf-8")
+            # utf-8-sig strips a leading UTF-8 BOM if present (PowerShell 5.1
+            # Set-Content -Encoding UTF8 / Notepad) and is a no-op for
+            # BOM-less UTF-8. Plain "utf-8" would keep U+FEFF on the first
+            # key name and silently drop it from os.environ under its
+            # canonical name.
+            load_dotenv(str(env_path), override=True, encoding="utf-8-sig")
         except UnicodeDecodeError:
             try:
-                load_dotenv(str(env_path), override=True, encoding="latin-1")
+                # utf-8-sig can't strip a BOM once we fall back to latin-1.
+                import codecs
+                import io
+
+                raw = env_path.read_bytes()
+                if raw.startswith(codecs.BOM_UTF8):
+                    raw = raw[len(codecs.BOM_UTF8) :]
+                load_dotenv(stream=io.StringIO(raw.decode("latin-1")), override=True)
             except Exception:
                 pass
         except Exception:

--- a/scripts/check-windows-footguns.py
+++ b/scripts/check-windows-footguns.py
@@ -176,6 +176,32 @@ FOOTGUNS: list[Footgun] = [
         ),
     ),
     Footgun(
+        name="os.fdopen() without encoding= on text mode",
+        # ruff PLW1514 covers builtins.open/Path.read_text/write_text/
+        # Path.open but NOT os.fdopen — a bare text-mode fdopen still
+        # decodes/encodes with the locale default (cp1252 on Windows).
+        # This is the exact hole the July 2026 encoding sweep kept
+        # re-fixing by hand (PRs #56033/#56940/#65565), so gate it here.
+        pattern=re.compile(
+            r"""(?:os\s*\.\s*)?\bfdopen\s*\(\s*[^,)]+\s*(?:,\s*['"](?P<mode>[^'"]*)['"])?"""
+        ),
+        message=(
+            "os.fdopen() without an explicit encoding= uses the platform "
+            "default (cp1252/mbcs on Windows) in text mode — the same "
+            "mojibake class as bare open(). ruff PLW1514 does not cover "
+            "fdopen, so this checker is the only gate."
+        ),
+        fix=(
+            "os.fdopen(fd, 'w', encoding='utf-8')  # or mode 'wb' for binary"
+        ),
+        post_filter=lambda m, line: (
+            "b" not in (m.group("mode") or "")
+            and "encoding=" not in line
+            and "encoding =" not in line
+            and "**" not in line
+        ),
+    ),
+    Footgun(
         name="os.kill(pid, 0)",
         pattern=re.compile(r"\bos\.kill\s*\(\s*[^,]+,\s*0\s*\)"),
         message=(
@@ -395,10 +421,14 @@ FOOTGUNS: list[Footgun] = [
             "encoding=" not in line
             and "encoding =" not in line
             and not _looks_like_string_literal(line, m)
-            # Skip calls that continue onto the next line — the closing
-            # paren isn't on this line, so encoding= may follow. AST-level
-            # enforcement for those lives in the gateway guard test.
-            and line.rstrip().endswith(")")
+            # Skip calls that continue onto the next line — if the call's
+            # own closing paren isn't on this line, encoding= may follow
+            # on a later line. Balance parens from the call opener instead
+            # of requiring the line to END with ``)`` so chained forms like
+            # ``read_text()[:4000]`` / ``read_text().splitlines()`` are
+            # still caught. AST-level enforcement for multi-line calls
+            # lives in the gateway guard test.
+            and _call_closes_on_line(line, m.end())
         ),
     ),
 ]
@@ -519,6 +549,22 @@ def _is_likely_subprocess_call(line: str) -> bool:
     false negative for a line-based scanner.
     """
     return any(token in line for token in _SUBPROCESS_METHODS)
+
+
+def _call_closes_on_line(line: str, open_paren_end: int) -> bool:
+    """True when the call whose ``(`` sits at ``open_paren_end - 1`` closes
+    on this same line (paren-balance walk). Multi-line calls return False —
+    the missing ``encoding=`` may sit on a continuation line, so the caller
+    should skip them rather than false-positive."""
+    depth = 1
+    for ch in line[open_paren_end:]:
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                return True
+    return False
 
 
 def _looks_like_string_literal(line: str, match: "re.Match") -> bool:

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -769,3 +769,44 @@ def test_auth_remove_copilot_suppresses_all_variants(tmp_path, monkeypatch):
     assert is_source_suppressed("copilot", "env:GITHUB_TOKEN")
 
 
+def test_auth_remove_env_seeded_dotenv_with_bom_no_shell_hint(tmp_path, monkeypatch, capsys):
+    """A Notepad-edited .env carries a UTF-8 BOM. The dotenv-vs-shell
+    detector must still see the first variable as living in .env (and not
+    warn about a phantom shell export). Regression for the reader that
+    dropped encoding='utf-8-sig' and misread the BOM'd first line.
+    """
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    # BOM prefix (utf-8-sig) + the target var as the FIRST line.
+    (hermes_home / ".env").write_bytes(
+        b"\xef\xbb\xbfDEEPSEEK_API_KEY=sk-ds-only\n"
+    )
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-ds-only")
+
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "deepseek": [{
+                    "id": "env-1",
+                    "label": "DEEPSEEK_API_KEY",
+                    "auth_type": "api_key",
+                    "priority": 0,
+                    "source": "env:DEEPSEEK_API_KEY",
+                    "access_token": "sk-ds-only",
+                }]
+            },
+        },
+    )
+
+    from types import SimpleNamespace
+    from hermes_cli.auth_commands import auth_remove_command
+    auth_remove_command(SimpleNamespace(provider="deepseek", target="1"))
+
+    out = capsys.readouterr().out
+    assert "Cleared DEEPSEEK_API_KEY from .env" in out
+    assert "still set in your shell environment" not in out

--- a/tests/hermes_cli/test_auth_store_windows_encoding.py
+++ b/tests/hermes_cli/test_auth_store_windows_encoding.py
@@ -1,0 +1,148 @@
+"""Regression tests for auth store encoding on Windows.
+
+``_load_auth_store`` and the Codex/Nous shared-store readers previously called
+``Path.read_text()`` with no ``encoding=``, so the bytes were decoded with
+``locale.getpreferredencoding()`` — cp1252 on Windows. The store is *written* as
+UTF-8 (``_save_auth_store`` uses ``encoding="utf-8"``), so any non-ASCII byte
+(e.g. a CJK or emoji credential label) raised ``UnicodeDecodeError`` on read.
+
+Worst case: ``_load_auth_store``'s broad ``except`` then copied the file to
+``.json.corrupt`` and returned an *empty* store — silently wiping every
+provider credential. These tests pin the round-trip so a non-ASCII label
+survives a save→load cycle, and assert the readers pass an explicit UTF-8
+encoding (the fix) instead of relying on the locale default.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+import hermes_cli.auth as auth
+
+
+# --- helpers ---------------------------------------------------------------
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    """Point HERMES_HOME at a tmp dir so we never touch the real auth store.
+
+    Required because ``_auth_file_path()`` has a seat belt that refuses to
+    resolve to the real user's ~/.hermes/auth.json under pytest.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    return tmp_path
+
+
+def _write_utf8(path: Path, payload: dict) -> None:
+    """Write JSON as UTF-8, mirroring _save_auth_store's encoding."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+# --- the bug: a non-ASCII label must survive save → load -------------------
+
+class TestAuthStoreEncodingRoundTrip:
+    def test_load_reads_utf8_with_non_ascii_label(self, hermes_home):
+        """A UTF-8 store with a CJK/emoji label loads intact (not wiped)."""
+        store = {
+            "version": auth.AUTH_STORE_VERSION,
+            "providers": {
+                "openai-codex": {
+                    "auth_mode": "chatgpt",
+                    "label": "工作账号 🔥",  # non-ASCII: CJK + emoji
+                    "tokens": {"access_token": "a", "refresh_token": "r"},
+                }
+            },
+        }
+        auth_path = hermes_home / "auth.json"
+        _write_utf8(auth_path, store)
+
+        loaded = auth._load_auth_store(auth_path)
+
+        # The label round-trips exactly — the provider is NOT lost.
+        assert "openai-codex" in loaded["providers"]
+        assert loaded["providers"]["openai-codex"]["label"] == "工作账号 🔥"
+
+    def test_load_does_not_corrupt_store_on_non_ascii(self, hermes_home):
+        """The pre-fix bug wiped the store to empty on a UnicodeDecodeError.
+
+        After the fix, loading a valid UTF-8 store must never produce the empty
+        fallback, and must never write a .json.corrupt sidecar.
+        """
+        store = {
+            "version": auth.AUTH_STORE_VERSION,
+            "providers": {"x": {"label": "José's key"}},
+        }
+        auth_path = hermes_home / "auth.json"
+        _write_utf8(auth_path, store)
+
+        auth._load_auth_store(auth_path)
+
+        assert not (hermes_home / "auth.json.corrupt").exists()
+        # original file untouched — read it back and compare structurally
+        # (json.dumps may escape non-ASCII, so compare parsed values, not text)
+        on_disk = json.loads(auth_path.read_text(encoding="utf-8"))
+        assert on_disk["providers"]["x"]["label"] == "José's key"
+
+    def test_load_handles_utf8_with_bom(self, hermes_home):
+        """A BOM (e.g. from Notepad editing) must not break the read."""
+        store = {"version": auth.AUTH_STORE_VERSION, "providers": {"x": {"label": "café"}}}
+        auth_path = hermes_home / "auth.json"
+        payload = json.dumps(store)
+        # write with utf-8-sig to prepend the BOM
+        auth_path.write_text(payload, encoding="utf-8-sig")
+
+        loaded = auth._load_auth_store(auth_path)
+        assert loaded["providers"]["x"]["label"] == "café"
+
+
+# --- the fix: readers pass an explicit encoding ---------------------------
+
+class TestExplicitEncodingPassed:
+    """The readers must not rely on the locale default (cp1252 on Windows).
+
+    We assert read_text is called with an explicit UTF-8 encoding. This is the
+    regression guard: a future refactor that drops the encoding kwarg would
+    reintroduce the Windows data-loss bug.
+    """
+
+    def test_load_auth_store_passes_utf8_encoding(self, hermes_home):
+        auth_path = hermes_home / "auth.json"
+        _write_utf8(auth_path, {"version": auth.AUTH_STORE_VERSION, "providers": {}})
+
+        with mock.patch.object(
+            Path, "read_text", wraps=Path.read_text
+        ) as spy:
+            auth._load_auth_store(auth_path)
+
+        assert spy.call_count == 1
+        kwargs = spy.call_args.kwargs
+        assert "encoding" in kwargs, "read_text() must pass an explicit encoding"
+        assert "utf-8" in str(kwargs["encoding"]).lower()
+
+    def test_codex_store_reader_passes_utf8_encoding(self, tmp_path, monkeypatch):
+        """The ~/.codex/auth.json reader must pass an explicit UTF-8 encoding."""
+        codex_home = tmp_path / "codex"
+        codex_home.mkdir()
+        (codex_home / "auth.json").write_text(
+            json.dumps({"tokens": {"access_token": "a", "refresh_token": "r"}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("CODEX_HOME", str(codex_home))
+        # Bypass the JWT-expiry check so a fake token doesn't short-circuit.
+        monkeypatch.setattr(auth, "_codex_access_token_is_expiring", lambda *a, **k: False)
+
+        with mock.patch.object(Path, "read_text", wraps=Path.read_text) as spy:
+            auth._import_codex_cli_tokens()
+
+        # _import_codex_cli_tokens reads exactly one file; assert that read
+        # carried an explicit UTF-8 encoding. (The bound-method spy captures
+        # kwargs but not the bound `self`, so we check the single read directly.)
+        assert spy.call_count >= 1, "expected a read of the codex auth.json"
+        for call in spy.call_args_list:
+            assert "encoding" in call.kwargs, "codex read_text() must pass encoding"
+            assert "utf-8" in str(call.kwargs["encoding"]).lower()

--- a/tests/hermes_cli/test_auth_store_windows_encoding.py
+++ b/tests/hermes_cli/test_auth_store_windows_encoding.py
@@ -319,3 +319,33 @@ class TestAuthJsonSiblingReaders:
 
         assert main_mod._has_any_provider_configured() is True
 
+    def test_managed_tool_gateway_reads_non_ascii_nous_state(
+        self, hermes_home, windows_default_encoding
+    ):
+        """tools.managed_tool_gateway._read_nous_provider_state reads auth.json.
+
+        The Nous provider entry can carry a non-ASCII label. Under the
+        Windows-default-encoding fixture a no-encoding read raises and the
+        broad except swallows it, returning None — so the gateway treats
+        Nous as unconfigured.
+        """
+        store = {
+            "version": auth.AUTH_STORE_VERSION,
+            "providers": {
+                "nous": {
+                    "agent_key": "k",
+                    # Non-ASCII label → UTF-8 bytes cp1252 cannot decode.
+                    "label": "工作账号",
+                }
+            },
+        }
+        _write_utf8(hermes_home / "auth.json", store)
+
+        from tools.managed_tool_gateway import _read_nous_provider_state
+
+        nous = _read_nous_provider_state()
+        assert nous is not None
+        assert nous.get("agent_key") == "k"
+        # The non-ASCII label round-trips intact.
+        assert nous.get("label") == "工作账号"
+

--- a/tests/hermes_cli/test_auth_store_windows_encoding.py
+++ b/tests/hermes_cli/test_auth_store_windows_encoding.py
@@ -241,3 +241,81 @@ class TestAuthJsonSiblingReaders:
         assert provider is not None
         assert provider.get("agent_key") == "k"
 
+    def test_read_shared_nous_state_reads_non_ascii_store(
+        self, tmp_path, monkeypatch, windows_default_encoding
+    ):
+        """hermes_cli.auth._read_shared_nous_state must read a non-ASCII store.
+
+        The shared Nous store (``nous_auth.json``) is written as UTF-8. A
+        non-ASCII field (e.g. an accented display name) must not cause the
+        read to raise under the Windows-default-encoding fixture and be
+        silently swallowed — which would drop the user's shared OAuth
+        credentials and force a device-code re-login.
+        """
+        # The shared-store path has a seat belt that refuses to resolve to the
+        # real user's store under pytest; pin it to a tmp dir explicitly.
+        shared_dir = tmp_path / "shared"
+        monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+
+        payload = {
+            "refresh_token": "rt",
+            "access_token": "at",
+            # Non-ASCII display name → UTF-8 bytes cp1252 cannot decode.
+            "display_name": "Réne — Noël",
+        }
+        _write_utf8(shared_dir / "nous_auth.json", payload)
+
+        provider = auth._read_shared_nous_state()
+        assert provider is not None
+        assert provider["access_token"] == "at"
+        assert provider["refresh_token"] == "rt"
+        # The non-ASCII field round-trips intact.
+        assert provider["display_name"] == "Réne — Noël"
+
+    def test_has_any_provider_configured_reads_non_ascii_auth_store(
+        self, hermes_home, monkeypatch, windows_default_encoding
+    ):
+        """hermes_cli.main._has_any_provider_configured reads auth.json.
+
+        When the active provider's auth.json store contains a non-ASCII
+        label, the read must not raise under the Windows-default-encoding
+        fixture (which would be swallowed and make a configured provider
+        look absent, wrongly re-triggering the setup wizard).
+        """
+        store = {
+            "version": auth.AUTH_STORE_VERSION,
+            "active_provider": "openai-codex",
+            "providers": {
+                "openai-codex": {
+                    "auth_mode": "chatgpt",
+                    "label": "工作账号",  # non-ASCII CJK
+                    "tokens": {"access_token": "a", "refresh_token": "r"},
+                }
+            },
+        }
+        _write_utf8(hermes_home / "auth.json", store)
+
+        import hermes_cli.auth as auth_mod
+        import hermes_cli.main as main_mod
+
+        # No provider env vars, no .env, and PROVIDER_REGISTRY lookups report
+        # not-logged-in — so the function reaches the auth.json branch and the
+        # result is driven by reading the (non-ASCII) store + the active
+        # provider's status. The active provider IS logged in, so the UTF-8
+        # read must succeed and surface True.
+        def fake_status(provider_id=None):
+            if provider_id == "openai-codex":
+                return {"logged_in": True}
+            return {"logged_in": False}
+
+        monkeypatch.setattr(auth_mod, "get_auth_status", fake_status)
+        # _has_any_provider_configured imports get_auth_status lazily from
+        # hermes_cli.auth; patch it on the source module so the local import
+        # sees the fake.
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+        assert main_mod._has_any_provider_configured() is True
+

--- a/tests/hermes_cli/test_auth_store_windows_encoding.py
+++ b/tests/hermes_cli/test_auth_store_windows_encoding.py
@@ -38,16 +38,51 @@ def hermes_home(tmp_path, monkeypatch):
 
 
 def _write_utf8(path: Path, payload: dict) -> None:
-    """Write JSON as UTF-8, mirroring _save_auth_store's encoding."""
+    """Write JSON as UTF-8 with non-ASCII chars as real UTF-8 bytes.
+
+    Uses ``ensure_ascii=False`` so the file actually contains non-ASCII bytes
+    (the trigger for the Windows cp1252 bug). The default ``ensure_ascii=True``
+    would escape them to ``\\uXXXX`` ASCII, hiding the bug.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload), encoding="utf-8")
+    path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+
+@pytest.fixture
+def windows_default_encoding(monkeypatch):
+    """Simulate the Windows locale default for ``Path.read_text()``.
+
+    On Windows, ``locale.getpreferredencoding()`` is ``cp1252``, so a bare
+    ``read_text()`` decodes UTF-8 bytes as cp1252 and raises
+    ``UnicodeDecodeError`` on any non-ASCII byte. POSIX test runners default to
+    UTF-8, so the bug is invisible there — this fixture makes a no-encoding
+    ``read_text()`` behave like Windows (cp1252), while leaving calls that pass
+    an explicit encoding untouched. That lets the regression tests actually
+    catch the bug on any platform.
+    """
+    real_read_text = Path.read_text
+
+    def _windows_read_text(self, *args, **kwargs):
+        if "encoding" not in kwargs and not args:
+            # No explicit encoding → force the Windows default.
+            kwargs["encoding"] = "cp1252"
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _windows_read_text)
+
+
 
 
 # --- the bug: a non-ASCII label must survive save → load -------------------
 
 class TestAuthStoreEncodingRoundTrip:
-    def test_load_reads_utf8_with_non_ascii_label(self, hermes_home):
-        """A UTF-8 store with a CJK/emoji label loads intact (not wiped)."""
+    def test_load_reads_utf8_with_non_ascii_label(self, hermes_home, windows_default_encoding):
+        """A UTF-8 store with a CJK/emoji label loads intact (not wiped).
+
+        Under the Windows-default-encoding fixture, a no-encoding read_text()
+        raises UnicodeDecodeError on the non-ASCII bytes and the broad except
+        wipes the store — so this test catches the bug on any platform.
+        """
         store = {
             "version": auth.AUTH_STORE_VERSION,
             "providers": {
@@ -67,7 +102,7 @@ class TestAuthStoreEncodingRoundTrip:
         assert "openai-codex" in loaded["providers"]
         assert loaded["providers"]["openai-codex"]["label"] == "工作账号 🔥"
 
-    def test_load_does_not_corrupt_store_on_non_ascii(self, hermes_home):
+    def test_load_does_not_corrupt_store_on_non_ascii(self, hermes_home, windows_default_encoding):
         """The pre-fix bug wiped the store to empty on a UnicodeDecodeError.
 
         After the fix, loading a valid UTF-8 store must never produce the empty
@@ -146,3 +181,63 @@ class TestExplicitEncodingPassed:
         for call in spy.call_args_list:
             assert "encoding" in call.kwargs, "codex read_text() must pass encoding"
             assert "utf-8" in str(call.kwargs["encoding"]).lower()
+
+
+# --- sibling readers of the same ~/.hermes/auth.json in other modules -------
+#
+# _load_auth_store lives in hermes_cli/auth.py, but several other modules read
+# the same ~/.hermes/auth.json directly. They had the same UTF-8-vs-cp1252
+# asymmetry on Windows — these tests pin the sibling reads too.
+
+class TestAuthJsonSiblingReaders:
+    def test_has_xai_credentials_reads_non_ascii_store(self, hermes_home, windows_default_encoding, monkeypatch):
+        """tools/xai_http.has_xai_credentials must read a non-ASCII auth.json.
+
+        Pre-fix, a UTF-8 store with a non-ASCII label raised UnicodeDecodeError
+        here (cp1252 default on Windows), the broad except swallowed it, and
+        xAI OAuth silently looked absent.
+        """
+        # No XAI_API_KEY env → force the auth.json code path.
+        monkeypatch.delenv("XAI_API_KEY", raising=False)
+        store = {
+            "version": auth.AUTH_STORE_VERSION,
+            "providers": {
+                "xai-oauth": {
+                    # CJK label → UTF-8 bytes (e.g. 0xE5..) that cp1252 cannot
+                    # decode, so a no-encoding read raises UnicodeDecodeError.
+                    "label": "工作账号",
+                    "tokens": {"access_token": "tok"},
+                }
+            },
+        }
+        _write_utf8(hermes_home / "auth.json", store)
+
+        from tools.xai_http import has_xai_credentials
+
+        assert has_xai_credentials() is True
+
+    def test_auxiliary_nous_provider_reads_non_ascii_store(self, hermes_home, windows_default_encoding, monkeypatch):
+        """agent/auxiliary_client's Nous-provider lookup reads the same store.
+
+        The lookup returns None on any read failure, silently disabling Nous as
+        the auxiliary (vision/summarization) provider. A non-ASCII label must
+        not trigger that path.
+        """
+        store = {
+            "version": auth.AUTH_STORE_VERSION,
+            "active_provider": "nous",
+            "providers": {"nous": {"agent_key": "k", "label": "工作账号"}},
+        }
+        _write_utf8(hermes_home / "auth.json", store)
+
+        import agent.auxiliary_client as aux
+
+        # _read_nous_auth consults the credential pool FIRST and returns early
+        # when a pool entry exists, never reaching the auth.json read. Force the
+        # pool-absent path so the auth.json code under test actually runs.
+        monkeypatch.setattr(aux, "_select_pool_entry", lambda _provider: (False, None))
+
+        provider = aux._read_nous_auth()
+        assert provider is not None
+        assert provider.get("agent_key") == "k"
+

--- a/tests/hermes_cli/test_auth_store_windows_encoding.py
+++ b/tests/hermes_cli/test_auth_store_windows_encoding.py
@@ -232,6 +232,11 @@ class TestAuthJsonSiblingReaders:
 
         import agent.auxiliary_client as aux
 
+        # _AUTH_JSON_PATH is resolved at module import time, so the
+        # HERMES_HOME env from the fixture doesn't reach it — point it at
+        # the tmp store explicitly.
+        monkeypatch.setattr(aux, "_AUTH_JSON_PATH", hermes_home / "auth.json")
+
         # _read_nous_auth consults the credential pool FIRST and returns early
         # when a pool entry exists, never reaching the auth.json read. Force the
         # pool-absent path so the auth.json code under test actually runs.

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -6,21 +6,92 @@ import sys
 from hermes_cli.env_loader import load_hermes_dotenv
 
 
+def test_utf8_bom_does_not_mangle_first_key(tmp_path, monkeypatch):
+    """A leading UTF-8 BOM must not prefix the first key name in os.environ.
+
+    PowerShell 5.1 ``Set-Content -Encoding UTF8`` and Windows Notepad write
+    a BOM (EF BB BF). With encoding=utf-8, python-dotenv keeps U+FEFF on the
+    first key so the canonical name is absent and callers see "not configured".
+    """
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    env_file.write_bytes(
+        b"\xef\xbb\xbfFIRST_KEY=first-value\nSECOND_KEY=second-value\n"
+    )
+
+    monkeypatch.delenv("FIRST_KEY", raising=False)
+    monkeypatch.delenv("SECOND_KEY", raising=False)
+    monkeypatch.delenv("\ufeffFIRST_KEY", raising=False)
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == [env_file]
+    assert os.getenv("FIRST_KEY") == "first-value"
+    assert os.getenv("SECOND_KEY") == "second-value"
+    assert os.environ.get("\ufeffFIRST_KEY") is None
 
 
+def test_bomless_utf8_env_still_loads(tmp_path, monkeypatch):
+    """BOM-less UTF-8 .env files must keep loading after utf-8-sig."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    env_file.write_text("OPENAI_API_KEY=sk-plain\nSECOND_KEY=ok\n", encoding="utf-8")
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("SECOND_KEY", raising=False)
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == [env_file]
+    assert os.getenv("OPENAI_API_KEY") == "sk-plain"
+    assert os.getenv("SECOND_KEY") == "ok"
 
 
+def test_latin1_env_falls_back(tmp_path, monkeypatch):
+    """Invalid UTF-8 bytes must still load via the latin-1 fallback."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    # 0xE9 is "é" in latin-1 and not a valid UTF-8 lead sequence alone.
+    env_file.write_bytes(b"LATIN1_VALUE=caf\xe9\n")
+
+    monkeypatch.delenv("LATIN1_VALUE", raising=False)
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == [env_file]
+    assert os.getenv("LATIN1_VALUE") == "café"
 
 
+def test_utf8_bom_preserves_first_api_key_name(tmp_path, monkeypatch):
+    """Real-world case: BOM + first line is a provider API key name."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    env_file.write_bytes(
+        b"\xef\xbb\xbfANTHROPIC_API_KEY=sk-test-123\nSECOND_KEY=ok\n"
+    )
+
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("SECOND_KEY", raising=False)
+    monkeypatch.delenv("\ufeffANTHROPIC_API_KEY", raising=False)
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == [env_file]
+    assert os.getenv("ANTHROPIC_API_KEY") == "sk-test-123"
+    assert os.getenv("SECOND_KEY") == "ok"
+    assert os.environ.get("\ufeffANTHROPIC_API_KEY") is None
 
 
 # ---------------------------------------------------------------------------
 # UTF-16 / UTF-32 .env sanitizer coverage
 #
-# Scope note: intentionally NO UTF-8-BOM assertions here. UTF-8 BOM handling
-# for _load_dotenv_with_fallback is #65124's un-merged fix; a test here would
-# couple the PRs. This suite covers only the sanitizer rewrite path for
-# UTF-16/32 (and UTF-8 / cp1252 regression guards for that path).
+# UTF-8 BOM handling for _load_dotenv_with_fallback is covered above (#65124).
+# This section covers the sanitizer rewrite path for UTF-16/32 (and UTF-8 /
+# cp1252 regression guards for that path).
 # ---------------------------------------------------------------------------
 
 

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -86,6 +86,90 @@ def test_utf8_bom_preserves_first_api_key_name(tmp_path, monkeypatch):
     assert os.environ.get("\ufeffANTHROPIC_API_KEY") is None
 
 
+def test_utf8_bom_plus_invalid_utf8_preserves_first_key(tmp_path, monkeypatch):
+    """BOM + non-UTF-8 body must load via latin-1 without mangling the first key.
+
+    utf-8-sig only applies on the primary path. When invalid UTF-8 forces the
+    latin-1 fallback, a leading EF BB BF would otherwise become part of the
+    first key name under latin-1 and drop the canonical name.
+    """
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    # BOM + valid first key + latin-1 é (0xE9) in a later value.
+    env_file.write_bytes(
+        b"\xef\xbb\xbfANTHROPIC_API_KEY=sk-test-123\nBAD=caf\xe9\n"
+    )
+
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("BAD", raising=False)
+    monkeypatch.delenv("\ufeffANTHROPIC_API_KEY", raising=False)
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == [env_file]
+    assert os.getenv("ANTHROPIC_API_KEY") == "sk-test-123"
+    assert os.getenv("BAD") == "café"
+    assert os.environ.get("\ufeffANTHROPIC_API_KEY") is None
+
+def test_bomless_latin1_env_still_loads(tmp_path, monkeypatch):
+    """BOM-less cp1252/latin-1 .env files must keep loading after the BOM strip."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    env_file.write_bytes(b"LATIN1_VALUE=caf\xe9\nOTHER=ok\n")
+
+    monkeypatch.delenv("LATIN1_VALUE", raising=False)
+    monkeypatch.delenv("OTHER", raising=False)
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == [env_file]
+    assert os.getenv("LATIN1_VALUE") == "café"
+    assert os.getenv("OTHER") == "ok"
+
+def test_latin1_fallback_stream_honors_override(tmp_path, monkeypatch):
+    """Stream-based latin-1 fallback must honor override= identically to dotenv_path."""
+    from hermes_cli.env_loader import _load_dotenv_with_fallback
+
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    # Invalid UTF-8 forces the stream/latin-1 path.
+    env_file.write_bytes(b"OVERRIDE_PROBE=from-file\nLATIN1_VALUE=caf\xe9\n")
+
+    monkeypatch.setenv("OVERRIDE_PROBE", "from-shell")
+    monkeypatch.delenv("LATIN1_VALUE", raising=False)
+
+    # override=False: shell value must win (same as dotenv_path form).
+    _load_dotenv_with_fallback(env_file, override=False)
+    assert os.getenv("OVERRIDE_PROBE") == "from-shell"
+    assert os.getenv("LATIN1_VALUE") == "café"
+
+    # override=True: file value must win (user-env path).
+    _load_dotenv_with_fallback(env_file, override=True)
+    assert os.getenv("OVERRIDE_PROBE") == "from-file"
+    assert os.getenv("LATIN1_VALUE") == "café"
+
+def test_latin1_fallback_stream_preserves_interpolation(tmp_path, monkeypatch):
+    """Stream/latin-1 path must still expand ${VAR} like the dotenv_path form."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    # 0xE9 forces latin-1 fallback; ${FOO} must still expand.
+    env_file.write_bytes(b"FOO=bar\nBAR=${FOO}\nLATIN1_VALUE=caf\xe9\n")
+
+    monkeypatch.delenv("FOO", raising=False)
+    monkeypatch.delenv("BAR", raising=False)
+    monkeypatch.delenv("LATIN1_VALUE", raising=False)
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == [env_file]
+    assert os.getenv("FOO") == "bar"
+    assert os.getenv("BAR") == "bar"
+    assert os.getenv("LATIN1_VALUE") == "café"
+
 # ---------------------------------------------------------------------------
 # UTF-16 / UTF-32 .env sanitizer coverage
 #

--- a/tests/hermes_cli/test_send_cmd.py
+++ b/tests/hermes_cli/test_send_cmd.py
@@ -234,3 +234,144 @@ def test_load_hermes_env_bridges_config_yaml_scalars(tmp_path, monkeypatch):
     assert os.environ.get("TELEGRAM_HOME_CHANNEL") == "5550001111"
 
 
+def test_load_hermes_env_utf8_bom_preserves_first_key(tmp_path, monkeypatch):
+    """A leading UTF-8 BOM must not mangle the first .env key name.
+
+    PowerShell 5.1 `Set-Content -Encoding UTF8` and Notepad prepend a BOM
+    (EF BB BF). With encoding=utf-8, python-dotenv kept U+FEFF on the first
+    key, so the credential never appeared under its canonical name and
+    `hermes send` failed to authenticate.
+    """
+    import os
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / ".env").write_bytes(
+        b"\xef\xbb\xbfSEND_BOM_BOT_TOKEN=tok-first\nSEND_BOM_SECOND=two\n"
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("SEND_BOM_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("SEND_BOM_SECOND", raising=False)
+
+    from importlib import reload
+    import hermes_cli.config as _hc_config
+    reload(_hc_config)
+
+    send_cmd._load_hermes_env()
+
+    assert os.environ.get("SEND_BOM_BOT_TOKEN") == "tok-first"
+    assert os.environ.get("SEND_BOM_SECOND") == "two"
+    assert "\ufeff" + "SEND_BOM_BOT_TOKEN" not in os.environ
+
+def test_load_hermes_env_bomless_utf8_still_loads(tmp_path, monkeypatch):
+    """BOM-less UTF-8 .env files must keep loading after the utf-8-sig switch."""
+    import os
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / ".env").write_bytes(b"SEND_PLAIN_TOKEN=plain-val\n")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("SEND_PLAIN_TOKEN", raising=False)
+
+    from importlib import reload
+    import hermes_cli.config as _hc_config
+    reload(_hc_config)
+
+    send_cmd._load_hermes_env()
+
+    assert os.environ.get("SEND_PLAIN_TOKEN") == "plain-val"
+
+def test_load_hermes_env_latin1_fallback_still_loads(tmp_path, monkeypatch):
+    """Invalid UTF-8 bytes must still load via the latin-1 fallback path,
+    and a leading BOM must be stripped before the latin-1 decode so the
+    first key keeps its canonical name."""
+    import os
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    # BOM + valid first key + latin-1 é (0xE9, invalid UTF-8 alone) in a
+    # later value — forces the UnicodeDecodeError → latin-1 stream path.
+    (hermes_home / ".env").write_bytes(
+        b"\xef\xbb\xbfSEND_L1_TOKEN=tok-l1\nSEND_L1_NOTE=caf\xe9\n"
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("SEND_L1_TOKEN", raising=False)
+    monkeypatch.delenv("SEND_L1_NOTE", raising=False)
+
+    from importlib import reload
+    import hermes_cli.config as _hc_config
+    reload(_hc_config)
+
+    send_cmd._load_hermes_env()
+
+    assert os.environ.get("SEND_L1_TOKEN") == "tok-l1"
+    assert os.environ.get("SEND_L1_NOTE") == "caf\xe9"
+    assert "\ufeff" + "SEND_L1_TOKEN" not in os.environ
+
+def test_load_hermes_env_latin1_fallback_overrides_shell(tmp_path, monkeypatch):
+    """The stream-based latin-1 fallback must keep override=True semantics:
+    the .env value wins over a stale shell export, same as the primary path."""
+    import os
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    # 0xE9 forces the UnicodeDecodeError \u2192 latin-1 stream fallback.
+    (hermes_home / ".env").write_bytes(b"SEND_OVR_TOKEN=caf\xe9-file\n")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("SEND_OVR_TOKEN", "stale-shell-value")
+
+    from importlib import reload
+    import hermes_cli.config as _hc_config
+    reload(_hc_config)
+
+    send_cmd._load_hermes_env()
+
+    assert os.environ.get("SEND_OVR_TOKEN") == "caf\xe9-file"
+
+def test_load_hermes_env_fallback_read_error_is_swallowed(tmp_path, monkeypatch):
+    """An I/O error inside the latin-1 fallback must not escape \u2014 the send
+    path is best-effort by design and must never crash on a broken .env."""
+    from pathlib import Path
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    # Invalid UTF-8 so the fallback (and its read_bytes call) is reached.
+    (hermes_home / ".env").write_bytes(b"SEND_ERR_TOKEN=caf\xe9\n")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    def _boom(self):
+        raise OSError("disk went away")
+
+    monkeypatch.setattr(Path, "read_bytes", _boom)
+
+    from importlib import reload
+    import hermes_cli.config as _hc_config
+    reload(_hc_config)
+
+    # Should not raise.
+    send_cmd._load_hermes_env()
+
+def test_load_hermes_env_bom_only_env_is_noop(tmp_path, monkeypatch):
+    """A .env containing only a BOM must load zero vars without error."""
+    import os
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / ".env").write_bytes(b"\xef\xbb\xbf")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from importlib import reload
+    import hermes_cli.config as _hc_config
+    reload(_hc_config)
+
+    before = dict(os.environ)
+    send_cmd._load_hermes_env()
+
+    added = {k: v for k, v in os.environ.items() if k not in before}
+    assert "\ufeff" not in "".join(added)

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -338,6 +338,21 @@ assert escaped.startswith("'")
         self.assertEqual(result["status"], "success")
 
 
+    def test_json_parse_helper_bom(self):
+        """json_parse strips a leading UTF-8 BOM and tolerates control chars (#57870)."""
+        code = """
+from hermes_tools import json_parse
+# A leading UTF-8 BOM (e.g. from Windows CLI output) must also parse (#57870)
+bom_text = "\\ufeff" + '{"body": "bom-ok"}'
+bom_result = json_parse(bom_text)
+assert bom_result == {"body": "bom-ok"}, bom_result
+print("bom:" + bom_result["body"])
+"""
+        result = self._run(code)
+        self.assertEqual(result["status"], "success")
+        self.assertIn("bom:bom-ok", result["output"])
+
+
     def test_retry_helper_all_fail(self):
         """retry raises the last error when all attempts fail."""
         code = """

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -627,3 +627,41 @@ class TestLoadTimeSnapshotSanitization:
         # Block marker appears exactly once, not nested
         assert snapshot.count("[BLOCKED:") == 1
         assert "Clean fact" in snapshot
+
+
+class TestBomToleranceInMemoryFiles:
+    """A Notepad-edited MEMORY.md carries a UTF-8 BOM (issue #10878 / PR #10888).
+
+    Reads go through utf-8-sig so the BOM never glues U+FEFF onto the first
+    entry. Decode errors stay strict — invalid bytes must still surface as
+    unreadable (read_ok=False) rather than silently degrade via replacement
+    characters (which a read-modify-write would then persist over the real
+    file contents).
+    """
+
+    def test_bom_is_stripped_from_first_entry(self, store, tmp_path):
+        path = store._path_for("memory")
+        path.write_bytes("\ufeffFirst fact.".encode("utf-8"))
+        raw, read_ok = MemoryStore._read_raw_checked(path)
+        assert read_ok is True
+        assert not raw.startswith("\ufeff")
+        entries, ok = MemoryStore._read_entries_checked(path)
+        assert ok is True
+        assert entries == ["First fact."]
+
+    def test_bom_file_add_keeps_existing_entry_intact(self, store):
+        path = store._path_for("memory")
+        path.write_bytes("\ufeffExisting BOM fact.".encode("utf-8"))
+        result = store.add("memory", "A second fact.")
+        assert result["success"] is True
+        text = path.read_text(encoding="utf-8")
+        assert "\ufeff" not in text
+        assert "Existing BOM fact." in text
+        assert "A second fact." in text
+
+    def test_invalid_utf8_still_reports_unreadable(self, store):
+        path = store._path_for("memory")
+        path.write_bytes(b"\xff\xfe\x80\x81 not utf-8")
+        raw, read_ok = MemoryStore._read_raw_checked(path)
+        assert read_ok is False
+        assert raw == ""

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -473,9 +473,12 @@ _COMMON_HELPERS = '''\
 # ---------------------------------------------------------------------------
 
 def json_parse(text: str):
-    """Parse JSON tolerant of control characters (strict=False).
+    """Parse JSON tolerant of control characters and UTF-8 BOM (strict=False).
     Use this instead of json.loads() when parsing output from terminal()
-    or web_extract() that may contain raw tabs/newlines in strings."""
+    or web_extract() that may contain raw tabs/newlines in strings,
+    or from tools/files that prepend a UTF-8 BOM (salvage #57870, credit @woxinwuhen713-bit)."""
+    if isinstance(text, str) and text.startswith("﻿"):
+        text = text[1:]
     return json.loads(text, strict=False)
 
 

--- a/tools/managed_tool_gateway.py
+++ b/tools/managed_tool_gateway.py
@@ -38,7 +38,7 @@ def _read_nous_provider_state() -> Optional[dict]:
         path = auth_json_path()
         if not path.is_file():
             return None
-        data = json.loads(path.read_text(encoding="utf-8"))
+        data = json.loads(path.read_text(encoding="utf-8-sig"))
         providers = data.get("providers", {})
         if not isinstance(providers, dict):
             return None

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -766,7 +766,15 @@ class MemoryStore:
         if not path.exists():
             return "", True
         try:
-            return path.read_text(encoding="utf-8"), True
+            # utf-8-sig strips a leading UTF-8 BOM (Notepad-edited memory
+            # files on Windows) and is byte-identical to utf-8 otherwise.
+            # Plain utf-8 kept U+FEFF glued to the first entry, corrupting
+            # matching/dedup for that entry forever (#10878 / PR #10888).
+            # Decode errors stay STRICT on purpose: errors="replace" would
+            # hand read-modify-write callers a lossy view that a subsequent
+            # save persists over the real bytes — the wipe class documented
+            # above. Undecodable bytes must surface as read_ok=False.
+            return path.read_text(encoding="utf-8-sig"), True
         except (OSError, IOError, UnicodeDecodeError):
             return "", False
 

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -211,7 +211,10 @@ def load_env() -> Dict[str, str]:
     if not env_path.exists():
         return env_vars
 
-    with env_path.open(encoding="utf-8") as f:
+    # utf-8-sig: users hand-edit .env in Notepad, which prepends a BOM that
+    # would otherwise glue U+FEFF onto the first key name (same dialect as
+    # the canonical readers in hermes_cli/config.py).
+    with env_path.open(encoding="utf-8-sig", errors="replace") as f:
         for line in f:
             line = line.strip()
             if line and not line.startswith("#") and "=" in line:
@@ -726,7 +729,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
             skill_dir = skill_md.parent
 
             try:
-                content = skill_md.read_text(encoding="utf-8")[:4000]
+                content = skill_md.read_text(encoding="utf-8-sig", errors="replace")[:4000]
                 frontmatter, body = _parse_frontmatter(content)
 
                 if not skill_matches_platform(frontmatter):
@@ -884,7 +887,12 @@ def _serve_plugin_skill(
         )
 
     try:
-        content = skill_md.read_text(encoding="utf-8")
+        # utf-8-sig + errors="replace": SKILL.md files are user-authored and
+        # sometimes carry a Notepad BOM or stray non-UTF-8 bytes. Pinning
+        # UTF-8 with replacement keeps skill_view deterministic across
+        # platforms — falling back to the machine locale (cp1252/GBK) would
+        # make the same skill render differently per host (see PR #51701).
+        content = skill_md.read_text(encoding="utf-8-sig", errors="replace")
     except Exception as e:
         return json.dumps(
             {"success": False, "error": f"Failed to read skill '{namespace}:{bare}': {e}"},
@@ -941,7 +949,7 @@ def _serve_plugin_skill(
                 ensure_ascii=False,
             )
         try:
-            content = target.read_text(encoding="utf-8")
+            content = target.read_text(encoding="utf-8-sig", errors="replace")
         except UnicodeDecodeError:
             return json.dumps(
                 {
@@ -1251,7 +1259,7 @@ def skill_view(
                     _record(found_skill_md.parent, found_skill_md)
                     continue
                 try:
-                    fm_content = found_skill_md.read_text(encoding="utf-8")
+                    fm_content = found_skill_md.read_text(encoding="utf-8-sig", errors="replace")
                     fm, _ = _parse_frontmatter(fm_content)
                 except Exception:
                     fm = {}
@@ -1309,7 +1317,7 @@ def skill_view(
 
         # Read the file once — reused for platform check and main content below
         try:
-            content = skill_md.read_text(encoding="utf-8")
+            content = skill_md.read_text(encoding="utf-8-sig", errors="replace")
         except Exception as e:
             return json.dumps(
                 {
@@ -1454,7 +1462,7 @@ def skill_view(
 
             # Read the file content
             try:
-                content = target_file.read_text(encoding="utf-8")
+                content = target_file.read_text(encoding="utf-8-sig", errors="replace")
             except UnicodeDecodeError:
                 # Binary file - return info about it instead
                 return json.dumps(
@@ -1681,7 +1689,7 @@ def skill_view(
                                     / "_org"
                                     / prov_org
                                     / ORG_PROVENANCE_FILE
-                                ).read_text(encoding="utf-8")
+                                ).read_text(encoding="utf-8-sig", errors="replace")
                             )
                             author = str(
                                 prov.get("author_device")

--- a/tools/xai_http.py
+++ b/tools/xai_http.py
@@ -50,7 +50,7 @@ def has_xai_credentials() -> bool:
         auth_path = get_hermes_home() / "auth.json"
         if not auth_path.exists():
             return False
-        store = json.loads(auth_path.read_text(encoding="utf-8"))
+        store = json.loads(auth_path.read_text(encoding="utf-8-sig"))
         providers = store.get("providers") if isinstance(store, dict) else None
         xai_state = providers.get("xai-oauth") if isinstance(providers, dict) else None
         tokens = xai_state.get("tokens") if isinstance(xai_state, dict) else None


### PR DESCRIPTION
## Summary
Closes the residual explicit-encoding backlog. PLW1514 turned out to be already enabled and clean on main — but the bug class wasn't dead: BOM'd .env files dropped their first key, memory files kept \ufeff glued to the first entry, and auth-store readers were strict-utf-8 with no BOM tolerance.

## Changes
- Salvaged @pnascimento9596 #65124 (.env utf-8-sig in loader + hermes send path)
- Salvaged @nolanchic #58158 (utf-8-sig across all auth-store readers + 351-line regression file), upgraded to preserve main's newer OSError handling
- Additional BOM/encoding closures across memory files, SKILL.md frontmatter, json_parse (crediting the parallel PR series via Co-authored-by)
- skill_view: utf-8 with graceful degradation instead of #51701's locale fallback (locale fallback re-introduces host-dependence)
- Footgun scan clean over 939 files; sabotage runs prove the lint gate catches regressions

## Validation
| | Result |
|---|---|
| touched-surface tests | 148 passed |
| ruff check . | clean |

## Infographic

![bom-drops-tonight](https://v3b.fal.media/files/b/0aa58cea/Ktsh4zi-_GUUbblSniVLT_RhroMIKs.png)
