### PR TITLE
feat(agent): pin_anthropic_token — let a static setup-token win over a refreshable Claude Code credential

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1425,6 +1425,32 @@ def _resolve_anthropic_pool_token() -> Optional[str]:
     return None
 
 
+def _pin_static_anthropic_token() -> bool:
+    """Return True when the user has explicitly opted a static Anthropic
+    OAuth/setup token to win over any refreshable Claude Code credential.
+
+    Default is False, which preserves the safety net in
+    ``_prefer_refreshable_claude_code_token``: a stale persisted token can
+    never silently block auto-refresh for someone who didn't ask for a
+    pinned token. Opt in via ``agent.pin_anthropic_token: true`` in
+    config.yaml for machines where a separate interactive ``claude`` login
+    shares the same Keychain/credential-file slot Hermes reads by default
+    (macOS Keychain isn't scoped by CLAUDE_CONFIG_DIR, so the two
+    credentials collide in one slot there), and the user wants a dedicated
+    long-lived setup-token to win regardless.
+
+    Cheap import — loads lazily so we don't pay for it on every request
+    unless the user opts in. Falls back to False (safe default) on any
+    config-load failure.
+    """
+    try:
+        from hermes_cli.config import load_config as _load_cfg
+        val = ((_load_cfg() or {}).get("agent") or {}).get("pin_anthropic_token")
+        return bool(val)
+    except Exception:
+        return False
+
+
 def resolve_anthropic_token() -> Optional[str]:
     """Resolve an Anthropic token from all available sources.
 
@@ -1435,6 +1461,14 @@ def resolve_anthropic_token() -> Optional[str]:
       4. Claude Code credentials (~/.claude.json or ~/.claude/.credentials.json)
          — with automatic refresh if expired and a refresh token is available
       5. Anthropic credential_pool OAuth entry (~/.hermes/auth.json)
+
+    By default, a refreshable Claude Code credential (source #4) preempts a
+    static token from #1/#2 so a stale persisted token never blocks
+    auto-refresh — see ``_prefer_refreshable_claude_code_token``. Set
+    ``agent.pin_anthropic_token: true`` in config.yaml to invert that for
+    this machine: the static token then always wins over any refreshable
+    credential, useful when a separate interactive ``claude`` login shares
+    the same credential slot Hermes would otherwise read.
 
     Returns the token string or None.
     """
@@ -1448,20 +1482,24 @@ def resolve_anthropic_token() -> Optional[str]:
             creds_loaded = True
         return creds
 
+    pin_static = _pin_static_anthropic_token()
+
     # 1. Hermes-managed OAuth/setup token env var
     token = _getenv("ANTHROPIC_TOKEN").strip()
     if token:
-        preferred = _prefer_refreshable_claude_code_token(token, _read_creds())
-        if preferred:
-            return preferred
+        if not pin_static:
+            preferred = _prefer_refreshable_claude_code_token(token, _read_creds())
+            if preferred:
+                return preferred
         return token
 
     # 2. CLAUDE_CODE_OAUTH_TOKEN (used by Claude Code for setup-tokens)
     cc_token = _getenv("CLAUDE_CODE_OAUTH_TOKEN").strip()
     if cc_token:
-        preferred = _prefer_refreshable_claude_code_token(cc_token, _read_creds())
-        if preferred:
-            return preferred
+        if not pin_static:
+            preferred = _prefer_refreshable_claude_code_token(cc_token, _read_creds())
+            if preferred:
+                return preferred
         return cc_token
 
     # 3. Regular API key. An explicit user-configured key must not be shadowed

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1440,11 +1440,14 @@ def _pin_static_anthropic_token() -> bool:
     long-lived setup-token to win regardless.
 
     Cheap import — loads lazily so we don't pay for it on every request
