### PR TITLE
fix(desktop): allow get-windows install script in allowScripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "agent-browser@0.26.0": true,
     "electron@40.10.2": true,
     "fsevents@2.3.2": true,
-    "fsevents@2.3.3": true
+    "fsevents@2.3.3": true,
+    "get-windows@9.3.0": true
   }
 }


### PR DESCRIPTION
## Problem

`hermes desktop` (and the desktop updater's rebuild step) fails on Windows with:

```
Error: [stage-native-deps] get-windows has no win32 prebuilt binding under lib/binding; reinstall dependencies on the Windows build host.
```

## Root cause

`apps/desktop` depends on `get-windows@9.3.0` (native module, added recently). Its install script is `node-pre-gyp install --fallback-to-build`, which downloads the win32 prebuilt binding (`napi-9-win32-unknown-x64/node-get-windows.node`) into `lib/binding`.

npm's allowScripts gate (the root `package.json` `allowScripts` field) blocks that install script, so the win32 binding is never downloaded. The tarball only bundles darwin bindings, so `stageGetWindowsInto` finds no `*-win32-*` dir and throws. This breaks every desktop build on Windows, including the official updater's headless rebuild — so Windows users cannot update the desktop app at all.

## Fix

Add `"get-windows@9.3.0": true` to the root `package.json` `allowScripts`, matching how the other native deps (`node-pty`, `fsevents`, `electron-winstaller`) are already allowed.

Verified: after `npm install-scripts approve get-windows` + `npm rebuild get-windows`, the win32 binding downloads and `hermes desktop --build-only` completes successfully.