### PR TITLE
fix(auth): make the first pooled credential the active provider on every `auth add` branch

### DIFF
--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -217,7 +217,21 @@ def auth_add_command(args) -> None:
             access_token=token,
             base_url=_provider_base_url(provider),
         )
+        first_credential = not pool.entries()
         pool.add_entry(entry)
+        # Adding the very first credential should make it the active provider,
+        # matching the openai-codex / xai-oauth / qwen-oauth / minimax-oauth
+        # paths below. Without this, `hermes setup` reports "No inference
+        # provider configured" for a credential `hermes auth list` just showed,
+        # because _model_section_has_credentials() consults
+        # get_active_provider() and an API key added here sets no env var.
+        # Guarded on PROVIDER_REGISTRY because resolve_provider() only honours
+        # an active_provider it can find there — writing a `custom:*` pool key
+        # would satisfy the wizard while resolution still failed. `openrouter`
+        # is deliberately outside the registry and already resolves from its
+        # own pool tier, so it needs no marking either.
+        if first_credential and provider in PROVIDER_REGISTRY:
+            auth_mod.mark_provider_active_if_unset(provider)
         print(f'Added {provider} credential #{len(pool.entries())}: "{label}"')
         return
 
@@ -243,7 +257,16 @@ def auth_add_command(args) -> None:
             expires_at_ms=creds.get("expires_at_ms"),
             base_url=_provider_base_url(provider),
         )
+        first_credential = not pool.entries()
         pool.add_entry(entry)
+        # run_hermes_oauth_login_pure() is pure — it returns tokens and persists
+        # nothing — so this pool insert is the only write on this branch. Mirror
+        # the openai-codex / xai-oauth first-credential marking below.
+        # `anthropic` is a static PROVIDER_REGISTRY member, so no registry guard
+        # is needed here (unlike the API-key branch above, which accepts
+        # `custom:*` pool keys).
+        if first_credential:
+            auth_mod.mark_provider_active_if_unset(provider)
         print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')
         return
 

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -380,6 +380,152 @@ def test_auth_add_xai_oauth_sets_active_provider(tmp_path, monkeypatch):
     assert entry["base_url"] == "https://api.x.ai/v1"
 
 
