### PR TITLE
fix(sessions): include gateway turns when continuing sessions on Desktop

### DIFF
--- a/tests/tui_gateway/test_live_history_refresh.py
+++ b/tests/tui_gateway/test_live_history_refresh.py
@@ -1,0 +1,146 @@
+"""Live desktop sessions refresh model history from durable cross-process writes."""
+
+from __future__ import annotations
+
+import threading
+import types
+
+from tui_gateway import server
+
+
+class _InlineThread:
+    def __init__(self, target=None, daemon=None, args=(), kwargs=None):
+        self._target = target
+        self._args = args
+        self._kwargs = kwargs or {}
+
+    def start(self):
+        if self._target is not None:
+            self._target(*self._args, **self._kwargs)
+
+    def is_alive(self):
+        return False
+
+
+class _HistoryDB:
+    def __init__(self, messages):
+        self.messages = list(messages)
+        self.reads = []
+
+    def get_messages_as_conversation(self, session_id, **kwargs):
+        self.reads.append((session_id, kwargs))
+        return list(self.messages)
+
+
+def _msg(role: str, content: str, row_id: int | None = None) -> dict:
+    message = {"role": role, "content": content}
+    if row_id is not None:
+        message["_row_id"] = row_id
+    return message
+
+
+def _session(history: list[dict]) -> dict:
+    ready = threading.Event()
+    ready.set()
+    return {
+        "agent": types.SimpleNamespace(),
+        "agent_ready": ready,
+        "session_key": "shared-session",
+        "history": list(history),
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "attached_images": [],
+        "inflight_turn": None,
+        "cols": 80,
+        "cwd": "",
+        "source": "desktop",
+    }
+
+
+def test_prompt_submit_refreshes_external_durable_history_before_dispatch(monkeypatch):
+    initial = [_msg("user", "initial", 1), _msg("assistant", "reply", 2)]
+    external = [_msg("user", "from gateway", 3), _msg("assistant", "gateway reply", 4)]
+    db = _HistoryDB(initial + external)
+    session = _session(initial)
+    captured = []
+
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(server, "_ensure_active_session_slot", lambda *_args: None)
+    monkeypatch.setattr(server, "_load_dashboard_process_isolation_config", lambda: {})
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda _session: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: None)
+    monkeypatch.setattr(server, "_wait_agent_for_prompt", lambda *_args: None)
+    monkeypatch.setattr(server.threading, "Thread", _InlineThread)
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda _rid, _sid, live, _text: captured.append(list(live["history"])),
+    )
+    server._sessions["desktop-live"] = session
+
+    response = server.handle_request(
+        {
+            "id": "submit-1",
+            "method": "prompt.submit",
+            "params": {"session_id": "desktop-live", "text": "continue"},
+        }
+    )
+
+    assert response["result"]["status"] == "streaming"
+    assert captured == [initial + external]
+    assert db.reads == [
+        (
+            "shared-session",
+            {"repair_alternation": True, "include_row_ids": True},
+        )
+    ]
+
+
+def test_refresh_preserves_live_only_tail_when_durable_history_lags(monkeypatch):
+    persisted = [_msg("user", "initial", 1), _msg("assistant", "reply", 2)]
+    live_tail = [_msg("user", "local turn"), _msg("assistant", "local reply")]
+    session = _session(persisted + live_tail)
+    monkeypatch.setattr(server, "_get_db", lambda: _HistoryDB(persisted))
+
+    changed = server._refresh_live_model_history(session)
+
+    assert changed is False
+    assert session["history"] == persisted + live_tail
+    assert session["history_version"] == 0
+
+
+def test_refresh_merges_external_and_live_only_append_tails(monkeypatch):
+    initial = [_msg("user", "initial", 1), _msg("assistant", "reply", 2)]
+    external = [_msg("user", "from gateway", 3), _msg("assistant", "gateway reply", 4)]
+    live_marker = {
+        "role": "user",
+        "content": "[Model switched to test/model]",
+        "display_kind": "model_switch",
+    }
+    session = _session(initial + [live_marker])
+    monkeypatch.setattr(server, "_get_db", lambda: _HistoryDB(initial + external))
+
+    changed = server._refresh_live_model_history(session)
+
+    assert changed is True
+    assert session["history"] == initial + external + [live_marker]
+    assert session["history_version"] == 1
+
+
+def test_refresh_failure_leaves_live_history_untouched(monkeypatch):
+    live = [_msg("user", "keep me"), _msg("assistant", "still here")]
+    session = _session(live)
+
+    class _BrokenDB:
+        def get_messages_as_conversation(self, *_args, **_kwargs):
+            raise RuntimeError("database is locked")
+
+    monkeypatch.setattr(server, "_get_db", lambda: _BrokenDB())
+
+    changed = server._refresh_live_model_history(session)
+
+    assert changed is False
+    assert session["history"] == live
+    assert session["history_version"] == 0

