### PR TITLE
fix(backup): bound unbounded SQLite busy-retry + stop misclassifying transient files as hard errors

### DIFF
--- a/docs/fix-backup-sqlite-busy-retry-unbounded.md
+++ b/docs/fix-backup-sqlite-busy-retry-unbounded.md
@@ -1,0 +1,129 @@
+# Fix: bound `_safe_copy_db`'s SQLite busy/locked retry
+
+**Status:** fixed and verified (unit tests + live in-situ against a real lock).
+**Follows:** `docs/rca-backup-sqlite-busy-retry-unbounded.md` (root cause).
+
+## What changed
+
+One change in `hermes_cli/backup.py::_safe_copy_db()`: the previously-bare
+`conn.backup(backup_conn)` call is now bounded against a sustained
+`SQLITE_BUSY`/`SQLITE_LOCKED` source.
+
+```python
+def _abort_past_deadline(status, remaining, total):
+    if status in (sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED) and time.monotonic() > deadline:
+        raise _SafeCopyBusyTimeout(...)
+
+conn.backup(backup_conn, progress=_abort_past_deadline)
+```
+
+### Design choices and why
+
+1. **Bound via `progress=`, not a wrapper timeout/thread.**
+   `Connection.backup()`'s `progress=` callback fires after *every*
+   `sqlite3_backup_step()` call, including ones that returned
+   `SQLITE_BUSY`/`SQLITE_LOCKED`, and CPython already treats a raising
+   callback as "abort backup and bail" — it still calls
+   `sqlite3_backup_finish()` internally, so no backup handle is leaked. This
+   needed no new thread, signal, or subprocess machinery.
+
+2. **Gate the deadline check on the status code, not raw elapsed time.**
+   With the default `pages=-1`, a healthy, *uncontended* copy — however
+   large — completes in a single `sqlite3_backup_step()` call, and the
+   progress callback only fires *after* that (possibly slow, for a
+   many-GB `state.db`) step finishes. A time-only check would incorrectly
+   discard an already-successful large, non-busy copy just because it took
+   a while. Gating on `status in (SQLITE_BUSY, SQLITE_LOCKED)` keeps the
+   deadline meaningful only for genuine lock contention. Verified: an 87MB
+   non-busy source completes normally even against a 1ms deadline; a
+   167MB/300k-row non-busy source copies correctly with a 1ms deadline too.
+
+3. **Open both connections with `timeout=0` in the bounded path.**
+   This is load-bearing, not cosmetic (see the RCA's point 5): the
+   `sqlite3.connect()` default `timeout=5.0` installs SQLite's own internal
+   busy-handler, which silently retries *inside* a single
+   `sqlite3_backup_step()` call for up to that many seconds before ever
+   returning control to the progress callback. With `timeout=0`, each step
+   call fails fast on contention and control returns to the callback at
+   roughly `backup()`'s own retry cadence (`sleep=`, default 250ms), so the
+   deadline is enforced with the intended granularity instead of a coarse
+   ~5-8s one. This doesn't change success-path behavior: an uncontended
+   copy never touches the busy-handler either way, and the destination is
+   always a fresh tempfile the caller just created (never independently
+   contended).
+
+4. **The raised exception is a plain `Exception` subclass
+   (`_SafeCopyBusyTimeout`).** It's caught by `_safe_copy_db`'s existing
+   `except Exception as exc:` clause with zero control-flow changes: a
+   busy-timeout abort degrades to the exact same "SQLite safe copy failed"
+   warning + `False` return as any other `backup()` failure, which both
+   call sites (`_run_backup_locked`'s per-file loop and
+   `_write_full_zip_backup_locked`'s automatic-backup path) already handle
+   via the vanished-vs-genuine-failure distinction landed in
+   `docs/fix-chrome-debug-transient-files-backup.md`. A file that stays
+   locked past the deadline still exists on disk, so it's classified as a
+   genuine `errors` entry (not a benign `transient_skipped` vanish) in both
+   paths — the safest default, since we don't actually know whether it will
+   eventually copy successfully or not, just that it exceeded its budget.
+
+5. **Deadline is configurable, with an explicit escape hatch.**
+   Default 30 seconds (`_SAFE_COPY_BUSY_DEADLINE_SECONDS`). Override via
+   `HERMES_BACKUP_SQLITE_BUSY_DEADLINE_SECONDS` (float, seconds). A
+   non-positive value disables bounding entirely, restoring the exact
+   pre-fix indefinite-retry behavior for anyone who wants it.
+
+## Tests added
+
+`tests/hermes_cli/test_backup.py::TestSafeCopyDbBusyBounding` (6 tests):
+
+- `test_busy_source_is_bounded_not_indefinite` — a source locked longer than
+  the deadline returns `False` in roughly the deadline window, not after the
+  lock clears.
+- `test_short_busy_window_still_succeeds` — a lock that clears *before* the
+  deadline still succeeds normally (bounding must not penalize ordinary WAL
+  contention).
+- `test_connection_timeout_parameter_does_not_bound_backup_loop` —
+  documents/locks in *why* a naive `timeout=` fix wouldn't have worked (the
+  RCA's point 2), as a guard against someone "simplifying" the fix later.
+- `test_large_non_busy_copy_is_unaffected_by_bounding` — an absurdly tiny
+  deadline (1ms) does not abort a large (20k-row), non-busy copy, proving
+  the status-gate (not time alone) governs the deadline.
+- `test_negative_deadline_disables_bounding` — the escape hatch restores
+  indefinite retry.
+
+All pre-existing tests in `test_backup.py` (54), `test_backup_stability.py`,
+`test_curator_backup.py`, `test_execution_ledger.py`, `test_state_db_guard.py`,
+and `test_sizefmt.py` (106 total across the backup-adjacent surface) still
+pass — no regressions. `ruff check` clean on both changed files.
+
+## Live end-to-end verification
+
+At the time of this fix, the user's actual `chrome-debug/first_party_sets.db`
+was independently confirmed locked (`sqlite3 ... "SELECT 1"` →
+`database is locked (5)`), with zero interaction from this session:
+
+- **Before the fix**, the real (unpatched) `_safe_copy_db()` against this
+  live file blocked for **61.4 seconds** before the lock happened to clear.
+- **After the fix**, with a shortened 10s deadline override (to avoid
+  waiting out the full 30s default for this one verification run), the
+  same live file — while still genuinely locked — was aborted cleanly at
+  **10.1 seconds**, logging `SQLite safe copy failed for
+  .../first_party_sets.db: source stayed SQLITE_BUSY/SQLITE_LOCKED for
+  over 10s` and returning `False`, exactly as designed.
+
+This confirms the fix against the actual real-world condition the RCA
+describes, not just a synthetic repro.
+
+## Follow-ups intentionally not done here
+
+- Not adding a user-facing summary line distinguishing "busy-timeout skip"
+  from other `errors` entries — out of scope for this task; the existing
+  generic "SQLite safe copy failed" warning already surfaces the file and
+  underlying exception message (which now includes
+  "stayed SQLITE_BUSY/SQLITE_LOCKED for over Ns"), which is enough signal
+  for a human reading backup output to understand what happened.
+- Not investigating whether this is specific to a particular Chrome version
+  or has always been present — the RCA notes it reproduces against the
+  user's separate personal Chrome profile too, suggesting it's a general
+  Chrome/SQLite characteristic rather than a regression, but pinning down
+  *which* Chrome versions would need a wider survey out of scope here.

--- a/docs/fix-chrome-debug-transient-files-backup.md
+++ b/docs/fix-chrome-debug-transient-files-backup.md
@@ -1,0 +1,180 @@
+# Fix: `hermes backup` no longer errors on transient chrome-debug files
+
+**Status:** fixed and live-verified.
+**Follows:** `docs/rca-chrome-debug-transient-files-backup.md` (root cause).
+
+## What changed
+
+Two complementary changes in `hermes_cli/backup.py`, matching the RCA's two
+recommendations, plus one additional fix the RCA flagged as a same-class risk
+in the secondary (automatic backup) code path.
+
+### 1. Exclude known-transient chrome-debug subpaths from the backup walk
+
+Added `_CHROME_DEBUG_ROOT_DIR`, `_CHROME_DEBUG_TRANSIENT_DIRS`,
+`_CHROME_DEBUG_TRANSIENT_FILES`, and `_is_chrome_debug_transient_dir()`.
+Wired into:
+
+- `_should_exclude()` — file-level exclusion used by both backup paths via
+  `_should_skip_backup_file()`.
+- Both `os.walk()` scan loops (`_run_backup_locked` and
+  `_write_full_zip_backup_locked`) — directory-level pruning so `os.walk`
+  never descends into `chrome-debug/*/Sessions/`,
+  `chrome-debug/*/shared_proto_db/`, or `chrome-debug/BrowserMetrics/` at
+  all, not just filtering their contents after the fact.
+
+Scoped to fire only when rooted under the top-level `chrome-debug/`
+directory, so a same-named `Sessions`/`shared_proto_db` directory elsewhere
+under `HERMES_HOME` (e.g. inside a skill) is never affected — covered by
+`test_chrome_debug_exclusion_is_scoped_to_top_level_dir`.
+
+This eliminates the scan-then-archive race in the common case: the files
+that were racing the backup are no longer scanned or archived at all, so
+there's nothing to vanish out from under `zf.write()`.
+
+### 2. Reclassify vanished-mid-backup skips as "transient", not "errors"
+
+Defense in depth for any file that isn't covered by the exclusion above (a
+different live process racing the backup, or a transient chrome-debug file
+type not yet catalogued):
+
+- **`_run_backup_locked`** (the primary `hermes backup` / `hermes import`
+  path): the archive loop now catches `FileNotFoundError` *before* the
+  broader `(PermissionError, OSError, ValueError)` clause and appends to a
+  new `transient_skipped` list instead of `errors`. The finalize/summary
+  block only flips to `"Backup incomplete"` and suppresses the restore hint
+  when `errors` is non-empty — `transient_skipped` entries print as a
+  separate, clearly-labeled "Note (N file(s) changed during backup,
+  harmless -- nothing to restore there)" section instead.
+- The `.db` safe-copy branch (`_safe_copy_db()` returning `False`) now
+  checks `abs_path.exists()` post-hoc: if the source vanished (the
+  chrome-debug `*.db` race described in the RCA), it's `transient_skipped`;
+  if the source is still there but genuinely failed to copy (locked,
+  corrupt, permissions), it's still a hard `errors` entry and still flips
+  the summary. `sqlite3.connect()` raises a generic `OperationalError` for a
+  missing file rather than `FileNotFoundError`, so this existence check is
+  the only reliable way to distinguish the two cases from inside
+  `_safe_copy_db`'s boolean return.
+- **`_write_full_zip_backup_locked`** (the shared helper behind `hermes
+  update`'s pre-update backup and `hermes claw migrate`'s pre-migration
+  backup): this path had a *more severe* version of the same bug that the
+  RCA flagged as "not yet observed live but same code path" — a vanished
+  `.db` file raised `_SQLiteSnapshotError`, which the outer `except`
+  caught and turned into a full `return None`, discarding the *entire*
+  archive (all files scanned before AND after the vanished one), not just
+  skipping that one file. Now a vanished `.db` (source doesn't exist after
+  `_safe_copy_db` returns `False`) or a `FileNotFoundError` from a plain
+  `zf.write()` is logged and skipped via `continue`, and the archive
+  completes with everything else intact. A `.db` file that's still present
+  but genuinely fails to copy still raises `_SQLiteSnapshotError` and still
+  aborts+preserves the previous archive — unchanged, and still covered by
+  the existing `test_automatic_backup_still_aborts_on_genuine_db_failure`
+  (formerly `test_failed_automatic_backup_preserves_previous_archive` in
+  `test_backup_stability.py`).
+
+## Tests added
+
+`tests/hermes_cli/test_backup.py`:
+
+- `TestShouldExclude.test_excludes_chrome_debug_transient_subpaths`
+- `TestShouldExclude.test_chrome_debug_exclusion_is_scoped_to_top_level_dir`
+- `TestChromeDebugTransientRace` (new class, 7 tests): vanished plain file
+  is a warning not fatal; genuine `PermissionError` is still fatal; vanished
+  `.db` is skipped not reported as a copy failure; a `.db` that's present
+  but genuinely fails is still fatal; the automatic backup path tolerates
+  both a vanished plain file and a vanished `.db` without aborting; the
+  automatic backup path still aborts+preserves the previous archive on a
+  genuine (non-vanished) `.db` failure.
+
+All 55 tests in `test_backup.py` + `test_backup_stability.py` pass
+(46 pre-existing + 9 new), plus the 10 pre-existing tests in
+`test_curator_backup.py` and 36 in `test_execution_ledger.py` /
+`test_sizefmt.py` / `test_state_db_guard.py` (other callers of
+`hermes_cli.backup`) — no regressions.
+
+## Live end-to-end verification
+
+Launched the debug Chrome via the real Hermes code path
+(`hermes_cli.browser_connect.launch_chrome_debug(9222)`, the same function
+`/browser connect` uses) against the live `~/.hermes`, then ran `hermes
+backup` while it was actively running, navigating a couple of real pages via
+its CDP endpoint mid-backup to force genuine `Session_*`/`Tabs_*` file
+churn (new session/tab files with fresh timestamps appeared under
+`chrome-debug/Default/Sessions/` during the run, confirming the race
+window was live, not simulated):
+
+```
+Scanning ~/.hermes ...
+Backing up 4170 files ...
+  500/4170 files ...
+  1000/4170 files ...
+  1500/4170 files ...
+  2000/4170 files ...
+  2500/4170 files ...
+  3000/4170 files ...
+  3500/4170 files ...
+  4000/4170 files ...
+
+Backup complete: /private/tmp/hermes-backup-verify/full.zip
+  Files:       4170
+  Original:    543.3 MB
+  Compressed:  221.9 MB
+  Time:        28.9s
+
+  Excluded directories:
+    chrome-debug/Default/Sessions/
+    chrome-debug/Default/shared_proto_db/
+    hermes-agent/
+    lsp/node_modules/
+    node/lib/node_modules/
+
+Restore with: hermes import full.zip
+EXIT_CODE=0
+```
+
+Confirms, live, against the real bug scenario:
+
+- **"Backup complete"**, not "Backup incomplete" — this is the exact label
+  flip the RCA identified as the actual user-facing bug.
+- **`Restore with:` hint present** — previously suppressed by any nonzero
+  `errors` count; chrome-debug races no longer populate `errors` at all.
+- **`chrome-debug/Default/Sessions/` and `chrome-debug/Default/shared_proto_db/`
+  listed as excluded directories** — the race is prevented at scan time,
+  not merely caught and downgraded at archive time.
+- **No chrome-debug warnings at all** in this run (vs. the original ticket's
+  6 ENOENT warnings) — proof the primary fix (exclusion) eliminates the
+  race in the common case, with the secondary fix (transient
+  reclassification) as a backstop for anything the exclusion list doesn't
+  cover.
+- **Archive integrity confirmed**: `zipfile.ZipFile(...).testzip()` returns
+  `None` (no CRC/corruption), 4170 entries with 0 `Sessions/`/
+  `shared_proto_db/` entries and real profile data (e.g.
+  `chrome-debug/Default/Cookies`) correctly still present.
+
+### A separate, pre-existing, out-of-scope finding
+
+While live-testing, repeated interaction with the debug Chrome (rapid
+tab open/close cycles over CDP) was observed to put one or more of Chrome's
+own small SQLite files under `chrome-debug/` (`first_party_sets.db`,
+`Default/heavy_ad_intervention_opt_out.db`,
+`Default/declarative_performance_observer.db`) into a **sustained
+`SQLITE_BUSY` lock** that `sqlite3.Connection.backup()` retries
+indefinitely with no overall bound (confirmed independently of
+`_safe_copy_db`, and confirmed to reproduce identically against this
+change's own *unpatched* pre-fix code — i.e. not a regression introduced by
+this fix). This was also observed, with much lower probability, from a
+completely idle debug Chrome with zero interaction from this session, and
+even against the user's separate, long-running personal Chrome instance's
+own `first_party_sets.db` — so it is a general characteristic of this
+Chrome version's own internal use of these files, not something specific to
+the Hermes-managed debug profile.
+
+This is a different bug class from the one this task fixes (indefinite
+lock-wait vs. the ENOENT-vanished-file race) and the original ticket's own
+captured logs show no evidence of it (only the 6 ENOENT warnings, with a
+clean 250.2s total runtime) — so it's flagged here for a possible follow-up
+rather than addressed in this change. `_safe_copy_db()` would benefit from
+a bounded retry (e.g. `conn.backup(target, progress=<callback that raises
+past a deadline>)`) so a persistently-busy source file degrades to a
+skipped-with-warning outcome instead of stalling the whole backup
+indefinitely.

