### PR TITLE
fix(desktop): make the session status dot mean one thing

### DIFF
--- a/apps/desktop/src/app/chat/session-status-dot.tsx
+++ b/apps/desktop/src/app/chat/session-status-dot.tsx
@@ -1,88 +1,76 @@
 import { useStore } from '@nanostores/react'
 
-import { StatusPulse } from '@/components/ui/status-pulse'
 import { type Translations, useI18n } from '@/i18n'
 import { useStoreSelector } from '@/lib/use-session-slice'
 import { cn } from '@/lib/utils'
-import { $backgroundRunningSessionIds } from '@/store/composer-status'
-import { $unreadFinishedSessionIds } from '@/store/session'
 import { $sessionColorById, sessionColorFor } from '@/store/session-color'
-import { $attentionSessionIds, $stalledSessionIds, $workingSessionIds } from '@/store/session-states'
+import { $sessionDotStateById, type SessionDotState } from '@/store/session-dot-state'
 import type { SessionInfo } from '@/types/hermes'
 
-import { type SessionDotState, sessionDotState } from './sidebar/session-row-state'
-
 // A pure lookup table: each state maps to its className, aria-label, and title.
-// No priority resolution here — sessionDotState already picked one. Label/title
-// resolve from sidebar.row translations, keyed by name.
+// No priority resolution here — $sessionDotStateById already picked one.
+// Label/title resolve from sidebar.row translations, keyed by name.
 type DotVariant = {
   ariaLabel?: (r: Translations['sidebar']['row']) => string
   className: string
-  pulse?: {
-    className: string
-    opacity: number
-  }
   role?: 'status'
   title?: (r: Translations['sidebar']['row']) => string
 }
 
 // Shared base for every active dot; idle is smaller and uses its own class.
-const DOT_BASE = 'relative size-1.5 rounded-full'
+const DOT_BASE = 'size-1.5 rounded-full'
 
+// Three colors and one fill/hollow axis, none of it moving. Motion on a 6px
+// circle can only say "something is happening" — which the row's arc already
+// says, better — while costing a repaint per frame on every row at once. What
+// the dot is for is telling states APART, and that is a job for color and fill:
+// filled means producing, hollow means open but quiet. The two states this
+// replaces differed by 30% opacity and were, in practice, the same dot.
 const DOT_VARIANTS: Record<SessionDotState, DotVariant> = {
-  // Amber steady — a clarify/approval is blocking the turn. Steady (not
-  // pulsing) reads as "your turn", distinct from the accent pulse of a turn.
+  // Amber — a clarify/approval is blocking the turn. The one "act now" color,
+  // and the only state the user is required to do something about.
   'needs-input': {
     ariaLabel: r => r.needsInput,
-    className: `${DOT_BASE} quest-glow bg-amber-500`,
+    className: `${DOT_BASE} bg-amber-500`,
     role: 'status',
     title: r => r.waitingForAnswer
   },
-  // Accent pulse — the LLM turn is actively running.
+  // Accent — the turn is running. The row's arc carries the motion.
   working: {
     ariaLabel: r => r.sessionRunning,
-    className: `${DOT_BASE} bg-(--ui-accent) shadow-[0_0_0.625rem_color-mix(in_srgb,var(--ui-accent)_55%,transparent)]`,
-    pulse: {
-      className: 'absolute inset-0 rounded-full bg-(--ui-accent) opacity-0',
-      opacity: 0.7
-    },
+    className: `${DOT_BASE} bg-(--ui-accent)`,
     role: 'status'
   },
-  // Quiet accent pulse — the turn is still authoritative-running, but no
-  // stream activity has arrived for the watchdog window.
+  // Hollow accent — still authoritatively running, but nothing has arrived for
+  // the watchdog window. Same color as working because it IS working; hollow
+  // because nothing is coming out of it right now.
   stalled: {
     ariaLabel: r => r.sessionRunning,
-    className: `${DOT_BASE} bg-(--ui-accent) opacity-70`,
-    pulse: {
-      className: 'absolute inset-0 rounded-full bg-(--ui-accent) opacity-0',
-      opacity: 0.4
-    },
+    className: `${DOT_BASE} border border-(--ui-accent)`,
     role: 'status',
     title: r => r.sessionRunning
   },
-  // Pulsing gray — a terminal(background=true) process is alive while the LLM
-  // is idle. Gray (not accent) reads as "something chugging along". Brighter
-  // than muted-foreground so it's visible against the surface.
+  // Hollow muted — a terminal(background=true) process outlived the turn. An
+  // outline reads as "still open" without claiming the model is working; a
+  // filled grey dot read as finished, the opposite of what this means.
   background: {
     ariaLabel: r => r.backgroundRunning,
-    className: `${DOT_BASE} bg-muted-foreground/80`,
-    pulse: {
-      className: 'absolute inset-0 rounded-full bg-muted-foreground/80 opacity-0',
-      opacity: 0.6
-    },
+    className: `${DOT_BASE} border border-(--ui-text-tertiary)`,
     role: 'status',
     title: r => r.backgroundRunning
   },
-  // Steady green — a background session's turn completed and the user hasn't
-  // opened it since. "Something new here, go look."
+  // Emerald — the turn finished while the user was looking elsewhere.
   unread: {
     ariaLabel: r => r.finishedUnread,
     className: `${DOT_BASE} bg-emerald-500`,
     role: 'status',
     title: r => r.finishedUnread
   },
+  // Settled: the project color, or nothing at all. An uncolored session used to
+  // get a grey dot, which put a mark of the same weight as a status next to
+  // every resting row and made "no color" look like a state of its own.
   idle: {
-    className: 'size-1 rounded-full bg-(--ui-text-quaternary) opacity-80'
+    className: 'size-1 rounded-full'
   }
 }
 