--- a/tests/tui_gateway/test_live_history_refresh.py
+++ b/tests/tui_gateway/test_live_history_refresh.py
@@ -144,3 +144,82 @@ def test_refresh_failure_leaves_live_history_untouched(monkeypatch):
     assert changed is False
     assert session["history"] == live
     assert session["history_version"] == 0
+
+
+def test_refresh_does_not_mutate_history_when_turn_starts_during_db_read(monkeypatch):
+    initial = [_msg("user", "initial", 1), _msg("assistant", "reply", 2)]
+    external = [_msg("user", "external", 3), _msg("assistant", "external reply", 4)]
+    read_started = threading.Event()
+    release_read = threading.Event()
+
+    class _BlockingDB(_HistoryDB):
+        def get_messages_as_conversation(self, session_id, **kwargs):
+            read_started.set()
+            assert release_read.wait(5)
+            return super().get_messages_as_conversation(session_id, **kwargs)
+
+    session = _session(initial)
+    monkeypatch.setattr(server, "_get_db", lambda: _BlockingDB(initial + external))
+    result = []
+    worker = threading.Thread(
+        target=lambda: result.append(server._refresh_live_model_history(session))
+    )
+
+    worker.start()
+    assert read_started.wait(5)
+    with session["history_lock"]:
+        session["running"] = True
+    release_read.set()
+    worker.join(5)
+
+    assert not worker.is_alive()
+    assert result == [False]
+    assert session["history"] == initial
+    assert session["history_version"] == 0
+
+
+def test_queued_inline_dispatch_refreshes_external_durable_history(monkeypatch):
+    initial = [_msg("user", "initial", 1), _msg("assistant", "reply", 2)]
+    external = [_msg("user", "external", 3), _msg("assistant", "external reply", 4)]
+    db = _HistoryDB(initial + external)
+    session = _session(initial)
+    session["queued_prompt"] = {"text": "queued", "transport": None}
+    captured = []
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda _session: False)
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda _rid, _sid, live, _text, **_kwargs: captured.append(
+            list(live["history"])
+        ),
+    )
+
+    assert server._drain_queued_prompt("queued", "sid", session) is True
+
+    assert captured == [initial + external]
+    assert len(db.reads) == 1
+
+
+def test_queued_compute_host_frame_refreshes_external_durable_history(monkeypatch):
+    initial = [_msg("user", "initial", 1), _msg("assistant", "reply", 2)]
+    external = [_msg("user", "external", 3), _msg("assistant", "external reply", 4)]
+    db = _HistoryDB(initial + external)
+    session = _session(initial)
+    session["queued_prompt"] = {"text": "queued", "transport": None}
+    captured = []
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda _session: True)
+    monkeypatch.setattr(
+        server,
+        "_submit_prompt_to_compute_host",
+        lambda _rid, _sid, live, _text, **_kwargs: (
+            captured.append(list(live["history"]))
+            or {"result": {"status": "streaming"}}
+        ),
+    )
+
+    assert server._drain_queued_prompt("queued", "sid", session) is True
+
+    assert captured == [initial + external]
+    assert len(db.reads) == 1

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -128,6 +128,10 @@ def _(rid, params: dict) -> dict:
     # or fallback moved the session transport to stdio.
     if (t := current_transport()) is not None:
         session["transport"] = t
+    # Refresh before the busy/claim loop, not between its idle observation and
+    # the final claim. The helper rechecks ``running`` after its DB read, so a
+    # turn that wins while storage is in flight keeps its working history.
+    _refresh_live_model_history(session)
     while True:
         busy_transport = None
         with session["history_lock"]:
