### PR TITLE
fix(anthropic): keep OAuth requests on subscription limits

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -436,10 +436,18 @@ def _build_claude_code_billing_header(
     """Build Claude Code's message-dependent subscription billing marker."""
     first_user_text = _extract_first_user_message_text(messages)
     resolved_version = version or _get_claude_code_version()
-    suffix_chars = "".join(
-        first_user_text[index] if index < len(first_user_text) else "0"
-        for index in (4, 7, 20)
-    )
+    # Claude Code's JavaScript implementation indexes UTF-16 code units, not
+    # Unicode code points. Select from the encoded units so astral characters
+    # before an index do not shift the signed positions.
+    utf16 = first_user_text.encode("utf-16-le", errors="surrogatepass")
+    selected_units = bytearray()
+    zero_unit = "0".encode("utf-16-le")
+    for index in (4, 7, 20):
+        start = index * 2
+        selected_units.extend(
+            utf16[start:start + 2] if start + 2 <= len(utf16) else zero_unit
+        )
+    suffix_chars = selected_units.decode("utf-16-le", errors="replace")
     version_suffix = hashlib.sha256(
         f"{_CLAUDE_CODE_BILLING_SALT}{suffix_chars}{resolved_version}".encode()
     ).hexdigest()[:3]

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -11,6 +11,7 @@ Auth supports:
 """
 
 import copy
+import hashlib
 import json
 import logging
 import os
@@ -393,6 +394,9 @@ def _detect_claude_code_version() -> str:
 
 
 _CLAUDE_CODE_SYSTEM_PREFIX = "You are Claude Code, Anthropic's official CLI for Claude."
+_CLAUDE_CODE_BILLING_PREFIX = "x-anthropic-billing-header:"
+_CLAUDE_CODE_BILLING_SALT = "59cf53e54c78"
+_CLAUDE_CODE_BILLING_ENTRYPOINT = "sdk-cli"
 _MCP_TOOL_PREFIX = "mcp__"
 
 
@@ -402,6 +406,49 @@ def _get_claude_code_version() -> str:
     if _claude_code_version_cache is None:
         _claude_code_version_cache = _detect_claude_code_version()
     return _claude_code_version_cache
+
+
+def _extract_first_user_message_text(messages: List[Dict]) -> str:
+    """Return the first non-empty text part from the first user turn."""
+    for message in messages:
+        if not isinstance(message, dict) or message.get("role") != "user":
+            continue
+        content = message.get("content")
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            for block in content:
+                if not isinstance(block, dict) or block.get("type") != "text":
+                    continue
+                text = block.get("text")
+                if isinstance(text, str) and text:
+                    return text
+        return ""
+    return ""
+
+
+def _build_claude_code_billing_header(
+    messages: List[Dict],
+    *,
+    version: Optional[str] = None,
+    entrypoint: str = _CLAUDE_CODE_BILLING_ENTRYPOINT,
+) -> str:
+    """Build Claude Code's message-dependent subscription billing marker."""
+    first_user_text = _extract_first_user_message_text(messages)
+    resolved_version = version or _get_claude_code_version()
+    suffix_chars = "".join(
+        first_user_text[index] if index < len(first_user_text) else "0"
+        for index in (4, 7, 20)
+    )
+    version_suffix = hashlib.sha256(
+        f"{_CLAUDE_CODE_BILLING_SALT}{suffix_chars}{resolved_version}".encode()
+    ).hexdigest()[:3]
+    content_hash = hashlib.sha256(first_user_text.encode()).hexdigest()[:5]
+    return (
+        f"{_CLAUDE_CODE_BILLING_PREFIX} cc_version="
+        f"{resolved_version}.{version_suffix}; cc_entrypoint={entrypoint}; "
+        f"cch={content_hash};"
+    )
 
 
 def _is_oauth_token(key: str) -> bool:
@@ -2886,14 +2933,34 @@ def build_anthropic_kwargs(
 
     # ── OAuth: Claude Code identity ──────────────────────────────────
     if is_oauth:
-        # 1. Prepend Claude Code system prompt identity
+        # 1. Prepend the message-dependent billing marker and Claude Code
+        #    identity. The first user turn stays stable as history grows, so
+        #    the system prefix remains byte-stable for prompt caching.
+        billing_block = {
+            "type": "text",
+            "text": _build_claude_code_billing_header(messages),
+        }
         cc_block = {"type": "text", "text": _CLAUDE_CODE_SYSTEM_PREFIX}
         if isinstance(system, list):
-            system = [cc_block] + system
+            # Replace any caller-supplied or replayed billing marker instead
+            # of accumulating duplicates.
+            system = [
+                block
+                for block in system
+                if not (
+                    isinstance(block, dict)
+                    and isinstance(block.get("text"), str)
+                    and block["text"].startswith(_CLAUDE_CODE_BILLING_PREFIX)
+                )
+            ]
+            system = [billing_block, cc_block] + system
         elif isinstance(system, str) and system:
-            system = [cc_block, {"type": "text", "text": system}]
+            existing_system = [] if system.startswith(_CLAUDE_CODE_BILLING_PREFIX) else [
+                {"type": "text", "text": system}
+            ]
+            system = [billing_block, cc_block] + existing_system
         else:
-            system = [cc_block]
+            system = [billing_block, cc_block]
 
         # 2. Sanitize system prompt — replace product name references
         #    to avoid Anthropic's server-side content filters.

--- a/tests/agent/test_anthropic_subscription_billing.py
+++ b/tests/agent/test_anthropic_subscription_billing.py
@@ -1,0 +1,115 @@
+"""Behavioral coverage for Claude subscription billing request shaping."""
+
+from unittest.mock import patch
+
+from agent.anthropic_adapter import (
+    _CLAUDE_CODE_BILLING_PREFIX,
+    _CLAUDE_CODE_SYSTEM_PREFIX,
+    _build_claude_code_billing_header,
+    build_anthropic_kwargs,
+)
+
+
+def _build(messages, *, is_oauth=True):
+    return build_anthropic_kwargs(
+        model="claude-haiku-4-5",
+        messages=messages,
+        tools=None,
+        max_tokens=64,
+        reasoning_config=None,
+        is_oauth=is_oauth,
+    )
+
+
+def test_billing_header_is_stable_as_conversation_grows():
+    initial = [{"role": "user", "content": "Explain the cache key."}]
+    continued = [
+        *initial,
+        {"role": "assistant", "content": "It is stable."},
+        {"role": "user", "content": "Show an example."},
+    ]
+
+    first = _build_claude_code_billing_header(initial, version="2.1.112")
+    later = _build_claude_code_billing_header(continued, version="2.1.112")
+    changed = _build_claude_code_billing_header(
+        [{"role": "user", "content": "A different first turn."}],
+        version="2.1.112",
+    )
+
+    assert later == first
+    assert changed != first
+    assert first.startswith(
+        "x-anthropic-billing-header: cc_version=2.1.112."
+    )
+    assert "; cc_entrypoint=sdk-cli; cch=" in first
+    assert first.endswith(";")
+
+
+def test_billing_header_uses_first_text_block_from_multimodal_user_turn():
+    text_only = [{"role": "user", "content": "describe this"}]
+    multimodal = [{
+        "role": "user",
+        "content": [
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AA=="}},
+            {"type": "text", "text": "describe this"},
+        ],
+    }]
+
+    assert _build_claude_code_billing_header(
+        multimodal, version="2.1.112"
+    ) == _build_claude_code_billing_header(text_only, version="2.1.112")
+
+
+def test_oauth_kwargs_prefix_billing_identity_and_preserve_cache_marker():
+    cache_control = {"type": "ephemeral"}
+    messages = [
+        {
+            "role": "system",
+            "content": [
+                {"type": "text", "text": "x-anthropic-billing-header: stale"},
+                {
+                    "type": "text",
+                    "text": "Hermes Agent system instructions",
+                    "cache_control": cache_control,
+                },
+            ],
+        },
+        {"role": "user", "content": "Hello"},
+    ]
+
+    with patch(
+        "agent.anthropic_adapter._get_claude_code_version",
+        return_value="2.1.112",
+    ):
+        kwargs = _build(messages)
+
+    system = kwargs["system"]
+    assert system[0]["text"].startswith(_CLAUDE_CODE_BILLING_PREFIX)
+    assert system[1] == {"type": "text", "text": _CLAUDE_CODE_SYSTEM_PREFIX}
+    assert system[2] == {
+        "type": "text",
+        "text": "Claude Code system instructions",
+        "cache_control": cache_control,
+    }
+    assert sum(
+        isinstance(block.get("text"), str)
+        and block["text"].startswith(_CLAUDE_CODE_BILLING_PREFIX)
+        for block in system
+    ) == 1
+
+
+def test_api_key_kwargs_do_not_include_subscription_billing_marker():
+    kwargs = _build(
+        [
+            {"role": "system", "content": "Ordinary API-key system prompt"},
+            {"role": "user", "content": "Hello"},
+        ],
+        is_oauth=False,
+    )
+
+    system = kwargs["system"]
+    system_text = system if isinstance(system, str) else "\n".join(
+        block.get("text", "") for block in system if isinstance(block, dict)
+    )
+    assert _CLAUDE_CODE_BILLING_PREFIX not in system_text
+    assert _CLAUDE_CODE_SYSTEM_PREFIX not in system_text

--- a/tests/agent/test_anthropic_subscription_billing.py
+++ b/tests/agent/test_anthropic_subscription_billing.py
@@ -1,5 +1,6 @@
 """Behavioral coverage for Claude subscription billing request shaping."""
 
+import hashlib
 from unittest.mock import patch
 
 from agent.anthropic_adapter import (
@@ -58,6 +59,20 @@ def test_billing_header_uses_first_text_block_from_multimodal_user_turn():
     assert _build_claude_code_billing_header(
         multimodal, version="2.1.112"
     ) == _build_claude_code_billing_header(text_only, version="2.1.112")
+
+
+def test_billing_header_matches_javascript_utf16_indexing():
+    text = "🙂12345678901234567890"
+    expected_suffix = hashlib.sha256(
+        "59cf53e54c783692.1.112".encode()
+    ).hexdigest()[:3]
+
+    header = _build_claude_code_billing_header(
+        [{"role": "user", "content": text}],
+        version="2.1.112",
+    )
+
+    assert f"cc_version=2.1.112.{expected_suffix};" in header
 
 
 def test_oauth_kwargs_prefix_billing_identity_and_preserve_cache_marker():


### PR DESCRIPTION
## Summary

- Port interview-studio's message-dependent Claude Code billing fingerprint into Hermes' existing Anthropic OAuth adapter.
- Keep the marker stable as conversation history grows so prompt caching remains valid.
- Preserve existing system cache markers and leave API-key and third-party provider requests unchanged.

## Reproduction

On current `main`, with valid Claude Code subscription credentials:

```sh
hermes -z 'Reply with exactly OK.' --provider anthropic -m claude-haiku-4-5 --safe-mode
```

Hermes returns HTTP 400 with `You're out of extra usage`.
The same prompt, model, and credentials return `OK` through interview-studio.
A controlled Hermes request with only the signed billing system block added also returns `OK`, isolating the missing marker from other request-shape differences.

## Verification

- [x] Reproduced the user-visible failure on current `main`.
- [x] Confirmed the same request succeeds through interview-studio.
- [x] Confirmed billing-marker-only Hermes request succeeds.
- [x] 112 Anthropic adapter, OAuth, keychain, and billing tests pass through `scripts/run_tests.sh`.
- [x] Full `ruff check .` passes.
- [x] Patched real Hermes one-shot returns `OK` with the configured Claude subscription.
- [ ] GitHub CI.

Closes #82064
