### PR TITLE
feat(voice): add editable TUI transcript drafts

### DIFF
--- a/contributors/emails/khanhngoo3116@gmail.com
+++ b/contributors/emails/khanhngoo3116@gmail.com
@@ -1,0 +1,1 @@
+khanhngoo

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1919,6 +1919,20 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
 
     issues: List[ConfigIssue] = []
 
+    # ── voice.submit_mode: direct | draft ────────────────────────────────
+    voice_cfg = config.get("voice")
+    if isinstance(voice_cfg, dict) and "submit_mode" in voice_cfg:
+        submit_mode = voice_cfg.get("submit_mode")
+        normalized_submit_mode = (
+            submit_mode.strip().lower() if isinstance(submit_mode, str) else None
+        )
+        if normalized_submit_mode not in {"direct", "draft"}:
+            issues.append(ConfigIssue(
+                "error",
+                f"voice.submit_mode must be 'direct' or 'draft', got {submit_mode!r}",
+                "Set voice.submit_mode to direct (submit immediately) or draft (edit before sending)",
+            ))
+
     # ── custom_providers must be a list, not a dict ──────────────────────
     cp = config.get("custom_providers")
     if cp is not None:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1627,6 +1627,7 @@ DEFAULT_CONFIG = {
 
     "voice": {
         "record_key": "ctrl+b",
+        "submit_mode": "direct",       # TUI: direct submits immediately; draft leaves an editable transcript
         "max_recording_seconds": 120,
         "auto_tts": False,
         "beep_enabled": True,         # Play record start/stop beeps in CLI voice mode

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1607,6 +1607,7 @@ DEFAULT_CONFIG = {
 
     "voice": {
         "record_key": "ctrl+b",
+        "submit_mode": "direct",       # TUI: direct submits immediately; draft leaves an editable transcript
         "max_recording_seconds": 120,
         "auto_tts": False,
         "beep_enabled": True,         # Play record start/stop beeps in CLI voice mode

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -90,6 +90,27 @@ class TestConfigIssueDataclass:
         assert a == b
 
 
+class TestVoiceSubmitModeValidation:
+    def test_default_is_direct(self):
+        assert DEFAULT_CONFIG["voice"]["submit_mode"] == "direct"
+
+    def test_direct_and_draft_are_valid(self):
+        for mode in ("direct", "draft"):
+            issues = validate_config_structure({"voice": {"submit_mode": mode}})
+            assert not any("voice.submit_mode" in issue.message for issue in issues)
+
+    def test_invalid_mode_is_reported(self):
+        issues = validate_config_structure({"voice": {"submit_mode": "refine"}})
+
+        assert any(
+            issue.severity == "error"
+            and "voice.submit_mode" in issue.message
+            and "direct" in issue.hint
+            and "draft" in issue.hint
+            for issue in issues
+        )
+
+
 class TestUnknownTopLevelKeys:
     """Arbitrary top-level keys must NOT warn — they are bridged to os.environ.
 

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -893,6 +893,35 @@ describe('createGatewayEventHandler', () => {
     expect(ctx.voice.setVoiceEnabled).not.toHaveBeenCalled()
   })
 
+  it('leaves voice transcripts editable when voice.submit_mode is draft', async () => {
+    const ctx = buildCtx([])
+
+    ctx.gateway.rpc = vi.fn(async (method: string) =>
+      method === 'config.get' ? { config: { voice: { submit_mode: 'draft' } } } : null
+    )
+    const onEvent = createGatewayEventHandler(ctx)
+
+    onEvent({ payload: { text: '  edit this first  ' }, type: 'voice.transcript' } as any)
+
+    await vi.waitFor(() => expect(ctx.composer.setInput).toHaveBeenCalledWith('edit this first'))
+    expect(ctx.submission.submitRef.current).not.toHaveBeenCalled()
+    expect(ctx.gateway.rpc).toHaveBeenCalledWith('config.get', { key: 'full' })
+  })
+
+  it('falls back to direct submit for an invalid voice.submit_mode', async () => {
+    const ctx = buildCtx([])
+
+    ctx.gateway.rpc = vi.fn(async (method: string) =>
+      method === 'config.get' ? { config: { voice: { submit_mode: 'refine' } } } : null
+    )
+    const onEvent = createGatewayEventHandler(ctx)
+
+    onEvent({ payload: { text: 'send safely' }, type: 'voice.transcript' } as any)
+
+    await vi.waitFor(() => expect(ctx.submission.submitRef.current).toHaveBeenCalledWith('send safely'))
+    expect(ctx.composer.setInput).toHaveBeenCalledWith('')
+  })
+
   it('opens a fresh session before starting voice after wake detection', async () => {
     const ctx = buildCtx([])
     ctx.session.newSession = vi.fn(async () => patchUiState({ sid: 'wake-session' }))

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -895,15 +895,19 @@ describe('createGatewayEventHandler', () => {
 
   it('leaves voice transcripts editable when voice.submit_mode is draft', async () => {
     const ctx = buildCtx([])
+    let composerInput = 'existing draft'
 
     ctx.gateway.rpc = vi.fn(async (method: string) =>
       method === 'config.get' ? { config: { voice: { submit_mode: 'draft' } } } : null
     )
+    ctx.composer.setInput = vi.fn((next: string | ((current: string) => string)) => {
+      composerInput = typeof next === 'function' ? next(composerInput) : next
+    })
     const onEvent = createGatewayEventHandler(ctx)
 
     onEvent({ payload: { text: '  edit this first  ' }, type: 'voice.transcript' } as any)
 
-    await vi.waitFor(() => expect(ctx.composer.setInput).toHaveBeenCalledWith('edit this first'))
+    await vi.waitFor(() => expect(composerInput).toBe('existing draft edit this first'))
     expect(ctx.submission.submitRef.current).not.toHaveBeenCalled()
     expect(ctx.gateway.rpc).toHaveBeenCalledWith('config.get', { key: 'full' })
   })

--- a/ui-tui/src/__tests__/voiceSubmitModeRenderer.test.tsx
+++ b/ui-tui/src/__tests__/voiceSubmitModeRenderer.test.tsx
@@ -1,0 +1,96 @@
+import { PassThrough } from 'stream'
+
+import { renderSync, Text } from '@hermes/ink'
+import React, { useMemo, useState } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { createGatewayEventHandler } from '../app/createGatewayEventHandler.js'
+
+const ref = <T,>(current: T) => ({ current })
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+describe('voice.submit_mode live composer rendering', () => {
+  it('renders a draft transcript in the real React composer state without submitting it', async () => {
+    const exposed = { current: null as null | ((event: any) => void) }
+    const submit = vi.fn()
+
+    function Harness() {
+      const [input, setInput] = useState('')
+
+      const handler = useMemo(
+        () =>
+          createGatewayEventHandler({
+            composer: {
+              dequeue: () => undefined,
+              queueEditRef: ref<null | number>(null),
+              sendQueued: vi.fn(),
+              setInput
+            },
+            gateway: {
+              gw: { request: vi.fn() },
+              rpc: vi.fn(async (method: string) =>
+                method === 'config.get' ? { config: { voice: { submit_mode: 'draft' } } } : null
+              )
+            },
+            session: {
+              STARTUP_RESUME_ID: '',
+              colsRef: ref(80),
+              newSession: vi.fn(),
+              resetSession: vi.fn(),
+              resumeById: vi.fn(),
+              setCatalog: vi.fn()
+            },
+            submission: { submitRef: ref(submit) },
+            system: { bellOnComplete: false, sys: vi.fn() },
+            transcript: {
+              appendMessage: vi.fn(),
+              panel: vi.fn(),
+              setHistoryItems: vi.fn()
+            },
+            voice: {
+              setProcessing: vi.fn(),
+              setRecording: vi.fn(),
+              setVoiceEnabled: vi.fn()
+            }
+          } as any),
+        []
+      )
+
+      exposed.current = handler
+
+      return <Text>{input || 'empty composer'}</Text>
+    }
+
+    const stdin = new PassThrough()
+    const stdout = new PassThrough()
+    const stderr = new PassThrough()
+    let output = ''
+
+    Object.assign(stdin, { isTTY: false })
+    Object.assign(stdout, { columns: 80, isTTY: false, rows: 20 })
+    stdout.on('data', chunk => {
+      output += chunk.toString()
+    })
+
+    const instance = renderSync(<Harness />, {
+      patchConsole: false,
+      stderr: stderr as NodeJS.WriteStream,
+      stdin: stdin as NodeJS.ReadStream,
+      stdout: stdout as NodeJS.WriteStream
+    })
+
+    try {
+      expect(exposed.current).not.toBeNull()
+      exposed.current!({ payload: { text: 'editable voice draft' }, type: 'voice.transcript' })
+
+      for (let i = 0; i < 20 && !output.includes('editable voice draft'); i += 1) {
+        await delay(10)
+      }
+
+      expect(output).toContain('editable voice draft')
+      expect(submit).not.toHaveBeenCalled()
+    } finally {
+      instance.unmount()
+    }
+  })
+})

--- a/ui-tui/src/__tests__/voiceSubmitModeRenderer.test.tsx
+++ b/ui-tui/src/__tests__/voiceSubmitModeRenderer.test.tsx
@@ -15,7 +15,7 @@ describe('voice.submit_mode live composer rendering', () => {
     const submit = vi.fn()
 
     function Harness() {
-      const [input, setInput] = useState('')
+      const [input, setInput] = useState('existing draft')
 
       const handler = useMemo(
         () =>
@@ -87,7 +87,7 @@ describe('voice.submit_mode live composer rendering', () => {
         await delay(10)
       }
 
-      expect(output).toContain('editable voice draft')
+      expect(output).toContain('existing draft editable voice draft')
       expect(submit).not.toHaveBeenCalled()
     } finally {
       instance.unmount()

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -36,6 +36,11 @@ import { isWakeUserDisabled } from './wakeState.js'
 
 const NO_PROVIDER_RE = /\bNo (?:LLM|inference) provider configured\b/i
 
+type VoiceSubmitMode = 'direct' | 'draft'
+
+const normalizeVoiceSubmitMode = (value: unknown): VoiceSubmitMode =>
+  typeof value === 'string' && value.trim().toLowerCase() === 'draft' ? 'draft' : 'direct'
+
 const statusFromBusy = () => (getUiState().busy ? 'running…' : 'ready')
 
 // The last gateway skin, kept so the theme can be re-derived when the OSC-11
@@ -944,16 +949,21 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
           return
         }
 
-        // CLI parity: _pending_input.put(transcript) unconditionally feeds
-        // the transcript to the agent as its next turn — draft handling
-        // doesn't apply because voice-mode users are speaking, not typing.
-        //
-        // We can't branch on composer input from inside a setInput updater
-        // (React strict mode double-invokes it, duplicating the submit).
-        // Just clear + defer submit so the cleared input is committed before
-        // submit reads it.
-        setInput('')
-        setTimeout(() => submitRef.current(text), 0)
+        void getFullConfigOnce().then(cfg => {
+          const submitMode = normalizeVoiceSubmitMode(cfg?.config?.voice?.submit_mode)
+
+          if (submitMode === 'draft') {
+            setInput(text)
+
+            return
+          }
+
+          // Default to CLI parity. Clear + defer submit so the cleared input
+          // is committed before submit reads it; invalid config also falls
+          // back to this established direct-submit behavior.
+          setInput('')
+          setTimeout(() => submitRef.current(text), 0)
+        })
 
         return
       }

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -953,7 +953,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
           const submitMode = normalizeVoiceSubmitMode(cfg?.config?.voice?.submit_mode)
 
           if (submitMode === 'draft') {
-            setInput(text)
+            setInput(current => (current.trim() ? `${current.trimEnd()} ${text}` : text))
 
             return
           }

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -113,9 +113,10 @@ export interface ConfigDisplayConfig {
 }
 
 export interface ConfigVoiceConfig {
-  // Raw `yaml.safe_load()` value from config; may be non-string if hand-edited.
-  // Callers must normalize/validate at runtime (parseVoiceRecordKey()).
+  // Raw `yaml.safe_load()` values from config may be non-string if hand-edited.
+  // Callers must normalize/validate at runtime.
   record_key?: unknown
+  submit_mode?: unknown
 }
 
 export interface ConfigFullResponse {

--- a/website/docs/guides/use-voice-mode-with-hermes.md
+++ b/website/docs/guides/use-voice-mode-with-hermes.md
@@ -166,6 +166,7 @@ If you skip that install or it fails, the wizard falls back to Edge TTS.
 ```yaml
 voice:
   record_key: "ctrl+b"
+  submit_mode: "direct"  # TUI: direct | draft
   max_recording_seconds: 120
   auto_tts: false
   beep_enabled: true
@@ -184,6 +185,18 @@ tts:
 ```
 
 This is a good conservative default for most people.
+
+In the TUI, `voice.submit_mode` controls what happens after transcription:
+
+- `direct` (default) submits the transcript immediately.
+- `draft` puts the transcript in the composer so you can edit or cancel it before pressing Enter.
+
+For editable voice drafts, set:
+
+```yaml
+voice:
+  submit_mode: "draft"
+```
 
 If you want local TTS instead, switch the `tts` block to:
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/use-voice-mode-with-hermes.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/use-voice-mode-with-hermes.md
@@ -162,6 +162,7 @@ python -m pip install -U neutts[all]
 ```yaml
 voice:
   record_key: "ctrl+b"
+  submit_mode: "direct"  # TUI：direct | draft
   max_recording_seconds: 120
   auto_tts: false
   beep_enabled: true
@@ -180,6 +181,18 @@ tts:
 ```
 
 这是适合大多数人的保守默认配置。
+
+在 TUI 中，`voice.submit_mode` 控制转写完成后的行为：
+
+- `direct`（默认）会立即提交转写文本。
+- `draft` 会把转写文本放入输入框，供你编辑或取消，按 Enter 后才发送。
+
+如需可编辑的语音草稿，请设置：
+
+```yaml
+voice:
+  submit_mode: "draft"
+```
 
 如果想改用本地 TTS，将 `tts` 块替换为：
 


### PR DESCRIPTION
## Summary

Voice transcripts can now be placed into the TUI composer for review and editing instead of always submitting immediately.

## Changes

- Add `voice.submit_mode` with `direct` as the backward-compatible default and `draft` as the editable mode.
- Insert draft transcripts after existing composer text instead of overwriting user input.
- Validate the config value and document both modes in English and Simplified Chinese.
- Preserve Khánh Ngô’s original contribution and credit BELIVIN MEDIA’s related proposal.

## Validation

| Check | Result |
|---|---|
| Config validation | 11 passed |
| TUI handler and real Ink renderer | 99 passed |
| TypeScript typecheck | Passed |
| ESLint | Passed; one unrelated existing hook warning |
| TUI production build | Passed |
| English + zh-Hans docs build | Passed |
| Regression sabotage | Both non-empty-composer tests failed on overwrite behavior, then passed after restoration |

The prior implementation replaced the entire composer value when draft mode received a transcript. Draft insertion now appends with one separating space while direct mode remains unchanged.

## Infographic

![Voice transcript submission modes](https://v3b.fal.media/files/b/0aa592f6/eNimqRUwNQUxaR5Odh9Ss_USR2ozoI.png)