@@ -148,13 +152,6 @@ def _(rid, params: dict) -> dict:
         # The old turn finished between the two lock acquisitions. Retry the
         # claim so this prompt starts normally instead of being stranded in a
         # queue whose drain already ran.
-
-    # A warm desktop/TUI record can outlive writes from another gateway
-    # process. Refresh before claiming the turn so both the inline snapshot and
-    # the compute-host frame receive the authoritative durable model rows while
-    # retaining any newer live-only tail. Best-effort: storage failures leave
-    # the current in-memory history untouched.
-    _refresh_live_model_history(session)
 
     with session["history_lock"]:
         # A watch session's run lives in the PARENT turn, so its own running

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -149,6 +149,13 @@ def _(rid, params: dict) -> dict:
         # claim so this prompt starts normally instead of being stranded in a
         # queue whose drain already ran.
 
+    # A warm desktop/TUI record can outlive writes from another gateway
+    # process. Refresh before claiming the turn so both the inline snapshot and
+    # the compute-host frame receive the authoritative durable model rows while
+    # retaining any newer live-only tail. Best-effort: storage failures leave
+    # the current in-memory history untouched.
+    _refresh_live_model_history(session)
+
     with session["history_lock"]:
         # A watch session's run lives in the PARENT turn, so its own running
         # flag is False — without this, typing mid-run builds a second agent

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8094,6 +8094,101 @@ def _live_visible_history(session: dict, db, in_memory_fallback: list[dict]) -> 
     return in_memory_fallback
 
 