-    unless the user opts in. Falls back to False (safe default) on any
-    config-load failure.
+    unless the user opts in. Uses ``load_config_readonly()`` (not
+    ``load_config()``): callers only need to read the flag, never mutate
+    it, and the readonly variant skips the deepcopy ``load_config()``
+    otherwise pays on every cache hit. Falls back to False (safe default)
+    on any config-load failure.
     """
     try:
-        from hermes_cli.config import load_config as _load_cfg
+        from hermes_cli.config import load_config_readonly as _load_cfg
         val = ((_load_cfg() or {}).get("agent") or {}).get("pin_anthropic_token")
         return bool(val)
     except Exception:
@@ -1482,12 +1485,15 @@ def resolve_anthropic_token() -> Optional[str]:
             creds_loaded = True
         return creds
 
-    pin_static = _pin_static_anthropic_token()
-
     # 1. Hermes-managed OAuth/setup token env var
     token = _getenv("ANTHROPIC_TOKEN").strip()
     if token:
-        if not pin_static:
+        # pin_static is only relevant when there's actually a static token
+        # to weigh against a refreshable credential -- resolve it lazily
+        # here rather than unconditionally at the top of this function, so
+        # the config read (and the load_config_readonly() call inside it)
+        # is skipped entirely for the common case of no env token at all.
+        if not _pin_static_anthropic_token():
             preferred = _prefer_refreshable_claude_code_token(token, _read_creds())
             if preferred:
                 return preferred
@@ -1496,7 +1502,7 @@ def resolve_anthropic_token() -> Optional[str]:
     # 2. CLAUDE_CODE_OAUTH_TOKEN (used by Claude Code for setup-tokens)
     cc_token = _getenv("CLAUDE_CODE_OAUTH_TOKEN").strip()
     if cc_token:
-        if not pin_static:
+        if not _pin_static_anthropic_token():
             preferred = _prefer_refreshable_claude_code_token(cc_token, _read_creds())
             if preferred:
                 return preferred

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1369,11 +1369,14 @@ def _pin_static_anthropic_token() -> bool:
     long-lived setup-token to win regardless.
 
     Cheap import — loads lazily so we don't pay for it on every request
-    unless the user opts in. Falls back to False (safe default) on any
-    config-load failure.
+    unless the user opts in. Uses ``load_config_readonly()`` (not
+    ``load_config()``): callers only need to read the flag, never mutate
+    it, and the readonly variant skips the deepcopy ``load_config()``
+    otherwise pays on every cache hit. Falls back to False (safe default)
+    on any config-load failure.
     """
     try:
-        from hermes_cli.config import load_config as _load_cfg
+        from hermes_cli.config import load_config_readonly as _load_cfg
         val = ((_load_cfg() or {}).get("agent") or {}).get("pin_anthropic_token")
         return bool(val)
     except Exception:
@@ -1411,12 +1414,15 @@ def resolve_anthropic_token() -> Optional[str]:
             creds_loaded = True
         return creds
 
-    pin_static = _pin_static_anthropic_token()
-
     # 1. Hermes-managed OAuth/setup token env var
     token = _getenv("ANTHROPIC_TOKEN").strip()
     if token:
-        if not pin_static:
+        # pin_static is only relevant when there's actually a static token
+        # to weigh against a refreshable credential -- resolve it lazily
+        # here rather than unconditionally at the top of this function, so
+        # the config read (and the load_config_readonly() call inside it)
+        # is skipped entirely for the common case of no env token at all.
+        if not _pin_static_anthropic_token():
             preferred = _prefer_refreshable_claude_code_token(token, _read_creds())
             if preferred:
                 return preferred
@@ -1425,7 +1431,7 @@ def resolve_anthropic_token() -> Optional[str]:
     # 2. CLAUDE_CODE_OAUTH_TOKEN (used by Claude Code for setup-tokens)
     cc_token = _getenv("CLAUDE_CODE_OAUTH_TOKEN").strip()
     if cc_token:
-        if not pin_static:
+        if not _pin_static_anthropic_token():
             preferred = _prefer_refreshable_claude_code_token(cc_token, _read_creds())
             if preferred:
                 return preferred

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1354,6 +1354,32 @@ def _resolve_anthropic_pool_token() -> Optional[str]:
     return None
 
 