--- a/docs/rca-backup-sqlite-busy-retry-unbounded.md
+++ b/docs/rca-backup-sqlite-busy-retry-unbounded.md
@@ -1,0 +1,122 @@
+# RCA: `hermes backup` can stall indefinitely on a busy/locked SQLite file
+
+**Status:** root-caused and fixed (see `docs/fix-backup-sqlite-busy-retry-unbounded.md`).
+**Severity:** P3 — latent risk, not yet reported by a real user as a stalled
+backup. Discovered as a side finding while live-verifying
+`docs/fix-chrome-debug-transient-files-backup.md` (a different bug: transient
+ENOENT races, not lock contention).
+
+## Summary
+
+`hermes_cli/backup.py::_safe_copy_db()` copies each `.db` file via
+`sqlite3.Connection.backup()`. That call has **no bounded retry**: when the
+source is `SQLITE_BUSY` (another process holds a write transaction), it
+retries with `sqlite3_sleep()` indefinitely until the lock clears, regardless
+of the `timeout=` either connection was opened with.
+
+While repeatedly killing/relaunching the Hermes-managed debug Chrome and
+driving it via CDP during unrelated live testing, one or more of Chrome's own
+small SQLite files under `chrome-debug/` (`first_party_sets.db`,
+`Default/heavy_ad_intervention_opt_out.db`,
+`Default/declarative_performance_observer.db`) went into a sustained locked
+state that stalled a raw `_safe_copy_db()` call for 5-10+ minutes on that one
+file.
+
+## Root cause
+
+### 1. `Connection.backup()`'s retry loop has no deadline
+
+CPython's C implementation
+(`Modules/_sqlite/connection.c::pysqlite_connection_backup_impl`) runs:
+
+```c
+do {
+    rc = sqlite3_backup_step(bck_handle, pages);
+    if (progress != Py_None) { /* call the progress= callback */ }
+    if (rc == SQLITE_BUSY || rc == SQLITE_LOCKED) {
+        sqlite3_sleep(sleep_ms);   /* default 250ms */
+    }
+} while (rc == SQLITE_OK || rc == SQLITE_BUSY || rc == SQLITE_LOCKED);
+```
+
+There is no time budget anywhere in this loop. It retries for as long as the
+source stays busy/locked, full stop.
+
+### 2. The connection's `timeout=` parameter does not help
+
+`sqlite3.connect(..., timeout=N)` only bounds how long *ordinary statement
+execution* waits to acquire a lock before raising `OperationalError`. It has
+no effect on the C loop above. Confirmed empirically: opening both the
+source and destination connections with `timeout=2` while an external
+`BEGIN EXCLUSIVE` held the source locked for 8s still blocked `backup()` for
+the full 8s — the short timeout was silently ignored by this code path.
+
+### 3. Deterministic isolated repro
+
+A background thread/connection holding `BEGIN EXCLUSIVE` on a copy of one of
+the affected `.db` files while `_safe_copy_db` runs against it reproduces the
+indefinite retry in isolation, 100% of the time, regardless of hold duration
+(6s, 8s, 10s all block for the full hold).
+
+### 4. Live, real-world in-situ reproduction
+
+At the time of this investigation, the user's actual, live
+`chrome-debug/first_party_sets.db` was independently found to be
+`SQLITE_BUSY` (`sqlite3 ... "SELECT 1"` → `database is locked (5)`, repeated
+over 5s of polling) with **zero interaction from this session** — not a
+synthetic setup. Running the real (unpatched) `_safe_copy_db()` against it
+directly blocked for **61.4 seconds** before the lock happened to clear on
+its own. The user's separate, unrelated, long-running personal Chrome
+profile's own copy of `first_party_sets.db` was *also* locked at the same
+moment. This corroborates the original finding: this is a general
+characteristic of this Chrome version's own use of these files/locking
+pattern, not something specific to the Hermes-managed `chrome-debug/`
+profile, and not an artifact of the interactive CDP testing that first
+surfaced it.
+
+### 5. A second, subtler contributor: the connection's default `timeout=5.0`
+
+While prototyping the fix (bound the retry via `backup(progress=...)`, which
+fires on every step including busy ones, and can raise to abort), an
+apparently-working prototype turned out to be **flaky** — a deadline of 2s
+against an 8s external lock sometimes still took the full ~8s. Root cause:
+`sqlite3.connect()`'s **default** `timeout=5.0` installs SQLite's own
+internal busy-handler, which retries *inside a single*
+`sqlite3_backup_step()` call for up to that many seconds before ever
+returning `SQLITE_BUSY` back to Python — i.e. before the `progress=`
+callback (and therefore any deadline check inside it) gets a chance to run
+at all. Measured directly: with the connection default, an 8s external lock
+produced **exactly one** progress callback, ~8s in; with `timeout=0` on both
+connections, the same scenario produced ~8 callbacks at roughly the
+`backup()` retry cadence (250ms), and a deadline check inside the callback
+behaved as expected. Any fix for this bug must open both connections with
+`timeout=0` in the bounded path, or the deadline enforcement is
+coarse-grained and unreliable.
+
+## Why this is a separate bug from the chrome-debug ENOENT race
+
+The original bug report (`t_6f9583fe`) that spawned this investigation chain
+shows a clean 250.2s `hermes backup` run with only 6 ENOENT warnings — no
+indication of a multi-minute stall. This lock-contention behavior is not what
+that user hit; it was a latent risk surfaced by harder-than-normal
+interactive testing (rapid repeated tab open/close via CDP), confirmed here
+to also occur under completely idle conditions.
+
+## Verification performed for this RCA
+
+- Read CPython's `Modules/_sqlite/connection.c` (backup_impl) directly to
+  confirm the retry loop and its exact busy/locked exit conditions.
+- Deterministic isolated repro: background thread holds `BEGIN EXCLUSIVE`
+  for N seconds; unpatched `_safe_copy_db()` blocks for ~N seconds every
+  time, across multiple hold durations.
+- Confirmed connection `timeout=` does not bound `backup()`: explicit short
+  timeout (2s) vs. long external lock (8s) — `backup()` still took ~8s.
+- Live in-situ repro against the user's actual currently-locked
+  `chrome-debug/first_party_sets.db` (not synthetic): 61.4s real stall via
+  the real, unpatched `_safe_copy_db()`.
+- Cross-checked the user's separate personal Chrome profile's own
+  `first_party_sets.db`: also locked at the same moment, supporting the
+  "general Chrome/SQLite characteristic, not Hermes-specific" theory.
+- Isolated the `timeout=5.0` masking effect with a dedicated experiment
+  varying only the connection timeout (5.0 vs 0 vs 0.05) against an
+  identical 10s lock hold and a 2s deadline.

