### PR TITLE
feat(tui): auto-collapse reasoning blocks only when the reasoning phase ends

### DIFF
--- a/ui-tui/src/__tests__/thinkingLiveCollapse.test.tsx
+++ b/ui-tui/src/__tests__/thinkingLiveCollapse.test.tsx
@@ -1,0 +1,118 @@
+import { PassThrough } from 'stream'
+
+import { renderSync } from '@hermes/ink'
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { ToolTrail } from '../components/thinking.js'
+import { stripAnsi } from '../lib/text.js'
+import { DEFAULT_THEME } from '../theme.js'
+
+const flushEffects = async () => {
+  // Passive effects + the re-render they trigger need a few macrotask
+  // turns (React's scheduler uses MessageChannel) before the next frame
+  // paints — setTimeout(0)-class waits, not setImmediate (which can land
+  // in the wrong phase and observe the pre-effect frame).
+  for (let i = 0; i < 10; i++) {
+    await new Promise(resolve => setTimeout(resolve, 5))
+  }
+}
+
+const mountTrail = (reasoningActive: boolean, sections?: Record<string, string>) => {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+  let output = ''
+
+  Object.assign(stdout, { columns: 60, isTTY: false, rows: 20 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const instance = renderSync(
+    <ToolTrail
+      reasoning="Live reasoning text."
+      reasoningActive={reasoningActive}
+      sections={sections ?? { thinking: 'collapsed' }}
+      t={DEFAULT_THEME}
+    />,
+    {
+      patchConsole: false,
+      stderr: stderr as NodeJS.WriteStream,
+      stdin: stdin as NodeJS.ReadStream,
+      stdout: stdout as NodeJS.WriteStream
+    }
+  )
+
+  // The PassThrough accumulates every repaint, and a collapsed panel stops
+  // repainting entirely once settled — so assert on the FINAL chevron state
+  // in the accumulated output rather than the tail after a clear().
+  const finalChevronOpen = () => stripAnsi(output).lastIndexOf('▾ ') > stripAnsi(output).lastIndexOf('▸ ')
+
+  return { finalChevronOpen, instance }
+}
+
+describe('ToolTrail — collapsed mode auto-expands while reasoning is live', () => {
+  it('opens (▾) when reasoningActive is true under sections.thinking: collapsed', async () => {
+    const { finalChevronOpen, instance } = mountTrail(true)
+
+    await flushEffects()
+
+    expect(finalChevronOpen()).toBe(true)
+
+    instance.unmount()
+    instance.cleanup()
+  })
+
+  it('collapses (▸) when reasoningActive is false under sections.thinking: collapsed', async () => {
+    const { finalChevronOpen, instance } = mountTrail(false)
+
+    await flushEffects()
+
+    expect(finalChevronOpen()).toBe(false)
+
+    instance.unmount()
+    instance.cleanup()
+  })
+
+  it('closes the panel when the reasoning phase ends mid-turn (rerender)', async () => {
+    const { finalChevronOpen, instance } = mountTrail(true)
+
+    await flushEffects()
+
+    expect(finalChevronOpen()).toBe(true)
+
+    // Reasoning phase finished (final answer / tool call started) — the
+    // turn's reasoningActive drops and the panel must collapse.
+    instance.rerender(
+      <ToolTrail
+        reasoning="Live reasoning text."
+        reasoningActive={false}
+        sections={{ thinking: 'collapsed' }}
+        t={DEFAULT_THEME}
+      />
+    )
+
+    await flushEffects()
+
+    expect(finalChevronOpen()).toBe(false)
+
+    instance.unmount()
+    instance.cleanup()
+  })
+
+  it('leaves expanded-mode panels fully manual (no forced collapse)', async () => {
+    const { finalChevronOpen, instance } = mountTrail(false, { thinking: 'expanded' })
+
+    await flushEffects()
+
+    // `expanded` is a manual preference: reasoningActive=false must NOT
+    // force it closed (the auto behavior only applies to `collapsed`).
+    expect(finalChevronOpen()).toBe(true)
+
+    instance.unmount()
+    instance.cleanup()
+  })
+})

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -266,6 +266,12 @@ class TurnController {
 
   endReasoningPhase() {
     this.reasoningStreamingTimer = clear(this.reasoningStreamingTimer)
+    // Seal any open reasoning segment so its isLiveReasoning flag drops the
+    // moment the reasoning phase ends — the panel must stop tracking the
+    // turn's global reasoningActive, not stay "live" for the rest of the turn.
+    if (this.reasoningSegmentIndex !== null) {
+      this.syncReasoningSegment(false)
+    }
     patchTurnState({ reasoningActive: false, reasoningStreaming: false })
   }
 
@@ -359,7 +365,7 @@ class TurnController {
     })
   }
 
-  private syncReasoningSegment() {
+  private syncReasoningSegment(live = true) {
     const thinking = this.activeReasoningText.trim()
 
     if (!thinking) {
@@ -372,7 +378,8 @@ class TurnController {
       text: '',
       thinking,
       thinkingTokens: estimateTokensRough(thinking),
-      toolTokens: this.toolTokenAcc || undefined
+      toolTokens: this.toolTokenAcc || undefined,
+      ...(live ? { isLiveReasoning: true } : {})
     }
 
     if (this.reasoningSegmentIndex === null) {
@@ -386,7 +393,7 @@ class TurnController {
   }
 
   private closeReasoningSegment() {
-    this.syncReasoningSegment()
+    this.syncReasoningSegment(false)
     this.activeReasoningText = ''
     this.reasoningSegmentIndex = null
   }

--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -36,6 +36,7 @@ export const MessageLine = memo(function MessageLine({
   isStreaming = false,
   msg,
   prev,
+  reasoningActive = false,
   sections,
   t,
   tools = []
@@ -82,6 +83,7 @@ export const MessageLine = memo(function MessageLine({
           commandOverride={detailsModeCommandOverride}
           detailsMode={detailsMode}
           reasoning={thinking}
+          reasoningActive={reasoningActive}
           reasoningAlwaysVisible={msg.isMoaReference}
           reasoningTokens={msg.thinkingTokens}
           sections={sections}
@@ -246,6 +248,7 @@ export const MessageLine = memo(function MessageLine({
             commandOverride={detailsModeCommandOverride}
             detailsMode={detailsMode}
             reasoning={thinking}
+            reasoningActive={reasoningActive}
             reasoningTokens={msg.thinkingTokens}
             sections={sections}
             t={t}
@@ -305,6 +308,7 @@ interface MessageLineProps {
   // lead gap (see domain/blockLayout.ts::hasLeadGap). Undefined at the top of
   // the transcript or when spacing is irrelevant.
   prev?: Msg
+  reasoningActive?: boolean
   sections?: SectionVisibility
   t: Theme
   tools?: ActiveTool[]

--- a/ui-tui/src/components/streamingAssistant.tsx
+++ b/ui-tui/src/components/streamingAssistant.tsx
@@ -78,6 +78,7 @@ export const StreamingAssistant = memo(function StreamingAssistant({
             key={block.key}
             msg={block.msg}
             prev={prev}
+            reasoningActive={block.msg.isLiveReasoning === true}
             sections={sections}
             t={ui.theme}
             {...(block.tools ? { tools: block.tools } : {})}

--- a/ui-tui/src/components/thinking.tsx
+++ b/ui-tui/src/components/thinking.tsx
@@ -772,6 +772,20 @@ export const ToolTrail = memo(function ToolTrail({
     setOpenMeta(visible.activity === 'expanded')
   }, [visible])
 
+  // `collapsed` is an auto preference: keep the panel open while reasoning
+  // is live (stream pulses keep `reasoningActive` true) and collapse it the
+  // moment the reasoning phase ends (`endReasoningPhase` flips it false).
+  // `expanded` stays fully manual, `hidden` never renders content, and MoA
+  // reference panels (reasoningAlwaysVisible) are left alone.
+  const thinkingAuto = visible.thinking === 'collapsed' && !reasoningAlwaysVisible
+  useEffect(() => {
+    if (!thinkingAuto) {
+      return
+    }
+
+    setOpenThinking(reasoningActive)
+  }, [thinkingAuto, reasoningActive])
+
   const cot = useMemo(() => thinkingPreview(reasoning, 'full', THINKING_COT_MAX), [reasoning])
 
   // Spawn-tree derivations must live above any early return so React's

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -125,6 +125,11 @@ export interface Msg {
   // user-facing mixture-of-agents process the user opted into, so it stays
   // visible even when `display.sections.thinking` is hidden.
   isMoaReference?: boolean
+  // True only while this trail segment's reasoning is being streamed live by
+  // the current turn (see turnController's syncReasoningSegment). Sealed
+  // reasoning segments from earlier in the turn carry no flag, so the TUI can
+  // tell "the reasoning happening right now" apart from finished blocks.
+  isLiveReasoning?: boolean
   thinkingTokens?: number
   toolTokens?: number
   tools?: string[]


### PR DESCRIPTION
## Summary

- `display.sections.thinking: collapsed` now behaves as an **auto** preference: the TUI keeps the *live* reasoning panel open while reasoning streams, and collapses it the moment the reasoning phase ends (first tool call, final answer, or new turn)
- Sealed reasoning segments from earlier phases in the same turn stay collapsed — only the currently-streaming block expands
- `expanded` / `hidden` / MoA-reference panel semantics are unchanged

## Motivation

With `thinking: collapsed`, the TUI collapsed **every** reasoning block — including the one currently being generated — so users couldn't watch reasoning stream while keeping finished blocks tidy. There was no mode for "expanded while live, collapsed when done". This PR makes `collapsed` that mode.

## Changes

- `ui-tui/src/app/turnController.ts` — `syncReasoningSegment()` tags the open segment `isLiveReasoning`; `endReasoningPhase()` / `closeReasoningSegment()` seal the tag when reasoning ends
- `ui-tui/src/components/streamingAssistant.tsx` — passes `reasoningActive` only to the live segment (`block.msg.isLiveReasoning`), not to every block
- `ui-tui/src/components/thinking.tsx` — `ToolTrail` auto-opens while `reasoningActive` under `collapsed` mode; `expanded`/`hidden`/MoA references keep manual/current semantics
- `ui-tui/src/components/messageLine.tsx` — threads `reasoningActive` through to `ToolTrail`
- `ui-tui/src/types.ts` — new `Msg.isLiveReasoning` field
- `ui-tui/src/__tests__/thinkingLiveCollapse.test.tsx` — new tests: open-on-stream, collapse-on-finish (incl. mid-turn rerender), expanded-mode no-op

## Test Plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] New `thinkingLiveCollapse.test.tsx` (4 tests) + existing `details`, `messageLine`, `thinkingMoaReferenceVisibility`, `blockLayout`, `queueSubmission` suites all pass
- [x] Full ui-tui suite: 0 new failures vs baseline (21 pre-existing failures in `subscriptionOverlay`/`ink-backpressure`/`appChromeBlockedTimers` — unrelated, A/B-verified on unpatched HEAD)
- [x] Manual: reasoning-heavy prompt in TUI — panel opens while streaming, collapses when reasoning ends, only current block expands

## Notes for Reviewers

- The `isLiveReasoning` flag approach was chosen over "last thinking segment" heuristics because the turn controller already tracks the open segment index precisely, and the flag survives segment merging (`mergeToolShelfInto` spreads the target msg).
- Behavior is gated on the existing `display.sections.thinking: collapsed` config value — no new config keys.

## Semantics change (reviewer note)

`display.sections.thinking: collapsed` previously meant "always collapsed". This PR redefines it as an *auto* preference: expanded while reasoning is live, collapsed when the reasoning phase ends. The strict "never expanded" behavior is still reachable via `display.sections.thinking: hidden`, and manual chevron clicks mid-stream still win (the auto-open only re-applies when the reasoning phase changes). Alternative considered: a new `auto` mode value leaving `collapsed` strict — rejected to avoid a second knob for the same concept; happy to split if maintainers prefer.
