### PR TITLE
feat(terminal): recover cleanly when cached remote backends go offline

### DIFF
--- a/tests/tools/test_terminal_degraded_mode.py
+++ b/tests/tools/test_terminal_degraded_mode.py
@@ -35,6 +35,12 @@ def isolated_env(tmp_path, monkeypatch):
         with tt._env_lock:
             tt._active_environments.clear()
             tt._last_activity.clear()
+        try:
+            from tools.file_tools import clear_file_ops_cache
+
+            clear_file_ops_cache()
+        except ImportError:
+            pass
 
     _clear()
     yield tt
@@ -179,6 +185,134 @@ class TestNonInfrastructureFailuresUntouched:
             "definitely_not_a_real_command_zzz_42", task_id="t-degraded-notfound"))
         assert r["exit_code"] != 0
         assert r.get("status") != "degraded"
+
+
+class TestCachedBackendFailures:
+    @staticmethod
+    def _cache_env(terminal_module, task_id, env):
+        cache_key = terminal_module._resolve_container_task_id(task_id)
+        with terminal_module._env_lock:
+            terminal_module._active_environments[cache_key] = env
+        return cache_key
+
+    def test_foreground_connection_error_reaches_degraded_handler(
+        self, isolated_env, monkeypatch
+    ):
+        from tools import file_tools
+
+        _ssh_backend_env(monkeypatch)
+        monkeypatch.setattr(isolated_env.time, "sleep", lambda _seconds: None)
+        env = MagicMock()
+        env.cwd = "~"
+        env.env = {}
+        env.execute.side_effect = EnvironmentConnectionError(
+            "cached SSH connection lost",
+            retry_hint="Restore connectivity and retry.",
+        )
+        cache_key = self._cache_env(isolated_env, "t-cached-foreground", env)
+        file_tools._file_ops_cache[cache_key] = object()
+
+        result = json.loads(
+            isolated_env.terminal_tool("echo hi", task_id="t-cached-foreground")
+        )
+
+        assert result["status"] == "degraded"
+        assert env.execute.call_count == 1
+        assert cache_key not in isolated_env._active_environments
+        assert cache_key not in file_tools._file_ops_cache
+        env.cleanup.assert_called_once_with()
+
+    def test_background_connection_error_reaches_degraded_handler(
+        self, isolated_env, monkeypatch
+    ):
+        _ssh_backend_env(monkeypatch)
+        env = MagicMock()
+        env.cwd = "~"
+        env.env = {}
+        env.get_temp_dir.return_value = "/tmp"
+        env.execute.side_effect = EnvironmentConnectionError(
+            "cached SSH connection lost",
+            retry_hint="Restore connectivity and retry.",
+        )
+        cache_key = self._cache_env(isolated_env, "t-cached-background", env)
+
+        result = json.loads(
+            isolated_env.terminal_tool(
+                "echo hi", background=True, task_id="t-cached-background"
+            )
+        )
+
+        assert result["status"] == "degraded"
+        assert env.execute.call_count == 1
+        assert cache_key not in isolated_env._active_environments
+
+
+class TestRuntimeTransportClassification:
+    def test_ssh_transport_failure_after_init_raises_connection_error(self, monkeypatch):
+        from tools.environments.base import BaseEnvironment
+        from tools.environments.ssh import SSHEnvironment
+
+        env = object.__new__(SSHEnvironment)
+        env.host = "unreachable.invalid"
+        env.user = "nobody"
+        env.port = 22
+        monkeypatch.setattr(
+            BaseEnvironment,
+            "execute",
+            lambda *_args, **_kwargs: {
+                "output": (
+                    "ssh: connect to host unreachable.invalid port 22: "
+                    "Connection refused"
+                ),
+                "returncode": 255,
+            },
+        )
+        monkeypatch.setattr(env, "_connection_probe_failed", lambda: True, raising=False)
+
+        with pytest.raises(EnvironmentConnectionError, match="SSH connection failed"):
+            env.execute("echo hi")
+
+    def test_ssh_remote_exit_255_is_not_automatically_degraded(self, monkeypatch):
+        from tools.environments.base import BaseEnvironment
+        from tools.environments.ssh import SSHEnvironment
+
+        expected = {"output": "remote command failed", "returncode": 255}
+        env = object.__new__(SSHEnvironment)
+        env.host = "reachable.example"
+        env.user = "nobody"
+        env.port = 22
+        probe = MagicMock(return_value=True)
+        monkeypatch.setattr(BaseEnvironment, "execute", lambda *_a, **_k: expected)
+        monkeypatch.setattr(env, "_connection_probe_failed", probe, raising=False)
+
+        assert env.execute("exit 255") is expected
+        probe.assert_not_called()
+
+    def test_docker_daemon_failure_after_init_raises_connection_error(self, monkeypatch):
+        from tools.environments.base import BaseEnvironment
+        from tools.environments import docker as docker_env
+
+        env = object.__new__(docker_env.DockerEnvironment)
+        env._persist_across_processes = False
+        monkeypatch.setattr(
+            BaseEnvironment,
+            "execute",
+            lambda *_args, **_kwargs: {
+                "output": (
+                    "Cannot connect to the Docker daemon at unix:///var/run/docker.sock. "
+                    "Is the docker daemon running?"
+                ),
+                "returncode": 1,
+            },
+        )
+
+        def _daemon_down():
+            raise EnvironmentConnectionError("Docker daemon is not responding")
+
+        monkeypatch.setattr(docker_env, "_ensure_docker_available", _daemon_down)
+
+        with pytest.raises(EnvironmentConnectionError, match="Docker daemon"):
+            env.execute("echo hi")
 
 
 class TestFailModePreservesRaiseBehavior:

--- a/tests/tools/test_terminal_degraded_mode.py
+++ b/tests/tools/test_terminal_degraded_mode.py
@@ -220,7 +220,9 @@ class TestCachedBackendFailures:
         assert env.execute.call_count == 1
         assert cache_key not in isolated_env._active_environments
         assert cache_key not in file_tools._file_ops_cache
-        env.cleanup.assert_called_once_with()
+        # Normal remote cleanup can perform multi-minute sync-back retries.
+        # A backend known to be unreachable must be discarded without it.
+        env.cleanup.assert_not_called()
 
     def test_background_connection_error_reaches_degraded_handler(
         self, isolated_env, monkeypatch

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -863,6 +863,15 @@ class DockerEnvironment(BaseEnvironment):
 
     _profile_scoped_passthrough = True
 
+    _DAEMON_UNAVAILABLE_PATTERNS = (
+        "cannot connect to the docker daemon",
+        "docker daemon is not running",
+        "error during connect",
+        "failed to connect to the docker api",
+        "is the docker daemon running",
+        "request returned internal server error for api route",
+    )
+
     def _additional_profile_scoped_passthrough_names(self) -> tuple[str, ...]:
         """Keep explicit docker_forward_env values out of shared snapshots."""
         return tuple(self._forward_env)
@@ -1641,6 +1650,11 @@ class DockerEnvironment(BaseEnvironment):
         """Return True if the output indicates the container no longer exists."""
         return any(p in output for p in self._NO_CONTAINER_PATTERNS)
 
+    @classmethod
+    def _looks_like_daemon_unavailable(cls, output: str) -> bool:
+        lowered = output.lower()
+        return any(pattern in lowered for pattern in cls._DAEMON_UNAVAILABLE_PATTERNS)
+
     def _recreate_container(self) -> bool:
         """Recreate the container after it was removed out-of-band.
 
@@ -1733,6 +1747,16 @@ class DockerEnvironment(BaseEnvironment):
         transparently before retrying once.
         """
         result = super().execute(command, cwd, **kwargs)
+        daemon_unavailable = (
+            result.get("returncode", 0) != 0
+            and self._looks_like_daemon_unavailable(result.get("output", ""))
+        )
+        if daemon_unavailable:
+            # Reuse the definitive daemon probe. If the daemon recovered
+            # between docker exec and this check, preserve the original command
+            # result; otherwise the probe raises EnvironmentConnectionError.
+            _ensure_docker_available()
+            return result
         if (
             result.get("returncode", 0) != 0
             and self._is_container_gone(result.get("output", ""))

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -46,6 +46,23 @@ class SSHEnvironment(BaseEnvironment):
     Uses SSH ControlMaster for connection reuse.
     """
 
+    _CONNECTION_FAILURE_MARKERS = (
+        "connect to host",
+        "connection refused",
+        "connection timed out",
+        "connection reset by peer",
+        "connection closed by",
+        "closed by remote host",
+        "could not resolve hostname",
+        "host key verification failed",
+        "kex_exchange_identification",
+        "network is unreachable",
+        "no route to host",
+        "permission denied (publickey",
+        "remote host has disconnected",
+        "ssh_exchange_identification",
+    )
+
     def __init__(self, host: str, user: str, cwd: str = "~",
                  timeout: int = 60, port: int = 22, key_path: str = ""):
         super().__init__(cwd=cwd, timeout=timeout)
@@ -402,6 +419,53 @@ class SSHEnvironment(BaseEnvironment):
             cmd.extend(["bash", "-c", shlex.quote(cmd_string)])
 
         return _popen_bash(cmd, stdin_data)
+
+    @classmethod
+    def _looks_like_connection_failure(cls, result: dict) -> bool:
+        """Return whether an ssh exit looks like a transport/auth failure."""
+        if int(result.get("returncode") or 0) != 255:
+            return False
+        output = str(result.get("output") or "").lower()
+        return any(marker in output for marker in cls._CONNECTION_FAILURE_MARKERS)
+
+    def _connection_probe_failed(self) -> bool:
+        """Confirm a candidate ssh diagnostic is infrastructure-level.
+
+        ssh uses exit 255 for client errors, but a remote command can also
+        intentionally return 255. A one-shot no-op probe avoids degrading a
+        healthy connection based solely on user-command output.
+        """
+        cmd = self._build_ssh_command()
+        cmd.append("true")
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=15,
+                stdin=subprocess.DEVNULL,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return True
+        return result.returncode != 0
+
+    def execute(self, command: str, cwd: str = "", **kwargs) -> dict:
+        result = super().execute(command, cwd, **kwargs)
+        if (
+            self._looks_like_connection_failure(result)
+            and self._connection_probe_failed()
+        ):
+            raise EnvironmentConnectionError(
+                "SSH connection failed during command execution for "
+                f"{self.user}@{self.host}",
+                retry_hint=(
+                    f"Verify {self.user}@{self.host}:{self.port} is reachable "
+                    "and authentication is valid, then retry the same command."
+                ),
+            )
+        return result
 
     def cleanup(self):
         if self._sync_manager:

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -43,6 +43,7 @@ import uuid
 from pathlib import Path
 
 _IS_WINDOWS = platform.system() == "Windows"
+from tools.environments.base import EnvironmentConnectionError
 from tools.environments.local import _find_shell, _resolve_safe_cwd, _sanitize_subprocess_env
 from hermes_cli._subprocess_compat import windows_hide_flags
 from dataclasses import dataclass, field
@@ -1259,6 +1260,11 @@ class ProcessRegistry:
                 session.completion_reason = "failed_start"
                 session.termination_source = "failed_start"
                 session.output_buffer = result.get("output", "").strip()
+        except EnvironmentConnectionError:
+            # terminal_tool owns the degraded-mode response and cache eviction.
+            # Converting this into a failed ProcessSession would hide the
+            # infrastructure failure from that boundary.
+            raise
         except Exception as e:
             session.exited = True
             session.exit_code = -1

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3038,6 +3038,11 @@ def terminal_tool(
                     result_data["watch_patterns"] = proc_session.watch_patterns
 
                 return json.dumps(result_data, ensure_ascii=False)
+            except EnvironmentConnectionError:
+                # Let the outer degraded-mode boundary classify and evict a
+                # cached backend instead of turning infrastructure loss into a
+                # generic failed-start result.
+                raise
             except Exception as e:
                 return json.dumps({
                     "output": "",
@@ -3081,6 +3086,11 @@ def terminal_tool(
                         "bounded_capture": True,
                     }
                     result = env.execute(command, **execute_kwargs)
+                except EnvironmentConnectionError:
+                    # Retrying the same cached backend cannot repair a dead
+                    # transport. The outer handler evicts it so the next tool
+                    # call creates a fresh environment.
+                    raise
                 except Exception as e:
                     error_str = str(e).lower()
                     if "timeout" in error_str:
@@ -3379,6 +3389,17 @@ def _evict_environment_for_task(task_id: Optional[str]) -> None:
             _last_activity.pop(key, None)
             if env is not None:
                 evicted.append(env)
+    # ShellFileOperations stores the environment object, not just its key. If
+    # a terminal retry creates a new environment before the next file-tool
+    # call, a stale cache entry would otherwise pass file_tools' key-presence
+    # check and keep using the evicted backend.
+    try:
+        from tools.file_tools import clear_file_ops_cache
+
+        for key in keys:
+            clear_file_ops_cache(key)
+    except Exception:
+        logger.debug("file-ops cache eviction failed", exc_info=True)
     for env in evicted:
         try:
             env.cleanup()

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3382,13 +3382,10 @@ def _evict_environment_for_task(task_id: Optional[str]) -> None:
     keys = {_resolve_container_task_id(task_id)}
     if task_id:
         keys.add(task_id)
-    evicted = []
     with _env_lock:
         for key in keys:
-            env = _active_environments.pop(key, None)
+            _active_environments.pop(key, None)
             _last_activity.pop(key, None)
-            if env is not None:
-                evicted.append(env)
     # ShellFileOperations stores the environment object, not just its key. If
     # a terminal retry creates a new environment before the next file-tool
     # call, a stale cache entry would otherwise pass file_tools' key-presence
@@ -3400,11 +3397,10 @@ def _evict_environment_for_task(task_id: Optional[str]) -> None:
             clear_file_ops_cache(key)
     except Exception:
         logger.debug("file-ops cache eviction failed", exc_info=True)
-    for env in evicted:
-        try:
-            env.cleanup()
-        except Exception:
-            logger.debug("cleanup of degraded environment failed", exc_info=True)
+    # Do not call normal backend cleanup here. Remote cleanup can perform
+    # networked sync-back and retry for minutes, but this path is reached only
+    # after that connection is known to be unavailable. Dropping references is
+    # intentional; normal lifecycle cleanup remains unchanged.
 
 
 def check_terminal_requirements() -> bool:


### PR DESCRIPTION
## What does this PR do?

This PR keeps graceful terminal degradation working when a cached SSH or Docker backend goes offline after successful initialization. Foreground and background calls now return the configured structured degraded result, discard stale terminal and file-operation cache entries, and avoid network-dependent cleanup against a backend already known to be unavailable.

### Motivation

Runtime backend outages previously took different paths from startup failures. Connection exceptions could be absorbed by foreground retries or background process wrappers, while SSH and Docker command execution did not consistently promote confirmed transport failures to the terminal degradation boundary. Users therefore received generic failures instead of a reason and retry hint, and subsequent file operations could retain a stale environment reference.

### Behavior

- Confirmed SSH transport failures during command execution become degraded terminal results.
- Docker daemon failures detected after environment startup become degraded terminal results.
- Foreground and background command paths preserve connection exceptions for centralized handling.
- Terminal and file-operation caches are invalidated together.
- Degraded eviction does not run remote cleanup that may block on the unavailable transport.
- Ordinary command failures, including a healthy remote command exiting with status 255, remain unchanged.

### Implementation

SSH runtime diagnostics are classified only when the command exits with the SSH client failure status, includes a known connection marker, and a no-op connection probe also fails. Docker runtime diagnostics reuse the existing daemon availability probe. The terminal and process-registry wrappers re-raise connection exceptions to the outer degraded-mode handler, which evicts both cache layers without synchronous remote cleanup.

## Related Issue

Closes #82011

## Type of Change

- [x] New feature

## Changes Made

- `tools/environments/ssh.py` - classify confirmed runtime SSH transport failures without misclassifying remote exit status 255.
- `tools/environments/docker.py` - classify runtime Docker daemon outages with the existing availability probe.
- `tools/process_registry.py` - preserve connection failures from remote background process startup.
- `tools/terminal_tool.py` - route cached foreground and background failures through degraded handling and invalidate terminal and file caches without blocking cleanup.
- `tests/tools/test_terminal_degraded_mode.py` - cover runtime classification, foreground and background propagation, cache invalidation, and non-blocking eviction.

## How to Test

The focused CI-parity test commands below passed 108 tests:

```bash
scripts/run_tests.sh tests/tools/test_terminal_degraded_mode.py tests/tools/test_terminal_config_env_sync.py tests/tools/test_ssh_environment.py tests/tools/test_terminal_tool.py tests/tools/test_terminal_error_redaction.py tests/tools/test_terminal_tool_exception_redaction.py
scripts/run_tests.sh tests/tools/test_docker_environment.py -k "not wrapped_exec_scopes_explicit_forward_env_across_profiles"
scripts/run_tests.sh tests/tools/test_process_registry.py -k spawn_via_env
```

## Checklist

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this feature
- [x] I have run the repository test entry on relevant tests and all targeted tests pass
- [x] I have added tests for the new runtime degradation behavior
- [x] I have tested the deterministic backend-failure paths on Windows 10