### PR TITLE
feat(skills): add e2a email integration

### DIFF
--- a/optional-skills/email/e2a/SKILL.md
+++ b/optional-skills/email/e2a/SKILL.md
@@ -15,22 +15,28 @@ metadata:
     related_skills: []
 ---
 
-# e2a — Authenticated Email for AI Agents
+# e2a Skill
 
-e2a gives Hermes its own verified email identity and inbox. This is for mail
-the agent owns and operates, not for reading a user's personal mailbox.
+Give Hermes a verified email identity and inbox through e2a's hosted MCP
+server. Operate mail owned by the agent; do not use this skill to read a
+user's personal mailbox.
 
 ## When to Use
 
-Use this skill when Hermes needs to create or operate an e2a inbox, read
-incoming agent mail, send a new email, reply in an existing thread, or connect
-e2a to a backend through its SDKs and webhooks.
+Use this skill to:
 
-## Setup
+- Create or select an e2a agent inbox.
+- Read incoming agent mail and attachments.
+- Send a new message or reply in an existing email thread.
+- Configure a custom domain owned by the user.
+- Direct a backend integration toward e2a's SDKs and webhooks.
 
-### 1. Add the hosted MCP server
+## Prerequisites
 
-Add this to `~/.hermes/config.yaml`:
+Use the hosted e2a MCP server at `https://api.e2a.dev/mcp`.
+
+For an interactive Hermes installation, add this entry to
+`~/.hermes/config.yaml`:
 
 ```yaml
 mcp_servers:
@@ -39,12 +45,11 @@ mcp_servers:
     auth: oauth
 ```
 
-Restart Hermes, then complete the browser authorization when prompted. Hermes
-stores the OAuth credentials locally and refreshes them as needed. Do not paste
-an API key into chat or commit one to a configuration file.
+Complete authorization with `hermes mcp login e2a`. Hermes stores and refreshes
+the OAuth credentials locally.
 
-For headless deployments, use an e2a API key supplied through a secret manager
-and an environment reference instead:
+For a headless deployment, supply an e2a API key through a secret manager and
+reference the environment variable:
 
 ```yaml
 mcp_servers:
@@ -54,26 +59,71 @@ mcp_servers:
       Authorization: "Bearer ${E2A_API_KEY}"
 ```
 
-API keys are scoped either to one agent inbox or to the account. Prefer an
-agent-scoped key for a deployed Hermes instance.
+Prefer an agent-scoped key for a deployed Hermes instance. Never paste an API
+key into chat or commit one to a configuration file.
 
-## Operating the inbox
+## How to Run
 
-Before the first operation, call `whoami` to learn the credential scope:
+Install the optional skill and authenticate the MCP server through the
+`terminal` tool:
 
-- An **agent-scoped** credential is already bound to one inbox; use the
-  returned `agent_email`.
-- An **account-scoped** credential can manage multiple inboxes; call
-  `list_agents` and choose the inbox explicitly. Never guess a default.
+```bash
+hermes skills install official/email/e2a
+hermes mcp login e2a
+hermes chat
+```
 
-The inbox belongs to Hermes. Use `list_messages` and `get_message` to read mail,
-`send_message` for a new conversation, and `reply_to_message` when responding
-to a message. Replies preserve the email client's thread; reusing
-`conversation_id` alone does not.
+After setup, ask Hermes to use e2a for inbox work. Hermes discovers the e2a
+tools from the connected MCP server; do not infer tool signatures from this
+skill when the server's `tools/list` result is available.
 
-### Send safely
+## Quick Reference
 
