### PR TITLE
fix(desktop): recover stale Linux singleton lock

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -12165,9 +12165,64 @@ function registerDeepLinkProtocol() {
 // Single-instance lock: deep links on a running app (Win/Linux) arrive as a
 // second-instance argv. Without the lock a second `hermes://` launch spawns a
 // whole new app instead of routing into the running one.
-const _gotSingleInstanceLock = app.requestSingleInstanceLock()
+//
+// Electron can leave these user-data symlinks behind after an abnormal exit on
+// Linux/X11. A dead or zombie PID cannot receive a second-instance event, so
+// clean up only that provably stale local lock and retry once.
+function clearStaleLinuxSingletonLock(): boolean {
+  if (process.platform !== 'linux') {
+    return false
+  }
+
+  const userData = app.getPath('userData')
+  const lockPath = path.join(userData, 'SingletonLock')
+  let target: string
+
+  try {
+    target = fs.readlinkSync(lockPath)
+  } catch {
+    return false
+  }
+
+  const hostPrefix = `${os.hostname()}-`
+  const pidText = target.startsWith(hostPrefix) ? target.slice(hostPrefix.length) : ''
+  if (!/^\d+$/.test(pidText)) {
+    return false
+  }
+
+  const pid = Number(pidText)
+  let stale = false
+  try {
+    process.kill(pid, 0)
+    // kill(pid, 0) succeeds for zombies. /proc state Z is equally stale.
+    const state = fs.readFileSync(`/proc/${pid}/stat`, 'utf8').match(/\)\s+([A-Z])/)
+    stale = state?.[1] === 'Z'
+  } catch {
+    stale = true
+  }
+  if (!stale) {
+    return false
+  }
+
+  try {
+    for (const name of ['SingletonLock', 'SingletonCookie', 'SingletonSocket']) {
+      fs.rmSync(path.join(userData, name), { force: true })
+    }
+    rememberLog(`[startup] removed stale Electron SingletonLock for dead PID ${pid}`)
+    return true
+  } catch (err) {
+    rememberLog(`[startup] could not remove stale Electron SingletonLock: ${err.message}`)
+    return false
+  }
+}
+
+let _gotSingleInstanceLock = app.requestSingleInstanceLock()
+if (!_gotSingleInstanceLock && clearStaleLinuxSingletonLock()) {
+  _gotSingleInstanceLock = app.requestSingleInstanceLock()
+}
 
 if (!_gotSingleInstanceLock) {
+  rememberLog('[startup] Electron single-instance lock is held by a live process; exiting')
   app.quit()
 } else {
   app.on('second-instance', (_event, argv) => {


### PR DESCRIPTION
## Problem

On Linux/X11, Electron can leave `SingletonLock`, `SingletonCookie`, and `SingletonSocket` in the Hermes user-data directory after an abnormal desktop-process exit (for example a crash, OOM kill, or `kill -9`).

On the next `hermes desktop` or app-menu launch, `app.requestSingleInstanceLock()` returns `false`. Hermes immediately calls `app.quit()` with exit code 0. There may be no existing Electron instance to receive `second-instance`, no visible window, and no useful desktop-log explanation.

This is the silent-exit failure reported in #78101 on Ubuntu/X11.

## Root cause

`apps/desktop/electron/main.ts` acquires the Electron single-instance lock once:

```ts
const gotSingleInstanceLock = app.requestSingleInstanceLock()
if (!gotSingleInstanceLock) app.quit()
```

Electron lock acquisition cannot distinguish a genuinely running first instance from a stale Linux singleton symlink. The current implementation therefore exits on both cases.

## Change

- On Linux only, inspect `SingletonLock` *after* the initial `requestSingleInstanceLock()` failure.
- Parse only lock targets for the current hostname with an exact numeric PID. Malformed, remote-host, or ambiguous targets are left untouched.
- Treat the lock as stale only when the PID no longer exists or `/proc/<pid>/stat` reports zombie state (`Z`).
- Remove only Electron's three singleton artifacts under the current `app.getPath('userData')`.
- Retry `requestSingleInstanceLock()` exactly once after successful stale-lock cleanup.
- Preserve the existing behavior for a live lock owner, but write a concrete reason to `desktop.log` instead of silently exiting.

## Safety behavior

This does **not** disable Electron single-instance protection and does not delete a lock for a live PID. It does not operate outside Linux. Cleanup is constrained to the current Hermes user-data directory and only occurs after a failed Electron lock acquisition plus proof that the local PID is dead or zombie.

A reused but live PID is intentionally treated as live, favoring safety over automatic recovery.

## Reproduction

1. Start Hermes Desktop.
2. Terminate the Electron main process abnormally.
3. Confirm `SingletonLock` remains and names the dead/zombie local PID.
4. Launch Hermes Desktop again.
5. Before this change: process exits silently with no window.
6. With this change: stale singleton files are removed, the lock is reacquired, and startup continues.

## Verification

Ran from an isolated worktree based on current `NousResearch/main`:

- `npm run typecheck -- --pretty false`
- `npm run lint -- --quiet`
- `npm run test:desktop:platforms` — **960 passed, 2 skipped**
- `npm run check` — passed, including UI tests, Electron tests, and a packaged Linux `linux-unpacked` artifact build

## Scope

One file changed:

- `apps/desktop/electron/main.ts`

No configuration, dependency, sandbox, update, or renderer changes.

Closes #78101