### PR TITLE
fix(tools): keep spilled delegate and web results readable on remote backends

### DIFF
--- a/tests/tools/test_delegate_summary_budget.py
+++ b/tests/tools/test_delegate_summary_budget.py
@@ -69,6 +69,34 @@ def test_batch_overflow_trimmed_and_spilled_losslessly(monkeypatch):
             assert os.path.join("cache", "delegation") in path
 
 
+@pytest.mark.parametrize(
+    ("backend", "visible_prefix"),
+    [
+        ("docker", "/root/.hermes/cache/delegation/"),
+        ("modal", "/root/.hermes/cache/delegation/"),
+        ("ssh", "~/.hermes/cache/delegation/"),
+        ("local", None),
+    ],
+)
+def test_summary_footer_publishes_agent_visible_spill_path(
+    tmp_path, monkeypatch, backend, visible_prefix
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setenv("TERMINAL_ENV", backend)
+
+    summary = "HEAD\n" + ("middle\n" * 500) + "TAIL"
+    model_text, host_path = dt._trim_summary_with_footer(summary, 1000, 0)
+
+    assert host_path is not None and os.path.exists(host_path)
+    with open(host_path, encoding="utf-8") as fh:
+        assert fh.read() == summary
+    if visible_prefix is None:
+        assert host_path in model_text
+    else:
+        assert visible_prefix in model_text
+        assert host_path not in model_text
+
+
 def test_empty_results_is_noop():
     # No summaries → nothing to do, must not raise.
     dt._apply_summary_budget([], _FakeParent(131_000, 1_000, 8_000))

--- a/tests/tools/test_delegation_live_log.py
+++ b/tests/tools/test_delegation_live_log.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+import tools.delegate_tool as dt
 from tools import delegation_live_log as dll
 from tools.delegation_live_log import (
     LiveTranscriptWriter,
@@ -167,6 +168,64 @@ def _fake_run(task_index, goal, child=None, parent_agent=None, **kw):
         "summary": f"done: {goal}", "api_calls": 1,
         "duration_seconds": 0.1, "model": "m", "exit_reason": "completed",
     }
+
+
+def _patch_delegate_runtime(monkeypatch):
+    child = MagicMock()
+    child._delegate_role = "leaf"
+    child._subagent_id = "s1"
+    monkeypatch.setattr(dt, "_build_child_agent", lambda **kw: child)
+    monkeypatch.setattr(dt, "_run_single_child", _fake_run)
+    monkeypatch.setattr(
+        dt, "_resolve_delegation_credentials", lambda *a, **kw: _CREDS
+    )
+
+
+def test_sync_result_publishes_agent_visible_live_transcripts(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    _patch_delegate_runtime(monkeypatch)
+
+    result = json.loads(
+        dt.delegate_task(goal="inspect paths", parent_agent=_make_parent())
+    )
+
+    paths = result["live_transcripts"]
+    assert paths[0].startswith("/root/.hermes/cache/delegation/live/")
+    assert result["results"][0]["live_transcript"] == paths[0]
+    assert str(tmp_path) not in json.dumps(result)
+
+
+def test_background_dispatch_publishes_agent_visible_live_transcripts(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+    _patch_delegate_runtime(monkeypatch)
+    monkeypatch.setattr(
+        "gateway.session_context.async_delivery_supported", lambda: True
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.dispatch_async_delegation_batch",
+        lambda **kw: {
+            "status": "dispatched",
+            "delegation_id": kw["delegation_id"],
+        },
+    )
+
+    result = json.loads(
+        dt.delegate_task(
+            goal="inspect paths", background=True, parent_agent=_make_parent()
+        )
+    )
+
+    assert result["status"] == "dispatched"
+    assert result["live_transcripts"][0].startswith(
+        "~/.hermes/cache/delegation/live/"
+    )
+    assert str(tmp_path) not in json.dumps(result)
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_web_tools_truncate.py
+++ b/tests/tools/test_web_tools_truncate.py
@@ -54,6 +54,36 @@ class TestTruncation:
         assert "UNIQUE_MIDDLE_MARKER" in full
         assert "row 2500" in full  # the omitted-middle row is in the stored file
 
+    @pytest.mark.parametrize(
+        ("backend", "visible_prefix"),
+        [
+            ("docker", "/root/.hermes/cache/web/"),
+            ("modal", "/root/.hermes/cache/web/"),
+            ("ssh", "~/.hermes/cache/web/"),
+            ("local", None),
+        ],
+    )
+    def test_footer_publishes_agent_visible_stored_path(
+        self, tmp_path, monkeypatch, backend, visible_prefix
+    ):
+        hermes_home = tmp_path / ".hermes"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TERMINAL_ENV", backend)
+        body = "\n".join(f"row {i}" for i in range(1000))
+
+        out, truncated = wt._truncate_with_footer(
+            body, "https://example.com/doc", 1000
+        )
+
+        assert truncated is True
+        stored = list((hermes_home / "cache" / "web").glob("*.md"))
+        assert len(stored) == 1 and stored[0].read_text(encoding="utf-8") == body
+        if visible_prefix is None:
+            assert str(stored[0]) in out
+        else:
+            assert visible_prefix in out
+            assert str(stored[0]) not in out
+
 
 class TestCharLimitConfig:
     def test_default_when_unset(self):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -41,6 +41,7 @@ from agent.interrupt_compat import request_hard_interrupt
 # Must match hermes_cli.runtime_provider.RUNTIME_PROVIDER_TYPE_CUSTOM.
 _RUNTIME_PROVIDER_CUSTOM = "custom"
 from tools import file_state
+from tools.credential_files import to_agent_visible_cache_path
 from tools.terminal_tool import set_approval_callback as _set_subagent_approval_cb
 from utils import base_url_hostname, is_truthy_value
 
@@ -1951,6 +1952,9 @@ def _trim_summary_with_footer(
         tail = tail[nl + 1:]
 
     spill_path = _spill_summary_to_file(task_index, summary)
+    visible_spill_path = (
+        to_agent_visible_cache_path(spill_path) if spill_path else None
+    )
 
     footer_lines = [
         "",
@@ -1958,12 +1962,14 @@ def _trim_summary_with_footer(
         f"Showing {len(head):,} chars (head) + {len(tail):,} chars (tail) "
         f"of {original_len:,} total — trimmed to protect the parent's context window.",
     ]
-    if spill_path:
+    if visible_spill_path:
         # read_file is 1-indexed; +2 moves past the last head line shown.
         middle_start_line = head.count("\n") + 2
-        footer_lines.append(f"Full subagent output saved to: {spill_path}")
         footer_lines.append(
-            f'To read the omitted middle: read_file path="{spill_path}" '
+            f"Full subagent output saved to: {visible_spill_path}"
+        )
+        footer_lines.append(
+            f'To read the omitted middle: read_file path="{visible_spill_path}" '
             f"offset={middle_start_line} limit=200  (the file is the complete "
             f"summary; raise/lower offset to page through it)."
         )
@@ -3293,6 +3299,9 @@ def delegate_task(
     live_deleg_id, live_writers, live_paths = create_live_transcripts(
         task_list, context
     )
+    agent_live_paths = [
+        to_agent_visible_cache_path(path) for path in live_paths
+    ]
 
     # Capture the ORIGINATING session's wake target BEFORE any child agent is
     # constructed: _build_child_agent() -> AIAgent() -> agent_init calls
@@ -3552,16 +3561,16 @@ def delegate_task(
                     _w.finalize(entry)
                 except Exception:
                     logger.debug("Live transcript finalize failed", exc_info=True)
-                if _idx < len(live_paths):
-                    entry["live_transcript"] = live_paths[_idx]
+                if _idx < len(agent_live_paths):
+                    entry["live_transcript"] = agent_live_paths[_idx]
         update_manifest_statuses(live_deleg_id, results)
 
         combined: Dict[str, Any] = {
             "results": results,
             "total_duration_seconds": total_duration,
         }
-        if live_paths:
-            combined["live_transcripts"] = list(live_paths)
+        if agent_live_paths:
+            combined["live_transcripts"] = list(agent_live_paths)
         return combined
 
     # ----- Background dispatch: run the WHOLE batch as one async unit -----
@@ -3771,8 +3780,8 @@ def delegate_task(
                 "goals": _goals,
                 "note": note,
             }
-            if live_paths:
-                payload["live_transcripts"] = list(live_paths)
+            if agent_live_paths:
+                payload["live_transcripts"] = list(agent_live_paths)
                 payload["live_transcripts_hint"] = (
                     "Each subagent streams a human-readable transcript of its "
                     "operations to the file listed above (append-only, one per "

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -84,6 +84,7 @@ _async_parallel_client: Optional[Any] = None
 _exa_client: Optional[Any] = None
 
 from tools.debug_helpers import DebugSession
+from tools.credential_files import to_agent_visible_cache_path
 # Imported solely so unit tests can monkeypatch these names on
 # tools.web_tools (the firecrawl plugin reads them via its own import chain).
 from tools.managed_tool_gateway import (  # noqa: F401 — backward-compat names for tests
@@ -545,6 +546,9 @@ def _truncate_with_footer(
 
     total = len(content)
     stored_path = _store_full_text(url, content)
+    visible_stored_path = (
+        to_agent_visible_cache_path(stored_path) if stored_path else None
+    )
 
     footer_lines = [
         "",
@@ -552,15 +556,15 @@ def _truncate_with_footer(
         f"Showing {len(head):,} chars (head) + {len(tail):,} chars (tail) "
         f"of {total:,} total clean characters.",
     ]
-    if stored_path:
+    if visible_stored_path:
         # The omitted middle begins right after the head we're showing. Give
         # the model a concrete starting line (head line count + 1) so its first
         # read_file lands in the gap instead of guessing <line>. read_file is
         # 1-indexed; +1 moves past the last head line we already showed.
         middle_start_line = head.count("\n") + 2
-        footer_lines.append(f"Full text saved to: {stored_path}")
+        footer_lines.append(f"Full text saved to: {visible_stored_path}")
         footer_lines.append(
-            f'To read the omitted middle: read_file path="{stored_path}" '
+            f'To read the omitted middle: read_file path="{visible_stored_path}" '
             f"offset={middle_start_line} limit=200  (the file is the complete page; "
             f"raise/lower offset to page through it)."
         )


### PR DESCRIPTION
## What does this PR do?

When `delegate_task` summaries or transcripts and `web_extract` pages spill to disk, remote agents can now follow the published `read_file` guidance. Docker, Modal, and SSH previously received host-absolute cache paths that they could not resolve, so the complete output was unreadable even though the backing file was mounted or synced. This change translates only model-facing paths through the existing backend-aware cache mapper and preserves host paths for host-side storage.

### Symptom

A truncated delegate summary or web extraction tells the agent to read a host path. Live transcript fields expose the same kind of host path. On Docker, Modal, or SSH backends, following that guidance returns `File not found` instead of the omitted content or transcript.

### Impact

Remote-backend agents cannot recover complete spilled output or inspect live child transcripts. They may lose necessary context or repeat delegation and extraction work even though the data already exists in a reachable cache mount.

### Bug Cause

**Trigger:** `tools/delegate_tool.py:1954` in `_trim_summary_with_footer`, `tools/delegate_tool.py:3299` around live-transcript publication, and `tools/web_tools.py:548` in `_truncate_with_footer`.

**Causal chain:**
1. Host-side producers write complete summaries, transcripts, and extracted pages under `cache/delegation` or `cache/web`.
2. Model-facing footers and result payloads publish those returned host paths without translating them for the active terminal backend.
3. Remote `read_file` calls resolve paths inside the Docker, Modal, or SSH namespace and fail to find the host-absolute path.

**Why it is wrong:** Cache storage and cache publication cross different filesystem namespaces on remote backends. Publishing the host storage path violates the existing mounted-cache path contract.

**Working sibling / contrast:** The existing `to_agent_visible_cache_path()` helper already maps mounted cache paths to `/root/.hermes` for Docker and Modal, to `~/.hermes` for SSH, and leaves local paths unchanged.

**Ruled out:** The cache files were not missing. Real Docker verification showed that the original host paths failed while the translated paths were readable, and the relevant cache directories were already mounted.

### Fix

Translate summary spill footers, synchronous and background live-transcript fields, and web extraction spill footers at their model-facing publication boundaries. Keep `summary_full_path` and all writer inputs as host paths so host-side storage behavior remains unchanged.

## Related Issue

Closes #81984

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/delegate_tool.py` - publish backend-visible summary spill and live-transcript paths while retaining host backing paths.
- `tools/web_tools.py` - publish backend-visible stored-page paths in truncation footers.
- `tests/tools/test_delegate_summary_budget.py` - cover summary footer translation for Docker, Modal, SSH, and local backends.
- `tests/tools/test_delegation_live_log.py` - cover synchronous and immediate background transcript publication.
- `tests/tools/test_web_tools_truncate.py` - cover web extraction footer translation and host backing-file preservation.

## How to Test

1. Use a Docker terminal backend and trigger a truncated delegate summary, a live transcript, and a truncated `web_extract` result.
2. Confirm every published path uses `/root/.hermes/cache/...`, `read_file` can read it, and the corresponding host backing file remains present and complete.
3. Run the focused suites:

```bash
scripts/run_tests.sh tests/tools/test_delegate_summary_budget.py tests/tools/test_delegation_live_log.py tests/tools/test_web_tools_truncate.py
scripts/run_tests.sh tests/tools/test_credential_files.py -k TestToAgentVisiblePathPerBackend
```

The focused runs passed 35 and 6 tests respectively.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10 with a Podman-backed Docker environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; no user-facing configuration or workflow changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; the existing tool contract is unchanged

## Screenshots / Logs

N/A - focused test results and Docker backend verification are documented above.
