### PR TITLE
fix(honcho): don't upload owner memory files under non-owner peers in shared channels

### DIFF
--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -1110,7 +1110,16 @@ class HonchoSessionManager:
         # under the NON-OWNER's peer, and Honcho's deriver attributes the
         # owner's facts to that person. SOUL.md describes the agent, not a
         # human, but skipping it here too keeps the migration owner-scoped.
-        if session.user_peer_id != self._sanitize_id(self._config.peer_name):
+        #
+        # Compare against the full explicit-owner set (peer_name + aliases) and
+        # only skip when we can actually identify an owner. peer_name is
+        # optional (default None), and the owner's sessions may resolve via a
+        # configured alias rather than the raw peer_name — in both cases the
+        # old check either crashed (TypeError in _sanitize_id, swallowed by
+        # the caller) or skipped the owner's own migration. With no owner
+        # configured at all, preserve the pre-guard behaviour and migrate.
+        owner_peer_ids = self._explicit_user_peer_ids()
+        if owner_peer_ids and session.user_peer_id not in owner_peer_ids:
             logger.info(
                 "Skipping memory-file migration for non-owner session (user=%s)",
                 session.user_peer_id,

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -1103,6 +1103,20 @@ class HonchoSessionManager:
             logger.warning("No Honcho session cached for '%s', skipping memory migration", session_key)
             return False
 
+        # Only migrate the owner-describing memory files (MEMORY.md / USER.md)
+        # when the session's user peer IS the configured owner peer. Otherwise a
+        # non-owner triggering a new session (e.g. any other human in a shared
+        # Slack/Discord channel) gets the owner's full profile files uploaded
+        # under the NON-OWNER's peer, and Honcho's deriver attributes the
+        # owner's facts to that person. SOUL.md describes the agent, not a
+        # human, but skipping it here too keeps the migration owner-scoped.
+        if session.user_peer_id != self._sanitize_id(self._config.peer_name):
+            logger.info(
+                "Skipping memory-file migration for non-owner session (user=%s)",
+                session.user_peer_id,
+            )
+            return False
+
         uploaded = False
         files = [
             (

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -389,6 +389,137 @@ class TestPerSessionMigrateGuard:
         mock_manager.migrate_memory_files.assert_not_called()
 
 
+class TestMigrateMemoryFilesOwnerGuard:
+    """Regression tests for the owner guard in migrate_memory_files.
+
+    The guard must skip migration only when an owner is configured AND the
+    session's user peer is not that owner. Three failure modes covered:
+
+    1. peer_name=None (the default): the old guard called
+       _sanitize_id(None) → TypeError, swallowed by callers → migration
+       silently disabled for every single-user install.
+    2. Owner session resolving via alias: user_peer_id equals an alias,
+       not the raw peer_name — must NOT be skipped.
+    3. Non-owner session in a shared channel: must be skipped.
+    """
+
+    def _make_manager(self, tmp_path, peer_name=None, aliases=None):
+        """Build a HonchoSessionManager with a cached session ready to migrate."""
+        from plugins.memory.honcho.client import HonchoClientConfig
+
+        cfg = HonchoClientConfig(
+            api_key="test-key",
+            enabled=True,
+            recall_mode="tools",
+            peer_name=peer_name,
+            user_peer_aliases=aliases or {},
+        )
+        manager = HonchoSessionManager(honcho=MagicMock(), config=cfg)
+        return manager
+
+    def _seed_session(self, manager, user_peer_id, key="slack:C123"):
+        """Insert a cached session + fake Honcho session so the guard is reached."""
+        session = HonchoSession(
+            key=key,
+            user_peer_id=user_peer_id,
+            assistant_peer_id="hermes-assistant",
+            honcho_session_id="hs-123",
+        )
+        manager._cache[key] = session
+        manager._sessions_cache["hs-123"] = MagicMock()
+        return session
+
+    def _write_memory_files(self, tmp_path):
+        for name in ("MEMORY.md", "USER.md", "SOUL.md"):
+            (tmp_path / name).write_text(f"# {name} content", encoding="utf-8")
+
+    def test_peer_name_none_does_not_crash_and_migrates(self, tmp_path):
+        """peer_name=None (default) must not TypeError; migration proceeds."""
+        manager = self._make_manager(tmp_path, peer_name=None)
+        session = self._seed_session(manager, user_peer_id="user-slack-U999")
+        self._write_memory_files(tmp_path)
+
+        # Mock the upload path so we don't hit the network
+        uploaded = []
+        def fake_upload(**kwargs):
+            uploaded.append(kwargs)
+        manager._sdk_session = MagicMock(return_value=MagicMock(upload_file=fake_upload))
+        manager._get_or_create_peer = MagicMock(side_effect=lambda peer_id: MagicMock())
+
+        result = manager.migrate_memory_files("slack:C123", str(tmp_path))
+        assert result is True
+        assert len(uploaded) == 3  # MEMORY, USER, SOUL all uploaded
+
+    def test_owner_via_alias_is_not_skipped(self, tmp_path):
+        """Owner whose session resolves via alias must NOT be skipped."""
+        manager = self._make_manager(
+            tmp_path, peer_name="Minh", aliases={"U123": "minh-alias"}
+        )
+        # Session's user peer is the alias, NOT the raw peer_name
+        session = self._seed_session(manager, user_peer_id="minh-alias")
+        self._write_memory_files(tmp_path)
+
+        uploaded = []
+        def fake_upload(**kwargs):
+            uploaded.append(kwargs)
+        manager._sdk_session = MagicMock(return_value=MagicMock(upload_file=fake_upload))
+        manager._get_or_create_peer = MagicMock(side_effect=lambda peer_id: MagicMock())
+
+        result = manager.migrate_memory_files("slack:C123", str(tmp_path))
+        assert result is True
+        assert len(uploaded) == 3
+
+    def test_owner_via_peer_name_is_not_skipped(self, tmp_path):
+        """Owner whose session resolves via peer_name directly is not skipped."""
+        manager = self._make_manager(tmp_path, peer_name="Minh")
+        session = self._seed_session(manager, user_peer_id="Minh")
+        self._write_memory_files(tmp_path)
+
+        uploaded = []
+        def fake_upload(**kwargs):
+            uploaded.append(kwargs)
+        manager._sdk_session = MagicMock(return_value=MagicMock(upload_file=fake_upload))
+        manager._get_or_create_peer = MagicMock(side_effect=lambda peer_id: MagicMock())
+
+        result = manager.migrate_memory_files("slack:C123", str(tmp_path))
+        assert result is True
+        assert len(uploaded) == 3
+
+    def test_non_owner_is_skipped(self, tmp_path):
+        """Non-owner session in a shared channel must be skipped."""
+        manager = self._make_manager(tmp_path, peer_name="Minh")
+        session = self._seed_session(manager, user_peer_id="user-slack-U999")
+        self._write_memory_files(tmp_path)
+
+        uploaded = []
+        def fake_upload(**kwargs):
+            uploaded.append(kwargs)
+        manager._sdk_session = MagicMock(return_value=MagicMock(upload_file=fake_upload))
+        manager._get_or_create_peer = MagicMock(side_effect=lambda peer_id: MagicMock())
+
+        result = manager.migrate_memory_files("slack:C123", str(tmp_path))
+        assert result is False
+        assert len(uploaded) == 0
+
+    def test_non_owner_alias_mismatch_is_skipped(self, tmp_path):
+        """Session peer matching neither peer_name nor any alias is skipped."""
+        manager = self._make_manager(
+            tmp_path, peer_name="Minh", aliases={"U123": "minh-alias"}
+        )
+        session = self._seed_session(manager, user_peer_id="user-slack-U999")
+        self._write_memory_files(tmp_path)
+
+        uploaded = []
+        def fake_upload(**kwargs):
+            uploaded.append(kwargs)
+        manager._sdk_session = MagicMock(return_value=MagicMock(upload_file=fake_upload))
+        manager._get_or_create_peer = MagicMock(side_effect=lambda peer_id: MagicMock())
+
+        result = manager.migrate_memory_files("slack:C123", str(tmp_path))
+        assert result is False
+        assert len(uploaded) == 0
+
+
 class TestChunkMessage:
     def test_short_message_single_chunk(self):
         result = HonchoMemoryProvider._chunk_message("hello world", 100)


### PR DESCRIPTION
## Problem

`plugins/memory/honcho/session.py::migrate_memory_files()` uploads `MEMORY.md` and `USER.md` into the Honcho session with the upload bound to the session's **runtime user peer** — i.e. whoever happened to trigger the session.

In any deployment where more than one human can trigger sessions (shared Slack/Discord channels, group chats), a **non-owner** opening a new thread causes the owner's full profile files to be uploaded under the **non-owner's Honcho peer**. Honcho's deriver then processes messages "from" that peer whose content is literally the owner's profile, and derives conclusions attributing the owner's facts to the wrong person.

This is not cosmetic — in our deployment it put the owner's psychometric battery, medical/ADHD details, relationship facts, and personal philosophy onto the Honcho peers of a work colleague and an external contact. We count 55 of 70 contaminated sessions carrying this exact payload. It also defeats `userPeerAliases` / `observationMode=unified` hygiene: even with perfectly correct sender→peer routing, the files still land under whoever triggered the session (correct peer, poisoned payload).

## Repro

1. Configure the Honcho memory plugin with `USER.md`/`MEMORY.md` present in the memories dir.
2. Have a second human (not the configured `peerName` owner) trigger a brand-new session (new Slack thread etc.), so `migrate_memory_files` fires (`not session.messages and session_strategy != "per-session"`).
3. Inspect the resulting Honcho session: it contains `<prior_memory_file>`-wrapped `USER.md`/`MEMORY.md` messages authored by the second human's peer.
4. Wait for the deriver: conclusions of the form `<second-human>'s <owner's facts>` appear on their peer.

The wrapper text itself ("Treat as foundational context **for this user**") makes the deriver's mis-attribution entirely reasonable given the input — the bug is the binding, not the deriver.

## Fix

Skip the migration upload unless the session's user peer is the configured owner (`config.peer_name`, sanitized). The files describe the agent's owner; uploading them into sessions "owned" by someone else has no legitimate use and a severe mis-attribution cost. `SOUL.md` is uploaded under the assistant peer and is not implicated, but skipping it here too keeps the migration strictly owner-scoped.

One-line guard, no behavior change for single-user deployments (the overwhelmingly common case): when the session user IS the owner, everything proceeds exactly as before.

## Notes

- Found and verified in production over 2026-08-06 → 2026-08-09; happy to share the full forensic trail (conclusion→session→message traces, dump files) if useful.
- We run this exact patch locally; syntax + accessor pattern verified against the existing `_resolve_user_peer_id` code path.
- Related Honcho-server-side findings (session-delete cascade not covering conclusions; phantom peer→session rows; no peer merge/delete API) are being filed separately against `plastic-labs/honcho`.
