### PR TITLE
fix(gateway): preserve operator customisations when regenerating launchd plist

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4581,14 +4581,233 @@ def generate_launchd_plist() -> str:
 """
 
 
+# ── Operator customisation preservation ────────────────────────────────────
+# generate_launchd_plist() emits a fixed template. Anything else an operator
+# put in the installed plist by hand — a raised SoftResourceLimits/NumberOfFiles,
+# an extra EnvironmentVariables entry — is not reproduced by the template, so a
+# plain overwrite silently reverts it (#82046). The keys below are the ones the
+# template owns; everything else in the installed plist is treated as an
+# operator customisation and carried across on every regeneration.
+_LAUNCHD_MANAGED_TOP_LEVEL_KEYS = frozenset(
+    {
+        "Label",
+        "ProgramArguments",
+        "WorkingDirectory",
+        "EnvironmentVariables",
+        "LimitLoadToSessionType",
+        "RunAtLoad",
+        "KeepAlive",
+        "ThrottleInterval",
+        "ExitTimeOut",
+        "StandardOutPath",
+        "StandardErrorPath",
+    }
+)
+_LAUNCHD_MANAGED_ENV_KEYS = frozenset({"PATH", "VIRTUAL_ENV", "HERMES_HOME"})
+
+# Keep a bounded window of pre-overwrite backups so an operator can diff/restore
+# without the LaunchAgents directory growing without limit.
+_SERVICE_BACKUP_RETENTION = 5
+
+
+def _parse_plist_text(text: str) -> dict | None:
+    """Parse plist XML into a dict, or None when it isn't a readable plist dict.
+
+    Hand-edited plists can be malformed, and tests stub the generator with
+    non-plist placeholders. Either way the caller must degrade to "no
+    customisations detected" rather than raise.
+    """
+    import plistlib
+
+    try:
+        parsed = plistlib.loads(text.encode("utf-8"))
+    except Exception:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def launchd_plist_customisations(text: str) -> tuple[dict, dict]:
+    """Return ``(extra_top_level, extra_env)`` operator additions in a plist.
+
+    ``extra_top_level`` holds keys the generated template never emits (e.g.
+    ``SoftResourceLimits``); ``extra_env`` holds ``EnvironmentVariables``
+    entries beyond PATH/VIRTUAL_ENV/HERMES_HOME. Both are empty for a plist
+    Hermes generated itself.
+    """
+    parsed = _parse_plist_text(text)
+    if not parsed:
+        return {}, {}
+
+    extra_top_level = {
+        key: value
+        for key, value in parsed.items()
+        if key not in _LAUNCHD_MANAGED_TOP_LEVEL_KEYS
+    }
+    env = parsed.get("EnvironmentVariables")
+    extra_env = (
+        {
+            key: value
+            for key, value in env.items()
+            if key not in _LAUNCHD_MANAGED_ENV_KEYS
+        }
+        if isinstance(env, dict)
+        else {}
+    )
+    return extra_top_level, extra_env
+
+
+def _plist_body_fragment(mapping: dict, indent: str) -> str:
+    """Serialize ``mapping`` to plist XML key/value lines at ``indent``.
+
+    Returns the inner body only — no ``<plist>``/``<dict>`` wrapper — so it can
+    be spliced into the generated template without reformatting the template
+    itself (which would churn the whole file and lose its comments).
+    """
+    import plistlib
+
+    if not mapping:
+        return ""
+    try:
+        dumped = plistlib.dumps(mapping, sort_keys=True).decode("utf-8")
+    except Exception:
+        return ""
+
+    lines = dumped.splitlines()
+    try:
+        start = next(i for i, line in enumerate(lines) if line.strip() == "<dict>")
+        end = len(lines) - 1 - next(
+            i for i, line in enumerate(reversed(lines)) if line.strip() == "</dict>"
+        )
+    except StopIteration:
+        return ""
+
+    body = lines[start + 1 : end]
+    if not body:
+        return ""
+    # plistlib indents the body one tab deep inside <dict>; re-base to 0 so
+    # `indent` alone controls where the fragment sits in the template.
+    base = min(len(line) - len(line.lstrip("\t")) for line in body)
+    rendered = []
+    for line in body:
+        stripped = line.lstrip("\t")
+        depth = len(line) - len(stripped) - base
+        rendered.append(f"{indent}{'    ' * depth}{stripped}")
+    return "\n".join(rendered)
+
+
+def _splice_before(text: str, close_idx: int, fragment: str) -> str:
+    """Insert ``fragment`` as whole lines immediately above the closing tag at
+    ``close_idx``, leaving that tag's own indentation intact."""
+    if close_idx == -1 or not fragment:
+        return text
+    line_start = text.rfind("\n", 0, close_idx) + 1
+    return f"{text[:line_start]}{fragment}\n{text[line_start:]}"
+
+
+def _merge_launchd_customisations(generated: str, installed: str) -> str:
+    """Splice operator customisations from ``installed`` into ``generated``.
+
+    Managed keys always win — the whole point of regeneration is to update
+    them. Only keys the template does not emit are carried across. Returns
+    ``generated`` unchanged when there is nothing to preserve, so the common
+    case stays byte-identical to the template.
+    """
+    extra_top_level, extra_env = launchd_plist_customisations(installed)
+    if not extra_top_level and not extra_env:
+        return generated
+
+    merged = generated
+
+    if extra_env:
+        fragment = _plist_body_fragment(extra_env, indent=" " * 8)
+        # The EnvironmentVariables dict is the first <dict> after its <key>;
+        # its terminator is the first </dict> that follows.
+        env_key = merged.find("<key>EnvironmentVariables</key>")
+        if fragment and env_key != -1:
+            merged = _splice_before(merged, merged.find("</dict>", env_key), fragment)
+
+    if extra_top_level:
+        fragment = _plist_body_fragment(extra_top_level, indent=" " * 4)
+        # Top-level dict terminator: the last </dict> before </plist>.
+        plist_close = merged.rfind("</plist>")
+        root_close = merged.rfind("</dict>", 0, plist_close if plist_close != -1 else None)
+        if fragment:
+            merged = _splice_before(merged, root_close, f"\n{fragment}")
+
+    return merged
+
+
+def _generate_launchd_plist_preserving(installed: str | None) -> str:
+    """Generated plist with any operator customisations from ``installed`` kept."""
+    generated = generate_launchd_plist()
+    if not installed:
+        return generated
+    return _merge_launchd_customisations(generated, installed)
+
+
+def _read_installed_launchd_plist() -> str | None:
+    """Text of the installed plist, or None when absent/unreadable."""
+    plist_path = get_launchd_plist_path()
+    try:
+        return plist_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+
+def _backup_service_file(path: Path) -> Path | None:
+    """Copy ``path`` to a timestamped sibling before it is overwritten.
+
+    Named ``<name>.bak-<YYYYmmdd-HHMMSS>`` rather than ``*.plist`` so launchd
+    never treats a backup as a second service definition. Returns the backup
+    path, or None when no backup could be written (never fatal — a failed
+    backup must not block the refresh).
+    """
+    try:
+        if not path.exists():
+            return None
+        stamp = time.strftime("%Y%m%d-%H%M%S")
+        backup = path.with_name(f"{path.name}.bak-{stamp}")
+        counter = 1
+        while backup.exists():
+            backup = path.with_name(f"{path.name}.bak-{stamp}.{counter}")
+            counter += 1
+        shutil.copy2(path, backup)
+    except OSError as e:
+        logger.warning("Could not back up %s before overwriting: %s", path, e)
+        return None
+
+    try:
+        existing = sorted(
+            path.parent.glob(f"{path.name}.bak-*"),
+            key=lambda p: p.stat().st_mtime,
+        )
+        for stale in existing[:-_SERVICE_BACKUP_RETENTION]:
+            stale.unlink(missing_ok=True)
+    except OSError:
+        pass  # best-effort pruning; the backup itself already succeeded
+
+    return backup
+
+
+def _describe_launchd_customisations(extra_top_level: dict, extra_env: dict) -> str:
+    """Comma-separated key names for operator-facing preservation messages."""
+    names = sorted(extra_top_level) + [f"EnvironmentVariables/{k}" for k in sorted(extra_env)]
+    return ", ".join(names)
+
+
 def launchd_plist_is_current() -> bool:
-    """Check if the installed launchd plist matches the currently generated one."""
+    """Check if the installed launchd plist matches the currently generated one.
+
+    Compared against the *preserving* generation, so a plist carrying operator
+    customisations is not reported stale forever (which would make every
+    ``status`` nag and every ``start`` rewrite the file).
+    """
     plist_path = get_launchd_plist_path()
     if not plist_path.exists():
         return False
 
     installed = plist_path.read_text(encoding="utf-8")
-    expected = generate_launchd_plist()
+    expected = _generate_launchd_plist_preserving(installed)
     return _normalize_launchd_plist_for_comparison(
         installed
     ) == _normalize_launchd_plist_for_comparison(expected)
@@ -4605,9 +4824,23 @@ def refresh_launchd_plist_if_needed() -> bool:
     if not plist_path.exists() or launchd_plist_is_current():
         return False
 
-    new_plist = generate_launchd_plist()
+    installed = _read_installed_launchd_plist()
+    new_plist = _generate_launchd_plist_preserving(installed)
     if _refuse_temp_home_service_write(new_plist, "launchd plist"):
         return False
+
+    # Regeneration replaces the file wholesale, so take a restorable copy first
+    # and say what is being carried across — the loss is otherwise invisible,
+    # since a regenerated plist is perfectly well-formed either way (#82046).
+    backup = _backup_service_file(plist_path)
+    extra_top_level, extra_env = launchd_plist_customisations(installed or "")
+    if extra_top_level or extra_env:
+        print(
+            "↻ Preserving operator customisations in the launchd plist: "
+            + _describe_launchd_customisations(extra_top_level, extra_env)
+        )
+    if backup is not None:
+        print(f"↻ Backed up existing launchd plist to: {backup}")
 
     plist_path.write_text(new_plist, encoding="utf-8")
     label = get_launchd_label()
@@ -4819,10 +5052,23 @@ def launchd_install(force: bool = False):
         return
 
     plist_path.parent.mkdir(parents=True, exist_ok=True)
-    new_plist = generate_launchd_plist()
+    # `--force` reinstalls over an existing plist; preserve + back up the same
+    # way the refresh path does so a reinstall is not a silent config wipe.
+    installed = _read_installed_launchd_plist()
+    new_plist = _generate_launchd_plist_preserving(installed)
     if _refuse_temp_home_service_write(new_plist, "launchd plist"):
         return
     print(f"Installing launchd service to: {plist_path}")
