### PR TITLE
fix(buzz): classify DMs from authoritative channel metadata

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -962,13 +962,34 @@ class BuzzAdapter(BasePlatformAdapter):
         if code == 0:
             for dm in _parse_json_list(out):
                 dm_id = str(dm.get("dm_id") or "")
-                if not dm_id or dm_id in self._channel_state:
+                if not dm_id:
                     continue
-                if seed:
+                existing_state = self._channel_state.get(dm_id)
+                if existing_state is not None:
+                    existing_state["chat_type"] = "dm"
+                elif seed:
                     await self._seed_channel(dm_id, chat_type="dm")
                 else:
                     self._channel_state[dm_id] = {"chat_type": "dm", "last_ts": 0, "seen": OrderedDict()}
                 self._channel_names.setdefault(dm_id, "DM")
+
+        # `channels list` omits the metadata `t` tag, while current Buzz
+        # relays may also omit recipient p-tags from kind-9 DM messages.  Ask
+        # the richer search projection for exact `t=dm` confirmation so those
+        # conversations can bypass the channel mention gate safely.  Older
+        # CLI builds without `channels search` simply fall back to the existing
+        # p-tag latch below.
+        confirmed_dm_ids: set[str] = set()
+        search_code, search_out, _search_err = await self._run_cli(
+            ["channels", "search", "--query", "DM", "--exact", "--include-archived"]
+        )
+        if search_code == 0:
+            confirmed_dm_ids = {
+                str(item.get("channel_id"))
+                for item in _parse_json_list(search_out)
+                if item.get("channel_id")
+                and str(item.get("channel_type") or "").strip().lower() == "dm"
+            }
 
         code, out, _err = await self._run_cli(["channels", "list"])
         if code != 0:
@@ -979,12 +1000,22 @@ class BuzzAdapter(BasePlatformAdapter):
                 continue
             self._channel_meta[ch_id] = ch
             self._channel_names.setdefault(ch_id, str(ch.get("name") or ch_id))
-            if ch_id in self._channel_state or not self._may_reclassify_as_dm(ch_id):
+            if not self._may_reclassify_as_dm(ch_id):
                 continue
+            existing_state = self._channel_state.get(ch_id)
+            if existing_state is not None:
+                if ch_id in confirmed_dm_ids:
+                    existing_state["chat_type"] = "dm"
+                continue
+            chat_type = "dm" if ch_id in confirmed_dm_ids else "group"
             if seed:
-                await self._seed_channel(ch_id, chat_type="group")
+                await self._seed_channel(ch_id, chat_type=chat_type)
             else:
-                self._channel_state[ch_id] = {"chat_type": "group", "last_ts": 0, "seen": OrderedDict()}
+                self._channel_state[ch_id] = {
+                    "chat_type": chat_type,
+                    "last_ts": 0,
+                    "seen": OrderedDict(),
+                }
 
     async def _poll_channel(self, channel_id: str) -> None:
         state = self._channel_state.get(channel_id)

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -456,6 +456,52 @@ class BuzzAdapter(BasePlatformAdapter):
 
     # ── Connection lifecycle ──────────────────────────────────────────────
 
