### PR TITLE
fix(tui): fail closed for empty toolsets

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -987,6 +987,11 @@ agent:
 #   platform_toolsets:
 #     discord: [web, vision, skills, todo]
 #
+#   # Deny all model-callable tools for CLI, Desktop, and TUI sessions:
+#   # (an explicit empty list is fail-closed, including MCP and GUI tools)
+#   platform_toolsets:
+#     cli: []
+#
 # If not set, defaults are:
 #   cli:           hermes-cli            (everything + cronjob management)
 #   telegram:      hermes-telegram       (terminal, file, web, vision, image, tts, browser, skills, todo, cronjob, messaging)

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2269,6 +2269,14 @@ def _get_platform_tools(
     # Normalise to str so downstream sorted() never mixes types.
     toolset_names = [str(ts) for ts in toolset_names]
 
+    # An explicitly saved empty list is a deliberate deny-all policy, not an
+    # incomplete platform configuration. It must win over every later recovery
+    # path (default plugins, MCP servers, and non-configurable native toolsets),
+    # otherwise a persisted zero-tool selection can silently grow a callable
+    # schema after a restart.
+    if explicitly_configured and not toolset_names:
+        return set()
+
     configurable_keys = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
     plugin_ts_keys = _get_plugin_toolset_keys()
     platform_default_keys = {p["default_toolset"] for p in PLATFORMS.values()}
@@ -2520,19 +2528,21 @@ def _get_platform_tools(
         from toolsets import validate_toolset
 
         _named = [str(t) for t in _explicit if isinstance(t, str) and t]
-        if (
-            _named
-            and not any(validate_toolset(t) for t in _named)
-            and platform not in _warned_invalid_platform_toolsets
-        ):
-            _warned_invalid_platform_toolsets.add(platform)
-            logger.warning(
-                "platform '%s' has no valid toolsets configured (unknown "
-                "name(s): %s) - tools will be unavailable. Run `hermes tools` "
-                "to reconfigure. See issue #38798.",
-                platform,
-                ", ".join(_named),
-            )
+        invalid_selection = _named and not any(
+            validate_toolset(t) or t in enabled_mcp_servers or t == "no_mcp"
+            for t in _named
+        )
+        if invalid_selection:
+            if platform not in _warned_invalid_platform_toolsets:
+                _warned_invalid_platform_toolsets.add(platform)
+                logger.warning(
+                    "platform '%s' has no valid toolsets configured (unknown "
+                    "name(s): %s) - tools will be unavailable. Run `hermes tools` "
+                    "to reconfigure. See issue #38798.",
+                    platform,
+                    ", ".join(_named),
+                )
+            return set()
 
     return enabled_toolsets
 

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -44,10 +44,11 @@ def test_all_invalid_platform_toolsets_logs_runtime_warning(caplog):
     config = {"platform_toolsets": {"cli": ["hermes"]}}
 
     with caplog.at_level(logging.WARNING, logger="hermes_cli.tools_config"):
-        _get_platform_tools(config, "cli")
+        enabled = _get_platform_tools(config, "cli")
 
     warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
     assert any("#38798" in m and "hermes" in m for m in warnings), warnings
+    assert enabled == set()
 
 
 def test_valid_platform_toolsets_no_runtime_warning(caplog):
@@ -70,6 +71,17 @@ def test_partially_valid_platform_toolsets_no_runtime_warning(caplog):
         _get_platform_tools(config, "cli")
 
     assert not any("#38798" in r.getMessage() for r in caplog.records)
+
+
+def test_explicit_empty_platform_toolsets_disable_all_recovery_paths():
+    """A saved empty list is a durable deny-all policy, not a fallback cue."""
+    enabled = _get_platform_tools(
+        {"platform_toolsets": {"cli": []}},
+        "cli",
+        include_default_mcp_servers=True,
+    )
+
+    assert enabled == set()
 
 
 

--- a/tests/tui_gateway/test_gui_surface_toolsets.py
+++ b/tests/tui_gateway/test_gui_surface_toolsets.py
@@ -12,6 +12,9 @@ session's own ``source`` (``session.create``'s ``source: 'desktop'``), so the
 answer is identical on every connection topology.
 """
 
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 import tui_gateway.server as server
@@ -107,8 +110,148 @@ class TestResolverPlumbing:
         assert "desktop_ui" in desktop
         assert "desktop_ui" not in tui
 
+    def test_explicit_empty_config_overrides_posture_and_gui_surfaces(
+        self, no_desktop_env
+    ):
+        import agent.coding_context as cc
+        import hermes_cli.config as config_mod
+
+        no_desktop_env.setattr(cc, "coding_selection", lambda **_: ["coding"])
+        no_desktop_env.setattr(
+            config_mod, "load_config", lambda: {"platform_toolsets": {"cli": []}}
+        )
+
+        assert server._load_enabled_toolsets("desktop") == []
+        assert server._load_enabled_toolsets("tui") == []
+
+    def test_invalid_config_fails_closed_without_gui_surfaces(self, no_desktop_env):
+        import agent.coding_context as cc
+        import hermes_cli.config as config_mod
+
+        no_desktop_env.setattr(cc, "coding_selection", lambda **_: None)
+        no_desktop_env.setattr(
+            config_mod,
+            "load_config",
+            lambda: {"platform_toolsets": {"cli": ["not-a-real-toolset"]}},
+        )
+
+        assert server._load_enabled_toolsets("desktop") == []
+
     def test_explicit_env_pin_still_wins(self, no_desktop_env):
         """HERMES_TUI_TOOLSETS is an operator override; surface can't re-add."""
         no_desktop_env.setenv("HERMES_TUI_TOOLSETS", "web,memory")
 
         assert server._load_enabled_toolsets("desktop") == ["web", "memory"]
+
+
+def test_make_agent_preserves_explicit_empty_toolsets(monkeypatch):
+    """A fresh desktop session must construct its live agent without tools."""
+    import agent.coding_context as cc
+    import hermes_cli.config as config_mod
+
+    config = {"platform_toolsets": {"cli": []}}
+    runtime = SimpleNamespace(
+        runtime={
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+            "command": None,
+            "args": None,
+            "credential_pool": None,
+        },
+        used_fallback=False,
+        selected_model="",
+    )
+    monkeypatch.setattr(cc, "coding_selection", lambda **_: ["coding"])
+    monkeypatch.setattr(config_mod, "load_config", lambda: config)
+
+    with (
+        patch("tui_gateway.server._load_cfg", return_value={}),
+        patch("tui_gateway.server._get_db", return_value=MagicMock()),
+        patch("tui_gateway.server._load_reasoning_config", return_value=None),
+        patch("tui_gateway.server._load_service_tier", return_value=None),
+        patch("tui_gateway.server._resolve_startup_runtime", return_value=("test-model", None)),
+        patch("tui_gateway.server._resolve_runtime_with_fallback", return_value=runtime),
+        patch("tui_gateway.server._load_provider_routing", return_value={}),
+        patch("tui_gateway.server._load_fallback_model", return_value=[]),
+        patch("run_agent.AIAgent") as agent_cls,
+    ):
+        server._make_agent("empty-tools", "empty-tools", platform_override="desktop")
+
+    assert agent_cls.call_args.kwargs["enabled_toolsets"] == []
+
+
+def test_zero_tool_reports_remain_empty(monkeypatch):
+    """The live session and the request-level tool inspector agree on zero."""
+    agent = SimpleNamespace(enabled_toolsets=[], tools=[], model="test-model")
+    session = {"agent": agent, "session_key": "empty-tools", "source": "desktop"}
+    monkeypatch.setitem(server._sessions, "empty-tools", session)
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+
+    try:
+        response = server._methods["tools.show"](
+            "empty-tools", {"session_id": "empty-tools"}
+        )
+        toolsets = server._methods["toolsets.list"](
+            "empty-toolsets", {"session_id": "empty-tools"}
+        )
+        info = server._session_info(agent, session)
+    finally:
+        server._sessions.pop("empty-tools", None)
+
+    assert response["result"] == {"sections": [], "total": 0}
+    assert not any(item["enabled"] for item in toolsets["result"]["toolsets"])
+    assert info["tools"] == {}
+
+
+def test_background_preview_and_mcp_reload_preserve_explicit_empty_toolsets(
+    monkeypatch,
+):
+    """No secondary TUI agent may turn an explicit deny-all back into tools."""
+    import agent.coding_context as cc
+    import hermes_cli.config as config_mod
+    import tools.mcp_tool as mcp_tool
+
+    config = {"platform_toolsets": {"cli": []}}
+    parent = SimpleNamespace(enabled_toolsets=[], model="test-model", tools=[])
+    monkeypatch.setattr(cc, "coding_selection", lambda **_: ["coding"])
+    monkeypatch.setattr(config_mod, "load_config", lambda: config)
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
+    monkeypatch.setattr(server, "_get_db", MagicMock())
+    monkeypatch.setattr(server, "_load_reasoning_config", lambda *_: None)
+    monkeypatch.setattr(server, "_load_service_tier", lambda: None)
+    monkeypatch.setattr(server, "_agent_fallback_model", lambda _: [])
+    monkeypatch.setattr(server, "_mcp_reload_gen", 0)
+    monkeypatch.setattr(server, "_mcp_reload_loaded_rev", "")
+
+    assert server._background_agent_kwargs(parent, "background")["enabled_toolsets"] == []
+    assert server._ephemeral_preview_agent_kwargs(parent, "preview")["enabled_toolsets"] == []
+
+    seen: dict[str, object] = {}
+    monkeypatch.setitem(
+        server._sessions,
+        "empty-tools",
+        {"agent": parent, "session_key": "empty-tools", "source": "desktop"},
+    )
+    monkeypatch.setattr(mcp_tool, "shutdown_mcp_servers", lambda: None)
+    monkeypatch.setattr(mcp_tool, "discover_mcp_tools", lambda: None)
+    monkeypatch.setattr(
+        mcp_tool,
+        "refresh_agent_mcp_tools",
+        lambda _agent, **kwargs: seen.update(kwargs),
+    )
+    monkeypatch.setattr(server, "_compute_mcp_rev", lambda: "empty-tools")
+    monkeypatch.setattr(server, "_session_info", lambda *_: {})
+    monkeypatch.setattr(server, "_emit", lambda *_: None)
+
+    try:
+        response = server._methods["reload.mcp"](
+            "reload-empty", {"session_id": "empty-tools", "confirm": True}
+        )
+    finally:
+        server._sessions.pop("empty-tools", None)
+
+    assert response["result"]["status"] == "reloaded"
+    assert seen["enabled_override"] == []

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -152,7 +152,7 @@ def _(rid, params: dict) -> dict:
                 # user just enabled in config this session is picked up.
                 refresh_agent_mcp_tools(
                     agent,
-                    enabled_override=_load_enabled_toolsets(),
+                    enabled_override=_load_enabled_toolsets(_session_source(session)),
                     quiet_mode=True,
                 )
             except Exception as _exc:
@@ -1435,11 +1435,12 @@ def _(rid, params: dict) -> dict:
         from toolsets import get_all_toolsets, get_toolset_info
 
         session = _sessions.get(params.get("session_id", ""))
-        enabled = (
-            set(getattr(session["agent"], "enabled_toolsets", []) or [])
+        enabled_toolsets = (
+            getattr(session["agent"], "enabled_toolsets", None)
             if session
-            else set(_load_enabled_toolsets() or [])
+            else _load_enabled_toolsets()
         )
+        enabled = set(enabled_toolsets or [])
 
         items = []
         for name in sorted(get_all_toolsets().keys()):
@@ -1451,7 +1452,7 @@ def _(rid, params: dict) -> dict:
                     "name": name,
                     "description": info["description"],
                     "tool_count": info["tool_count"],
-                    "enabled": name in enabled if enabled else True,
+                    "enabled": name in enabled if enabled_toolsets is not None else True,
                     "tools": info["resolved_tools"],
                 }
             )
