### PR TITLE
fix(tui): refresh context usage between agent steps

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3178,7 +3178,13 @@ def test_status_callback_accepts_single_message_argument():
 
 def test_step_callback_emits_live_usage_snapshot(monkeypatch):
     usage = {
+        "model": "gpt-5.6-sol",
         "calls": 7,
+        "input": 100,
+        "output": 20,
+        "prompt": 90,
+        "completion": 18,
+        "total": 120,
         "context_used": 123_456,
         "context_max": 272_000,
         "context_percent": 45,
@@ -3190,7 +3196,19 @@ def test_step_callback_emits_live_usage_snapshot(monkeypatch):
         cb = server._agent_cbs("sid")["step_callback"]
         cb(8, [])
 
-    emit.assert_called_once_with("usage.update", "sid", usage)
+    emit.assert_called_once_with(
+        "usage.update",
+        "sid",
+        {
+            "calls": 7,
+            "input": 100,
+            "output": 20,
+            "total": 120,
+            "context_used": 123_456,
+            "context_max": 272_000,
+            "context_percent": 45,
+        },
+    )
 
 
 def test_resolve_model_uses_inference_model_env(monkeypatch):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3176,6 +3176,23 @@ def test_status_callback_accepts_single_message_argument():
     )
 
 
+def test_step_callback_emits_live_usage_snapshot(monkeypatch):
+    usage = {
+        "calls": 7,
+        "context_used": 123_456,
+        "context_max": 272_000,
+        "context_percent": 45,
+    }
+    monkeypatch.setitem(server._sessions, "sid", {"agent": object()})
+    monkeypatch.setattr(server, "_session_usage_snapshot", lambda _session: usage)
+
+    with patch("tui_gateway.server._emit") as emit:
+        cb = server._agent_cbs("sid")["step_callback"]
+        cb(8, [])
+
+    emit.assert_called_once_with("usage.update", "sid", usage)
+
+
 def test_resolve_model_uses_inference_model_env(monkeypatch):
     monkeypatch.delenv("HERMES_MODEL", raising=False)
     monkeypatch.setenv("HERMES_INFERENCE_MODEL", " anthropic/claude-sonnet-4.6\n")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5099,6 +5099,33 @@ def _session_usage_snapshot(session: dict | None) -> dict:
     return dict(mirror_usage) if isinstance(mirror_usage, dict) else {}
 
 