+    def _merge_channel_metadata(
+        self,
+        channel_id: str,
+        projection: Optional[dict] = None,
+        *,
+        explicit_type: str = "",
+    ) -> str:
+        """Merge a lossy channel projection without forgetting known type.
+
+        Search metadata is authoritative when present. Otherwise a non-empty
+        type in the new projection wins, then the last known explicit non-DM
+        type. Positive DM classification must be refreshed by current evidence;
+        only negative evidence is retained fail-closed across lossy projections.
+        Returns the normalized effective type (or an empty string).
+        """
+        previous = self._channel_meta.get(channel_id) or {}
+        merged = dict(previous)
+        if projection:
+            merged.update(projection)
+        previous_type = str(previous.get("channel_type") or "").strip().lower()
+        projected_type = str((projection or {}).get("channel_type") or "").strip().lower()
+        retained_type = previous_type if previous_type and previous_type != "dm" else ""
+        effective_type = explicit_type.strip().lower() or projected_type or retained_type
+        if effective_type:
+            merged["channel_type"] = effective_type
+        else:
+            merged.pop("channel_type", None)
+        self._channel_meta[channel_id] = merged
+        return effective_type
+
+    def _reconcile_channel_state_type(
+        self,
+        channel_id: str,
+        channel_type: str,
+        *,
+        confirmed_dm: bool,
+    ) -> None:
+        """Apply authoritative type evidence without resetting de-dupe state."""
+        state = self._channel_state.get(channel_id)
+        if state is None:
+            return
+        if confirmed_dm or channel_type == "dm":
+            state["chat_type"] = "dm"
+        elif channel_type:
+            state["chat_type"] = "group"
+
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Verify relay credentials, seed high-water marks, start polling."""
         if not self.relay_url:
@@ -525,7 +571,7 @@ class BuzzAdapter(BasePlatformAdapter):
         }
         for ch in listed:
             if ch.get("channel_id"):
-                self._channel_meta[str(ch["channel_id"])] = ch
+                self._merge_channel_metadata(str(ch["channel_id"]), ch)
         watch = self.channels or list(self._channel_names)
         if not watch:
             logger.error("Buzz: no channels to watch (configure BUZZ_CHANNELS or join a channel)")
@@ -958,12 +1004,14 @@ class BuzzAdapter(BasePlatformAdapter):
         detection (_is_direct_message_event) rather than trusting the name
         alone to unlock the mention-free DM path.
         """
+        confirmed_dm_ids: set[str] = set()
         code, out, _err = await self._run_cli(["dms", "list"])
         if code == 0:
             for dm in _parse_json_list(out):
                 dm_id = str(dm.get("dm_id") or "")
                 if not dm_id:
                     continue
+                confirmed_dm_ids.add(dm_id)
                 existing_state = self._channel_state.get(dm_id)
                 if existing_state is not None:
                     existing_state["chat_type"] = "dm"
@@ -979,17 +1027,33 @@ class BuzzAdapter(BasePlatformAdapter):
         # conversations can bypass the channel mention gate safely.  Older
         # CLI builds without `channels search` simply fall back to the existing
         # p-tag latch below.
-        confirmed_dm_ids: set[str] = set()
+        search_channel_types: dict[str, str] = {}
         search_code, search_out, _search_err = await self._run_cli(
             ["channels", "search", "--query", "DM", "--exact", "--include-archived"]
         )
         if search_code == 0:
-            confirmed_dm_ids = {
-                str(item.get("channel_id"))
-                for item in _parse_json_list(search_out)
-                if item.get("channel_id")
-                and str(item.get("channel_type") or "").strip().lower() == "dm"
-            }
+            for item in _parse_json_list(search_out):
+                ch_id = str(item.get("channel_id") or "")
+                channel_type = str(item.get("channel_type") or "").strip().lower()
+                if ch_id and channel_type:
+                    search_channel_types[ch_id] = channel_type
+        confirmed_dm_ids.update(
+            ch_id for ch_id, channel_type in search_channel_types.items()
+            if channel_type == "dm"
+        )
+
+        # Apply fresh search evidence immediately.  Reconciliation must not
+        # depend on the poorer channels-list projection succeeding or even
+        # containing the same conversation.
+        for ch_id, channel_type in search_channel_types.items():
+            effective_type = self._merge_channel_metadata(
+                ch_id, explicit_type=channel_type,
+            )
+            self._reconcile_channel_state_type(
+                ch_id,
+                effective_type,
+                confirmed_dm=ch_id in confirmed_dm_ids,
+            )
 
         code, out, _err = await self._run_cli(["channels", "list"])
         if code != 0:
@@ -998,14 +1062,21 @@ class BuzzAdapter(BasePlatformAdapter):
             ch_id = str(ch.get("channel_id") or "")
             if not ch_id:
                 continue
-            self._channel_meta[ch_id] = ch
+            effective_type = self._merge_channel_metadata(
+                ch_id,
+                ch,
+                explicit_type=search_channel_types.get(ch_id, ""),
+            )
             self._channel_names.setdefault(ch_id, str(ch.get("name") or ch_id))