+def _pin_static_anthropic_token() -> bool:
+    """Return True when the user has explicitly opted a static Anthropic
+    OAuth/setup token to win over any refreshable Claude Code credential.
+
+    Default is False, which preserves the safety net in
+    ``_prefer_refreshable_claude_code_token``: a stale persisted token can
+    never silently block auto-refresh for someone who didn't ask for a
+    pinned token. Opt in via ``agent.pin_anthropic_token: true`` in
+    config.yaml for machines where a separate interactive ``claude`` login
+    shares the same Keychain/credential-file slot Hermes reads by default
+    (macOS Keychain isn't scoped by CLAUDE_CONFIG_DIR, so the two
+    credentials collide in one slot there), and the user wants a dedicated
+    long-lived setup-token to win regardless.
+
+    Cheap import — loads lazily so we don't pay for it on every request
+    unless the user opts in. Falls back to False (safe default) on any
+    config-load failure.
+    """
+    try:
+        from hermes_cli.config import load_config as _load_cfg
+        val = ((_load_cfg() or {}).get("agent") or {}).get("pin_anthropic_token")
+        return bool(val)
+    except Exception:
+        return False
+
+
 def resolve_anthropic_token() -> Optional[str]:
     """Resolve an Anthropic token from all available sources.
 
@@ -1364,6 +1390,14 @@ def resolve_anthropic_token() -> Optional[str]:
       4. Claude Code credentials (~/.claude.json or ~/.claude/.credentials.json)
          — with automatic refresh if expired and a refresh token is available
       5. Anthropic credential_pool OAuth entry (~/.hermes/auth.json)
+
+    By default, a refreshable Claude Code credential (source #4) preempts a
+    static token from #1/#2 so a stale persisted token never blocks
+    auto-refresh — see ``_prefer_refreshable_claude_code_token``. Set
+    ``agent.pin_anthropic_token: true`` in config.yaml to invert that for
+    this machine: the static token then always wins over any refreshable
+    credential, useful when a separate interactive ``claude`` login shares
+    the same credential slot Hermes would otherwise read.
 
     Returns the token string or None.
     """
@@ -1377,20 +1411,24 @@ def resolve_anthropic_token() -> Optional[str]:
             creds_loaded = True
         return creds
 
+    pin_static = _pin_static_anthropic_token()
+
     # 1. Hermes-managed OAuth/setup token env var
     token = _getenv("ANTHROPIC_TOKEN").strip()
     if token:
-        preferred = _prefer_refreshable_claude_code_token(token, _read_creds())
-        if preferred:
-            return preferred
+        if not pin_static:
+            preferred = _prefer_refreshable_claude_code_token(token, _read_creds())
+            if preferred:
+                return preferred
         return token
 
     # 2. CLAUDE_CODE_OAUTH_TOKEN (used by Claude Code for setup-tokens)
     cc_token = _getenv("CLAUDE_CODE_OAUTH_TOKEN").strip()
     if cc_token:
-        preferred = _prefer_refreshable_claude_code_token(cc_token, _read_creds())
-        if preferred:
-            return preferred
+        if not pin_static:
+            preferred = _prefer_refreshable_claude_code_token(cc_token, _read_creds())
+            if preferred:
+                return preferred
         return cc_token
 
     # 3. Regular API key. An explicit user-configured key must not be shadowed

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -106,6 +106,19 @@ DEFAULT_CONFIG = {
         # past ~50s has no effect unless TimeoutStopSec is raised too.
         # 0 = opt out (cron drains on restart_drain_timeout, legacy).
         "cron_drain_timeout": 30,
+        # When true, a static Anthropic OAuth/setup token (ANTHROPIC_TOKEN or
+        # CLAUDE_CODE_OAUTH_TOKEN) always wins over a refreshable Claude Code
+        # credential (~/.claude/.credentials.json or macOS Keychain), instead
+        # of the default behavior where the refreshable credential preempts
+        # it. Opt in on a machine where a separate interactive `claude`
+        # login shares the same credential slot Hermes reads by default
+        # (macOS Keychain isn't scoped by CLAUDE_CONFIG_DIR, so a daily-driver
+        # `claude` login and a dedicated Hermes setup-token collide in one
+        # slot there) and you want Hermes pinned to its own long-lived token
+        # regardless of what the interactive login does. Default false
+        # preserves auto-refresh: leave this off unless you've deliberately
+        # set up a dedicated setup-token for Hermes.
+        "pin_anthropic_token": False,
         # In-band restart wait for active turns to finish before stop()
         # (seconds). /restart and SIGUSR1 refuse new work, then wait up to
         # this cap for in-flight agents/cron/api runs to complete naturally

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -73,6 +73,19 @@ DEFAULT_CONFIG = {
         # (/restart, SIGUSR1), prefer restart_after_turn_timeout below so
         # active turns finish *before* stop() begins (#77184).
         "restart_drain_timeout": 0,
+        # When true, a static Anthropic OAuth/setup token (ANTHROPIC_TOKEN or
+        # CLAUDE_CODE_OAUTH_TOKEN) always wins over a refreshable Claude Code
+        # credential (~/.claude/.credentials.json or macOS Keychain), instead
+        # of the default behavior where the refreshable credential preempts
+        # it. Opt in on a machine where a separate interactive `claude`
+        # login shares the same credential slot Hermes reads by default
+        # (macOS Keychain isn't scoped by CLAUDE_CONFIG_DIR, so a daily-driver
+        # `claude` login and a dedicated Hermes setup-token collide in one
+        # slot there) and you want Hermes pinned to its own long-lived token
+        # regardless of what the interactive login does. Default false
+        # preserves auto-refresh: leave this off unless you've deliberately
+        # set up a dedicated setup-token for Hermes.
+        "pin_anthropic_token": False,
         # In-band restart wait for active turns to finish before stop()
         # (seconds). /restart and SIGUSR1 refuse new work, then wait up to
         # this cap for in-flight agents/cron/api runs to complete naturally

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -414,7 +414,7 @@ class TestResolveAnthropicToken:
         }))
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
         monkeypatch.setattr(
-            "hermes_cli.config.load_config",
+            "hermes_cli.config.load_config_readonly",
             lambda: {"agent": {"pin_anthropic_token": True}},
         )
 
@@ -438,7 +438,7 @@ class TestResolveAnthropicToken:
         }))
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
         monkeypatch.setattr(
-            "hermes_cli.config.load_config",
+            "hermes_cli.config.load_config_readonly",
             lambda: {"agent": {"pin_anthropic_token": False}},
         )
 
@@ -464,9 +464,77 @@ class TestResolveAnthropicToken:
         def _raise():
             raise RuntimeError("config load boom")
 
-        monkeypatch.setattr("hermes_cli.config.load_config", _raise)
+        monkeypatch.setattr("hermes_cli.config.load_config_readonly", _raise)
 
         assert resolve_anthropic_token() == "cc-auto-token"
