### PR TITLE
fix(acp): resume parent after background completions

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -88,6 +88,10 @@ from tools.process_registry import process_registry
 logger = logging.getLogger(__name__)
 
 
+class _SyntheticNotificationBusy(RuntimeError):
+    """The target session became busy before an autonomous turn started."""
+
+
 def _named_custom_provider_catalogs() -> list[tuple[str, str, list[tuple[str, str]]]]:
     """Return ``(slug, label, [(model_id, description), ...])`` for named endpoints.
 
@@ -634,6 +638,7 @@ class HermesACPAgent(acp.Agent):
     _EDIT_APPROVAL_POLICY_TO_MODE = {
         value: key for key, value in _MODE_TO_EDIT_APPROVAL_POLICY.items()
     }
+    _BACKGROUND_CLAIM_RENEW_INTERVAL_SECONDS = 60.0
 
     def __init__(self, session_manager: SessionManager | None = None):
         super().__init__()
@@ -676,8 +681,34 @@ class HermesACPAgent(acp.Agent):
             self._background_notification_task = None
             logger.debug("ACP connection has no running loop for background notifications")
 
+    async def _renew_background_delivery_claim(
+        self,
+        event: dict[str, Any],
+        claim: str,
+    ) -> None:
+        """Keep a durable delegation claim live during a long model turn."""
+        from tools.async_delegation import renew_event_delivery
+
+        while True:
+            await asyncio.sleep(self._BACKGROUND_CLAIM_RENEW_INTERVAL_SECONDS)
+            try:
+                renewed = await asyncio.to_thread(renew_event_delivery, event, claim)
+            except Exception:
+                logger.warning(
+                    "ACP background notification claim renewal failed delegation=%s",
+                    event.get("delegation_id"),
+                    exc_info=True,
+                )
+                return
+            if not renewed:
+                logger.warning(
+                    "ACP background notification claim expired delegation=%s",
+                    event.get("delegation_id"),
+                )
+                return
+
     async def _dispatch_background_notifications_once(self) -> int:
-        """Deliver pending process events owned by sessions on this ACP connection."""
+        """Run autonomous turns for pending events owned by this connection."""
         conn = self._conn
         if conn is None or not self._connected_session_ids:
             return 0
@@ -696,48 +727,129 @@ class HermesACPAgent(acp.Agent):
 
         for index, (event, text) in enumerate(pending):
             session_id = str(event.get("session_key") or "")
+            state = self.session_manager.get_in_memory(session_id)
+            if state is None:
+                # Only an attached in-process session may receive an autonomous
+                # turn. Leave the event pending for a later reconnect rather
+                # than restoring a database-only session in this transport.
+                self._connected_session_ids.discard(session_id)
+                process_registry.completion_queue.put(event)
+                continue
+
+            with state.runtime_lock:
+                if state.is_running:
+                    # Never interrupt or redirect a user-owned turn. The next
+                    # dispatcher pass will retry once the session is idle.
+                    process_registry.completion_queue.put(event)
+                    continue
+
+            from tools.async_delegation import (
+                claim_event_delivery,
+                complete_event_delivery,
+                release_event_delivery,
+            )
+
+            claim = claim_event_delivery(event, f"acp:{os.getpid()}")
+            if claim is None:
+                continue
+            renewal_task: asyncio.Task | None = None
+            turn_task: asyncio.Task | None = None
+            turn_progress = {"model_started": False, "model_completed": False}
             try:
                 event_type = str(event.get("type") or "completion")
-                process_status = "running"
-                if event_type == "completion":
-                    process_status = "completed" if event.get("exit_code") == 0 else "failed"
-                process_meta = {
-                    "id": str(event.get("session_id") or ""),
+                process_status = str(event.get("status") or "")
+                if not process_status:
+                    process_status = "running"
+                    if event_type == "completion":
+                        process_status = (
+                            "completed" if event.get("exit_code") == 0 else "failed"
+                        )
+                process_meta: dict[str, Any] = {
+                    "id": str(
+                        event.get("delegation_id") or event.get("session_id") or ""
+                    ),
                     "event": event_type,
                     "status": process_status,
                 }
                 if event.get("exit_code") is not None:
                     process_meta["exitCode"] = event.get("exit_code")
-                await conn.session_update(
-                    session_id=session_id,
-                    update=AgentMessageChunk(
-                        session_update="agent_message_chunk",
-                        content=TextContentBlock(type="text", text=text),
-                        field_meta={
+                if claim:
+                    renewal_task = asyncio.create_task(
+                        self._renew_background_delivery_claim(event, claim)
+                    )
+                turn_task = asyncio.create_task(
+                    self.prompt(
+                        prompt=[TextContentBlock(type="text", text=text)],
+                        session_id=session_id,
+                        _synthetic_notification=True,
+                        _synthetic_notification_progress=turn_progress,
+                        _synthetic_notification_meta={
                             "hermes": {
                                 "backgroundNotification": True,
                                 "process": process_meta,
                             }
                         },
-                    ),
+                    )
                 )
+                # Connection replacement cancels the dispatcher, not the
+                # already-accepted model turn. Let that turn finish against its
+                # captured transport so it cannot race a retry in the new one.
+                await asyncio.shield(turn_task)
+                complete_event_delivery(event, claim)
                 delivered += 1
                 logger.info(
-                    "ACP background notification delivered session=%s process=%s status=%s",
+                    "ACP background notification resumed session=%s process=%s status=%s",
                     session_id,
                     process_meta["id"],
                     process_meta["status"],
                 )
+            except _SyntheticNotificationBusy:
+                release_event_delivery(event, claim)
+                process_registry.completion_queue.put(event)
+                continue
             except asyncio.CancelledError:
-                # A replacement connection cancels this task while a drained
-                # event may be in flight. Restore the undelivered suffix before
-                # propagating cancellation to the connection-bound loop.
-                requeue_from(index)
+                turn_completed = False
+                if turn_task is not None:
+                    if not turn_progress["model_started"]:
+                        turn_task.cancel()
+                        try:
+                            await turn_task
+                        except asyncio.CancelledError:
+                            pass
+                        with state.runtime_lock:
+                            if state.active_turn_origin == "autonomous":
+                                state.is_running = False
+                                state.current_prompt_text = ""
+                                state.active_turn_origin = ""
+                    else:
+                        try:
+                            await turn_task
+                        except asyncio.CancelledError:
+                            logger.debug(
+                                "Cancelled ACP autonomous turn did not finish for %s",
+                                session_id,
+                            )
+                        except Exception:
+                            logger.debug(
+                                "Cancelled ACP dispatcher's autonomous turn failed for %s",
+                                session_id,
+                                exc_info=True,
+                            )
+                        if turn_progress["model_completed"]:
+                            complete_event_delivery(event, claim)
+                            turn_completed = True
+                if not turn_completed:
+                    release_event_delivery(event, claim)
+                    process_registry.completion_queue.put(event)
+                # The rest of the drained batch has not started and must remain
+                # available to the replacement connection.
+                requeue_from(index + 1)
                 raise
             except Exception:
                 # Preserve this event and every not-yet-attempted owned event.
                 # The transport is no longer usable, so do not repeatedly drain
                 # and retry the same queue entries on this connection.
+                release_event_delivery(event, claim)
                 requeue_from(index)
                 if self._conn is conn:
                     self._conn = None
@@ -747,6 +859,13 @@ class HermesACPAgent(acp.Agent):
                     exc_info=True,
                 )
                 break
+            finally:
+                if renewal_task is not None:
+                    renewal_task.cancel()
+                    try:
+                        await renewal_task
+                    except asyncio.CancelledError:
+                        pass
         return delivered
 
     async def _background_notification_loop(self, conn: acp.Client) -> None:
@@ -1683,7 +1802,11 @@ class HermesACPAgent(acp.Agent):
         state = self.session_manager.get_session(session_id)
         if state and state.cancel_event:
             with state.runtime_lock:
-                if state.is_running and state.current_prompt_text:
+                if (
+                    state.is_running
+                    and state.active_turn_origin == "user"
+                    and state.current_prompt_text
+                ):
                     state.interrupted_prompt_text = state.current_prompt_text
                 # Publish cancellation and hard-stop the agent before another
                 # prompt can acquire this lock and mistake the turn for
@@ -1780,7 +1903,12 @@ class HermesACPAgent(acp.Agent):
         session_id: str,
         **kwargs: Any,
     ) -> PromptResponse:
-        """Run Hermes on the user's prompt and stream events back to the editor."""
+        """Run Hermes on a user prompt or an internal completion notification."""
+        synthetic_notification = bool(kwargs.pop("_synthetic_notification", False))
+        synthetic_notification_progress = kwargs.pop(
+            "_synthetic_notification_progress", None
+        )
+        synthetic_notification_meta = kwargs.pop("_synthetic_notification_meta", None)
         self._ensure_background_notification_task()
         state = self.session_manager.get_session(session_id)
         if state is None:
@@ -1809,7 +1937,12 @@ class HermesACPAgent(acp.Agent):
         #      silently append to state.queued_prompts and respond with
         #      "No active turn — queued for the next turn", which looks like
         #      /queue even though the user never typed /queue.
-        if text_only_prompt and isinstance(user_content, str) and user_text.startswith("/steer"):
+        if (
+            not synthetic_notification
+            and text_only_prompt
+            and isinstance(user_content, str)
+            and user_text.startswith("/steer")
+        ):
             steer_text = user_text.split(maxsplit=1)[1].strip() if len(user_text.split(maxsplit=1)) > 1 else ""
             interrupted_prompt = ""
             rewrite_idle = False
@@ -1830,7 +1963,8 @@ class HermesACPAgent(acp.Agent):
                 user_text = steer_text
                 user_content = steer_text
         elif (
-            text_only_prompt
+            not synthetic_notification
+            and text_only_prompt
             and isinstance(user_content, str)
             and not user_text.startswith("/")
         ):
@@ -1854,7 +1988,12 @@ class HermesACPAgent(acp.Agent):
         # Slash commands are text-only; if the client included images/resources,
         # send the whole multimodal prompt to the agent instead of treating it as
         # an ACP command.
-        if text_only_prompt and isinstance(user_content, str) and user_text.startswith("/"):
+        if (
+            not synthetic_notification
+            and text_only_prompt
+            and isinstance(user_content, str)
+            and user_text.startswith("/")
+        ):
             response_text = self._handle_slash_command(user_text, state)
             if response_text is not None:
                 if self._conn:
@@ -1870,9 +2009,12 @@ class HermesACPAgent(acp.Agent):
         queued_depth: int | None = None
         with state.runtime_lock:
             if state.is_running:
+                if synthetic_notification:
+                    raise _SyntheticNotificationBusy(session_id)
                 if (
                     text_only_prompt
                     and isinstance(user_content, str)
+                    and state.active_turn_origin != "autonomous"
                     and getattr(
                         state.agent,
                         "_supports_active_turn_redirect",
@@ -1894,8 +2036,13 @@ class HermesACPAgent(acp.Agent):
                     state.queued_prompts.append(queued_text)
                     queued_depth = len(state.queued_prompts)
             else:
+                if state.cancel_event:
+                    state.cancel_event.clear()
                 state.is_running = True
                 state.current_prompt_text = user_text or "[Image attachment]"
+                state.active_turn_origin = (
+                    "autonomous" if synthetic_notification else "user"
+                )
 
         if redirected:
             if self._conn:
@@ -1917,8 +2064,28 @@ class HermesACPAgent(acp.Agent):
         conn = self._conn
         loop = asyncio.get_running_loop()
 
-        if state.cancel_event:
-            state.cancel_event.clear()
+        if synthetic_notification and conn:
+            try:
+                await conn.session_update(
+                    session_id=session_id,
+                    update=UserMessageChunk(
+                        session_update="user_message_chunk",
+                        content=TextContentBlock(type="text", text=user_text),
+                        field_meta=synthetic_notification_meta,
+                    ),
+                )
+            except asyncio.CancelledError:
+                with state.runtime_lock:
+                    state.is_running = False
+                    state.current_prompt_text = ""
+                    state.active_turn_origin = ""
+                raise
+            except Exception:
+                with state.runtime_lock:
+                    state.is_running = False
+                    state.current_prompt_text = ""
+                    state.active_turn_origin = ""
+                raise
 
         tool_call_ids: dict[str, Deque[str]] = defaultdict(deque)
         tool_call_meta: dict[str, dict[str, Any]] = {}
@@ -2099,12 +2266,19 @@ class HermesACPAgent(acp.Agent):
             # stomp on each other's ContextVar writes (HERMES_SESSION_KEY in
             # particular — used by the interactive sudo password cache scope).
             ctx = contextvars.copy_context()
+            if synthetic_notification_progress is not None:
+                synthetic_notification_progress["model_started"] = True
             result = await loop.run_in_executor(_executor, ctx.run, _run_agent)
+            if synthetic_notification_progress is not None:
+                synthetic_notification_progress["model_completed"] = True
         except Exception:
             logger.exception("Executor error for session %s", session_id)
             with state.runtime_lock:
                 state.is_running = False
                 state.current_prompt_text = ""
+                state.active_turn_origin = ""
+            if synthetic_notification:
+                raise
             return PromptResponse(stop_reason="end_turn")
 
         if result.get("messages"):
@@ -2146,7 +2320,7 @@ class HermesACPAgent(acp.Agent):
         suppress_interrupt_response = interrupted and final_response.startswith(
             INTERRUPT_WAITING_FOR_MODEL_PREFIX
         )
-        if final_response and not suppress_interrupt_response:
+        if final_response and not suppress_interrupt_response and not synthetic_notification:
             try:
                 from agent.title_generator import maybe_auto_title
 
@@ -2191,7 +2365,19 @@ class HermesACPAgent(acp.Agent):
             # finished (e.g. transform_llm_output) — otherwise the appended /
             # rewritten text never reaches the client.
             update = acp.update_agent_message_text(final_response)
-            await conn.session_update(session_id, update)
+            try:
+                await conn.session_update(session_id, update)
+            except Exception:
+                if not synthetic_notification:
+                    raise
+                # The autonomous result is already persisted in session
+                # history. A replacement client can replay it; retrying the
+                # completion would instead make the parent act twice.
+                logger.warning(
+                    "ACP transport closed after autonomous result for %s",
+                    session_id,
+                    exc_info=True,
+                )
 
         # Mark this turn idle before draining queued work so recursive prompt()
         # calls can acquire the session. Queued turns are intentionally run as
@@ -2199,6 +2385,7 @@ class HermesACPAgent(acp.Agent):
         with state.runtime_lock:
             state.is_running = False
             state.current_prompt_text = ""
+            state.active_turn_origin = ""
 
         while True:
             with state.runtime_lock:
@@ -2225,7 +2412,8 @@ class HermesACPAgent(acp.Agent):
                 cached_read_tokens=result.get("cache_read_tokens"),
             )
 
-        await self._send_usage_update(state)
+        if not synthetic_notification or self._conn is conn:
+            await self._send_usage_update(state)
 
         stop_reason = "cancelled" if cancelled else "end_turn"
         return PromptResponse(stop_reason=stop_reason, usage=usage)

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -83,6 +83,7 @@ from tools.approval import (
     reset_hermes_interactive_context,
     set_hermes_interactive_context,
 )
+from tools.process_registry import process_registry
 
 logger = logging.getLogger(__name__)
 
@@ -638,14 +639,128 @@ class HermesACPAgent(acp.Agent):
         super().__init__()
         self.session_manager = session_manager or SessionManager()
         self._conn: Optional[acp.Client] = None
+        self._connected_session_ids: set[str] = set()
+        self._background_notification_task: asyncio.Task | None = None
 
     # ---- Connection lifecycle -----------------------------------------------
 
     def on_connect(self, conn: acp.Client) -> None:
         """Store the client connection for sending session updates."""
+        if self._background_notification_task is not None:
+            self._background_notification_task.cancel()
+        self._background_notification_task = None
+        # Session ownership belongs to one transport connection. A replacement
+        # client must attach or load its own sessions before receiving events.
+        self._connected_session_ids.clear()
         self._conn = conn
         logger.info("ACP client connected")
+        self._ensure_background_notification_task()
 
+    def _ensure_background_notification_task(self) -> None:
+        """Ensure async process notifications have a live dispatcher on this loop."""
+        conn = self._conn
+        task = self._background_notification_task
+        if conn is None or (task is not None and not task.done()):
+            return
+        try:
+            loop = asyncio.get_running_loop()
+            coroutine = self._background_notification_loop(conn)
+            created = loop.create_task(coroutine)
+            if not asyncio.isfuture(created):
+                coroutine.close()
+                self._background_notification_task = None
+                return
+            self._background_notification_task = created
+            logger.info("ACP background notification dispatcher started")
+        except RuntimeError:
+            self._background_notification_task = None
+            logger.debug("ACP connection has no running loop for background notifications")
+
+    async def _dispatch_background_notifications_once(self) -> int:
+        """Deliver pending process events owned by sessions on this ACP connection."""
+        conn = self._conn
+        if conn is None or not self._connected_session_ids:
+            return 0
+        pending = process_registry.drain_notifications(
+            owns_event=lambda event: str(event.get("session_key") or "")
+            in self._connected_session_ids,
+            # ACP, like gateway/TUI, must still deliver an autonomous result
+            # after the agent only polled the process status inline.
+            skip_poll_observed=False,
+        )
+        delivered = 0
+
+        def requeue_from(start_index: int) -> None:
+            for queued_event, _ in pending[start_index:]:
+                process_registry.completion_queue.put(queued_event)
+
+        for index, (event, text) in enumerate(pending):
+            session_id = str(event.get("session_key") or "")
+            try:
+                event_type = str(event.get("type") or "completion")
+                process_status = "running"
+                if event_type == "completion":
+                    process_status = "completed" if event.get("exit_code") == 0 else "failed"
+                process_meta = {
+                    "id": str(event.get("session_id") or ""),
+                    "event": event_type,
+                    "status": process_status,
+                }
+                if event.get("exit_code") is not None:
+                    process_meta["exitCode"] = event.get("exit_code")
+                await conn.session_update(
+                    session_id=session_id,
+                    update=AgentMessageChunk(
+                        session_update="agent_message_chunk",
+                        content=TextContentBlock(type="text", text=text),
+                        field_meta={
+                            "hermes": {
+                                "backgroundNotification": True,
+                                "process": process_meta,
+                            }
+                        },
+                    ),
+                )
+                delivered += 1
+                logger.info(
+                    "ACP background notification delivered session=%s process=%s status=%s",
+                    session_id,
+                    process_meta["id"],
+                    process_meta["status"],
+                )
+            except asyncio.CancelledError:
+                # A replacement connection cancels this task while a drained
+                # event may be in flight. Restore the undelivered suffix before
+                # propagating cancellation to the connection-bound loop.
+                requeue_from(index)
+                raise
+            except Exception:
+                # Preserve this event and every not-yet-attempted owned event.
+                # The transport is no longer usable, so do not repeatedly drain
+                # and retry the same queue entries on this connection.
+                requeue_from(index)
+                if self._conn is conn:
+                    self._conn = None
+                logger.debug(
+                    "Failed to deliver ACP background notification for %s",
+                    session_id,
+                    exc_info=True,
+                )
+                break
+        return delivered
+
+    async def _background_notification_loop(self, conn: acp.Client) -> None:
+        """Poll the shared completion queue while this ACP connection is active."""
+        try:
+            while self._conn is conn:
+                await self._dispatch_background_notifications_once()
+                if self._conn is not conn:
+                    break
+                await asyncio.sleep(0.25)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning("ACP background notification loop stopped", exc_info=True)
 
     def _session_modes(self, state: SessionState) -> SessionModeState:
         """Return ACP session modes while preserving Zed's separate model picker.
@@ -1439,6 +1554,7 @@ class HermesACPAgent(acp.Agent):
         **kwargs: Any,
     ) -> NewSessionResponse:
         state = self.session_manager.create_session(cwd=cwd)
+        self._connected_session_ids.add(state.session_id)
         await self._register_session_mcp_servers(state, mcp_servers)
         self._schedule_mcp_late_refresh(state)
         logger.info("New session %s (cwd=%s)", state.session_id, cwd)
@@ -1464,6 +1580,7 @@ class HermesACPAgent(acp.Agent):
         if state is None:
             logger.warning("load_session: session %s not found", session_id)
             return None
+        self._connected_session_ids.add(state.session_id)
         await self._register_session_mcp_servers(state, mcp_servers)
         self._schedule_mcp_late_refresh(state)
         logger.info("Loaded session %s", session_id)
@@ -1512,6 +1629,7 @@ class HermesACPAgent(acp.Agent):
         if state is None:
             logger.warning("resume_session: session %s not found, creating new", session_id)
             state = self.session_manager.create_session(cwd=cwd)
+        self._connected_session_ids.add(state.session_id)
         await self._register_session_mcp_servers(state, mcp_servers)
         self._schedule_mcp_late_refresh(state)
         logger.info("Resumed session %s", state.session_id)
@@ -1568,6 +1686,7 @@ class HermesACPAgent(acp.Agent):
         state = self.session_manager.fork_session(session_id, cwd=cwd)
         new_id = state.session_id if state else ""
         if state is not None:
+            self._connected_session_ids.add(state.session_id)
             await self._register_session_mcp_servers(state, mcp_servers)
         logger.info("Forked session %s -> %s", session_id, new_id)
         if new_id:
@@ -1638,11 +1757,13 @@ class HermesACPAgent(acp.Agent):
         **kwargs: Any,
     ) -> PromptResponse:
         """Run Hermes on the user's prompt and stream events back to the editor."""
+        self._ensure_background_notification_task()
         state = self.session_manager.get_session(session_id)
         if state is None:
             logger.error("prompt: session %s not found", session_id)
             return PromptResponse(stop_reason="refusal")
 
+        self._connected_session_ids.add(state.session_id)
         user_text = _extract_text(prompt).strip()
         user_content = _content_blocks_to_openai_user_content(prompt)
         text_only_prompt = all(isinstance(block, TextContentBlock) for block in prompt)

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1075,6 +1075,30 @@ class HermesACPAgent(acp.Agent):
         except Exception:
             logger.debug("Could not send ACP session info update for %s", session_id, exc_info=True)
 
+    def _schedule_session_info_update_from_thread(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        session_id: str,
+    ) -> None:
+        """Schedule a title/provenance update without creating an orphan coroutine.
+
+        Auto-title callbacks run on a worker thread. Constructing the coroutine
+        before ``call_soon_threadsafe`` leaks it when the owning ACP event loop
+        has already closed. Defer construction until the callback executes on
+        that loop instead.
+        """
+
+        def _schedule_on_loop() -> None:
+            asyncio.create_task(self._send_session_info_update(session_id))
+
+        try:
+            loop.call_soon_threadsafe(_schedule_on_loop)
+        except RuntimeError:
+            logger.debug(
+                "ACP event loop closed before title update for %s",
+                session_id,
+            )
+
     def _schedule_usage_update(self, state: SessionState) -> None:
         """Schedule native context indicator refresh after ACP responses."""
         if not self._conn:
@@ -2128,10 +2152,7 @@ class HermesACPAgent(acp.Agent):
 
                 def _notify_title_update(_title: str) -> None:
                     if conn:
-                        loop.call_soon_threadsafe(
-                            asyncio.create_task,
-                            self._send_session_info_update(session_id),
-                        )
+                        self._schedule_session_info_update_from_thread(loop, session_id)
 
                 # Snapshot the runtime identity; the validator lets the
                 # background titler skip its LLM call if the session's model

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -170,6 +170,7 @@ class SessionState:
     runtime_lock: Any = field(default_factory=Lock)
     current_prompt_text: str = ""
     interrupted_prompt_text: str = ""
+    active_turn_origin: str = ""
 
 
 class SessionManager:
@@ -229,6 +230,11 @@ class SessionManager:
             return state
         # Attempt to restore from database.
         return self._restore(session_id)
+
+    def get_in_memory(self, session_id: str) -> Optional[SessionState]:
+        """Return an attached in-process session without restoring from disk."""
+        with self._lock:
+            return self._sessions.get(session_id)
 
     def remove_session(self, session_id: str) -> bool:
         """Remove a session from memory and database. Returns True if it existed."""

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -587,6 +587,20 @@ class TestPrompt:
 
         assert captured.get("child") == resp.session_id
 
+    def test_title_update_does_not_create_coroutine_after_loop_closes(self, agent):
+        class ClosedLoop:
+            def call_soon_threadsafe(self, _callback):
+                raise RuntimeError("event loop is closed")
+
+        agent._send_session_info_update = MagicMock()
+
+        agent._schedule_session_info_update_from_thread(
+            ClosedLoop(),
+            "closed-session",
+        )
+
+        agent._send_session_info_update.assert_not_called()
+
 
 
 

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import os
+import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock, AsyncMock, patch
 
@@ -178,6 +179,24 @@ class TestAuthenticate:
 class TestSessionOps:
 
     @pytest.mark.asyncio
+    async def test_cancel_autonomous_turn_does_not_salvage_internal_notification(
+        self, agent, monkeypatch
+    ):
+        state = agent.session_manager.create_session(cwd="/tmp")
+        state.is_running = True
+        state.active_turn_origin = "autonomous"
+        state.current_prompt_text = "Internal background completion"
+        state.interrupted_prompt_text = "Earlier user request"
+        interrupt = MagicMock()
+        monkeypatch.setattr("acp_adapter.server.request_hard_interrupt", interrupt)
+
+        await agent.cancel(state.session_id)
+
+        assert state.cancel_event.is_set()
+        assert state.interrupted_prompt_text == "Earlier user request"
+        interrupt.assert_called_once_with(state.agent)
+
+    @pytest.mark.asyncio
     async def test_dispatches_only_background_notifications_owned_by_connected_sessions(
         self, agent, monkeypatch
     ):
@@ -187,14 +206,23 @@ class TestSessionOps:
         conn = MagicMock()
         conn.session_update = AsyncMock()
         agent._conn = conn
-        agent._connected_session_ids.add("acp-owned")
+        state = agent.session_manager.create_session(cwd="/tmp")
+        state.agent.run_conversation.return_value = {
+            "final_response": "Parent report.",
+            "messages": [
+                {"role": "user", "content": "Background process completed."},
+                {"role": "assistant", "content": "Parent report."},
+            ],
+        }
+        state.interrupted_prompt_text = "Cancelled user request"
+        agent._connected_session_ids.add(state.session_id)
         monkeypatch.setattr("acp_adapter.server.process_registry", registry)
 
         registry.completion_queue.put(
             {
                 "type": "completion",
                 "session_id": "proc_owned",
-                "session_key": "acp-owned",
+                "session_key": state.session_id,
                 "command": "printf done",
                 "exit_code": 0,
                 "output": "done",
@@ -215,11 +243,14 @@ class TestSessionOps:
         delivered = await agent._dispatch_background_notifications_once()
 
         assert delivered == 1
-        conn.session_update.assert_awaited_once()
-        assert conn.session_update.await_args.kwargs["session_id"] == "acp-owned"
-        update = conn.session_update.await_args.kwargs["update"]
-        assert update.session_update == "agent_message_chunk"
-        assert update.field_meta == {
+        updates = [
+            call.kwargs.get("update") or call.args[1]
+            for call in conn.session_update.await_args_list
+        ]
+        notification = next(
+            update for update in updates if update.session_update == "user_message_chunk"
+        )
+        assert notification.field_meta == {
             "hermes": {
                 "backgroundNotification": True,
                 "process": {
@@ -230,8 +261,108 @@ class TestSessionOps:
                 },
             }
         }
-        assert "proc_owned completed normally" in update.content.text
+        assert "proc_owned completed normally" in notification.content.text
+        assert any(
+            update.session_update == "agent_message_chunk"
+            and update.content.text == "Parent report."
+            for update in updates
+        )
+        state.agent.run_conversation.assert_called_once()
+        assert "proc_owned completed normally" in state.agent.run_conversation.call_args.kwargs[
+            "user_message"
+        ]
+        assert "Cancelled user request" not in state.agent.run_conversation.call_args.kwargs[
+            "user_message"
+        ]
+        assert state.interrupted_prompt_text == "Cancelled user request"
         assert registry.completion_queue.get_nowait()["session_id"] == "proc_foreign"
+
+    @pytest.mark.asyncio
+    async def test_busy_session_keeps_background_notification_pending(
+        self, agent, monkeypatch
+    ):
+        from tools.process_registry import ProcessRegistry
+
+        registry = ProcessRegistry()
+        conn = MagicMock()
+        conn.session_update = AsyncMock()
+        agent._conn = conn
+        state = agent.session_manager.create_session(cwd="/tmp")
+        state.is_running = True
+        state.active_turn_origin = "user"
+        agent._connected_session_ids.add(state.session_id)
+        monkeypatch.setattr("acp_adapter.server.process_registry", registry)
+        registry.completion_queue.put(
+            {
+                "type": "completion",
+                "session_id": "proc_busy",
+                "session_key": state.session_id,
+                "command": "printf done",
+                "exit_code": 0,
+                "output": "done",
+            }
+        )
+
+        delivered = await agent._dispatch_background_notifications_once()
+
+        assert delivered == 0
+        assert registry.completion_queue.get_nowait()["session_id"] == "proc_busy"
+        state.agent.run_conversation.assert_not_called()
+        conn.session_update.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_async_delegation_turn_completes_its_durable_claim(
+        self, agent, monkeypatch
+    ):
+        from tools.process_registry import ProcessRegistry
+
+        registry = ProcessRegistry()
+        conn = MagicMock()
+        conn.session_update = AsyncMock()
+        agent._conn = conn
+        state = agent.session_manager.create_session(cwd="/tmp")
+        state.agent.run_conversation.return_value = {
+            "final_response": "Consolidated parent report.",
+            "messages": [],
+        }
+        agent._connected_session_ids.add(state.session_id)
+        monkeypatch.setattr("acp_adapter.server.process_registry", registry)
+
+        claim = MagicMock(return_value="claim-1")
+        complete = MagicMock()
+        release = MagicMock()
+        monkeypatch.setattr("tools.async_delegation.claim_event_delivery", claim)
+        monkeypatch.setattr("tools.async_delegation.complete_event_delivery", complete)
+        monkeypatch.setattr("tools.async_delegation.release_event_delivery", release)
+
+        event = {
+            "type": "async_delegation",
+            "delegation_id": "deleg_test",
+            "session_key": state.session_id,
+            "status": "completed",
+            "is_batch": True,
+            "goals": ["inspect the regression"],
+            "results": [
+                {
+                    "task_index": 0,
+                    "status": "completed",
+                    "summary": "Child found the missing ACP queue drain.",
+                }
+            ],
+        }
+        registry.completion_queue.put(event)
+
+        delivered = await agent._dispatch_background_notifications_once()
+
+        assert delivered == 1
+        claimed_event, consumer = claim.call_args.args
+        assert claimed_event == event
+        assert consumer.startswith("acp:")
+        complete.assert_called_once_with(event, "claim-1")
+        release.assert_not_called()
+        prompt_text = state.agent.run_conversation.call_args.kwargs["user_message"]
+        assert "Child found the missing ACP queue drain." in prompt_text
+        assert "deleg_test" in prompt_text
 
     @pytest.mark.asyncio
     async def test_background_notification_loop_stops_after_transport_failure(
@@ -243,14 +374,15 @@ class TestSessionOps:
         conn = MagicMock()
         conn.session_update = AsyncMock(side_effect=ConnectionError("disconnected"))
         agent._conn = conn
-        agent._connected_session_ids.add("acp-owned")
+        state = agent.session_manager.create_session(cwd="/tmp")
+        agent._connected_session_ids.add(state.session_id)
         monkeypatch.setattr("acp_adapter.server.process_registry", registry)
 
         registry.completion_queue.put(
             {
                 "type": "completion",
                 "session_id": "proc_owned",
-                "session_key": "acp-owned",
+                "session_key": state.session_id,
                 "command": "printf done",
                 "exit_code": 0,
                 "output": "done",
@@ -282,7 +414,8 @@ class TestSessionOps:
         old_conn.session_update = AsyncMock(side_effect=blocked_session_update)
         new_conn.session_update = AsyncMock()
         agent._conn = old_conn
-        agent._connected_session_ids.add("acp-owned")
+        state = agent.session_manager.create_session(cwd="/tmp")
+        agent._connected_session_ids.add(state.session_id)
         monkeypatch.setattr("acp_adapter.server.process_registry", registry)
 
         for process_id in ("proc_first", "proc_second"):
@@ -290,7 +423,7 @@ class TestSessionOps:
                 {
                     "type": "completion",
                     "session_id": process_id,
-                    "session_key": "acp-owned",
+                    "session_key": state.session_id,
                     "command": "printf done",
                     "exit_code": 0,
                     "output": "done",
@@ -311,6 +444,131 @@ class TestSessionOps:
                 registry.completion_queue.get_nowait()["session_id"],
             ]
             assert queued_ids == ["proc_first", "proc_second"]
+            assert registry.completion_queue.empty()
+        finally:
+            if new_task is not None:
+                new_task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await new_task
+
+    @pytest.mark.asyncio
+    async def test_connection_replacement_does_not_replay_started_autonomous_turn(
+        self, agent, monkeypatch
+    ):
+        from tools.process_registry import ProcessRegistry
+
+        registry = ProcessRegistry()
+        old_conn = MagicMock()
+        new_conn = MagicMock()
+        old_conn.session_update = AsyncMock()
+        new_conn.session_update = AsyncMock()
+        agent._conn = old_conn
+        state = agent.session_manager.create_session(cwd="/tmp")
+        agent._connected_session_ids.add(state.session_id)
+        monkeypatch.setattr("acp_adapter.server.process_registry", registry)
+
+        run_started = threading.Event()
+        allow_finish = threading.Event()
+
+        def run_parent(**_kwargs):
+            run_started.set()
+            assert allow_finish.wait(timeout=1)
+            return {
+                "final_response": "Parent finished once.",
+                "messages": [
+                    {"role": "user", "content": "Background process completed."},
+                    {"role": "assistant", "content": "Parent finished once."},
+                ],
+            }
+
+        state.agent.run_conversation.side_effect = run_parent
+        for process_id in ("proc_started", "proc_waiting"):
+            registry.completion_queue.put(
+                {
+                    "type": "completion",
+                    "session_id": process_id,
+                    "session_key": state.session_id,
+                    "command": "printf done",
+                    "exit_code": 0,
+                    "output": "done",
+                }
+            )
+
+        old_task = asyncio.create_task(agent._background_notification_loop(old_conn))
+        agent._background_notification_task = old_task
+        assert await asyncio.to_thread(run_started.wait, 1)
+
+        agent.on_connect(new_conn)
+        new_task = agent._background_notification_task
+        allow_finish.set()
+        try:
+            with pytest.raises(asyncio.CancelledError):
+                await old_task
+            state.agent.run_conversation.assert_called_once()
+            assert registry.completion_queue.get_nowait()["session_id"] == "proc_waiting"
+            assert registry.completion_queue.empty()
+        finally:
+            if new_task is not None:
+                new_task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await new_task
+
+    @pytest.mark.asyncio
+    async def test_connection_replacement_after_model_completion_does_not_replay(
+        self, agent, monkeypatch
+    ):
+        from tools.process_registry import ProcessRegistry
+
+        registry = ProcessRegistry()
+        old_conn = MagicMock()
+        new_conn = MagicMock()
+        result_delivery_started = asyncio.Event()
+        allow_result_delivery = asyncio.Event()
+
+        async def block_final_result(*args, **kwargs):
+            update = kwargs.get("update") or args[1]
+            if update.session_update == "agent_message_chunk":
+                result_delivery_started.set()
+                await allow_result_delivery.wait()
+
+        old_conn.session_update = AsyncMock(side_effect=block_final_result)
+        new_conn.session_update = AsyncMock()
+        agent._conn = old_conn
+        state = agent.session_manager.create_session(cwd="/tmp")
+        state.agent.run_conversation.return_value = {
+            "final_response": "Parent result is durable.",
+            "messages": [
+                {"role": "user", "content": "Background process completed."},
+                {"role": "assistant", "content": "Parent result is durable."},
+            ],
+        }
+        agent._connected_session_ids.add(state.session_id)
+        monkeypatch.setattr("acp_adapter.server.process_registry", registry)
+
+        for process_id in ("proc_completed", "proc_waiting"):
+            registry.completion_queue.put(
+                {
+                    "type": "completion",
+                    "session_id": process_id,
+                    "session_key": state.session_id,
+                    "command": "printf done",
+                    "exit_code": 0,
+                    "output": "done",
+                }
+            )
+
+        old_task = asyncio.create_task(agent._background_notification_loop(old_conn))
+        agent._background_notification_task = old_task
+        await asyncio.wait_for(result_delivery_started.wait(), timeout=1)
+
+        agent.on_connect(new_conn)
+        new_task = agent._background_notification_task
+        allow_result_delivery.set()
+        try:
+            with pytest.raises(asyncio.CancelledError):
+                await old_task
+            state.agent.run_conversation.assert_called_once()
+            assert registry.completion_queue.get_nowait()["session_id"] == "proc_waiting"
             assert registry.completion_queue.empty()
         finally:
             if new_task is not None:
@@ -586,6 +844,29 @@ class TestPrompt:
         )
 
         assert captured.get("child") == resp.session_id
+
+    @pytest.mark.asyncio
+    async def test_user_prompt_queues_behind_autonomous_turn_without_redirecting(
+        self, agent, mock_manager
+    ):
+        resp = await agent.new_session(cwd=".")
+        state = mock_manager.get_session(resp.session_id)
+        state.is_running = True
+        state.active_turn_origin = "autonomous"
+        state.agent._supports_active_turn_redirect = True
+        state.agent.redirect = MagicMock(return_value=True)
+        conn = MagicMock(spec=acp.Client)
+        conn.session_update = AsyncMock()
+        agent._conn = conn
+
+        result = await agent.prompt(
+            prompt=[TextContentBlock(type="text", text="new user request")],
+            session_id=resp.session_id,
+        )
+
+        assert result.stop_reason == "end_turn"
+        assert state.queued_prompts == ["new user request"]
+        state.agent.redirect.assert_not_called()
 
     def test_title_update_does_not_create_coroutine_after_loop_closes(self, agent):
         class ClosedLoop:

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -178,6 +178,147 @@ class TestAuthenticate:
 class TestSessionOps:
 
     @pytest.mark.asyncio
+    async def test_dispatches_only_background_notifications_owned_by_connected_sessions(
+        self, agent, monkeypatch
+    ):
+        from tools.process_registry import ProcessRegistry
+
+        registry = ProcessRegistry()
+        conn = MagicMock()
+        conn.session_update = AsyncMock()
+        agent._conn = conn
+        agent._connected_session_ids.add("acp-owned")
+        monkeypatch.setattr("acp_adapter.server.process_registry", registry)
+
+        registry.completion_queue.put(
+            {
+                "type": "completion",
+                "session_id": "proc_owned",
+                "session_key": "acp-owned",
+                "command": "printf done",
+                "exit_code": 0,
+                "output": "done",
+            }
+        )
+        registry.completion_queue.put(
+            {
+                "type": "completion",
+                "session_id": "proc_foreign",
+                "session_key": "acp-foreign",
+                "command": "printf secret",
+                "exit_code": 0,
+                "output": "secret",
+            }
+        )
+        registry._poll_observed.add("proc_owned")
+
+        delivered = await agent._dispatch_background_notifications_once()
+
+        assert delivered == 1
+        conn.session_update.assert_awaited_once()
+        assert conn.session_update.await_args.kwargs["session_id"] == "acp-owned"
+        update = conn.session_update.await_args.kwargs["update"]
+        assert update.session_update == "agent_message_chunk"
+        assert update.field_meta == {
+            "hermes": {
+                "backgroundNotification": True,
+                "process": {
+                    "id": "proc_owned",
+                    "event": "completion",
+                    "status": "completed",
+                    "exitCode": 0,
+                },
+            }
+        }
+        assert "proc_owned completed normally" in update.content.text
+        assert registry.completion_queue.get_nowait()["session_id"] == "proc_foreign"
+
+    @pytest.mark.asyncio
+    async def test_background_notification_loop_stops_after_transport_failure(
+        self, agent, monkeypatch
+    ):
+        from tools.process_registry import ProcessRegistry
+
+        registry = ProcessRegistry()
+        conn = MagicMock()
+        conn.session_update = AsyncMock(side_effect=ConnectionError("disconnected"))
+        agent._conn = conn
+        agent._connected_session_ids.add("acp-owned")
+        monkeypatch.setattr("acp_adapter.server.process_registry", registry)
+
+        registry.completion_queue.put(
+            {
+                "type": "completion",
+                "session_id": "proc_owned",
+                "session_key": "acp-owned",
+                "command": "printf done",
+                "exit_code": 0,
+                "output": "done",
+            }
+        )
+
+        await asyncio.wait_for(agent._background_notification_loop(conn), timeout=0.05)
+
+        assert agent._conn is None
+        conn.session_update.assert_awaited_once()
+        assert registry.completion_queue.get_nowait()["session_id"] == "proc_owned"
+
+    @pytest.mark.asyncio
+    async def test_connection_replacement_requeues_cancelled_delivery_suffix(
+        self, agent, monkeypatch
+    ):
+        from tools.process_registry import ProcessRegistry
+
+        registry = ProcessRegistry()
+        old_conn = MagicMock()
+        new_conn = MagicMock()
+        delivery_started = asyncio.Event()
+        block_delivery = asyncio.Event()
+
+        async def blocked_session_update(**_kwargs):
+            delivery_started.set()
+            await block_delivery.wait()
+
+        old_conn.session_update = AsyncMock(side_effect=blocked_session_update)
+        new_conn.session_update = AsyncMock()
+        agent._conn = old_conn
+        agent._connected_session_ids.add("acp-owned")
+        monkeypatch.setattr("acp_adapter.server.process_registry", registry)
+
+        for process_id in ("proc_first", "proc_second"):
+            registry.completion_queue.put(
+                {
+                    "type": "completion",
+                    "session_id": process_id,
+                    "session_key": "acp-owned",
+                    "command": "printf done",
+                    "exit_code": 0,
+                    "output": "done",
+                }
+            )
+
+        old_task = asyncio.create_task(agent._background_notification_loop(old_conn))
+        agent._background_notification_task = old_task
+        await asyncio.wait_for(delivery_started.wait(), timeout=0.1)
+
+        agent.on_connect(new_conn)
+        new_task = agent._background_notification_task
+        try:
+            with pytest.raises(asyncio.CancelledError):
+                await old_task
+            queued_ids = [
+                registry.completion_queue.get_nowait()["session_id"],
+                registry.completion_queue.get_nowait()["session_id"],
+            ]
+            assert queued_ids == ["proc_first", "proc_second"]
+            assert registry.completion_queue.empty()
+        finally:
+            if new_task is not None:
+                new_task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await new_task
+
+    @pytest.mark.asyncio
     async def test_new_session_returns_authenticated_cross_provider_model_state(self):
         manager = SessionManager(
             agent_factory=lambda: SimpleNamespace(
@@ -472,6 +613,17 @@ class TestOnConnect:
         mock_conn = MagicMock(spec=acp.Client)
         agent.on_connect(mock_conn)
         assert agent._conn is mock_conn
+
+    def test_on_connect_replaces_connection_session_ownership(self, agent):
+        old_conn = MagicMock(spec=acp.Client)
+        new_conn = MagicMock(spec=acp.Client)
+        agent._conn = old_conn
+        agent._connected_session_ids.add("old-session")
+
+        agent.on_connect(new_conn)
+
+        assert agent._conn is new_conn
+        assert agent._connected_session_ids == set()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_async_delegation_fd_leak.py
+++ b/tests/tools/test_async_delegation_fd_leak.py
@@ -73,6 +73,7 @@ def test_ledger_operations_close_every_connection(monkeypatch, tmp_path):
     ad.restore_undelivered_completions(queue.Queue())
     ad.mark_completion_delivered("nope")
     ad.claim_completion_delivery("nope", "claim-1")
+    ad.renew_completion_delivery("nope", "claim-1")
 
     assert opened, "expected at least one connection to be opened"
     assert len(opened) == len(closed)
@@ -104,3 +105,32 @@ def test_schema_init_failure_still_closes_connection(monkeypatch, tmp_path):
 
     assert len(opened) == 1
     assert len(closed) == 1
+
+
+def test_completion_claim_renewal_extends_only_the_owners_lease(
+    monkeypatch, tmp_path
+):
+    """A long autonomous turn must retain its durable at-most-once claim."""
+    _point_ledger(monkeypatch, tmp_path)
+    monkeypatch.setattr(ad.time, "time", lambda: 1_000.0)
+    ad._persist_dispatch(
+        {
+            "delegation_id": "deleg-renew",
+            "goal": "wait for a background result",
+            "session_key": "acp-session",
+            "dispatched_at": 900.0,
+        }
+    )
+    assert ad.claim_completion_delivery("deleg-renew", "claim-owner") is True
+
+    monkeypatch.setattr(ad.time, "time", lambda: 1_060.0)
+    assert ad.renew_completion_delivery("deleg-renew", "claim-other") is False
+    assert ad.renew_completion_delivery("deleg-renew", "claim-owner") is True
+
+    with ad._DB_LOCK, ad._transaction() as conn:
+        claim, claimed_at = conn.execute(
+            "SELECT delivery_claim, delivery_claimed_at "
+            "FROM async_delegations WHERE delegation_id='deleg-renew'"
+        ).fetchone()
+    assert claim == "claim-owner"
+    assert claimed_at == 1_060.0

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -2102,3 +2102,18 @@ class TestSystemdCgroupIsolation:
         )
 
         assert pr._stop_systemd_unit("hermes-worker-gone.scope") is True
+
+
+class TestAtomicCompletionNotification:
+    def test_fast_process_keeps_spawn_time_notification_intent(self, registry, tmp_path):
+        session = registry.spawn_local(
+            "printf fast-done",
+            cwd=str(tmp_path),
+            session_key="acp-session",
+            notify_on_complete=True,
+        )
+        assert session._completion_event.wait(timeout=5)
+        event = registry.completion_queue.get(timeout=1)
+        assert event["session_id"] == session.id
+        assert event["session_key"] == "acp-session"
+        assert event["exit_code"] == 0

--- a/tests/tools/test_terminal_task_cwd.py
+++ b/tests/tools/test_terminal_task_cwd.py
@@ -170,6 +170,7 @@ def test_background_command_prefers_recorded_session_cwd_over_init_time_cwd(monk
         "session_key": task_id,
         "env_vars": {},
         "use_pty": False,
+        "notify_on_complete": False,
     }]
 
 

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -411,6 +411,35 @@ def claim_event_delivery(evt: Dict[str, Any], consumer: str) -> Optional[str]:
     return claim_id if claim_completion_delivery(delegation_id, claim_id) else None
 
 
+def renew_completion_delivery(delegation_id: str, claim_id: str) -> bool:
+    """Extend the lease for a pending completion held by ``claim_id``."""
+    now = time.time()
+    with _DB_LOCK, _transaction() as conn:
+        row = conn.execute(
+            "SELECT delivery_state FROM async_delegations WHERE delegation_id=?",
+            (delegation_id,),
+        ).fetchone()
+        if row is None:
+            return True  # legacy event created before durable dispatch
+        cur = conn.execute(
+            """UPDATE async_delegations SET delivery_claimed_at=?, updated_at=?
+               WHERE delegation_id=? AND delivery_state='pending'
+                 AND delivery_claim=?""",
+            (now, now, delegation_id, claim_id),
+        )
+        return cur.rowcount == 1
+
+
+def renew_event_delivery(evt: Dict[str, Any], claim_id: str) -> bool:
+    """Renew a durable delegation claim; non-durable events need no lease."""
+    if not claim_id or evt.get("type") != "async_delegation":
+        return True
+    delegation_id = str(evt.get("delegation_id") or "")
+    if not delegation_id:
+        return True
+    return renew_completion_delivery(delegation_id, claim_id)
+
+
 def release_completion_delivery(delegation_id: str, claim_id: str) -> bool:
     """Release a failed delivery claim so another consumer may retry.
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -946,6 +946,7 @@ class ProcessRegistry:
         session_key: str = "",
         env_vars: dict = None,
         use_pty: bool = False,
+        notify_on_complete: bool = False,
     ) -> ProcessSession:
         """
         Spawn a background process locally.
@@ -973,6 +974,7 @@ class ProcessRegistry:
             session_key=session_key,
             cwd=_resolve_safe_cwd(cwd or os.getcwd()),
             started_at=time.time(),
+            notify_on_complete=notify_on_complete,
         )
 
         pty_scope_attempted = False
@@ -1195,6 +1197,7 @@ class ProcessRegistry:
         task_id: str = "",
         session_key: str = "",
         timeout: int = 10,
+        notify_on_complete: bool = False,
     ) -> ProcessSession:
         """
         Spawn a background process through a non-local environment backend.
@@ -1216,6 +1219,7 @@ class ProcessRegistry:
             started_at=time.time(),
             env_ref=env,
             pid_scope="sandbox",
+            notify_on_complete=notify_on_complete,
         )
 
         # Run the command in the sandbox with output capture
@@ -1658,6 +1662,7 @@ class ProcessRegistry:
         retain that legacy behavior even when a filter is provided. When a
         filter is provided, ownerless async-delegation events remain
         fail-closed and require positive proof.
+
         """
         results: "list[tuple[dict, str]]" = []
         requeue: "list[dict]" = []

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2817,6 +2817,7 @@ def terminal_tool(
                         session_key=session_key,
                         env_vars=env.env if hasattr(env, 'env') else None,
                         use_pty=effective_pty,
+                        notify_on_complete=bool(notify_on_complete),
                     )
                 else:
                     proc_session = process_registry.spawn_via_env(
@@ -2825,6 +2826,7 @@ def terminal_tool(
                         cwd=effective_cwd,
                         task_id=effective_task_id,
                         session_key=session_key,
+                        notify_on_complete=bool(notify_on_complete),
                     )
 
                 result_data = {


### PR DESCRIPTION
## Summary

- turn owned process and async-delegation completion events into synthetic ACP turns so the parent model can consolidate and report without a follow-up user prompt
- inject the full formatted completion payload, including batch results, while preserving ACP metadata for clients
- never interrupt a foreground user turn; user prompts that arrive during an autonomous turn queue behind it instead of redirecting it
- keep durable delivery claims alive during long model turns and complete or release them safely across transport replacement
- fail closed to sessions attached in memory to the current ACP process

## Context

Paseo already fixed forwarding of out-of-prompt ACP updates in getpaseo/paseo#2058, with lifecycle follow-up getpaseo/paseo#2148. The remaining failure is provider-side: Hermes can deliver the completion text but does not re-enter the parent model after the foreground prompt has returned.

This PR is intentionally stacked on #62558, which provides the delivery queue and durable claim layer. Its two commits remain authored by Stefan van Biljon. The new commit adds autonomous continuation on top; it can be rebased to a single commit after #62558 lands.

Fixes #72472.

The synthetic-turn and fail-closed ownership approach also builds on prior exploration by Israel Lot in YallaPlay/hermes-agent; the new commit credits that contribution.

## Safety properties

- only an attached in-process session can own an autonomous turn
- busy sessions retain notifications for a later pass
- connection replacement cancels and requeues a turn only before the model starts
- once the model has completed, transport cleanup cannot cause the same completion to run twice
- long turns renew their durable claim lease
- synthetic input bypasses slash-command parsing and interrupted-user-prompt salvage
- Stop does not turn an internal notification into a replayable user prompt

## Validation

- scripts/run_tests.sh tests/acp/test_server.py tests/tools/test_async_delegation_fd_leak.py tests/tools/test_process_registry.py tests/tools/test_terminal_task_cwd.py tests/tools/test_restored_delegation_ownership.py -q
  - 124 passed
- Ruff check on all five touched files
- Python bytecode compilation for all touched source files
- git diff --check
- targeted Ty comparison: 68 diagnostics on the stacked base, 67 on this branch; no new diagnostics