+            existing_state = self._channel_state.get(ch_id)
+            self._reconcile_channel_state_type(
+                ch_id,
+                effective_type,
+                confirmed_dm=ch_id in confirmed_dm_ids,
+            )
             if not self._may_reclassify_as_dm(ch_id):
                 continue
-            existing_state = self._channel_state.get(ch_id)
             if existing_state is not None:
-                if ch_id in confirmed_dm_ids:
-                    existing_state["chat_type"] = "dm"
                 continue
             chat_type = "dm" if ch_id in confirmed_dm_ids else "group"
             if seed:
@@ -1126,6 +1197,9 @@ class BuzzAdapter(BasePlatformAdapter):
         meta = self._channel_meta.get(channel_id)
         if meta is None:
             return channel_id not in self.channels
+        channel_type = str(meta.get("channel_type") or "").strip().lower()
+        if channel_type:
+            return channel_type == "dm"
         name = str(meta.get("name") or "").strip()
         description = str(meta.get("description") or "").strip()
         return name == "DM" and not description

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -380,6 +380,77 @@ class TestDmClassification:
         assert CHANNEL not in a._channel_state
         assert a._may_reclassify_as_dm(CHANNEL) is False
 
+    @pytest.mark.asyncio
+    async def test_channel_type_metadata_confirms_dm_without_message_ptags(self):
+        """Current Buzz relay messages carry only h-tags in DMs, so the
+        adapter must use the metadata t=dm marker exposed by channels search
+        when dms list is empty."""
+        a = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("dms", "list", [])
+        cli.script("channels", "list", [
+            {"channel_id": DM_CHANNEL, "name": "DM", "description": "", "created_at": 1},
+        ])
+        cli.script("channels", "search", [
+            {"channel_id": DM_CHANNEL, "name": "DM", "channel_type": "dm"},
+        ])
+        a._run_cli = cli
+
+        await a._discover_dms(seed=False)
+
+        assert a._channel_state[DM_CHANNEL]["chat_type"] == "dm"
+
+    @pytest.mark.asyncio
+    async def test_channel_type_metadata_upgrades_preseeded_group_to_dm(self):
+        """Startup seeds listed channels as groups before DM discovery; exact
+        t=dm metadata must upgrade that state without losing its high-water mark."""
+        a = _make_adapter()
+        seen = {"seed-event": None}
+        a._channel_state[DM_CHANNEL] = {
+            "chat_type": "group",
+            "last_ts": 42,
+            "seen": seen,
+        }
+        cli = _ScriptedCli()
+        cli.script("dms", "list", [])
+        cli.script("channels", "list", [
+            {"channel_id": DM_CHANNEL, "name": "DM", "description": "", "created_at": 1},
+        ])
+        cli.script("channels", "search", [
+            {"channel_id": DM_CHANNEL, "name": "DM", "channel_type": "dm"},
+        ])
+        a._run_cli = cli
+
+        await a._discover_dms(seed=True)
+
+        assert a._channel_state[DM_CHANNEL] == {
+            "chat_type": "dm",
+            "last_ts": 42,
+            "seen": seen,
+        }
+
+    @pytest.mark.asyncio
+    async def test_dms_list_upgrades_preseeded_group_when_search_is_unsupported(self):
+        """An older CLI may support dms list but not channels search; the
+        authoritative DM list must still upgrade startup's preseeded state."""
+        a = _make_adapter()
+        a._channel_state[DM_CHANNEL] = {
+            "chat_type": "group",
+            "last_ts": 42,
+            "seen": {},
+        }
+        cli = _ScriptedCli()
+        cli.script("dms", "list", [{"dm_id": DM_CHANNEL, "participants": [SELF_PUBKEY]}])
+        cli.script("channels", "search", "", code=2, stderr="unsupported command")
+        cli.script("channels", "list", [
+            {"channel_id": DM_CHANNEL, "name": "DM", "description": "", "created_at": 1},
+        ])
+        a._run_cli = cli
+
+        await a._discover_dms(seed=True)
+
+        assert a._channel_state[DM_CHANNEL]["chat_type"] == "dm"
+
 
 # ── Sending ───────────────────────────────────────────────────────────────
 

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -430,6 +430,212 @@ class TestDmClassification:
         }
 
     @pytest.mark.asyncio