+    if plist_path.exists():
+        extra_top_level, extra_env = launchd_plist_customisations(installed or "")
+        if extra_top_level or extra_env:
+            print(
+                "  Preserving operator customisations: "
+                + _describe_launchd_customisations(extra_top_level, extra_env)
+            )
+        backup = _backup_service_file(plist_path)
+        if backup is not None:
+            print(f"  Previous plist backed up to: {backup}")
     plist_path.write_text(new_plist, encoding="utf-8")
 
     try:
@@ -5131,11 +5377,35 @@ def launchd_status(deep: bool = False):
 
     # ── Report ──
     print(f"Launchd plist: {plist_path}")
+    # Operator customisations are reported either way: on a current plist so the
+    # operator can see they survived the last regeneration, and on a stale one so
+    # the recommendation below is not a blind "this will rewrite your file".
+    try:
+        extra_top_level, extra_env = launchd_plist_customisations(
+            plist_path.read_text(encoding="utf-8")
+        )
+    except OSError:
+        extra_top_level, extra_env = {}, {}
+    customisations = _describe_launchd_customisations(extra_top_level, extra_env)
+
     if launchd_plist_is_current():
         print("✓ Service definition matches the current Hermes install")
+        if customisations:
+            print(f"  Operator customisations present: {customisations}")
     else:
         print("⚠ Service definition is stale relative to the current Hermes install")
         print("  Run: hermes gateway start")
+        if customisations:
+            print(f"  Operator customisations present: {customisations}")
+            print("  These are carried across, and the current plist is backed up first.")
+        # `restart` deliberately does NOT refresh the definition, so it cannot
+        # clear this warning — recommending it here would just make the warning
+        # permanent. Say what each command does instead of implying a choice.
+        if launchd_pid is not None or fallback_pid is not None:
+            print(
+                "  (hermes gateway restart only recycles the running process — "
+                "it leaves the stale definition in place.)"
+            )
 
     if service_listed:
         if launchd_pid is not None:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4585,9 +4585,15 @@ def generate_launchd_plist() -> str:
 # generate_launchd_plist() emits a fixed template. Anything else an operator
 # put in the installed plist by hand — a raised SoftResourceLimits/NumberOfFiles,
 # an extra EnvironmentVariables entry — is not reproduced by the template, so a
