### PR TITLE
fix(gateway): remove --replace from LaunchAgent plist to prevent kill loops

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -661,7 +661,7 @@ def _gateway_run_args_for_profile(profile: str) -> list[str]:
     args = [get_python_path(), "-m", "hermes_cli.main"]
     if profile != "default":
         args.extend(["--profile", profile])
-    args.extend(["gateway", "run", "--replace"])
+    args.extend(["gateway", "run"])
     return args
 
 
@@ -4091,7 +4091,6 @@ def generate_launchd_plist() -> str:
         [
             "<string>gateway</string>",
             "<string>run</string>",
-            "<string>--replace</string>",
         ]
     )
     prog_args_xml = "\n        ".join(prog_args)


### PR DESCRIPTION
## Problem

When `hermes gateway install` generates a LaunchAgent with `KeepAlive=true`, including `--replace` in `ProgramArguments` causes an **infinite kill loop**:

1. New instance starts with `--replace`, sends SIGTERM to running instance (planned takeover)
2. Supervisor's `KeepAlive` revives the killed instance
3. Revived instance starts with `--replace`, kills the one from step 1
4. Repeat forever

Observed on macOS with 4 profiles, each with its own LaunchAgent. The `--replace` flag caused each profile to fight itself, producing a continuous cycle that blocked all message processing.

## Root cause

`_gateway_run_args_for_profile()` and `generate_launchd_plist()` unconditionally append `--replace`. The flag is designed for manual shell use. In a supervised context the supervisor already owns lifecycle — `--replace` actively sabotages it.

## Fix

Remove `--replace` from:
- `_gateway_run_args_for_profile()` (restart watcher)
- `generate_launchd_plist()` (`hermes gateway install`)

Keep in `_spawn_detached_gateway()` where takeover semantics are needed.

## Testing

- Verified all 4 profiles start cleanly without loops after removing `--replace`
- `hermes gateway restart` still works (uses restart watcher path)
- Manual `hermes gateway run --replace` from shell still works (CLI flag, not plist)