+def test_auth_add_anthropic_oauth_sets_active_provider(tmp_path, monkeypatch):
+    """hermes auth add anthropic must set active_provider and write a pool entry.
+
+    Same regression class as ``test_auth_add_xai_oauth_sets_active_provider``
+    above, on the branch that fix never reached. ``run_hermes_oauth_login_pure``
+    is pure — it returns tokens and persists nothing — so the pool insert used
+    to be the only write, leaving ``active_provider`` unset and the setup
+    wizard reporting "No inference provider configured" for a credential
+    ``hermes auth list`` had just shown. OAuth is the default auth type for
+    anthropic, so this is what a bare ``hermes auth add anthropic`` does.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+    access_token = _jwt_with_email("anthropic@example.com")
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.run_hermes_oauth_login_pure",
+        lambda **kwargs: {
+            "access_token": access_token,
+            "refresh_token": "anthropic-refresh-token",
+            "expires_at_ms": 1_800_000_000_000,
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "anthropic"
+        auth_type = "oauth"
+        api_key = None
+        label = None
+
+    auth_add_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    # active_provider must be set — the core of the regression
+    assert payload["active_provider"] == "anthropic"
+    entries = payload["credential_pool"]["anthropic"]
+    entry = next(item for item in entries if item["source"] == "manual:hermes_pkce")
+    assert entry["access_token"] == access_token
+    assert entry["refresh_token"] == "anthropic-refresh-token"
+
+
+def test_auth_add_api_key_sets_active_provider(tmp_path, monkeypatch):
+    """hermes auth add <registry provider> --type api-key must set active_provider.
+
+    A manually added API key writes no environment variable, so
+    ``_model_section_has_credentials()`` can only see it through
+    ``get_active_provider()``. Without the marking the wizard reported "No
+    inference provider configured" for a key ``hermes auth list`` had just
+    shown.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "deepseek"
+        auth_type = "api-key"
+        api_key = "sk-deepseek-manual"
+        label = "work"
+
+    auth_add_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert payload["active_provider"] == "deepseek"
+    entries = payload["credential_pool"]["deepseek"]
+    entry = next(item for item in entries if item["source"] == "manual")
+    assert entry["label"] == "work"
+    assert entry["access_token"] == "sk-deepseek-manual"
+
+
+def test_auth_add_does_not_steal_an_existing_active_provider(tmp_path, monkeypatch):
+    """Neither add path may override an active provider the user already chose.
+
+    ``mark_provider_active_if_unset`` is only reached on the first credential
+    for the pool, and only writes when ``active_provider`` is empty. This pins
+    both halves for the two branches above, so the marking cannot regress into
+    "last add wins".
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {"version": 1, "providers": {}, "active_provider": "openai-codex"},
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.run_hermes_oauth_login_pure",
+        lambda **kwargs: {
+            "access_token": _jwt_with_email("anthropic@example.com"),
+            "refresh_token": "anthropic-refresh-token",
+            "expires_at_ms": 1_800_000_000_000,
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _OAuthArgs:
+        provider = "anthropic"
+        auth_type = "oauth"
+        api_key = None
+        label = None
+
+    class _ApiKeyArgs:
+        provider = "deepseek"
+        auth_type = "api-key"
+        api_key = "sk-deepseek-manual"
+        label = "work"
+
+    auth_add_command(_OAuthArgs())
+    auth_add_command(_ApiKeyArgs())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert payload["active_provider"] == "openai-codex"
+    # Both credentials still landed in their pools — only the marking is skipped.
+    assert payload["credential_pool"]["anthropic"]
+    assert payload["credential_pool"]["deepseek"]
+
+
+def test_auth_add_custom_pool_api_key_leaves_active_provider_unset(tmp_path, monkeypatch):
+    """A ``custom:*`` pool key must never become active_provider.
+
+    ``resolve_provider`` only honours an ``active_provider`` it can find in
+    ``PROVIDER_REGISTRY``, so marking a custom pool alias active would silence
+    the setup wizard while provider resolution still failed — strictly worse
+    than leaving it unset. This pins the ``provider in PROVIDER_REGISTRY``
+    guard on the API-key branch.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "custom:mylocal"
+        auth_type = "api-key"
+        api_key = "sk-custom-manual"
+        label = "local"
+
+    auth_add_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert not (payload.get("active_provider") or "").strip()
+    assert payload["credential_pool"]["custom:mylocal"]
+
+
 def test_auth_add_xai_oauth_keeps_distinct_pool_accounts(tmp_path, monkeypatch):
     """Two ``hermes auth add xai-oauth`` runs must produce independent pool entries.
 


### PR DESCRIPTION
## What does this PR do?

`hermes auth add` puts a credential in the pool and then, on most branches, marks that provider active. On two branches it doesn't — so the credential lands, `hermes auth list` shows it, and `hermes setup` still says **"No inference provider configured"**.

`auth_add_command` has six `pool.add_entry()` sites. Four establish an active provider:

| line | branch | marks `active_provider` | how |
|---|---|---|---|
| 220 | generic **API-key** (all providers) | **no** | — |
| 246 | **anthropic OAuth** | **no** | — |
| 339 | openai-codex | yes | `first_credential` guard → `mark_provider_active_if_unset` |
| 380 | xai-oauth | yes | same guarded pattern |
| 406 | qwen-oauth | yes | `_mark_qwen_oauth_active` → `_save_provider_state` |
| 430 | minimax-oauth | yes | `_minimax_oauth_login` → `_minimax_save_auth_state` → `_save_provider_state` |
| 279/303 | nous | yes | `persist_nous_credentials` → `_save_provider_state` |

The two gaps are the widest-reach paths:

- **API-key branch** — serves *every* provider. A manually pasted key writes no environment variable.
- **anthropic OAuth branch** — `run_hermes_oauth_login_pure()` is pure: it returns tokens and persists nothing, so the pool insert is the only write on that path. OAuth is the default auth type for `anthropic` (`_OAUTH_CAPABLE_PROVIDERS`), so a bare `hermes auth add anthropic` lands here.

`_model_section_has_credentials()` (`hermes_cli/setup.py:2445`) returns True only on `get_active_provider()` or an API-key env var. Neither of the above sets either, so the wizard reports the provider missing.

This is not a new invariant — the repo states it against itself. `mark_provider_active_if_unset`'s docstring (`hermes_cli/auth.py:1485`):

> Adding the very first credential for a provider should make it the active provider so the setup wizard's `_model_section_has_credentials()` check (which consults `get_active_provider()`) does not report "No inference provider configured". Subsequent adds for an already-active setup leave the user's chosen active provider untouched.

And `test_auth_add_xai_oauth_sets_active_provider` (`tests/hermes_cli/test_auth_commands.py:328`) records the same bug on the branch it was already fixed on:

> Early path called `pool.add_entry()` without `active_provider`, so the setup wizard reported "No inference provider configured".

### The `PROVIDER_REGISTRY` guard on the API-key branch is load-bearing

The API-key branch also accepts `custom:*` pool keys and `openrouter`, neither of which is a `PROVIDER_REGISTRY` member. `mark_provider_active_if_unset` does no validation, and `_model_section_has_credentials` returns True for *any* truthy `get_active_provider()` — but `resolve_provider` (`hermes_cli/auth.py:2118`) only honours an `active_provider` when `_maybe in PROVIDER_REGISTRY`.

So marking a `custom:foo` pool active would **silence the wizard while resolution still failed** — strictly worse than the current behaviour. Hence `if first_credential and provider in PROVIDER_REGISTRY:`. `openrouter` is deliberately outside the registry (see the `provider != "openrouter"` special case at `auth_commands.py:166`) and already resolves through its own credential-pool tier at `auth.py:2103-2109`, so skipping it is correct rather than an omission. `anthropic` *is* a static registry member, so the OAuth branch needs no registry guard.

### Scope of the claim

This restores the **wizard/status** signal — `_model_section_has_credentials()`. `resolve_provider`'s active-provider fallback additionally requires `get_auth_status(<provider>).get("logged_in")`; this PR does not change that, and the tests do not claim it.

### Known follow-up, declared

`hermes_cli/web_server.py:10297` (dashboard anthropic PKCE pool insert) and `:12813` (`POST /api/credentials/pool`, whose own comment says it *"Mirrors the `hermes auth add` behaviour in auth_commands.py"*) share this root cause. They are **deliberately excluded** here: I already have an open PR against that file (#74356), and stacking an unrelated concern onto it would make both harder to review. I'll file the mirror as a sibling PR once that one closes.

## Related Issue

No filed issue — found while tracing why a fresh `hermes auth add anthropic` leaves `hermes setup` reporting no provider. The strongest precedent is that this exact fix was already shipped on the sibling branches, merged by @teknium1:

- #39011 — `fix(auth): set active_provider after hermes auth add qwen-oauth`
- #39012 — `fix(auth): set active_provider after hermes auth add google-gemini-cli`
- #39015 — `fix(auth): use _save_xai_oauth_tokens in auth_commands to set active_provider`
- #42316 — `fix(auth): keep Codex OAuth pool accounts distinct on add + re-auth (#39236)`

This PR completes that series on the two branches it never reached.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/auth_commands.py` — API-key branch: capture `first_credential = not pool.entries()` before the insert, then `mark_provider_active_if_unset(provider)` when it is the first credential **and** `provider in PROVIDER_REGISTRY`.
- `hermes_cli/auth_commands.py` — anthropic OAuth branch: same `first_credential` guard, no registry check needed (`anthropic` is statically in the registry).
- `tests/hermes_cli/test_auth_commands.py` — four tests, inserted next to the existing xai-oauth active-provider tests and following their template (assert on the `auth.json` payload rather than through `get_active_provider()`):
  - `test_auth_add_anthropic_oauth_sets_active_provider`
  - `test_auth_add_api_key_sets_active_provider`
  - `test_auth_add_does_not_steal_an_existing_active_provider` — control: with `active_provider` already set to `openai-codex`, neither new marking call overrides it, while both credentials still land in their pools. This is what keeps the change from degenerating into "last add wins".
  - `test_auth_add_custom_pool_api_key_leaves_active_provider_unset` — pins the `PROVIDER_REGISTRY` guard so a `custom:*` pool can never be written as an unresolvable `active_provider`.

No import churn — `auth_mod` and `PROVIDER_REGISTRY` are already imported in this module and used at `:344` / `:165`.

### Sibling-site sweep

`git grep -n "\.add_entry(" -- '*.py'` on production code returns **8 sites**: the 6 in `auth_commands.py` in the table above (2 fixed here, 4 already correct) and the 2 in `web_server.py` excluded above with reasons. No other caller of `pool.add_entry` exists.

## How to Test

Repro on a clean profile:

```bash
export HERMES_HOME=$(mktemp -d)
hermes auth add anthropic        # OAuth is the default type for anthropic
hermes auth list                 # shows the credential
hermes setup                     # before: "No inference provider configured"
```

Same for `hermes auth add deepseek --type api-key`.

Automated, and verified in both directions:

```bash
pytest tests/hermes_cli/test_auth_commands.py -v
```

**Before the production change** (test file applied to clean `main`) — the two positive tests fail on exactly the reported symptom, with the success message printed and no `active_provider` written:

```
FAILED test_auth_add_anthropic_oauth_sets_active_provider - KeyError: 'active_provider'
FAILED test_auth_add_api_key_sets_active_provider          - KeyError: 'active_provider'
2 failed, 3 passed
----- Captured stdout -----
Added anthropic OAuth credential #1: "anthropic@example.com"
Added deepseek credential #1: "work"
```

The control and the `custom:*` guard test pass in both directions by design — they are invariants, not regressions, and are there so the fix cannot be loosened later.

**After**: `22 passed` for the whole file. Adjacent auth/provider/setup suites also green (`211 passed`):

```
tests/hermes_cli/test_setup_model_provider.py
tests/hermes_cli/test_setup_blank_slate.py
tests/hermes_cli/test_resolve_provider_openrouter_pool.py
tests/hermes_cli/test_runtime_provider_resolution.py
tests/hermes_cli/test_anthropic_oauth_flow.py
tests/hermes_cli/test_anthropic_provider_persistence.py
tests/hermes_cli/test_api_key_providers.py
tests/hermes_cli/test_auth_provider_gate.py
tests/hermes_cli/test_auth_xai_oauth_provider.py
tests/hermes_cli/test_auth_codex_provider.py
```

`test_auth_xai_oauth_provider.py` and `test_auth_commands.py` are the only two test files in the repo that invoke `auth_add_command`, so the behavioural blast radius is fully covered.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the focused + adjacent suites listed under "How to Test" (233 tests, all green) rather than the full suite; happy to run anything wider on request
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4.0), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no user-facing surface changes; the reasoning lives in code comments at both sites
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A, pure auth-store dict logic with no path, process, or terminal handling; tests set `HERMES_HOME` rather than assuming a home layout
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

Several open PRs touch `auth_add_command` in nearby regions. None addresses this defect, and none touches `pool.add_entry` or anything after it, so this is not a duplicate of any of them — though a three-way merge may be needed on the first two if they land first:

- **#76987 / #77583** — add a `name=` kwarg *inside* the `PooledCredential(...)` constructors at both sites.
- **#66971** — adds a `--base-url` flag, changing the `base_url=` kwarg on the API-key constructor.
- **#72416** — passes `open_browser=` into `run_hermes_oauth_login_pure()`.
- **#70088** — inserts a shared-Anthropic-pool early return before the OAuth flow.
- **#65980** — `make_first=True` ordering on the openai-codex branch only.
- **#37648** — *clears* `active_provider` when removing the active OAuth provider; the complementary direction of the same invariant.