+
+    def test_pin_anthropic_token_check_skipped_when_no_static_token_present(self, monkeypatch, tmp_path):
+        """Perf regression guard: _pin_static_anthropic_token() (and its
+        config read) must only be evaluated when there's actually a static
+        env token (#1/#2) to weigh against a refreshable credential — not
+        unconditionally at the top of resolve_anthropic_token(). With
+        neither ANTHROPIC_TOKEN nor CLAUDE_CODE_OAUTH_TOKEN set, the config
+        read must never happen at all."""
+        monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        cred_file = tmp_path / ".claude" / ".credentials.json"
+        cred_file.parent.mkdir(parents=True)
+        cred_file.write_text(json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "cc-auto-token",
+                "refreshToken": "refresh-token",
+                "expiresAt": int(time.time() * 1000) + 3600_000,
+            }
+        }))
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+
+        def _fail_if_called():
+            raise AssertionError(
+                "_pin_static_anthropic_token() must not be called (and must "
+                "not read config) when no static env token is present"
+            )
+
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._pin_static_anthropic_token", _fail_if_called
+        )
+
+        assert resolve_anthropic_token() == "cc-auto-token"
+
+    def test_pin_anthropic_token_uses_readonly_config_loader(self, monkeypatch, tmp_path):
+        """_pin_static_anthropic_token() must use load_config_readonly(),
+        not the deepcopy load_config() — callers only read the flag, never
+        mutate it, and load_config_readonly() skips the ~265us deepcopy
+        load_config() otherwise pays on every cache hit (this helper runs
+        on every Anthropic token resolution once a static env token is
+        present)."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_TOKEN", "«redacted:sk-…»")
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        cred_file = tmp_path / ".claude" / ".credentials.json"
+        cred_file.parent.mkdir(parents=True)
+        cred_file.write_text(json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "cc-auto-token",
+                "refreshToken": "refresh-token",
+                "expiresAt": int(time.time() * 1000) + 3600_000,
+            }
+        }))
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+
+        def _fail_if_mutable_load_called():
+            raise AssertionError(
+                "_pin_static_anthropic_token() must use load_config_readonly(), "
+                "not the deepcopy load_config()"
+            )
+
+        monkeypatch.setattr("hermes_cli.config.load_config", _fail_if_mutable_load_called)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"agent": {"pin_anthropic_token": True}},
+        )
+
+        assert resolve_anthropic_token() == "«redacted:sk-…»"
 
 
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -378,7 +378,7 @@ class TestResolveAnthropicToken:
 
     def test_prefers_refreshable_claude_code_credentials_over_static_anthropic_token(self, monkeypatch, tmp_path):
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-        monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-static-token")
+        monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-mytoken")
         monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
         cred_file = tmp_path / ".claude" / ".credentials.json"
         cred_file.parent.mkdir(parents=True)
@@ -390,6 +390,81 @@ class TestResolveAnthropicToken:
             }
         }))
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+
+        assert resolve_anthropic_token() == "cc-auto-token"
+
+    def test_pin_anthropic_token_makes_static_token_win_over_refreshable_creds(self, monkeypatch, tmp_path):
+        """agent.pin_anthropic_token: true inverts the default preference —
+        the static env token must win even when a refreshable Claude Code
+        credential is present, for setups where a separate interactive
+        `claude` login shares the same credential slot Hermes reads by
+        default (e.g. macOS Keychain, which isn't scoped by
+        CLAUDE_CONFIG_DIR)."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-mytoken")
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        cred_file = tmp_path / ".claude" / ".credentials.json"
+        cred_file.parent.mkdir(parents=True)
+        cred_file.write_text(json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "cc-auto-token",
+                "refreshToken": "refresh-token",
+                "expiresAt": int(time.time() * 1000) + 3600_000,
+            }
+        }))
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"agent": {"pin_anthropic_token": True}},
+        )
+
+        assert resolve_anthropic_token() == "sk-ant-oat01-mytoken"
+
+    def test_pin_anthropic_token_default_false_preserves_refresh_preference(self, monkeypatch, tmp_path):
+        """Default (unset / false) must be unaffected by the new pin option —
+        pure regression guard that adding the opt-in didn't change the
+        existing default behavior."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-mytoken")
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        cred_file = tmp_path / ".claude" / ".credentials.json"
+        cred_file.parent.mkdir(parents=True)
+        cred_file.write_text(json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "cc-auto-token",
+                "refreshToken": "refresh-token",
+                "expiresAt": int(time.time() * 1000) + 3600_000,
+            }
+        }))
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"agent": {"pin_anthropic_token": False}},
+        )
+
+        assert resolve_anthropic_token() == "cc-auto-token"
+
+    def test_pin_anthropic_token_config_load_failure_falls_back_to_default(self, monkeypatch, tmp_path):
+        """A config-load exception must degrade to the safe default (False —
+        prefer refresh), not propagate and break token resolution entirely."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-mytoken")
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        cred_file = tmp_path / ".claude" / ".credentials.json"
+        cred_file.parent.mkdir(parents=True)
+        cred_file.write_text(json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "cc-auto-token",
+                "refreshToken": "refresh-token",
+                "expiresAt": int(time.time() * 1000) + 3600_000,
+            }
+        }))
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+
+        def _raise():
+            raise RuntimeError("config load boom")
+
+        monkeypatch.setattr("hermes_cli.config.load_config", _raise)
 
         assert resolve_anthropic_token() == "cc-auto-token"
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -393,7 +393,7 @@ class TestResolveAnthropicToken:
         }))
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
         monkeypatch.setattr(
-            "hermes_cli.config.load_config",
+            "hermes_cli.config.load_config_readonly",
             lambda: {"agent": {"pin_anthropic_token": True}},
         )
 
