### PR TITLE
fix(desktop): collapse repeated separators in path comparison

### DIFF
--- a/apps/desktop/src/lib/path-compare.test.ts
+++ b/apps/desktop/src/lib/path-compare.test.ts
@@ -11,6 +11,18 @@ describe('cleanPath', () => {
   it('keeps root rather than collapsing to empty', () => {
     expect(cleanPath('/')).toBe('/')
   })
+
+  it('collapses repeated separators', () => {
+    expect(cleanPath('C:/Repos//App')).toBe('C:/Repos/App')
+    expect(cleanPath('C:\\Repos\\\\App')).toBe('C:/Repos/App')
+    expect(cleanPath('/home/u//repo')).toBe('/home/u/repo')
+  })
+
+  it('keeps the leading double separator of a UNC path', () => {
+    expect(cleanPath('//server/share/proj')).toBe('//server/share/proj')
+    expect(cleanPath('\\\\server\\share\\proj')).toBe('//server/share/proj')
+    expect(cleanPath('//server//share')).toBe('//server/share')
+  })
 })
 
 describe('comparisonPath', () => {
@@ -34,5 +46,18 @@ describe('isUnderPath', () => {
 
   it('does not treat a sibling with a shared prefix as nested', () => {
     expect(isUnderPath('/repos/app', '/repos/app-retry')).toBe(false)
+  })
+
+  it('matches when either side carries a doubled separator', () => {
+    // A root that already ends in a separator, joined with a child.
+    expect(isUnderPath('C:/Repos//App', 'C:/Repos/App/src')).toBe(true)
+    expect(isUnderPath('C:/Repos/App', 'C:/Repos//App/src')).toBe(true)
+    expect(isUnderPath('C:\\Repos\\\\App', 'c:/repos/app/src')).toBe(true)
+    expect(isUnderPath('/home/u//repo', '/home/u/repo/src')).toBe(true)
+  })
+
+  it('still matches under a UNC root', () => {
+    expect(isUnderPath('//server/share/proj', '//SERVER/share/proj/src')).toBe(true)
+    expect(isUnderPath('\\\\server\\share\\proj', '//server/share/proj')).toBe(true)
   })
 })

--- a/apps/desktop/src/lib/path-compare.ts
+++ b/apps/desktop/src/lib/path-compare.ts
@@ -5,8 +5,19 @@
  *  case. Compare through these rather than `===` / `startsWith`.
  */
 
-/** POSIX-style spelling: one separator, no trailing slash. */
-export const cleanPath = (path: string): string => path.trim().replace(/\\/g, '/').replace(/\/+$/, '') || '/'
+/** POSIX-style spelling: one separator, no trailing slash.
+ *
+ *  Repeated separators collapse as well: `C:/Repos//App` names the same
+ *  directory as `C:/Repos/App`, and a cwd assembled by joining a root that
+ *  already ends in a separator arrives spelled that way. A UNC path keeps its
+ *  leading `//`, the one place a doubled separator carries meaning. */
+export const cleanPath = (path: string): string => {
+  const unified = path.trim().replace(/\\/g, '/')
+  const uncPrefix = unified.startsWith('//') ? '/' : ''
+  const collapsed = unified.replace(/\/{2,}/g, '/').replace(/\/+$/, '')
+
+  return collapsed === '' ? '/' : `${uncPrefix}${collapsed}`
+}
 
 /** Case-folded comparison key. Windows drive/UNC paths are case-insensitive;
  *  POSIX paths are not, and callers that display a path want its real spelling,


### PR DESCRIPTION
## What

bd39673b8 (2026-08-08, "refactor(desktop): one path-comparison helper instead of two") made `lib/path-compare` the single Windows-aware comparison behind project ownership and the file tree. Its header states the rule it exists to enforce:

> A cwd reaches us from the backend, a picker, a session row and a project record, and the four don't agree on separator, trailing slash or drive-letter case. Compare through these rather than `===` / `startsWith`.

Repeated separators belong to that same family, and `cleanPath` doesn't fold them. It strips a *trailing* run but leaves an internal one, and `isUnderPath` then compares by string prefix:

```
isUnderPath('C:/Repos//App', 'C:/Repos/App/src')   -> false
isUnderPath('C:/Repos/App',  'C:/Repos//App/src')  -> false
isUnderPath('C:\Repos\\App', 'c:/repos/app/src')   -> false
isUnderPath('/home/u//repo', '/home/u/repo/src')   -> false
```

Every one of those pairs names the same directory. A cwd assembled by joining a root that already ends in a separator arrives spelled exactly that way, and the resulting symptom is the one 7ff9d7db9 (2026-08-08, "fix(desktop): match a project to its cwd across Windows path spellings") set out to remove: the session falls out of its project, and the file tree stops treating the path as inside its root.

The third copy of this logic makes the inconsistency concrete. `app/chat/sidebar/projects/workspace-groups.ts` — which the refactor did not reach — folds repeated separators as a side effect of how it normalises:

```ts
const segments = (path: string): string[] =>
  path.replace(/[/\\]+$/, '').split(/[/\\]/).filter(Boolean)
```

`filter(Boolean)` drops the empty piece a doubled separator produces, so its `isPathUnder` answers `true` for exactly the pairs above. The lane grouping and the ownership check disagree about the same two paths today.

## The fix

Collapse runs of separators in `cleanPath`, preserving the leading `//` of a UNC path — the one place a doubled separator carries meaning. `comparisonPath` and `isUnderPath` are untouched; they inherit the corrected key.

Dot segments (`C:/Repos/./App`) are deliberately left alone: that is a different normalisation axis, `workspace-groups` doesn't fold them either, and resolving them properly needs the filesystem.

## Tests and results

Added to `path-compare.test.ts`, the file bd39673b8 created:

- `cleanPath` collapses repeated separators, across `/`, `\` and POSIX
- `cleanPath` keeps a UNC path's leading `//`, including when the rest of it is doubled
- `isUnderPath` matches when either side carries the doubled separator
- `isUnderPath` still matches under a UNC root

vitest isn't installed in this checkout, so I ran every assertion in the file — the six pre-existing ones and the new ones — directly against the module under Node's TypeScript support. With the fix: 23 assertions, 23 pass. On `main`: 15 pass, 8 fail, and the 8 are exactly the new duplicate-separator cases. The pre-existing 15 pass on both sides, so nothing established changed.

The helper's only two consumers are `store/projects.ts` and `right-sidebar/files/ipc.ts`; neither their tests nor any other desktop test asserts on a doubled-separator path, and both are cases this fix makes match rather than stop matching.