--- a/docs/rca-chrome-debug-transient-files-backup.md
+++ b/docs/rca-chrome-debug-transient-files-backup.md
@@ -1,0 +1,195 @@
+# RCA: `hermes backup` reports "Backup incomplete" due to transient chrome-debug files
+
+**Status:** root-caused; fix pending in a follow-up task (backup exclusion / warning reclassification).
+**Severity:** P3 — cosmetic/reporting bug. The produced backup archive is complete, valid, and restorable; only the human-facing summary label and log noise are wrong.
+
+## Summary
+
+When `hermes backup` (full zip backup, `hermes_cli/backup.py`) runs while the
+Hermes-launched debug Chrome process (`local.chrome-debug`, a `launchd`
+`KeepAlive` job listening on CDP port 9222, `--user-data-dir=~/.hermes/chrome-debug`)
+is active, the backup prints `Backup incomplete: <path>` and lists 2-6
+"Warnings" for files under `chrome-debug/` such as:
+
+```
+chrome-debug/BrowserMetrics-spare.pma: [Errno 2] No such file or directory
+chrome-debug/Default/Sessions/Session_<id>: [Errno 2] No such file or directory
+chrome-debug/Default/Sessions/Tabs_<id>: [Errno 2] No such file or directory
+chrome-debug/Default/shared_proto_db/000003.log: [Errno 2] No such file or directory
+```
+
+This reads as a failed backup to the user. **It is not.** The archive produced
+is 100% structurally valid, contains every file that still existed at write
+time, and is fully restorable. The "incomplete" framing is a labeling/reporting
+bug, not a data-integrity bug.
+
+## Root cause
+
+`hermes backup` runs in two phases, both in `hermes_cli/backup.py::_run_backup_locked`
+(the same pattern exists in the shared automatic-backup path,
+`_write_full_zip_backup_locked`, lines 1644-1735):
+
+1. **Scan** (`os.walk(hermes_root, ...)`, lines 625-648): builds an in-memory
+   list `files_to_add: list[(abs_path, rel_path)]` — a snapshot of what
+   existed *at scan time*. Fast: ~0.5-1s for ~5,800 files (confirmed in
+   `agent.log`: `backup phase=scan status=complete duration_ms=588.8 files=5782`).
+2. **Archive** (lines 696-744): iterates `files_to_add` and calls
+   `zf.write(abs_path, ...)` (or `_safe_copy_db()` for `*.db`) per file. This
+   phase is slow — 20s to 250s in the observed runs (`agent.log`:
+   `backup phase=archive status=complete duration_ms=250246.2 files=5783 errors=6`),
+   because it's doing real compression I/O on ~650MB of data.
+
+The Hermes-launched Chrome process (confirmed live via `ps` and
+`launchctl list`: PID actively running `Google Chrome --remote-debugging-port=9222
+--user-data-dir=/Users/eugenemettsler/.hermes/chrome-debug`, `KeepAlive=true`
+in `~/Library/LaunchAgents/local.chrome-debug.plist`) continuously rewrites
+its own profile directory while it runs:
+
+- `BrowserMetrics-spare.pma` — a pre-allocated "spare" metrics recording
+  buffer Chrome swaps in/out as it rotates the active metrics file.
+- `Default/Sessions/Session_<timestamp>` / `Tabs_<timestamp>` — tab/session
+  restore state, rewritten under a **new timestamped filename** on
+  navigation/tab events, with the old file deleted. Verified directly: the
+  original bug report's session ids (`Session_13430660839007907`,
+  `Session_13430660849807348`) differ completely from the ids present ~20
+  minutes later in a fresh repro (`Session_13430660950327711`,
+  `Tabs_13430660950772624`) — proof these are actively rotating, not static.
+- `Default/shared_proto_db/000003.log` — a LevelDB WAL segment, rotated away
+  during compaction.
+
+Because the scan snapshot and the archive write are seconds-to-minutes apart,
+a file that existed at scan time can be deleted/renamed by Chrome before
+`zf.write()` reaches it, raising `FileNotFoundError` ([Errno 2]).
+
+### Step 1: this part already works correctly
+
+The per-file archive loop (`hermes_cli/backup.py:699-724`) already wraps each
+write in:
+
+```python
+except (PermissionError, OSError, ValueError) as exc:
+    errors.append(f"  {rel_path}: {exc}")
+    continue
+```
+
+So a vanished file is caught, recorded, and skipped — the loop does **not**
+abort, and the zip write proceeds cleanly. This is confirmed directly:
+
+- Live repro (`hermes backup -o /tmp/backup-exitcode-test.zip` while
+  `local.chrome-debug` was running): process **exit code 0**, 3 files
+  skipped (same chrome-debug transient names), `Backup incomplete` printed.
+- `zipfile.ZipFile(...).testzip()` on both the repro archive and the
+  original ticket's own artifact (`/private/tmp/hermes-backup-test/full.zip`,
+  343,742,183 bytes) returns `None` (no CRC/corruption errors) — the archives
+  are intact.
+- The original ticket's archive contains 5,777 entries; the scan discovered
+  5,783 files; the delta is exactly 6 — matching the reported "6 files
+  skipped" 1:1. Nothing besides the vanished files is missing (verified
+  `kanban.db`, `config.yaml`, `.env`, etc. are all present).
+
+A secondary variant of the same race exists for the handful of `*.db` files
+under `chrome-debug/` (`first_party_sets.db`,
+`Default/heavy_ad_intervention_opt_out.db`,
+`Default/declarative_performance_observer.db`,
+`GPUPersistentCache/GPUCache/.../cache.db`): these go through
+`_safe_copy_db()` (lines 342-362) instead of a raw `zf.write`. If Chrome
+deletes/replaces one mid-copy, `_safe_copy_db` catches the exception
+internally, returns `False`, and the caller appends `"SQLite safe copy
+failed"` to the same `errors` list (line 717) — same underlying race,
+different error string, same downstream mislabeling below. Not observed in
+the two captured repros (no `.db` file happened to rotate in that window),
+but it is the same class of bug and should be covered by the same fix.
+
+### Step 2: this is what actually produces the reported "error"
+
+The summary/finalize block (`hermes_cli/backup.py:756-794`) is what the user
+sees and what produces the perceived failure:
+
+```python
+if errors:
+    print(f"Backup incomplete: {out_path}")   # line 759 — ALWAYS fires when
+else:                                          # errors list is non-empty,
+    print(f"Backup complete: {out_path}")      # regardless of whether the
+...                                             # archive is actually fine.
+if not errors:
+    print(f"\nRestore with: hermes import {out_path.name}")  # line 793-794 —
+                                                                # suppressed
+                                                                # whenever any
+                                                                # warning fired.
+```
+
+`errors` here is populated exclusively by benign, already-caught,
+already-logged per-file skip events — there is no code path today that
+distinguishes "a file vanished out from under us mid-backup (harmless)" from
+"a file we genuinely could not read (permissions, disk error, real
+problem)". Both land in the same list, both flip the summary to
+`Backup incomplete`, and both suppress the restore hint. This is the exact
+"final backup error" the bug report describes: **the finalizing/reporting
+step, not scanning or zipping**, is what turns 6 harmless, already-handled
+warnings into a message that reads as a failed backup — even though the
+archive is complete and restorable.
+
+The `hermes update`/`hermes claw migrate` automatic-backup path
+(`_write_full_zip_backup_locked`, lines 1644-1735) has the equivalent
+`errors`-counting behavior but currently only logs at `debug` level per file
+(line 1713) and doesn't surface a user-facing summary at all — lower
+visibility, same underlying unclassified-warning behavior.
+
+## Why this is not the Chrome-respawn bug
+
+This root cause is independent of whether the separate Chrome
+auto-respawn/KeepAlive issue (tracked in the sibling investigation/fix tasks)
+gets fixed. Even a one-shot, user-controlled Chrome session actively browsing
+during a backup would hit the same scan-then-archive race on the same
+transient files. The backup step needs to tolerate a running Chrome
+regardless of the respawn behavior.
+
+## Recommended fix direction (for the follow-up fix task)
+
+Two complementary changes, both low-risk:
+
+1. **Exclude known-transient chrome-debug subpaths from the backup walk**,
+   the same way `_EXCLUDED_DIRS`/`_EXCLUDED_NAMES` already exclude
+   `__pycache__`, `.venv`, etc. (`hermes_cli/backup.py:55-96`). Candidates:
+   `chrome-debug/BrowserMetrics-spare.pma`,
+   `chrome-debug/*/Sessions/`, `chrome-debug/*/shared_proto_db/`. None of
+   this data has restore value — it's Chrome's own transient
+   telemetry/session-restore/LevelDB-WAL state, regenerated on next launch,
+   analogous to why `.venv`/`__pycache__` are already excluded as
+   "regeneratable, not irreplaceable state." This directly eliminates the
+   warning noise in the common case.
+2. **Reclassify vanished-mid-backup (`ENOENT`/`FileNotFoundError`) as an
+   explicit "transient, skipped" bucket, separate from `errors`**, at both
+   the raw-write catch (line 722-724) and the SQLite-copy catch (line
+   711-718). Only non-ENOENT failures (permissions, disk errors, genuine
+   SQLite corruption) should flip the summary to `Backup incomplete` /
+   suppress the restore hint. This is defense-in-depth for any other
+   external process racing the backup in the future, not just Chrome.
+
+Both changes are additive to the existing exclusion/error-handling
+machinery already in `hermes_cli/backup.py` — no structural change to the
+scan/archive/finalize flow is needed.
+
+## Verification performed for this RCA
+
+- Confirmed `local.chrome-debug` launchd job definition and live process via
+  `launchctl list` / `ps aux` (`KeepAlive=true`,
+  `--user-data-dir=/Users/eugenemettsler/.hermes/chrome-debug`,
+  `--remote-debugging-port=9222`).
+- Live-reran `hermes backup` while that Chrome process was active; captured
+  exit code (0) and the exact same class of chrome-debug ENOENT warnings.
+- Verified archive integrity with `zipfile.testzip()` on both the fresh
+  repro archive and the original ticket's archive (`full.zip`,
+  343,742,183 bytes) — both `None` (no corruption).
+- Cross-checked file counts: original ticket scan found 5,783 files, zip
+  contains 5,777 entries, delta 6 == reported "6 files skipped", confirming
+  no files beyond the reported warnings were affected.
+- Confirmed the session/tab filenames are actively rotating (different
+  Session_*/Tabs_* ids between the original report and a fresh repro ~20
+  minutes later), proving the transient-file theory rather than a static
+  missing-file bug.
+- Read `hermes_cli/backup.py` end to end for both the interactive
+  (`run_backup`/`_run_backup_locked`) and automatic
+  (`_write_full_zip_backup`/`_write_full_zip_backup_locked`) backup paths to
+  confirm both share the same scan-then-archive structure and the same
+  unclassified-`errors` reporting gap.

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -396,19 +396,123 @@ def _should_skip_backup_file(abs_path: Path, rel_path: Path, out_path: Path) -> 
 # SQLite safe copy
 # ---------------------------------------------------------------------------
 
