### PR TITLE
fix(cron): avoid third-party utils import collision (#82069)

### DIFF
--- a/cron/_hermes_utils.py
+++ b/cron/_hermes_utils.py
@@ -1,0 +1,17 @@
+"""Load Hermes' top-level utilities without colliding with third-party ``utils``."""
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+
+_UTILS_PATH = Path(__file__).resolve().parent.parent / "utils.py"
+_SPEC = spec_from_file_location("_hermes_utils_impl", _UTILS_PATH)
+if _SPEC is None or _SPEC.loader is None:  # pragma: no cover - broken install
+    raise ImportError(f"Unable to load Hermes utilities from {_UTILS_PATH}")
+_MODULE = module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+
+atomic_replace = _MODULE.atomic_replace
+atomic_write_text = _MODULE.atomic_write_text
+
+__all__ = ["atomic_replace", "atomic_write_text"]

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -39,7 +39,7 @@ from typing import Optional, Dict, List, Any, Set, Tuple, Union, Collection
 logger = logging.getLogger(__name__)
 
 from hermes_time import now as _hermes_now
-from utils import atomic_replace, atomic_write_text
+from cron._hermes_utils import atomic_replace, atomic_write_text
 
 # ``croniter`` compiles ~15 ms of regexes at import and only matters for
 # 5-field cron expressions. Resolve lazily; ``HAS_CRONITER`` stays a module

--- a/tests/cron/test_cron_utils_import.py
+++ b/tests/cron/test_cron_utils_import.py
@@ -1,0 +1,18 @@
+"""Regression tests for cron imports in environments with a third-party utils module."""
+
+import importlib
+import sys
+import types
+
+
+def test_cron_jobs_does_not_use_unrelated_utils_module(monkeypatch):
+    unrelated_utils = types.ModuleType("utils")
+    unrelated_utils.atomic_replace = None
+    monkeypatch.setitem(sys.modules, "utils", unrelated_utils)
+    for name in ("cron.jobs", "cron._hermes_utils"):
+        sys.modules.pop(name, None)
+
+    jobs = importlib.import_module("cron.jobs")
+
+    assert callable(jobs.atomic_replace)
+    assert callable(jobs.atomic_write_text)


### PR DESCRIPTION
## Summary
- avoid importing an unrelated third-party `utils` module when cron jobs are loaded from a mounted Hermes source tree
- load Hermes' packaged utility implementation by its path and add a regression test for the collision

Closes #82069

## Test plan
- `python3 -m pytest -q tests/cron/test_cron_utils_import.py`
- `python3 -m py_compile cron/jobs.py cron/_hermes_utils.py tests/cron/test_cron_utils_import.py`
- Existing `tests/cron/test_jobs.py` has unrelated pre-existing failures under the current test environment.