+    async def test_non_dm_channel_type_keeps_dm_shaped_channel_mention_gated(
+        self, adapter,
+    ):
+        """Authoritative search metadata must override a misleading DM-like
+        name/description and prevent the p-tag fallback from unlocking an
+        ordinary channel's mention gate."""
+        a = adapter
+        cli = _ScriptedCli()
+        cli.script("dms", "list", [])
+        cli.script("channels", "list", [
+            {"channel_id": CHANNEL, "name": "DM", "description": "", "created_at": 1},
+        ])
+        cli.script("channels", "search", [
+            {"channel_id": CHANNEL, "name": "DM", "channel_type": "channel"},
+        ])
+        a._run_cli = cli
+
+        await a._discover_dms(seed=False)
+        assert a._channel_state[CHANNEL]["chat_type"] == "group"
+
+        cli.responses.clear()
+        cli.script("messages", "get", [
+            _tagged_event(
+                "e1", CHANNEL, content="ordinary channel broadcast", p=SELF_PUBKEY,
+            ),
+        ])
+        await a._poll_channel(CHANNEL)
+
+        assert a._channel_state[CHANNEL]["chat_type"] == "group"
+        assert a._dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_non_dm_channel_type_reconciles_configured_channel_seed_latch(
+        self, adapter,
+    ):
+        """Search metadata arrives after startup seeding, so an explicit
+        non-DM type must undo a history-based latch without losing de-dupe
+        state for a configured channel."""
+        a = adapter
+        a.channels = [CHANNEL]
+        a._channel_meta[CHANNEL] = {
+            "channel_id": CHANNEL,
+            "name": "DM",
+            "description": "",
+        }
+        cli = _ScriptedCli()
+        cli.script("messages", "get", [
+            _tagged_event(
+                "seed-e1", CHANNEL, content="seeded broadcast", p=SELF_PUBKEY,
+            ),
+        ])
+        a._run_cli = cli
+
+        await a._seed_channel(CHANNEL, chat_type="group")
+        state = a._channel_state[CHANNEL]
+        assert state["chat_type"] == "dm"
+        seen = state["seen"]
+
+        cli.script("dms", "list", [])
+        cli.script("channels", "search", [
+            {"channel_id": CHANNEL, "name": "DM", "channel_type": "channel"},
+        ])
+        cli.script("channels", "list", [
+            {"channel_id": CHANNEL, "name": "DM", "description": "", "created_at": 1},
+        ])
+        await a._discover_dms(seed=True)
+
+        assert a._channel_state[CHANNEL] == {
+            "chat_type": "group",
+            "last_ts": 1000,
+            "seen": seen,
+        }
+        assert list(seen) == ["seed-e1"]
+        assert a._may_reclassify_as_dm(CHANNEL) is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("later_search", ["unsupported", "missing_type"])
+    async def test_non_dm_channel_type_survives_partial_rediscovery(
+        self, adapter, later_search,
+    ):
+        """A transient/partial search result must not erase a previously
+        authoritative non-DM type and reopen the p-tag fallback."""
+        a = adapter
+        cli = _ScriptedCli()
+        cli.script("dms", "list", [])
+        cli.script("dms", "list", [])
+        cli.script("channels", "search", [
+            {"channel_id": CHANNEL, "name": "DM", "channel_type": "channel"},
+        ])
+        if later_search == "unsupported":
+            cli.script("channels", "search", "", code=2, stderr="unsupported command")
+        else:
+            cli.script("channels", "search", [
+                {"channel_id": CHANNEL, "name": "DM"},
+            ])
+        channel_listing = [
+            {"channel_id": CHANNEL, "name": "DM", "description": "", "created_at": 1},
+        ]
+        cli.script("channels", "list", channel_listing)
+        cli.script("channels", "list", channel_listing)
+        a._run_cli = cli
+
+        await a._discover_dms(seed=False)
+        await a._discover_dms(seed=False)
+
+        assert a._channel_meta[CHANNEL]["channel_type"] == "channel"
+        assert a._may_reclassify_as_dm(CHANNEL) is False
+
+        cli.script("messages", "get", [
+            _tagged_event(
+                "e1", CHANNEL, content="ordinary channel broadcast", p=SELF_PUBKEY,
+            ),
+        ])
+        await a._poll_channel(CHANNEL)
+
+        assert a._channel_state[CHANNEL]["chat_type"] == "group"
+        assert a._dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_reconnect_preserves_non_dm_type_before_history_seed(self, monkeypatch):
+        """The poorer connect-time list projection must not erase a type
+        learned by an earlier connection before history is seeded."""
+        import gateway.status as gateway_status
+
+        monkeypatch.setattr(gateway_status, "acquire_scoped_lock", lambda *_args: True)
+        monkeypatch.setattr(gateway_status, "release_scoped_lock", lambda *_args: None)
+        monkeypatch.setattr(_buzz_mod, "_resolve_private_key", lambda *_args: "nsec1test")
+        a = _make_adapter({
+            "channels": [CHANNEL],
+            "transport": "poll",
+            "poll_interval": 999,
+            "private_key": "nsec1test",
+        })
+        a.cli_path = "buzz"
+        a._channel_meta[CHANNEL] = {
+            "channel_id": CHANNEL,
+            "name": "DM",
+            "description": "",
+            "channel_type": "channel",
+        }
+        cli = _ScriptedCli()
+        cli.script("users", "get", [
+            {"pubkey": SELF_PUBKEY, "display_name": "Chip"},
+        ])
+        listing = [
+            {"channel_id": CHANNEL, "name": "DM", "description": "", "created_at": 1},
+        ]
+        cli.script("channels", "list", listing)
+        cli.script("channels", "list", listing)
+        cli.script("messages", "get", [
+            _tagged_event(
+                "seed-e1", CHANNEL, content="seeded broadcast", p=SELF_PUBKEY,
+            ),
+        ])
+        cli.script("dms", "list", [])
+        cli.script("channels", "search", "", code=2, stderr="unsupported command")
+        a._run_cli = cli
+
+        try:
+            assert await a.connect(is_reconnect=True) is True
+            assert a._channel_meta[CHANNEL]["channel_type"] == "channel"
+            assert a._channel_state[CHANNEL]["chat_type"] == "group"
+            assert a._may_reclassify_as_dm(CHANNEL) is False
+        finally:
+            await a.disconnect()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("list_result", ["failure", "omitted"])
+    async def test_fresh_non_dm_search_reconciles_without_list_projection(
+        self, adapter, list_result,
+    ):
+        """Fresh search evidence must close the mention bypass even when the
+        following channels-list projection fails or omits the conversation."""
+        a = adapter
+        seen = a._channel_state[CHANNEL]["seen"]
+        a._channel_state[CHANNEL].update({
+            "chat_type": "dm",
+            "last_ts": 42,
+        })
+        a._channel_meta[CHANNEL] = {
+            "channel_id": CHANNEL,
+            "name": "DM",
+            "description": "",
+        }
+        cli = _ScriptedCli()
+        cli.script("dms", "list", [])
+        cli.script("channels", "search", [
+            {"channel_id": CHANNEL, "name": "DM", "channel_type": "channel"},
+        ])
+        if list_result == "failure":
+            cli.script("channels", "list", "", code=2, stderr="temporary failure")
+        else:
+            cli.script("channels", "list", [])
+        a._run_cli = cli
+
+        await a._discover_dms(seed=False)
+
+        assert a._channel_meta[CHANNEL]["channel_type"] == "channel"
+        assert a._channel_state[CHANNEL] == {
+            "chat_type": "group",
+            "last_ts": 42,
+            "seen": seen,
+        }
+        assert a._may_reclassify_as_dm(CHANNEL) is False
+
+    @pytest.mark.asyncio
     async def test_dms_list_upgrades_preseeded_group_when_search_is_unsupported(self):
         """An older CLI may support dms list but not channels search; the
         authoritative DM list must still upgrade startup's preseeded state."""
