### PR TITLE
fix(web): route every extract backend through the escalation chain

### DIFF
--- a/tests/tools/test_web_extract_escalation.py
+++ b/tests/tools/test_web_extract_escalation.py
@@ -1,0 +1,976 @@
+import asyncio
+import itertools
+import json
+import sys
+import threading
+import types
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolated_hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+
+class FakeWebSocket:
+    def __init__(self, responder):
+        self.sent = []
+        self._inbound = asyncio.Queue()
+        self._responder = responder
+
+    async def send(self, raw):
+        message = json.loads(raw)
+        self.sent.append(message)
+        self._responder(self, message)
+
+    async def recv(self):
+        return await self._inbound.get()
+
+    def feed(self, payload):
+        self._inbound.put_nowait(json.dumps(payload))
+
+
+class FakeConnection:
+    def __init__(self, websocket):
+        self.websocket = websocket
+
+    async def __aenter__(self):
+        return self.websocket
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+
+def install_fake_websockets(monkeypatch, websocket):
+    module = types.SimpleNamespace(
+        connect=lambda *args, **kwargs: FakeConnection(websocket)
+    )
+    monkeypatch.setitem(sys.modules, "websockets", module)
+
+
+def standard_cdp_response(websocket, message, *, reply_to_close=True):
+    method = message["method"]
+    result = {}
+
+    if method == "Target.createTarget":
+        result = {"targetId": "target-1"}
+    elif method == "Target.attachToTarget":
+        result = {"sessionId": "session-1"}
+    elif method == "Runtime.evaluate":
+        expression = message.get("params", {}).get("expression", "")
+        if expression == "location.href":
+            result = {
+                "result": {
+                    "value": "https://public.example/final",
+                }
+            }
+        else:
+            result = {
+                "result": {
+                    "value": json.dumps(
+                        {
+                            "title": "Public page",
+                            "content": "public content",
+                        }
+                    )
+                }
+            }
+    elif method == "Page.navigate":
+        websocket.feed({"id": message["id"], "result": {}})
+        websocket.feed(
+            {
+                "sessionId": "session-1",
+                "method": "Page.loadEventFired",
+                "params": {},
+            }
+        )
+        return
+    elif method == "Target.closeTarget" and not reply_to_close:
+        return
+
+    websocket.feed({"id": message["id"], "result": result})
+
+
+class FakeCloudProvider:
+    def __init__(
+        self,
+        name="browser-use",
+        available=True,
+        close_result=True,
+        create_started=None,
+        create_release=None,
+    ):
+        self.name = name
+        self.available = available
+        self.close_result = close_result
+        self.create_started = create_started
+        self.create_release = create_release
+        self.created = []
+        self.closed = []
+        self.emergency_cleanups = []
+
+    def is_available(self):
+        return self.available
+
+    def create_session(self, task_id):
+        self.created.append(task_id)
+        if self.create_started is not None:
+            self.create_started.set()
+        if self.create_release is not None:
+            self.create_release.wait(timeout=2)
+        return {
+            "bb_session_id": "cloud-session-1",
+            "cdp_url": "wss://cloud.example/devtools/browser/1",
+        }
+
+    def close_session(self, session_id):
+        self.closed.append(session_id)
+        return self.close_result
+
+    def emergency_cleanup(self, session_id):
+        self.emergency_cleanups.append(session_id)
+
+
+def test_block_signal_detects_jina_captcha_notice():
+    from tools import web_tools
+
+    result = {
+        "url": "https://example.com",
+        "content": "Warning: This page maybe requiring CAPTCHA",
+        "raw_content": "Warning: This page maybe requiring CAPTCHA",
+        "metadata": {"status_code": 200},
+    }
+
+    assert web_tools._extract_block_signal(result)
+
+
+def test_block_signal_does_not_treat_404_as_escalation():
+    from tools import web_tools
+
+    result = {
+        "url": "https://example.com/missing",
+        "error": "Jina Reader returned 404",
+        "metadata": {"status_code": 404},
+    }
+
+    assert web_tools._extract_block_signal(result) is None
+    assert web_tools._extract_is_technical_failure(result) is False
+
+
+def test_block_signal_detects_jina_wrapped_403_even_on_full_page():
+    """Jina wraps upstream 403 in a 200 response — must still escalate."""
+    from tools import web_tools
+
+    jina_403 = (
+        "Title: \n\n"
+        "URL Source: https://www.reddit.com/r/peptides/\n\n"
+        "Warning: Target URL returned error 403: Forbidden\n\n"
+        "Markdown Content:\nYou've been blocked by network security.\n\n"
+        "To continue, log in to your Reddit account or use your developer token\n"
+    )
+    assert len(jina_403.strip()) > web_tools._NEAR_EMPTY_BLOCK_CHARS
+
+    result = {
+        "url": "https://www.reddit.com/r/peptides/",
+        "content": jina_403,
+        "raw_content": jina_403,
+        "metadata": {"status_code": 200},
+    }
+
+    signal = web_tools._extract_block_signal(result)
+    assert signal
+    assert "403" in signal
+
+
+def test_block_signal_detects_g2_jina_captcha_notice_under_200_chars():
+    """Regression: Jina's G2 CAPTCHA warning is 193 chars and must escalate."""
+    from tools import web_tools
+
+    jina_notice = (
+        "Title: g2.com\n\n"
+        "URL Source: https://www.g2.com/products/firecrawl/reviews\n\n"
+        "Warning: This page maybe requiring CAPTCHA, please make sure you are authorized to access this page.\n\n"
+        "Markdown Content:\n\n"
+    )
+    assert len(jina_notice.strip()) < 200
+
+    result = {
+        "url": "https://www.g2.com/products/firecrawl/reviews",
+        "content": jina_notice,
+        "raw_content": jina_notice,
+        "metadata": {"status_code": 200},
+    }
+
+    signal = web_tools._extract_block_signal(result)
+    assert signal
+    assert "captcha" in signal.lower()
+
+
+def test_hard_interstitial_detects_datadome_from_browser_lane():
+    """A full-size DataDome interstitial from Browser Use is classified as blocked."""
+    from tools import web_tools
+
+    datadome_page = (
+        '- Iframe "DataDome Device Check" [ref=e1]\n'
+        "  - generic\n"
+        "    - paragraph\n"
+        '      - StaticText "Access is temporarily restricted"\n'
+    ) * 3
+    assert len(datadome_page.strip()) > web_tools._HARD_INTERSTITIAL_MIN_CHARS
+
+    result = {
+        "url": "https://blocked.example",
+        "content": datadome_page,
+        "raw_content": datadome_page,
+        "metadata": {"lane": "browser_use_cloud"},
+    }
+
+    assert web_tools._is_hard_interstitial(result)
+    # Should NOT be caught by normal block signal (page is too large)
+    assert web_tools._extract_block_signal(result) is None
+
+
+def test_block_signal_does_not_escalate_on_marker_in_full_page():
+    """A page with real content that merely mentions 'captcha' is NOT a block."""
+    from tools import web_tools
+
+    real_page = "This is a normal article discussing captcha detection systems. " * 20
+    result = {
+        "url": "https://example.com",
+        "content": real_page,
+        "raw_content": real_page,
+        "metadata": {"status_code": 200},
+    }
+
+    assert web_tools._extract_block_signal(result) is None
+
+
+def test_block_signal_detects_403_alone():
+    from tools import web_tools
+
+    result = {
+        "url": "https://blocked.example",
+        "content": "some content",
+        "raw_content": "some content",
+        "metadata": {"status_code": 403},
+    }
+
+    signal = web_tools._extract_block_signal(result)
+    assert signal
+    assert "403" in signal
+
+
+def test_block_signal_detects_429_alone():
+    from tools import web_tools
+
+    result = {
+        "url": "https://rate-limited.example",
+        "error": "Rate limit",
+        "metadata": {"status_code": 429},
+    }
+
+    signal = web_tools._extract_block_signal(result)
+    assert signal
+    assert "429" in signal
+
+
+@pytest.mark.asyncio
+async def test_jina_block_skips_unsafe_automatic_home_chrome_and_uses_cloud(
+    monkeypatch,
+):
+    from tools import web_routing
+
+    class JinaProvider:
+        name = "jina"
+
+        async def extract(self, urls, **kwargs):
+            return [{
+                "url": urls[0],
+                "content": "Warning: This page maybe requiring CAPTCHA",
+                "raw_content": "Warning: This page maybe requiring CAPTCHA",
+                "metadata": {"status_code": 200},
+            }]
+
+    async def cloud_success(url, lanes):
+        return {
+            "url": url,
+            "title": "OK",
+            "content": "isolated cloud content",
+            "raw_content": "isolated cloud content",
+        }
+
+    monkeypatch.setattr(
+        web_routing, "_extract_via_browser_use_cloud", cloud_success
+    )
+
+    results = await web_routing._extract_with_jina_escalation(JinaProvider(), ["https://blocked.example"], format=None)
+
+    assert results[0]["title"] == "OK"
+    assert results[0]["content"] == "isolated cloud content"
+    assert results[0]["routing"]["lanes"] == [
+        "jina",
+        "home_chrome_cdp",
+        "browser_use_cloud",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_large_initial_jina_interstitial_escalates_to_home_chrome(monkeypatch):
+    from tools import web_routing
+
+    interstitial = (
+        "DataDome Device Check\n"
+        "Access is temporarily restricted\n"
+        + ("Complete the browser verification challenge. " * 20)
+    )
+    initial = {
+        "content": interstitial,
+        "raw_content": interstitial,
+    }
+    assert web_routing._extract_block_signal(initial) is None
+    assert web_routing._is_hard_interstitial(initial)
+
+    class JinaProvider:
+        name = "jina"
+
+        async def extract(self, urls, **kwargs):
+            return [{
+                "url": urls[0],
+                "content": interstitial,
+                "raw_content": interstitial,
+                "metadata": {"status_code": 200},
+            }]
+
+    calls = []
+
+    async def chrome_refusal(url):
+        calls.append(("chrome", url))
+        return {"url": url, "error": "automatic Home Chrome is disabled"}
+
+    async def cloud_success(url, lanes):
+        calls.append(("cloud", url))
+        return {
+            "url": url,
+            "title": "Recovered",
+            "content": "isolated cloud content",
+            "raw_content": "isolated cloud content",
+        }
+
+    monkeypatch.setattr(
+        web_routing, "_extract_via_home_chrome_cdp", chrome_refusal
+    )
+    monkeypatch.setattr(
+        web_routing, "_extract_via_browser_use_cloud", cloud_success
+    )
+
+    results = await web_routing._extract_with_jina_escalation(
+        JinaProvider(), ["https://blocked.example"], format=None
+    )
+
+    assert calls == [
+        ("chrome", "https://blocked.example"),
+        ("cloud", "https://blocked.example"),
+    ]
+    assert results[0]["content"] == "isolated cloud content"
+    assert results[0]["routing"]["lanes"] == [
+        "jina",
+        "home_chrome_cdp",
+        "browser_use_cloud",
+    ]
+    assert "interstitial" in results[0]["routing"]["escalation_reason"].lower()
+
+
+@pytest.mark.asyncio
+async def test_automatic_home_chrome_lane_fails_closed():
+    from tools import web_routing
+
+    result = await web_routing._extract_via_home_chrome_cdp(
+        "https://public.example"
+    )
+
+    assert result.get("error")
+    assert "disabled" in result["error"].lower()
+    assert "explicit browser" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_browser_use_escalation_logs_once(monkeypatch, tmp_path):
+    from tools import web_routing
+
+    class JinaProvider:
+        name = "jina"
+
+        async def extract(self, urls, **kwargs):
+            return [{
+                "url": urls[0],
+                "content": "DataDome captcha",
+                "raw_content": "DataDome captcha",
+                "metadata": {"status_code": 403},
+            }]
+
+    async def blocked_chrome(url):
+        return {"url": url, "content": "Cloudflare captcha", "raw_content": "Cloudflare captcha"}
+
+    async def browser_use_success(url, lanes):
+        web_routing._append_capped_lane_log(url, lanes, "success")
+        return {"url": url, "title": "OK", "content": "browser use content", "raw_content": "browser use content"}
+
+    monkeypatch.setattr(web_routing, "_extract_via_home_chrome_cdp", blocked_chrome)
+    monkeypatch.setattr(web_routing, "_extract_via_browser_use_cloud", browser_use_success)
+    monkeypatch.setattr(web_routing, "get_hermes_home", lambda: tmp_path)
+
+    results = await web_routing._extract_with_jina_escalation(JinaProvider(), ["https://blocked.example"], format=None)
+
+    assert results[0]["content"] == "browser use content"
+    log = tmp_path.joinpath("logs/lane_escalation.log").read_text()
+    assert "https://blocked.example" in log
+    assert "lanes=jina,home_chrome_cdp,browser_use_cloud" in log
+
+
+def test_lane_log_removes_userinfo_query_and_fragment(monkeypatch, tmp_path):
+    from tools import web_routing
+
+    monkeypatch.setattr(web_routing, "get_hermes_home", lambda: tmp_path)
+
+    web_routing._append_capped_lane_log(
+        "https://user:password@example.com/path?access_token=secret#private",
+        ["jina", "browser_use_cloud"],
+        "failed",
+    )
+
+    log = tmp_path.joinpath("logs/lane_escalation.log").read_text()
+    assert "https://example.com/path" in log
+    assert "user" not in log
+    assert "password" not in log
+    assert "access_token" not in log
+    assert "secret" not in log
+    assert "private" not in log
+
+
+@pytest.mark.asyncio
+async def test_cdp_call_times_out_when_no_response_arrives():
+    from tools import web_routing
+
+    class SilentWebSocket:
+        async def send(self, raw):
+            return None
+
+        async def recv(self):
+            await asyncio.Future()
+
+    with pytest.raises(TimeoutError, match="Runtime.evaluate"):
+        await asyncio.wait_for(
+            web_routing._cdp_call(
+                SilentWebSocket(),
+                itertools.count(1),
+                "Runtime.evaluate",
+                timeout_s=0.02,
+            ),
+            timeout=0.25,
+        )
+
+
+@pytest.mark.asyncio
+async def test_cdp_events_do_not_reset_command_deadline():
+    from tools import web_routing
+
+    class EventFloodWebSocket:
+        async def send(self, raw):
+            return None
+
+        async def recv(self):
+            await asyncio.sleep(0.005)
+            return json.dumps(
+                {
+                    "method": "Page.frameNavigated",
+                    "params": {},
+                }
+            )
+
+    with pytest.raises(TimeoutError, match="Page.navigate"):
+        await asyncio.wait_for(
+            web_routing._cdp_call(
+                EventFloodWebSocket(),
+                itertools.count(1),
+                "Page.navigate",
+                timeout_s=0.03,
+            ),
+            timeout=0.25,
+        )
+
+
+@pytest.mark.asyncio
+async def test_cdp_rejects_unsafe_initial_url_before_connect(monkeypatch):
+    from tools import web_routing
+
+    async def unsafe(_url):
+        return False
+
+    connected = []
+
+    def unexpected_connect(*args, **kwargs):
+        connected.append(True)
+        raise AssertionError("unsafe URL must be rejected before CDP connection")
+
+    monkeypatch.setattr(web_routing, "async_is_safe_url", unsafe)
+    monkeypatch.setattr(web_routing, "check_website_access", lambda url: None)
+    monkeypatch.setitem(
+        sys.modules,
+        "websockets",
+        types.SimpleNamespace(connect=unexpected_connect),
+    )
+
+    result = await web_routing._extract_via_cdp(
+        "http://127.0.0.1/private",
+        "ws://chrome.example/devtools/browser/1",
+        "test_lane",
+    )
+
+    assert connected == []
+    assert result.get("error")
+    assert any(
+        token in result["error"].lower()
+        for token in ("private", "internal", "unsafe")
+    )
+
+
+@pytest.mark.asyncio
+async def test_cdp_fetch_blocks_private_redirect_before_page_extraction(monkeypatch):
+    from tools import web_routing
+
+    private_url = "http://127.0.0.1/admin"
+
+    async def safe_url(candidate):
+        return candidate != private_url
+
+    def responder(websocket, message):
+        if message["method"] == "Page.navigate":
+            websocket.feed({"id": message["id"], "result": {}})
+            websocket.feed(
+                {
+                    "sessionId": "session-1",
+                    "method": "Fetch.requestPaused",
+                    "params": {
+                        "requestId": "redirect-1",
+                        "request": {"url": private_url},
+                        "resourceType": "Document",
+                    },
+                }
+            )
+            websocket.feed(
+                {
+                    "sessionId": "session-1",
+                    "method": "Page.loadEventFired",
+                    "params": {},
+                }
+            )
+            return
+        standard_cdp_response(websocket, message)
+
+    websocket = FakeWebSocket(responder)
+    install_fake_websockets(monkeypatch, websocket)
+    monkeypatch.setattr(web_routing, "async_is_safe_url", safe_url)
+    monkeypatch.setattr(web_routing, "check_website_access", lambda url: None)
+
+    result = await asyncio.wait_for(
+        web_routing._extract_via_cdp(
+            "https://public.example/start",
+            "ws://chrome.example/devtools/browser/1",
+            "test_lane",
+        ),
+        timeout=0.25,
+    )
+
+    methods = [message["method"] for message in websocket.sent]
+    assert methods.index("Fetch.enable") < methods.index("Page.navigate")
+    assert "Runtime.evaluate" not in methods
+
+    enable = next(
+        message for message in websocket.sent
+        if message["method"] == "Fetch.enable"
+    )
+    patterns = enable["params"]["patterns"]
+    assert {
+        (pattern.get("urlPattern"), pattern.get("requestStage"))
+        for pattern in patterns
+    } == {
+        ("http://*", "Request"),
+        ("https://*", "Request"),
+    }
+
+    failed = [
+        message for message in websocket.sent
+        if message["method"] == "Fetch.failRequest"
+    ]
+    assert [message["params"]["requestId"] for message in failed] == [
+        "redirect-1"
+    ]
+    assert not any(
+        message["method"] == "Fetch.continueRequest"
+        and message["params"].get("requestId") == "redirect-1"
+        for message in websocket.sent
+    )
+    assert result.get("error")
+    assert any(
+        token in result["error"].lower()
+        for token in ("private", "internal")
+    )
+
+
+@pytest.mark.asyncio
+async def test_cdp_cleanup_timeout_does_not_hide_success(monkeypatch):
+    from tools import web_routing
+
+    def responder(websocket, message):
+        standard_cdp_response(
+            websocket,
+            message,
+            reply_to_close=False,
+        )
+
+    websocket = FakeWebSocket(responder)
+    install_fake_websockets(monkeypatch, websocket)
+
+    async def allow_url(url, lane, **kwargs):
+        return None
+
+    monkeypatch.setattr(web_routing, "_navigation_block_reason", allow_url)
+    monkeypatch.setattr(web_routing, "_CDP_CLEANUP_TIMEOUT_S", 0.01)
+
+    result = await asyncio.wait_for(
+        web_routing._extract_via_cdp(
+            "https://public.example/start",
+            "ws://chrome.example/devtools/browser/1",
+            "test_lane",
+        ),
+        timeout=0.25,
+    )
+
+    assert result["content"] == "public content"
+    assert any(
+        message["method"] == "Target.closeTarget"
+        for message in websocket.sent
+    )
+
+
+@pytest.mark.asyncio
+async def test_cdp_continues_safe_document_and_signed_subframe(monkeypatch):
+    from tools import web_routing
+
+    initial_url = "https://public.example/start"
+    signed_subframe = (
+        "https://cdn.example/embed?"
+        "X-Amz-Signature=page-generated-signature"
+    )
+    navigate_id = None
+
+    def responder(websocket, message):
+        nonlocal navigate_id
+        method = message["method"]
+        if method == "Page.navigate":
+            navigate_id = message["id"]
+            websocket.feed(
+                {
+                    "sessionId": "session-1",
+                    "method": "Fetch.requestPaused",
+                    "params": {
+                        "requestId": "document-1",
+                        "request": {"url": initial_url},
+                        "resourceType": "Document",
+                        "frameId": "",
+                    },
+                }
+            )
+            return
+        if (
+            method == "Fetch.continueRequest"
+            and message["params"]["requestId"] == "document-1"
+        ):
+            websocket.feed({"id": message["id"], "result": {}})
+            websocket.feed({"id": navigate_id, "result": {}})
+            websocket.feed(
+                {
+                    "sessionId": "session-1",
+                    "method": "Fetch.requestPaused",
+                    "params": {
+                        "requestId": "subframe-1",
+                        "request": {"url": signed_subframe},
+                        "resourceType": "Document",
+                        "frameId": "child-frame",
+                    },
+                }
+            )
+            return
+        if (
+            method == "Fetch.continueRequest"
+            and message["params"]["requestId"] == "subframe-1"
+        ):
+            websocket.feed({"id": message["id"], "result": {}})
+            websocket.feed(
+                {
+                    "sessionId": "session-1",
+                    "method": "Page.loadEventFired",
+                    "params": {},
+                }
+            )
+            return
+        standard_cdp_response(websocket, message)
+
+    websocket = FakeWebSocket(responder)
+    install_fake_websockets(monkeypatch, websocket)
+
+    async def safe_url(_url):
+        return True
+
+    monkeypatch.setattr(web_routing, "async_is_safe_url", safe_url)
+    monkeypatch.setattr(web_routing, "check_website_access", lambda url: None)
+
+    result = await web_routing._extract_via_cdp(
+        initial_url,
+        "wss://cloud.example/devtools/browser/1",
+        "browser_use_cloud",
+    )
+
+    assert result["content"] == "public content"
+    continued = {
+        message["params"]["requestId"]
+        for message in websocket.sent
+        if message["method"] == "Fetch.continueRequest"
+    }
+    assert continued == {"document-1", "subframe-1"}
+    assert not any(
+        message["method"] == "Fetch.failRequest"
+        for message in websocket.sent
+    )
+
+
+@pytest.mark.asyncio
+async def test_browser_use_lane_honors_local_profile_config(monkeypatch, tmp_path):
+    from tools import browser_tool, web_routing
+    from plugins.browser.browser_use import provider as browser_use_provider
+
+    tmp_path.joinpath("config.yaml").write_text(
+        "browser:\n  cloud_provider: local\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(browser_tool, "_cached_cloud_provider", None)
+    monkeypatch.setattr(browser_tool, "_cloud_provider_resolved", False)
+
+    constructed = []
+
+    class UnexpectedBrowserUse:
+        def __init__(self):  # pragma: no cover - must not run
+            constructed.append(True)
+            raise AssertionError("local profile must not construct Browser Use")
+
+    async def allow_url(url, lane, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        browser_use_provider,
+        "BrowserUseBrowserProvider",
+        UnexpectedBrowserUse,
+    )
+    monkeypatch.setattr(web_routing, "_navigation_block_reason", allow_url)
+
+    result = await web_routing._extract_via_browser_use_cloud(
+        "https://public.example",
+        ["jina", "home_chrome_cdp", "browser_use_cloud"],
+    )
+
+    assert constructed == []
+    assert result.get("error")
+    assert "browser use" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_browser_use_lane_refuses_different_selected_provider(monkeypatch):
+    from tools import browser_tool, web_routing
+
+    provider = FakeCloudProvider(name="browserbase")
+
+    async def allow_url(url, lane, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        browser_tool, "_get_cloud_provider", lambda: provider
+    )
+    monkeypatch.setattr(web_routing, "_navigation_block_reason", allow_url)
+
+    result = await web_routing._extract_via_browser_use_cloud(
+        "https://public.example",
+        ["jina", "home_chrome_cdp", "browser_use_cloud"],
+    )
+
+    assert provider.created == []
+    assert result.get("error")
+
+
+@pytest.mark.asyncio
+async def test_browser_use_lane_refuses_unavailable_selected_provider(monkeypatch):
+    from tools import browser_tool, web_routing
+
+    provider = FakeCloudProvider(available=False)
+
+    async def allow_url(url, lane, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        browser_tool, "_get_cloud_provider", lambda: provider
+    )
+    monkeypatch.setattr(web_routing, "_navigation_block_reason", allow_url)
+
+    result = await web_routing._extract_via_browser_use_cloud(
+        "https://public.example",
+        ["jina", "home_chrome_cdp", "browser_use_cloud"],
+    )
+
+    assert provider.created == []
+    assert result.get("error")
+
+
+@pytest.mark.asyncio
+async def test_browser_use_lane_rejects_credential_query_before_session(monkeypatch):
+    from tools import browser_tool, web_routing
+
+    provider = FakeCloudProvider()
+    monkeypatch.setattr(
+        browser_tool, "_get_cloud_provider", lambda: provider
+    )
+
+    result = await web_routing._extract_via_browser_use_cloud(
+        "https://public.example/?access_token=secret",
+        ["jina", "home_chrome_cdp", "browser_use_cloud"],
+    )
+
+    assert provider.created == []
+    assert "credential" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("outcome", ["success", "error", "exception"])
+async def test_browser_use_session_closes_for_every_extract_outcome(
+    monkeypatch, outcome
+):
+    from tools import browser_tool, web_routing
+
+    provider = FakeCloudProvider()
+
+    async def allow_url(url, lane, **kwargs):
+        return None
+
+    async def extract(url, cdp_url, lane):
+        if outcome == "exception":
+            raise RuntimeError("CDP failed")
+        if outcome == "error":
+            return {"url": url, "error": "CDP failed"}
+        return {
+            "url": url,
+            "content": "cloud content",
+            "raw_content": "cloud content",
+        }
+
+    monkeypatch.setattr(
+        browser_tool, "_get_cloud_provider", lambda: provider
+    )
+    monkeypatch.setattr(web_routing, "_navigation_block_reason", allow_url)
+    monkeypatch.setattr(web_routing, "_extract_via_cdp", extract)
+
+    result = await web_routing._extract_via_browser_use_cloud(
+        "https://public.example",
+        ["jina", "home_chrome_cdp", "browser_use_cloud"],
+    )
+
+    assert len(provider.created) == 1
+    assert provider.closed == ["cloud-session-1"]
+    if outcome == "success":
+        assert result["content"] == "cloud content"
+    else:
+        assert result.get("error")
+
+
+@pytest.mark.asyncio
+async def test_browser_use_false_close_is_reported_and_emergency_cleanup_runs(
+    monkeypatch,
+):
+    from tools import browser_tool, web_routing
+
+    provider = FakeCloudProvider(close_result=False)
+
+    async def allow_url(url, lane, **kwargs):
+        return None
+
+    async def extract(url, cdp_url, lane):
+        return {
+            "url": url,
+            "content": "cloud content",
+            "raw_content": "cloud content",
+        }
+
+    monkeypatch.setattr(
+        browser_tool, "_get_cloud_provider", lambda: provider
+    )
+    monkeypatch.setattr(web_routing, "_navigation_block_reason", allow_url)
+    monkeypatch.setattr(web_routing, "_extract_via_cdp", extract)
+
+    result = await web_routing._extract_via_browser_use_cloud(
+        "https://public.example",
+        ["jina", "home_chrome_cdp", "browser_use_cloud"],
+    )
+
+    assert provider.closed == ["cloud-session-1", "cloud-session-1"]
+    assert provider.emergency_cleanups == ["cloud-session-1"]
+    assert "cleanup failed" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_browser_use_creation_cancellation_reconciles_and_closes_session(
+    monkeypatch,
+):
+    from tools import browser_tool, web_routing
+
+    create_started = threading.Event()
+    create_release = threading.Event()
+    provider = FakeCloudProvider(
+        create_started=create_started,
+        create_release=create_release,
+    )
+
+    async def allow_url(url, lane, **kwargs):
+        return None
+
+    async def unexpected_extract(url, cdp_url, lane):  # pragma: no cover
+        raise AssertionError("cancelled creation must not begin extraction")
+
+    monkeypatch.setattr(
+        browser_tool, "_get_cloud_provider", lambda: provider
+    )
+    monkeypatch.setattr(web_routing, "_navigation_block_reason", allow_url)
+    monkeypatch.setattr(web_routing, "_extract_via_cdp", unexpected_extract)
+
+    task = asyncio.create_task(
+        web_routing._extract_via_browser_use_cloud(
+            "https://public.example",
+            ["jina", "home_chrome_cdp", "browser_use_cloud"],
+        )
+    )
+    started = await asyncio.wait_for(
+        asyncio.to_thread(create_started.wait, 2),
+        timeout=3,
+    )
+    assert started is True
+
+    task.cancel()
+    create_release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert provider.closed == ["cloud-session-1"]
+
+
+
+# NOTE: tests for web_extract_tool-level website-policy blocking and the
+# extract-path disabled-plugin guard depend on local-only web_tools behavior
+# and are upstreamed separately.

--- a/tools/web_routing.py
+++ b/tools/web_routing.py
@@ -1,0 +1,728 @@
+"""Deterministic fallback routing for Hermes web search and extraction.
+
+Firecrawl intentionally does not appear in this module's automatic paths. It
+remains an explicit crawl/map tool, never a surprise search/extract escalation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import itertools
+import json
+import logging
+import re
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+from urllib.parse import unquote, urlsplit, urlunsplit
+
+from agent.redact import _PREFIX_RE
+from hermes_constants import get_hermes_home
+from tools.url_safety import async_is_safe_url, sensitive_query_param_name
+from tools.website_policy import check_website_access
+
+logger = logging.getLogger(__name__)
+
+_NEAR_EMPTY_BLOCK_CHARS = 200
+_HARD_INTERSTITIAL_MIN_CHARS = 300
+_CDP_CALL_TIMEOUT_S = 10.0
+_CDP_LOAD_TIMEOUT_S = 15.0
+_CDP_CLEANUP_TIMEOUT_S = 2.0
+_URL_POLICY_TIMEOUT_S = 5.0
+_BROWSER_USE_CLEANUP_TIMEOUT_S = 12.0
+_BLOCK_MARKERS = (
+    "captcha",
+    "cloudflare",
+    "datadome",
+    "akamai",
+    "perimeterx",
+    "imperva",
+    "incapsula",
+    "ddos-guard",
+    "access is temporarily restricted",
+    "you've been blocked",
+    "you have been blocked",
+    "bot detection",
+    "verification required",
+    "checking your browser",
+    "just a moment",
+)
+
+
+def _search_with_provider_fallback(
+    primary: Any, ddgs_fallback: Optional[Any], query: str, limit: int
+) -> Dict[str, Any]:
+    """Run Brave, then DDGS only after a real Brave failure.
+
+    A valid zero-result response is not a failure, so it does not get silently
+    replaced by a different provider's results.
+    """
+    providers = [primary]
+    if getattr(primary, "name", "") == "brave-free" and ddgs_fallback is not None:
+        providers.append(ddgs_fallback)
+
+    attempted: List[str] = []
+    last_error = "Search failed"
+    for provider in providers:
+        name = str(getattr(provider, "name", "unknown"))
+        attempted.append(name)
+        try:
+            response = provider.search(query, limit)
+        except Exception as exc:  # provider failure is the fallback signal
+            last_error = f"{name} unavailable: {exc}"
+            continue
+        if isinstance(response, dict) and response.get("success") is not False:
+            response = dict(response)
+            response["routing"] = {"attempted": attempted, "selected": name}
+            return response
+        last_error = (
+            str(response.get("error") or f"{name} failed")
+            if isinstance(response, dict)
+            else f"{name} returned an invalid response"
+        )
+
+    return {
+        "success": False,
+        "error": last_error,
+        "routing": {"attempted": attempted, "selected": None},
+    }
+
+
+def _result_text(result: Dict[str, Any]) -> str:
+    # Providers commonly mirror the same text into ``content`` and
+    # ``raw_content``. Count it once so the near-empty threshold reflects the
+    # actual page instead of an implementation detail of the provider shape.
+    parts: List[str] = []
+    for key in ("error", "content", "raw_content"):
+        value = str(result.get(key) or "").strip()
+        if value and value not in parts:
+            parts.append(value)
+    return "\n".join(parts)
+
+
+def _status_code(result: Dict[str, Any]) -> Optional[int]:
+    metadata = result.get("metadata")
+    value = metadata.get("status_code") if isinstance(metadata, dict) else None
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _extract_block_signal(result: Dict[str, Any]) -> Optional[str]:
+    """Classify actual bot blocks while avoiding false positives in articles."""
+    status = _status_code(result)
+    if status in {403, 429}:
+        return f"HTTP {status}"
+
+    text = _result_text(result)
+    lowered = text.lower()
+    # Matches both the classic wording ("returned error 403") and provider
+    # wrappers such as the crawl4ai plugin ("Crawl4AI returned HTTP 403").
+    wrapped = re.search(r"(?:target\s+url\s+)?returned\s+(?:error|http)\s+(403|429)\b", lowered)
+    if wrapped:
+        return f"wrapped HTTP {wrapped.group(1)}"
+
+    if len(text) <= _NEAR_EMPTY_BLOCK_CHARS:
+        for marker in _BLOCK_MARKERS:
+            if marker in lowered:
+                return marker
+    return None
+
+
+def _extract_is_technical_failure(result: Dict[str, Any]) -> bool:
+    """Classify transport failures without turning a valid 404 into escalation."""
+    status = _status_code(result)
+    if status in {400, 404, 410} or _extract_block_signal(result):
+        return False
+    error = str(result.get("error") or "").lower()
+    return bool(error and any(token in error for token in (
+        "timeout", "connection", "temporarily", "network", "dns", "reset",
+    )))
+
+
+def _is_hard_interstitial(result: Dict[str, Any]) -> bool:
+    """Detect a rendered challenge page that is too large for near-empty rules."""
+    text = _result_text(result)
+    if len(text) < _HARD_INTERSTITIAL_MIN_CHARS:
+        return False
+    lowered = text.lower()
+    hits = sum(marker in lowered for marker in _BLOCK_MARKERS)
+    return hits >= 2 or (
+        "datadome" in lowered and "access is temporarily restricted" in lowered
+    )
+
+
+def _is_usable_extraction(result: Dict[str, Any]) -> bool:
+    return bool(
+        result
+        and not result.get("error")
+        and str(result.get("content") or result.get("raw_content") or "").strip()
+        and not _extract_block_signal(result)
+        and not _is_hard_interstitial(result)
+    )
+
+
+def _set_extraction_routing(
+    result: Dict[str, Any], lanes: List[str], *, reason: Optional[str] = None
+) -> Dict[str, Any]:
+    routed = dict(result)
+    routing: Dict[str, Any] = {"lanes": list(lanes), "selected": lanes[-1]}
+    if reason:
+        routing["escalation_reason"] = reason
+    routed["routing"] = routing
+    return routed
+
+
+def _append_capped_lane_log(url: str, lanes: List[str], outcome: str) -> None:
+    """Write a bounded audit record for the paid Browser Use escalation."""
+    log_path = Path(get_hermes_home()) / "logs" / "lane_escalation.log"
+    line = (
+        f"{time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())} "
+        f"url={_redact_url_for_logs(url)} lanes={','.join(lanes)} outcome={outcome}\n"
+    )
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        if log_path.exists() and log_path.stat().st_size > 256_000:
+            tail = log_path.read_text(encoding="utf-8", errors="replace")[-128_000:]
+            log_path.write_text(tail, encoding="utf-8")
+        with log_path.open("a", encoding="utf-8") as handle:
+            handle.write(line)
+    except OSError as exc:
+        logger.debug("Could not write web lane escalation log: %s", exc)
+
+
+def _redact_url_for_logs(url: str) -> str:
+    """Drop userinfo, query data, and fragments from a URL before logging."""
+    try:
+        parsed = urlsplit(str(url or "").strip())
+        if not parsed.scheme or not parsed.netloc:
+            return "<redacted-url>"
+        netloc = parsed.netloc.rsplit("@", 1)[-1]
+        return urlunsplit((parsed.scheme, netloc, parsed.path, "", ""))
+    except (TypeError, ValueError):
+        return "<redacted-url>"
+
+
+def _cloud_sensitive_url_reason(url: str) -> Optional[str]:
+    """Reject credentials before a URL leaves the local/VPS trust boundary."""
+    try:
+        parsed = urlsplit(str(url or "").strip())
+    except (TypeError, ValueError):
+        return "URL could not be parsed safely"
+    if parsed.username or parsed.password:
+        return "URL contains user credentials"
+    if _PREFIX_RE.search(url) or _PREFIX_RE.search(unquote(url)):
+        return "URL contains what appears to be an API key or token"
+    sensitive_key = sensitive_query_param_name(url)
+    if sensitive_key:
+        return f"credential-like query parameter ({sensitive_key})"
+    if parsed.fragment:
+        fragment_url = f"https://fragment.invalid/?{parsed.fragment}"
+        sensitive_key = sensitive_query_param_name(fragment_url)
+        if sensitive_key:
+            return f"credential-like fragment parameter ({sensitive_key})"
+    return None
+
+
+async def _navigation_block_reason(
+    url: str,
+    lane: str,
+    *,
+    check_cloud_credentials: bool = True,
+) -> Optional[str]:
+    """Return a fail-closed reason before a browser may dispatch ``url``."""
+    if lane == "browser_use_cloud" and check_cloud_credentials:
+        sensitive_reason = _cloud_sensitive_url_reason(url)
+        if sensitive_reason:
+            return sensitive_reason
+
+    try:
+        policy = check_website_access(_redact_url_for_logs(url))
+    except Exception:
+        return "website policy validation failed"
+    if policy:
+        return str(policy.get("message") or "blocked by website policy")
+
+    try:
+        is_safe = await asyncio.wait_for(
+            async_is_safe_url(url), timeout=_URL_POLICY_TIMEOUT_S
+        )
+        if not is_safe:
+            return "URL targets a private or internal network address"
+    except Exception:
+        return "URL safety validation failed"
+    return None
+
+
+class _CDPRequestBlocked(RuntimeError):
+    def __init__(self, url: str, reason: str):
+        super().__init__(reason)
+        self.url = url
+        self.reason = reason
+
+
+async def _dispatch_cdp_event(
+    on_event: Optional[Callable[[Dict[str, Any]], Any]],
+    payload: Dict[str, Any],
+    deadline: float,
+    timeout_message: str,
+) -> None:
+    if on_event is None:
+        return
+    handled = on_event(payload)
+    if not inspect.isawaitable(handled):
+        return
+    remaining = deadline - asyncio.get_running_loop().time()
+    if remaining <= 0:
+        raise TimeoutError(timeout_message)
+    try:
+        await asyncio.wait_for(handled, timeout=remaining)
+    except asyncio.TimeoutError as exc:
+        raise TimeoutError(timeout_message) from exc
+
+
+async def _cdp_call(
+    ws: Any,
+    request_ids: Any,
+    method: str,
+    params: Optional[Dict[str, Any]] = None,
+    session_id: Optional[str] = None,
+    *,
+    timeout_s: float = _CDP_CALL_TIMEOUT_S,
+    on_event: Optional[Callable[[Dict[str, Any]], Any]] = None,
+) -> Dict[str, Any]:
+    timeout_message = f"CDP {method} timed out"
+    deadline = asyncio.get_running_loop().time() + timeout_s
+    request_id = next(request_ids)
+    message: Dict[str, Any] = {"id": request_id, "method": method}
+    if params:
+        message["params"] = params
+    if session_id:
+        message["sessionId"] = session_id
+    remaining = deadline - asyncio.get_running_loop().time()
+    if remaining <= 0:
+        raise TimeoutError(timeout_message)
+    try:
+        await asyncio.wait_for(ws.send(json.dumps(message)), timeout=remaining)
+    except asyncio.TimeoutError as exc:
+        raise TimeoutError(timeout_message) from exc
+    while True:
+        remaining = deadline - asyncio.get_running_loop().time()
+        if remaining <= 0:
+            raise TimeoutError(timeout_message)
+        try:
+            raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
+        except asyncio.TimeoutError as exc:
+            raise TimeoutError(timeout_message) from exc
+        payload = json.loads(raw)
+        if payload.get("id") != request_id:
+            await _dispatch_cdp_event(on_event, payload, deadline, timeout_message)
+            continue
+        if "error" in payload:
+            raise RuntimeError(str(payload["error"].get("message") or payload["error"]))
+        return payload.get("result") or {}
+
+
+async def _cdp_wait_for_load(
+    ws: Any,
+    session_id: str,
+    timeout_s: float = _CDP_LOAD_TIMEOUT_S,
+    on_event: Optional[Callable[[Dict[str, Any]], Any]] = None,
+) -> None:
+    """Wait for an initial load event, but do not reject JS-heavy sites on timeout."""
+    deadline = asyncio.get_running_loop().time() + timeout_s
+    while True:
+        remaining = deadline - asyncio.get_running_loop().time()
+        if remaining <= 0:
+            return
+        try:
+            payload = json.loads(await asyncio.wait_for(ws.recv(), timeout=remaining))
+        except asyncio.TimeoutError:
+            return
+        await _dispatch_cdp_event(
+            on_event, payload, deadline, "CDP page load handling timed out"
+        )
+        if payload.get("sessionId") == session_id and payload.get("method") == "Page.loadEventFired":
+            return
+
+
+async def _send_cdp_command(
+    ws: Any,
+    request_ids: Any,
+    method: str,
+    params: Dict[str, Any],
+    session_id: str,
+    timeout_s: float = _CDP_CLEANUP_TIMEOUT_S,
+) -> None:
+    """Send a CDP command without recursively consuming the outer call's reply."""
+    message = {
+        "id": next(request_ids),
+        "method": method,
+        "params": params,
+        "sessionId": session_id,
+    }
+    try:
+        await asyncio.wait_for(ws.send(json.dumps(message)), timeout=timeout_s)
+    except asyncio.TimeoutError as exc:
+        raise TimeoutError(f"CDP {method} send timed out") from exc
+
+
+async def _extract_via_cdp(url: str, cdp_url: str, lane: str) -> Dict[str, Any]:
+    """Read title/body text from a temporary target without reading browser secrets."""
+    if not cdp_url.startswith(("ws://", "wss://")):
+        return {"url": url, "error": f"{lane} CDP endpoint is unavailable"}
+    initial_block = await _navigation_block_reason(url, lane)
+    if initial_block:
+        return {"url": url, "error": f"{lane} refused URL before browser dispatch: {initial_block}"}
+    try:
+        import websockets
+    except ImportError:
+        return {"url": url, "error": "websockets dependency is unavailable"}
+
+    try:
+        async with websockets.connect(
+            cdp_url, open_timeout=10, close_timeout=5, max_size=4_000_000
+        ) as ws:
+            request_ids = itertools.count(1)
+            target_id = ""
+            try:
+                created = await _cdp_call(
+                    ws, request_ids, "Target.createTarget", {"url": "about:blank"}
+                )
+                target_id = str(created.get("targetId") or "")
+                if not target_id:
+                    raise RuntimeError("Target.createTarget returned no target id")
+                attached = await _cdp_call(
+                    ws, request_ids, "Target.attachToTarget", {"targetId": target_id, "flatten": True}
+                )
+                session_id = str(attached.get("sessionId") or "")
+                if not session_id:
+                    raise RuntimeError("Target.attachToTarget returned no session id")
+
+                load_event_seen = False
+                main_document_frame_id = ""
+                main_document_seen = False
+
+                async def handle_fetch_event(payload: Dict[str, Any]) -> None:
+                    nonlocal load_event_seen, main_document_frame_id, main_document_seen
+                    if (
+                        payload.get("sessionId") == session_id
+                        and payload.get("method") == "Page.loadEventFired"
+                    ):
+                        load_event_seen = True
+                        return
+                    if (
+                        payload.get("sessionId") != session_id
+                        or payload.get("method") != "Fetch.requestPaused"
+                    ):
+                        return
+                    event_params = payload.get("params") or {}
+                    request_id = str(event_params.get("requestId") or "")
+                    request = event_params.get("request") or {}
+                    request_url = str(request.get("url") or "")
+                    if not request_id or not request_url:
+                        raise RuntimeError("Fetch.requestPaused omitted request metadata")
+
+                    resource_type = str(event_params.get("resourceType") or "")
+                    frame_id = str(event_params.get("frameId") or "")
+                    if resource_type == "Document" and not main_document_seen:
+                        main_document_seen = True
+                        main_document_frame_id = frame_id
+                    is_main_document = (
+                        resource_type == "Document"
+                        and (
+                            not frame_id
+                            or frame_id == main_document_frame_id
+                        )
+                    )
+                    reason = await _navigation_block_reason(
+                        request_url,
+                        lane,
+                        check_cloud_credentials=is_main_document,
+                    )
+                    if reason:
+                        await _send_cdp_command(
+                            ws,
+                            request_ids,
+                            "Fetch.failRequest",
+                            {"requestId": request_id, "errorReason": "BlockedByClient"},
+                            session_id,
+                        )
+                        raise _CDPRequestBlocked(request_url, reason)
+                    await _send_cdp_command(
+                        ws,
+                        request_ids,
+                        "Fetch.continueRequest",
+                        {"requestId": request_id},
+                        session_id,
+                    )
+
+                await _cdp_call(ws, request_ids, "Page.enable", session_id=session_id)
+                await _cdp_call(
+                    ws,
+                    request_ids,
+                    "Fetch.enable",
+                    {
+                        "patterns": [
+                            {"urlPattern": "http://*", "requestStage": "Request"},
+                            {"urlPattern": "https://*", "requestStage": "Request"},
+                        ]
+                    },
+                    session_id,
+                )
+                await _cdp_call(
+                    ws,
+                    request_ids,
+                    "Page.navigate",
+                    {"url": url},
+                    session_id,
+                    on_event=handle_fetch_event,
+                )
+                if not load_event_seen:
+                    await _cdp_wait_for_load(
+                        ws,
+                        session_id,
+                        on_event=handle_fetch_event,
+                    )
+
+                location = await _cdp_call(
+                    ws, request_ids, "Runtime.evaluate",
+                    {"expression": "location.href", "returnByValue": True}, session_id,
+                    on_event=handle_fetch_event,
+                )
+                final_url = str(location.get("result", {}).get("value") or url)
+                final_block = await _navigation_block_reason(final_url, lane)
+                if final_block:
+                    return {
+                        "url": url,
+                        "error": f"{lane} redirect was rejected: {final_block}",
+                    }
+
+                page = await _cdp_call(
+                    ws, request_ids, "Runtime.evaluate",
+                    {
+                        "expression": "JSON.stringify({title:document.title||'',content:document.body?.innerText||''})",
+                        "returnByValue": True,
+                    }, session_id,
+                    on_event=handle_fetch_event,
+                )
+                value = page.get("result", {}).get("value") or "{}"
+                extracted = json.loads(value) if isinstance(value, str) else value
+                if not isinstance(extracted, dict):
+                    raise RuntimeError("CDP extraction returned invalid page data")
+                content = str(extracted.get("content") or "")
+                return {
+                    "url": final_url,
+                    "title": str(extracted.get("title") or ""),
+                    "content": content,
+                    "raw_content": content,
+                    "metadata": {"lane": lane},
+                }
+            finally:
+                if target_id:
+                    try:
+                        await _cdp_call(
+                            ws,
+                            request_ids,
+                            "Target.closeTarget",
+                            {"targetId": target_id},
+                            timeout_s=_CDP_CLEANUP_TIMEOUT_S,
+                        )
+                    except Exception:  # best-effort tab cleanup only
+                        pass
+    except _CDPRequestBlocked as exc:
+        logger.info(
+            "%s blocked a browser request before dispatch: url=%s reason=%s",
+            lane,
+            _redact_url_for_logs(exc.url),
+            exc.reason,
+        )
+        return {
+            "url": url,
+            "error": f"{lane} blocked a browser request before dispatch: {exc.reason}",
+        }
+    except Exception as exc:  # lane error is returned for deterministic fallback
+        logger.info(
+            "%s extract failed for %s: %s",
+            lane,
+            _redact_url_for_logs(url),
+            type(exc).__name__,
+        )
+        return {"url": url, "error": f"{lane} extraction failed: {type(exc).__name__}"}
+
+
+async def _extract_via_home_chrome_cdp(url: str) -> Dict[str, Any]:
+    """Refuse automatic navigation of Darin's authenticated Home Chrome.
+
+    The VPS can validate DNS and redirect URLs, but Windows Chrome performs
+    the actual DNS lookup and connection. That split cannot safely defeat DNS
+    rebinding without a browser-side egress proxy or equivalent connect-time
+    control. Explicit browser tools remain available through the CDP bridge.
+    """
+    return {
+        "url": url,
+        "error": (
+            "Automatic Home Chrome extraction is disabled: use an explicit "
+            "browser workflow for authenticated or sensitive pages"
+        ),
+    }
+
+
+async def _close_browser_use_session(provider: Any, session_id: str) -> bool:
+    """Retry normal close, then attempt bounded emergency cleanup."""
+    for _attempt in range(2):
+        try:
+            closed = await asyncio.wait_for(
+                asyncio.to_thread(provider.close_session, session_id),
+                timeout=_BROWSER_USE_CLEANUP_TIMEOUT_S,
+            )
+        except Exception:
+            closed = False
+        if closed is True:
+            return True
+
+    try:
+        await asyncio.wait_for(
+            asyncio.to_thread(provider.emergency_cleanup, session_id),
+            timeout=_BROWSER_USE_CLEANUP_TIMEOUT_S,
+        )
+    except Exception:
+        pass
+    return False
+
+
+async def _extract_via_browser_use_cloud(url: str, lanes: List[str]) -> Dict[str, Any]:
+    """Create and always close a one-off Browser Use session for a public page."""
+    session: Optional[Dict[str, Any]] = None
+    provider: Any = None
+    result: Dict[str, Any] = {"url": url, "error": "Browser Use is not configured"}
+    cleanup_failed = False
+    try:
+        preflight_block = await _navigation_block_reason(url, "browser_use_cloud")
+        if preflight_block:
+            result = {
+                "url": url,
+                "error": f"Browser Use automatic escalation refused: {preflight_block}",
+            }
+        else:
+            from tools.browser_tool import _get_cloud_provider
+
+            provider = _get_cloud_provider()
+            provider_name = str(getattr(provider, "name", "") or "")
+            if provider is None:
+                result = {
+                    "url": url,
+                    "error": "Browser Use cloud escalation is disabled or unavailable",
+                }
+            elif provider_name != "browser-use":
+                result = {
+                    "url": url,
+                    "error": (
+                        f"Browser Use cloud escalation is not allowed by the active "
+                        f"provider policy ({provider_name or 'unknown'})"
+                    ),
+                }
+            elif not provider.is_available():
+                result = {"url": url, "error": "Browser Use is not configured"}
+            else:
+                create_task = asyncio.create_task(
+                    asyncio.to_thread(
+                        provider.create_session,
+                        f"web-extract-{uuid.uuid4().hex}",
+                    )
+                )
+                try:
+                    created_session = await asyncio.shield(create_task)
+                except asyncio.CancelledError:
+                    try:
+                        late_session = await asyncio.shield(create_task)
+                        if isinstance(late_session, dict):
+                            session = late_session
+                    except Exception:
+                        pass
+                    raise
+                if not isinstance(created_session, dict):
+                    raise RuntimeError("Browser Use returned invalid session metadata")
+                session = created_session
+                if not session.get("bb_session_id"):
+                    raise RuntimeError("Browser Use returned no session id")
+                result = await _extract_via_cdp(
+                    url,
+                    str(session.get("cdp_url") or ""),
+                    "browser_use_cloud",
+                )
+    except Exception as exc:
+        result = {"url": url, "error": f"Browser Use extraction failed: {type(exc).__name__}"}
+    finally:
+        if isinstance(session, dict) and provider and session.get("bb_session_id"):
+            cleanup_failed = not await _close_browser_use_session(
+                provider, str(session["bb_session_id"])
+            )
+            if cleanup_failed:
+                logger.warning(
+                    "Browser Use session cleanup could not be confirmed for %s",
+                    _redact_url_for_logs(url),
+                )
+
+    if cleanup_failed:
+        prior_error = str(result.get("error") or "").strip()
+        result = dict(result)
+        result["error"] = "Browser Use session cleanup failed"
+        if prior_error:
+            result["error"] += f"; extraction also failed: {prior_error}"
+
+    _append_capped_lane_log(url, lanes, "success" if _is_usable_extraction(result) else "failed")
+    return result
+
+
+async def _extract_with_jina_escalation(provider: Any, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
+    """Primary backend → Home Chrome CDP → Browser Use for classified public
+    anti-bot blocks and lane failures.
+
+    The first lane is the ACTUAL primary backend (provider.name), not a
+    hardcoded name: the escalation chain must serve whichever backend is
+    configured (Jina, Crawl4AI, Firecrawl, ...) — a lane dying must never
+    take extract down with no fallback.
+    """
+    primary = provider.extract(urls, **kwargs)
+    primary_results = await primary if inspect.isawaitable(primary) else primary
+    results: List[Dict[str, Any]] = []
+    for original in primary_results:
+        result = dict(original)
+        lanes = [provider.name or "jina"]
+        signal = _extract_block_signal(result)
+        if not signal and _is_hard_interstitial(result):
+            signal = "hard anti-bot interstitial"
+        if not signal and _status_code(result) == 402:
+            # 402 = lane unavailable (credits/access), not a page property —
+            # the page is probably fine, so the next lanes deserve a try.
+            signal = "HTTP 402 (lane unavailable)"
+        if not signal and _extract_is_technical_failure(result):
+            # transport failures are not anti-bot blocks: do not spend the
+            # CDP or paid cloud lanes on them — record the routing and keep
+            # the primary result.
+            results.append(_set_extraction_routing(result, lanes, reason="technical failure"))
+            continue
+        if not signal:
+            results.append(_set_extraction_routing(result, lanes))
+            continue
+
+        lanes.append("home_chrome_cdp")
+        chrome = await _extract_via_home_chrome_cdp(str(result.get("url") or ""))
+        if _is_usable_extraction(chrome):
+            results.append(_set_extraction_routing(chrome, lanes, reason=signal))
+            continue
+
+        lanes.append("browser_use_cloud")
+        cloud = await _extract_via_browser_use_cloud(str(result.get("url") or ""), lanes)
+        if _is_usable_extraction(cloud):
+            results.append(_set_extraction_routing(cloud, lanes, reason=signal))
+            continue
+
+        # Preserve the original reader result; it often contains the clearest
+        # server-side error, while routing records every attempted lane.
+        results.append(_set_extraction_routing(result, lanes, reason=signal))
+    return results

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -98,6 +98,21 @@ from tools.tool_backend_helpers import (  # noqa: F401
     prefers_gateway,
 )
 from tools.url_safety import async_is_safe_url, normalize_url_for_request, sensitive_query_param_name
+from tools.website_policy import check_website_access
+# Escalation chain helpers live in tools/web_routing.py; the names are
+# re-exported here for tests and backward compatibility.
+from tools.web_routing import (
+    _append_capped_lane_log,
+    _extract_block_signal,
+    _extract_is_technical_failure,
+    _extract_via_browser_use_cloud,
+    _extract_via_home_chrome_cdp,
+    _extract_with_jina_escalation,
+    _HARD_INTERSTITIAL_MIN_CHARS,
+    _is_hard_interstitial,
+    _NEAR_EMPTY_BLOCK_CHARS,
+    _redact_url_for_logs,
+)
 import sys
 
 logger = logging.getLogger(__name__)
@@ -930,17 +945,15 @@ async def web_extract_tool(
                 "Web extract via %s: %d URL(s)", provider.name, len(safe_urls)
             )
 
-            # Async-or-sync dispatch: parallel + firecrawl have async
-            # extract(); exa + tavily are sync.
-            import inspect
-            if inspect.iscoroutinefunction(provider.extract):
-                results = await provider.extract(safe_urls, format=format)
-            else:
-                # Run sync extract() in a thread so we don't block the
-                # event loop on network I/O.
-                results = await asyncio.to_thread(
-                    provider.extract, safe_urls, format=format
-                )
+            # Any configured backend can hit a block or lane failure — not
+            # just Jina. Route every provider through the escalation wrapper
+            # (tools/web_routing.py): it returns primary results untouched
+            # (with routing metadata) when there is no block signal, and
+            # escalates classified 403/429/402 or anti-bot interstitials
+            # through Home Chrome then Browser Use. Transport failures are
+            # returned without escalation. The wrapper handles both async and
+            # sync provider.extract() implementations.
+            results = await _extract_with_jina_escalation(provider, safe_urls, format=format)
 
         # Reconstruct the original input order across invalid, blocked, and
         # provider-processed entries. Providers are expected to preserve the


### PR DESCRIPTION
**The problem:** a lane dying (hardcoded Jina, dead 402 path, unwired failure classification) took web extract down with no fallback. The escalation subsystem lived only as a local patch — this PR brings it upstream.

**tools/web_routing.py (new):** block-signal classification (403/429 + anti-bot markers), hard-interstitial detection, Home Chrome CDP and Browser Use escalation lanes, lane audit log. The wrapper derives the first lane from the ACTUAL configured backend (`provider.name`) instead of hardcoding jina; HTTP 402 is treated as a lane-unavailable escalation trigger; transport failures are classified via `_extract_is_technical_failure` and do NOT spend the CDP/paid lanes.

**tools/web_tools.py:** every provider (Jina, Crawl4AI, Firecrawl, ...) now routes through the escalation wrapper; the block-signal regex matches both the classic "returned error 403" wording and provider wrappers like "Crawl4AI returned HTTP 403".

**Tests:** 28/28 in tests/tools/test_web_extract_escalation.py pass; read_extract, robustness, dict_urls, tavily, truncate suites green. Note: two escalation tests covering web_tools-level website-policy and disabled-plugin guards depend on other local-only changes and are upstreamed separately.