### PR TITLE
feat(tools): let the model name command runs via a title arg

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -322,6 +322,24 @@ def _is_shell_boundary_echo(segment: str) -> bool:
     return bool(re.search(r"-{2,}|_exit=|(?:^|\s|=)\$[?{]|PIPESTATUS", rest))
 
 
+def _shell_segment_label(segment: str) -> str:
+    """Program plus its first argument (usually the subcommand), so a compound
+    reads `git add · git commit · git push` instead of flooding the row."""
+    words = _split_shell_words(segment)
+    index = 0
+    while index < len(words) and re.match(r"^[A-Za-z_]\w*=", words[index]):
+        index += 1
+    if index >= len(words):
+        # Every word was an env assignment (`FOO=1`): label from the
+        # assignment itself so the slot never renders empty.
+        env = words[0]
+        return f"{env[:21]}..." if len(env) > 24 else env
+    head = _shell_basename(words[index])
+    arg = words[index + 1] if index + 1 < len(words) else ""
+    arg_short = f"{arg[:21]}..." if len(arg) > 24 else arg
+    return f"{head} {arg_short}" if arg_short else head
+
+
 def summarize_shell_command(command: str) -> str:
     """Compact shell wrapper/plumbing for display while preserving raw command elsewhere."""
     original = _oneline(command)
@@ -344,8 +362,10 @@ def summarize_shell_command(command: str) -> str:
     if len(core) == 1:
         return core[0]
 
-    count = len(core) - 1
-    return f"{core[0]} + {count} {'command' if count == 1 else 'commands'}"
+    labels = [_shell_segment_label(segment) for segment in core]
+    if len(labels) <= 3:
+        return " · ".join(labels)
+    return f"{' · '.join(labels[:3])} + {len(labels) - 3} more"
 
 
 def _read_file_line_label(args: dict) -> str:

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
@@ -90,6 +90,22 @@ describe('buildToolView terminal exit-code status', () => {
     expect(view.terminalCommand).toBe('npm run check --workspace=apps/desktop')
     expect(view.terminalExitCode).toBe(0)
   })
