### PR TITLE
fix(process-registry): keep CLI workers off controlling tty

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1652,6 +1652,10 @@ class TestSystemdCgroupIsolation:
     @pytest.fixture(autouse=True)
     def _mark_gateway_process(self, monkeypatch):
         monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid",
+            lambda *, cleanup_stale=False: os.getpid(),
+        )
 
     def _fake_popen_capture(self):
         """Return (fake_popen, captured) where captured["argv"] gets the
@@ -1689,20 +1693,26 @@ class TestSystemdCgroupIsolation:
         # _build_systemd_scope_argv calls shutil.which — point it at a stub.
         monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
 
-        with patch("subprocess.Popen", side_effect=fake_popen), \
-            patch("threading.Thread", return_value=MagicMock()), \
-            patch.object(registry, "_write_checkpoint"):
+        with (
+            patch("subprocess.Popen", side_effect=fake_popen),
+            patch("threading.Thread", return_value=MagicMock()),
+            patch.object(registry, "_write_checkpoint"),
+        ):
             session = registry.spawn_local("echo hello", cwd="/tmp")
 
         argv = captured["argv"]
         assert argv[0] == "/usr/bin/systemd-run", argv
         assert "--user" in argv
         assert "--scope" in argv
-        assert "--quiet" in argv, "systemd-run argv must include --quiet (#70716 gap #3)"
+        assert "--quiet" in argv, (
+            "systemd-run argv must include --quiet (#70716 gap #3)"
+        )
         assert "--unit" in argv
         unit_idx = argv.index("--unit")
         assert argv[unit_idx + 1].startswith("hermes-worker-"), argv
-        assert argv[unit_idx + 1] == f"hermes-worker-{session.id}", argv  # _build_systemd_scope_argv uses bare name
+        assert argv[unit_idx + 1] == f"hermes-worker-{session.id}", (
+            argv
+        )  # _build_systemd_scope_argv uses bare name
         properties = [
             argv[index + 1]
             for index, value in enumerate(argv[:-1])
@@ -1726,9 +1736,7 @@ class TestSystemdCgroupIsolation:
         # The session must record the unit name so kill_process can stop it.
         assert session.systemd_unit == f"hermes-worker-{session.id}.scope"
 
-    def test_falls_back_when_systemd_run_unavailable(
-        self, registry, monkeypatch
-    ):
+    def test_falls_back_when_systemd_run_unavailable(self, registry, monkeypatch):
         """Under a supervisor but without systemd-run, fall back to the
         legacy ``start_new_session=True`` path (worker shares the gateway
         cgroup)."""
@@ -1744,9 +1752,11 @@ class TestSystemdCgroupIsolation:
             lambda: True,
         )
 
-        with patch("subprocess.Popen", side_effect=fake_popen), \
-            patch("threading.Thread", return_value=MagicMock()), \
-            patch.object(registry, "_write_checkpoint"):
+        with (
+            patch("subprocess.Popen", side_effect=fake_popen),
+            patch("threading.Thread", return_value=MagicMock()),
+            patch.object(registry, "_write_checkpoint"),
+        ):
             registry.spawn_local("echo hello", cwd="/tmp")
 
         argv = captured["argv"]
@@ -1754,9 +1764,7 @@ class TestSystemdCgroupIsolation:
         assert argv == ["/bin/bash", "-lic", "set +m; echo hello"], argv
         assert captured["start_new_session"] is True
 
-    def test_falls_back_when_not_under_supervisor(
-        self, registry, monkeypatch
-    ):
+    def test_falls_back_when_not_under_supervisor(self, registry, monkeypatch):
         """CLI mode (no supervisor) must NOT wrap in a systemd scope even if
         systemd-run is available — isolation is a gateway concern."""
         fake_popen, captured = self._fake_popen_capture()
@@ -1771,9 +1779,11 @@ class TestSystemdCgroupIsolation:
             lambda: False,
         )
 
-        with patch("subprocess.Popen", side_effect=fake_popen), \
-            patch("threading.Thread", return_value=MagicMock()), \
-            patch.object(registry, "_write_checkpoint"):
+        with (
+            patch("subprocess.Popen", side_effect=fake_popen),
+            patch("threading.Thread", return_value=MagicMock()),
+            patch.object(registry, "_write_checkpoint"),
+        ):
             registry.spawn_local("echo hello", cwd="/tmp")
 
         argv = captured["argv"]
@@ -1795,9 +1805,11 @@ class TestSystemdCgroupIsolation:
         )
         monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
 
-        with patch("subprocess.Popen", side_effect=fake_popen), \
-            patch("threading.Thread", return_value=MagicMock()), \
-            patch.object(registry, "_write_checkpoint"):
+        with (
+            patch("subprocess.Popen", side_effect=fake_popen),
+            patch("threading.Thread", return_value=MagicMock()),
+            patch.object(registry, "_write_checkpoint"),
+        ):
             registry.spawn_local("echo hello", cwd="/tmp")
 
         assert captured["argv"] == [
@@ -1825,9 +1837,79 @@ class TestSystemdCgroupIsolation:
         )
         monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
 
-        with patch.object(PtyProcess, "spawn", return_value=fake_pty) as pty_spawn, \
-            patch("threading.Thread", return_value=MagicMock()), \
-            patch.object(registry, "_write_checkpoint"):
+        with (
+            patch.object(PtyProcess, "spawn", return_value=fake_pty) as pty_spawn,
+            patch("threading.Thread", return_value=MagicMock()),
+            patch.object(registry, "_write_checkpoint"),
+        ):
+            session = registry.spawn_local("codex", cwd="/tmp", use_pty=True)
+
+        assert pty_spawn.call_args.args[0] == [
+            "/bin/bash",
+            "-lic",
+            "set +m; codex",
+        ]
+        assert session.systemd_unit == ""
+
+    def test_inherited_gateway_tree_markers_do_not_scope_child_cli(
+        self, registry, monkeypatch
+    ):
+        """Gateway descendants are not the gateway process that owns the PID file."""
+        fake_popen, captured = self._fake_popen_capture()
+
+        monkeypatch.setenv("INVOCATION_ID", "inherited-systemd-marker")
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid",
+            lambda *, cleanup_stale=False: os.getpid() + 1,
+        )
+        monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
+        monkeypatch.setattr(
+            "tools.process_registry._systemd_run_user_scope_available",
+            lambda: True,
+        )
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
+
+        with (
+            patch("subprocess.Popen", side_effect=fake_popen),
+            patch("threading.Thread", return_value=MagicMock()),
+            patch.object(registry, "_write_checkpoint"),
+        ):
+            registry.spawn_local("echo hello", cwd="/tmp")
+
+        assert captured["argv"] == [
+            "/bin/bash",
+            "-lic",
+            "set +m; echo hello",
+        ]
+        assert captured["start_new_session"] is True
+
+    def test_inherited_gateway_tree_markers_do_not_scope_child_cli_pty(
+        self, registry, monkeypatch
+    ):
+        """The PID-bound gateway identity gate also protects PTY-backed children."""
+        from ptyprocess import PtyProcess
+
+        fake_pty = MagicMock(pid=4321)
+
+        monkeypatch.setenv("INVOCATION_ID", "inherited-systemd-marker")
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid",
+            lambda *, cleanup_stale=False: os.getpid() + 1,
+        )
+        monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
+        monkeypatch.setattr(
+            "tools.process_registry._systemd_run_user_scope_available",
+            lambda: True,
+        )
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
+
+        with (
+            patch.object(PtyProcess, "spawn", return_value=fake_pty) as pty_spawn,
+            patch("threading.Thread", return_value=MagicMock()),
+            patch.object(registry, "_write_checkpoint"),
+        ):
             session = registry.spawn_local("codex", cwd="/tmp", use_pty=True)
 
         assert pty_spawn.call_args.args[0] == [

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1649,6 +1649,10 @@ class TestSystemdCgroupIsolation:
     ENTIRE gateway cgroup, taking down the messaging control plane.
     """
 