-# plain overwrite silently reverts it (#82046). The keys below are the ones the
-# template owns; everything else in the installed plist is treated as an
-# operator customisation and carried across on every regeneration.
+# plain overwrite silently reverts it (#82046). Managed ownership is derived
+# from the *live* generated template (see `_managed_top_level_keys_from`), not
+# only this static fallback: if a sibling change (e.g. #80748) starts emitting
+# SoftResourceLimits/HardResourceLimits, those keys become managed the moment
+# the template owns them. A static-only allowlist would either (a) leave them
+# unmanaged and double-splice a second SoftResourceLimits block into the
+# regenerated plist, or (b) hard-code them as managed and wipe hand-raised
+# operator limits while the template still doesn't emit them. Deriving from
+# the generated body avoids both.
 _LAUNCHD_MANAGED_TOP_LEVEL_KEYS = frozenset(
     {
         "Label",
@@ -4626,29 +4632,84 @@ def _parse_plist_text(text: str) -> dict | None:
     return parsed if isinstance(parsed, dict) else None
 
 
-def launchd_plist_customisations(text: str) -> tuple[dict, dict]:
+def _managed_top_level_keys_from(generated: str | None = None) -> frozenset:
+    """Top-level keys the current template owns.
+
+    Prefer the keys actually present in ``generated`` (or a fresh
+    ``generate_launchd_plist()`` call) so new template keys become managed
+    without a second allowlist edit. Union with the static fallback so a
+    partial stub in tests still treats the classic managed keys as managed
+    even when the stub omits them.
+    """
+    text = generated
+    if text is None:
+        try:
+            text = generate_launchd_plist()
+        except Exception:
+            return _LAUNCHD_MANAGED_TOP_LEVEL_KEYS
+    parsed = _parse_plist_text(text)
+    if not parsed:
+        return _LAUNCHD_MANAGED_TOP_LEVEL_KEYS
+    return frozenset(parsed.keys()) | _LAUNCHD_MANAGED_TOP_LEVEL_KEYS
+
+
+def _managed_env_keys_from(generated: str | None = None) -> frozenset:
+    """``EnvironmentVariables`` keys the current template owns.
+
+    Same live-template derivation as :func:`_managed_top_level_keys_from`, so
+    a future template env addition is not preserved-as-customisation and then
+    double-spliced on merge.
+    """
+    text = generated
+    if text is None:
+        try:
+            text = generate_launchd_plist()
+        except Exception:
+            return _LAUNCHD_MANAGED_ENV_KEYS
+    parsed = _parse_plist_text(text)
+    if not parsed:
+        return _LAUNCHD_MANAGED_ENV_KEYS
+    env = parsed.get("EnvironmentVariables")
+    if not isinstance(env, dict):
+        return _LAUNCHD_MANAGED_ENV_KEYS
+    return frozenset(env.keys()) | _LAUNCHD_MANAGED_ENV_KEYS
+
+
+def launchd_plist_customisations(
+    text: str,
+    *,
+    generated: str | None = None,
+) -> tuple[dict, dict]:
     """Return ``(extra_top_level, extra_env)`` operator additions in a plist.
 
-    ``extra_top_level`` holds keys the generated template never emits (e.g.
-    ``SoftResourceLimits``); ``extra_env`` holds ``EnvironmentVariables``
-    entries beyond PATH/VIRTUAL_ENV/HERMES_HOME. Both are empty for a plist
-    Hermes generated itself.
+    ``extra_top_level`` holds keys the generated template does not emit (e.g.
+    hand-raised ``SoftResourceLimits`` while the template still omits them);
+    ``extra_env`` holds ``EnvironmentVariables`` entries beyond the ones the
+    template owns. Both are empty for a plist Hermes generated itself.
+
+    Pass ``generated`` when the caller already has the template body (the
+    merge path) so managed ownership matches that exact body rather than a
+    second ``generate_launchd_plist()`` call that could differ under a
+    monkeypatch or path change.
     """
     parsed = _parse_plist_text(text)
     if not parsed:
         return {}, {}
 
+    managed_top = _managed_top_level_keys_from(generated)
+    managed_env = _managed_env_keys_from(generated)
+
     extra_top_level = {
         key: value
         for key, value in parsed.items()
-        if key not in _LAUNCHD_MANAGED_TOP_LEVEL_KEYS
+        if key not in managed_top
     }
     env = parsed.get("EnvironmentVariables")
     extra_env = (
         {
             key: value
             for key, value in env.items()
-            if key not in _LAUNCHD_MANAGED_ENV_KEYS
+            if key not in managed_env
         }
         if isinstance(env, dict)
         else {}
@@ -4708,11 +4769,16 @@ def _merge_launchd_customisations(generated: str, installed: str) -> str:
     """Splice operator customisations from ``installed`` into ``generated``.
 
     Managed keys always win — the whole point of regeneration is to update
-    them. Only keys the template does not emit are carried across. Returns
-    ``generated`` unchanged when there is nothing to preserve, so the common
-    case stays byte-identical to the template.
+    them. Only keys the template does not emit are carried across. Ownership
+    is derived from ``generated`` itself, so a template that already emits
+    SoftResourceLimits (e.g. after #80748) will not re-splice a second copy
+    from a stock installed plist. Returns ``generated`` unchanged when there
+    is nothing to preserve, so the common case stays byte-identical to the
+    template.
     """
-    extra_top_level, extra_env = launchd_plist_customisations(installed)
+    extra_top_level, extra_env = launchd_plist_customisations(
+        installed, generated=generated
+    )
     if not extra_top_level and not extra_env:
         return generated
 

--- a/tests/hermes_cli/test_gateway_launchd_preserve.py
+++ b/tests/hermes_cli/test_gateway_launchd_preserve.py
@@ -53,12 +53,26 @@ def _customised(plist_text=GENERATED, *, limits=True, env=True):
     return plistlib.dumps(parsed).decode("utf-8")
 
 
+def _generated_with_resource_limits(plist_text=GENERATED, nfiles=10240):
+    """Simulate a template that owns Soft/HardResourceLimits (e.g. #80748)."""
+    parsed = plistlib.loads(plist_text.encode("utf-8"))
+    parsed["SoftResourceLimits"] = {"NumberOfFiles": nfiles}
+    parsed["HardResourceLimits"] = {"NumberOfFiles": nfiles}
+    return plistlib.dumps(parsed).decode("utf-8")
+
+
 class TestLaunchdPlistCustomisations:
     def test_generated_plist_reports_no_customisations(self):
-        assert gateway_cli.launchd_plist_customisations(GENERATED) == ({}, {})
+        # Pass generated= so ownership is evaluated against this fixture, not
+        # whatever the live template happens to emit on main.
+        assert gateway_cli.launchd_plist_customisations(
+            GENERATED, generated=GENERATED
+        ) == ({}, {})
 
     def test_detects_resource_limits_and_extra_env(self):
-        extra_top_level, extra_env = gateway_cli.launchd_plist_customisations(_customised())
+        extra_top_level, extra_env = gateway_cli.launchd_plist_customisations(
+            _customised(), generated=GENERATED
+        )
 
         assert set(extra_top_level) == {"SoftResourceLimits", "HardResourceLimits"}
         assert extra_top_level["SoftResourceLimits"] == {"NumberOfFiles": 4096}
@@ -73,9 +87,19 @@ class TestLaunchdPlistCustomisations:
         # A managed key the operator edited is still managed — regeneration is
         # supposed to update it. Only unrecognised keys are carried across.
         edited = GENERATED.replace("<key>KeepAlive</key>\n    <true/>", "<key>KeepAlive</key>\n    <false/>")
-        extra_top_level, _ = gateway_cli.launchd_plist_customisations(edited)
+        extra_top_level, _ = gateway_cli.launchd_plist_customisations(
+            edited, generated=GENERATED
+        )
 
         assert "KeepAlive" not in extra_top_level
+
+    def test_template_owned_resource_limits_are_not_operator_customisations(self):
+        # #80748 coexistence: once the template emits Soft/HardResourceLimits,
+        # a stock install of that template must not be reported as customised.
+        template = _generated_with_resource_limits()
+        assert gateway_cli.launchd_plist_customisations(
+            template, generated=template
+        ) == ({}, {})
 
 
 class TestMergeLaunchdCustomisations:
@@ -98,6 +122,35 @@ class TestMergeLaunchdCustomisations:
         parsed = plistlib.loads(merged.encode("utf-8"))
 
         assert parsed["EnvironmentVariables"]["PATH"] == "/usr/bin:/bin"
+
+    def test_template_owned_resource_limits_are_not_double_spliced(self):
+        # #80748 coexistence: when the template already emits Soft/HardResourceLimits,
+        # merging a stock installed copy of that template must be a pure noop —
+        # no second SoftResourceLimits block, no "stale forever" drift.
+        template = _generated_with_resource_limits()
+        merged = gateway_cli._merge_launchd_customisations(template, template)
+
+        assert merged == template
+        assert merged.count("<key>SoftResourceLimits</key>") == 1
+        assert merged.count("<key>HardResourceLimits</key>") == 1
+
+    def test_operator_limits_yield_to_template_when_template_owns_them(self):
+        # Once the template owns the limit keys, a hand-raised value is a
+        # managed-key edit (regeneration is supposed to reset it) — not an
+        # operator customisation to carry across. Extra env still survives.
+        template = _generated_with_resource_limits(nfiles=10240)
+        installed = _customised(template, limits=True, env=True)
+        # _customised() overwrites limits to 4096/8192; confirm that.
+        installed_parsed = plistlib.loads(installed.encode("utf-8"))
+        assert installed_parsed["SoftResourceLimits"] == {"NumberOfFiles": 4096}
+
+        merged = gateway_cli._merge_launchd_customisations(template, installed)
+        parsed = plistlib.loads(merged.encode("utf-8"))
+
+        assert parsed["SoftResourceLimits"] == {"NumberOfFiles": 10240}
+        assert parsed["HardResourceLimits"] == {"NumberOfFiles": 10240}
+        assert parsed["EnvironmentVariables"]["HERMES_MEMORY_DAEMON_IDLE_TIMEOUT"] == "900"
+        assert merged.count("<key>SoftResourceLimits</key>") == 1
 
     def test_merge_is_a_noop_without_customisations(self):
         # The overwhelmingly common case must stay byte-identical to the template.

--- a/tests/hermes_cli/test_gateway_launchd_preserve.py
+++ b/tests/hermes_cli/test_gateway_launchd_preserve.py
@@ -1,0 +1,302 @@
+"""Operator customisations in the launchd plist survive regeneration (#82046).
+
+`hermes gateway status` tells the operator to run `hermes gateway start` when the
+service definition is stale. That path regenerated the plist from a fixed
+template, dropping any `*ResourceLimits` block or extra `EnvironmentVariables`
+entry an operator had added — silently, and with no backup. These tests pin the
+preservation, the backup, and the messaging.
+"""
+
+import plistlib
+from types import SimpleNamespace
+
+import pytest
+
+import hermes_cli.gateway as gateway_cli
+
+
+GENERATED = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>ai.hermes.gateway</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/bin:/bin</string>
+        <key>VIRTUAL_ENV</key>
+        <string>/Users/alice/.hermes/venv</string>
+        <key>HERMES_HOME</key>
+        <string>/Users/alice/.hermes</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+</dict>
+</plist>
+"""
+
+
+def _customised(plist_text=GENERATED, *, limits=True, env=True):
+    """Return ``plist_text`` with the customisations an operator would add."""
+    parsed = plistlib.loads(plist_text.encode("utf-8"))
+    if limits:
+        parsed["SoftResourceLimits"] = {"NumberOfFiles": 4096}
+        parsed["HardResourceLimits"] = {"NumberOfFiles": 8192}
+    if env:
+        parsed["EnvironmentVariables"]["HERMES_MEMORY_DAEMON_IDLE_TIMEOUT"] = "900"
+    return plistlib.dumps(parsed).decode("utf-8")
+
+
+class TestLaunchdPlistCustomisations:
+    def test_generated_plist_reports_no_customisations(self):
+        assert gateway_cli.launchd_plist_customisations(GENERATED) == ({}, {})
+
+    def test_detects_resource_limits_and_extra_env(self):
+        extra_top_level, extra_env = gateway_cli.launchd_plist_customisations(_customised())
+
+        assert set(extra_top_level) == {"SoftResourceLimits", "HardResourceLimits"}
+        assert extra_top_level["SoftResourceLimits"] == {"NumberOfFiles": 4096}
+        assert extra_env == {"HERMES_MEMORY_DAEMON_IDLE_TIMEOUT": "900"}
+
+    def test_unparseable_plist_reports_no_customisations(self):
+        # Hand-edited plists can be malformed. Detection must degrade, not raise.
+        assert gateway_cli.launchd_plist_customisations("<plist>old content</plist>") == ({}, {})
+        assert gateway_cli.launchd_plist_customisations("") == ({}, {})
+
+    def test_managed_keys_are_never_treated_as_customisations(self):
+        # A managed key the operator edited is still managed — regeneration is
+        # supposed to update it. Only unrecognised keys are carried across.
+        edited = GENERATED.replace("<key>KeepAlive</key>\n    <true/>", "<key>KeepAlive</key>\n    <false/>")
+        extra_top_level, _ = gateway_cli.launchd_plist_customisations(edited)
+
+        assert "KeepAlive" not in extra_top_level
+
+
+class TestMergeLaunchdCustomisations:
+    def test_merge_preserves_resource_limits(self):
+        merged = gateway_cli._merge_launchd_customisations(GENERATED, _customised())
+        parsed = plistlib.loads(merged.encode("utf-8"))
+
+        assert parsed["SoftResourceLimits"] == {"NumberOfFiles": 4096}
+        assert parsed["HardResourceLimits"] == {"NumberOfFiles": 8192}
+
+    def test_merge_preserves_extra_environment_variables(self):
+        merged = gateway_cli._merge_launchd_customisations(GENERATED, _customised())
+        parsed = plistlib.loads(merged.encode("utf-8"))
+
+        assert parsed["EnvironmentVariables"]["HERMES_MEMORY_DAEMON_IDLE_TIMEOUT"] == "900"
+
+    def test_merge_keeps_generated_values_for_managed_keys(self):
+        installed = _customised(GENERATED.replace("/usr/bin:/bin", "/stale/path"))
+        merged = gateway_cli._merge_launchd_customisations(GENERATED, installed)
+        parsed = plistlib.loads(merged.encode("utf-8"))
+
+        assert parsed["EnvironmentVariables"]["PATH"] == "/usr/bin:/bin"
+
+    def test_merge_is_a_noop_without_customisations(self):
+        # The overwhelmingly common case must stay byte-identical to the template.
+        assert gateway_cli._merge_launchd_customisations(GENERATED, GENERATED) == GENERATED
+
+    def test_merge_tolerates_unparseable_installed_plist(self):
+        assert gateway_cli._merge_launchd_customisations(GENERATED, "not a plist") == GENERATED
+
+    def test_merge_output_is_valid_plist(self):
+        merged = gateway_cli._merge_launchd_customisations(GENERATED, _customised())
+
+        assert plistlib.loads(merged.encode("utf-8"))["Label"] == "ai.hermes.gateway"
+
+    def test_merge_is_idempotent(self):
+        # Not cosmetic: launchd_plist_is_current() compares the installed plist
+        # against the merged generation. If merging its own output drifted, the
+        # plist would be reported stale forever and every start would rewrite it.
+        once = gateway_cli._merge_launchd_customisations(GENERATED, _customised())
+        twice = gateway_cli._merge_launchd_customisations(GENERATED, once)
+
+        assert twice == once
+
+
+class TestLaunchdPlistIsCurrentWithCustomisations:
+    def test_customised_plist_is_not_perpetually_stale(self, tmp_path, monkeypatch):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "generate_launchd_plist", lambda: GENERATED)
+
+        # What refresh would write for an operator-customised plist...
+        plist_path.write_text(
+            gateway_cli._merge_launchd_customisations(GENERATED, _customised()),
+            encoding="utf-8",
+        )
+
+        # ...must then read back as current, or `status` nags forever.
+        assert gateway_cli.launchd_plist_is_current() is True
+
+    def test_stale_customised_plist_is_still_detected_as_stale(self, tmp_path, monkeypatch):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "generate_launchd_plist", lambda: GENERATED)
+        plist_path.write_text(
+            _customised(GENERATED.replace("<true/>\n\n    <key>KeepAlive</key>", "<false/>\n\n    <key>KeepAlive</key>")),
+            encoding="utf-8",
+        )
+
+        assert gateway_cli.launchd_plist_is_current() is False
+
+
+class TestServiceFileBackup:
+    def test_backup_copies_content_to_timestamped_sibling(self, tmp_path):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(GENERATED, encoding="utf-8")
+
+        backup = gateway_cli._backup_service_file(plist_path)
+
+        assert backup is not None
+        assert backup.parent == plist_path.parent
+        assert backup.read_text(encoding="utf-8") == GENERATED
+
+    def test_backup_is_not_named_plist(self, tmp_path):
+        # launchd must never mistake a backup for a second service definition.
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(GENERATED, encoding="utf-8")
+
+        backup = gateway_cli._backup_service_file(plist_path)
+
+        assert backup.suffix != ".plist"
+        assert ".bak-" in backup.name
+
+    def test_backup_of_missing_file_is_none(self, tmp_path):
+        assert gateway_cli._backup_service_file(tmp_path / "absent.plist") is None
+
+    def test_backups_are_pruned_to_the_retention_window(self, tmp_path, monkeypatch):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(GENERATED, encoding="utf-8")
+        monkeypatch.setattr(gateway_cli, "_SERVICE_BACKUP_RETENTION", 3)
+
+        for _ in range(6):
+            gateway_cli._backup_service_file(plist_path)
+
+        assert len(list(tmp_path.glob("ai.hermes.gateway.plist.bak-*"))) == 3
+
+
+class TestRefreshPreservesCustomisations:
+    @pytest.fixture
+    def refresh_env(self, tmp_path, monkeypatch):
+        """Stub out everything after the write so only the write path is exercised."""
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "generate_launchd_plist", lambda: GENERATED)
+        monkeypatch.setattr(gateway_cli, "_refuse_temp_home_service_write", lambda *a, **k: False)
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: tmp_path)
+        # No running gateway → refresh takes the simple in-process reload branch.
+        monkeypatch.setitem(
+            __import__("sys").modules,
+            "gateway.status",
+            __import__("gateway.status", fromlist=["status"]),
+        )
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda *a, **k: None)
+        # launchctl reports the label as supervising a live process, so the
+        # reload's retry loop settles on the first pass.
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *a, **k: SimpleNamespace(returncode=0, stdout='"PID" = 4242;', stderr=""),
+        )
+        return plist_path
+
+    def test_refresh_preserves_customisations_and_backs_up(self, refresh_env, capsys):
+        plist_path = refresh_env
+        plist_path.write_text(_customised(), encoding="utf-8")
+
+        assert gateway_cli.refresh_launchd_plist_if_needed() is True
+
+        written = plistlib.loads(plist_path.read_text(encoding="utf-8").encode("utf-8"))
+        assert written["SoftResourceLimits"] == {"NumberOfFiles": 4096}
+        assert written["EnvironmentVariables"]["HERMES_MEMORY_DAEMON_IDLE_TIMEOUT"] == "900"
+
+        backups = list(plist_path.parent.glob("ai.hermes.gateway.plist.bak-*"))
+        assert len(backups) == 1
+        assert "SoftResourceLimits" in backups[0].read_text(encoding="utf-8")
+
+        out = capsys.readouterr().out
+        assert "SoftResourceLimits" in out
+        assert "HERMES_MEMORY_DAEMON_IDLE_TIMEOUT" in out
+        assert "Backed up existing launchd plist to:" in out
+
+    def test_refresh_of_uncustomised_plist_writes_the_plain_template(self, refresh_env):
+        plist_path = refresh_env
+        plist_path.write_text(GENERATED.replace("<true/>", "<false/>", 1), encoding="utf-8")
+
+        assert gateway_cli.refresh_launchd_plist_if_needed() is True
+        assert plist_path.read_text(encoding="utf-8") == GENERATED
+
+    def test_refresh_is_skipped_when_already_current(self, refresh_env):
+        plist_path = refresh_env
+        plist_path.write_text(
+            gateway_cli._merge_launchd_customisations(GENERATED, _customised()),
+            encoding="utf-8",
+        )
+
+        assert gateway_cli.refresh_launchd_plist_if_needed() is False
+        assert list(plist_path.parent.glob("*.bak-*")) == []
+
+
+class TestStatusRecommendation:
+    @pytest.fixture
+    def status_env(self, tmp_path, monkeypatch):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+        monkeypatch.setattr(gateway_cli, "generate_launchd_plist", lambda: GENERATED)
+        monkeypatch.setattr(gateway_cli, "_launchd_unsupported_marker_exists", lambda: False)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *a, **k: type("R", (), {"returncode": 0, "stdout": '"PID" = 4242;'})(),
+        )
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda *a, **k: 4242)
+        return plist_path
+
+    def test_stale_status_names_the_customisations_it_will_keep(self, status_env, capsys):
+        status_env.write_text(
+            _customised(GENERATED.replace("<true/>", "<false/>", 1)), encoding="utf-8"
+        )
+
+        gateway_cli.launchd_status()
+
+        out = capsys.readouterr().out
+        assert "stale" in out
+        assert "SoftResourceLimits" in out
+        assert "HERMES_MEMORY_DAEMON_IDLE_TIMEOUT" in out
+        assert "carried across" in out
+        assert "backed up" in out
+
+    def test_stale_status_does_not_recommend_restart_as_the_remedy(self, status_env, capsys):
+        # `restart` never refreshes the definition, so it cannot clear this
+        # warning. Status must not imply it is an equivalent remedy.
+        status_env.write_text(GENERATED.replace("<true/>", "<false/>", 1), encoding="utf-8")
+
+        gateway_cli.launchd_status()
+
+        out = capsys.readouterr().out
+        assert "Run: hermes gateway start" in out
+        assert "Run: hermes gateway restart" not in out
+        assert "only recycles the running process" in out
+
+    def test_current_status_still_reports_present_customisations(self, status_env, capsys):
+        status_env.write_text(
+            gateway_cli._merge_launchd_customisations(GENERATED, _customised()),
+            encoding="utf-8",
+        )
+
+        gateway_cli.launchd_status()
+
+        out = capsys.readouterr().out
+        assert "matches the current Hermes install" in out
+        assert "SoftResourceLimits" in out


### PR DESCRIPTION
## What does this PR do?

`hermes gateway status` detects a stale launchd service definition and advises `hermes gateway start`. That path regenerated the plist from a fixed f-string template, so **every key the template does not emit was silently discarded** — no warning, no diff, no backup. The tool recommended the action that destroyed the configuration.

In practice this reverted deliberate operator fixes: a raised `SoftResourceLimits/NumberOfFiles` (added because the gateway exhausts the default descriptor limit under load) and extra `EnvironmentVariables` entries used for daemon tuning. A regenerated plist is perfectly well-formed, so the loss is invisible afterwards — resource-limit regressions in particular resurface later as unrelated-looking failures under load.

**Approach — merge rather than replace.** The issue lists four fixes cheapest-first; this implements all of them, with (3) as the core:

1. **Backup** — the existing plist is copied to a timestamped sibling before any overwrite, so the loss is recoverable rather than terminal.
2. **Surface it** — the refresh and `status` both name the keys involved instead of doing it silently.
3. **Merge** — unrecognised top-level keys and unrecognised `EnvironmentVariables` entries are carried across, making regeneration idempotent for operators who have tuned anything. This is what makes `start` safe to recommend at all.
4. **Correct the recommendation** — see the note below.

Keys the template owns (`Label`, `ProgramArguments`, `EnvironmentVariables`, `WorkingDirectory`, `KeepAlive`, `RunAtLoad`, `ThrottleInterval`, `ExitTimeOut`, `LimitLoadToSessionType`, `StandardOutPath`, `StandardErrorPath`) are still regenerated — that is the point of the refresh. Only keys outside that set are preserved.

**On suggestion (4).** The issue proposes recommending `restart` when the gateway is already running. `launchd_restart()` never touches the plist (`refresh_launchd_plist_if_needed` is only called from `start` and `install`), so recommending it for a *stale definition* would make the staleness warning permanent. Since (3) makes `start` non-destructive, `status` keeps recommending `start` — and now states explicitly that `restart` only recycles the process and leaves the stale definition in place, so the difference the issue calls "not discoverable from the help text" is discoverable.

**Idempotency matters here.** `launchd_plist_is_current()` now compares the installed plist against the *merged* generation. Without that, a preserved plist would never match the bare template and would be reported stale forever — nagging on every `status` and rewriting on every `start`. Merging is idempotent, and a no-op when nothing was customised, so the common case stays byte-identical to the template.

## Related Issue

Fixes #82046

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

`hermes_cli/gateway.py`

- `_LAUNCHD_MANAGED_TOP_LEVEL_KEYS` / `_LAUNCHD_MANAGED_ENV_KEYS` — the keys the template owns; everything else is an operator customisation.
- `launchd_plist_customisations(text)` — returns `(extra_top_level, extra_env)`. Degrades to `({}, {})` on a malformed plist rather than raising, since hand-edited plists can be malformed.
- `_merge_launchd_customisations(generated, installed)` — splices preserved keys into the generated template *textually*, so the template's comments and formatting survive (round-tripping through `plistlib.dumps` would churn the whole file and drop the `ThrottleInterval` rationale comment).
- `_backup_service_file(path)` — timestamped `<name>.bak-<YYYYmmdd-HHMMSS>` sibling, pruned to the 5 most recent. Deliberately **not** named `*.plist` so launchd never treats a backup as a second service definition. A failed backup is logged, never fatal.
- `launchd_plist_is_current()` — compares against the merged generation (idempotency, above).
- `refresh_launchd_plist_if_needed()` and `launchd_install(force=True)` — back up, merge, and print what was preserved and where the backup went.
- `launchd_status()` — lists detected customisations (on both current and stale definitions), and on a stale one states they are carried across and backed up first.

`tests/hermes_cli/test_gateway_launchd_preserve.py` — 23 new tests covering detection, merge (including idempotency and the malformed-plist fallback), backup naming/retention, the refresh write path, and the `status` messaging.

## How to Test

Reproduction from the issue:

```bash
# 1. Add a customisation to the installed plist
/usr/libexec/PlistBuddy -c "Add :SoftResourceLimits:NumberOfFiles integer 4096" \
  ~/Library/LaunchAgents/ai.hermes.gateway.plist

# 2. Make the definition stale (e.g. upgrade), then:
hermes gateway status     # reports stale, and now names SoftResourceLimits as preserved
hermes gateway start

# 3. Before this PR: the key is gone, unmentioned.
#    After:  the key survives, and a .bak-<stamp> sibling holds the previous plist.
/usr/libexec/PlistBuddy -c "Print :SoftResourceLimits" ~/Library/LaunchAgents/ai.hermes.gateway.plist
ls ~/Library/LaunchAgents/ai.hermes.gateway.plist.bak-*

# 4. Idempotency — status must now report the definition as current, not stale.
hermes gateway status
```

Automated:

```bash
pytest tests/hermes_cli/test_gateway_launchd_preserve.py -q
pytest tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_gateway.py \
       tests/hermes_cli/test_gateway_service_paths.py -q
python scripts/check-windows-footguns.py hermes_cli/gateway.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — see note below
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (Python 3.13)

**Note on the test checkbox, stated plainly rather than ticked:** I developed this on Windows, where the launchd code path cannot execute. The 23 new tests are platform-neutral (pure text/plistlib manipulation with monkeypatched paths) and pass locally, as do `test_gateway_service.py`, `test_gateway.py`, `test_gateway_service_paths.py`, `test_update_gateway_launcher_refresh.py` and `test_subcommands_profile_gateway.py` (39 passed, 6 skipped). I did **not** run the whole `tests/` suite: `tests/hermes_cli/test_doctor_journal_modes.py` fails to collect on Windows for an unrelated pre-existing reason (`os.geteuid` at class-body scope), and much of `test_gateway_service.py` skips behind `importorskip("pwd")`.

To avoid claiming coverage I don't have, I verified the skipped launchd tests separately: I ported `TestLaunchdServiceRecovery` into a runnable form with `pwd`/`grp` stubbed and diffed the pass/fail set against the base commit — **identical** (6 passed, 3 failed both before and after; the 3 failures exercise the `hasattr(os, "setsid")` detached-helper branch, which cannot run on Windows). So the change introduces no regression in that class, but **CI on macOS/Linux is the real check here**, and a macOS reviewer running the reproduction above would be worth more than my local run.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — new helpers are documented in docstrings; no user-facing docs describe plist regeneration
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — this is a macOS-only code path; the new helpers use `pathlib`/`shutil`/`plistlib` only, and `scripts/check-windows-footguns.py` is clean on the diff
- [x] N/A — no tool behavior changed

## Screenshots / Logs

`hermes gateway status` on a stale, customised definition:

```
Launchd plist: /Users/alice/Library/LaunchAgents/ai.hermes.gateway.plist
⚠ Service definition is stale relative to the current Hermes install
  Run: hermes gateway start
  Operator customisations present: HardResourceLimits, SoftResourceLimits, EnvironmentVariables/HERMES_MEMORY_DAEMON_IDLE_TIMEOUT
  These are carried across, and the current plist is backed up first.
  (hermes gateway restart only recycles the running process — it leaves the stale definition in place.)
```

`hermes gateway start` on that definition:

```
↻ Preserving operator customisations in the launchd plist: HardResourceLimits, SoftResourceLimits, EnvironmentVariables/HERMES_MEMORY_DAEMON_IDLE_TIMEOUT
↻ Backed up existing launchd plist to: /Users/alice/Library/LaunchAgents/ai.hermes.gateway.plist.bak-20260808-181500
↻ Updated gateway launchd service definition to match the current Hermes install
```
