### PR TITLE
fix(agent): a failed preflight compaction must not take the turn down

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -964,10 +964,30 @@ def build_turn_context(
                 _orig_len = len(messages)
                 _orig_tokens = _preflight_tokens
                 _preflight_input = messages
-                messages, active_system_prompt = agent._compress_context(
-                    messages, system_message, approx_tokens=_preflight_tokens,
-                    task_id=effective_task_id,
-                )
+                try:
+                    messages, active_system_prompt = agent._compress_context(
+                        messages, system_message, approx_tokens=_preflight_tokens,
+                        task_id=effective_task_id,
+                    )
+                except Exception as _preflight_compress_exc:
+                    # Preflight compaction is an optimization, not a
+                    # precondition for the turn. _compress_context re-raises
+                    # every failure after releasing the session lock — a
+                    # summary-model "Request timed out" on a large transcript
+                    # included — and nothing between here and the caller
+                    # catches it, so one oversized session takes the whole
+                    # turn down. Degrade to the state the
+                    # insufficient-progress path already uses: no compaction
+                    # this turn, and let the loop's own error handling, with
+                    # its retry budget, deal with an oversized request.
+                    logger.warning(
+                        "Preflight compression failed (%s: %s); continuing the "
+                        "turn without compaction",
+                        type(_preflight_compress_exc).__name__,
+                        _preflight_compress_exc,
+                    )
+                    _preflight_compression_blocked = True
+                    break
                 if (
                     messages is _preflight_input
                     and compression_skipped_due_to_lock(agent)
@@ -1097,10 +1117,23 @@ def build_turn_context(
                     f"{getattr(_compressor, 'threshold_tokens', 0):,}",
                 )
                 _engine_input = messages
-                messages, active_system_prompt = agent._compress_context(
-                    messages, system_message, approx_tokens=_preflight_tokens,
-                    task_id=effective_task_id,
-                )
+                try:
+                    messages, active_system_prompt = agent._compress_context(
+                        messages, system_message, approx_tokens=_preflight_tokens,
+                        task_id=effective_task_id,
+                    )
+                except Exception as _engine_compress_exc:
+                    # Same contract as the threshold passes above: a failed
+                    # maintenance compaction must not take the turn with it.
+                    # Restoring the input list makes the skip check below
+                    # read this as the no-op it turned out to be.
+                    logger.warning(
+                        "Engine-driven preflight maintenance failed (%s: %s); "
+                        "continuing the turn without compaction",
+                        type(_engine_compress_exc).__name__,
+                        _engine_compress_exc,
+                    )
+                    messages = _engine_input
                 # ``_compress_context`` returns the INPUT list object on every
                 # skip path (per-session lock held elsewhere, cooldown,
                 # anti-thrash breaker, codex-native routing) and an engine may

--- a/tests/agent/test_preflight_compression_failure.py
+++ b/tests/agent/test_preflight_compression_failure.py
@@ -1,0 +1,101 @@
+"""A failed preflight compaction must not take the turn down with it.
+
+``_compress_context`` re-raises every failure after releasing the session
+lock — a summary-model "Request timed out" on a large transcript included.
+Both preflight call sites in ``build_turn_context`` (the over-threshold pass
+loop and the engine-driven sub-threshold maintenance pass) called it bare, so
+that exception escaped the turn setup entirely. A session big enough to fail
+compaction then took the process down on every attempt to serve it.
+
+Preflight compaction is an optimization, not a precondition: a failure has to
+degrade to "no compaction this turn" and let the loop's own error handling,
+with its retry budget, deal with the oversized request.
+"""
+
+from __future__ import annotations
+
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.agent.test_turn_context import _FakeAgent, _build
+
+
+@pytest.fixture(autouse=True)
+def _stub_runtime_main():
+    with patch("agent.auxiliary_client.set_runtime_main", lambda *a, **k: None):
+        yield
+
+
+def _pressured_compressor():
+    """Over-threshold stub that opens the preflight threshold path."""
+    return types.SimpleNamespace(
+        protect_first_n=0,
+        protect_last_n=0,
+        threshold_tokens=1,
+        context_length=100_000,
+        last_prompt_tokens=0,
+        should_compress=lambda _tokens=None: True,
+        should_compress_info=lambda _tokens=None: (True, None),
+        should_defer_preflight_to_real_usage=lambda _t: False,
+        get_active_compression_failure_cooldown=lambda: None,
+    )
+
+
+def _make_agent(compressor):
+    agent = _FakeAgent()
+    agent.compression_enabled = True
+    agent.context_compressor = compressor
+    agent._emit_status = MagicMock()
+    return agent
+
+
+_HISTORY = [{"role": "user", "content": "old"}, {"role": "assistant", "content": "older"}]
+
+
+def test_threshold_pass_failure_does_not_escape_the_turn():
+    """The reported crash: the summary model times out mid-compaction."""
+    agent = _make_agent(_pressured_compressor())
+    calls = []
+
+    def _timing_out_compress(_messages, _system_message, **_kwargs):
+        calls.append(1)
+        raise TimeoutError("Request timed out.")
+
+    agent._compress_context = _timing_out_compress
+
+    ctx = _build(agent, conversation_history=list(_HISTORY))
+
+    # The turn was built rather than destroyed, the failure armed the blocker,
+    # and the loop stopped instead of retrying a compaction that just failed.
+    assert ctx.preflight_compression_blocked is True
+    assert calls == [1]
+
+
+def test_threshold_pass_failure_keeps_the_transcript():
+    """Degrading must not cost the turn its messages."""
+    agent = _make_agent(_pressured_compressor())
+
+    def _failing_compress(_messages, _system_message, **_kwargs):
+        raise RuntimeError("aux provider exploded")
+
+    agent._compress_context = _failing_compress
+
+    ctx = _build(agent, conversation_history=list(_HISTORY))
+
+    roles = [m.get("role") for m in ctx.messages]
+    assert "user" in roles
+
+
+def test_interrupts_still_propagate():
+    """Only Exception is absorbed — cancellation must keep unwinding."""
+    agent = _make_agent(_pressured_compressor())
+
+    def _interrupted_compress(_messages, _system_message, **_kwargs):
+        raise KeyboardInterrupt()
+
+    agent._compress_context = _interrupted_compress
+
+    with pytest.raises(KeyboardInterrupt):
+        _build(agent, conversation_history=list(_HISTORY))


### PR DESCRIPTION
Related to #79624 — the sibling call path, not a claim on that issue's crash. Scope is stated precisely at the bottom.

## What

`build_turn_context` runs preflight compaction at two places, and both call `agent._compress_context()` bare:

- the over-threshold pass loop
- the engine-driven sub-threshold maintenance pass

`_compress_context` re-raises every failure after releasing the session lock. Its own `except BaseException` handler exists to stop a compression error from stranding the lease, not to contain the error — it releases, emits telemetry, and re-raises. So a summary-model failure during the turn's preflight escapes turn setup completely, and the turn dies before reaching the loop that knows how to handle an oversized request.

Nothing about that is self-correcting. A transcript large enough that summarising it times out is still that large next turn, so it fails the same way every time it is served.

The guard immediately next to this code covers the `should_compress_preflight()` **predicate**, and says so: a buggy engine must never break an otherwise-healthy turn. It went in with 929c95259 (2026-07-22, fix(agent): wire should_compress_preflight into the turn-start preflight flow), which wired the hook and wrapped the hook call. The compaction that the hook gates — the part that talks to a model over a network — was left bare. That is the wrong way round: the predicate is local and cheap, the compaction is the part that can fail.

Preflight compaction is an optimization, not a precondition. The pass loop already treats a lock-contended no-op and an insufficient-progress pass as ordinary outcomes and carries on; a failed compaction belongs in the same category.

## The fix

Absorb `Exception` at both sites.

The threshold pass logs the failure, arms `preflight_compression_blocked` and stops the loop — the same state the insufficient-progress path already produces, so downstream bookkeeping needs no new case, and the loop's own error handling receives the oversized request with its retry budget intact.

The maintenance pass restores the input list, which makes the existing `messages is not _engine_input` skip check read the failure as the no-op it turned out to be. It deliberately does not arm the blocker: a sub-threshold pass proves nothing about over-threshold compressibility.

`Exception`, not `BaseException` — cancellation and interrupts must keep unwinding. Explicit compression cancellation is already handled inside `_compress_context` and returns normally, so it is unaffected.

## Tests and results

New `tests/agent/test_preflight_compression_failure.py` — 3 passed, driving the real `build_turn_context` through the existing turn-context harness:

- a `_compress_context` that raises `TimeoutError("Request timed out.")` yields a built turn with `preflight_compression_blocked` set, and exactly one pass rather than a retry of the compaction that just failed
- the degraded turn keeps its transcript
- `KeyboardInterrupt` still propagates

Reverting only the source change and re-running the file turns the first two red, with the exception escaping `build_turn_context`; restoring it turns them green.

`test_preflight_compression_failure.py`, `test_preflight_lock_defer.py`, `test_engine_preflight_wire.py`, `test_turn_context.py`, `test_idle_compaction_lock_and_guards.py` together — 19 passed.

## Scope — what this is and is not

This is the agent-side preflight path in `agent/turn_context.py`. It is **not** a second attempt at #79624's crash site, and it does not overlap the fixes already merged for it: #79741 and #79773 hardened the gateway session-hygiene path in `gateway/run.py` / `gateway/session_state.py` with the failure-cooldown ladder, and touched this file only to make `compression_made_progress` public.

The `📦 Preflight compression` status line in that issue's log is emitted from two places — `agent/turn_context.py:946` and `gateway/run.py:298` — so the reported process exit plausibly belongs to the gateway path that has since been hardened. I have not tried to attribute it here.

What I did verify is that the agent-side path still lets a compaction failure escape turn setup on current `main`, which is the code path the review on #79691 pointed at as the one that should be carrying this. Worth having on its own terms; happy to retarget or drop it if you read the ownership differently.