-- A response to existing mail should use `reply_to_message`, not a fresh send.
+| Task | e2a tool | Notes |
+|---|---|---|
+| Identify credential scope | `whoami` | Call first |
+| List account inboxes | `list_agents` | Account scope only |
+| Create an inbox | `create_agent` | Account scope only |
+| List inbound mail | `list_messages` | Defaults to unread inbound mail |
+| Read a message | `get_message` | Returns body, headers, and attachment metadata |
+| Download an attachment | `get_attachment` | Use the message's zero-based attachment index |
+| Start a new thread | `send_message` | Do not use for a reply |
+| Reply in-thread | `reply_to_message` | Preserves email threading headers |
+| Start custom-domain setup | `register_domain` | Returns DNS records to publish |
+| Verify custom-domain DNS | `verify_domain` | Call after DNS propagation |
+
+## Procedure
+
+1. **Confirm the connection.** Call `whoami` before the first operation. If
+   the e2a tools are absent, configure the MCP server under Prerequisites and
+   authenticate it before continuing.
+2. **Select the inbox.** For agent scope, use the returned `agent_email`. For
+   account scope, call `list_agents` and select the inbox explicitly. If no
+   inbox exists, create one on the shared domain, such as
+   `hermes-agent@agents.e2a.dev`; the shared domain requires no DNS setup.
+3. **Read mail.** Call `list_messages`, then `get_message` for the complete
+   body and sender-authentication evidence. Fetch attachment bytes only when
+   needed with `get_attachment`.
+4. **Continue an existing conversation.** Call `reply_to_message` with the
+   original `message_id`. Keep the subject stable. Use `conversation_id` only
+   for application correlation; it does not preserve an email-client thread.
+5. **Start a new conversation.** Call `send_message` with the selected inbox,
+   recipients, subject, and a complete plain-text body. Include equivalent
+   HTML only when it improves structured content.
+6. **Configure a custom domain only when requested.** Call `register_domain`,
+   have the user publish every returned DNS record verbatim, wait for DNS
+   propagation, then call `verify_domain`. Poll `get_domain` before promising
+   branded outbound sending because inbound and outbound verification are
+   separate.
+7. **Use SDKs for backend integrations.** When a service—not Hermes itself—must
+   receive or send mail, follow e2a's SDK and webhook documentation instead of
+   treating MCP as a deployed webhook receiver.
+
+## Pitfalls
+
+- Do not guess an inbox for an account-scoped credential. Call `list_agents`
+  and select one explicitly.
+- Use `reply_to_message`, not a fresh send, when responding to existing mail.
 - Treat `accepted`, `scheduled`, and `pending_review` as successful durable
   acceptance. Do not resend; inspect the message later or consume webhook
   events for the terminal outcome.
@@ -83,24 +133,25 @@ to a message. Replies preserve the email client's thread; reusing
 - For attachments, pass base64 returned by an attachment/file tool; do not
   invent or hand-edit encoded bytes. Use `get_attachment` when bytes are
   needed.
+- Do not call `verify_domain` immediately after registration. DNS propagation
+  is asynchronous.
+- Do not treat an e2a inbox as the user's personal email account. The agent is
+  the mailbox owner and the visible sender.
+- Do not expose API keys in chat, logs, source files, or committed Hermes
+  configuration.
 
-### Create an inbox
+## Verification
 
-With an account-scoped session, call `create_agent` with an address on the
-shared `agents.e2a.dev` domain, such as `hermes-agent@agents.e2a.dev`. The
-shared domain requires no DNS setup. Use a custom domain only when the user
-owns it: `register_domain` returns DNS records, and `verify_domain` must be
-called after publication and propagation. Inbound and outbound custom-domain
-verification are separate; check `get_domain` before promising branded sending.
+Run:
 
-## Common use cases
+```bash
+hermes --toolsets mcp -q "Call e2a whoami and report the credential scope without changing anything"
+```
 
-- Give Hermes a durable identity for agent-to-human or agent-to-agent email.
-- Monitor an inbox with `list_messages` and inspect full messages with
-  `get_message`.
-- Send concise plain-text or HTML updates and continue conversations in-thread.
-- Use e2a webhooks and SDKs for a backend service; MCP is for Hermes operating
-  the inbox interactively.
+Verification succeeds when Hermes discovers the e2a MCP tools, `whoami`
+returns the credential scope, and no mutating tool is called. For account
+scope, a subsequent read-only `list_agents` call should return the available
+inboxes.
 
 ## References
 

--- a/optional-skills/email/e2a/SKILL.md
+++ b/optional-skills/email/e2a/SKILL.md
@@ -2,7 +2,7 @@
 name: e2a
 description: "Use e2a for Hermes-owned email over hosted MCP."
 version: 1.0.0
-author: TokenCanopy
+author: Josh Zhang (jiashuoz)
 license: Apache-2.0
 platforms:
   - linux

--- a/optional-skills/email/e2a/SKILL.md
+++ b/optional-skills/email/e2a/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: e2a
-description: "Use e2a for Hermes-owned email over hosted MCP."
+description: "Operate Hermes-owned email through a hosted MCP server."
 version: 1.0.0
 author: Josh Zhang (jiashuoz)
 license: Apache-2.0
@@ -99,8 +99,8 @@ skill when the server's `tools/list` result is available.
    authenticate it before continuing.
 2. **Select the inbox.** For agent scope, use the returned `agent_email`. For
    account scope, call `list_agents` and select the inbox explicitly. If no
-   inbox exists, create one on the shared domain, such as
-   `hermes-agent@agents.e2a.dev`; the shared domain requires no DNS setup.
+   inbox exists, create one on the hosted shared domain; it requires no DNS
+   setup.
 3. **Read mail.** Call `list_messages`, then `get_message` for the complete
    body and sender-authentication evidence. Fetch attachment bytes only when
    needed with `get_attachment`.