+def _model_history_reconcile_key(message: dict) -> tuple:
+    """Return the stable, model-relevant identity used for append reconciliation."""
+    if not isinstance(message, dict):
+        return ("", repr(message), "", "", "")
+    tool_calls = message.get("tool_calls")
+    try:
+        tool_calls_key = json.dumps(tool_calls, sort_keys=True, ensure_ascii=False)
+    except (TypeError, ValueError):
+        tool_calls_key = repr(tool_calls)
+    return (
+        message.get("role"),
+        _coerce_message_text(message.get("content")),
+        message.get("tool_call_id"),
+        message.get("tool_name") or message.get("name"),
+        tool_calls_key,
+    )
+
+
+def _reconcile_model_with_live(
+    persisted_history: list[dict], live_history: list[dict]
+) -> list[dict]:
+    """Merge durable and live append-only model-history tails.
+
+    Durable rows are authoritative for cross-process appends, while the live
+    record may be ahead because the current process has not flushed its newest
+    turn or because it carries a runtime-only marker. Preserve the longer side
+    when one is a prefix of the other. If both appended after the same prefix,
+    keep both tails (durable first, then live-only). A fully divergent durable
+    projection is not safe to apply automatically: keep memory rather than
+    replacing a potentially newer runtime after an external rewrite.
+    """
+    if not persisted_history:
+        return list(live_history)
+    if not live_history:
+        return list(persisted_history)
+
+    shared = 0
+    limit = min(len(persisted_history), len(live_history))
+    while shared < limit and _model_history_reconcile_key(
+        persisted_history[shared]
+    ) == _model_history_reconcile_key(live_history[shared]):
+        shared += 1
+
+    if shared == len(live_history):
+        return list(persisted_history)
+    if shared == len(persisted_history):
+        return list(live_history)
+    if shared:
+        return list(persisted_history) + list(live_history[shared:])
+    return list(live_history)
+
+
+def _refresh_live_model_history(session: dict) -> bool:
+    """Refresh a live session from durable rows before its next model turn.
+
+    Another gateway process can append to the same SessionDB while the desktop
+    keeps a warm session record. UI hydration already reads the durable display
+    projection, but model inference uses ``session['history']``; reconcile that
+    model projection here so inline and compute-host turns see the same current
+    segment. DB failures are fail-open and leave the live record untouched.
+    """
+    session_key = str(session.get("session_key") or "")
+    if not session_key:
+        return False
+    try:
+        with _session_db(session) as db:
+            if db is None:
+                return False
+            persisted = db.get_messages_as_conversation(
+                session_key,
+                repair_alternation=True,
+                include_row_ids=True,
+            )
+        persisted = sanitize_replay_history(persisted)
+    except Exception:
+        logger.debug("live model history refresh failed", exc_info=True)
+        return False
+
+    with session["history_lock"]:
+        live = list(session.get("history") or [])
+        refreshed = _reconcile_model_with_live(persisted, live)
+        if refreshed == live:
+            return False
+        session["history"] = refreshed
+        session["history_version"] = int(session.get("history_version", 0)) + 1
+    logger.info(
+        "Refreshed live model history for session %s (disk=%d, memory=%d, merged=%d)",
+        session_key,
+        len(persisted),
+        len(live),
+        len(refreshed),
+    )
+    return True
+
+
 def _live_session_payload(
     sid: str,
     session: dict,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7623,6 +7623,14 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
     lower-priority follow-ups this cycle — the user's message wins). Mirrors the
     claim-under-lock pattern used by the goal-continuation re-fire.
     """
+    # Busy prompt.submit returns before the ordinary idle-turn refresh. Refresh
+    # here as the queued sibling becomes runnable so both inline and compute-host
+    # dispatch see cross-process appends. Re-read the queue under the claim lock:
+    # another submit can win the session while the DB read is in flight.
+    with session["history_lock"]:
+        if not session.get("queued_prompt") or session.get("running"):
+            return False
+    _refresh_live_model_history(session)
     with session["history_lock"]:
         queued = session.get("queued_prompt")
         if not queued or session.get("running"):
@@ -8155,6 +8163,12 @@ def _refresh_live_model_history(session: dict) -> bool:
     model projection here so inline and compute-host turns see the same current
     segment. DB failures are fail-open and leave the live record untouched.
     """
+    # Never rewrite the working list underneath an active turn. The caller may
+    # observe an idle record and then lose the claim while this SQLite read is
+    # in flight, so guard both sides of the read.
+    with session["history_lock"]:
+        if session.get("running"):
+            return False
     session_key = str(session.get("session_key") or "")
     if not session_key:
         return False
@@ -8173,6 +8187,8 @@ def _refresh_live_model_history(session: dict) -> bool:
         return False
 
     with session["history_lock"]:
+        if session.get("running"):
+            return False
         live = list(session.get("history") or [])
         refreshed = _reconcile_model_with_live(persisted, live)
         if refreshed == live:


### PR DESCRIPTION
## What does this PR do?

Desktop and TUI sessions can stay warm while another gateway process appends turns to the same durable session. Before this change, the UI displayed those durable turns but the next model request reused the stale in-memory history, silently omitting part of the conversation and producing answers without the latest context.

This change refreshes the model-facing projection from SessionDB immediately before an ordinary or queued turn claims the live session. It reconciles append-only durable and live tails without replacing a newer active-turn snapshot.

## Related Issue

Fixes #81951

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` - add stable model-history reconciliation, refresh live sessions from durable rows before dispatch, and cover queued inline and compute-host paths.
- `tui_gateway/methods_prompt.py` - refresh live model history before the prompt claim loop while rechecking active-turn ownership after the database read.
- `tests/tui_gateway/test_live_history_refresh.py` - cover cross-process appends, live-only tails, divergent append-only tails, read failures, active-turn races, and queued dispatch.

## How to Test

1. Create and resume a session so the gateway holds a warm in-memory history.
2. Append additional active messages to the same session from a second process, then submit a Desktop prompt.
3. Confirm the UI and model-facing `conversation_history` contain the same ordered durable messages, while the new prompt remains the separate user turn.
4. Run the focused regression suites:

```bash
scripts/run_tests.sh tests/tui_gateway/test_live_history_refresh.py tests/test_tui_gateway_queue_on_busy.py
```

Result: 22 tests passed.

A real SessionDB flow also verified that all 8 active rows reached both the UI and model-facing history with no compaction, summary, or session rotation.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant suites and all 22 tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] Relevant documentation: N/A; no user-facing configuration or workflow changed
- [x] `cli-config.yaml.example`: N/A; no configuration keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A; no architecture or contributor workflow changed
- [x] Cross-platform impact considered; the change uses existing Python and SessionDB synchronization primitives
- [x] Tool descriptions/schemas: N/A; no model tool behavior changed

## Screenshots / Logs

N/A; this fixes the model-facing session projection without changing the visual layout.
