### PR TITLE
fix(terminal): keep background workers in a private session under systemd scope (#70716)

### DIFF
--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1104,10 +1104,17 @@ class ProcessRegistry:
                 shell_argv, unit_suffix=unit_suffix,
             )
             session.systemd_unit = f"hermes-worker-{unit_suffix}.scope"
-            # systemd-run creates the new session/cgroup for us; do NOT also
-            # set start_new_session (harmless, but redundant and it can mask
-            # scope-creation failures in some systemd versions).
-            popen_start_new_session = False
+            # CRITICAL (#70716 regression): systemd-run --scope does NOT give
+            # the worker a new session — the invoked process keeps the
+            # parent's session and inherits its controlling terminal.  From an
+            # interactive TUI this drops the worker into the same session as
+            # the foreground process group: background spawns then stop the
+            # whole session (observed as 5 dead TUIs in state T / "Arrêté").
+            # start_new_session=True gives systemd-run (and the scoped worker
+            # below it) a private session.  Cgroup isolation is preserved:
+            # the scope is attached to the invoked process, not to the
+            # spawning session.
+            popen_start_new_session = True
         else:
             spawn_argv = shell_argv
             popen_start_new_session = True
@@ -1163,10 +1170,12 @@ class ProcessRegistry:
             # leak as untracked background processes.
             try:
                 if session.systemd_unit:
-                    # systemd-run --scope shares the gateway's process group
-                    # because start_new_session=False.  Never killpg here: that
-                    # can signal the gateway itself.  Stop the sibling cgroup,
-                    # then safely terminate the wrapper PID tree as fallback.
+                    # The worker runs in its own systemd scope and, since the
+                    # #70716 session-isolation fix, its own session.  Stop the
+                    # scope (kills every process in the worker cgroup), then
+                    # terminate the systemd-run wrapper PID as fallback.
+                    # Never killpg: scope teardown is the authoritative
+                    # cleanup for the worker cgroup.
                     _stop_systemd_unit(session.systemd_unit)
                     self._terminate_host_pid(proc.pid, session.host_start_time)
                 elif not _IS_WINDOWS:


### PR DESCRIPTION
## Problem

Since #70716 (cgroup isolation for background executors), every background
process spawned from an interactive Hermes TUI stops the whole TUI session.

Observed 2026-08-08: 5 TUI sessions died in state `T` (`[N]+ Arrêté hermes`)
back-to-back, each right after a `terminal(background=true)` call. The
repro is deterministic: launch a TUI whose env contains `INVOCATION_ID`
(any shell under a systemd user session), then spawn a background process —
the TUI stops immediately.

## Root cause

`is_gateway_supervisor_process()` returns True whenever `INVOCATION_ID` is
present, so a TUI started from a systemd-managed shell takes the
systemd-scope spawn path. In `ProcessRegistry.spawn_local` the
systemd-scope branch set `popen_start_new_session = False` with the
rationale that `systemd-run --scope` creates the new session itself.

It does not. `systemd-run --scope` puts the *invoked process* in a new
cgroup and a new process group, but the process keeps the parent's
**session** and inherits its **controlling terminal**. The worker therefore
lands in the same session as the TUI's foreground process group; the spawn
then stops the whole session (SIGTTIN/SIGTTOU family on the shared
terminal), observed as state `T` on the TUI process.

## Fix

`popen_start_new_session = True` in the systemd-scope branch of
`spawn_local`. The worker (and the `systemd-run` wrapper) get a private
session. Cgroup isolation is preserved: the scope is attached to the
invoked process, not to the spawning session, so the OOM-isolation intent
of #70716 is untouched.

## Verification

Simulated TUI (process with `INVOCATION_ID` set) + `ProcessRegistry.spawn_local`:

- worker spawns inside `hermes-worker-*.scope` (systemd cgroup path active)
- worker `sid !=` simulator `sid` (before the fix: same sid -> stopped)
- worker exits cleanly, simulator stays alive and un-stopped

Also verified the old behavior on the same host: same-sid worker + TUI on a
pts -> TUI goes to state `T` (the 5 observed deaths).
