### PR TITLE
fix(telegram): preserve rich formatting after draft streaming

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -1257,7 +1257,10 @@ class GatewayStreamConsumer:
                 chat_id=self.chat_id,
                 content=text,
                 reply_to=reply_to_id,
-                metadata=self._metadata_for_send(final=final, expect_edits=True),
+                metadata=self._metadata_for_send(
+                    final=final,
+                    expect_edits=not final,
+                ),
             )
             if result.success and result.message_id:
                 self._message_id = str(result.message_id)

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -2371,7 +2371,7 @@ class GatewayStreamConsumer:
                     reply_to=self._initial_reply_to_id,
                     metadata=self._metadata_for_send(
                         final=finalize,
-                        expect_edits=True,
+                        expect_edits=not finalize,
                     ),
                 )
                 if result.success:

--- a/tests/gateway/test_stream_consumer_draft.py
+++ b/tests/gateway/test_stream_consumer_draft.py
@@ -136,6 +136,9 @@ class TestDraftStreamingHappyPath:
             else final_call.args[1] if len(final_call.args) > 1 else None
         )
         assert sent_content == "Hello world!"
+        final_metadata = final_call.kwargs.get("metadata") or {}
+        assert final_metadata.get("notify") is True
+        assert "expect_edits" not in final_metadata
 
 
 class TestDraftFallbackOnFailure:

--- a/tests/gateway/test_stream_consumer_draft.py
+++ b/tests/gateway/test_stream_consumer_draft.py
@@ -140,6 +140,37 @@ class TestDraftStreamingHappyPath:
         assert final_metadata.get("notify") is True
         assert "expect_edits" not in final_metadata
 
+    @pytest.mark.asyncio
+    async def test_edit_preview_still_marks_expect_edits(self):
+        adapter = _make_draft_capable_adapter(supports_draft=False)
+        cfg = StreamConsumerConfig(transport="edit", chat_type="dm", cursor="")
+        consumer = GatewayStreamConsumer(adapter, "12345", cfg)
+
+        delivered = await consumer._send_or_edit("Preview", finalize=False)
+
+        assert delivered is True
+        send_mock = adapter.__dict__["send"]
+        metadata = send_mock.call_args.kwargs.get("metadata") or {}
+        assert metadata.get("expect_edits") is True
+        assert "notify" not in metadata
+
+    @pytest.mark.asyncio
+    async def test_final_split_chunk_does_not_mark_expect_edits(self):
+        adapter = _make_draft_capable_adapter(supports_draft=False)
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "12345",
+            StreamConsumerConfig(transport="edit", chat_type="dm", cursor=""),
+        )
+
+        message_id = await consumer._send_new_chunk("Sealed head", None, final=True)
+
+        assert message_id == "msg_real"
+        send_mock = adapter.__dict__["send"]
+        metadata = send_mock.call_args.kwargs.get("metadata") or {}
+        assert metadata.get("notify") is True
+        assert "expect_edits" not in metadata
+
 
 class TestDraftFallbackOnFailure:
     """When a draft frame fails, the consumer disables drafts for the rest

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -18,6 +18,7 @@ import pytest
 
 from gateway.config import PlatformConfig
 from gateway.platforms.base import SendResult
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
 from plugins.platforms.telegram.adapter import TelegramAdapter
 from telegram.error import BadRequest, NetworkError, TimedOut
 
@@ -382,6 +383,29 @@ async def test_cjk_rich_content_skips_rich_draft_to_avoid_tdesktop_garble():
 def test_prefers_fresh_final_streaming_stays_disabled_when_rich_enabled():
     adapter = _make_adapter()
     assert adapter.prefers_fresh_final_streaming(RICH_CONTENT) is False
+
+
+@pytest.mark.asyncio
+async def test_legacy_draft_stream_finalizes_with_persistent_rich_message():
+    """A MarkdownV2 draft must not force the persistent final to MarkdownV2."""
+    adapter = _make_adapter()  # rich messages on, rich drafts off
+    assert adapter.supports_draft_streaming(chat_type="dm") is True
+
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "12345",
+        StreamConsumerConfig(transport="auto", chat_type="dm", cursor=""),
+    )
+    consumer._use_draft_streaming = True
+
+    delivered = await consumer._send_or_edit(RICH_CONTENT, finalize=True)
+
+    assert delivered is True
+    bot = adapter._bot
+    assert bot is not None
+    bot.do_api_request.assert_awaited_once()
+    assert bot.do_api_request.call_args.args[0] == "sendRichMessage"
+    bot.send_message.assert_not_called()
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Telegram DM draft streaming now preserves rich tables and other native formatting in the persistent final response.

The stream consumer marked finalized sends as `expect_edits`, forcing the Telegram adapter onto legacy MarkdownV2 even though no future edit was expected.

## Changes
- Final native-draft sends omit `expect_edits`, allowing `sendRichMessage` for the persistent response.
- Sealed split chunks follow the same finality rule instead of independently forcing legacy formatting.
- Live edit previews retain `expect_edits` and remain safely editable.
- Regression coverage exercises the real adapter with `rich_messages: true` and `rich_drafts: false`.

## Validation

| Path | Before | After |
|---|---|---|
| Legacy DM draft → persistent final | MarkdownV2 table conversion | Native rich table |
| Live edit preview | Editable legacy path | Editable legacy path preserved |
| Sealed split chunk | Incorrectly marked for future edits | Eligible for native rich rendering |

- `scripts/run_tests.sh tests/gateway/test_stream_consumer_draft.py tests/gateway/test_telegram_rich_messages.py` — 38 passed
- Live-ish real-adapter probe — 1 draft frame, 1 persistent rich send, 0 legacy persistent sends
- Ruff — passed on all three changed files

## Contributor credit
- Root fix adapted from #46536 by @liuhao1024; authorship preserved in commit history.
- #78525 by @Slobaka isolated the `rich_messages: true` / `rich_drafts: false` production path and is credited in the follow-up commit.

## Infographic

![Rich tables stay rich](https://v3b.fal.media/files/b/0aa590cc/e7SjFwwTrQgMHLrR9N7nX_a6SxXr2T.png)
