### PR TITLE
feat(agent): warn when per-turn reasoning exceeds configurable budgets

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -979,7 +979,12 @@ def init_agent(
     # '<think>' as delta1 and 'Let me check' as delta2 — the regex
     # erased delta1, so downstream state machines never learned a
     # block was open and leaked delta2 as content).
-    agent._stream_think_scrubber = StreamingThinkScrubber()
+    _reasoning_budget_sink = getattr(agent, "_track_reasoning_budget_delta", None)
+    agent._stream_think_scrubber = StreamingThinkScrubber(
+        on_reasoning_delta=(
+            _reasoning_budget_sink if callable(_reasoning_budget_sink) else None
+        )
+    )
     # Visible assistant text already delivered through live token callbacks
     # during the current model response. Used to avoid re-sending the same
     # commentary when the provider later returns it as a completed interim

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2890,7 +2890,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     {"stream": stream},
                     on_text_delta=_on_text if agent._has_stream_consumers() else None,
                     on_tool_start=_on_tool,
-                    on_reasoning_delta=_on_reasoning if agent.reasoning_callback or agent.stream_delta_callback else None,
+                    # Budget accounting consumes the same reasoning stream even
+                    # when this caller has no live reasoning display callback.
+                    on_reasoning_delta=_on_reasoning,
                     on_interrupt_check=lambda: agent._interrupt_requested,
                     on_event=lambda: _bedrock_last_event.__setitem__("t", time.time()),
                 )

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3476,12 +3476,23 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 # reasoning display.  Non-reasoning text is harmlessly
                 # suppressed by the CLI's _stream_delta when the stream
                 # box is already closed (tool boundary flush).
