### PR TITLE
test: make test suite pass on macOS (Apple Silicon)

### DIFF
--- a/tests/gateway/test_systemd_notify.py
+++ b/tests/gateway/test_systemd_notify.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import socket
+import sys
 
 import pytest
 
 
 @pytest.mark.skipif(
-    not hasattr(socket, "AF_UNIX"), reason="Unix datagram sockets are unavailable"
+    sys.platform != "linux" or not hasattr(socket, "AF_UNIX"),
+    reason="systemd abstract UNIX sockets are Linux-only",
 )
 def test_notify_supports_systemd_abstract_socket(monkeypatch):
     name = "\0hermes-test-notify"

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -7,6 +7,8 @@ implementation in this same file once that phase ships.
 """
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from hermes_cli.service_manager import (
@@ -192,7 +194,7 @@ def fake_subprocess_run(monkeypatch: pytest.MonkeyPatch):
 # tests/docker/test_s6_profile_gateway_integration.py.
 
 
-def test_seed_supervise_skeleton_creates_expected_layout(tmp_path) -> None:
+def test_seed_supervise_skeleton_creates_expected_layout(tmp_path, monkeypatch) -> None:
     """Verifies the dirs + FIFO + modes the helper lays down."""
     import stat
 
@@ -200,6 +202,18 @@ def test_seed_supervise_skeleton_creates_expected_layout(tmp_path) -> None:
 
     svc_dir = tmp_path / "gateway-foo"
     svc_dir.mkdir()
+    # chmod can only set the setgid bit on a dir owned by your group; under
+    # a wheel-owned TMPDIR (e.g. /private/tmp on macOS) that fails. Make the
+    # skeleton root ours so the layout modes are reproducible everywhere.
+    os.chown(svc_dir, os.getuid(), os.getgid())
+
+    # Mock chown: on macOS a real os.chown() clears the setgid bit (Darwin
+    # semantics differ from Linux), making the resulting mode dependent on
+    # whether the caller is in the target group. The skeleton layout test
+    # asserts the modes the helper intends to lay down, so keep chown a
+    # no-op. _seed_supervise_skeleton imports os locally, but patching the
+    # os module itself covers any local `import os` reference.
+    monkeypatch.setattr(os, "chown", lambda *a, **k: None)
 
     _seed_supervise_skeleton(svc_dir)
 

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -101,8 +101,15 @@ class TestDetectDangerousRm:
 
     def test_nonrecursive_verification_artifact_cleanup_is_not_dangerous(self):
         with mock_patch("tempfile.gettempdir", return_value="/tmp"):
+            # realpath() the mock too: on macOS /tmp is a symlink to
+            # /private/tmp, and detect_dangerous_command canonicalizes the
+            # temp dir before comparing, so the operand must use the same
+            # canonical path or a legitimate cleanup is flagged dangerous.
+            canonical_tmp = os.path.realpath("/tmp")
             for prefix in ("hermes-verify-", "hermes-ad-hoc-"):
-                assert detect_dangerous_command(f"rm -f /tmp/{prefix}example.py") == (
+                assert detect_dangerous_command(
+                    f"rm -f {canonical_tmp}/{prefix}example.py"
+                ) == (
                     False,
                     None,
                     None,

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1221,6 +1221,9 @@ class TestCaptureAppFilterNoMatch:
         assert backend._active_pid is None
         assert backend._active_window_id is None
 
+    @pytest.mark.skipif(
+        sys.platform != "linux", reason="GNOME Shell helper filtering is Linux-only"
+    )
     def test_linux_default_capture_skips_gnome_shell_helper(self):
         windows = [
             {"app_name": "", "pid": 100, "window_id": 1,

--- a/tests/tools/test_execution_flag_detection.py
+++ b/tests/tools/test_execution_flag_detection.py
@@ -50,6 +50,20 @@ def test_real_binaries_execute_leading_dash_program_payload(
     if shutil.which(tool) is None or (needs_tty and shutil.which("script") is None):
         pytest.skip(f"{tool} or script is not installed")
 
+    # These cases assert GNU-specific behavior (--compress-program / --pager
+    # executing a leading-dash program argument). BSD builds (macOS default
+    # sort/man) parse the same flags differently or hang, so require the GNU
+    # flavor — the payload-execution invariant only holds there.
+    if tool in ("sort", "man"):
+        try:
+            version_out = subprocess.run(
+                [tool, "--version"], capture_output=True, text=True, timeout=5
+            ).stdout
+        except (OSError, subprocess.TimeoutExpired):
+            version_out = ""
+        if "GNU" not in version_out:
+            pytest.skip(f"{tool} is not the GNU build (no --compress-program/--pager payload semantics)")
+
     marker = tmp_path / "executed"
     payload = tmp_path / "-payload-marker"
     payload.write_text("#!/bin/sh\nprintf executed > \"$MARKER\"\ncat\n")

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,6 +6,7 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -54,7 +55,9 @@ class TestWriteFileHandler:
         from tools.file_tools import write_file_tool
         result = json.loads(write_file_tool("/tmp/out.txt", "hello world!\n"))
         assert result["status"] == "ok"
-        mock_ops.write_file.assert_called_once_with("/tmp/out.txt", "hello world!\n")
+        # write_file_tool resolves paths; on macOS /tmp is a symlink to
+        # /private/tmp, so expect the canonical path.
+        mock_ops.write_file.assert_called_once_with(os.path.realpath("/tmp/out.txt"), "hello world!\n")
 
     @patch("tools.file_tools._get_file_ops")
     def test_permission_error_returns_error_json_without_error_log(self, mock_get, caplog):
@@ -145,7 +148,7 @@ class TestPatchHandler:
             old_string="foo", new_string="bar"
         ))
         assert result["status"] == "ok"
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "foo", "bar", False)
+        mock_ops.patch_replace.assert_called_once_with(os.path.realpath("/tmp/f.py"), "foo", "bar", False)
 
 
     @patch("tools.file_tools._get_file_ops")

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -397,6 +397,7 @@ class TestTranscribeLocalExtended:
              patch("faster_whisper.WhisperModel", mock_whisper_cls), \
              patch("tools.transcription_tools._local_model", None), \
              patch("tools.transcription_tools._local_model_name", None), \
+             patch("tools.transcription_tools._should_force_faster_whisper_cpu", return_value=False), \
              patch("tools.transcription_tools._load_stt_config", return_value=fake_config):
             from tools.transcription_tools import _transcribe_local
             result = _transcribe_local(str(audio), "base")

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -121,10 +121,20 @@ def fake_clock(monkeypatch):
 # ============================================================================
 
 class TestPulseSocketReachable:
-    def test_stale_socket_file_not_reachable(self, monkeypatch, tmp_path):
+    def _short_socket_dir(self):
+        """Return a SHORT socket directory under the system tmp dir.
+
+        macOS caps AF_UNIX socket paths at 104 bytes; pytest tmp_path lives
+        under /private/var/folders/... which already exceeds that once
+        'pulse/native' is appended. A short dir keeps these tests portable.
+        """
+        import tempfile
+        return tempfile.mkdtemp(prefix="pulse-")
+
+    def test_stale_socket_file_not_reachable(self, monkeypatch):
         """A socket file with no listener should not count as reachable."""
         import socket as _socket
-        sock_path = tmp_path / "pulse" / "native"
+        sock_path = Path(self._short_socket_dir()) / "pulse" / "native"
         sock_path.parent.mkdir(parents=True)
         # Create + bind, then close so the path is a stale socket file.
         s = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
@@ -132,14 +142,14 @@ class TestPulseSocketReachable:
         s.close()
         monkeypatch.delenv("PULSE_SERVER", raising=False)
         monkeypatch.delenv("PULSE_RUNTIME_PATH", raising=False)
-        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(sock_path.parent.parent))
         from tools.voice_mode import _pulse_socket_reachable
         assert _pulse_socket_reachable() is False
 
-    def test_listening_socket_reachable_via_xdg_runtime(self, monkeypatch, tmp_path):
+    def test_listening_socket_reachable_via_xdg_runtime(self, monkeypatch):
         """A live PulseAudio-style socket under XDG_RUNTIME_DIR is reachable (#35622)."""
         import socket as _socket
-        sock_path = tmp_path / "pulse" / "native"
+        sock_path = Path(self._short_socket_dir()) / "pulse" / "native"
         sock_path.parent.mkdir(parents=True)
         server = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
         server.bind(str(sock_path))
@@ -147,7 +157,7 @@ class TestPulseSocketReachable:
         try:
             monkeypatch.delenv("PULSE_SERVER", raising=False)
             monkeypatch.delenv("PULSE_RUNTIME_PATH", raising=False)
-            monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+            monkeypatch.setenv("XDG_RUNTIME_DIR", str(sock_path.parent.parent))
             from tools.voice_mode import _pulse_socket_reachable
             assert _pulse_socket_reachable() is True
         finally:
@@ -695,8 +705,12 @@ class TestCleanupTempRecordings:
 # ============================================================================
 
 class TestPlayBeep:
-    def test_beep_calls_sounddevice_play(self, mock_sd):
+    def test_beep_calls_sounddevice_play(self, mock_sd, monkeypatch):
         np = pytest.importorskip("numpy")
+
+        # On macOS beeps route through afplay (TCC-safe); mock the gate so
+        # this test exercises the sounddevice path it was written for.
+        monkeypatch.setattr("tools.voice_mode._sounddevice_output_allowed", lambda: True)
 
         from tools.voice_mode import play_beep
 
@@ -1414,6 +1428,7 @@ class TestWSL2PowerShellFallback:
             return m
 
         with patch("tools.voice_mode._is_wsl2_env", return_value=True), \
+             patch("tools.voice_mode.platform.system", return_value="Linux"), \
              patch("tools.voice_mode._import_audio", side_effect=ImportError), \
              patch("tools.voice_mode.shutil.which",
                    side_effect=lambda x: f"/bin/{x}" if x in ("powershell.exe", "ffmpeg", "ffplay", "sh") else (x if x.startswith("/") else None)), \
@@ -1466,6 +1481,7 @@ class TestWSL2PowerShellFallback:
             return open(path, *args, **kwargs)
 
         with patch("builtins.open", side_effect=_fake_open), \
+             patch("tools.voice_mode.platform.system", return_value="Linux"), \
              patch("shutil.which", side_effect=lambda x: f"/bin/{x}" if x in ("powershell.exe", "ffmpeg", "ffplay") else None), \
              patch("subprocess.check_output", side_effect=_capture_check_output), \
              patch("subprocess.Popen", return_value=MagicMock(returncode=0, wait=lambda **k: 0)), \


### PR DESCRIPTION
## Summary

Fixes the npm audit findings reported by `hermes doctor` and makes the Python test suite pass on a fresh macOS (Apple Silicon) install.

### npm security fixes
- Bump root `brace-expansion` override 5.0.8 → 5.0.9 (DoS via unbounded arrays)
- Bump `ui-tui` `undici` 6.27.0 → 6.28.0 (response desync, CRLF/cookie injection)
- Transitive `nanoid` 3.3.16 → 3.3.18 and `undici` 7.28.0 → 7.29.0 via audit fix
- Result: `npm audit` 0/0/0 on all targets (agent-browser, web, ui-tui), `npm run check` green

### macOS test portability fixes
- **systemd_notify**: abstract UNIX sockets are Linux-only — gate on `sys.platform`, not just AF_UNIX presence
- **computer_use**: GNOME Shell helper filtering is Linux-only — add skipif
- **approval**: canonicalize mocked tempdir via `realpath()` (`/tmp` → `/private/tmp` symlink on macOS) so legitimate `hermes-verify` cleanup is not flagged dangerous
- **file_tools**: expect `realpath()`d paths (same `/tmp` symlink)
- **execution_flag_detection**: sort/man payload-execution assertions only hold for GNU coreutils — skip non-GNU builds
- **service_manager**: `chmod` setgid + Darwin `os.chown()` semantics — make skeleton root ours, mock chown
- **transcription_tools**: mock `_should_force_faster_whisper_cpu` so the config-path regression test works on Apple Silicon
- **voice_mode**: short AF_UNIX socket dir (104-byte macOS cap), mock sounddevice gate for beep path, force Linux platform for WSL2 tests

## Test Plan
- [x] `scripts/run_tests.sh` on macOS: 27,380 passed, 0 failed
- [x] `npm run check`: exit 0
- [x] `npm audit` all targets: 0 vulnerabilities

Verified on macOS 27.0 (Apple Silicon, fresh install).