### PR TITLE
fix(model-picker): serve cached custom-provider catalog on no-probe opens (supersedes #81665, #81556)

### DIFF
--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -1561,11 +1561,24 @@ def _model_flow_named_custom(config, provider_info):
         fetch_kwargs = {"timeout": 8.0}
         if api_mode:
             fetch_kwargs["api_mode"] = api_mode
-        models = fetch_api_models(api_key, base_url, **fetch_kwargs)
+        live_models = fetch_api_models(api_key, base_url, **fetch_kwargs)
         # If the probe came back empty but the operator configured an explicit
         # list, fall back to it rather than forcing manual entry.
-        if not models and configured_models:
-            models = configured_models
+        models = live_models or configured_models
+        # Persist the live catalog back to the custom_providers entry so that
+        # no-probe surfaces (dashboard, desktop, ACP) show the full model list
+        # instead of collapsing to the single ``model:`` default. Mirrors the
+        # picker path in model_switch.py::_save_discovered_models_to_config; a
+        # failed save is non-fatal.
+        if live_models:
+            try:
+                from hermes_cli.model_switch import (
+                    _save_discovered_models_to_config,
+                )
+
+                _save_discovered_models_to_config(base_url, live_models)
+            except Exception:
+                pass
 
     if models:
         default_idx = 0

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2720,10 +2720,16 @@ def list_authenticated_providers(
                     and _ep_url_norm == _current_base_url_norm
                 )
             )
