### PR TITLE
fix(gateway): keep auto voice replies off the text path

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6210,6 +6210,11 @@ class BasePlatformAdapter(ABC):
             if getattr(result, "success", False):
                 delivery_succeeded = True
 
+        def _release_deferred_auto_voice_reply() -> None:
+            gate = getattr(event, "_hermes_auto_voice_text_delivered", None)
+            if isinstance(gate, asyncio.Event):
+                gate.set()
+
         # Reuse the interrupt event set by handle_message() (which marks
         # the session active before spawning this task to prevent races).
         # Fall back to a new Event only if the entry was removed externally.
@@ -6525,6 +6530,10 @@ class BasePlatformAdapter(ABC):
                         reply_to=_reply_anchor,
                         metadata=_final_thread_metadata,
                     )
+                    # Runner-managed whole-file auto-TTS waits here so slow
+                    # synthesis cannot delay text and fast synthesis cannot
+                    # overtake the corresponding final response (#81162).
+                    _release_deferred_auto_voice_reply()
                     _record_delivery(result)
                     if _obligation_id is not None:
                         try:
@@ -6803,6 +6812,10 @@ class BasePlatformAdapter(ABC):
                     self.name, notify_err, exc_info=True,
                 )  # Last resort — don't let error reporting crash the handler
         finally:
+            # Release tasks when text was suppressed, failed before send, or
+            # returned through a non-standard adapter path. Shutdown still
+            # owns a bounded drain if synthesis itself remains slow.
+            _release_deferred_auto_voice_reply()
             # Stop typing before any deferred callback work.  Post-delivery
             # callbacks may perform platform I/O; a stuck callback must not
             # leave the typing refresh task running indefinitely.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6757,6 +6757,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Track background tasks to prevent garbage collection mid-execution
         self._background_tasks: set = set()
+        # Whole-file auto voice replies run after the text delivery attempt.
+        # Track them separately so same-session replies stay ordered and
+        # shutdown can drain them before disconnecting their adapters.
+        self._voice_reply_tasks: set[asyncio.Task] = set()
+        self._voice_reply_tails: Dict[str, asyncio.Task] = {}
 
         # Event-loop liveness heartbeat (#66892): rewritten every 30s while
         # the loop is dispatching. External supervisors use the file mtime /
@@ -8057,6 +8062,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if any(
             not t.done() and not getattr(t, "_hermes_supervised_watcher", False)
             for t in self._background_tasks
+        ):
+            return True
+        if any(
+            not t.done()
+            for t in getattr(self, "_voice_reply_tasks", set())
         ):
             return True
         try:
@@ -13912,6 +13922,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if cancel_completion_batches is not None:
                 await cancel_completion_batches()
 
+            _drain_voice_replies = getattr(
+                self, "_drain_voice_reply_tasks", None
+            )
+            if callable(_drain_voice_replies):
+                _voice_drained = await _drain_voice_replies(
+                    self._adapter_disconnect_timeout_secs()
+                )
+                if not _voice_drained:
+                    logger.warning(
+                        "Timed out draining auto voice replies; cancelled pending "
+                        "voice work before adapter teardown"
+                    )
+
             for platform, adapter in list(self.adapters.items()):
                 await self._bounded_adapter_teardown(adapter, platform)
 
@@ -19656,7 +19679,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 response = ""
 
-            # Auto voice reply: send TTS audio before the text response
+            # Auto voice reply: synthesize after the adapter attempts the text
+            # delivery. Slow whole-file TTS must not hold the text response on
+            # the agent-handler critical path (#81162).
             _already_sent = bool(agent_result.get("already_sent"))
             # Skip when streaming TTS already delivered audio for this turn (#60671).
             _stts_adapter = self._adapter_for_source(source)
@@ -19668,7 +19693,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 not _streaming_tts_done
                 and self._should_send_voice_reply(event, response, agent_messages, already_sent=_already_sent)
             ):
-                await self._send_voice_reply(event, response)
+                _text_delivery_gate = asyncio.Event()
+                if _already_sent:
+                    _text_delivery_gate.set()
+                else:
+                    # BasePlatformAdapter releases this immediately after the
+                    # final text send attempt, with a finally fallback for
+                    # suppressed/error paths.
+                    event._hermes_auto_voice_text_delivered = _text_delivery_gate
+                try:
+                    self._schedule_voice_reply(
+                        self._voice_reply_delivery_key(event),
+                        event,
+                        response,
+                        _text_delivery_gate,
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to schedule auto voice reply: %s",
+                        exc,
+                        exc_info=True,
+                    )
 
             # If streaming already delivered the response, extract and
             # deliver any MEDIA: files before returning None.  Streaming
