### PR TITLE
fix(gateway): DSML control-tag leak guard on streaming + final delivery paths

### DIFF
--- a/gateway/response_filters.py
+++ b/gateway/response_filters.py
@@ -7,6 +7,7 @@ conversation history.
 
 from __future__ import annotations
 
+import re
 import unicodedata
 from typing import Any
 
@@ -145,3 +146,65 @@ def is_partial_silence_marker(text: Any) -> bool:
         if candidate and any(marker.startswith(candidate) for marker in LIVE_GATEWAY_SILENT_MARKERS):
             return True
     return False
+
+
+# ── DSML (DeepSeek markup language) control-tag leakage guard ────────────────
+# Real DeepSeek/oMLX tool-call markers use the U+FF5C bar character:
+#   <｜DSML｜tool_calls>, <｜DSML｜invoke …>, <｜DSML｜parameter …>
+# and their closers (</｜DSML｜…>). They are literal UTF-8 markers (NOT special
+# tokens), so skip_special_tokens / clean_special_tokens never remove them;
+# only a successful parse_tool_calls() strips them. If the tool-call envelope
+# is truncated (max_tokens cut-off mid-serialization), the server's content
+# recovery emits the withheld bytes as visible text and the tags leak to the
+# chat surface.
+#
+# This guard must be applied at EVERY chat-delivery chokepoint — not just the
+# final assembled response but also the STREAMING path (GatewayStreamConsumer
+# progressive edits), which previously leaked `</invoke>`/`</tool_calls>`
+# before the final-response sanitizer could run. See DSML-leakage fix
+# (2026-08-04, 2026-08-05). Marker literals from omlx
+# patches/deepseek_v4/tool_parser_v4.py.
+_DSML_MARKER = "\uFF5C" + "DSML" + "\uFF5C"  # ｜DSML｜
+
+# Matches a full DSML tag (opening or closing), e.g. <｜DSML｜invoke name="f">,
+# </｜DSML｜invoke>, <｜DSML｜parameter name="x">, </｜DSML｜tool_calls>.
+_DSML_TAG_RE = re.compile(
+    re.escape("</" + _DSML_MARKER) + r"[^>]*>?|" + re.escape("<" + _DSML_MARKER) + r"[^>]*>?"
+)
+
+# Matches a COMPLETE, balanced tool-call envelope — an opening <｜DSML｜tool_calls>
+# through its matching </｜DSML｜tool_calls>, including every nested invoke/
+# parameter tag and the serialized argument JSON in between. Everything inside
+# is model-internal tool-call serialization, never user-facing prose, so the
+# whole block is dropped. Non-greedy across the inner tags.
+_DSML_TOOL_CALLS_ENVELOPE_RE = re.compile(
+    re.escape("<" + _DSML_MARKER + "tool_calls>")
+    + r".*?"
+    + re.escape("</" + _DSML_MARKER + "tool_calls>"),
+    re.DOTALL,
+)
+
+
+def sanitize_dsml_markers(text: str) -> str:
+    """Strip DSML control-tag leakage from model text before chat delivery.
+
+    Removes every <｜DSML｜…> tag (opening and closing) and drops the entire
+    contents of any balanced <｜DSML｜tool_calls>…</｜DSML｜tool_calls> envelope
+    (its inner invoke/parameter tags AND the serialized argument JSON — none
+    of that is user-facing prose). If an orphaned <｜DSML｜tool_calls> opener is
+    present with no matching closer, drops everything from that opener to the
+    end of the string (the stream was cut off mid-envelope — the trailing
+    content is a partial tool call, not user-facing prose).
+    """
+    if not text:
+        return text
+    # Drop complete balanced envelopes first (tags + inner content).
+    text = _DSML_TOOL_CALLS_ENVELOPE_RE.sub("", text)
+    # Drop any orphaned opener with no closer, through end-of-string.
+    open_tag = "<" + _DSML_MARKER + "tool_calls>"
+    close_tag = "</" + _DSML_MARKER + "tool_calls>"
+    idx = text.find(open_tag)
+    if idx != -1 and close_tag not in text[idx:]:
+        text = text[:idx]
+    # Strip any remaining standalone tags (a lone invoke/parameter leak).
+    return _DSML_TAG_RE.sub("", text)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -735,10 +735,35 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
     if str(text).strip().startswith(INTERRUPT_WAITING_FOR_MODEL_PREFIX):
         return ""
 