@@ -145,7 +145,7 @@ skill when the server's `tools/list` result is available.
 Run:
 
 ```bash
-hermes --toolsets mcp -q "Call e2a whoami and report the credential scope without changing anything"
+hermes --toolsets skills,mcp-e2a -q "Use the e2a skill to call whoami and report the credential scope without changing anything"
 ```
 
 Verification succeeds when Hermes discovers the e2a MCP tools, `whoami`

--- a/optional-skills/email/e2a/SKILL.md
+++ b/optional-skills/email/e2a/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: e2a
+description: "Use e2a for Hermes-owned email over hosted MCP."
+version: 1.0.0
+author: TokenCanopy
+license: Apache-2.0
+platforms:
+  - linux
+  - macos
+  - windows
+metadata:
+  hermes:
+    tags: [email, communication, e2a, mcp, oauth]
+    category: email
+    related_skills: []
+---
+
+# e2a — Authenticated Email for AI Agents
+
+e2a gives Hermes its own verified email identity and inbox. This is for mail
+the agent owns and operates, not for reading a user's personal mailbox.
+
+## When to Use
+
+Use this skill when Hermes needs to create or operate an e2a inbox, read
+incoming agent mail, send a new email, reply in an existing thread, or connect
+e2a to a backend through its SDKs and webhooks.
+
+## Setup
+
+### 1. Add the hosted MCP server
+
+Add this to `~/.hermes/config.yaml`:
+
+```yaml
+mcp_servers:
+  e2a:
+    url: "https://api.e2a.dev/mcp"
+    auth: oauth
+```
+
+Restart Hermes, then complete the browser authorization when prompted. Hermes
+stores the OAuth credentials locally and refreshes them as needed. Do not paste
+an API key into chat or commit one to a configuration file.
+
+For headless deployments, use an e2a API key supplied through a secret manager
+and an environment reference instead:
+
+```yaml
+mcp_servers:
+  e2a:
+    url: "https://api.e2a.dev/mcp"
+    headers:
+      Authorization: "Bearer ${E2A_API_KEY}"
+```
+
+API keys are scoped either to one agent inbox or to the account. Prefer an
+agent-scoped key for a deployed Hermes instance.
+
+## Operating the inbox
+
+Before the first operation, call `whoami` to learn the credential scope:
+
+- An **agent-scoped** credential is already bound to one inbox; use the
+  returned `agent_email`.
+- An **account-scoped** credential can manage multiple inboxes; call
+  `list_agents` and choose the inbox explicitly. Never guess a default.
+
+The inbox belongs to Hermes. Use `list_messages` and `get_message` to read mail,
+`send_message` for a new conversation, and `reply_to_message` when responding
+to a message. Replies preserve the email client's thread; reusing
+`conversation_id` alone does not.
+
+### Send safely
+
+- A response to existing mail should use `reply_to_message`, not a fresh send.
+- Treat `accepted`, `scheduled`, and `pending_review` as successful durable
+  acceptance. Do not resend; inspect the message later or consume webhook
+  events for the terminal outcome.
+- A future `send_at` is a beta scheduled send. If an outbound message is held
+  for review, its schedule is preserved as `scheduled_at` and re-armed when a
+  reviewer approves it.
+- For attachments, pass base64 returned by an attachment/file tool; do not
+  invent or hand-edit encoded bytes. Use `get_attachment` when bytes are
+  needed.
+
+### Create an inbox
+
+With an account-scoped session, call `create_agent` with an address on the
+shared `agents.e2a.dev` domain, such as `hermes-agent@agents.e2a.dev`. The
+shared domain requires no DNS setup. Use a custom domain only when the user
+owns it: `register_domain` returns DNS records, and `verify_domain` must be
+called after publication and propagation. Inbound and outbound custom-domain
+verification are separate; check `get_domain` before promising branded sending.
+
+## Common use cases
+
+- Give Hermes a durable identity for agent-to-human or agent-to-agent email.
+- Monitor an inbox with `list_messages` and inspect full messages with
+  `get_message`.
+- Send concise plain-text or HTML updates and continue conversations in-thread.
+- Use e2a webhooks and SDKs for a backend service; MCP is for Hermes operating
+  the inbox interactively.
+
+## References
+
+- Setup: https://e2a.dev/setup.md
+- Authentication: https://e2a.dev/auth.md
+- SDK and webhooks: https://e2a.dev/sdk.md
+- Exact MCP tool signatures: use the connected server's `tools/list` result
+- e2a MCP endpoint: https://api.e2a.dev/mcp

