### PR TITLE
test(mcp): cover message-less AnyIO transport errors in session-expiry detection

### DIFF
--- a/tests/tools/test_mcp_tool_session_expired.py
+++ b/tests/tools/test_mcp_tool_session_expired.py
@@ -47,6 +47,56 @@ def test_is_session_expired_detects_session_not_found():
     assert _is_session_expired_error(RuntimeError("Unknown session: abc123")) is True
 
 
+def test_is_session_expired_detects_message_less_anyio_transport_errors():
+    """The bare AnyIO exceptions, not a RuntimeError carrying their name.
+
+    ``anyio.ClosedResourceError`` and friends are raised without an argument,
+    so ``str(exc)`` is ``""`` and marker matching alone cannot see them. This
+    is the exact shape both MCP transports emit when a stdio child dies or an
+    HTTP stream is torn down, so assert on the genuine types — a regression
+    here silently sends every post-teardown tool call to the caller as
+    ``ClosedResourceError`` instead of reconnecting (#61010).
+    """
+    import anyio
+
+    from tools.mcp_tool import _is_session_expired_error
+
+    for exc in (
+        anyio.ClosedResourceError(),
+        anyio.BrokenResourceError(),
+        anyio.EndOfStream(),
+    ):
+        assert str(exc) == ""  # guards the premise of this test
+        assert _is_session_expired_error(exc) is True, type(exc).__name__
+
+
+def test_is_session_expired_unwraps_message_less_error_inside_exception_group():
+    """AnyIO task groups surface transport failures inside an ExceptionGroup.
+
+    The group itself carries no session marker, so classification has to look
+    at the members. Same for the ``raise ... from exc`` wrapping the SDK does.
+    """
+    import anyio
+
+    from tools.mcp_tool import _is_session_expired_error
+
+    group = ExceptionGroup("unhandled errors in a TaskGroup", [anyio.ClosedResourceError()])
+    assert _is_session_expired_error(group) is True
+
+    wrapper = RuntimeError("transport failure")
+    wrapper.__cause__ = anyio.ClosedResourceError()
+    assert _is_session_expired_error(wrapper) is True
+
+
+def test_is_session_expired_ignores_unrelated_message_less_errors():
+    """Type-based detection must not turn every blank exception into a retry."""
+    from tools.mcp_tool import _is_session_expired_error
+
+    assert _is_session_expired_error(ValueError()) is False
+    assert _is_session_expired_error(KeyError()) is False
+    assert _is_session_expired_error(ExceptionGroup("boom", [ValueError()])) is False
+
+
 def test_is_session_expired_traversal_is_budget_bounded():
     """Pathologically long chains stop at the node budget without spinning."""
     import tools.mcp_tool as mcp_mod


### PR DESCRIPTION
## What does this PR do?

Adds regression coverage for the `isinstance`-based branch of `_is_session_expired_error()` — the part that makes stdio MCP recovery work at all.

`anyio.ClosedResourceError`, `BrokenResourceError` and `EndOfStream` are raised **without an argument**, so `str(exc)` is `""` and the `_SESSION_EXPIRED_MARKERS` substring match cannot see them. Detection therefore depends entirely on the type check. Nothing in the suite pinned that down: the closest existing case passes `RuntimeError("ClosedResourceError")`, a stand-in whose `str()` merely *contains* the name. Delete the `isinstance` branch and the suite still passes green, while in production every tool call after a transport teardown returns a raw `ClosedResourceError` to the caller instead of reconnecting.

That failure mode is what users report in #61010 (all stdio MCP servers failing with `ClosedResourceError`, servers listed as connected).

No production code is touched — `main` already classifies these correctly. This only stops the behaviour from silently regressing.

## Related Issue

Refs #61010

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tests/tools/test_mcp_tool_session_expired.py`:
  - `test_is_session_expired_detects_message_less_anyio_transport_errors` — the genuine bare AnyIO types, asserting `str(exc) == ""` first so the premise of the test is itself guarded.
  - `test_is_session_expired_unwraps_message_less_error_inside_exception_group` — the `ExceptionGroup` an AnyIO task group actually raises, plus the `__cause__` wrapper shape.
  - `test_is_session_expired_ignores_unrelated_message_less_errors` — negative case: blank `ValueError`/`KeyError` and a non-transport `ExceptionGroup` must still classify `False`, so the type check can't become a catch-all retry.

## How to Test

1. `pytest tests/tools/test_mcp_tool_session_expired.py -q` → 16 passed.
2. Reverse test (proves the tests bite): in `tools/mcp_tool.py::_is_session_expired_error`, delete
   ```python
   if isinstance(current, transport_error_types):
       transport_error_found = True
   ```
   Re-run → the two new detection tests fail. Restore → green again.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the tests and all pass (`scripts/run_tests.sh tests/tools/test_mcp_tool_session_expired.py` → 16 passed, 0 failed; `ruff check` clean)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 (WSL2)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (tests only)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (no platform-specific code; the AnyIO types are cross-platform)
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Reverse test, with the `isinstance` branch removed:

```
FAILED tests/tools/test_mcp_tool_session_expired.py::test_is_session_expired_detects_message_less_anyio_transport_errors
FAILED tests/tools/test_mcp_tool_session_expired.py::test_is_session_expired_unwraps_message_less_error_inside_exception_group
4 failed, 12 passed
```

Restored:

```
16 passed in 2.75s
```
