### PR TITLE
fix(desktop): allow get-windows@9.3.0 install script in allowScripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "agent-browser@0.26.0": true,
     "electron@40.10.2": true,
     "fsevents@2.3.2": true,
-    "fsevents@2.3.3": true
+    "fsevents@2.3.3": true,
+    "get-windows@9.3.0": true
   }
 }


### PR DESCRIPTION
## 原因（Why）

Windows 用户安装/更新 Hermes 时，**desktop 构建阶段**会失败：

```
Error: [stage-native-deps] get-windows has no win32 prebuilt binding under lib/binding; reinstall dependencies on the Windows build host.
```

`get-windows@9.3.0` 是 `apps/desktop` 的**直接依赖**，它的 install 脚本（`node-pre-gyp install --fallback-to-build`）负责下载 Windows 平台预编译绑定。但根目录 `package.json` 的 `allowScripts` 白名单（npm 12 强制执行，由 #75037 引入）里**没有包含它**，导致 `npm ci` 直接跳过该脚本：

```
npm warn install-scripts   get-windows@9.3.0 (install: node-pre-gyp install --fallback-to-build)
```

结果 `node_modules/get-windows/lib/binding/` 下只有 npm 包自带的 darwin 绑定，`apps/desktop/scripts/stage-native-deps.mjs` 检测不到 win32 绑定后直接报错，安装器显示 `apps/desktop build failed (exit 1)` / “Hermes INSTALL DIDN'T FINISH”。

## 改动（What changed）

在根目录 `package.json` 的 `allowScripts` 中加入 `"get-windows@9.3.0": true`，与已有的 `node-pty@1.1.0`、`electron@40.10.2`、`esbuild@0.28.1` 等条目保持同一模式。`allowScripts` 只存在于 `package.json`，不会写入 `package-lock.json`，因此无需改动 lockfile。

## 测试计划（Test plan）

- [x] `npm ci`（Windows，npm 12.0.2）：成功；不再出现 `install-scripts` 警告；`node_modules/get-windows/lib/binding/napi-9-win32-unknown-x64/node-get-windows.node` 正常下载
- [x] `npm run build`（`apps/desktop`）：成功；日志输出 `[stage-native-deps] staged get-windows (win32)`
- [x] `npm run builder -- --dir`（`apps/desktop`）：成功；产出 `release/win-unpacked/Hermes.exe`