@@ -20825,7 +20870,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return bool(getattr(self.config, "stt_echo_transcripts", True))
 
     async def _send_voice_reply(self, event: MessageEvent, text: str) -> None:
-        """Generate TTS audio and send as a voice message before the text reply."""
+        """Generate TTS audio and send it after the text delivery attempt."""
         audio_path = None
         actual_paths: List[str] = []
         try:
@@ -20914,6 +20959,107 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     os.unlink(p)
                 except OSError:
                     pass
+
+    def _schedule_voice_reply(
+        self,
+        delivery_key: str,
+        event: MessageEvent,
+        text: str,
+        text_delivery_gate: asyncio.Event,
+    ) -> asyncio.Task:
+        """Schedule one ordered whole-file auto voice reply.
+
+        A per-session predecessor chain keeps voice replies in turn order
+        without serializing unrelated chats. The text-delivery gate keeps a
+        fast TTS backend from overtaking the corresponding text response.
+        """
+        tasks = getattr(self, "_voice_reply_tasks", None)
+        if tasks is None:
+            tasks = set()
+            self._voice_reply_tasks = tasks
+        tails = getattr(self, "_voice_reply_tails", None)
+        if tails is None:
+            tails = {}
+            self._voice_reply_tails = tails
+
+        predecessor = tails.get(delivery_key)
+
+        async def _run_ordered() -> None:
+            if predecessor is not None:
+                try:
+                    await asyncio.shield(predecessor)
+                except asyncio.CancelledError:
+                    # A cancelled predecessor should not poison a later reply.
+                    # Preserve cancellation directed at this task itself.
+                    current = asyncio.current_task()
+                    if current is not None and current.cancelling():
+                        raise
+                except Exception:
+                    # _send_voice_reply is best-effort and normally contains
+                    # its own failures. Keep the FIFO moving if an unexpected
+                    # predecessor exception escapes.
+                    pass
+            await text_delivery_gate.wait()
+            await self._send_voice_reply(event, text)
+
+        task = asyncio.create_task(
+            _run_ordered(),
+            name=f"gateway-auto-voice:{delivery_key}",
+        )
+        tasks.add(task)
+        tails[delivery_key] = task
+
+        def _finished(done: asyncio.Task) -> None:
+            tasks.discard(done)
+            if tails.get(delivery_key) is done:
+                tails.pop(delivery_key, None)
+            if done.cancelled():
+                return
+            try:
+                done.result()
+            except Exception:
+                logger.warning("Auto voice reply task failed", exc_info=True)
+
+        task.add_done_callback(_finished)
+        return task
+
+    @staticmethod
+    def _voice_reply_delivery_key(event: MessageEvent) -> str:
+        """Return the visible route whose voice replies must stay ordered."""
+        source = event.source
+        platform = getattr(source.platform, "value", source.platform)
+        return ":".join(
+            str(part or "")
+            for part in (
+                platform,
+                source.profile,
+                source.scope_id,
+                source.chat_id,
+                source.thread_id,
+            )
+        )
+
+    async def _drain_voice_reply_tasks(self, timeout: float) -> bool:
+        """Drain auto voice replies before adapter teardown, then cancel late work."""
+        tasks = {
+            task
+            for task in getattr(self, "_voice_reply_tasks", set())
+            if not task.done()
+        }
+        if not tasks:
+            return True
+
+        _done, pending = await asyncio.wait(
+            tasks,
+            timeout=max(0.0, float(timeout)),
+        )
+        if not pending:
+            return True
+
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+        return False
 
     async def _deliver_media_from_response(
         self,

--- a/tests/gateway/test_async_auto_voice_reply.py
+++ b/tests/gateway/test_async_auto_voice_reply.py
@@ -1,0 +1,279 @@
+"""Regression coverage for non-blocking, ordered gateway auto voice replies."""
+
+import asyncio
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    SendResult,
+)
+from gateway.session import SessionEntry, SessionSource
+
+
+SESSION_KEY = "agent:main:telegram:group:-1001:12345"
+
+
+class _DeliveryAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True), Platform.TELEGRAM)
+        self.send_started = asyncio.Event()
+        self.release_send = asyncio.Event()
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.send_started.set()
+        await self.release_send.wait()
+        return SendResult(success=True, message_id="text-reply")
+
+
+def _source(chat_id: str = "-1001") -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=chat_id,
+        chat_type="group",
+        user_id="12345",
+    )
+
+
+def _event(chat_id: str = "-1001") -> MessageEvent:
+    return MessageEvent(
+        text="speak this reply",
+        source=_source(chat_id),
+        message_id=f"message:{chat_id}",
+    )
+
+
+def _handler_runner(monkeypatch, tmp_path):
+    runner = gateway_run.GatewayRunner(GatewayConfig())
+    runner.adapters = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    monkeypatch.setattr(runner, "_is_user_authorized", lambda _source: True)
+    monkeypatch.setattr(runner, "_set_session_env", lambda _context: None)
+    monkeypatch.setattr(
+        runner,
+        "_handle_active_session_busy_message",
+        AsyncMock(return_value=False),
+    )
+    runner._session_db = MagicMock()
+    monkeypatch.setattr(
+        runner, "_recover_telegram_topic_thread_id", lambda _source: None
+    )
+    monkeypatch.setattr(
+        runner, "_cache_session_source", lambda _key, _source: None
+    )
+    monkeypatch.setattr(
+        runner, "_is_session_run_current", lambda _key, _generation: True
+    )
+    monkeypatch.setattr(runner, "_reply_anchor_for_event", lambda _event: None)
+    monkeypatch.setattr(runner, "_get_guild_id", lambda _event: None)
+    monkeypatch.setattr(
+        runner, "_should_send_voice_reply", lambda *_args, **_kwargs: True
+    )
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key=SESSION_KEY,
+        session_id="session-async-voice",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+    )
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+    monkeypatch.setattr(
+        runner,
+        "_run_agent",
+        AsyncMock(
+            return_value={
+                "final_response": "The text reply",
+                "messages": [
+                    {"role": "user", "content": "speak this reply"},
+                    {"role": "assistant", "content": "The text reply"},
+                ],
+                "tools": [],
+                "history_offset": 0,
+                "last_prompt_tokens": 0,
+                "api_calls": 1,
+                "failed": False,
+            }
+        ),
+    )
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"}
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100_000,
+    )
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_agent_handler_returns_before_auto_voice_synthesis(
+    monkeypatch, tmp_path
+):
+    runner = _handler_runner(monkeypatch, tmp_path)
+    voice_started = asyncio.Event()
+    release_voice = asyncio.Event()
+
+    async def slow_voice(_event, _text):
+        voice_started.set()
+        await release_voice.wait()
+
+    runner._send_voice_reply = AsyncMock(side_effect=slow_voice)
+    event = _event()
+
+    response = await asyncio.wait_for(
+        runner._handle_message_with_agent(event, event.source, SESSION_KEY, 1),
+        timeout=1,
+    )
+
+    assert response == "The text reply"
+    assert not voice_started.is_set()
+
+    getattr(event, "_hermes_auto_voice_text_delivered").set()
+    await asyncio.wait_for(voice_started.wait(), timeout=1)
+    release_voice.set()
+    assert await runner._drain_voice_reply_tasks(timeout=1) is True
+
+
+@pytest.mark.asyncio
+async def test_base_adapter_releases_voice_only_after_text_send(monkeypatch):
+    adapter = _DeliveryAdapter()
+    event = _event()
+    text_delivered = asyncio.Event()
+    setattr(event, "_hermes_auto_voice_text_delivered", text_delivered)
+    adapter.set_message_handler(AsyncMock(return_value="The text reply"))
+    session_key = "agent:main:telegram:group:-1001"
+    adapter._active_sessions[session_key] = asyncio.Event()
+    monkeypatch.setattr("gateway.delivery_ledger.ledger_enabled", lambda: False)
+
+    processing = asyncio.create_task(
+        adapter._process_message_background(event, session_key)
+    )
+    await asyncio.wait_for(adapter.send_started.wait(), timeout=1)
+    assert not text_delivered.is_set()
+
+    adapter.release_send.set()
+    await asyncio.wait_for(processing, timeout=1)
+    assert text_delivered.is_set()
+
+
+@pytest.mark.asyncio
+async def test_auto_voice_reply_is_fifo_per_session():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._voice_reply_tasks = set()
+    runner._voice_reply_tails = {}
+    first_release = asyncio.Event()
+    calls = []
+
+    async def send_voice(_event, text):
+        calls.append(f"start:{text}")
+        if text == "first":
+            await first_release.wait()
+        calls.append(f"end:{text}")
+
+    runner._send_voice_reply = send_voice
+    first_gate = asyncio.Event()
+    second_gate = asyncio.Event()
+    first_gate.set()
+    second_gate.set()
+
+    first = runner._schedule_voice_reply(
+        "same-session", _event(), "first", first_gate
+    )
+    second = runner._schedule_voice_reply(
+        "same-session", _event(), "second", second_gate
+    )
+    await asyncio.sleep(0)
+
+    assert calls == ["start:first"]
+    first_release.set()
+    await asyncio.gather(first, second)
+    assert calls == ["start:first", "end:first", "start:second", "end:second"]
+    await asyncio.sleep(0)
+    assert runner._voice_reply_tasks == set()
+    assert runner._voice_reply_tails == {}
+
+
+def test_voice_delivery_key_ignores_per_user_session_partition():
+    first = _event()
+    second = _event()
+    first.source.user_id = "user-one"
+    second.source.user_id = "user-two"
+
+    assert gateway_run.GatewayRunner._voice_reply_delivery_key(
+        first
+    ) == gateway_run.GatewayRunner._voice_reply_delivery_key(second)
+
+
+@pytest.mark.asyncio
+async def test_auto_voice_reply_does_not_serialize_unrelated_sessions():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._voice_reply_tasks = set()
+    runner._voice_reply_tails = {}
+    first_release = asyncio.Event()
+    second_done = asyncio.Event()
+
+    async def send_voice(event, _text):
+        if event.source.chat_id == "first":
+            await first_release.wait()
+        else:
+            second_done.set()
+
+    runner._send_voice_reply = send_voice
+    gate = asyncio.Event()
+    gate.set()
+
+    runner._schedule_voice_reply("session:first", _event("first"), "one", gate)
+    runner._schedule_voice_reply("session:second", _event("second"), "two", gate)
+
+    await asyncio.wait_for(second_done.wait(), timeout=1)
+    first_release.set()
+    assert await runner._drain_voice_reply_tasks(timeout=1) is True
+
+
+@pytest.mark.asyncio
+async def test_voice_reply_drain_cancels_tasks_at_deadline():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._voice_reply_tasks = set()
+    runner._voice_reply_tails = {}
+    started = asyncio.Event()
+
+    async def send_voice(_event, _text):
+        started.set()
+        await asyncio.Event().wait()
+
+    runner._send_voice_reply = send_voice
+    gate = asyncio.Event()
+    gate.set()
+    task = runner._schedule_voice_reply("session", _event(), "slow", gate)
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    assert await runner._drain_voice_reply_tasks(timeout=0) is False
+    assert task.cancelled()
+    assert runner._voice_reply_tasks == set()
+    assert runner._voice_reply_tails == {}