--- a/tests/skills/test_e2a_skill.py
+++ b/tests/skills/test_e2a_skill.py
@@ -1,0 +1,109 @@
+"""Static compliance tests for the optional e2a skill.
+
+These tests validate the contribution-guide hardlines and operational safety
+without making live network calls.
+"""
+
+import re
+from pathlib import Path
+
+SKILL_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "email"
+    / "e2a"
+    / "SKILL.md"
+)
+
+REQUIRED_SECTIONS = (
+    "# e2a Skill",
+    "## When to Use",
+    "## Prerequisites",
+    "## How to Run",
+    "## Quick Reference",
+    "## Procedure",
+    "## Pitfalls",
+    "## Verification",
+)
+
+
+def _frontmatter_and_body():
+    content = SKILL_PATH.read_text(encoding="utf-8")
+    assert content.startswith("---\n")
+    match = re.search(r"^---\n(.*?)\n---\n", content, re.DOTALL)
+    assert match, "frontmatter must close with ---"
+    return match.group(1), content[match.end() :]
+
+
+def _field(frontmatter: str, name: str) -> str:
+    match = re.search(rf"^{re.escape(name)}:\s*[\"']?(.*?)[\"']?\s*$", frontmatter, re.MULTILINE)
+    assert match, f"missing frontmatter field: {name}"
+    return match.group(1).rstrip("\"'")
+
+
+def test_skill_file_exists():
+    assert SKILL_PATH.is_file()
+
+
+def test_frontmatter_required_fields():
+    frontmatter, _ = _frontmatter_and_body()
+    for field in ("name", "description", "version", "author", "license", "platforms"):
+        assert re.search(rf"^{field}:", frontmatter, re.MULTILINE), (
+            f"missing frontmatter field: {field}"
+        )
+    assert _field(frontmatter, "name") == "e2a"
+    assert re.search(r"^metadata:\n\s+hermes:", frontmatter, re.MULTILINE)
+    assert re.search(r"^\s+tags:\s*\[[^]]+\]", frontmatter, re.MULTILINE)
+    assert re.search(r"^\s+related_skills:", frontmatter, re.MULTILINE)
+
+
+def test_description_hardline():
+    frontmatter, _ = _frontmatter_and_body()
+    description = _field(frontmatter, "description")
+    assert len(description) <= 60
+    assert description.endswith(".")
+    assert _field(frontmatter, "name").lower() not in description.lower()
+
+
+def test_author_credits_human_first():
+    frontmatter, _ = _frontmatter_and_body()
+    author = _field(frontmatter, "author")
+    assert not author.startswith("Hermes Agent")
+    assert "jiashuoz" in author
+
+
+def test_required_section_order():
+    _, body = _frontmatter_and_body()
+    positions = [body.index(section) for section in REQUIRED_SECTIONS]
+    assert positions == sorted(positions)
+
+
+def test_mcp_prerequisites_are_explicit_and_secret_safe():
+    _, body = _frontmatter_and_body()
+    assert "https://api.e2a.dev/mcp" in body
+    assert "auth: oauth" in body
+    assert 'Authorization: "Bearer ${E2A_API_KEY}"' in body
+    assert "hermes mcp login e2a" in body
+
+
+def test_email_operations_preserve_threading_and_durable_acceptance():
+    _, body = _frontmatter_and_body()
+    assert "reply_to_message" in body
+    for status in ("accepted", "scheduled", "pending_review"):
+        assert f"`{status}`" in body
+    assert "Do not resend" in body
+    assert "send_at" in body and "scheduled_at" in body
+
+
+def test_verification_uses_skill_and_dynamic_mcp_toolsets_read_only():
+    _, body = _frontmatter_and_body()
+    assert "--toolsets skills,mcp-e2a" in body
+    assert "whoami" in body
+    assert "without changing anything" in body
+
+
+def test_no_machine_local_paths_or_hosted_customer_addresses():
+    content = SKILL_PATH.read_text(encoding="utf-8")
+    assert "/home/" not in content
+    assert not re.search(r"[A-Z]:\\\\Users", content)
+    assert not re.search(r"[A-Z0-9._%+-]+@agents\.e2a\.dev", content, re.IGNORECASE)

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -98,7 +98,7 @@ hermes skills uninstall <skill-name>
 | Skill | Description |
 |-------|-------------|
 | [**agentmail**](/docs/user-guide/skills/optional/email/email-agentmail) | Give the agent its own inbox: send and receive email. |
-| [**e2a**](/docs/user-guide/skills/optional/email/email-e2a) | Give Hermes an authenticated, agent-owned email inbox through e2a's hosted MCP server. |
+| [**e2a**](/docs/user-guide/skills/optional/email/email-e2a) | Use e2a for Hermes-owned email over hosted MCP. |
 
 ## finance
 

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -98,7 +98,7 @@ hermes skills uninstall <skill-name>
 | Skill | Description |
 |-------|-------------|
 | [**agentmail**](/docs/user-guide/skills/optional/email/email-agentmail) | Give the agent its own inbox: send and receive email. |