@@ -105,14 +93,13 @@ export interface SessionStatusDotProps {
 }
 
 /**
- * SESSION STATUS DOT — the ONE primitive both the sidebar row and the pane tab
- * render, so a session's status/color can never disagree between the two
- * surfaces. It reads every signal itself from the shared stores keyed by the
- * stored session id: live state (working / needs-input / stalled / unread /
- * background, mutually exclusive via `sessionDotState`) and the resolved color
- * (override → project color, via `sessionColorFor`). An idle session shows its
- * project color; the active states own the dot with their semantic color so an
- * attention cue is never masked by the inherited tint.
+ * SESSION STATUS DOT — the ONE primitive the sidebar row, the pane tabs, and
+ * the session switcher render, so a session's status can never disagree
+ * between surfaces. It resolves everything itself from the stored session id:
+ * the live state (via `$sessionDotStateById`, already reduced to one mutually
+ * exclusive answer) and the color (override → project, via `sessionColorFor`).
+ * An idle session shows its project color; the active states own the dot with
+ * their semantic color so an attention cue is never masked by the tint.
  */
 export function SessionStatusDot({ storedSessionId, session, branchStem, className }: SessionStatusDotProps) {
   const { t } = useI18n()
@@ -123,17 +110,9 @@ export function SessionStatusDot({ storedSessionId, session, branchStem, classNa
   useStore($sessionColorById)
   const color = sessionColorFor(session) ?? null
 
-  // Per-session membership as booleans via useStoreSelector: these arrays tick
-  // on every stream delta (any session working/stalled/etc changes the array
-  // reference), but a given dot only repaints when ITS OWN membership flips.
-  // A plain useStore(array).includes(id) re-rendered every dot on every tick.
-  const needsInput = useStoreSelector($attentionSessionIds, ids => ids.includes(storedSessionId))
-  const isWorking = useStoreSelector($workingSessionIds, ids => ids.includes(storedSessionId))
-  const isStalled = useStoreSelector($stalledSessionIds, ids => ids.includes(storedSessionId))
-  const isUnread = useStoreSelector($unreadFinishedSessionIds, ids => ids.includes(storedSessionId))
-  const hasBackground = useStoreSelector($backgroundRunningSessionIds, ids => ids.includes(storedSessionId))
-
-  const dotState = sessionDotState({ hasBackground, isStalled, isUnread, isWorking, needsInput })
+  // Selector, not a plain useStore: the map is rebuilt whenever any session's
+  // status changes, but a given dot only repaints when ITS OWN state flips.
+  const dotState = useStoreSelector($sessionDotStateById, states => states[storedSessionId] ?? 'idle')
   const variant = DOT_VARIANTS[dotState]
 
   return (
@@ -143,24 +122,18 @@ export function SessionStatusDot({ storedSessionId, session, branchStem, classNa
           {branchStem}
         </span>
       ) : null}
-      {dotState === 'idle' && color ? (
-        <span aria-hidden="true" className="size-1 rounded-full" style={{ backgroundColor: color }} />
+      {dotState === 'idle' ? (
+        // Rendered even with no color to paint: an empty dot of the same size
+        // keeps every row's title on one left edge, so a session finishing
+        // can't shift the list under the pointer.
+        <span aria-hidden="true" className={variant.className} style={color ? { backgroundColor: color } : undefined} />
       ) : (
         <span
           aria-label={variant.ariaLabel?.(r)}
           className={variant.className}
           role={variant.role}
           title={variant.title?.(r)}
-        >
-          {variant.pulse ? (
-            <StatusPulse
-              aria-hidden="true"
-              className={variant.pulse.className}
-              kind="ping"
-              opacity={variant.pulse.opacity}
-            />
-          ) : null}
-        </span>
+        />
       )}
     </span>
   )

--- a/apps/desktop/src/app/chat/sidebar/session-row-state.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-row-state.test.ts
@@ -1,43 +1,17 @@
 import { describe, expect, it } from 'vitest'
 
-import { sessionDotState, sessionShowsRunningArc } from './session-row-state'
+import { sessionShowsRunningArc } from './session-row-state'
 
 describe('session row running appearance', () => {
   it('keeps the running arc when an authoritative turn becomes quiet', () => {
     expect(sessionShowsRunningArc({ isWorking: true, needsInput: false })).toBe(true)
-    expect(
-      sessionDotState({
-        hasBackground: false,
-        isStalled: true,
-        isUnread: false,
-        isWorking: true,
-        needsInput: false
-      })
-    ).toBe('stalled')
   })
 
   it('uses the needs-input treatment instead of the running arc', () => {
     expect(sessionShowsRunningArc({ isWorking: true, needsInput: true })).toBe(false)
-    expect(
-      sessionDotState({
-        hasBackground: true,
-        isStalled: true,
-        isUnread: true,
-        isWorking: true,
-        needsInput: true
-      })
-    ).toBe('needs-input')
   })
 
-  it('keeps background and unread states below active-turn states', () => {
-    expect(
-      sessionDotState({
-        hasBackground: true,
-        isStalled: false,
-        isUnread: true,
-        isWorking: false,
-        needsInput: false
-      })
-    ).toBe('background')
+  it('shows no arc for a session that is not running', () => {
+    expect(sessionShowsRunningArc({ isWorking: false, needsInput: false })).toBe(false)
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/session-row-state.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-row-state.ts
@@ -1,42 +1,12 @@
-export type SessionDotState = 'background' | 'idle' | 'needs-input' | 'stalled' | 'unread' | 'working'
-
-interface SessionRowState {
-  hasBackground: boolean
-  isStalled: boolean
-  isUnread: boolean
-  isWorking: boolean
-  needsInput: boolean
-}
-
-/** Resolve the sidebar dot's mutually-exclusive display state by priority. */
-export function sessionDotState({
-  hasBackground,
-  isStalled,
-  isUnread,
-  isWorking,
-  needsInput
-}: SessionRowState): SessionDotState {
-  if (needsInput) {
-    return 'needs-input'
-  }
-
-  if (isWorking) {
-    return isStalled ? 'stalled' : 'working'
-  }
-
-  if (hasBackground) {
-    return 'background'
-  }
-
-  return isUnread ? 'unread' : 'idle'
-}
-
 /** A quiet turn is still authoritatively running. Keep the unmistakable row
  * arc until the gateway reports completion; only a blocking prompt suppresses
  * it in favour of the needs-input treatment. */
 export function sessionShowsRunningArc({
   isWorking,
   needsInput
-}: Pick<SessionRowState, 'isWorking' | 'needsInput'>): boolean {
+}: {
+  isWorking: boolean
+  needsInput: boolean
+}): boolean {
   return isWorking && !needsInput
 }

--- a/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
@@ -114,6 +114,14 @@ function makeSession(overrides: Partial<SessionInfo> & { title: string }): Sessi
 
 const tipTrigger = (el: HTMLElement) => el.closest('[data-slot="tooltip-trigger"]')
 
+// The status dot always paints an aria-hidden placeholder so every row's title
+// keeps the same left edge, so "the row's aria-hidden span" no longer names the
+// avatar on its own. `inline-grid` is PlatformAvatar's own layout class in both
+// of its branches — brand glyph and first-letter fallback — and the row passes
+// it no display class that tailwind-merge could drop it for.
+const handoffAvatar = (container: HTMLElement) =>
+  container.querySelector<HTMLElement>('span[aria-hidden="true"].inline-grid')
+
 const noop = vi.fn()
 
 describe('SidebarSessionRow', () => {
@@ -149,11 +157,7 @@ describe('SidebarSessionRow', () => {
       />
     )
 
-    // PlatformAvatar's span is the only aria-hidden SPAN this row ever
-    // renders (idle dot / arc-border / branch-stem are all inactive here) —
-    // Codicon icons (e.g. the kebab trigger) are also aria-hidden but render
-    // as <i>, not <span>, so this selector doesn't accidentally match them.
-    expect(container.querySelector('span[aria-hidden="true"]')).toBeNull()
+    expect(handoffAvatar(container)).toBeNull()
   })
 
   it('wraps the handoff platform avatar in a Tip for a session started on another platform', () => {
@@ -176,11 +180,11 @@ describe('SidebarSessionRow', () => {
 
     // PlatformAvatar is the REAL component here (see the note above the vi.mock
     // block, #67500 third pass) — it renders the Telegram brand SVG rather
-    // than the platform name as text, so query the avatar span itself (the
-    // row's only aria-hidden span in this state) rather than text content,
-    // and confirm its tooltip trigger actually attaches to it — proving the
-    // real forwardRef/...rest path works, not a mock that fakes it.
-    const avatar = container.querySelector('span[aria-hidden="true"]')
+    // than the platform name as text, so query the avatar span itself rather
+    // than text content, and confirm its tooltip trigger actually attaches to
+    // it — proving the real forwardRef/...rest path works, not a mock that
+    // fakes it.
+    const avatar = handoffAvatar(container)
     expect(avatar).toBeTruthy()
     expect(tipTrigger(avatar as HTMLElement)).toBeTruthy()
   })

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -211,12 +211,7 @@ function SidebarSessionRowImpl({
           }}
         >
           {reorderable ? (
-            <SidebarRowGrab
-              ariaLabel={handleLabel}
-              dragging={dragging}
-              dragHandleProps={dragHandleProps}
-              leadClassName={needsInput ? 'overflow-visible' : undefined}
-            >
+            <SidebarRowGrab ariaLabel={handleLabel} dragging={dragging} dragHandleProps={dragHandleProps}>
               <SessionStatusDot
                 branchStem={branchStem}
                 className="transition-opacity group-hover/handle:opacity-0 group-focus-within/handle:opacity-0"
@@ -225,7 +220,7 @@ function SidebarSessionRowImpl({
               />
             </SidebarRowGrab>
           ) : (
-            <SidebarRowLead className={needsInput ? 'overflow-visible' : 'overflow-hidden'}>
+            <SidebarRowLead className="overflow-hidden">
               <SessionStatusDot branchStem={branchStem} session={session} storedSessionId={session.id} />
             </SidebarRowLead>
           )}

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -92,18 +92,26 @@ export function rehydrateLiveSessionStatuses(
 
     const existing = $sessionStates.get()[runtimeSessionId]
 
+    // A turn we just submitted is not yet running as far as the backend is
+    // concerned, so the snapshot honestly reports it idle — but the local
+    // stream is already waiting on its first token, and it is the newer
+    // information. The stream path refuses to clear busy in exactly this window
+    // (`awaitingResponse && !sawAssistantPayload`); without the same refusal
+    // here a poll lands between submit and first token and darkens the row.
+    const busy = working || Boolean(existing?.awaitingResponse && !existing.sawAssistantPayload)
+
     // Avoid re-arming the watchdog on every poll. Publish only when the
     // authoritative live snapshot differs from the renderer mirror; normal
     // gateway events continue to own subsequent transitions.
     if (
       !existing ||
       existing.storedSessionId !== storedSessionId ||
-      existing.busy !== working ||
+      existing.busy !== busy ||
       existing.needsInput !== needsInput
     ) {
       publishSessionState(runtimeSessionId, {
         ...(existing ?? createClientSessionState(storedSessionId)),
-        busy: working,
+        busy,
         needsInput,
         storedSessionId
       })

--- a/apps/desktop/src/app/session-switcher.tsx
+++ b/apps/desktop/src/app/session-switcher.tsx
@@ -5,10 +5,9 @@ import { useNavigate } from 'react-router'
 
 import { sessionTitle } from '@/lib/chat-runtime'
 import { cn } from '@/lib/utils'
-import { $unreadFinishedSessionIds } from '@/store/session'
-import { $attentionSessionIds, $workingSessionIds } from '@/store/session-states'
 import { $switcherIndex, $switcherOpen, $switcherSessions, closeSwitcher } from '@/store/session-switcher'
 
+import { SessionStatusDot } from './chat/session-status-dot'
 import { HUD_ITEM, HUD_POSITION, HUD_SURFACE, HUD_TEXT } from './floating-hud'
 import { openSession } from './open-session'
 
@@ -18,9 +17,6 @@ export function SessionSwitcher() {
   const open = useStore($switcherOpen)
   const sessions = useStore($switcherSessions)
   const index = useStore($switcherIndex)
-  const working = useStore($workingSessionIds)
-  const attention = useStore($attentionSessionIds)
-  const unread = useStore($unreadFinishedSessionIds)
   const navigate = useNavigate()
 
   const activeRef = useRef<HTMLDivElement>(null)
@@ -32,10 +28,6 @@ export function SessionSwitcher() {
   if (!open || sessions.length === 0) {
     return null
   }
-
-  const workingIds = new Set(working)
-  const attentionIds = new Set(attention)
-  const unreadIds = new Set(unread)
 
   const pick = (sessionId: string) => {
     closeSwitcher()
@@ -77,11 +69,7 @@ export function SessionSwitcher() {
               }}
               ref={selected ? activeRef : undefined}
             >
-              <SwitcherDot
-                attention={attentionIds.has(session.id)}
-                unread={unreadIds.has(session.id)}
-                working={workingIds.has(session.id)}
-              />
+              <SessionStatusDot className="shrink-0" session={session} storedSessionId={session.id} />
               <span className="min-w-0 flex-1 truncate">{sessionTitle(session)}</span>
               {i < 9 && (
                 <span
@@ -99,22 +87,5 @@ export function SessionSwitcher() {
       </div>
     </>,
     document.body
-  )
-}
-
-function SwitcherDot({ attention, working, unread }: { attention: boolean; working: boolean; unread: boolean }) {
-  return (
-    <span
-      className={cn(
-        'size-1 shrink-0 rounded-full',
-        attention
-          ? 'bg-amber-400'
-          : working
-            ? 'animate-pulse bg-(--ui-accent)'
-            : unread
-              ? 'bg-emerald-500'
-              : 'bg-(--ui-text-quaternary)/50'
-      )}
-    />
   )
 }

--- a/apps/desktop/src/lib/stable-array.ts
+++ b/apps/desktop/src/lib/stable-array.ts
@@ -5,3 +5,13 @@
  *  would corrupt the cache — fail loud instead. */
 export const stableArray = <T>(prev: readonly T[], next: T[]): readonly T[] =>
   prev.length === next.length && prev.every((v, i) => v === next[i]) ? prev : Object.freeze(next)
+
+/** {@link stableArray} for a keyed projection. */
+export const stableRecord = <T>(
+  prev: Readonly<Record<string, T>>,
+  next: Record<string, T>
+): Readonly<Record<string, T>> => {
+  const keys = Object.keys(next)
+
+  return keys.length === Object.keys(prev).length && keys.every(k => prev[k] === next[k]) ? prev : Object.freeze(next)
+}

--- a/apps/desktop/src/store/composer-status.ts
+++ b/apps/desktop/src/store/composer-status.ts
@@ -8,6 +8,7 @@ import { $gateway } from './gateway'
 import { $goalsBySession, type GoalStatus } from './goals'
 import { dispatchNativeNotification } from './native-notifications'
 import { notifyError } from './notifications'
+import { $sessions, lineageAliases } from './session'
 import { $sessionStates } from './session-states'
 import { $subagentsBySession, type SubagentProgress } from './subagents'
 import { $todosBySession } from './todos'
@@ -41,32 +42,38 @@ export interface ComposerStatusItem {
 export const $backgroundStatusBySession = atom<Record<string, ComposerStatusItem[]>>({})
 
 // Stored session ids that have at least one RUNNING background process. The
-// sidebar row reads this for a pulsing gray dot — distinct from the accent
-// pulse of an active LLM turn — so the user can tell at a glance "this session
-// has something chugging along in the background" even when the turn is idle.
+// sidebar row reads this for a hollow dot — distinct from the filled dot of an
+// active LLM turn — so the user can tell at a glance "this session has
+// something chugging along in the background" even when the turn is idle.
 //
 // $backgroundStatusBySession is keyed by RUNTIME session id (gateway events
 // and process.list both speak that); the sidebar row knows only the STORED id.
-// $sessionStates bridges the two: runtime id → state.storedSessionId.
+// $sessionStates bridges the two: runtime id → state.storedSessionId, then
+// lineageAliases covers whichever tip of that conversation a surface holds.
 // Perf: recomputes on every $sessionStates change (message deltas, tens/sec),
 // but the background-running set rarely moves. `stableArray` keeps the prior
 // reference when unchanged so rows reading this don't re-render per token.
 let backgroundRunningIds: readonly string[] = []
-export const $backgroundRunningSessionIds = computed([$backgroundStatusBySession, $sessionStates], (bg, states) => {
-  const ids = new Set<string>()
+export const $backgroundRunningSessionIds = computed(
+  [$backgroundStatusBySession, $sessionStates, $sessions],
+  (bg, states, sessions) => {
+    const ids = new Set<string>()
 
-  for (const [runtimeId, items] of Object.entries(bg)) {
-    if (items.some(i => i.state === 'running')) {
-      const storedId = states[runtimeId]?.storedSessionId
+    for (const [runtimeId, items] of Object.entries(bg)) {
+      if (!items.some(i => i.state === 'running')) {
+        continue
+      }
 
-      if (storedId) {
-        ids.add(storedId)
+      // Same fresh-chat fallback as the working/attention projections: before a
+      // conversation is persisted its runtime id is the id surfaces key on.
+      for (const alias of lineageAliases(states[runtimeId]?.storedSessionId ?? runtimeId, sessions)) {
+        ids.add(alias)
       }
     }
-  }
 
-  return (backgroundRunningIds = stableArray(backgroundRunningIds, [...ids]))
-})
+    return (backgroundRunningIds = stableArray(backgroundRunningIds, [...ids]))
+  }
+)
 
 // Rows the user X-ed away. The registry keeps finished processes around for a
 // while, so without this every refresh would resurrect a dismissed row.

--- a/apps/desktop/src/store/session-dot-state.ts
+++ b/apps/desktop/src/store/session-dot-state.ts
@@ -1,0 +1,75 @@
+/**
+ * SESSION DOT STATE — one map from session id to the single status a surface
+ * should paint, so the sidebar, the pane tabs, and the switcher can never
+ * disagree about what a session is doing.
+ *
+ * It exists for two reasons the individual membership atoms cannot cover:
+ *
+ * 1. PRIORITY IN ONE PLACE. The signals overlap — a session can be working AND
+ *    unread AND running a background job — and resolving that per call site is
+ *    how surfaces drift apart.
+ * 2. LINEAGE. Compression rotates a conversation's stored id, so a sidebar row,
+ *    a persisted tile, and the route can each hold a different tip of one
+ *    lineage. Every state is claimed under every alias (see `lineageAliases`),
+ *    so a surface gets the right answer whichever tip it happens to hold.
+ *
+ * The inputs are all reference-stable across stream deltas, so this recomputes
+ * on status edges rather than per token.
+ */
+
+import { computed } from 'nanostores'
+
+import { stableRecord } from '@/lib/stable-array'
+
+import { $backgroundRunningSessionIds } from './composer-status'
+import { $sessions, $unreadFinishedSessionIds, lineageAliases } from './session'
+import { $attentionSessionIds, $stalledSessionIds, $workingSessionIds } from './session-states'
+
+export type SessionDotState = 'background' | 'idle' | 'needs-input' | 'stalled' | 'unread' | 'working'
+
+let dotStates: Readonly<Record<string, SessionDotState>> = {}
+
+export const $sessionDotStateById = computed(
+  [
+    $attentionSessionIds,
+    $workingSessionIds,
+    $stalledSessionIds,
+    $backgroundRunningSessionIds,
+    $unreadFinishedSessionIds,
+    $sessions
+  ],
+  (attention, working, stalled, background, unread, sessions) => {
+    const next: Record<string, SessionDotState> = {}
+
+    const claim = (ids: readonly string[], state: SessionDotState) => {
+      for (const id of ids) {
+        for (const alias of lineageAliases(id, sessions)) {
+          next[alias] = state
+        }
+      }
+    }
+
+    // Weakest claim first — each pass overwrites the one above it, so the order
+    // below IS the priority order. A blocking prompt outranks everything: it is
+    // the only state that needs the user.
+    claim(unread, 'unread')
+    claim(background, 'background')
+    claim(working, 'working')
+
+    // Stalled REFINES working rather than rivalling it — the turn is still
+    // authoritatively running, it has just gone quiet — so it only downgrades a
+    // session already claimed as working. The hint outlives its turn by a tick
+    // on some paths; without this it could invent a running session.
+    for (const id of stalled) {
+      for (const alias of lineageAliases(id, sessions)) {
+        if (next[alias] === 'working') {
+          next[alias] = 'stalled'
+        }
+      }
+    }
+
+    claim(attention, 'needs-input')
+
+    return (dotStates = stableRecord(dotStates, next))
+  }
+)

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -30,12 +30,15 @@ import {
 } from '@/components/pane-shell/tree/store'
 import { stableArray } from '@/lib/stable-array'
 import { readJson, writeJson } from '@/lib/storage'
+import type { SessionInfo } from '@/types/hermes'
 
 import { $activeGatewayProfile, normalizeProfileKey } from './profile'
 import {
   $activeSessionId,
   $selectedStoredSessionId,
+  $sessions,
   $unreadFinishedSessionIds,
+  lineageAliases,
   setActiveSessionStoredIdRotation
 } from './session'
 import { isSecondaryWindow } from './windows'
@@ -67,8 +70,13 @@ export function setSessionStalled(storedSessionId: string | null | undefined, st
   }
 }
 
-// --- Watchdog: marks busy sessions quiet after 8 min of stream silence -----
-export const SESSION_WATCHDOG_TIMEOUT_MS = 8 * 60 * 1000
+// --- Watchdog: marks busy sessions quiet after a long stream silence -------
+// Tuned against what this app actually does rather than a round number: a
+// typecheck or a full test run here goes quiet for minutes at a stretch and is
+// perfectly healthy, so anything under ~4 min would paint normal work as
+// suspect. Eight minutes was the other failure — longer than a user is willing
+// to sit and wonder, so the hint arrived after they had already given up on it.
+export const SESSION_WATCHDOG_TIMEOUT_MS = 5 * 60 * 1000
 const sessionWatchdogTimers = new Map<string, ReturnType<typeof setTimeout>>()
 
 function armWatchdog(runtimeId: string) {
@@ -249,28 +257,54 @@ export function clearAllSessionStates() {
 // a turn), but these sets only change on busy/needsInput edges. `stableArray`
 // keeps the prior reference when membership is unchanged so `computed` skips the
 // emit — otherwise the whole sidebar + every row re-renders per token.
-const storedIds = (states: Record<string, ClientSessionState>, pred: (s: ClientSessionState) => boolean) =>
-  Object.values(states)
-    .filter(s => pred(s) && s.storedSessionId)
-    .map(s => s.storedSessionId!)
+// Published under every id the conversation answers to, not just its current
+// tip: consumers hold whichever id they were created with, and compression
+// rotates the tip out from under them (see lineageAliases).
+//
+// A conversation that has not been persisted yet has no stored id at all, and
+// dropping it here is what left the FIRST turn of a new chat with no running
+// indicator anywhere — no dot, no row arc — for as long as it took the backend
+// to hand one back. Its runtime id is the right fallback because until a stored
+// id exists the two are the same value (submit.ts: "an unpersisted
+// conversation's queue key IS its runtime id"), so the row matches; once a
+// session is persisted its runtime id is nobody's key and the fallback is inert.
+const storedIds = (
+  states: Record<string, ClientSessionState>,
+  sessions: readonly SessionInfo[],
+  pred: (s: ClientSessionState) => boolean
+) => {
+  const ids = new Set<string>()
+
+  for (const [runtimeId, state] of Object.entries(states)) {
+    if (!pred(state)) {
+      continue
+    }
+
+    for (const alias of lineageAliases(state.storedSessionId ?? runtimeId, sessions)) {
+      ids.add(alias)
+    }
+  }
+
+  return [...ids]
+}
 
 let workingIds: readonly string[] = []
 export const $workingSessionIds = computed(
-  $sessionStates,
-  states =>
+  [$sessionStates, $sessions],
+  (states, sessions) =>
     (workingIds = stableArray(
       workingIds,
-      storedIds(states, s => s.busy)
+      storedIds(states, sessions, s => s.busy)
     ))
 )
 
 let attentionIds: readonly string[] = []
 export const $attentionSessionIds = computed(
-  $sessionStates,
-  states =>
+  [$sessionStates, $sessions],
+  (states, sessions) =>
     (attentionIds = stableArray(
       attentionIds,
-      storedIds(states, s => s.needsInput)
+      storedIds(states, sessions, s => s.needsInput)
     ))
 )
 

--- a/apps/desktop/src/store/session-watchdog.test.ts
+++ b/apps/desktop/src/store/session-watchdog.test.ts
@@ -10,10 +10,13 @@ import {
   $workingSessionIds,
   clearAllSessionStates,
   getRecentlySettledSessionIds,
-  publishSessionState
+  publishSessionState,
+  SESSION_WATCHDOG_TIMEOUT_MS
 } from './session-states'
 
-const WATCHDOG_MS = 8 * 60 * 1000
+// Read from the store rather than restated here: these assert what happens on
+// either side of the threshold, not what the threshold is.
+const WATCHDOG_MS = SESSION_WATCHDOG_TIMEOUT_MS
 
 function state(over: Partial<ClientSessionState> = {}): ClientSessionState {
   return { ...createClientSessionState(null), storedSessionId: 's1', ...over }
@@ -213,12 +216,14 @@ describe('computed $workingSessionIds', () => {
     expect($workingSessionIds.get()).toEqual([])
   })
 
-  it('reflects sessions with busy=true and a storedSessionId', () => {
+  it('reflects busy sessions under the id their surfaces key on', () => {
     publishSessionState('rt1', state({ busy: true, storedSessionId: 's1' }))
     publishSessionState('rt2', state({ busy: false, storedSessionId: 's2' }))
+    // Not yet persisted, so the runtime id is the only id it has — and the one
+    // the row is keyed by until the backend hands a stored id back.
     publishSessionState('rt3', state({ busy: true, storedSessionId: null }))
 
-    expect($workingSessionIds.get()).toEqual(['s1'])
+    expect($workingSessionIds.get()).toEqual(['s1', 'rt3'])
   })
 
   it('updates when session state changes', () => {

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -81,9 +81,12 @@ describe('computed $attentionSessionIds', () => {
     expect($attentionSessionIds.get()).toEqual([])
   })
 
-  it('ignores sessions without a storedSessionId', () => {
+  // A chat that hasn't been persisted yet has no stored id, and until it gets
+  // one the surfaces key on its runtime id — so publishing under that is what
+  // lets a clarify prompt on the very first turn reach the row.
+  it('falls back to the runtime id for a session with no storedSessionId', () => {
     publishSessionState('rt1', { ...createClientSessionState(null), needsInput: true })
-    expect($attentionSessionIds.get()).toEqual([])
+    expect($attentionSessionIds.get()).toEqual(['rt1'])
   })
 })
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -254,6 +254,35 @@ export const sessionMatchesStoredId = (
   storedSessionId: string
 ): boolean => session.id === storedSessionId || session._lineage_root_id === storedSessionId
 
+/** Every id one conversation answers to: the id we were handed, plus the live
+ *  id and lineage root of each session it resolves to.
+ *
+ *  Status sets are published under a session's CURRENT stored id, but a sidebar
+ *  row, a persisted tile, and the route can each hold a different tip of the
+ *  same lineage after a compression. Publishing every alias lets those surfaces
+ *  keep using a plain membership test instead of each re-deriving lineage —
+ *  and getting it wrong, which reads as a running session going idle mid-turn. */
+export function lineageAliases(
+  storedId: string,
+  sessions: readonly Pick<SessionInfo, '_lineage_root_id' | 'id'>[]
+): string[] {
+  const aliases = new Set([storedId])
+
+  for (const session of sessions) {
+    if (!sessionMatchesStoredId(session, storedId)) {
+      continue
+    }
+
+    aliases.add(session.id)
+
+    if (session._lineage_root_id) {
+      aliases.add(session._lineage_root_id)
+    }
+  }
+
+  return [...aliases]
+}
+
 /** True when two ids name the same conversation across compression tip rotation. */
 export function idsShareLineage(
   a: string,

--- a/apps/desktop/src/store/working-ids-stored-id.test.ts
+++ b/apps/desktop/src/store/working-ids-stored-id.test.ts
@@ -4,24 +4,20 @@ import { createClientSessionState } from '@/lib/chat-runtime'
 import { $workingSessionIds, clearAllSessionStates, publishSessionState } from '@/store/session-states'
 
 /**
- * (C) The sidebar spinner reads `$workingSessionIds`, which projects
- * `$sessionStates` down to STORED session ids and drops any entry whose
- * `storedSessionId` is null. `message.start` flips `busy` without carrying a
- * stored id, so a runtime that was never seeded with one goes busy invisibly:
- * the backend works, the thread name stays bare.
+ * The sidebar spinner and the row arc read `$workingSessionIds`, which projects
+ * `$sessionStates` down to the ids surfaces actually key on. `message.start`
+ * flips `busy` without carrying a stored id, so an unpersisted chat has none
+ * yet — and until it does, its runtime id is that id.
  */
 describe('$workingSessionIds — a busy runtime with no stored id', () => {
   afterEach(() => {
     clearAllSessionStates()
   })
 
-  it('cannot show a spinner for a busy runtime that has no stored id', () => {
+  it('shows a new chat as running under its runtime id before it is persisted', () => {
     publishSessionState('runtime-unmapped', { ...createClientSessionState(null), busy: true })
 
-    // Documents the constraint rather than asserting the bug is fine: the
-    // projection is keyed by stored id, so an unmapped runtime is unreachable
-    // from the sidebar no matter how busy it is.
-    expect($workingSessionIds.get()).toEqual([])
+    expect($workingSessionIds.get()).toEqual(['runtime-unmapped'])
   })
 
   it('shows the spinner as soon as the stored id is known', () => {

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -847,24 +847,6 @@
   --arc-c1: var(--dt-foreground);
 }
 
-/* Quest-style "needs you" pulse for a clarify-blocked session's dot —
-   a soft amber glow that breathes so the row draws the eye without a toast. */
-@keyframes quest-glow {
-  0%,
-  100% {
-    transform: scale(1);
-    box-shadow:
-      0 0 0.1875rem color-mix(in srgb, var(--color-amber-500, #f59e0b) 70%, transparent),
-      0 0 0.5rem color-mix(in srgb, var(--color-amber-500, #f59e0b) 45%, transparent);
-  }
-  50% {
-    transform: scale(1.18);
-    box-shadow:
-      0 0 0.3125rem color-mix(in srgb, var(--color-amber-500, #f59e0b) 90%, transparent),
-      0 0 0.875rem color-mix(in srgb, var(--color-amber-500, #f59e0b) 65%, transparent);
-  }
-}
-
 /* Landed `memory` tool row — gold → purple on the brain glyph + title.
    Pair with `text-transparent` so the scaffold label color can't win. */
 .tool-memory-legendary-title {
@@ -886,19 +868,6 @@
 
 .tool-memory-legendary-meta {
   color: var(--tool-memory-legendary-meta);
-}
-
-.quest-glow {
-  animation: quest-glow 1.8s ease-in-out infinite;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .quest-glow {
-    animation: none;
-    box-shadow:
-      0 0 0.25rem color-mix(in srgb, var(--color-amber-500, #f59e0b) 80%, transparent),
-      0 0 0.625rem color-mix(in srgb, var(--color-amber-500, #f59e0b) 55%, transparent);
-  }
 }
 
 /* Command-palette deep-link: briefly flash the targeted settings row. */


### PR DESCRIPTION
The dot next to a session read as unreliable, and it was: it could sit grey
while the model was working, it was missing entirely for the first turn of a
new chat, and the same session could show a different state in the sidebar
than in the switcher. Underneath that, five overlapping signals were being
ranked separately at each call site, and every one of them matched session ids
with a plain equality check that a compression could invalidate mid-turn.

This gives the dot a single resolver and a visual language small enough to
read at a glance.

**One source of truth.** `$sessionDotStateById` reduces the five status sets
to one answer per session, so the sidebar row, the pane tabs and the Ctrl-Tab
switcher can't disagree. The switcher had its own three-state dot; it renders
the shared one now.

**Lineage-aware membership.** Compression rotates a conversation's stored id
while surfaces keep holding whichever tip they were created with. Each state
is published under every id the conversation answers to, so a running session
stops falling out of the working set and dropping to idle mid-turn.

**A new chat shows up immediately.** An unpersisted conversation has no stored
id, and the projection dropped it, which is why the first turn had no dot and
no row arc until the backend answered. It falls back to the runtime id, which
is the same value the surfaces key on until persistence.

**Three colors, one fill/hollow axis, no motion.** Amber needs you, accent is
running, emerald finished while you were elsewhere; filled means producing and
hollow means open but quiet. Working and stalled had differed by 30% opacity
and were in practice the same dot, and a background job showed a filled grey
that read as finished. The pulsing amber glow is gone — motion on a six-pixel
circle can only repeat what the row's arc already says, at a repaint per frame
on every row at once.

A settled session now paints its project color or nothing at all, instead of a
grey mark with the same visual weight as a real status.

The stalled watchdog fired at eight minutes; it fires at five now, past this
app's own long-but-healthy silences like a typecheck without outlasting the
person waiting on it.

## Test plan

- [ ] Send a message in a brand-new chat: the dot and the row arc appear on the first turn, not after the backend answers.
- [ ] Let a long turn run: the dot stays accent for its whole duration, including across a compression.
- [ ] Trigger a clarify prompt: amber, steady, and the row arc yields to it.
- [ ] Start a `terminal(background=true)` job and let the turn finish: hollow grey while it runs.
- [ ] Open Ctrl-Tab mid-turn: the switcher shows the same state as the sidebar for that session.