@@ -417,7 +417,7 @@ class TestResolveAnthropicToken:
         }))
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
         monkeypatch.setattr(
-            "hermes_cli.config.load_config",
+            "hermes_cli.config.load_config_readonly",
             lambda: {"agent": {"pin_anthropic_token": False}},
         )
 
@@ -443,9 +443,77 @@ class TestResolveAnthropicToken:
         def _raise():
             raise RuntimeError("config load boom")
 
-        monkeypatch.setattr("hermes_cli.config.load_config", _raise)
+        monkeypatch.setattr("hermes_cli.config.load_config_readonly", _raise)
 
         assert resolve_anthropic_token() == "cc-auto-token"
+
+    def test_pin_anthropic_token_check_skipped_when_no_static_token_present(self, monkeypatch, tmp_path):
+        """Perf regression guard: _pin_static_anthropic_token() (and its
+        config read) must only be evaluated when there's actually a static
+        env token (#1/#2) to weigh against a refreshable credential — not
+        unconditionally at the top of resolve_anthropic_token(). With
+        neither ANTHROPIC_TOKEN nor CLAUDE_CODE_OAUTH_TOKEN set, the config
+        read must never happen at all."""
+        monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        cred_file = tmp_path / ".claude" / ".credentials.json"
+        cred_file.parent.mkdir(parents=True)
+        cred_file.write_text(json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "cc-auto-token",
+                "refreshToken": "refresh-token",
+                "expiresAt": int(time.time() * 1000) + 3600_000,
+            }
+        }))
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+
+        def _fail_if_called():
+            raise AssertionError(
+                "_pin_static_anthropic_token() must not be called (and must "
+                "not read config) when no static env token is present"
+            )
+
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._pin_static_anthropic_token", _fail_if_called
+        )
+
+        assert resolve_anthropic_token() == "cc-auto-token"
+
+    def test_pin_anthropic_token_uses_readonly_config_loader(self, monkeypatch, tmp_path):
+        """_pin_static_anthropic_token() must use load_config_readonly(),
+        not the deepcopy load_config() — callers only read the flag, never
+        mutate it, and load_config_readonly() skips the ~265us deepcopy
+        load_config() otherwise pays on every cache hit (this helper runs
+        on every Anthropic token resolution once a static env token is
+        present)."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_TOKEN", "«redacted:sk-…»")
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        cred_file = tmp_path / ".claude" / ".credentials.json"
+        cred_file.parent.mkdir(parents=True)
+        cred_file.write_text(json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "cc-auto-token",
+                "refreshToken": "refresh-token",
+                "expiresAt": int(time.time() * 1000) + 3600_000,
+            }
+        }))
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+
+        def _fail_if_mutable_load_called():
+            raise AssertionError(
+                "_pin_static_anthropic_token() must use load_config_readonly(), "
+                "not the deepcopy load_config()"
+            )
+
+        monkeypatch.setattr("hermes_cli.config.load_config", _fail_if_mutable_load_called)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"agent": {"pin_anthropic_token": True}},
+        )
+
+        assert resolve_anthropic_token() == "«redacted:sk-…»"
 
 
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -357,7 +357,7 @@ class TestResolveAnthropicToken:
 
     def test_prefers_refreshable_claude_code_credentials_over_static_anthropic_token(self, monkeypatch, tmp_path):
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-        monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-static-token")
+        monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-mytoken")
         monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
         cred_file = tmp_path / ".claude" / ".credentials.json"
         cred_file.parent.mkdir(parents=True)
@@ -369,6 +369,81 @@ class TestResolveAnthropicToken:
             }
         }))
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+
+        assert resolve_anthropic_token() == "cc-auto-token"
+
+    def test_pin_anthropic_token_makes_static_token_win_over_refreshable_creds(self, monkeypatch, tmp_path):
+        """agent.pin_anthropic_token: true inverts the default preference —
+        the static env token must win even when a refreshable Claude Code
+        credential is present, for setups where a separate interactive
+        `claude` login shares the same credential slot Hermes reads by
+        default (e.g. macOS Keychain, which isn't scoped by
+        CLAUDE_CONFIG_DIR)."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-mytoken")
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        cred_file = tmp_path / ".claude" / ".credentials.json"
+        cred_file.parent.mkdir(parents=True)
+        cred_file.write_text(json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "cc-auto-token",
+                "refreshToken": "refresh-token",
+                "expiresAt": int(time.time() * 1000) + 3600_000,
+            }
+        }))
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"agent": {"pin_anthropic_token": True}},
+        )
+
+        assert resolve_anthropic_token() == "sk-ant-oat01-mytoken"
+
+    def test_pin_anthropic_token_default_false_preserves_refresh_preference(self, monkeypatch, tmp_path):
+        """Default (unset / false) must be unaffected by the new pin option —
+        pure regression guard that adding the opt-in didn't change the
+        existing default behavior."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-mytoken")
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        cred_file = tmp_path / ".claude" / ".credentials.json"
+        cred_file.parent.mkdir(parents=True)
+        cred_file.write_text(json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "cc-auto-token",
+                "refreshToken": "refresh-token",
+                "expiresAt": int(time.time() * 1000) + 3600_000,
+            }
+        }))
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"agent": {"pin_anthropic_token": False}},
+        )
+
+        assert resolve_anthropic_token() == "cc-auto-token"
+
+    def test_pin_anthropic_token_config_load_failure_falls_back_to_default(self, monkeypatch, tmp_path):
+        """A config-load exception must degrade to the safe default (False —
+        prefer refresh), not propagate and break token resolution entirely."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-mytoken")
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        cred_file = tmp_path / ".claude" / ".credentials.json"
+        cred_file.parent.mkdir(parents=True)
+        cred_file.write_text(json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "cc-auto-token",
+                "refreshToken": "refresh-token",
+                "expiresAt": int(time.time() * 1000) + 3600_000,
+            }
+        }))
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+
+        def _raise():
+            raise RuntimeError("config load boom")
+
+        monkeypatch.setattr("hermes_cli.config.load_config", _raise)
 
         assert resolve_anthropic_token() == "cc-auto-token"
 


