### PR TITLE
fix(agent): materialize data-URL vision images inside the media cache

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6573,7 +6573,25 @@ class AIAgent:
             "image/jpeg": ".jpg",
             "image/jpg": ".jpg",
         }.get(mime, ".jpg")
-        tmp = tempfile.NamedTemporaryFile(prefix="anthropic_image_", suffix=suffix, delete=False)
+        # Materialize into the agent's own media cache rather than the system
+        # temp dir. image_source._permitted_host_read_target() confines host
+        # reads to _media_cache_roots() under a non-local terminal backend, so
+        # a /tmp path is refused on the host and then looked for inside the
+        # sandbox, where it was never written — every data-URL image fails with
+        # "not reachable inside the sandbox". Falls back to the previous
+        # behaviour if the cache dir cannot be created.
+        _vision_dir = None
+        try:
+            from hermes_constants import get_hermes_home
+
+            _cache = get_hermes_home() / "cache" / "vision"
+            _cache.mkdir(parents=True, exist_ok=True)
+            _vision_dir = str(_cache)
+        except Exception:  # noqa: BLE001 — unwritable cache: keep the old path
+            _vision_dir = None
+        tmp = tempfile.NamedTemporaryFile(
+            prefix="anthropic_image_", suffix=suffix, delete=False, dir=_vision_dir
+        )
         try:
             with tmp:
                 tmp.write(base64.b64decode(data))

--- a/tests/run_agent/test_vision_data_url_temp_location.py
+++ b/tests/run_agent/test_vision_data_url_temp_location.py
@@ -1,0 +1,92 @@
+"""A materialized data-URL image must be readable back by the vision resolver.
+
+``AIAgent._materialize_data_url_for_vision`` writes the decoded image to a temp
+file and hands the path to ``vision_analyze``. Under a non-local terminal
+backend, ``tools.image_source`` confines host reads to ``_media_cache_roots()``
+and otherwise re-reads the path *inside the sandbox* — where a host temp file
+was never written. Writing outside those roots therefore makes every inbound
+data-URL image fail with "not reachable inside the sandbox and no active
+sandbox session is available to read it", with no other symptom.
+
+The assertion here is the invariant (produced path is host-readable per the
+resolver's own allowlist), not a literal directory, so it keeps holding if the
+cache layout is reorganised.
+"""
+
+import base64
+import importlib
+from pathlib import Path
+
+import pytest
+
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+DATA_URL = "data:image/png;base64," + base64.b64encode(PNG_BYTES).decode()
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import hermes_constants
+    importlib.reload(hermes_constants)
+    return home
+
+
+def _media_cache_roots():
+    import tools.image_source as isrc
+    importlib.reload(isrc)
+    return [Path(r).resolve() for r in isrc._media_cache_roots()]
+
+
+def _under_a_media_root(path: Path) -> bool:
+    resolved = Path(path).resolve()
+    for root in _media_cache_roots():
+        try:
+            resolved.relative_to(root)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def test_data_url_lands_where_vision_may_read_it(hermes_home):
+    from run_agent import AIAgent
+
+    path_str, cleanup = AIAgent._materialize_data_url_for_vision(DATA_URL)
+    try:
+        assert path_str, "materialization returned no path"
+        produced = Path(path_str)
+        assert produced.is_file()
+        assert produced.read_bytes() == PNG_BYTES
+        assert _under_a_media_root(produced), (
+            f"{produced} is outside the media-cache roots, so image_source will "
+            f"refuse the host read and then look for it inside the sandbox"
+        )
+    finally:
+        if cleanup is not None and Path(cleanup).exists():
+            Path(cleanup).unlink()
+
+
+def test_cleanup_path_is_returned_so_the_caller_can_unlink(hermes_home):
+    """delete=False means the caller owns removal; it needs the path back."""
+    from run_agent import AIAgent
+
+    path_str, cleanup = AIAgent._materialize_data_url_for_vision(DATA_URL)
+    assert cleanup is not None
+    assert str(cleanup) == path_str
+    cleanup.unlink()
+    assert not Path(path_str).exists()
+
+
+def test_oversized_data_url_is_skipped(hermes_home):
+    """The size guard runs before any file is created."""
+    from run_agent import AIAgent
+
+    oversized = "data:image/png;base64," + "A" * (
+        AIAgent._MAX_DATA_URL_BASE64_BYTES + 1
+    )
+    path_str, cleanup = AIAgent._materialize_data_url_for_vision(oversized)
+    assert path_str == ""
+    assert cleanup is None


### PR DESCRIPTION
## What

`AIAgent._materialize_data_url_for_vision` writes the decoded image with
`tempfile.NamedTemporaryFile(...)`, i.e. into the **system temp dir**, then hands
the path to `vision_analyze`.

`tools/image_source.py` confines host reads to `_media_cache_roots()` whenever the
terminal backend is non-local, and falls back to re-reading the path *inside the
sandbox* for anything outside those roots. A host temp file was never written
there, so the read fails twice and the tool returns:

```
Error analyzing image: '/tmp/anthropic_image_xxxx.jpg' is not reachable inside
the sandbox and no active sandbox session is available to read it
```

The file is written to a location the same codebase's resolver refuses to read.
Net effect: on docker/ssh/modal/daytona backends **every inbound data-URL image
silently fails to be described** — there is no other symptom, the turn just
proceeds without the image. It showed up 15 times across three days in one
profile's logs before being tracked down.

## Why this fix

Same class as the desktop/TUI upload paths in #65380 and #69575, which were fixed
by adding those directories to the media-cache allowlist. Doing that here would
mean allowlisting the world-writable system temp dir, weakening the confinement
model (GHSA-gpxw-6wxv-w3qq). So this is fixed from the other side: write into
`<HERMES_HOME>/cache/vision`, already covered by the existing `cache` root.

- The caller's `finally` still unlinks the file, so nothing accumulates.
- If the cache dir can't be created, it falls back to the previous behaviour —
  strictly no worse than today.

## How to test

Added `tests/run_agent/test_vision_data_url_temp_location.py`. The main test
asserts the invariant — the produced path is host-readable per
`image_source._media_cache_roots()` — rather than a literal directory, so it
keeps holding if the cache layout is reorganised.

```
$ pytest tests/run_agent/test_vision_data_url_temp_location.py -q
3 passed
```

Against the unpatched tree it fails exactly where it should:

```
AssertionError: /tmp/anthropic_image_k2u0x3mf.png is outside the media-cache
roots, so image_source will refuse the host read and then look for it inside
the sandbox
```

Manual reproduction (docker backend): send an image to a gateway profile and
watch `logs/errors.log` — before, `vision_tools: Error analyzing image ... not
reachable inside the sandbox`; after, the image is described normally.

## Platforms

Tested on Linux (Ubuntu, docker terminal backend, Python 3.11). The change is a
`dir=` argument plus a `mkdir(parents=True, exist_ok=True)`, so no
platform-specific behaviour is involved.