-| [**e2a**](/docs/user-guide/skills/optional/email/email-e2a) | Use e2a for Hermes-owned email over hosted MCP. |
+| [**e2a**](/docs/user-guide/skills/optional/email/email-e2a) | Operate Hermes-owned email through a hosted MCP server. |
 
 ## finance
 

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -98,6 +98,7 @@ hermes skills uninstall <skill-name>
 | Skill | Description |
 |-------|-------------|
 | [**agentmail**](/docs/user-guide/skills/optional/email/email-agentmail) | Give the agent its own inbox: send and receive email. |
+| [**e2a**](/docs/user-guide/skills/optional/email/email-e2a) | Give Hermes an authenticated, agent-owned email inbox through e2a's hosted MCP server. |
 
 ## finance
 

--- a/website/docs/user-guide/skills/optional/email/email-e2a.md
+++ b/website/docs/user-guide/skills/optional/email/email-e2a.md
@@ -1,0 +1,116 @@
+---
+title: "E2A — Give Hermes an authenticated, agent-owned email inbox through e2a's hosted MCP server"
+sidebar_label: "E2A"
+description: "Give Hermes an authenticated, agent-owned email inbox through e2a's hosted MCP server"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# E2A
+
+Give Hermes an authenticated, agent-owned email inbox through e2a's hosted MCP server.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/email/e2a` |
+| Path | `optional-skills/email/e2a` |
+| Version | `1.0.0` |
+| Platforms | linux, macos, windows |
+| Tags | `email`, `communication`, `e2a`, `mcp`, `oauth` |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# e2a — Authenticated Email for AI Agents
+
+e2a gives Hermes its own verified email identity and inbox. This is for mail
+the agent owns and operates, not for reading a user's personal mailbox.
+
+## Setup
+
+### 1. Add the hosted MCP server
+
+Add this to `~/.hermes/config.yaml`:
+
+```yaml
+mcp_servers:
+  e2a:
+    url: "https://api.e2a.dev/mcp"
+    auth: oauth
+```
+
+Restart Hermes, then complete the browser authorization when prompted. Hermes
+stores the OAuth credentials locally and refreshes them as needed. Do not paste
+an API key into chat or commit one to a configuration file.
+
+For headless deployments, use an e2a API key supplied through a secret manager
+and an environment reference instead:
+
+```yaml
+mcp_servers:
+  e2a:
+    url: "https://api.e2a.dev/mcp"
+    headers:
+      Authorization: "Bearer ${E2A_API_KEY}"
+```
+
+API keys are scoped either to one agent inbox or to the account. Prefer an
+agent-scoped key for a deployed Hermes instance.
+
+## Operating the inbox
+
+Before the first operation, call `whoami` to learn the credential scope:
+
+- An **agent-scoped** credential is already bound to one inbox; use the
+  returned `agent_email`.
+- An **account-scoped** credential can manage multiple inboxes; call
+  `list_agents` and choose the inbox explicitly. Never guess a default.
+
+The inbox belongs to Hermes. Use `list_messages` and `get_message` to read mail,
+`send_message` for a new conversation, and `reply_to_message` when responding
+to a message. Replies preserve the email client's thread; reusing
+`conversation_id` alone does not.
+
+### Send safely
+
+- A response to existing mail should use `reply_to_message`, not a fresh send.
+- Treat `accepted`, `scheduled`, and `pending_review` as successful durable
+  acceptance. Do not resend; inspect the message later or consume webhook
+  events for the terminal outcome.
+- A future `send_at` is a beta scheduled send. If an outbound message is held
+  for review, its schedule is preserved as `scheduled_at` and re-armed when a
+  reviewer approves it.
+- For attachments, pass base64 returned by an attachment/file tool; do not
+  invent or hand-edit encoded bytes. Use `get_attachment` when bytes are
+  needed.
+
+### Create an inbox
+
+With an account-scoped session, call `create_agent` with an address on the
+shared `agents.e2a.dev` domain, such as `hermes-agent@agents.e2a.dev`. The
+shared domain requires no DNS setup. Use a custom domain only when the user
+owns it: `register_domain` returns DNS records, and `verify_domain` must be
+called after publication and propagation. Inbound and outbound custom-domain
+verification are separate; check `get_domain` before promising branded sending.
+
+## Common use cases
+
+- Give Hermes a durable identity for agent-to-human or agent-to-agent email.
+- Monitor an inbox with `list_messages` and inspect full messages with
+  `get_message`.
+- Send concise plain-text or HTML updates and continue conversations in-thread.
+- Use e2a webhooks and SDKs for a backend service; MCP is for Hermes operating
+  the inbox interactively.
+
+## References
+
+- Setup: https://e2a.dev/setup.md
+- Authentication: https://e2a.dev/auth.md
+- SDK and webhooks: https://e2a.dev/sdk.md
+- Exact MCP tool signatures: use the connected server's `tools/list` result
+- e2a MCP endpoint: https://api.e2a.dev/mcp