-            should_probe = _can_probe_custom_provider(row_is_current=_ep_is_current) and bool(api_url) and discover and (
+            # See section 4: when live probing is suppressed for latency, a
+            # warm same-fingerprint cache entry still serves the full catalog
+            # with no network round-trip.
+            _discovery_allowed = bool(api_url) and discover and (
                 bool(api_key) or not has_explicit_models
             )
-            if should_probe:
+            _probe_live = _discovery_allowed and _can_probe_custom_provider(
+                row_is_current=_ep_is_current
+            )
+            if _discovery_allowed:
                 try:
                     from hermes_cli.models import cached_fetch_api_models
                     live_models = cached_fetch_api_models(
@@ -2731,6 +2737,7 @@ def list_authenticated_providers(
                         api_url,
                         timeout=1.5 if for_picker else 5.0,  # picker: fail fast so a slow custom endpoint doesn't block /model
                         headers=_extra_headers_from_config(ep_cfg) or None,
+                        cache_only=not _probe_live,
                     )
                     if live_models:
                         models_list = live_models
@@ -2793,19 +2800,22 @@ def list_authenticated_providers(
         )
     ):
         _models = [current_model] if current_model else []
-        if refresh or probe_current_custom_provider:
-            try:
-                from hermes_cli.models import cached_fetch_api_models
+        # As in sections 3 and 4: with live probing suppressed, fall back to
+        # the cached catalog rather than to the single active model.
+        _probe_live = bool(refresh or probe_current_custom_provider)
+        try:
+            from hermes_cli.models import cached_fetch_api_models
 
-                _live_models = cached_fetch_api_models(
-                    "",
-                    str(current_base_url).strip().rstrip("/"),
-                    timeout=1.5 if for_picker else 5.0,  # picker: fail fast on a slow current endpoint
-                )
-                if _live_models:
-                    _models = _live_models
-            except Exception:
-                pass
+            _live_models = cached_fetch_api_models(
+                "",
+                str(current_base_url).strip().rstrip("/"),
+                timeout=1.5 if for_picker else 5.0,  # picker: fail fast on a slow current endpoint
+                cache_only=not _probe_live,
+            )
+            if _live_models:
+                _models = _live_models
+        except Exception:
+            pass
         results.append({
             "slug": "custom",
             "name": "Custom endpoint",
@@ -3031,13 +3041,20 @@ def list_authenticated_providers(
                 and _grp_url_norm == _current_base_url_norm
                 and _current_base_url_group_count == 1
             )
-            should_probe = (
-                _can_probe_custom_provider(row_is_current=_grp_is_current)
-                and bool(api_url)
+            # Discovery is what the user's config asks for; probing is how we
+            # get it. When the caller suppresses live probing for latency, the
+            # already-discovered catalog on disk still answers the question
+            # without a round-trip — skipping it too is what collapsed a
+            # multi-model endpoint to its config-declared subset.
+            _discovery_allowed = (
+                bool(api_url)
                 and (bool(api_key) or not grp.get("has_explicit_models"))
                 and grp.get("discover_models", True)
             )
-            if should_probe:
+            _probe_live = _discovery_allowed and _can_probe_custom_provider(
+                row_is_current=_grp_is_current
+            )
+            if _discovery_allowed:
                 try:
                     from hermes_cli.models import cached_fetch_api_models
 
@@ -3046,6 +3063,7 @@ def list_authenticated_providers(
                         api_url,
                         timeout=1.5 if for_picker else 5.0,  # picker: fail fast so a slow custom endpoint doesn't block /model
                         headers=grp.get("extra_headers") or None,
+                        cache_only=not _probe_live,
                     )
                     if live_models:
                         grp["models"] = live_models
@@ -3053,9 +3071,12 @@ def list_authenticated_providers(
                         # Auto-save discovered models back to config so
                         # ``discover_models: false`` has a populated cache
                         # on the next read.  A failed save is non-fatal.
-                        _save_discovered_models_to_config(
-                            api_url, live_models
-                        )
+                        # Only after a real probe: a cache hit is already the
+                        # product of an earlier probe that saved it.
+                        if _probe_live:
+                            _save_discovered_models_to_config(
+                                api_url, live_models
+                            )
                 except Exception:
                     pass
             results.append({

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2648,6 +2648,12 @@ def list_authenticated_providers(
                     "models": [],
                     "has_explicit_models": False,
                     "ep_cfg": ep_cfg,  # used below for discover_models / api_key
+                    # Part of group_key, so it is constant across the group.
+                    # The render loop below needs it to key the model cache:
+                    # api_mode changes the wire protocol (``x-api-key`` vs
+                    # ``Authorization: Bearer``), so two rows that differ only
+                    # by it must not share a cached catalog.
+                    "api_mode": api_mode,
                     "raw_names": [],
                     "aliases": set(),
                 }
@@ -2743,6 +2749,7 @@ def list_authenticated_providers(
                         api_key,
                         api_url,
                         timeout=1.5 if for_picker else 5.0,  # picker: fail fast so a slow custom endpoint doesn't block /model
+                        api_mode=grp.get("api_mode") or None,
                         headers=_extra_headers_from_config(ep_cfg) or None,
                         cache_only=not _probe_live,
                     )
@@ -2928,6 +2935,11 @@ def list_authenticated_providers(
                     "has_explicit_models": False,
                     "discover_models": discover,
                     "extra_headers": entry_extra_headers,
+                    # Part of group_key, so constant across the group. Needed
+                    # in the render loop to key the model cache — api_mode
+                    # selects the wire protocol, so rows differing only by it
+                    # must not share a cached catalog.
+                    "api_mode": api_mode,
                     "aliases": set(),
                 }
             else:
@@ -3082,6 +3094,7 @@ def list_authenticated_providers(
                         api_key,
                         api_url,
                         timeout=1.5 if for_picker else 5.0,  # picker: fail fast so a slow custom endpoint doesn't block /model
+                        api_mode=grp.get("api_mode") or None,
                         headers=grp.get("extra_headers") or None,
                         cache_only=not _probe_live,
                     )

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2723,11 +2723,18 @@ def list_authenticated_providers(
             # See section 4: when live probing is suppressed for latency, a
             # warm same-fingerprint cache entry still serves the full catalog
             # with no network round-trip.
-            _discovery_allowed = bool(api_url) and discover and (
-                bool(api_key) or not has_explicit_models
-            )
-            _probe_live = _discovery_allowed and _can_probe_custom_provider(
-                row_is_current=_ep_is_current
+            #
+            # ``has_explicit_models`` gates the *probe*, not the cache read:
+            # it exists so a keyless endpoint with a declared catalog is not
+            # hammered over the network (5f00f36ba, 1039e90b5). Reading a
+            # catalog an earlier probe already paid for costs nothing, and
+            # applying the probe gate to it re-pins the endpoint — see
+            # ``_discovery_allowed`` in section 4 for the full rationale.
+            _discovery_allowed = bool(api_url) and discover
+            _probe_live = (
+                _discovery_allowed
+                and (bool(api_key) or not has_explicit_models)
+                and _can_probe_custom_provider(row_is_current=_ep_is_current)
             )
             if _discovery_allowed:
                 try:
@@ -3046,13 +3053,26 @@ def list_authenticated_providers(
             # already-discovered catalog on disk still answers the question
             # without a round-trip — skipping it too is what collapsed a
             # multi-model endpoint to its config-declared subset.
-            _discovery_allowed = (
-                bool(api_url)
+            #
+            # ``has_explicit_models`` belongs on the probe side of that line.
+            # It is a network-cost gate: don't hammer a keyless endpoint that
+            # already declares its catalog (5f00f36ba, 1039e90b5). It is not a
+            # user pin — ``discover_models: false`` is the documented way to
+            # pin, and it is honored above.
+            #
+            # Keeping it on the discovery side re-pins the endpoint it was
+            # meant to spare, because a successful probe calls
+            # ``_save_discovered_models_to_config()``, which writes a plain
+            # list — the exact shape ``_models_config_is_allowlist()`` reads
+            # back as an explicit allowlist. A keyless local server therefore
+            # self-pins on its first probe and can never widen again. f66319097
+            # already carved the dict shape out of that trap for the same
+            # reason; the list shape is the other door into it.
+            _discovery_allowed = bool(api_url) and grp.get("discover_models", True)
+            _probe_live = (
+                _discovery_allowed
                 and (bool(api_key) or not grp.get("has_explicit_models"))
-                and grp.get("discover_models", True)
-            )
-            _probe_live = _discovery_allowed and _can_probe_custom_provider(
-                row_is_current=_grp_is_current
+                and _can_probe_custom_provider(row_is_current=_grp_is_current)
             )
             if _discovery_allowed:
                 try:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -4704,6 +4704,7 @@ def cached_fetch_api_models(
     api_mode: Optional[str] = None,
     headers: Optional[dict[str, str]] = None,
     force_refresh: bool = False,
+    cache_only: bool = False,
     ttl_seconds: int = _PROVIDER_MODELS_CACHE_TTL,
 ) -> Optional[list[str]]:
     """Disk-cached wrapper around :func:`fetch_api_models` for custom endpoints.
@@ -4717,9 +4718,18 @@ def cached_fetch_api_models(
     last same-fingerprint result rather than an empty list. Returns whatever
     :func:`fetch_api_models` would (a list or ``None``); corrupt cache rows
     degrade to a live fetch instead of raising.
+
+    ``cache_only`` serves a previously-discovered catalog without touching
+    the network at all — no live fetch, no background revalidation — and
+    returns ``None`` when nothing usable is cached. Callers that deliberately
+    skip live probing for latency reasons (GUI picker opens, which must not
+    block on a stopped local endpoint) use this so a warm catalog still
+    reaches the picker instead of collapsing to the config-declared subset.
     """
     normalized_url = str(base_url or "").strip().rstrip("/").lower()
     if not normalized_url:
+        if cache_only:
+            return None
         # No base_url means nothing to key the cache on — fall through to a
         # live call so callers keep getting fetch_api_models' own behavior.
         return fetch_api_models(
@@ -4731,6 +4741,17 @@ def cached_fetch_api_models(
     cache = _load_provider_models_cache()
     entry = cache.get(cache_key)
     now = time.time()
+
+    if cache_only:
+        # Same trust window as the stale-while-revalidate tier below, minus
+        # the revalidation: an entry this side of the bound is good enough to
+        # render, and anything older is treated as a miss so the caller falls
+        # back to its configured list rather than showing a stale catalog.
+        if force_refresh or not _cache_entry_valid(entry, fp):
+            return None
+        if now - entry["at"] >= _PROVIDER_MODELS_STALE_SERVE_MAX:
+            return None
+        return list(entry["models"])
 
     if not force_refresh and _cache_entry_valid(entry, fp):
         age = now - entry["at"]

--- a/tests/hermes_cli/test_cached_fetch_api_models.py
+++ b/tests/hermes_cli/test_cached_fetch_api_models.py
@@ -128,6 +128,73 @@ class TestCachedFetchApiModels:
         assert out is None
         save.assert_not_called()
 
+
+class TestCacheOnly:
+    """``cache_only=True`` is the no-network read used by picker opens that
+    deliberately skip live probing. It must answer from disk or not at all —
+    never a live fetch, never a background revalidation."""
+
+    def _entry(self, models, age_seconds, fp="fp"):
+        return {"fp": fp, "at": time.time() - age_seconds, "models": list(models)}
+
+    def _call(self, cache, *, fp="fp", **kwargs):
+        import hermes_cli.models as mod
+
+        with patch.object(mod, "_load_provider_models_cache", return_value=cache), \
+             patch.object(mod, "_custom_endpoint_fingerprint", return_value=fp), \
+             patch.object(mod, "_save_provider_models_cache") as save, \
+             patch.object(mod, "_spawn_swr_refresh") as swr, \
+             patch.object(mod, "fetch_api_models") as live:
+            out = mod.cached_fetch_api_models(
+                "sk-key", "https://gw.example.com/v1", cache_only=True, **kwargs
+            )
+        live.assert_not_called()
+        swr.assert_not_called()
+        save.assert_not_called()
+        return out
+
+    def test_fresh_entry_is_served(self):
+        cache = {"custom:https://gw.example.com/v1": self._entry(["m1", "m2"], 10)}
+        assert self._call(cache) == ["m1", "m2"]
+
+    def test_entry_past_ttl_is_still_served_within_the_stale_window(self):
+        """The TTL governs when to *revalidate*, and cache_only cannot. Inside
+        the stale-serve bound the entry is still the best answer available —
+        collapsing to the config subset an hour in would reintroduce the bug."""
+        import hermes_cli.models as mod
+
+        age = mod._PROVIDER_MODELS_CACHE_TTL + 60
+        cache = {"custom:https://gw.example.com/v1": self._entry(["m1", "m2"], age)}
+        assert self._call(cache) == ["m1", "m2"]
+
+    def test_entry_beyond_the_stale_window_is_a_miss(self):
+        import hermes_cli.models as mod
+
+        age = mod._PROVIDER_MODELS_STALE_SERVE_MAX + 60
+        cache = {"custom:https://gw.example.com/v1": self._entry(["ancient"], age)}
+        assert self._call(cache) is None
+
+    def test_empty_cache_is_a_miss(self):
+        assert self._call({}) is None
+
+    def test_rotated_credentials_are_a_miss(self):
+        cache = {"custom:https://gw.example.com/v1": self._entry(["old"], 10, fp="old-fp")}
+        assert self._call(cache, fp="new-fp") is None
+
+    def test_force_refresh_is_a_miss_rather_than_a_live_fetch(self):
+        """cache_only outranks force_refresh: the caller has said no network,
+        so an un-revalidatable entry is withheld instead of fetched."""
+        cache = {"custom:https://gw.example.com/v1": self._entry(["m1"], 10)}
+        assert self._call(cache, force_refresh=True) is None
+
+    def test_missing_base_url_is_a_miss_rather_than_a_live_fetch(self):
+        import hermes_cli.models as mod
+
+        with patch.object(mod, "fetch_api_models") as live:
+            out = mod.cached_fetch_api_models("sk-key", "", cache_only=True)
+        assert out is None
+        live.assert_not_called()
+
     def test_empty_live_result_is_not_persisted(self):
         """An empty list from a transient error must never pin an empty
         cache entry over real data on the next open."""

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -832,6 +832,74 @@ def test_save_discovered_models_preserves_dict_form(monkeypatch):
     )
 
 
+def test_model_flow_named_custom_persists_discovered_models(monkeypatch):
+    """The ``hermes model`` named-custom-provider flow persists the discovered
+    catalog back to the entry's ``models:`` list.
+
+    No-probe surfaces (dashboard, desktop, ACP) call
+    ``build_models_payload(..., probe_custom_providers=False)`` and only show
+    the configured ``models:`` list. The CLI flow probes and shows the full
+    catalog but (before this fix) never saved it, so a provider added via
+    ``hermes model`` collapsed to the single ``model:`` default everywhere but
+    the CLI. It must persist discovered models the same way the picker path in
+    ``_save_discovered_models_to_config`` does.
+    """
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_api_models",
+        lambda api_key, base_url, **kw: [
+            "discovered-a",
+            "discovered-b",
+            "discovered-c",
+        ],
+    )
+    # Non-interactive model selection.
+    monkeypatch.setattr(
+        "hermes_cli.curses_ui.curses_radiolist", lambda *a, **k: 0
+    )
+    # No-op downstream writes so the test never touches a real config.
+    monkeypatch.setattr("hermes_cli.main._save_custom_provider", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.auth._save_model_choice", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.auth.deactivate_provider", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": {}, "providers": {}, "custom_providers": []},
+    )
+    monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
+
+    save_calls = []
+    monkeypatch.setattr(
+        "hermes_cli.model_switch._save_discovered_models_to_config",
+        lambda api_url, model_ids: save_calls.append((api_url, model_ids)),
+    )
+
+    from hermes_cli.model_setup_flows import _model_flow_named_custom
+
+    _model_flow_named_custom(
+        {},
+        {
+            "name": "Dragomes",
+            "base_url": "http://example.com/v1",
+            "api_mode": "anthropic_messages",
+            "api_key": "sk-test",
+            "key_env": "",
+            "model": "MiniMax-M3",
+            "provider_key": "",
+            "discover_models": True,
+            "models": {},
+        },
+    )
+
+    assert save_calls == [
+        (
+            "http://example.com/v1",
+            ["discovered-a", "discovered-b", "discovered-c"],
+        )
+    ], (
+        "_model_flow_named_custom must persist discovered models "
+        "(base_url, model_ids) after a successful probe"
+    )
+
+
 def test_shared_url_different_display_names_are_separate_rows(monkeypatch):
     """Multiple custom_providers entries sharing base_url + api_key + api_mode
     but with *different* display-name prefixes (e.g. a proxy fronting

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -5,6 +5,8 @@ shared slash-command pipeline (`/model` in CLI/gateway/Telegram) historically
 only looked at `providers:`.
 """
 
+import time
+
 import hermes_cli.providers as providers_mod
 import pytest
 from hermes_cli.model_switch import list_authenticated_providers, switch_model
@@ -972,3 +974,205 @@ def test_custom_provider_dict_models_pin_requires_discover_false(monkeypatch):
     row = next(p for p in providers if p["name"] == "Local Ollama")
     assert calls == []
     assert row["models"] == ["llama3"]
+
+
+# ─── No-probe picker opens still serve the cached catalog ───────────────
+#
+# #58183 stopped GUI picker opens from live-probing saved custom endpoints so
+# a stopped local server could not stall the picker. It skipped the cached
+# read along with the network one, so a non-current endpoint collapsed to the
+# one model named in config even with a full catalog already on disk. These
+# pin both halves: the cache is served, the network is not touched.
+
+
+_LOCAL_ENDPOINT = "http://127.0.0.1:8000/v1"
+_LOCAL_CATALOG = [f"omlx-model-{i}" for i in range(1, 9)]
+
+
+def _seed_custom_model_cache(monkeypatch, models, *, age_seconds=10):
+    """Put *models* on disk for ``_LOCAL_ENDPOINT`` under the no-credential
+    fingerprint the picker probes local endpoints with."""
+    import hermes_cli.models as models_mod
+
+    fp = models_mod._custom_endpoint_fingerprint("", None, None)
+    cache = {
+        f"custom:{_LOCAL_ENDPOINT}": {
+            "fp": fp,
+            "at": time.time() - age_seconds,
+            "models": list(models),
+        }
+    }
+    monkeypatch.setattr(models_mod, "_load_provider_models_cache", lambda: cache)
+
+
+def _no_probe_local_row(monkeypatch, *, custom_providers=None, user_providers=None,
+                        current_provider="nous", **kwargs):
+    """Run the GUI picker path (no live probing) and return the local row
+    plus every base_url a live fetch was attempted against."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    fetched = []
+
+    def fetch(_api_key, base_url, **_kwargs):
+        fetched.append(base_url)
+        return ["should-not-be-reached"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fetch)
+
+    providers = list_authenticated_providers(
+        current_provider=current_provider,
+        user_providers=user_providers or {},
+        custom_providers=custom_providers or [],
+        for_picker=True,
+        refresh=False,
+        probe_custom_providers=False,
+        probe_current_custom_provider=True,
+        **kwargs,
+    )
+    row = next(
+        (p for p in providers if _LOCAL_ENDPOINT in str(p.get("api_url", ""))), None
+    )
+    return row, fetched
+
+
+def test_no_probe_open_serves_cached_catalog_for_custom_provider(monkeypatch):
+    """A ``custom_providers`` endpoint that is not the current provider still
+    shows its full discovered catalog, from cache, with no network call."""
+    _seed_custom_model_cache(monkeypatch, _LOCAL_CATALOG)
+
+    row, fetched = _no_probe_local_row(
+        monkeypatch,
+        custom_providers=[
+            {
+                "name": "Local (127.0.0.1:8000)",
+                "base_url": _LOCAL_ENDPOINT,
+                "model": "omlx-model-1",
+            }
+        ],
+    )
+
+    assert row is not None
+    assert row["is_current"] is False
+    assert row["models"] == _LOCAL_CATALOG
+    assert row["total_models"] == len(_LOCAL_CATALOG)
+    assert fetched == []
+
+
+def test_no_probe_open_serves_cached_catalog_for_user_provider(monkeypatch):
+    """Same contract for a ``providers:`` entry (section 3)."""
+    _seed_custom_model_cache(monkeypatch, _LOCAL_CATALOG)
+
+    row, fetched = _no_probe_local_row(
+        monkeypatch,
+        user_providers={
+            "local-8000": {
+                "name": "Local (127.0.0.1:8000)",
+                "base_url": _LOCAL_ENDPOINT,
+                "default_model": "omlx-model-1",
+            }
+        },
+    )
+
+    assert row is not None
+    assert row["models"] == _LOCAL_CATALOG
+    assert fetched == []
+
+
+def test_no_probe_open_serves_cached_catalog_for_bare_custom_endpoint(monkeypatch):
+    """Same contract for the bare ``provider: custom`` shape (section 3b),
+    where the fallback would otherwise be the single active model."""
+    _seed_custom_model_cache(monkeypatch, _LOCAL_CATALOG)
+
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    fetched = []
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_api_models",
+        lambda _k, base_url, **_kw: (fetched.append(base_url), None)[1],
+    )
+
+    providers = list_authenticated_providers(
+        current_provider="custom",
+        current_base_url=_LOCAL_ENDPOINT,
+        current_model="omlx-model-1",
+        user_providers={},
+        custom_providers=[],
+        for_picker=True,
+        refresh=False,
+        probe_custom_providers=False,
+        probe_current_custom_provider=False,
+    )
+
+    row = next(p for p in providers if p["slug"] == "custom")
+    assert row["models"] == _LOCAL_CATALOG
+    assert fetched == []
+
+
+def test_no_probe_open_without_cache_keeps_configured_models_and_stays_offline(
+    monkeypatch,
+):
+    """The #58183 guarantee: a cold cache must not trigger a live probe. The
+    row degrades to its configured list rather than stalling on a dead port."""
+    _seed_custom_model_cache(monkeypatch, [], age_seconds=10)
+
+    row, fetched = _no_probe_local_row(
+        monkeypatch,
+        custom_providers=[
+            {
+                "name": "Local (127.0.0.1:8000)",
+                "base_url": _LOCAL_ENDPOINT,
+                "model": "omlx-model-1",
+            }
+        ],
+    )
+
+    assert row is not None
+    assert row["models"] == ["omlx-model-1"]
+    assert fetched == []
+
+
+def test_no_probe_open_respects_discover_models_false(monkeypatch):
+    """A user who pinned their catalog must not have it replaced from cache."""
+    _seed_custom_model_cache(monkeypatch, _LOCAL_CATALOG)
+
+    row, fetched = _no_probe_local_row(
+        monkeypatch,
+        custom_providers=[
+            {
+                "name": "Local (127.0.0.1:8000)",
+                "base_url": _LOCAL_ENDPOINT,
+                "model": "pinned-model",
+                "models": ["pinned-model"],
+                "discover_models": False,
+            }
+        ],
+    )
+
+    assert row is not None
+    assert row["models"] == ["pinned-model"]
+    assert fetched == []
+
+
+def test_cached_catalog_is_not_written_back_to_config(monkeypatch):
+    """Only a real probe persists discovered models; a cache hit is already
+    the product of the probe that saved it."""
+    _seed_custom_model_cache(monkeypatch, _LOCAL_CATALOG)
+    saves = []
+    monkeypatch.setattr(
+        "hermes_cli.model_switch._save_discovered_models_to_config",
+        lambda api_url, model_ids: saves.append((api_url, model_ids)),
+    )
+
+    row, _ = _no_probe_local_row(
+        monkeypatch,
+        custom_providers=[
+            {
+                "name": "Local (127.0.0.1:8000)",
+                "base_url": _LOCAL_ENDPOINT,
+                "model": "omlx-model-1",
+            }
+        ],
+    )
+
+    assert row["models"] == _LOCAL_CATALOG
+    assert saves == []

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -9,7 +9,12 @@ import time
 
 import hermes_cli.providers as providers_mod
 import pytest
-from hermes_cli.model_switch import list_authenticated_providers, switch_model
+import yaml
+from hermes_cli.model_switch import (
+    _save_discovered_models_to_config,
+    list_authenticated_providers,
+    switch_model,
+)
 from hermes_cli.providers import resolve_provider_full
 
 
@@ -1244,3 +1249,118 @@ def test_cached_catalog_is_not_written_back_to_config(monkeypatch):
 
     assert row["models"] == _LOCAL_CATALOG
     assert saves == []
+
+
+def test_keyless_endpoint_with_saved_catalog_still_reads_cache(monkeypatch):
+    """A keyless local server must not be pinned by Hermes' own auto-save.
+
+    ``_save_discovered_models_to_config()`` writes a plain list into
+    ``models:``, which ``_models_config_is_allowlist()`` reads back as an
+    explicit allowlist. Combined with the no-key discovery gate, a keyless
+    endpoint (the common local-model-server shape) froze on the catalog of
+    its first probe and could never widen again — the exact "lineup changes
+    after config was written" case. The cache read must not be subject to the
+    probe's network-cost gate.
+    """
+    _seed_custom_model_cache(monkeypatch, _LOCAL_CATALOG)
+
+    row, fetched = _no_probe_local_row(
+        monkeypatch,
+        custom_providers=[
+            {
+                "name": "Local (127.0.0.1:8000)",
+                "base_url": _LOCAL_ENDPOINT,
+                "model": "omlx-model-1",
+                # No api_key, and a models: list of the shape our own
+                # auto-save writes after a successful probe.
+                "models": ["omlx-model-1"],
+            }
+        ],
+    )
+
+    assert row is not None
+    assert row["models"] == _LOCAL_CATALOG
+    assert fetched == []
+
+
+def test_keyless_endpoint_with_saved_catalog_is_still_not_probed(monkeypatch):
+    """...but the network-cost gate it rides on must survive intact.
+
+    The no-key + declared-catalog combination exists to keep Hermes from
+    probing an endpoint it cannot authenticate to. Serving that endpoint from
+    a warm cache is free; hitting the network is not. With a cold cache and
+    live probing fully enabled, this row must still make zero fetches.
+    """
+    _seed_custom_model_cache(monkeypatch, [])  # cold: only a probe could answer
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    fetched = []
+
+    def fetch(_api_key, base_url, **_kwargs):
+        fetched.append(base_url)
+        return ["should-not-be-reached"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fetch)
+
+    providers = list_authenticated_providers(
+        current_provider="nous",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "Local (127.0.0.1:8000)",
+                "base_url": _LOCAL_ENDPOINT,
+                "model": "omlx-model-1",
+                "models": ["omlx-model-1"],
+            }
+        ],
+        for_picker=True,
+        refresh=False,
+        probe_custom_providers=True,  # live probing fully enabled
+    )
+    row = next(
+        (p for p in providers if _LOCAL_ENDPOINT in str(p.get("api_url", ""))), None
+    )
+
+    assert row is not None
+    assert row["models"] == ["omlx-model-1"]
+    assert fetched == []
+
+
+def test_auto_saved_catalog_round_trips_without_pinning(tmp_path, monkeypatch):
+    """End-to-end: the shape we persist must not read back as a user pin.
+
+    Guards the whole chain rather than one branch — probe saves a catalog,
+    config is reloaded, and the endpoint must still be discoverable. If a
+    future change makes the saved shape look like an intentional allowlist
+    again, this fails even if the gate logic above is refactored away.
+    """
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(
+        "custom_providers:\n"
+        f"  - name: Local MLX\n    base_url: {_LOCAL_ENDPOINT}\n"
+        "    model: omlx-model-1\n"
+    )
+    monkeypatch.setattr(config_mod, "CONFIG_PATH", str(cfg_path), raising=False)
+
+    _save_discovered_models_to_config(_LOCAL_ENDPOINT, list(_LOCAL_CATALOG))
+
+    saved = yaml.safe_load(cfg_path.read_text())["custom_providers"][0]
+    assert saved["models"] == _LOCAL_CATALOG, "probe result should be persisted"
+
+    # The persisted shape is what the picker will read on the next open. It
+    # must not, on a keyless entry, suppress discovery of a wider catalog.
+    _seed_custom_model_cache(monkeypatch, [*_LOCAL_CATALOG, "omlx-model-9"])
+    row, fetched = _no_probe_local_row(
+        monkeypatch, custom_providers=[saved]
+    )
+
+    assert row is not None
+    assert row["models"] == [*_LOCAL_CATALOG, "omlx-model-9"], (
+        "an auto-saved catalog must not pin the endpoint against a newer "
+        "cached lineup"
+    )
+    assert fetched == []

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -1060,6 +1060,7 @@ def test_custom_provider_dict_models_pin_requires_discover_false(monkeypatch):
 
 _LOCAL_ENDPOINT = "http://127.0.0.1:8000/v1"
 _LOCAL_CATALOG = [f"omlx-model-{i}" for i in range(1, 9)]
+_SHARED_PROXY_URL = "https://proxy.example.com/v1"
 
 
 def _seed_custom_model_cache(monkeypatch, models, *, age_seconds=10):
@@ -1324,6 +1325,84 @@ def test_keyless_endpoint_with_saved_catalog_is_still_not_probed(monkeypatch):
 
     assert row is not None
     assert row["models"] == ["omlx-model-1"]
+    assert fetched == []
+
+
+def test_api_mode_rows_do_not_share_a_cached_catalog(monkeypatch):
+    """Two rows differing only by ``api_mode`` must not share a cache entry.
+
+    ``api_mode`` selects the wire protocol — ``x-api-key`` +
+    ``anthropic-version`` versus ``Authorization: Bearer`` — so it is part of
+    both the picker's group identity and
+    ``_custom_endpoint_fingerprint()``. The cache read has to pass it through
+    or an ``anthropic_messages`` row renders whatever the OpenAI-mode row
+    cached against the same base_url.
+    """
+    import hermes_cli.models as models_mod
+
+    openai_catalog = ["gpt-oss-a", "gpt-oss-b"]
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    fetched = []
+
+    def fetch(_api_key, base_url, **_kwargs):
+        fetched.append(base_url)
+        return ["should-not-be-reached"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fetch)
+
+    # Only the OpenAI-mode probe (api_mode=None) is on disk.
+    fp = models_mod._custom_endpoint_fingerprint("sk-shared", None, None)
+    cache = {
+        f"custom:{_SHARED_PROXY_URL}": {
+            "fp": fp,
+            "at": time.time() - 10,
+            "models": list(openai_catalog),
+        }
+    }
+    monkeypatch.setattr(models_mod, "_load_provider_models_cache", lambda: cache)
+
+    def _row(entry):
+        providers = list_authenticated_providers(
+            current_provider="nous",
+            user_providers={},
+            custom_providers=[entry],
+            for_picker=True,
+            refresh=False,
+            probe_custom_providers=False,
+            probe_current_custom_provider=True,
+        )
+        return next(
+            (p for p in providers if _SHARED_PROXY_URL in str(p.get("api_url", ""))),
+            None,
+        )
+
+    anthropic_row = _row(
+        {
+            "name": "Proxy Anthropic",
+            "base_url": _SHARED_PROXY_URL,
+            "api_key": "sk-shared",
+            "api_mode": "anthropic_messages",
+            "model": "claude-via-proxy",
+        }
+    )
+    openai_row = _row(
+        {
+            "name": "Proxy OpenAI",
+            "base_url": _SHARED_PROXY_URL,
+            "api_key": "sk-shared",
+            "model": "gpt-via-proxy",
+        }
+    )
+
+    assert anthropic_row is not None and openai_row is not None
+    assert anthropic_row["models"] == ["claude-via-proxy"], (
+        "an anthropic_messages row must not render the OpenAI-mode catalog "
+        "cached against the same base_url"
+    )
+    # ...while the row the entry actually belongs to still resolves.
+    assert openai_row["models"] == openai_catalog
     assert fetched == []
 
 


### PR DESCRIPTION
## Summary

Supersedes #81665 and #81556 — the read side and the write side of one bug: a saved custom OpenAI-compatible endpoint renders only the model(s) named in `config.yaml` on Desktop/dashboard picker opens, even when a full catalog for that endpoint is already on disk in `provider_models_cache.json`.

Reported against v0.20.0: a local oMLX-style server on `127.0.0.1:8000` with 8 models loaded renders 1 in the picker, while `GET /api/model/options?refresh=true` returns all 8.

Both PRs are cherry-picked here with authorship intact. The third piece is the residual gap that kept the reported case broken on either of them alone.

## Root cause

#58183 stopped GUI picker opens from live-probing saved custom endpoints, so a stopped local server could not stall the picker. Correct goal, but it gated the entire discovery block rather than just the network call, so `cached_fetch_api_models()` was skipped along with `fetch_api_models()` — and with it the catalog an earlier probe had already written to disk.

Fixing only that is not enough, because the read never reaches the shape that motivated it. The remaining gate is:

```python
bool(api_key) or not has_explicit_models
```

That clause is a **network-cost** gate — don't probe an endpoint we cannot authenticate to when it already declares its catalog (5f00f36ba, 1039e90b5). It is not a user pin; `discover_models: false` is the documented way to pin, and it is honored separately.

Left on the discovery side, it re-pins the very endpoints it was meant to spare. A successful probe calls `_save_discovered_models_to_config()`, which writes a plain list into `models:` — exactly the shape `_models_config_is_allowlist()` reads back as an explicit user allowlist. So a **keyless** local server (the common local-model-server shape, and the reported one) freezes on the catalog of its first probe and can never widen again. That is precisely the "endpoint whose lineup changes after config was written" case.

This bug class is already known here: `f66319097` ("treat models dict as metadata, not allowlist") carved the **dict** shape out of the same trap, with a docstring describing keyless Ollama pinning. `_save_discovered_models_to_config` writes the **list** shape, which was never carved out. Same trap, other door.

## What this PR does

- **`hermes_cli/models.py`** (@xxxigm) — `cache_only` on `cached_fetch_api_models()`: serves a valid same-fingerprint entry within the existing stale-serve window, never fetches, never spawns background revalidation, returns `None` on a miss. `cache_only` outranks `force_refresh`.
- **`hermes_cli/model_switch.py`** (@xxxigm) — the three custom-endpoint sites in `list_authenticated_providers()` separate what config permits from how we may obtain it; suppressing the probe downgrades to a cached read instead of skipping discovery. A cache hit no longer writes back to config.
- **`hermes_cli/model_setup_flows.py`** (@Navlem) — the `hermes model` named-custom-provider flow persists its discovered catalog, so a provider added there is not left at its single `model:` default on no-probe surfaces.
- **`hermes_cli/model_switch.py`** (this PR) — move `has_explicit_models` from `_discovery_allowed` to `_probe_live` at both custom-endpoint sites, so the cache read is not subject to the probe's network-cost gate.

## Verification

Real imports, temp `HERMES_HOME`, `fetch_api_models` spied. The endpoint shape matrix, with 8 models cached on disk in every row:

| Endpoint shape | main | #81665 | #81665+#81556 | this PR |
|---|---|---|---|---|
| keyed + auto-written `models:` | 1 | 8 | 8 | **8** |
| **keyless + auto-written `models:`** (reported case) | 1 | 1 | 1 | **8** |
| keyless, no `models:` | 1 | 8 | 8 | **8** |
| keyless + dict-shaped `models:` | 1 | 8 | 8 | **8** |

Live fetches: **0** in every cell.

The round trip that produces the pin, run against the real save function:

```
BEFORE _save_discovered_models_to_config -> models: None      allowlist? False
AFTER                                    -> models: [8 ids]   allowlist? True
```

## Behavior preserved

- **#58183's latency win.** A cold cache is a miss, so picker opens against offline endpoints still make zero network calls.
- **The network-cost gate.** With a cold cache and probing fully enabled, a keyless endpoint with a declared catalog still makes zero fetches — byte-identical to `main` across the keyed/keyless × declared/undeclared matrix.
- **`discover_models: false` still pins.** The cache cannot override an explicit narrowing.
- **Explicit Refresh unchanged** (full live probe of every custom provider).

## Test plan

- `scripts/run_tests.sh tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_cached_fetch_api_models.py -q` → **70 passed**
- `scripts/run_tests.sh` across `test_inventory`, `test_picker_prewarm`, `test_tui_gateway_server`, `test_model_catalog`, `test_model_cache_swr`, `test_models`, `test_user_providers_model_switch`, `test_custom_provider_model_switch`, `test_configured_builtin_models`, `acp/test_server` → **655 passed, 0 failed**
- `ruff check` on both changed files → clean
- The three new tests were run against the pre-fix gating and **fail** there (2 of 3; the third is the probe-suppression guard that must stay green both ways), so they cover the bug class rather than snapshotting current output.

New coverage asserts contracts: cache-hit/miss boundaries for `cache_only`, full-catalog rendering across all three provider shapes with a warm cache, cold-cache degradation with zero fetches, `discover_models: false` pinning, no config write-back on a cache hit, the keyless auto-save case, its probe-suppression counterpart, and a save→reload round trip asserting the persisted shape never reads back as a user pin.

Credit: @xxxigm (#81665, read side + `cache_only`), @Navlem (#81556, write side). Both cherry-picked, authorship preserved in git history.



Closes #63583 — verified against the exact `providers:` config and endpoint in that report: a normal `/model` open with the provider not current goes from **0 models to 13** (the count the reporter cited), with zero live fetches.
