### PR TITLE
fix(matrix): rebind EventType after import-time stubs

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1016,7 +1016,14 @@ def ensure_matrix_deps() -> bool:
         missing = ()
         ensure_and_bind = None  # type: ignore[assignment]
 
-    if missing or ensure_and_bind is None:
+    # Stubs are installed at import-time when mautrix is missing. If packages
+    # become available later without going through ensure_and_bind, EventType
+    # stays as string stubs and Client.add_event_handler raises
+    # ValueError("Invalid event type") after E2EE setup.
+    _et = globals().get("EventType")
+    _stubbed_event_types = isinstance(getattr(_et, "ROOM_MESSAGE", None), str)
+
+    if missing or ensure_and_bind is None or _stubbed_event_types:
         def _import():
             from mautrix.types import (
                 ContentURI, EventID, EventType, PaginationDirection,
@@ -1037,8 +1044,17 @@ def ensure_matrix_deps() -> bool:
             }
 
         if ensure_and_bind is None:
-            return False
-        if not ensure_and_bind("platform.matrix", _import, globals(), prompt=False):
+            # Still try a direct rebind when only stubs are the problem and
+            # mautrix is already importable in this process.
+            if _stubbed_event_types and not missing:
+                try:
+                    globals().update(_import())
+                except Exception as exc:
+                    logger.warning("Matrix: failed to rebind mautrix types: %s", exc)
+                    return False
+            else:
+                return False
+        elif not ensure_and_bind("platform.matrix", _import, globals(), prompt=False):
             logger.warning(
                 "Matrix: required packages not installed (%s). "
                 "Run: pip install 'mautrix[encryption]' asyncpg aiosqlite "
@@ -2028,19 +2044,27 @@ class MatrixAdapter(BasePlatformAdapter):
                         return False
 
         # Register event handlers.
+        # Always re-import live mautrix event types in this stack frame. Module-
+        # level EventType can still be the import-time stub (plain strings) when
+        # the plugin was first loaded before mautrix was importable; mautrix's
+        # Syncer.add_event_handler then raises ValueError("Invalid event type").
+        from mautrix.types import EventType as LiveEventType
         from mautrix.client import InternalEventType as IntEvt
         from mautrix.client.dispatcher import MembershipEventDispatcher
+
+        # Keep module globals in sync for later send/history helpers.
+        globals()["EventType"] = LiveEventType
 
         # Without this the INVITE handler below never fires.
         client.add_dispatcher(MembershipEventDispatcher)
 
         client.add_event_handler(
-            EventType.ROOM_MESSAGE,
+            LiveEventType.ROOM_MESSAGE,
             self._on_room_message,
             wait_sync=True,
         )
         client.add_event_handler(
-            EventType.REACTION,
+            LiveEventType.REACTION,
             self._on_reaction,
             wait_sync=True,
         )

--- a/tests/gateway/test_matrix_eventtype_rebind.py
+++ b/tests/gateway/test_matrix_eventtype_rebind.py
@@ -1,0 +1,109 @@
+"""Regression: rebind mautrix EventType after import-time stubs.
+
+When the Matrix plugin module is imported before mautrix is importable, the
+adapter installs string stubs (``EventType.ROOM_MESSAGE = "m.room.message"``).
+If mautrix later becomes available without rebinding those globals,
+``Client.add_event_handler`` raises ``ValueError("Invalid event type")`` right
+after E2EE setup — Matrix never finishes connecting.
+
+These tests lock the rebind path in ``ensure_matrix_deps``.
+"""
+from __future__ import annotations
+
+import sys
+import types
+
+import plugins.platforms.matrix.adapter as matrix_adapter
+
+
+class _StubEventType:
+    """Mirrors the import-time fallback in adapter.py when mautrix is missing."""
+
+    ROOM_MESSAGE = "m.room.message"
+    REACTION = "m.reaction"
+    ROOM_ENCRYPTED = "m.room.encrypted"
+    ROOM_NAME = "m.room.name"
+
+
+class _LiveEventType:
+    """Stand-in for a real mautrix EventType class (identity matters)."""
+
+    ROOM_MESSAGE = object()
+    REACTION = object()
+    ROOM_ENCRYPTED = object()
+    ROOM_NAME = object()
+
+
+def _install_fake_mautrix_types(monkeypatch):
+    """Provide ``mautrix.types`` symbols that ``ensure_matrix_deps`` imports."""
+    mautrix = types.ModuleType("mautrix")
+    mautrix_types = types.ModuleType("mautrix.types")
+    for name, value in {
+        "ContentURI": str,
+        "EventID": str,
+        "EventType": _LiveEventType,
+        "PaginationDirection": object(),
+        "PresenceState": object(),
+        "RoomCreatePreset": object(),
+        "RoomID": str,
+        "SyncToken": str,
+        "TrustState": object(),
+        "UserID": str,
+    }.items():
+        setattr(mautrix_types, name, value)
+    mautrix.types = mautrix_types
+    monkeypatch.setitem(sys.modules, "mautrix", mautrix)
+    monkeypatch.setitem(sys.modules, "mautrix.types", mautrix_types)
+
+
+def test_ensure_matrix_deps_rebinds_string_stubs_via_ensure_and_bind(monkeypatch):
+    """Stubs must be replaced even when feature_missing reports nothing missing."""
+    monkeypatch.setattr(matrix_adapter, "EventType", _StubEventType)
+    assert isinstance(matrix_adapter.EventType.ROOM_MESSAGE, str)
+
+    import tools.lazy_deps as lazy_deps_mod
+
+    monkeypatch.setattr(lazy_deps_mod, "feature_missing", lambda feature: ())
+    _install_fake_mautrix_types(monkeypatch)
+
+    def _ensure_and_bind(feature, importer, target_globals, prompt=False):
+        assert feature == "platform.matrix"
+        target_globals.update(importer())
+        return True
+
+    monkeypatch.setattr(lazy_deps_mod, "ensure_and_bind", _ensure_and_bind)
+    monkeypatch.setattr(matrix_adapter, "_resolve_e2ee_mode", lambda *a, **k: "off")
+
+    assert matrix_adapter.ensure_matrix_deps() is True
+    assert matrix_adapter.EventType is _LiveEventType
+    assert not isinstance(matrix_adapter.EventType.ROOM_MESSAGE, str)
+
+
+def test_ensure_matrix_deps_direct_rebind_when_ensure_and_bind_missing(monkeypatch):
+    """If ensure_and_bind is unavailable, still rebind when types can import."""
+    monkeypatch.setattr(matrix_adapter, "EventType", _StubEventType)
+
+    import tools.lazy_deps as lazy_deps_mod
+
+    monkeypatch.setattr(lazy_deps_mod, "feature_missing", lambda feature: ())
+    # Force the ``ensure_and_bind is None`` branch.
+    monkeypatch.setattr(lazy_deps_mod, "ensure_and_bind", None)
+    _install_fake_mautrix_types(monkeypatch)
+    monkeypatch.setattr(matrix_adapter, "_resolve_e2ee_mode", lambda *a, **k: "off")
+
+    assert matrix_adapter.ensure_matrix_deps() is True
+    assert matrix_adapter.EventType is _LiveEventType
+    assert not isinstance(matrix_adapter.EventType.ROOM_MESSAGE, str)
+
+
+def test_string_event_type_fails_mautrix_isinstance_guard():
+    """Document the mautrix Syncer guard this fix prevents tripping."""
+    pytest = __import__("pytest")
+    try:
+        from mautrix.client import InternalEventType
+        from mautrix.types import EventType
+    except ImportError:
+        pytest.skip("mautrix not installed in this environment")
+
+    assert not isinstance("m.room.message", (EventType, InternalEventType))
+    assert not isinstance(_StubEventType.ROOM_MESSAGE, (EventType, InternalEventType))


### PR DESCRIPTION
## Summary

Fix Matrix gateway failing to connect with `ValueError: Invalid event type` after E2EE setup when the Matrix plugin module was imported before `mautrix` was available.

### Problem

1. At import time, if `mautrix` is missing, the adapter installs **string stubs**:
   `EventType.ROOM_MESSAGE = "m.room.message"`.
2. Later, `mautrix` becomes importable (lazy install / post-update venv repair), but **module-level `EventType` is not rebound** when `feature_missing("platform.matrix")` is already empty.
3. `connect()` completes E2EE (local `mautrix.crypto` imports work), then calls `Client.add_event_handler(EventType.ROOM_MESSAGE, ...)`.
4. mautrix `Syncer.add_event_handler` does `isinstance(event_type, (EventType, InternalEventType))` → **false for strings** → `ValueError("Invalid event type")`.
5. Gateway logs: E2EE enabled → immediately `✗ matrix error: Invalid event type` → reconnect loop.

Observed after `hermes update` restarted the gateway while deps/runtime were being repaired.

### Fix

- **`ensure_matrix_deps`**: detect string stubs (`isinstance(EventType.ROOM_MESSAGE, str)`) and rebind even when nothing is “missing”; direct rebind path if `ensure_and_bind` is unavailable.
- **`connect`**: always re-import a live `EventType` immediately before registering handlers, and refresh module globals so later helpers stay consistent.
- **Tests**: lock both rebind paths + document the mautrix isinstance guard.

### Test plan

- [x] `pytest tests/gateway/test_matrix_eventtype_rebind.py -v` (3 passed)
- [x] Production repro: force stubs → `connect()` raised `Invalid event type` before fix; returns success after fix
- [x] Live gateway after patch: Matrix `connected`, initial sync, home-channel startup notification sent

### Apply without waiting for merge

```bash
cd ~/.hermes/hermes-agent
git fetch  # if using a fork remote
git cherry-pick 3a7aeb712d3f2c5eada22453ddc679cb1001caf5
# or:
git am /path/to/0001-fix-matrix-rebind-EventType-after-import-time-stubs.patch
hermes gateway restart
```

### Commit

- Branch: `fix/matrix-eventtype-stub-rebind`
- SHA: `3a7aeb712d3f2c5eada22453ddc679cb1001caf5`
- Message: `fix(matrix): rebind EventType after import-time stubs`