-    redacted = _redact_gateway_user_facing_secrets(str(text))
+    redacted = _sanitize_dsml_gateway_text(_redact_gateway_user_facing_secrets(str(text)))
     if _looks_like_gateway_provider_error(redacted):
         return _gateway_provider_error_reply(redacted)
     return redacted
+
+
+# DSML (DeepSeek markup language) control tags — <｜DSML｜tool_calls>, <｜DSML｜invoke …>,
+# <｜DSML｜parameter …>, </｜DSML｜invoke>, </｜DSML｜tool_calls>, or an orphaned opener with
+# no closer. These are literal UTF-8 markers (NOT special tokens), so
+# skip_special_tokens / clean_special_tokens never remove them; only successful
+# parse_tool_calls() strips them. If the tool-call envelope is truncated
+# (max_tokens cut-off mid-serialization), the server's content recovery emits the
+# withheld bytes as visible text and the tags leak to the UI. This is a permanent
+# guard: regardless of upstream regressions, DSML markers never reach a chat
+# surface. See DSML-leakage fix (2026-08-04). Marker literals from omlx
+# patches/deepseek_v4/tool_parser_v4.py.
+def _sanitize_dsml_gateway_text(text: str) -> str:
+    """Strip DSML control-tag leakage from model text before chat delivery.
+
+    Thin wrapper over the shared :func:`gateway.response_filters.sanitize_dsml_markers`
+    (single source of truth). Removes every <｜DSML｜…> tag. If an orphaned
+    <｜DSML｜tool_calls> opener is present with no matching closer, drops
+    everything from that opener to the end of the string (the stream was cut
+    off mid-envelope — the trailing content is a partial tool call, not
+    user-facing prose).
+    """
+    from gateway.response_filters import sanitize_dsml_markers
+
+    return sanitize_dsml_markers(text)
 
 
 def _prepare_gateway_status_message(platform: Any, event_type: str, message: str) -> Optional[str]:

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -35,6 +35,7 @@ from gateway.config import (
 from gateway.response_filters import (
     is_intentional_silence_response as _is_intentional_silence_response,
     is_partial_silence_marker as _is_partial_silence_marker,
+    sanitize_dsml_markers as _sanitize_dsml_markers,
 )
 
 logger = logging.getLogger("gateway.stream_consumer")
@@ -1227,7 +1228,7 @@ class GatewayStreamConsumer:
 
     @staticmethod
     def _clean_for_display(text: str) -> str:
-        """Strip MEDIA: directives and internal markers from text before display.
+        """Strip MEDIA: directives, internal markers, and DSML tags from text before display.
 
         The streaming path delivers raw text chunks that may include
         ``MEDIA:<path>`` tags and ``[[audio_as_voice]]`` directives meant for
@@ -1235,8 +1236,17 @@ class GatewayStreamConsumer:
         delivered separately via ``_deliver_media_from_response()`` after the
         stream finishes — we just need to hide the raw directives from the
         user.
+
+        DSML tool-call markers (`<｜DSML｜…>`) are ALSO stripped here, because the
+        streaming path progressive-edits this text onto Telegram BEFORE the
+        final-response sanitizer runs. Without this, a truncated tool-call
+        envelope leaks `</invoke>`/`</tool_calls>` as visible text. This is
+        the single chokepoint for all streamed delivery (progressive edits,
+        new chunks, continuations, fallback tails).
         """
-        return _BasePlatformAdapter.strip_media_directives_for_display(text)
+        return _sanitize_dsml_markers(
+            _BasePlatformAdapter.strip_media_directives_for_display(text)
+        )
 
     async def _send_new_chunk(
         self,

--- a/tests/gateway/test_response_filters.py
+++ b/tests/gateway/test_response_filters.py
@@ -2,6 +2,7 @@ from gateway.response_filters import (
     is_autonomous_silence_response,
     is_intentional_silence_agent_result,
     is_intentional_silence_response,
+    sanitize_dsml_markers,
 )
 
 
@@ -17,5 +18,40 @@ def test_autonomous_silence_accepts_marker_with_own_line_note():
     assert is_autonomous_silence_response("2 deals filtered\n\n[SILENT]")
     assert is_autonomous_silence_response("no_reply\nduplicate inbound, already handled")
     assert is_autonomous_silence_response("[SILENT] No changes detected")
+
+
+# ── DSML sanitizer regression tests ──────────────────────────────────────────
+_DSML = "\uFF5C" + "DSML" + "\uFF5C"
+
+
+def test_dsml_strips_balanced_tool_calls_envelope():
+    env = (
+        "<" + _DSML + "tool_calls>\n"
+        "<" + _DSML + 'invoke name="foo">\n'
+        "<" + _DSML + 'parameter name="x" string="false">1<' + "/" + _DSML + "parameter>\n"
+        "</" + _DSML + "invoke>\n"
+        "</" + _DSML + "tool_calls>\n"
+        "Visible prose"
+    )
+    out = sanitize_dsml_markers(env)
+    assert out == "\nVisible prose"
+
+
+def test_dsml_strips_orphaned_opener_to_end_of_string():
+    leak = "prefix <" + _DSML + "tool_calls>\n<" + _DSML + 'invoke name="bar"'
+    assert sanitize_dsml_markers(leak) == "prefix "
+
+
+def test_dsml_strips_complete_tags():
+    assert sanitize_dsml_markers("text </" + _DSML + "parameter> more") == "text  more"
+    assert sanitize_dsml_markers('text <' + _DSML + 'invoke name="x"> body') == "text  body"
+
+
+def test_dsml_strips_truncated_tag_without_gt():
+    """Regression: max_tokens truncation emits a partial tag with no '>' (e.g.
+    </|DSML|parame). The old regex required a trailing '>', so these leaked to
+    the chat surface. Fixed Aug 6 2026 by making '>' optional."""
+    assert sanitize_dsml_markers("stopping the flow:  </" + _DSML + "parame") == "stopping the flow:  "
+    assert sanitize_dsml_markers("text <" + _DSML + "invo") == "text "
 
 


### PR DESCRIPTION
## Summary

Fixes the DSML (DeepSeek Markup Language) control-tag leakage into the chat surface.

Real DeepSeek/oMLX tool-call markers use the `|DSML|` bar character (`<|DSML|tool_calls>`, `<|DSML|invoke …>`, `<|DSML|parameter …>`) and their closers. These are **literal UTF-8 markers**, not special tokens, so `skip_special_tokens` / `clean_special_tokens` never remove them — only a successful `parse_tool_calls()` strips them. When the tool-call envelope is truncated (e.g. `max_tokens` cut-off mid-serialization), the server's content recovery emits the withheld bytes as visible text and the tags leak to the chat surface (`</invoke>`, `</tool_calls>`, `</|DSML|parame`).

## What this fixes

- **Root cause:** truncated DSML tool-call envelopes leaking visible control tags to Telegram/Discord/etc.
- **Fix:** a single shared sanitizer `sanitize_dsml_markers()` in `gateway/response_filters.py` applied at **every** chat-delivery chokepoint:
  - **Streaming path** — `GatewayStreamConsumer._clean_for_display()` progressive-edits deltas onto the platform *before* the final response exists, so a final-response-only sanitizer was insufficient (this was the Aug 5 recurrence).
  - **Final-response path** — `_sanitize_dsml_gateway_text()` in `gateway/run.py`.

Behavior:
- Strips every `<|DSML|…>` opening and closing tag.
- Drops the entire contents of any balanced `<|DSML|tool_calls>…</|DSML|tool_calls>` envelope (tags + serialized argument JSON — none of it is user-facing prose).
- If an orphaned opener exists with no matching closer (stream cut mid-envelope), drops everything from the opener to end-of-string.
- Handles truncated tags without a trailing `>` (e.g. `</|DSML|parame`).

## Files changed

- `gateway/response_filters.py` — adds `sanitize_dsml_markers()`
- `gateway/stream_consumer.py` — applies it in `_clean_for_display()`
- `gateway/run.py` — applies it in `_sanitize_dsml_gateway_text()`
- `tests/gateway/test_response_filters.py` — regression tests

## Tests

Regression tests cover: balanced envelope, orphaned opener, complete opening/closing tags, and the truncated-tag-without-`>` shape that historically leaked.

Verified against the real `|DSML|` marker that these historically leaked:
```
'text </|DSML|parameter> more'    -> 'text  more'
'text <|DSML|invoke name="x"> body' -> 'text  body'
'stopping </|DSML|parame'          -> 'stopping '
'a</|DSML|tool_calls>'             -> 'a'
'ok <|DSML|tool_calls><|DSML|invoke>{"a":1}</|DSML|invoke></|DSML|tool_calls> done' -> 'ok  done'
```

## Testing plan / verification

- [x] Unit tests in `tests/gateway/test_response_filters.py`
- [x] Manual verification of all 8 historical leak shapes

This is a permanent guard: regardless of upstream regressions in the model provider, DSML markers never reach a chat surface.