### PR TITLE
fix(video): bind managed SeedVR to source request

### DIFF
--- a/plugins/video_gen/fal/__init__.py
+++ b/plugins/video_gen/fal/__init__.py
@@ -542,7 +542,10 @@ UPSCALER_ENDPOINT = "fal-ai/seedvr/upscale/video"
 UPSCALER_FACTOR = 2
 
 
-def _upscale_video(video_url: str) -> Optional[str]:
+def _upscale_video(
+    video_url: str,
+    source_request_id: Optional[str] = None,
+) -> Optional[str]:
     """Upscale a generated video via SeedVR2; return the new URL or None.
 
     Best-effort: any failure logs and returns ``None`` so the caller falls
@@ -551,11 +554,16 @@ def _upscale_video(video_url: str) -> Optional[str]:
     """
     try:
         logger.info("Upscaling video with SeedVR2 (%dx)...", UPSCALER_FACTOR)
-        handle = _submit_fal_video_request(UPSCALER_ENDPOINT, {
+        arguments: Dict[str, Any] = {
             "video_url": video_url,
             "upscale_mode": "factor",
             "upscale_factor": UPSCALER_FACTOR,
-        })
+        }
+        if _resolve_managed_fal_video_gateway() is not None:
+            if not source_request_id:
+                raise RuntimeError("Managed SeedVR upscale requires the source FAL request id")
+            arguments["source_request_id"] = source_request_id
+        handle = _submit_fal_video_request(UPSCALER_ENDPOINT, arguments)
         result = handle.get()
     except Exception as exc:  # noqa: BLE001
         logger.warning("Video upscale failed: %s", exc)
@@ -735,6 +743,7 @@ class FALVideoGenProvider(VideoGenProvider):
 
         try:
             handle = _submit_fal_video_request(endpoint, payload)
+            source_request_id = getattr(handle, "request_id", None)
             result = handle.get()
         except Exception as exc:
             logger.warning(
@@ -767,7 +776,7 @@ class FALVideoGenProvider(VideoGenProvider):
         # video rather than failing the generation.
         upscaled = False
         if upscale:
-            upscaled_url = _upscale_video(url)
+            upscaled_url = _upscale_video(url, source_request_id)
             if upscaled_url:
                 url = upscaled_url
                 upscaled = True

--- a/tests/plugins/video_gen/test_fal_plugin.py
+++ b/tests/plugins/video_gen/test_fal_plugin.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import Mock
+
 import pytest
 
 from agent import video_gen_registry
@@ -409,10 +411,60 @@ class TestUpscalePass:
         from plugins.video_gen import fal as fal_plugin
         from plugins.video_gen.fal import FALVideoGenProvider
 
-        monkeypatch.setattr(fal_plugin, "_upscale_video", lambda url: None)
+        monkeypatch.setattr(
+            fal_plugin,
+            "_upscale_video",
+            lambda url, source_request_id=None: None,
+        )
         result = FALVideoGenProvider().generate(
             "a dog", model="pixverse-v6", upscale=True,
         )
         assert result["success"] is True
         assert result["video"] == "https://fake/native.mp4"
         assert result["upscaled"] is False
+
+    def test_managed_upscale_binds_the_source_request(self, monkeypatch):
+        from plugins.video_gen import fal as fal_plugin
+
+        captured = {}
+
+        class FakeHandle:
+            def get(self):
+                return {"video": {"url": "https://fake/upscaled.mp4"}}
+
+        monkeypatch.setattr(
+            fal_plugin,
+            "_resolve_managed_fal_video_gateway",
+            lambda: object(),
+        )
+        monkeypatch.setattr(
+            fal_plugin,
+            "_submit_fal_video_request",
+            lambda endpoint, arguments: (
+                captured.update(endpoint=endpoint, arguments=arguments)
+                or FakeHandle()
+            ),
+        )
+
+        assert (
+            fal_plugin._upscale_video(
+                "https://fake/native.mp4",
+                "source-request-1",
+            )
+            == "https://fake/upscaled.mp4"
+        )
+        assert captured["arguments"]["source_request_id"] == "source-request-1"
+
+    def test_managed_upscale_without_source_request_falls_back(self, monkeypatch):
+        from plugins.video_gen import fal as fal_plugin
+
+        submit = Mock()
+        monkeypatch.setattr(
+            fal_plugin,
+            "_resolve_managed_fal_video_gateway",
+            lambda: object(),
+        )
+        monkeypatch.setattr(fal_plugin, "_submit_fal_video_request", submit)
+
+        assert fal_plugin._upscale_video("https://fake/native.mp4") is None
+        submit.assert_not_called()


### PR DESCRIPTION
## What this does for users

Keeps managed SeedVR2 video upscaling bounded to the video Hermes just generated. Hermes now forwards the original managed FAL `request_id` with the native video URL, allowing Tool Gateway to verify ownership and source provenance before billing.

- Managed Portal requests carry `source_request_id`.
- Direct FAL requests remain unchanged.
- Missing provenance makes the optional upscale fail safely while preserving the native video.

## Why

Tool Gateway reserves SeedVR against the maximum output of Hermes-managed video generation. Without source binding, a caller could substitute an arbitrary longer video and exceed that authorization ceiling.

Companion hardening: NousResearch/tool-gateway#46.

## Validation

- `scripts/run_tests.sh tests/plugins/video_gen/test_fal_plugin.py -q`: 22 passed
- Python lint checks passed on both changed files.

## Infographic

![Managed SeedVR Provenance](https://v3b.fal.media/files/b/0aa59348/PDZ5dmM79MSNwXWUGrjVA_cPfQy7T0.png)
