### PR TITLE
HUD: only take the mouse where the HUD actually is

### DIFF
--- a/apps/desktop/src/app/hud/click-through.test.ts
+++ b/apps/desktop/src/app/hud/click-through.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { hudIgnoresMouse } from './click-through'
+
+/** The HUD's real shape: a React mount wrapping the shell, the bar inside it,
+ *  and a portalled overlay as a sibling of the mount under <body>. */
+function hud() {
+  document.body.innerHTML = ''
+
+  const mount = document.createElement('div')
+  mount.id = 'root'
+
+  const shell = document.createElement('div')
+  shell.setAttribute('data-hud-shell', '')
+
+  const bar = document.createElement('input')
+
+  const overlay = document.createElement('div')
+  overlay.setAttribute('role', 'dialog')
+
+  shell.append(bar)
+  mount.append(shell)
+  document.body.append(mount, overlay)
+
+  return { bar, mount, overlay, shell }
+}
+
+describe('hudIgnoresMouse', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('hands the mouse back over the scaffolding the HUD hangs in', () => {
+    const { mount, shell } = hud()
+
+    for (const around of [mount, document.body, document.documentElement, shell]) {
+      expect(hudIgnoresMouse(shell, around, null, true)).toBe(true)
+    }
+  })
+
+  it('keeps the window solid over the HUD and over portalled overlays', () => {
+    const { bar, overlay, shell } = hud()
+
+    expect(hudIgnoresMouse(shell, bar, null, true)).toBe(false)
+    expect(hudIgnoresMouse(shell, overlay, null, true)).toBe(false)
+  })
+
+  it('does not pin the window just because the composer holds the caret', () => {
+    const { bar, mount, shell } = hud()
+
+    expect(hudIgnoresMouse(shell, mount, bar, true)).toBe(true)
+  })
+
+  it('pins the window while a portalled overlay holds focus, so an outside click can dismiss it', () => {
+    const { mount, overlay, shell } = hud()
+
+    expect(hudIgnoresMouse(shell, mount, overlay, true)).toBe(false)
+  })
+
+  it('lets a stale focus go once the window is no longer the active one', () => {
+    const { mount, overlay, shell } = hud()
+
+    expect(hudIgnoresMouse(shell, mount, overlay, false)).toBe(true)
+  })
+
+  it('treats an unfocused document body as nothing holding focus', () => {
+    const { mount, shell } = hud()
+
+    expect(hudIgnoresMouse(shell, mount, document.body, true)).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/hud/click-through.ts
+++ b/apps/desktop/src/app/hud/click-through.ts
@@ -1,12 +1,46 @@
 import { type RefObject, useEffect } from 'react'
 
 /**
+ * Whether the OS window should hand the mouse to whatever is behind it.
+ *
+ * `hit` is what the document reports under the cursor, `active` what holds
+ * focus; both are answered against the shell by where they sit in the tree.
+ *
+ * - Anything that CONTAINS the shell is the scaffolding the HUD hangs in — the
+ *   React mount, `<body>`, the document. Those are full-window and
+ *   hit-testable, so a hit on one means the cursor is over nothing. Naming them
+ *   was the earlier mistake: the list had `<body>` and `<html>` and missed
+ *   `#root`, so every point in the window reported something and the window
+ *   never went transparent at all.
+ * - Focus BESIDE the shell is a portalled dialog, popover or menu, and it owns
+ *   the next click — including the one outside itself that dismisses it, which
+ *   the hit test cannot see coming. That pins the window solid.
+ * - Focus INSIDE the shell does not. The composer holding the caret is the
+ *   HUD's resting state rather than a claim on the whole rectangle, and reading
+ *   it as one is what made an engaged HUD eat every click in its own empty
+ *   space — on a fresh thread, the entire window.
+ */
+export function hudIgnoresMouse(
+  root: Element,
+  hit: Element | null,
+  active: Element | null,
+  windowFocused: boolean
+): boolean {
+  const overSomething = hit !== null && !hit.contains(root)
+  // `windowFocused` is what stops a stale `active` — the composer keeps focus
+  // after you click away to another app — pinning the HUD solid forever.
+  const overlayFocused = windowFocused && active !== null && !root.contains(active) && !active.contains(root)
+
+  return !overSomething && !overlayFocused
+}
+
+/**
  * Let clicks fall through the HUD everywhere it isn't really there.
  *
  * The one thing about HUD mode that CSS cannot express, because it is a
- * property of the OS WINDOW rather than of the page. It reads the engaged state
- * off the DOM (`:focus-within`) rather than keeping a second copy, so there is
- * one answer to "is the HUD in use" and the stylesheet owns it.
+ * property of the OS WINDOW rather than of the page. It asks the document what
+ * is under the cursor rather than keeping a second copy of the answer, so the
+ * stylesheet stays the one place that decides what the HUD is made of.
  *
  * An always-on-top window eats every click inside its rectangle, visible or
  * not — and most of the HUD's rectangle is a faded-out band over whatever the
@@ -14,9 +48,10 @@ import { type RefObject, useEffect } from 'react'
  * page-level property, and the click never reaches the page.
  *
  * So the window itself is made mouse-transparent except where it is genuinely
- * interactive: wherever the cursor is over something, and whenever anything in
- * the window holds focus. `forward: true` keeps mousemove flowing while
- * ignoring, which is what lets it re-arm when the cursor comes back to the bar.
+ * interactive: wherever the cursor is over something the HUD paints, and
+ * whenever a portalled overlay holds focus. `forward: true` keeps mousemove
+ * flowing while ignoring, which is what lets it re-arm when the cursor comes
+ * back to the bar.
  */
 export function useHudClickThrough(rootRef: RefObject<HTMLElement | null>): void {
   useEffect(() => {
@@ -34,33 +69,14 @@ export function useHudClickThrough(rootRef: RefObject<HTMLElement | null>): void
     let point: { x: number; y: number } | null = null
 
     // Hit-test rather than enumerate. Everything the HUD doesn't want to catch
-    // — the shell's dead space, the sheet, the faded band — is already
-    // `pointer-events: none`, so anything the document hands back at this point
-    // is something real: the bar, a control, the exit chip, a popover, a dialog.
-    // Listing those instead is how links and dialogs ended up unclickable, since
-    // portalled overlays live outside the shell and moving focus into one takes
-    // `:focus-within` with it.
-    const overSomething = () => {
-      if (!point) {
-        return false
-      }
-
-      const hit = document.elementFromPoint(point.x, point.y)
-
-      return Boolean(hit) && hit !== root && hit !== document.body && hit !== document.documentElement
-    }
-
-    // Focus is asked of the document, not of the shell. A dialog or popover is
-    // portalled to `document.body`, so focus entering one leaves the shell's
-    // `:focus-within` — and a HUD that decides it is unused the moment it opens
-    // a dialog goes mouse-transparent underneath it. Nothing but the HUD lives
-    // in this window, so any focus at all is the HUD in use. `hasFocus` gates it
-    // so a stale `activeElement` — the composer keeps it after you click away to
-    // another app — can't pin the HUD solid forever.
-    const focused = () => document.hasFocus() && document.activeElement !== document.body
-
+    // — the shell's dead space, the sheet, the faded band — is
+    // `pointer-events: none` in the stylesheet, so whatever the document hands
+    // back is something real: the bar, a control, the exit chip, a popover, a
+    // dialog. Listing those instead is how links and dialogs ended up
+    // unclickable, since portalled overlays live outside the shell.
     const apply = () => {
-      const next = !focused() && !overSomething()
+      const hit = point ? document.elementFromPoint(point.x, point.y) : null
+      const next = hudIgnoresMouse(root, hit, document.activeElement, document.hasFocus())
 
       if (ignoring !== next) {
         ignoring = next

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2337,7 +2337,14 @@ button[data-slot='aui_msg-reactions'] svg {
   border-radius: 0.75rem 0.75rem 0 0;
   /* No fill of its own — the sheet is its own layer behind this one
      ([data-hud-glass]), so it can be sized to the transcript while this box
-     stays the full window for the drag region and the scroll container. */
+     stays the full window for the drag region and the scroll container.
+
+     The box stays full-window; the part of it that answers the cursor must
+     not, or an engaged HUD swallows every click in the empty space above a
+     short transcript — the whole window on a fresh thread. Hit-testing honours
+     clip-path, so clipping to the sheet bounds the surface the same way #81920
+     bounded the frost. */
+  clip-path: inset(calc(100% - min(100%, var(--hud-band-height, 0px))) 0 0 0);
   background: transparent !important;
   /* Three opacity states: gone at rest, half strength when a turn is recent or
      you've just let go of the composer (there to glance at, not to demand
@@ -2430,7 +2437,18 @@ button[data-slot='aui_msg-reactions'] svg {
   border-radius: 0 0 0.75rem 0.75rem;
 }
 
-[data-hud-shell] [data-slot='composer-bounds'] {
+/* WHAT ANSWERS THE CURSOR — and, because `useHudClickThrough` hands the window
+   to the desktop wherever the document reports nothing under the mouse, what
+   the HUD occupies as far as the rest of the screen is concerned.
+
+   Default to none and let surfaces opt in. The HUD is mostly scaffolding — the
+   shell, the chat surface, the routes wrapper — all full-window, all invisible,
+   and all hit-testable, so the window came back "something is here" for every
+   point in its rectangle and ate clicks meant for the app behind it. Written
+   this way round because that scaffolding is not a list anyone maintains: one
+   more wrapper between the shell and the bar would quietly restore the dead
+   rectangle, whereas a control that forgets to opt in is visibly dead. */
+[data-hud-shell] {
   pointer-events: none;
 }
 
@@ -2565,6 +2583,7 @@ button[data-slot='aui_msg-reactions'] svg {
 
 [data-hud-shell][data-hud-edge='top'] [data-slot='composer-bounds'] {
   border-radius: 0 0 0.75rem 0.75rem;
+  clip-path: inset(0 0 calc(100% - min(100%, var(--hud-band-height, 0px))) 0);
 }
 
 /* Flipped, the bar is at the TOP, so the clearance has to be too — the app's
@@ -2593,6 +2612,9 @@ button[data-slot='aui_msg-reactions'] svg {
   height: 2rem;
   z-index: 10;
   -webkit-app-region: drag;
+  /* Blank to the eye, but this is the grab handle: a strip the window ignores
+     is a strip you cannot drag the HUD by. */
+  pointer-events: auto;
 }
 
 /* Tighten the thread on every side. The docked chat's gutters (px-6 py-8 plus
@@ -2650,6 +2672,9 @@ button[data-slot='aui_msg-reactions'] svg {
    controls carve themselves back out (a drag region eats their clicks too). */
 [data-hud-shell] [data-slot='composer-dock'] {
   -webkit-app-region: drag;
+  /* The one surface that is always there, so the one that always takes the
+     mouse — everything else in the shell earns it by being on screen. */
+  pointer-events: auto;
 }
 
 /* Focusables, not a list of the controls that happen to be in the bar today —


### PR DESCRIPTION
Follow-up to #81920. That one bounded the frost to the sheet, so nothing paints
in the empty space above a short transcript any more — but clicks still die
there. The window is always-on-top and eats everything inside its rectangle
unless it is told to ignore the mouse, and it was never being told.

Three things had to be true at once and none of them were.

The click-through hit test asks the document what is under the cursor and
treats "nothing" as a cue to hand the window to the desktop. Its list of what
counts as nothing named `<body>` and `<html>` and missed `#root`, which is
full-window and hit-testable — so every point in the window answered "something
is here" and the window never went transparent at all. It asks the tree now:
anything that CONTAINS the shell is scaffolding around the HUD, not part of it.

Underneath that, the shell's own scaffolding — the chat surface and the wrapper
between it and the shell — is full-window, invisible, and hit-testable. The
stylesheet defaults the shell to `pointer-events: none` and lets the bar, the
grab strip and the band opt back in, rather than listing the scaffolding to
exclude: one more wrapper and the dead rectangle comes back, whereas a control
that forgets to opt in is visibly dead.

And the band's box is the whole window by design, because it is the scroll
container. Engaging the HUD turned that whole rectangle into a click target,
which on a fresh thread is a window-sized hole over whatever you were working
in. It is clipped to the sheet now — hit-testing honours `clip-path` — which is
the same bound #81920 put on the frost.

Focus is the last piece. #81552 pinned the window solid whenever anything in it
held focus, to stop the HUD going click-through under its own dialogs. But the
composer holds focus as the HUD's resting state, so that pinned the whole
rectangle for the entire time the HUD was in use. What that fix actually needed
was focus BESIDE the shell: a portalled dialog, popover or menu owns the next
click, including the one outside it that dismisses it, and the hit test cannot
see that one coming. Focus inside the shell is just the composer, and the hit
test already covers everything the composer can reach.

## Test plan

Verified here:

- [x] `clip-path` bounds `elementFromPoint`, in Chrome against the real HUD
      layer stack — dead space falls through to the mount, the band and the bar
      do not, and an empty thread passes the cursor through everywhere
- [x] The ignore-mouse decision, unit-tested against a real DOM: scaffolding
      hands the mouse back, the HUD and portalled overlays keep it, a focused
      composer no longer pins the window, a focused overlay still does, and
      stale focus after switching apps lets go

Wants a pass on the running app:

- [ ] Empty thread, composer focused — clicks in the dead space reach the app behind
- [ ] Short transcript — the band takes clicks, the space above it does not
- [ ] Bar, exit chip and the top grab strip stay clickable and draggable
- [ ] A dialog or the model picker still dismisses on an outside click