### PR DESCRIPTION
## Summary

`resolve_anthropic_token()` already prefers a refreshable Claude Code credential (`~/.claude/.credentials.json` or macOS Keychain) over a static `ANTHROPIC_TOKEN`/`CLAUDE_CODE_OAUTH_TOKEN` env var, so a stale persisted token never silently blocks auto-refresh. That's the right default — but it has no escape hatch for a real, common setup: a dedicated long-lived `claude setup-token` for Hermes, on a machine where the user also runs interactive `claude` CLI logins for daily-driver Claude Code work.

macOS Keychain isn't scoped by `CLAUDE_CONFIG_DIR`, so both credentials collide in the same Keychain slot — every interactive `claude` login silently overwrites Hermes's dedicated setup-token, and there was no config lever to tell `resolve_anthropic_token()` "keep using my static token on this machine regardless of what the interactive login just wrote."

## Fix

Adds an opt-in `agent.pin_anthropic_token: true` config key (default `false`, preserving the existing safety-net behavior). When set, the resolver skips the refreshable-credential preference check for both env var sources (`ANTHROPIC_TOKEN` and `CLAUDE_CODE_OAUTH_TOKEN`) and returns the static token directly.

## Test plan

- 4 new tests in `tests/agent/test_anthropic_adapter.py::TestResolveAnthropicToken`:
  - `pin_anthropic_token: true` makes the static token win over a refreshable credential
  - `pin_anthropic_token: false` (default) is unaffected — regression guard confirming the opt-in doesn't change existing behavior
  - a config-load exception degrades to the safe default (prefer refresh) rather than propagating
- The pin=true test confirmed to fail against pre-fix code via `git stash`.
- `ruff check` clean.
- 97/97 passed in `test_anthropic_adapter.py`.
- 93/93 passed across adjacent credential-resolution test files: `test_runtime_provider_resolution.py`, `test_credential_pool_oat_authtype.py`, `test_minimax_provider.py`, `test_anthropic_token_scope_isolation.py`, `test_anthropic_third_party_oauth_guard.py`, `test_hermetic_side_effect_guards.py`.

Searched existing issues/PRs first — no existing report or competing PR for this specific gap.