+_USAGE_UPDATE_FIELDS = frozenset(
+    {
+        "active_subagents",
+        "calls",
+        "compressions",
+        "context_max",
+        "context_percent",
+        "context_used",
+        "cost_status",
+        "cost_usd",
+        "dev_credits_spent_micros",
+        "input",
+        "output",
+        "reasoning",
+        "total",
+    }
+)
+
+
+def _usage_update_snapshot(session: dict | None) -> dict:
+    return {
+        key: value
+        for key, value in _session_usage_snapshot(session).items()
+        if key in _USAGE_UPDATE_FIELDS
+    }
+
+
 def _project_info_for_cwd(cwd: str) -> dict | None:
     """Return the first-class Project owning ``cwd`` for UI status surfaces.
 
@@ -5763,7 +5790,7 @@ def _agent_cbs(sid: str) -> dict:
         # updated the agent's token counters. Push that fresh snapshot instead
         # of leaving the context meter frozen until the entire turn ends.
         "step_callback": lambda _iteration, _prev_tools: _emit(
-            "usage.update", sid, _session_usage_snapshot(_sessions.get(sid))
+            "usage.update", sid, _usage_update_snapshot(_sessions.get(sid))
         ),
         # Credits/notice spine (L1): an AgentNotice fired by the agent becomes a
         # notification.show WS event; a recovery clear becomes notification.clear.

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5759,6 +5759,12 @@ def _agent_cbs(sid: str) -> dict:
         "status_callback": lambda kind, text=None: _status_update(
             sid, str(kind), None if text is None else str(text)
         ),
+        # A step begins after the preceding API response and tool batch have
+        # updated the agent's token counters. Push that fresh snapshot instead
+        # of leaving the context meter frozen until the entire turn ends.
+        "step_callback": lambda _iteration, _prev_tools: _emit(
+            "usage.update", sid, _session_usage_snapshot(_sessions.get(sid))
+        ),
         # Credits/notice spine (L1): an AgentNotice fired by the agent becomes a
         # notification.show WS event; a recovery clear becomes notification.clear.
         # Snake_case payload to match the existing gateway-event convention.

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -83,7 +83,7 @@ describe('createGatewayEventHandler', () => {
     onEvent({
       payload: { calls: 3, context_max: 272_000, context_percent: 50, context_used: 136_000, total: 30 },
       type: 'usage.update'
-    } as any)
+    })
 
     expect(getUiState().usage).toMatchObject({
       calls: 3,

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -66,6 +66,36 @@ describe('createGatewayEventHandler', () => {
     patchUiState({ showReasoning: true })
   })
 
+  it('refreshes the live context meter from usage.update events', () => {
+    patchUiState({
+      usage: {
+        calls: 2,
+        context_max: 272_000,
+        context_percent: 25,
+        context_used: 68_000,
+        input: 10,
+        output: 5,
+        total: 15
+      }
+    })
+    const onEvent = createGatewayEventHandler(buildCtx([]))
+
+    onEvent({
+      payload: { calls: 3, context_max: 272_000, context_percent: 50, context_used: 136_000, total: 30 },
+      type: 'usage.update'
+    } as any)
+
+    expect(getUiState().usage).toMatchObject({
+      calls: 3,
+      context_max: 272_000,
+      context_percent: 50,
+      context_used: 136_000,
+      input: 10,
+      output: 5,
+      total: 30
+    })
+  })
+
   it('archives incomplete todos into transcript flow at end of turn so they scroll up', () => {
     const appended: Msg[] = []
 

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -747,6 +747,10 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         return
       }
+      case 'usage.update':
+        patchUiState(state => ({ ...state, usage: { ...state.usage, ...ev.payload } }))
+
+        return
 
       case 'thinking.delta': {
         if (!getUiState().busy) {

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -604,6 +604,7 @@ export type GatewayEvent =
   | { payload?: { skin?: GatewaySkin }; session_id?: string; type: 'gateway.ready' }
   | { payload?: GatewaySkin; session_id?: string; type: 'skin.changed' }
   | { payload: SessionInfo; session_id?: string; type: 'session.info' }
+  | { payload: Usage; session_id?: string; type: 'usage.update' }
   | { payload?: { text?: string }; session_id?: string; type: 'thinking.delta' }
   | { payload?: { kind?: string }; session_id?: string; type: 'reaction' }
   | { payload?: undefined; session_id?: string; type: 'message.start' }

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -604,7 +604,7 @@ export type GatewayEvent =
   | { payload?: { skin?: GatewaySkin }; session_id?: string; type: 'gateway.ready' }
   | { payload?: GatewaySkin; session_id?: string; type: 'skin.changed' }
   | { payload: SessionInfo; session_id?: string; type: 'session.info' }
-  | { payload: Usage; session_id?: string; type: 'usage.update' }
+  | { payload: Partial<Usage>; session_id?: string; type: 'usage.update' }
   | { payload?: { text?: string }; session_id?: string; type: 'thinking.delta' }
   | { payload?: { kind?: string }; session_id?: string; type: 'reaction' }
   | { payload?: undefined; session_id?: string; type: 'message.start' }


### PR DESCRIPTION
## Summary
- emit a lightweight `usage.update` event at each agent step
- merge the fresh usage snapshot into TUI state without rebuilding full session metadata
- keep the context meter current during long multi-step turns instead of waiting for turn completion

## Test plan
- `pytest -q tests/test_tui_gateway_server.py::test_step_callback_emits_live_usage_snapshot tests/test_tui_gateway_server.py::test_status_callback_emits_kind_and_text`
- `npm test --workspace=ui-tui -- --run src/__tests__/createGatewayEventHandler.test.ts src/__tests__/appChromeStatusRule.test.tsx`
- `npm run typecheck --workspace=ui-tui`
- `npm run build --workspace=ui-tui`