-                elif agent.stream_delta_callback:
-                    try:
-                        agent.stream_delta_callback(delta.content)
-                        agent._record_streamed_assistant_text(delta.content)
-                    except Exception:
-                        pass
+                else:
+                    # Keep inline-reasoning accounting independent of the
+                    # presentation callback.  This content intentionally
+                    # bypasses _fire_stream_delta once a tool call is active,
+                    # but the shared think scrubber still owns split-tag state
+                    # and the reasoning-budget sink.
+                    think_scrubber = getattr(
+                        agent, "_stream_think_scrubber", None
+                    )
+                    if think_scrubber is not None:
+                        think_scrubber.feed(delta.content)
+                    if agent.stream_delta_callback:
+                        try:
+                            agent.stream_delta_callback(delta.content)
+                            agent._record_streamed_assistant_text(delta.content)
+                        except Exception:
+                            pass
 
             # Accumulate tool call deltas — notify display on first name
             if delta and delta.tool_calls:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2056,6 +2056,9 @@ def run_conversation(
         request_pressure_tokens = approx_tokens + (
             _estimate_tools_tokens_rough(agent.tools) if agent.tools else 0
         )
+        from agent.reasoning_budget import set_reasoning_prompt_tokens
+
+        set_reasoning_prompt_tokens(agent, request_pressure_tokens)
         total_chars = approx_tokens * 4
         # Stash this request's rough estimate so update_from_response() can
         # pair it with the provider's real prompt count — the (rough, real)

--- a/agent/reasoning_budget.py
+++ b/agent/reasoning_budget.py
@@ -1,0 +1,178 @@
+"""Per-turn reasoning-output budget accounting."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, Mapping
+
+from agent.model_metadata import estimate_tokens_rough
+
+
+@dataclass(frozen=True)
+class ReasoningBudgetConfig:
+    """Configuration for reasoning-output warnings."""
+
+    warn_after_tokens: int = 100_000
+    context_ratio: float = 8.0
+    ratio_min_tokens: int = 8_192
+    nudge_next_turn: bool = False
+
+    @classmethod
+    def from_mapping(cls, values: Mapping[str, Any] | None) -> "ReasoningBudgetConfig":
+        values = values if isinstance(values, Mapping) else {}
+        defaults = cls()
+
+        def _number(key: str, default: int | float, cast):
+            try:
+                return max(0, cast(values.get(key, default)))
+            except (TypeError, ValueError):
+                return default
+
+        raw_nudge = values.get("reasoning_warn_nudge", defaults.nudge_next_turn)
+        if isinstance(raw_nudge, str):
+            nudge = raw_nudge.strip().lower() in {"1", "true", "yes", "on"}
+        else:
+            nudge = bool(raw_nudge)
+        return cls(
+            warn_after_tokens=_number(
+                "reasoning_warn_after_tokens", defaults.warn_after_tokens, int
+            ),
+            context_ratio=_number(
+                "reasoning_warn_context_ratio", defaults.context_ratio, float
+            ),
+            ratio_min_tokens=_number(
+                "reasoning_warn_ratio_min_tokens", defaults.ratio_min_tokens, int
+            ),
+            nudge_next_turn=nudge,
+        )
+
+
+@dataclass(frozen=True)
+class ReasoningBudgetWarning:
+    """A newly crossed reasoning-budget threshold."""
+
+    reason: Literal["absolute", "ratio"]
+    reasoning_tokens: int
+    prompt_tokens: int
+
+
+class ReasoningBudgetTracker:
+    """Estimate streamed reasoning tokens and emit at most once per turn."""
+
+    _CHUNK_SIZE = 256
+
+    def __init__(self, config: ReasoningBudgetConfig) -> None:
+        self.config = config
+        self._estimated_tokens = 0
+        self._pending_text = ""
+        self.prompt_tokens = 0
+        self.warned = False
+
+    @property
+    def reasoning_tokens(self) -> int:
+        return self._estimated_tokens + estimate_tokens_rough(self._pending_text)
+
+    def set_prompt_tokens(self, prompt_tokens: int) -> None:
+        self.prompt_tokens = max(0, int(prompt_tokens or 0))
+
+    def reset_turn(self) -> None:
+        self._estimated_tokens = 0
+        self._pending_text = ""
+        self.prompt_tokens = 0
+        self.warned = False
+
+    def add_delta(self, text: str) -> ReasoningBudgetWarning | None:
+        if (
+            self.config.warn_after_tokens <= 0
+            or self.warned
+            or not isinstance(text, str)
+            or not text
+        ):
+            return None
+        self._pending_text += text
+        while len(self._pending_text) >= self._CHUNK_SIZE:
+            chunk = self._pending_text[: self._CHUNK_SIZE]
+            self._pending_text = self._pending_text[self._CHUNK_SIZE :]
+            self._estimated_tokens += estimate_tokens_rough(chunk)
+
+        tokens = self.reasoning_tokens
+        if self.config.warn_after_tokens > 0 and tokens >= self.config.warn_after_tokens:
+            self.warned = True
+            return ReasoningBudgetWarning(
+                reason="absolute",
+                reasoning_tokens=tokens,
+                prompt_tokens=self.prompt_tokens,
+            )
+        if (
+            self.config.context_ratio > 0
+            and self.prompt_tokens > 0
+            and tokens >= self.config.ratio_min_tokens
+            and tokens >= self.prompt_tokens * self.config.context_ratio
+        ):
+            self.warned = True
+            return ReasoningBudgetWarning(
+                reason="ratio",
+                reasoning_tokens=tokens,
+                prompt_tokens=self.prompt_tokens,
+            )
+        return None
+
+
+_CONCLUSION_NUDGE = (
+    "[System note: The previous model response used an unusually large "
+    "reasoning budget. Conclude directly or make the planned tool call now; "
+    "do not repeat prior analysis.]"
+)
+
+
+def _tracker_for(agent: Any) -> ReasoningBudgetTracker:
+    tracker = getattr(agent, "_reasoning_budget_tracker", None)
+    if isinstance(tracker, ReasoningBudgetTracker):
+        return tracker
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        raw_config = load_config_readonly()
+        agent_config = raw_config.get("agent", {}) if isinstance(raw_config, Mapping) else {}
+    except Exception:
+        agent_config = {}
+    tracker = ReasoningBudgetTracker(ReasoningBudgetConfig.from_mapping(agent_config))
+    agent._reasoning_budget_tracker = tracker
+    return tracker
+
+
+def set_reasoning_prompt_tokens(agent: Any, prompt_tokens: int) -> None:
+    """Record the current request size for the ratio threshold."""
+    _tracker_for(agent).set_prompt_tokens(prompt_tokens)
+
+
+def track_reasoning_delta(agent: Any, text: str) -> str | None:
+    """Account for a reasoning delta and return a new warning message, if any."""
+    tracker = _tracker_for(agent)
+    warning = tracker.add_delta(text)
+    if warning is None:
+        return None
+    if tracker.config.nudge_next_turn:
+        agent._pending_reasoning_budget_nudge = True
+    context = ""
+    if warning.prompt_tokens > 0:
+        ratio = warning.reasoning_tokens / warning.prompt_tokens
+        context = (
+            f" ({ratio:.1f}x the current ~{warning.prompt_tokens:,}-token "
+            "request context)"
+        )
+    return (
+        "⚠️ Reasoning budget warning: the model has produced "
+        f"~{warning.reasoning_tokens:,} reasoning tokens this turn{context}. "
+        "Consider interrupting if it is not making progress."
+    )
+
+
+def begin_reasoning_budget_turn(agent: Any) -> str:
+    """Reset turn accounting and consume any staged one-shot nudge."""
+    pending_nudge = bool(getattr(agent, "_pending_reasoning_budget_nudge", False))
+    agent._pending_reasoning_budget_nudge = False
+    tracker = getattr(agent, "_reasoning_budget_tracker", None)
+    if isinstance(tracker, ReasoningBudgetTracker):
+        tracker.reset_turn()
+    return _CONCLUSION_NUDGE if pending_nudge else ""

--- a/agent/think_scrubber.py
+++ b/agent/think_scrubber.py
@@ -56,7 +56,7 @@ intentional, bounded construct.
 
 from __future__ import annotations
 
-from typing import Tuple
+from typing import Callable, Tuple
 
 __all__ = ["StreamingThinkScrubber"]
 
@@ -92,10 +92,14 @@ class StreamingThinkScrubber:
     # Pre-compute the longest tag (for partial-tag hold-back bound).
     _MAX_TAG_LEN: int = max(len(tag) for tag in _OPEN_TAGS + _CLOSE_TAGS)
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        on_reasoning_delta: Callable[[str], None] | None = None,
+    ) -> None:
         self._in_block: bool = False
         self._buf: str = ""
         self._last_emitted_ended_newline: bool = True
+        self._on_reasoning_delta = on_reasoning_delta
 
     def reset(self) -> None:
         """Reset all state.  Call at the top of every new turn."""
@@ -126,9 +130,11 @@ class StreamingThinkScrubber:
                     # No close yet — hold back a potential partial
                     # close-tag prefix; discard everything else.
                     held = self._max_partial_suffix(buf, self._CLOSE_TAGS)
+                    self._emit_reasoning(buf[:-held] if held else buf)
                     self._buf = buf[-held:] if held else ""
                     return "".join(out)
                 # Found close: discard block content + tag, continue.
+                self._emit_reasoning(buf[:close_idx])
                 buf = buf[close_idx + close_len:]
                 self._in_block = False
             else:
@@ -149,7 +155,7 @@ class StreamingThinkScrubber:
                 if pair is not None and (
                     open_idx == -1 or pair[0] <= open_idx
                 ):
-                    start_idx, end_idx = pair
+                    start_idx, end_idx, content_start, content_end = pair
                     preceding = buf[:start_idx]
                     if preceding:
                         preceding = self._strip_orphan_close_tags(preceding)
@@ -158,6 +164,7 @@ class StreamingThinkScrubber:
                             self._last_emitted_ended_newline = (
                                 preceding.endswith("\n")
                             )
+                    self._emit_reasoning(buf[content_start:content_end])
                     buf = buf[end_idx:]
                     continue
 
@@ -253,7 +260,7 @@ class StreamingThinkScrubber:
         return best_idx, best_len
 
     def _find_earliest_closed_pair(self, buf: str):
-        """Return (start_idx, end_idx) of the earliest closed pair, else None.
+        """Return bounds for the earliest closed pair, else None.
 
         A closed pair is ``<tag>...</tag>`` of any variant.  Matches are
         case-insensitive and non-greedy (the closest close tag after
@@ -263,7 +270,7 @@ class StreamingThinkScrubber:
         earlier wins.
         """
         buf_lower = buf.lower()
-        best: "tuple[int, int] | None" = None
+        best: "tuple[int, int, int, int] | None" = None
         for open_tag, close_tag in zip(self._OPEN_TAGS, self._CLOSE_TAGS):
             open_lower = open_tag.lower()
             close_lower = close_tag.lower()
@@ -277,8 +284,24 @@ class StreamingThinkScrubber:
                 continue
             end_idx = close_idx + len(close_lower)
             if best is None or open_idx < best[0]:
-                best = (open_idx, end_idx)
+                best = (
+                    open_idx,
+                    end_idx,
+                    open_idx + len(open_lower),
+                    close_idx,
+                )
         return best
+
+    def _emit_reasoning(self, text: str) -> None:
+        """Report suppressed reasoning without affecting visible output."""
+        if not text or self._on_reasoning_delta is None:
+            return
+        try:
+            self._on_reasoning_delta(text)
+        except Exception:
+            # Display scrubbing is a privacy boundary. A telemetry consumer
+            # must never make suppressed reasoning leak into visible output.
+            pass
 
     def _find_open_at_boundary(
         self, buf: str, already_emitted: list[str],

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -445,6 +445,10 @@ def build_turn_context(
     if isinstance(persist_user_message, str):
         persist_user_message = sanitize_surrogates(persist_user_message)
 
+    from agent.reasoning_budget import begin_reasoning_budget_turn
+
+    reasoning_budget_nudge = begin_reasoning_budget_turn(agent)
+
     # Store stream callback for _interruptible_api_call to pick up.
     agent._stream_callback = stream_callback
     agent._persist_user_message_idx = None
@@ -1123,6 +1127,10 @@ def build_turn_context(
     # Multimodal (list) content can't take the string sidecar — append a
     # durable text part instead of dropping the fact.
     _gateway_notes = consume_gateway_turn_context_notes(agent)
+    if reasoning_budget_nudge:
+        _gateway_notes = "\n\n".join(
+            note for note in (_gateway_notes, reasoning_budget_nudge) if note
+        )
     if _gateway_notes:
         _gw_turn_content = (
             messages[current_turn_user_idx].get("content")

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -833,6 +833,17 @@ agent:
   # Recommended: 20-30 for focused tasks, 50-100 for open exploration
   max_turns: 500
 
+  # Warn once when one user turn streams an unusually large amount of model
+  # reasoning. Token counts are approximate. The absolute threshold and the
+  # ratio threshold (reasoning output / current request context) can each fire;
+  # ratio checks wait for ratio_min_tokens to avoid noise on tiny responses.
+  # Set reasoning_warn_after_tokens to 0 to disable the feature entirely.
+  reasoning_warn_after_tokens: 100000
+  reasoning_warn_context_ratio: 8.0
+  reasoning_warn_ratio_min_tokens: 8192
+  # Opt in to add a one-shot conclusion note to the next user-message sidecar.
+  reasoning_warn_nudge: false
+
   # Inactivity timeout for gateway agent runs (seconds, 0 = unlimited).
   # The agent can run indefinitely when actively calling tools or receiving
   # API responses.  Only fires after the agent has been idle for this duration.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -30,6 +30,12 @@ DEFAULT_CONFIG = {
     "max_live_sessions": 16,
     "agent": {
         "max_turns": 500,
+        # One-shot warning for unusually large streamed reasoning output.
+        # Set warn_after_tokens to 0 to disable both absolute and ratio checks.
+        "reasoning_warn_after_tokens": 100_000,
+        "reasoning_warn_context_ratio": 8.0,
+        "reasoning_warn_ratio_min_tokens": 8_192,
+        "reasoning_warn_nudge": False,
         # Inactivity timeout for gateway agent execution (seconds).
         # The agent can run indefinitely as long as it's actively calling
         # tools or receiving API responses.  Only fires when the agent has

--- a/run_agent.py
+++ b/run_agent.py
@@ -6492,13 +6492,26 @@ class AIAgent:
         if delivered:
             self._record_streamed_assistant_text(text)
 
+    def _track_reasoning_budget_delta(self, text: str) -> None:
+        """Account for reasoning text and surface a newly crossed budget."""
+        try:
+            from agent.reasoning_budget import track_reasoning_delta
+
+            warning_text = track_reasoning_delta(self, text)
+        except Exception:
+            logger.debug("Reasoning budget tracking failed", exc_info=True)
+            return
+        if warning_text:
+            self._emit_warning(warning_text)
+
     def _fire_reasoning_delta(self, text: str) -> None:
-        """Fire reasoning callback if registered."""
+        """Account for reasoning and fire its display callback if registered."""
         # Single-writer guard (#65991): fence out a superseded stream's
         # reasoning deltas the same way as content deltas.
         if self._stream_writer_superseded():
             self._note_dropped_stream_writer("_fire_reasoning_delta")
             return
+        self._track_reasoning_budget_delta(text)
         cb = self.reasoning_callback
         if cb is not None:
             try:

--- a/tests/agent/test_api_content_sidecar.py
+++ b/tests/agent/test_api_content_sidecar.py
@@ -269,6 +269,23 @@ class TestPrologueStamping:
         assert "api_content" not in ctx.messages[ctx.current_turn_user_idx]
         assert agent.api_content_at_persist is None
 
+    def test_reasoning_budget_nudge_is_a_one_shot_sidecar(self):
+        agent = _FakeAgent()
+        agent._pending_reasoning_budget_nudge = True
+
+        with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+            ctx = _build(agent)
+
+        msg = ctx.messages[ctx.current_turn_user_idx]
+        assert msg["content"] == "hello"
+        assert "previous model response used an unusually large" in msg["api_content"]
+        assert agent.api_content_at_persist == msg["api_content"]
+        assert agent._pending_reasoning_budget_nudge is False
+
+        with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+            next_ctx = _build(agent)
+        assert "api_content" not in next_ctx.messages[next_ctx.current_turn_user_idx]
+
     def test_no_stamp_for_codex_app_server(self):
         """codex_app_server turns bypass the api_messages build, so the
         injected bytes are never sent — stamping would persist a lie."""

--- a/tests/agent/test_reasoning_budget.py
+++ b/tests/agent/test_reasoning_budget.py
@@ -1,0 +1,189 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from agent.reasoning_budget import (
+    ReasoningBudgetConfig,
+    ReasoningBudgetTracker,
+    begin_reasoning_budget_turn,
+    set_reasoning_prompt_tokens,
+    track_reasoning_delta,
+)
+from agent.think_scrubber import StreamingThinkScrubber
+
+
+def test_absolute_budget_warns_once_at_token_threshold() -> None:
+    tracker = ReasoningBudgetTracker(
+        ReasoningBudgetConfig(
+            warn_after_tokens=4,
+            context_ratio=0,
+            ratio_min_tokens=0,
+            nudge_next_turn=False,
+        )
+    )
+    tracker.set_prompt_tokens(1_000)
+
+    for _ in range(12):
+        assert tracker.add_delta("a") is None
+
+    warning = tracker.add_delta("a")
+
+    assert warning is not None
+    assert warning.reason == "absolute"
+    assert warning.reasoning_tokens == 4
+    assert tracker.add_delta("more reasoning") is None
+
+
+def test_ratio_budget_warns_before_absolute_threshold() -> None:
+    tracker = ReasoningBudgetTracker(
+        ReasoningBudgetConfig(
+            warn_after_tokens=100,
+            context_ratio=2,
+            ratio_min_tokens=4,
+            nudge_next_turn=False,
+        )
+    )
+    tracker.set_prompt_tokens(2)
+
+    warning = tracker.add_delta("a" * 13)
+
+    assert warning is not None
+    assert warning.reason == "ratio"
+    assert warning.reasoning_tokens == 4
+    assert warning.prompt_tokens == 2
+
+
+def test_ratio_budget_waits_for_minimum_output_floor() -> None:
+    tracker = ReasoningBudgetTracker(
+        ReasoningBudgetConfig(
+            warn_after_tokens=100,
+            context_ratio=1,
+            ratio_min_tokens=5,
+            nudge_next_turn=False,
+        )
+    )
+    tracker.set_prompt_tokens(1)
+
+    assert tracker.add_delta("a" * 13) is None
+    assert tracker.add_delta("a" * 4).reason == "ratio"
+
+
+def test_zero_absolute_budget_disables_absolute_and_ratio_warnings() -> None:
+    tracker = ReasoningBudgetTracker(
+        ReasoningBudgetConfig(
+            warn_after_tokens=0,
+            context_ratio=1,
+            ratio_min_tokens=1,
+            nudge_next_turn=True,
+        )
+    )
+    tracker.set_prompt_tokens(1)
+
+    assert tracker.add_delta("a" * 1_000) is None
+
+
+def test_config_reads_agent_mapping_and_clamps_invalid_values() -> None:
+    config = ReasoningBudgetConfig.from_mapping(
+        {
+            "reasoning_warn_after_tokens": "64",
+            "reasoning_warn_context_ratio": "3.5",
+            "reasoning_warn_ratio_min_tokens": -10,
+            "reasoning_warn_nudge": "true",
+        }
+    )
+
+    assert config == ReasoningBudgetConfig(
+        warn_after_tokens=64,
+        context_ratio=3.5,
+        ratio_min_tokens=0,
+        nudge_next_turn=True,
+    )
+
+
+def test_runtime_defaults_match_config_defaults() -> None:
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+    assert ReasoningBudgetConfig.from_mapping(
+        DEFAULT_CONFIG["agent"]
+    ) == ReasoningBudgetConfig()
+
+
+def test_agent_helpers_stage_and_consume_one_shot_nudge() -> None:
+    agent = SimpleNamespace(
+        _reasoning_budget_tracker=ReasoningBudgetTracker(
+            ReasoningBudgetConfig(
+                warn_after_tokens=4,
+                context_ratio=0,
+                ratio_min_tokens=0,
+                nudge_next_turn=True,
+            )
+        ),
+        _pending_reasoning_budget_nudge=False,
+    )
+    set_reasoning_prompt_tokens(agent, 20)
+
+    warning_text = track_reasoning_delta(agent, "a" * 13)
+
+    assert warning_text is not None
+    assert "~4 reasoning tokens" in warning_text
+    assert "~20-token request context" in warning_text
+    assert agent._pending_reasoning_budget_nudge is True
+
+    nudge = begin_reasoning_budget_turn(agent)
+
+    assert "Conclude directly or make the planned tool call now" in nudge
+    assert agent._pending_reasoning_budget_nudge is False
+    assert agent._reasoning_budget_tracker.reasoning_tokens == 0
+    assert begin_reasoning_budget_turn(agent) == ""
+
+
+def test_shared_reasoning_sink_emits_budget_warning() -> None:
+    from run_agent import AIAgent
+
+    agent = object.__new__(AIAgent)
+    agent._reasoning_budget_tracker = ReasoningBudgetTracker(
+        ReasoningBudgetConfig(
+            warn_after_tokens=4,
+            context_ratio=0,
+            ratio_min_tokens=0,
+            nudge_next_turn=False,
+        )
+    )
+    agent._pending_reasoning_budget_nudge = False
+    agent._stream_writer_tls = None
+    agent.reasoning_callback = MagicMock()
+    agent._emit_warning = MagicMock()
+
+    agent._fire_reasoning_delta("a" * 13)
+
+    agent.reasoning_callback.assert_called_once_with("a" * 13)
+    agent._emit_warning.assert_called_once()
+    assert "~4 reasoning tokens" in agent._emit_warning.call_args.args[0]
+
+
+def test_inline_think_stream_counts_suppressed_reasoning() -> None:
+    agent = SimpleNamespace(
+        _reasoning_budget_tracker=ReasoningBudgetTracker(
+            ReasoningBudgetConfig(
+                warn_after_tokens=4,
+                context_ratio=0,
+                ratio_min_tokens=0,
+                nudge_next_turn=False,
+            )
+        ),
+        _pending_reasoning_budget_nudge=False,
+    )
+    warnings: list[str] = []
+    scrubber = StreamingThinkScrubber(
+        on_reasoning_delta=lambda text: warnings.append(
+            track_reasoning_delta(agent, text) or ""
+        )
+    )
+
+    visible = "".join(
+        scrubber.feed(delta)
+        for delta in ("<think>", "a" * 13, "</think>", "done")
+    )
+
+    assert visible == "done"
+    assert len([warning for warning in warnings if warning]) == 1
+    assert "~4 reasoning tokens" in next(w for w in warnings if w)

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -478,6 +478,59 @@ class TestReasoningStreaming:
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_tool_call_inline_reasoning_counts_without_display_callback(
+        self, mock_close, mock_create
+    ):
+        """Suppressed tool-call content still reaches the shared budget sink."""
+        from agent.reasoning_budget import (
+            ReasoningBudgetConfig,
+            ReasoningBudgetTracker,
+        )
+        from run_agent import AIAgent
+
+        chunks = [
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(
+                    index=0,
+                    tc_id="call_123",
+                    name="terminal",
+                )
+            ]),
+            _make_stream_chunk(content="<think>"),
+            _make_stream_chunk(content="a" * 13),
+            _make_stream_chunk(content="</think>"),
+            _make_stream_chunk(finish_reason="tool_calls"),
+        ]
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter(chunks)
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+        agent._reasoning_budget_tracker = ReasoningBudgetTracker(
+            ReasoningBudgetConfig(
+                warn_after_tokens=4,
+                context_ratio=0,
+                ratio_min_tokens=0,
+                nudge_next_turn=False,
+            )
+        )
+        agent._emit_warning = MagicMock()
+
+        agent._interruptible_streaming_api_call({})
+
+        agent._emit_warning.assert_called_once()
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
     def test_reasoning_callback_fires(self, mock_close, mock_create):
         """Reasoning deltas fire the reasoning_callback."""
         from run_agent import AIAgent

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -980,6 +980,20 @@ When the iteration budget is fully exhausted, the CLI shows a notification to th
 
 `agent.api_max_retries` controls how many times Hermes retries a provider API call on transient errors (rate limits, connection drops, 5xx) **before** fallback-provider switching engages. The default is `3` — four attempts total. If you have [fallback providers](/user-guide/features/fallback-providers) configured and want to fail over faster, drop this to `0` so the first transient error on your primary immediately hands off to the fallback instead of churning retries against the flaky endpoint.
 
+## Reasoning Output Budget Warnings
+
+Hermes can warn when a single user turn streams an unusually large amount of model reasoning. The check is provider-independent: structured reasoning deltas from chat-completions, Anthropic, Bedrock, and Codex transports all pass through the same counter. It never stops the stream automatically; it emits one visible warning per user turn so you can decide whether to interrupt.
+
+```yaml
+agent:
+  reasoning_warn_after_tokens: 100000    # Absolute approximate-token threshold; 0 disables the feature
+  reasoning_warn_context_ratio: 8.0      # Also warn at 8x the current request-context estimate; 0 disables this check
+  reasoning_warn_ratio_min_tokens: 8192  # Do not apply the ratio check below this output size
+  reasoning_warn_nudge: false            # Add a one-shot conclusion note to the next user-message sidecar
+```
+
+Token counts are approximate. Either the absolute threshold or the ratio threshold can trigger the warning; the ratio floor avoids noisy warnings on tiny prompts and responses. Set `reasoning_warn_after_tokens: 0` to disable both checks. The optional nudge is off by default and is attached to the next user message rather than changing the conversation's cached system prompt.
+
 ## Verify-on-Stop (coding verification)
 
 When enabled, Hermes refuses to accept a final answer on a turn where the agent edited code in a workspace but produced no fresh verification evidence (a passing test run, build, lint, etc.) — it injects a synthetic follow-up asking the agent to verify or explain why it can't. Doc/markdown/skill-only edits never trigger it, and the loop is bounded so it can never trap the agent.


### PR DESCRIPTION
## What does this PR do?

Adds configurable, one-shot warnings when a model's streamed reasoning exceeds either an absolute per-turn token estimate or a configurable ratio to the current request context. The stream remains uninterrupted, so users can decide whether a long reasoning task is productive while gaining visibility before repeated reasoning is carried into later requests.

Warnings flow through the existing reasoning-delta path across supported transports. An optional next-turn sidecar can also ask the model to conclude or make its planned tool call without mutating the cached system prompt.

## Related Issue

Closes #82032

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/reasoning_budget.py` adds per-turn approximate-token accounting, absolute and request-context ratio thresholds, one-shot warning behavior, and an optional conclusion nudge.
- `agent/think_scrubber.py` and `agent/chat_completion_helpers.py` route structured and inline reasoning through the shared budget sink, including content suppressed after a tool-call boundary.
- `agent/turn_context.py`, `agent/conversation_loop.py`, `agent/agent_init.py`, and `run_agent.py` reset turn state, record request size, emit warnings through existing UI plumbing, and stage the optional cache-safe sidecar.
- `hermes_cli/config_defaults.py`, `cli-config.yaml.example`, and `website/docs/user-guide/configuration.md` document defaults and disable semantics.
- Focused tests cover absolute, ratio, disabled, one-shot, nudge, sidecar, and streaming behavior.

## How to Test

1. Configure a low `agent.reasoning_warn_after_tokens` value and start a reasoning-model turn that streams more reasoning than the threshold; verify exactly one warning appears and the response continues.
2. Set `agent.reasoning_warn_after_tokens: 0`; verify no budget warning is emitted.
3. Run the focused automated suite:

```bash
scripts/run_tests.sh tests/agent/test_reasoning_budget.py tests/agent/test_api_content_sidecar.py tests/run_agent/test_streaming.py -k 'not anthropic'
C:/workspace/hermes-agent/.venv/Scripts/python.exe scripts/check-windows-footguns.py agent/agent_init.py agent/chat_completion_helpers.py agent/conversation_loop.py agent/reasoning_budget.py agent/think_scrubber.py agent/turn_context.py hermes_cli/config_defaults.py run_agent.py tests/agent/test_api_content_sidecar.py tests/agent/test_reasoning_budget.py tests/run_agent/test_streaming.py
```

Result: 66 passed, 0 failed; no Windows footguns found in the 11 scanned Python files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all 66 selected tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example` for the new config keys
- [x] N/A - no contributor architecture or workflow documentation changed
- [x] I've considered cross-platform impact; the feature uses provider-neutral Python paths
- [x] N/A - no tool descriptions or schemas changed

## Screenshots / Logs

```text
=== Summary: 3 files, 66 tests passed, 0 failed (100% complete) ===
```