--- a/website/docs/user-guide/skills/optional/email/email-e2a.md
+++ b/website/docs/user-guide/skills/optional/email/email-e2a.md
@@ -1,14 +1,14 @@
 ---
-title: "E2A — Give Hermes an authenticated, agent-owned email inbox through e2a's hosted MCP server"
+title: "E2A — Use e2a for Hermes-owned email over hosted MCP"
 sidebar_label: "E2A"
-description: "Give Hermes an authenticated, agent-owned email inbox through e2a's hosted MCP server"
+description: "Use e2a for Hermes-owned email over hosted MCP"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # E2A
 
-Give Hermes an authenticated, agent-owned email inbox through e2a's hosted MCP server.
+Use e2a for Hermes-owned email over hosted MCP.
 
 ## Skill metadata
 
@@ -17,6 +17,8 @@ Give Hermes an authenticated, agent-owned email inbox through e2a's hosted MCP s
 | Source | Optional — install with `hermes skills install official/email/e2a` |
 | Path | `optional-skills/email/e2a` |
 | Version | `1.0.0` |
+| Author | Josh Zhang (jiashuoz) |
+| License | Apache-2.0 |
 | Platforms | linux, macos, windows |
 | Tags | `email`, `communication`, `e2a`, `mcp`, `oauth` |
 
@@ -26,16 +28,28 @@ Give Hermes an authenticated, agent-owned email inbox through e2a's hosted MCP s
 The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
 :::
 
-# e2a — Authenticated Email for AI Agents
+# e2a Skill
 
-e2a gives Hermes its own verified email identity and inbox. This is for mail
-the agent owns and operates, not for reading a user's personal mailbox.
+Give Hermes a verified email identity and inbox through e2a's hosted MCP
+server. Operate mail owned by the agent; do not use this skill to read a
+user's personal mailbox.
 
-## Setup
+## When to Use
 
-### 1. Add the hosted MCP server
+Use this skill to:
 
-Add this to `~/.hermes/config.yaml`:
+- Create or select an e2a agent inbox.
+- Read incoming agent mail and attachments.
+- Send a new message or reply in an existing email thread.
+- Configure a custom domain owned by the user.
+- Direct a backend integration toward e2a's SDKs and webhooks.
+
+## Prerequisites
+
+Use the hosted e2a MCP server at `https://api.e2a.dev/mcp`.
+
+For an interactive Hermes installation, add this entry to
+`~/.hermes/config.yaml`:
 
 ```yaml
 mcp_servers:
@@ -44,12 +58,11 @@ mcp_servers:
     auth: oauth
 ```
 
-Restart Hermes, then complete the browser authorization when prompted. Hermes
-stores the OAuth credentials locally and refreshes them as needed. Do not paste
-an API key into chat or commit one to a configuration file.
+Complete authorization with `hermes mcp login e2a`. Hermes stores and refreshes
+the OAuth credentials locally.
 
-For headless deployments, use an e2a API key supplied through a secret manager
-and an environment reference instead:
+For a headless deployment, supply an e2a API key through a secret manager and
+reference the environment variable:
 
 ```yaml
 mcp_servers:
@@ -59,26 +72,71 @@ mcp_servers:
       Authorization: "Bearer ${E2A_API_KEY}"
 ```
 
-API keys are scoped either to one agent inbox or to the account. Prefer an
-agent-scoped key for a deployed Hermes instance.
+Prefer an agent-scoped key for a deployed Hermes instance. Never paste an API
+key into chat or commit one to a configuration file.
 
-## Operating the inbox
+## How to Run
 
-Before the first operation, call `whoami` to learn the credential scope:
+Install the optional skill and authenticate the MCP server through the
+`terminal` tool:
 
-- An **agent-scoped** credential is already bound to one inbox; use the
-  returned `agent_email`.
-- An **account-scoped** credential can manage multiple inboxes; call
-  `list_agents` and choose the inbox explicitly. Never guess a default.
+```bash
+hermes skills install official/email/e2a
+hermes mcp login e2a
+hermes chat
+```
 
