### PR TITLE
fix(whatsapp): authenticate the bridge control channel (#80096)

### DIFF
--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -35,6 +35,7 @@ import json
 import logging
 import os
 import re
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
@@ -503,6 +504,102 @@ class WhatsAppBehaviorMixin:
 # Shared bridge directory resolution for CLI and adapter
 # ---------------------------------------------------------------------------
 
+_WHATSAPP_BRIDGE_MANIFEST = ".hermes-source-manifest.json"
+_WHATSAPP_BRIDGE_SHIPPED_FILES = (
+    "README.md",
+    "allowlist.js",
+    "bridge-launcher.js",
+    "bridge.js",
+    "bridge_helpers.js",
+    "outbound_ids.js",
+    "owner_message_gate.js",
+    "package-lock.json",
+    "package.json",
+)
+
+
+def _whatsapp_bridge_source_manifest(source: Path) -> dict[str, str]:
+    """Hash the shipped bridge contract without touching runtime-owned data."""
+    import hashlib
+
+    manifest: dict[str, str] = {}
+    for name in _WHATSAPP_BRIDGE_SHIPPED_FILES:
+        path = source / name
+        if not path.exists():
+            continue
+        if path.is_symlink() or not path.is_file():
+            raise OSError(f"WhatsApp bridge source is not a regular file: {path}")
+        manifest[name] = hashlib.sha256(path.read_bytes()).hexdigest()
+    if "bridge.js" not in manifest or "package.json" not in manifest:
+        raise OSError("WhatsApp bridge source is missing bridge.js or package.json")
+    return manifest
+
+
+def _atomic_write_bridge_file(path: Path, data: bytes) -> None:
+    """Replace one mirror file atomically, cleaning an incomplete temp file."""
+    import tempfile
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    temp_path = Path(temp_name)
+    try:
+        with os.fdopen(fd, "wb") as temp_file:
+            fd = -1
+            temp_file.write(data)
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        os.replace(temp_path, path)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        try:
+            temp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def _refresh_whatsapp_bridge_mirror(source: Path, mirror: Path) -> None:
+    """Synchronize shipped source and commit freshness with a final manifest.
+
+    Each source file is replaced atomically and the content manifest is written
+    last. If any step fails, callers reject the mirror. ``node_modules`` and
+    unrecognized files are never copied, removed, or traversed, preserving npm
+    state and any runtime-owned data without treating it as shipped source.
+    """
+    import hashlib
+
+    expected = _whatsapp_bridge_source_manifest(source)
+    if mirror.is_symlink() or (mirror.exists() and not mirror.is_dir()):
+        raise OSError(f"WhatsApp bridge mirror is not a real directory: {mirror}")
+    mirror.mkdir(parents=True, exist_ok=True)
+    for name, expected_hash in expected.items():
+        destination = mirror / name
+        try:
+            current_hash = hashlib.sha256(destination.read_bytes()).hexdigest()
+        except OSError:
+            current_hash = ""
+        if current_hash != expected_hash:
+            _atomic_write_bridge_file(destination, (source / name).read_bytes())
+
+    # Verify the complete source set before publishing the freshness gate.
+    if _whatsapp_bridge_source_manifest(mirror) != expected:
+        raise OSError("WhatsApp bridge mirror failed source verification")
+
+    manifest_payload = json.dumps(
+        {"format": 1, "files": expected}, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8") + b"\n"
+    _atomic_write_bridge_file(mirror / _WHATSAPP_BRIDGE_MANIFEST, manifest_payload)
+
+    try:
+        recorded = json.loads(
+            (mirror / _WHATSAPP_BRIDGE_MANIFEST).read_text(encoding="utf-8")
+        )
+    except (OSError, ValueError, TypeError) as exc:
+        raise OSError("WhatsApp bridge mirror manifest is unreadable") from exc
+    if recorded != {"format": 1, "files": expected}:
+        raise OSError("WhatsApp bridge mirror manifest does not match its source")
+
+
 def resolve_whatsapp_bridge_dir() -> Path:
     """Resolve the WhatsApp bridge directory, mirroring to HERMES_HOME if needed.
 
@@ -512,7 +609,6 @@ def resolve_whatsapp_bridge_dir() -> Path:
 
     Returns the resolved bridge directory path.
     """
-    import shutil
     from pathlib import Path as _Path
 
     # Default location in install tree (may be read-only)
@@ -535,18 +631,19 @@ def resolve_whatsapp_bridge_dir() -> Path:
     if install_writable:
         return install_bridge
 
-    # Install dir is read-only, mirror to HERMES_HOME if needed
-    if hermes_home_bridge.exists():
-        return hermes_home_bridge
-
-    # Mirror the bridge source to HERMES_HOME
+    # Install dir is read-only. Refresh the writable mirror on every resolve:
+    # HERMES_HOME persists across Docker/image upgrades, so existence alone is
+    # not evidence that bridge.js implements the current authenticated IPC
+    # contract. A final manifest gates selection after atomic file replacement.
     try:
         hermes_home_bridge.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(
-            install_bridge,
-            hermes_home_bridge,
-            dirs_exist_ok=False,
-        )
+        _refresh_whatsapp_bridge_mirror(install_bridge, hermes_home_bridge)
         return hermes_home_bridge
-    except Exception:
+    except Exception as exc:
+        logger.warning(
+            "[whatsapp] Could not refresh read-only bridge mirror at %s (%s); "
+            "using the current install source instead",
+            hermes_home_bridge,
+            exc,
+        )
         return install_bridge

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13594,10 +13594,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 owner = claimed.get(listener_claim)
                 if owner is not None:
                     bind, port = listener_claim[-2:]
+                    port_key = (
+                        "bridge_port"
+                        if platform is Platform.WHATSAPP
+                        else "sidecar_port"
+                    )
                     logger.error(
                         "Profile '%s' and '%s' both configure %s sidecars on "
                         "%s:%s — refusing to start the duplicate listener. "
-                        "Set platforms.%s.extra.sidecar_port to a distinct port "
+                        "Set platforms.%s.extra.%s to a distinct port "
                         "for profile '%s'.",
                         owner,
                         profile_name,
@@ -13605,6 +13610,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         bind,
                         port,
                         platform.value,
+                        port_key,
                         profile_name,
                     )
                     # Like credential conflicts, this adapter never connected
@@ -13881,13 +13887,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     def _adapter_listener_claim(platform: Platform, adapter: Any) -> Optional[tuple]:
         """Return the exclusive listener resource claimed by an adapter.
 
-        Photon sidecars are per-profile processes. Even when two profiles use
-        different project credentials, their sidecars cannot share a bind and
-        port. Represent that endpoint as a claim so multiplex startup rejects
-        the later adapter before either ``connect()`` or ``disconnect()`` can
-        disturb the first profile.
+        Per-profile sidecars cannot share their configured endpoint identity.
+        Represent Photon and WhatsApp endpoints as claims so multiplex startup
+        rejects a later colliding adapter before either ``connect()`` or
+        ``disconnect()`` can disturb the first profile.
         """
-        if getattr(platform, "value", None) != "photon":
+        platform_value = getattr(platform, "value", None)
+        if platform_value == "whatsapp":
+            port = getattr(adapter, "_bridge_port", None)
+            try:
+                port = int(port)
+            except (TypeError, ValueError):
+                return None
+            return ("listener", "whatsapp", "127.0.0.1", port)
+        if platform_value != "photon":
             return None
         bind = getattr(adapter, "_sidecar_bind", None)
         port = getattr(adapter, "_sidecar_port", None)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16128,6 +16128,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 owner = claimed.get(listener_claim)
                 if owner is not None:
                     bind, port = listener_claim[-2:]
+                    port_key = (
+                        "bridge_port"
+                        if platform is Platform.WHATSAPP
+                        else "sidecar_port"
+                    )
                     message = (
                         f"Profile '{owner}' and '{profile_name}' both configure "
                         f"{platform.value} sidecars on the same listener. Configure "
@@ -16136,7 +16141,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     logger.error(
                         "Profile '%s' and '%s' both configure %s sidecars on "
                         "%s:%s — refusing to start the duplicate listener. "
-                        "Set platforms.%s.extra.sidecar_port to a distinct port "
+                        "Set platforms.%s.extra.%s to a distinct port "
                         "for profile '%s'.",
                         owner,
                         profile_name,
@@ -16144,6 +16149,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         bind,
                         port,
                         platform.value,
+                        port_key,
                         profile_name,
                     )
                     self._update_platform_runtime_status(
@@ -16660,13 +16666,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     def _adapter_listener_claim(platform: Platform, adapter: Any) -> Optional[tuple]:
         """Return the exclusive listener resource claimed by an adapter.
 
-        Photon sidecars are per-profile processes. Even when two profiles use
-        different project credentials, their sidecars cannot share a bind and
-        port. Represent that endpoint as a claim so multiplex startup rejects
-        the later adapter before either ``connect()`` or ``disconnect()`` can
-        disturb the first profile.
+        Per-profile sidecars cannot share their configured endpoint identity.
+        Represent Photon and WhatsApp endpoints as claims so multiplex startup
+        rejects a later colliding adapter before either ``connect()`` or
+        ``disconnect()`` can disturb the first profile.
         """
-        if getattr(platform, "value", None) != "photon":
+        platform_value = getattr(platform, "value", None)
+        if platform_value == "whatsapp":
+            port = getattr(adapter, "_bridge_port", None)
+            try:
+                port = int(port)
+            except (TypeError, ValueError):
+                return None
+            return ("listener", "whatsapp", "127.0.0.1", port)
+        if platform_value != "photon":
             return None
         bind = getattr(adapter, "_sidecar_bind", None)
         port = getattr(adapter, "_sidecar_port", None)

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -157,7 +157,7 @@ _IMPORT_SKIP_NAMES = {
 }
 
 # zipfile.open() drops Unix mode bits on extract; restore tightens these to 0600.
-_SECRET_FILE_NAMES = {".env", "auth.json", "state.db"}
+_SECRET_FILE_NAMES = {".env", ".bridge-token", "auth.json", "state.db"}
 
 # Reserved archive subtree for provider state that lives OUTSIDE HERMES_HOME
 # (e.g. ~/.honcho, ~/.hindsight). The active memory provider declares these via

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -129,7 +129,7 @@ _IMPORT_SKIP_NAMES = {
 }
 
 # zipfile.open() drops Unix mode bits on extract; restore tightens these to 0600.
-_SECRET_FILE_NAMES = {".env", "auth.json", "state.db"}
+_SECRET_FILE_NAMES = {".env", ".bridge-token", "auth.json", "state.db"}
 
 # Reserved archive subtree for provider state that lives OUTSIDE HERMES_HOME
 # (e.g. ~/.honcho, ~/.hindsight). The active memory provider declares these via

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -16,11 +16,15 @@ with different backends via a bridge pattern.
 """
 
 import asyncio
+import hashlib
 import logging
 import os
 import platform
 import re
+import secrets
 import signal
+import socket
+import stat
 import subprocess
 
 _IS_WINDOWS = platform.system() == "Windows"
@@ -57,13 +61,198 @@ def _wenv(name: str, default: str = "") -> str:
 
 logger = logging.getLogger(__name__)
 
+_BRIDGE_TOKEN_FILENAME = ".bridge-token"
+_BRIDGE_HTTP_BASE = "http://localhost"
+_WINDOWS_BRIDGE_UNSUPPORTED = (
+    "The personal-account WhatsApp gateway is not supported on native Windows: "
+    "the bundled Node/aiohttp named-pipe runtime cannot authenticate the pipe "
+    "server before sending bridge credentials or message data. Run Hermes in "
+    "WSL2/Linux for WhatsApp gateway operation; `hermes whatsapp` pairing mode "
+    "remains safe because it starts no bridge control server."
+)
+
+
+def _bridge_token_path(session_path: Path) -> Path:
+    return session_path / _BRIDGE_TOKEN_FILENAME
+
+
+def _read_bridge_token(session_path: Path) -> str:
+    """Read the private token shared with an already-running bridge.
+
+    On POSIX the opened file descriptor, rather than a pathname-only stat, is
+    tightened and rechecked before its contents are accepted. This both
+    repairs permission drift from copies/restores and avoids following a
+    replacement symlink between a check and the read.
+    """
+    token_path = _bridge_token_path(session_path)
+    flags = os.O_RDONLY
+    if not _IS_WINDOWS and hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = -1
+    try:
+        fd = os.open(token_path, flags)
+        if not _IS_WINDOWS:
+            opened = os.fstat(fd)
+            if not stat.S_ISREG(opened.st_mode):
+                return ""
+            if stat.S_IMODE(opened.st_mode) != 0o600:
+                os.fchmod(fd, 0o600)
+                if stat.S_IMODE(os.fstat(fd).st_mode) != 0o600:
+                    return ""
+        with os.fdopen(fd, "r", encoding="utf-8") as token_file:
+            fd = -1
+            token = token_file.read().strip()
+    except OSError:
+        return ""
+    finally:
+        if fd >= 0:
+            os.close(fd)
+    if not re.fullmatch(r"[A-Za-z0-9_-]{32,128}", token):
+        return ""
+    return token
+
+
+def _rotate_bridge_token(session_path: Path) -> str:
+    """Atomically replace the session's bridge token with a mode-0600 value."""
+    token = secrets.token_urlsafe(32)
+    token_path = _bridge_token_path(session_path)
+    temp_path = token_path.with_name(
+        f".{token_path.name}.{os.getpid()}.{secrets.token_hex(6)}.tmp"
+    )
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    fd = os.open(temp_path, flags, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as token_file:
+            fd = -1
+            token_file.write(token)
+            token_file.flush()
+            os.fsync(token_file.fileno())
+        os.replace(temp_path, token_path)
+        if not _IS_WINDOWS:
+            os.chmod(token_path, 0o600)
+            if stat.S_IMODE(token_path.stat().st_mode) != 0o600:
+                raise OSError("WhatsApp bridge token permissions are not private")
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        try:
+            temp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+    return token
+
+
+def _bridge_auth_headers(token: str) -> Dict[str, str]:
+    return {"Authorization": f"Bearer {token}"} if token else {}
+
+
+def _bridge_ipc_endpoint(session_path: Path, bridge_port: int, token: str) -> str:
+    """Return the OS-local bridge endpoint for one session and port.
+
+    POSIX uses a mode-0600, current-user-owned Unix socket with a short,
+    token-derived path in the sticky system runtime directory. Native Windows
+    fails closed until its supported runtimes can authenticate a named-pipe
+    peer before writes. The token itself is never placed in the endpoint name.
+    """
+    if _IS_WINDOWS:
+        raise RuntimeError(_WINDOWS_BRIDGE_UNSUPPORTED)
+    # sockaddr_un paths are commonly limited to 108 bytes, while profile and
+    # managed-test session paths can be much longer. Use the sticky system
+    # runtime directory with an owner-qualified, token-derived name; the
+    # client separately requires current-user ownership and mode 0600.
+    material = f"{session_path.resolve()}\0{int(bridge_port)}\0{token}"
+    suffix = hashlib.sha256(material.encode("utf-8")).hexdigest()[:24]
+    uid = os.geteuid() if hasattr(os, "geteuid") else os.getpid()
+    return f"/tmp/hermes-whatsapp-{uid}-{suffix}.sock"
+
+
+def _ensure_private_bridge_directory(session_path: Path) -> None:
+    """Make the session directory an owner-only IPC namespace on POSIX."""
+    if _IS_WINDOWS:
+        return
+    session_info = session_path.stat()
+    if not stat.S_ISDIR(session_info.st_mode):
+        raise OSError(f"WhatsApp session path is not a directory: {session_path}")
+    if hasattr(os, "geteuid") and session_info.st_uid != os.geteuid():
+        raise OSError(f"WhatsApp session directory has a foreign owner: {session_path}")
+    if stat.S_IMODE(session_info.st_mode) != 0o700:
+        os.chmod(session_path, 0o700)
+        if stat.S_IMODE(session_path.stat().st_mode) != 0o700:
+            raise OSError("WhatsApp session directory permissions are not private")
+
+
+def _validate_bridge_endpoint(endpoint: str) -> None:
+    """Require the POSIX IPC endpoint to be an owner-only Unix socket."""
+    if _IS_WINDOWS:
+        raise RuntimeError(_WINDOWS_BRIDGE_UNSUPPORTED)
+    endpoint_info = Path(endpoint).lstat()
+    if not stat.S_ISSOCK(endpoint_info.st_mode):
+        raise OSError(f"WhatsApp bridge endpoint is not a socket: {endpoint}")
+    if hasattr(os, "geteuid") and endpoint_info.st_uid != os.geteuid():
+        raise OSError(f"WhatsApp bridge endpoint has a foreign owner: {endpoint}")
+    if stat.S_IMODE(endpoint_info.st_mode) != 0o600:
+        raise OSError("WhatsApp bridge endpoint permissions are not private")
+
+
+def _bridge_unix_connector(aiohttp, endpoint: str):
+    """Build a connector that authenticates the endpoint on every reconnect."""
+
+    class _ValidatedUnixConnector(aiohttp.UnixConnector):
+        async def _create_connection(self, *args, **kwargs):
+            # aiohttp may reconnect a persistent session after its bridge
+            # exits. Recheck the filesystem identity immediately before every
+            # physical connection so a replacement listener never receives
+            # the bearer or request body. The sticky /tmp directory prevents
+            # another uid from swapping the path after this owner/mode check
+            # and before connect(2).
+            _validate_bridge_endpoint(endpoint)
+            return await super()._create_connection(*args, **kwargs)
+
+    return _ValidatedUnixConnector(path=endpoint)
+
+
+def _bridge_client_session(aiohttp, session_path: Path, bridge_port: int, token: str):
+    """Create a bearer-authenticated client over the private OS IPC channel."""
+    if _IS_WINDOWS:
+        # aiohttp's NamedPipeConnector connects by observable pipe name and can
+        # serialize headers/body before application code can authenticate the
+        # connected server PID/SID. Until the supported runtimes expose a
+        # pre-write peer-auth hook (and Node creates a private DACL), native
+        # Windows must fail closed instead of treating name possession as
+        # reciprocal authentication.
+        raise RuntimeError(_WINDOWS_BRIDGE_UNSUPPORTED)
+    endpoint = _bridge_ipc_endpoint(session_path, bridge_port, token)
+    _ensure_private_bridge_directory(session_path)
+    _validate_bridge_endpoint(endpoint)
+    connector = _bridge_unix_connector(aiohttp, endpoint)
+    return aiohttp.ClientSession(
+        connector=connector,
+        headers=_bridge_auth_headers(token),
+    )
+
+
+def _remove_stale_bridge_endpoint(session_path: Path, bridge_port: int, token: str) -> None:
+    """Remove only a stale, current-user POSIX bridge socket before launch."""
+    if _IS_WINDOWS:
+        return  # Named pipes disappear when their owning server exits.
+    endpoint = Path(_bridge_ipc_endpoint(session_path, bridge_port, token))
+    try:
+        endpoint_info = endpoint.lstat()
+    except FileNotFoundError:
+        return
+    if not stat.S_ISSOCK(endpoint_info.st_mode):
+        raise RuntimeError(f"Refusing to replace non-socket bridge endpoint: {endpoint}")
+    if hasattr(os, "geteuid") and endpoint_info.st_uid != os.geteuid():
+        raise RuntimeError(f"Refusing to replace foreign bridge endpoint: {endpoint}")
+    endpoint.unlink()
+
 # Inbound owner-typed WhatsApp text is prefixed at MessageEvent construction so
 # transcripts stay disambiguated even if downstream plugins fail before silent_ingest.
 _OWNER_REPLY_PREFIX = "[owner reply] "
 
 
 def _listener_pids_on_port(port: int) -> list:
-    """PIDs of processes *listening* on ``port`` (POSIX) — never clients.
+    """PIDs of processes *listening* on ``port`` — never clients.
 
     This must match only LISTEN sockets. A bare ``lsof -i :PORT`` (or
     ``fuser PORT/tcp``) also returns *clients* whose connection merely involves
@@ -73,6 +262,22 @@ def _listener_pids_on_port(port: int) -> list:
     without ever touching an unrelated client.
     """
     pids: list = []
+    if _IS_WINDOWS:
+        try:
+            import psutil
+
+            for connection in psutil.net_connections(kind="tcp"):
+                local_address = connection.laddr
+                if (
+                    connection.status == psutil.CONN_LISTEN
+                    and local_address
+                    and int(local_address.port) == int(port)
+                    and connection.pid is not None
+                ):
+                    pids.append(int(connection.pid))
+        except Exception:
+            pass
+        return sorted(set(pids))
     try:
         result = subprocess.run(
             ["lsof", "-ti", f"tcp:{port}", "-sTCP:LISTEN"],
@@ -97,7 +302,180 @@ def _listener_pids_on_port(port: int) -> list:
             pids.append(int(m.group(1)))
     except FileNotFoundError:
         pass
-    return pids
+    return sorted(set(pids))
+
+
+def _tcp_listener_is_occupied(port: int) -> bool:
+    """Return whether loopback accepts a TCP connection, without sending data."""
+    try:
+        with socket.create_connection(("127.0.0.1", int(port)), timeout=0.25):
+            return True
+    except (ConnectionRefusedError, TimeoutError, OSError, ValueError):
+        return False
+
+
+def _legacy_bridge_process_identity(
+    pid: int,
+    bridge_path: Path,
+    session_path: Path,
+    bridge_port: int,
+):
+    """Return a stable start fingerprint for an exact legacy bridge process.
+
+    The no-pidfile migration may signal a listener only when the live process
+    argv identifies Node, the configured bridge script, the exact session, and
+    the configured port. Failure to inspect or match any element is unproven.
+    """
+    try:
+        import psutil
+
+        argv = psutil.Process(pid).cmdline()
+    except Exception:
+        return None
+    if not argv or Path(argv[0]).name.lower() not in {"node", "node.exe"}:
+        return None
+
+    def _arg_after(flag: str):
+        try:
+            return argv[argv.index(flag) + 1]
+        except (ValueError, IndexError):
+            return None
+
+    try:
+        script_matches = any(
+            Path(value).resolve() == bridge_path.resolve()
+            for value in argv[1:]
+            if value and not value.startswith("-")
+        )
+        session_matches = (
+            Path(_arg_after("--session") or "").resolve() == session_path.resolve()
+        )
+        port_matches = int(_arg_after("--port") or -1) == int(bridge_port)
+    except (OSError, TypeError, ValueError):
+        return None
+    if not (script_matches and session_matches and port_matches):
+        return None
+
+    from gateway.status import get_process_start_time
+
+    return get_process_start_time(pid)
+
+
+async def _legacy_bridge_health_is_valid(port: int) -> bool:
+    """Probe only the public legacy health route; send no bearer or body."""
+    import http.client
+    import json
+
+    def _probe():
+        connection = http.client.HTTPConnection("127.0.0.1", int(port), timeout=2)
+        try:
+            # HTTPConnection omits Content-Length for a bodyless GET. This
+            # narrow legacy probe carries neither a bearer nor protected data
+            # and does not construct aiohttp's Windows connector/session.
+            connection.request("GET", "/health")
+            response = connection.getresponse()
+            if response.status != 200:
+                return None
+            payload = response.read(65537)
+            if len(payload) > 65536:
+                return None
+            return json.loads(payload.decode("utf-8"))
+        except Exception:
+            return None
+        finally:
+            connection.close()
+
+    data = await asyncio.to_thread(_probe)
+    return (
+        isinstance(data, dict)
+        and data.get("status") in {"connected", "connecting", "disconnected"}
+        and isinstance(data.get("queueLength"), int)
+        and isinstance(data.get("uptime"), (int, float))
+        and bool(re.fullmatch(r"[0-9a-f]{16}", str(data.get("scriptHash", ""))))
+        and isinstance(data.get("sendReadReceipts"), bool)
+    )
+
+
+async def _migrate_legacy_tcp_bridge(
+    bridge_port: int,
+    bridge_path: Path,
+    session_path: Path,
+) -> bool:
+    """Retire a verifiably genuine pre-IPC bridge or fail closed.
+
+    Older gateways could leave a TCP bridge alive while deleting bridge.pid.
+    Starting the IPC bridge beside it creates two Baileys sessions. An occupied
+    port is therefore a migration signal, never authority to kill its owner.
+    """
+    if not _tcp_listener_is_occupied(bridge_port):
+        return False
+
+    pids = _listener_pids_on_port(bridge_port)
+    identity = None
+    pid = pids[0] if len(pids) == 1 else None
+    if pid is not None:
+        identity = _legacy_bridge_process_identity(
+            pid, bridge_path, session_path, bridge_port
+        )
+    if identity is None or not await _legacy_bridge_health_is_valid(bridge_port):
+        raise RuntimeError(
+            f"Configured WhatsApp bridge_port {bridge_port} is occupied by a "
+            "legacy TCP listener whose identity could not be proven. Stop the "
+            f"old WhatsApp bridge for session {session_path} (or move the "
+            "unrelated service), then restart Hermes. No listener was terminated "
+            "and no replacement bridge was started."
+        )
+
+    # Rebind the process identity after the network probe so PID reuse or a
+    # listener swap can never turn verified migration into an arbitrary kill.
+    if (
+        _legacy_bridge_process_identity(pid, bridge_path, session_path, bridge_port)
+        != identity
+    ):
+        raise RuntimeError(
+            "The legacy WhatsApp bridge changed during identity verification; "
+            "startup stopped without terminating it. Stop it manually and retry."
+        )
+
+    from gateway.status import terminate_pid
+
+    terminate_pid(pid)
+    for _attempt in range(50):
+        if not _tcp_listener_is_occupied(bridge_port):
+            logger.info(
+                "[whatsapp] Retired verified legacy TCP bridge PID %d on port %d",
+                pid,
+                bridge_port,
+            )
+            return True
+        await asyncio.sleep(0.1)
+
+    # The identity is still required immediately before escalation.
+    if (
+        _legacy_bridge_process_identity(pid, bridge_path, session_path, bridge_port)
+        != identity
+    ):
+        raise RuntimeError(
+            "The verified legacy WhatsApp bridge did not exit and its process "
+            "identity changed; startup stopped without force-terminating it."
+        )
+    if _IS_WINDOWS:
+        # Native cleanup must not launch taskkill or any other child process.
+        # The stable identity was rebound immediately above; psutil's direct
+        # process handle now provides the bounded force-retirement primitive.
+        import psutil
+
+        psutil.Process(pid).kill()
+    else:
+        terminate_pid(pid, force=True)
+    for _attempt in range(20):
+        if not _tcp_listener_is_occupied(bridge_port):
+            return True
+        await asyncio.sleep(0.1)
+    raise RuntimeError(
+        "The verified legacy WhatsApp bridge did not release its TCP listener; "
+        "startup stopped before launching a competing bridge."
+    )
 
 
 def _kill_port_process(port: int) -> None:
@@ -169,7 +547,11 @@ def _bridge_pid_is_ours(pid: int, session_path: Path, expected_start) -> bool:
     return ("node" in cmdline) and (str(session_path) in cmdline)
 
 
-def _kill_stale_bridge_by_pidfile(session_path: Path) -> None:
+def _kill_stale_bridge_by_pidfile(
+    session_path: Path,
+    bridge_path: Optional[Path] = None,
+    bridge_port: Optional[int] = None,
+) -> bool:
     """Kill a bridge process recorded in a PID file from a previous run.
 
     The bridge writes ``bridge.pid`` into the session directory when it
@@ -182,7 +564,7 @@ def _kill_stale_bridge_by_pidfile(session_path: Path) -> None:
     """
     pid_file = session_path / "bridge.pid"
     if not pid_file.exists():
-        return
+        return False
     pid = None
     recorded_start = None
     try:
@@ -197,10 +579,23 @@ def _kill_stale_bridge_by_pidfile(session_path: Path) -> None:
             pid_file.unlink()
         except OSError:
             pass
-        return
-    if _bridge_pid_is_ours(pid, session_path, recorded_start):
+        return False
+    if recorded_start is not None:
+        identity_matches = _bridge_pid_is_ours(pid, session_path, recorded_start)
+    elif bridge_path is not None and bridge_port is not None:
+        # Upgrade cleanup has the exact configured script/session/port. Require
+        # all of them for legacy pidfiles instead of the older loose cmdline
+        # fallback used by callers that lack those dimensions.
+        identity_matches = _legacy_bridge_process_identity(
+            pid, bridge_path, session_path, bridge_port
+        ) is not None
+    else:
+        identity_matches = _bridge_pid_is_ours(pid, session_path, recorded_start)
+    terminated = False
+    if identity_matches:
         try:
             os.kill(pid, signal.SIGTERM)
+            terminated = True
             logger.info("[whatsapp] Killed stale bridge PID %d from pidfile", pid)
         except (ProcessLookupError, PermissionError, OSError):
             pass
@@ -216,6 +611,7 @@ def _kill_stale_bridge_by_pidfile(session_path: Path) -> None:
         pid_file.unlink()
     except OSError:
         pass
+    return terminated
 
 
 def _write_bridge_pidfile(session_path: Path, pid: int) -> None:
@@ -394,7 +790,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     
     Configuration:
     - bridge_script: Path to the Node.js bridge script
-    - bridge_port: Port for HTTP communication (default: 3000)
+    - bridge_port: Stable bridge-instance/multiplex discriminator retained for
+      config compatibility (default: 3000); no TCP listener is opened
     - session_path: Path to store WhatsApp session data
     - dm_policy: "open" | "allowlist" | "disabled" | "pairing" — how DMs are handled (default: "pairing")
     - allow_from: List of sender IDs allowed in DMs (when dm_policy="allowlist")
@@ -427,6 +824,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             "session_path",
             get_hermes_dir("platforms/whatsapp/session", "whatsapp/session")
         ))
+        self._bridge_token: str = ""
         self._reply_prefix: Optional[str] = config.extra.get("reply_prefix")
         self._dm_policy = str(config.extra.get("dm_policy") or _wenv("WHATSAPP_DM_POLICY", "pairing")).strip().lower()
         # Prefer config.extra, then the documented WHATSAPP_ALLOWED_USERS env
@@ -512,6 +910,81 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         
         This launches the Node.js bridge process and waits for it to be ready.
         """
+        if _IS_WINDOWS:
+            # Native serving remains unsupported, but upgrades may inherit a
+            # pre-IPC unauthenticated TCP bridge. Retire only a bridge proven
+            # to own this exact script/session/port while holding the same
+            # lifecycle lock used by supported startup. This path deliberately
+            # does not read/rotate the bearer, construct an aiohttp session, or
+            # reach Node process launch.
+            bridge_path = Path(self._bridge_script)
+            lock_acquired = False
+            try:
+                lock_acquired = self._acquire_platform_lock(
+                    "whatsapp-session", str(self._session_path), "WhatsApp session"
+                )
+            except Exception as lock_error:
+                message = (
+                    "Could not acquire the WhatsApp session lock needed to "
+                    f"retire a legacy bridge safely: {lock_error}. Stop any old "
+                    "WhatsApp gateway and retry. No listener was terminated."
+                )
+                logger.error("[%s] %s", self.name, message)
+                self._set_fatal_error(
+                    "whatsapp_legacy_bridge_migration_required",
+                    message,
+                    retryable=False,
+                )
+                return False
+            if not lock_acquired:
+                message = (
+                    "The WhatsApp session lock is held by another gateway, so "
+                    "legacy bridge ownership cannot be proven safely. Stop the "
+                    "other gateway and retry. No listener was terminated."
+                )
+                self._set_fatal_error(
+                    "whatsapp_legacy_bridge_migration_required",
+                    message,
+                    retryable=False,
+                )
+                return False
+
+            try:
+                pidfile_signalled = _kill_stale_bridge_by_pidfile(
+                    self._session_path,
+                    bridge_path,
+                    self._bridge_port,
+                )
+                if pidfile_signalled:
+                    # Give an exact pidfile owner a bounded graceful-exit window;
+                    # the migration helper then either proves and finishes it or
+                    # fails closed on the still-occupied/ambiguous listener.
+                    await asyncio.sleep(1)
+                await _migrate_legacy_tcp_bridge(
+                    self._bridge_port,
+                    bridge_path,
+                    self._session_path,
+                )
+            except Exception as migration_error:
+                message = str(migration_error)
+                logger.error("[%s] %s", self.name, message)
+                self._set_fatal_error(
+                    "whatsapp_legacy_bridge_migration_required",
+                    message,
+                    retryable=False,
+                )
+                return False
+            finally:
+                self._release_platform_lock()
+
+            logger.error("[%s] %s", self.name, _WINDOWS_BRIDGE_UNSUPPORTED)
+            self._set_fatal_error(
+                "whatsapp_windows_ipc_unsupported",
+                _WINDOWS_BRIDGE_UNSUPPORTED,
+                retryable=False,
+            )
+            return False
+
         if not check_whatsapp_requirements():
             logger.warning("[%s] Node.js not found. WhatsApp requires Node.js.", self.name)
             self._set_fatal_error(
@@ -623,13 +1096,24 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
             # Ensure session directory exists
             self._session_path.mkdir(parents=True, exist_ok=True)
+            _ensure_private_bridge_directory(self._session_path)
+
+            # Authenticate to a reusable bridge with the token from its
+            # WhatsApp session directory. Missing or malformed files simply
+            # make the old listener ineligible for reuse; it is replaced below.
+            self._bridge_token = _read_bridge_token(self._session_path)
             
             # Check if bridge is already running and connected
             import aiohttp
             try:
-                async with aiohttp.ClientSession() as session:
+                async with _bridge_client_session(
+                    aiohttp,
+                    self._session_path,
+                    self._bridge_port,
+                    self._bridge_token,
+                ) as session:
                     async with session.get(
-                        f"http://127.0.0.1:{self._bridge_port}/health",
+                        f"{_BRIDGE_HTTP_BASE}/health",
                         timeout=aiohttp.ClientTimeout(total=2)
                     ) as resp:
                         if resp.status == 200:
@@ -658,7 +1142,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                     print(f"[{self.name}] Using existing bridge (status: {bridge_status})")
                                     self._mark_connected()
                                     self._bridge_process = None  # Not managed by us
-                                    self._http_session = aiohttp.ClientSession()
+                                    self._http_session = _bridge_client_session(
+                                        aiohttp,
+                                        self._session_path,
+                                        self._bridge_port,
+                                        self._bridge_token,
+                                    )
                                     self._poll_task = asyncio.create_task(self._poll_messages())
                                     # Plugin-registered native handlers.
                                     self._wire_plugin_handlers(None)
@@ -675,9 +1164,44 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 pass  # Bridge not running, start a new one
             
             # Kill any orphaned bridge from a previous gateway run
-            _kill_stale_bridge_by_pidfile(self._session_path)
-            _kill_port_process(self._bridge_port)
+            _kill_stale_bridge_by_pidfile(
+                self._session_path,
+                bridge_path,
+                self._bridge_port,
+            )
             await asyncio.sleep(1)
+
+            # Pre-IPC gateways could deliberately reuse an external bridge and
+            # then delete bridge.pid on disconnect. Detect that upgrade state
+            # before rotating credentials or spawning another Baileys session.
+            # The migration helper retires only a command-line, start-time, and
+            # health-verified bridge for this exact script/session/port; every
+            # unproven listener blocks startup with manual guidance.
+            try:
+                await _migrate_legacy_tcp_bridge(
+                    self._bridge_port,
+                    bridge_path,
+                    self._session_path,
+                )
+            except RuntimeError as migration_error:
+                message = str(migration_error)
+                logger.error("[%s] %s", self.name, message)
+                self._set_fatal_error(
+                    "whatsapp_legacy_bridge_migration_required",
+                    message,
+                    retryable=False,
+                )
+                return False
+            _remove_stale_bridge_endpoint(
+                self._session_path,
+                self._bridge_port,
+                self._bridge_token,
+            )
+
+            # Rotate only when launching a new bridge. This preserves the
+            # existing-bridge reuse contract while ensuring a replaced bridge
+            # cannot be reached with its predecessor's credential.
+            self._bridge_token = _rotate_bridge_token(self._session_path)
             
             # Start the bridge process in its own process group.
             # Route output to a log file so QR codes, errors, and reconnection
@@ -692,6 +1216,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # can use it without the user needing to set a separate env var.
             # with_hermes_node_path() copies os.environ when called with no arg.
             bridge_env = with_hermes_node_path()
+            bridge_env["WHATSAPP_BRIDGE_TOKEN"] = self._bridge_token
+            bridge_env["WHATSAPP_BRIDGE_ENDPOINT"] = _bridge_ipc_endpoint(
+                self._session_path,
+                self._bridge_port,
+                self._bridge_token,
+            )
             if self._reply_prefix is not None:
                 bridge_env["WHATSAPP_REPLY_PREFIX"] = self._reply_prefix
             bridge_env["WHATSAPP_SEND_READ_RECEIPTS"] = (
@@ -763,9 +1293,14 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     self._close_bridge_log()
                     return False
                 try:
-                    async with aiohttp.ClientSession() as session:
+                    async with _bridge_client_session(
+                        aiohttp,
+                        self._session_path,
+                        self._bridge_port,
+                        self._bridge_token,
+                    ) as session:
                         async with session.get(
-                            f"http://127.0.0.1:{self._bridge_port}/health",
+                            f"{_BRIDGE_HTTP_BASE}/health",
                             timeout=aiohttp.ClientTimeout(total=2)
                         ) as resp:
                             if resp.status == 200:
@@ -795,9 +1330,14 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         self._close_bridge_log()
                         return False
                     try:
-                        async with aiohttp.ClientSession() as session:
+                        async with _bridge_client_session(
+                            aiohttp,
+                            self._session_path,
+                            self._bridge_port,
+                            self._bridge_token,
+                        ) as session:
                             async with session.get(
-                                f"http://127.0.0.1:{self._bridge_port}/health",
+                                f"{_BRIDGE_HTTP_BASE}/health",
                                 timeout=aiohttp.ClientTimeout(total=2)
                             ) as resp:
                                 if resp.status == 200:
@@ -815,13 +1355,18 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     print(f"[{self.name}]   If session expired, re-pair: hermes whatsapp")
             
             # Create a persistent HTTP session for all bridge communication
-            self._http_session = aiohttp.ClientSession()
+            self._http_session = _bridge_client_session(
+                aiohttp,
+                self._session_path,
+                self._bridge_port,
+                self._bridge_token,
+            )
 
             # Start message polling task
             self._poll_task = asyncio.create_task(self._poll_messages())
             
             self._mark_connected()
-            print(f"[{self.name}] Bridge started on port {self._bridge_port}")
+            print(f"[{self.name}] Bridge started on private local IPC")
             # Plugin-registered native handlers.
             self._wire_plugin_handlers(None)
             return True
@@ -900,11 +1445,14 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # Bridge was not started by us, don't kill it
             print(f"[{self.name}] Disconnecting (external bridge left running)")
 
-        # Clean up PID file
-        try:
-            (self._session_path / "bridge.pid").unlink(missing_ok=True)
-        except OSError:
-            pass
+        # Preserve the PID/start-time identity for a reused external bridge.
+        # A later gateway must still be able to authenticate that process
+        # before replacing a stale endpoint.
+        if self._bridge_process:
+            try:
+                (self._session_path / "bridge.pid").unlink(missing_ok=True)
+            except OSError:
+                pass
 
         # Cancel the poll task explicitly
         if self._poll_task and not self._poll_task.done():
@@ -970,7 +1518,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     payload["replyTo"] = reply_to
 
                 async with self._http_session.post(
-                    f"http://127.0.0.1:{self._bridge_port}/send",
+                    f"{_BRIDGE_HTTP_BASE}/send",
                     json=payload,
                     timeout=aiohttp.ClientTimeout(total=30)
                 ) as resp:
@@ -1013,7 +1561,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         try:
             import aiohttp
             async with self._http_session.post(
-                f"http://127.0.0.1:{self._bridge_port}/edit",
+                f"{_BRIDGE_HTTP_BASE}/edit",
                 json={
                     "chatId": to_whatsapp_jid(chat_id),
                     "messageId": message_id,
@@ -1060,7 +1608,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 payload["fileName"] = file_name
 
             async with self._http_session.post(
-                f"http://127.0.0.1:{self._bridge_port}/send-media",
+                f"{_BRIDGE_HTTP_BASE}/send-media",
                 json=payload,
                 timeout=aiohttp.ClientTimeout(total=120),
             ) as resp:
@@ -1107,7 +1655,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "selectableCount": selectable_count,
             }
             async with self._http_session.post(
-                f"http://127.0.0.1:{self._bridge_port}/send-poll",
+                f"{_BRIDGE_HTTP_BASE}/send-poll",
                 json=payload,
                 timeout=aiohttp.ClientTimeout(total=30),
             ) as resp:
@@ -1194,7 +1742,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             if address:
                 payload["address"] = address
             async with self._http_session.post(
-                f"http://127.0.0.1:{self._bridge_port}/send-location",
+                f"{_BRIDGE_HTTP_BASE}/send-location",
                 json=payload,
                 timeout=aiohttp.ClientTimeout(total=30),
             ) as resp:
@@ -1293,7 +1841,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # leaves the response object alive until GC, holding its TCP
             # socket in CLOSE_WAIT. See #18451.
             async with self._http_session.post(
-                f"http://127.0.0.1:{self._bridge_port}/typing",
+                f"{_BRIDGE_HTTP_BASE}/typing",
                 json={"chatId": to_whatsapp_jid(chat_id)},
                 timeout=aiohttp.ClientTimeout(total=5)
             ):
@@ -1312,7 +1860,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             import aiohttp
 
             async with self._http_session.get(
-                f"http://127.0.0.1:{self._bridge_port}/chat/{to_whatsapp_jid(chat_id)}",
+                f"{_BRIDGE_HTTP_BASE}/chat/{to_whatsapp_jid(chat_id)}",
                 timeout=aiohttp.ClientTimeout(total=10)
             ) as resp:
                 if resp.status == 200:
@@ -1340,7 +1888,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 break
             try:
                 async with self._http_session.get(
-                    f"http://127.0.0.1:{self._bridge_port}/messages",
+                    f"{_BRIDGE_HTTP_BASE}/messages",
                     timeout=aiohttp.ClientTimeout(total=30)
                 ) as resp:
                     if resp.status == 200:
@@ -1379,7 +1927,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             import aiohttp
 
             async with self._http_session.post(
-                f"http://127.0.0.1:{self._bridge_port}/read",
+                f"{_BRIDGE_HTTP_BASE}/read",
                 json={"key": key},
                 timeout=aiohttp.ClientTimeout(total=5),
             ) as resp:
@@ -1724,6 +2272,17 @@ async def _standalone_send(
         return {"error": "aiohttp not installed. Run: pip install aiohttp"}
     try:
         bridge_port = extra.get("bridge_port", 3000)
+        session_path = Path(extra.get(
+            "session_path",
+            get_hermes_dir("platforms/whatsapp/session", "whatsapp/session"),
+        ))
+        bridge_token = _read_bridge_token(session_path)
+        if not bridge_token:
+            return {
+                "error": "WhatsApp bridge authentication is unavailable; "
+                "start or reconnect the WhatsApp gateway first."
+            }
+        _ensure_private_bridge_directory(session_path)
         normalized_chat_id = to_whatsapp_jid(chat_id)
         media = media_files or []
         text = message or ""
@@ -1731,12 +2290,17 @@ async def _standalone_send(
         # a caption is never silently repeated across a multi-file send.
         media_caption = caption if (caption and len(media) == 1) else None
         last_message_id = None
-        async with aiohttp.ClientSession() as session:
+        async with _bridge_client_session(
+            aiohttp,
+            session_path,
+            bridge_port,
+            bridge_token,
+        ) as session:
             # 1) Text first (skip the /send call when this chunk is media-only
             #    or when the text is delivered as the media caption instead).
             if text.strip() and not media_caption:
                 async with session.post(
-                    f"http://localhost:{bridge_port}/send",
+                    f"{_BRIDGE_HTTP_BASE}/send",
                     json={"chatId": normalized_chat_id, "message": text},
                     timeout=aiohttp.ClientTimeout(total=30),
                 ) as resp:
@@ -1759,7 +2323,7 @@ async def _standalone_send(
                     if media_caption:
                         try:
                             async with session.post(
-                                f"http://localhost:{bridge_port}/send",
+                                f"{_BRIDGE_HTTP_BASE}/send",
                                 json={"chatId": normalized_chat_id, "message": media_caption},
                                 timeout=aiohttp.ClientTimeout(total=30),
                             ) as resp:
@@ -1779,7 +2343,7 @@ async def _standalone_send(
                 if media_caption:
                     payload["caption"] = media_caption
                 async with session.post(
-                    f"http://localhost:{bridge_port}/send-media",
+                    f"{_BRIDGE_HTTP_BASE}/send-media",
                     json=payload,
                     timeout=aiohttp.ClientTimeout(total=120),
                 ) as resp:
@@ -1816,8 +2380,15 @@ def interactive_setup() -> None:
     )
 
     print_header("WhatsApp")
-    print_info("WhatsApp uses a local Node.js bridge (WhatsApp Web client).")
-    print_info("Start the bridge separately; the gateway connects to it over HTTP.")
+    print_info("WhatsApp uses a gateway-managed Node.js bridge (WhatsApp Web client).")
+    print_info("The gateway launches it and connects over private authenticated local IPC.")
+    if _IS_WINDOWS:
+        print_info(
+            "Native Windows WhatsApp gateway operation is currently unsupported "
+            "because the available named-pipe runtimes cannot authenticate the "
+            "server before protected data is sent. Use WSL2/Linux; pairing-only "
+            "mode remains available through `hermes whatsapp`."
+        )
     existing = get_env_value("WHATSAPP_ENABLED")
     if existing and existing.lower() in {"true", "1", "yes"}:
         print_info("WhatsApp: already enabled")
@@ -1885,8 +2456,9 @@ def _is_connected(config) -> bool:
     """WhatsApp is considered connected when the user has explicitly enabled it
     via ``WHATSAPP_ENABLED`` (or the YAML-bridged equivalent on the config).
 
-    Auth itself is handled by the external Node.js bridge — we can't verify the
-    bridge token here — so the opt-in flag is the connection signal. The legacy
+    Auth itself is handled by the gateway-managed Node.js bridge — setup status
+    does not launch or probe that private IPC service — so the opt-in flag is
+    the connection signal. The legacy
     built-in path keyed off ``WHATSAPP_ENABLED`` in both the connected-platforms
     check and the setup-status display; returning an unconditional True here
     would make WhatsApp always show as "configured" in ``hermes setup`` even

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -16,11 +16,15 @@ with different backends via a bridge pattern.
 """
 
 import asyncio
+import hashlib
 import logging
 import os
 import platform
 import re
+import secrets
 import signal
+import socket
+import stat
 import subprocess
 
 _IS_WINDOWS = platform.system() == "Windows"
@@ -57,13 +61,198 @@ def _wenv(name: str, default: str = "") -> str:
 
 logger = logging.getLogger(__name__)
 
+_BRIDGE_TOKEN_FILENAME = ".bridge-token"
+_BRIDGE_HTTP_BASE = "http://localhost"
+_WINDOWS_BRIDGE_UNSUPPORTED = (
+    "The personal-account WhatsApp gateway is not supported on native Windows: "
+    "the bundled Node/aiohttp named-pipe runtime cannot authenticate the pipe "
+    "server before sending bridge credentials or message data. Run Hermes in "
+    "WSL2/Linux for WhatsApp gateway operation; `hermes whatsapp` pairing mode "
+    "remains safe because it starts no bridge control server."
+)
+
+
+def _bridge_token_path(session_path: Path) -> Path:
+    return session_path / _BRIDGE_TOKEN_FILENAME
+
+
+def _read_bridge_token(session_path: Path) -> str:
+    """Read the private token shared with an already-running bridge.
+
+    On POSIX the opened file descriptor, rather than a pathname-only stat, is
+    tightened and rechecked before its contents are accepted. This both
+    repairs permission drift from copies/restores and avoids following a
+    replacement symlink between a check and the read.
+    """
+    token_path = _bridge_token_path(session_path)
+    flags = os.O_RDONLY
+    if not _IS_WINDOWS and hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = -1
+    try:
+        fd = os.open(token_path, flags)
+        if not _IS_WINDOWS:
+            opened = os.fstat(fd)
+            if not stat.S_ISREG(opened.st_mode):
+                return ""
+            if stat.S_IMODE(opened.st_mode) != 0o600:
+                os.fchmod(fd, 0o600)
+                if stat.S_IMODE(os.fstat(fd).st_mode) != 0o600:
+                    return ""
+        with os.fdopen(fd, "r", encoding="utf-8") as token_file:
+            fd = -1
+            token = token_file.read().strip()
+    except OSError:
+        return ""
+    finally:
+        if fd >= 0:
+            os.close(fd)
+    if not re.fullmatch(r"[A-Za-z0-9_-]{32,128}", token):
+        return ""
+    return token
+
+
+def _rotate_bridge_token(session_path: Path) -> str:
+    """Atomically replace the session's bridge token with a mode-0600 value."""
+    token = secrets.token_urlsafe(32)
+    token_path = _bridge_token_path(session_path)
+    temp_path = token_path.with_name(
+        f".{token_path.name}.{os.getpid()}.{secrets.token_hex(6)}.tmp"
+    )
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    fd = os.open(temp_path, flags, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as token_file:
+            fd = -1
+            token_file.write(token)
+            token_file.flush()
+            os.fsync(token_file.fileno())
+        os.replace(temp_path, token_path)
+        if not _IS_WINDOWS:
+            os.chmod(token_path, 0o600)
+            if stat.S_IMODE(token_path.stat().st_mode) != 0o600:
+                raise OSError("WhatsApp bridge token permissions are not private")
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        try:
+            temp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+    return token
+
+
+def _bridge_auth_headers(token: str) -> Dict[str, str]:
+    return {"Authorization": f"Bearer {token}"} if token else {}
+
+
+def _bridge_ipc_endpoint(session_path: Path, bridge_port: int, token: str) -> str:
+    """Return the OS-local bridge endpoint for one session and port.
+
+    POSIX uses a mode-0600, current-user-owned Unix socket with a short,
+    token-derived path in the sticky system runtime directory. Native Windows
+    fails closed until its supported runtimes can authenticate a named-pipe
+    peer before writes. The token itself is never placed in the endpoint name.
+    """
+    if _IS_WINDOWS:
+        raise RuntimeError(_WINDOWS_BRIDGE_UNSUPPORTED)
+    # sockaddr_un paths are commonly limited to 108 bytes, while profile and
+    # managed-test session paths can be much longer. Use the sticky system
+    # runtime directory with an owner-qualified, token-derived name; the
+    # client separately requires current-user ownership and mode 0600.
+    material = f"{session_path.resolve()}\0{int(bridge_port)}\0{token}"
+    suffix = hashlib.sha256(material.encode("utf-8")).hexdigest()[:24]
+    uid = os.geteuid() if hasattr(os, "geteuid") else os.getpid()
+    return f"/tmp/hermes-whatsapp-{uid}-{suffix}.sock"
+
+
+def _ensure_private_bridge_directory(session_path: Path) -> None:
+    """Make the session directory an owner-only IPC namespace on POSIX."""
+    if _IS_WINDOWS:
+        return
+    session_info = session_path.stat()
+    if not stat.S_ISDIR(session_info.st_mode):
+        raise OSError(f"WhatsApp session path is not a directory: {session_path}")
+    if hasattr(os, "geteuid") and session_info.st_uid != os.geteuid():
+        raise OSError(f"WhatsApp session directory has a foreign owner: {session_path}")
+    if stat.S_IMODE(session_info.st_mode) != 0o700:
+        os.chmod(session_path, 0o700)
+        if stat.S_IMODE(session_path.stat().st_mode) != 0o700:
+            raise OSError("WhatsApp session directory permissions are not private")
+
+
+def _validate_bridge_endpoint(endpoint: str) -> None:
+    """Require the POSIX IPC endpoint to be an owner-only Unix socket."""
+    if _IS_WINDOWS:
+        raise RuntimeError(_WINDOWS_BRIDGE_UNSUPPORTED)
+    endpoint_info = Path(endpoint).lstat()
+    if not stat.S_ISSOCK(endpoint_info.st_mode):
+        raise OSError(f"WhatsApp bridge endpoint is not a socket: {endpoint}")
+    if hasattr(os, "geteuid") and endpoint_info.st_uid != os.geteuid():
+        raise OSError(f"WhatsApp bridge endpoint has a foreign owner: {endpoint}")
+    if stat.S_IMODE(endpoint_info.st_mode) != 0o600:
+        raise OSError("WhatsApp bridge endpoint permissions are not private")
+
+
+def _bridge_unix_connector(aiohttp, endpoint: str):
+    """Build a connector that authenticates the endpoint on every reconnect."""
+
+    class _ValidatedUnixConnector(aiohttp.UnixConnector):
+        async def _create_connection(self, *args, **kwargs):
+            # aiohttp may reconnect a persistent session after its bridge
+            # exits. Recheck the filesystem identity immediately before every
+            # physical connection so a replacement listener never receives
+            # the bearer or request body. The sticky /tmp directory prevents
+            # another uid from swapping the path after this owner/mode check
+            # and before connect(2).
+            _validate_bridge_endpoint(endpoint)
+            return await super()._create_connection(*args, **kwargs)
+
+    return _ValidatedUnixConnector(path=endpoint)
+
+
+def _bridge_client_session(aiohttp, session_path: Path, bridge_port: int, token: str):
+    """Create a bearer-authenticated client over the private OS IPC channel."""
+    if _IS_WINDOWS:
+        # aiohttp's NamedPipeConnector connects by observable pipe name and can
+        # serialize headers/body before application code can authenticate the
+        # connected server PID/SID. Until the supported runtimes expose a
+        # pre-write peer-auth hook (and Node creates a private DACL), native
+        # Windows must fail closed instead of treating name possession as
+        # reciprocal authentication.
+        raise RuntimeError(_WINDOWS_BRIDGE_UNSUPPORTED)
+    endpoint = _bridge_ipc_endpoint(session_path, bridge_port, token)
+    _ensure_private_bridge_directory(session_path)
+    _validate_bridge_endpoint(endpoint)
+    connector = _bridge_unix_connector(aiohttp, endpoint)
+    return aiohttp.ClientSession(
+        connector=connector,
+        headers=_bridge_auth_headers(token),
+    )
+
+
+def _remove_stale_bridge_endpoint(session_path: Path, bridge_port: int, token: str) -> None:
+    """Remove only a stale, current-user POSIX bridge socket before launch."""
+    if _IS_WINDOWS:
+        return  # Named pipes disappear when their owning server exits.
+    endpoint = Path(_bridge_ipc_endpoint(session_path, bridge_port, token))
+    try:
+        endpoint_info = endpoint.lstat()
+    except FileNotFoundError:
+        return
+    if not stat.S_ISSOCK(endpoint_info.st_mode):
+        raise RuntimeError(f"Refusing to replace non-socket bridge endpoint: {endpoint}")
+    if hasattr(os, "geteuid") and endpoint_info.st_uid != os.geteuid():
+        raise RuntimeError(f"Refusing to replace foreign bridge endpoint: {endpoint}")
+    endpoint.unlink()
+
 # Inbound owner-typed WhatsApp text is prefixed at MessageEvent construction so
 # transcripts stay disambiguated even if downstream plugins fail before silent_ingest.
 _OWNER_REPLY_PREFIX = "[owner reply] "
 
 
 def _listener_pids_on_port(port: int) -> list:
-    """PIDs of processes *listening* on ``port`` (POSIX) — never clients.
+    """PIDs of processes *listening* on ``port`` — never clients.
 
     This must match only LISTEN sockets. A bare ``lsof -i :PORT`` (or
     ``fuser PORT/tcp``) also returns *clients* whose connection merely involves
@@ -73,6 +262,22 @@ def _listener_pids_on_port(port: int) -> list:
     without ever touching an unrelated client.
     """
     pids: list = []
+    if _IS_WINDOWS:
+        try:
+            import psutil
+
+            for connection in psutil.net_connections(kind="tcp"):
+                local_address = connection.laddr
+                if (
+                    connection.status == psutil.CONN_LISTEN
+                    and local_address
+                    and int(local_address.port) == int(port)
+                    and connection.pid is not None
+                ):
+                    pids.append(int(connection.pid))
+        except Exception:
+            pass
+        return sorted(set(pids))
     try:
         result = subprocess.run(
             ["lsof", "-ti", f"tcp:{port}", "-sTCP:LISTEN"],
@@ -97,7 +302,180 @@ def _listener_pids_on_port(port: int) -> list:
             pids.append(int(m.group(1)))
     except FileNotFoundError:
         pass
-    return pids
+    return sorted(set(pids))
+
+
+def _tcp_listener_is_occupied(port: int) -> bool:
+    """Return whether loopback accepts a TCP connection, without sending data."""
+    try:
+        with socket.create_connection(("127.0.0.1", int(port)), timeout=0.25):
+            return True
+    except (ConnectionRefusedError, TimeoutError, OSError, ValueError):
+        return False
+
+
+def _legacy_bridge_process_identity(
+    pid: int,
+    bridge_path: Path,
+    session_path: Path,
+    bridge_port: int,
+):
+    """Return a stable start fingerprint for an exact legacy bridge process.
+
+    The no-pidfile migration may signal a listener only when the live process
+    argv identifies Node, the configured bridge script, the exact session, and
+    the configured port. Failure to inspect or match any element is unproven.
+    """
+    try:
+        import psutil
+
+        argv = psutil.Process(pid).cmdline()
+    except Exception:
+        return None
+    if not argv or Path(argv[0]).name.lower() not in {"node", "node.exe"}:
+        return None
+
+    def _arg_after(flag: str):
+        try:
+            return argv[argv.index(flag) + 1]
+        except (ValueError, IndexError):
+            return None
+
+    try:
+        script_matches = any(
+            Path(value).resolve() == bridge_path.resolve()
+            for value in argv[1:]
+            if value and not value.startswith("-")
+        )
+        session_matches = (
+            Path(_arg_after("--session") or "").resolve() == session_path.resolve()
+        )
+        port_matches = int(_arg_after("--port") or -1) == int(bridge_port)
+    except (OSError, TypeError, ValueError):
+        return None
+    if not (script_matches and session_matches and port_matches):
+        return None
+
+    from gateway.status import get_process_start_time
+
+    return get_process_start_time(pid)
+
+
+async def _legacy_bridge_health_is_valid(port: int) -> bool:
+    """Probe only the public legacy health route; send no bearer or body."""
+    import http.client
+    import json
+
+    def _probe():
+        connection = http.client.HTTPConnection("127.0.0.1", int(port), timeout=2)
+        try:
+            # HTTPConnection omits Content-Length for a bodyless GET. This
+            # narrow legacy probe carries neither a bearer nor protected data
+            # and does not construct aiohttp's Windows connector/session.
+            connection.request("GET", "/health")
+            response = connection.getresponse()
+            if response.status != 200:
+                return None
+            payload = response.read(65537)
+            if len(payload) > 65536:
+                return None
+            return json.loads(payload.decode("utf-8"))
+        except Exception:
+            return None
+        finally:
+            connection.close()
+
+    data = await asyncio.to_thread(_probe)
+    return (
+        isinstance(data, dict)
+        and data.get("status") in {"connected", "connecting", "disconnected"}
+        and isinstance(data.get("queueLength"), int)
+        and isinstance(data.get("uptime"), (int, float))
+        and bool(re.fullmatch(r"[0-9a-f]{16}", str(data.get("scriptHash", ""))))
+        and isinstance(data.get("sendReadReceipts"), bool)
+    )
+
+
+async def _migrate_legacy_tcp_bridge(
+    bridge_port: int,
+    bridge_path: Path,
+    session_path: Path,
+) -> bool:
+    """Retire a verifiably genuine pre-IPC bridge or fail closed.
+
+    Older gateways could leave a TCP bridge alive while deleting bridge.pid.
+    Starting the IPC bridge beside it creates two Baileys sessions. An occupied
+    port is therefore a migration signal, never authority to kill its owner.
+    """
+    if not _tcp_listener_is_occupied(bridge_port):
+        return False
+
+    pids = _listener_pids_on_port(bridge_port)
+    identity = None
+    pid = pids[0] if len(pids) == 1 else None
+    if pid is not None:
+        identity = _legacy_bridge_process_identity(
+            pid, bridge_path, session_path, bridge_port
+        )
+    if identity is None or not await _legacy_bridge_health_is_valid(bridge_port):
+        raise RuntimeError(
+            f"Configured WhatsApp bridge_port {bridge_port} is occupied by a "
+            "legacy TCP listener whose identity could not be proven. Stop the "
+            f"old WhatsApp bridge for session {session_path} (or move the "
+            "unrelated service), then restart Hermes. No listener was terminated "
+            "and no replacement bridge was started."
+        )
+
+    # Rebind the process identity after the network probe so PID reuse or a
+    # listener swap can never turn verified migration into an arbitrary kill.
+    if (
+        _legacy_bridge_process_identity(pid, bridge_path, session_path, bridge_port)
+        != identity
+    ):
+        raise RuntimeError(
+            "The legacy WhatsApp bridge changed during identity verification; "
+            "startup stopped without terminating it. Stop it manually and retry."
+        )
+
+    from gateway.status import terminate_pid
+
+    terminate_pid(pid)
+    for _attempt in range(50):
+        if not _tcp_listener_is_occupied(bridge_port):
+            logger.info(
+                "[whatsapp] Retired verified legacy TCP bridge PID %d on port %d",
+                pid,
+                bridge_port,
+            )
+            return True
+        await asyncio.sleep(0.1)
+
+    # The identity is still required immediately before escalation.
+    if (
+        _legacy_bridge_process_identity(pid, bridge_path, session_path, bridge_port)
+        != identity
+    ):
+        raise RuntimeError(
+            "The verified legacy WhatsApp bridge did not exit and its process "
+            "identity changed; startup stopped without force-terminating it."
+        )
+    if _IS_WINDOWS:
+        # Native cleanup must not launch taskkill or any other child process.
+        # The stable identity was rebound immediately above; psutil's direct
+        # process handle now provides the bounded force-retirement primitive.
+        import psutil
+
+        psutil.Process(pid).kill()
+    else:
+        terminate_pid(pid, force=True)
+    for _attempt in range(20):
+        if not _tcp_listener_is_occupied(bridge_port):
+            return True
+        await asyncio.sleep(0.1)
+    raise RuntimeError(
+        "The verified legacy WhatsApp bridge did not release its TCP listener; "
+        "startup stopped before launching a competing bridge."
+    )
 
 
 def _kill_port_process(port: int) -> None:
@@ -169,7 +547,11 @@ def _bridge_pid_is_ours(pid: int, session_path: Path, expected_start) -> bool:
     return ("node" in cmdline) and (str(session_path) in cmdline)
 
 
-def _kill_stale_bridge_by_pidfile(session_path: Path) -> None:
+def _kill_stale_bridge_by_pidfile(
+    session_path: Path,
+    bridge_path: Optional[Path] = None,
+    bridge_port: Optional[int] = None,
+) -> bool:
     """Kill a bridge process recorded in a PID file from a previous run.
 
     The bridge writes ``bridge.pid`` into the session directory when it
@@ -182,7 +564,7 @@ def _kill_stale_bridge_by_pidfile(session_path: Path) -> None:
     """
     pid_file = session_path / "bridge.pid"
     if not pid_file.exists():
-        return
+        return False
     pid = None
     recorded_start = None
     try:
@@ -197,10 +579,23 @@ def _kill_stale_bridge_by_pidfile(session_path: Path) -> None:
             pid_file.unlink()
         except OSError:
             pass
-        return
-    if _bridge_pid_is_ours(pid, session_path, recorded_start):
+        return False
+    if recorded_start is not None:
+        identity_matches = _bridge_pid_is_ours(pid, session_path, recorded_start)
+    elif bridge_path is not None and bridge_port is not None:
+        # Upgrade cleanup has the exact configured script/session/port. Require
+        # all of them for legacy pidfiles instead of the older loose cmdline
+        # fallback used by callers that lack those dimensions.
+        identity_matches = _legacy_bridge_process_identity(
+            pid, bridge_path, session_path, bridge_port
+        ) is not None
+    else:
+        identity_matches = _bridge_pid_is_ours(pid, session_path, recorded_start)
+    terminated = False
+    if identity_matches:
         try:
             os.kill(pid, signal.SIGTERM)
+            terminated = True
             logger.info("[whatsapp] Killed stale bridge PID %d from pidfile", pid)
         except (ProcessLookupError, PermissionError, OSError):
             pass
@@ -216,6 +611,7 @@ def _kill_stale_bridge_by_pidfile(session_path: Path) -> None:
         pid_file.unlink()
     except OSError:
         pass
+    return terminated
 
 
 def _write_bridge_pidfile(session_path: Path, pid: int) -> None:
@@ -394,7 +790,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     
     Configuration:
     - bridge_script: Path to the Node.js bridge script
-    - bridge_port: Port for HTTP communication (default: 3000)
+    - bridge_port: Stable bridge-instance/multiplex discriminator retained for
+      config compatibility (default: 3000); no TCP listener is opened
     - session_path: Path to store WhatsApp session data
     - dm_policy: "open" | "allowlist" | "disabled" | "pairing" — how DMs are handled (default: "pairing")
     - allow_from: List of sender IDs allowed in DMs (when dm_policy="allowlist")
@@ -427,6 +824,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             "session_path",
             get_hermes_dir("platforms/whatsapp/session", "whatsapp/session")
         ))
+        self._bridge_token: str = ""
         self._reply_prefix: Optional[str] = config.extra.get("reply_prefix")
         self._dm_policy = str(config.extra.get("dm_policy") or _wenv("WHATSAPP_DM_POLICY", "pairing")).strip().lower()
         # Prefer config.extra, then the documented WHATSAPP_ALLOWED_USERS env
@@ -512,6 +910,81 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         
         This launches the Node.js bridge process and waits for it to be ready.
         """
+        if _IS_WINDOWS:
+            # Native serving remains unsupported, but upgrades may inherit a
+            # pre-IPC unauthenticated TCP bridge. Retire only a bridge proven
+            # to own this exact script/session/port while holding the same
+            # lifecycle lock used by supported startup. This path deliberately
+            # does not read/rotate the bearer, construct an aiohttp session, or
+            # reach Node process launch.
+            bridge_path = Path(self._bridge_script)
+            lock_acquired = False
+            try:
+                lock_acquired = self._acquire_platform_lock(
+                    "whatsapp-session", str(self._session_path), "WhatsApp session"
+                )
+            except Exception as lock_error:
+                message = (
+                    "Could not acquire the WhatsApp session lock needed to "
+                    f"retire a legacy bridge safely: {lock_error}. Stop any old "
+                    "WhatsApp gateway and retry. No listener was terminated."
+                )
+                logger.error("[%s] %s", self.name, message)
+                self._set_fatal_error(
+                    "whatsapp_legacy_bridge_migration_required",
+                    message,
+                    retryable=False,
+                )
+                return False
+            if not lock_acquired:
+                message = (
+                    "The WhatsApp session lock is held by another gateway, so "
+                    "legacy bridge ownership cannot be proven safely. Stop the "
+                    "other gateway and retry. No listener was terminated."
+                )
+                self._set_fatal_error(
+                    "whatsapp_legacy_bridge_migration_required",
+                    message,
+                    retryable=False,
+                )
+                return False
+
+            try:
+                pidfile_signalled = _kill_stale_bridge_by_pidfile(
+                    self._session_path,
+                    bridge_path,
+                    self._bridge_port,
+                )
+                if pidfile_signalled:
+                    # Give an exact pidfile owner a bounded graceful-exit window;
+                    # the migration helper then either proves and finishes it or
+                    # fails closed on the still-occupied/ambiguous listener.
+                    await asyncio.sleep(1)
+                await _migrate_legacy_tcp_bridge(
+                    self._bridge_port,
+                    bridge_path,
+                    self._session_path,
+                )
+            except Exception as migration_error:
+                message = str(migration_error)
+                logger.error("[%s] %s", self.name, message)
+                self._set_fatal_error(
+                    "whatsapp_legacy_bridge_migration_required",
+                    message,
+                    retryable=False,
+                )
+                return False
+            finally:
+                self._release_platform_lock()
+
+            logger.error("[%s] %s", self.name, _WINDOWS_BRIDGE_UNSUPPORTED)
+            self._set_fatal_error(
+                "whatsapp_windows_ipc_unsupported",
+                _WINDOWS_BRIDGE_UNSUPPORTED,
+                retryable=False,
+            )
+            return False
+
         if not check_whatsapp_requirements():
             logger.warning("[%s] Node.js not found. WhatsApp requires Node.js.", self.name)
             self._set_fatal_error(
@@ -613,13 +1086,24 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
             # Ensure session directory exists
             self._session_path.mkdir(parents=True, exist_ok=True)
+            _ensure_private_bridge_directory(self._session_path)
+
+            # Authenticate to a reusable bridge with the token from its
+            # WhatsApp session directory. Missing or malformed files simply
+            # make the old listener ineligible for reuse; it is replaced below.
+            self._bridge_token = _read_bridge_token(self._session_path)
             
             # Check if bridge is already running and connected
             import aiohttp
             try:
-                async with aiohttp.ClientSession() as session:
+                async with _bridge_client_session(
+                    aiohttp,
+                    self._session_path,
+                    self._bridge_port,
+                    self._bridge_token,
+                ) as session:
                     async with session.get(
-                        f"http://127.0.0.1:{self._bridge_port}/health",
+                        f"{_BRIDGE_HTTP_BASE}/health",
                         timeout=aiohttp.ClientTimeout(total=2)
                     ) as resp:
                         if resp.status == 200:
@@ -648,7 +1132,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                     print(f"[{self.name}] Using existing bridge (status: {bridge_status})")
                                     self._mark_connected()
                                     self._bridge_process = None  # Not managed by us
-                                    self._http_session = aiohttp.ClientSession()
+                                    self._http_session = _bridge_client_session(
+                                        aiohttp,
+                                        self._session_path,
+                                        self._bridge_port,
+                                        self._bridge_token,
+                                    )
                                     self._poll_task = asyncio.create_task(self._poll_messages())
                                     return True
                                 stale_reason = (
@@ -663,9 +1152,44 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 pass  # Bridge not running, start a new one
             
             # Kill any orphaned bridge from a previous gateway run
-            _kill_stale_bridge_by_pidfile(self._session_path)
-            _kill_port_process(self._bridge_port)
+            _kill_stale_bridge_by_pidfile(
+                self._session_path,
+                bridge_path,
+                self._bridge_port,
+            )
             await asyncio.sleep(1)
+
+            # Pre-IPC gateways could deliberately reuse an external bridge and
+            # then delete bridge.pid on disconnect. Detect that upgrade state
+            # before rotating credentials or spawning another Baileys session.
+            # The migration helper retires only a command-line, start-time, and
+            # health-verified bridge for this exact script/session/port; every
+            # unproven listener blocks startup with manual guidance.
+            try:
+                await _migrate_legacy_tcp_bridge(
+                    self._bridge_port,
+                    bridge_path,
+                    self._session_path,
+                )
+            except RuntimeError as migration_error:
+                message = str(migration_error)
+                logger.error("[%s] %s", self.name, message)
+                self._set_fatal_error(
+                    "whatsapp_legacy_bridge_migration_required",
+                    message,
+                    retryable=False,
+                )
+                return False
+            _remove_stale_bridge_endpoint(
+                self._session_path,
+                self._bridge_port,
+                self._bridge_token,
+            )
+
+            # Rotate only when launching a new bridge. This preserves the
+            # existing-bridge reuse contract while ensuring a replaced bridge
+            # cannot be reached with its predecessor's credential.
+            self._bridge_token = _rotate_bridge_token(self._session_path)
             
             # Start the bridge process in its own process group.
             # Route output to a log file so QR codes, errors, and reconnection
@@ -680,6 +1204,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # can use it without the user needing to set a separate env var.
             # with_hermes_node_path() copies os.environ when called with no arg.
             bridge_env = with_hermes_node_path()
+            bridge_env["WHATSAPP_BRIDGE_TOKEN"] = self._bridge_token
+            bridge_env["WHATSAPP_BRIDGE_ENDPOINT"] = _bridge_ipc_endpoint(
+                self._session_path,
+                self._bridge_port,
+                self._bridge_token,
+            )
             if self._reply_prefix is not None:
                 bridge_env["WHATSAPP_REPLY_PREFIX"] = self._reply_prefix
             bridge_env["WHATSAPP_SEND_READ_RECEIPTS"] = (
@@ -751,9 +1281,14 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     self._close_bridge_log()
                     return False
                 try:
-                    async with aiohttp.ClientSession() as session:
+                    async with _bridge_client_session(
+                        aiohttp,
+                        self._session_path,
+                        self._bridge_port,
+                        self._bridge_token,
+                    ) as session:
                         async with session.get(
-                            f"http://127.0.0.1:{self._bridge_port}/health",
+                            f"{_BRIDGE_HTTP_BASE}/health",
                             timeout=aiohttp.ClientTimeout(total=2)
                         ) as resp:
                             if resp.status == 200:
@@ -783,9 +1318,14 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         self._close_bridge_log()
                         return False
                     try:
-                        async with aiohttp.ClientSession() as session:
+                        async with _bridge_client_session(
+                            aiohttp,
+                            self._session_path,
+                            self._bridge_port,
+                            self._bridge_token,
+                        ) as session:
                             async with session.get(
-                                f"http://127.0.0.1:{self._bridge_port}/health",
+                                f"{_BRIDGE_HTTP_BASE}/health",
                                 timeout=aiohttp.ClientTimeout(total=2)
                             ) as resp:
                                 if resp.status == 200:
@@ -803,13 +1343,18 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     print(f"[{self.name}]   If session expired, re-pair: hermes whatsapp")
             
             # Create a persistent HTTP session for all bridge communication
-            self._http_session = aiohttp.ClientSession()
+            self._http_session = _bridge_client_session(
+                aiohttp,
+                self._session_path,
+                self._bridge_port,
+                self._bridge_token,
+            )
 
             # Start message polling task
             self._poll_task = asyncio.create_task(self._poll_messages())
             
             self._mark_connected()
-            print(f"[{self.name}] Bridge started on port {self._bridge_port}")
+            print(f"[{self.name}] Bridge started on private local IPC")
             return True
             
         except Exception as e:
@@ -886,11 +1431,14 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # Bridge was not started by us, don't kill it
             print(f"[{self.name}] Disconnecting (external bridge left running)")
 
-        # Clean up PID file
-        try:
-            (self._session_path / "bridge.pid").unlink(missing_ok=True)
-        except OSError:
-            pass
+        # Preserve the PID/start-time identity for a reused external bridge.
+        # A later gateway must still be able to authenticate that process
+        # before replacing a stale endpoint.
+        if self._bridge_process:
+            try:
+                (self._session_path / "bridge.pid").unlink(missing_ok=True)
+            except OSError:
+                pass
 
         # Cancel the poll task explicitly
         if self._poll_task and not self._poll_task.done():
@@ -956,7 +1504,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     payload["replyTo"] = reply_to
 
                 async with self._http_session.post(
-                    f"http://127.0.0.1:{self._bridge_port}/send",
+                    f"{_BRIDGE_HTTP_BASE}/send",
                     json=payload,
                     timeout=aiohttp.ClientTimeout(total=30)
                 ) as resp:
@@ -999,7 +1547,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         try:
             import aiohttp
             async with self._http_session.post(
-                f"http://127.0.0.1:{self._bridge_port}/edit",
+                f"{_BRIDGE_HTTP_BASE}/edit",
                 json={
                     "chatId": to_whatsapp_jid(chat_id),
                     "messageId": message_id,
@@ -1046,7 +1594,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 payload["fileName"] = file_name
 
             async with self._http_session.post(
-                f"http://127.0.0.1:{self._bridge_port}/send-media",
+                f"{_BRIDGE_HTTP_BASE}/send-media",
                 json=payload,
                 timeout=aiohttp.ClientTimeout(total=120),
             ) as resp:
@@ -1093,7 +1641,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "selectableCount": selectable_count,
             }
             async with self._http_session.post(
-                f"http://127.0.0.1:{self._bridge_port}/send-poll",
+                f"{_BRIDGE_HTTP_BASE}/send-poll",
                 json=payload,
                 timeout=aiohttp.ClientTimeout(total=30),
             ) as resp:
@@ -1180,7 +1728,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             if address:
                 payload["address"] = address
             async with self._http_session.post(
-                f"http://127.0.0.1:{self._bridge_port}/send-location",
+                f"{_BRIDGE_HTTP_BASE}/send-location",
                 json=payload,
                 timeout=aiohttp.ClientTimeout(total=30),
             ) as resp:
@@ -1279,7 +1827,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # leaves the response object alive until GC, holding its TCP
             # socket in CLOSE_WAIT. See #18451.
             async with self._http_session.post(
-                f"http://127.0.0.1:{self._bridge_port}/typing",
+                f"{_BRIDGE_HTTP_BASE}/typing",
                 json={"chatId": to_whatsapp_jid(chat_id)},
                 timeout=aiohttp.ClientTimeout(total=5)
             ):
@@ -1298,7 +1846,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             import aiohttp
 
             async with self._http_session.get(
-                f"http://127.0.0.1:{self._bridge_port}/chat/{to_whatsapp_jid(chat_id)}",
+                f"{_BRIDGE_HTTP_BASE}/chat/{to_whatsapp_jid(chat_id)}",
                 timeout=aiohttp.ClientTimeout(total=10)
             ) as resp:
                 if resp.status == 200:
@@ -1326,7 +1874,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 break
             try:
                 async with self._http_session.get(
-                    f"http://127.0.0.1:{self._bridge_port}/messages",
+                    f"{_BRIDGE_HTTP_BASE}/messages",
                     timeout=aiohttp.ClientTimeout(total=30)
                 ) as resp:
                     if resp.status == 200:
@@ -1365,7 +1913,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             import aiohttp
 
             async with self._http_session.post(
-                f"http://127.0.0.1:{self._bridge_port}/read",
+                f"{_BRIDGE_HTTP_BASE}/read",
                 json={"key": key},
                 timeout=aiohttp.ClientTimeout(total=5),
             ) as resp:
@@ -1710,6 +2258,17 @@ async def _standalone_send(
         return {"error": "aiohttp not installed. Run: pip install aiohttp"}
     try:
         bridge_port = extra.get("bridge_port", 3000)
+        session_path = Path(extra.get(
+            "session_path",
+            get_hermes_dir("platforms/whatsapp/session", "whatsapp/session"),
+        ))
+        bridge_token = _read_bridge_token(session_path)
+        if not bridge_token:
+            return {
+                "error": "WhatsApp bridge authentication is unavailable; "
+                "start or reconnect the WhatsApp gateway first."
+            }
+        _ensure_private_bridge_directory(session_path)
         normalized_chat_id = to_whatsapp_jid(chat_id)
         media = media_files or []
         text = message or ""
@@ -1717,12 +2276,17 @@ async def _standalone_send(
         # a caption is never silently repeated across a multi-file send.
         media_caption = caption if (caption and len(media) == 1) else None
         last_message_id = None
-        async with aiohttp.ClientSession() as session:
+        async with _bridge_client_session(
+            aiohttp,
+            session_path,
+            bridge_port,
+            bridge_token,
+        ) as session:
             # 1) Text first (skip the /send call when this chunk is media-only
             #    or when the text is delivered as the media caption instead).
             if text.strip() and not media_caption:
                 async with session.post(
-                    f"http://localhost:{bridge_port}/send",
+                    f"{_BRIDGE_HTTP_BASE}/send",
                     json={"chatId": normalized_chat_id, "message": text},
                     timeout=aiohttp.ClientTimeout(total=30),
                 ) as resp:
@@ -1745,7 +2309,7 @@ async def _standalone_send(
                     if media_caption:
                         try:
                             async with session.post(
-                                f"http://localhost:{bridge_port}/send",
+                                f"{_BRIDGE_HTTP_BASE}/send",
                                 json={"chatId": normalized_chat_id, "message": media_caption},
                                 timeout=aiohttp.ClientTimeout(total=30),
                             ) as resp:
@@ -1765,7 +2329,7 @@ async def _standalone_send(
                 if media_caption:
                     payload["caption"] = media_caption
                 async with session.post(
-                    f"http://localhost:{bridge_port}/send-media",
+                    f"{_BRIDGE_HTTP_BASE}/send-media",
                     json=payload,
                     timeout=aiohttp.ClientTimeout(total=120),
                 ) as resp:
@@ -1802,8 +2366,15 @@ def interactive_setup() -> None:
     )
 
     print_header("WhatsApp")
-    print_info("WhatsApp uses a local Node.js bridge (WhatsApp Web client).")
-    print_info("Start the bridge separately; the gateway connects to it over HTTP.")
+    print_info("WhatsApp uses a gateway-managed Node.js bridge (WhatsApp Web client).")
+    print_info("The gateway launches it and connects over private authenticated local IPC.")
+    if _IS_WINDOWS:
+        print_info(
+            "Native Windows WhatsApp gateway operation is currently unsupported "
+            "because the available named-pipe runtimes cannot authenticate the "
+            "server before protected data is sent. Use WSL2/Linux; pairing-only "
+            "mode remains available through `hermes whatsapp`."
+        )
     existing = get_env_value("WHATSAPP_ENABLED")
     if existing and existing.lower() in {"true", "1", "yes"}:
         print_info("WhatsApp: already enabled")
@@ -1871,8 +2442,9 @@ def _is_connected(config) -> bool:
     """WhatsApp is considered connected when the user has explicitly enabled it
     via ``WHATSAPP_ENABLED`` (or the YAML-bridged equivalent on the config).
 
-    Auth itself is handled by the external Node.js bridge — we can't verify the
-    bridge token here — so the opt-in flag is the connection signal. The legacy
+    Auth itself is handled by the gateway-managed Node.js bridge — setup status
+    does not launch or probe that private IPC service — so the opt-in flag is
+    the connection signal. The legacy
     built-in path keyed off ``WHATSAPP_ENABLED`` in both the connected-platforms
     check and the setup-status display; returning an unconditional True here
     would make WhatsApp always show as "configured" in ``hermes setup`` even

--- a/plugins/platforms/whatsapp/plugin.yaml
+++ b/plugins/platforms/whatsapp/plugin.yaml
@@ -4,14 +4,16 @@ kind: platform
 version: 1.0.0
 description: >
   WhatsApp gateway adapter for Hermes Agent.
-  Connects to WhatsApp via a local Node.js bridge (WhatsApp Web client) over
-  an HTTP API and relays messages between WhatsApp chats and the Hermes agent.
+  Connects to WhatsApp via a gateway-managed Node.js bridge (WhatsApp Web
+  client) over authenticated private local IPC and relays messages between
+  WhatsApp chats and the Hermes agent. Native Windows gateway serving is not
+  currently supported; use WSL2/Linux. Pairing-only mode starts no IPC server.
   Supports DM/group policies, mention gating, free-response chats, and
   per-user allowlists.
 author: NousResearch
 requires_env:
   - name: WHATSAPP_ENABLED
-    description: "Enable the WhatsApp adapter (requires the Node.js bridge running)"
+    description: "Enable the WhatsApp adapter (the gateway manages its private bridge)"
     prompt: "Enable WhatsApp? (true/false)"
     password: false
 optional_env:

--- a/scripts/whatsapp-bridge/README.md
+++ b/scripts/whatsapp-bridge/README.md
@@ -1,0 +1,23 @@
+# Hermes WhatsApp bridge
+
+The personal-account WhatsApp bridge is launched and authenticated by
+`hermes gateway`. Its HTTP semantics run over a private Unix-domain socket;
+`bridge_port` remains only a stable instance and multiplex discriminator for
+configuration compatibility. It does not open that TCP port.
+
+Do not start serving mode with `node bridge.js`, hand-author
+`WHATSAPP_BRIDGE_TOKEN`, or hand-author `WHATSAPP_BRIDGE_ENDPOINT`. Those are
+gateway-owned credentials and endpoint state. `npm start` prints this guidance
+instead of starting an unauthenticated or incomplete server.
+
+For pairing, run `hermes whatsapp`. Pair-only mode starts no bridge control
+server. When developing the package directly, the low-level equivalent is
+`node bridge.js --pair-only --session <path>`; always provide the intended
+session directory explicitly.
+
+Gateway serving is supported on Linux and macOS. Native Windows named-pipe
+runtimes used by Node and aiohttp do not currently provide the pre-write peer
+authentication required to keep bearer tokens and message payloads from a
+replacement local pipe server. Native Windows therefore fails closed; use
+WSL2/Linux for WhatsApp gateway operation. Pair-only mode remains available on
+native Windows because it exposes no control server.

--- a/scripts/whatsapp-bridge/bridge-launcher.js
+++ b/scripts/whatsapp-bridge/bridge-launcher.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+const guidance = [
+  'WhatsApp bridge serving is gateway-managed.',
+  'Run `hermes gateway` to launch the authenticated private IPC bridge.',
+  'Run `hermes whatsapp` for pairing-only mode (no control server).',
+  'Native Windows serving is not supported; use WSL2/Linux.',
+].join('\n');
+
+console.error(guidance);
+process.exitCode = 1;

--- a/scripts/whatsapp-bridge/bridge.auth.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.auth.test.mjs
@@ -1,0 +1,170 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import express from 'express';
+
+import {
+  createAuthenticatedBridgeApp,
+  createBridgeAuthMiddleware,
+  validateBridgeLaunch,
+} from './bridge_helpers.js';
+
+function responseRecorder() {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    set(name, value) {
+      this.headers[name] = value;
+      return this;
+    },
+    json(body) {
+      this.body = body;
+      return this;
+    },
+  };
+}
+
+function invokeAuth(authorization, expectedToken = 'session-token') {
+  const req = { headers: {} };
+  if (authorization !== undefined) req.headers.authorization = authorization;
+  const res = responseRecorder();
+  let nextCalled = false;
+  createBridgeAuthMiddleware(expectedToken)(req, res, () => {
+    nextCalled = true;
+  });
+  return { res, nextCalled };
+}
+
+test('bridge bearer auth rejects requests without credentials', () => {
+  const { res, nextCalled } = invokeAuth(undefined);
+
+  assert.equal(nextCalled, false);
+  assert.equal(res.statusCode, 401);
+  assert.equal(res.headers['WWW-Authenticate'], 'Bearer');
+  assert.deepEqual(res.body, { error: 'Unauthorized' });
+});
+
+test('bridge bearer auth rejects malformed and incorrect credentials', () => {
+  for (const authorization of [
+    '',
+    'Basic session-token',
+    'Bearer',
+    'Bearer wrong-token',
+    'Bearer session-token extra',
+  ]) {
+    const { res, nextCalled } = invokeAuth(authorization);
+    assert.equal(nextCalled, false, authorization);
+    assert.equal(res.statusCode, 401, authorization);
+  }
+});
+
+test('bridge bearer auth accepts the exact session token', () => {
+  const { res, nextCalled } = invokeAuth('Bearer session-token');
+
+  assert.equal(nextCalled, true);
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body, null);
+});
+
+test('bridge bearer auth fails closed without a configured token', () => {
+  const { res, nextCalled } = invokeAuth('Bearer session-token', '');
+
+  assert.equal(nextCalled, false);
+  assert.equal(res.statusCode, 401);
+});
+
+function request(server, { authorization, body }) {
+  const { port } = server.address();
+  return new Promise((resolve, reject) => {
+    const headers = {
+      host: 'localhost',
+      'content-type': 'application/json',
+      'content-length': Buffer.byteLength(body),
+    };
+    if (authorization) headers.authorization = authorization;
+    const req = http.request({
+      host: '127.0.0.1', port, path: '/probe', method: 'POST', headers,
+    }, (res) => {
+      const chunks = [];
+      res.on('data', (chunk) => chunks.push(chunk));
+      res.on('end', () => resolve({
+        status: res.statusCode,
+        body: Buffer.concat(chunks).toString('utf8'),
+      }));
+    });
+    req.on('error', reject);
+    req.end(body);
+  });
+}
+
+test('real Express app authenticates before parsing and routes', async (t) => {
+  const app = createAuthenticatedBridgeApp(express, 'session-token');
+  let routeCalls = 0;
+  app.post('/probe', (req, res) => {
+    routeCalls += 1;
+    res.json({ received: req.body.message });
+  });
+  app.use((err, _req, res, _next) => {
+    res.status(err.status || 500).json({ error: 'Invalid request body' });
+  });
+  const server = app.listen(0, '127.0.0.1');
+  await new Promise((resolve) => server.once('listening', resolve));
+  t.after(() => new Promise((resolve) => server.close(resolve)));
+
+  const unauthenticated = await request(server, {
+    // Express defaults to a 100 KiB JSON limit. Keep this large enough to prove
+    // auth runs before parsing without overflowing local socket buffers.
+    body: '{'.repeat(128 * 1024),
+  });
+  assert.equal(unauthenticated.status, 401);
+  assert.equal(routeCalls, 0);
+
+  const malformedAuthenticated = await request(server, {
+    authorization: 'Bearer session-token',
+    body: '{',
+  });
+  assert.equal(malformedAuthenticated.status, 400);
+  assert.equal(routeCalls, 0);
+
+  const authenticated = await request(server, {
+    authorization: 'Bearer session-token',
+    body: JSON.stringify({ message: 'private' }),
+  });
+  assert.equal(authenticated.status, 200);
+  assert.deepEqual(JSON.parse(authenticated.body), { received: 'private' });
+  assert.equal(routeCalls, 1);
+});
+
+test('native Windows serving fails before named-pipe listen', () => {
+  assert.throws(
+    () => validateBridgeLaunch({
+      platform: 'win32',
+      pairOnly: false,
+      endpoint: String.raw`\\.\pipe\observed-name`,
+      token: 'session-token',
+    }),
+    /Native Windows.*unsupported/,
+  );
+  assert.doesNotThrow(() => validateBridgeLaunch({
+    platform: 'win32',
+    pairOnly: true,
+    endpoint: '',
+    token: '',
+  }));
+});
+
+test('public npm-start launcher gives actionable gateway guidance', () => {
+  const result = spawnSync(process.execPath, ['bridge-launcher.js'], {
+    cwd: import.meta.dirname,
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /hermes gateway/);
+  assert.match(result.stderr, /hermes whatsapp/);
+});

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -2,8 +2,8 @@
 /**
  * Hermes Agent WhatsApp Bridge
  *
- * Standalone Node.js process that connects to WhatsApp via Baileys
- * and exposes HTTP endpoints for the Python gateway adapter.
+ * Gateway-managed Node.js process that connects to WhatsApp via Baileys
+ * and exposes authenticated HTTP semantics over private local IPC.
  *
  * Endpoints (matches gateway/platforms/whatsapp.py expectations):
  *   GET  /messages       - Long-poll for new incoming messages
@@ -15,8 +15,12 @@
  *   GET  /chat/:id       - Get chat info
  *   GET  /health         - Health check
  *
- * Usage:
- *   node bridge.js --port 3000 --session ~/.hermes/whatsapp/session
+ * Supported entrypoints:
+ *   hermes gateway                    gateway-managed authenticated serving
+ *   hermes whatsapp                   pairing only (no control server)
+ *   node bridge.js --pair-only --session <path>  low-level pairing equivalent
+ *
+ * Do not launch serving mode directly or hand-author bridge credentials.
  */
 
 import { makeWASocket, useMultiFileAuthState, DisconnectReason, fetchLatestBaileysVersion, downloadMediaMessage, getAggregateVotesInPollMessage, decryptPollVote, getKeyAuthor, jidNormalizedUser } from '@whiskeysockets/baileys';
@@ -24,7 +28,7 @@ import express from 'express';
 import { Boom } from '@hapi/boom';
 import pino from 'pino';
 import path from 'path';
-import { mkdirSync, readFileSync, existsSync, readdirSync, unlinkSync } from 'fs';
+import { chmodSync, lstatSync, mkdirSync, readFileSync, existsSync, readdirSync, unlinkSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { randomBytes, createHash } from 'crypto';
 import { execFileSync } from 'child_process';
@@ -35,6 +39,7 @@ import { createOutboundIdTracker } from './outbound_ids.js';
 import { classifyOwnerMessageGate } from './owner_message_gate.js';
 import {
   buildPollPayload,
+  createAuthenticatedBridgeApp,
   createReconnectScheduler,
   createVersionResolver,
   buildLocationPayload,
@@ -46,6 +51,7 @@ import {
   mediaPayloadForFile,
   pollCreationMessageFromPayload,
   pollUpdateForAggregation,
+  validateBridgeLaunch,
 } from './bridge_helpers.js';
 
 // Parse CLI args
@@ -110,6 +116,10 @@ try {
 } catch {}
 const PAIR_ONLY = args.includes('--pair-only');
 const PAIR_JSON = args.includes('--pair-json');
+const BRIDGE_AUTH_TOKEN = process.env.WHATSAPP_BRIDGE_TOKEN || '';
+delete process.env.WHATSAPP_BRIDGE_TOKEN;
+const BRIDGE_IPC_ENDPOINT = process.env.WHATSAPP_BRIDGE_ENDPOINT || '';
+delete process.env.WHATSAPP_BRIDGE_ENDPOINT;
 const WHATSAPP_MODE = getArg('mode', process.env.WHATSAPP_MODE || 'self-chat'); // "bot" or "self-chat"
 const WHATSAPP_DM_POLICY = String(process.env.WHATSAPP_DM_POLICY || 'open').trim().toLowerCase();
 const ALLOWED_USERS = parseAllowedUsers(process.env.WHATSAPP_ALLOWED_USERS || '');
@@ -778,40 +788,10 @@ async function startSocket() {
   });
 }
 
-// HTTP server
-const app = express();
-app.use(express.json());
-
-// Host-header validation — defends against DNS rebinding.
-// The bridge binds loopback-only (127.0.0.1) but a victim browser on
-// the same machine could be tricked into fetching from an attacker
-// hostname that TTL-flips to 127.0.0.1. Reject any request whose Host
-// header doesn't resolve to a loopback alias.
-// See GHSA-ppp5-vxwm-4cf7.
-const _ACCEPTED_HOST_VALUES = new Set([
-  'localhost',
-  '127.0.0.1',
-  '[::1]',
-  '::1',
-]);
-
-app.use((req, res, next) => {
-  const raw = (req.headers.host || '').trim();
-  if (!raw) {
-    return res.status(400).json({ error: 'Missing Host header' });
-  }
-  // Strip port suffix: "localhost:3000" → "localhost"
-  const hostOnly = (raw.includes(':')
-    ? raw.substring(0, raw.lastIndexOf(':'))
-    : raw
-  ).replace(/^\[|\]$/g, '').toLowerCase();
-  if (!_ACCEPTED_HOST_VALUES.has(hostOnly)) {
-    return res.status(400).json({
-      error: 'Invalid Host header. Bridge accepts loopback hosts only.',
-    });
-  }
-  next();
-});
+// Production's only Express app is born with Host validation, bearer auth, and
+// authenticated-only body parsing already installed. Routes cannot precede the
+// security boundary by construction. See GHSA-ppp5-vxwm-4cf7.
+const app = createAuthenticatedBridgeApp(express, BRIDGE_AUTH_TOKEN);
 
 // Poll for new messages (long-poll style)
 app.get('/messages', (req, res) => {
@@ -1132,24 +1112,73 @@ if (PAIR_ONLY) {
     process.exit(1);
   });
 } else {
-  app.listen(PORT, '127.0.0.1', () => {
-    console.log(`🌉 WhatsApp bridge listening on port ${PORT} (mode: ${WHATSAPP_MODE})`);
-    console.log(`📁 Session stored in: ${SESSION_DIR}`);
-    if (ALLOWED_USERS.size > 0) {
-      console.log(`🔒 Allowed users: ${Array.from(ALLOWED_USERS).join(', ')}`);
-    } else if (WHATSAPP_MODE === 'self-chat') {
-      console.log(`🔒 Self-chat mode — only your own messages to yourself are processed.`);
-    } else if (WHATSAPP_MODE === 'bot' && WHATSAPP_DM_POLICY === 'pairing') {
-      console.log(`🤝 WHATSAPP_DM_POLICY=pairing — unknown DMs are forwarded for gateway pairing.`);
-    } else {
-      console.log(`🔒 No WHATSAPP_ALLOWED_USERS set — incoming messages are rejected.`);
-      console.log(`   Set WHATSAPP_ALLOWED_USERS=<phone> to authorize specific users,`);
-      console.log(`   or WHATSAPP_ALLOWED_USERS=* for an explicit open bot.`);
+  try {
+    validateBridgeLaunch({
+      platform: process.platform,
+      pairOnly: false,
+      endpoint: BRIDGE_IPC_ENDPOINT,
+      token: BRIDGE_AUTH_TOKEN,
+    });
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+  if (process.platform !== 'win32' && existsSync(BRIDGE_IPC_ENDPOINT)) {
+    const endpointInfo = lstatSync(BRIDGE_IPC_ENDPOINT);
+    if (!endpointInfo.isSocket()) {
+      console.error('Refusing to replace a non-socket WhatsApp bridge endpoint');
+      process.exit(1);
     }
-    if (WHATSAPP_MODE === 'bot' && FORWARD_OWNER_MESSAGES) {
-      console.log(`👤 WHATSAPP_FORWARD_OWNER_MESSAGES=true — owner-typed messages will be forwarded with fromOwner:true`);
+    if (typeof process.geteuid === 'function' && endpointInfo.uid !== process.geteuid()) {
+      console.error('Refusing to replace a foreign WhatsApp bridge endpoint');
+      process.exit(1);
     }
-    console.log();
-    scheduleReconnect(0);
+    unlinkSync(BRIDGE_IPC_ENDPOINT);
+  }
+  const previousUmask = process.platform === 'win32' ? null : process.umask(0o077);
+  let umaskRestored = false;
+  const restoreUmask = () => {
+    if (previousUmask !== null && !umaskRestored) {
+      umaskRestored = true;
+      process.umask(previousUmask);
+    }
+  };
+  let bridgeServer;
+  try {
+    bridgeServer = app.listen(BRIDGE_IPC_ENDPOINT, () => {
+      try {
+        if (process.platform !== 'win32') {
+          chmodSync(BRIDGE_IPC_ENDPOINT, 0o600);
+        }
+      } finally {
+        restoreUmask();
+      }
+      console.log(`🌉 WhatsApp bridge listening on private local IPC (mode: ${WHATSAPP_MODE})`);
+      console.log(`📁 Session stored in: ${SESSION_DIR}`);
+      if (ALLOWED_USERS.size > 0) {
+        console.log(`🔒 Allowed users: ${Array.from(ALLOWED_USERS).join(', ')}`);
+      } else if (WHATSAPP_MODE === 'self-chat') {
+        console.log(`🔒 Self-chat mode — only your own messages to yourself are processed.`);
+      } else if (WHATSAPP_MODE === 'bot' && WHATSAPP_DM_POLICY === 'pairing') {
+        console.log(`🤝 WHATSAPP_DM_POLICY=pairing — unknown DMs are forwarded for gateway pairing.`);
+      } else {
+        console.log(`🔒 No WHATSAPP_ALLOWED_USERS set — incoming messages are rejected.`);
+        console.log(`   Set WHATSAPP_ALLOWED_USERS=<phone> to authorize specific users,`);
+        console.log(`   or WHATSAPP_ALLOWED_USERS=* for an explicit open bot.`);
+      }
+      if (WHATSAPP_MODE === 'bot' && FORWARD_OWNER_MESSAGES) {
+        console.log(`👤 WHATSAPP_FORWARD_OWNER_MESSAGES=true — owner-typed messages will be forwarded with fromOwner:true`);
+      }
+      console.log();
+      scheduleReconnect(0);
+    });
+  } catch (err) {
+    restoreUmask();
+    throw err;
+  }
+  bridgeServer.on('error', (err) => {
+    restoreUmask();
+    console.error(`WhatsApp bridge IPC listener failed: ${err.message}`);
+    process.exit(1);
   });
 }

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -1,6 +1,101 @@
 import path from 'path';
 import { mkdirSync, writeFileSync } from 'fs';
-import { randomBytes } from 'crypto';
+import { randomBytes, timingSafeEqual } from 'crypto';
+
+export function createBridgeAuthMiddleware(expectedToken) {
+  const expected = typeof expectedToken === 'string'
+    ? Buffer.from(expectedToken, 'utf8')
+    : Buffer.alloc(0);
+
+  return function bridgeAuth(req, res, next) {
+    const authorization = req?.headers?.authorization;
+    const prefix = 'Bearer ';
+    const suppliedToken = typeof authorization === 'string'
+      && authorization.startsWith(prefix)
+      ? authorization.slice(prefix.length)
+      : '';
+    const supplied = Buffer.from(suppliedToken, 'utf8');
+    const authorized = expected.length > 0
+      && supplied.length === expected.length
+      && timingSafeEqual(supplied, expected);
+
+    if (!authorized) {
+      return res
+        .status(401)
+        .set('WWW-Authenticate', 'Bearer')
+        .json({ error: 'Unauthorized' });
+    }
+    return next();
+  };
+}
+
+export function installBridgeHttpSecurity(app, expectedToken, jsonParser) {
+  // Keep authentication ahead of body parsing. This function owns the
+  // ordering as runtime composition rather than leaving it as a convention at
+  // the bridge call site.
+  app.use(createBridgeAuthMiddleware(expectedToken));
+  app.use(jsonParser);
+}
+
+const ACCEPTED_BRIDGE_HOSTS = new Set([
+  'localhost',
+  '127.0.0.1',
+  '[::1]',
+  '::1',
+]);
+
+export function createBridgeHostMiddleware() {
+  return function bridgeHost(req, res, next) {
+    const raw = (req.headers.host || '').trim();
+    if (!raw) {
+      return res.status(400).json({ error: 'Missing Host header' });
+    }
+    const hostOnly = (raw.includes(':')
+      ? raw.substring(0, raw.lastIndexOf(':'))
+      : raw
+    ).replace(/^\[|\]$/g, '').toLowerCase();
+    if (!ACCEPTED_BRIDGE_HOSTS.has(hostOnly)) {
+      return res.status(400).json({
+        error: 'Invalid Host header. Bridge accepts loopback hosts only.',
+      });
+    }
+    return next();
+  };
+}
+
+export function createAuthenticatedBridgeApp(expressModule, expectedToken) {
+  // Production obtains its only Express app through this factory. Therefore no
+  // route can be registered before Host validation, bearer authentication, and
+  // the authenticated-only JSON parser are installed.
+  const app = expressModule();
+  app.use(createBridgeHostMiddleware());
+  installBridgeHttpSecurity(app, expectedToken, expressModule.json());
+  return app;
+}
+
+export const WINDOWS_BRIDGE_UNSUPPORTED =
+  'Native Windows WhatsApp gateway serving is unsupported because the bundled '
+  + 'named-pipe runtimes cannot authenticate the server before protected data '
+  + 'is sent. Use WSL2/Linux; pairing-only mode remains available.';
+
+export function validateBridgeLaunch({
+  platform,
+  pairOnly,
+  endpoint,
+  token,
+}) {
+  if (pairOnly) return;
+  if (platform === 'win32') {
+    throw new Error(WINDOWS_BRIDGE_UNSUPPORTED);
+  }
+  if (!endpoint || !token) {
+    throw new Error(
+      'WhatsApp gateway serving is managed by Hermes and requires a private '
+      + 'authenticated IPC endpoint. Run `hermes gateway`; use `hermes whatsapp` '
+      + 'for pairing-only mode.',
+    );
+  }
+}
 
 export const MIME_MAP = {
   jpg: 'image/jpeg', jpeg: 'image/jpeg', png: 'image/png',

--- a/scripts/whatsapp-bridge/package.json
+++ b/scripts/whatsapp-bridge/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start": "node bridge.js"
+    "start": "node bridge-launcher.js"
   },
   "dependencies": {
     "@whiskeysockets/baileys": "7.0.0-rc13",

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -820,6 +820,108 @@ class TestSecondaryProfileConfigHandling:
         assert second == 1
         assert runner._profile_adapters["later"][photon] is later
 
+    @pytest.mark.asyncio
+    async def test_secondary_whatsapp_default_port_collision_never_connects_or_disconnects(
+        self, monkeypatch
+    ):
+        """A second default-port profile cannot disturb the active bridge."""
+        class _WhatsAppAdapter:
+            def __init__(self, port=3000):
+                self._bridge_port = port
+                self.platform = Platform.WHATSAPP
+                self.config = PlatformConfig(enabled=True)
+                self.connect_calls = 0
+                self.disconnect_calls = 0
+
+            def __getattr__(self, name):
+                if name.startswith("set_"):
+                    return lambda *args, **kwargs: None
+                raise AttributeError(name)
+
+            async def disconnect(self):
+                self.disconnect_calls += 1
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._profile_adapters = {}
+        runner.session_store = None
+        runner._busy_text_mode = "queue"
+        whatsapp = Platform.WHATSAPP
+        profile_cfg = GatewayConfig(multiplex_profiles=True)
+        profile_cfg.platforms = {whatsapp: PlatformConfig(enabled=True)}
+        primary = _WhatsAppAdapter()
+        secondary = _WhatsAppAdapter()
+        claimed = {
+            GatewayRunner._adapter_listener_claim(whatsapp, primary): "default"
+        }
+
+        async def _connect(adapter, platform):
+            adapter.connect_calls += 1
+            return True
+
+        monkeypatch.setattr("gateway.config.load_gateway_config", lambda: profile_cfg)
+        monkeypatch.setattr(runner, "_create_adapter", lambda p, c: secondary)
+        monkeypatch.setattr(runner, "_connect_initial_adapter_with_timeout", _connect)
+
+        connected = await runner._start_one_profile_adapters(
+            "reviewer", Path("/tmp/reviewer"), claimed
+        )
+
+        assert connected == 0
+        assert primary.connect_calls == primary.disconnect_calls == 0
+        assert secondary.connect_calls == secondary.disconnect_calls == 0
+        assert "reviewer" not in runner._profile_adapters or not runner._profile_adapters["reviewer"]
+
+    @pytest.mark.asyncio
+    async def test_secondary_whatsapp_distinct_port_connects(self, monkeypatch):
+        """Explicitly separate WhatsApp bridge ports remain multiplexable."""
+        class _WhatsAppAdapter:
+            def __init__(self, port):
+                self._bridge_port = port
+                self.platform = Platform.WHATSAPP
+                self.config = PlatformConfig(enabled=True)
+                self.connected = False
+                self.disconnected = False
+
+            def __getattr__(self, name):
+                if name.startswith("set_"):
+                    return lambda *args, **kwargs: None
+                raise AttributeError(name)
+
+            async def disconnect(self):
+                self.disconnected = True
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._profile_adapters = {}
+        runner.session_store = None
+        runner._busy_text_mode = "queue"
+        whatsapp = Platform.WHATSAPP
+        profile_cfg = GatewayConfig(multiplex_profiles=True)
+        profile_cfg.platforms = {whatsapp: PlatformConfig(enabled=True)}
+        primary = _WhatsAppAdapter(3000)
+        secondary = _WhatsAppAdapter(3001)
+        claimed = {
+            GatewayRunner._adapter_listener_claim(whatsapp, primary): "default"
+        }
+
+        async def _connect(adapter, platform):
+            adapter.connected = True
+            return True
+
+        monkeypatch.setattr("gateway.config.load_gateway_config", lambda: profile_cfg)
+        monkeypatch.setattr(runner, "_create_adapter", lambda p, c: secondary)
+        monkeypatch.setattr(runner, "_connect_initial_adapter_with_timeout", _connect)
+
+        connected = await runner._start_one_profile_adapters(
+            "reviewer", Path("/tmp/reviewer"), claimed
+        )
+
+        assert connected == 1
+        assert secondary.connected is True
+        assert secondary.disconnected is False
+        assert runner._profile_adapters["reviewer"][whatsapp] is secondary
+
 
 class TestFeishuPortBindingConditional:
     """Feishu websocket mode does NOT bind a port; only webhook mode does (#52563)."""
@@ -846,5 +948,4 @@ class TestFeishuPortBindingConditional:
 
         connected = await runner._start_one_profile_adapters("reviewer", "/tmp/x", {})
         assert connected == 0  # no error, just nothing connected
-
 

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -467,6 +467,108 @@ class TestSecondaryProfileConfigHandling:
         assert second == 1
         assert runner._profile_adapters["later"][photon] is later
 
+    @pytest.mark.asyncio
+    async def test_secondary_whatsapp_default_port_collision_never_connects_or_disconnects(
+        self, monkeypatch
+    ):
+        """A second default-port profile cannot disturb the active bridge."""
+        class _WhatsAppAdapter:
+            def __init__(self, port=3000):
+                self._bridge_port = port
+                self.platform = Platform.WHATSAPP
+                self.config = PlatformConfig(enabled=True)
+                self.connect_calls = 0
+                self.disconnect_calls = 0
+
+            def __getattr__(self, name):
+                if name.startswith("set_"):
+                    return lambda *args, **kwargs: None
+                raise AttributeError(name)
+
+            async def disconnect(self):
+                self.disconnect_calls += 1
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._profile_adapters = {}
+        runner.session_store = None
+        runner._busy_text_mode = "queue"
+        whatsapp = Platform.WHATSAPP
+        profile_cfg = GatewayConfig(multiplex_profiles=True)
+        profile_cfg.platforms = {whatsapp: PlatformConfig(enabled=True)}
+        primary = _WhatsAppAdapter()
+        secondary = _WhatsAppAdapter()
+        claimed = {
+            GatewayRunner._adapter_listener_claim(whatsapp, primary): "default"
+        }
+
+        async def _connect(adapter, platform):
+            adapter.connect_calls += 1
+            return True
+
+        monkeypatch.setattr("gateway.config.load_gateway_config", lambda: profile_cfg)
+        monkeypatch.setattr(runner, "_create_adapter", lambda p, c: secondary)
+        monkeypatch.setattr(runner, "_connect_initial_adapter_with_timeout", _connect)
+
+        connected = await runner._start_one_profile_adapters(
+            "reviewer", Path("/tmp/reviewer"), claimed
+        )
+
+        assert connected == 0
+        assert primary.connect_calls == primary.disconnect_calls == 0
+        assert secondary.connect_calls == secondary.disconnect_calls == 0
+        assert "reviewer" not in runner._profile_adapters or not runner._profile_adapters["reviewer"]
+
+    @pytest.mark.asyncio
+    async def test_secondary_whatsapp_distinct_port_connects(self, monkeypatch):
+        """Explicitly separate WhatsApp bridge ports remain multiplexable."""
+        class _WhatsAppAdapter:
+            def __init__(self, port):
+                self._bridge_port = port
+                self.platform = Platform.WHATSAPP
+                self.config = PlatformConfig(enabled=True)
+                self.connected = False
+                self.disconnected = False
+
+            def __getattr__(self, name):
+                if name.startswith("set_"):
+                    return lambda *args, **kwargs: None
+                raise AttributeError(name)
+
+            async def disconnect(self):
+                self.disconnected = True
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._profile_adapters = {}
+        runner.session_store = None
+        runner._busy_text_mode = "queue"
+        whatsapp = Platform.WHATSAPP
+        profile_cfg = GatewayConfig(multiplex_profiles=True)
+        profile_cfg.platforms = {whatsapp: PlatformConfig(enabled=True)}
+        primary = _WhatsAppAdapter(3000)
+        secondary = _WhatsAppAdapter(3001)
+        claimed = {
+            GatewayRunner._adapter_listener_claim(whatsapp, primary): "default"
+        }
+
+        async def _connect(adapter, platform):
+            adapter.connected = True
+            return True
+
+        monkeypatch.setattr("gateway.config.load_gateway_config", lambda: profile_cfg)
+        monkeypatch.setattr(runner, "_create_adapter", lambda p, c: secondary)
+        monkeypatch.setattr(runner, "_connect_initial_adapter_with_timeout", _connect)
+
+        connected = await runner._start_one_profile_adapters(
+            "reviewer", Path("/tmp/reviewer"), claimed
+        )
+
+        assert connected == 1
+        assert secondary.connected is True
+        assert secondary.disconnected is False
+        assert runner._profile_adapters["reviewer"][whatsapp] is secondary
+
 
 class TestFeishuPortBindingConditional:
     """Feishu websocket mode does NOT bind a port; only webhook mode does (#52563)."""
@@ -493,5 +595,4 @@ class TestFeishuPortBindingConditional:
 
         connected = await runner._start_one_profile_adapters("reviewer", "/tmp/x", {})
         assert connected == 0  # no error, just nothing connected
-
 

--- a/tests/gateway/test_whatsapp_bridge_auth.py
+++ b/tests/gateway/test_whatsapp_bridge_auth.py
@@ -1,0 +1,526 @@
+"""Authentication boundary for the local WhatsApp bridge HTTP API."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import stat
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.whatsapp.adapter import (
+    WhatsAppAdapter,
+    _bridge_auth_headers,
+    _bridge_client_session,
+    _bridge_ipc_endpoint,
+    _file_content_hash,
+    _read_bridge_token,
+    _rotate_bridge_token,
+    _standalone_send,
+)
+
+
+class _AsyncContext:
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, *_exc):
+        return False
+
+
+def test_bridge_token_round_trip_is_private_and_rotates(tmp_path: Path) -> None:
+    session_path = tmp_path / "session"
+    session_path.mkdir()
+
+    first = _rotate_bridge_token(session_path)
+    token_path = session_path / ".bridge-token"
+
+    assert _read_bridge_token(session_path) == first
+    if os.name != "nt":
+        assert stat.S_IMODE(token_path.stat().st_mode) == 0o600
+    assert _bridge_auth_headers(first) == {"Authorization": f"Bearer {first}"}
+
+    second = _rotate_bridge_token(session_path)
+    assert second != first
+    assert _read_bridge_token(session_path) == second
+    if os.name != "nt":
+        assert stat.S_IMODE(token_path.stat().st_mode) == 0o600
+
+
+def test_bridge_token_reader_rejects_malformed_credentials(tmp_path: Path) -> None:
+    session_path = tmp_path / "session"
+    session_path.mkdir()
+    token_path = session_path / ".bridge-token"
+
+    for malformed in ("", "short", "token with spaces", "a" * 129):
+        token_path.write_text(malformed, encoding="utf-8")
+        assert _read_bridge_token(session_path) == ""
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file permissions only")
+def test_bridge_token_reader_repairs_overbroad_mode(tmp_path: Path) -> None:
+    session_path = tmp_path / "session"
+    session_path.mkdir()
+    token = _rotate_bridge_token(session_path)
+    token_path = session_path / ".bridge-token"
+    token_path.chmod(0o644)
+
+    assert _read_bridge_token(session_path) == token
+    assert stat.S_IMODE(token_path.stat().st_mode) == 0o600
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file permissions only")
+def test_bridge_token_reader_fails_closed_when_mode_repair_fails(tmp_path: Path) -> None:
+    session_path = tmp_path / "session"
+    session_path.mkdir()
+    _rotate_bridge_token(session_path)
+    (session_path / ".bridge-token").chmod(0o644)
+
+    with patch("plugins.platforms.whatsapp.adapter.os.fchmod", side_effect=OSError("denied")):
+        assert _read_bridge_token(session_path) == ""
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(os.name == "nt", reason="adversarial Unix-socket transport test")
+async def test_standalone_send_ignores_fake_loopback_listener(tmp_path: Path) -> None:
+    """A process owning the configured TCP port sees neither auth nor payload."""
+    from aiohttp import web
+
+    session_path = tmp_path / "session"
+    session_path.mkdir()
+    token = _rotate_bridge_token(session_path)
+    fake_requests = []
+    genuine_requests = []
+
+    async def fake_handler(request):
+        fake_requests.append((dict(request.headers), await request.read()))
+        return web.json_response({"messageId": "forged"})
+
+    fake_app = web.Application()
+    fake_app.router.add_route("*", "/{tail:.*}", fake_handler)
+    fake_runner = web.AppRunner(fake_app)
+    await fake_runner.setup()
+    fake_site = web.TCPSite(fake_runner, "127.0.0.1", 0)
+    await fake_site.start()
+    bridge_port = fake_site._server.sockets[0].getsockname()[1]
+
+    async def genuine_send(request):
+        genuine_requests.append((request.path, request.headers.get("Authorization"), await request.json()))
+        return web.json_response({"messageId": "genuine"})
+
+    genuine_app = web.Application()
+    genuine_app.router.add_post("/send", genuine_send)
+    genuine_app.router.add_post("/send-media", genuine_send)
+    genuine_runner = web.AppRunner(genuine_app)
+    await genuine_runner.setup()
+    endpoint = _bridge_ipc_endpoint(session_path, bridge_port, token)
+    genuine_site = web.UnixSite(genuine_runner, endpoint)
+    await genuine_site.start()
+    Path(endpoint).chmod(0o600)
+
+    config = SimpleNamespace(
+        token="",
+        extra={"bridge_port": bridge_port, "session_path": str(session_path)},
+    )
+    media_path = tmp_path / "private.jpg"
+    media_path.write_bytes(b"image")
+    try:
+        result = await _standalone_send(config, "15551234567", "private message")
+        media_result = await _standalone_send(
+            config,
+            "15551234567",
+            "",
+            media_files=[(str(media_path), False)],
+            caption="private caption",
+        )
+    finally:
+        await genuine_runner.cleanup()
+        await fake_runner.cleanup()
+
+    assert result["success"] is True
+    assert media_result["success"] is True
+    assert result["message_id"] == "genuine"
+    assert genuine_requests == [
+        (
+            "/send",
+            f"Bearer {token}",
+            {"chatId": "15551234567@s.whatsapp.net", "message": "private message"},
+        ),
+        (
+            "/send-media",
+            f"Bearer {token}",
+            {
+                "chatId": "15551234567@s.whatsapp.net",
+                "filePath": str(media_path),
+                "mediaType": "image",
+                "caption": "private caption",
+            },
+        ),
+    ]
+    assert fake_requests == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(os.name == "nt", reason="adversarial Unix-socket transport test")
+async def test_standalone_send_rejects_untrusted_socket_before_http(tmp_path: Path) -> None:
+    """An endpoint without the private socket invariant receives no request."""
+    from aiohttp import web
+
+    session_path = tmp_path / "session"
+    session_path.mkdir()
+    token = _rotate_bridge_token(session_path)
+    bridge_port = 30124
+    received = []
+
+    async def fake_send(request):
+        received.append((dict(request.headers), await request.read()))
+        return web.json_response({"messageId": "forged"})
+
+    app = web.Application()
+    app.router.add_post("/send", fake_send)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    endpoint = _bridge_ipc_endpoint(session_path, bridge_port, token)
+    site = web.UnixSite(runner, endpoint)
+    await site.start()
+    Path(endpoint).chmod(0o666)
+    config = SimpleNamespace(
+        token="",
+        extra={"bridge_port": bridge_port, "session_path": str(session_path)},
+    )
+    try:
+        result = await _standalone_send(config, "15551234567", "secret")
+    finally:
+        await runner.cleanup()
+
+    assert "permissions are not private" in result["error"]
+    assert received == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(os.name == "nt", reason="adversarial Unix-socket transport test")
+async def test_persistent_session_rejects_replacement_listener_on_reconnect(
+    tmp_path: Path,
+) -> None:
+    """A live client revalidates OS identity before a replacement connection."""
+    import aiohttp
+    from aiohttp import web
+
+    session_path = tmp_path / "session"
+    session_path.mkdir()
+    token = _rotate_bridge_token(session_path)
+    bridge_port = 30125
+    endpoint = _bridge_ipc_endpoint(session_path, bridge_port, token)
+
+    async def genuine_health(_request):
+        return web.json_response({"status": "connected"})
+
+    genuine_app = web.Application()
+    genuine_app.router.add_get("/health", genuine_health)
+    genuine_runner = web.AppRunner(genuine_app)
+    await genuine_runner.setup()
+    genuine_site = web.UnixSite(genuine_runner, endpoint)
+    await genuine_site.start()
+    Path(endpoint).chmod(0o600)
+
+    received = []
+
+    async def replacement_send(request):
+        received.append((dict(request.headers), await request.read()))
+        return web.json_response({"messageId": "forged"})
+
+    session = _bridge_client_session(aiohttp, session_path, bridge_port, token)
+    replacement_runner = None
+    try:
+        async with session.get("http://localhost/health") as response:
+            assert response.status == 200
+        await genuine_runner.cleanup()
+        Path(endpoint).unlink(missing_ok=True)
+
+        replacement_app = web.Application()
+        replacement_app.router.add_post("/send", replacement_send)
+        replacement_runner = web.AppRunner(replacement_app)
+        await replacement_runner.setup()
+        replacement_site = web.UnixSite(replacement_runner, endpoint)
+        await replacement_site.start()
+        Path(endpoint).chmod(0o666)
+
+        with pytest.raises(OSError, match="permissions are not private"):
+            await session.post(
+                "http://localhost/send",
+                json={"message": "must remain private"},
+            )
+    finally:
+        await session.close()
+        if replacement_runner is not None:
+            await replacement_runner.cleanup()
+        else:
+            await genuine_runner.cleanup()
+
+    assert received == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(os.name == "nt", reason="adversarial Unix-socket transport test")
+async def test_fake_loopback_listener_cannot_forge_health_or_persistent_calls(
+    tmp_path: Path,
+) -> None:
+    """Reuse and the persistent client stay on the authenticated OS channel."""
+    from aiohttp import web
+
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    bridge_script = bridge_dir / "bridge.js"
+    bridge_script.write_text("// current bridge\n", encoding="utf-8")
+    package_json = bridge_dir / "package.json"
+    package_json.write_text('{"name":"bridge"}\n', encoding="utf-8")
+    node_modules = bridge_dir / "node_modules"
+    node_modules.mkdir()
+    (node_modules / ".hermes-pkg-hash").write_text(
+        _file_content_hash(package_json), encoding="utf-8"
+    )
+    session_path = tmp_path / "session"
+    session_path.mkdir()
+    (session_path / "creds.json").write_text("{}", encoding="utf-8")
+    token = _rotate_bridge_token(session_path)
+    fake_requests = []
+    genuine_sends = []
+
+    async def fake_handler(request):
+        fake_requests.append((dict(request.headers), await request.read()))
+        return web.json_response({
+            "status": "connected",
+            "scriptHash": _file_content_hash(bridge_script),
+            "sendReadReceipts": False,
+            "messageId": "forged",
+        })
+
+    fake_app = web.Application()
+    fake_app.router.add_route("*", "/{tail:.*}", fake_handler)
+    fake_runner = web.AppRunner(fake_app)
+    await fake_runner.setup()
+    fake_site = web.TCPSite(fake_runner, "127.0.0.1", 0)
+    await fake_site.start()
+    bridge_port = fake_site._server.sockets[0].getsockname()[1]
+
+    async def genuine_health(_request):
+        return web.json_response({
+            "status": "connected",
+            "scriptHash": _file_content_hash(bridge_script),
+            "sendReadReceipts": False,
+        })
+
+    async def genuine_send(request):
+        genuine_sends.append(await request.json())
+        return web.json_response({"messageId": "genuine"})
+
+    async def genuine_messages(_request):
+        return web.json_response([])
+
+    genuine_app = web.Application()
+    genuine_app.router.add_get("/health", genuine_health)
+    genuine_app.router.add_post("/send", genuine_send)
+    genuine_app.router.add_get("/messages", genuine_messages)
+    genuine_runner = web.AppRunner(genuine_app)
+    await genuine_runner.setup()
+    endpoint = _bridge_ipc_endpoint(session_path, bridge_port, token)
+    genuine_site = web.UnixSite(genuine_runner, endpoint)
+    await genuine_site.start()
+    Path(endpoint).chmod(0o600)
+
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={
+        "bridge_script": str(bridge_script),
+        "session_path": str(session_path),
+        "bridge_port": bridge_port,
+    }))
+
+    def consume_poll_task(coroutine):
+        coroutine.close()
+        return MagicMock()
+
+    try:
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch.object(adapter, "_acquire_platform_lock", return_value=True), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.create_task", side_effect=consume_poll_task):
+            connected = await adapter.connect()
+        sent = await adapter.send("15551234567", "persistent private message")
+        async with adapter._http_session.get("http://localhost/messages") as response:
+            messages = await response.json()
+    finally:
+        if adapter._http_session and not adapter._http_session.closed:
+            await adapter._http_session.close()
+        await genuine_runner.cleanup()
+        await fake_runner.cleanup()
+
+    assert connected is True
+    assert sent.success is True
+    assert messages == []
+    assert sent.message_id == "genuine"
+    assert genuine_sends == [{
+        "chatId": "15551234567@s.whatsapp.net",
+        "message": "persistent private message",
+    }]
+    assert fake_requests == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(os.name == "nt", reason="adversarial Unix-socket transport test")
+async def test_standalone_send_revalidates_replaced_bridge_endpoint(tmp_path: Path) -> None:
+    """Each standalone call reconnects through the owner-only socket path."""
+    from aiohttp import web
+
+    session_path = tmp_path / "session"
+    session_path.mkdir()
+    token = _rotate_bridge_token(session_path)
+    bridge_port = 30123
+    endpoint = _bridge_ipc_endpoint(session_path, bridge_port, token)
+    config = SimpleNamespace(
+        token="",
+        extra={"bridge_port": bridge_port, "session_path": str(session_path)},
+    )
+    responders = []
+
+    async def run_one(message_id):
+        async def send_handler(request):
+            responders.append((message_id, await request.json()))
+            return web.json_response({"messageId": message_id})
+
+        app = web.Application()
+        app.router.add_post("/send", send_handler)
+        runner = web.AppRunner(app)
+        await runner.setup()
+        site = web.UnixSite(runner, endpoint)
+        await site.start()
+        Path(endpoint).chmod(0o600)
+        try:
+            return await _standalone_send(config, "15551234567", message_id)
+        finally:
+            await runner.cleanup()
+            Path(endpoint).unlink(missing_ok=True)
+
+    first = await run_one("first-bridge")
+    second = await run_one("replacement-bridge")
+
+    assert first["message_id"] == "first-bridge"
+    assert second["message_id"] == "replacement-bridge"
+    assert [name for name, _payload in responders] == [
+        "first-bridge",
+        "replacement-bridge",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_matching_running_bridge_is_reused_with_bearer_token(tmp_path: Path) -> None:
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    bridge_script = bridge_dir / "bridge.js"
+    bridge_script.write_text("// current bridge\n", encoding="utf-8")
+    package_json = bridge_dir / "package.json"
+    package_json.write_text('{"name":"bridge"}\n', encoding="utf-8")
+    node_modules = bridge_dir / "node_modules"
+    node_modules.mkdir()
+    (node_modules / ".hermes-pkg-hash").write_text(
+        _file_content_hash(package_json), encoding="utf-8"
+    )
+    session_path = tmp_path / "session"
+    session_path.mkdir()
+    (session_path / "creds.json").write_text("{}", encoding="utf-8")
+    token = _rotate_bridge_token(session_path)
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={
+        "bridge_script": str(bridge_script),
+        "session_path": str(session_path),
+        "bridge_port": 19876,
+    }))
+
+    health_response = MagicMock()
+    health_response.status = 200
+    health_response.json = AsyncMock(return_value={
+        "status": "connected",
+        "scriptHash": _file_content_hash(bridge_script),
+        "sendReadReceipts": False,
+    })
+    transient_session = MagicMock()
+    transient_session.get.return_value = _AsyncContext(health_response)
+    persistent_session = MagicMock()
+    session_factory = MagicMock(side_effect=[
+        _AsyncContext(transient_session),
+        persistent_session,
+    ])
+
+    def consume_poll_task(coroutine):
+        coroutine.close()
+        return MagicMock()
+
+    connector = MagicMock()
+    with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+         patch("aiohttp.ClientSession", session_factory), \
+         patch("plugins.platforms.whatsapp.adapter._bridge_unix_connector", return_value=connector), \
+         patch("plugins.platforms.whatsapp.adapter._validate_bridge_endpoint"), \
+         patch.object(adapter, "_acquire_platform_lock", return_value=True), \
+         patch("plugins.platforms.whatsapp.adapter.asyncio.create_task", side_effect=consume_poll_task):
+        connected = await adapter.connect()
+
+    assert connected is True
+    assert adapter._bridge_process is None
+    assert adapter._bridge_token == token
+    assert "headers" not in transient_session.get.call_args.kwargs
+    assert session_factory.call_args_list[0].kwargs == {
+        "connector": connector,
+        "headers": {"Authorization": f"Bearer {token}"},
+    }
+    assert session_factory.call_args_list[1].kwargs["headers"] == {
+        "Authorization": f"Bearer {token}"
+    }
+
+
+def test_standalone_sender_uses_session_bearer_token(tmp_path: Path) -> None:
+    session_path = tmp_path / "session"
+    session_path.mkdir()
+    token = _rotate_bridge_token(session_path)
+    config = SimpleNamespace(
+        token="",
+        extra={"bridge_port": 3000, "session_path": str(session_path)},
+    )
+    response = AsyncMock()
+    response.status = 200
+    response.json = AsyncMock(return_value={"messageId": "outbound-1"})
+    response_context = MagicMock()
+    response_context.__aenter__ = AsyncMock(return_value=response)
+    response_context.__aexit__ = AsyncMock(return_value=False)
+    session = MagicMock()
+    session.post.return_value = response_context
+    session_context = MagicMock()
+    session_context.__aenter__ = AsyncMock(return_value=session)
+    session_context.__aexit__ = AsyncMock(return_value=False)
+
+    connector = MagicMock()
+    with patch("aiohttp.ClientSession", return_value=session_context) as client_session, \
+         patch("plugins.platforms.whatsapp.adapter._bridge_unix_connector", return_value=connector), \
+         patch("plugins.platforms.whatsapp.adapter._validate_bridge_endpoint"):
+        result = asyncio.run(_standalone_send(config, "15551234567", "hello"))
+
+    assert result["success"] is True
+    client_session.assert_called_once_with(
+        connector=connector,
+        headers={"Authorization": f"Bearer {token}"}
+    )
+
+
+def test_standalone_sender_fails_closed_without_session_token(tmp_path: Path) -> None:
+    config = SimpleNamespace(
+        token="",
+        extra={"bridge_port": 3000, "session_path": str(tmp_path / "missing")},
+    )
+
+    with patch("aiohttp.ClientSession") as client_session:
+        result = asyncio.run(_standalone_send(config, "15551234567", "hello"))
+
+    assert "authentication is unavailable" in result["error"]
+    client_session.assert_not_called()

--- a/tests/gateway/test_whatsapp_bridge_dir_resolution.py
+++ b/tests/gateway/test_whatsapp_bridge_dir_resolution.py
@@ -7,6 +7,7 @@ bridge source into a writable HERMES_HOME location instead.
 """
 import importlib
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -58,3 +59,127 @@ def test_readonly_install_mirrors_to_hermes_home(tmp_path, monkeypatch):
     assert (expected / "package.json").exists()
 
 
+def test_readonly_upgrade_refreshes_source_and_preserves_runtime_state(
+    tmp_path, monkeypatch
+):
+    """An existing writable mirror is upgraded before it can be selected."""
+    install_root = tmp_path / "install"
+    install_bridge = install_root / "scripts" / "whatsapp-bridge"
+    _seed_install_tree(install_bridge)
+    (install_bridge / "bridge.js").write_text("// authenticated IPC bridge\n")
+    (install_bridge / "bridge_helpers.js").write_text("// IPC helpers\n")
+    (install_bridge / "bridge-launcher.js").write_text("// auth launcher\n")
+    # Runtime state and secrets are never part of the shipped-source contract.
+    (install_bridge / ".bridge-token").write_text("must-not-be-mirrored")
+
+    hermes_home = tmp_path / "hermes_home"
+    mirror = hermes_home / "scripts" / "whatsapp-bridge"
+    node_modules = mirror / "node_modules"
+    node_modules.mkdir(parents=True)
+    (mirror / "bridge.js").write_text("// old unauthenticated TCP bridge\n")
+    (mirror / "package.json").write_text('{"name": "old-bridge"}\n')
+    dependency_sentinel = node_modules / "preserved-package.js"
+    dependency_sentinel.write_text("// installed dependency\n")
+    runtime_state = mirror / "session-runtime.json"
+    runtime_state.write_text('{"preserve": true}\n')
+
+    monkeypatch.setattr(
+        whatsapp_common,
+        "__file__",
+        str(install_root / "gateway" / "platforms" / "whatsapp_common.py"),
+    )
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: hermes_home)
+    _force_readonly_install(monkeypatch, install_bridge)
+
+    resolved = whatsapp_common.resolve_whatsapp_bridge_dir()
+
+    assert resolved == mirror
+    assert (resolved / "bridge.js").read_text() == "// authenticated IPC bridge\n"
+    assert (resolved / "bridge_helpers.js").read_text() == "// IPC helpers\n"
+    assert (resolved / "bridge-launcher.js").read_text() == "// auth launcher\n"
+    assert dependency_sentinel.read_text() == "// installed dependency\n"
+    assert runtime_state.read_text() == '{"preserve": true}\n'
+    assert not (resolved / ".bridge-token").exists()
+    assert (resolved / ".hermes-source-manifest.json").is_file()
+
+    # The default adapter path is resolved only after the refresh completes,
+    # so startup cannot select the stale TCP implementation.
+    from gateway.config import PlatformConfig
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    monkeypatch.setattr(WhatsAppAdapter, "_DEFAULT_BRIDGE_DIR", None)
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={}))
+    assert Path(adapter._bridge_script).read_text() == "// authenticated IPC bridge\n"
+
+
+def test_failed_readonly_refresh_never_returns_partial_mirror(tmp_path, monkeypatch):
+    """A failed atomic source update falls back instead of selecting stale code."""
+    install_root = tmp_path / "install"
+    install_bridge = install_root / "scripts" / "whatsapp-bridge"
+    _seed_install_tree(install_bridge)
+    (install_bridge / "bridge.js").write_text("// authenticated IPC bridge\n")
+
+    hermes_home = tmp_path / "hermes_home"
+    mirror = hermes_home / "scripts" / "whatsapp-bridge"
+    mirror.mkdir(parents=True)
+    (mirror / "bridge.js").write_text("// old unauthenticated TCP bridge\n")
+
+    monkeypatch.setattr(
+        whatsapp_common,
+        "__file__",
+        str(install_root / "gateway" / "platforms" / "whatsapp_common.py"),
+    )
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: hermes_home)
+    _force_readonly_install(monkeypatch, install_bridge)
+
+    real_replace = whatsapp_common.os.replace
+
+    def fail_manifest_commit(source, destination):
+        if Path(destination).name == ".hermes-source-manifest.json":
+            raise OSError("disk full")
+        return real_replace(source, destination)
+
+    with patch(
+        "gateway.platforms.whatsapp_common.os.replace",
+        side_effect=fail_manifest_commit,
+    ):
+        resolved = whatsapp_common.resolve_whatsapp_bridge_dir()
+
+    assert resolved == install_bridge
+    assert (mirror / "bridge.js").read_text() == "// authenticated IPC bridge\n"
+    assert not (mirror / ".hermes-source-manifest.json").exists()
+
+
+def test_readonly_refresh_refuses_symlink_mirror(tmp_path, monkeypatch):
+    """Refresh never follows an existing mirror symlink to overwrite its target."""
+    install_root = tmp_path / "install"
+    install_bridge = install_root / "scripts" / "whatsapp-bridge"
+    _seed_install_tree(install_bridge)
+    hermes_home = tmp_path / "hermes_home"
+    target = tmp_path / "operator-files"
+    target.mkdir()
+    mirror = hermes_home / "scripts" / "whatsapp-bridge"
+    mirror.parent.mkdir(parents=True)
+    mirror.symlink_to(target, target_is_directory=True)
+
+    monkeypatch.setattr(
+        whatsapp_common,
+        "__file__",
+        str(install_root / "gateway" / "platforms" / "whatsapp_common.py"),
+    )
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: hermes_home)
+    _force_readonly_install(monkeypatch, install_bridge)
+
+    assert whatsapp_common.resolve_whatsapp_bridge_dir() == install_bridge
+    assert list(target.iterdir()) == []
+
+
+def _force_readonly_install(monkeypatch, install_bridge: Path) -> None:
+    real_touch = Path.touch
+
+    def fake_touch(self, *args, **kwargs):
+        if self.name == ".write_test" and install_bridge in self.parents:
+            raise PermissionError("read-only install tree")
+        return real_touch(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "touch", fake_touch)

--- a/tests/gateway/test_whatsapp_bridge_migration.py
+++ b/tests/gateway/test_whatsapp_bridge_migration.py
@@ -1,0 +1,407 @@
+"""Upgrade and unsupported-platform boundaries for the WhatsApp bridge."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import textwrap
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.whatsapp.adapter import (
+    WhatsAppAdapter,
+    _bridge_client_session,
+    _bridge_ipc_endpoint,
+    _file_content_hash,
+    _kill_stale_bridge_by_pidfile,
+    _listener_pids_on_port,
+    _migrate_legacy_tcp_bridge,
+    _standalone_send,
+)
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_for_listener(port: int, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.settimeout(0.1)
+            if sock.connect_ex(("127.0.0.1", port)) == 0:
+                return
+        time.sleep(0.05)
+    raise AssertionError(f"listener on port {port} did not start")
+
+
+def _stop(proc: subprocess.Popen) -> None:
+    if proc.poll() is None:
+        proc.kill()
+    proc.wait(timeout=5)
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process migration integration test")
+async def test_no_pid_legacy_tcp_bridge_is_verified_and_retired(tmp_path: Path) -> None:
+    """A command-line and health-verified pre-IPC bridge is safely migrated."""
+    node_binary = shutil.which("node")
+    if node_binary is None:
+        pytest.skip("Node.js is required for the legacy bridge migration test")
+
+    port = _free_port()
+    session_path = tmp_path / "session"
+    session_path.mkdir()
+    bridge_script = tmp_path / "legacy_bridge.mjs"
+    capture_path = tmp_path / "legacy-request.json"
+    bridge_script.write_text(
+        textwrap.dedent(
+            """
+            import http from 'node:http';
+            import { writeFileSync } from 'node:fs';
+            const args = process.argv.slice(2);
+            const value = (name) => args[args.indexOf(name) + 1];
+            const port = Number(value('--port'));
+            const server = http.createServer((req, res) => {
+              if (req.url !== '/health') { res.writeHead(404).end(); return; }
+              writeFileSync(value('--capture'), JSON.stringify({
+                authorization: req.headers.authorization || null,
+                contentLength: req.headers['content-length'] || null,
+                method: req.method,
+                url: req.url,
+              }));
+              res.setHeader('content-type', 'application/json');
+              res.end(JSON.stringify({
+                status: 'connected', queueLength: 0, uptime: process.uptime(),
+                scriptHash: '0123456789abcdef', sendReadReceipts: false,
+              }));
+            });
+            server.listen(port, '127.0.0.1');
+            """
+        ),
+        encoding="utf-8",
+    )
+    proc = subprocess.Popen(
+        [
+            node_binary,
+            str(bridge_script),
+            "--port",
+            str(port),
+            "--session",
+            str(session_path),
+            "--capture",
+            str(capture_path),
+        ]
+    )
+    try:
+        _wait_for_listener(port)
+        assert not (session_path / "bridge.pid").exists()
+
+        with patch("aiohttp.ClientSession") as client_session:
+            migrated = await _migrate_legacy_tcp_bridge(
+                port, bridge_script, session_path
+            )
+
+        assert migrated is True
+        client_session.assert_not_called()
+        assert proc.wait(timeout=5) is not None
+        assert capture_path.read_text(encoding="utf-8") == (
+            '{"authorization":null,"contentLength":null,'
+            '"method":"GET","url":"/health"}'
+        )
+    finally:
+        if proc.poll() is None:
+            _stop(proc)
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process migration integration test")
+async def test_unproven_legacy_port_owner_blocks_without_termination(tmp_path: Path) -> None:
+    """An arbitrary listener is never killed to make room for the IPC bridge."""
+    port = _free_port()
+    session_path = tmp_path / "session"
+    session_path.mkdir()
+    bridge_script = tmp_path / "bridge.js"
+    bridge_script.write_text("// configured bridge\n", encoding="utf-8")
+    server_script = tmp_path / "unrelated.py"
+    server_script.write_text(
+        "import http.server,sys; "
+        "http.server.HTTPServer(('127.0.0.1', int(sys.argv[1])), "
+        "http.server.BaseHTTPRequestHandler).serve_forever()\n",
+        encoding="utf-8",
+    )
+    proc = subprocess.Popen([sys.executable, str(server_script), str(port)])
+    try:
+        _wait_for_listener(port)
+        with pytest.raises(RuntimeError, match="legacy TCP listener"):
+            await _migrate_legacy_tcp_bridge(port, bridge_script, session_path)
+        assert proc.poll() is None
+    finally:
+        _stop(proc)
+
+
+def test_windows_client_gate_sends_no_protected_bytes(tmp_path: Path) -> None:
+    """Unsupported native Windows fails before connector/session construction."""
+    fake_aiohttp = MagicMock()
+    with patch("plugins.platforms.whatsapp.adapter._IS_WINDOWS", True):
+        with pytest.raises(RuntimeError, match="native Windows"):
+            _bridge_ipc_endpoint(tmp_path, 3000, "secret-token")
+        with pytest.raises(RuntimeError, match="native Windows"):
+            _bridge_client_session(fake_aiohttp, tmp_path, 3000, "secret-token")
+
+    fake_aiohttp.NamedPipeConnector.assert_not_called()
+    fake_aiohttp.ClientSession.assert_not_called()
+
+
+def test_windows_listener_enumeration_spawns_no_child() -> None:
+    """Native retirement uses psutil directly instead of netstat/task shells."""
+    connections = [
+        SimpleNamespace(
+            status="LISTEN",
+            laddr=SimpleNamespace(port=30131),
+            pid=321,
+        ),
+        SimpleNamespace(
+            status="ESTABLISHED",
+            laddr=SimpleNamespace(port=30131),
+            pid=654,
+        ),
+    ]
+    with patch("plugins.platforms.whatsapp.adapter._IS_WINDOWS", True), patch(
+        "psutil.net_connections", return_value=connections
+    ), patch("subprocess.run") as run:
+        pids = _listener_pids_on_port(30131)
+
+    assert pids == [321]
+    run.assert_not_called()
+
+
+def test_windows_standalone_send_fails_before_http(tmp_path: Path) -> None:
+    session_path = tmp_path / "session"
+    session_path.mkdir()
+    (session_path / ".bridge-token").write_text("A" * 43, encoding="utf-8")
+    config = SimpleNamespace(
+        token="",
+        extra={"bridge_port": 3000, "session_path": str(session_path)},
+    )
+
+    with patch("plugins.platforms.whatsapp.adapter._IS_WINDOWS", True), patch(
+        "aiohttp.ClientSession"
+    ) as client_session:
+        result = asyncio.run(_standalone_send(config, "15551234567", "secret"))
+
+    assert "native Windows" in result["error"]
+    client_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_windows_gateway_connect_fails_before_process_start(tmp_path: Path) -> None:
+    bridge_script = tmp_path / "bridge.js"
+    session_path = tmp_path / "session"
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={
+        "bridge_script": str(bridge_script),
+        "bridge_port": 30127,
+        "session_path": str(session_path),
+    }))
+
+    with patch("plugins.platforms.whatsapp.adapter._IS_WINDOWS", True), patch(
+        "plugins.platforms.whatsapp.adapter.check_whatsapp_requirements"
+    ) as requirements, patch.object(
+        adapter, "_acquire_platform_lock", return_value=True
+    ) as acquire_lock, patch.object(
+        adapter, "_release_platform_lock"
+    ) as release_lock, patch(
+        "plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"
+    ) as pidfile_cleanup, patch(
+        "plugins.platforms.whatsapp.adapter._migrate_legacy_tcp_bridge",
+        new_callable=AsyncMock,
+        return_value=True,
+    ) as migrate_legacy, patch(
+        "plugins.platforms.whatsapp.adapter._read_bridge_token"
+    ) as read_token, patch(
+        "plugins.platforms.whatsapp.adapter._rotate_bridge_token"
+    ) as rotate_token, patch(
+        "plugins.platforms.whatsapp.adapter._bridge_client_session"
+    ) as client_session, patch("subprocess.run") as run, patch(
+        "subprocess.Popen"
+    ) as popen:
+        connected = await adapter.connect()
+
+    assert connected is False
+    assert adapter.fatal_error_code == "whatsapp_windows_ipc_unsupported"
+    acquire_lock.assert_called_once_with(
+        "whatsapp-session", str(session_path), "WhatsApp session"
+    )
+    pidfile_cleanup.assert_called_once_with(session_path, bridge_script, 30127)
+    migrate_legacy.assert_awaited_once_with(30127, bridge_script, session_path)
+    release_lock.assert_called_once_with()
+    requirements.assert_not_called()
+    read_token.assert_not_called()
+    rotate_token.assert_not_called()
+    client_session.assert_not_called()
+    run.assert_not_called()
+    popen.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_windows_gateway_unproven_legacy_listener_blocks_unsupported(
+    tmp_path: Path,
+) -> None:
+    """An ambiguous listener stays alive and produces migration guidance."""
+    bridge_script = tmp_path / "bridge.js"
+    session_path = tmp_path / "session"
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={
+        "bridge_script": str(bridge_script),
+        "bridge_port": 30128,
+        "session_path": str(session_path),
+    }))
+
+    with patch("plugins.platforms.whatsapp.adapter._IS_WINDOWS", True), patch.object(
+        adapter, "_acquire_platform_lock", return_value=True
+    ), patch.object(adapter, "_release_platform_lock") as release_lock, patch(
+        "plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"
+    ), patch(
+        "plugins.platforms.whatsapp.adapter._migrate_legacy_tcp_bridge",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("unproven legacy TCP listener; stop it manually"),
+    ), patch(
+        "plugins.platforms.whatsapp.adapter._read_bridge_token"
+    ) as read_token, patch(
+        "plugins.platforms.whatsapp.adapter._rotate_bridge_token"
+    ) as rotate_token, patch(
+        "plugins.platforms.whatsapp.adapter._bridge_client_session"
+    ) as client_session, patch("subprocess.Popen") as popen:
+        connected = await adapter.connect()
+
+    assert connected is False
+    assert adapter.fatal_error_code == "whatsapp_legacy_bridge_migration_required"
+    assert "stop it manually" in adapter.fatal_error_message
+    release_lock.assert_called_once_with()
+    read_token.assert_not_called()
+    rotate_token.assert_not_called()
+    client_session.assert_not_called()
+    popen.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_windows_verified_migration_rebinds_before_termination(tmp_path: Path) -> None:
+    """Windows retirement signals only a stable exact legacy bridge owner."""
+    bridge_script = tmp_path / "bridge.js"
+    session_path = tmp_path / "session"
+    events = []
+
+    def identity(*args):
+        events.append(("identity", args))
+        return 123456
+
+    async def health(port):
+        events.append(("health", port))
+        return True
+
+    def terminate(pid, *, force=False):
+        events.append(("terminate", pid, force))
+
+    with patch("plugins.platforms.whatsapp.adapter._IS_WINDOWS", True), patch(
+        "plugins.platforms.whatsapp.adapter._tcp_listener_is_occupied",
+        side_effect=[True, False],
+    ), patch(
+        "plugins.platforms.whatsapp.adapter._listener_pids_on_port",
+        return_value=[4123],
+    ), patch(
+        "plugins.platforms.whatsapp.adapter._legacy_bridge_process_identity",
+        side_effect=identity,
+    ), patch(
+        "plugins.platforms.whatsapp.adapter._legacy_bridge_health_is_valid",
+        side_effect=health,
+    ), patch("gateway.status.terminate_pid", side_effect=terminate):
+        migrated = await _migrate_legacy_tcp_bridge(
+            30129, bridge_script, session_path
+        )
+
+    assert migrated is True
+    assert events == [
+        ("identity", (4123, bridge_script, session_path, 30129)),
+        ("health", 30129),
+        ("identity", (4123, bridge_script, session_path, 30129)),
+        ("terminate", 4123, False),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_unproven_legacy_listener_blocks_replacement_spawn(tmp_path: Path) -> None:
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    bridge_script = bridge_dir / "bridge.js"
+    bridge_script.write_text("// current bridge\n", encoding="utf-8")
+    package_json = bridge_dir / "package.json"
+    package_json.write_text('{"name":"bridge"}\n', encoding="utf-8")
+    node_modules = bridge_dir / "node_modules"
+    node_modules.mkdir()
+    (node_modules / ".hermes-pkg-hash").write_text(
+        _file_content_hash(package_json), encoding="utf-8"
+    )
+    session_path = tmp_path / "session"
+    session_path.mkdir()
+    (session_path / "creds.json").write_text("{}", encoding="utf-8")
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={
+        "bridge_script": str(bridge_script),
+        "session_path": str(session_path),
+        "bridge_port": 30126,
+    }))
+
+    with patch(
+        "plugins.platforms.whatsapp.adapter.check_whatsapp_requirements",
+        return_value=True,
+    ), patch.object(
+        adapter, "_acquire_platform_lock", return_value=True
+    ), patch(
+        "plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile",
+        return_value=False,
+    ), patch(
+        "plugins.platforms.whatsapp.adapter._migrate_legacy_tcp_bridge",
+        side_effect=RuntimeError("unproven legacy TCP listener"),
+    ), patch("subprocess.Popen") as popen:
+        connected = await adapter.connect()
+
+    assert connected is False
+    assert adapter.fatal_error_code == "whatsapp_legacy_bridge_migration_required"
+    popen.assert_not_called()
+
+
+def test_windows_legacy_pidfile_requires_exact_configured_identity(
+    tmp_path: Path,
+) -> None:
+    """A loose node/session match cannot authorize Windows upgrade cleanup."""
+    session_path = tmp_path / "session"
+    session_path.mkdir()
+    (session_path / "bridge.pid").write_text("4123", encoding="utf-8")
+    bridge_script = tmp_path / "bridge.js"
+
+    with patch(
+        "plugins.platforms.whatsapp.adapter._legacy_bridge_process_identity",
+        return_value=None,
+    ) as exact_identity, patch(
+        "plugins.platforms.whatsapp.adapter._bridge_pid_is_ours",
+        return_value=True,
+    ) as loose_identity, patch(
+        "gateway.status._pid_exists", return_value=True
+    ), patch("plugins.platforms.whatsapp.adapter.os.kill") as kill:
+        terminated = _kill_stale_bridge_by_pidfile(
+            session_path, bridge_script, 30130
+        )
+
+    assert terminated is False
+    exact_identity.assert_called_once_with(4123, bridge_script, session_path, 30130)
+    loose_identity.assert_not_called()
+    kill.assert_not_called()

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -99,6 +99,9 @@ def _connect_patches(mock_proc, mock_fh, mock_client_cls=None):
         patch("builtins.open", return_value=mock_fh),
         patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock),
         patch("plugins.platforms.whatsapp.adapter.asyncio.create_task"),
+        patch("plugins.platforms.whatsapp.adapter._rotate_bridge_token", return_value="test-session-token"),
+        patch("plugins.platforms.whatsapp.adapter._ensure_private_bridge_directory"),
+        patch("plugins.platforms.whatsapp.adapter._validate_bridge_endpoint"),
     ]
     if mock_client_cls is not None:
         base.append(patch("aiohttp.ClientSession", mock_client_cls))
@@ -159,6 +162,7 @@ class TestDataInitialized:
 
         with patches[0], patches[1], patches[2], patches[3], patches[4], \
              patches[5], patches[6], patches[7], patches[8], \
+             patches[9], patches[10], patches[11], \
              patch.object(type(adapter), "_poll_messages", return_value=MagicMock()):
             # Must NOT raise NameError
             result = await adapter.connect()
@@ -188,7 +192,8 @@ class TestFileHandleClosedOnError:
         patches = _connect_patches(mock_proc, mock_fh)
 
         with patches[0], patches[1], patches[2], patches[3], patches[4], \
-             patches[5], patches[6], patches[7]:
+             patches[5], patches[6], patches[7], patches[8], patches[9], \
+             patches[10]:
             result = await adapter.connect()
 
         assert result is False
@@ -297,7 +302,8 @@ class TestBridgeRuntimeFailure:
         patches = _connect_patches(mock_proc, mock_fh, mock_client_cls)
 
         with patches[0], patches[1], patches[2], patches[3], patches[4], \
-             patches[5], patches[6], patches[7], patches[8]:
+             patches[5], patches[6], patches[7], patches[8], patches[9], \
+             patches[10], patches[11]:
             result = await adapter.connect()
 
         assert result is False

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -99,6 +99,9 @@ def _connect_patches(mock_proc, mock_fh, mock_client_cls=None):
         patch("builtins.open", return_value=mock_fh),
         patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock),
         patch("plugins.platforms.whatsapp.adapter.asyncio.create_task"),
+        patch("plugins.platforms.whatsapp.adapter._rotate_bridge_token", return_value="test-session-token"),
+        patch("plugins.platforms.whatsapp.adapter._ensure_private_bridge_directory"),
+        patch("plugins.platforms.whatsapp.adapter._validate_bridge_endpoint"),
     ]
     if mock_client_cls is not None:
         base.append(patch("aiohttp.ClientSession", mock_client_cls))
@@ -159,6 +162,7 @@ class TestDataInitialized:
 
         with patches[0], patches[1], patches[2], patches[3], patches[4], \
              patches[5], patches[6], patches[7], patches[8], \
+             patches[9], patches[10], patches[11], \
              patch.object(type(adapter), "_poll_messages", return_value=MagicMock()):
             # Must NOT raise NameError
             result = await adapter.connect()
@@ -188,7 +192,8 @@ class TestFileHandleClosedOnError:
         patches = _connect_patches(mock_proc, mock_fh)
 
         with patches[0], patches[1], patches[2], patches[3], patches[4], \
-             patches[5], patches[6], patches[7]:
+             patches[5], patches[6], patches[7], patches[8], patches[9], \
+             patches[10]:
             result = await adapter.connect()
 
         assert result is False
@@ -300,7 +305,8 @@ class TestBridgeRuntimeFailure:
         patches = _connect_patches(mock_proc, mock_fh, mock_client_cls)
 
         with patches[0], patches[1], patches[2], patches[3], patches[4], \
-             patches[5], patches[6], patches[7], patches[8]:
+             patches[5], patches[6], patches[7], patches[8], patches[9], \
+             patches[10], patches[11]:
             result = await adapter.connect()
 
         assert result is False

--- a/tests/gateway/test_whatsapp_native_delivery.py
+++ b/tests/gateway/test_whatsapp_native_delivery.py
@@ -33,7 +33,7 @@ async def test_send_location_posts_to_bridge_location_endpoint():
     assert result.success
     assert result.message_id == "loc-msg"
     call = adapter._http_session.post.call_args
-    assert call.args[0] == "http://127.0.0.1:3000/send-location"
+    assert call.args[0] == "http://localhost/send-location"
     assert call.kwargs["json"] == {
         "chatId": "15551234567@s.whatsapp.net",
         "latitude": 41.015,
@@ -41,5 +41,4 @@ async def test_send_location_posts_to_bridge_location_endpoint():
         "name": "HQ",
         "address": "Example Street",
     }
-
 

--- a/tests/gateway/test_whatsapp_stale_bridge.py
+++ b/tests/gateway/test_whatsapp_stale_bridge.py
@@ -211,3 +211,7 @@ class TestCacheDirEnvPassthrough:
         assert env["HERMES_AUDIO_CACHE_DIR"] == str(get_audio_cache_dir())
         assert env["HERMES_DOCUMENT_CACHE_DIR"] == str(get_document_cache_dir())
         assert env["WHATSAPP_SEND_READ_RECEIPTS"] == "true"
+        assert env["WHATSAPP_BRIDGE_TOKEN"]
+        assert env["WHATSAPP_BRIDGE_TOKEN"] == (
+            tmp_path / "session" / ".bridge-token"
+        ).read_text(encoding="utf-8")

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -480,6 +480,7 @@ class TestImport:
             "auth.json": '{"providers": {"nous": "token"}}',
             "state.db": b"SQLite format 3\x00",
             "profiles/coder/.env": "ANTHROPIC_API_KEY=sk-ant-secret\n",
+            "platforms/whatsapp/session/.bridge-token": "A" * 43,
         })
 
         args = Namespace(zipfile=str(zip_path), force=True)
@@ -487,7 +488,13 @@ class TestImport:
         from hermes_cli.backup import run_import
         run_import(args)
 
-        for rel in (".env", "auth.json", "state.db", "profiles/coder/.env"):
+        for rel in (
+            ".env",
+            "auth.json",
+            "state.db",
+            "profiles/coder/.env",
+            "platforms/whatsapp/session/.bridge-token",
+        ):
             mode = (hermes_home / rel).stat().st_mode & 0o777
             assert mode == 0o600, f"{rel} restored with mode {oct(mode)}, expected 0o600"
 
@@ -1850,7 +1857,6 @@ class TestMemoryProviderExternalPaths:
         assert (restored.stat().st_mode & 0o777) == 0o600
         # External state did NOT leak into HERMES_HOME.
         assert not (hermes_home / "_external").exists()
-
 
 
 

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -351,6 +351,7 @@ class TestImport:
             "auth.json": '{"providers": {"nous": "token"}}',
             "state.db": b"SQLite format 3\x00",
             "profiles/coder/.env": "ANTHROPIC_API_KEY=sk-ant-secret\n",
+            "platforms/whatsapp/session/.bridge-token": "A" * 43,
         })
 
         args = Namespace(zipfile=str(zip_path), force=True)
@@ -358,7 +359,13 @@ class TestImport:
         from hermes_cli.backup import run_import
         run_import(args)
 
-        for rel in (".env", "auth.json", "state.db", "profiles/coder/.env"):
+        for rel in (
+            ".env",
+            "auth.json",
+            "state.db",
+            "profiles/coder/.env",
+            "platforms/whatsapp/session/.bridge-token",
+        ):
             mode = (hermes_home / rel).stat().st_mode & 0o777
             assert mode == 0o600, f"{rel} restored with mode {oct(mode)}, expected 0o600"
 
@@ -1242,7 +1249,6 @@ class TestMemoryProviderExternalPaths:
         assert (restored.stat().st_mode & 0o777) == 0o600
         # External state did NOT leak into HERMES_HOME.
         assert not (hermes_home / "_external").exists()
-
 
 
 

--- a/tests/tools/test_whatsapp_send_message_media.py
+++ b/tests/tools/test_whatsapp_send_message_media.py
@@ -16,7 +16,25 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from plugins.platforms.whatsapp import adapter as whatsapp_adapter
 from plugins.platforms.whatsapp.adapter import _bridge_media_type, _standalone_send
+
+
+@pytest.fixture(autouse=True)
+def _session_bridge_token(monkeypatch):
+    monkeypatch.setattr(whatsapp_adapter, "_read_bridge_token", lambda _path: "test-session-token")
+    monkeypatch.setattr(
+        whatsapp_adapter,
+        "_ensure_private_bridge_directory",
+        lambda _path: None,
+    )
+    monkeypatch.setattr(
+        whatsapp_adapter,
+        "_bridge_client_session",
+        lambda aiohttp, _path, _port, token: aiohttp.ClientSession(
+            headers=whatsapp_adapter._bridge_auth_headers(token)
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -112,7 +130,7 @@ def test_text_plus_mixed_media_routes_native_types():
                 _resp(200, {"messageId": "m3"}),
             ]
         )
-        with patch("aiohttp.ClientSession", return_value=session_ctx):
+        with patch("aiohttp.ClientSession", return_value=session_ctx) as client_session:
             res = asyncio.run(
                 _standalone_send(
                     _pconfig(),
@@ -122,6 +140,9 @@ def test_text_plus_mixed_media_routes_native_types():
                 )
             )
         assert res["success"] is True
+        client_session.assert_called_once_with(
+            headers={"Authorization": "Bearer test-session-token"}
+        )
         # text first, then three media uploads in order
         assert calls[0][0].endswith("/send")
         assert calls[0][1]["message"] == "hello"

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -18,6 +18,17 @@ If you're running a real business bot and want stability, see the **[WhatsApp Bu
 The two adapters can also run in parallel against different phone numbers if you have a reason to.
 :::
 
+:::warning Platform support for the personal-account gateway
+The Baileys gateway can serve WhatsApp on **Linux, macOS, and WSL2**. On native
+Windows, `hermes whatsapp` pairing remains supported, but serving the paired
+account through `hermes gateway` is not supported. Run Hermes inside WSL2 or on
+Linux to serve this integration.
+
+This limitation applies only to the personal-account Baileys bridge documented
+on this page. It does not describe the separate
+[WhatsApp Business Cloud API adapter](./whatsapp-cloud.md).
+:::
+
 :::warning Unofficial API — Ban Risk
 WhatsApp does **not** officially support third-party bots outside the Business API. Using a third-party bridge carries a small risk of account restrictions. To minimize risk:
 - **Use a dedicated phone number** for the bot (not your personal number)
@@ -142,6 +153,25 @@ The gateway starts the WhatsApp bridge automatically using the saved session.
 
 ---
 
+## Multiple Profiles and `bridge_port`
+
+When one gateway [multiplexes multiple profiles](../multi-profile-gateways.md),
+each WhatsApp profile must set a distinct
+`gateway.platforms.whatsapp.extra.bridge_port` value. The default is `3000`, so
+only one multiplexed WhatsApp profile can rely on the default.
+
+Despite its historical name, `bridge_port` is not a TCP bind for the current
+Baileys gateway. It is a stable per-profile bridge instance and multiplex
+discriminator. Keep each profile's value stable across restarts. If two
+profiles use the same value, including two omitted values that both default to
+`3000`, the later profile is rejected before its adapter's lifecycle methods
+run. The first profile continues to serve normally.
+
+See [the two-profile configuration example](../multi-profile-gateways.md#whatsapp-bridge-instance-discriminators)
+for complete default-profile and named-profile YAML.
+
+---
+
 ## Session Persistence
 
 The Baileys bridge saves its session under `~/.hermes/platforms/whatsapp/session`. This means:
@@ -250,6 +280,7 @@ Set `text_batch_delay_seconds: 0` to dispatch each message immediately (disables
 | **Logged out unexpectedly** | WhatsApp unlinks devices after long inactivity. Keep the phone on and connected to the network, then re-pair with `hermes whatsapp` if needed. |
 | **Bridge crashes or reconnect loops** | Restart the gateway, update Hermes, and re-pair if the session was invalidated by a WhatsApp protocol change. |
 | **Bot stops working after WhatsApp update** | Update Hermes to get the latest bridge version, then re-pair. |
+| **Native Windows pairs successfully but the gateway says serving is unsupported** | Pairing-only mode works on native Windows, but the personal-account Baileys gateway must run inside WSL2 or on Linux to serve messages. This does not apply to the separate WhatsApp Business Cloud API adapter. |
 | **macOS: "Node.js not installed" but node works in terminal** | launchd services don't inherit your shell PATH. Run `hermes gateway install` to re-snapshot your current PATH into the plist, then `hermes gateway start`. See the [Gateway Service docs](./index.md#macos-launchd) for details. |
 | **Messages not being received** | Verify `WHATSAPP_ALLOWED_USERS` includes the sender's number (with country code, no `+` or spaces), or set it to `*` to allow everyone. Set `WHATSAPP_DEBUG=true` in `.env` and restart the gateway to see raw message events in `bridge.log`. |
 | **Bot replies to strangers with a pairing code** | Set `whatsapp.unauthorized_dm_behavior: ignore` in `~/.hermes/config.yaml` if you want unauthorized DMs to be silently ignored instead. |

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -192,6 +192,44 @@ configure the same `(platform, token)`, startup fails fast naming both profiles
 (see [Token-conflict safety](#token-conflict-safety) — the rule is unchanged,
 it's just enforced inside the one process now).
 
+WhatsApp's personal-account Baileys bridge is the exception to token-only
+guidance: every multiplexed WhatsApp profile also needs a distinct
+`gateway.platforms.whatsapp.extra.bridge_port`. Despite its historical name,
+this value is not a TCP bind for the current bridge. It is a stable per-profile
+bridge instance and multiplex discriminator, with a default of `3000`.
+
+##### WhatsApp bridge instance discriminators
+
+For example, the default profile can keep `3000` in
+`~/.hermes/config.yaml`:
+
+```yaml
+gateway:
+  multiplex_profiles: true
+  platforms:
+    whatsapp:
+      extra:
+        bridge_port: 3000
+```
+
+Give a named profile, such as `coder`, a different stable value in
+`~/.hermes/profiles/coder/config.yaml`:
+
+```yaml
+gateway:
+  platforms:
+    whatsapp:
+      extra:
+        bridge_port: 3001
+```
+
+If both profiles omit `bridge_port`, both inherit `3000`. The later duplicate
+is rejected before either of its adapter lifecycle methods runs, so it cannot
+connect, disconnect, or replace the first profile's bridge. The first profile
+and unrelated healthy profiles continue normally. See the
+[WhatsApp guide](./messaging/whatsapp.md) for the bridge-specific contract and
+platform support boundary.
+
 #### 4. Session keys are namespaced by profile
 
 Each profile's sessions live under an `agent:<profile>:…` namespace so two

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -190,6 +190,44 @@ configure the same `(platform, token)`, startup fails fast naming both profiles
 (see [Token-conflict safety](#token-conflict-safety) — the rule is unchanged,
 it's just enforced inside the one process now).
 
+WhatsApp's personal-account Baileys bridge is the exception to token-only
+guidance: every multiplexed WhatsApp profile also needs a distinct
+`gateway.platforms.whatsapp.extra.bridge_port`. Despite its historical name,
+this value is not a TCP bind for the current bridge. It is a stable per-profile
+bridge instance and multiplex discriminator, with a default of `3000`.
+
+##### WhatsApp bridge instance discriminators
+
+For example, the default profile can keep `3000` in
+`~/.hermes/config.yaml`:
+
+```yaml
+gateway:
+  multiplex_profiles: true
+  platforms:
+    whatsapp:
+      extra:
+        bridge_port: 3000
+```
+
+Give a named profile, such as `coder`, a different stable value in
+`~/.hermes/profiles/coder/config.yaml`:
+
+```yaml
+gateway:
+  platforms:
+    whatsapp:
+      extra:
+        bridge_port: 3001
+```
+
+If both profiles omit `bridge_port`, both inherit `3000`. The later duplicate
+is rejected before either of its adapter lifecycle methods runs, so it cannot
+connect, disconnect, or replace the first profile's bridge. The first profile
+and unrelated healthy profiles continue normally. See the
+[WhatsApp guide](./messaging/whatsapp.md) for the bridge-specific contract and
+platform support boundary.
+
 #### 4. Session keys are namespaced by profile
 
 Each profile's sessions live under an `agent:<profile>:…` namespace so two


### PR DESCRIPTION
## Summary

- Require Host validation plus exact bearer authentication on every personal-account WhatsApp bridge route before body parsing or routing.
- Replace managed loopback TCP control traffic with owner-only token-derived POSIX IPC, with atomic 0600 token storage and rotation.
- Retire legacy listeners only after exact process identity checks, fail closed for native-Windows serving, refresh stale read-only mirrors, and reject per-profile listener collisions.
- Preserve pairing-only native-Windows use, the separate WhatsApp Cloud API, standalone sends, and the public message APIs.
- Document the Linux/macOS/WSL2 serving path and stable per-profile bridge_port discriminators.

## Previously recorded validation

- WhatsApp Python matrix: 123 passed.
- WhatsApp bridge Node matrix: 29 passed.
- Ruff, py_compile, Node syntax checks, and git diff --check: passed.
- Docusaurus English production build: passed.
- Diagram lint: 399 files checked, 0 errors.
- Independent deep security and compatibility reviews: clean.
- CodeRabbit was attempted through the review cycles; provider seat-limit failures were treated fail-open under the project policy.

Full repository execution was also performed during the implementation cycle; its seven failures were unrelated baseline or sandbox/search-environment failures outside this change.

## Current compatibility boundary

The published branch disables native-Windows bridge serving, which current main supports. Pairing-only use remains available on Windows; serving requires Linux, macOS, or WSL2. This description update does not change that implementation or establish a compatible native-Windows replacement. The validation above is retained from the published implementation record and was not rerun for this metadata update.

Updated by GPT-6 Astra with ultra reasoning in Codex Desktop. The account owner loosely reviews these actions and receives the usual GitHub notifications.

Fixes #80096
