### PR TITLE
perf(cache): split skill turns at a builder-declared stable/volatile boundary

### DIFF
--- a/agent/prompt_cache_boundary.py
+++ b/agent/prompt_cache_boundary.py
@@ -1,0 +1,73 @@
+"""Builder-declared stable prefixes for Anthropic prompt caching (#81867).
+
+Skill, webhook, and cron builders concatenate a large static scaffold
+(activation note + expanded skill body) with a small volatile invocation
+tail (ticket payload, timestamps, run context) into one user-message
+string. Only the builder knows the exact byte where the volatile tail
+begins, so it registers the stable prefix here at construction time; the
+cache planner consults the registry to place a cache breakpoint at that
+boundary instead of caching the whole message as one atomic block.
+
+This deliberately avoids re-parsing scaffold marker strings out of the
+message at request time: markers can legitimately appear inside skill
+bodies or inside event payloads (e.g. a helpdesk ticket quoting an agent
+transcript), and any delimiter-search heuristic then either shrinks the
+cached prefix or — worse — silently absorbs volatile bytes into it,
+reintroducing the per-invocation cache miss this exists to fix.
+
+The registry is process-local by design. A freshly fired webhook/cron
+invocation is always built and sent by the same process, which is the
+only window where the split pays off. Any miss (restart, eviction,
+historic message) falls back to the pre-existing whole-message policy.
+"""
+
+import threading
+from collections import OrderedDict
+from typing import Optional
+
+# A couple dozen distinct active scaffolds (webhook routes x skills x cron
+# jobs) is generous for one gateway process; beyond that, oldest entries
+# fall back to whole-message caching rather than growing unboundedly.
+_MAX_ENTRIES = 32
+
+_lock = threading.Lock()
+_prefixes: "OrderedDict[str, None]" = OrderedDict()
+
+
+def register_stable_prefix(prefix: str) -> None:
+    """Record ``prefix`` as the stable scaffold of a just-built message."""
+    if not prefix:
+        return
+    with _lock:
+        _prefixes[prefix] = None
+        _prefixes.move_to_end(prefix)
+        while len(_prefixes) > _MAX_ENTRIES:
+            _prefixes.popitem(last=False)
+
+
+def find_stable_prefix(content: str) -> Optional[str]:
+    """Longest registered prefix that is a *proper* prefix of ``content``.
+
+    Proper (``len(content) > len(prefix)``) so the split never produces an
+    empty volatile text block, which Anthropic rejects on the wire.
+    """
+    with _lock:
+        candidates = list(_prefixes)
+    best: Optional[str] = None
+    for prefix in candidates:
+        if len(content) > len(prefix) and content.startswith(prefix):
+            if best is None or len(prefix) > len(best):
+                best = prefix
+    return best
+
+
+def is_registered_stable_prefix(text: str) -> bool:
+    """Exact-match check used when flattening a decorated split back."""
+    with _lock:
+        return text in _prefixes
+
+
+def clear_stable_prefixes() -> None:
+    """Test isolation helper."""
+    with _lock:
+        _prefixes.clear()

--- a/agent/prompt_cache_boundary.py
+++ b/agent/prompt_cache_boundary.py
@@ -30,6 +30,13 @@ from typing import Optional
 # fall back to whole-message caching rather than growing unboundedly.
 _MAX_ENTRIES = 32
 
+# Entries hold whole expanded skill bodies, so an entry count alone does not
+# bound memory — a handful of large skills can retain tens of MB in a
+# long-lived gateway process. Evict by total retained bytes too, always
+# keeping the newest entry so a single oversized scaffold still gets a
+# boundary instead of silently disabling the split.
+_MAX_BYTES = 4 * 1024 * 1024
+
 _lock = threading.Lock()
 _prefixes: "OrderedDict[str, None]" = OrderedDict()
 
@@ -43,6 +50,8 @@ def register_stable_prefix(prefix: str) -> None:
         _prefixes.move_to_end(prefix)
         while len(_prefixes) > _MAX_ENTRIES:
             _prefixes.popitem(last=False)
+        while len(_prefixes) > 1 and sum(map(len, _prefixes)) > _MAX_BYTES:
+            _prefixes.popitem(last=False)
 
 
 def find_stable_prefix(content: str) -> Optional[str]:
@@ -50,6 +59,10 @@ def find_stable_prefix(content: str) -> Optional[str]:
 
     Proper (``len(content) > len(prefix)``) so the split never produces an
     empty volatile text block, which Anthropic rejects on the wire.
