### PR TITLE
fix(titles): fall back when JSON schema is unavailable

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -248,6 +248,15 @@ def derive_title(user_message: str) -> Optional[str]:
     return line or None
 
 
+def _response_format_is_unavailable(exc: Exception) -> bool:
+    """Return whether a provider rejected the requested response-format mode."""
+    message = str(exc).lower()
+    return "response_format" in message and any(
+        marker in message
+        for marker in ("unavailable", "unsupported", "not supported", "unknown")
+    )
+
+
 def _extract_title_text(content: str) -> str:
     """Pull the title out of a model response.
 
@@ -366,17 +375,31 @@ def generate_title(
     ]
 
     try:
-        response = call_llm(
-            task="title_generation",
-            messages=messages,
+        request_kwargs = {
+            "task": "title_generation",
+            "messages": messages,
             # A title is a handful of tokens. The old 500-token ceiling let a
             # chatty model burn seconds generating prose we then threw away.
-            max_tokens=64,
-            temperature=0.3,
-            timeout=timeout,
-            main_runtime=main_runtime,
-            extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
-        )
+            "max_tokens": 64,
+            "temperature": 0.3,
+            "timeout": timeout,
+            "main_runtime": main_runtime,
+        }
+        try:
+            response = call_llm(
+                **request_kwargs,
+                extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
+            )
+        except Exception as exc:
+            if not _response_format_is_unavailable(exc):
+                raise
+            logger.info(
+                "Title provider rejected json_schema; retrying with json_object"
+            )
+            response = call_llm(
+                **request_kwargs,
+                extra_body={"response_format": {"type": "json_object"}},
+            )
         content = response.choices[0].message.content or ""
         return _clean_title(_extract_title_text(content))
     except Exception as e:

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -46,7 +46,27 @@ class TestGenerateTitle:
         assert captured_kwargs["task"] == "title_generation"
         assert captured_kwargs["timeout"] is None
 
+    def test_retries_with_json_object_when_json_schema_is_unavailable(self):
+        calls = []
 
+        def mock_call_llm(**kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                raise RuntimeError("This response_format type is unavailable now")
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = '{"title":"Fix response format warning"}'
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            assert generate_title("fix the response format warning") == (
+                "Fix response format warning"
+            )
+
+        assert calls[0]["extra_body"]["response_format"]["type"] == "json_schema"
+        assert calls[1]["extra_body"] == {
+            "response_format": {"type": "json_object"}
+        }
 
     def test_strips_think_blocks(self):
         """Reasoning-model output wrapped in <think>...</think> must not


### PR DESCRIPTION
## Summary

- retain strict `json_schema` for providers that support it
- detect provider errors that explicitly reject the requested `response_format`
- retry title generation once with the broadly supported `json_object` mode
- preserve existing best-effort failure handling for unrelated API errors

## Problem

Delegated DeepSeek sessions route title generation through the worker's main runtime. DeepSeek currently rejects the strict JSON-schema response format with HTTP 400:

`This response_format type is unavailable now`

The title generator catches that error only at its outer best-effort boundary, producing a visible warning and leaving the deterministic title in place even though DeepSeek supports `json_object`.

## Verification

- `pytest tests/agent/test_title_generator.py -q` — 19 passed
- `ruff check agent/title_generator.py tests/agent/test_title_generator.py` — passed
- real `deepseek/deepseek-v4-flash` delegated-runtime probe:
  - strict `json_schema` request reproduced HTTP 400
  - compatibility fallback retried with `json_object`
  - retry returned HTTP 200 and a valid title

The fallback is narrowly gated on errors mentioning `response_format` together with an unavailable/unsupported marker; unrelated failures are not retried.
