### PR TITLE
fix(docker): refresh uv image for patched rustls-webpki (#51292)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get -o Acquire::Retries=3 update && \
     make -j"$(nproc)" && \
     make install
 
-FROM ghcr.io/astral-sh/uv:0.11.6-python3.13-trixie@sha256:b3c543b6c4f23a5f2df22866bd7857e5d304b67a564f4feab6ac22044dde719b AS uv_source
+FROM ghcr.io/astral-sh/uv:0.11.33-python3.13-trixie@sha256:83447533ae5dab3fbe1b09dff4d34bce0b796d65392179007c04ce1d72d3d752 AS uv_source
 # Node 26 source stage. Debian trixie's bundled nodejs is pinned to 20.x
 # which reached EOL in April 2026 — we copy node + npm from the upstream
 # node:26 image instead (Hermes pins its toolchain to Node 26 everywhere).

--- a/tests/tools/test_dockerfile_uv_source.py
+++ b/tests/tools/test_dockerfile_uv_source.py
@@ -1,0 +1,63 @@
+"""Security contract for the uv binaries copied into the container image."""
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCKERFILE = REPO_ROOT / "Dockerfile"
+
+# Each entry must be backed by an audit of the immutable registry image and its
+# dependency graph. uv 0.11.33 embeds the rustls-webpki 0.103.13 fix required by
+# #51292; its GHCR manifest resolves to the digest below.
+_APPROVED_UV_SOURCE_DIGESTS = {
+    "0.11.33-python3.13-trixie": (
+        "83447533ae5dab3fbe1b09dff4d34bce0b796d65392179007c04ce1d72d3d752"
+    ),
+}
+_VULNERABLE_UV_SOURCE_DIGEST = (
+    "b3c543b6c4f23a5f2df22866bd7857e5d304b67a564f4feab6ac22044dde719b"
+)
+_UV_SOURCE_RE = re.compile(
+    r"^FROM ghcr\.io/astral-sh/uv:"
+    r"(?P<source>\d+\.\d+\.\d+-[^@\s]+)"
+    r"@sha256:(?P<digest>[0-9a-f]{64}) AS uv_source$",
+    re.MULTILINE,
+)
+
+
+def _assert_approved_uv_source(dockerfile: str) -> None:
+    match = _UV_SOURCE_RE.search(dockerfile)
+
+    assert match is not None, (
+        "Dockerfile must pin the uv source image by version and sha256 digest; "
+        "keep the source stage name stable so this container security contract applies"
+    )
+    source = match.group("source")
+    assert source in _APPROVED_UV_SOURCE_DIGESTS, (
+        f"uv source {source} has not been audited for the rustls-webpki security "
+        "floor required by #51292"
+    )
+    assert match.group("digest") == _APPROVED_UV_SOURCE_DIGESTS[source], (
+        f"uv source {source} must use its independently audited, approved digest"
+    )
+
+
+def test_container_uv_source_excludes_vulnerable_rustls_webpki():
+    """The copied uv/uvx binaries must use the patched Rust dependency graph."""
+    _assert_approved_uv_source(DOCKERFILE.read_text(encoding="utf-8"))
+
+
+def test_container_uv_source_rejects_vulnerable_digest_with_approved_tag():
+    """A safe-looking tag cannot mask selection of the retired vulnerable image."""
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+    approved_digest = _APPROVED_UV_SOURCE_DIGESTS["0.11.33-python3.13-trixie"]
+    vulnerable_source = dockerfile.replace(
+        approved_digest, _VULNERABLE_UV_SOURCE_DIGEST
+    )
+
+    assert vulnerable_source != dockerfile
+    with pytest.raises(AssertionError, match="independently audited, approved digest"):
+        _assert_approved_uv_source(vulnerable_source)


### PR DESCRIPTION
The Docker uv source embeds rustls-webpki 0.103.10, below the 0.103.13 fix for [GHSA-82j2-j2ch-gfr8](https://github.com/rustls/webpki/security/advisories/GHSA-82j2-j2ch-gfr8). Update it to uv 0.11.33, retaining the Python 3.13 trixie image family and the immutable multi-architecture digest `sha256:83447533ae5dab3fbe1b09dff4d34bce0b796d65392179007c04ce1d72d3d752`.

The existing uv/uvx copy paths and Debian runtime are unchanged. This addresses the Rust binary dependency finding in the broader container CVE report; it does not claim that every finding in that report is resolved.

Validation on Linux amd64, integrated onto `485aaf69b7f0930a5f6631752172d90a4a5575c6`:
- Verified the GHCR index bytes against the pinned digest and confirmed Linux amd64 and arm64 manifests.
- The [official uv source lockfile](https://github.com/astral-sh/uv/blob/fece32fc54b0e6fb6a031d3c80397cc4afb25737/Cargo.lock) records rustls-webpki 0.103.13; the pulled amd64 uv executable also contains that dependency's build path.
- Built a focused Podman image using the Dockerfile's exact uv source and COPY instruction into Debian 13.4. Both binaries report 0.11.33 and their pip/tool commands load. The official source image also creates and queries a Python 3.13 virtual environment.
- `scripts/run_tests.sh tests/test_packaging_metadata.py tests/test_packaging_py_modules.py tests/tools/test_dockerfile_immutable_install.py -j 3 -q`: 16 passed; `git diff --check` passes.

Not checked: the complete Hermes Docker build, native arm64 execution, a fresh whole-image vulnerability scan, the full suite, and CodeRabbit (self-authored P2 PR). The dependency pin is not a claim that uv enables the advisory's opt-in CRL-validation attack path.

Part of #51292

Updated by GPT-6 Astra with ultra reasoning in Codex Desktop. The account owner loosely reviews these actions and receives the usual GitHub notifications.