+
+    A hit refreshes the entry's LRU position: a scaffold fired every minute
+    by cron must not be evicted by a burst of one-off skill invocations,
+    which would silently drop it back to whole-message caching.
     """
     with _lock:
         candidates = list(_prefixes)
@@ -58,13 +71,11 @@ def find_stable_prefix(content: str) -> Optional[str]:
         if len(content) > len(prefix) and content.startswith(prefix):
             if best is None or len(prefix) > len(best):
                 best = prefix
+    if best is not None:
+        with _lock:
+            if best in _prefixes:
+                _prefixes.move_to_end(best)
     return best
-
-
-def is_registered_stable_prefix(text: str) -> bool:
-    """Exact-match check used when flattening a decorated split back."""
-    with _lock:
-        return text in _prefixes
 
 
 def clear_stable_prefixes() -> None:

--- a/agent/prompt_caching.py
+++ b/agent/prompt_caching.py
@@ -14,7 +14,7 @@ import copy
 from dataclasses import dataclass
 from typing import Any, Dict, List
 
-from agent.prompt_cache_boundary import find_stable_prefix, is_registered_stable_prefix
+from agent.prompt_cache_boundary import find_stable_prefix
 
 
 @dataclass(frozen=True)
@@ -193,8 +193,11 @@ def strip_anthropic_cache_control(
 
     Flattening back to a plain string is restricted to the exact shapes
     :func:`apply_anthropic_cache_control` produces from string content —
-    a single ``{"type": "text"}`` part, or the two-part ``[static, volatile]``
-    system split — so the ``""``-join is provably byte-exact. Organic
+    a single ``{"type": "text"}`` part, the two-part ``[static, volatile]``
+    system split, or the two-part builder-declared skill split (recognised
+    by its marker-on-the-first-part shape, so flattening never depends on
+    the prefix registry still holding the entry) — so the ``""``-join is
+    provably byte-exact. Organic
     multi-part text (merged user turns, imported transcripts) and parts
     carrying extra keys (``citations`` etc.) keep their structure; only
     per-part markers are removed. Marker removal is copy-on-write on the
@@ -213,6 +216,21 @@ def strip_anthropic_cache_control(
         content = msg.get("content")
         if not isinstance(content, list):
             continue
+        # Two-part skill-invocation split (#81867). The builder-declared
+        # boundary is the only decoration that marks the *first* part of a
+        # user message: list content otherwise receives its marker on the
+        # last part, and the two-part [static, volatile] split is role-gated
+        # to system. So the shape alone identifies it, and flattening stays
+        # correct even when the prefix registry has since evicted the entry
+        # (failover re-decorates a request built many messages ago, #72626).
+        skill_split_shape = (
+            msg.get("role") == "user"
+            and len(content) == 2
+            and isinstance(content[0], dict)
+            and isinstance(content[1], dict)
+            and "cache_control" in content[0]
+            and "cache_control" not in content[1]
+        )
         if any(isinstance(part, dict) and "cache_control" in part for part in content):
             content = [
                 {k: v for k, v in part.items() if k != "cache_control"}
@@ -230,14 +248,7 @@ def strip_anthropic_cache_control(
         ) and (
             len(content) == 1
             or (msg.get("role") == "system" and len(content) == 2)
-            or (
-                # Two-part skill-invocation split: the first part is byte-for-
-                # byte a builder-registered scaffold, so the ""-join provably
-                # reconstructs the original string.
-                msg.get("role") == "user"
-                and len(content) == 2
-                and is_registered_stable_prefix(content[0]["text"])
-            )
+            or skill_split_shape
         )
         if decoration_shape:
             msg["content"] = "".join(part["text"] for part in content)

--- a/agent/prompt_caching.py
+++ b/agent/prompt_caching.py
@@ -14,6 +14,8 @@ import copy
 from dataclasses import dataclass
 from typing import Any, Dict, List
 
+from agent.prompt_cache_boundary import find_stable_prefix, is_registered_stable_prefix
+
 
 @dataclass(frozen=True)
 class PromptCachePlan:
@@ -58,6 +60,23 @@ def _apply_cache_marker(msg: dict, cache_marker: dict, native_anthropic: bool = 
         return
 
     if isinstance(content, str):
+        if role == "user":
+            stable_prefix = find_stable_prefix(content)
+            if stable_prefix is not None:
+                # Builder-declared boundary (#81867): the scaffold carries the
+                # breakpoint, the volatile invocation tail rides unmarked so a
+                # changed ticket ID or timestamp no longer invalidates the
+                # whole skill body. Request-local only — the canonical session
+                # message stays a plain string.
+                msg["content"] = [
+                    {
+                        "type": "text",
+                        "text": stable_prefix,
+                        "cache_control": cache_marker,
+                    },
+                    {"type": "text", "text": content[len(stable_prefix):]},
+                ]
+                return
         msg["content"] = [
             {"type": "text", "text": content, "cache_control": cache_marker}
         ]
@@ -211,6 +230,14 @@ def strip_anthropic_cache_control(
         ) and (
             len(content) == 1
             or (msg.get("role") == "system" and len(content) == 2)
+            or (
+                # Two-part skill-invocation split: the first part is byte-for-
+                # byte a builder-registered scaffold, so the ""-join provably
+                # reconstructs the original string.
+                msg.get("role") == "user"
+                and len(content) == 2
+                and is_registered_stable_prefix(content[0]["text"])
+            )
         )
         if decoration_shape:
             msg["content"] = "".join(part["text"] for part in content)

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from hermes_constants import display_hermes_home
+from agent.prompt_cache_boundary import register_stable_prefix
 from agent.skill_preprocessing import (
     expand_inline_shell as _expand_inline_shell,
     load_skills_config as _load_skills_config,
@@ -360,15 +361,26 @@ def _build_skill_message(
             f"(e.g. `node {skill_dir}/scripts/foo.js`)."
         )
 
+    stable_prefix = None
     if user_instruction:
         parts.append("")
-        parts.append(f"The user has provided the following instruction alongside the skill invocation: {user_instruction}")
+        # Everything before the caller-supplied instruction is a stable
+        # scaffold; declare the exact boundary so the Anthropic cache planner
+        # can put a breakpoint on it instead of caching the whole message as
+        # one atomic block (#81867). The static instruction prose stays on
+        # the stable side; the volatile instruction (webhook payload, ticket
+        # IDs, timestamps) and any runtime note ride in the tail.
+        stable_prefix = "\n".join(parts) + "\n" + _SINGLE_SKILL_INSTRUCTION
+        parts.append(f"{_SINGLE_SKILL_INSTRUCTION}{user_instruction}")
 
     if runtime_note:
         parts.append("")
         parts.append(f"[Runtime note: {runtime_note}]")
 
-    return "\n".join(parts)
+    message = "\n".join(parts)
+    if stable_prefix is not None and len(message) > len(stable_prefix):
+        register_stable_prefix(stable_prefix)
+    return message
 
 
 def scan_skill_commands() -> Dict[str, Dict[str, Any]]:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2813,9 +2813,26 @@ def _build_job_prompt(
         )
         parts.insert(0, notice)
 
+    stable_prefix = None
     if prompt:
-        parts.extend(["", f"The user has provided the following instruction alongside the skill invocation: {prompt}"])
-    return _scan_assembled_cron_prompt("\n".join(parts), job, has_skills=True)
+        from agent.skill_commands import _SINGLE_SKILL_INSTRUCTION
+
+        parts.append("")
+        # The skill blocks (and any skipped-skill notice) above are stable per
+        # job config; the appended instruction carries the volatile per-run
+        # data (cron hint + prompt + script output + run context). Declare
+        # that boundary for the Anthropic cache planner (#81867).
+        stable_prefix = "\n".join(parts) + "\n" + _SINGLE_SKILL_INSTRUCTION
+        parts.append(f"{_SINGLE_SKILL_INSTRUCTION}{prompt}")
+    assembled = _scan_assembled_cron_prompt("\n".join(parts), job, has_skills=True)
+    if stable_prefix and len(assembled) > len(stable_prefix) and assembled.startswith(stable_prefix):
+        # Guarded because the injection scanner may sanitize (mutate) the
+        # assembled bytes; a mismatch simply falls back to whole-message
+        # caching.
+        from agent.prompt_cache_boundary import register_stable_prefix
+
+        register_stable_prefix(stable_prefix)
+    return assembled
 
 
 def _scan_assembled_cron_prompt(

--- a/tests/agent/test_prompt_cache_boundary.py
+++ b/tests/agent/test_prompt_cache_boundary.py
@@ -1,0 +1,309 @@
+"""Builder-declared stable-prefix cache boundaries (#81867).
+
+Webhook/cron skill invocations concatenate a large static scaffold with a
+small volatile tail into one user string; without a declared boundary the
+whole message is cached as one atomic block and a changed ticket ID or
+timestamp forces a full cache rewrite. These tests cover the registry, the
+request-local split, the failover round-trip, and — via the real builders —
+that the boundary comes from construction, not from re-parsing marker
+strings (so payloads that quote the marker cannot poison the stable prefix).
+"""
+
+import copy
+
+import pytest
+from unittest.mock import patch
+
+import agent.skill_bundles as skill_bundles
+import agent.skill_commands as skill_commands
+import tools.skills_tool as skills_tool
+from agent.prompt_cache_boundary import (
+    clear_stable_prefixes,
+    find_stable_prefix,
+    is_registered_stable_prefix,
+    register_stable_prefix,
+)
+from agent.prompt_caching import (
+    apply_anthropic_cache_control,
+    build_prompt_cache_plan,
+    strip_anthropic_cache_control,
+)
+from agent.skill_commands import _SINGLE_SKILL_INSTRUCTION
+
+MARKER = {"type": "ephemeral"}
+
+SKILL_BODY = "Inspect the report carefully and preserve the stable instructions."
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry():
+    clear_stable_prefixes()
+    yield
+    clear_stable_prefixes()
+
+
+def _write_skill(skills_dir, name, body=SKILL_BODY):
+    skill_dir = skills_dir / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: Description for {name}\n---\n\n# {name}\n\n{body}\n"
+    )
+    return skill_dir
+
+
+@pytest.fixture()
+def skills(tmp_path, monkeypatch):
+    skills_dir = tmp_path / "skills"
+    _write_skill(skills_dir, "triage")
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    monkeypatch.setattr(skill_commands, "_skill_commands", {})
+    monkeypatch.setattr(skill_commands, "_skill_commands_platform", None)
+    monkeypatch.setattr(skill_bundles, "_bundles_cache", {})
+    monkeypatch.setattr(skill_bundles, "_bundles_cache_mtime", None)
+    skill_commands.scan_skill_commands()
+    return skills_dir
+
+
+class TestRegistry:
+    def test_requires_proper_prefix(self):
+        register_stable_prefix("scaffold")
+        assert find_stable_prefix("scaffold volatile") == "scaffold"
+        # Exact match would leave an empty volatile block — never split.
+        assert find_stable_prefix("scaffold") is None
+        assert find_stable_prefix("other") is None
+
+    def test_longest_registered_prefix_wins(self):
+        register_stable_prefix("scaffold")
+        register_stable_prefix("scaffold extended")
+        assert find_stable_prefix("scaffold extended tail") == "scaffold extended"
+
+    def test_lru_eviction_falls_back_safely(self):
+        from agent import prompt_cache_boundary
+
+        for index in range(prompt_cache_boundary._MAX_ENTRIES + 1):
+            register_stable_prefix(f"scaffold-{index} ")
+        assert find_stable_prefix("scaffold-0 volatile") is None
+        assert find_stable_prefix("scaffold-1 volatile") == "scaffold-1 "
+
+    def test_empty_prefix_never_registered(self):
+        register_stable_prefix("")
+        assert not is_registered_stable_prefix("")
+
+
+class TestRequestLocalSplit:
+    def test_volatile_tail_does_not_change_marked_prefix(self):
+        scaffold = "stable skill scaffold\n\n" + _SINGLE_SKILL_INSTRUCTION
+        register_stable_prefix(scaffold)
+
+        first = apply_anthropic_cache_control(
+            [{"role": "user", "content": scaffold + "ticket=one time=10:00"}]
+        )[0]["content"]
+        second = apply_anthropic_cache_control(
+            [{"role": "user", "content": scaffold + "ticket=two time=10:01"}]
+        )[0]["content"]
+
+        assert len(first) == len(second) == 2
+        assert first[0] == second[0]
+        assert first[0] == {"type": "text", "text": scaffold, "cache_control": MARKER}
+        assert "cache_control" not in first[1]
+        assert first[1]["text"] == "ticket=one time=10:00"
+        assert second[1]["text"] == "ticket=two time=10:01"
+
+    def test_unregistered_message_keeps_whole_block_layout(self):
+        content = "stable-looking scaffold\n\n" + _SINGLE_SKILL_INSTRUCTION + "tail"
+        marked = apply_anthropic_cache_control([{"role": "user", "content": content}])
+        assert marked[0]["content"] == [
+            {"type": "text", "text": content, "cache_control": MARKER}
+        ]
+
+    def test_assistant_string_matching_a_prefix_is_not_split(self):
+        register_stable_prefix("scaffold ")
+        marked = apply_anthropic_cache_control(
+            [
+                {"role": "user", "content": "question"},
+                {"role": "assistant", "content": "scaffold reply"},
+            ]
+        )
+        assert marked[1]["content"] == [
+            {"type": "text", "text": "scaffold reply", "cache_control": MARKER}
+        ]
+
+    def test_canonical_message_stays_a_string_in_plan(self):
+        scaffold = "stable scaffold "
+        register_stable_prefix(scaffold)
+        original = scaffold + "volatile"
+        messages = [{"role": "user", "content": original}]
+
+        plan = build_prompt_cache_plan(messages, [], native_anthropic=True)
+
+        assert messages == [{"role": "user", "content": original}]
+        assert isinstance(plan.messages[0]["content"], list)
+        assert plan.messages[0]["content"][0]["cache_control"] == MARKER
+        assert "cache_control" not in plan.messages[0]["content"][1]
+
+    def test_strip_reconstructs_exact_string_and_redecorates_identically(self):
+        scaffold = "stable scaffold\n\n" + _SINGLE_SKILL_INSTRUCTION
+        register_stable_prefix(scaffold)
+        original = [{"role": "user", "content": scaffold + "ticket=one"}]
+
+        marked = apply_anthropic_cache_control(copy.deepcopy(original))
+        first_wire = copy.deepcopy(marked)
+        stripped = strip_anthropic_cache_control(marked)
+
+        assert stripped == original
+        assert apply_anthropic_cache_control(copy.deepcopy(stripped)) == first_wire
+
+    def test_strip_leaves_organic_two_part_user_content_structured(self):
+        organic = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "part one"},
+                    {"type": "text", "text": "part two"},
+                ],
+            }
+        ]
+        stripped = strip_anthropic_cache_control(copy.deepcopy(organic))
+        assert stripped == organic
+
+
+class TestRealBuilders:
+    def test_two_invocations_share_the_marked_scaffold(self, skills):
+        first = skill_commands.build_skill_invocation_message(
+            "/triage", user_instruction="ticket=one time=10:00"
+        )
+        second = skill_commands.build_skill_invocation_message(
+            "/triage", user_instruction="ticket=two time=10:01"
+        )
+
+        first_blocks = apply_anthropic_cache_control(
+            [{"role": "user", "content": first}], native_anthropic=True
+        )[0]["content"]
+        second_blocks = apply_anthropic_cache_control(
+            [{"role": "user", "content": second}], native_anthropic=True
+        )[0]["content"]
+
+        assert len(first_blocks) == len(second_blocks) == 2
+        assert first_blocks[0] == second_blocks[0]
+        assert first_blocks[0]["cache_control"] == MARKER
+        assert SKILL_BODY in first_blocks[0]["text"]
+        assert "ticket=one" not in first_blocks[0]["text"]
+        assert "cache_control" not in first_blocks[1]
+        assert first_blocks[1]["text"] == "ticket=one time=10:00"
+
+    def test_payload_quoting_the_marker_cannot_poison_the_stable_prefix(self, skills):
+        """The differentiator vs marker-search heuristics: a ticket that quotes
+        the instruction marker (e.g. a pasted agent transcript) must stay
+        entirely in the volatile tail, or two invocations stop sharing the
+        cached prefix."""
+        hostile = (
+            "ticket=one\n\n" + _SINGLE_SKILL_INSTRUCTION + "quoted transcript line"
+        )
+        benign = "ticket=two"
+
+        hostile_blocks = apply_anthropic_cache_control(
+            [
+                {
+                    "role": "user",
+                    "content": skill_commands.build_skill_invocation_message(
+                        "/triage", user_instruction=hostile
+                    ),
+                }
+            ]
+        )[0]["content"]
+        benign_blocks = apply_anthropic_cache_control(
+            [
+                {
+                    "role": "user",
+                    "content": skill_commands.build_skill_invocation_message(
+                        "/triage", user_instruction=benign
+                    ),
+                }
+            ]
+        )[0]["content"]
+
+        assert hostile_blocks[0] == benign_blocks[0]
+        assert hostile_blocks[1]["text"] == hostile
+        assert benign_blocks[1]["text"] == benign
+
+    def test_bare_invocation_keeps_whole_block_layout(self, skills):
+        message = skill_commands.build_skill_invocation_message("/triage")
+        blocks = apply_anthropic_cache_control(
+            [{"role": "user", "content": message}]
+        )[0]["content"]
+        assert blocks == [{"type": "text", "text": message, "cache_control": MARKER}]
+
+    def test_builder_round_trip_survives_failover_strip(self, skills):
+        original = [
+            {
+                "role": "user",
+                "content": skill_commands.build_skill_invocation_message(
+                    "/triage", user_instruction="ticket=one"
+                ),
+            }
+        ]
+        marked = apply_anthropic_cache_control(copy.deepcopy(original))
+        assert strip_anthropic_cache_control(marked) == original
+
+
+class TestCronBuilder:
+    def _prompts(self, jobs):
+        from cron.scheduler import _build_job_prompt
+
+        with patch(
+            "agent.skill_bundles.resolve_bundle_command_key", return_value=None
+        ), patch(
+            "tools.skills_tool.skill_view", side_effect=self._skill_view
+        ), patch(
+            "tools.skill_usage.bump_use"
+        ):
+            return [_build_job_prompt(job) for job in jobs]
+
+    @staticmethod
+    def _skill_view(name: str) -> str:
+        import json
+
+        if name == "missing":
+            return json.dumps({"success": False, "error": "missing"})
+        return json.dumps({"success": True, "content": f"Stable content for {name}."})
+
+    def test_cron_runs_share_the_marked_scaffold(self):
+        common = {"id": "job-cache", "name": "cache boundary", "skills": ["alpha", "beta"]}
+        first, second = self._prompts(
+            [
+                {**common, "prompt": "ticket=one time=10:00"},
+                {**common, "prompt": "ticket=two time=10:01"},
+            ]
+        )
+
+        first_blocks = apply_anthropic_cache_control(
+            [{"role": "user", "content": first}]
+        )[0]["content"]
+        second_blocks = apply_anthropic_cache_control(
+            [{"role": "user", "content": second}]
+        )[0]["content"]
+
+        assert isinstance(first, str) and isinstance(second, str)
+        assert len(first_blocks) == len(second_blocks) == 2
+        assert first_blocks[0] == second_blocks[0]
+        assert first_blocks[0]["cache_control"] == MARKER
+        assert "Stable content for alpha." in first_blocks[0]["text"]
+        assert "ticket=one" not in first_blocks[0]["text"]
+        assert first_blocks[1]["text"].endswith("ticket=one time=10:00")
+
+    def test_missing_skill_notice_stays_in_the_stable_prefix(self):
+        common = {"id": "job-skip", "name": "skip notice", "skills": ["missing", "alpha"]}
+        first, second = self._prompts(
+            [{**common, "prompt": "ticket=one"}, {**common, "prompt": "ticket=two"}]
+        )
+
+        first_blocks = apply_anthropic_cache_control(
+            [{"role": "user", "content": first}]
+        )[0]["content"]
+        second_blocks = apply_anthropic_cache_control(
+            [{"role": "user", "content": second}]
+        )[0]["content"]
+
+        assert first_blocks[0] == second_blocks[0]
+        assert "could not be found" in first_blocks[0]["text"]
+        assert first_blocks[1]["text"].endswith("ticket=one")

--- a/tests/agent/test_prompt_cache_boundary.py
+++ b/tests/agent/test_prompt_cache_boundary.py
@@ -20,7 +20,6 @@ import tools.skills_tool as skills_tool
 from agent.prompt_cache_boundary import (
     clear_stable_prefixes,
     find_stable_prefix,
-    is_registered_stable_prefix,
     register_stable_prefix,
 )
 from agent.prompt_caching import (
@@ -87,7 +86,47 @@ class TestRegistry:
 
     def test_empty_prefix_never_registered(self):
         register_stable_prefix("")
-        assert not is_registered_stable_prefix("")
+        assert find_stable_prefix("anything") is None
+
+    def test_lookup_refreshes_the_entry_lru_position(self):
+        """A cron scaffold fired every minute must survive a burst of one-off
+        invocations; without the refresh it silently drops back to
+        whole-message caching while still being the hottest prefix."""
+        from agent import prompt_cache_boundary
+
+        register_stable_prefix("hot-scaffold ")
+        for index in range(prompt_cache_boundary._MAX_ENTRIES - 1):
+            register_stable_prefix(f"cold-{index} ")
+
+        assert find_stable_prefix("hot-scaffold volatile") == "hot-scaffold "
+
+        register_stable_prefix("newcomer ")
+
+        assert find_stable_prefix("hot-scaffold volatile") == "hot-scaffold "
+        assert find_stable_prefix("cold-0 volatile") is None
+
+    def test_total_byte_cap_evicts_oldest_and_keeps_newest(self, monkeypatch):
+        """Entries retain whole skill bodies, so the entry count alone does
+        not bound memory."""
+        from agent import prompt_cache_boundary
+
+        monkeypatch.setattr(prompt_cache_boundary, "_MAX_BYTES", 100)
+
+        register_stable_prefix("a" * 80)
+        register_stable_prefix("b" * 80)
+
+        assert find_stable_prefix("a" * 80 + "tail") is None
+        assert find_stable_prefix("b" * 80 + "tail") == "b" * 80
+
+    def test_single_oversized_prefix_still_registers(self, monkeypatch):
+        from agent import prompt_cache_boundary
+
+        monkeypatch.setattr(prompt_cache_boundary, "_MAX_BYTES", 10)
+        oversized = "x" * 500
+
+        register_stable_prefix(oversized)
+
+        assert find_stable_prefix(oversized + "tail") == oversized
 
 
 class TestRequestLocalSplit:
@@ -152,6 +191,25 @@ class TestRequestLocalSplit:
 
         assert stripped == original
         assert apply_anthropic_cache_control(copy.deepcopy(stripped)) == first_wire
+
+    def test_strip_flattens_even_after_the_prefix_was_evicted(self):
+        """Mid-turn failover re-decorates a request built many messages ago
+        (#72626). If flattening depended on the registry still holding the
+        entry, a busy gateway that registered _MAX_ENTRIES newer scaffolds in
+        between would ship the split shape to the next provider instead of
+        the canonical string."""
+        from agent import prompt_cache_boundary
+
+        scaffold = "stable scaffold\n\n" + _SINGLE_SKILL_INSTRUCTION
+        register_stable_prefix(scaffold)
+        original = [{"role": "user", "content": scaffold + "ticket=one"}]
+        marked = apply_anthropic_cache_control(copy.deepcopy(original))
+
+        for index in range(prompt_cache_boundary._MAX_ENTRIES + 1):
+            register_stable_prefix(f"unrelated-scaffold-{index} ")
+        assert find_stable_prefix(scaffold + "ticket=one") is None
+
+        assert strip_anthropic_cache_control(marked) == original
 
     def test_strip_leaves_organic_two_part_user_content_structured(self):
         organic = [


### PR DESCRIPTION
## What does this PR do?

Fixes the atomic-block caching of webhook/cron skill invocations (#81867) by making the **message builders declare the exact stable/volatile boundary** at construction time, instead of re-deriving it from marker-string searches at request time.

Skill builders register the stable scaffold prefix (activation note + expanded skill body + the static instruction prose) in a small process-local LRU registry (`agent/prompt_cache_boundary.py`). When the Anthropic cache planner marks a user message whose string starts with a registered prefix, it emits `[marked stable prefix, unmarked volatile tail]` request-locally. Canonical session history stays a plain string, and the failover stripper flattens the split back byte-exactly via an O(1) exact registry lookup. Any miss (restart, eviction, unrecognized message) falls back to the existing whole-message policy.


## Root cause

`_apply_cache_marker` (`agent/prompt_caching.py`) wraps a string user message in a single marked text block. Webhook (`gateway/platforms/webhook.py`), slash-command, TUI, and cron (`cron/scheduler.py::_build_job_prompt`) all funnel through builders that append the volatile per-event data **after** a large static scaffold — but the boundary was discarded when the parts were joined into one string, so a few changed tail bytes (ticket ID, timestamp) invalidated the entire ~21K-char cached block on every invocation (measured ~58% of account spend going to cache writes on one production route).

## Why a third PR — this is not a duplicate of #81928 / #81929

Both open PRs re-parse the boundary out of the final string with `str.rfind(<instruction marker>)`. That heuristic has a silent failure mode in exactly the production scenario from the issue (helpdesk tickets): **if the volatile payload itself quotes the instruction marker** (e.g. a user pastes an agent transcript into a ticket), `rfind` splits *inside the payload*, volatile bytes leak into the "stable" prefix, and the per-invocation cache miss silently returns — with no test able to catch it generically, because the parser has no ground truth. #81929 additionally needs ~5 special-cased shape branches (cron skip-notice, cron-bundle, runtime-note fallback) to approximate what the builders already know.

This PR removes the guesswork instead of refining it:

| | #81928 / #81929 | this PR |
|---|---|---|
| Boundary source | marker search (`rfind`) over the final string | declared by the builder that created the boundary |
| Payload quoting the marker | volatile bytes absorbed into the cached prefix → cache misses return silently | impossible by construction (regression-tested) |
| Cron skip-notice / bundle-in-cron shapes | missed (#81928) or special-cased (#81929) | covered by the same single primitive |
| Failover flatten check | re-parse + concatenation compare | shape match, no process state consulted |
| Unrecognized / post-restart messages | n/a | explicit fallback to today's whole-message policy |

Trade-off, stated openly: the registry is process-local mutable state (thread-safe, 32-entry LRU capped at 4 MiB of retained scaffolds). A restart only affects messages built before it, which then simply keep today's behavior — never worse than main.

## Changes Made

- `agent/prompt_cache_boundary.py` *(new, ~70 lines)* — thread-safe LRU registry: `register_stable_prefix`, `find_stable_prefix` (longest proper prefix), `is_registered_stable_prefix`, test-isolation `clear_stable_prefixes`.
- `agent/skill_commands.py` — `_build_skill_message` registers the scaffold when a `user_instruction` is appended (covers webhook, gateway/CLI slash commands, TUI). Message bytes are unchanged.
- `cron/scheduler.py` — `_build_job_prompt` registers the scaffold before the volatile instruction tail, guarded so injection-scanner sanitization mutations skip registration instead of corrupting it.
- `agent/prompt_caching.py` — `_apply_cache_marker` splits registered user strings; `strip_anthropic_cache_control` flattens the two-part split back byte-exactly.
- `tests/agent/test_prompt_cache_boundary.py` *(new, 16 tests)* — registry semantics (proper prefix, longest match, LRU fallback), request-local split, canonical-history isolation, strip/redecorate round-trip, organic multi-part content untouched, real-builder coverage (shared marked scaffold, bare invocation, **marker-quoting payload cannot poison the prefix**), cron multi-skill and skipped-skill-notice shapes.

## Related Issue

Fixes #81867

## Type of Change

- [x] Performance improvement
- [x] Bug fix (non-breaking change)
- [x] Tests

## How to Test

```bash
uv run ruff check .
scripts/run_tests.sh \
  tests/agent/test_prompt_cache_boundary.py \
  tests/agent/test_prompt_caching.py \
  tests/agent/test_anthropic_adapter.py \
  tests/agent/test_moa_aggregator_cache_control.py \
  tests/agent/test_cache_disabled_on_stubs.py \
  tests/agent/test_skill_commands.py \
  tests/agent/test_skill_invocation_description.py \
  tests/agent/test_skill_bundles.py \
  tests/agent/test_memory_skill_scaffolding.py \
  tests/agent/test_failover_identity.py \
  tests/test_session_skill_previews.py \
  tests/cron/test_cron_prompt_injection_skill.py \
  tests/cron/test_scheduler.py \
  tests/gateway/test_webhook_integration.py \
  tests/run_agent/test_background_review_cache_parity.py \
  tests/run_agent/test_conversation_fallback_state.py \
  tests/run_agent/test_moa_loop_mode.py \
  tests/openviking_plugin/test_openviking.py
```

Local result: all listed suites pass (16 new + neighborhood green); the only failures on this machine are 3 pre-existing Windows-only inline-shell tests in `tests/agent/test_skill_commands.py` that fail identically on unmodified `main`. `ruff check` clean, `git diff --check` clean.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs (#81928, #81929) and documented above why this is a different implementation, not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added regression tests, including the marker-quoting failure mode unique to this approach

 


---

## Follow-up hardening (review pass, commit `006009f0`)

A second pass over this PR looked for ways the boundary could silently stop paying off — or keep costing — inside a long-lived gateway process. Three were found and fixed. All three preserve happy-path behaviour and are covered by new tests.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A[🩸 Skill Turn Built] -->|Declare Exact Boundary| R[(🔥 Stable Prefix Registry<br/>32 entries · 4 MiB cap)]
    R -->|Longest Prefix Hit<br/>refreshes LRU slot| S[⚔️ Request-Local Split<br/>marked prefix + unmarked tail]
    S --> W[🚀 Outbound Provider Request]
    W -->|Provider Failure| F[💀 Mid-Turn Failover]
    F --> X{🕯️ Flatten Check<br/>shape-based}
    X -->|Marker On First Part| C[✅ Canonical String Restored]
    X -->|Any Other Shape| K[🛡️ Structure Preserved]
    C --> D[🔥 Re-Decorate For New Provider]
    R -.->|Entry Evicted Meanwhile<br/>no longer breaks flattening| X
```
## Infographic :
<img width="1024" height="1024" alt="issue_82049_infographic" src="https://github.com/user-attachments/assets/38bf28a5-2123-47c1-b01c-8c5998dc3118" />



### 1. Flattening no longer consults the registry — correctness

`strip_anthropic_cache_control` used to identify the decorated split by looking the first block up in the prefix registry. A mid-turn failover re-decorates a request that was built many messages earlier (#72626), so on a busy gateway that had registered `_MAX_ENTRIES` newer scaffolds in the meantime, the entry could already be evicted: flattening was skipped and the *next* provider received the two-part shape instead of the canonical string.

The split is now matched by its **shape** instead: a marker on the *first* part of a `role: "user"` message is something no other decoration produces — list content otherwise receives its marker on the last part, and the two-part `[static, volatile]` split is role-gated to `system`. The `""`-join therefore stays provably byte-exact with zero dependency on process state. This also removes `is_registered_stable_prefix` and one lock acquisition per stripped message.

### 2. Lookups refresh LRU position — throughput

`find_stable_prefix` did not bump the entry it matched, so a scaffold fired every minute by cron could be evicted by a burst of one-off skill invocations while still being the hottest prefix in the process — silently reverting that job to whole-message caching. Hits now `move_to_end`.

### 3. Registration also evicts by retained bytes — memory

Entries hold whole expanded skill bodies, so a 32-entry cap alone does not bound memory: a handful of large skills can retain tens of MB for the lifetime of the gateway. Registration now also evicts oldest-first past a 4 MiB total, while always keeping the newest entry so a single oversized scaffold still gets a boundary instead of disabling the split.

### New tests

- `test_strip_flattens_even_after_the_prefix_was_evicted` — decorate, evict the entry, then assert the failover strip still reconstructs the exact original string.
- `test_lookup_refreshes_the_entry_lru_position` — a hot prefix survives a full sweep of newer registrations.
- `test_total_byte_cap_evicts_oldest_and_keeps_newest` / `test_single_oversized_prefix_still_registers` — byte-cap eviction and the always-keep-newest guarantee.

`tests/agent/test_prompt_cache_boundary.py` is now 20 tests; the suites listed above still pass, `ruff check` is clean, `git diff --check` is clean.

### Known gap, deliberately out of scope

Direct (non-cron) **bundle and stacked-skill** invocations put `User instruction:` in the header, *before* the loaded skill blocks (`agent/skill_bundles.py`, `build_stacked_skill_invocation_message`). There is no stable prefix to mark in that layout, so no boundary applies — for this PR or for the alternatives. Cron-driven bundles *are* covered here, because the cron builder appends its own instruction after every stable block. Making the direct bundle layout cacheable means reordering that scaffold, which changes prompt text and belongs in its own change.
