### PR TITLE
feat(skills): update hermes-agent-skill-authoring to v2.1.0

### DIFF
--- a/skills/software-development/hermes-agent-skill-authoring/SKILL.md
+++ b/skills/software-development/hermes-agent-skill-authoring/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: hermes-agent-skill-authoring
 description: "Author in-repo SKILL.md files: frontmatter and structure."
-version: 2.0.0
-author: Hermes Agent
+version: 2.1.0
+author: tShields (trojandnc), Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [skills, authoring, hermes-agent, conventions, skill-md]
-    related_skills: [plan, requesting-code-review]
+    related_skills: [plan, requesting-code-review, skill-architecture-patterns]
 ---
 
 # Authoring Hermes-Agent Skills (in-repo)
@@ -21,6 +21,8 @@ There are two places a SKILL.md can live:
 2. **In-repo (this skill is about this case):** `skills/<category>/<name>/SKILL.md` or `optional-skills/<category>/<name>/SKILL.md` inside the hermes-agent repo — committed, shipped with the package. Use `write_file` + `git add`. `skill_manage(action='create')` does NOT target this tree.
 
 In-repo skills must meet the repo's **hardline authoring standards** (see AGENTS.md, "Skill authoring standards (HARDLINE)" — that section is the source of truth; this skill is the operational walkthrough). Reviewers reject PRs that violate them, so meeting them up front is cheaper than a salvage pass later.
+
+**Backward compatibility:** The standards below apply to **new skills and skills under active edit in a PR**. Untouched existing in-repo skills are **grandfathered** — no mandatory batch rewrite. Optional hygiene: a separate scan of descriptions >57 chars or weak When to Use sections is not a gate on this standard.
 
 ## When to Use
 
@@ -70,11 +72,17 @@ metadata:
 
 ### `description` rules (HARDLINE — the validator's 1024 is NOT the standard)
 
-- **≤ 60 characters.** One sentence. Ends with a period.
-- State the capability, not the implementation, and don't repeat the skill name.
-- No marketing words ("powerful", "comprehensive", "seamless", "advanced").
-- The system prompt skill index truncates at 57 chars + "..." — the trigger/capability must be self-contained in that window.
-- If the description contains a `:`, wrap it in double quotes or YAML parses it as a mapping and the docs generator crashes. Quotes don't count toward the 60.
+The description is the **highest-leverage always-paid surface** in a skill.
+Every token in it is paid on every turn via the skill index. Write it with
+more care than the body — a beautiful Procedure with a vague description
+is a skill that fails selection.
+
+- **≤ 60 characters** (hardline). One sentence. Ends with a period.
+- **Effective window: 57 characters.** The skill index truncates at 57 + "..." — the trigger/capability must be self-contained in the first 57 even if total length is 58–60.
+- State the **capability**, not the implementation, and don't repeat the skill name.
+- No marketing words ("powerful", "comprehensive", "seamless", "advanced", "robust", "end-to-end"). Use judgment: "advanced" and "comprehensive" are legitimate when they describe scope, not fluff. Flag for review, not auto-reject.
+- Prefer verbs of effect over setup narrative ("Track…", "Author…", "Review…").
+- If the description contains a `:`, wrap it in double quotes or YAML parses it as a mapping and the docs generator crashes.
 
 Good: `Track named companies for material news with cited digests.`
 Bad: `Use when a user asks to monitor named competitors or companies for product launches, pricing changes, funding, ...` (240 chars — rejected in review)
@@ -111,12 +119,16 @@ POSIX-only signals to search for in `scripts/`: `fcntl`, `termios`, `pty`, `os.f
 
 ## Body Structure (modern section order)
 
+For the progressive-disclosure theory underpinning layered section design, see `skill-architecture-patterns`. This section is the operational slot map.
+
 ```
 # <Skill> Skill
 2-3 sentence intro: what it does, what it doesn't do, dependency stance.
 
-## When to Use          — bulleted triggers (+ "Don't use for:" counter-triggers)
+## When to Use          — DEFINITION: bulleted triggers (+ "Don't use for:" counter-triggers)
 ## Prerequisites        — exact env vars, installs, API key sourcing
+## Safety & Enforcement — when side effects / sensitive data (see references/)
+## Dynamic Loading Rules — when 2+ references/*.md  (see references/)
 ## How to Run           — canonical invocation through the `terminal` tool
 ## Quick Reference      — flat command list, no narration
 ## Procedure            — numbered steps, each with a checkable completion criterion
@@ -124,7 +136,7 @@ POSIX-only signals to search for in `scripts/`: `fcntl`, `termios`, `pty`, `os.f
 ## Verification         — how to prove the skill worked
 ```
 
-Not every section applies to every skill (a pure-procedure task skill may have no Quick Reference), but When to Use + actionable body + Pitfalls + Verification are the minimum. Cut marketing intros, "Setup Check" no-ops, and re-explanations of env vars already in Prerequisites.
+Not every section applies to every skill. The minimum is When to Use + actionable body + Pitfalls + Verification. Safety & Enforcement and Dynamic Loading Rules are **required** when their triggers fire (side effects / sensitive data, 2+ reference files), **optional** otherwise. Cut marketing intros, "Setup Check" no-ops, and re-explanations of env vars already in Prerequisites.
 
 ### Reference Hermes tools, not raw shell
 