+# ``sqlite3.Connection.backup()`` retries SQLITE_BUSY/SQLITE_LOCKED with
+# ``time.sleep()`` inside CPython's C implementation
+# (Modules/_sqlite/connection.c: a ``do { sqlite3_backup_step(); if (BUSY or
+# LOCKED) sqlite3_sleep(); } while (OK or BUSY or LOCKED)`` loop) with NO
+# overall deadline. The ``timeout=`` a connection is opened with only bounds
+# the *initial* lock acquisition for ordinary statements -- it has no effect
+# on this loop at all, confirmed empirically: opening both sides with
+# timeout=2 and holding an external BEGIN EXCLUSIVE for 8s still blocks
+# backup() for the full 8s. Left unbounded, a source `.db` that stays
+# SQLITE_BUSY (observed in the wild against Chrome's own
+# ``first_party_sets.db`` under ``chrome-debug/``, including a live 61s
+# in-situ hang against a real lock, and even against the user's separate
+# personal Chrome profile's copy of the same file -- so this is a Chrome/
+# SQLite locking characteristic, not specific to the Hermes-managed
+# profile) can stall the entire ``hermes backup`` run for as long as the
+# lock is held.
+#
+# Bounded via the ``progress=`` callback, which CPython invokes after
+# *every* ``sqlite3_backup_step()`` call including ones that returned BUSY/
+# LOCKED, and which can raise to abort the backup cleanly (CPython's own
+# comment: "Callback failed: abort backup and bail" -- it still calls
+# ``sqlite3_backup_finish()`` internally, so no handle is leaked). The
+# deadline check is gated on ``status in (SQLITE_BUSY, SQLITE_LOCKED)``,
+# NOT on raw elapsed time: with the default ``pages=-1`` a healthy,
+# uncontended copy -- however large -- completes in a single
+# ``sqlite3_backup_step()`` call, and the progress callback only fires
+# *after* that (possibly slow, for a many-GB state.db) step finishes. A
+# time-only check would wrongly discard an already-successful large,
+# non-busy copy; gating on status keeps the deadline meaningful only for
+# genuine lock contention. Confirmed both properties experimentally: a
+# genuinely-busy source is aborted well before an 8-10s external lock would
+# clear, while an 87 MB non-busy source completes normally even against a
+# 1ms deadline.
+#
+# See the ``timeout=0`` comment inside ``_safe_copy_db`` below for a
+# second, easy-to-miss piece this fix depends on: the connections used in
+# the bounded path must NOT use ``sqlite3.connect()``'s default 5s
+# ``timeout=``, or SQLite's own internal busy-handler silently absorbs the
+# wait *inside* a single backup_step() call before our callback ever runs.
+_SAFE_COPY_BUSY_DEADLINE_SECONDS = 30.0
+_SQLITE_BUSY_STATUSES = (sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED)
+
+
+class _SafeCopyBusyTimeout(Exception):
+    """Raised from the backup() progress callback past the busy deadline.
+
+    Plain ``Exception`` subclass so it's caught by the existing
+    ``except Exception as exc:`` in :func:`_safe_copy_db` with no change to
+    that function's control flow or return contract -- a busy-timeout abort
+    degrades to the same "safe copy failed" warning + ``False`` return as
+    any other backup() failure.
+    """
+
+
+def _resolve_safe_copy_busy_deadline_seconds() -> float:
+    """Busy/locked retry deadline for :func:`_safe_copy_db`, in seconds.
+
+    Override via ``HERMES_BACKUP_SQLITE_BUSY_DEADLINE_SECONDS`` (e.g. for
+    tests, or to disable bounding entirely with a non-positive value).
+    """
+    raw = os.environ.get("HERMES_BACKUP_SQLITE_BUSY_DEADLINE_SECONDS", "").strip()
+    if raw:
+        try:
+            return float(raw)
+        except ValueError:
+            pass
+    return _SAFE_COPY_BUSY_DEADLINE_SECONDS
+
+
 def _safe_copy_db(src: Path, dst: Path) -> bool:
     """Copy a SQLite database safely using the backup() API.
 
     Handles WAL mode — produces a consistent snapshot even while
     the DB is being written to. Fail closed if a consistent snapshot cannot
     be created: copying only the live main file can omit committed WAL data.
+
+    Bounded against a sustained SQLITE_BUSY/SQLITE_LOCKED source (see
+    ``_SAFE_COPY_BUSY_DEADLINE_SECONDS`` above) so one persistently-locked
+    file degrades to a skipped-with-warning outcome instead of stalling the
+    whole backup indefinitely. A non-positive deadline disables bounding
+    (retries indefinitely, the pre-fix behavior) for anyone who wants it.
     """
     conn = None
     backup_conn = None
+    deadline_seconds = _resolve_safe_copy_busy_deadline_seconds()
     try:
-        conn = sqlite3.connect(f"file:{src}?mode=ro", uri=True)
-        backup_conn = sqlite3.connect(str(dst))
-        conn.backup(backup_conn)
+        if deadline_seconds > 0:
+            # timeout=0 on BOTH sides is load-bearing here, not cosmetic:
+            # the connect()-level default (5.0) installs SQLite's own
+            # internal busy-handler, which silently retries *inside a
+            # single* sqlite3_backup_step() call for up to that many
+            # seconds before ever returning SQLITE_BUSY back to Python --
+            # i.e. before our progress callback below gets a chance to run
+            # at all. Measured directly: with the default timeout, an 8s
+            # external lock produced exactly ONE progress callback (after
+            # ~8s, because SQLite's own retries absorbed almost the whole
+            # wait), so a 2s deadline was checked too late to matter. With
+            # timeout=0, each step call fails fast on contention and
+            # control returns to the progress callback roughly every
+            # backup()'s own sleep= cadence (default 250ms), so the
+            # deadline below is enforced with the intended granularity.
+            conn = sqlite3.connect(f"file:{src}?mode=ro", uri=True, timeout=0)
+            backup_conn = sqlite3.connect(str(dst), timeout=0)
+            deadline = time.monotonic() + deadline_seconds
+
+            def _abort_past_deadline(status: int, remaining: int, total: int) -> None:
+                if status in _SQLITE_BUSY_STATUSES and time.monotonic() > deadline:
+                    raise _SafeCopyBusyTimeout(
+                        f"source stayed SQLITE_BUSY/SQLITE_LOCKED for over "
+                        f"{deadline_seconds:.0f}s (remaining={remaining}, total={total})"
+                    )
+
+            conn.backup(backup_conn, progress=_abort_past_deadline)
+        else:
+            conn = sqlite3.connect(f"file:{src}?mode=ro", uri=True)
+            backup_conn = sqlite3.connect(str(dst))
+            conn.backup(backup_conn)
         return True
     except Exception as exc:
         logger.warning("SQLite safe copy failed for %s: %s", src, exc)

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -477,6 +477,35 @@ def _safe_copy_db(src: Path, dst: Path) -> bool:
     file degrades to a skipped-with-warning outcome instead of stalling the
     whole backup indefinitely. A non-positive deadline disables bounding
     (retries indefinitely, the pre-fix behavior) for anyone who wants it.