-The inbox belongs to Hermes. Use `list_messages` and `get_message` to read mail,
-`send_message` for a new conversation, and `reply_to_message` when responding
-to a message. Replies preserve the email client's thread; reusing
-`conversation_id` alone does not.
+After setup, ask Hermes to use e2a for inbox work. Hermes discovers the e2a
+tools from the connected MCP server; do not infer tool signatures from this
+skill when the server's `tools/list` result is available.
 
-### Send safely
+## Quick Reference
 
-- A response to existing mail should use `reply_to_message`, not a fresh send.
+| Task | e2a tool | Notes |
+|---|---|---|
+| Identify credential scope | `whoami` | Call first |
+| List account inboxes | `list_agents` | Account scope only |
+| Create an inbox | `create_agent` | Account scope only |
+| List inbound mail | `list_messages` | Defaults to unread inbound mail |
+| Read a message | `get_message` | Returns body, headers, and attachment metadata |
+| Download an attachment | `get_attachment` | Use the message's zero-based attachment index |
+| Start a new thread | `send_message` | Do not use for a reply |
+| Reply in-thread | `reply_to_message` | Preserves email threading headers |
+| Start custom-domain setup | `register_domain` | Returns DNS records to publish |
+| Verify custom-domain DNS | `verify_domain` | Call after DNS propagation |
+
+## Procedure
+
+1. **Confirm the connection.** Call `whoami` before the first operation. If
+   the e2a tools are absent, configure the MCP server under Prerequisites and
+   authenticate it before continuing.
+2. **Select the inbox.** For agent scope, use the returned `agent_email`. For
+   account scope, call `list_agents` and select the inbox explicitly. If no
+   inbox exists, create one on the shared domain, such as
+   `hermes-agent@agents.e2a.dev`; the shared domain requires no DNS setup.
+3. **Read mail.** Call `list_messages`, then `get_message` for the complete
+   body and sender-authentication evidence. Fetch attachment bytes only when
+   needed with `get_attachment`.
+4. **Continue an existing conversation.** Call `reply_to_message` with the
+   original `message_id`. Keep the subject stable. Use `conversation_id` only
+   for application correlation; it does not preserve an email-client thread.
+5. **Start a new conversation.** Call `send_message` with the selected inbox,
+   recipients, subject, and a complete plain-text body. Include equivalent
+   HTML only when it improves structured content.
+6. **Configure a custom domain only when requested.** Call `register_domain`,
+   have the user publish every returned DNS record verbatim, wait for DNS
+   propagation, then call `verify_domain`. Poll `get_domain` before promising
+   branded outbound sending because inbound and outbound verification are
+   separate.
+7. **Use SDKs for backend integrations.** When a service—not Hermes itself—must
+   receive or send mail, follow e2a's SDK and webhook documentation instead of
+   treating MCP as a deployed webhook receiver.
+
+## Pitfalls
+
+- Do not guess an inbox for an account-scoped credential. Call `list_agents`
+  and select one explicitly.
+- Use `reply_to_message`, not a fresh send, when responding to existing mail.
 - Treat `accepted`, `scheduled`, and `pending_review` as successful durable
   acceptance. Do not resend; inspect the message later or consume webhook
   events for the terminal outcome.
@@ -88,24 +146,25 @@ to a message. Replies preserve the email client's thread; reusing
 - For attachments, pass base64 returned by an attachment/file tool; do not
   invent or hand-edit encoded bytes. Use `get_attachment` when bytes are
   needed.
+- Do not call `verify_domain` immediately after registration. DNS propagation
+  is asynchronous.
+- Do not treat an e2a inbox as the user's personal email account. The agent is
+  the mailbox owner and the visible sender.
+- Do not expose API keys in chat, logs, source files, or committed Hermes
+  configuration.
 
-### Create an inbox
+## Verification
 
-With an account-scoped session, call `create_agent` with an address on the
-shared `agents.e2a.dev` domain, such as `hermes-agent@agents.e2a.dev`. The
-shared domain requires no DNS setup. Use a custom domain only when the user
-owns it: `register_domain` returns DNS records, and `verify_domain` must be
-called after publication and propagation. Inbound and outbound custom-domain
-verification are separate; check `get_domain` before promising branded sending.
+Run:
 
-## Common use cases
+```bash
+hermes --toolsets mcp -q "Call e2a whoami and report the credential scope without changing anything"
+```
 
-- Give Hermes a durable identity for agent-to-human or agent-to-agent email.
-- Monitor an inbox with `list_messages` and inspect full messages with
-  `get_message`.
-- Send concise plain-text or HTML updates and continue conversations in-thread.
-- Use e2a webhooks and SDKs for a backend service; MCP is for Hermes operating
-  the inbox interactively.
+Verification succeeds when Hermes discovers the e2a MCP tools, `whoami`
+returns the credential scope, and no mutating tool is called. For account
+scope, a subsequent read-only `list_agents` call should return the available
+inboxes.
 
 ## References
 