@@ -1578,11 +1579,12 @@ def _(rid, params: dict) -> dict:
         from toolsets import get_all_toolsets, get_toolset_info
 
         session = _sessions.get(params.get("session_id", ""))
-        enabled = (
-            set(getattr(session["agent"], "enabled_toolsets", []) or [])
+        enabled_toolsets = (
+            getattr(session["agent"], "enabled_toolsets", None)
             if session
-            else set(_load_enabled_toolsets() or [])
+            else _load_enabled_toolsets()
         )
+        enabled = set(enabled_toolsets or [])
 
         items = []
         for name in sorted(get_all_toolsets().keys()):
@@ -1594,7 +1596,7 @@ def _(rid, params: dict) -> dict:
                     "name": name,
                     "description": info["description"],
                     "tool_count": info["tool_count"],
-                    "enabled": name in enabled if enabled else True,
+                    "enabled": name in enabled if enabled_toolsets is not None else True,
                 }
             )
         return _ok(rid, {"toolsets": items})

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4191,14 +4191,31 @@ def _load_enabled_toolsets(platform: str | None = None) -> list[str] | None:
     # Coding posture (base Hermes): with no explicit pin, collapse to the
     # coding toolset (+ enabled MCP servers) when sitting in a code workspace.
     # The desktop app and `hermes --tui` both land here. See
