### PR TITLE
fix(personality): make personality selection round-trip without clobbering the manual system prompt (supersedes #81792, #56773, #51906)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -50,6 +50,7 @@ logger = logging.getLogger(__name__)
 # Suppress startup messages for clean CLI experience
 os.environ["HERMES_QUIET"] = "1"  # Our own modules
 
+from hermes_cli.config import resolve_personality_overlay
 from hermes_cli.fallback_config import get_fallback_chain
 from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
 from hermes_cli.cli_commands_mixin import CLICommandsMixin
@@ -4502,11 +4503,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # AGENTS.md/SOUL.md/.cursorrules and persistent memory are not loaded.
         self.ignore_rules = ignore_rules or os.environ.get("HERMES_IGNORE_RULES") == "1"
         
-        # Ephemeral system prompt: env var takes precedence, then config
-        self.system_prompt = (
-            os.getenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", "")
-            or CLI_CONFIG["agent"].get("system_prompt", "")
-        )
+        # Prompt overlay: env var wins, then the user's manual
+        # agent.system_prompt composed with the selected display.personality.
+        self.system_prompt = os.getenv(
+            "HERMES_EPHEMERAL_SYSTEM_PROMPT", ""
+        ) or resolve_personality_overlay(CLI_CONFIG)
         self.personalities = CLI_CONFIG["agent"].get("personalities", {})
         
         # Ephemeral prefill messages (few-shot priming, never persisted)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -63,7 +63,11 @@ from agent.interrupt_compat import request_hard_interrupt
 from agent.turn_context import (
     compression_made_progress,
 )
-from hermes_cli.config import _is_ssh_remote_tilde_cwd, cfg_get
+from hermes_cli.config import (
+    _is_ssh_remote_tilde_cwd,
+    cfg_get,
+    resolve_personality_overlay,
+)
 from hermes_cli.fallback_config import get_fallback_chain
 
 # --- Agent cache tuning ---------------------------------------------------
@@ -8169,16 +8173,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     @staticmethod
     def _load_ephemeral_system_prompt() -> str:
-        """Load ephemeral system prompt from config or env var.
-        
-        Checks HERMES_EPHEMERAL_SYSTEM_PROMPT env var first, then falls back to
-        agent.system_prompt in ~/.hermes/config.yaml.
+        """Load the prompt overlay from config or env var.
+
+        Checks HERMES_EPHEMERAL_SYSTEM_PROMPT env var first, then composes the
+        manual agent.system_prompt with the selected display.personality in
+        ~/.hermes/config.yaml.
         """
         prompt = os.getenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", "")
         if prompt:
             return prompt
         cfg = _load_gateway_runtime_config()
-        return str(cfg_get(cfg, "agent", "system_prompt", default="") or "").strip()
+        return resolve_personality_overlay(cfg)
 
     def _resolve_model_for_channel(
         self,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -40,7 +40,12 @@ from gateway.session import (
     build_session_key,
     is_shared_multi_user_session,
 )
-from hermes_cli.config import atomic_config_write, cfg_get, clear_model_endpoint_credentials
+from hermes_cli.config import (
+    atomic_config_write,
+    cfg_get,
+    clear_model_endpoint_credentials,
+    resolve_personality_overlay,
+)
 from utils import (
     atomic_json_write,
     base_url_host_matches,
@@ -2519,40 +2524,31 @@ class GatewaySlashCommandsMixin:
             lines.append(t("gateway.personality.usage"))
             return "\n".join(lines)
 
-        def _resolve_prompt(value):
-            if isinstance(value, dict):
-                parts = [value.get("system_prompt", "")]
-                if value.get("tone"):
-                    parts.append(f'Tone: {value["tone"]}')
-                if value.get("style"):
-                    parts.append(f'Style: {value["style"]}')
-                return "\n".join(p for p in parts if p)
-            return str(value)
-
         if args in {"none", "default", "neutral"}:
             try:
-                if "agent" not in config or not isinstance(config.get("agent"), dict):
-                    config["agent"] = {}
-                config["agent"]["system_prompt"] = ""
+                if "display" not in config or not isinstance(config.get("display"), dict):
+                    config["display"] = {}
+                config["display"]["personality"] = ""
                 atomic_config_write(config_path, config)
             except Exception as e:
                 return t("gateway.personality.save_failed", error=str(e))
-            self._ephemeral_system_prompt = ""
+            self._ephemeral_system_prompt = resolve_personality_overlay(config)
             return t("gateway.personality.cleared")
         elif args in personalities:
-            new_prompt = _resolve_prompt(personalities[args])
-
-            # Write to config.yaml, same pattern as CLI save_config_value.
+            # Persist the selection by name only — the personality's text is an
+            # overlay composed at read time, so agent.system_prompt stays the
+            # user's own manual prompt.
             try:
-                if "agent" not in config or not isinstance(config.get("agent"), dict):
-                    config["agent"] = {}
-                config["agent"]["system_prompt"] = new_prompt
+                if "display" not in config or not isinstance(config.get("display"), dict):
+                    config["display"] = {}
+                config["display"]["personality"] = args
                 atomic_config_write(config_path, config)
             except Exception as e:
                 return t("gateway.personality.save_failed", error=str(e))
 
-            # Update in-memory so it takes effect on the very next message.
-            self._ephemeral_system_prompt = new_prompt
+            # Update in-memory so it takes effect on the very next message,
+            # matching what a restart would resolve.
+            self._ephemeral_system_prompt = resolve_personality_overlay(config)
 
             return t("gateway.personality.set_to", name=args)
 

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1333,6 +1333,27 @@ class CLICommandsMixin:
     def _handle_personality_command(self, cmd: str):
         """Handle the /personality command to set predefined personalities."""
         from cli import save_config_value
+        from hermes_cli.config import read_raw_config, resolve_personality_overlay
+
+        def _overlay_for(name: str) -> str:
+            """What a restart would resolve for ``name``.
+
+            Composed through the shared resolver (reading the manual prompt
+            fresh from disk) so the live session and the next start agree.
+            """
+            try:
+                cfg = read_raw_config()
+            except Exception:
+                cfg = {}
+            probe = {
+                "agent": {
+                    "system_prompt": (cfg.get("agent") or {}).get("system_prompt", ""),
+                    "personalities": self.personalities,
+                },
+                "display": {"personality": name},
+            }
+            return resolve_personality_overlay(probe)
+
         parts = cmd.split(maxsplit=1)
         
         if len(parts) > 1:
@@ -1340,21 +1361,25 @@ class CLICommandsMixin:
             personality_name = parts[1].strip().lower()
             
             if personality_name in {"none", "default", "neutral"}:
-                self.system_prompt = ""
+                self.system_prompt = _overlay_for("")
                 self.agent = None  # Force re-init
-                if save_config_value("agent.system_prompt", ""):
+                if save_config_value("display.personality", ""):
                     print("(^_^)b Personality cleared (saved to config)")
                 else:
                     print("(^_^) Personality cleared (session only)")
                 print("  No personality overlay — using base agent behavior.")
             elif personality_name in self.personalities:
-                self.system_prompt = self._resolve_personality_prompt(self.personalities[personality_name])
+                personality_prompt = self._resolve_personality_prompt(
+                    self.personalities[personality_name]
+                )
+                self.system_prompt = _overlay_for(personality_name)
                 self.agent = None  # Force re-init
-                if save_config_value("agent.system_prompt", self.system_prompt):
+                if save_config_value("display.personality", personality_name):
                     print(f"(^_^)b Personality set to '{personality_name}' (saved to config)")
                 else:
                     print(f"(^_^) Personality set to '{personality_name}' (session only)")
-                print(f"  \"{self.system_prompt[:60]}{'...' if len(self.system_prompt) > 60 else ''}\"")
+                preview = personality_prompt[:60]
+                print(f"  \"{preview}{'...' if len(personality_prompt) > 60 else ''}\"")
             else:
                 print(f"(._.) Unknown personality: {personality_name}")
                 print(f"  Available: none, {', '.join(self.personalities.keys())}")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2930,6 +2930,75 @@ def cfg_get(cfg: Optional[Dict[str, Any]], *keys: str, default: Any = None) -> A
 
 
 
+NEUTRAL_PERSONALITY_NAMES = frozenset({"", "none", "default", "neutral"})
+
+
+def _personality_prompt_text(value: Any) -> str:
+    """Normalize a YAML prompt value (str / list / scalar) to a prompt string."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, list):
+        return "\n".join(str(item).strip() for item in value if str(item).strip())
+    return str(value).strip()
+
+
+def render_personality_prompt(value: Any) -> str:
+    """Render a personality definition (string or ``{system_prompt, tone, style}``).
+
+    Canonical implementation for the renderer that was previously copy-pasted
+    into ``tui_gateway/server.py``, ``cli.py`` and ``gateway/slash_commands.py``.
+    """
+    if isinstance(value, dict):
+        parts = [value.get("system_prompt", "")]
+        if value.get("tone"):
+            parts.append(f'Tone: {value["tone"]}')
+        if value.get("style"):
+            parts.append(f'Style: {value["style"]}')
+        return "\n".join(str(part).strip() for part in parts if str(part).strip())
+    return _personality_prompt_text(value)
+
+
+def resolve_personality_overlay(cfg: Optional[Dict[str, Any]]) -> str:
+    """Resolve the startup prompt overlay from config.
+
+    ``display.personality`` names the selected personality and is the
+    authoritative record of that selection; ``agent.system_prompt`` is the
+    user's own manual prompt. Both are honored, and when both are present the
+    manual prompt comes first so the personality reads as a modifier on top of
+    the user's standing instructions.
+
+    Historically the personality's *text* was copied into
+    ``agent.system_prompt`` on every selection, which destroyed whatever the
+    user had written there. Configs written by those older builds still carry
+    such a copy, so a manual prompt that exactly matches a known personality's
+    rendered text is treated as that legacy cache and dropped rather than
+    doubled.
+    """
+    manual = _personality_prompt_text(cfg_get(cfg, "agent", "system_prompt", default=""))
+
+    name = str(cfg_get(cfg, "display", "personality", default="") or "").strip().lower()
+    personalities = cfg_get(cfg, "agent", "personalities", default={}) or {}
+    if name in NEUTRAL_PERSONALITY_NAMES or not isinstance(personalities, dict):
+        return manual
+    if name not in personalities:
+        return manual
+
+    personality_prompt = render_personality_prompt(personalities[name])
+    if not personality_prompt:
+        return manual
+
+    if manual:
+        legacy_copies = {
+            render_personality_prompt(value) for value in personalities.values()
+        }
+        if manual in legacy_copies:
+            manual = ""
+
+    return "\n\n".join(part for part in (manual, personality_prompt) if part)
+
+
 def read_raw_config() -> Dict[str, Any]:
     """Read ~/.hermes/config.yaml as-is, without merging defaults or migrating.
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -60,6 +60,7 @@ from hermes_cli import __version__, __release_date__
 from hermes_cli.config import (
     cfg_get,
     DEFAULT_CONFIG,
+    NEUTRAL_PERSONALITY_NAMES,
     OPTIONAL_ENV_VARS,
     clear_model_endpoint_credentials,
     get_config_path,
@@ -6959,6 +6960,32 @@ def _denormalize_config_from_web(config: Dict[str, Any]) -> Dict[str, Any]:
     return config
 
 
+def _validate_web_personality(incoming: Dict[str, Any], existing: Dict[str, Any]) -> None:
+    """Reject an unknown ``display.personality`` from the dashboard.
+
+    The dashboard writes the personality *by name*; the prompt overlay is
+    resolved at startup by ``resolve_personality_overlay``. Writing the
+    personality's text into ``agent.system_prompt`` here would clobber the
+    user's manual prompt, so the name is all that is persisted.
+    """
+    display = incoming.get("display")
+    if not isinstance(display, dict) or "personality" not in display:
+        return
+
+    raw = str(display.get("personality") or "").strip()
+    name = raw.lower()
+    if not name or name in NEUTRAL_PERSONALITY_NAMES:
+        display["personality"] = ""
+        return
+
+    merged_agent = {**(existing.get("agent") or {}), **(incoming.get("agent") or {})}
+    personalities = merged_agent.get("personalities")
+    if not isinstance(personalities, dict) or name not in personalities:
+        raise HTTPException(status_code=400, detail=f"Unknown personality: `{raw}`.")
+
+    display["personality"] = name
+
+
 @app.put("/api/config")
 async def update_config(body: ConfigUpdate, profile: Optional[str] = None):
     def _run():
@@ -6972,6 +6999,7 @@ async def update_config(body: ConfigUpdate, profile: Optional[str] = None):
             with _CONFIG_MUTATION_LOCK:
                 existing = read_raw_config()
                 incoming = _denormalize_config_from_web(body.config)
+                _validate_web_personality(incoming, existing)
                 save_config(_deep_merge(existing, incoming))
         return {"ok": True}
 

--- a/tests/test_personality_config_roundtrip.py
+++ b/tests/test_personality_config_roundtrip.py
@@ -1,0 +1,350 @@
+"""Personality selection must round-trip: survive a restart AND leave the
+user's manual ``agent.system_prompt`` intact.
+
+Regression coverage for the cluster:
+  * #81791 — selecting a personality clobbered the manual agent.system_prompt
+  * #51882 — Desktop Settings wrote only display.personality, overlay ignored
+  * #58774 / #51155 — personality selection did not persist across sessions
+
+The invariant under test is the *round trip*, not any single write:
+
+    select personality -> persist -> restart -> personality still active
+                                             -> manual prompt still intact
+
+Both halves are asserted together on purpose. Fixing either one alone
+reintroduces the other (that is exactly how this cluster arose), so a test
+that checks only one half would go green on a half-fix.
+"""
+
+import pytest
+
+from hermes_cli.config import (
+    render_personality_prompt,
+    resolve_personality_overlay,
+)
+
+
+PERSONALITIES = {
+    "pirate": "You are a pirate. Arr.",
+    "coder": {"system_prompt": "You write code.", "tone": "terse", "style": "examples"},
+    "listy": ["Line one.", "Line two."],
+}
+
+
+def _cfg(manual="", personality="", personalities=None):
+    return {
+        "agent": {
+            "system_prompt": manual,
+            "personalities": PERSONALITIES if personalities is None else personalities,
+        },
+        "display": {"personality": personality},
+    }
+
+
+# --------------------------------------------------------------------------
+# render_personality_prompt — one canonical renderer for every call site
+# --------------------------------------------------------------------------
+
+def test_render_plain_string():
+    assert render_personality_prompt("You are a pirate.") == "You are a pirate."
+
+
+def test_render_dict_composes_tone_and_style():
+    out = render_personality_prompt(PERSONALITIES["coder"])
+    assert out == "You write code.\nTone: terse\nStyle: examples"
+
+
+def test_render_dict_omits_absent_optional_fields():
+    assert render_personality_prompt({"system_prompt": "Just this."}) == "Just this."
+
+
+def test_render_list_joins_lines():
+    assert render_personality_prompt(["Line one.", "Line two."]) == "Line one.\nLine two."
+
+
+def test_render_none_is_empty():
+    assert render_personality_prompt(None) == ""
+
+
+# --------------------------------------------------------------------------
+# resolve_personality_overlay — the startup read side
+# --------------------------------------------------------------------------
+
+def test_personality_alone_resolves_to_its_prompt():
+    """#58774/#51155: a saved selection must actually apply on next start."""
+    assert resolve_personality_overlay(_cfg(personality="pirate")) == "You are a pirate. Arr."
+
+
+def test_manual_prompt_alone_is_returned_unchanged():
+    assert resolve_personality_overlay(_cfg(manual="Be concise.")) == "Be concise."
+
+
+def test_manual_and_personality_compose_manual_first():
+    """#81791: the manual prompt is preserved, not replaced."""
+    out = resolve_personality_overlay(_cfg(manual="Be concise.", personality="pirate"))
+    assert out == "Be concise.\n\nYou are a pirate. Arr."
+
+
+def test_neutral_names_disable_the_overlay():
+    for name in ("", "none", "default", "neutral", "NONE", "  Neutral  "):
+        out = resolve_personality_overlay(_cfg(manual="Be concise.", personality=name))
+        assert out == "Be concise.", f"{name!r} should clear the overlay"
+
+
+def test_personality_name_is_case_insensitive():
+    assert resolve_personality_overlay(_cfg(personality="PiRaTe")) == "You are a pirate. Arr."
+
+
+def test_unknown_personality_falls_back_to_manual_prompt():
+    out = resolve_personality_overlay(_cfg(manual="Be concise.", personality="nope"))
+    assert out == "Be concise."
+
+
+def test_legacy_personality_copy_is_not_doubled():
+    """Configs written by older builds hold a personality's text in
+    agent.system_prompt. That copy is legacy cache, not a manual prompt —
+    it must not be concatenated in front of the same personality."""
+    stale = PERSONALITIES["pirate"]
+    out = resolve_personality_overlay(_cfg(manual=stale, personality="pirate"))
+    assert out == "You are a pirate. Arr."
+    assert out.count("Arr.") == 1
+
+
+def test_legacy_copy_of_a_different_personality_is_dropped():
+    """display.personality is authoritative; a stale copy of some *other*
+    personality's text is not the user's manual prompt."""
+    out = resolve_personality_overlay(
+        _cfg(manual=PERSONALITIES["pirate"], personality="coder")
+    )
+    assert out == "You write code.\nTone: terse\nStyle: examples"
+    assert "pirate" not in out.lower()
+
+
+def test_dict_personality_resolves_through_the_overlay():
+    out = resolve_personality_overlay(_cfg(personality="coder"))
+    assert out == "You write code.\nTone: terse\nStyle: examples"
+
+
+def test_missing_and_malformed_config_sections_are_tolerated():
+    assert resolve_personality_overlay(None) == ""
+    assert resolve_personality_overlay({}) == ""
+    assert resolve_personality_overlay({"agent": "not-a-dict"}) == ""
+    assert resolve_personality_overlay({"display": {"personality": "pirate"}}) == ""
+    assert (
+        resolve_personality_overlay(
+            {"agent": {"system_prompt": "M", "personalities": None},
+             "display": {"personality": "pirate"}}
+        )
+        == "M"
+    )
+
+
+# --------------------------------------------------------------------------
+# The round trip, per write path
+# --------------------------------------------------------------------------
+
+def _select_via_tui_gateway(cfg, name):
+    """Drive the real tui_gateway config.set personality write semantics."""
+    import tui_gateway.server as server
+
+    # _available_personalities() intentionally prefers the real loaded config
+    # over the dict passed in, so pin it to this test's fixture.
+    original = server._available_personalities
+    server._available_personalities = lambda c=None: (
+        (cfg.get("agent") or {}).get("personalities") or {}
+    )
+    try:
+        pname, _prompt = server._validate_personality(name, cfg)
+    finally:
+        server._available_personalities = original
+    cfg.setdefault("display", {})["personality"] = pname
+    return cfg
+
+
+def _select_via_gateway_slash(cfg, name):
+    """Mirror gateway/slash_commands.py /personality persistence."""
+    cfg.setdefault("display", {})["personality"] = (
+        "" if name in {"none", "default", "neutral"} else name
+    )
+    return cfg
+
+
+def _select_via_web_put(cfg, name):
+    """Drive the real dashboard PUT /api/config validation + normalization."""
+    from hermes_cli.web_server import _validate_web_personality
+
+    incoming = {"display": {"personality": name}}
+    _validate_web_personality(incoming, cfg)
+    cfg.setdefault("display", {})["personality"] = incoming["display"]["personality"]
+    return cfg
+
+
+ALL_WRITE_PATHS = {
+    "tui_gateway_rpc": _select_via_tui_gateway,
+    "gateway_slash": _select_via_gateway_slash,
+    "web_put_api_config": _select_via_web_put,
+}
+
+
+@pytest.mark.parametrize("path_name", sorted(ALL_WRITE_PATHS))
+def test_round_trip_preserves_manual_prompt_and_personality(path_name):
+    """THE bug-class test. Every write path, both invariants, after restart."""
+    select = ALL_WRITE_PATHS[path_name]
+    cfg = _cfg(manual="Be concise.")
+
+    cfg = select(cfg, "pirate")
+
+    # "Restart": resolve from the persisted config exactly as startup does.
+    overlay = resolve_personality_overlay(cfg)
+
+    assert cfg["agent"]["system_prompt"] == "Be concise.", (
+        f"{path_name}: manual agent.system_prompt was clobbered (#81791)"
+    )
+    assert "You are a pirate. Arr." in overlay, (
+        f"{path_name}: personality did not survive the restart (#58774/#51155)"
+    )
+    assert "Be concise." in overlay, (
+        f"{path_name}: manual prompt dropped out of the resolved overlay"
+    )
+
+
+@pytest.mark.parametrize("path_name", sorted(ALL_WRITE_PATHS))
+def test_round_trip_switching_leaves_no_stale_text(path_name):
+    """Switching personalities must not accumulate or strand prior text."""
+    select = ALL_WRITE_PATHS[path_name]
+    cfg = _cfg(manual="Be concise.")
+
+    cfg = select(cfg, "pirate")
+    cfg = select(cfg, "coder")
+    overlay = resolve_personality_overlay(cfg)
+
+    assert cfg["agent"]["system_prompt"] == "Be concise."
+    assert "You write code." in overlay
+    assert "pirate" not in overlay.lower(), f"{path_name}: stale personality text"
+
+
+@pytest.mark.parametrize("path_name", sorted(ALL_WRITE_PATHS))
+def test_round_trip_clearing_restores_bare_manual_prompt(path_name):
+    select = ALL_WRITE_PATHS[path_name]
+    cfg = _cfg(manual="Be concise.")
+
+    cfg = select(cfg, "pirate")
+    cfg = select(cfg, "none")
+
+    assert resolve_personality_overlay(cfg) == "Be concise."
+    assert cfg["agent"]["system_prompt"] == "Be concise."
+
+
+def test_round_trip_without_manual_prompt_is_personality_only():
+    cfg = _select_via_tui_gateway(_cfg(manual=""), "pirate")
+    assert resolve_personality_overlay(cfg) == "You are a pirate. Arr."
+
+
+def test_web_put_rejects_unknown_personality():
+    """#51906's one genuinely better behavior, kept."""
+    from fastapi import HTTPException
+    from hermes_cli.web_server import _validate_web_personality
+
+    with pytest.raises(HTTPException) as exc:
+        _validate_web_personality({"display": {"personality": "nope"}}, _cfg())
+    assert exc.value.status_code == 400
+
+
+def test_web_put_without_personality_key_is_untouched():
+    from hermes_cli.web_server import _validate_web_personality
+
+    incoming = {"agent": {"model": "x"}}
+    _validate_web_personality(incoming, _cfg())
+    assert incoming == {"agent": {"model": "x"}}
+
+
+def test_tui_gateway_session_overlay_matches_a_restart(tmp_path, monkeypatch):
+    """The live session's ephemeral prompt must equal what a restart resolves,
+    or the assistant silently changes behavior when the app is reopened."""
+    import tui_gateway.server as server
+
+    cfg = _cfg(manual="Be concise.")
+    monkeypatch.setattr(server, "_load_cfg", lambda: cfg)
+    monkeypatch.setattr(server, "_available_personalities", lambda c=None: PERSONALITIES)
+
+    pname, prompt = server._validate_personality("pirate", cfg)
+    live_overlay = server._composed_personality_overlay(pname, prompt)
+
+    persisted = _select_via_tui_gateway(dict(cfg), "pirate")
+    assert live_overlay == resolve_personality_overlay(persisted)
+    assert live_overlay == "Be concise.\n\nYou are a pirate. Arr."
+
+
+# --------------------------------------------------------------------------
+# CLI /personality — the fourth write path
+# --------------------------------------------------------------------------
+
+class _FakeCLI:
+    """Minimal stand-in exposing what _handle_personality_command touches."""
+
+    from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+    _handle_personality_command = CLICommandsMixin._handle_personality_command
+    _resolve_personality_prompt = staticmethod(render_personality_prompt)
+
+    def __init__(self):
+        self.personalities = dict(PERSONALITIES)
+        self.system_prompt = ""
+        self.agent = object()
+
+
+@pytest.fixture
+def cli_with_manual_prompt(monkeypatch):
+    """A CLI whose on-disk config carries a manual prompt, with the config
+    writes captured instead of hitting the filesystem."""
+    import hermes_cli.config as config_mod
+
+    disk = _cfg(manual="Be concise.")
+    saved = []
+
+    monkeypatch.setattr(config_mod, "read_raw_config", lambda: disk)
+
+    import cli as cli_mod
+
+    def _save(key, value):
+        saved.append((key, value))
+        node = disk
+        parts = key.split(".")
+        for part in parts[:-1]:
+            node = node.setdefault(part, {})
+        node[parts[-1]] = value
+        return True
+
+    monkeypatch.setattr(cli_mod, "save_config_value", _save)
+    return _FakeCLI(), disk, saved
+
+
+def test_cli_personality_preserves_manual_prompt(cli_with_manual_prompt):
+    cli, disk, saved = cli_with_manual_prompt
+
+    cli._handle_personality_command("/personality pirate")
+
+    assert disk["agent"]["system_prompt"] == "Be concise.", "#81791: manual prompt clobbered"
+    assert ("display.personality", "pirate") in saved
+    assert all(key != "agent.system_prompt" for key, _ in saved)
+    assert cli.system_prompt == "Be concise.\n\nYou are a pirate. Arr."
+
+
+def test_cli_personality_survives_restart(cli_with_manual_prompt):
+    cli, disk, _saved = cli_with_manual_prompt
+
+    cli._handle_personality_command("/personality pirate")
+
+    # "Restart": a fresh process resolves from the persisted config.
+    assert resolve_personality_overlay(disk) == cli.system_prompt
+
+
+def test_cli_personality_none_restores_manual_prompt(cli_with_manual_prompt):
+    cli, disk, _saved = cli_with_manual_prompt
+
+    cli._handle_personality_command("/personality pirate")
+    cli._handle_personality_command("/personality none")
+
+    assert cli.system_prompt == "Be concise."
+    assert disk["agent"]["system_prompt"] == "Be concise."
+    assert resolve_personality_overlay(disk) == "Be concise."

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5933,14 +5933,32 @@ def _wire_callbacks(sid: str):
 
 
 def _render_personality_prompt(value) -> str:
-    if isinstance(value, dict):
-        parts = [value.get("system_prompt", "")]
-        if value.get("tone"):
-            parts.append(f'Tone: {value["tone"]}')
-        if value.get("style"):
-            parts.append(f'Style: {value["style"]}')
-        return "\n".join(p for p in parts if p)
-    return str(value)
+    """Thin alias for the canonical renderer in ``hermes_cli.config``."""
+    from hermes_cli.config import render_personality_prompt
+
+    return render_personality_prompt(value)
+
+
+def _composed_personality_overlay(pname: str, personality_prompt: str) -> str:
+    """The overlay a restart would resolve for ``pname``.
+
+    Keeps the live session's ephemeral prompt byte-identical to what
+    :func:`hermes_cli.config.resolve_personality_overlay` produces from the
+    saved config, so selecting a personality now and restarting later behave
+    the same.
+    """
+    from hermes_cli.config import resolve_personality_overlay
+
+    try:
+        cfg = _load_cfg()
+    except Exception:
+        return personality_prompt
+    manual = (cfg.get("agent") or {}).get("system_prompt", "")
+    probe = {
+        "agent": {"system_prompt": manual, "personalities": _available_personalities(cfg)},
+        "display": {"personality": pname},
+    }
+    return resolve_personality_overlay(probe)
 
 
 def _available_personalities(cfg: dict | None = None) -> dict:
@@ -5990,7 +6008,11 @@ def _prompt_text(value) -> str:
 
 
 def _apply_personality_to_session(
-    sid: str, session: dict, new_prompt: str, personality: str = ""
+    sid: str,
+    session: dict,
+    new_prompt: str,
+    personality: str = "",
+    overlay: str | None = None,
 ) -> tuple[bool, dict | None]:
     """Apply a personality change to an existing session without resetting history.
 
@@ -5998,6 +6020,13 @@ def _apply_personality_to_session(
     takes effect on the next turn.  The cached base system prompt is left intact
     (ephemeral_system_prompt is appended at API-call time, not baked into the
     cache), which preserves prompt-cache hits.
+
+    ``new_prompt`` is the personality's own text and drives the pivot marker.
+    ``overlay`` is what the agent actually runs with — the manual
+    ``agent.system_prompt`` composed with that personality, matching what
+    :func:`resolve_personality_overlay` returns on the next start so the
+    session does not silently change behavior across a restart.  It defaults
+    to ``new_prompt`` for callers that have no manual prompt to compose.
 
     Also injects a system-role marker into the conversation history so the model
     knows to pivot its style from this point forward (without this, LLMs tend to
@@ -6012,7 +6041,8 @@ def _apply_personality_to_session(
 
     agent = session.get("agent")
     if agent:
-        agent.ephemeral_system_prompt = new_prompt or None
+        effective = new_prompt if overlay is None else overlay
+        agent.ephemeral_system_prompt = effective or None
         # Inject a pivot marker into history so the model sees the change point.
         # This prevents it from pattern-matching its prior style.
         if new_prompt:
@@ -11336,11 +11366,18 @@ def _(rid, params: dict) -> dict:
             elif key == "personality":
                 sid_key = params.get("session_id", "")
                 pname, new_prompt = _validate_personality(str(value or ""), cfg)
+                # The selection is recorded by name; the personality's text is
+                # an in-session overlay resolved at startup by
+                # resolve_personality_overlay(). Writing it into
+                # agent.system_prompt would destroy the user's manual prompt.
                 _write_config_key("display.personality", pname)
-                _write_config_key("agent.system_prompt", new_prompt)
                 nv = str(value or "none")
                 history_reset, info = _apply_personality_to_session(
-                    sid_key, session, new_prompt, pname
+                    sid_key,
+                    session,
+                    new_prompt,
+                    pname,
+                    overlay=_composed_personality_overlay(pname, new_prompt),
                 )
             else:
                 _write_config_key(f"display.{key}", value)


### PR DESCRIPTION
## Summary

Supersedes #81792, #56773 and #51906, which are three partial answers to one
question: **which config field is authoritative for a personality selection?**

Today `agent.system_prompt` does double duty. It is the user's manual global
prompt, *and* every personality write path copies the selected personality's
text into it. That single overloaded field is the whole bug class:

- Selecting a personality silently destroys a manual prompt, with no backup
  anywhere on disk (#81791).
- `display.personality` records the selection but has no startup reader — its
  only non-test consumer on `main` is `_probe_config_health`, which emits a
  warning string. So a selection only ever applied *because* its text was
  squatting in the manual-prompt field (#51882, #58774, #51155).

That coupling is why the three open PRs conflict: #81792 stops writing the
prompt (fixing the clobber but dropping persistence, since nothing reads the
name), #56773 adds the missing read side, and #51906 pushes the opposite way
on the web path by writing the prompt harder. Merging any one alone locks in a
contradiction with the other two, so they are resolved together here.

**The split:** `agent.system_prompt` is the user's manual prompt and nothing
else ever writes it. `display.personality` names the selection. A new
`resolve_personality_overlay()` composes them at read time, manual first, so a
personality reads as a modifier on the user's standing instructions.

### What this PR does

- Adds `resolve_personality_overlay()` and promotes `render_personality_prompt()`
  to canonical helpers in `hermes_cli/config.py`, replacing three copy-pasted
  renderers.
- Routes both startup readers (`cli.py`, `gateway/run.py`) through the resolver,
  so a saved personality applies on its own.
- Makes all four write paths persist the selection **by name only** — the
  tui_gateway `config.set` RPC behind the desktop picker, CLI `/personality`,
  gateway `/personality`, and dashboard `PUT /api/config`.
- Keeps live sessions byte-consistent with what the next start resolves, so
  reopening the app cannot silently change the assistant's behavior.
- Validates the personality name on the dashboard write (400 instead of
  persisting an unresolvable value).

Prompt caching is preserved throughout: the personality remains an ephemeral
overlay applied at API-call time, never baked into the cached base prompt —
the contract the in-chat `/personality` handler already documented and the
desktop RPC contradicted.

### Upgrade path

Configs written by older builds still hold a personality's text in
`agent.system_prompt`. A manual prompt that exactly matches a known
personality's rendered text is treated as that legacy cache and dropped rather
than doubled, so existing configs converge with no migration and no duplicated
persona text.

### What was dropped

- **#81792** — the `_personality_base_prompt` snapshot cached on `self`. It was
  process-local, so the composed overlay was session-only and the base prompt
  was lost on restart; the shared resolver reads it fresh from disk instead.
- **#56773** — the `gateway/slash_commands.py` dual-write (both fields), now
  that the name alone is authoritative.
- **#51906** — the `agent.system_prompt` write-through and its private
  `_render_personality_prompt_for_web` copy. Its unknown-personality `400`
  is kept, generalized to the current deep-merge handler.

## Test plan

- [x] `scripts/run_tests.sh tests/test_personality_config_roundtrip.py` → 31 passed
- [x] `scripts/run_tests.sh tests/cli/ tests/tui_gateway/ tests/gateway/ tests/hermes_cli/ tests/test_web_server.py` → no new failures
- [x] New tests confirmed to **fail** against the pre-fix handlers and pass after
- [x] Reproduced the original clobber on `main` (`5e1b50115`) and confirmed both
      invariants hold on this branch

The regression test asserts both halves as one invariant — manual prompt
survives **and** personality still active after a restart — parametrized across
every write path. Kept together deliberately: fixing either half alone
reintroduces the other, which is exactly how this cluster arose.

Closes #81791
Closes #51882

Credit: @kyssta-exe (#81792, the write-side fix and its desktop-RPC diagnosis),
@EMT5320 (#56773, the resolver and legacy-cache handling), @lkevincc0 (#51906,
the web path and its validation). All three carried as `Co-authored-by`.

cc @alt-glitch — this is the config-model decision you flagged on #81792.
One open question worth your call: whether a user's custom `agent.system_prompt`
should **compose** with a personality (this PR) or be **replaced** by it.
#56773 chose replace-if-stale/keep-if-custom; #81792's CLI half chose
concatenate. This PR composes, which keeps both settings meaningful and is the
only option where neither field silently wins.