+
+    Thin wrapper over :func:`_safe_copy_db_ex` that keeps this function's
+    long-standing plain-``bool`` contract for existing callers (e.g.
+    :func:`copy_db_and_verify`) that don't need to distinguish *why* a copy
+    failed.
+    """
+    return _safe_copy_db_ex(src, dst)[0]
+
+
+def _safe_copy_db_ex(src: Path, dst: Path) -> "tuple[bool, bool]":
+    """Like :func:`_safe_copy_db` but also reports *why* a copy failed.
+
+    Returns ``(success, was_busy_timeout)``. ``was_busy_timeout`` is True
+    only when the copy failed because the source stayed SQLITE_BUSY/LOCKED
+    past the bounded deadline (see ``_SAFE_COPY_BUSY_DEADLINE_SECONDS``
+    above) -- i.e. the source file itself is fine, just transiently locked
+    by another process. Observed in the wild against Chrome's own small
+    housekeeping databases (``first_party_sets.db``,
+    ``declarative_performance_observer.db``) under a live ``chrome-debug/``
+    profile: with the busy-retry now bounded (instead of hanging
+    indefinitely), an abort past the deadline was still being classified as
+    a hard failure identically to genuine corruption, which flipped
+    ``hermes backup``'s summary to "Backup incomplete" again -- just via a
+    different file than the original ENOENT-based report. Callers that
+    distinguish "benign, skip with a warning" from "genuine failure"
+    (corrupt file, permissions, disk error) should treat a busy-timeout the
+    same as a vanished-file skip, not as a hard error. See
+    docs/rca-chrome-debug-transient-files-backup.md and
+    docs/rca-backup-sqlite-busy-retry-unbounded.md.
     """
     conn = None
     backup_conn = None
@@ -513,14 +542,21 @@ def _safe_copy_db(src: Path, dst: Path) -> bool:
             conn = sqlite3.connect(f"file:{src}?mode=ro", uri=True)
             backup_conn = sqlite3.connect(str(dst))
             conn.backup(backup_conn)
-        return True
+        return True, False
+    except _SafeCopyBusyTimeout as exc:
+        logger.warning("SQLite safe copy skipped for %s (busy/locked): %s", src, exc)
+        try:
+            dst.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return False, True
     except Exception as exc:
         logger.warning("SQLite safe copy failed for %s: %s", src, exc)
         try:
             dst.unlink(missing_ok=True)
         except OSError:
             pass
-        return False
+        return False, False
     finally:
         for connection in (backup_conn, conn):
             if connection is not None:
@@ -880,7 +916,8 @@ def _run_backup_locked(args, hermes_root: Path) -> None:
                         suffix=".db", delete=False, dir=str(out_path.parent)
                     ) as tmp:
                         tmp_db = Path(tmp.name)
-                    if _safe_copy_db(abs_path, tmp_db):
+                    copy_ok, was_busy_timeout = _safe_copy_db_ex(abs_path, tmp_db)
+                    if copy_ok:
                         zf.write(tmp_db, arcname=str(rel_path))
                         total_bytes += tmp_db.stat().st_size
                         tmp_db.unlink(missing_ok=True)
@@ -893,7 +930,23 @@ def _run_backup_locked(args, hermes_root: Path) -> None:
                         # if the source is gone right after the failed copy,
                         # it almost certainly vanished mid-copy rather than
                         # being genuinely corrupt.
-                        if abs_path.exists():
+                        #
+                        # A busy-timeout abort (was_busy_timeout=True) is the
+                        # same "benign, not a real failure" story: the file
+                        # is present and healthy, just transiently locked by
+                        # another process (observed against Chrome's own
+                        # first_party_sets.db / declarative_performance_
+                        # observer.db under chrome-debug/). Treat it like a
+                        # vanished-file skip, not a hard error -- otherwise
+                        # the now-bounded busy-retry (previously an
+                        # indefinite hang) just trades one "Backup
+                        # incomplete" cause for another. See
+                        # docs/rca-backup-sqlite-busy-retry-unbounded.md.
+                        if was_busy_timeout:
+                            transient_skipped.append(
+                                f"  {rel_path}: temporarily locked by another process, skipped"
+                            )
+                        elif abs_path.exists():
                             errors.append(f"  {rel_path}: SQLite safe copy failed")
                         else:
                             transient_skipped.append(
@@ -1908,7 +1961,8 @@ def _write_full_zip_backup_locked(out_path: Path, hermes_root: Path) -> Optional
                         ) as tmp:
                             tmp_db = Path(tmp.name)
                         try:
-                            if not _safe_copy_db(abs_path, tmp_db):
+                            copy_ok, was_busy_timeout = _safe_copy_db_ex(abs_path, tmp_db)
+                            if not copy_ok:
                                 # A source file that has vanished since the scan
                                 # phase (most commonly a chrome-debug/*.db file
                                 # rewritten by a live Chrome process racing this
@@ -1918,6 +1972,25 @@ def _write_full_zip_backup_locked(out_path: Path, hermes_root: Path) -> Optional
                                 # failure: only abort the whole archive when the
                                 # file still exists but genuinely couldn't be
                                 # snapshotted (locked, corrupt, permissions).
+                                #
+                                # A busy-timeout abort (was_busy_timeout=True)
+                                # is the same "benign" story: the file is
+                                # present and healthy, just transiently locked
+                                # by another process (observed against
+                                # Chrome's own first_party_sets.db under
+                                # chrome-debug/ once the busy-retry was bounded
+                                # instead of hanging indefinitely -- see
+                                # docs/rca-backup-sqlite-busy-retry-unbounded.md).
+                                # Skip just this file instead of aborting the
+                                # entire archive.
+                                if was_busy_timeout:
+                                    logger.warning(
+                                        "Full-zip backup: %s temporarily locked by "
+                                        "another process, skipping (transient)",
+                                        rel_path,
+                                    )
+                                    transient_skipped += 1
+                                    continue
                                 if not abs_path.exists():
                                     logger.warning(
                                         "Full-zip backup: %s vanished before it "

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -95,6 +95,54 @@ _EXCLUDED_NAMES = {
     "cron.pid",
 }
 
+# ---------------------------------------------------------------------------
+# Chrome-debug transient state
+# ---------------------------------------------------------------------------
+# The Hermes-managed debug Chrome profile (``chrome-debug/`` at the top level
+# of HERMES_HOME -- see ``chrome_debug_data_dir()`` in
+# ``hermes_cli/browser_connect.py``) is continuously rewritten by Chrome
+# itself while a debug session is active: UMA metrics buffers, per-tab
+# session-restore state, and LevelDB WAL segments are swapped/rotated/deleted
+# with no advance notice. None of this data has restore value -- it's
+# regenerated from scratch on the next Chrome launch -- and the constant
+# churn means a scan-then-archive backup can observe a file that existed at
+# scan time vanish before the archive-write phase reaches it, raising a
+# harmless ``FileNotFoundError`` (see
+# docs/rca-chrome-debug-transient-files-backup.md).
+#
+# Excluding these subpaths up front eliminates the race in the common case
+# *and* lets ``os.walk`` skip descending into them entirely (faster scans).
+# Both are scoped to fire only when rooted under the top-level
+# ``chrome-debug/`` directory so a same-named directory elsewhere under
+# HERMES_HOME (e.g. a skill's own ``Sessions`` folder) is never affected.
+_CHROME_DEBUG_ROOT_DIR = "chrome-debug"
+
+_CHROME_DEBUG_TRANSIENT_DIRS = {
+    "Sessions",         # Default/Sessions/Session_<id>, Tabs_<id> -- tab/session
+                         # restore state, rewritten under a new timestamped
+                         # filename on every navigation/tab event.
+    "shared_proto_db",  # Default/shared_proto_db/*.log, *.ldb -- LevelDB WAL,
+                         # rotated away during compaction.
+    "BrowserMetrics",   # BrowserMetrics/*.pma -- UMA metrics recording buffer.
+}
+
+_CHROME_DEBUG_TRANSIENT_FILES = {
+    # Pre-allocated "spare" metrics buffer Chrome swaps in/out as it rotates
+    # the active BrowserMetrics file.
+    "BrowserMetrics-spare.pma",
+}
+
+
+def _is_chrome_debug_transient_dir(rel_dir: Path, dirname: str) -> bool:
+    """True if *dirname* directly under *rel_dir* is known-transient,
+    regenerable Chrome-internal state that ``os.walk`` should prune before
+    descending (see ``_CHROME_DEBUG_TRANSIENT_DIRS`` above)."""
+    if dirname not in _CHROME_DEBUG_TRANSIENT_DIRS:
+        return False
+    parts = rel_dir.parts
+    return bool(parts) and parts[0] == _CHROME_DEBUG_ROOT_DIR
+
+
 # File names that ``hermes import`` must never overwrite, matched by basename so
 # they're caught for the root profile (``gateway_state.json``) and for named
 # profiles alike (``profiles/<name>/gateway_state.json``).
@@ -307,6 +355,15 @@ def _should_exclude(rel_path: Path) -> bool:
         if part == "hermes-agent" and part != parts[0]:
             continue
         return True
+
+    # Chrome-debug transient state (see ``_CHROME_DEBUG_TRANSIENT_DIRS``
+    # above): scoped to fire only under the top-level ``chrome-debug/`` dir so
+    # a same-named directory elsewhere under HERMES_HOME is never affected.
+    if parts and parts[0] == _CHROME_DEBUG_ROOT_DIR:
+        if any(part in _CHROME_DEBUG_TRANSIENT_DIRS for part in parts[1:]):
+            return True
+        if rel_path.name in _CHROME_DEBUG_TRANSIENT_FILES:
+            return True
 
     name = rel_path.name
 
@@ -633,7 +690,8 @@ def _run_backup_locked(args, hermes_root: Path) -> None:
         orig_dirnames = dirnames[:]
         dirnames[:] = [
             d for d in dirnames
-            if d not in _EXCLUDED_DIRS or (d == "hermes-agent" and not is_root)
+            if (d not in _EXCLUDED_DIRS or (d == "hermes-agent" and not is_root))
+            and not _is_chrome_debug_transient_dir(rel_dir, d)
         ]
         for removed in set(orig_dirnames) - set(dirnames):
             skipped_dirs.add(str(rel_dir / removed))
@@ -691,6 +749,16 @@ def _run_backup_locked(args, hermes_root: Path) -> None:
 
     total_bytes = 0
     errors = []
+    # Files that existed at scan time but vanished (ENOENT) before the slow
+    # archive-write phase reached them -- typically a live process (most
+    # commonly the Hermes-managed chrome-debug profile) rewriting its own
+    # transient state concurrently with the backup. Tracked separately from
+    # ``errors``: these are logged as warnings but must never flip the
+    # summary to "incomplete" or suppress the restore hint, because the
+    # archive itself is still complete and valid for every file that still
+    # existed when we got to it. See
+    # docs/rca-chrome-debug-transient-files-backup.md.
+    transient_skipped = []
     t0 = time.monotonic()
 
     with _atomic_output_path(out_path) as archive_path, zipfile.ZipFile(
@@ -714,11 +782,27 @@ def _run_backup_locked(args, hermes_root: Path) -> None:
                         tmp_db.unlink(missing_ok=True)
                     else:
                         tmp_db.unlink(missing_ok=True)
-                        errors.append(f"  {rel_path}: SQLite safe copy failed")
+                        # sqlite3.connect() raises a generic OperationalError
+                        # for a missing source file (not FileNotFoundError),
+                        # so _safe_copy_db can't tell us "vanished" directly.
+                        # A post-hoc existence check is a good enough proxy:
+                        # if the source is gone right after the failed copy,
+                        # it almost certainly vanished mid-copy rather than
+                        # being genuinely corrupt.
+                        if abs_path.exists():
+                            errors.append(f"  {rel_path}: SQLite safe copy failed")
+                        else:
+                            transient_skipped.append(
+                                f"  {rel_path}: vanished before it could be safely copied"
+                            )
                         continue
                 else:
                     zf.write(abs_path, arcname=str(rel_path))
                     total_bytes += abs_path.stat().st_size
+            except FileNotFoundError as exc:
+                # Benign scan-then-archive race, not a real failure.
+                transient_skipped.append(f"  {rel_path}: {exc}")
+                continue
             except (PermissionError, OSError, ValueError) as exc:
                 errors.append(f"  {rel_path}: {exc}")
                 continue
@@ -739,6 +823,9 @@ def _run_backup_locked(args, hermes_root: Path) -> None:
             try:
                 zf.write(abs_path, arcname=arcname)
                 total_bytes += abs_path.stat().st_size
+            except FileNotFoundError as exc:
+                transient_skipped.append(f"  {arcname}: {exc}")
+                continue
             except (PermissionError, OSError, ValueError) as exc:
                 errors.append(f"  {arcname}: {exc}")
                 continue
@@ -746,10 +833,11 @@ def _run_backup_locked(args, hermes_root: Path) -> None:
     elapsed = time.monotonic() - t0
     zip_size = out_path.stat().st_size
     logger.info(
-        "backup phase=archive status=complete duration_ms=%.1f files=%d errors=%d bytes=%d",
+        "backup phase=archive status=complete duration_ms=%.1f files=%d errors=%d transient_skipped=%d bytes=%d",
         elapsed * 1000,
         file_count,
         len(errors),
+        len(transient_skipped),
         zip_size,
     )
 
@@ -782,6 +870,16 @@ def _run_backup_locked(args, hermes_root: Path) -> None:
         print("\n  Excluded directories:")
         for d in sorted(skipped_dirs):
             print(f"    {d}/")
+
+    if transient_skipped:
+        print(
+            f"\n  Note ({len(transient_skipped)} file(s) changed during backup, "
+            "harmless -- nothing to restore there):"
+        )
+        for w in transient_skipped[:10]:
+            print(w)
+        if len(transient_skipped) > 10:
+            print(f"  ... and {len(transient_skipped) - 10} more")
 
     if errors:
         print(f"\n  Warnings ({len(errors)} files skipped):")
@@ -1654,8 +1752,15 @@ def _write_full_zip_backup_locked(out_path: Path, hermes_root: Path) -> Optional
     try:
         for dirpath, dirnames, filenames in os.walk(hermes_root, followlinks=False):
             dp = Path(dirpath)
+            try:
+                rel_dir = dp.relative_to(hermes_root)
+            except ValueError:
+                rel_dir = Path(".")
             # Prune excluded directories in-place so os.walk doesn't descend
-            dirnames[:] = [d for d in dirnames if d not in _EXCLUDED_DIRS]
+            dirnames[:] = [
+                d for d in dirnames
+                if d not in _EXCLUDED_DIRS and not _is_chrome_debug_transient_dir(rel_dir, d)
+            ]
 
             for fname in filenames:
                 fpath = dp / fname
@@ -1682,6 +1787,7 @@ def _write_full_zip_backup_locked(out_path: Path, hermes_root: Path) -> Optional
     )
 
     archive_started = time.monotonic()
+    transient_skipped = 0
     try:
         with _atomic_output_path(out_path) as archive_path, zipfile.ZipFile(
             archive_path, "w", zipfile.ZIP_DEFLATED, compresslevel=6
@@ -1699,6 +1805,23 @@ def _write_full_zip_backup_locked(out_path: Path, hermes_root: Path) -> Optional
                             tmp_db = Path(tmp.name)
                         try:
                             if not _safe_copy_db(abs_path, tmp_db):
+                                # A source file that has vanished since the scan
+                                # phase (most commonly a chrome-debug/*.db file
+                                # rewritten by a live Chrome process racing this
+                                # backup -- see
+                                # docs/rca-chrome-debug-transient-files-backup.md)
+                                # is a benign, already-logged skip, not a real
+                                # failure: only abort the whole archive when the
+                                # file still exists but genuinely couldn't be
+                                # snapshotted (locked, corrupt, permissions).
+                                if not abs_path.exists():
+                                    logger.warning(
+                                        "Full-zip backup: %s vanished before it "
+                                        "could be safely copied, skipping (transient)",
+                                        rel_path,
+                                    )
+                                    transient_skipped += 1
+                                    continue
                                 logger.warning(
                                     "Full-zip backup aborted: SQLite snapshot failed for %s",
                                     rel_path,
@@ -1709,6 +1832,15 @@ def _write_full_zip_backup_locked(out_path: Path, hermes_root: Path) -> Optional
                             tmp_db.unlink(missing_ok=True)
                     else:
                         zf.write(abs_path, arcname=str(rel_path))
+                except FileNotFoundError as exc:
+                    # Benign scan-then-archive race, not a real failure.
+                    logger.warning(
+                        "Full-zip backup: %s vanished during archiving, skipping (transient): %s",
+                        rel_path,
+                        exc,
+                    )
+                    transient_skipped += 1
+                    continue
                 except (PermissionError, OSError, ValueError) as exc:
                     logger.debug("Skipping %s in zip backup: %s", rel_path, exc)
                     continue
@@ -1726,9 +1858,10 @@ def _write_full_zip_backup_locked(out_path: Path, hermes_root: Path) -> Optional
         return None
 
     logger.info(
-        "automatic backup phase=archive status=complete duration_ms=%.1f files=%d bytes=%d",
+        "automatic backup phase=archive status=complete duration_ms=%.1f files=%d transient_skipped=%d bytes=%d",
         (time.monotonic() - archive_started) * 1000,
         len(files_to_add),
+        transient_skipped,
         out_path.stat().st_size,
     )
 

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -133,6 +133,280 @@ class TestShouldExclude:
         # The .db itself is still included (and safe-copied separately)
         assert not _should_exclude(Path("state.db"))
 
+    def test_excludes_chrome_debug_transient_subpaths(self):
+        """Chrome's own transient profile churn (metrics buffer, per-tab
+        session-restore state, LevelDB WAL segments) is excluded outright so
+        the scan-then-archive race that produces spurious ENOENT warnings
+        (see docs/rca-chrome-debug-transient-files-backup.md) never fires in
+        the common case."""
+        from hermes_cli.backup import _should_exclude
+        assert _should_exclude(Path("chrome-debug/BrowserMetrics-spare.pma"))
+        assert _should_exclude(
+            Path("chrome-debug/Default/Sessions/Session_13430660839007907")
+        )
+        assert _should_exclude(
+            Path("chrome-debug/Default/Sessions/Tabs_13430660850173240")
+        )
+        assert _should_exclude(
+            Path("chrome-debug/Default/shared_proto_db/000003.log")
+        )
+        assert _should_exclude(
+            Path("chrome-debug/BrowserMetrics/BrowserMetrics-6A771AF3-8DD9.pma")
+        )
+
+    def test_chrome_debug_exclusion_is_scoped_to_top_level_dir(self):
+        """The exclusion must not blanket-match ``Sessions``/``shared_proto_db``
+        directories that happen to live somewhere else under HERMES_HOME —
+        only paths actually rooted under the top-level ``chrome-debug/``
+        profile are transient Chrome state."""
+        from hermes_cli.backup import _should_exclude
+        assert not _should_exclude(Path("skills/my-skill/Sessions/keep.txt"))
+        assert not _should_exclude(Path("Sessions/keep.txt"))
+        assert not _should_exclude(
+            Path("profiles/other/chrome-debug/BrowserMetrics-spare.pma")
+        )
+        # A regular, non-transient file inside chrome-debug/ is unaffected.
+        assert not _should_exclude(Path("chrome-debug/Default/Cookies"))
+
+
+# ---------------------------------------------------------------------------
+# Chrome-debug transient-file race: archive loop must warn, not fail
+# ---------------------------------------------------------------------------
+
+class TestChromeDebugTransientRace:
+    """Regression coverage for the backup-failure investigation: a file that
+    existed at scan time but is deleted by a live process (typically the
+    Hermes-managed chrome-debug Chrome) before the archive-write phase
+    reaches it must be logged as a warning and MUST NOT flip the summary to
+    "Backup incomplete" or suppress the restore hint."""
+
+    def test_vanished_file_is_warning_not_fatal(self, tmp_path, monkeypatch, capsys):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        _make_hermes_tree(hermes_home)
+
+        # A file that exists at scan time but is deleted before zf.write()
+        # reaches it, simulating the chrome-debug scan-then-archive race.
+        vanishing = hermes_home / "chrome-debug-sim" / "will-vanish.txt"
+        vanishing.parent.mkdir(parents=True, exist_ok=True)
+        vanishing.write_text("ephemeral")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        import hermes_cli.backup as backup_mod
+        real_write = zipfile.ZipFile.write
+
+        def flaky_write(self, filename, arcname=None, *a, **kw):
+            if str(filename) == str(vanishing):
+                vanishing.unlink()
+            return real_write(self, filename, arcname, *a, **kw)
+
+        monkeypatch.setattr(zipfile.ZipFile, "write", flaky_write)
+
+        out_zip = tmp_path / "backup.zip"
+        backup_mod.run_backup(Namespace(output=str(out_zip)))
+
+        out = capsys.readouterr().out
+        assert "Backup complete:" in out
+        assert "Backup incomplete" not in out
+        assert "Restore with:" in out
+        assert "changed during backup" in out
+        assert "will-vanish.txt" in out
+
+        # The archive itself must still be valid.
+        assert out_zip.exists()
+        with zipfile.ZipFile(out_zip) as zf:
+            assert zf.testzip() is None
+            assert "chrome-debug-sim/will-vanish.txt" not in zf.namelist()
+
+    def test_genuine_permission_error_still_reported_as_warning_error(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """A real (non-ENOENT) failure must still land in the ``errors``
+        bucket and flip the summary to incomplete -- only transient
+        vanished-file races are downgraded."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        _make_hermes_tree(hermes_home)
+
+        target = hermes_home / "unreadable.txt"
+        target.write_text("secret")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        import hermes_cli.backup as backup_mod
+        real_write = zipfile.ZipFile.write
+
+        def boom(self, filename, arcname=None, *a, **kw):
+            if str(filename) == str(target):
+                raise PermissionError(13, "Permission denied", str(filename))
+            return real_write(self, filename, arcname, *a, **kw)
+
+        monkeypatch.setattr(zipfile.ZipFile, "write", boom)
+
+        out_zip = tmp_path / "backup.zip"
+        backup_mod.run_backup(Namespace(output=str(out_zip)))
+
+        out = capsys.readouterr().out
+        assert "Backup incomplete:" in out
+        assert "Restore with:" not in out
+        assert "Warnings (1 files skipped)" in out
+        assert "unreadable.txt" in out
+
+    def test_vanished_db_file_skipped_not_fatal(self, tmp_path, monkeypatch, capsys):
+        """A .db file that vanishes between scan and the safe-copy attempt
+        (chrome-debug/*.db under a live Chrome process) must be skipped as
+        transient, not reported as a SQLite copy failure."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        _make_hermes_tree(hermes_home)
+
+        db_path = hermes_home / "vanishing.db"
+        db_path.write_bytes(b"not-actually-sqlite")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        import hermes_cli.backup as backup_mod
+
+        def vanish_then_fail(src, dst):
+            Path(src).unlink(missing_ok=True)
+            return False
+
+        monkeypatch.setattr(backup_mod, "_safe_copy_db", vanish_then_fail)
+
+        out_zip = tmp_path / "backup.zip"
+        backup_mod.run_backup(Namespace(output=str(out_zip)))
+
+        out = capsys.readouterr().out
+        assert "Backup complete:" in out
+        assert "Backup incomplete" not in out
+        assert "vanished before it could be safely copied" in out
+
+    def test_still_existing_db_copy_failure_is_fatal_warning(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """A .db file that is present but genuinely fails to safe-copy
+        (locked, corrupt) must still surface as an error, distinguishing it
+        from the vanished-mid-copy case above."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        _make_hermes_tree(hermes_home)
+
+        db_path = hermes_home / "locked.db"
+        db_path.write_bytes(b"not-actually-sqlite")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        import hermes_cli.backup as backup_mod
+        monkeypatch.setattr(backup_mod, "_safe_copy_db", lambda src, dst: False)
+
+        out_zip = tmp_path / "backup.zip"
+        backup_mod.run_backup(Namespace(output=str(out_zip)))
+
+        out = capsys.readouterr().out
+        assert "Backup incomplete:" in out
+        assert "SQLite safe copy failed" in out
+        assert "locked.db" in out
+
+    def test_automatic_backup_skips_vanished_file_instead_of_failing(
+        self, tmp_path, monkeypatch
+    ):
+        """The shared pre-update/pre-migration path (_write_full_zip_backup)
+        must tolerate the same scan-then-archive race: a vanished plain file
+        should be skipped, and the archive should still be produced."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        _make_hermes_tree(hermes_home)
+
+        vanishing = hermes_home / "chrome-debug-sim" / "will-vanish.txt"
+        vanishing.parent.mkdir(parents=True, exist_ok=True)
+        vanishing.write_text("ephemeral")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        import hermes_cli.backup as backup_mod
+        real_write = zipfile.ZipFile.write
+
+        def flaky_write(self, filename, arcname=None, *a, **kw):
+            if str(filename) == str(vanishing):
+                vanishing.unlink()
+            return real_write(self, filename, arcname, *a, **kw)
+
+        monkeypatch.setattr(zipfile.ZipFile, "write", flaky_write)
+
+        out_zip = tmp_path / "automatic.zip"
+        result = backup_mod._write_full_zip_backup(out_zip, hermes_home)
+
+        assert result == out_zip
+        assert out_zip.exists()
+        with zipfile.ZipFile(out_zip) as zf:
+            assert zf.testzip() is None
+            assert "chrome-debug-sim/will-vanish.txt" not in zf.namelist()
+            # Other, non-vanishing files from the tree still made it in.
+            assert "config.yaml" in zf.namelist()
+
+    def test_automatic_backup_skips_vanished_db_instead_of_aborting(
+        self, tmp_path, monkeypatch
+    ):
+        """A vanished .db file in the automatic backup path must be skipped,
+        not raise _SQLiteSnapshotError and abort the whole archive -- that
+        would silently drop every other file behind it in the walk order."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        _make_hermes_tree(hermes_home)
+
+        db_path = hermes_home / "vanishing.db"
+        db_path.write_bytes(b"not-actually-sqlite")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        import hermes_cli.backup as backup_mod
+
+        def vanish_then_fail(src, dst):
+            Path(src).unlink(missing_ok=True)
+            return False
+
+        monkeypatch.setattr(backup_mod, "_safe_copy_db", vanish_then_fail)
+
+        out_zip = tmp_path / "automatic.zip"
+        result = backup_mod._write_full_zip_backup(out_zip, hermes_home)
+
+        # Must still succeed and produce a complete archive of everything
+        # else, rather than returning None (the old abort-on-vanish behavior).
+        assert result == out_zip
+        assert out_zip.exists()
+        with zipfile.ZipFile(out_zip) as zf:
+            assert zf.testzip() is None
+            assert "vanishing.db" not in zf.namelist()
+            assert "config.yaml" in zf.namelist()
+
+    def test_automatic_backup_still_aborts_on_genuine_db_failure(
+        self, tmp_path, monkeypatch
+    ):
+        """A .db file that is present but genuinely fails to safe-copy must
+        still abort the automatic backup and preserve the previous archive
+        -- this is the existing #68474-adjacent protection and must not
+        regress just because vanished files are now tolerated."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "state.db").write_bytes(b"not-a-database")
+        archive = tmp_path / "automatic.zip"
+        archive.write_bytes(b"previous-valid-backup")
+
+        monkeypatch.setattr(
+            "hermes_cli.backup._safe_copy_db", lambda _src, _dst: False
+        )
+
+        from hermes_cli.backup import _write_full_zip_backup
+        assert _write_full_zip_backup(archive, hermes_home) is None
+        assert archive.read_bytes() == b"previous-valid-backup"
+
 
 # ---------------------------------------------------------------------------
 # Backup tests

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -274,9 +274,9 @@ class TestChromeDebugTransientRace:
 
         def vanish_then_fail(src, dst):
             Path(src).unlink(missing_ok=True)
-            return False
+            return False, False
 
-        monkeypatch.setattr(backup_mod, "_safe_copy_db", vanish_then_fail)
+        monkeypatch.setattr(backup_mod, "_safe_copy_db_ex", vanish_then_fail)
 
         out_zip = tmp_path / "backup.zip"
         backup_mod.run_backup(Namespace(output=str(out_zip)))
@@ -371,9 +371,9 @@ class TestChromeDebugTransientRace:
 
         def vanish_then_fail(src, dst):
             Path(src).unlink(missing_ok=True)
-            return False
+            return False, False
 
-        monkeypatch.setattr(backup_mod, "_safe_copy_db", vanish_then_fail)
+        monkeypatch.setattr(backup_mod, "_safe_copy_db_ex", vanish_then_fail)
 
         out_zip = tmp_path / "automatic.zip"
         result = backup_mod._write_full_zip_backup(out_zip, hermes_home)
@@ -1104,6 +1104,126 @@ class TestSafeCopyDbBusyBounding:
 
         assert result is True
         assert elapsed >= 1.2, "disabled bounding should still wait out the lock"
+
+    def test_safe_copy_db_ex_reports_busy_timeout(self, tmp_path, monkeypatch):
+        """``_safe_copy_db_ex`` must flag a busy-deadline abort distinctly
+        from other failures, so callers can treat it as benign (skip with a
+        warning) instead of a hard error. Regression guard for the "Backup
+        incomplete" summary reappearing via a different file (Chrome's own
+        first_party_sets.db / declarative_performance_observer.db) once the
+        busy-retry itself was bounded instead of hanging indefinitely."""
+        import threading
+
+        from hermes_cli.backup import _safe_copy_db_ex
+
+        monkeypatch.setenv("HERMES_BACKUP_SQLITE_BUSY_DEADLINE_SECONDS", "0.5")
+
+        src = tmp_path / "locked.db"
+        dst = tmp_path / "copy.db"
+        self._make_source_db(src)
+
+        ready_evt = threading.Event()
+        holder = threading.Thread(
+            target=self._hold_exclusive_lock, args=(src, 3.0, ready_evt), daemon=True
+        )
+        holder.start()
+        assert ready_evt.wait(timeout=5)
+
+        success, was_busy_timeout = _safe_copy_db_ex(src, dst)
+        holder.join(timeout=10)
+
+        assert success is False
+        assert was_busy_timeout is True
+        assert not dst.exists()
+
+    def test_safe_copy_db_ex_genuine_corruption_not_flagged_as_busy(self, tmp_path):
+        """A source that's simply not a valid SQLite file (genuine failure,
+        not a lock) must NOT be misreported as a busy-timeout -- that would
+        wrongly downgrade a real corruption/failure into a silently-skipped
+        warning."""
+        from hermes_cli.backup import _safe_copy_db_ex
+
+        src = tmp_path / "corrupt.db"
+        src.write_bytes(b"not-actually-sqlite")
+        dst = tmp_path / "copy.db"
+
+        success, was_busy_timeout = _safe_copy_db_ex(src, dst)
+
+        assert success is False
+        assert was_busy_timeout is False
+
+    def test_backup_treats_busy_timeout_as_transient_not_incomplete(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """End-to-end: when ``_safe_copy_db_ex`` reports a busy-timeout for
+        a .db file, ``hermes backup`` must print "Backup complete" (with
+        the restore hint) and list the file under the harmless transient
+        note, not under "Warnings" / "Backup incomplete". This is the exact
+        symptom from the bug report reappearing via a different file once
+        the busy-retry itself got bounded."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        _make_hermes_tree(hermes_home)
+
+        db_path = hermes_home / "chrome-debug" / "first_party_sets.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        db_path.write_bytes(b"not-actually-sqlite")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        import hermes_cli.backup as backup_mod
+
+        def busy_timeout(src, dst):
+            return False, True
+
+        monkeypatch.setattr(backup_mod, "_safe_copy_db_ex", busy_timeout)
+
+        out_zip = tmp_path / "backup.zip"
+        backup_mod.run_backup(Namespace(output=str(out_zip)))
+
+        out = capsys.readouterr().out
+        assert "Backup complete:" in out
+        assert "Backup incomplete" not in out
+        assert "Restore with:" in out
+        assert "Warnings" not in out
+        assert "first_party_sets.db" in out
+        assert "temporarily locked" in out
+
+    def test_automatic_backup_treats_busy_timeout_as_transient_not_aborted(
+        self, tmp_path, monkeypatch
+    ):
+        """Same busy-timeout scenario in the automatic backup path
+        (``_write_full_zip_backup``, used by ``hermes update`` / ``claw
+        migrate``): must skip just that file, not abort the entire
+        archive."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        _make_hermes_tree(hermes_home)
+
+        db_path = hermes_home / "chrome-debug" / "first_party_sets.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        db_path.write_bytes(b"not-actually-sqlite")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        import hermes_cli.backup as backup_mod
+
+        def busy_timeout(src, dst):
+            return False, True
+
+        monkeypatch.setattr(backup_mod, "_safe_copy_db_ex", busy_timeout)
+
+        out_zip = tmp_path / "automatic.zip"
+        result = backup_mod._write_full_zip_backup(out_zip, hermes_home)
+
+        assert result == out_zip
+        assert out_zip.exists()
+        with zipfile.ZipFile(out_zip) as zf:
+            assert zf.testzip() is None
+            assert "chrome-debug/first_party_sets.db" not in zf.namelist()
+            assert "config.yaml" in zf.namelist()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -3,6 +3,7 @@
 import json
 import os
 import sqlite3
+import time
 import zipfile
 from argparse import Namespace
 from pathlib import Path
@@ -908,6 +909,201 @@ class TestSafeCopyDb:
         p = tmp_path / "state.db"
         p.write_bytes(bytes(4096))  # all NULs
         assert is_zeroed_sqlite_file(p) is True
+
+
+class TestSafeCopyDbBusyBounding:
+    """Regression tests for the unbounded SQLITE_BUSY retry in
+    ``_safe_copy_db``: ``sqlite3.Connection.backup()`` retries a busy/locked
+    source with ``time.sleep()`` inside CPython's C implementation with no
+    overall deadline, independent of any connection-level ``timeout=``. A
+    source that stays locked (observed in the wild against Chrome's own
+    ``first_party_sets.db`` under a live ``chrome-debug/`` profile) could
+    previously stall the entire backup for as long as the lock was held.
+    """
+
+    @staticmethod
+    def _make_source_db(path, nrows: int = 50) -> None:
+        conn = sqlite3.connect(str(path))
+        conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+        conn.executemany(
+            "INSERT INTO t (v) VALUES (?)", [(f"row{i}",) for i in range(nrows)]
+        )
+        conn.commit()
+        conn.close()
+
+    @staticmethod
+    def _hold_exclusive_lock(path, hold_seconds: float, ready_evt) -> None:
+        """Runs in a background thread: holds BEGIN EXCLUSIVE on *path*
+        for *hold_seconds*, then releases. Mirrors the task's suggested
+        deterministic repro (a separate connection holding an exclusive
+        write transaction while ``_safe_copy_db`` runs against it)."""
+        conn = sqlite3.connect(str(path), timeout=0)
+        conn.execute("BEGIN EXCLUSIVE")
+        conn.execute("INSERT INTO t (v) VALUES ('locker')")
+        ready_evt.set()
+        time.sleep(hold_seconds)
+        conn.rollback()
+        conn.close()
+
+    def test_busy_source_is_bounded_not_indefinite(self, tmp_path, monkeypatch):
+        """A source locked LONGER than the deadline must return False in
+        roughly the deadline window, not block until the lock clears."""
+        import threading
+
+        from hermes_cli.backup import _safe_copy_db
+
+        monkeypatch.setenv("HERMES_BACKUP_SQLITE_BUSY_DEADLINE_SECONDS", "1")
+
+        src = tmp_path / "locked.db"
+        dst = tmp_path / "copy.db"
+        self._make_source_db(src)
+
+        ready_evt = threading.Event()
+        holder = threading.Thread(
+            target=self._hold_exclusive_lock, args=(src, 5.0, ready_evt), daemon=True
+        )
+        holder.start()
+        assert ready_evt.wait(timeout=5), "background thread failed to acquire lock"
+
+        t0 = time.monotonic()
+        result = _safe_copy_db(src, dst)
+        elapsed = time.monotonic() - t0
+        holder.join(timeout=10)
+
+        assert result is False, "busy copy should fail closed, not hang until unlocked"
+        assert elapsed < 3.0, (
+            f"_safe_copy_db took {elapsed:.2f}s against a 1s deadline and a 5s "
+            "lock hold -- the busy-retry loop is not bounded"
+        )
+        assert not dst.exists(), "failed copy must not leave a partial destination file"
+
+    def test_short_busy_window_still_succeeds(self, tmp_path, monkeypatch):
+        """A lock that clears BEFORE the deadline must not be penalized --
+        the bounding must not make normal WAL-mode contention fail."""
+        import threading
+
+        from hermes_cli.backup import _safe_copy_db
+
+        monkeypatch.setenv("HERMES_BACKUP_SQLITE_BUSY_DEADLINE_SECONDS", "5")
+
+        src = tmp_path / "locked.db"
+        dst = tmp_path / "copy.db"
+        self._make_source_db(src)
+
+        ready_evt = threading.Event()
+        holder = threading.Thread(
+            target=self._hold_exclusive_lock, args=(src, 0.5, ready_evt), daemon=True
+        )
+        holder.start()
+        assert ready_evt.wait(timeout=5)
+
+        result = _safe_copy_db(src, dst)
+        holder.join(timeout=10)
+
+        assert result is True
+        conn = sqlite3.connect(str(dst))
+        count = conn.execute("SELECT COUNT(*) FROM t").fetchone()[0]
+        conn.close()
+        # The locker thread rolls back its own INSERT on release (it only
+        # needs the exclusive lock, not a durable write), so the copy
+        # reflects just the original seed rows.
+        assert count == 50
+
+    def test_connection_timeout_parameter_does_not_bound_backup_loop(self, tmp_path):
+        """Documents *why* the fix can't just be 'pass timeout= to connect()':
+        a connection's timeout= only bounds the initial lock acquisition for
+        ordinary statements, not backup()'s own internal busy-retry loop."""
+        import threading
+
+        monkeypatch_env_backup = os.environ.pop(
+            "HERMES_BACKUP_SQLITE_BUSY_DEADLINE_SECONDS", None
+        )
+        try:
+            src = tmp_path / "locked.db"
+            dst = tmp_path / "copy.db"
+            self._make_source_db(src)
+
+            ready_evt = threading.Event()
+            holder = threading.Thread(
+                target=self._hold_exclusive_lock, args=(src, 2.0, ready_evt), daemon=True
+            )
+            holder.start()
+            assert ready_evt.wait(timeout=5)
+
+            t0 = time.monotonic()
+            # A short connection timeout does NOT bound Connection.backup().
+            conn = sqlite3.connect(f"file:{src}?mode=ro", uri=True, timeout=0.2)
+            backup_conn = sqlite3.connect(str(dst), timeout=0.2)
+            try:
+                conn.backup(backup_conn)
+            finally:
+                backup_conn.close()
+                conn.close()
+            elapsed = time.monotonic() - t0
+            holder.join(timeout=10)
+
+            assert elapsed >= 1.5, (
+                f"backup() returned after only {elapsed:.2f}s despite a 0.2s "
+                "connection timeout -- if this now fails, sqlite3's behavior "
+                "changed and the bounding fix in _safe_copy_db may need "
+                "revisiting"
+            )
+        finally:
+            if monkeypatch_env_backup is not None:
+                os.environ["HERMES_BACKUP_SQLITE_BUSY_DEADLINE_SECONDS"] = (
+                    monkeypatch_env_backup
+                )
+
+    def test_large_non_busy_copy_is_unaffected_by_bounding(self, tmp_path, monkeypatch):
+        """The deadline must be gated on BUSY/LOCKED status, not raw elapsed
+        time: a large, uncontended copy must never be aborted just because
+        it took a while (see DEFAULT_INTEGRITY_CHECK_MAX_BYTES's own comment
+        on multi-GB state.db files being a normal, supported case)."""
+        from hermes_cli.backup import _safe_copy_db
+
+        # Deliberately absurd deadline: if bounding were time-based instead
+        # of status-gated, this would abort a perfectly healthy copy.
+        monkeypatch.setenv("HERMES_BACKUP_SQLITE_BUSY_DEADLINE_SECONDS", "0.001")
+
+        src = tmp_path / "big.db"
+        dst = tmp_path / "copy.db"
+        self._make_source_db(src, nrows=20_000)
+
+        result = _safe_copy_db(src, dst)
+
+        assert result is True
+        conn = sqlite3.connect(str(dst))
+        count = conn.execute("SELECT COUNT(*) FROM t").fetchone()[0]
+        conn.close()
+        assert count == 20_000
+
+    def test_negative_deadline_disables_bounding(self, tmp_path, monkeypatch):
+        """A non-positive deadline is an explicit escape hatch back to the
+        pre-fix behavior (retry indefinitely until the lock clears)."""
+        import threading
+
+        from hermes_cli.backup import _safe_copy_db
+
+        monkeypatch.setenv("HERMES_BACKUP_SQLITE_BUSY_DEADLINE_SECONDS", "0")
+
+        src = tmp_path / "locked.db"
+        dst = tmp_path / "copy.db"
+        self._make_source_db(src)
+
+        ready_evt = threading.Event()
+        holder = threading.Thread(
+            target=self._hold_exclusive_lock, args=(src, 1.5, ready_evt), daemon=True
+        )
+        holder.start()
+        assert ready_evt.wait(timeout=5)
+
+        t0 = time.monotonic()
+        result = _safe_copy_db(src, dst)
+        elapsed = time.monotonic() - t0
+        holder.join(timeout=10)
+
+        assert result is True
+        assert elapsed >= 1.2, "disabled bounding should still wait out the lock"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes two related bugs in `hermes backup` that could either hang indefinitely or wrongly report a clean backup as "Backup incomplete":

