### PR TITLE
fix(kanban): mark create-time blocked tasks sticky

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3123,13 +3123,27 @@ def create_task(
     # insert, at which point both rows exist but the next lookup stabilises.
     if idempotency_key:
         row = conn.execute(
-            "SELECT id FROM tasks WHERE idempotency_key = ? "
+            "SELECT id, status FROM tasks WHERE idempotency_key = ? "
             "AND status != 'archived' "
             "ORDER BY created_at DESC LIMIT 1",
             (idempotency_key,),
         ).fetchone()
         if row:
-            return row["id"]
+            existing_id = row["id"]
+            if (
+                initial_status == "blocked"
+                and row["status"] == "blocked"
+                and not _has_sticky_block(conn, existing_id)
+            ):
+                with write_txn(conn):
+                    if not _has_sticky_block(conn, existing_id):
+                        _append_event(
+                            conn,
+                            existing_id,
+                            "blocked",
+                            {"reason": "initial_status=blocked", "kind": "needs_input"},
+                        )
+            return existing_id
 
     now = int(time.time())
 
@@ -3270,6 +3284,13 @@ def create_task(
                         "provider_override": provider_override,
                     },
                 )
+                if initial_status == "blocked":
+                    _append_event(
+                        conn,
+                        task_id,
+                        "blocked",
+                        {"reason": "initial_status=blocked", "kind": "needs_input"},
+                    )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
             return task_id
         except sqlite3.IntegrityError:

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -48,6 +48,16 @@ def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return home
 
 
+def _event_kinds(conn, task_id: str) -> list[str]:
+    return [
+        row["kind"]
+        for row in conn.execute(
+            "SELECT kind FROM task_events WHERE task_id = ? ORDER BY id ASC",
+            (task_id,),
+        ).fetchall()
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Worker-initiated kanban_block must be sticky
 # ---------------------------------------------------------------------------
@@ -77,12 +87,94 @@ def test_worker_block_is_not_auto_promoted_by_recompute_ready(kanban_home: Path)
 
 
 
+def test_create_time_blocked_parent_free_task_is_sticky(kanban_home: Path) -> None:
+    """``initial_status='blocked'`` is an explicit human-ops block.
+
+    Even with no parents, dispatcher recomputation must not silently
+    promote it to ready/claimable. The sticky marker must be durable and
+    ordered after the ``created`` event so notification cursors can inherit
+    both creation facts before they are caught up.
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="parked for ops", initial_status="blocked")
+
+        assert kb.get_task(conn, tid).status == "blocked"
+        assert _event_kinds(conn, tid) == ["created", "blocked"]
+
+        assert kb.recompute_ready(conn) == 0
+        assert kb.claim_task(conn, tid) is None
+        assert kb.get_task(conn, tid).status == "blocked"
+
+
+def test_create_time_blocked_child_with_done_parent_is_sticky(kanban_home: Path) -> None:
+    """A blocked child must not become claimable when its parents are done."""
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="already reviewed parent")
+        assert kb.complete_task(conn, parent, summary="done")
+        child = kb.create_task(
+            conn,
+            title="child parked for ops",
+            parents=[parent],
+            initial_status="blocked",
+        )
+
+        assert kb.get_task(conn, child).status == "blocked"
+        assert _event_kinds(conn, child)[:2] == ["created", "blocked"]
+
+        assert kb.recompute_ready(conn) == 0
+        assert kb.claim_task(conn, child) is None
+        assert kb.get_task(conn, child).status == "blocked"
+
+
+def test_reused_still_blocked_idempotent_task_gets_sticky_marker_only_on_explicit_block_request(
+    kanban_home: Path,
+) -> None:
+    """Legacy idempotent rows may already be blocked without a marker.
+
+    Backfill the marker only when the retried creator again explicitly asks
+    for ``initial_status='blocked'``. Default idempotent reuse keeps the old
+    non-sticky auto-recover behavior.
+    """
+    with kb.connect() as conn:
+        non_explicit = kb.create_task(
+            conn, title="legacy default reuse", idempotency_key="default-reuse"
+        )
+        conn.execute("UPDATE tasks SET status = 'blocked' WHERE id = ?", (non_explicit,))
+        conn.commit()
+
+        assert (
+            kb.create_task(
+                conn, title="legacy default reuse", idempotency_key="default-reuse"
+            )
+            == non_explicit
+        )
+        assert _event_kinds(conn, non_explicit) == ["created"]
+        assert kb.recompute_ready(conn) == 1
+        assert kb.get_task(conn, non_explicit).status == "ready"
+
+        explicit = kb.create_task(
+            conn, title="legacy blocked reuse", idempotency_key="blocked-reuse"
+        )
+        conn.execute("UPDATE tasks SET status = 'blocked' WHERE id = ?", (explicit,))
+        conn.commit()
+
+        assert (
+            kb.create_task(
+                conn,
+                title="legacy blocked reuse",
+                idempotency_key="blocked-reuse",
+                initial_status="blocked",
+            )
+            == explicit
+        )
+        assert _event_kinds(conn, explicit) == ["created", "blocked"]
+        assert kb.recompute_ready(conn) == 0
+        assert kb.get_task(conn, explicit).status == "blocked"
+
 
 # ---------------------------------------------------------------------------
 # Circuit-breaker blocks still auto-recover (preserve #40c1decb3 intent)
 # ---------------------------------------------------------------------------
-
-
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a durable blocked marker when create_task(..., initial_status="blocked") creates a blocked row
- backfill that marker for still-blocked idempotent legacy rows only when the retry explicitly requests initial_status="blocked"
- cover parent-free and done-parent child blocked tasks so recompute_ready cannot promote/claim them

## Test Plan
- uv run --extra dev pytest tests/hermes_cli/test_kanban_blocked_sticky.py -q
- uv run --extra dev pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_blocked_sticky.py -q
- uv run --extra dev ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_blocked_sticky.py

## Bounds
- Source-only current-main correction
- No runtime/config/router/cron/install/live 4174 actions taken