+
+  it('prefers the model-provided title over the raw command in the header', () => {
+    const view = buildToolView(
+      part({
+        args: {
+          command: 'powershell -NoProfile -ExecutionPolicy Bypass -File C:\\Users\\owner\\probe.ps1',
+          title: 'List Hermes processes'
+        },
+        result: undefined,
+        toolName: 'terminal'
+      }),
+      ''
+    )
+
+    expect(view.title).toBe('Running List Hermes processes')
+  })
 })
 
 describe('buildToolView web-search query', () => {
@@ -296,11 +312,11 @@ describe('buildToolView title actions', () => {
       ],
       [
         'which node pnpm corepack; node -v; echo "---"; corepack --version 2>&1; echo "---pnpm via corepack---"; pnpm --version 2>&1 | tail -5',
-        'Ran which node pnpm corepack + 3 commands'
+        'Ran which node · node -v · corepack --version + 1 more'
       ],
       [
         'echo "--- proto pnpm direct ---"; ~/.proto/tools/node/24.11.0/bin/pnpm --version 2>&1 | tail -3; echo "--- proto node ---"; ls ~/.proto/tools/node/ 2>&1; echo "--- corepack cache ---"; ls ~/.cache/node/corepack/v1/pnpm/ 2>&1',
-        'Ran ~/.proto/tools/node/24.11.0/bin/pnpm --version + 2 commands'
+        'Ran pnpm --version · ls ~/.proto/tools/node/ · ls ~/.cache/node/corepac...'
       ],
       [
         'cd /Users/brooklyn/www/bb-rainbows && COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm@10.20.0 --version 2>&1 | tail -3',
@@ -357,7 +373,7 @@ describe('buildToolView title actions', () => {
       ''
     )
 
-    expect(view.title).toBe('Ran sleep 70 + 2 commands')
+    expect(view.title).toBe('Ran sleep 70 · echo "a" · echo "b"')
     expect(view.terminalCommand).toBe(command)
     expect(view.detail).toBe('')
   })

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
@@ -1384,13 +1384,14 @@ function dynamicTitle(
           ? verb(translateNow('assistant.tool.actions.runningCode'), translateNow('assistant.tool.actions.ranCode'))
           : verb(translateNow('assistant.tool.actions.running'), translateNow('assistant.tool.actions.ran'))
 
+      // A model-provided `title` names the run in the model's own words
+      // ("List Hermes processes"); the deterministic command summary stays
+      // the fallback. The raw command remains in the row's detail/payload.
+      const label = firstStringField(args, ['title']) || summarizeShellCommand(command)
+
       return titledAction(
         action,
-        translateNow(
-          'assistant.tool.titleTemplates.actionCommand',
-          action,
-          compactPreview(summarizeShellCommand(command), 160)
-        )
+        translateNow('assistant.tool.titleTemplates.actionCommand', action, compactPreview(label, 160))
       )
     }
   }

--- a/apps/desktop/src/components/assistant-ui/tool/run-summary.test.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/run-summary.test.ts
@@ -34,6 +34,22 @@ describe('summarizeToolRun', () => {
     )
   })
 
+  it('keeps a settled command named when the model titled it', () => {
+    expect(settled([tool('terminal', { command: 'git status', title: 'Check working tree' }, { exit_code: 0 })])).toBe(
+      'Ran Check working tree'
+    )
+    // Untitled commands still collapse to a count.
+    expect(settled([ran('git status')])).toBe('Ran 1 command')
+  })
+
+  it('caps a rambling model title so it cannot flood the group line', () => {
+    const longTitle = 'x'.repeat(200)
+
+    expect(settled([tool('terminal', { command: 'git status', title: longTitle }, { exit_code: 0 })])).toBe(
+      `Ran ${'x'.repeat(79)}…`
+    )
+  })
+
   it('puts the running category in the present tense and leaves the rest past', () => {
     expect(running([read('a.ts'), tool('read_file', { path: 'b.ts' }), ran('x'), ran('y')])).toBe(
       'Exploring 2 files, ran 2 commands'
@@ -42,6 +58,17 @@ describe('summarizeToolRun', () => {
 
   it('names the command that is still running', () => {
     expect(running([tool('terminal', { command: 'npm run typecheck' })])).toMatch(/^Running /)
+  })
+
+  it('prefers the model-provided title over the command summary', () => {
+    expect(
+      running([
+        tool('terminal', {
+          command: 'powershell -NoProfile -ExecutionPolicy Bypass -File C:\\Users\\owner\\probe.ps1',
+          title: 'List Hermes processes'
+        })
+      ])
+    ).toBe('Running List Hermes processes')
   })
 
   // Sequential calls leave a gap where the run is still going but nothing is

--- a/apps/desktop/src/components/assistant-ui/tool/run-summary.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/run-summary.ts
@@ -2,6 +2,12 @@ import { summarizeShellCommand } from '@/lib/summarize-command'
 
 import { fileEditBasename, firstStringField, isFileEditTool, parseMaybeObject } from './fallback-model'
 
+// A `title` is trusted display text, but the model still controls its length —
+// cap it so a rambling one can't flood the collapsed group line.
+function shortTitle(title: string): string {
+  return title.length > 80 ? `${title.slice(0, 79)}…` : title
+}
+
 /**
  * The little a summary needs from a tool call, stated structurally so both
  * shapes of tool part satisfy it — the stored `ChatMessagePart` and the live
@@ -80,7 +86,11 @@ function toolTarget(tool: ToolCallLike): string {
   const args = parseMaybeObject(tool.args)
 
   if (toolCategory(tool.toolName) === 'run') {
-    return summarizeShellCommand(firstStringField(args, ['command', 'code']))
+    // The model can name its own run (`title` arg) — prefer that over the
+    // deterministic command summary when it bothered.
+    const title = firstStringField(args, ['title'])
+
+    return title ? shortTitle(title) : summarizeShellCommand(firstStringField(args, ['command', 'code']))
   }
 
   const path = firstStringField(args, ['path', 'file', 'filepath'])
@@ -90,16 +100,23 @@ function toolTarget(tool: ToolCallLike): string {
 
 /**
  * One clause per category. A category holding a single thing says what it was
- * ("Edited wiring.tsx"); anything else counts ("explored 3 files"). A settled
- * command is the exception — "ran 5 commands" is the useful reading, and a
- * command line only earns its space while it's the thing you're waiting on.
+ * ("Edited wiring.tsx"); anything else counts ("explored 3 files"). Settled
+ * commands are the exception — "ran 5 commands" is the useful reading, and a
+ * raw command line only earns its space while it's the thing you're waiting
+ * on, or when the model gave it a short `title` worth keeping.
  */
 function clause(category: RunCategory, tools: ToolCallLike[], live: boolean): string {
   const copy = CATEGORY_COPY[category]
   const verb = live ? copy.present : copy.past
   const target = tools.length === 1 ? toolTarget(tools[0]) : ''
 
-  if (target && (live || category !== 'run')) {
+  // A settled command stays a count ("ran 3 commands") because raw command
+  // lines are long — unless the model named it with a short `title`, which
+  // reads fine in the collapsed line ("Ran List Hermes processes").
+  const runTitled =
+    category === 'run' && tools.length === 1 && Boolean(firstStringField(parseMaybeObject(tools[0]!.args), ['title']))
+
+  if (target && (live || category !== 'run' || runTitled)) {
     return `${verb} ${target}`
   }
 

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -779,6 +779,25 @@ describe('upsertToolPart', () => {
     })
   })
 
+  it('carries the model-provided title from tool.start into live args', () => {
+    const started = upsertToolPart(
+      [],
+      {
+        context: 'rm -rf "C:\\Users\\owner\\approval-test-dir2"',
+        name: 'terminal',
+        title: 'Delete approval test directory',
+        tool_id: 'term-title-1'
+      },
+      'running'
+    )
+
+    const [part] = started
+
+    expect((part as Extract<ChatMessagePart, { type: 'tool-call' }>).args).toMatchObject({
+      title: 'Delete approval test directory'
+    })
+  })
+
   it('preserves query args when completion payload omits context', () => {
     const started = upsertToolPart(
       [],

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -96,7 +96,10 @@ export type GatewayEventPayload = {
   row_id?: number
   reactions?: MessageReaction[]
   role?: string
-  // session.title (live auto-title push) — stored session id + generated title
+  // session.title (live auto-title push) — stored session id + generated title.
+  // Also tool.start: the model-provided short label for a command run
+  // (terminal/execute_code `title` arg), so pending/approval rows can show it
+  // before the persisted args load.
   session_id?: string
   title?: string
   // session.info — the stored (durable) session id for this runtime session.
@@ -643,6 +646,7 @@ function toolArgs(payload: GatewayEventPayload | undefined, prevArgs?: unknown):
     ...eventArgs,
     ...(payload?.context ? { context: payload.context } : {}),
     ...(payload?.preview ? { preview: payload.preview } : {}),
+    ...(payload?.title ? { title: payload.title } : {}),
     ...carryTodos(payload, prevArgs)
   }
 }

--- a/apps/desktop/src/lib/summarize-command.test.ts
+++ b/apps/desktop/src/lib/summarize-command.test.ts
@@ -25,9 +25,9 @@ describe('summarizeShellCommand', () => {
     )
   })
 
-  it('compacts a genuine multi-command compound without listing every command', () => {
+  it('names every command in a two-command compound', () => {
     const compound = 'git add -A && git commit -m "wip"'
-    expect(summarizeShellCommand(compound)).toBe('git add -A + 1 command')
+    expect(summarizeShellCommand(compound)).toBe('git add · git commit')
   })
 
   it('leaves a single bare command untouched', () => {
@@ -71,25 +71,29 @@ describe('summarizeShellCommand', () => {
     )
   })
 
-  it('compacts a genuine multi-command probe from session 20260624_231846_bdbd1e', () => {
+  it('names each segment of a multi-command probe from session 20260624_231846_bdbd1e', () => {
     const probe = 'which node pnpm corepack; node -v; corepack --version 2>&1'
-    expect(summarizeShellCommand(probe)).toBe('which node pnpm corepack + 2 commands')
+    expect(summarizeShellCommand(probe)).toBe('which node · node -v · corepack --version')
   })
 
-  it('compacts the corepack diagnostic command from session 20260624_231846_bdbd1e', () => {
+  it('labels an env-assignment-only segment instead of leaving an empty slot', () => {
+    expect(summarizeShellCommand('FOO=1 && npm test')).toBe('FOO=1 · npm test')
+  })
+
+  it('names the first three and counts the rest for long compounds', () => {
     expect(
       summarizeShellCommand(
         'which node pnpm corepack; node -v; echo "---"; corepack --version 2>&1; echo "---pnpm via corepack---"; pnpm --version 2>&1 | tail -5'
       )
-    ).toBe('which node pnpm corepack + 3 commands')
+    ).toBe('which node · node -v · corepack --version + 1 more')
   })
 
-  it('compacts the proto/cache probe from session 20260624_231846_bdbd1e', () => {
+  it('names each surviving segment of the proto/cache probe from session 20260624_231846_bdbd1e', () => {
     expect(
       summarizeShellCommand(
         'echo "--- proto pnpm direct ---"; ~/.proto/tools/node/24.11.0/bin/pnpm --version 2>&1 | tail -3; echo "--- proto node ---"; ls ~/.proto/tools/node/ 2>&1; echo "--- corepack cache ---"; ls ~/.cache/node/corepack/v1/pnpm/ 2>&1'
       )
-    ).toBe('~/.proto/tools/node/24.11.0/bin/pnpm --version + 2 commands')
+    ).toBe('pnpm --version · ls ~/.proto/tools/node/ · ls ~/.cache/node/corepac...')
   })
 
   it('summarizes the successful lint command from session 20260624_231846_bdbd1e', () => {

--- a/apps/desktop/src/lib/summarize-command.ts
+++ b/apps/desktop/src/lib/summarize-command.ts
@@ -168,6 +168,31 @@ function isBoundaryEcho(segment: string): boolean {
   return /-{2,}|_exit=|(?:^|\s|=)\$[?{]|PIPESTATUS/.test(rest)
 }
 
+// A segment in a few characters: program plus its first argument (usually the
+// subcommand), so a compound reads `git add · git commit · git push` instead
+// of flooding the row with full command lines.
+function segmentLabel(segment: string): string {
+  const words = splitWords(segment)
+  let index = 0
+
+  while (index < words.length && /^[A-Za-z_]\w*=/.test(words[index]!)) {
+    index += 1
+  }
+
+  // Every word was an env assignment (`FOO=1`): label from the assignment
+  // itself so the slot never renders empty.
+  if (index >= words.length) {
+    const env = words[0]!
+    return env.length > 24 ? `${env.slice(0, 21)}...` : env
+  }
+
+  const head = basename(words[index]!)
+  const arg = words[index + 1] ?? ''
+  const argShort = arg.length > 24 ? `${arg.slice(0, 21)}...` : arg
+
+  return argShort ? `${head} ${argShort}` : head
+}
+
 /**
  * Reduce a verbose shell command to the "main" command, for display only.
  *
@@ -181,9 +206,11 @@ function isBoundaryEcho(segment: string): boolean {
  *   3. clean env var prefixes / redirects
  *   4. drop setup/banner/status segments
  *
- * If one real command survives, show it. If multiple real commands survive,
- * show a short `first command + N commands` label instead of flooding the row
- * with every probe. The full command is always still available via Copy/detail.
+ * If one real command survives, show it in full. If multiple survive, name
+ * each briefly — `head sub` per segment, joined with ` · ` for up to three,
+ * `+ N more` beyond — so every command in a compound is identifiable from the
+ * row alone without flooding it. The full command is always still available
+ * via Copy/detail.
  */
 export function summarizeShellCommand(raw: string): string {
   const original = (raw ?? '').trim()
@@ -212,5 +239,11 @@ export function summarizeShellCommand(raw: string): string {
     return core[0]!
   }
 
-  return `${core[0]} + ${core.length - 1} ${core.length === 2 ? 'command' : 'commands'}`
+  const labels = core.map(segmentLabel)
+
+  if (labels.length <= 3) {
+    return labels.join(' · ')
+  }
+
+  return `${labels.slice(0, 3).join(' · ')} + ${labels.length - 3} more`
 }

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -13,6 +13,7 @@ from agent.display import (
     prepare_tool_preview,
     redact_tool_args_for_display,
     set_tool_preview_max_len,
+    summarize_shell_command,
     _render_inline_unified_diff,
     _summarize_rendered_diff_sections,
     render_edit_diff_with_delta,
@@ -34,6 +35,19 @@ def test_cute_tool_message_falls_back_when_renderer_raises(monkeypatch):
 
     assert get_cute_tool_message("web_extract", {"urls": []}, 0.25) == (
         "┊ ⚡ web_extra completed  0.2s"
+    )
+
+
+def test_summarize_shell_command_env_only_segment():
+    """An env-assignment-only member (`FOO=1`) must still render its own text."""
+    assert summarize_shell_command("FOO=1 && npm test") == "FOO=1 · npm test"
+
+
+def test_summarize_shell_command_compound_names_every_segment():
+    assert summarize_shell_command("node -v; npm -v; echo x") == "node -v · npm -v · echo x"
+    assert (
+        summarize_shell_command("which node; node -v; corepack --version; exit 0")
+        == "which node · node -v · corepack --version + 1 more"
     )
 
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1045,6 +1045,33 @@ def test_tui_verbose_tool_events_omit_details_when_redaction_fails(monkeypatch):
     assert "result_text" not in events[1][2]
 
 
+def test_tool_start_forwards_model_title_for_pending_labels(monkeypatch):
+    # The desktop's pending/approval rows render before persisted args load,
+    # so the model-provided command title must ride the tool.start payload.
+    events: list[tuple[str, str, dict]] = []
+    monkeypatch.setattr(
+        server, "_emit", lambda event_type, sid, payload: events.append((event_type, sid, payload))
+    )
+    monkeypatch.setitem(
+        server._sessions,
+        "title-test",
+        {"tool_progress_mode": "all"},
+    )
+
+    server._on_tool_start(
+        "title-test",
+        "tool-1",
+        "terminal",
+        {"command": "powershell -NoProfile ...", "title": "List Hermes processes"},
+    )
+    assert events[0][0] == "tool.start"
+    assert events[0][2]["title"] == "List Hermes processes"
+
+    events.clear()
+    server._on_tool_start("title-test", "tool-2", "terminal", {"command": "pwd"})
+    assert "title" not in events[0][2]
+
+
 def test_tui_tool_output_risk_event_exposes_metadata_without_raw_output(monkeypatch):
     events: list[tuple[str, str, dict]] = []
     monkeypatch.setattr(
@@ -2264,10 +2291,10 @@ def test_tool_start_ships_full_args(monkeypatch):
 def test_tool_ctx_sends_an_arg_preview_not_a_phrased_label():
     # Clients phrase their own verb around this string: the TUI renders
     # `Terminal("<ctx>")` and the desktop prepends "Running"/"Ran". Sending a
-    # pre-phrased label made both stutter ("Ran Running sleep 70 + 2 commands")
+    # pre-phrased label made both stutter ("Ran Running sleep 70 · echo a ...")
     # and stood in for the real command in the desktop's `$` transcript.
     assert server._tool_ctx("terminal", {"command": 'sleep 70; echo "a"; echo "b"'}) == (
-        "sleep 70 + 2 commands"
+        'sleep 70 · echo "a" · echo "b"'
     )
     assert server._tool_ctx("read_file", {"path": "/tmp/demo/package.json"}) == "package.json"
     assert server._tool_ctx("web_search", {"query": "weather in NYC"}) == "weather in NYC"

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -367,9 +367,9 @@ _TOOL_STUBS = {
     ),
     "terminal": (
         "terminal",
-        "command: str, timeout: int = None, workdir: str = None",
-        '"""Run a shell command (foreground only). Returns dict with "output" and "exit_code"."""',
-        '{"command": command, "timeout": timeout, "workdir": workdir}',
+        "command: str, timeout: int = None, workdir: str = None, title: str = None",
+        '"""Run a shell command (foreground only). Returns dict with "output" and "exit_code". title: optional short human-readable label shown in the UI while the command runs."""',
+        '{"command": command, "timeout": timeout, "workdir": workdir, "title": title}',
     ),
 }
 
@@ -2047,6 +2047,16 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
                         "Python code to execute. Import tools with "
                         f"`from hermes_tools import {import_str}` "
                         "and print your final result to stdout."
+                    ),
+                },
+                "title": {
+                    "type": "string",
+                    "description": (
+                        "Short human-readable label for the script (3-8 words, "
+                        "under 80 characters, "
+                        "e.g. \"Summarize CSV sales by region\"). Surfaces show it "
+                        "while the script runs and on approval prompts instead of "
+                        "the raw code."
                     ),
                 },
             },

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3740,6 +3740,10 @@ TERMINAL_SCHEMA = {
                 "type": "string",
                 "description": "The command to execute on the VM"
             },
+            "title": {
+                "type": "string",
+                "description": "Short human-readable label for the command (3-8 words, under 80 characters, e.g. \"List Hermes processes\"). Surfaces show it while the command runs and on approval prompts instead of the raw command line. Provide it whenever the command is long, wrapped, or hard to read at a glance."
+            },
             "background": {
                 "type": "boolean",
                 "description": "Run in the background, returning a session_id. Pair with notify_on_complete=true for anything with a defined end (tests, builds, deploys) — without it the process runs silently. Only servers/watchers/daemons that never exit should stay silent. Short commands: prefer foreground with a generous timeout.",

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5493,6 +5493,13 @@ def _on_tool_start(sid: str, tool_call_id: str, name: str, args: dict):
         # tool runs, at the cost of one duplicate transient payload per call.
         if args:
             payload["args"] = args
+        # The model can name its own command run (terminal/execute_code
+        # `title` arg). Forward it so pending and approval rows can show the
+        # short label instead of the raw command — the only window where the
+        # full persisted args aren't available to the UI yet.
+        title = args.get("title") if isinstance(args, dict) else None
+        if isinstance(title, str) and title.strip():
+            payload["title"] = title.strip()
         if _session_verbose(sid):
             args_text = _tool_args_text(args)
             if args_text:

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -274,6 +274,22 @@ describe('createGatewayEventHandler', () => {
     expect(getTurnState().todos).toEqual([])
   })
 
+  it('shows the model-provided title instead of the command preview on tool.start', () => {
+    const onEvent = createGatewayEventHandler(buildCtx([]))
+
+    onEvent({
+      payload: {
+        context: 'powershell -NoProfile -ExecutionPolicy Bypass -File probe.ps1',
+        name: 'terminal',
+        title: 'List Hermes processes',
+        tool_id: 'tool-t1'
+      },
+      type: 'tool.start'
+    } as any)
+
+    expect(turnController.activeTools[0]?.context).toBe('List Hermes processes')
+  })
+
   it('persists completed tool rows when message.complete lands immediately after tool.complete', () => {
     const appended: Msg[] = []
 

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -1116,7 +1116,9 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         turnController.recordToolStart(
           ev.payload.tool_id,
           ev.payload.name ?? 'tool',
-          ev.payload.context ?? '',
+          // The model can name its own command run (`title` arg) — show that
+          // instead of the raw command preview when it bothered.
+          ev.payload.title ?? ev.payload.context ?? '',
           ev.payload.args_text ? stripAnsi(String(ev.payload.args_text)) : undefined
         )
 

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -674,7 +674,14 @@ export type GatewayEvent =
   | { payload: { name?: string; preview?: string }; session_id?: string; type: 'tool.progress' }
   | { payload: { name?: string }; session_id?: string; type: 'tool.generating' }
   | {
-      payload: { args_text?: string; context?: string; name?: string; tool_id: string; todos?: unknown[] }
+      payload: {
+        args_text?: string
+        context?: string
+        name?: string
+        title?: string
+        tool_id: string
+        todos?: unknown[]
+      }
       session_id?: string
       type: 'tool.start'
     }


### PR DESCRIPTION
## What does this PR do?

`terminal` and `execute_code` gain an optional `title` arg (3-8 word human label). The gateway forwards it on `tool.start`, and the desktop + TUI prefer it over the deterministic command summary for **pending, settled, group-summary, and approval rows** - the exact spots where a long command like `powershell -NoProfile -ExecutionPolicy Bypass -Command "..."` is currently dumped raw into the row header. The model supplies the label at tool-call time, so this costs zero extra LLM calls (the aux-summarization approach was considered and rejected: extra call + latency + cost per approval).

A second, tightly coupled change in the same UX surface: compound-command summaries now name each segment (`npx tsc · echo TSC-OK · npx vitest`, `+ N more` beyond three) instead of the opaque `first + N commands` that hid every segment after the first. Same files, same summarizer functions, same problem (unreadable command rows) - happy to split into a second PR if reviewers prefer.

Untitled runs keep today's behavior everywhere; the raw command always stays in the row detail/payload.

## Related Issue

No tracking issue found. Prior art checked before building (per CONTRIBUTING search-first): PR #22363 (`approval_purpose`/`effect`/`risk` fields - structured risk context via a gateway follow-up message, different UX) and PR #68199 (Matrix-only async summary) are both open and complementary, not duplicates. This PR is the display-label counterpart at the row header.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/terminal_tool.py` - optional `title` property in `TERMINAL_SCHEMA` (3-8 words, under 80 chars, prompted for long/wrapped commands)
- `tools/code_execution_tool.py` - same for the `execute_code` schema; `_TOOL_STUBS` sandbox stub updated to match (keeps `TestStubSchemaDrift` green)
- `tui_gateway/server.py::_on_tool_start` - forwards `title` on `tool.start`; the only window where pending/approval rows render before persisted args load
- `apps/desktop/src/lib/chat-messages.ts` - `GatewayEventPayload.title` documented for tool.start + forwarded into live tool args in `toolArgs()`
- `apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts` - pending row header prefers `args.title` (length-capped via existing `compactPreview`)
- `apps/desktop/src/components/assistant-ui/tool/run-summary.ts` - group/ticker line prefers `title` (new 80-char cap: model controls the string); settled titled commands stay named (`Ran List Hermes processes`) while untitled ones still collapse to `Ran N commands`
- `ui-tui/src/app/createGatewayEventHandler.ts` + `gatewayTypes.ts` - TUI shows the title in place of the command preview
- `apps/desktop/src/lib/summarize-command.ts` + `agent/display.py` - compound summaries name every segment (`head sub` per segment, ` · `-joined, `+ N more` past three); both implementations kept in lockstep
- Tests: new coverage for every hop (schema drift, gateway forwarding, desktop args merge, label preference, title cap, compound naming, TUI handler)

## How to Test

1. Start a new conversation (prompt-cache invariant: existing conversations keep the old schema)
2. Ask the agent to run a long wrapped command, or watch it emit `title` on its own for long commands
3. Observe: pending row shows `Running <title>`, settled row/group shows `Ran <title>`, and an approval prompt (with `approvals.mode: manual`) shows the title instead of the raw command
4. Run an untitled compound (`node -v; npm -v; echo x`): row reads `node -v · npm -v · echo x`
5. Untitled single commands and multi-tool groups render exactly as before

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(tools):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#22363, #68199 - complementary, noted above)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass *(affected suites: gateway server, display, code-execution stub drift - all green; the ~18 `tests/tools/` live-shell failures on this Windows machine reproduce identically on pristine `origin/main` and are pre-existing/environmental)*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (desktop app + CLI end-to-end; renderer labels verified live in the packed app)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A (tool schemas are the user-facing docs here and are updated; the website tools-reference has no per-arg tables)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A (no architecture change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - pure string processing + one additive event field, no OS calls; `scripts/check-windows-footguns.py --diff` flags 15 pre-existing `read_text()` findings in `tests/test_tui_gateway_server.py` that are not added by this diff (0 flagged lines originate from this PR)
- [x] I've updated tool descriptions/schemas if I changed tool behavior

## Compatibility / prompt-cache notes

- Additive optional schema arg + additive event payload field: existing conversations keep their cached schema; old backends without the field degrade to today's labels; a `title`-emitting model against an old backend is harmless (handlers ignore unknown keys).

## Screenshots / Logs

Verified live in the packed desktop app (Windows): titled settled row `Ran List Hermes data directories 2.4s`; titled group line `Ran Show Hermes working tree status, used 1 tool`; untitled compounds collapsed as `Ran ls -la · powershell -NoProfile · tail -3 3.3s`.

<img width="809" height="525" alt="image" src="https://github.com/user-attachments/assets/52df41c9-ff88-4c84-a2c7-14f01f5b9204" />

<img width="754" height="757" alt="image" src="https://github.com/user-attachments/assets/3a3befb1-3f25-47b8-bb95-56435928910b" />


