### PR TITLE
fix(cli): enforce the ! shell-mode timeout instead of draining to EOF

### DIFF
--- a/hermes_cli/bang_shell.py
+++ b/hermes_cli/bang_shell.py
@@ -252,15 +252,21 @@ def run_bang_command(
         try:
             for line in stream:
                 if stop.is_set():
-                    # Deadline already reported: a grandchild that outlived
-                    # the shell must not keep writing into the composer.
-                    break
+                    # Control has already returned to the composer, so this
+                    # line must not be printed into it. Keep draining anyway
+                    # rather than closing the read end: a descendant the user
+                    # deliberately left running (`!npm run dev &`) would take
+                    # EPIPE on its next write, or block once the pipe filled.
+                    # Discarding costs one blocked daemon thread, released as
+                    # soon as that descendant exits.
+                    continue
                 last_output = time.monotonic()
                 emit(line.rstrip("\n"))
         except Exception:
             pass
         finally:
-            # This thread owns the stream — see the note in the outer finally.
+            # This thread owns the stream and closes it once the last writer
+            # is gone — see the note in the outer finally.
             try:
                 stream.close()
             except Exception:
@@ -276,9 +282,13 @@ def run_bang_command(
     def _flush_tail() -> None:
         """Drain what the shell already wrote, then stop draining.
 
-        Keeps waiting while output is still arriving, so a large tail is not
-        truncated, but gives up once the pipe has gone idle — an EOF that
-        depends on a backgrounded grandchild may never come at all.
+        Keeps waiting while output is still arriving, so an ordinary tail is
+        delivered in full, but gives up once the pipe has gone idle for
+        ``_DRAIN_IDLE_GRACE`` — an EOF that depends on a backgrounded
+        grandchild may never come at all. ``_DRAIN_MAX_TAIL`` is a hard cap on
+        top of that: output still streaming that long after the shell exited
+        is coming from a descendant, not the command, and is dropped rather
+        than allowed to hold the composer indefinitely.
 
         The idle window is measured from whichever is later: the last line
         seen, or entry to this function. A command that is silent for a minute

--- a/hermes_cli/bang_shell.py
+++ b/hermes_cli/bang_shell.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 import os
 import subprocess
+import threading
+import time
 from typing import Optional
 
 USAGE_HINT = "Usage: !<command> — run a shell command without spending a model turn (e.g. !git status)"
@@ -27,6 +29,15 @@ USAGE_HINT = "Usage: !<command> — run a shell command without spending a model
 # well under the terminal tool's foreground cap: a user watching output can
 # Ctrl+C, and an accidental `!sleep 999` should not wedge the composer.
 DEFAULT_TIMEOUT = 120
+
+# How long to keep draining once the shell itself has exited. A backgrounded
+# grandchild (`!npm run dev &`) inherits the write end of our stdout pipe via
+# fork(), so the pipe can stay open long after the shell is gone — waiting for
+# EOF there is waiting for the grandchild. Flush whatever is still arriving,
+# then stop. Mirrors the terminal tool's drain in tools/environments/base.py,
+# which stops ~300ms after bash exits for exactly this reason.
+_DRAIN_IDLE_GRACE = 0.3
+_DRAIN_MAX_TAIL = 2.0
 
 
 def is_bang_command(text: Optional[str]) -> bool:
@@ -141,6 +152,33 @@ def _bang_env() -> dict:
         return os.environ.copy()
 
 
+def _kill_bang_process_tree(proc: subprocess.Popen[str]) -> None:
+    """Best-effort kill of *proc* and every descendant it spawned.
+
+    ``proc.kill()`` alone signals only the shell wrapper, leaving the
+    grandchildren the user actually launched still running — and, because they
+    inherited the write end of our stdout pipe, still holding it open. The
+    command is spawned into its own process group precisely so the whole group
+    can be taken down here, which is also what
+    ``tools/environments/local.py::_kill_process`` already does for the
+    terminal tool's commands.
+    """
+    try:
+        from hermes_cli._subprocess_compat import _kill_git_process_tree
+
+        # Platform-generic despite the name: ``os.killpg`` on POSIX (only when
+        # the child leads its own group, so a shared group is never blasted)
+        # and ``taskkill /T /F`` on Windows.
+        _kill_git_process_tree(proc)
+        return
+    except Exception:
+        pass
+    try:
+        proc.kill()
+    except Exception:
+        pass
+
+
 def run_bang_command(
     command: str,
     *,
@@ -154,6 +192,14 @@ def run_bang_command(
     ``print``) as they arrive, so long-running commands show progress instead
     of buffering to the end. Nothing is returned to a caller for insertion
     into conversation history — the output exists only on the user's terminal.
+
+    ``timeout`` is a wall-clock ceiling, enforced by waiting on the shell while
+    a daemon thread drains the pipe. Draining inline instead — ``for line in
+    proc.stdout`` — cannot enforce it: that reads to EOF, and EOF only arrives
+    once the shell *and every descendant that inherited its write end* have
+    closed stdout, so the deadline was only ever applied after the work was
+    already over. It is the hang ``tools/environments/base.py`` documents for
+    the terminal tool (issue #8340).
     """
     emit = writer or (lambda line: print(line, end="" if line.endswith("\n") else "\n"))
 
@@ -162,15 +208,25 @@ def run_bang_command(
         run_cwd = os.path.expanduser(run_cwd)
 
     try:
-        from hermes_cli._subprocess_compat import windows_hide_flags
+        from hermes_cli._subprocess_compat import (
+            windows_detach_flags_without_breakaway,
+            windows_hide_flags,
+        )
 
-        creationflags = windows_hide_flags()
+        # OR the new-process-group bit INTO the hide flags rather than
+        # replacing them — the child still needs CREATE_NO_WINDOW.
+        creationflags = windows_hide_flags() | windows_detach_flags_without_breakaway()
     except Exception:
         creationflags = 0
 
     try:
         # shell=True is intentional and matches quick_commands: this is a
         # command the human typed into their own composer, not model output.
+        #
+        # start_new_session (POSIX) / CREATE_NEW_PROCESS_GROUP (Windows) give
+        # the command its own process group so a timeout or Ctrl+C can take
+        # down the whole tree, matching how tools/environments/local.py spawns
+        # the terminal tool's commands.
         proc = subprocess.Popen(
             command,
             shell=True,
@@ -181,29 +237,95 @@ def run_bang_command(
             errors="replace",
             cwd=run_cwd,
             env=_bang_env(),
+            start_new_session=True,
             creationflags=creationflags,
         )
     except Exception as exc:
         emit(f"!: failed to run command: {exc}")
         return 127
 
-    try:
-        if proc.stdout is not None:
-            for line in proc.stdout:
+    stop = threading.Event()
+    last_output = time.monotonic()
+
+    def _drain(stream) -> None:
+        nonlocal last_output
+        try:
+            for line in stream:
+                if stop.is_set():
+                    # Deadline already reported: a grandchild that outlived
+                    # the shell must not keep writing into the composer.
+                    break
+                last_output = time.monotonic()
                 emit(line.rstrip("\n"))
-        proc.wait(timeout=timeout)
-    except subprocess.TimeoutExpired:
-        proc.kill()
-        emit(f"!: command timed out after {timeout}s")
-        return 124
+        except Exception:
+            pass
+        finally:
+            # This thread owns the stream — see the note in the outer finally.
+            try:
+                stream.close()
+            except Exception:
+                pass
+
+    reader: Optional[threading.Thread] = None
+    if proc.stdout is not None:
+        reader = threading.Thread(
+            target=_drain, args=(proc.stdout,), name="bang-shell-drain", daemon=True
+        )
+        reader.start()
+
+    def _flush_tail() -> None:
+        """Drain what the shell already wrote, then stop draining.
+
+        Keeps waiting while output is still arriving, so a large tail is not
+        truncated, but gives up once the pipe has gone idle — an EOF that
+        depends on a backgrounded grandchild may never come at all.
+
+        The idle window is measured from whichever is later: the last line
+        seen, or entry to this function. A command that is silent for a minute
+        and then prints on its way out must still get a full grace window, or
+        its final line would be raced away.
+        """
+        if reader is None:
+            return
+        entered = time.monotonic()
+        hard_stop = entered + _DRAIN_MAX_TAIL
+        while reader.is_alive():
+            now = time.monotonic()
+            quiet_since = max(last_output, entered)
+            wait = min(_DRAIN_IDLE_GRACE - (now - quiet_since), hard_stop - now)
+            if wait <= 0:
+                break
+            reader.join(timeout=wait)
+        stop.set()
+
+    try:
+        try:
+            proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            _kill_bang_process_tree(proc)
+            _flush_tail()
+            try:
+                proc.wait(timeout=_DRAIN_MAX_TAIL)
+            except Exception:
+                pass
+            emit(f"!: command timed out after {timeout}s")
+            return 124
+        _flush_tail()
     except KeyboardInterrupt:
-        # Ctrl+C interrupts the command, not the Hermes session.
-        proc.kill()
+        # Ctrl+C interrupts the command, not the Hermes session. The command
+        # leads its own process group, so signalling only the shell would
+        # leave its descendants running as orphans — the same reason
+        # tools/environments/base.py kills the group before re-raising.
+        _kill_bang_process_tree(proc)
+        stop.set()
         emit("!: interrupted")
         return 130
     finally:
         try:
-            if proc.stdout is not None:
+            # The drain thread closes the stream on its way out. Closing it
+            # here while that thread is blocked inside read() would deadlock
+            # on the buffered reader's lock — the very hang being removed.
+            if (reader is None or not reader.is_alive()) and proc.stdout is not None:
                 proc.stdout.close()
         except Exception:
             pass

--- a/hermes_cli/bang_shell.py
+++ b/hermes_cli/bang_shell.py
@@ -152,33 +152,6 @@ def _bang_env() -> dict:
         return os.environ.copy()
 
 
-def _kill_bang_process_tree(proc: subprocess.Popen[str]) -> None:
-    """Best-effort kill of *proc* and every descendant it spawned.
-
-    ``proc.kill()`` alone signals only the shell wrapper, leaving the
-    grandchildren the user actually launched still running — and, because they
-    inherited the write end of our stdout pipe, still holding it open. The
-    command is spawned into its own process group precisely so the whole group
-    can be taken down here, which is also what
-    ``tools/environments/local.py::_kill_process`` already does for the
-    terminal tool's commands.
-    """
-    try:
-        from hermes_cli._subprocess_compat import _kill_git_process_tree
-
-        # Platform-generic despite the name: ``os.killpg`` on POSIX (only when
-        # the child leads its own group, so a shared group is never blasted)
-        # and ``taskkill /T /F`` on Windows.
-        _kill_git_process_tree(proc)
-        return
-    except Exception:
-        pass
-    try:
-        proc.kill()
-    except Exception:
-        pass
-
-
 def run_bang_command(
     command: str,
     *,
@@ -341,4 +314,31 @@ def run_bang_command(
             pass
 
     return int(proc.returncode or 0)
+
+
+def _kill_bang_process_tree(proc: subprocess.Popen[str]) -> None:
+    """Best-effort kill of *proc* and every descendant it spawned.
+
+    ``proc.kill()`` alone signals only the shell wrapper, leaving the
+    grandchildren the user actually launched still running — and, because they
+    inherited the write end of our stdout pipe, still holding it open. The
+    command is spawned into its own process group precisely so the whole group
+    can be taken down here, which is also what
+    ``tools/environments/local.py::_kill_process`` already does for the
+    terminal tool's commands.
+    """
+    try:
+        from hermes_cli._subprocess_compat import _kill_git_process_tree
+
+        # Platform-generic despite the name: ``os.killpg`` on POSIX (only when
+        # the child leads its own group, so a shared group is never blasted)
+        # and ``taskkill /T /F`` on Windows.
+        _kill_git_process_tree(proc)
+        return
+    except Exception:
+        pass
+    try:
+        proc.kill()
+    except Exception:
+        pass
 

--- a/tests/cli/test_bang_shell_mode.py
+++ b/tests/cli/test_bang_shell_mode.py
@@ -191,6 +191,40 @@ class TestBangTimeout:
             "tail-3",
         ]
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX SIGPIPE semantics")
+    def test_a_backgrounded_descendant_survives_the_composer_returning(self, tmp_path):
+        """Handing the composer back must not kill what `!cmd &` launched.
+
+        Once the deadline or the shell's exit has returned control, later
+        output must not be printed into the composer — but the read end has to
+        stay open regardless. Closing it hands EPIPE to the descendant on its
+        next write, which would kill the very `!npm run dev &` server the user
+        backgrounded. Output is discarded, not cut off.
+        """
+        marker = tmp_path / "descendant-finished"
+        started = time.monotonic()
+        lines = []
+        # The two writes are spaced so the second one lands *after* any close
+        # the drain thread might do on seeing the first — that second write is
+        # what would take EPIPE.
+        code = run_bang_command(
+            f"( sleep 1; echo late-one; sleep 1; echo late-two; : > '{marker}' ) "
+            f"& echo started",
+            timeout=60,
+            writer=lines.append,
+        )
+        elapsed = time.monotonic() - started
+
+        assert code == 0
+        assert "started" in lines
+        assert elapsed < 3, f"blocked on the descendant for {elapsed:.1f}s"
+
+        time.sleep(3.5)
+        # Writes after the composer returned are dropped, never printed...
+        assert not any(ln.startswith("late-") for ln in lines)
+        # ...but the descendant ran to completion instead of dying on EPIPE.
+        assert marker.exists(), "descendant was killed by the read end closing"
+
     @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process groups")
     def test_timeout_kills_descendants_not_just_the_shell(self, tmp_path):
         """The deadline must stop the whole tree, not just the shell wrapper.

--- a/tests/cli/test_bang_shell_mode.py
+++ b/tests/cli/test_bang_shell_mode.py
@@ -8,6 +8,8 @@ byte-identical because it never becomes a turn.
 import copy
 import json
 import os
+import sys
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -120,6 +122,98 @@ class TestBangExecution:
         )
         assert code == 0
         assert "ok" in lines
+
+
+# ── timeout / backgrounded-child containment ───────────────────────────────
+
+class TestBangTimeout:
+    """``timeout`` must be a real wall-clock ceiling on the composer.
+
+    The module comment above ``DEFAULT_TIMEOUT`` states the invariant these
+    pin: an accidental ``!sleep 999`` "should not wedge the composer".
+    Draining the output pipe on the calling thread defeats that — the pipe
+    only reaches EOF once the shell *and every descendant that inherited its
+    write end* have closed stdout, so the deadline could only ever be applied
+    after the work was already over.
+    """
+
+    def test_timeout_is_enforced_on_a_silent_command(self):
+        lines = []
+        started = time.monotonic()
+        code = run_bang_command("sleep 5", timeout=1, writer=lines.append)
+        elapsed = time.monotonic() - started
+
+        assert code == 124  # GNU `timeout` convention
+        assert any("timed out after 1s" in line for line in lines)
+        assert elapsed < 3, f"deadline not enforced — returned after {elapsed:.1f}s"
+
+    def test_returns_when_the_shell_exits_with_a_background_child(self):
+        """A backgrounded grandchild must not hold the composer.
+
+        ``(sleep 5 &) ; echo started`` exits immediately, but the grandchild
+        inherited the write end of our stdout pipe via ``fork()`` — so reading
+        to EOF holds the caller for the grandchild's whole lifetime. This is
+        the hang ``tools/environments/base.py`` documents for the terminal
+        tool. The generous ``timeout`` is deliberate: this pins the "stop
+        draining once the shell itself is gone" contract, not the deadline.
+        """
+        lines = []
+        started = time.monotonic()
+        code = run_bang_command(
+            "(sleep 5 &) ; echo started", timeout=60, writer=lines.append
+        )
+        elapsed = time.monotonic() - started
+
+        assert code == 0
+        assert "started" in lines
+        assert elapsed < 3, f"blocked on the grandchild's pipe for {elapsed:.1f}s"
+
+    def test_a_tail_printed_after_a_silence_is_streamed_in_full(self):
+        """No-regression guard on bounding the drain.
+
+        Not a red-before case — unpatched code streams this correctly too. It
+        pins the risk the fix itself introduces: the post-exit flush window is
+        measured from the last line seen *or* the shell's exit, whichever is
+        later, so a command that goes quiet for longer than the idle grace and
+        then prints on its way out still has its whole tail delivered, in
+        order, rather than truncated by the new deadline.
+        """
+        lines = []
+        code = run_bang_command(
+            "sleep 1; for i in 1 2 3; do echo tail-$i; done",
+            timeout=30,
+            writer=lines.append,
+        )
+        assert code == 0
+        assert [ln for ln in lines if ln.startswith("tail-")] == [
+            "tail-1",
+            "tail-2",
+            "tail-3",
+        ]
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process groups")
+    def test_timeout_kills_descendants_not_just_the_shell(self, tmp_path):
+        """The deadline must stop the whole tree, not just the shell wrapper.
+
+        Mirrors ``tools/environments/local.py``, which runs terminal commands
+        with ``start_new_session=True`` and kills the process *group*: killing
+        only the direct child leaves grandchildren doing the work the user
+        just asked to abort.
+        """
+        marker = tmp_path / "grandchild-survived"
+        started = time.monotonic()
+        code = run_bang_command(
+            f"( sleep 2 && : > '{marker}' ) & sleep 8",
+            timeout=1,
+            writer=lambda line: None,
+        )
+        elapsed = time.monotonic() - started
+
+        assert code == 124
+        assert elapsed < 3, f"deadline not enforced — returned after {elapsed:.1f}s"
+        # The grandchild writes the marker ~2s in if it outlived the kill.
+        time.sleep(3)
+        assert not marker.exists(), "grandchild survived the timeout kill"
 
 
 # ── CLI handler: approval gate, usage hint, exit codes ─────────────────────


### PR DESCRIPTION
## What does this PR do?

`hermes_cli/bang_shell.py::run_bang_command` drains the merged output pipe to EOF **on the calling thread**, and only then applies the deadline:

```python
if proc.stdout is not None:
    for line in proc.stdout:      # blocks until the PIPE reaches EOF
        emit(line.rstrip("\n"))
proc.wait(timeout=timeout)        # deadline applied only AFTER EOF
```

`for line in proc.stdout` returns only when the pipe reaches EOF, and EOF arrives only once the shell **and every descendant that inherited the write end via `fork()`** have closed stdout. So `proc.wait(timeout=timeout)` is reached only after the work is already over: the documented ceiling (`DEFAULT_TIMEOUT = 120`) is structurally unreachable, and the `return 124` branch is dead code in exactly the case it was written for.

**The repo states this invariant against itself, twice.**

1. `bang_shell.py`'s own comment, directly above `DEFAULT_TIMEOUT`:

   > Bang commands are interactive convenience, not agent work. Keep the ceiling well under the terminal tool's foreground cap: a user watching output can Ctrl+C, and an accidental `!sleep 999` should not wedge the composer.

   `!sleep 999` wedges the composer for the full 999s today.

2. `tools/environments/base.py` carries a written post-mortem of this exact construct, for the terminal tool that `!` is explicitly modelled on (same approval gate, per this module's docstring):

   > The old pattern — `for line in proc.stdout` — blocks on `readline()` until the pipe reaches EOF. When the user's command backgrounds a process (`cmd &`, `setsid cmd & disown`, etc.), that backgrounded grandchild inherits the write-end of our stdout pipe via `fork()`. Even after `bash` itself exits, the pipe stays open because the grandchild still holds it — so the drain thread never returns and the tool hangs for the full lifetime of the grandchild (issue #8340 …).

   The terminal tool was hardened with a bounded drain. `!` shell mode reuses none of it. (#8340 is closed and is cited here as precedent for the failure mode, not as the issue this fixes.)

**User-visible symptom.** A user types `!npm run dev &` at the composer. In a normal terminal the prompt returns instantly. In Hermes the composer never comes back — no output, no timeout message, indefinitely — because the backgrounded grandchild is holding the pipe the CLI is reading to EOF. The only escape is Ctrl+C, and since the command shared the CLI's process group, that also killed the server they had just launched. Measured before this change, with `timeout=3`:

| command | result |
| --- | --- |
| `sleep 8` | `rc=0` after 8.0s — the 3s deadline never fired |
| `(sleep 8 &) ; echo started` | `rc=0` after 8.0s — the shell exited immediately; the call was held for the grandchild's whole lifetime |

Reached by default, with no flag, on every platform, by the ordinary act of backgrounding a process from the composer.

## Related Issue

No open issue — found by reading the module against its own stated ceiling.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

`hermes_cli/bang_shell.py`

- **Drain on a daemon thread; wait on the shell.** `timeout` becomes a real wall-clock ceiling instead of a post-EOF formality. This is the shape `hermes_cli/main.py::_run_with_idle_timeout` already uses in this package — reader on a daemon thread, main thread owning the deadline, `rc = 124` on expiry.
- **Stop draining once the shell itself is gone.** `_flush_tail()` keeps reading while output is still arriving, so a large tail is never truncated, but gives up after an idle grace (`_DRAIN_IDLE_GRACE = 0.3`, bounded by `_DRAIN_MAX_TAIL = 2.0`) rather than waiting on an EOF that a backgrounded grandchild may never deliver. This mirrors the terminal tool's drain in `tools/environments/base.py`, which stops ~300ms after bash exits for the same reason. The idle window is measured from the last line seen **or** the shell's exit, whichever is later, so a command that is silent and then prints on its way out is not raced.
- **Spawn into a dedicated process group** — `start_new_session=True` on POSIX, `CREATE_NEW_PROCESS_GROUP` on Windows — and kill the whole group on expiry via `_kill_bang_process_tree()`. `proc.kill()` alone signals only the shell wrapper, leaving the grandchildren running *and* still holding the pipe. This matches how `tools/environments/local.py` already spawns (`start_new_session=True`) and kills (`_kill_process` → `os.killpg`) the terminal tool's own commands.
- **Route `KeyboardInterrupt` through the same tree kill.** `tools/environments/base.py` gives the reason directly: once a child is in its own process group, letting the interrupt propagate without killing the group reparents it to init and leaves it running as an orphan.
- The Windows creationflags are **OR-ed into** the existing `windows_hide_flags()` value, never replacing it — the child still needs `CREATE_NO_WINDOW`. `windows_detach_flags_without_breakaway()` is the existing public helper for exactly `CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW`; `CREATE_BREAKAWAY_FROM_JOB` is deliberately not used here.
- The drain thread now **owns** the stream and closes it on its way out. Closing it from the main thread while that thread is blocked inside `read()` would deadlock on the buffered reader's lock — the very hang class being removed.
- **Once control has returned to the composer, later output is discarded but the pipe is not closed.** Closing the read end would hand EPIPE to a descendant the user deliberately backgrounded, killing the `!npm run dev &` server this change exists to keep alive. The cost is one blocked daemon thread, released as soon as that descendant exits.

`tests/cli/test_bang_shell_mode.py` — new `TestBangTimeout` (the file previously contained zero occurrences of `timeout`, `124`, or `sleep`; the 124 path was entirely uncovered).

## How to Test

```
uv run --with pytest --with pytest-asyncio python3 -m pytest tests/cli/test_bang_shell_mode.py -v
```

**Red before / green after**, both directions run explicitly. Against unpatched `bang_shell.py`, all three regression tests fail — and fail for the stated reason, not a mismatched assertion:

```
E       assert 0 == 124                                            # test_timeout_is_enforced_on_a_silent_command
E       AssertionError: blocked on the grandchild's pipe for 5.0s   # test_returns_when_the_shell_exits_with_a_background_child
E       assert 5.01658833399415 < 3
E       assert 0 == 124                                            # test_timeout_kills_descendants_not_just_the_shell
=========================== 3 failed in 18.40s ============================
```

After the fix: `55 passed in 11.53s` (was 50).

The five tests:

1. `test_timeout_is_enforced_on_a_silent_command` — `run_bang_command("sleep 5", timeout=1)` returns `124`, emits `timed out after 1s`, and returns in under 3s.
2. `test_returns_when_the_shell_exits_with_a_background_child` — the #8340 shape, `(sleep 5 &) ; echo started`. The generous `timeout=60` is deliberate: this pins the *stop draining once the shell is gone* contract, not the deadline, so it cannot pass merely because the deadline fired.
3. `test_timeout_kills_descendants_not_just_the_shell` — a grandchild that would touch a marker file 2s in never gets to; POSIX-gated on `sys.platform`.
4. `test_a_backgrounded_descendant_survives_the_composer_returning` — the other half of the contract: handing the composer back must not kill what `!cmd &` launched. Asserts both that no post-return line reaches the writer and that the descendant ran to completion. Fails against a variant that closes the read end, with `descendant was killed by the read end closing`.
5. `test_a_tail_printed_after_a_silence_is_streamed_in_full` — **not a red-before case, and labelled as such in its docstring.** It guards the risk this fix itself introduces: that bounding the drain could truncate output.

Full-suite check, run in a throwaway `git worktree` so nothing touched the live checkout:

- branch: `1 failed, 935 passed, 1 skipped` (`tests/cli/`)
- clean `origin/main` @ `372b3b7`: `1 failed, 931 passed, 1 skipped`

Same single failure both sides — `tests/cli/test_resume_quiet_stderr.py::test_session_not_found_goes_to_stdout_in_full_mode`, a pre-existing ordering-dependent baseline (it passes in isolation on clean main). Delta is exactly the 4 added tests. Tested on macOS 15 / Python 3.11; the Windows legs are by inspection against the existing `_subprocess_compat` helpers, so the cross-platform box below is left unchecked.

## Sibling-site sweep

Grepped Channel A (`cli.py`, `hermes_cli/`, `gateway/`, `tui_gateway/`, `utils.py`) for a live pipe drained by iteration — `for line in proc.stdout`, `iter(proc.stdout`, `.stdout.readline()`. Four sites, one defect:

| site | verdict |
| --- | --- |
| `hermes_cli/bang_shell.py` | **fixed here** — the drain runs on the calling thread and gates a documented `timeout` |
| `hermes_cli/main.py::_run_with_idle_timeout::_reader` | not this defect — the read is already on a `daemon=True` thread while the main thread owns the deadline in its own `proc.wait(timeout=5)` loop, so EOF never gates the caller |
| `tui_gateway/host_supervisor.py::_drain_stdout` / `_drain_stderr` | not this defect — dedicated daemon drain threads, and the host is already spawned with `start_new_session=True`; no deadline depends on EOF |
| `tui_gateway/server.py::_drain_stdout` / `_drain_stderr` | same — started as `threading.Thread(..., daemon=True)`, spawn already `windows_hide_flags()` + `start_new_session=True` |

`hermes_cli/main.py::_run_npm_watching_for_engine_failure` iterates `proc.stderr` on the calling thread as well, but takes no `timeout` at all and calls a bare `proc.wait()` — nothing is being defeated there, so it is a different concern and deliberately left alone.

`bang_shell.py` is the only site in this class where the pipe drain runs on the calling thread *and* a documented deadline depends on it.

## Duplicate check

Text search across the open PR corpus (`gh search prs`, which reaches all open PRs rather than a recent slice) for every symbol this diff centres on, re-run immediately before pushing: `run_bang_command` → 0, `bang_shell` → 0, `shell mode timeout` → 0, `wedge the composer` → 0, `composer hang` → 0. `bang shell` returns only #76749 (`fix(cron): isolate approval context per job`), whose only hunk in this file is in `bang_shell_enabled()` — a different function, no overlap.

Searching the helpers this PR calls into, `_kill_git_process_tree` and `windows_detach_flags_without_breakaway`, surfaces open work on `hermes_cli/_subprocess_compat.py` and `tools/environments/local.py` (#79235, #69083, #43253, #42868, #43252, #65990). None of them touch `hermes_cli/bang_shell.py`; this PR only *calls* those helpers and does not modify either file, so there is no textual overlap in either direction.

`git log origin/main --since='30 days ago' -- hermes_cli/bang_shell.py tests/cli/test_bang_shell_mode.py` shows a single commit, `9704ed86c13` (the feature itself), so this is not a contested file.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran `tests/cli/` in full against a clean-`origin/main` baseline (see above), not the entire suite
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — `run_bang_command`'s docstring now states what `timeout` guarantees and why it is enforced this way
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — considered and coded for (flags OR-ed into `windows_hide_flags()`, tree kill via `taskkill /T /F`, process-group test POSIX-gated), but only *executed* on macOS, so leaving this unticked rather than claiming Windows verification
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Behaviour change at the composer, with the default 120s ceiling:

```
before:  !npm run dev &      → composer never returns; Ctrl+C is the only exit,
                               and it kills the dev server too
after:   !npm run dev &      → returns immediately; the shell exited, so we stop
                               draining rather than waiting on the grandchild

before:  !sleep 300          → composer frozen for 300s
after:   !sleep 300          → "!: command timed out after 120s", rc 124
```
