### PR TITLE
fix(dashboard): give the console socket the same connect deadlines as the PTY

### DIFF
--- a/web/src/components/HermesConsoleModal.tsx
+++ b/web/src/components/HermesConsoleModal.tsx
@@ -11,6 +11,11 @@ import { Button } from "@nous-research/ui/ui/components/button";
 import { useModalBehavior } from "@/hooks/useModalBehavior";
 import { useProfileScope } from "@/contexts/useProfileScope";
 import { api } from "@/lib/api";
+import {
+  CONSOLE_CONNECTING_TIMEOUT_MS,
+  CONSOLE_TICKET_TIMEOUT_MS,
+  raceTicket,
+} from "@/lib/console-connect";
 import { maybeReloadForLoopbackWsAuthFailure } from "@/lib/dashboard-auth-reload";
 import { cn, themedBody } from "@/lib/utils";
 import { useTheme } from "@/themes";
@@ -397,15 +402,60 @@ export function HermesConsoleModal({ open, onClose }: HermesConsoleModalProps) {
     hasReadyFrameRef.current = false;
     writeLine(term, "\x1b[2mConnecting to Hermes Console...\x1b[0m");
 
+    // Two phases here can wedge without ever producing a `close` event,
+    // leaving the modal on "connecting" with nothing to act on: the ticket
+    // request that runs before any socket exists, and a socket that never
+    // leaves CONNECTING. Mirrors the guards the PTY surface carries
+    // (PTY_TICKET_TIMEOUT_MS / PTY_CONNECTING_TIMEOUT_MS in lib/pty-reconnect).
+    let connectingTimer: null | ReturnType<typeof setTimeout> = null;
+    const clearConnectingTimer = () => {
+      if (connectingTimer !== null) {
+        clearTimeout(connectingTimer);
+        connectingTimer = null;
+      }
+    };
+
     void (async () => {
       try {
         const params = profile ? { profile } : undefined;
-        const url = await api.buildWsUrl("/api/console", params);
+
+        const ticket = await raceTicket(() =>
+          api.buildWsUrl("/api/console", params),
+        );
         if (cancelled) return;
-        const ws = new WebSocket(url);
+        if (ticket.status === "timeout") {
+          setConnectionState("error");
+          writeLine(
+            term,
+            `\x1b[31mConsole did not get a connection ticket within ${Math.round(
+              CONSOLE_TICKET_TIMEOUT_MS / 1000,
+            )}s. Close and reopen to retry.\x1b[0m`,
+          );
+          return;
+        }
+        if (ticket.status === "failed") {
+          throw ticket.error;
+        }
+
+        const ws = new WebSocket(ticket.value);
         wsRef.current = ws;
 
+        // A socket can sit in CONNECTING indefinitely (radio handoff, a proxy
+        // that accepts and stalls) without firing onclose. Force-close it so
+        // the onclose handler below reports the failure.
+        connectingTimer = setTimeout(() => {
+          connectingTimer = null;
+          if (wsRef.current === ws && ws.readyState === WebSocket.CONNECTING) {
+            try {
+              ws.close();
+            } catch {
+              /* already tearing down */
+            }
+          }
+        }, CONSOLE_CONNECTING_TIMEOUT_MS);
+
         ws.onopen = () => {
+          clearConnectingTimer();
           setConnectionState("connecting");
         };
 
@@ -424,6 +474,7 @@ export function HermesConsoleModal({ open, onClose }: HermesConsoleModalProps) {
         };
 
         ws.onclose = (ev) => {
+          clearConnectingTimer();
           if (maybeReloadForLoopbackWsAuthFailure(ev.code)) {
             return;
           }
@@ -448,6 +499,7 @@ export function HermesConsoleModal({ open, onClose }: HermesConsoleModalProps) {
 
     return () => {
       cancelled = true;
+      clearConnectingTimer();
       dataDisposable.dispose();
       ro.disconnect();
       if (resizeFrame) cancelAnimationFrame(resizeFrame);

--- a/web/src/lib/console-connect.test.ts
+++ b/web/src/lib/console-connect.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CONSOLE_TICKET_TIMEOUT_MS, raceTicket } from "./console-connect";
+
+describe("raceTicket", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns the ticket when it arrives in time", async () => {
+    const promise = raceTicket(async () => "ws://localhost/api/console");
+    await vi.advanceTimersByTimeAsync(0);
+
+    await expect(promise).resolves.toEqual({
+      status: "ok",
+      value: "ws://localhost/api/console",
+    });
+  });
+
+  it("reports a rejection rather than waiting out the deadline", async () => {
+    const boom = new Error("ticket endpoint unavailable");
+    const promise = raceTicket(() => Promise.reject(boom));
+    await vi.advanceTimersByTimeAsync(0);
+
+    await expect(promise).resolves.toEqual({ error: boom, status: "failed" });
+  });
+
+  it("times out a stalled request", async () => {
+    const promise = raceTicket(() => new Promise<string>(() => {}));
+
+    await vi.advanceTimersByTimeAsync(CONSOLE_TICKET_TIMEOUT_MS);
+
+    await expect(promise).resolves.toEqual({ status: "timeout" });
+  });
+
+  it("keeps the timeout verdict when the ticket lands late", async () => {
+    let land!: (url: string) => void;
+    const promise = raceTicket(
+      () =>
+        new Promise<string>((resolve) => {
+          land = resolve;
+        }),
+    );
+
+    await vi.advanceTimersByTimeAsync(CONSOLE_TICKET_TIMEOUT_MS);
+    land("ws://localhost/api/console?ticket=stale");
+    await vi.advanceTimersByTimeAsync(0);
+
+    // A late ticket must not become a socket behind the reported failure.
+    await expect(promise).resolves.toEqual({ status: "timeout" });
+  });
+
+  it("does not leave its timer armed after settling", async () => {
+    const promise = raceTicket(async () => "ws://localhost/api/console");
+    await vi.advanceTimersByTimeAsync(0);
+    await promise;
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/web/src/lib/console-connect.ts
+++ b/web/src/lib/console-connect.ts
@@ -1,0 +1,49 @@
+/** Deadlines for the Hermes Console websocket connect.
+ *
+ *  Two phases can wedge without ever producing a `close` event, which is the
+ *  only signal the modal's error path listens to:
+ *
+ *  - the single-use ticket `api.buildWsUrl` mints, which runs *before* any
+ *    socket exists, so a hang produces no socket and no `close`;
+ *  - the socket itself sitting in `CONNECTING` after a radio handoff or
+ *    behind a proxy that accepts and stalls.
+ *
+ *  Mirrors `pty-reconnect`'s PTY_TICKET_TIMEOUT_MS / PTY_CONNECTING_TIMEOUT_MS
+ *  for the console surface.
+ */
+
+export const CONSOLE_TICKET_TIMEOUT_MS = 8000
+
+export const CONSOLE_CONNECTING_TIMEOUT_MS = 8000
+
+export type TicketOutcome<T> =
+  | { status: 'failed'; error: unknown }
+  | { status: 'ok'; value: T }
+  | { status: 'timeout' }
+
+/** Await `mint()` under a deadline.
+ *
+ *  Resolves `timeout` when the budget runs out first — and keeps resolving
+ *  `timeout` if the request lands afterwards, so a late ticket can never open
+ *  a socket behind the failure the caller already reported.
+ */
+export function raceTicket<T>(
+  mint: () => Promise<T>,
+  timeoutMs: number = CONSOLE_TICKET_TIMEOUT_MS,
+): Promise<TicketOutcome<T>> {
+  return new Promise<TicketOutcome<T>>(resolve => {
+    let settled = false
+    const finish = (outcome: TicketOutcome<T>) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      resolve(outcome)
+    }
+    const timer = setTimeout(() => finish({ status: 'timeout' }), timeoutMs)
+
+    mint().then(
+      value => finish({ status: 'ok', value }),
+      error => finish({ error, status: 'failed' }),
+    )
+  })
+}


### PR DESCRIPTION
## What

2382f50f5 (2026-08-08, "fix(dashboard): bound WS ticket minting on the events + PTY sockets") states the class:

> ChatPage's connect awaits a single-use ticket from `api.buildWsUrl()` before `new WebSocket()`. That request produces no socket, so a rejection or a hang emits no `close` event and never arms PTY_CONNECTING_TIMEOUT_MS (set after the socket is constructed).

It fixed the events feed and the PTY surface. There is a third caller of `api.buildWsUrl` in the dashboard:

```
web/src/components/ChatSidebar.tsx:339    buildWsUrl("/api/events", …)     fixed
web/src/pages/ChatPage.tsx                api.buildWsUrl("/api/pty", …)    fixed
web/src/components/HermesConsoleModal.tsx api.buildWsUrl("/api/console", …)
```

The console modal has the same shape and neither guard. `ChatPage.tsx` now imports `PTY_TICKET_TIMEOUT_MS` and `PTY_CONNECTING_TIMEOUT_MS`; `HermesConsoleModal.tsx` contains no `setTimeout` at all.

Two ways it wedges on `Connecting to Hermes Console...`:

- **the ticket hangs.** `await api.buildWsUrl(...)` never settles, so no socket is built, no `close` fires, and the `catch` below never runs. Nothing moves `connectionState` off `"connecting"`.
- **the socket stays in CONNECTING.** `onclose` is the only path that reports an error here, and a wedged handshake never fires it.

A *rejected* ticket was already handled by the existing `catch`, so what this closes is the hang half of both phases — the same half 2382f50f5 called out for the PTY.

The console is a live surface: 66132 proposed removing it and was closed.

## The fix

The ticket race lives in `lib/console-connect`, next to `lib/pty-reconnect`, so the deadline is unit-testable rather than only reachable by driving the modal. It keeps returning `timeout` if the request lands afterwards, so a stale ticket cannot open a socket behind a failure the modal already reported — the `ticketSuperseded` property from the sibling fix.

The CONNECTING deadline force-closes a socket that never opens, which routes into the existing `onclose` reporting rather than adding a second error path. Both timers are cleared on open, on close, and on unmount.

## Tests and results

`web/src/lib/console-connect.test.ts` covers the ticket race: a ticket that arrives in time, a rejection reported rather than waited out, a stalled request timing out, a late ticket that must not flip the verdict, and no timer left armed after settling.

`node_modules` isn't installed for `web/` in this checkout, so vitest could not be run here. I verified two ways instead:

- type-checked `HermesConsoleModal.tsx` and `console-connect.ts` with the repo's `tsc`; the only diagnostics left are the missing-`@types/react` JSX noise and the `xterm.css` side-effect import, both artifacts of the uninstalled deps, and none in the edited region
- executed every assertion from the test file against the real module under Node with real short timers: 8 assertions, 8 pass

The component change is confined to the connect effect; no existing test touches `HermesConsoleModal`.