@@ -139,7 +151,7 @@ Write repo-relative paths (`skills/...`, `tools/skill_manager_tool.py`). A `/hom
 A skill exists to make the agent's process more predictable — the agent reliably follows the same useful discipline.
 
 1. **Optimize for process predictability.** If a line does not change behavior, cut it.
-2. **Choose the right context load.** The description is paid for every turn; details go in the body or linked references.
+2. **Definition-first order.** Polish description + When to Use before body section polish. The description is paid for every turn; details go in the body or linked references.
 3. **End steps with completion criteria.** Checkable and, when it matters, exhaustive: "every modified file accounted for" beats "summarize changes."
 4. **Co-locate rules with the concept they govern.**
 5. **Use strong leading words** ("tight loop," "root cause," "regression test") over long repeated explanations.
@@ -148,15 +160,37 @@ A skill exists to make the agent's process more predictable — the agent reliab
 ## Tests and Docs (required for repo skills)
 
 1. **Tests** live at `tests/skills/test_<skill>_skill.py` — stdlib + pytest + `unittest.mock` only, no live network. Run via `scripts/run_tests.sh tests/skills/test_<skill>_skill.py -q`. (The generic `tests/tools/test_skill_manager_tool.py` passing proves nothing about YOUR skill.)
+   - **Definition tests:** verify description ≤ 60 chars, ends with period, no banned marketing words. Optionally check When to Use section presence.
+   - **Enforcement tests (Safety & Enforcement):** deny + allow + side-effect not called + audit on deny. See `references/safety-enforcement-template.md` for the full skeleton.
+   - **Structural tests (Dynamic Loading Rules):** section present when 2+ references/*.md, backticked paths resolve, no "load all" phrasing, no orphans. See `references/dynamic-loading-rules-template.md` for the full skeleton.
 2. **Docs regen:** run `python3 website/scripts/generate-skill-docs.py`, then apply scope discipline — the generator rewrites EVERY auto-gen page. `git checkout --` everything that isn't yours; the final diff must show only your SKILL.md, your one per-skill docs page, a one-line catalog row, and a one-line `website/sidebars.ts` insertion (verify with `search_files(pattern='<your-slug>', path='website/sidebars.ts')` — exactly one hit, or the page is an orphan).
 3. **`.env.example`** (only if the skill needs new env vars): one clearly delimited commented block; touch nothing else in the file.
+
+## Dynamic Loading Rules
+
+This skill ships two reference files (`references/safety-enforcement-template.md` and
+`references/dynamic-loading-rules-template.md`). Load them **only** when the
+current task involves writing or reviewing enforcement or loading rules.
+
+**Default: load no reference files** until a matching task scope.
+
+| When the task involves… | Load (skill-relative) |
+|---|---|
+| Adding or reviewing policy guards, data-exposure preconditions, or enforcement tests | `references/safety-enforcement-template.md` (not the loading rules template) |
+| Adding or reviewing file-size thresholds, progressive-disclosure rules, or structural loading tests | `references/dynamic-loading-rules-template.md` (not the safety template) |
+| Authoring a new skill with both side effects and multi-reference material | Both reference files (use `read_file` on each separately) |
+
+As a heuristic, limit per-turn loads to 3–4 files. Not a hard rule.
+
+Paths are skill-relative (`references/...`), never machine-local.
 
 ## Workflow
 
 1. **Survey peers** in the target category with `search_files(target='files')` and read 2-3 peer SKILL.md files to match tone and structure. Prefer extending an existing skill over creating a narrow sibling.
 2. **Decide tier and category** (see above). When in doubt, optional — and ask before pushing rather than defaulting.
-3. **Draft** with `write_file` to `skills/<category>/<name>/SKILL.md` (or `optional-skills/...`).
-4. **Validate locally**:
+3. **Define first.** Write `name` + `description` + When to Use / Don't use before drafting the body. Validate description length, period, and banned-word checks before proceeding to body sections.
+4. **Draft** with `write_file` to `skills/<category>/<name>/SKILL.md` (or `optional-skills/...`).
+5. **Validate locally**:
    ```python
    import yaml, re, pathlib
    content = pathlib.Path("skills/<category>/<name>/SKILL.md").read_text()
@@ -170,9 +204,9 @@ A skill exists to make the agent's process more predictable — the agent reliab
    assert len(content) <= 100_000
    ```
    Also verify every `related_skills` entry exists in-repo.
-5. **Add tests + regen docs** (previous section).
-6. **Git add + commit** on the active branch; open a PR.
-7. **Note:** the CURRENT session's skill loader is cached — `skill_view` / `skills_list` will not see the new skill until a new session. This is expected, not a bug.
+6. **Add tests + regen docs** (previous section).
+7. **Git add + commit** on the active branch; open a PR.
+8. **Note:** the CURRENT session's skill loader is cached — `skill_view` / `skills_list` will not see the new skill until a new session. This is expected, not a bug.
 
 ## Editing Existing In-Repo Skills
 
@@ -193,6 +227,11 @@ A skill exists to make the agent's process more predictable — the agent reliab
 8. **Skipping the docs generator or pushing its unrelated drift.** Both directions are wrong: no regen = orphan skill with no docs page; blind regen = a ballooned diff full of other skills' drift.
 9. **Expecting the current session to see the new skill.** The loader is initialized at session start.
 10. **Letting skills accumulate sediment.** When adding a rule, remove the old wording it replaces.
+11. **Implementation dump in description** — "runs pytest then parses JSON…" belongs in body or references, not the always-paid description.
+12. **Vague trigger** — "use when user asks about X" with no capability verb; prefer "Author…", "Track…", "Review…".
+13. **Description only works after reading the body** — the description must be self-contained for catalog selection.
+14. **Missing Don't-use** when a peer skill shares vocabulary — causes false-positive loads.
+15. **Relying on a future router/embedding layer** instead of fixing the definition — precise definitions beat routers at current scale.
 
 ## Verification Checklist
 
@@ -200,13 +239,17 @@ A skill exists to make the agent's process more predictable — the agent reliab
 - [ ] File at `skills/<category>/<name>/SKILL.md` or `optional-skills/<category>/<name>/SKILL.md`
 - [ ] Frontmatter starts at byte 0 with `---`, closes with `\n---\n`
 - [ ] `name`, `description`, `version`, `author`, `license`, `platforms`, `metadata.hermes.{tags, related_skills}` all present
-- [ ] Description ≤ 60 chars, one sentence, ends with a period, no marketing words
+- [ ] Description ≤ 60 chars, one sentence, ends with a period, no marketing words, trigger self-contained in first 57-char window
+- [ ] Description written and validated **before** body section polish (definition-first rule)
+- [ ] When to Use includes counter-triggers when peer skills share vocabulary
 - [ ] `author` credits the human contributor first
 - [ ] `platforms:` audited against actual prose/scripts, not copied from a sibling
 - [ ] Every `related_skills` entry resolves in-repo
 - [ ] Body follows the modern section order; commands framed through Hermes tools
 - [ ] No machine-local paths anywhere in the file
 - [ ] Each ordered step has a checkable completion criterion
+- [ ] Side effects / sensitive data → `## Safety & Enforcement` present with matching policy tests (deny + allow + side-effect not called + audit on deny)
+- [ ] 2+ `references/*.md` → `## Dynamic Loading Rules` present with structural tests (paths resolve, no load-all, no orphans)
 - [ ] Tests at `tests/skills/test_<skill>_skill.py` pass under `scripts/run_tests.sh`
 - [ ] Docs regenerated with scope discipline; sidebar has exactly one entry for the slug
 - [ ] `git add` + commit on the intended branch; PR opened

