### PR TITLE
fix(update): classify long-path runtime gateways from live argv

### DIFF
--- a/hermes_cli/_scan_venv_blockers.py
+++ b/hermes_cli/_scan_venv_blockers.py
@@ -126,6 +126,24 @@ def _is_pausable_gateway(cmdline: str) -> bool:
     return looks_like_gateway_command_line(cmdline)
 
 
+def _live_cmdline_for_classification(pid: int, fallback: str) -> str:
+    """Return the process's full live argv for blocker classification.
+
+    ``_detect_venv_python_processes`` intentionally limits its diagnostic
+    cmdline to 120 characters. Managed-runtime executable paths can exceed that
+    by themselves, cutting off the trailing ``gateway run`` tokens and making a
+    pausable gateway look like an opaque Python blocker. Re-read argv only for
+    classification; reporting still uses the bounded, redacted fallback.
+    """
+    try:
+        import psutil  # noqa: PLC0415
+
+        live = " ".join(psutil.Process(int(pid)).cmdline())
+    except Exception:
+        return fallback
+    return live or fallback
+
+
 def main() -> None:
     """Entry point.  Prints one JSON doc to stdout.  Exits 0 for valid scan."""
     try:
@@ -140,16 +158,24 @@ def main() -> None:
     except Exception as exc:
         _emit_probe_fail(f"scan aborted: {exc}")
 
+    classified = [
+        (pid, name, cmdline, _live_cmdline_for_classification(pid, cmdline))
+        for pid, name, cmdline in matches
+    ]
     processes = [
         {
             "pid": pid,
             "name": name,
             "cmdline": _redact_sensitive_cmdline(cmdline),
         }
-        for pid, name, cmdline in matches
-        if not _is_pausable_gateway(cmdline)
+        for pid, name, cmdline, classification_cmdline in classified
+        if not _is_pausable_gateway(classification_cmdline)
     ]
-    exempted = sum(1 for _pid, _name, cmdline in matches if _is_pausable_gateway(cmdline))
+    exempted = sum(
+        1
+        for _pid, _name, _cmdline, classification_cmdline in classified
+        if _is_pausable_gateway(classification_cmdline)
+    )
     data = {
         "ok": True,
         "blocked": bool(processes),

--- a/tests/hermes_cli/test_scan_venv_blockers.py
+++ b/tests/hermes_cli/test_scan_venv_blockers.py
@@ -199,6 +199,45 @@ def test_main_exempts_gateway_chain_but_keeps_other_holders(monkeypatch, capsys)
     assert data["pausable_gateways"] == 2
 
 
+def test_main_rehydrates_truncated_runtime_gateway_cmdline(monkeypatch, capsys):
+    """A long managed-runtime path can consume the detector's 120-char
+    diagnostic prefix before ``gateway run`` appears. Classification must use
+    the live argv, otherwise a pausable gateway blocks every Desktop update."""
+    pid = 35140
+    runtime_prefix = (
+        r"C:\Users\Jose\AppData\Local\hermes\hermes-agent\.hermes-runtime\python"
+        r"\generation-1785951912-33788-b5f7a5d0\cpython-3.11-windows-x86_64-none\python.exe"
+    )
+    truncated = runtime_prefix[:120]
+    live_argv = [
+        runtime_prefix,
+        "-m",
+        "hermes_cli.main",
+        "gateway",
+        "run",
+        "--replace",
+    ]
+    fake_process = types.SimpleNamespace(cmdline=lambda: live_argv)
+    fake_psutil = types.SimpleNamespace(Process=lambda requested_pid: fake_process)
+    monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+
+    import hermes_cli.main as cli_main
+
+    monkeypatch.setattr(
+        cli_main,
+        "_detect_venv_python_processes",
+        lambda: [(pid, "python.exe", truncated)],
+    )
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+
+    data = json.loads(capsys.readouterr().out)
+    assert excinfo.value.code == 0
+    assert data["blocked"] is False
+    assert data["processes"] == []
+    assert data["pausable_gateways"] == 1
+
+
 def test_main_desktop_serve_backend_still_blocks(monkeypatch, capsys):
     """The desktop's own `serve` backend has no downstream pause — it must
     keep blocking exactly as before the exemption."""


### PR DESCRIPTION
## Summary
- re-read the full live process argv when classifying Windows venv blockers
- keep the existing bounded, redacted command line for diagnostics
- prevent managed-runtime gateway paths longer than 120 characters from being misclassified as external blockers

## Root cause
`_detect_venv_python_processes()` intentionally truncates diagnostic command lines to 120 characters. A managed runtime path under `.hermes-runtime/python/generation-*` can consume the entire prefix before `gateway run` appears. The Desktop preflight then treats the pausable gateway as an opaque Python process and aborts every update before the updater can stop that gateway.

## Verification
- `uv run --with pytest --with pytest-xdist python -m pytest tests/hermes_cli/test_scan_venv_blockers.py tests/hermes_cli/test_update_venv_health.py -v --tb=short -n 0`
- 29 passed
- live preflight after the fix: `{"ok": true, "blocked": false, "processes": [], "pausable_gateways": 2}`