--- a/website/docs/user-guide/skills/optional/email/email-e2a.md
+++ b/website/docs/user-guide/skills/optional/email/email-e2a.md
@@ -1,14 +1,14 @@
 ---
-title: "E2A — Use e2a for Hermes-owned email over hosted MCP"
+title: "E2A — Operate Hermes-owned email through a hosted MCP server"
 sidebar_label: "E2A"
-description: "Use e2a for Hermes-owned email over hosted MCP"
+description: "Operate Hermes-owned email through a hosted MCP server"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # E2A
 
-Use e2a for Hermes-owned email over hosted MCP.
+Operate Hermes-owned email through a hosted MCP server.
 
 ## Skill metadata
 
@@ -112,8 +112,8 @@ skill when the server's `tools/list` result is available.
    authenticate it before continuing.
 2. **Select the inbox.** For agent scope, use the returned `agent_email`. For
    account scope, call `list_agents` and select the inbox explicitly. If no
-   inbox exists, create one on the shared domain, such as
-   `hermes-agent@agents.e2a.dev`; the shared domain requires no DNS setup.
+   inbox exists, create one on the hosted shared domain; it requires no DNS
+   setup.
 3. **Read mail.** Call `list_messages`, then `get_message` for the complete
    body and sender-authentication evidence. Fetch attachment bytes only when
    needed with `get_attachment`.
@@ -158,7 +158,7 @@ skill when the server's `tools/list` result is available.
 Run:
 
 ```bash
-hermes --toolsets mcp -q "Call e2a whoami and report the credential scope without changing anything"
+hermes --toolsets skills,mcp-e2a -q "Use the e2a skill to call whoami and report the credential scope without changing anything"
 ```
 
 Verification succeeds when Hermes discovers the e2a MCP tools, `whoami`

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -428,6 +428,7 @@ const sidebars: SidebarsConfig = {
                   collapsed: true,
                   items: [
                     'user-guide/skills/optional/email/email-agentmail',
+                    'user-guide/skills/optional/email/email-e2a',
                   ],
                 },
                 {


### PR DESCRIPTION
## What does this PR do?

Adds e2a as an official optional email skill so Hermes can operate an agent-owned inbox through e2a's hosted MCP server. The skill documents OAuth and headless API-key setup, credential-scope-aware inbox selection, safe message reading and sending, reply threading, durable send outcomes, attachments, scheduled sends, and custom domains. It does not access a user's personal mailbox.

The integration stays in `optional-skills/` because it is a service-specific capability and requires no Hermes runtime changes or new package dependencies.

## Related Issue

Related: #329 (prior request for an agent-owned email integration). No dedicated e2a issue exists; a duplicate search found only this PR.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [x] 🎯 New skill (bundled or hub)

## Changes Made

- Add `optional-skills/email/e2a/SKILL.md` in the required modern section order.
- Configure the hosted `e2a` MCP server with OAuth and an environment-variable API-key alternative.
- Use the dynamic `mcp-e2a` toolset in the read-only verification command.
- Add hermetic static compliance coverage in `tests/skills/test_e2a_skill.py`.
- Generate the e2a website page, catalog entry, and sidebar entry.
- Credit Josh Zhang (`jiashuoz`) as the human contributor.

## How to Test

1. Run `scripts/run_tests.sh tests/skills/test_e2a_skill.py -q` (9 tests pass).
2. Run `.venv/bin/python -m tools.skill_linter optional-skills/email/e2a/SKILL.md` (clean).
3. Run `.venv/bin/python scripts/check-windows-footguns.py` with the PR changes staged (clean).
4. Run `git diff --check origin/main...HEAD` (clean).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.3 (Apple Silicon)

The canonical full-suite runner was attempted locally. The desktop sandbox denied loopback socket binds and process-signal tests, producing unrelated failures; the run was stopped after the result was conclusive. The required skill-specific hermetic suite passes 9/9.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — generated skill page, catalog, and sidebar
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no Hermes config key was added
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no scripts; all supported platforms declared; footgun check clean
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool behavior changed

## For New Skills

- [x] This skill is **broadly useful** to most users (if bundled) — N/A; this is an optional service integration, not bundled
- [x] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [x] No external dependencies that aren't already available — uses a configured hosted MCP server and adds no local package or script dependency
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills,mcp-e2a -q "Use the e2a skill to call whoami and report the credential scope without changing anything"`

The live end-to-end command requires an authorized e2a MCP account and an LLM provider. It is intentionally left unchecked rather than claiming an unverified live run; the verification path itself is read-only.

## Screenshots / Logs

Not applicable; this PR adds a Markdown skill and generated documentation.