--- a/skills/software-development/hermes-agent-skill-authoring/references/dynamic-loading-rules-template.md
+++ b/skills/software-development/hermes-agent-skill-authoring/references/dynamic-loading-rules-template.md
@@ -1,0 +1,234 @@
+---
+title: "Dynamic Loading Rules Section Template"
+---
+
+# Dynamic Loading Rules — body section template
+
+**Architecture rule:** Progressive disclosure — SKILL.md body stays operational
+core. Bulky material lives in `references/`, `scripts/`, `templates/` and is
+loaded **by task scope**, never all at once. This is not a router/index/hub
+skill and not a selectable "catalog" skill.
+
+## When section is required vs optional
+
+| Skill has… | Section |
+|---|---|
+| **2+** files under `references/` (or equivalent bulky docs the body only points at) | **Required** |
+| One short reference + body already covers the workflow | Optional / omit (prefer a one-line "load when…" pointer) |
+| No `references/`, only thin `scripts/` invoked via `terminal` | Optional / omit |
+| Framework / multi-domain skill (OWASP-style categories, multi-family guides) | **Required** — priority-based loading is the whole point |
+
+## What this section is *not*
+
+| Anti-pattern | Why |
+|---|---|
+| A skill that is *only* a table of "load skill X / Y / Z" | Banned router/index/hub |
+| "Read all of `references/` before starting" | Context blow-up; defeats progressive disclosure |
+| Machine-local absolute paths | Review-blocking; use skill-relative `references/...` |
+| Vague "see references as needed" with no scope→file map | Unactionable — agent loads everything or nothing |
+
+## Template: paste into SKILL.md body
+
+Replace bracketed placeholders. Keep rules as checkable if→then lines, not essays.
+
+```markdown
+## Dynamic Loading Rules
+
+Progressive disclosure: keep this body as the operational core.
+Load bundled resources **only when a rule below matches the current task**.
+Default: **load no reference files** until a match. Prefer `read_file` on the
+specific path; run scripts via `terminal` without pasting their source into context.
+
+**Scripts are excluded from this table.** Deterministic helpers in `scripts/`
+should be invoked via `terminal` without reading their source into context.
+Only add a row here when a script requires a reference doc to interpret its output.
+
+### Scope → resource map
+
+| When the task involves… | Load (skill-relative) |
+|---|---|
+| [e.g. secret/credential scanning] | `references/secret-detection.md` (not other category files) |
+| [e.g. access control only] | `references/a01-broken-access-control.md` (not full category set) |
+| [e.g. multi-category review] | Shared methodology first (`references/methodology.md`), then only category files in scope |
+| [e.g. compose with MML] | `references/message-composition.md` (not config deep-dives) |
+| [e.g. first-time config] | `references/configuration.md` (not composition guide) |
+
+Negative exclusions go inline in the Load cell only when the excluded set is
+small and informative — do not invent a separate "Do not load" column.
+
+### Priority and load discipline
+
+1. Match the **narrowest** row that covers the user request (most-specific wins).
+2. **As a heuristic, limit per-turn loads to 3–4 reference files** unless the
+   user explicitly requests a full baseline. This is **not a hard rule**.
+3. Prefer executing `scripts/<helper>.py` via `terminal` over `read_file` of the
+   script source.
+4. Never pre-load "just in case." Re-evaluate after each phase of the Procedure.
+
+### How to load
+
+```
+read_file(path="references/<file>.md")
+terminal(command="python3 scripts/<helper>.py ...", timeout=...)
+```
+
+Paths are **skill-relative** (under this skill's directory), never machine-local.
+
+### Completion criterion (agent-facing)
+
+Before heavy Procedure work: every loaded reference is justified by a row above;
+unrelated references remain unread; prefer staying near the 3–4 file heuristic
+unless the user explicitly requested a full pass.
+
+### Author verification (author-facing)
+
+Ensure **every file under `references/` is named in at least one row** of the
+scope map. Unreferenced files are orphaned and should be removed or mapped.
+```
+
+## Relationship to Safety & Enforcement
+
+| Concern | Where it lives | When it runs |
+|---|---|---|
+| Preconditions / PII / auth / rate limits | `## Safety & Enforcement` + `scripts/policy.py` | Every invocation before side effects |
+| Which docs enter context | `## Dynamic Loading Rules` | Only when body alone is insufficient for the task |
+
+Do not conflate them. Loading a reference is not a substitute for a code-level guard.
+
+## Structural test skeleton
+
+Runtime "did the model follow the rules?" is not CI-testable without a live
+agent. Test what *is* deterministic: the skill package's structure and the
+rules prose.
+
+Conventions: stdlib + pytest + `unittest.mock` only, no live network.
+Run: `scripts/run_tests.sh tests/skills/test_<skill>_skill.py -q`
+
+### Import / path note
+
+Tests should locate the skill via **repo-relative** path
+(`skills/<category>/<name>/` or `optional-skills/...`), never `$HOME`.
+
+```python
+"""Structural tests for Dynamic Loading Rules in <skill>."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+# Adjust to the skill under test (repo-relative from hermes-agent root).
+SKILL_DIR = Path("skills/<category>/<name>")
+SKILL_MD = SKILL_DIR / "SKILL.md"
+REFERENCES = SKILL_DIR / "references"
+
+
+def _skill_text() -> str:
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+def _reference_files() -> list[Path]:
+    if not REFERENCES.is_dir():
+        return []
+    return sorted(p for p in REFERENCES.rglob("*.md") if p.is_file())
+
+
+class TestDynamicLoadingRulesPresence:
+    def test_multi_ref_skills_have_section(self):
+        refs = _reference_files()
+        if len(refs) < 2:
+            pytest.skip("fewer than 2 reference files — section optional")
+        text = _skill_text()
+        assert re.search(r"^## Dynamic Loading Rules\s*$", text, re.M), (
+            "skills with 2+ references/*.md must include ## Dynamic Loading Rules"
+        )
+
+    def test_section_declares_default_load_none_or_match_only(self):
+        refs = _reference_files()
+        if len(refs) < 2:
+            pytest.skip("section not required")
+        text = _skill_text()
+        m = re.search(r"## Dynamic Loading Rules\n(.*?)(?=\n## |\Z)", text, re.S)
+        assert m, "Dynamic Loading Rules section missing"
+        body = m.group(1).lower()
+        signals = ("load no", "only when", "when the task", "never pre-load", "default", "heuristic")
+        assert any(s in body for s in signals), (
+            "section must state default/scoped loading, not unbounded read of references/"
+        )
+
+
+class TestReferencePathsResolve:
+    def test_backticked_reference_paths_exist(self):
+        text = _skill_text()
+        mentioned = set(re.findall(r"`(references/[^`]+)`", text))
+        if not mentioned:
+            pytest.skip("no backticked references/ paths in SKILL.md")
+        missing = []
+        for rel in mentioned:
+            rel_path = rel.split("#", 1)[0]
+            if not (SKILL_DIR / rel_path).is_file():
+                missing.append(rel_path)
+        assert not missing, f"SKILL.md references missing files: {missing}"
+
+    def test_every_reference_file_is_mapped(self):
+        refs = _reference_files()
+        if len(refs) < 2:
+            pytest.skip("section not required")
+        text = _skill_text()
+        orphans = []
+        for path in refs:
+            rel = path.relative_to(SKILL_DIR).as_posix()
+            if rel not in text and path.name not in text:
+                orphans.append(rel)
+        assert not orphans, f"orphan references (not named in SKILL.md): {orphans}"
+
+    def test_no_machine_local_reference_paths(self):
+        text = _skill_text()
+        bad = re.findall(r"`(/Users/[^`]+|/home/[^`]+|~/?\.hermes/skills/[^`]+)`", text)
+        assert not bad, f"machine-local paths in skill: {bad}"
+
+
+class TestNoLoadAllAntiPattern:
+    def test_skill_md_avoids_load_all_phrasing(self):
+        text = _skill_text().lower()
+        banned = ["read all of references", "load all references", "load the entire references", "read every reference"]
+        hits = [b for b in banned if b in text]
+        assert not hits, f"load-all anti-pattern phrasing found: {hits}"
+
+
+class TestScopeMapTableShape:
+    def test_loading_rules_table_has_when_and_load_columns(self):
+        refs = _reference_files()
+        if len(refs) < 2:
+            pytest.skip("section not required")
+        text = _skill_text()
+        m = re.search(r"## Dynamic Loading Rules\n(.*?)(?=\n## |\Z)", text, re.S)
+        assert m
+        section = m.group(1)
+        assert "|" in section, "prefer a scope→resource table for scanability"
+        header = section.lower()
+        assert "when" in header or "task" in header
+        assert "load" in header or "references/" in section
+```
+
+### Done checklist for loading-rule tests
+
+- [ ] Section present when `len(references/*.md) >= 2`
+- [ ] Every backticked `references/...` path in SKILL.md exists on disk
+- [ ] Every file under `references/` is named somewhere in SKILL.md (no orphans)
+- [ ] No machine-local paths
+- [ ] No "load all references" phrasing
+- [ ] Section states scoped / default-none discipline
+- [ ] **Not required:** live model follow-through (document as residual risk in Pitfalls)
+- [ ] **Not required:** numeric "≤4 files" as a CI assertion (heuristic only)
+
+## Anti-patterns
+
+1. Load-all default — "read everything in references/ first" — banned
+2. Orphan references — files on disk never named in the scope map
+3. Router skill disguised as loading rules — rules that only point at other skills
+4. Inlining reference bodies back into SKILL.md — blows past the size target
+5. Treating 3–4 files/turn as a hard rule or CI gate — it is a diagnostic heuristic
+6. Testing only happy-path Procedure with zero structural checks on reference paths
+7. Putting every `scripts/` helper in the scope table — only map when a ref is needed to interpret output

--- a/skills/software-development/hermes-agent-skill-authoring/references/safety-enforcement-template.md
+++ b/skills/software-development/hermes-agent-skill-authoring/references/safety-enforcement-template.md
@@ -1,0 +1,240 @@
+---
+title: "Safety & Enforcement Section Template"
+---
+
+# Safety & Enforcement — body section template
+
+**Architecture rule:** Enforcement lives *inside* the skill's execution path via a
+shared code-level utility (import/call). Never as an agent-selectable policy skill.
+
+## Shared utility (code-level)
+
+- Module: `scripts/policy.py` — repo-relative; never a machine-local path.
+- Entry points this skill uses:
+  - `policy.check_<guard>(...)` → returns `Decision` (never raises); caller reads `d.allowed`
+  - `policy.enforce_<guard>(...)` → calls `check_*`, audit-logs, raises `PolicyViolation` on deny
+  - `policy.audit_log(decision, context)` → structured decision record (no secrets)
+
+## When section is required vs optional
+
+| Skill does… | Section |
+|---|---|
+| Write/delete files, call external APIs, send messages, mutate shared state, handle PII/credentials, enforce auth/rate limits | **Required** (bundled); **Recommended** (optional-skills) |
+| Pure read of public docs, formatting, local analysis of user-supplied non-sensitive text | Optional / omit |
+
+## Template: paste into SKILL.md body
+
+Replace bracketed placeholders. Keep prose short — process predictability over narrative.
+
+```markdown
+## Safety & Enforcement
+
+Self-guarding: this skill validates preconditions **before** any side effect.
+Enforcement is embedded in the skill's own path via a shared code utility —
+not a separate agent-visible policy skill.
+
+### Preconditions (fail closed)
+
+| Guard | Trigger | On violation |
+|---|---|---|
+| [e.g. PII present] | [e.g. content matches `detect_pii`] | Block write; return clear error; audit-log |
+| [e.g. missing auth] | [e.g. required env var empty] | Abort before API call |
+| [e.g. rate limit] | [e.g. N calls / window exceeded] | Defer or refuse; do not retry-storm |
+
+### Procedure integration
+
+1. **Load inputs** (paths, payloads, env) with `read_file` / env checks as needed.
+2. **Run guards** via the skill helper (preferred) or:
+   ```
+   terminal(command="python3 -c 'from scripts.policy import enforce_<guard>; enforce_<guard>(...)'", timeout=30)
+   ```
+3. **Only on allow:** proceed to side-effect steps in Procedure.
+4. **On deny:** stop; surface the violation message; do not partial-apply.
+
+Completion criterion for this section: every side-effect step in Procedure is
+preceded by a named guard, and a unit test asserts the guard blocks a
+known-bad input without network (side effect not called; audit log called on deny).
+```
+
+## Shared utility contract (`scripts/policy.py`)
+
+Interface contract only — do not ship until a first consumer skill needs it.
+
+```python
+"""Shared policy helpers for skill scripts. Not an agent-selectable skill."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+class PolicyViolation(Exception):
+    """Raised when a skill must fail closed."""
+    def __init__(self, code: str, message: str):
+        self.code = code
+        self.message = message
+        super().__init__(f"{code}: {message}")
+
+
+@dataclass(frozen=True)
+class Decision:
+    allowed: bool
+    code: str
+    message: str
+    context: dict[str, Any]
+
+
+# Example guards — replace/extend per domain; keep regexes here, not copy-pasted in every skill.
+_EMAIL = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
+_SSN = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
+
+
+def detect_pii(text: str) -> list[str]:
+    """Return list of PII kind labels found (empty if clean)."""
+    found: list[str] = []
+    if _EMAIL.search(text or ""):
+        found.append("email")
+    if _SSN.search(text or ""):
+        found.append("ssn")
+    return found
+
+
+def check_no_pii(text: str, *, action: str = "write") -> Decision:
+    """Return a Decision. Never raises — caller inspects d.allowed."""
+    kinds = detect_pii(text)
+    if kinds:
+        return Decision(
+            allowed=False, code="pii_detected",
+            message=f"Refusing {action}: detected {', '.join(kinds)}",
+            context={"kinds": kinds},
+        )
+    return Decision(allowed=True, code="ok", message="clean", context={})
+
+
+def enforce_no_pii(text: str, *, action: str = "write") -> None:
+    """Call check_*, audit_log both outcomes, raise PolicyViolation on deny."""
+    d = check_no_pii(text, action=action)
+    if not d.allowed:
+        audit_log(d)
+        raise PolicyViolation(d.code, d.message)
+    audit_log(d)
+
+
+def audit_log(decision: Decision, extra: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+    """Return a structured record. Never include raw secrets or full PII payloads."""
+    record = {
+        "allowed": decision.allowed,
+        "code": decision.code,
+        "message": decision.message,
+        "context": {**decision.context, **(extra or {})},
+    }
+    return record
+```
+
+| Function family | Behavior |
+|---|---|
+| `check_*` | Returns `Decision` only — **never raises** |
+| `enforce_*` | Calls `check_*` → `audit_log` → raises `PolicyViolation` on deny |
+| `audit_log` | Structured record; codes/kinds only; no raw secrets/PII payloads |
+
+## Unit-test skeleton
+
+Conventions: stdlib + pytest + `unittest.mock` only, no live network.
+Run: `scripts/run_tests.sh tests/skills/test_<skill>_skill.py -q`
+
+### Import / PYTHONPATH note
+
+> `scripts/` must be on `PYTHONPATH` when tests run. Existing Hermes test
+> convention uses `python -m pytest` from the repo root (which adds the root to
+> `sys.path`). If the skill is in `optional-skills/`, adjust the import to
+> `optional_skills.<category>.<name>.scripts.policy` or add a `conftest.py`
+> that extends `sys.path`. See `hermes-agent-skill-authoring` → Tests and Docs
+> for the canonical pattern.
+
+```python
+"""Policy / enforcement tests for <skill>."""
+from __future__ import annotations
+
+import pytest
+from unittest import mock
+
+# Adjust import path: repo-root pytest → scripts.policy;
+# optional-skills → optional_skills.<cat>.<name>.scripts.policy
+from scripts.policy import (
+    PolicyViolation, check_no_pii, enforce_no_pii, detect_pii, audit_log,
+)
+
+
+class TestPiiGuard:
+    def test_detects_email(self):
+        assert "email" in detect_pii("contact me at user@example.com please")
+
+    def test_clean_text_has_no_pii(self):
+        assert detect_pii("deploy the canary to staging") == []
+
+    def test_check_no_pii_denies_on_ssn(self):
+        d = check_no_pii("ssn 123-45-6789", action="bucket_write")
+        assert d.allowed is False
+        assert d.code == "pii_detected"
+
+    def test_enforce_no_pii_raises(self):
+        with pytest.raises(PolicyViolation) as ei:
+            enforce_no_pii("email user@example.com", action="bucket_write")
+        assert ei.value.code == "pii_detected"
+
+    def test_enforce_no_pii_allows_clean(self):
+        enforce_no_pii("no sensitive content here", action="bucket_write")
+
+
+class TestSkillEmbedsEnforcement:
+    """Prove the skill path calls the shared utility before side effects."""
+
+    def test_blocks_write_and_audits(self):
+        from scripts import policy as policy_mod
+        side_effect = mock.Mock(name="write_bucket")
+        with mock.patch.object(policy_mod, "audit_log") as mock_audit:
+            def skill_write(payload: str) -> None:
+                policy_mod.enforce_no_pii(payload, action="bucket_write")
+                side_effect(payload)
+            with pytest.raises(PolicyViolation):
+                skill_write("leak user@example.com")
+            mock_audit.assert_called_once()
+        side_effect.assert_not_called()
+
+    def test_allows_write_when_clean(self):
+        from scripts import policy as policy_mod
+        side_effect = mock.Mock(name="write_bucket")
+        def skill_write(payload: str) -> None:
+            policy_mod.enforce_no_pii(payload, action="bucket_write")
+            side_effect(payload)
+        skill_write("metrics batch 42")
+        side_effect.assert_called_once_with("metrics batch 42")
+
+
+class TestAuditLogShape:
+    def test_audit_record_has_no_raw_payload(self):
+        d = check_no_pii("user@example.com")
+        record = audit_log(d, extra={"skill": "example-skill"})
+        assert set(record) >= {"allowed", "code", "message", "context"}
+        blob = str(record)
+        assert "user@example.com" not in blob
+```
+
+### Done checklist for enforcement tests
+
+- [ ] Deny case: violation input → guard raises/returns deny
+- [ ] Allow case: clean input → side effect proceeds
+- [ ] Side-effect mock **not** called on deny
+- [ ] Deny path **calls `audit_log`** (mock and assert)
+- [ ] No network fixtures, no live credentials
+- [ ] Shared utility is the SUT for detection logic; skill tests only prove the call is wired before the side effect
+
+## Anti-patterns
+
+1. Agent-visible policy skill — banned; use `scripts/policy.py`
+2. Copy-pasted regexes across 20 skills — put patterns in the shared module
+3. Guards only in prose with no test — add `tests/skills/test_*_skill.py`
+4. Logging full PII/secrets in audit trails — log codes/kinds only
+5. Fail open ("couldn't check, proceed anyway") — fail closed
+6. Shipping `scripts/policy.py` with no consumer — template-only until first skill needs it

--- a/tests/skills/test_hermes_agent_skill_authoring_skill.py
+++ b/tests/skills/test_hermes_agent_skill_authoring_skill.py
@@ -1,0 +1,228 @@
+"""Tests for the hermes-agent-skill-authoring SKILL.md and its references.
+
+Validates:
+  - Frontmatter: required fields, ≤60-char description, ends with period,
+    trigger self-contained in first 57 characters
+  - Body structure: section presence, no machine-local paths
+  - Dynamic Loading Rules: present with 2+ references/*.md, paths resolve,
+    no load-all phrasing, no orphans
+  - Safety & Enforcement template reference resolves
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+SKILL_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "skills"
+    / "software-development"
+    / "hermes-agent-skill-authoring"
+)
+SKILL_MD = SKILL_DIR / "SKILL.md"
+REFERENCES = SKILL_DIR / "references"
+
+BANNED_MARKETING = {"powerful", "comprehensive", "seamless", "advanced", "robust", "end-to-end"}
+
+
+@pytest.fixture(scope="module")
+def skill_source() -> str:
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def frontmatter(skill_source) -> dict:
+    m = re.search(r"^---\n(.*?)\n---", skill_source, re.DOTALL)
+    assert m, "SKILL.md missing YAML frontmatter"
+    return yaml.safe_load(m.group(1))
+
+
+@pytest.fixture(scope="module")
+def reference_files() -> list[Path]:
+    if not REFERENCES.is_dir():
+        return []
+    return sorted(p for p in REFERENCES.rglob("*.md") if p.is_file())
+
+
+# ── Frontmatter ──────────────────────────────────────────────────────────────
+
+class TestFrontmatter:
+    def test_skill_dir_exists(self) -> None:
+        assert SKILL_DIR.is_dir(), f"missing skill dir: {SKILL_DIR}"
+
+    def test_starts_with_frontmatter(self, skill_source: str) -> None:
+        assert skill_source.startswith("---"), "SKILL.md must start with ---"
+
+    def test_required_fields_present(self, frontmatter: dict) -> None:
+        for field in ("name", "description", "version", "author", "license", "platforms"):
+            assert field in frontmatter, f"missing required field: {field}"
+
+    def test_metadata_tags_present(self, frontmatter: dict) -> None:
+        meta = frontmatter.get("metadata", {})
+        assert "hermes" in meta, "missing metadata.hermes"
+        assert "tags" in meta["hermes"], "missing metadata.hermes.tags"
+
+    def test_description_under_60_chars(self, frontmatter: dict) -> None:
+        desc = frontmatter["description"]
+        assert len(desc) <= 60, f"description is {len(desc)} chars (limit ≤60): {desc!r}"
+
+    def test_description_ends_with_period(self, frontmatter: dict) -> None:
+        desc = frontmatter["description"]
+        assert desc.endswith("."), f"description must end with a period: {desc!r}"
+
+    def test_description_trigger_in_first_57(self, frontmatter: dict) -> None:
+        """Trigger/capability must be self-contained in the effective window."""
+        desc = frontmatter["description"]
+        if len(desc) > 57:
+            window = desc[:57]
+            # The first 57 chars must contain a capability verb, not just setup
+            assert any(
+                word in window.lower()
+                for word in ("author", "create", "track", "review", "manage", "search", "build", "run", "generate")
+            ), f"Description trigger not self-contained in first 57 chars: {window!r}"
+
+    def test_no_author_hermes_alone(self, frontmatter: dict) -> None:
+        author = frontmatter.get("author", "")
+        assert "Hermes Agent" not in author or "," in author or "(" in author, (
+            "author must credit the human first: {author!r}"
+        )
+
+    def test_platforms_present(self, frontmatter: dict) -> None:
+        assert "platforms" in frontmatter
+        assert isinstance(frontmatter["platforms"], list)
+
+    def test_skip_banned_marketing_words(self, frontmatter: dict) -> None:
+        """Use judgment for context-dependent words — flag not auto-fail."""
+        desc = frontmatter["description"].lower()
+        found = [w for w in BANNED_MARKETING if w in desc]
+        if found:
+            pytest.skip(f"description contains flagged terms (review): {found}")
+
+
+# ── Body structure ────────────────────────────────────────────────────────────
+
+class TestBodyStructure:
+    def test_has_when_to_use_section(self, skill_source: str) -> None:
+        assert re.search(r"^## When to Use\s*$", skill_source, re.M), "missing ## When to Use"
+
+    def test_has_verification_section(self, skill_source: str) -> None:
+        assert re.search(r"^## Verification Checklist\s*$", skill_source, re.M), (
+            "missing ## Verification Checklist"
+        )
+
+    def test_no_machine_local_paths(self, skill_source: str) -> None:
+        # Exclude teaching/anti-pattern examples: <you>, <category>, ~/.hermes/skills/ (doc path)
+        bad = re.findall(
+            r"`(/Users/[^`/<]+[^`]*|/home/[^`/<]+[^`]*|~/?\.hermes/skills/[^`]+)`",
+            skill_source,
+        )
+        # Filter out patterns with angle brackets (teaching examples) or <category> variables
+        bad = [p for p in bad if "<" not in p and ">" not in p]
+        assert not bad, f"machine-local paths in skill: {bad}"
+
+    def test_skill_size_under_limit(self, skill_source: str) -> None:
+        assert len(skill_source) <= 100_000, (
+            f"SKILL.md is {len(skill_source)} chars (limit 100,000)"
+        )
+
+
+# ── Dynamic Loading Rules (2+ references/*.md present) ───────────────────────
+
+class TestDynamicLoadingRules:
+    def test_multi_ref_skills_have_section(self, skill_source: str, reference_files: list[Path]) -> None:
+        if len(reference_files) < 2:
+            pytest.skip("fewer than 2 reference files — section optional")
+        assert re.search(r"^## Dynamic Loading Rules\s*$", skill_source, re.M), (
+            "skills with 2+ references/*.md must include ## Dynamic Loading Rules"
+        )
+
+    def test_section_declares_scoped_loading(self, skill_source: str, reference_files: list[Path]) -> None:
+        if len(reference_files) < 2:
+            pytest.skip("section not required")
+        m = re.search(r"## Dynamic Loading Rules\n(.*?)(?=\n## |\Z)", skill_source, re.S)
+        assert m, "Dynamic Loading Rules section missing"
+        body = m.group(1).lower()
+        signals = ("load no", "only when", "when the task", "never pre-load", "default", "heuristic")
+        assert any(s in body for s in signals), (
+            "section must state default/scoped loading, not unbounded read of references/"
+        )
+
+    def test_backticked_reference_paths_exist(self, skill_source: str) -> None:
+        # Exclude glob patterns like `references/*.md`
+        mentioned = set(re.findall(r"`(references/[^`*]+)`", skill_source))
+        # Exclude convention/teaching placeholders containing ellipsis
+        mentioned = {m for m in mentioned if "..." not in m}
+        if not mentioned:
+            pytest.skip("no backticked references/ paths in SKILL.md")
+        missing = []
+        for rel in mentioned:
+            rel_path = rel.split("#", 1)[0]
+            if not (SKILL_DIR / rel_path).is_file():
+                missing.append(rel_path)
+        assert not missing, f"SKILL.md references missing files: {missing}"
+
+    def test_every_reference_file_is_mapped(self, skill_source: str, reference_files: list[Path]) -> None:
+        if len(reference_files) < 2:
+            pytest.skip("section not required")
+        orphans = []
+        for path in reference_files:
+            rel = path.relative_to(SKILL_DIR).as_posix()
+            if rel not in skill_source and path.name not in skill_source:
+                orphans.append(rel)
+        assert not orphans, f"orphan references (not named in SKILL.md): {orphans}"
+
+    def test_no_machine_local_reference_paths(self, skill_source: str) -> None:
+        bad = re.findall(
+            r"`(/Users/[^`/<]+[^`]*|/home/[^`/<]+[^`]*|~/?\.hermes/skills/[^`]+)`",
+            skill_source,
+        )
+        bad = [p for p in bad if "<" not in p and ">" not in p]
+        assert not bad, f"machine-local paths in skill: {bad}"
+
+    def test_avoids_load_all_phrasing(self, skill_source: str) -> None:
+        text = skill_source.lower()
+        banned = [
+            "read all of references",
+            "load all references",
+            "load the entire references",
+            "read every reference",
+        ]
+        hits = [b for b in banned if b in text]
+        assert not hits, f"load-all anti-pattern phrasing found: {hits}"
+
+
+# ── Safety template access ───────────────────────────────────────────────────
+
+class TestSafetyTemplate:
+    def test_safety_reference_exists(self) -> None:
+        safepath = REFERENCES / "safety-enforcement-template.md"
+        assert safepath.is_file(), f"missing reference: {safepath}"
+
+    def test_safety_referenced_in_skill_md(self, skill_source: str) -> None:
+        assert "safety-enforcement-template.md" in skill_source, (
+            "SKILL.md must reference the safety template"
+        )
+
+
+# ── Dynamic Loading template access ──────────────────────────────────────────
+
+class TestDynamicLoadingTemplate:
+    def test_dynamic_loading_reference_exists(self) -> None:
+        dlpath = REFERENCES / "dynamic-loading-rules-template.md"
+        assert dlpath.is_file(), f"missing reference: {dlpath}"
+
+    def test_dynamic_loading_referenced_in_skill_md(self, skill_source: str) -> None:
+        assert "dynamic-loading-rules-template.md" in skill_source, (
+            "SKILL.md must reference the dynamic loading template"
+        )
+
+
+# ── Frontmatter consistency ──────────────────────────────────────────────────
+
+class TestVersionSemver:
+    def test_version_is_semver(self, frontmatter: dict) -> None:
+        v = frontmatter.get("version", "")
+        assert re.match(r"^\d+\.\d+\.\d+$", v), f"version not semver: {v!r}"

--- a/website/docs/user-guide/skills/bundled/software-development/software-development-hermes-agent-skill-authoring.md
+++ b/website/docs/user-guide/skills/bundled/software-development/software-development-hermes-agent-skill-authoring.md
@@ -16,12 +16,12 @@ Author in-repo SKILL.md files: frontmatter and structure.
 |---|---|
 | Source | Bundled (installed by default) |
 | Path | `skills/software-development/hermes-agent-skill-authoring` |
-| Version | `2.0.0` |
-| Author | Hermes Agent |
+| Version | `2.1.0` |
+| Author | tShields (trojandnc), Hermes Agent |
 | License | MIT |
 | Platforms | linux, macos, windows |
 | Tags | `skills`, `authoring`, `hermes-agent`, `conventions`, `skill-md` |
-| Related skills | [`plan`](/docs/user-guide/skills/bundled/software-development/software-development-plan), [`requesting-code-review`](/docs/user-guide/skills/bundled/software-development/software-development-requesting-code-review) |
+| Related skills | [`plan`](/docs/user-guide/skills/bundled/software-development/software-development-plan), [`requesting-code-review`](/docs/user-guide/skills/bundled/software-development/software-development-requesting-code-review), `skill-architecture-patterns` |
 
 ## Reference: full SKILL.md
 
@@ -39,6 +39,8 @@ There are two places a SKILL.md can live:
 2. **In-repo (this skill is about this case):** `skills/<category>/<name>/SKILL.md` or `optional-skills/<category>/<name>/SKILL.md` inside the hermes-agent repo — committed, shipped with the package. Use `write_file` + `git add`. `skill_manage(action='create')` does NOT target this tree.
 
 In-repo skills must meet the repo's **hardline authoring standards** (see AGENTS.md, "Skill authoring standards (HARDLINE)" — that section is the source of truth; this skill is the operational walkthrough). Reviewers reject PRs that violate them, so meeting them up front is cheaper than a salvage pass later.
+
+**Backward compatibility:** The standards below apply to **new skills and skills under active edit in a PR**. Untouched existing in-repo skills are **grandfathered** — no mandatory batch rewrite. Optional hygiene: a separate scan of descriptions >57 chars or weak When to Use sections is not a gate on this standard.
 
 ## When to Use
 
@@ -88,11 +90,17 @@ metadata:
 
 ### `description` rules (HARDLINE — the validator's 1024 is NOT the standard)
 
-- **≤ 60 characters.** One sentence. Ends with a period.
-- State the capability, not the implementation, and don't repeat the skill name.
-- No marketing words ("powerful", "comprehensive", "seamless", "advanced").
-- The system prompt skill index truncates at 57 chars + "..." — the trigger/capability must be self-contained in that window.
-- If the description contains a `:`, wrap it in double quotes or YAML parses it as a mapping and the docs generator crashes. Quotes don't count toward the 60.
+The description is the **highest-leverage always-paid surface** in a skill.
+Every token in it is paid on every turn via the skill index. Write it with
+more care than the body — a beautiful Procedure with a vague description
+is a skill that fails selection.
+
+- **≤ 60 characters** (hardline). One sentence. Ends with a period.
+- **Effective window: 57 characters.** The skill index truncates at 57 + "..." — the trigger/capability must be self-contained in the first 57 even if total length is 58–60.
+- State the **capability**, not the implementation, and don't repeat the skill name.
+- No marketing words ("powerful", "comprehensive", "seamless", "advanced", "robust", "end-to-end"). Use judgment: "advanced" and "comprehensive" are legitimate when they describe scope, not fluff. Flag for review, not auto-reject.
+- Prefer verbs of effect over setup narrative ("Track…", "Author…", "Review…").
+- If the description contains a `:`, wrap it in double quotes or YAML parses it as a mapping and the docs generator crashes.
 
 Good: `Track named companies for material news with cited digests.`
 Bad: `Use when a user asks to monitor named competitors or companies for product launches, pricing changes, funding, ...` (240 chars — rejected in review)
@@ -129,12 +137,16 @@ POSIX-only signals to search for in `scripts/`: `fcntl`, `termios`, `pty`, `os.f
 
 ## Body Structure (modern section order)
 
+For the progressive-disclosure theory underpinning layered section design, see `skill-architecture-patterns`. This section is the operational slot map.
+
 ```
 # <Skill> Skill
 2-3 sentence intro: what it does, what it doesn't do, dependency stance.
 
-## When to Use          — bulleted triggers (+ "Don't use for:" counter-triggers)
+## When to Use          — DEFINITION: bulleted triggers (+ "Don't use for:" counter-triggers)
 ## Prerequisites        — exact env vars, installs, API key sourcing
+## Safety & Enforcement — when side effects / sensitive data (see references/)
+## Dynamic Loading Rules — when 2+ references/*.md  (see references/)
 ## How to Run           — canonical invocation through the `terminal` tool
 ## Quick Reference      — flat command list, no narration
 ## Procedure            — numbered steps, each with a checkable completion criterion
@@ -142,7 +154,7 @@ POSIX-only signals to search for in `scripts/`: `fcntl`, `termios`, `pty`, `os.f
 ## Verification         — how to prove the skill worked
 ```
 
-Not every section applies to every skill (a pure-procedure task skill may have no Quick Reference), but When to Use + actionable body + Pitfalls + Verification are the minimum. Cut marketing intros, "Setup Check" no-ops, and re-explanations of env vars already in Prerequisites.
+Not every section applies to every skill. The minimum is When to Use + actionable body + Pitfalls + Verification. Safety & Enforcement and Dynamic Loading Rules are **required** when their triggers fire (side effects / sensitive data, 2+ reference files), **optional** otherwise. Cut marketing intros, "Setup Check" no-ops, and re-explanations of env vars already in Prerequisites.
 
 ### Reference Hermes tools, not raw shell
 
@@ -157,7 +169,7 @@ Write repo-relative paths (`skills/...`, `tools/skill_manager_tool.py`). A `/hom
 A skill exists to make the agent's process more predictable — the agent reliably follows the same useful discipline.
 
 1. **Optimize for process predictability.** If a line does not change behavior, cut it.
-2. **Choose the right context load.** The description is paid for every turn; details go in the body or linked references.
+2. **Definition-first order.** Polish description + When to Use before body section polish. The description is paid for every turn; details go in the body or linked references.
 3. **End steps with completion criteria.** Checkable and, when it matters, exhaustive: "every modified file accounted for" beats "summarize changes."
 4. **Co-locate rules with the concept they govern.**
 5. **Use strong leading words** ("tight loop," "root cause," "regression test") over long repeated explanations.
@@ -166,15 +178,37 @@ A skill exists to make the agent's process more predictable — the agent reliab
 ## Tests and Docs (required for repo skills)
 
 1. **Tests** live at `tests/skills/test_<skill>_skill.py` — stdlib + pytest + `unittest.mock` only, no live network. Run via `scripts/run_tests.sh tests/skills/test_<skill>_skill.py -q`. (The generic `tests/tools/test_skill_manager_tool.py` passing proves nothing about YOUR skill.)
+   - **Definition tests:** verify description ≤ 60 chars, ends with period, no banned marketing words. Optionally check When to Use section presence.
+   - **Enforcement tests (Safety & Enforcement):** deny + allow + side-effect not called + audit on deny. See `references/safety-enforcement-template.md` for the full skeleton.
+   - **Structural tests (Dynamic Loading Rules):** section present when 2+ references/*.md, backticked paths resolve, no "load all" phrasing, no orphans. See `references/dynamic-loading-rules-template.md` for the full skeleton.
 2. **Docs regen:** run `python3 website/scripts/generate-skill-docs.py`, then apply scope discipline — the generator rewrites EVERY auto-gen page. `git checkout --` everything that isn't yours; the final diff must show only your SKILL.md, your one per-skill docs page, a one-line catalog row, and a one-line `website/sidebars.ts` insertion (verify with `search_files(pattern='<your-slug>', path='website/sidebars.ts')` — exactly one hit, or the page is an orphan).
 3. **`.env.example`** (only if the skill needs new env vars): one clearly delimited commented block; touch nothing else in the file.
+
+## Dynamic Loading Rules
+
+This skill ships two reference files (`references/safety-enforcement-template.md` and
+`references/dynamic-loading-rules-template.md`). Load them **only** when the
+current task involves writing or reviewing enforcement or loading rules.
+
+**Default: load no reference files** until a matching task scope.
+
+| When the task involves… | Load (skill-relative) |
+|---|---|
+| Adding or reviewing policy guards, data-exposure preconditions, or enforcement tests | `references/safety-enforcement-template.md` (not the loading rules template) |
+| Adding or reviewing file-size thresholds, progressive-disclosure rules, or structural loading tests | `references/dynamic-loading-rules-template.md` (not the safety template) |
+| Authoring a new skill with both side effects and multi-reference material | Both reference files (use `read_file` on each separately) |
+
+As a heuristic, limit per-turn loads to 3–4 files. Not a hard rule.
+
+Paths are skill-relative (`references/...`), never machine-local.
 
 ## Workflow
 
 1. **Survey peers** in the target category with `search_files(target='files')` and read 2-3 peer SKILL.md files to match tone and structure. Prefer extending an existing skill over creating a narrow sibling.
 2. **Decide tier and category** (see above). When in doubt, optional — and ask before pushing rather than defaulting.
-3. **Draft** with `write_file` to `skills/<category>/<name>/SKILL.md` (or `optional-skills/...`).
-4. **Validate locally**:
+3. **Define first.** Write `name` + `description` + When to Use / Don't use before drafting the body. Validate description length, period, and banned-word checks before proceeding to body sections.
+4. **Draft** with `write_file` to `skills/<category>/<name>/SKILL.md` (or `optional-skills/...`).
+5. **Validate locally**:
    ```python
    import yaml, re, pathlib
    content = pathlib.Path("skills/<category>/<name>/SKILL.md").read_text()
@@ -188,9 +222,9 @@ A skill exists to make the agent's process more predictable — the agent reliab
    assert len(content) <= 100_000
    ```
    Also verify every `related_skills` entry exists in-repo.
-5. **Add tests + regen docs** (previous section).
-6. **Git add + commit** on the active branch; open a PR.
-7. **Note:** the CURRENT session's skill loader is cached — `skill_view` / `skills_list` will not see the new skill until a new session. This is expected, not a bug.
+6. **Add tests + regen docs** (previous section).
+7. **Git add + commit** on the active branch; open a PR.
+8. **Note:** the CURRENT session's skill loader is cached — `skill_view` / `skills_list` will not see the new skill until a new session. This is expected, not a bug.
 
 ## Editing Existing In-Repo Skills
 
@@ -211,6 +245,11 @@ A skill exists to make the agent's process more predictable — the agent reliab
 8. **Skipping the docs generator or pushing its unrelated drift.** Both directions are wrong: no regen = orphan skill with no docs page; blind regen = a ballooned diff full of other skills' drift.
 9. **Expecting the current session to see the new skill.** The loader is initialized at session start.
 10. **Letting skills accumulate sediment.** When adding a rule, remove the old wording it replaces.
+11. **Implementation dump in description** — "runs pytest then parses JSON…" belongs in body or references, not the always-paid description.
+12. **Vague trigger** — "use when user asks about X" with no capability verb; prefer "Author…", "Track…", "Review…".
+13. **Description only works after reading the body** — the description must be self-contained for catalog selection.
+14. **Missing Don't-use** when a peer skill shares vocabulary — causes false-positive loads.
+15. **Relying on a future router/embedding layer** instead of fixing the definition — precise definitions beat routers at current scale.
 
 ## Verification Checklist
 
@@ -218,13 +257,17 @@ A skill exists to make the agent's process more predictable — the agent reliab
 - [ ] File at `skills/<category>/<name>/SKILL.md` or `optional-skills/<category>/<name>/SKILL.md`
 - [ ] Frontmatter starts at byte 0 with `---`, closes with `\n---\n`
 - [ ] `name`, `description`, `version`, `author`, `license`, `platforms`, `metadata.hermes.{tags, related_skills}` all present
-- [ ] Description ≤ 60 chars, one sentence, ends with a period, no marketing words
+- [ ] Description ≤ 60 chars, one sentence, ends with a period, no marketing words, trigger self-contained in first 57-char window
+- [ ] Description written and validated **before** body section polish (definition-first rule)
+- [ ] When to Use includes counter-triggers when peer skills share vocabulary
 - [ ] `author` credits the human contributor first
 - [ ] `platforms:` audited against actual prose/scripts, not copied from a sibling
 - [ ] Every `related_skills` entry resolves in-repo
 - [ ] Body follows the modern section order; commands framed through Hermes tools
 - [ ] No machine-local paths anywhere in the file
 - [ ] Each ordered step has a checkable completion criterion
+- [ ] Side effects / sensitive data → `## Safety & Enforcement` present with matching policy tests (deny + allow + side-effect not called + audit on deny)
+- [ ] 2+ `references/*.md` → `## Dynamic Loading Rules` present with structural tests (paths resolve, no load-all, no orphans)
 - [ ] Tests at `tests/skills/test_<skill>_skill.py` pass under `scripts/run_tests.sh`
 - [ ] Docs regenerated with scope discipline; sidebar has exactly one entry for the slug
 - [ ] `git add` + commit on the intended branch; PR opened


### PR DESCRIPTION

## What
Update the in-repo hermes-agent-skill-authoring skill from v2.0.0 to v2.1.0 with the user-local improvements, now vendored for the repo.

### Changes
- **Description two-layer rule:** 60-char hardline + 57-char effective window (first 57 chars must be self-contained)
- **Grandfathering clause:** new rules apply to new/edit PRs only; untouched skills exempt
- **Definition-first authoring order:** write name + description + When to Use before body
- **Body structure:** Safety & Enforcement and Dynamic Loading Rules sections added (required when triggers fire)
- **Vendored reference templates:**  and  replace Buzz Nest RESEARCH/ paths
- **5 additional pitfalls** (11-15): implementation dump in description, vague trigger, body-dependent description, missing Don't-use, router reliance
- **Expanded verification checklist:** 57-char window, definition-first check, Safety/Dynamic Loading cross-references
- **:** added 
- **Author attribution:** tShields (trojandnc), Hermes Agent (human first)

### Tests
New test file at `tests/skills/test_hermes_agent_skill_authoring_skill.py` (25 tests):
- Frontmatter validation (description length, period, 57-char window, author format, platforms, semver)
- Body structure checks (section presence, no machine-local paths)
- Dynamic Loading Rules (section present, paths resolve, no load-all phrasing, no orphans, no glob/ellipsis false positives)
- Safety template and Dynamic Loading template checks (files exist, referenced in SKILL.md)

### Test run
```
25 passed in 0.06s
```

### Docs regenerated
`website/docs/user-guide/skills/bundled/software-development/software-development-hermes-agent-skill-authoring.md` updated by running `generate-skill-docs.py` with scope discipline applied.