@@ -442,6 +648,38 @@ class TestDmClassification:
         cli = _ScriptedCli()
         cli.script("dms", "list", [{"dm_id": DM_CHANNEL, "participants": [SELF_PUBKEY]}])
         cli.script("channels", "search", "", code=2, stderr="unsupported command")
+        cli.script("channels", "list", [
+            {"channel_id": DM_CHANNEL, "name": "DM", "description": "", "created_at": 1},
+        ])
+        a._run_cli = cli
+
+        await a._discover_dms(seed=True)
+
+        assert a._channel_state[DM_CHANNEL]["chat_type"] == "dm"
+
+    @pytest.mark.asyncio
+    async def test_current_dms_list_confirmation_wins_over_non_dm_search_type(self):
+        """A current authoritative DM-list result must not be downgraded by
+        contradictory channel-search metadata in the same discovery pass."""
+        a = _make_adapter()
+        a._channel_state[DM_CHANNEL] = {
+            "chat_type": "group",
+            "last_ts": 42,
+            "seen": {},
+        }
+        a._channel_meta[DM_CHANNEL] = {
+            "channel_id": DM_CHANNEL,
+            "name": "DM",
+            "description": "",
+            "channel_type": "channel",
+        }
+        cli = _ScriptedCli()
+        cli.script("dms", "list", [
+            {"dm_id": DM_CHANNEL, "participants": [SELF_PUBKEY]},
+        ])
+        cli.script("channels", "search", [
+            {"channel_id": DM_CHANNEL, "name": "DM", "channel_type": "channel"},
+        ])
         cli.script("channels", "list", [
             {"channel_id": DM_CHANNEL, "name": "DM", "description": "", "created_at": 1},
         ])


