### PR TITLE
fix(fallback): honor explicit transport overrides (#81932)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2099,6 +2099,30 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         ):
             fb_api_mode = "bedrock_converse"
 
+        # An explicit per-entry transport is authoritative.  Legacy entries
+        # that omit both spellings retain the provider/URL/model inference
+        # above.  This matters for mixed fallback chains where the default
+        # chat-completions mode would otherwise mask a configured Responses
+        # or Anthropic transport.
+        _explicit_fb_api_mode = fb.get("api_mode") or fb.get("transport")
+        if _explicit_fb_api_mode:
+            _explicit_fb_api_mode = str(_explicit_fb_api_mode).strip()
+            if _explicit_fb_api_mode in {
+                "chat_completions",
+                "codex_responses",
+                "anthropic_messages",
+                "bedrock_converse",
+                "codex_app_server",
+            }:
+                fb_api_mode = _explicit_fb_api_mode
+            else:
+                logger.warning(
+                    "Ignoring unsupported fallback api_mode %r for %s/%s",
+                    _explicit_fb_api_mode,
+                    fb_provider,
+                    fb_model,
+                )
+
         old_model = agent.model
         old_provider = agent.provider
 

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -146,6 +146,34 @@ class TestFallbackChainAdvancement:
             assert mock_rpc.call_args.kwargs["explicit_api_key"] == "env-secret"
 
 
+    def test_explicit_fallback_transport_overrides_heuristics(self):
+        """Per-entry api_mode/transport must win over fallback inference."""
+        fbs = [
+            {
+                "provider": "custom",
+                "model": "fallback-model",
+                "base_url": "https://gateway.example/v1",
+                "transport": "codex_responses",
+            }
+        ]
+        agent = _make_agent(fallback_model=fbs)
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(
+                    _mock_client(base_url="https://gateway.example/v1"),
+                    "fallback-model",
+                ),
+            ),
+            patch(
+                "hermes_cli.model_normalize.normalize_model_for_provider",
+                side_effect=lambda m, p: m,
+            ),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent.api_mode == "codex_responses"
+
     def test_nous_anthropic_fallback_uses_the_messages_wire(self):
         """Portal Claude fallbacks must not stay on chat_completions.
 


### PR DESCRIPTION
## Summary
- honor explicit `api_mode` or `transport` values on fallback entries
- retain existing provider/URL/model inference for entries without an override
- add regression coverage for a custom Responses transport fallback

Closes #81932

## Verification
- `pytest -q tests/run_agent/test_provider_fallback.py` (15 passed)
- `python3 -m py_compile agent/chat_completion_helpers.py tests/run_agent/test_provider_fallback.py`
- `git diff --check`