### PR TITLE
fix(cli): reject corrupt config in noninteractive runs

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -42,6 +42,10 @@ logger = logging.getLogger(__name__)
 _CONFIG_PARSE_WARNED: set = set()
 
 
+class InvalidUserConfigError(RuntimeError):
+    """Raised when a run that cannot repair config finds invalid user YAML."""
+
+
 def _backup_corrupt_config(config_path: Path) -> Optional[Path]:
     """Preserve a corrupted ``config.yaml`` by copying it to a timestamped ``.bak``.
 
@@ -694,6 +698,48 @@ from utils import atomic_replace, fast_safe_load
 def get_config_path() -> Path:
     """Get the main config file path."""
     return get_hermes_home() / "config.yaml"
+
+
+def require_parseable_user_config(*, ignore_user_config: bool = False) -> None:
+    """Reject an existing invalid config before a non-interactive agent run.
+
+    Interactive surfaces retain ``load_config()``'s recovery behavior so the
+    operator can repair their configuration. A one-shot or single-query run
+    has no such repair opportunity: allowing defaults there can silently pick
+    a hosted provider/model and spend against credentials loaded from ``.env``.
+
+    Missing and empty files remain valid first-run states. The explicit
+    ``--ignore-user-config``/safe-mode escape hatch also remains authoritative.
+    """
+    if ignore_user_config or os.environ.get("HERMES_IGNORE_USER_CONFIG") == "1":
+        return
+
+    config_path = get_config_path()
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            data = fast_safe_load(f)
+    except FileNotFoundError:
+        return
+    except Exception as exc:
+        parse_error = exc
+    else:
+        if data is None or isinstance(data, dict):
+            return
+        parse_error = TypeError(
+            f"top-level YAML value must be a mapping, got {type(data).__name__}"
+        )
+
+    backup_path = _backup_corrupt_config(config_path)
+    message = (
+        f"Refusing non-interactive startup because {config_path} is invalid: "
+        f"{parse_error}. Repair the file or pass --ignore-user-config to "
+        "intentionally run with built-in defaults."
+    )
+    if backup_path is not None:
+        message += f" A copy was saved to {backup_path}."
+    logger.error(message)
+    raise InvalidUserConfigError(message) from parse_error
+
 
 def get_env_path() -> Path:
     """Get the .env file path (for API keys)."""

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2530,9 +2530,10 @@ def _resolve_use_tui(args) -> bool:
 
 def cmd_chat(args):
     """Run interactive chat CLI."""
-    use_tui = _resolve_use_tui(args)
-
     _apply_safe_mode(args)
+    _apply_user_config_bypass(args)
+    _guard_noninteractive_user_config(args)
+    use_tui = _resolve_use_tui(args)
 
     # --in DIR: run in DIR. Must happen before any session resolution so the
     # workspace-scoped "latest"/-c lookups key off DIR, and it pins the
@@ -2703,14 +2704,6 @@ def cmd_chat(args):
     # that invoke cmd_chat directly (e.g. subcommand dispatch).
     if getattr(args, "yolo", False):
         os.environ["HERMES_YOLO_MODE"] = "1"
-
-    # --ignore-user-config: make load_cli_config() / load_config() skip the
-    # user's ~/.hermes/config.yaml and return built-in defaults. Set BEFORE
-    # importing cli (which runs `CLI_CONFIG = load_cli_config()` at module
-    # import time). Credentials in .env are still loaded — this flag only
-    # ignores behavioral/config settings.
-    if getattr(args, "ignore_user_config", False):
-        os.environ["HERMES_IGNORE_USER_CONFIG"] = "1"
 
     # --ignore-rules: skip auto-injection of AGENTS.md/SOUL.md/.cursorrules
     # (rules), memory entries, and any preloaded skills coming from user config.
@@ -10825,6 +10818,8 @@ def _prepare_agent_startup(args) -> None:
     if getattr(args, "yolo", False):
         os.environ["HERMES_YOLO_MODE"] = "1"
     _apply_safe_mode(args)
+    _apply_user_config_bypass(args)
+    _guard_noninteractive_user_config(args)
 
     _sub_attr, _sub_set = _AGENT_SUBCOMMANDS.get(args.command, (None, None))
     if not (
@@ -10904,6 +10899,44 @@ def _apply_safe_mode(args) -> None:
     os.environ["HERMES_SAFE_MODE"] = "1"
     os.environ["HERMES_IGNORE_USER_CONFIG"] = "1"
     os.environ["HERMES_IGNORE_RULES"] = "1"
+
+
+def _apply_user_config_bypass(args) -> None:
+    """Apply the explicit config bypass before any startup config reads."""
+    if getattr(args, "ignore_user_config", False):
+        os.environ["HERMES_IGNORE_USER_CONFIG"] = "1"
+
+
+def _guard_noninteractive_user_config(args) -> None:
+    """Fail closed before a non-interactive invocation initializes providers."""
+    if getattr(args, "_noninteractive_config_validated", False):
+        return
+
+    is_noninteractive = (
+        bool(getattr(args, "oneshot", None))
+        or getattr(args, "query", None) is not None
+        or bool(getattr(args, "quiet", False))
+    )
+    if not is_noninteractive:
+        return
+
+    from hermes_cli.config import (
+        InvalidUserConfigError,
+        require_parseable_user_config,
+    )
+
+    try:
+        require_parseable_user_config(
+            ignore_user_config=bool(
+                getattr(args, "ignore_user_config", False)
+                or getattr(args, "safe_mode", False)
+            )
+        )
+    except InvalidUserConfigError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc
+
+    setattr(args, "_noninteractive_config_validated", True)
 
 
 def _set_chat_arg_defaults(args) -> None:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10914,7 +10914,7 @@ def _guard_noninteractive_user_config(args) -> None:
 
     is_noninteractive = (
         bool(getattr(args, "oneshot", None))
-        or getattr(args, "query", None) is not None
+        or bool(getattr(args, "query", None))
         or bool(getattr(args, "quiet", False))
     )
     if not is_noninteractive:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10915,7 +10915,6 @@ def _guard_noninteractive_user_config(args) -> None:
     is_noninteractive = (
         bool(getattr(args, "oneshot", None))
         or bool(getattr(args, "query", None))
-        or bool(getattr(args, "quiet", False))
     )
     if not is_noninteractive:
         return

--- a/tests/hermes_cli/test_noninteractive_config_guard.py
+++ b/tests/hermes_cli/test_noninteractive_config_guard.py
@@ -38,9 +38,9 @@ def _isolated_config_env(monkeypatch, tmp_path):
     [
         _args(query="hello"),
         _args(command=None, query=None, oneshot="hello"),
-        _args(query=None, quiet=True),
+        _args(query="hello", quiet=True),
     ],
-    ids=["single-query", "oneshot", "quiet"],
+    ids=["single-query", "oneshot", "quiet-query"],
 )
 def test_noninteractive_guard_rejects_malformed_yaml(args, tmp_path, caplog, capsys):
     from hermes_cli import main as main_mod
@@ -146,11 +146,19 @@ def test_interactive_chat_keeps_existing_repair_behavior(tmp_path):
     assert list(tmp_path.glob("config.yaml.corrupt.*.bak")) == []
 
 
-def test_empty_query_keeps_interactive_repair_behavior(tmp_path):
+@pytest.mark.parametrize(
+    "args",
+    [
+        _args(query=""),
+        _args(query=None, quiet=True),
+        _args(query="", quiet=True),
+    ],
+    ids=["empty-query", "quiet", "quiet-empty-query"],
+)
+def test_queryless_chat_keeps_interactive_repair_behavior(args, tmp_path):
     from hermes_cli import main as main_mod
 
     (tmp_path / "config.yaml").write_text("model: [unterminated\n")
-    args = _args(query="")
 
     main_mod._guard_noninteractive_user_config(args)
 

--- a/tests/hermes_cli/test_noninteractive_config_guard.py
+++ b/tests/hermes_cli/test_noninteractive_config_guard.py
@@ -1,0 +1,156 @@
+"""Regression coverage for fail-closed non-interactive config startup."""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import types
+from argparse import Namespace
+
+import pytest
+
+
+def _args(**overrides) -> Namespace:
+    values = {
+        "command": "chat",
+        "ignore_user_config": False,
+        "oneshot": None,
+        "query": "hello",
+        "quiet": False,
+        "safe_mode": False,
+        "yolo": False,
+    }
+    values.update(overrides)
+    return Namespace(**values)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_config_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_IGNORE_USER_CONFIG", raising=False)
+    yield
+    os.environ.pop("HERMES_IGNORE_USER_CONFIG", None)
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        _args(query="hello"),
+        _args(command=None, query=None, oneshot="hello"),
+        _args(query=None, quiet=True),
+    ],
+    ids=["single-query", "oneshot", "quiet"],
+)
+def test_noninteractive_guard_rejects_malformed_yaml(args, tmp_path, caplog, capsys):
+    from hermes_cli import main as main_mod
+
+    broken = "model: [unterminated\n"
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(broken, encoding="utf-8")
+
+    with caplog.at_level(logging.ERROR, logger="hermes_cli.config"):
+        with pytest.raises(SystemExit) as exc_info:
+            main_mod._guard_noninteractive_user_config(args)
+
+    assert exc_info.value.code == 2
+    assert "Refusing non-interactive startup" in capsys.readouterr().err
+    assert any(
+        record.levelno == logging.ERROR
+        and "Refusing non-interactive startup" in record.getMessage()
+        for record in caplog.records
+    )
+    assert config_path.read_text(encoding="utf-8") == broken
+    backups = list(tmp_path.glob("config.yaml.corrupt.*.bak"))
+    assert len(backups) == 1
+    assert backups[0].read_text(encoding="utf-8") == broken
+
+
+def test_prepare_rejects_bad_config_before_plugin_discovery(monkeypatch, tmp_path):
+    from hermes_cli import main as main_mod
+
+    (tmp_path / "config.yaml").write_text("model: [unterminated\n")
+    discovery_calls = []
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(
+            discover_plugins=lambda: discovery_calls.append("plugins")
+        ),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        main_mod._prepare_agent_startup(_args())
+
+    assert exc_info.value.code == 2
+    assert discovery_calls == []
+
+
+@pytest.mark.parametrize(
+    "content", [None, "", "{}\n", "model:\n  default: local/test\n"]
+)
+def test_noninteractive_guard_accepts_missing_empty_and_mapping_configs(
+    content, tmp_path
+):
+    from hermes_cli import main as main_mod
+
+    if content is not None:
+        (tmp_path / "config.yaml").write_text(content, encoding="utf-8")
+    args = _args()
+
+    main_mod._guard_noninteractive_user_config(args)
+
+    assert args._noninteractive_config_validated is True
+
+
+def test_noninteractive_guard_rejects_non_mapping_yaml(tmp_path, capsys):
+    from hermes_cli import main as main_mod
+
+    (tmp_path / "config.yaml").write_text("- model\n- provider\n")
+
+    with pytest.raises(SystemExit) as exc_info:
+        main_mod._guard_noninteractive_user_config(_args())
+
+    assert exc_info.value.code == 2
+    assert "top-level YAML value must be a mapping" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        _args(ignore_user_config=True),
+        _args(safe_mode=True),
+    ],
+    ids=["ignore-user-config", "safe-mode"],
+)
+def test_explicit_config_bypasses_allow_noninteractive_recovery(args, tmp_path):
+    from hermes_cli import main as main_mod
+
+    (tmp_path / "config.yaml").write_text("model: [unterminated\n")
+
+    main_mod._guard_noninteractive_user_config(args)
+
+    assert args._noninteractive_config_validated is True
+    assert list(tmp_path.glob("config.yaml.corrupt.*.bak")) == []
+
+
+def test_interactive_chat_keeps_existing_repair_behavior(tmp_path):
+    from hermes_cli import main as main_mod
+
+    (tmp_path / "config.yaml").write_text("model: [unterminated\n")
+    args = _args(query=None)
+
+    main_mod._guard_noninteractive_user_config(args)
+
+    assert not hasattr(args, "_noninteractive_config_validated")
+    assert list(tmp_path.glob("config.yaml.corrupt.*.bak")) == []
+
+
+def test_ignore_user_config_is_applied_before_oneshot_startup(monkeypatch):
+    from hermes_cli import main as main_mod
+
+    monkeypatch.delenv("HERMES_IGNORE_USER_CONFIG", raising=False)
+
+    main_mod._apply_user_config_bypass(_args(ignore_user_config=True))
+
+    assert os.environ["HERMES_IGNORE_USER_CONFIG"] == "1"

--- a/tests/hermes_cli/test_noninteractive_config_guard.py
+++ b/tests/hermes_cli/test_noninteractive_config_guard.py
@@ -146,6 +146,47 @@ def test_interactive_chat_keeps_existing_repair_behavior(tmp_path):
     assert list(tmp_path.glob("config.yaml.corrupt.*.bak")) == []
 
 
+def test_empty_query_keeps_interactive_repair_behavior(tmp_path):
+    from hermes_cli import main as main_mod
+
+    (tmp_path / "config.yaml").write_text("model: [unterminated\n")
+    args = _args(query="")
+
+    main_mod._guard_noninteractive_user_config(args)
+
+    assert not hasattr(args, "_noninteractive_config_validated")
+    assert list(tmp_path.glob("config.yaml.corrupt.*.bak")) == []
+
+
+def test_env_only_config_bypass_allows_noninteractive_recovery(monkeypatch, tmp_path):
+    from hermes_cli import main as main_mod
+
+    (tmp_path / "config.yaml").write_text("model: [unterminated\n")
+    monkeypatch.setenv("HERMES_IGNORE_USER_CONFIG", "1")
+    args = _args()
+
+    main_mod._guard_noninteractive_user_config(args)
+
+    assert args._noninteractive_config_validated is True
+    assert list(tmp_path.glob("config.yaml.corrupt.*.bak")) == []
+
+
+def test_reused_args_can_retry_after_config_repair(tmp_path):
+    from hermes_cli import main as main_mod
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("model: [unterminated\n")
+    args = _args()
+
+    with pytest.raises(SystemExit):
+        main_mod._guard_noninteractive_user_config(args)
+
+    config_path.write_text("model:\n  default: local/test\n")
+    main_mod._guard_noninteractive_user_config(args)
+
+    assert args._noninteractive_config_validated is True
+
+
 def test_ignore_user_config_is_applied_before_oneshot_startup(monkeypatch):
     from hermes_cli import main as main_mod
 


### PR DESCRIPTION
## Summary

- reject existing malformed or non-mapping profile config before quiet, single-query, or oneshot startup
- log the refusal at ERROR and preserve the existing corrupt-config backup behavior
- keep missing/empty config, interactive repair, safe mode, and explicit `--ignore-user-config` behavior intact

## Why

A fresh process currently falls back to defaults after a config parse failure. If the profile `.env` contains `OPENROUTER_API_KEY`, a noninteractive run can then resolve OpenRouter and silently incur spend against a provider the broken config never selected.

The guard runs before plugin discovery or provider initialization and covers the full parser, Termux fast path, and direct `cmd_chat` callers.

## Verification

- focused and adjacent regression after review follow-up: 45 passed
- focused and adjacent CLI suites before the edge-case-only follow-up: 112 passed
- full `tests/hermes_cli` matrix: 4,610 passed; one unrelated macOS service-manager mode test was flaky and passed standalone on both exact base and this branch
- isolated cron-style subprocess: exit 2, refusal present in stderr and `errors.log`, corrupt file preserved and backed up, no provider initialization or API call
- `ruff`, `git diff --check`, publish-range gitleaks, and metadata checks passed

Fixes #81952