### PR TITLE
fix(agent): refresh xAI OAuth credentials on a 403 bad-credentials

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -37,7 +37,11 @@ from agent.conversation_compression import (
 )
 from agent.context_engine import automatic_compaction_status_message
 from agent.display import KawaiiSpinner
-from agent.error_classifier import FailoverReason, classify_api_error
+from agent.error_classifier import (
+    FailoverReason,
+    classify_api_error,
+    is_stale_oauth_token_403,
+)
 from agent.message_metadata import append_message
 from agent.turn_context import (
     _compression_warrants_another_preflight_pass,
@@ -385,6 +389,39 @@ def _is_stale_copilot_credential_error(status_code: Optional[int], error_message
         or "model_not_supported" in lowered
         or "the requested model is not supported" in lowered
     )
+
+
+def _should_refresh_codex_credentials(
+    agent: Any,
+    status_code: Optional[int],
+    error: Exception,
+    retry_state: Any,
+) -> bool:
+    """Should this API error trigger a forced Codex/xAI credential refresh?
+
+    A 401 is the ordinary signal.  xAI also reports an *expired access token*
+    as HTTP 403 with body code ``unauthenticated:bad-credentials`` — before
+    #82052 that 403 fell straight through to the non-retryable abort, so a
+    long-lived worker (tui_gateway slash_worker, gateway session) replayed its
+    stale in-memory token on every turn and never recovered until the process
+    was restarted.  ``_try_refresh_codex_client_credentials`` is the only place
+    that worker's ``api_key`` gets replaced, so the 403 has to reach it.
+
+    xAI's *other* 403 — ``personal-team-blocked:spending-limit`` — is excluded
+    by :func:`is_stale_oauth_token_403`: a billing wall cannot be refreshed
+    away, and retrying it would spin.  The single-shot ``retry_state`` guard
+    bounds this to one extra attempt per turn either way, so a revoked (rather
+    than merely expired) refresh token still aborts as before.
+    """
+    if retry_state.codex_auth_retry_attempted:
+        return False
+    if getattr(agent, "api_mode", None) != "codex_responses":
+        return False
+    if getattr(agent, "provider", None) not in {"openai-codex", "xai-oauth"}:
+        return False
+    if status_code == 401:
+        return True
+    return status_code == 403 and is_stale_oauth_token_403(error)
 
 
 def _image_error_max_dimension(error: Exception) -> Optional[int]:
@@ -4559,16 +4596,15 @@ def run_conversation(
                         )
                         continue
 
-                if (
-                    agent.api_mode == "codex_responses"
-                    and agent.provider in {"openai-codex", "xai-oauth"}
-                    and status_code == 401
-                    and not _retry.codex_auth_retry_attempted
+                if _should_refresh_codex_credentials(
+                    agent, status_code, api_error, _retry
                 ):
                     _retry.codex_auth_retry_attempted = True
                     if agent._try_refresh_codex_client_credentials(force=True):
                         _label = "xAI OAuth" if agent.provider == "xai-oauth" else "Codex"
-                        agent._buffer_vprint(f"🔐 {_label} auth refreshed after 401. Retrying request...")
+                        agent._buffer_vprint(
+                            f"🔐 {_label} auth refreshed after {status_code}. Retrying request..."
+                        )
                         continue
                 if (
                     agent.api_mode == "chat_completions"

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -164,6 +164,17 @@ def _billing_ambiguity_context(error_msg: str) -> Dict[str, Any]:
 # auth failures when they arrive as 403.
 _XAI_SPENDING_LIMIT_ERROR_CODE = "personal-team-blocked:spending-limit"
 
+# xAI reports an expired or invalid OAuth2 access token as HTTP 403 with body
+# code ``unauthenticated:bad-credentials`` instead of 401.  Semantically it is
+# a stale-token auth failure that one forced credential refresh recovers, so
+# it must stay distinguishable from _XAI_SPENDING_LIMIT_ERROR_CODE — the other
+# xAI 403, which no amount of refreshing fixes.
+_STALE_OAUTH_TOKEN_ERROR_CODE_PREFIX = "unauthenticated:"
+_STALE_OAUTH_TOKEN_PATTERNS = (
+    "bad-credentials",
+    "access token could not be validated",
+)
+
 # Structured provider codes that mean the account cannot serve paid traffic
 # until credits/subscription capacity is restored. xAI returns its explicit
 # Grok spending-limit signal as HTTP 403 rather than 402.
@@ -668,6 +679,35 @@ _SSL_TRANSIENT_PATTERNS = [
     # Python ssl module prefix, e.g. "[SSL: BAD_RECORD_MAC]"
     "[ssl:",
 ]
+
+
+# ── Provider-shape predicates ───────────────────────────────────────────
+
+def is_stale_oauth_token_403(error: Exception) -> bool:
+    """True when an HTTP 403 is really an expired OAuth access token.
+
+    xAI answers a stale in-memory access token with
+    ``403 {"code": "unauthenticated:bad-credentials", "error": "The OAuth2
+    access token could not be validated."}`` rather than the 401 every other
+    OAuth provider returns.  Callers use this to run the same forced credential
+    refresh they already run for a 401 (issue #82052).
+
+    Deliberately narrow: the account-level xAI 403
+    (``personal-team-blocked:spending-limit``) is a billing wall that refreshing
+    cannot clear, and must not match here.
+    """
+    if _extract_status_code(error) != 403:
+        return False
+    body = _extract_error_body(error)
+    code = (_extract_error_code(body) or "").lower()
+    if code == _XAI_SPENDING_LIMIT_ERROR_CODE:
+        return False
+    if code.startswith(_STALE_OAUTH_TOKEN_ERROR_CODE_PREFIX):
+        return True
+    # Fall back to the message: the SDK's stringified error embeds the raw body
+    # for transports that don't hand us a parseable dict.
+    haystack = f"{error} {body}".lower()
+    return any(pattern in haystack for pattern in _STALE_OAUTH_TOKEN_PATTERNS)
 
 
 # ── Classification pipeline ─────────────────────────────────────────────

--- a/tests/agent/test_error_classifier_xai_stale_token.py
+++ b/tests/agent/test_error_classifier_xai_stale_token.py
@@ -1,0 +1,94 @@
+"""Tests for ``is_stale_oauth_token_403`` — the xAI expired-access-token 403.
+
+xAI answers a stale OAuth2 access token with HTTP 403 and body code
+``unauthenticated:bad-credentials`` instead of the 401 every other OAuth
+provider returns (issue #82052).  The predicate lets the conversation loop run
+the same forced credential refresh it already runs for a 401.
+
+The critical property is narrowness: xAI's *other* 403,
+``personal-team-blocked:spending-limit``, is a billing wall that refreshing
+cannot clear and must never match.
+"""
+
+import pytest
+
+from agent.error_classifier import is_stale_oauth_token_403
+
+
+def _error(status_code=None, body=None, message="api error"):
+    """Build an exception shaped like the OpenAI SDK's APIStatusError."""
+    exc = Exception(message)
+    if status_code is not None:
+        exc.status_code = status_code
+    if body is not None:
+        exc.body = body
+    return exc
+
+
+class TestStaleTokenMatches:
+    def test_structured_bad_credentials_body(self):
+        """The exact body from the issue report."""
+        exc = _error(
+            403,
+            {
+                "code": "unauthenticated:bad-credentials",
+                "error": "The OAuth2 access token could not be validated.",
+            },
+        )
+        assert is_stale_oauth_token_403(exc) is True
+
+    def test_other_unauthenticated_subcode(self):
+        """Any ``unauthenticated:*`` subcode is a token problem, not a plan problem."""
+        exc = _error(403, {"code": "unauthenticated:token-expired"})
+        assert is_stale_oauth_token_403(exc) is True
+
+    def test_message_only_wke_marker(self):
+        """No parseable body — match the stringified error the SDK gives us."""
+        exc = _error(
+            403,
+            message=(
+                "Error code: 403 - {'error': 'The OAuth2 access token could not "
+                "be validated. [WKE=unauthenticated:bad-credentials]'}"
+            ),
+        )
+        assert is_stale_oauth_token_403(exc) is True
+
+    def test_nested_error_object_body(self):
+        """Providers that wrap the code under ``error``."""
+        exc = _error(
+            403,
+            {"error": {"code": "unauthenticated:bad-credentials", "message": "nope"}},
+        )
+        assert is_stale_oauth_token_403(exc) is True
+
+
+class TestStaleTokenDoesNotMatch:
+    def test_spending_limit_403_is_not_a_stale_token(self):
+        """The regression that matters: a billing wall must not trigger refresh."""
+        exc = _error(
+            403,
+            {"code": "personal-team-blocked:spending-limit"},
+            message="Error code: 403 - spending limit reached",
+        )
+        assert is_stale_oauth_token_403(exc) is False
+
+    def test_generic_403_is_not_a_stale_token(self):
+        exc = _error(403, message="Error code: 403 - forbidden")
+        assert is_stale_oauth_token_403(exc) is False
+
+    @pytest.mark.parametrize("status", [401, 429, 500, None])
+    def test_non_403_statuses_never_match(self, status):
+        """Only 403 is ambiguous. 401 already has its own refresh branch."""
+        exc = _error(
+            status,
+            {
+                "code": "unauthenticated:bad-credentials",
+                "error": "The OAuth2 access token could not be validated.",
+            },
+        )
+        assert is_stale_oauth_token_403(exc) is False
+
+    def test_unauthenticated_word_alone_does_not_match(self):
+        """Bare 'unauthenticated' prose is not the structured xAI signal."""
+        exc = _error(403, message="unauthenticated request rejected")
+        assert is_stale_oauth_token_403(exc) is False

--- a/tests/run_agent/test_codex_xai_oauth_recovery.py
+++ b/tests/run_agent/test_codex_xai_oauth_recovery.py
@@ -698,3 +698,131 @@ def test_transport_round_trip_drops_foreign_reasoning():
         "Cross-issuer reasoning leaked through build_kwargs — this is the "
         "exact regression that broke session 40de1ae0 on 2026-05-25 01:09."
     )
+
+
+# ---------------------------------------------------------------------------
+# Fix E: an expired xAI access token arrives as 403, not 401 (#82052)
+#
+# xAI answers a stale in-memory OAuth access token with
+# ``403 {"code": "unauthenticated:bad-credentials"}``.  The conversation
+# loop's forced-refresh branch only fired on 401, so the 403 fell through to
+# the non-retryable abort and a long-lived worker (tui_gateway slash_worker)
+# replayed the dead token on every turn until the process was restarted —
+# even though a fresh CLI probe on the same box succeeded, proving the
+# refresh token and credential store were healthy.
+#
+# ``_should_refresh_codex_credentials`` is the gate.  It must open for the
+# stale-token 403 and stay shut for the spending-limit 403, which no amount
+# of refreshing can clear.
+# ---------------------------------------------------------------------------
+
+
+def _retry_state(attempted=False):
+    from agent.turn_retry_state import TurnRetryState
+
+    state = TurnRetryState()
+    state.codex_auth_retry_attempted = attempted
+    return state
+
+
+def _stale_token_403():
+    """The exact error from the issue report."""
+    exc = Exception(
+        'HTTP 403: {"code":"unauthenticated:bad-credentials","error":'
+        '"The OAuth2 access token could not be validated."}'
+    )
+    exc.status_code = 403
+    exc.body = {
+        "code": "unauthenticated:bad-credentials",
+        "error": "The OAuth2 access token could not be validated.",
+    }
+    return exc
+
+
+def _spending_limit_403():
+    exc = Exception("Error code: 403 - spending limit")
+    exc.status_code = 403
+    exc.body = {
+        "code": "personal-team-blocked:spending-limit",
+        "error": "You have run out of credits or need a Grok subscription.",
+    }
+    return exc
+
+
+def test_stale_token_403_opens_the_refresh_gate():
+    """The regression: 403 bad-credentials must reach the credential refresh."""
+    from agent.conversation_loop import _should_refresh_codex_credentials
+
+    agent = _make_codex_agent()
+
+    assert _should_refresh_codex_credentials(
+        agent, 403, _stale_token_403(), _retry_state()
+    ) is True
+
+
+def test_spending_limit_403_keeps_the_refresh_gate_shut():
+    """A billing wall is not a stale token — refreshing it would spin forever."""
+    from agent.conversation_loop import _should_refresh_codex_credentials
+
+    agent = _make_codex_agent()
+
+    assert _should_refresh_codex_credentials(
+        agent, 403, _spending_limit_403(), _retry_state()
+    ) is False
+
+
+def test_plain_401_still_opens_the_refresh_gate():
+    """Pre-existing behaviour is untouched."""
+    from agent.conversation_loop import _should_refresh_codex_credentials
+
+    agent = _make_codex_agent()
+    exc = Exception("Error code: 401 - unauthorized")
+    exc.status_code = 401
+
+    assert _should_refresh_codex_credentials(
+        agent, 401, exc, _retry_state()
+    ) is True
+
+
+def test_stale_token_403_refreshes_at_most_once_per_turn():
+    """The single-shot guard bounds a revoked refresh token to one attempt."""
+    from agent.conversation_loop import _should_refresh_codex_credentials
+
+    agent = _make_codex_agent()
+
+    assert _should_refresh_codex_credentials(
+        agent, 403, _stale_token_403(), _retry_state(attempted=True)
+    ) is False
+
+
+def test_generic_403_does_not_open_the_refresh_gate():
+    """An ordinary permission denial is not a credential problem."""
+    from agent.conversation_loop import _should_refresh_codex_credentials
+
+    agent = _make_codex_agent()
+    exc = Exception("Error code: 403 - forbidden")
+    exc.status_code = 403
+
+    assert _should_refresh_codex_credentials(
+        agent, 403, exc, _retry_state()
+    ) is False
+
+
+@pytest.mark.parametrize(
+    "api_mode,provider",
+    [
+        ("chat_completions", "xai-oauth"),  # wrong transport
+        ("codex_responses", "openrouter"),  # wrong provider
+    ],
+)
+def test_refresh_gate_stays_provider_scoped(api_mode, provider):
+    """Only the Codex/xAI Responses path owns this recovery."""
+    from agent.conversation_loop import _should_refresh_codex_credentials
+
+    agent = _make_codex_agent()
+    agent.api_mode = api_mode
+    agent.provider = provider
+
+    assert _should_refresh_codex_credentials(
+        agent, 403, _stale_token_403(), _retry_state()
+    ) is False


### PR DESCRIPTION
## What does this PR do?

xAI reports an **expired OAuth2 access token as HTTP 403** with body code `unauthenticated:bad-credentials` — not the 401 every other OAuth provider returns.

The conversation loop's forced credential refresh (`agent/conversation_loop.py`) only fired on `status_code == 401`. A 403 never reached it, so it fell through to the non-retryable client-error abort. Because `_try_refresh_codex_client_credentials` (`run_agent.py`) is the **only** place a worker's in-memory `self.api_key` is replaced, a long-lived worker (tui_gateway `slash_worker`, gateway session) kept replaying its dead token on every turn and never recovered:

```
⚠️  API call failed (attempt 1/3): PermissionDeniedError [HTTP 403]
   🔌 Provider: xai-oauth  Model: grok-4.5
   📝 Error: HTTP 403: {"code":"unauthenticated:bad-credentials","error":"The OAuth2 access token could not be validated."}
❌ Non-retryable client error (HTTP 403). Aborting.
```

Only restarting the process cleared it — even though the refresh token and credential store were healthy (a fresh CLI probe on the same box succeeded immediately, and a cron job on the same provider had succeeded earlier the same day).

**The fix** extends the existing `codex_responses` refresh branch to cover this 403, reusing the `codex_auth_retry_attempted` single-shot guard so a *revoked* (rather than merely expired) refresh token still aborts exactly as it does today — at most one extra attempt per turn.

### Why this approach

This mirrors precedent already in-tree. `agent/auxiliary_client.py::_is_auth_error` has treated `403` + `bad-credentials` as an auth failure since #34431 — the main conversation loop simply never got the same treatment. This PR closes that gap rather than inventing a new recovery mechanism.

The match is **deliberately narrow**. xAI's *other* 403, `personal-team-blocked:spending-limit`, is a billing wall that refreshing cannot clear; retrying it would spin. `is_stale_oauth_token_403()` excludes it explicitly, and the pre-existing entitlement-403 guard (`test_recover_with_credential_pool_skips_refresh_on_entitlement_403`, the #29344 regression) still passes.

I deliberately did **not** change what `_classify_by_status` returns for 403 — adding `should_rotate_credential` there would alter multi-account pool rotation behavior well beyond this bug.

### Not a duplicate of #73736

#73736 adds `"unauthenticated"` to `_AUTH_PATTERNS`, but that list is only consulted by `_classify_by_message` when `status_code is None` (the SSE-frame variant). With a real HTTP 403 the status branch wins first (`error_classifier.py`), so this variant stays broken with or without that PR. The two are complementary and touch different code paths.

## Related Issue

Fixes #82052

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`agent/error_classifier.py`** — new public predicate `is_stale_oauth_token_403(error)`, plus the `_STALE_OAUTH_TOKEN_*` constants it matches on. Checks the structured body code first (`unauthenticated:*`), falls back to the stringified error for transports that don't hand us a parseable dict, and returns `False` for `personal-team-blocked:spending-limit` before anything else. Placed next to the existing `_XAI_SPENDING_LIMIT_ERROR_CODE` so the "which xAI 403 is which" logic lives in one place.
- **`agent/conversation_loop.py`** — extracted the refresh gate into `_should_refresh_codex_credentials(agent, status_code, error, retry_state)` (sitting beside its sibling `_is_stale_copilot_credential_error`) and extended it to fire on the stale-token 403 as well as 401. The inline `if` at the call site is replaced by the helper, which also makes the branch directly testable. The retry log line now interpolates the actual status instead of hardcoding `401`.
- **`tests/agent/test_error_classifier_xai_stale_token.py`** *(new)* — 11 tests pinning the predicate's narrowness: structured body, nested `error.code` body, message-only `[WKE=...]` marker, and negative cases for spending-limit, generic 403, bare "unauthenticated" prose, and non-403 statuses.
- **`tests/run_agent/test_codex_xai_oauth_recovery.py`** — 7 tests on the gate itself: the stale-token 403 opens it, the spending-limit 403 does not, plain 401 still does, the single-shot guard holds, generic 403 is ignored, and the gate stays scoped to `codex_responses` + `openai-codex`/`xai-oauth`.

## How to Test

**Reproduce (before the fix):** on a long-lived xAI OAuth session, let the in-memory access token expire (or force it). Every turn then fails with `403 unauthenticated:bad-credentials` → `Non-retryable client error. Aborting.`, while `hermes -z "Reply with exactly: OK" --provider xai-oauth --model grok-4.5` still succeeds — proving the stored credentials are fine and only the worker's cached token is stale. Only `systemctl --user restart hermes-dashboard` recovers it.

**Automated proof:**

```bash
scripts/run_tests.sh \
  tests/agent/test_error_classifier_xai_stale_token.py \
  tests/run_agent/test_codex_xai_oauth_recovery.py \
  tests/agent/test_auxiliary_client_xai_oauth_recovery.py \
  tests/agent/test_error_classifier.py \
  tests/run_agent/test_run_agent_codex_responses.py -q
# => 165 passed
```

**Negative control** — I verified the new tests actually catch the bug rather than just passing. Stubbing the new clause out:

```diff
-    return status_code == 403 and is_stale_oauth_token_403(error)
+    return False
```

fails exactly one test, the one that matters:

```
FAILED tests/run_agent/test_codex_xai_oauth_recovery.py::test_stale_token_403_opens_the_refresh_gate
1 failed, 25 passed
```

**Manual exercise through the real loop.** The unit tests above cover the gate predicate; this drives the actual `run_conversation()` against a provider that always answers 403, counting API attempts and refresh calls:

| case | API attempts | refreshes | |
|---|---|---|---|
| stale-token 403 | 2 | 1 | recovers |
| spending-limit 403 | 1 | 0 | aborts with billing guidance |

Pre-fix, the first row is 1 attempt / 0 refreshes — the bug. The second row confirms the billing wall still short-circuits.

**No regressions — full suite, both sides.** `scripts/run_tests.sh` (entire `tests/`), same machine, same env:

| | files | passed | failed | failing files |
|---|---|---|---|---|
| baseline `3e6a081d6` | 2720 | 28040 | 488 | 189 |
| with this change | 2721 | 27987 | 486 | 188 |

Diffing the failing-file sets: **zero files fail with this change that pass at baseline.** One unrelated file (`tests/test_minimax_oauth.py`) fails at baseline and passes here — flaky.

The absolute pass counts move in both directions because this environment (Windows, 64-way parallel, no docker/modal) has substantial timeout flakiness — 396 timeout mentions with the change vs 403 at baseline. The per-file set difference is the meaningful signal, not the totals. The ~188 pre-existing failures are unrelated subsystems (terminal/file-ops sandboxing, docker, modal, skills-hub); none are files this PR touches.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — closest is #73736, which fixes the `status_code is None` SSE path and does not cover this variant (see above)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` over the entire `tests/` tree, on both this branch and the baseline commit — zero new failing files (see comparison above)
- [x] I've added tests for my changes (18 new tests, including a verified negative control)
- [x] I've tested on my platform: Windows 11, Python 3.13.14 — automated suite plus the manual loop exercise above. I do not have an xAI OAuth account, so the live 403-from-a-genuinely-expired-token path is reproduced via the provider error shape from the issue report rather than against real xAI infrastructure.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on both new functions; no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — pure Python control flow, no OS-specific calls; `scripts/check-windows-footguns.py` is clean on all four changed files
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Retry path after the fix (the message now interpolates the real status, so a 403 recovery is distinguishable from a 401 recovery in logs):

```
🔐 xAI OAuth auth refreshed after 403. Retrying request...
```