### PR DESCRIPTION
## Summary

Fix Buzz direct-message classification when `buzz dms list` is empty and inbound kind-9 DM events contain no recipient `p` tag.

The adapter now uses the richer `channels search` projection as an authoritative fallback: only an exact normalized `channel_type == "dm"` can upgrade a listed conversation from `group` to `dm`. Existing high-water and de-duplication state is preserved during the upgrade.

## Root cause

On Buzz v0.5.7, the affected conversation had this shape:

- `dms list` returned `[]`;
- `channels list` exposed the conversation as `name="DM"` with an empty description but omitted type metadata;
- `channels search --query DM --exact` returned `channel_type="dm"`;
- inbound kind-9 DM events contained an `h` channel tag but no recipient `p` tag.

Hermes therefore preseeded the conversation as a group and left it behind the group mention gate, silently ignoring ordinary mention-free DMs.

## Change

- Query `channels search --query DM --exact --include-archived` during DM discovery.
- Accept only valid search results whose normalized `channel_type` is exactly `dm`.
- Intersect that confirmation with channels already accepted by the existing DM-shaped metadata guard.
- Upgrade startup-preseeded group state in place, preserving `last_ts`, `seen`, and other state.
- Preserve `dms list` as the authoritative path for older CLI versions; an unsupported search command fails conservatively.
- Continue rejecting display-name-only inference: `name="DM"` is not sufficient to bypass mention gating.

## Security boundary

This intentionally differs from #78041: the display name and empty description remain only a shape guard, not positive DM authority. Mention-free dispatch is unlocked only by exact `channel_type="dm"`, authoritative `dms list` membership, or the pre-existing guarded message-tag latch.

## Verification

On current `origin/main` (`81413f00772d7b096377841242a4e978e5ed77fd`):

```text
scripts/run_tests.sh -j 2 tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_websocket.py
=== Summary: 2 files, 30 tests passed, 0 failed
```

Additional checks:

- `ruff check plugins/platforms/buzz/adapter.py tests/gateway/test_buzz_adapter.py` — passed
- `git diff --check` — passed
- Independent read-only security/compatibility re-review — PASS
- Isolated local gateway canaries — mention-free owner DM, reconnect, and outsider allowlist-negative all passed
- Relay remained bound to `127.0.0.1:3000`; production/default Hermes and Hearth were unchanged

## Regression coverage

- exact `channel_type=dm` confirms a DM without message `p` tags;
- startup-preseeded group state is upgraded without losing high-water/de-duplication fields;
- `dms list` still upgrades preseeded state when channel search is unsupported.

Related: #77987, #78041
