### PR TITLE
fix(cron): preserve profile context during session DB init

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3387,7 +3387,18 @@ def run_job(
         if _session_db_timeout > 0:
             _session_db_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
             try:
-                _session_db = _session_db_pool.submit(SessionDB).result(timeout=_session_db_timeout)
+                # The timeout worker is a second thread, so it does not inherit
+                # the multiplexed profile ContextVar automatically. Capture it
+                # before submitting SessionDB and pass the resolved database path
+                # explicitly so profile cron runs cannot fall back to the
+                # process-global default state.db.
+                _session_db_context = contextvars.copy_context()
+                _session_db_path = _get_hermes_home() / "state.db"
+                _session_db = _session_db_pool.submit(
+                    _session_db_context.run,
+                    SessionDB,
+                    db_path=_session_db_path,
+                ).result(timeout=_session_db_timeout)
             finally:
                 # Don't wait for a wedged connect() to unwind — abandon the
                 # worker thread (same pattern as the agent inactivity timeout

--- a/tests/cron/test_sessiondb_init_hang.py
+++ b/tests/cron/test_sessiondb_init_hang.py
@@ -73,6 +73,55 @@ def _session_db_executor(timeouts: list, *, instant_timeout: bool = True):
 
 
 class TestSessionDbInitTimeout:
+    def test_sessiondb_init_preserves_multiplex_profile_context(
+        self, tmp_path, monkeypatch
+    ):
+        """The timeout worker must construct SessionDB under the active profile."""
+        from hermes_constants import (
+            get_hermes_home,
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        default_home = tmp_path / "default"
+        profile_home = tmp_path / "profiles" / "jobsearch"
+        monkeypatch.setenv("HERMES_HOME", str(default_home))
+        observed_homes = []
+        observed_paths = []
+        fake_db = MagicMock()
+
+        def make_session_db(*, db_path=None):
+            observed_homes.append(get_hermes_home())
+            observed_paths.append(db_path)
+            return fake_db
+
+        job = {"id": "profile-sessiondb", "name": "test", "prompt": "hello"}
+        profile_token = set_hermes_home_override(profile_home)
+        try:
+            with patch("cron.scheduler._hermes_home", None), \
+                 patch("cron.scheduler._resolve_origin", return_value=None), \
+                 patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+                 patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+                 patch("hermes_state.SessionDB", side_effect=make_session_db), \
+                 patch(
+                     "hermes_cli.runtime_provider.resolve_runtime_provider",
+                     return_value=_RUNTIME,
+                 ), \
+                 patch("run_agent.AIAgent") as mock_agent_cls:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "ok"}
+                mock_agent_cls.return_value = mock_agent
+
+                success, _output, final_response, error = run_job(job)
+        finally:
+            reset_hermes_home_override(profile_token)
+
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+        assert observed_homes == [profile_home]
+        assert observed_paths == [profile_home / "state.db"]
+
     def test_run_job_does_not_hang_when_sessiondb_init_wedges(self, tmp_path, monkeypatch):
         """run_job proceeds without a session store when SessionDB init times out."""
         monkeypatch.setenv("HERMES_CRON_SESSION_DB_TIMEOUT", "0.2")


### PR DESCRIPTION
## What does this PR do?

Fixes profile isolation for cron session persistence in multiplexed gateways.

When `gateway.multiplex_profiles` is enabled, the cron scheduler correctly enters the active profile context. However, `run_job()` creates `SessionDB` inside a second timeout-protection `ThreadPoolExecutor`. That inner worker did not inherit the profile `ContextVar`, and the constructor had no explicit database path, so a job could load the secondary profile's `.env` and configuration while persisting its session to the process-global default `state.db`.

The fix captures the active context and resolves the profile-specific `state.db` path before submitting the constructor. It then runs `SessionDB(db_path=...)` under the copied context. Existing timeout and fallback behavior is unchanged.

## Related Issue

No existing issue found; reproduces in a multiplexed profile installation.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py`: preserve the active profile context and pass the resolved profile database path through the timeout worker used for `SessionDB` initialization.
- `tests/cron/test_sessiondb_init_hang.py`: add a regression test proving that a multiplexed profile's `SessionDB` constructor observes the profile home and receives its profile-specific database path rather than the process default.

## How to Test

1. Run the focused regression file:
   `pytest -q tests/cron/test_sessiondb_init_hang.py`
2. Run the full cron suite:
   `pytest -q tests/cron`
3. Run Ruff against the changed files:
   `ruff check cron/scheduler.py tests/cron/test_sessiondb_init_hang.py`

Results from the Ubuntu 24.04 test worktree:

- focused file: 5 passed
- full cron suite: 516 passed, 1 pre-existing runtime warning
- Ruff: all checks passed

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] My PR contains only changes related to this fix
- [x] I've added a regression test for the bug
- [x] I've tested on Ubuntu 24.04

### Documentation & Housekeeping

- [x] Documentation/config examples: N/A; no user-facing configuration changed
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

The production symptom was a cron session with `profile_name=jobsearch` written to the default profile database. No credentials or private logs are included here.
