### PR TITLE
fix(desktop): archive kanban boards from Board settings

### DIFF
--- a/apps/desktop/src/plugins/kanban/api.ts
+++ b/apps/desktop/src/plugins/kanban/api.ts
@@ -238,6 +238,11 @@ export const estimateNew = (title: string, body: string) =>
 export const updateBoard = (slug: string, patch: Record<string, unknown>) =>
   call<{ board: BoardMeta }>(`/boards/${encodeURIComponent(slug)}`, { method: 'PATCH', body: patch })
 
+/** Archive a board (backend default for DELETE). Hard-delete stays CLI-only
+ *  (`?delete=true` / `hermes kanban boards rm --delete`). `default` is refused. */
+export const archiveBoard = (slug: string) =>
+  call<{ current: string; result: unknown }>(`/boards/${encodeURIComponent(slug)}`, { method: 'DELETE' })
+
 export const nudgeDispatcher = () => call<{ spawned?: unknown[] }>(withBoard('/dispatch'), { method: 'POST', body: {} })
 
 export const saveOrchestration = (patch: Record<string, unknown>) =>

--- a/apps/desktop/src/plugins/kanban/board-switcher.tsx
+++ b/apps/desktop/src/plugins/kanban/board-switcher.tsx
@@ -8,6 +8,7 @@
 import {
   Button,
   Codicon,
+  ConfirmDialog,
   Dialog,
   DialogContent,
   DialogFooter,
@@ -32,7 +33,16 @@ import {
 } from '@hermes/plugin-sdk'
 import { useEffect, useState } from 'react'
 
-import { $boardSlug, BOARDS_KEY, createBoard, fetchBoards, fetchProjects, PROJECTS_KEY, updateBoard } from './api'
+import {
+  $boardSlug,
+  archiveBoard,
+  BOARDS_KEY,
+  createBoard,
+  fetchBoards,
+  fetchProjects,
+  PROJECTS_KEY,
+  updateBoard
+} from './api'
 import type { BoardMeta } from './types'
 import { errText, FIELD_LABEL, useKanban } from './ui'
 
@@ -135,13 +145,16 @@ function NewBoardDialog({ onClose, open }: { onClose: () => void; open: boolean 
 function BoardSettingsDialog({ board, onClose }: { board: BoardMeta | null; onClose: () => void }) {
   const k = useKanban()
   const qc = useQueryClient()
+  const selectedSlug = useValue($boardSlug)
   const [name, setName] = useState('')
   const [project, setProject] = useState('')
+  const [confirmArchive, setConfirmArchive] = useState(false)
 
   useEffect(() => {
     if (board) {
       setName(board.name || '')
       setProject(board.project_id || '')
+      setConfirmArchive(false)
     }
   }, [board])
 
@@ -156,30 +169,75 @@ function BoardSettingsDialog({ board, onClose }: { board: BoardMeta | null; onCl
     }
   })
 
+  // Parity with the browser dashboard Archive control + CLI
+  // `hermes kanban boards rm <slug>` (archive, not hard-delete). `default`
+  // cannot be removed — backend refuses it too.
+  const canArchive = Boolean(board && board.slug !== 'default')
+  const boardLabel = board ? board.name || board.slug : ''
+
+  const archive = useMutation({
+    mutationFn: () => archiveBoard(board!.slug),
+    onError: err => host.notify({ kind: 'error', message: errText(err) }),
+    onSuccess: result => {
+      const wasSelected = !selectedSlug || selectedSlug === board!.slug
+      if (wasSelected) {
+        // Fall back to the server's new current board (usually default).
+        // Empty slug means "server current" — same convention as the switcher.
+        $boardSlug.set(result.current && result.current !== 'default' ? result.current : '')
+      }
+      void qc.invalidateQueries({ queryKey: BOARDS_KEY })
+      setConfirmArchive(false)
+      onClose()
+    }
+  })
+
   return (
-    <Dialog onOpenChange={o => !o && onClose()} open={Boolean(board)}>
-      <DialogContent className="max-w-md">
-        <DialogHeader>
-          <DialogTitle>{board ? k.boardSettingsFor(board.name || board.slug) : k.boardSettings}</DialogTitle>
-        </DialogHeader>
-        <div className="flex flex-col gap-3">
-          <label className="flex flex-col gap-1">
-            <span className={FIELD_LABEL}>{k.name}</span>
-            <Input onChange={event => setName(event.target.value)} placeholder={k.boardNamePlaceholder} value={name} />
-            {board && <span className="text-[0.6875rem] text-(--ui-text-quaternary)">{k.slug(board.slug)}</span>}
-          </label>
-          <ProjectPicker onChange={setProject} value={project} />
-        </div>
-        <DialogFooter>
-          <Button onClick={onClose} variant="text">
-            {k.cancel}
-          </Button>
-          <Button disabled={save.isPending} onClick={() => save.mutate()}>
-            {k.save}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+    <>
+      <Dialog onOpenChange={o => !o && onClose()} open={Boolean(board)}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>{board ? k.boardSettingsFor(board.name || board.slug) : k.boardSettings}</DialogTitle>
+          </DialogHeader>
+          <div className="flex flex-col gap-3">
+            <label className="flex flex-col gap-1">
+              <span className={FIELD_LABEL}>{k.name}</span>
+              <Input onChange={event => setName(event.target.value)} placeholder={k.boardNamePlaceholder} value={name} />
+              {board && <span className="text-[0.6875rem] text-(--ui-text-quaternary)">{k.slug(board.slug)}</span>}
+            </label>
+            <ProjectPicker onChange={setProject} value={project} />
+          </div>
+          <DialogFooter className={canArchive ? 'sm:justify-between' : undefined}>
+            {canArchive ? (
+              <Button
+                disabled={save.isPending || archive.isPending}
+                onClick={() => setConfirmArchive(true)}
+                title={k.archiveBoardTitle}
+                variant="destructive"
+              >
+                {k.archiveBoard}
+              </Button>
+            ) : null}
+            <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+              <Button onClick={onClose} variant="text">
+                {k.cancel}
+              </Button>
+              <Button disabled={save.isPending || archive.isPending} onClick={() => save.mutate()}>
+                {k.save}
+              </Button>
+            </div>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <ConfirmDialog
+        confirmLabel={k.archiveBoard}
+        description={k.archiveBoardConfirm(boardLabel)}
+        destructive
+        onClose={() => setConfirmArchive(false)}
+        onConfirm={() => archive.mutateAsync()}
+        open={confirmArchive && canArchive}
+        title={k.archiveBoardTitle}
+      />
+    </>
   )
 }
 

--- a/apps/desktop/src/plugins/kanban/i18n.ts
+++ b/apps/desktop/src/plugins/kanban/i18n.ts
@@ -168,6 +168,9 @@ type KanbanMessages = {
   newBoardDots: string
   boardSettings: string
   boardSettingsFor: (name: string) => string
+  archiveBoard: string
+  archiveBoardTitle: string
+  archiveBoardConfirm: (name: string) => string
   name: string
   boardNamePlaceholder: string
   slug: (slug: string) => string
@@ -359,6 +362,10 @@ const en: KanbanMessages = {
   newBoardDots: 'New board…',
   boardSettings: 'Board settings…',
   boardSettingsFor: name => `Board settings — ${name}`,
+  archiveBoard: 'Archive board',
+  archiveBoardTitle: 'Archive this board',
+  archiveBoardConfirm: name =>
+    `Archive board “${name}”? It will be moved to boards/_archived/ so you can recover it later. Tasks on this board will no longer appear anywhere in the UI.`,
   name: 'Name',
   boardNamePlaceholder: 'Board name',
   slug: slug => `slug: ${slug}`,
@@ -550,6 +557,10 @@ const ja: KanbanMessages = {
   newBoardDots: '新しいボード…',
   boardSettings: 'ボード設定…',
   boardSettingsFor: name => `ボード設定 — ${name}`,
+  archiveBoard: 'ボードをアーカイブ',
+  archiveBoardTitle: 'このボードをアーカイブ',
+  archiveBoardConfirm: name =>
+    `ボード「${name}」をアーカイブしますか？ boards/_archived/ に移動されるので後から復元できます。このボード上のタスクは UI のどこにも表示されなくなります。`,
   name: '名前',
   boardNamePlaceholder: 'ボード名',
   slug: slug => `slug: ${slug}`,
@@ -739,6 +750,10 @@ const zh: KanbanMessages = {
   newBoardDots: '新建面板…',
   boardSettings: '面板设置…',
   boardSettingsFor: name => `面板设置 — ${name}`,
+  archiveBoard: '归档面板',
+  archiveBoardTitle: '归档此面板',
+  archiveBoardConfirm: name =>
+    `归档面板“${name}”？它会移到 boards/_archived/，之后仍可恢复。此面板上的任务将不再出现在任何界面中。`,
   name: '名称',
   boardNamePlaceholder: '面板名称',
   slug: slug => `slug: ${slug}`,
@@ -927,6 +942,10 @@ const zhHant: KanbanMessages = {
   newBoardDots: '新增面板…',
   boardSettings: '面板設定…',
   boardSettingsFor: name => `面板設定 — ${name}`,
+  archiveBoard: '封存面板',
+  archiveBoardTitle: '封存此面板',
+  archiveBoardConfirm: name =>
+    `封存面板「${name}」？它會移到 boards/_archived/，之後仍可還原。此面板上的任務將不再出現在任何介面中。`,
   name: '名稱',
   boardNamePlaceholder: '面板名稱',
   slug: slug => `slug: ${slug}`,


### PR DESCRIPTION
## Summary
Desktop Kanban **Board settings** only allowed renaming and project binding. There was no way to remove a board from the Desktop UI, even though:

- browser dashboard already has **Archive** for non-`default` boards
- backend already exposes `DELETE /api/plugins/kanban/boards/{slug}` (archive by default)
- CLI already has `hermes kanban boards rm <slug>`

This adds Desktop parity: **Archive board** in Board settings (destructive, confirmed), hidden on `default`. Hard-delete remains CLI-only (`--delete` / `?delete=true`).

## Changes
- `apps/desktop/src/plugins/kanban/api.ts` — `archiveBoard(slug)` → `DELETE /boards/{slug}`
- `apps/desktop/src/plugins/kanban/board-switcher.tsx` — Archive button + `ConfirmDialog`; switch away if the active board was archived
- `apps/desktop/src/plugins/kanban/i18n.ts` — en/ja/zh/zh-hant strings

## Test plan
- [ ] Open Kanban → board switcher → **Board settings…** on a non-default board
- [ ] Confirm **Archive board** appears (left, destructive) and is absent on `default`
- [ ] Cancel the confirm dialog → board unchanged
- [ ] Confirm archive → board leaves the switcher list; if it was active, UI falls back to the server current board (usually `default`)
- [ ] Board dir lands under `~/.hermes/kanban/boards/_archived/`
- [ ] `hermes kanban boards list` no longer shows the archived slug