### PR TITLE
fix(tools): decode git alias bodies as UTF-8 in the self-repo guard

### DIFF
--- a/tests/tools/test_self_repo_guard.py
+++ b/tests/tools/test_self_repo_guard.py
@@ -126,6 +126,43 @@ class TestBlocksMutationsInSourceRepo:
         hit, _ = _detect("git co main", repo, repo)
         assert hit is True
 
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "!git reset --hard HEAD~5 && echo bitti \U0001F40D",
+            "!git reset --hard HEAD~5 && echo 清理",
+            "!git reset --hard HEAD~5 && echo güncelleme",
+        ],
+        ids=["emoji", "cjk", "accented"],
+    )
+    def test_configured_git_alias_with_non_ascii_body(self, repo, body):
+        """An alias body is user text, and git hands it back as UTF-8.
+
+        Reading it with the process codepage loses the whole value on a
+        console codepage that cannot map one of its bytes, leaving the guard
+        with no alias to expand — so an ordinary alias carrying an emoji or a
+        CJK word walks a ``git reset --hard`` past a check the terminal tool
+        calls non-bypassable.
+        """
+        subprocess.run(
+            ["git", "-C", str(repo), "config", "alias.wipe", body],
+            check=True,
+        )
+        hit, msg = _detect("git wipe", repo, repo)
+        assert hit is True, "a non-ASCII alias body slipped the self-repo guard"
+        assert "git reset" in (msg or "")
+
+    def test_alias_body_is_read_back_verbatim(self, repo):
+        """Round-trip: what git stores is what the guard expands."""
+        from tools.self_repo_guard import _read_git_alias
+
+        body = "commit -m güncelleme-\U0001F40D"
+        subprocess.run(
+            ["git", "-C", str(repo), "config", "alias.ci", body],
+            check=True,
+        )
+        assert _read_git_alias("git", repo, "ci") == body
+
     def test_mutation_in_command_substitution(self, repo):
         hit, _ = _detect('echo "$(git checkout main)"', repo, repo)
         assert hit is True

--- a/tools/self_repo_guard.py
+++ b/tools/self_repo_guard.py
@@ -570,12 +570,22 @@ def _read_git_alias(executable: str, target: Path, alias: str) -> str | None:
             [executable, "-C", str(target), "config", "--get", f"alias.{alias}"],
             capture_output=True,
             text=True,
+            # An alias body is user-authored text and git hands it back as
+            # UTF-8. Decoding it with the process codepage instead means a
+            # body carrying one unmappable byte — a commit message with an
+            # emoji or CJK — kills subprocess's reader thread, so ``stdout``
+            # arrives as None and the guard loses the alias it was about to
+            # expand and inspect.
+            encoding="utf-8",
+            errors="replace",
             timeout=1,
             check=False,
         )
     except (OSError, subprocess.SubprocessError):
         return None
-    value = result.stdout.strip()
+    # Belt: ``stdout`` is only ever None on a capture failure, and this guard
+    # must return a verdict rather than raise into its unwrapped call site.
+    value = (result.stdout or "").strip()
     return value if result.returncode == 0 and value else None
 
 


### PR DESCRIPTION
## What

The self-repo guard expands `git <alias>` before deciding whether a command would rewrite the live checkout, reading the body with `git config --get alias.<name>`:

```python
result = subprocess.run(
    [executable, "-C", str(target), "config", "--get", f"alias.{alias}"],
    capture_output=True,
    text=True,
    timeout=1,
    check=False,
)
except (OSError, subprocess.SubprocessError):
    return None
value = result.stdout.strip()
```

Text mode with no encoding decodes with the process codepage under `errors="strict"`. An alias body is user-authored text and git returns it as UTF-8, so one byte the codepage cannot map — an emoji, a CJK word, an accented Turkish commit message — kills subprocess's reader thread. `result.stdout` comes back `None`, and the next line calls `.strip()` on it. `AttributeError` is not in the handler's `(OSError, SubprocessError)` tuple.

`terminal_tool.py` calls `detect_self_repo_git_mutation()` unwrapped, directly under a comment describing the check as non-bypassable:

```python
# Non-bypassable: rewriting the local checkout backing this interpreter
# can mix module versions.
_self_repo_hit, _self_repo_msg = detect_self_repo_git_mutation(command, guard_cwd)
```

Same repo, same alias name, same destructive body — only the trailing text differs:

```
!git reset --hard HEAD~5                        -> blocked
!git reset --hard HEAD~5 && echo bitti 🐍       -> AttributeError
!git reset --hard HEAD~5 && echo 清理            -> AttributeError
```

So an ordinary alias that happens to carry non-ASCII takes a `git reset --hard` past the guard. The reachable trigger is mundane: an operator who writes commit messages in their own language, or any alias with an emoji in an `echo`.

## The fix

Decode as UTF-8 with `errors="replace"` — what git emits, and what 81963 settled on for this class after 80236. Also read `stdout` defensively: this guard is called unwrapped, so it must return a verdict rather than raise into its call site.

`errors="replace"` is the right half of the pair here. A body that somehow isn't valid UTF-8 still yields an inspectable string with replacement characters instead of nothing at all, so the guard keeps deciding on partial text rather than going quiet.

Scope note: whether an *unreadable* alias should hard-block rather than fall through is the question 81664 is already handling for the recursion-depth path; this PR only makes the read succeed.

## Tests and results

Added next to the existing `test_configured_git_alias`, which becomes the ASCII control:

- `test_configured_git_alias_with_non_ascii_body` — parametrized over emoji, CJK, and accented Latin bodies; each must still block, with `git reset` named in the message
- `test_alias_body_is_read_back_verbatim` — the round trip through `_read_git_alias`

On `main` all three parametrized cases fail with `AttributeError: 'NoneType' object has no attribute 'strip'` at `tools/self_repo_guard.py:578`; they pass with the fix, and the ASCII control passes both ways.

`tests/tools/test_self_repo_guard.py` and `test_terminal_self_repo_guard.py` run before and after with byte-identical failure lists — 12 failures, all pre-existing on `main` (worktree path cases on this platform). `scripts/check-windows-footguns.py` reports the same 2 pre-existing findings on `main` as with the change; neither is in a line this PR touches.