### PR TITLE
fix(agent): stop the MoA prepared request reaching a swapped-in native client

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -182,6 +182,20 @@ _API_CALL_MODULES = frozenset({
 })
 
 
+def _moa_client_consumes_prepared_request(client: Any) -> bool:
+    """True when ``client`` is the in-process MoA facade.
+
+    ``_moa_prepared_request`` is a private handshake with
+    ``MoAChatCompletions.create``, and only that facade exposes ``prepare()``.
+    Every other chat-completions object raises TypeError on the unexpected
+    keyword — including the native OpenAI client that credential rotation,
+    provider fallback and dead-connection cleanup rebuild from
+    ``_client_kwargs`` while ``agent.provider`` stays ``"moa"``.
+    """
+    completions = getattr(getattr(client, "chat", None), "completions", None)
+    return callable(getattr(completions, "prepare", None))
+
+
 def _join_truncated_parts(parts: List[str]) -> str:
     """Join continuation fragments, adding a newline where two would glue together (#78577)."""
     joined = ""
@@ -2519,7 +2533,24 @@ def run_conversation(
                 # only after middleware, hooks, and debug dumps so none of them
                 # attempts to serialize it as part of the provider payload.
                 if _moa_prepared_request is not None and agent.provider == "moa":
-                    api_kwargs["_moa_prepared_request"] = _moa_prepared_request
+                    # Re-read the live client instead of trusting the one that
+                    # prepared the request above. Credential rotation, provider
+                    # fallback and dead-connection cleanup all rebuild
+                    # agent.client from _client_kwargs between attempts, and
+                    # pending_moa_prepared_request carries a prepared request
+                    # across exactly that boundary. The rebuilt client is a
+                    # native OpenAI client while provider stays "moa", so this
+                    # private key would reach the SDK as an unexpected keyword
+                    # — a non-retryable TypeError that kills every remaining
+                    # turn on the session.
+                    if _moa_client_consumes_prepared_request(agent.client):
+                        api_kwargs["_moa_prepared_request"] = _moa_prepared_request
+                    else:
+                        logger.warning(
+                            "MoA client replaced mid-turn (client=%s); sending the "
+                            "prepared prompt without the MoA handshake",
+                            type(agent.client).__name__,
+                        )
 
                 # Always prefer the streaming path — even without stream
                 # consumers.  Streaming gives us fine-grained health

--- a/tests/agent/test_moa_prepared_request_client_swap.py
+++ b/tests/agent/test_moa_prepared_request_client_swap.py
@@ -1,0 +1,62 @@
+"""`_moa_prepared_request` must never reach a client that cannot consume it.
+
+The key is a private handshake between the conversation loop and
+``MoAChatCompletions.create``. Credential rotation, provider fallback and
+dead-connection cleanup rebuild ``agent.client`` from ``_client_kwargs``
+between attempts — and a prepared request survives that boundary via
+``pending_moa_prepared_request`` — while ``agent.provider`` stays ``"moa"``.
+Handing the key to the rebuilt native client raises a non-retryable
+``TypeError`` that kills every remaining turn on the session.
+"""
+
+import types
+
+from agent.conversation_loop import _moa_client_consumes_prepared_request
+from agent.moa_loop import MoAChatCompletions
+
+
+def _client_with(completions):
+    return types.SimpleNamespace(
+        chat=types.SimpleNamespace(completions=completions)
+    )
+
+
+class _NativeCompletions:
+    """openai.resources.chat.Completions — an explicit keyword signature."""
+
+    def create(self, *, model=None, messages=None, tools=None, stream=None):
+        return "native ok"
+
+
+def test_native_client_does_not_consume_the_prepared_request():
+    assert _moa_client_consumes_prepared_request(_client_with(_NativeCompletions())) is False
+
+
+def test_real_moa_facade_consumes_the_prepared_request():
+    facade = MoAChatCompletions.__new__(MoAChatCompletions)
+    assert _moa_client_consumes_prepared_request(_client_with(facade)) is True
+
+
+def test_client_without_a_chat_attribute_is_not_a_facade():
+    assert _moa_client_consumes_prepared_request(object()) is False
+    assert _moa_client_consumes_prepared_request(None) is False
+
+
+def test_native_client_rejects_the_key_it_must_not_receive():
+    """Why the guard exists: the kwarg is fatal to a native client."""
+    native = _NativeCompletions()
+    try:
+        native.create(
+            model="2 model",
+            messages=[{"role": "user", "content": "hi"}],
+            _moa_prepared_request={"messages": [], "layers": 3},
+        )
+    except TypeError as exc:
+        assert "_moa_prepared_request" in str(exc)
+    else:  # pragma: no cover - would mean the premise no longer holds
+        raise AssertionError("native client accepted the private MoA kwarg")
+
+    # Without the key it is an ordinary call the rebuilt client can serve.
+    assert native.create(
+        model="2 model", messages=[{"role": "user", "content": "hi"}]
+    ) == "native ok"


### PR DESCRIPTION
Addresses #78382. Two PRs are already open on that issue — see "Relation to the open PRs" at the bottom before spending review time here.

## What

`_moa_prepared_request` is a private handshake: `agent/conversation_loop.py` attaches it to `api_kwargs`, and only `MoAChatCompletions.create` in `agent/moa_loop.py` pops it back off. It is attached on one condition — `agent.provider == "moa"` — which assumes `agent.client` is still the in-process MoA facade.

That assumption does not survive a client swap. `_replace_primary_openai_client` rebuilds `agent.client` from `_client_kwargs` on credential rotation, provider fallback and dead-connection cleanup, and it leaves `agent.provider` at `"moa"`. The rebuilt client is a native OpenAI client, so the key reaches an SDK that has never heard of it:

```
TypeError: Completions.create() got an unexpected keyword argument '_moa_prepared_request'
```

The error is non-retryable, so it is not a lost turn — every remaining turn on that session fails the same way.

The timing is not incidental. `pending_moa_prepared_request` deliberately carries a prepared request across attempt boundaries, and a client swap is exactly what happens at an attempt boundary. Preparation reads the facade; dispatch, one rotation later, does not.

Both dispatch paths are affected, for the same reason. The non-streaming one calls `agent.client.chat.completions.create(**api_kwargs)` directly, and the streaming one goes through `_create_request_openai_client`, which returns the primary client unchanged when the provider is `"moa"`.

This is the gap left by 3e86df275 (2026-07-27, fix(agent): redecorate prompt-cache breakpoints after provider failover). That commit already recognised, in this same function, that per-client request state has to be re-derived after a failover — it just re-derived the cache breakpoints and not the MoA handshake, which is attached a few lines later and swaps out under the same event.

## The fix

Re-read the live client at the point the key is attached, rather than trusting the one that prepared the request. Only the facade exposes `prepare()`, which is the same duck-type the preparation step above already uses, so no import and no new coupling:

- facade still in place — attach the key, behaviour unchanged
- facade gone — send the prepared prompt without the handshake and log the downgrade

Guarding at the attachment point rather than at the dispatch point covers the streaming and non-streaming paths with one check. The messages in `api_kwargs` are already the prepared ones, so the rebuilt client serves a well-formed request instead of raising.

## Tests and results

New `tests/agent/test_moa_prepared_request_client_swap.py` — 4 passed:

- a native-signature completions object is not treated as a facade
- a real `MoAChatCompletions` is
- a client with no `chat` attribute, and `None`, are not
- the premise itself: the native signature raises `TypeError` naming `_moa_prepared_request`, and the same call without the key succeeds

`tests/agent -k moa` — 68 passed, 3 skipped, no failures.

Reproduced the original error before the change by dispatching with `provider="moa"` and a native-signature client, and confirmed the same dispatch is clean once the key is withheld.

## Relation to the open PRs

I found #78409 and #80132 only after opening this. Recording the differences so a reviewer can pick one rather than diff three.

**#78409 — preserve the facade across client rebuilds (`run_agent.py`).** This is the root-cause repair: it restores the invariant that `provider == "moa"` implies `client is the facade`, instead of teaching callers to cope when it does not hold. If it holds up, it is the better fix and this PR is unnecessary. It is also the largest behavioural change of the three, since it alters what rotation produces.

**#80132 — pop the key at the non-streaming dispatch (`agent/chat_completion_helpers.py`).** Same intent as this PR, and it would stop the reported `TypeError`. Two things a reviewer should weigh:

- The pop is unconditional, so it also strips the key when the facade *is* still in place. `MoAChatCompletions.prepare` documents the contract it relies on — "when the loop supplies the returned private object back to `create()`, the advisor fan-out is not repeated" — and `rebase_prepared_request` exists specifically to avoid "a second costly fan-out". Dropping the key on the healthy path sends `create()` down its normal resolution branch, so the advisors run a second time on every non-streaming MoA turn.
- It guards the non-streaming dispatch only. The streaming path reaches the same swapped-in client through `_create_request_openai_client`, which returns the primary client unchanged for provider `"moa"`, and still carries the key.

This PR withholds the key only when the facade is actually gone, and does it once for both paths. I have no stake in which lands — if #78409 is the direction, close this.
