### PR TITLE
fix(agent): keep every truncated AGENTS.md chain source recoverable

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1968,19 +1968,21 @@ def _truncate_content(
     max_chars: Optional[int] = None,
     context_length: Optional[int] = None,
     read_path: Optional[str] = None,
+    read_paths: Optional[List[str]] = None,
 ) -> str:
     """Head/tail truncation with a marker in the middle.
 
     ``filename`` is the human label used in warnings. ``read_path`` is the
     concrete path the agent should ``read_file`` to recover the full content
-    (defaults to ``filename`` when not supplied). ``context_length`` lets the
-    cap scale to the model's window when no explicit config override is set.
+    (defaults to ``filename`` when not supplied). ``read_paths`` supplies every
+    source when ``content`` is an aggregate that cannot be recovered from one
+    file. ``context_length`` lets the cap scale to the model's window when no
+    explicit config override is set.
     """
     if max_chars is None:
         max_chars = _get_context_file_max_chars(context_length)
     if len(content) <= max_chars:
         return content
-    target = read_path or filename
     msg = (
         f"⚠️  Context file {filename} TRUNCATED: "
         f"{len(content)} chars exceeds limit of {max_chars} — "
@@ -1993,11 +1995,22 @@ def _truncate_content(
     tail_chars = int(max_chars * CONTEXT_TRUNCATE_TAIL_RATIO)
     head = content[:head_chars]
     tail = content[-tail_chars:]
+    if read_paths:
+        targets = "\n".join(f"- {path}" for path in read_paths)
+        recovery = (
+            "read each complete source file with the read_file tool:\n"
+            f"{targets}"
+        )
+    else:
+        target = read_path or filename
+        recovery = (
+            "read the complete file with the read_file tool: "
+            f"{target}"
+        )
     marker = (
         f"\n\n[...truncated {filename}: kept {head_chars}+{tail_chars} of "
         f"{len(content)} chars. The middle is omitted — if you need the full "
-        f"instructions, read the complete file with the read_file tool: "
-        f"{target}]\n\n"
+        f"instructions, {recovery}]\n\n"
     )
     return head + marker + tail
 
@@ -2099,6 +2112,7 @@ def _load_agents_md(cwd_path: Path, context_length: Optional[int] = None) -> str
     """
     cwd_resolved = cwd_path.resolve()
     sections: List[str] = []
+    source_paths: List[str] = []
     seen_content: set = set()
     for directory in _agents_md_directory_chain(cwd_resolved):
         for name in ["AGENTS.md", "agents.md"]:
@@ -2126,6 +2140,7 @@ def _load_agents_md(cwd_path: Path, context_length: Optional[int] = None) -> str
                 read_path=str(candidate),
             )
             sections.append(section)
+            source_paths.append(str(candidate))
             break  # first name match wins per directory
     if not sections:
         return ""
@@ -2137,7 +2152,7 @@ def _load_agents_md(cwd_path: Path, context_length: Optional[int] = None) -> str
     return _truncate_content(
         merged, "AGENTS.md (directory chain)",
         context_length=context_length,
-        read_path=str(cwd_resolved / "AGENTS.md"),
+        read_paths=source_paths,
     )
 
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -494,6 +494,30 @@ class TestBuildContextFilesPrompt:
         result = build_context_files_prompt(cwd=str(sub), skip_soul=True)
         assert result.count("Same rules everywhere.") == 1
 
+    def test_agents_md_chain_truncation_names_every_source(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+        monkeypatch.setattr("hermes_cli.config.load_config_readonly", lambda: {})
+        (tmp_path / ".git").mkdir()
+        root_agents = tmp_path / "AGENTS.md"
+        root_agents.write_text("R" * 12_000)
+        package = tmp_path / "packages"
+        package.mkdir()
+        package_agents = package / "AGENTS.md"
+        package_agents.write_text("P" * 12_000)
+        cwd = package / "app"
+        cwd.mkdir()
+
+        result = build_context_files_prompt(
+            cwd=str(cwd), skip_soul=True, context_length=8_000
+        )
+
+        assert "truncated AGENTS.md (directory chain)" in result
+        assert str(root_agents) in result
+        assert str(package_agents) in result
+        assert str(cwd / "AGENTS.md") not in result
+
     def test_agents_md_single_file_output_unchanged(self, tmp_path):
         # Zero-regression guarantee: with one AGENTS.md at cwd (git repo or
         # not), the section is byte-identical to historical single-file form.


### PR DESCRIPTION
## What does this PR do?

Multi-level AGENTS.md chains can exceed the aggregate context budget and produce a recovery marker that points to a nonexistent or incomplete `cwd/AGENTS.md`. This change keeps every real contributing source path in the marker, so an agent can recover all omitted instructions instead of failing to read the advertised file or loading only one level.

## Related Issue

Fixes #81981

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/prompt_builder.py` - let aggregate truncation markers list multiple recovery paths and collect every real AGENTS.md chain source.
- `tests/agent/test_prompt_builder.py` - cover aggregate overflow with root and intermediate sources when the working directory has no AGENTS.md.

## How to Test

1. Create a git root and an intermediate directory with oversized AGENTS.md files.
2. Build context from a deeper working directory with no local AGENTS.md and force aggregate truncation.
3. Confirm the marker lists both real source files and does not advertise the nonexistent working-directory file.
4. Run the focused suite:

```bash
scripts/run_tests.sh tests/agent/test_prompt_builder.py tests/agent/test_subdirectory_hints.py
```

Result: 86 passed, 0 failed.

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I ran the repository test entry on the relevant suites and all 86 tests pass
- [x] I added a regression test for the bug
- [x] I tested on Windows with Python 3.11.15

### Documentation & Housekeeping

- [x] I updated the affected helper docstring
- [x] `cli-config.yaml.example` changes are not applicable because no config key changed
- [x] Contributor architecture documentation changes are not applicable because no public workflow changed
- [x] I considered cross-platform impact; the source-path list uses the existing platform-native `Path` string conversion
- [x] Tool description and schema changes are not applicable because no model tool changed

## Screenshots / Logs

N/A - the deterministic regression test and focused suite cover the prompt output.
