### PR TITLE
fix(api): scope runtime env to agent runs

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -99,6 +99,11 @@ def bind_exact_redactions(values: Iterable[str]) -> Iterator[None]:
     finally:
         _EXACT_REDACTION_VALUES.reset(token)
 
+
+def get_exact_redactions() -> tuple[str, ...]:
+    """Return the opaque values bound to the current execution context."""
+    return _EXACT_REDACTION_VALUES.get()
+
 # Known API key prefixes -- match the prefix + contiguous token chars
 _PREFIX_PATTERNS = [
     r"sk-[A-Za-z0-9_-]{10,}",           # OpenAI / OpenRouter / Anthropic (sk-ant-*)
@@ -1220,4 +1225,9 @@ class RedactingFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:
         original = super().format(record)
+        # Async logging formats on a QueueListener thread, where ContextVars
+        # from the emitting worker are unavailable. Queue handlers attach the
+        # emitter's exact values to their shallow record copy before enqueue.
+        for secret in getattr(record, "_hermes_exact_redactions", ()):
+            original = original.replace(secret, "«redacted-secret»")
         return redact_sensitive_text(original)

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -11,6 +11,9 @@ import logging
 import os
 import re
 import shlex
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Iterable, Iterator
 from urllib.parse import unquote_plus
 
 # Basenames treated as ``.env`` files by _command_reads_env_file. Imported
@@ -74,6 +77,27 @@ _SENSITIVE_BODY_KEYS = frozenset({
 # warning is logged at gateway and CLI startup so operators see the
 # downgrade — see `_log_redaction_status()` in gateway/run.py and cli.py.
 _REDACT_ENABLED = os.getenv("HERMES_REDACT_SECRETS", "true").lower() in {"1", "true", "yes", "on"}
+
+_EXACT_REDACTION_VALUES: ContextVar[tuple[str, ...]] = ContextVar(
+    "hermes_exact_redaction_values", default=()
+)
+
+
+@contextmanager
+def bind_exact_redactions(values: Iterable[str]) -> Iterator[None]:
+    """Bind opaque secret values that must be redacted in this run only."""
+    cleaned = tuple(
+        sorted(
+            {value for value in values if isinstance(value, str) and value},
+            key=len,
+            reverse=True,
+        )
+    )
+    token = _EXACT_REDACTION_VALUES.set(cleaned)
+    try:
+        yield
+    finally:
+        _EXACT_REDACTION_VALUES.reset(token)
 
 # Known API key prefixes -- match the prefix + contiguous token chars
 _PREFIX_PATTERNS = [
@@ -820,6 +844,8 @@ def redact_sensitive_text(
         text = str(text)
     if not text:
         return text
+    for secret in _EXACT_REDACTION_VALUES.get():
+        text = text.replace(secret, "«redacted-secret»")
     if not (force or _REDACT_ENABLED):
         return text
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -70,6 +70,35 @@ _api_request_profile: ContextVar[Optional[str]] = ContextVar(
     "api_server_request_profile", default=None
 )
 
+_RUN_RUNTIME_ENV_KEYS = frozenset({
+    "PAPERCLIP_API_KEY",
+    "PAPERCLIP_API_URL",
+    "PAPERCLIP_AGENT_ID",
+    "PAPERCLIP_COMPANY_ID",
+    "PAPERCLIP_RUN_ID",
+    "PAPERCLIP_TASK_ID",
+})
+_RUN_RUNTIME_ENV_MAX_BYTES = 32 * 1024
+
+
+def _parse_run_runtime_env(body: Any) -> tuple[dict[str, str], Optional[str]]:
+    """Validate the narrow subprocess environment accepted by ``/v1/runs``."""
+    raw = body.get("runtime_env")
+    if raw is None:
+        return {}, None
+    if not isinstance(raw, dict):
+        return {}, "'runtime_env' must be an object"
+    if any(
+        not isinstance(key, str)
+        or key not in _RUN_RUNTIME_ENV_KEYS
+        or not isinstance(value, str)
+        for key, value in raw.items()
+    ):
+        return {}, "'runtime_env' contains an unsupported name or non-string value"
+    if sum(len(key.encode()) + len(value.encode()) for key, value in raw.items()) > _RUN_RUNTIME_ENV_MAX_BYTES:
+        return {}, "'runtime_env' is too large"
+    return dict(raw), None
+
 def _approval_event_choices(*, smart_denied: bool, allow_permanent: bool) -> list[str]:
     if smart_denied:
         return ["once", "deny"]
@@ -6470,6 +6499,10 @@ class APIServerAdapter(BasePlatformAdapter):
         except Exception:
             return web.json_response(_openai_error("Invalid JSON"), status=400)
 
+        runtime_env, runtime_env_error = _parse_run_runtime_env(body)
+        if runtime_env_error:
+            return web.json_response(_openai_error(runtime_env_error), status=400)
+
         raw_input = body.get("input")
         if not raw_input:
             return web.json_response(_openai_error("Missing 'input' field"), status=400)
@@ -6648,6 +6681,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         pass
 
                 def _run_sync():
+                    from gateway.runtime_context import bind_runtime_env
                     from gateway.session_context import clear_session_vars
                     from tools.approval import (
                         register_gateway_notify,
@@ -6659,7 +6693,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     effective_task_id = session_id or run_id
                     approval_token = None
                     session_tokens = []
-                    with self._profile_scope(request_profile):
+                    with self._profile_scope(request_profile), bind_runtime_env(runtime_env):
                         try:
                             # Bind approval/session identity for this API run via
                             # contextvars so concurrent runs do not share process

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6523,10 +6523,10 @@ class APIServerAdapter(BasePlatformAdapter):
         )
 
         def _redact_run_text(value: Any) -> str:
-            text = redact_sensitive_text(value, force=True)
+            text = str(value)
             for secret in exact_run_secrets:
                 text = text.replace(secret, "«redacted-secret»")
-            return text
+            return redact_sensitive_text(text, force=True)
 
         raw_input = body.get("input")
         if not raw_input:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -75,6 +75,8 @@ _RUN_RUNTIME_ENV_MAX_BYTES = 32 * 1024
 
 def _parse_run_runtime_env(body: Any) -> tuple[dict[str, str], Optional[str]]:
     """Validate the narrow subprocess environment accepted by ``/v1/runs``."""
+    if not isinstance(body, dict):
+        return {}, "request body must be an object"
     raw = body.get("runtime_env")
     environment = body.get("environment")
     if raw is not None and environment is not None:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -70,16 +70,6 @@ _api_request_profile: ContextVar[Optional[str]] = ContextVar(
     "api_server_request_profile", default=None
 )
 
-_RUN_RUNTIME_ENV_KEYS = frozenset({
-    "PAPERCLIP_API_KEY",
-    "PAPERCLIP_API_URL",
-    "PAPERCLIP_AGENT_ID",
-    "PAPERCLIP_COMPANY_ID",
-    "PAPERCLIP_ISSUE_WORK_MODE",
-    "PAPERCLIP_RUN_ID",
-    "PAPERCLIP_TASK_ID",
-    "PAPERCLIP_WAKE_REASON",
-})
 _RUN_RUNTIME_ENV_MAX_BYTES = 32 * 1024
 
 
@@ -97,12 +87,21 @@ def _parse_run_runtime_env(body: Any) -> tuple[dict[str, str], Optional[str]]:
         return {}, "'runtime_env' must be an object"
     if any(
         not isinstance(key, str)
-        or key not in _RUN_RUNTIME_ENV_KEYS
+        or key not in TRUSTED_RUNTIME_ENV_KEYS
         or not isinstance(value, str)
         for key, value in raw.items()
     ):
         return {}, "'runtime_env' contains an unsupported name or non-string value"
-    if sum(len(key.encode()) + len(value.encode()) for key, value in raw.items()) > _RUN_RUNTIME_ENV_MAX_BYTES:
+    if any("\x00" in value for value in raw.values()):
+        return {}, "'runtime_env' contains an invalid value"
+    try:
+        encoded_size = sum(
+            len(key.encode("utf-8")) + len(value.encode("utf-8"))
+            for key, value in raw.items()
+        )
+    except UnicodeEncodeError:
+        return {}, "'runtime_env' contains an invalid value"
+    if encoded_size > _RUN_RUNTIME_ENV_MAX_BYTES:
         return {}, "'runtime_env' is too large"
     return dict(raw), None
 
@@ -120,6 +119,7 @@ except ImportError:
     web = None  # type: ignore[assignment]
 
 from gateway.config import Platform, PlatformConfig
+from gateway.runtime_context import TRUSTED_RUNTIME_ENV_KEYS
 from gateway.platforms.base import (
     MEDIA_TAG_CLEANUP_RE,
     BasePlatformAdapter,
@@ -127,7 +127,7 @@ from gateway.platforms.base import (
     is_network_accessible,
     validate_media_delivery_path,
 )
-from agent.redact import redact_sensitive_text
+from agent.redact import bind_exact_redactions, redact_sensitive_text
 from agent.interrupt_compat import request_hard_interrupt
 from gateway.readiness import collect_runtime_readiness
 
@@ -6394,8 +6394,16 @@ class APIServerAdapter(BasePlatformAdapter):
         self._run_statuses[run_id] = current
         return current
 
-    def _make_run_event_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
+    def _make_run_event_callback(
+        self,
+        run_id: str,
+        loop: "asyncio.AbstractEventLoop",
+        redact_text=None,
+    ):
         """Return a tool_progress_callback that pushes structured events to the run's SSE queue."""
+        if redact_text is None:
+            redact_text = lambda value: redact_sensitive_text(value, force=True)
+
         def _push(event: Dict[str, Any]) -> None:
             self._set_run_status(
                 run_id,
@@ -6418,7 +6426,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "run_id": run_id,
                     "timestamp": ts,
                     "tool": tool_name,
-                    "preview": preview,
+                    "preview": redact_text(preview) if preview is not None else None,
                 })
             elif event_type == "tool.completed":
                 _push({
@@ -6434,7 +6442,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "event": "reasoning.available",
                     "run_id": run_id,
                     "timestamp": ts,
-                    "text": preview or "",
+                    "text": redact_text(preview or ""),
                 })
             elif event_type in {"subagent.start", "subagent.complete"}:
                 event = {
@@ -6443,9 +6451,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "timestamp": ts,
                 }
                 if preview is not None:
-                    event["preview"] = redact_sensitive_text(
-                        str(preview), force=True
-                    )
+                    event["preview"] = redact_text(str(preview))
                 for key in (
                     "goal",
                     "task_count",
@@ -6477,7 +6483,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     if key in ("goal", "summary", "output_tail") and isinstance(
                         value, str
                     ):
-                        value = redact_sensitive_text(value, force=True)
+                        value = redact_text(value)
                     event[key] = value
                 _push(event)
             # _thinking, subagent.tool, and subagent_progress are intentionally
@@ -6509,6 +6515,18 @@ class APIServerAdapter(BasePlatformAdapter):
         runtime_env, runtime_env_error = _parse_run_runtime_env(body)
         if runtime_env_error:
             return web.json_response(_openai_error(runtime_env_error), status=400)
+
+        exact_run_secrets = tuple(
+            value
+            for name, value in runtime_env.items()
+            if name == "PAPERCLIP_API_KEY" and value
+        )
+
+        def _redact_run_text(value: Any) -> str:
+            text = redact_sensitive_text(value, force=True)
+            for secret in exact_run_secrets:
+                text = text.replace(secret, "«redacted-secret»")
+            return text
 
         raw_input = body.get("input")
         if not raw_input:
@@ -6594,7 +6612,7 @@ class APIServerAdapter(BasePlatformAdapter):
         self._run_streams_created[run_id] = created_at
         self._run_approval_sessions[run_id] = approval_session_key
 
-        event_cb = self._make_run_event_callback(run_id, loop)
+        event_cb = self._make_run_event_callback(run_id, loop, _redact_run_text)
 
         def _put_event_if_active(event: Optional[Dict]) -> None:
             """Enqueue only while this run still owns live transport state."""
@@ -6605,6 +6623,11 @@ class APIServerAdapter(BasePlatformAdapter):
         def _text_cb(delta: Optional[str]) -> None:
             if delta is None:
                 return
+            # Exact-value redaction is not safe across arbitrary stream chunk
+            # boundaries. Runs carrying an opaque credential emit only the
+            # fully assembled, redacted completion event.
+            if exact_run_secrets:
+                return
             if run_id not in self._run_streams:
                 return
             try:
@@ -6612,7 +6635,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "event": "message.delta",
                     "run_id": run_id,
                     "timestamp": time.time(),
-                    "delta": delta,
+                    "delta": _redact_run_text(delta),
                 })
             except Exception:
                 pass
@@ -6667,7 +6690,9 @@ class APIServerAdapter(BasePlatformAdapter):
                     if "command" in event:
                         from gateway.run import _redact_approval_command
 
-                        event["command"] = _redact_approval_command(event.get("command"))
+                        event["command"] = _redact_run_text(
+                            _redact_approval_command(event.get("command"))
+                        )
                     event.update({
                         "event": "approval.request",
                         "run_id": run_id,
@@ -6700,7 +6725,11 @@ class APIServerAdapter(BasePlatformAdapter):
                     effective_task_id = session_id or run_id
                     approval_token = None
                     session_tokens = []
-                    with self._profile_scope(request_profile), bind_runtime_env(runtime_env):
+                    with (
+                        self._profile_scope(request_profile),
+                        bind_runtime_env(runtime_env),
+                        bind_exact_redactions(exact_run_secrets),
+                    ):
                         try:
                             # Bind approval/session identity for this API run via
                             # contextvars so concurrent runs do not share process
@@ -6773,7 +6802,9 @@ class APIServerAdapter(BasePlatformAdapter):
                 # 401/400 return failed=True instead of raising, so the except
                 # block below never fires — issue #15561).
                 elif isinstance(result, dict) and result.get("failed"):
-                    error_msg = _redact_api_error_text(result.get("error") or "agent run failed")
+                    error_msg = _redact_run_text(
+                        _redact_api_error_text(result.get("error") or "agent run failed")
+                    )
                     _put_event_if_active({
                         "event": "run.failed",
                         "run_id": run_id,
@@ -6787,7 +6818,9 @@ class APIServerAdapter(BasePlatformAdapter):
                         last_event="run.failed",
                     )
                 else:
-                    final_response = result.get("final_response", "") if isinstance(result, dict) else ""
+                    final_response = _redact_run_text(
+                        result.get("final_response", "") if isinstance(result, dict) else ""
+                    )
                     _put_event_if_active({
                         "event": "run.completed",
                         "run_id": run_id,
@@ -6825,8 +6858,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 # message the other endpoints give a provider auth/credential
                 # failure, instead of falling through to the generic
                 # except-Exception branch below.
-                logger.warning("Provider authentication failed for run=%s: %s", run_id, exc)
-                error_msg = f"⚠️ Provider authentication failed: {exc}"
+                error_msg = _redact_run_text(
+                    f"⚠️ Provider authentication failed: {exc}"
+                )
+                logger.warning("Provider authentication failed for run=%s: %s", run_id, error_msg)
                 self._set_run_status(
                     run_id,
                     "failed",
@@ -6843,11 +6878,12 @@ class APIServerAdapter(BasePlatformAdapter):
                 except Exception:
                     pass
             except Exception as exc:
-                logger.exception("[api_server] run %s failed", run_id)
+                error_msg = _redact_run_text(_redact_api_error_text(exc))
+                logger.error("[api_server] run %s failed: %s", run_id, error_msg)
                 self._set_run_status(
                     run_id,
                     "failed",
-                    error=_redact_api_error_text(exc),
+                    error=error_msg,
                     last_event="run.failed",
                 )
                 try:
@@ -6855,7 +6891,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         "event": "run.failed",
                         "run_id": run_id,
                         "timestamp": time.time(),
-                        "error": _redact_api_error_text(exc),
+                        "error": error_msg,
                     })
                 except Exception:
                     pass

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -75,8 +75,10 @@ _RUN_RUNTIME_ENV_KEYS = frozenset({
     "PAPERCLIP_API_URL",
     "PAPERCLIP_AGENT_ID",
     "PAPERCLIP_COMPANY_ID",
+    "PAPERCLIP_ISSUE_WORK_MODE",
     "PAPERCLIP_RUN_ID",
     "PAPERCLIP_TASK_ID",
+    "PAPERCLIP_WAKE_REASON",
 })
 _RUN_RUNTIME_ENV_MAX_BYTES = 32 * 1024
 
@@ -84,6 +86,11 @@ _RUN_RUNTIME_ENV_MAX_BYTES = 32 * 1024
 def _parse_run_runtime_env(body: Any) -> tuple[dict[str, str], Optional[str]]:
     """Validate the narrow subprocess environment accepted by ``/v1/runs``."""
     raw = body.get("runtime_env")
+    environment = body.get("environment")
+    if raw is not None and environment is not None:
+        return {}, "provide only one of 'runtime_env' or 'environment'"
+    if raw is None:
+        raw = environment
     if raw is None:
         return {}, None
     if not isinstance(raw, dict):

--- a/gateway/runtime_context.py
+++ b/gateway/runtime_context.py
@@ -1,0 +1,29 @@
+"""Request-local trusted runtime values for agent tool subprocesses.
+
+Values are bound by authenticated gateway entry points and bridged only into
+subprocess environments. They are never copied into prompts or global process
+environment state.
+"""
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Iterator, Mapping
+
+_runtime_env: ContextVar[dict[str, str]] = ContextVar(
+    "hermes_request_runtime_env", default={}
+)
+
+
+def get_runtime_env() -> dict[str, str]:
+    """Return a copy of the runtime values bound to the current request."""
+    return dict(_runtime_env.get())
+
+
+@contextmanager
+def bind_runtime_env(values: Mapping[str, str]) -> Iterator[None]:
+    """Bind trusted runtime values for one request and restore on exit."""
+    token = _runtime_env.set(dict(values))
+    try:
+        yield
+    finally:
+        _runtime_env.reset(token)

--- a/gateway/runtime_context.py
+++ b/gateway/runtime_context.py
@@ -7,16 +7,28 @@ environment state.
 
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import Iterator, Mapping
+from typing import Iterator, Mapping, Optional
 
-_runtime_env: ContextVar[dict[str, str]] = ContextVar(
-    "hermes_request_runtime_env", default={}
+TRUSTED_RUNTIME_ENV_KEYS = frozenset({
+    "PAPERCLIP_API_KEY",
+    "PAPERCLIP_API_URL",
+    "PAPERCLIP_AGENT_ID",
+    "PAPERCLIP_COMPANY_ID",
+    "PAPERCLIP_ISSUE_WORK_MODE",
+    "PAPERCLIP_RUN_ID",
+    "PAPERCLIP_TASK_ID",
+    "PAPERCLIP_WAKE_REASON",
+})
+
+_runtime_env: ContextVar[Optional[dict[str, str]]] = ContextVar(
+    "hermes_request_runtime_env", default=None
 )
 
 
-def get_runtime_env() -> dict[str, str]:
-    """Return a copy of the runtime values bound to the current request."""
-    return dict(_runtime_env.get())
+def get_runtime_env() -> Optional[dict[str, str]]:
+    """Return bound values, or ``None`` outside a trusted request scope."""
+    values = _runtime_env.get()
+    return dict(values) if values is not None else None
 
 
 @contextmanager

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -589,7 +589,11 @@ class _NonFormattingQueueHandler(QueueHandler):
     """
 
     def prepare(self, record: logging.LogRecord) -> logging.LogRecord:
-        return copy.copy(record)
+        prepared = copy.copy(record)
+        from agent.redact import get_exact_redactions
+
+        prepared._hermes_exact_redactions = get_exact_redactions()
+        return prepared
 
 
 def _stop_queue_listener_locked() -> None:

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -1,10 +1,18 @@
 """Tests for agent.redact -- secret masking in logs and output."""
 
 import logging
+import threading
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
-from agent.redact import mask_secret, redact_cdp_url, redact_sensitive_text, RedactingFormatter
+from agent.redact import (
+    RedactingFormatter,
+    bind_exact_redactions,
+    mask_secret,
+    redact_cdp_url,
+    redact_sensitive_text,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -13,6 +21,35 @@ def _ensure_redaction_enabled(monkeypatch):
     monkeypatch.delenv("HERMES_REDACT_SECRETS", raising=False)
     # Also patch the module-level snapshot so it reflects the cleared env var
     monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+
+
+def test_exact_redactions_are_scoped_and_mandatory(monkeypatch):
+    secret = "opaque-run-secret-with-no-known-prefix"
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+
+    with bind_exact_redactions([secret]):
+        result = redact_sensitive_text(f"echoed {secret}")
+
+    assert secret not in result
+    assert "redacted" in result
+    assert redact_sensitive_text(f"echoed {secret}") == f"echoed {secret}"
+
+
+def test_exact_redactions_are_isolated_between_threads():
+    barrier = threading.Barrier(2)
+
+    def redact_in_scope(secret):
+        with bind_exact_redactions([secret]):
+            barrier.wait(timeout=10)
+            return redact_sensitive_text("run-secret-a run-secret-b")
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        outputs = list(pool.map(redact_in_scope, ["run-secret-a", "run-secret-b"]))
+
+    assert "run-secret-a" not in outputs[0]
+    assert "run-secret-b" in outputs[0]
+    assert "run-secret-b" not in outputs[1]
+    assert "run-secret-a" in outputs[1]
 
 
 class TestKnownPrefixes:

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -9,6 +9,8 @@ Covers:
 """
 
 import asyncio
+import subprocess
+import sys
 import threading
 import time
 from unittest.mock import MagicMock, patch
@@ -189,6 +191,69 @@ class TestStartRun:
         assert captured.get("origin_session_id") == "runs-raw-sid", (
             "runs route must bind chat_id so delegation dispatch sees a wake target"
         )
+
+    @pytest.mark.asyncio
+    async def test_start_scopes_runtime_env_to_tool_subprocess(self, adapter):
+        app = _create_runs_app(adapter)
+        captured = {}
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+
+                def _capture_run(user_message=None, conversation_history=None, task_id=None):
+                    from tools.environments.local import _make_run_env
+
+                    child_env = _make_run_env({})
+                    captured["child"] = subprocess.check_output(
+                        [
+                            sys.executable,
+                            "-c",
+                            "import os; print(os.environ['PAPERCLIP_API_KEY']); print(os.environ['PAPERCLIP_RUN_ID'])",
+                        ],
+                        env=child_env,
+                        text=True,
+                    ).splitlines()
+                    return {"final_response": "done"}
+
+                mock_agent.run_conversation.side_effect = _capture_run
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "input": "hello",
+                        "runtime_env": {
+                            "PAPERCLIP_API_KEY": "scoped-test-token",
+                            "PAPERCLIP_RUN_ID": "paperclip-run-1",
+                        },
+                    },
+                )
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+                for _ in range(40):
+                    status = await (await cli.get(f"/v1/runs/{run_id}")).json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert captured["child"] == ["scoped-test-token", "paperclip-run-1"]
+        from gateway.runtime_context import get_runtime_env
+
+        assert get_runtime_env() == {}
+
+    @pytest.mark.asyncio
+    async def test_start_rejects_unallowlisted_runtime_env(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/runs",
+                json={"input": "hello", "runtime_env": {"PATH": "/tmp/unsafe"}},
+            )
+        assert resp.status == 400
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -196,6 +196,7 @@ class TestStartRun:
     async def test_start_scopes_runtime_env_to_tool_subprocess(self, adapter):
         app = _create_runs_app(adapter)
         captured = {}
+        child_ran = threading.Event()
 
         async with TestClient(TestServer(app)) as cli:
             with patch.object(adapter, "_create_agent") as mock_create:
@@ -214,6 +215,7 @@ class TestStartRun:
                         env=child_env,
                         text=True,
                     ).splitlines()
+                    child_ran.set()
                     return {"final_response": "done"}
 
                 mock_agent.run_conversation.side_effect = _capture_run
@@ -233,12 +235,7 @@ class TestStartRun:
                     },
                 )
                 assert resp.status == 202
-                run_id = (await resp.json())["run_id"]
-                for _ in range(40):
-                    status = await (await cli.get(f"/v1/runs/{run_id}")).json()
-                    if status["status"] == "completed":
-                        break
-                    await asyncio.sleep(0.05)
+                assert await asyncio.to_thread(child_ran.wait, 120)
 
         assert captured["child"] == ["scoped-test-token", "paperclip-run-1"]
         from gateway.runtime_context import get_runtime_env

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -241,7 +241,7 @@ class TestStartRun:
         assert captured["child"] == ["scoped-test-token", "paperclip-run-1"]
         from gateway.runtime_context import get_runtime_env
 
-        assert get_runtime_env() == {}
+        assert get_runtime_env() is None
 
     def test_runtime_env_isolated_between_concurrent_workers(self):
         from gateway.runtime_context import bind_runtime_env, get_runtime_env
@@ -258,7 +258,24 @@ class TestStartRun:
             values = list(pool.map(_read_bound_value, ["run-token-a", "run-token-b"]))
 
         assert values == ["run-token-a", "run-token-b"]
-        assert get_runtime_env() == {}
+        assert get_runtime_env() is None
+
+    def test_runtime_scope_replaces_ambient_paperclip_values(self, monkeypatch):
+        from gateway.runtime_context import bind_runtime_env
+        from tools.environments.local import _make_run_env
+
+        monkeypatch.setenv("PAPERCLIP_API_KEY", "ambient-token")
+        monkeypatch.setenv("PAPERCLIP_RUN_ID", "ambient-run")
+
+        with bind_runtime_env({}):
+            empty_scope = _make_run_env({})
+        with bind_runtime_env({"PAPERCLIP_API_KEY": "scoped-token"}):
+            scoped = _make_run_env({})
+
+        assert "PAPERCLIP_API_KEY" not in empty_scope
+        assert "PAPERCLIP_RUN_ID" not in empty_scope
+        assert scoped["PAPERCLIP_API_KEY"] == "scoped-token"
+        assert "PAPERCLIP_RUN_ID" not in scoped
 
     @pytest.mark.asyncio
     async def test_start_rejects_unallowlisted_runtime_env(self, adapter):
@@ -274,6 +291,54 @@ class TestStartRun:
             )
         assert resp.status == 400
         assert conflict.status == 400
+
+    def test_start_rejects_invalid_runtime_env_values(self):
+        from gateway.platforms.api_server import _parse_run_runtime_env
+
+        _, nul_error = _parse_run_runtime_env(
+            {"runtime_env": {"PAPERCLIP_API_KEY": "bad\u0000value"}}
+        )
+        _, surrogate_error = _parse_run_runtime_env(
+            {"runtime_env": {"PAPERCLIP_API_KEY": "\ud800"}}
+        )
+
+        assert nul_error is not None
+        assert surrogate_error is not None
+
+    @pytest.mark.asyncio
+    async def test_run_output_exactly_redacts_scoped_api_key(self, adapter):
+        app = _create_runs_app(adapter)
+        token = "opaque-paperclip-test-value"
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {
+                    "final_response": f"tool echoed {token}"
+                }
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "input": "hello",
+                        "runtime_env": {"PAPERCLIP_API_KEY": token},
+                    },
+                )
+                run_id = (await resp.json())["run_id"]
+
+                for _ in range(40):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert token not in status["output"]
+        assert "redacted" in status["output"].lower()
 
 
     @pytest.mark.asyncio
@@ -415,6 +480,42 @@ class TestRunEvents:
                 # Should contain run.completed
                 assert "run.completed" in body
                 assert "Hello!" in body
+
+    @pytest.mark.asyncio
+    async def test_credentialed_run_suppresses_deltas_and_redacts_completion(self, adapter):
+        app = _create_runs_app(adapter)
+        token = "opaque-stream-test-secret"
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+
+                def _run(**_kwargs):
+                    callback = mock_create.call_args.kwargs["stream_delta_callback"]
+                    callback(token[:10])
+                    callback(token[10:])
+                    return {"final_response": f"echoed {token}"}
+
+                mock_agent.run_conversation.side_effect = _run
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "input": "hello",
+                        "runtime_env": {"PAPERCLIP_API_KEY": token},
+                    },
+                )
+                run_id = (await resp.json())["run_id"]
+                events_resp = await cli.get(f"/v1/runs/{run_id}/events")
+                body = await events_resp.text()
+
+        assert "message.delta" not in body
+        assert token not in body
+        assert "redacted" in body.lower()
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -332,6 +332,17 @@ class TestStartRun:
         assert set(accepted) == TRUSTED_RUNTIME_ENV_KEYS
 
     @pytest.mark.asyncio