### PR DESCRIPTION
Fixes #81162

## What changed

Whole-file auto-TTS was awaited inside `_handle_message_with_agent`, so a slow backend delayed the text response by the full synthesis and upload time. This moves that work into runner-owned background tasks while preserving delivery ordering:

- the voice task waits until the adapter has attempted the corresponding final text send;
- replies to the same visible platform/profile/chat/thread route stay FIFO, including per-user sessions sharing one chat;
- unrelated routes can synthesize concurrently;
- scale-to-zero treats voice tasks as live work;
- shutdown drains them before adapter teardown, with a bounded timeout and cancellation fallback.

Scheduling remains best-effort. A TTS scheduling or synthesis failure cannot fail the text response.

## Reproduction and regression coverage

The new handler regression timed out on current main because execution remained inside `_send_voice_reply`; it passes with the handler returning before the slow synthesizer is released.

`tests/gateway/test_async_auto_voice_reply.py` also covers the real `BasePlatformAdapter` text-send boundary, same-route FIFO, cross-route concurrency, shared-chat ordering across per-user session partitions, and deadline cancellation/ownership cleanup.

## Validation

- focused regression: **6 passed**
- voice, TTS, shutdown, restart-drain, scale-to-zero, and delivery-ledger matrix: **172 passed**
- post-rebase stream-finalization/voice affected matrix: **68 passed**
- full `tests/gateway`: **5,055 passed**; the remaining 4 failures in 3 files were reproduced independently on the untouched exact base (`test_shutdown_forensics.py`, `test_systemd_notify.py`, and `test_wecom_callback.py` host/optional-backend limitations)
- Ruff: passed
- ty: **133 diagnostics on feature, 133 on exact base, zero semantic delta**; the new regression file reports zero diagnostics
- Windows footgun scan: passed
- bytecode compilation and `git diff --check`: passed
- gitleaks publish-range scan: passed

## Overlap audit

I inspected #76330/#76620 (MEDIA directive sanitization), #65745 (silent STT/media producers and send-result logging), #77741/#79341 (behavior-neutral extraction refactors), #81053/#81041 (voice-mode persistence), #81030/#80436 (Matrix routing and output-path safety), and #73060 (`/stop` queue draining). None addresses the blocking await, text-delivery gate, per-visible-route FIFO, or shutdown ownership implemented here.
