### PR TITLE
fix(read_extract): label unreadable PDF gaps from short dividers

### DIFF
--- a/tests/tools/test_read_extract.py
+++ b/tests/tools/test_read_extract.py
@@ -640,6 +640,25 @@ class TestPdfCoverageNote(unittest.TestCase):
             note,
         )
 
+    def test_short_divider_labels_following_blank_pages(self):
+        """A short divider remains context instead of joining the blank run."""
+        from tools import read_extract
+
+        texts = [
+            "Prior unrelated body with enough characters for the threshold",
+            "Exhibit A",
+            "",
+            "",
+        ]
+        with mock.patch.object(read_extract, "_pdf_page_texts", return_value=texts):
+            note = read_extract._pdf_coverage_note("/x/doc.pdf")
+
+        self.assertNotIn("pages 2-4", note)
+        self.assertIn(
+            'pages 3-4 (2 pages) — after "Exhibit A" (p2)',
+            note,
+        )
+
     def test_gap_map_caps_pathological_alternation(self):
         """Hundreds of alternating text/scan pages must not balloon the
         warning — gaps beyond the cap collapse to one summary line."""

--- a/tools/read_extract.py
+++ b/tools/read_extract.py
@@ -266,21 +266,49 @@ def _group_ranges(pages: list[int]) -> list[list[int]]:
 # summarized in one line.
 PDF_GAP_MAP_MAX_ENTRIES = 20
 _GAP_CONTEXT_CHARS = 60
+_GAP_CONTEXT_MIN_CHARS = 4
 
 
-def _gap_map(counts: list[int], texts: list[str], empty: list[int]) -> str:
+def _gap_context(text: str) -> str:
+    """Normalized label text, excluding 1-3 character OCR debris."""
+    normalized = " ".join(text.split())
+    return normalized if len(normalized) >= _GAP_CONTEXT_MIN_CHARS else ""
+
+
+def _group_gap_ranges(empty: list[int], texts: list[str]) -> list[list[int]]:
+    """Group sparse pages without swallowing nonblank divider text."""
+    ranges: list[list[int]] = []
+    for page in empty:
+        page_has_text = bool(_gap_context(texts[page - 1]))
+        previous_has_text = bool(
+            ranges and _gap_context(texts[ranges[-1][1] - 1])
+        )
+        if (
+            ranges
+            and page == ranges[-1][1] + 1
+            and not page_has_text
+            and not previous_has_text
+        ):
+            ranges[-1][1] = page
+        else:
+            ranges.append([page, page])
+    return ranges
+
+
+def _gap_map(texts: list[str], empty: list[int]) -> str:
     """Per-gap breakdown: each empty range labeled with the last text seen
     before it (usually a section divider/header page), so the agent can
     decide WHICH gaps it actually needs to read instead of OCRing all of
     them."""
-    ranges = _group_ranges(empty)
+    ranges = _group_gap_ranges(empty, texts)
     lines: list[str] = []
     for a, b in ranges[:PDF_GAP_MAP_MAX_ENTRIES]:
         label = ""
         # Walk back to the nearest preceding page with text.
         for prev in range(a - 2, -1, -1):
-            if counts[prev] >= PDF_EMPTY_PAGE_CHARS:
-                snippet = " ".join(texts[prev].split())[:_GAP_CONTEXT_CHARS]
+            context = _gap_context(texts[prev])
+            if context:
+                snippet = context[:_GAP_CONTEXT_CHARS]
                 label = f' — after "{snippet}" (p{prev + 1})'
                 break
         span = f"page {a}" if a == b else f"pages {a}-{b}"
@@ -321,7 +349,7 @@ def _pdf_coverage_note(path: str, display_path: Optional[str] = None) -> str:
         "is MISSING from the extracted text below, even where section "
         "headers appear with empty bodies. Unreadable gaps, each labeled "
         "with the last text extracted before it:\n"
-        f"{_gap_map(counts, texts, empty)}\n"
+        f"{_gap_map(texts, empty)}\n"
         "Decide which gaps you actually need — do NOT OCR or render "
         "everything. For the gaps that matter, render just that range with "
         f"`pdftoppm -jpeg -r 150 -f <first> -l <last> '{shown}' /tmp/page` "


### PR DESCRIPTION
## What does this PR do?

PDF extraction coverage warnings can fold a short divider such as `Exhibit A` into the following unreadable range and label that range with older unrelated text. This patch keeps meaningful short dividers outside blank-page ranges so agents receive the correct context when deciding which pages need rendering or OCR.

### Symptom

Given a long body on page 1, `Exhibit A` on page 2, and unreadable pages 3-4, main reports one `pages 2-4` gap labeled from page 1 instead of labeling pages 3-4 from page 2.

### Impact

Incorrect gap labels can make the agent skip relevant scanned pages or inspect unrelated pages, leading to incomplete PDF answers. The frequency across real-world PDFs has not been measured.

### Bug Cause

**Trigger:** `tools/read_extract.py:_gap_map` groups every page below `PDF_EMPTY_PAGE_CHARS` through `_group_ranges` before choosing a label.

**Causal chain:**
1. A meaningful divider contains fewer than 20 extracted characters, so warning eligibility classifies it as sparse.
2. Contiguous range grouping merges the divider with the following blank pages.
3. Label lookup begins before the merged range and reports older unrelated text.

**Why it is wrong:** Sparse-page warning eligibility and unreadable-range boundaries are different decisions. A short nonblank divider may count toward the sparse-page threshold while still remaining the context label for following blank pages.

**Working sibling / contrast:** Dividers with at least 20 characters are already excluded from the sparse-page list, so they split the range and label following blank pages correctly.

**Ruled out:** The divider is present in the extracted page text during the deterministic reproduction. The incorrect result is introduced by range grouping, not PDF text extraction.

### Fix

The patch keeps the existing warning threshold, groups sparse ranges without swallowing meaningful short text, and reuses normalized preceding text for labels. Text shorter than 4 characters remains excluded as likely OCR debris. A regression test covers a short divider followed by two blank pages.

## Related Issue

Fixes #82034

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/read_extract.py` - separate sparse warning eligibility from meaningful gap boundaries and label lookup.
- `tests/tools/test_read_extract.py` - cover a short divider immediately before blank pages.

## How to Test

1. Run the focused extraction test suite.
2. Confirm the short-divider regression labels pages 3-4 with `Exhibit A` from page 2.
3. Confirm the full focused suite passes.

```bash
scripts/run_tests.sh tests/tools/test_read_extract.py
```

Result: 42 passed, 0 failed, 3 skipped.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the focused extraction suite and all executed tests pass
- [x] I've added a regression test for the bug
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] Relevant documentation updates are N/A because this corrects existing warning behavior
- [x] `cli-config.yaml.example` updates are N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A because architecture and workflows did not change
- [x] I've considered cross-platform impact; the changed logic is platform-independent
- [x] Tool description and schema updates are N/A because the tool contract did not change

## Screenshots / Logs

N/A - deterministic unit-test reproduction and verification are included above.
