### PR TITLE
fix(desktop): make the HUD grabbable, and stop it painting over dead space

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -10034,6 +10034,23 @@ ipcMain.on('hermes:hud:ignore-mouse', (_event, ignore) => {
   }
 })
 
+ipcMain.on('hermes:hud:move-by', (event, delta) => {
+  if (!hudWindow || hudWindow.isDestroyed() || event.sender !== hudWindow.webContents) {
+    return
+  }
+
+  const dx = Number(delta?.x)
+  const dy = Number(delta?.y)
+
+  if (!Number.isFinite(dx) || !Number.isFinite(dy)) {
+    return
+  }
+
+  const [x, y] = hudWindow.getPosition()
+
+  hudWindow.setPosition(Math.round(x + dx), Math.round(y + dy))
+})
+
 // The HUD renderer reporting which session it is on, so the close broadcast
 // can hand it back to the app window (see hudSessionId).
 ipcMain.on('hermes:hud:session', (event, sessionId) => {

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -53,6 +53,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     open: request => ipcRenderer.invoke('hermes:hud:open', request),
     close: () => ipcRenderer.invoke('hermes:hud:close'),
     setIgnoreMouse: ignore => ipcRenderer.send('hermes:hud:ignore-mouse', ignore),
+    moveBy: delta => ipcRenderer.send('hermes:hud:move-by', delta),
     setVibrancy: on => ipcRenderer.invoke('hermes:hud:vibrancy', on),
     // The HUD tells main which session it is on; main hands that back to the
     // app window when the HUD closes, so the app can re-home onto it.

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -2,6 +2,7 @@ import { ComposerPrimitive } from '@assistant-ui/react'
 import { useStore } from '@nanostores/react'
 import { type ClipboardEvent, type FormEvent, type KeyboardEvent, useCallback, useEffect, useMemo, useRef } from 'react'
 
+import { useHudComposerDrag } from '@/app/hud/composer-drag'
 import { composerFill, composerFloatingStrip, composerSurfaceGlass } from '@/components/chat/composer-dock'
 import { Button } from '@/components/ui/button'
 import { Slot as ContribSlot } from '@/contrib/react/slot'
@@ -16,6 +17,7 @@ import { sessionCompacting } from '@/store/compaction'
 import { browseBackward, browseForward, deriveUserHistory, isBrowsingHistory } from '@/store/composer-input-history'
 import { POPOUT_WIDTH_REM } from '@/store/composer-popout'
 import { parkQueuedPrompts, removeQueuedPrompt, unparkQueuedPrompts } from '@/store/composer-queue'
+import { $hudMode } from '@/store/hud'
 import { toggleReview } from '@/store/review'
 import { $gatewayState } from '@/store/session'
 import { $threadScrolledUp } from '@/store/thread-scroll'
@@ -100,6 +102,9 @@ export function ChatBar({
   onSubmit: onSubmitProp,
   onTranscribeAudio
 }: ChatBarProps) {
+  const hudMode = useStore($hudMode)
+  const { grabbing: hudGrabbing, onPointerDown: onHudDragPointerDown } = useHudComposerDrag(hudMode)
+
   // Typed stop phrase during an active voice conversation ends it — same
   // semantics as SAYING "stop" (voice-stop-word.ts) or clicking the pill's
   // end control. Populated after useComposerVoice below (the submit wrapper
@@ -1123,11 +1128,14 @@ export function ChatBar({
             data-slot="composer-root"
             data-status-stack={statusStackVisible ? '' : undefined}
             data-thread-scrolled-up={scrolledUp ? '' : undefined}
+            data-hud-grabbing={hudGrabbing ? '' : undefined}
             onDragEnter={handleDragEnter}
             onDragLeave={handleDragLeave}
             onDragOver={handleDragOver}
             onDrop={handleDrop}
-            onPointerDown={popoutAllowed ? onComposerGesturePointerDown : undefined}
+            onPointerDown={
+              hudMode ? onHudDragPointerDown : popoutAllowed ? onComposerGesturePointerDown : undefined
+            }
             onSubmit={e => {
               e.preventDefault()
 

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -1180,6 +1180,7 @@ export function ChatBar({
               />
             )}
             <div className="relative w-full rounded-[inherit]">
+              {hudMode && busy && <span aria-hidden className="arc-border arc-composer" />}
               <div
                 className={cn(
                   'group/composer-surface relative z-4 isolate grid grid-rows-[auto_1fr] overflow-hidden rounded-[inherit] border border-[color-mix(in_srgb,var(--dt-composer-ring)_calc(18%*var(--composer-ring-strength)),var(--dt-input))]',

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -1124,11 +1124,11 @@ export function ChatBar({
               dragging && 'cursor-grabbing select-none touch-none'
             )}
             data-drag-active={dragActive ? '' : undefined}
+            data-hud-grabbing={hudGrabbing ? '' : undefined}
             data-popped-out={poppedOut ? '' : undefined}
             data-slot="composer-root"
             data-status-stack={statusStackVisible ? '' : undefined}
             data-thread-scrolled-up={scrolledUp ? '' : undefined}
-            data-hud-grabbing={hudGrabbing ? '' : undefined}
             onDragEnter={handleDragEnter}
             onDragLeave={handleDragLeave}
             onDragOver={handleDragOver}

--- a/apps/desktop/src/app/hud/click-through.ts
+++ b/apps/desktop/src/app/hud/click-through.ts
@@ -26,6 +26,13 @@ export function hudIgnoresMouse(
   active: Element | null,
   windowFocused: boolean
 ): boolean {
+  // A long-press drag in progress owns the window until it lets go. The cursor
+  // outruns the window it is moving, so the hit test goes empty mid-drag and
+  // would otherwise hand the mouse away underneath the user's own hand.
+  if (root.querySelector('[data-hud-grabbing]') !== null) {
+    return false
+  }
+
   const overSomething = hit !== null && !hit.contains(root)
   // `windowFocused` is what stops a stale `active` — the composer keeps focus
   // after you click away to another app — pinning the HUD solid forever.
@@ -52,6 +59,12 @@ export function hudIgnoresMouse(
  * whenever a portalled overlay holds focus. `forward: true` keeps mousemove
  * flowing while ignoring, which is what lets it re-arm when the cursor comes
  * back to the bar.
+ *
+ * It follows that nothing in HUD mode may declare `-webkit-app-region: drag`
+ * at all: a draggable region swallows the page's mouse events, so the moves
+ * never arrive and the window is stranded on whatever it last decided —
+ * usually transparent, which is also why pressing the handle fell through to
+ * the app behind. Dragging is `useHudComposerDrag` instead.
  */
 export function useHudClickThrough(rootRef: RefObject<HTMLElement | null>): void {
   useEffect(() => {
@@ -89,14 +102,31 @@ export function useHudClickThrough(rootRef: RefObject<HTMLElement | null>): void
       apply()
     }
 
+    // Whenever we stop knowing where the cursor is, hand the window back. Solid
+    // is only ever right under a cursor we can still see: the last point we saw
+    // is usually the bar, and holding that answer means the whole rectangle
+    // keeps eating clicks long after the cursor has left for another app. It
+    // costs nothing to give up — `forward: true` keeps the moves arriving while
+    // ignoring, so the bar is solid again well before a click reaches it.
+    const onLost = () => {
+      point = null
+      apply()
+    }
+
     apply()
     window.addEventListener('mousemove', onMove)
+    window.addEventListener('blur', onLost)
+    window.addEventListener('focus', apply)
+    document.addEventListener('mouseleave', onLost)
     document.addEventListener('focusin', apply)
     document.addEventListener('focusout', apply)
 
     return () => {
       setIgnoreMouse(false)
       window.removeEventListener('mousemove', onMove)
+      window.removeEventListener('blur', onLost)
+      window.removeEventListener('focus', apply)
+      document.removeEventListener('mouseleave', onLost)
       document.removeEventListener('focusin', apply)
       document.removeEventListener('focusout', apply)
     }

--- a/apps/desktop/src/app/hud/composer-drag.ts
+++ b/apps/desktop/src/app/hud/composer-drag.ts
@@ -97,7 +97,6 @@ export function useHudComposerDrag(enabled: boolean) {
     [enabled]
   )
 
-  // eslint-disable-next-line no-restricted-syntax -- pointer session, not atom mirror
   useEffect(() => {
     if (!enabled) {
       return

--- a/apps/desktop/src/app/hud/composer-drag.ts
+++ b/apps/desktop/src/app/hud/composer-drag.ts
@@ -1,0 +1,164 @@
+import { type PointerEvent as ReactPointerEvent, useCallback, useEffect, useRef, useState } from 'react'
+
+import { triggerHaptic } from '@/lib/haptics'
+
+/** Hold anywhere on the HUD composer before the bar becomes draggable. Short
+ *  enough to feel like grabbing it, long enough that a click still clicks. */
+const LONG_PRESS_MS = 140
+/** Slop before the hold is read as a text selection instead of a grab. */
+const MOVE_TOLERANCE = 8
+
+interface PressState {
+  armed: boolean
+  lastX: number
+  lastY: number
+  pointerId: number
+  startX: number
+  startY: number
+  target: HTMLElement
+}
+
+/**
+ * HUD-only: press and hold the composer, then drag to move the window.
+ *
+ * The only way to move the HUD. An `-webkit-app-region: drag` handle is the
+ * obvious alternative and cannot work here: the window manager takes a drag
+ * region's mouse input whole, which starves `useHudClickThrough` of the moves
+ * it decides solidity from, so the window is already transparent by the time
+ * the press lands and it falls through to the app behind. See click-through.ts.
+ *
+ * Deltas are read in SCREEN coordinates. Client coordinates are relative to the
+ * window we are moving, so a window that keeps up with the cursor reports the
+ * same clientX every frame — zero delta, and the drag dies one pixel in.
+ */
+export function useHudComposerDrag(enabled: boolean) {
+  const [grabbing, setGrabbing] = useState(false)
+  const stateRef = useRef<PressState | null>(null)
+  const timerRef = useRef<number | null>(null)
+
+  const reset = useCallback(() => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+
+    const state = stateRef.current
+
+    if (state?.target.hasPointerCapture(state.pointerId)) {
+      state.target.releasePointerCapture(state.pointerId)
+    }
+
+    stateRef.current = null
+    setGrabbing(false)
+  }, [])
+
+  const onPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => {
+      if (!enabled || event.button !== 0) {
+        return
+      }
+
+      const target = event.currentTarget
+
+      stateRef.current = {
+        armed: false,
+        lastX: event.screenX,
+        lastY: event.screenY,
+        pointerId: event.pointerId,
+        startX: event.screenX,
+        startY: event.screenY,
+        target
+      }
+
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current)
+      }
+
+      timerRef.current = window.setTimeout(() => {
+        const state = stateRef.current
+
+        if (!state || state.armed) {
+          return
+        }
+
+        state.armed = true
+        setGrabbing(true)
+        triggerHaptic('selection')
+
+        // Capture so the moves keep arriving once the cursor outruns the bar,
+        // and drop the caret so the drag isn't also extending a selection.
+        state.target.setPointerCapture(state.pointerId)
+
+        if (document.activeElement instanceof HTMLElement) {
+          document.activeElement.blur()
+        }
+      }, LONG_PRESS_MS)
+    },
+    [enabled]
+  )
+
+  // eslint-disable-next-line no-restricted-syntax -- pointer session, not atom mirror
+  useEffect(() => {
+    if (!enabled) {
+      return
+    }
+
+    const onMove = (event: PointerEvent) => {
+      const state = stateRef.current
+
+      if (!state || event.pointerId !== state.pointerId) {
+        return
+      }
+
+      if (!state.armed) {
+        if (
+          Math.abs(event.screenX - state.startX) > MOVE_TOLERANCE ||
+          Math.abs(event.screenY - state.startY) > MOVE_TOLERANCE
+        ) {
+          reset()
+        }
+
+        return
+      }
+
+      event.preventDefault()
+
+      const dx = event.screenX - state.lastX
+      const dy = event.screenY - state.lastY
+
+      state.lastX = event.screenX
+      state.lastY = event.screenY
+
+      window.hermesDesktop?.hud?.moveBy?.({ x: dx, y: dy })
+    }
+
+    const onUp = (event: PointerEvent) => {
+      const state = stateRef.current
+
+      if (!state || event.pointerId !== state.pointerId) {
+        return
+      }
+
+      // A completed hold is a grab, not a click on whatever was underneath it.
+      if (state.armed) {
+        window.addEventListener('click', click => click.stopPropagation(), { capture: true, once: true })
+      }
+
+      reset()
+    }
+
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onUp)
+    window.addEventListener('pointercancel', onUp)
+
+    return () => {
+      window.removeEventListener('pointermove', onMove)
+      window.removeEventListener('pointerup', onUp)
+      window.removeEventListener('pointercancel', onUp)
+    }
+  }, [enabled, reset])
+
+  useEffect(() => reset, [reset])
+
+  return { grabbing, onPointerDown }
+}

--- a/apps/desktop/src/app/hud/hud-shell.tsx
+++ b/apps/desktop/src/app/hud/hud-shell.tsx
@@ -46,6 +46,15 @@ const HUD_COLLAPSE_MS = Math.round(HUD_FADE_MS * 0.66)
  *  so an empty transcript measures a true zero instead of a 12px strip. */
 const HUD_SHEET_OVERHANG_PX = 12
 
+/** Ceiling on the transcript band, which still auto-sizes up from 0. It reads
+ *  over another app, so it is a glance rather than a panel: whichever of these
+ *  is smaller wins, so a tall HUD doesn't turn the band into a second window
+ *  and a short one doesn't get swallowed by it. */
+const HUD_BAND_MAX_PX = 152
+const HUD_BAND_MAX_FRACTION = 0.42
+
+const hudBandMaxPx = () => Math.min(window.innerHeight * HUD_BAND_MAX_FRACTION, HUD_BAND_MAX_PX)
+
 /** Composer on top, transcript always hanging below it — Spotlight's shape,
  *  rather than flipping to follow the screen edge the HUD is parked against. */
 const HUD_THREAD_ALWAYS_BELOW = true
@@ -216,11 +225,7 @@ export function HudShell() {
     }
   }, [])
 
-  // Whether the thread actually overflows its band. Gates the band's no-drag
-  // carve-out (styles.css): a band with nothing to scroll stays part of the
-  // window's drag region, so a short conversation never blocks moving the HUD.
-  const [scrollable, setScrollable] = useState(false)
-  // Whether the sheet reaches the top of the window. Gates the frost, which is
+  // Whether bar + band actually cover the window. Gates the frost, which is
   // native vibrancy and therefore the WINDOW's content view — it fills the whole
   // rectangle and nothing in the page can clip it to the sheet. Whenever the
   // sheet is shorter than the window, the difference is frost over empty space:
@@ -255,33 +260,25 @@ export function HudShell() {
         }
       }
 
-      setScrollable(Boolean(el && el.scrollHeight > el.clientHeight + 4))
-
-      // How tall the band actually needs to be. The transcript is packed to the
-      // bottom, so this is the distance from the topmost visible row down to the
-      // bar — which is 0 on a fresh session, and the glass then collapses behind
-      // the bar instead of painting an empty slab over the whole window.
-      //
-      // Written straight to the element rather than through state: it changes on
-      // every stream flush, and the sheet resizing must not re-render the tree.
+      // How tall the band actually needs to be — the tight bbox of the message
+      // rows only. Measuring to the viewport edge counted the full-window scroll
+      // container (min-height: 100%) as transcript and painted a empty slab almost
+      // the size of the HUD.
       const rows = el?.querySelectorAll<HTMLElement>('[data-slot="aui_thread-content"] > *:not([data-slot])')
-      const box = el?.getBoundingClientRect()
 
-      // Measured from the bar outward, so it flips with the layout: parked at
-      // the bottom the transcript grows up from the bar, parked at the top it
-      // hangs down from it.
-      const span =
-        !rows?.length || !box
-          ? 0
-          : HUD_SHEET_OVERHANG_PX +
-            (root.dataset.hudEdge === 'top'
-              ? rows[rows.length - 1].getBoundingClientRect().bottom - box.top
-              : box.bottom - rows[0].getBoundingClientRect().top)
+      // Zero-height rows are not a transcript. A fresh thread still renders
+      // scaffolding inside the content box (clearance, empty state), so
+      // counting rows alone paid the overhang for nothing and left a sliver of
+      // sheet hanging under the bar with no text in it.
+      const text = !rows?.length
+        ? 0
+        : Math.max(0, rows[rows.length - 1].getBoundingClientRect().bottom - rows[0].getBoundingClientRect().top)
 
-      root.style.setProperty('--hud-band-height', `${Math.max(0, Math.round(span))}px`)
-      // The sheet is capped at the window (`min(100%, …)`), so reaching the
-      // window's height is the same question as covering it.
-      setFilled(span >= window.innerHeight)
+      const contentSpan = text < 1 ? 0 : text + HUD_SHEET_OVERHANG_PX
+
+      const visible = Math.min(hudBandMaxPx(), Math.max(0, Math.round(contentSpan)))
+
+      root.style.setProperty('--hud-band-height', `${visible}px`)
 
       // …and the bar's real height, which is what the thread has to clear.
       // --composer-measured-height would be the obvious source, but it is a
@@ -296,7 +293,7 @@ export function HudShell() {
         root.style.setProperty('--hud-bar-height', `${Math.round(barHeight)}px`)
       }
 
-      void barHeight
+      setFilled(barHeight + visible >= window.innerHeight - 1)
     }
 
     // The viewport mounts async (lazy chat surface); poll briefly until it
@@ -310,9 +307,9 @@ export function HudShell() {
     }
   }, [])
 
-  useHudThreadFocus(rootRef)
   useHudGlass(rootRef, recent || held, filled)
   useHudClickThrough(rootRef)
+  useHudThreadFocus(rootRef)
 
   // Force the HOST layers transparent. index.html's pre-paint script writes an
   // opaque themed background onto <html> as an INLINE style (the anti-white-

--- a/apps/desktop/src/app/hud/hud-shell.tsx
+++ b/apps/desktop/src/app/hud/hud-shell.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react'
-import { type CSSProperties, useEffect, useRef, useState } from 'react'
+import { type CSSProperties, useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router'
 
 import { Button } from '@/components/ui/button'
@@ -144,7 +144,10 @@ function useRecentActivity(): [boolean, () => void] {
     }
   }, [])
 
-  return [recent, () => bumpRef.current()]
+  // Stable, so callers can hang listeners off it.
+  const holdBand = useCallback(() => bumpRef.current(), [])
+
+  return [recent, holdBand]
 }
 
 /**
@@ -182,6 +185,17 @@ export function HudShell() {
   const { t } = useI18n()
   const [recent, holdBand] = useRecentActivity()
   const held = useHudHeld()
+
+  // Clicking away to another APP is the most common way the HUD is let go of,
+  // and it fires no focusout: the composer stays document.activeElement while
+  // the window is inactive. Chrome stops matching `:focus` on an unfocused
+  // window all the same, so the band lost its focus state with no hold running
+  // and snapped shut instead of stepping down to the glanceable stage.
+  useEffect(() => {
+    window.addEventListener('blur', holdBand)
+
+    return () => window.removeEventListener('blur', holdBand)
+  }, [holdBand])
 
   // Main holds the session id on this window's behalf, so leaving HUD mode can
   // hand the app window back whatever conversation ended up here.

--- a/apps/desktop/src/app/hud/hud-shell.tsx
+++ b/apps/desktop/src/app/hud/hud-shell.tsx
@@ -23,8 +23,12 @@ import { useHudThreadFocus } from './thread-focus'
 /** How long the transcript lingers at its glanceable opacity — after a turn
  *  lands, or after you let go of the composer — before it goes. This is the ONLY
  *  hold: the CSS carries no transition-delay, because two stacked holds read as
- *  a third fade state that nobody asked for. Focus keeps it open past this. */
-const HUD_RECENT_HOLD_MS = 700
+ *  a third fade state that nobody asked for. Focus keeps it open past this.
+ *
+ *  Long enough to actually be the middle stage. Under a second it read as part
+ *  of the fade rather than a state you could still glance at and finish
+ *  reading. */
+const HUD_RECENT_HOLD_MS = 2500
 
 /** Band visibility timings, published to CSS as custom properties so this
  *  module and the stylesheet cannot drift apart. Reveal is quick — it is an
@@ -88,9 +92,13 @@ function useRecentActivity(): [boolean, () => void] {
   useEffect(() => {
     let signature = ''
 
-    const bump = () => {
+    // `letGo` is the deliberate gesture — clicking away from the composer —
+    // and always buys the full window. Ambient activity does not, unless the
+    // composer has focus: whatever is left of the current hold is what a HUD
+    // nobody is looking at gets.
+    const bump = (letGo = false) => {
       if (timerRef.current) {
-        if (!composerHasFocus()) {
+        if (!letGo && !composerHasFocus()) {
           return
         }
 
@@ -119,7 +127,7 @@ function useRecentActivity(): [boolean, () => void] {
       bump()
     }
 
-    bumpRef.current = bump
+    bumpRef.current = () => bump(true)
 
     // subscribe() fires immediately, so a HUD opened onto an existing
     // conversation starts with the thread showing, then fades.

--- a/apps/desktop/src/app/hud/hud-shell.tsx
+++ b/apps/desktop/src/app/hud/hud-shell.tsx
@@ -17,6 +17,7 @@ import { titlebarButtonClass } from '../shell/titlebar'
 import { useHudClickThrough } from './click-through'
 import { useHudGlass } from './glass'
 import { useHudGoto, useReportHudSession } from './handoff'
+import { useHudThreadFocus } from './thread-focus'
 
 /** How long the transcript lingers at its glanceable opacity — after a turn
  *  lands, or after you let go of the composer — before it goes. This is the ONLY
@@ -308,6 +309,7 @@ export function HudShell() {
     }
   }, [])
 
+  useHudThreadFocus(rootRef)
   useHudGlass(rootRef, recent || held, filled)
   useHudClickThrough(rootRef)
 

--- a/apps/desktop/src/app/hud/hud-shell.tsx
+++ b/apps/desktop/src/app/hud/hud-shell.tsx
@@ -11,6 +11,7 @@ import { closeHud } from '@/store/hud'
 import { $activeSessionAwaitingInput } from '@/store/prompts'
 import { $busy, $messages } from '@/store/session'
 
+import { RICH_INPUT_SLOT } from '../chat/composer/rich-editor'
 import { WiredPane } from '../contrib/wiring'
 import { titlebarButtonClass } from '../shell/titlebar'
 
@@ -59,16 +60,23 @@ const hudBandMaxPx = () => Math.min(window.innerHeight * HUD_BAND_MAX_FRACTION, 
  *  rather than flipping to follow the screen edge the HUD is parked against. */
 const HUD_THREAD_ALWAYS_BELOW = true
 
+const composerHasFocus = () =>
+  document.activeElement?.closest(`[data-slot="${RICH_INPUT_SLOT}"]`) != null
+
 /**
  * True for a hold window after any conversation activity (a message landing,
  * a stream flushing, a turn starting or ending). The CSS uses it — alongside
  * :focus-within — to decide whether the thread is visible; idle HUD mode is
  * just the Spotlight bar.
  *
- * $messages replaces ~30×/s mid-stream, so activity RESTARTS the timer on
- * every flush — the thread stays up while a reply is writing and for the hold
- * window after it finishes, without a per-flush re-render (state only changes
- * on the false↔true edges).
+ * $messages replaces ~30×/s mid-stream, so a FOCUSED composer restarts the
+ * timer on every flush and the thread stays up for the whole reply, without a
+ * per-flush re-render (state only changes on the false↔true edges).
+ *
+ * Unfocused, activity buys one hold window and no more. Re-arming there kept
+ * the band up for the entire length of a reply on a HUD nobody was looking at
+ * — the thing it exists to avoid. A turn landing still flashes it; watching
+ * one write is what focus is for.
  */
 function useRecentActivity(): [boolean, () => void] {
   const [recent, setRecent] = useState(false)
@@ -82,6 +90,10 @@ function useRecentActivity(): [boolean, () => void] {
 
     const bump = () => {
       if (timerRef.current) {
+        if (!composerHasFocus()) {
+          return
+        }
+
         clearTimeout(timerRef.current)
       }
 
@@ -130,21 +142,17 @@ function useRecentActivity(): [boolean, () => void] {
 /**
  * True while the HUD must stay up regardless of the hold timer.
  *
- * The fade is built for an idle transcript, and there are states where leaving
- * is the wrong answer: a clarify/approval/sudo/secret prompt is a question you
- * have to answer, and a running turn is progress you asked to watch. Letting
- * either fade hands you a surface you cannot use — the band goes to zero opacity
- * and the window goes mouse-transparent under it, so the prompt is neither
- * readable nor clickable.
+ * Only a question: a clarify/approval/sudo/secret prompt is something the agent
+ * cannot continue without, and letting it fade hands you a surface you cannot
+ * use — zero opacity, and the window goes mouse-transparent under it, so the
+ * prompt is neither readable nor clickable.
  *
- * `recent` alone doesn't cover it: it re-arms on transcript changes, so a long
- * tool call with no visible output would time out mid-turn.
+ * A merely BUSY session is not that. Pinning the band for the length of a turn
+ * meant a HUD you had walked away from sat open across the screen for as long
+ * as the agent worked; the answer arriving flashes it anyway.
  */
 function useHudHeld(): boolean {
-  const awaitingInput = useStore($activeSessionAwaitingInput)
-  const busy = useStore($busy)
-
-  return awaitingInput || busy
+  return useStore($activeSessionAwaitingInput)
 }
 
 /**

--- a/apps/desktop/src/app/hud/hud-shell.tsx
+++ b/apps/desktop/src/app/hud/hud-shell.tsx
@@ -224,8 +224,9 @@ export function HudShell() {
   // native vibrancy and therefore the WINDOW's content view — it fills the whole
   // rectangle and nothing in the page can clip it to the sheet. Whenever the
   // sheet is shorter than the window, the difference is frost over empty space:
-  // a grey slab hanging under the bar with nothing in it, worst on a fresh
-  // thread where the sheet is zero and the slab is the entire window.
+  // a grey slab hanging under the bar with nothing in it. Now that the band is
+  // capped it almost never covers the window, so this is almost always false —
+  // which is correct, and asking anything looser paints the slab back.
   const [filled, setFilled] = useState(false)
   const rootRef = useRef<HTMLDivElement | null>(null)
 
@@ -333,7 +334,6 @@ export function HudShell() {
       className="relative flex h-screen w-screen flex-col overflow-hidden"
       data-hud-edge={edge}
       data-hud-recent={recent || held ? '' : undefined}
-      data-hud-scrollable={scrollable ? '' : undefined}
       data-hud-shell
       // Letting go of the composer re-arms the hold, so the transcript steps
       // down to its glanceable opacity and lingers there instead of jumping
@@ -356,23 +356,8 @@ export function HudShell() {
 
       <WiredPane part="chatRoutes" />
 
-      {/* The top fade band, as a drag handle. Its text is masked to nothing up
-          there, so handing the band's mouse input to the window manager costs
-          no readable content — and it gives the HUD a grab area that isn't the
-          composer.
-
-          LAST child on purpose. Electron collects draggable regions by walking
-          the layout tree in order, uniting `drag` rects and subtracting
-          `no-drag` ones, so later elements win. Above `WiredPane` this strip
-          was silently subtracted away by the scrollback's full-height `no-drag`
-          rect (z-index does not enter into it — the region math is rect-based,
-          not paint-order-based). */}
-      <div aria-hidden data-hud-drag-strip />
-
-      {/* The way back. HUD mode has no titlebar, so without this the only
-          exits are ⌘⇧H and ⌘W — both invisible. Floats over the scrollback
-          (which is short and top-fades, so it rarely collides with text) and
-          carves itself out of the drag region so the click lands. */}
+      {/* The way back — without it the only exits are ⌘⇧H and ⌘W, both
+          invisible. Placed and revealed entirely from styles.css. */}
       <Tip label={t.titlebar.exitHud}>
         <Button
           aria-label={t.titlebar.exitHud}

--- a/apps/desktop/src/app/hud/hud-shell.tsx
+++ b/apps/desktop/src/app/hud/hud-shell.tsx
@@ -358,7 +358,7 @@ export function HudShell() {
       <Tip label={t.titlebar.exitHud}>
         <Button
           aria-label={t.titlebar.exitHud}
-          className={`${titlebarButtonClass} absolute right-1.5 top-1.5 z-20 bg-transparent [-webkit-app-region:no-drag]`}
+          className={`${titlebarButtonClass} absolute z-20`}
           data-hud-exit=""
           onClick={closeHud}
           size="icon-titlebar"

--- a/apps/desktop/src/app/hud/thread-focus.ts
+++ b/apps/desktop/src/app/hud/thread-focus.ts
@@ -1,0 +1,49 @@
+import { type RefObject, useEffect } from 'react'
+
+import { focusComposerInput } from '@/app/chat/composer/focus'
+import { RICH_INPUT_SLOT } from '@/app/chat/composer/rich-editor'
+
+const THREAD_INTERACTIVE = 'a[href], button, input, textarea, select, [contenteditable], [role="button"], [role="link"]'
+
+/**
+ * In HUD mode the band is for reading over another app — clicking a line is not
+ * leaving the composer. Without this, mousedown on the scrollback blurs the
+ * input, the band fades, and the focus ring vanishes mid-read.
+ */
+export function useHudThreadFocus(rootRef: RefObject<HTMLElement | null>): void {
+  useEffect(() => {
+    const root = rootRef.current
+
+    if (!root) {
+      return
+    }
+
+    const onPointerDown = (event: PointerEvent) => {
+      if (event.button !== 0) {
+        return
+      }
+
+      const target = event.target
+
+      if (!(target instanceof Element)) {
+        return
+      }
+
+      if (!target.closest('[data-slot="composer-bounds"]')) {
+        return
+      }
+
+      if (target.closest(THREAD_INTERACTIVE)) {
+        return
+      }
+
+      event.preventDefault()
+
+      focusComposerInput(root.querySelector<HTMLElement>(`[data-slot="${RICH_INPUT_SLOT}"]`))
+    }
+
+    root.addEventListener('pointerdown', onPointerDown, true)
+
+    return () => root.removeEventListener('pointerdown', onPointerDown, true)
+  }, [rootRef])
+}

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -348,7 +348,6 @@ export const UserMessage: FC<{
 
                         notifyThreadEditOpen()
                       }}
-                      title={copy.editMessage}
                       type="button"
                     >
                       {bubbleContent}

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -70,6 +70,7 @@ declare global {
         open: (request?: { sessionId?: null | string }) => Promise<{ ok: boolean }>
         close: () => Promise<{ ok: boolean }>
         setIgnoreMouse: (ignore: boolean) => void
+        moveBy: (delta: { x: number; y: number }) => void
         setVibrancy: (on: boolean) => Promise<{ ok: boolean }>
         setSession: (sessionId: null | string) => void
         onGoto: (callback: (sessionId: string) => void) => () => void

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2251,9 +2251,6 @@ button[data-slot='aui_msg-reactions'] svg {
 
 [data-hud-shell] {
   background: transparent;
-  /* Empty space drags the window; anything that needs the mouse carves itself
-     back out below. */
-  -webkit-app-region: drag;
   /* Arrive decisively and settle; leave gently and get out of the way. Linear
      both directions is what made this feel mechanical. */
   --hud-ease-enter: cubic-bezier(0.16, 1, 0.3, 1);
@@ -2524,21 +2521,6 @@ button[data-slot='aui_msg-reactions'] svg {
   display: none !important;
 }
 
-/* SCROLLING vs DRAGGING — pick one, per element, per STATE.
-   `-webkit-app-region: drag` hands an element's mouse input to the window
-   manager, wheel included — and the region math is rect-based, so a `no-drag`
-   band subtracts its rectangle even when it's pointer-transparent. The band is
-   most of the window, so giving its rect away permanently made the HUD nearly
-   immovable in practice (the composer almost always has focus while in use).
-
-   So the carve-out needs BOTH: composer focused AND actual overflow to scroll
-   (data-hud-scrollable, set by HudShell). A short conversation leaves the
-   whole window grabbable; the band only becomes a scroll surface when
-   scrolling is a real thing you could do with it. */
-[data-hud-shell][data-hud-scrollable]:focus-within [data-slot='composer-bounds'] {
-  -webkit-app-region: no-drag;
-}
-
 /* ── Edge flip ───────────────────────────────────────────────────────────────
    Parked in the top half of the screen (data-hud-edge='top', broadcast by
    main on move/resize), the whole HUD mirrors vertically: composer hugs the
@@ -2563,27 +2545,6 @@ button[data-slot='aui_msg-reactions'] svg {
 
 [data-hud-shell][data-hud-edge='top'] [data-slot='aui_thread-content'] {
   padding-block-start: calc(var(--hud-bar-height, var(--composer-fallback-height)) + 0.25rem) !important;
-}
-
-[data-hud-shell][data-hud-edge='top'] [data-hud-drag-strip] {
-  top: auto;
-  bottom: 0;
-}
-
-/* The drag handle is the top strip of the WINDOW, above the band. The band
-   itself scrolls (a drag region eats wheel events, so it can never be the
-   handle); this strip is dead space either way, so it drags. */
-[data-hud-shell] [data-hud-drag-strip] {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 2rem;
-  z-index: 10;
-  -webkit-app-region: drag;
-  /* Blank to the eye, but this is the grab handle: a strip the window ignores
-     is a strip you cannot drag the HUD by. */
-  pointer-events: auto;
 }
 
 /* Tighten the thread on every side. The docked chat's gutters (px-6 py-8 plus
@@ -2636,37 +2597,19 @@ button[data-slot='aui_msg-reactions'] svg {
   --thread-viewport-height: 100%;
 }
 
-/* The composer BAR is the drag handle: it's the one surface that isn't a
-   scroll container, so it's the only one that can be. Its frame drags; the
-   controls carve themselves back out (a drag region eats their clicks too). */
+/* NOTHING in HUD mode declares `-webkit-app-region: drag`. The window manager
+   takes a draggable region's mouse input whole, so the page never sees the
+   cursor arrive there — and `useHudClickThrough`, which decides whether the
+   window is solid from exactly those moves, has already handed the window away
+   by the time you press. Every version of the app-region handle was therefore
+   both unusable (the press fell through to the app behind) and the reason the
+   HUD stayed solid over dead space once you left it. The two mechanisms cannot
+   share a window; click-through wins, and dragging is `useHudComposerDrag` —
+   press and hold the bar, then move. */
 [data-hud-shell] [data-slot='composer-dock'] {
-  -webkit-app-region: drag;
   /* The one surface that is always there, so the one that always takes the
      mouse — everything else in the shell earns it by being on screen. */
   pointer-events: auto;
-}
-
-/* Focusables, not a list of the controls that happen to be in the bar today —
-   a drag region eats the clicks of anything it covers, so anything missed here
-   is a dead control. */
-[data-hud-shell] [data-slot='composer-rich-input'],
-[data-hud-shell]
-  [data-slot='composer-dock']
-  :is(
-    a[href],
-    button,
-    input,
-    label,
-    select,
-    textarea,
-    [contenteditable],
-    [role='button'],
-    [role='combobox'],
-    [role='menuitem'],
-    [role='switch'],
-    [tabindex]:not([tabindex='-1'])
-  ) {
-  -webkit-app-region: no-drag;
 }
 
 /* HUD mode is the input and the log — nothing else. The dock stacks
@@ -2829,17 +2772,6 @@ button[data-slot='aui_msg-reactions'] svg {
    transparent HUD it's a grey smear. */
 [data-hud-shell] [data-slot='composer-root'] > .pointer-events-none {
   display: none !important;
-}
-
-/* Portaled overlays (model picker, menus, dialogs, tooltips, the command
-   palette) mount into <body>, OUTSIDE [data-hud-shell] — so they never inherit
-   its `no-drag` carve-outs. And Electron's draggable region is RECT math, not
-   paint order: the shell's window-sized `drag` rect covers wherever the menu
-   opens, and anything that doesn't explicitly subtract itself is handed to the
-   window manager. The menu rendered, sat correctly, and swallowed every click
-   ("I can't even select a model"). Carve every portal back out. */
-html:has([data-hud-shell]) body > *:not(#root) {
-  -webkit-app-region: no-drag;
 }
 
 /* Popovers in a ~320px-tall window. Two separate problems:

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2266,6 +2266,11 @@ button[data-slot='aui_msg-reactions'] svg {
 /* The scrollback — the chat BAND, straight from the nous-viz2d chat (which is
    the reference for this whole surface): a fixed-height smoked strip hugging
    the input, tinted from the theme, with the text simply sitting in it.
+  /* The band is narrower than the bar, centred under it, so the bar's corner
+     controls sit clear of the sheet's edge instead of on top of it. */
+  --hud-band-inset: 0.5rem;
+  /* Clear space above the composer for the exit chip. */
+  --hud-chip-strip: 1.625rem;
 
      - viz2d: `bg-black/20` at rest → `bg-black/60` on hover / focus-within /
        pending. Same mechanism here, theme-aware: the tint is the theme's own
@@ -2310,7 +2315,9 @@ button[data-slot='aui_msg-reactions'] svg {
      short transcript — the whole window on a fresh thread. Hit-testing honours
      clip-path, so clipping to the sheet bounds the surface the same way #81920
      bounded the frost. */
-  clip-path: inset(calc(100% - min(100%, var(--hud-band-height, 0px))) 0 0 0);
+  clip-path: inset(
+    calc(100% - var(--hud-band-height, 0px)) var(--hud-band-inset) 0 var(--hud-band-inset)
+  );
   background: transparent !important;
   /* Three opacity states: gone at rest, half strength when a turn is recent or
      you've just let go of the composer (there to glance at, not to demand
@@ -2349,9 +2356,9 @@ button[data-slot='aui_msg-reactions'] svg {
      transcript. */
   anchor-name: --hud-band;
   position: absolute;
-  right: 0;
+  right: var(--hud-band-inset);
   bottom: 0;
-  left: 0;
+  left: var(--hud-band-inset);
   z-index: 0;
   pointer-events: none;
   border-radius: 0.75rem 0.75rem 0 0;
@@ -2366,7 +2373,7 @@ button[data-slot='aui_msg-reactions'] svg {
      The height below still tracks the transcript; only the offset animates on
      exit, and it finishes ahead of the fade so the panel has left while the last
      of the text is still going. */
-  height: min(100%, var(--hud-band-height, 0px));
+  height: var(--hud-band-height, 0px);
   translate: 0 var(--hud-exit-shift, 2.5rem);
   opacity: 0;
   transition:
@@ -2397,7 +2404,7 @@ button[data-slot='aui_msg-reactions'] svg {
 
 /* Flipped, the sheet hangs from the bar instead of standing on it. */
 [data-hud-shell][data-hud-edge='top'] [data-hud-glass] {
-  top: 0;
+  top: var(--hud-bar-height, var(--composer-fallback-height));
   bottom: auto;
   --hud-exit-shift: -2.5rem;
   border-radius: 0 0 0.75rem 0.75rem;
@@ -2534,7 +2541,17 @@ button[data-slot='aui_msg-reactions'] svg {
 
 [data-hud-shell][data-hud-edge='top'] [data-slot='composer-bounds'] {
   border-radius: 0 0 0.75rem 0.75rem;
-  clip-path: inset(0 0 calc(100% - min(100%, var(--hud-band-height, 0px))) 0);
+  /* Band hangs below the bar — not from the window's top edge. Bottom inset is
+     clamped so an oversized measure cannot invert the clip and paint the whole
+     HUD as one empty slab. */
+  clip-path: inset(
+    var(--hud-bar-height, var(--composer-fallback-height)) var(--hud-band-inset)
+      max(
+        0px,
+        calc(100% - var(--hud-bar-height, var(--composer-fallback-height)) - var(--hud-band-height, 0px))
+      )
+      var(--hud-band-inset)
+  );
 }
 
 /* Flipped, the bar is at the TOP, so the clearance has to be too — the app's
@@ -2788,6 +2805,13 @@ button[data-slot='aui_msg-reactions'] svg {
    a HUD is a small window and a 400px menu cannot fit in it. */
 html:has([data-hud-shell]) [data-slot='dropdown-menu-content'] [class*='max-h-'],
 html:has([data-hud-shell]) [data-slot='popover-content'] [class*='max-h-'] {
+/* The composer's drop target is a full-window dashed sheet sized for the app's
+   chat column. In the HUD it is a white slab hanging under the bar on a fresh
+   thread, and there is nowhere to drop anything into a bar anyway. */
+[data-hud-shell] [data-slot='chat-drop-overlay'] {
+  display: none !important;
+}
+
   max-height: max(5rem, calc(100dvh - 9rem)) !important;
 }
 

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -945,6 +945,17 @@
   --arc-c2: color-mix(in srgb, var(--arc-c1) 45%, transparent);
 }
 
+/* HUD composer — same travelling arc as a working sidebar row, 2px and pill-
+   rounded to match the bar. */
+.arc-border.arc-composer,
+:root.dark .arc-border.arc-composer {
+  --arc-width: 2px;
+  --arc-standoff: 0rem;
+  --arc-radius: 0.75rem;
+  --arc-c2: color-mix(in srgb, var(--arc-c1) 45%, transparent);
+  z-index: 6;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .arc-border::before {
     animation: none;
@@ -2255,6 +2266,11 @@ button[data-slot='aui_msg-reactions'] svg {
      both directions is what made this feel mechanical. */
   --hud-ease-enter: cubic-bezier(0.16, 1, 0.3, 1);
   --hud-ease-exit: cubic-bezier(0.4, 0, 0.7, 0.2);
+  /* The band is narrower than the bar, centred under it, so the bar's corner
+     controls sit clear of the sheet's edge instead of on top of it. */
+  --hud-band-inset: 0.5rem;
+  /* Clear space above the composer for the exit chip. */
+  --hud-chip-strip: 1.625rem;
 }
 
 /* Chat surface carries nothing in HUD mode — the visual is the BAND below. */
@@ -2266,11 +2282,6 @@ button[data-slot='aui_msg-reactions'] svg {
 /* The scrollback — the chat BAND, straight from the nous-viz2d chat (which is
    the reference for this whole surface): a fixed-height smoked strip hugging
    the input, tinted from the theme, with the text simply sitting in it.
-  /* The band is narrower than the bar, centred under it, so the bar's corner
-     controls sit clear of the sheet's edge instead of on top of it. */
-  --hud-band-inset: 0.5rem;
-  /* Clear space above the composer for the exit chip. */
-  --hud-chip-strip: 1.625rem;
 
      - viz2d: `bg-black/20` at rest → `bg-black/60` on hover / focus-within /
        pending. Same mechanism here, theme-aware: the tint is the theme's own
@@ -2351,10 +2362,6 @@ button[data-slot='aui_msg-reactions'] svg {
    should be disappearing. The way through is NSVisualEffectView.maskImage
    behind a small native addon, which is its own change. */
 [data-hud-shell] [data-hud-glass] {
-  /* The exit chip rides this box, not the band — the band is the whole window,
-     so anchoring there left the chip stranded in empty space above a short
-     transcript. */
-  anchor-name: --hud-band;
   position: absolute;
   right: var(--hud-band-inset);
   bottom: 0;
@@ -2531,12 +2538,18 @@ button[data-slot='aui_msg-reactions'] svg {
 /* ── Edge flip ───────────────────────────────────────────────────────────────
    Parked in the top half of the screen (data-hud-edge='top', broadcast by
    main on move/resize), the whole HUD mirrors vertically: composer hugs the
-   window's top edge, the band hangs BELOW it, text melts at the bottom, and
-   the drag strip moves to the bottom dead zone. Same four surfaces, same
-   variables — only the anchors swap. */
+   window's top edge, the band hangs BELOW it, and text melts at the bottom.
+   Same surfaces, same variables — only the anchors swap.
+
+   The bar would sit flush against the window's top edge, leaving no "above the
+   composer" to put anything in — which is where the exit chip belongs. Reserve
+   the strip as dock padding rather than moving the bar: --hud-bar-height is
+   measured from the dock's box, so the band's offset picks the gap up on its
+   own instead of needing a second variable kept in sync. */
 [data-hud-shell][data-hud-edge='top'] [data-slot='composer-dock'] {
   top: 0 !important;
   bottom: auto !important;
+  padding-top: var(--hud-chip-strip) !important;
 }
 
 [data-hud-shell][data-hud-edge='top'] [data-slot='composer-bounds'] {
@@ -2727,62 +2740,76 @@ button[data-slot='aui_msg-reactions'] svg {
   backdrop-filter: none !important;
   -webkit-backdrop-filter: none !important;
   box-shadow: none !important;
+  transition: border-color var(--hud-reveal) var(--hud-ease-enter);
 }
 
-/* The exit button: a real control, visible at rest, on a card chip so it
-   reads against any backdrop.
+/* Focus: the border the bar already has, in the accent. Everything with its own
+   geometry is out — the bar sits flush against the window, so a ring or a
+   shadow is sawn off by the window before any CSS can shape it, and paying for
+   the clearance moves the bar. Recolouring what is already drawn costs no
+   space, cannot be clipped, and leaves the working arc as the only ring. */
+[data-hud-shell]:has([data-slot='composer-rich-input']:focus) [data-slot='composer-surface'] {
+  border-color: var(--dt-primary) !important;
+}
 
-   Square (aspect-ratio 1/1 on the app's titlebar button size) and INSET from
-   the band's corner — tucked flush it read as a mistake; a chip floating in
-   the corner with its own margin reads as intentional. anchor() to the band:
-   calc()-based attempts drifted because the composer's measured vars are
-   inline-scoped and stale outside [data-chat-surface]. */
+/* Long-press drag armed — the whole bar is the handle until release. */
+[data-hud-shell] [data-slot='composer-root'][data-hud-grabbing] [data-slot='composer-dock'] {
+  cursor: grabbing;
+}
 
+/* The exit button. HUD mode has no titlebar, so this is the only visible way
+   back; it lives in the open space off the bar's outer edge, at the right.
+
+   A bare themed glyph rather than a chip: it sits over whatever the user is
+   really working in, and a card floating there is a stray fragment of app on
+   their screen.
+
+   Placed from --hud-bar-height rather than CSS anchor(). Lightning CSS drops a
+   whole rule containing an `anchor()` on the vertical axis, so the flipped-edge
+   override never reached the browser and the chip rendered off screen. */
 [data-hud-shell] [data-hud-exit] {
-  position-anchor: --hud-band;
   left: auto;
-  bottom: auto;
-  right: calc(anchor(right) + 0.5rem);
-  top: calc(anchor(top) + 0.5rem);
+  top: auto;
+  right: 0.375rem;
+  bottom: calc(var(--hud-bar-height, var(--composer-fallback-height)) + 0.375rem);
   aspect-ratio: 1;
   height: auto;
-  background: var(--dt-card) !important;
-  border: 1px solid var(--ui-stroke-tertiary);
-  border-radius: 0.5rem;
-  /* Part of the band, so it lives and dies with it — same states, same timing.
-     Left visible at rest it is a lone chip hovering in empty space a hundred
-     pixels above the bar; revealed on hovering the window it pops up whenever
-     the cursor crosses the HUD on its way somewhere else. */
+  background: transparent !important;
+  border: 0;
+  color: var(--ui-text-primary) !important;
+  /* Focus only. A turn landing brings the transcript up but doesn't mean you
+     are reaching for the window controls, and at rest this is a lone chip
+     hovering over whatever you're actually working in. */
   opacity: 0;
   transition: opacity var(--hud-fade) var(--hud-ease-exit);
-  /* And it takes clicks on exactly the same terms as the band it sits in —
-     visible or nothing. A faded-out control that still takes clicks is an
-     invisible button floating over the app behind; a lit one that doesn't is
-     the dead chip you get from keying this to focus alone. */
+  /* Clicks on exactly the same terms as the paint — a faded-out control that
+     still takes them is an invisible button floating over the app behind. */
   pointer-events: none;
 }
 
-[data-hud-shell][data-hud-recent] [data-hud-exit],
-[data-hud-shell]:focus-within [data-hud-exit] {
-  pointer-events: auto;
-}
-
-/* Flipped, the sheet's top corner is behind the bar — drop the chip clear of
-   it so it stays in the transcript rather than under the composer. */
+/* Flipped, "above the composer" is the reserved strip at the top of the
+   window rather than a gap the band has to leave. */
 [data-hud-shell][data-hud-edge='top'] [data-hud-exit] {
-  top: calc(anchor(top) + var(--hud-bar-height, var(--composer-fallback-height)) + 0.5rem);
+  bottom: auto;
+  top: 0;
 }
 
-[data-hud-shell][data-hud-recent] [data-hud-exit],
 [data-hud-shell]:has([data-slot='composer-rich-input']:focus) [data-hud-exit] {
   opacity: 0.75;
+  pointer-events: auto;
   transition-duration: var(--hud-reveal);
   transition-delay: 0s;
 }
 
-[data-hud-shell][data-hud-recent] [data-hud-exit]:hover,
 [data-hud-shell]:has([data-slot='composer-rich-input']:focus) [data-hud-exit]:hover {
   opacity: 1;
+}
+
+/* The composer's drop target is a full-window dashed sheet sized for the app's
+   chat column. In the HUD it is a white slab hanging under the bar on a fresh
+   thread, and there is nowhere to drop anything into a bar anyway. */
+[data-hud-shell] [data-slot='chat-drop-overlay'] {
+  display: none !important;
 }
 
 /* The dock's fade-to-surface gradient assumes a chat column behind it; over a
@@ -2805,13 +2832,6 @@ button[data-slot='aui_msg-reactions'] svg {
    a HUD is a small window and a 400px menu cannot fit in it. */
 html:has([data-hud-shell]) [data-slot='dropdown-menu-content'] [class*='max-h-'],
 html:has([data-hud-shell]) [data-slot='popover-content'] [class*='max-h-'] {
-/* The composer's drop target is a full-window dashed sheet sized for the app's
-   chat column. In the HUD it is a white slab hanging under the bar on a fresh
-   thread, and there is nowhere to drop anything into a bar anyway. */
-[data-hud-shell] [data-slot='chat-drop-overlay'] {
-  display: none !important;
-}
-
   max-height: max(5rem, calc(100dvh - 9rem)) !important;
 }
 

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2360,7 +2360,11 @@ button[data-slot='aui_msg-reactions'] svg {
   z-index: 0;
   pointer-events: none;
   border-radius: 0.75rem 0.75rem 0 0;
-  background: color-mix(in srgb, var(--dt-card) 55%, transparent);
+  /* Heavier than the text in front of it, deliberately: with no blur to
+     separate the band from what it lies over, the sheet is the only thing
+     keeping half-opacity text off someone else's UI. Fade the words, keep the
+     paper. */
+  background: color-mix(in srgb, var(--dt-card) 80%, transparent);
   /* Slides down behind the bar as it fades. A TRANSFORM, not height: it is
      composited, so it stays smooth where animating height re-lays-out the panel
      every frame and looked coarse — and it leaves the box alone, which matters

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2297,38 +2297,29 @@ button[data-slot='aui_msg-reactions'] svg {
    fade is furniture leaving the room. */
 [data-hud-shell] [data-slot='composer-bounds'] {
   position: absolute !important;
-  /* Anchored to the bar and sized to the transcript, exactly like the sheet
-     behind it — same box, same clock — so the text is clipped away as the panel
-     rolls rather than fading in place.
- 
-     Edge to edge with no dead margins, and it never computes where the bar's
-     top is: the bar simply covers this box's bottom. Every earlier attempt
-     derived that edge from --composer-surface-measured-height, which is the
-     composer's published height, rounded, while the real box is fractional —
-     so the math left a hairline that appeared and vanished as the composer grew
-     ("the gap is 0px until two lines"). What keeps the TEXT off the bar is the
-     app's own composer clearance, below. */
-  inset: 0 !important;
-  height: auto !important;
-  width: 100% !important;
+  /* THE BAND IS THIS BOX. It sits against the bar and is exactly as tall as the
+     transcript is allowed to be — same geometry as the sheet behind it, same
+     clock — so the text is clipped away as the panel rolls rather than fading
+     in place, and the box that scrolls is the box you can see.
+
+     It ran the full window for a long time, clipped down to the band for paint
+     and hit-testing. That works right up until the band is CAPPED: the scroll
+     container was still window-tall, so content shorter than the window never
+     overflowed it and never scrolled, while the clip hid everything past the
+     cap. A capped band has to be a real box or half the transcript is
+     unreachable.
+
+     No fill of its own — the sheet is its own layer ([data-hud-glass]) so it
+     can animate independently of the text. */
+  inset: auto var(--hud-band-inset) var(--hud-bar-height, var(--composer-fallback-height))
+    var(--hud-band-inset) !important;
+  height: var(--hud-band-height, 0px) !important;
+  width: auto !important;
   max-width: none !important;
   flex: none !important;
   border: 0 !important;
-  /* Rounded on top to match the window's own corners; square at the bottom,
-     where the bar covers it. */
+  /* Rounded away from the bar, square where it meets it. */
   border-radius: 0.75rem 0.75rem 0 0;
-  /* No fill of its own — the sheet is its own layer behind this one
-     ([data-hud-glass]), so it can be sized to the transcript while this box
-     stays the full window for the drag region and the scroll container.
-
-     The box stays full-window; the part of it that answers the cursor must
-     not, or an engaged HUD swallows every click in the empty space above a
-     short transcript — the whole window on a fresh thread. Hit-testing honours
-     clip-path, so clipping to the sheet bounds the surface the same way #81920
-     bounded the frost. */
-  clip-path: inset(
-    calc(100% - var(--hud-band-height, 0px)) var(--hud-band-inset) 0 var(--hud-band-inset)
-  );
   background: transparent !important;
   /* Three opacity states: gone at rest, half strength when a turn is recent or
      you've just let go of the composer (there to glance at, not to demand
@@ -2364,7 +2355,7 @@ button[data-slot='aui_msg-reactions'] svg {
 [data-hud-shell] [data-hud-glass] {
   position: absolute;
   right: var(--hud-band-inset);
-  bottom: 0;
+  bottom: var(--hud-bar-height, var(--composer-fallback-height));
   left: var(--hud-band-inset);
   z-index: 0;
   pointer-events: none;
@@ -2552,29 +2543,11 @@ button[data-slot='aui_msg-reactions'] svg {
   padding-top: var(--hud-chip-strip) !important;
 }
 
+/* Flipped, the band hangs from the bar instead of standing on it. */
 [data-hud-shell][data-hud-edge='top'] [data-slot='composer-bounds'] {
+  top: var(--hud-bar-height, var(--composer-fallback-height)) !important;
+  bottom: auto !important;
   border-radius: 0 0 0.75rem 0.75rem;
-  /* Band hangs below the bar — not from the window's top edge. Bottom inset is
-     clamped so an oversized measure cannot invert the clip and paint the whole
-     HUD as one empty slab. */
-  clip-path: inset(
-    var(--hud-bar-height, var(--composer-fallback-height)) var(--hud-band-inset)
-      max(
-        0px,
-        calc(100% - var(--hud-bar-height, var(--composer-fallback-height)) - var(--hud-band-height, 0px))
-      )
-      var(--hud-band-inset)
-  );
-}
-
-/* Flipped, the bar is at the TOP, so the clearance has to be too — the app's
-   clearance element only pads the end of the thread. */
-[data-hud-shell][data-hud-edge='top'] [data-chat-surface] {
-  --thread-last-message-clearance: 0.25rem;
-}
-
-[data-hud-shell][data-hud-edge='top'] [data-slot='aui_thread-content'] {
-  padding-block-start: calc(var(--hud-bar-height, var(--composer-fallback-height)) + 0.25rem) !important;
 }
 
 /* Tighten the thread on every side. The docked chat's gutters (px-6 py-8 plus
@@ -2599,13 +2572,11 @@ button[data-slot='aui_msg-reactions'] svg {
   justify-content: flex-start;
 }
 
-/* Space under the last message — the app's own measured-dock clearance, minus
-   the 2rem of breathing room a full window can afford. This is what holds the
-   text off the bar now that the band runs the whole window height, and it is
-   measured from the live dock, so it tracks the composer growing to two, three,
-   ten rows with no hairline and no hole. */
+/* The band's box already ends at the bar, so the app's dock clearance — sized
+   to hold text out from under a composer it overlaps — would only open a hole
+   the height of the bar between the last message and the composer. */
 [data-hud-shell] [data-chat-surface] {
-  --thread-last-message-clearance: var(--hud-bar-height, var(--composer-fallback-height));
+  --thread-last-message-clearance: 0.25rem;
 }
 
 /* Same for the dock's own bottom pad — this var also feeds

--- a/apps/desktop/src/themes/context.tsx
+++ b/apps/desktop/src/themes/context.tsx
@@ -69,6 +69,9 @@ const profilePref = <T extends string>(record: string, legacy: string, normalize
 export const skinPref = profilePref(PROFILE_SKINS_KEY, SKIN_KEY, normalizeSkin)
 export const modePref = profilePref(PROFILE_MODES_KEY, MODE_KEY, normalizeMode)
 
+/** Everything a peer window could change that this one has to repaint for. */
+const APPEARANCE_KEYS = new Set([SKIN_KEY, PROFILE_SKINS_KEY, MODE_KEY, PROFILE_MODES_KEY])
+
 // Last active profile — lets the boot paint pick its appearance before the
 // gateway reports which profile actually launched.
 const readBootProfileKey = () => normalizeProfileKey(storedString(LAST_PROFILE_KEY))
@@ -350,6 +353,27 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     setThemeNameState(skinPref.resolve(profileKey))
     setModeState(modePref.resolve(profileKey))
   }, [profileKey])
+
+  // Appearance is per-profile localStorage, and every desktop window is another
+  // renderer on the same origin — so a switch made in the HUD (or any peer
+  // window) only ever repainted the window it was made in. `storage` fires in
+  // the OTHER windows, which is exactly the set that needs to catch up.
+  useEffect(() => {
+    const onStorage = (event: StorageEvent) => {
+      if (event.key && !APPEARANCE_KEYS.has(event.key)) {
+        return
+      }
+
+      const live = normalizeProfileKey($activeGatewayProfile.get())
+
+      setThemeNameState(skinPref.resolve(live))
+      setModeState(modePref.resolve(live))
+    }
+
+    window.addEventListener('storage', onStorage)
+
+    return () => window.removeEventListener('storage', onStorage)
+  }, [])
 
   const systemDark = useMediaQuery('(prefers-color-scheme: dark)')
   const resolvedMode = resolveMode(mode, systemDark)


### PR DESCRIPTION
HUD mode is a composer bar floating over whatever you are actually working in,
so every pixel it paints and every click it takes belongs to something else.
This is a pass over the ways it wasn't holding to that: a grab handle that
could never work, a transcript that claimed most of the window and then could
not be scrolled once it was capped, and a fade that never fired for the one
gesture people actually use.

The pointer fix is the load-bearing one. `-webkit-app-region: drag` and
`useHudClickThrough` cannot share a window: the window manager takes a
draggable region's mouse input whole, so the page never sees the cursor arrive
there, and click-through — which decides whether the window is solid from
exactly those moves — has already handed the window to the desktop by the time
you press. Every version of the app-region handle was both unusable and the
reason the HUD stayed solid over its own dead space, eating clicks meant for
the app behind. No HUD surface declares a drag region any more; you move it by
pressing and holding the bar.

**Pointer and window**

- Drag by holding the composer, 140ms to arm, moving the window through a new
  `hud.moveBy` in screen coordinates with the pointer captured.
- Clicking the transcript no longer blurs the composer.

**The band**

- Height measured from the message rows rather than the viewport edge, and
  capped, so it grows from zero and stops at a glance rather than a panel.
- The band is now a real box anchored to the bar instead of a full-window box
  wearing a clip — a capped band that is only clipped cannot scroll, because
  the container never overflows and half the transcript is unreachable.
- Native vibrancy only when bar + band actually cover the window, which with a
  capped band is essentially never; anything looser is a grey slab. The sheet
  carries the separation instead, heavier than the text in front of it.

**When it shows**

- The glanceable stage lasts 2.5s. At 700ms it read as part of the fade rather
  than a state you could finish reading in.
- A busy session no longer pins the band open. Held is for a question the agent
  cannot continue without; watching a turn write itself is what focus is for.
- Losing window focus starts the hold. Clicking away to another app fires no
  focusout, so the band used to snap shut rather than step down.

**Elsewhere**

- Working state gets the sidebar's travelling arc; focus recolours the border
  the bar already draws (a ring or shadow is sawn off by the window edge).
- Exit control moves into the space above the bar, on focus only.
- Appearance changes propagate to peer windows via `storage`.
- App-wide: the "Edit message" title is gone from user bubbles.