-    # agent/coding_context.py. No config is loaded yet at this point, so we let
-    # coding_selection() load it lazily (cli.py passes its already-resolved
-    # CLI_CONFIG instead, purely to avoid a redundant read).
+    # agent/coding_context.py. Read config once up front so an explicit
+    # deny-all selection takes priority over focus posture.
     if not explicit:
+        try:
+            from hermes_cli.config import load_config
+
+            cfg = load_config()
+            platform_toolsets = (
+                cfg.get("platform_toolsets") if isinstance(cfg, dict) else None
+            )
+            if (
+                isinstance(platform_toolsets, dict)
+                and isinstance(platform_toolsets.get("cli"), list)
+                and not platform_toolsets["cli"]
+            ):
+                # ``platform_toolsets.cli: []`` is the durable, explicit
+                # deny-all state. It must short-circuit focus posture and
+                # session-only GUI surfaces just as it does later recovery.
+                return []
+        except Exception:
+            cfg = None
         try:
             from agent.coding_context import coding_selection
 
-            selection = coding_selection(platform=session_platform)
+            selection = coding_selection(platform=session_platform, config=cfg)
             if selection is not None:
                 # Fold in the client-surface toolsets here too: the focus-mode
                 # coding posture returns before the fallback path that normally
@@ -4314,7 +4331,10 @@ def _load_enabled_toolsets(platform: str | None = None) -> list[str] | None:
         if fallback_notice is not None:
             print(fallback_notice, file=sys.stderr, flush=True)
         if not enabled:
-            return None
+            # ``None`` means unrestricted/default selection to AIAgent; an
+            # empty resolver result means a configured deny-all policy.
+            # Preserve the latter without adding GUI-only toolsets.
+            return []
         # The client-surface toolsets are off _HERMES_CORE_TOOLS (every other
         # platform would carry their schema for nothing), so the platform
         # recovery above — which keys off hermes-cli's tool universe — can't
@@ -6083,6 +6103,7 @@ def _agent_fallback_model(agent):
 
 def _background_agent_kwargs(agent, task_id: str) -> dict:
     cfg = _load_cfg()
+    parent_toolsets = getattr(agent, "enabled_toolsets", None)
 
     return {
         "base_url": getattr(agent, "base_url", None) or None,
@@ -6093,12 +6114,15 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
         "acp_args": getattr(agent, "acp_args", None) or None,
         "model": getattr(agent, "model", None) or _resolve_model(),
         "max_iterations": _cfg_max_turns(cfg, 25),
-        "enabled_toolsets": getattr(agent, "enabled_toolsets", None)
         # Detached background tasks declare platform="tui" below: they have no
         # UI session id, so a renderer-routed event has nowhere to land. Resolve
         # their toolsets against that same platform rather than the gateway
         # process's, so they never carry GUI schema they cannot use.
-        or _load_enabled_toolsets("tui"),
+        "enabled_toolsets": (
+            parent_toolsets
+            if parent_toolsets is not None
+            else _load_enabled_toolsets("tui")
+        ),
         "quiet_mode": True,
         "verbose_logging": False,
         "ephemeral_system_prompt": getattr(agent, "ephemeral_system_prompt", None)
@@ -6127,7 +6151,11 @@ def _ephemeral_preview_agent_kwargs(agent, task_id: str) -> dict:
     kwargs = _background_agent_kwargs(agent, task_id)
     kwargs.update(
         {
-            "enabled_toolsets": ["terminal", "file"],
+            # Preview agents normally need their fixed terminal/file subset,
+            # but an explicit deny-all parent must remain tool-free.
+            "enabled_toolsets": []
+            if kwargs["enabled_toolsets"] == []
+            else ["terminal", "file"],
             "session_db": None,
             "skip_memory": True,
         }


### PR DESCRIPTION
## What does this PR do?

Makes a saved `platform_toolsets.cli: []` a durable, fail-closed zero-tool policy for Desktop and TUI sessions. The gateway now preserves the explicit empty selection through fresh agent construction, GUI-surface resolution, background and preview agents, MCP reload, and tool-inspection RPCs; all-invalid saved toolset names also resolve to no tools after their existing warning.

## Related Issue

Fixes #82010

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `hermes_cli/tools_config.py`: treat an explicit empty platform list as authoritative and fail closed for all-invalid lists while retaining the configuration warning.
- `tui_gateway/server.py`: preserve empty selections before focus/GUI recovery and in background/preview agent construction.
- `tui_gateway/methods_tools.py`: keep empty selections intact during MCP reload and report them accurately from toolset RPCs.
- `cli-config.yaml.example`: document the supported zero-tool configuration.
- `tests/hermes_cli/test_tools_config.py` and `tests/tui_gateway/test_gui_surface_toolsets.py`: cover configuration resolution, fresh desktop agents, tool reports, background/preview agents, and MCP reload.

## How to Test

1. Set `platform_toolsets.cli: []` in `config.yaml` and create Desktop or TUI sessions; `tools.show` and `session.info.tools` should report no model-callable tools.
2. Run `/opt/homebrew/bin/timeout -k 30 480 "$VIRTUAL_ENV/bin/python" -m pytest tests/tui_gateway/test_gui_surface_toolsets.py tests/hermes_cli/test_tools_config.py tests/tui_gateway/test_mcp_reload_rev.py -q -x --timeout=60` (49 passed locally).
3. Run `python scripts/check-windows-footguns.py hermes_cli/tools_config.py tui_gateway/server.py tui_gateway/methods_tools.py tests/hermes_cli/test_tools_config.py tests/tui_gateway/test_gui_surface_toolsets.py`.

### What platforms tested on

- macOS on darwin-arm64 (local)

The prescribed full `pytest tests/ -q -x --timeout=60` suite could not collect in this sandbox because FastAPI/Uvicorn are absent and the uv cache is read-only; the directly covering regression suite above passed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [ ] I searched for existing PRs to make sure this isn't a duplicate (GitHub API access was unavailable; the supplied open-PR inventory covered unrelated files).
- [x] My PR contains only changes related to this fix.
- [ ] I've run `pytest tests/ -q` and all tests pass (collection is blocked by the sandbox dependency issue noted above).
- [x] I've added tests for my changes.
- [x] I've tested on my platform: macOS on darwin-arm64.

### Documentation & Housekeeping

- [x] I've updated relevant documentation or examples.
- [x] I've updated `cli-config.yaml.example` for the documented configuration behavior.
- [x] I've considered cross-platform impact (Windows, macOS) and ran the Windows footguns check.
- [x] Tool descriptions/schemas are unchanged.

## Screenshots / Logs

Configuration-only change; no screenshots are applicable.

<!-- autocontrib:worker-id=issue-new-27088588 kind=pr-open -->