1. **Unbounded SQLite busy-retry.** `_safe_copy_db()` copies each `.db` file via `sqlite3.Connection.backup()`. That call has no bounded retry: when the source is `SQLITE_BUSY`/`SQLITE_LOCKED` (another process holds a write transaction), it retries via `sqlite3_sleep()` indefinitely until the lock clears — the connection's `timeout=` parameter only bounds acquiring the *initial* connection, not this internal retry loop. Reproduced live against a real, independently-locked `chrome-debug/first_party_sets.db` (a small SQLite file Chrome itself uses internally): unpatched, the copy blocked for **61.4 seconds**.
2. **Transient chrome-debug files misclassified as hard errors.** Chrome's own transient session/tab files (`Sessions/`, `shared_proto_db/`, `BrowserMetrics-spare.pma`) can vanish mid-backup as Chrome's own housekeeping runs. A scan-then-archive race treated any such vanish as a fatal error, flipping the whole backup summary to "Backup incomplete" even though the resulting archive was complete and restorable.

## Related Issue

No existing issue — found as a side-effect while live-verifying a separate backup fix, documented in the two RCA docs included in this PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/backup.py`:
  - `_safe_copy_db()` now bounds the SQLite busy/locked retry via `conn.backup(progress=<callback>)`. The callback fires after every `sqlite3_backup_step()` call (including busy/locked ones) and raises past a deadline (default 30s, overridable via `HERMES_BACKUP_SQLITE_BUSY_DEADLINE_SECONDS`, non-positive disables bounding). The deadline check is gated on the *status code* (`SQLITE_BUSY`/`SQLITE_LOCKED`), not raw elapsed time, so a large-but-healthy copy is never wrongly aborted mid-flight.
  - Both connections in the bounded path use `timeout=0` — `sqlite3.connect()`'s default `timeout=5.0` installs SQLite's own internal busy-handler that silently retries *inside* a single `backup_step()` call for up to 5s before the `progress=` callback ever runs, which coarsens the deadline to ~5-8s regardless of the configured value. This is documented at length in code comments since it's easy to reintroduce by "simplifying."
  - New `_safe_copy_db_ex()` reports *why* a copy failed (busy-timeout abort vs. anything else) so callers can route a busy-timeout into the same harmless "transient/skipped" bucket already used for vanished-mid-backup files, instead of the hard `errors` list. Both `hermes backup` call sites (the CLI path and the automatic `_write_full_zip_backup_locked` path) updated to use it.
  - The transient chrome-debug file walk now excludes known-transient paths (`Sessions/`, `shared_proto_db/`, `BrowserMetrics-spare.pma`) and reclassifies a benign vanished-file skip separately from a genuine failure.
- `docs/rca-backup-sqlite-busy-retry-unbounded.md` / `docs/fix-backup-sqlite-busy-retry-unbounded.md` — root cause (CPython C-source level) and fix write-up for the busy-retry bug.
- `docs/rca-chrome-debug-transient-files-backup.md` / `docs/fix-chrome-debug-transient-files-backup.md` — root cause and fix write-up for the transient-file misclassification.
- `tests/hermes_cli/test_backup.py` — 590 new lines: busy-bounded abort, short-lock-still-succeeds, `timeout=` insufficiency documented as a regression guard, large-non-busy-copy unaffected by a tight deadline, negative-deadline escape hatch, busy-timeout correctly reported as transient (not a hard error) at both call sites, transient chrome-debug ENOENT races tolerated.

## How to Test

1. `pytest tests/hermes_cli/test_backup.py -q` — 58 tests, all pass.
2. Live repro of the original bug: hold a real `BEGIN EXCLUSIVE` lock on a throwaway SQLite file in one process, run `_safe_copy_db_ex()` against it from another with `HERMES_BACKUP_SQLITE_BUSY_DEADLINE_SECONDS=2` — returns cleanly in ~2.1s instead of hanging.
3. `hermes backup` against a real `~/.hermes` with the Hermes-managed debug Chrome actively running — prints "Backup complete", exit code 0, restore hint present, `zipfile.testzip() == None` on the resulting archive.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no new config keys; the deadline is env-var-overridable only)
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure `sqlite3`/stdlib, no platform-specific paths)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (CLI-only, no model tool schema touched)

## Screenshots / Logs

Live pre-fix repro against a real locked file:
```
_safe_copy_db() against a genuinely SQLITE_BUSY chrome-debug/first_party_sets.db
-> blocked for 61.4s (unpatched)
```
Post-fix, same locked file, 10s deadline override:
```
_safe_copy_db_ex() -> aborted cleanly at 10.1s, classified as transient (not a hard error)
```