+    @pytest.fixture(autouse=True)
+    def _mark_gateway_process(self, monkeypatch):
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+
     def _fake_popen_capture(self):
         """Return (fake_popen, captured) where captured["argv"] gets the
         argv passed to subprocess.Popen."""
@@ -1775,6 +1779,63 @@ class TestSystemdCgroupIsolation:
         argv = captured["argv"]
         assert argv == ["/bin/bash", "-lic", "set +m; echo hello"], argv
         assert captured["start_new_session"] is True
+
+    def test_inherited_systemd_marker_does_not_scope_interactive_cli(
+        self, registry, monkeypatch
+    ):
+        """A CLI inside a supervised terminal must keep workers off its tty."""
+        fake_popen, captured = self._fake_popen_capture()
+
+        monkeypatch.setenv("INVOCATION_ID", "herdr-service-inherited-marker")
+        monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+        monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
+        monkeypatch.setattr(
+            "tools.process_registry._systemd_run_user_scope_available",
+            lambda: True,
+        )
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
+
+        with patch("subprocess.Popen", side_effect=fake_popen), \
+            patch("threading.Thread", return_value=MagicMock()), \
+            patch.object(registry, "_write_checkpoint"):
+            registry.spawn_local("echo hello", cwd="/tmp")
+
+        assert captured["argv"] == [
+            "/bin/bash",
+            "-lic",
+            "set +m; echo hello",
+        ]
+        assert captured["start_new_session"] is True
+
+    def test_inherited_systemd_marker_does_not_scope_interactive_cli_pty(
+        self, registry, monkeypatch
+    ):
+        """The same gateway-identity gate applies to PTY-backed workers."""
+        from ptyprocess import PtyProcess
+
+        fake_pty = MagicMock()
+        fake_pty.pid = 4321
+
+        monkeypatch.setenv("INVOCATION_ID", "herdr-service-inherited-marker")
+        monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+        monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
+        monkeypatch.setattr(
+            "tools.process_registry._systemd_run_user_scope_available",
+            lambda: True,
+        )
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
+
+        with patch.object(PtyProcess, "spawn", return_value=fake_pty) as pty_spawn, \
+            patch("threading.Thread", return_value=MagicMock()), \
+            patch.object(registry, "_write_checkpoint"):
+            session = registry.spawn_local("codex", cwd="/tmp", use_pty=True)
+
+        assert pty_spawn.call_args.args[0] == [
+            "/bin/bash",
+            "-lic",
+            "set +m; codex",
+        ]
+        assert session.systemd_unit == ""
 
     def test_systemd_post_spawn_failure_never_kills_gateway_process_group(
         self, registry, monkeypatch

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -245,6 +245,27 @@ def _systemd_run_user_scope_available() -> bool:
         return available
 
 
+def _is_supervised_gateway_process() -> bool:
+    """Return whether this process is in a supervised Hermes gateway runtime.
+
+    Supervisor markers such as systemd's ``INVOCATION_ID`` are inherited by
+    every descendant. An interactive CLI launched from a supervised terminal
+    manager therefore cannot use that marker alone: its login-shell workers
+    would stay in the CLI's session and could take ownership of the controlling
+    tty. ``gateway.run`` adds ``_HERMES_GATEWAY`` to the gateway process tree;
+    unrelated supervised terminal managers do not.
+    """
+    if os.environ.get("_HERMES_GATEWAY") != "1":
+        return False
+
+    try:
+        from gateway.restart import is_gateway_supervisor_process
+
+        return is_gateway_supervisor_process()
+    except Exception:
+        return False
+
+
 def _build_systemd_scope_argv(
     shell_argv: List[str],
     unit_suffix: str,
@@ -991,18 +1012,12 @@ class ProcessRegistry:
                 # Cgroup isolation for PTY mode (#70716, reviewer gap #1):
                 # Wrap the PTY command in a systemd scope so interactive
                 # executors get their own cgroup, same as pipe mode.
-                pty_use_systemd_scope = False
-                try:
-                    from gateway.restart import is_gateway_supervisor_process
-
-                    pty_under_supervisor = is_gateway_supervisor_process()
-                    pty_use_systemd_scope = (
-                        not _IS_WINDOWS
-                        and pty_under_supervisor
-                        and _systemd_run_user_scope_available()
-                    )
-                except Exception:
-                    pty_use_systemd_scope = False
+                pty_under_supervisor = _is_supervised_gateway_process()
+                pty_use_systemd_scope = (
+                    not _IS_WINDOWS
+                    and pty_under_supervisor
+                    and _systemd_run_user_scope_available()
+                )
 
                 if pty_use_systemd_scope:
                     pty_argv = _build_systemd_scope_argv(
@@ -1081,18 +1096,12 @@ class ProcessRegistry:
         # for both pipe mode and the PTY path above.
         shell_argv = [user_shell, "-lic", f"set +m; {safe_command}"]
         use_systemd_scope = False
-        under_supervisor = False
-        try:
-            from gateway.restart import is_gateway_supervisor_process
-
-            under_supervisor = is_gateway_supervisor_process()
-            use_systemd_scope = (
-                not _IS_WINDOWS
-                and under_supervisor
-                and _systemd_run_user_scope_available()
-            )
-        except Exception:
-            use_systemd_scope = False
+        under_supervisor = _is_supervised_gateway_process()
+        use_systemd_scope = (
+            not _IS_WINDOWS
+            and under_supervisor
+            and _systemd_run_user_scope_available()
+        )
 
         if use_systemd_scope:
             unit_suffix = (

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -248,21 +248,25 @@ def _systemd_run_user_scope_available() -> bool:
 def _is_supervised_gateway_process() -> bool:
     """Return whether this process is in a supervised Hermes gateway runtime.
 
-    Supervisor markers such as systemd's ``INVOCATION_ID`` are inherited by
-    every descendant. An interactive CLI launched from a supervised terminal
-    manager therefore cannot use that marker alone: its login-shell workers
-    would stay in the CLI's session and could take ownership of the controlling
-    tty. ``gateway.run`` adds ``_HERMES_GATEWAY`` to the gateway process tree;
-    unrelated supervised terminal managers do not.
+    Both supervisor markers and ``_HERMES_GATEWAY`` are inherited by every
+    descendant, and importing ``gateway.run`` also sets the latter. Require
+    this process to own the live gateway PID file as well. That keeps transient
+    systemd scopes limited to the gateway itself instead of terminal children
+    or unrelated interactive CLIs in the same supervised process tree.
     """
     if os.environ.get("_HERMES_GATEWAY") != "1":
         return False
 
     try:
         from gateway.restart import is_gateway_supervisor_process
+        from gateway.status import get_running_pid
 
-        return is_gateway_supervisor_process()
-    except Exception:
+        return (
+            is_gateway_supervisor_process()
+            and get_running_pid(cleanup_stale=False) == os.getpid()
+        )
+    except Exception as exc:
+        logger.debug("Could not verify supervised gateway process identity: %s", exc)
         return False
 
 
@@ -1012,30 +1016,26 @@ class ProcessRegistry:
                 # Cgroup isolation for PTY mode (#70716, reviewer gap #1):
                 # Wrap the PTY command in a systemd scope so interactive
                 # executors get their own cgroup, same as pipe mode.
-                pty_under_supervisor = _is_supervised_gateway_process()
+                pty_in_supervised_gateway = (
+                    not _IS_WINDOWS and _is_supervised_gateway_process()
+                )
                 pty_use_systemd_scope = (
-                    not _IS_WINDOWS
-                    and pty_under_supervisor
-                    and _systemd_run_user_scope_available()
+                    pty_in_supervised_gateway and _systemd_run_user_scope_available()
                 )
 
                 if pty_use_systemd_scope:
                     pty_argv = _build_systemd_scope_argv(
-                        pty_argv, unit_suffix=session.id,
+                        pty_argv,
+                        unit_suffix=session.id,
                     )
                     session.systemd_unit = f"hermes-worker-{session.id}.scope"
                     pty_scope_attempted = True
-                elif not _IS_WINDOWS:
-                    try:
-                        from gateway.restart import is_gateway_supervisor_process as _sup
-                        if _sup():
-                            logger.debug(
-                                "PTY background executor not isolated in a "
-                                "systemd scope (systemd-run --user unavailable); "
-                                "worker shares the gateway cgroup."
-                            )
-                    except Exception:
-                        pass
+                elif pty_in_supervised_gateway:
+                    logger.debug(
+                        "PTY background executor not isolated in a "
+                        "systemd scope (systemd-run --user unavailable); "
+                        "worker shares the gateway cgroup."
+                    )
 
                 pty_proc = _PtyProcessCls.spawn(
                     pty_argv,
@@ -1088,29 +1088,26 @@ class ProcessRegistry:
         bg_env["PYTHONUNBUFFERED"] = "1"
         _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
 
-        # Cgroup isolation (#70716): when running under a service manager
-        # (systemd gateway), wrap the worker in its own transient systemd
+        # Cgroup isolation (#70716): when running in the live, supervised
+        # systemd gateway, wrap the worker in its own transient systemd
         # scope so it gets a separate cgroup.  An OOM in the worker then
         # kills only the worker instead of taking down the whole gateway
-        # cgroup (and the messaging control plane with it).  We only do this
-        # for both pipe mode and the PTY path above.
+        # cgroup (and the messaging control plane with it). This applies to
+        # both pipe mode and the PTY path above.
         shell_argv = [user_shell, "-lic", f"set +m; {safe_command}"]
         use_systemd_scope = False
-        under_supervisor = _is_supervised_gateway_process()
+        in_supervised_gateway = not _IS_WINDOWS and _is_supervised_gateway_process()
         use_systemd_scope = (
-            not _IS_WINDOWS
-            and under_supervisor
-            and _systemd_run_user_scope_available()
+            in_supervised_gateway and _systemd_run_user_scope_available()
         )
 
         if use_systemd_scope:
             unit_suffix = (
-                f"{session.id}-pipe-fallback"
-                if pty_scope_attempted
-                else session.id
+                f"{session.id}-pipe-fallback" if pty_scope_attempted else session.id
             )
             spawn_argv = _build_systemd_scope_argv(
-                shell_argv, unit_suffix=unit_suffix,
+                shell_argv,
+                unit_suffix=unit_suffix,
             )
             session.systemd_unit = f"hermes-worker-{unit_suffix}.scope"
             # systemd-run creates the new session/cgroup for us; do NOT also
@@ -1120,7 +1117,7 @@ class ProcessRegistry:
         else:
             spawn_argv = shell_argv
             popen_start_new_session = True
-            if not _IS_WINDOWS and under_supervisor:
+            if in_supervised_gateway:
                 # Running under a supervisor but could not get a private
                 # cgroup — the worker shares the gateway cgroup, so an OOM
                 # in the worker can still kill the whole gateway (#70716).
@@ -1128,7 +1125,7 @@ class ProcessRegistry:
                     "Local background executor not isolated in a systemd scope "
                     "(supervisor=%s, systemd-run --user available=%s); "
                     "worker shares the gateway cgroup.",
-                    under_supervisor,
+                    in_supervised_gateway,
                     _systemd_run_user_scope_available(),
                 )
 


### PR DESCRIPTION
## Summary

Interactive Hermes CLIs launched from a supervised terminal manager no longer mistake inherited service-manager metadata for gateway identity.

That false classification sent tracked background workers through the gateway-only `systemd-run --scope` path without `start_new_session=True`. The login-shell worker stayed in the CLI's POSIX session, took foreground ownership of the controlling tty, and prompt-toolkit's next tty mode update stopped Hermes with `SIGTTOU` (`Tl`, `do_signal_stop`).

The fix requires the Hermes gateway marker, a real external supervisor, and ownership of the live gateway PID record before transient gateway worker scopes are used. Ordinary CLIs and inherited gateway descendants keep the existing detached-session launch path. Gateway cgroup isolation remains intact.

## Root cause and ownership

A deterministic PTY repro established the ownership boundary:

- The exact stop reproduces in a standalone PTY outside Herdr.
- Herdr reads foreground process-group state but does not call `tcsetpgrp` or `TIOCSPGRP`.
- In the Hermes `ProcessRegistry` path, an inherited `INVOCATION_ID` made `is_gateway_supervisor_process()` return true for an interactive CLI.
- The resulting tracked worker entered a new PGID in the Hermes SID and became the tty foreground PGID.
- Hermes then entered `Tl` on `SIGTTOU` when prompt-toolkit called `tcsetattr`.

This makes the defect Hermes-owned, not a Herdr PTY-master mutation.

A fresh production occurrence in coordinator pane `w2:p1B` matched the same signature before this fix was deployed:

- stale Hermes PID `2803963`: state `Tl`, PGID `2803963`, TPGID `3133270`, tty `pts/9`;
- healthy foreground replacement PID `3133270` in the same session; and
- the stopped parent still owned `terminal(background=true)` passive-monitor child PID `3130021` plus MCP watchdogs.

That process tree confirms the operational risk: the interactive parent can remain stopped while tracked children and watchdogs continue running behind a replacement foreground Hermes process.

## Changes

- Add one process-scope predicate that requires:
  - `_HERMES_GATEWAY=1`; and
  - a supported systemd/launchd/s6 supervisor marker; and
  - the current PID to own the live gateway PID record.
- Use that predicate for both pipe and PTY tracked-worker scope decisions.
- Keep the gateway-only transient scope path unchanged when all three conditions hold.
- Add behavior regressions for pipe and PTY launches proving that inherited supervisor metadata, including inherited `_HERMES_GATEWAY`, cannot activate the scope from a child process.

No signal is ignored or masked. Foreground terminal commands, tracked background work, process control, interrupts, and prompt-toolkit rendering remain enabled.

## TDD evidence

The new regression test was run before the implementation and failed for the expected reason:

```text
expected: /bin/bash -lic ... with start_new_session=True
actual:   /usr/bin/systemd-run ... with start_new_session=False
```

Independent review then identified that `_HERMES_GATEWAY` is also inherited and can be set by importing `gateway.run`. Two PID-ownership regressions were added and run RED before the follow-up implementation: both pipe and PTY tests selected `systemd-run` instead of the direct shell.

After rebasing onto current `origin/main` (`51597c5e`):

| Check | Result |
|---|---|
| ProcessRegistry, terminal background/PTY, PTY session, gateway PID status, and startup-failure selection | 172 passed |
| Final post-rebase systemd/gateway scope class | 18 passed |
| Targeted Ruff formatting and Ruff check | Passed |
| `py_compile` and `git diff --check` | Passed |

A pre-rebase bounded `tests/tools` run reached 32% at its five-minute cap and is not claimed as a full-suite pass. The first reported failure was an unrelated order-dependent approval-mode assertion; that test file passed 7/7 in isolation. No full-suite result is claimed.

## Real Herdr runtime verification

An isolated Hermes source process carrying the final patch ran in raw Herdr pane `w2:p1K` against a deterministic local OpenAI-compatible tool-call fixture. It deliberately inherited both `_HERMES_GATEWAY=1` and `INVOCATION_ID` while its isolated runtime did not own a live gateway PID record. The fixture used `--yolo` only to isolate PTY job control from the separately owned approval path; this PR makes no claim about Tirith approval behavior. The 172-test focused selection passed before the final clean rebase onto `51597c5e`; the 18-test scope class and static checks were rerun after that rebase.

1. `terminal(background=true)` started a tracked HTTP server.
   - Hermes PID `3165576` remained `Sl+`; its PGID and tty TPGID both remained `3165576`.
   - Tracked worker PID `3167939` had PGID/SID `3167939`, `TTY=?`, and `TPGID=-1`.
   - The checkpoint recorded `systemd_unit=""`, proving the inherited gateway tree markers did not activate the gateway scope path.
   - The listener and process checkpoint were verified.
   - `SIGTTIN` and `SIGTTOU` were absent from pending, blocked, ignored, and caught masks.
2. An 8-second foreground terminal command completed with exit code 0.
   - Hermes remained live and foreground throughout.
   - The foreground child had its own SID and no controlling tty.
   - `SIGTTIN` and `SIGTTOU` remained unmasked with no pending signal.
3. `process(action="kill")` removed the tracked server.
   - Listener closed.
   - Process checkpoint returned to `[]`.
   - Exactly one process held the isolated `state.db` before clean CLI exit; none remained afterward.
4. All fixture servers, workers, scopes, listeners, temporary state, and repro artifacts were removed. The raw pane returned to its original zsh foreground process.

## Compatibility and risk

- Linux: directly covers the observed systemd/zsh/PTY failure.
- macOS: launchd detection still works for the gateway, but an unrelated launchd marker alone cannot activate gateway worker scopes.
- Windows: unchanged; the systemd scope path remains disabled.
- Gateway workers retain sibling-cgroup OOM isolation.
- If gateway PID ownership cannot be verified, launch fails safe to the existing detached-session path rather than applying a gateway scope to an unverified process.
- The change does not reclaim a tty, suppress job-control signals, or change prompt-toolkit behavior. It prevents the wrong process from joining the tty session in the first place.

---

![Vintage UNIX operator-manual schematic showing an interactive Hermes process retaining foreground tty ownership while tracked workers launch in detached sessions](https://raw.githubusercontent.com/bgrablin/hermes-agent/fa21e0a82889b0c234c48bafb715dc24272d6e7c/hermes-pty-job-control.png)