+    async def test_start_rejects_non_object_json_body(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post("/v1/runs", json=[])
+            payload = await response.json()
+
+        assert response.status == 400
+        assert payload["error"]["type"] == "invalid_request_error"
+        assert payload["error"]["message"] == "request body must be an object"
+
+    @pytest.mark.asyncio
     async def test_run_output_exactly_redacts_scoped_api_key(self, adapter):
         app = _create_runs_app(adapter)
         token = "opaque-paperclip-test-value"

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -9,6 +9,7 @@ Covers:
 """
 
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 import subprocess
 import sys
 import threading
@@ -240,6 +241,23 @@ class TestStartRun:
         assert captured["child"] == ["scoped-test-token", "paperclip-run-1"]
         from gateway.runtime_context import get_runtime_env
 
+        assert get_runtime_env() == {}
+
+    def test_runtime_env_isolated_between_concurrent_workers(self):
+        from gateway.runtime_context import bind_runtime_env, get_runtime_env
+        from tools.environments.local import _make_run_env
+
+        barrier = threading.Barrier(2)
+
+        def _read_bound_value(value):
+            with bind_runtime_env({"PAPERCLIP_API_KEY": value}):
+                barrier.wait(timeout=10)
+                return _make_run_env({})["PAPERCLIP_API_KEY"]
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            values = list(pool.map(_read_bound_value, ["run-token-a", "run-token-b"]))
+
+        assert values == ["run-token-a", "run-token-b"]
         assert get_runtime_env() == {}
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -293,7 +293,11 @@ class TestStartRun:
         assert conflict.status == 400
 
     def test_start_rejects_invalid_runtime_env_values(self):
-        from gateway.platforms.api_server import _parse_run_runtime_env
+        from gateway.platforms.api_server import (
+            _RUN_RUNTIME_ENV_MAX_BYTES,
+            _parse_run_runtime_env,
+        )
+        from gateway.runtime_context import TRUSTED_RUNTIME_ENV_KEYS
 
         _, nul_error = _parse_run_runtime_env(
             {"runtime_env": {"PAPERCLIP_API_KEY": "bad\u0000value"}}
@@ -301,9 +305,24 @@ class TestStartRun:
         _, surrogate_error = _parse_run_runtime_env(
             {"runtime_env": {"PAPERCLIP_API_KEY": "\ud800"}}
         )
+        key = "PAPERCLIP_API_KEY"
+        boundary_value = "x" * (_RUN_RUNTIME_ENV_MAX_BYTES - len(key.encode("utf-8")))
+        _, boundary_error = _parse_run_runtime_env(
+            {"runtime_env": {key: boundary_value}}
+        )
+        _, oversized_error = _parse_run_runtime_env(
+            {"runtime_env": {key: boundary_value + "x"}}
+        )
+        accepted, allowlist_error = _parse_run_runtime_env(
+            {"runtime_env": {name: "value" for name in TRUSTED_RUNTIME_ENV_KEYS}}
+        )
 
         assert nul_error is not None
         assert surrogate_error is not None
+        assert boundary_error is None
+        assert oversized_error is not None
+        assert allowlist_error is None
+        assert set(accepted) == TRUSTED_RUNTIME_ENV_KEYS
 
     @pytest.mark.asyncio
     async def test_run_output_exactly_redacts_scoped_api_key(self, adapter):

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -266,15 +266,22 @@ class TestStartRun:
 
         monkeypatch.setenv("PAPERCLIP_API_KEY", "ambient-token")
         monkeypatch.setenv("PAPERCLIP_RUN_ID", "ambient-run")
+        monkeypatch.setenv("Paperclip_Api_Key", "mixed-case-ambient-token")
 
         with bind_runtime_env({}):
             empty_scope = _make_run_env({})
         with bind_runtime_env({"PAPERCLIP_API_KEY": "scoped-token"}):
             scoped = _make_run_env({})
 
-        assert "PAPERCLIP_API_KEY" not in empty_scope
-        assert "PAPERCLIP_RUN_ID" not in empty_scope
+        assert not any(
+            key.upper() in {"PAPERCLIP_API_KEY", "PAPERCLIP_RUN_ID"}
+            for key in empty_scope
+        )
         assert scoped["PAPERCLIP_API_KEY"] == "scoped-token"
+        assert not any(
+            key != "PAPERCLIP_API_KEY" and key.upper() == "PAPERCLIP_API_KEY"
+            for key in scoped
+        )
         assert "PAPERCLIP_RUN_ID" not in scoped
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -229,7 +229,7 @@ class TestStartRun:
                     "/v1/runs",
                     json={
                         "input": "hello",
-                        "runtime_env": {
+                        "environment": {
                             "PAPERCLIP_API_KEY": "scoped-test-token",
                             "PAPERCLIP_RUN_ID": "paperclip-run-1",
                         },
@@ -268,7 +268,12 @@ class TestStartRun:
                 "/v1/runs",
                 json={"input": "hello", "runtime_env": {"PATH": "/tmp/unsafe"}},
             )
+            conflict = await cli.post(
+                "/v1/runs",
+                json={"input": "hello", "runtime_env": {}, "environment": {}},
+            )
         assert resp.status == 400
+        assert conflict.status == 400
 
 
     @pytest.mark.asyncio

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -2,9 +2,11 @@
 import io
 import logging
 import os
+import queue
 import stat
 import sys
 import threading
+from logging.handlers import QueueListener
 from pathlib import Path
 from unittest.mock import patch
 
@@ -666,5 +668,32 @@ class TestAsyncQueueLogging:
             "agent.log" in getattr(h, "baseFilename", "")
             for h in hermes_logging.rotating_file_handlers()
         )
+
+    def test_exact_redactions_cross_queue_listener_thread(self):
+        from agent.redact import RedactingFormatter, bind_exact_redactions
+
+        secret = "opaque-paperclip-token-not-matched-by-prefix-rules"
+        stream = io.StringIO()
+        target = logging.StreamHandler(stream)
+        target.setFormatter(RedactingFormatter("%(message)s"))
+        records = queue.SimpleQueue()
+        queued = hermes_logging._NonFormattingQueueHandler(records)
+        listener = QueueListener(records, target)
+        logger = logging.getLogger("_test_async_exact_redaction")
+        logger.handlers = [queued]
+        logger.propagate = False
+        logger.setLevel(logging.INFO)
+
+        listener.start()
+        try:
+            with bind_exact_redactions([secret]):
+                logger.info("worker echoed %s", secret)
+        finally:
+            listener.stop()
+            logger.handlers = []
+
+        output = stream.getvalue()
+        assert secret not in output
+        assert "«redacted-secret»" in output
 
 

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -722,8 +722,9 @@ class TestSpawnEnvSanitization:
 
         home = tmp_path / "home"
         home.mkdir()
-        (home / ".bash_profile").write_text(
-            "printf 'startup=%s\\n' \"${PAPERCLIP_API_KEY-missing}\"\n"
+        startup_file = home / ".bash_profile"
+        startup_file.write_text(
+            "printf 'startup-sourced\\n'\n"
             "export PAPERCLIP_API_KEY=stale-login-token\n"
             "export Paperclip_Api_Key=mixed-case-stale-login-token\n",
             encoding="utf-8",
@@ -737,7 +738,11 @@ class TestSpawnEnvSanitization:
 
         with patch.dict(
             os.environ,
-            {"PATH": os.environ.get("PATH", ""), "HOME": str(home)},
+            {
+                "PATH": os.environ.get("PATH", ""),
+                "HOME": str(home),
+                "BASH_ENV": str(startup_file),
+            },
             clear=True,
         ), patch("tools.process_registry._find_shell", return_value="/bin/bash"), patch.object(
             registry, "_write_checkpoint"

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -279,8 +279,9 @@ class _FakeChunkProcess:
         return 0
 
 
-def _run_reader(registry, monkeypatch, chunks, sid="proc_utf8"):
+def _run_reader(registry, monkeypatch, chunks, sid="proc_utf8", exact_redactions=()):
     session = _make_session(sid=sid)
+    session.exact_redactions = tuple(exact_redactions)
     session.process = _FakeChunkProcess(chunks)
     monkeypatch.setattr(registry, "_check_watch_patterns", lambda _s, _c: None)
     monkeypatch.setattr(registry, "_emit_output", lambda _s, _c: None)
@@ -319,6 +320,33 @@ def test_reader_loop_still_replaces_genuinely_invalid_bytes(registry, monkeypatc
     assert session.output_buffer == "ok\ufffddone\n"
 
 
+def test_reader_loop_redacts_opaque_secret_split_across_chunks(registry):
+    """Background buffers, live output, and notifications retain no secret."""
+    secret = "opaque-paperclip-token-not-prefix-shaped"
+    session = _make_session(sid="proc_exact_notifications")
+    session.process = _FakeChunkProcess(
+        [b"before opaque-paperclip-", b"token-not-prefix-shaped after\n"]
+    )
+    session.exact_redactions = (secret,)
+    session.watch_patterns = ["after"]
+    session.notify_on_complete = True
+    emitted = []
+    registry.on_output = lambda _session, chunk: emitted.append(chunk)
+    registry._running[session.id] = session
+
+    registry._reader_loop(session)
+
+    events = []
+    while not registry.completion_queue.empty():
+        events.append(registry.completion_queue.get_nowait())
+    combined_events = repr(events)
+    assert secret not in session.output_buffer
+    assert secret not in "".join(emitted)
+    assert secret not in combined_events
+    assert "«redacted-secret»" in session.output_buffer
+    assert {event["type"] for event in events} == {"watch_match", "completion"}
+
+
 def test_pty_reader_loop_reassembles_multibyte_char_split_across_chunks(registry, monkeypatch):
     """The PTY reader gets the same incremental-decode treatment."""
 
@@ -348,6 +376,39 @@ def test_pty_reader_loop_reassembles_multibyte_char_split_across_chunks(registry
 
     assert session.output_buffer == "café\n"
     assert "\ufffd" not in session.output_buffer
+
+
+def test_pty_reader_loop_redacts_opaque_secret_split_across_chunks(registry, monkeypatch):
+    secret = "opaque-paperclip-pty-token-not-prefix-shaped"
+
+    class _FakePty:
+        def __init__(self):
+            self._chunks = [
+                b"before opaque-paperclip-pty-",
+                b"token-not-prefix-shaped after\n",
+            ]
+            self.exitstatus = 0
+
+        def isalive(self):
+            return bool(self._chunks)
+
+        def read(self, _n):
+            return self._chunks.pop(0)
+
+        def wait(self):
+            return 0
+
+    session = _make_session(sid="proc_pty_exact_redaction")
+    session.exact_redactions = (secret,)
+    session._pty = _FakePty()
+    monkeypatch.setattr(registry, "_check_watch_patterns", lambda _s, _c: None)
+    monkeypatch.setattr(registry, "_emit_output", lambda _s, _c: None)
+    monkeypatch.setattr(registry, "_move_to_finished", lambda _s: None)
+
+    registry._pty_reader_loop(session)
+
+    assert secret not in session.output_buffer
+    assert "«redacted-secret»" in session.output_buffer
 
 
 # =========================================================================
@@ -644,9 +705,11 @@ class TestPruning:
 
 class TestSpawnEnvSanitization:
     def test_spawn_local_pipe_uses_authoritative_request_scope(self, registry):
+        from agent.redact import bind_exact_redactions
         from gateway.runtime_context import bind_runtime_env
 
         captured = {}
+        secret = "opaque-scoped-token-for-background-output"
 
         def fake_popen(cmd, **kwargs):
             captured["env"] = kwargs["env"]
@@ -671,11 +734,14 @@ class TestSpawnEnvSanitization:
         ), patch("threading.Thread", return_value=MagicMock()), patch.object(
             registry, "_write_checkpoint"
         ):
-            with bind_runtime_env({"PAPERCLIP_API_KEY": "scoped-token"}):
-                registry.spawn_local("echo hello", cwd="/tmp")
+            with bind_runtime_env(
+                {"PAPERCLIP_API_KEY": "scoped-token"}
+            ), bind_exact_redactions([secret]):
+                session = registry.spawn_local("echo hello", cwd="/tmp")
 
         assert captured["env"]["PAPERCLIP_API_KEY"] == "scoped-token"
         assert "PAPERCLIP_RUN_ID" not in captured["env"]
+        assert session.exact_redactions == (secret,)
 
     def test_spawn_local_pty_uses_authoritative_empty_request_scope(self, registry):
         from gateway.runtime_context import bind_runtime_env

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -824,6 +824,7 @@ class TestSpawnEnvSanitization:
         captured = {}
 
         def fake_popen(cmd, **kwargs):
+            captured["cmd"] = cmd
             captured["env"] = kwargs["env"]
             proc = MagicMock()
             proc.pid = 4321
@@ -861,6 +862,7 @@ class TestSpawnEnvSanitization:
         assert "FIRECRAWL_API_KEY" not in env
         assert f"{_HERMES_PROVIDER_ENV_FORCE_PREFIX}TELEGRAM_BOT_TOKEN" not in env
         assert env["PYTHONUNBUFFERED"] == "1"
+        assert captured["cmd"][1] == "-lic"
 
     def test_spawn_via_env_checks_returncode_when_wrapper_fails(self, registry):
         class FakeEnv:

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -704,6 +704,51 @@ class TestPruning:
 # =========================================================================
 
 class TestSpawnEnvSanitization:
+
+    @pytest.mark.parametrize(
+        ("runtime_env", "expected"),
+        [
+            ({}, "missing"),
+            (
+                {"PAPERCLIP_API_KEY": "scoped-token"},
+                "PAPERCLIP_API_KEY=scoped-token",
+            ),
+        ],
+    )
+    def test_spawn_local_pipe_restores_authoritative_scope_after_login_startup(
+        self, registry, tmp_path, runtime_env, expected
+    ):
+        from gateway.runtime_context import bind_runtime_env
+
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / ".bash_profile").write_text(
+            "printf 'startup=%s\\n' \"${PAPERCLIP_API_KEY-missing}\"\n"
+            "export PAPERCLIP_API_KEY=stale-login-token\n"
+            "export Paperclip_Api_Key=mixed-case-stale-login-token\n",
+            encoding="utf-8",
+        )
+        command = (
+            "python3 -c \"import os; "
+            "matches=sorted(f'{k}={v}' for k,v in os.environ.items() "
+            "if k.upper() == 'PAPERCLIP_API_KEY'); "
+            "print('|'.join(matches) or 'missing')\""
+        )
+
+        with patch.dict(
+            os.environ,
+            {"PATH": os.environ.get("PATH", ""), "HOME": str(home)},
+            clear=True,
+        ), patch("tools.process_registry._find_shell", return_value="/bin/bash"), patch.object(
+            registry, "_write_checkpoint"
+        ):
+            with bind_runtime_env(runtime_env):
+                session = registry.spawn_local(command, cwd=str(tmp_path))
+                result = registry.wait(session.id, timeout=10)
+
+        assert result["status"] == "exited"
+        assert result["output"].splitlines() == [expected]
+
     def test_spawn_local_pipe_uses_authoritative_request_scope(self, registry):
         from agent.redact import bind_exact_redactions
         from gateway.runtime_context import bind_runtime_env
@@ -712,6 +757,7 @@ class TestSpawnEnvSanitization:
         secret = "opaque-scoped-token-for-background-output"
 
         def fake_popen(cmd, **kwargs):
+            captured["cmd"] = cmd
             captured["env"] = kwargs["env"]
             proc = MagicMock()
             proc.pid = 4321
@@ -741,6 +787,8 @@ class TestSpawnEnvSanitization:
 
         assert captured["env"]["PAPERCLIP_API_KEY"] == "scoped-token"
         assert "PAPERCLIP_RUN_ID" not in captured["env"]
+        assert "scoped-token" not in captured["cmd"][-1]
+        assert captured["cmd"][1] == "-c"
         assert session.exact_redactions == (secret,)
 
     def test_spawn_local_pty_uses_authoritative_empty_request_scope(self, registry):
@@ -767,8 +815,10 @@ class TestSpawnEnvSanitization:
                 registry.spawn_local("echo hello", cwd="/tmp", use_pty=True)
 
         child_env = spawn.call_args.kwargs["env"]
+        child_argv = spawn.call_args.args[0]
         assert "PAPERCLIP_API_KEY" not in child_env
         assert "PAPERCLIP_RUN_ID" not in child_env
+        assert child_argv[1] == "-c"
 
     def test_spawn_local_strips_blocked_vars_from_background_env(self, registry):
         captured = {}

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -643,6 +643,67 @@ class TestPruning:
 # =========================================================================
 
 class TestSpawnEnvSanitization:
+    def test_spawn_local_pipe_uses_authoritative_request_scope(self, registry):
+        from gateway.runtime_context import bind_runtime_env
+
+        captured = {}
+
+        def fake_popen(cmd, **kwargs):
+            captured["env"] = kwargs["env"]
+            proc = MagicMock()
+            proc.pid = 4321
+            proc.stdout = iter([])
+            proc.stdin = MagicMock()
+            proc.poll.return_value = None
+            return proc
+
+        with patch.dict(
+            os.environ,
+            {
+                "PATH": "/usr/bin:/bin",
+                "HOME": "/home/user",
+                "PAPERCLIP_API_KEY": "ambient-token",
+                "PAPERCLIP_RUN_ID": "ambient-run",
+            },
+            clear=True,
+        ), patch("tools.process_registry._find_shell", return_value="/bin/bash"), patch(
+            "subprocess.Popen", side_effect=fake_popen
+        ), patch("threading.Thread", return_value=MagicMock()), patch.object(
+            registry, "_write_checkpoint"
+        ):
+            with bind_runtime_env({"PAPERCLIP_API_KEY": "scoped-token"}):
+                registry.spawn_local("echo hello", cwd="/tmp")
+
+        assert captured["env"]["PAPERCLIP_API_KEY"] == "scoped-token"
+        assert "PAPERCLIP_RUN_ID" not in captured["env"]
+
+    def test_spawn_local_pty_uses_authoritative_empty_request_scope(self, registry):
+        from gateway.runtime_context import bind_runtime_env
+
+        pty_proc = MagicMock()
+        pty_proc.pid = 4321
+
+        with patch.dict(
+            os.environ,
+            {
+                "PATH": "/usr/bin:/bin",
+                "HOME": "/home/user",
+                "PAPERCLIP_API_KEY": "ambient-token",
+                "PAPERCLIP_RUN_ID": "ambient-run",
+            },
+            clear=True,
+        ), patch("tools.process_registry._find_shell", return_value="/bin/bash"), patch(
+            "ptyprocess.PtyProcess.spawn", return_value=pty_proc
+        ) as spawn, patch("threading.Thread", return_value=MagicMock()), patch.object(
+            registry, "_write_checkpoint"
+        ):
+            with bind_runtime_env({}):
+                registry.spawn_local("echo hello", cwd="/tmp", use_pty=True)
+
+        child_env = spawn.call_args.kwargs["env"]
+        assert "PAPERCLIP_API_KEY" not in child_env
+        assert "PAPERCLIP_RUN_ID" not in child_env
+
     def test_spawn_local_strips_blocked_vars_from_background_env(self, registry):
         captured = {}
 

--- a/tests/tools/test_snapshot_session_id_leak.py
+++ b/tests/tools/test_snapshot_session_id_leak.py
@@ -143,3 +143,34 @@ def test_shared_snapshot_no_cross_run_runtime_env_leak(tmp_path):
                 assert "PAPERCLIP_API_KEY" not in f.read()
     finally:
         env.cleanup()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX bash snapshot path")
+def test_shared_snapshot_excludes_mixed_case_runtime_names(tmp_path):
+    """Reserved names cannot persist under a Windows-equivalent spelling."""
+    from gateway.runtime_context import bind_runtime_env
+    from tools.environments.local import LocalEnvironment
+
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=30)
+    env.init_session()
+    try:
+        # Simulate a snapshot created by an older Hermes version before
+        # case-insensitive reserved-name filtering was introduced.
+        with open(env._snapshot_path, "w") as snapshot:
+            snapshot.write(
+                'declare -x Paperclip_Api_Key="mixed-case-stale-token"\n'
+            )
+
+        with bind_runtime_env({"PAPERCLIP_API_KEY": "scoped-token"}):
+            result = env.execute(
+                'printf "%s|%s" "$PAPERCLIP_API_KEY" '
+                '"${Paperclip_Api_Key-unset}"'
+            )
+        output = result.get("output", "")
+        assert "scoped-token|unset" in output
+        assert "mixed-case-stale-token" not in output
+
+        with open(env._snapshot_path) as snapshot:
+            assert "paperclip_api_key" not in snapshot.read().lower()
+    finally:
+        env.cleanup()

--- a/tests/tools/test_snapshot_session_id_leak.py
+++ b/tests/tools/test_snapshot_session_id_leak.py
@@ -106,3 +106,40 @@ def test_shared_snapshot_no_cross_session_leak(tmp_path):
                 assert "HERMES_SESSION_ID" not in f.read()
     finally:
         env.cleanup()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX bash snapshot path")
+def test_shared_snapshot_no_cross_run_runtime_env_leak(tmp_path):
+    """A later run must not source an earlier run's scoped credential."""
+    import threading
+
+    from gateway.runtime_context import bind_runtime_env
+    from tools.environments.local import LocalEnvironment
+
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=30)
+    env.init_session()
+    try:
+        def run_with_token(token):
+            out = {}
+
+            def worker():
+                with bind_runtime_env({"PAPERCLIP_API_KEY": token}):
+                    out["r"] = env.execute('echo "[$PAPERCLIP_API_KEY]"')
+
+            t = threading.Thread(target=worker)
+            t.start()
+            t.join()
+            return out["r"].get("output", "")
+
+        out_a = run_with_token("run-token-A")
+        out_b = run_with_token("run-token-B")
+
+        assert "run-token-A" in out_a, f"run A saw {out_a!r}"
+        assert "run-token-B" in out_b, f"run B saw {out_b!r}"
+        assert "run-token-A" not in out_b, f"run B leaked A's token: {out_b!r}"
+
+        if os.path.exists(env._snapshot_path):
+            with open(env._snapshot_path) as f:
+                assert "PAPERCLIP_API_KEY" not in f.read()
+    finally:
+        env.cleanup()

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -499,6 +499,29 @@ _SNAPSHOT_EXCLUDED_ENV_REGEX = (
 _SHELL_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
+def _casefold_unset_env_names(names: Iterable[str]) -> str:
+    """Return bash that unsets every case spelling of valid env names."""
+    patterns = []
+    for name in sorted(set(names)):
+        if not isinstance(name, str) or not _SHELL_ENV_NAME_RE.fullmatch(name):
+            continue
+        patterns.append(
+            "".join(
+                f"[{char.lower()}{char.upper()}]" if char.isalpha() else char
+                for char in name
+            )
+        )
+    if not patterns:
+        return ""
+    joined = "|".join(patterns)
+    return (
+        "for __hermes_env_name in $(compgen -A variable); do "
+        f'case "$__hermes_env_name" in {joined}) '
+        'unset "$__hermes_env_name" ;; esac; done; '
+        "unset __hermes_env_name; "
+    )
+
+
 def _export_dump_excluding_session_vars(
     tmp_path: str,
     excluded_names: Iterable[str] = (),
@@ -535,10 +558,16 @@ def _export_dump_excluding_session_vars(
     extra_unset = " ".join(shlex.quote(name) for name in sorted(safe_names))
     if extra_unset:
         extra_unset = f" {extra_unset}"
+    # Windows environment names are case-insensitive, while bash variable
+    # names and snapshots retain their spelling. Remove every case variant of
+    # caller-supplied reserved names before export so a mixed-case alias cannot
+    # persist and conflict with a later canonical request value.
+    casefold_unset = _casefold_unset_env_names(safe_names)
     return (
         "{ ( "
         "unset ${!HERMES_SESSION_*} ${!HERMES_CRON_AUTO_DELIVER_*} "
         f"HERMES_UI_SESSION_ID{extra_unset} 2>/dev/null; "
+        f"{casefold_unset}"
         "export -p; "
         ") || true; } "
         f"> {tmp_path}"
@@ -848,6 +877,10 @@ class BaseEnvironment(ABC):
             parts.append(
                 f"source {_quoted_snap} >/dev/null 2>&1 || true"
             )
+            # Old snapshots may predate reserved-name filtering and contain a
+            # mixed-case alias. Remove every spelling before restoring the
+            # canonical current-process values below.
+            parts.append(_casefold_unset_env_names(passthrough_names))
 
         for name, present, value in saved_names:
             parts.append(

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -638,18 +638,16 @@ class BaseEnvironment(ABC):
         if not self._profile_scoped_passthrough:
             return ()
         try:
+            names = list(self._additional_profile_scoped_passthrough_names())
             from agent.secret_scope import is_multiplex_active
             if is_multiplex_active():
                 from tools.env_passthrough import get_all_passthrough
-                names = (
-                    *get_all_passthrough(),
-                    *self._additional_profile_scoped_passthrough_names(),
-                )
-                self._snapshot_passthrough_names.update(
-                    name
-                    for name in names
-                    if isinstance(name, str) and _SHELL_ENV_NAME_RE.fullmatch(name)
-                )
+                names.extend(get_all_passthrough())
+            self._snapshot_passthrough_names.update(
+                name
+                for name in names
+                if isinstance(name, str) and _SHELL_ENV_NAME_RE.fullmatch(name)
+            )
         except Exception:
             logger.debug(
                 "Could not refresh profile-scoped snapshot exclusions",

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1325,6 +1325,12 @@ def _make_run_env(env: dict) -> dict:
 
     run_env = _scrub_delegated_child_kanban_env(run_env)
 
+    # Trusted `/v1/runs` integration values are request-local. Merge them last
+    # so they reach tool subprocesses without mutating process-global state.
+    from gateway.runtime_context import get_runtime_env
+
+    run_env.update(get_runtime_env())
+
     return run_env
 
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1327,9 +1327,15 @@ def _make_run_env(env: dict) -> dict:
 
     # Trusted `/v1/runs` integration values are request-local. Merge them last
     # so they reach tool subprocesses without mutating process-global state.
-    from gateway.runtime_context import get_runtime_env
+    from gateway.runtime_context import TRUSTED_RUNTIME_ENV_KEYS, get_runtime_env
 
-    run_env.update(get_runtime_env())
+    trusted_runtime_env = get_runtime_env()
+    if trusted_runtime_env is not None:
+        # A trusted request scope is authoritative, including an empty scope.
+        # Never fall back to a long-lived inherited value for these names.
+        for key in TRUSTED_RUNTIME_ENV_KEYS:
+            run_env.pop(key, None)
+        run_env.update(trusted_runtime_env)
 
     return run_env
 
@@ -1426,6 +1432,12 @@ class LocalEnvironment(BaseEnvironment):
     """
 
     _profile_scoped_passthrough = True
+
+    def _additional_profile_scoped_passthrough_names(self) -> tuple[str, ...]:
+        """Keep request-scoped runtime values out of shared shell snapshots."""
+        from gateway.runtime_context import TRUSTED_RUNTIME_ENV_KEYS
+
+        return tuple(TRUSTED_RUNTIME_ENV_KEYS)
 
     def __init__(self, cwd: str = "", timeout: int = 60, env: dict = None):
         cwd = _resolve_local_initial_cwd(cwd)

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1333,8 +1333,12 @@ def _make_run_env(env: dict) -> dict:
     if trusted_runtime_env is not None:
         # A trusted request scope is authoritative, including an empty scope.
         # Never fall back to a long-lived inherited value for these names.
-        for key in TRUSTED_RUNTIME_ENV_KEYS:
-            run_env.pop(key, None)
+        # Environment names are case-insensitive on Windows. Remove every
+        # spelling of the reserved names before injecting canonical keys so a
+        # mixed-case ambient value cannot survive or conflict with this scope.
+        for key in tuple(run_env):
+            if key.upper() in TRUSTED_RUNTIME_ENV_KEYS:
+                run_env.pop(key, None)
         run_env.update(trusted_runtime_env)
 
     return run_env

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1034,6 +1034,13 @@ class ProcessRegistry:
         # Do not run login/interactive startup files afterward: they could read
         # or overwrite the request credential before the user command starts.
         shell_flags = "-c" if runtime_env is not None else "-lic"
+        if runtime_env is not None:
+            # Non-interactive Bash and POSIX shells may still source a file from
+            # BASH_ENV/ENV. Remove aliases case-insensitively so managed runs do
+            # not regain a startup hook after switching away from ``-lic``.
+            for key in tuple(spawn_env):
+                if key.upper() in {"BASH_ENV", "ENV"}:
+                    spawn_env.pop(key, None)
         shell_command = f"set +m; {safe_command}"
 
         session = ProcessSession(

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -43,7 +43,7 @@ import uuid
 from pathlib import Path
 
 _IS_WINDOWS = platform.system() == "Windows"
-from tools.environments.local import _find_shell, _resolve_safe_cwd, _sanitize_subprocess_env
+from tools.environments.local import _find_shell, _resolve_safe_cwd
 from hermes_cli._subprocess_compat import windows_hide_flags
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
@@ -966,6 +966,14 @@ class ProcessRegistry:
 
         safe_command = _rewrite_bg(command)
 
+        # Build one authoritative local child environment for both PTY and
+        # pipe mode.  This applies trusted request-local values and, for an
+        # explicitly empty managed scope, removes ambient PAPERCLIP_* values
+        # instead of inheriting a stale gateway identity.
+        from tools.environments.local import _make_run_env
+
+        spawn_env = _make_run_env(env_vars or {})
+
         session = ProcessSession(
             id=f"proc_{uuid.uuid4().hex[:12]}",
             command=command,
@@ -984,7 +992,7 @@ class ProcessRegistry:
                 else:
                     from ptyprocess import PtyProcess as _PtyProcessCls
                 user_shell = _find_shell()
-                pty_env = _sanitize_subprocess_env(os.environ, env_vars)
+                pty_env = dict(spawn_env)
                 pty_env["PYTHONUNBUFFERED"] = "1"
                 pty_argv = [user_shell, "-lic", f"set +m; {safe_command}"]
 
@@ -1069,7 +1077,7 @@ class ProcessRegistry:
         # Force unbuffered output for Python scripts so progress is visible
         # during background execution (libraries like tqdm/datasets buffer when
         # stdout is a pipe, hiding output from process(action="poll")).
-        bg_env = _sanitize_subprocess_env(os.environ, env_vars)
+        bg_env = dict(spawn_env)
         bg_env["PYTHONUNBUFFERED"] = "1"
         _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1025,9 +1025,16 @@ class ProcessRegistry:
         # explicitly empty managed scope, removes ambient PAPERCLIP_* values
         # instead of inheriting a stale gateway identity.
         from agent.redact import get_exact_redactions
+        from gateway.runtime_context import get_runtime_env
         from tools.environments.local import _make_run_env
 
+        runtime_env = get_runtime_env()
         spawn_env = _make_run_env(env_vars or {})
+        # A managed request scope is already authoritative in ``spawn_env``.
+        # Do not run login/interactive startup files afterward: they could read
+        # or overwrite the request credential before the user command starts.
+        shell_flags = "-c" if runtime_env is not None else "-lic"
+        shell_command = f"set +m; {safe_command}"
 
         session = ProcessSession(
             id=f"proc_{uuid.uuid4().hex[:12]}",
@@ -1050,7 +1057,7 @@ class ProcessRegistry:
                 user_shell = _find_shell()
                 pty_env = dict(spawn_env)
                 pty_env["PYTHONUNBUFFERED"] = "1"
-                pty_argv = [user_shell, "-lic", f"set +m; {safe_command}"]
+                pty_argv = [user_shell, shell_flags, shell_command]
 
                 # Cgroup isolation for PTY mode (#70716, reviewer gap #1):
                 # Wrap the PTY command in a systemd scope so interactive
@@ -1143,7 +1150,7 @@ class ProcessRegistry:
         # kills only the worker instead of taking down the whole gateway
         # cgroup (and the messaging control plane with it).  We only do this
         # for both pipe mode and the PTY path above.
-        shell_argv = [user_shell, "-lic", f"set +m; {safe_command}"]
+        shell_argv = [user_shell, shell_flags, shell_command]
         use_systemd_scope = False
         under_supervisor = False
         try:

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -357,6 +357,8 @@ class ProcessSession:
     termination_source: str = ""                # process.kill|kill_all|backend_lost|failed_start
     output_buffer: str = ""                     # Rolling output (last MAX_OUTPUT_CHARS)
     max_output_chars: int = MAX_OUTPUT_CHARS
+    exact_redactions: tuple[str, ...] = field(default_factory=tuple, repr=False)
+    _redaction_pending: str = field(default="", repr=False)
     detached: bool = False                      # True if recovered from crash (no pipe)
     pid_scope: str = "host"                     # "host" for local/PTY PIDs, "sandbox" for env-local PIDs
     systemd_unit: str = ""                      # transient scope unit name when spawned under systemd-run (#70716)
@@ -483,6 +485,58 @@ class ProcessRegistry:
             sink(session, chunk)
         except Exception:
             pass
+
+    @staticmethod
+    def _redact_process_output(
+        session: ProcessSession,
+        text: str,
+        *,
+        final: bool = False,
+    ) -> str:
+        """Redact request-local opaque values across arbitrary output chunks."""
+        secrets = session.exact_redactions
+        if not secrets:
+            return text
+
+        pending = session._redaction_pending + text
+        output: list[str] = []
+        while pending:
+            matches = [
+                (index, -len(secret), secret)
+                for secret in secrets
+                if (index := pending.find(secret)) >= 0
+            ]
+            if matches:
+                index, _negative_length, secret = min(matches)
+                output.append(pending[:index])
+                output.append("«redacted-secret»")
+                pending = pending[index + len(secret):]
+                continue
+
+            if final:
+                output.append(pending)
+                pending = ""
+                break
+
+            # Retain only a suffix that could be the beginning of a secret.
+            # Everything before it is safe to release to buffers/watchers/UI.
+            hold = 0
+            for secret in secrets:
+                max_prefix = min(len(pending), len(secret) - 1)
+                for size in range(max_prefix, 0, -1):
+                    if pending.endswith(secret[:size]):
+                        hold = max(hold, size)
+                        break
+            if hold:
+                output.append(pending[:-hold])
+                pending = pending[-hold:]
+            else:
+                output.append(pending)
+                pending = ""
+            break
+
+        session._redaction_pending = pending
+        return "".join(output)
 
     def _check_watch_patterns(self, session: ProcessSession, new_text: str) -> None:
         """Scan new output for watch patterns and queue notifications.
@@ -970,6 +1024,7 @@ class ProcessRegistry:
         # pipe mode.  This applies trusted request-local values and, for an
         # explicitly empty managed scope, removes ambient PAPERCLIP_* values
         # instead of inheriting a stale gateway identity.
+        from agent.redact import get_exact_redactions
         from tools.environments.local import _make_run_env
 
         spawn_env = _make_run_env(env_vars or {})
@@ -981,6 +1036,7 @@ class ProcessRegistry:
             session_key=session_key,
             cwd=_resolve_safe_cwd(cwd or os.getcwd()),
             started_at=time.time(),
+            exact_redactions=get_exact_redactions(),
         )
 
         pty_scope_attempted = False
@@ -1330,11 +1386,14 @@ class ProcessRegistry:
         # (Ported from openclaw/openclaw#112325.)
         decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
 
-        def _append_chunk(chunk: str):
+        def _append_chunk(chunk: str, *, final: bool = False):
             nonlocal first_chunk
-            if first_chunk:
+            if first_chunk and chunk:
                 chunk = self._clean_shell_noise(chunk)
                 first_chunk = False
+            chunk = self._redact_process_output(session, chunk, final=final)
+            if not chunk:
+                return
             with session._lock:
                 session.output_buffer += chunk
                 if len(session.output_buffer) > session.max_output_chars:
@@ -1418,6 +1477,7 @@ class ProcessRegistry:
                     _append_chunk(tail)
             except Exception:
                 pass
+            _append_chunk("", final=True)
             # Always reap the child to prevent zombie processes.
             try:
                 session.process.wait(timeout=5)
@@ -1495,7 +1555,10 @@ class ProcessRegistry:
         # (Ported from openclaw/openclaw#112325.)
         decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
 
-        def _append_text(text: str):
+        def _append_text(text: str, *, final: bool = False):
+            text = self._redact_process_output(session, text, final=final)
+            if not text:
+                return
             with session._lock:
                 session.output_buffer += text
                 if len(session.output_buffer) > session.max_output_chars:
@@ -1526,6 +1589,7 @@ class ProcessRegistry:
                 _append_text(tail)
         except Exception:
             pass
+        _append_text("", final=True)
 
         # Process exited
         try:

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -355,6 +355,34 @@ Create a new agent run. Returns a `run_id` that can be used to subscribe to prog
 
 Runs accept a simple `input` string and optional `session_id`, `instructions`, `conversation_history`, or `previous_response_id`. When `session_id` is provided, Hermes surfaces it in the run status so external UIs can correlate runs with their own conversation IDs.
 
+You can also pass `runtime_env` (or the deprecated `environment` alias, but not both) to inject environment variables visible only to that run. This is how control-plane systems like Paperclip pass task context into the agent without persisting it in the shell or config. Only these eight keys are permitted: `PAPERCLIP_AGENT_ID`, `PAPERCLIP_API_KEY`, `PAPERCLIP_API_URL`, `PAPERCLIP_COMPANY_ID`, `PAPERCLIP_ISSUE_WORK_MODE`, `PAPERCLIP_RUN_ID`, `PAPERCLIP_TASK_ID`, `PAPERCLIP_WAKE_REASON`. The value must be an object where every value is a string. NUL bytes are rejected, and the total encoded size cannot exceed 32 KiB. Sending both `runtime_env` and `environment` returns 400 `provide only one of 'runtime_env' or 'environment'`. An unsupported key or non-string value returns 400 `'runtime_env' contains an unsupported name or non-string value`. A NUL byte returns 400 `'runtime_env' contains an invalid value`. Exceeding the size cap returns 400 `'runtime_env' is too large`.
+
+```json
+{
+  "input": "Review the latest metrics",
+  "session_id": "metrics-review-001",
+  "runtime_env": {
+    "PAPERCLIP_AGENT_ID": "b013c561-43a1-48bc-bf03-2adb66412343",
+    "PAPERCLIP_COMPANY_ID": "ac1b2405-20df-4df0-9f34-cd7c29d8463f",
+    "PAPERCLIP_RUN_ID": "4dbc2e17-bfb8-4f32-a22f-b3ef355b7a8f"
+  }
+}
+```
+
+Example:
+
+```json
+{
+  "input": "Resolve ACE-42",
+  "session_id": "task-session-123",
+  "runtime_env": {
+    "PAPERCLIP_RUN_ID": "abc-123",
+    "PAPERCLIP_TASK_ID": "ACE-42",
+    "PAPERCLIP_API_URL": "https://api.paperclip.example"
+  }
+}
+```
+
 ### GET /v1/runs/\{run_id\}
 
 Poll the current run state. This is useful for dashboards that need status without holding an SSE connection open, or for UIs that reconnect after navigation.


### PR DESCRIPTION
## What does this PR do?

Adds a request-scoped environment contract to `POST /v1/runs`. The endpoint accepts only eight explicit Paperclip runtime keys through `environment` or `runtime_env`. It rejects ambiguous dual-field requests, malformed values, and oversized payloads. Accepted values are stored in a `ContextVar` for one run and merged into local foreground, background, and PTY tool subprocesses without changing `os.environ`.

This fixes authenticated control-plane calls from a Paperclip-triggered Hermes run. The bearer stays outside prompts and process-global state. Exact-value redaction covers tool output, progress events, errors, status, logs, and final results. Credentialed runs suppress token-unsafe streaming deltas and emit the fully assembled redacted completion.

## Related Issue

No public Hermes issue exists. This is the Hermes half of the coordinated fix in paperclipai/paperclip#10625.

## Type of Change

- [x] Bug fix
- [x] Security fix
- [x] Tests

## Changes Made

- Add strict run-environment validation in `gateway/platforms/api_server.py`.
- Accept the existing Paperclip adapter's `environment` field and the explicit `runtime_env` spelling, but never both.
- Add request-local binding and one shared allowlist in `gateway/runtime_context.py`.
- Make an empty trusted request scope authoritative, so ambient `PAPERCLIP_*` credentials cannot fall through into a managed run.
- Bridge bound values into local tool subprocesses in `tools/environments/local.py`.
- Route local background and PTY spawns through the same authoritative child-environment builder in `tools/process_registry.py`.
- Keep scoped Paperclip values out of reusable shell snapshots and save/restore them around snapshot loading.
- Strip mixed-case reserved aliases from inherited environments and legacy snapshots for Windows-safe identity handling.
- Add run-local exact-value redaction and suppress token-unsafe delta streaming for credentialed runs.
- Capture exact redactions on queued log records before asynchronous file formatting crosses threads.
- Capture exact redactions on local background process sessions and redact split-chunk pipe/PTY output before buffers, live sinks, watch events, completion events, or later prompts can observe it.
- Use non-login, non-interactive shells for managed local pipe/PTY runs and strip `BASH_ENV`/`ENV` startup hooks so startup files cannot read or override request-scoped credentials; ordinary unscoped terminal behavior remains unchanged.
- Reject non-object `/v1/runs` JSON bodies with a controlled HTTP 400.
- Add propagation, validation, ambient-stripping, snapshot, sequential, concurrent, and output-redaction tests.

## How to Test

1. Run `/home/agent/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/test_hermes_logging.py tests/tools/test_process_registry.py tests/gateway/test_api_server_runs.py tests/tools/test_snapshot_session_id_leak.py tests/tools/test_local_env_session_leak.py tests/tools/test_terminal_env_bridge.py tests/agent/test_redact.py` with `PYTHONPATH=.`.
2. Confirm all 252 focused tests pass.
3. Post concurrent `/v1/runs` requests with different allowlisted values and confirm each tool subprocess sees only its own values.
4. Reuse one `LocalEnvironment` across two scoped runs and confirm its shell snapshot contains no `PAPERCLIP_API_KEY`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and found no duplicate Hermes PR
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on Linux 6.12

### Documentation & Housekeeping

- [x] Relevant behavior is documented in module and function docstrings
- [x] `cli-config.yaml.example` is not applicable because this adds no config key
- [x] `CONTRIBUTING.md` and `AGENTS.md` are not applicable
- [x] Cross-platform impact was considered. Credential bridging is intentionally limited to the local terminal backend in this PR. Docker, SSH, and Kubernetes are not claimed as supported.
- [x] Tool descriptions and schemas are not applicable

## Screenshots / Logs

Focused verification at commit `1fc4a65a179acae44c641e94969ebbfac7f8acf1`:

- API run, shell snapshot, local environment, foreground/background/PTY terminal output and notifications, managed shell-startup isolation, asynchronous logging, and redaction suites: 252 passed.
- Ruff passed for all changed Python files.
- `py_compile` passed for all changed Python files.
- `git diff --check` passed.

The full repository test suite was not run. The focused set covers the changed API, request context, local subprocess bridge, shell snapshot behavior, and redaction paths.

Deployment note: deploy this Hermes receiver before enabling paperclipai/paperclip#10625. An older Hermes gateway can ignore the new `environment` field, so sender-first rollout would create runs without the intended credential.

Residual limitation: a subprocess explicitly launched into the background can outlive the request context and retain the short-lived credential until that process exits or the Paperclip JWT expires.