### PR TITLE
fix(web_server): accept Tailscale MagicDNS hostnames in host header check

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -526,10 +526,16 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     if bound_host in {"0.0.0.0", "::"}:
         return True
 
-    # Loopback bind: accept the loopback names
+    # Loopback bind: accept the loopback names, plus Tailscale MagicDNS
+    # hostnames (*.ts.net) since tailscale serve proxies to localhost over
+    # an already-authenticated, encrypted tailnet tunnel.
     bound_lc = bound_host.lower()
     if bound_lc in _LOOPBACK_HOST_VALUES:
-        return host_only in _LOOPBACK_HOST_VALUES
+        if host_only in _LOOPBACK_HOST_VALUES:
+            return True
+        if host_only.endswith(".ts.net"):
+            return True
+        return False
 
     # Explicit non-loopback bind: require exact host match
     return host_only == bound_lc


### PR DESCRIPTION
## Problem

When the web dashboard is bound to loopback (default) and exposed via `tailscale serve`, the Host header contains the Tailscale MagicDNS hostname (e.g. `machine.tail1234.ts.net`) rather than `localhost`.

The current `_is_accepted_host` validation rejects these requests with a 403 because `*.ts.net` is not in `_LOOPBACK_HOST_VALUES`. This makes the dashboard inaccessible through the standard `tailscale serve` proxy pattern documented at https://tailscale.com/kb/1247/funnel-serve-use-cases.

## Setup

```bash
# Dashboard on loopback
hermes web server --port 9119  # binds 127.0.0.1

# Expose via Tailscale
tailscale serve --bg --https 443 http://127.0.0.1:9119
```

Browser visits `https://machine.tail1234.ts.net/` → 403 Forbidden.

## Fix

Accept `*.ts.net` suffixes in `_is_accepted_host` when bound to loopback. `tailscale serve` proxies to localhost over an already-authenticated, encrypted tailnet tunnel, so the Host-header defense is not bypassed — the trust boundary is the Tailscale connection itself.

The change is scoped: only `.ts.net` suffixes are accepted, and only when the server is bound to loopback. Non-loopback binds still require exact host match.

## Testing

- Verified dashboard accessible at `https://machine.tailf2f193.ts.net/` after patch
- Verified `localhost:9119` and `127.0.0.1:9119` still work
- Verified random host headers (e.g. `evil.com`) still rejected with 403
