### PR TITLE
fix(desktop): map connected Claude Code OAuth to the Anthropic model provider

### DIFF
--- a/apps/desktop/src/store/onboarding.test.ts
+++ b/apps/desktop/src/store/onboarding.test.ts
@@ -7,6 +7,7 @@ import {
   $desktopOnboarding,
   type DesktopOnboardingState,
   type OnboardingContext,
+  recheckExternalSignin,
   refreshOnboarding,
   requestDesktopOnboarding,
   saveOnboardingLocalEndpoint,
@@ -415,6 +416,78 @@ describe('OAuth onboarding', () => {
     expect(optionsIndex).toBeGreaterThanOrEqual(0)
     expect(recommendedIndex).toBeGreaterThan(optionsIndex)
     expect(setIndex).toBeGreaterThan(recommendedIndex)
+  })
+
+  it('maps connected Claude Code OAuth to the Anthropic model provider', async () => {
+    const model = 'claude-sonnet-4-6'
+    const calls: { body?: unknown; path: string }[] = []
+
+    installApiMock(async ({ body, path }: { body?: unknown; path: string }) => {
+      calls.push({ body, path })
+
+      if (path.startsWith('/api/model/options')) {
+        return {
+          providers: [
+            { name: 'OpenAI Codex', slug: 'openai-codex', models: ['gpt-5.6-sol'] },
+            { name: 'Anthropic', slug: 'anthropic', models: [model] }
+          ]
+        }
+      }
+
+      if (path.startsWith('/api/model/recommended-default?')) {
+        return { provider: 'anthropic', model, free_tier: null }
+      }
+
+      if (path === '/api/model/set') {
+        return { ok: true, provider: 'anthropic', model, gateway_tools: [] }
+      }
+
+      throw new Error(`unexpected api path: ${path}`)
+    })
+
+    const requestGateway: OnboardingContext['requestGateway'] = async (method, params) => {
+      if (method === 'reload.env') {
+        return {} as never
+      }
+
+      if (method === 'setup.status') {
+        return { provider_configured: true } as never
+      }
+
+      if (method === 'setup.runtime_check') {
+        expect(params).toEqual({ provider: 'anthropic' })
+
+        return { ok: true } as never
+      }
+
+      throw new Error(`unexpected gateway method: ${method}`)
+    }
+
+    const claudeCode = {
+      ...provider('claude-code', 'Anthropic OAuth'),
+      flow: 'external' as const,
+      status: { logged_in: true }
+    }
+
+    $desktopOnboarding.set(
+      baseState({
+        flow: { status: 'external_pending', provider: claudeCode, copied: false },
+        manual: true,
+        requested: true
+      })
+    )
+
+    await recheckExternalSignin(onboardingContext(requestGateway))
+
+    expect(calls).toContainEqual({
+      path: '/api/model/set',
+      body: { scope: 'main', provider: 'anthropic', model }
+    })
+    expect($desktopOnboarding.get().flow).toMatchObject({
+      status: 'confirming_model',
+      providerSlug: 'anthropic',
+      currentModel: model
+    })
   })
 })
 

--- a/apps/desktop/src/store/onboarding.ts
+++ b/apps/desktop/src/store/onboarding.ts
@@ -365,6 +365,15 @@ function providerResolutionFailure(reason: null | string) {
     : 'Connected, but Hermes still cannot resolve a usable provider.'
 }
 
+// The Accounts catalog exposes Claude Code as a synthetic external-auth row,
+// while inference runs through Hermes' native `anthropic` provider. Keep that
+// boundary translation here so model discovery, assignment, and runtime checks
+// all receive the executable provider slug after the user explicitly selects
+// the connected Claude Code account.
+function modelProviderSlugs(provider: OAuthProvider): string[] {
+  return provider.id === 'claude-code' ? ['anthropic'] : [provider.id]
+}
+
 async function refreshProviders() {
   if (providersRefreshPromise) {
     await providersRefreshPromise
@@ -733,7 +742,7 @@ export async function recheckExternalSignin(ctx: OnboardingContext) {
   }
 
   const { provider } = flow
-  await completeWithModelConfirm(ctx, provider.name, [provider.id], reason =>
+  await completeWithModelConfirm(ctx, provider.name, modelProviderSlugs(provider), reason =>
     setFlow({
       status: 'error',
       provider,


### PR DESCRIPTION
## Symptom

Desktop shows the Claude Code / Anthropic OAuth account as **Connected** on the Accounts screen, but the chat model picker never lists an **Anthropic** section — even after pressing Refresh Models. Users read this as "my Claude Code auth is broken/ignored".

Reproduced live on macOS with a valid Claude Max subscription:

- `claude auth status` → `loggedIn: true, subscriptionType: max`
- `read_claude_code_credentials()` → valid token from the macOS Keychain (`Claude Code-credentials`), `is_claude_code_token_valid` → `True`
- Accounts tab (`/api/providers/oauth`) → `claude-code` row: `logged_in: true`
- Chat picker (`GET /api/model/options?explicit_only=1`) → no `anthropic` row

## Root cause

The Accounts catalog exposes Claude Code as the **synthetic `claude-code` row** (`_OAUTH_PROVIDER_CATALOG` in `hermes_cli/web_server.py`), while inference runs through the native **`anthropic`** provider slug.

When the user selects that row in onboarding, `recheckExternalSignin()` passed `provider.id` (`claude-code`) as the preferred slug into `completeWithModelConfirm()`. Since `/api/model/options` never returns a `claude-code` row, the slug match failed and the flow silently fell back to `providers[0]` — the already-configured provider (e.g. `openai-codex`). Net effect:

- `/api/model/set` persisted the OLD provider again, so `model.provider` never became `anthropic` and `active_provider` in auth.json never changed;
- `is_provider_explicitly_configured("anthropic")` stayed `False`;
- the desktop picker's `explicit_only=1` filter (`_filter_explicit_provider_rows`) therefore kept hiding Anthropic — by design, per the PR #4210 consent gate — even though the user had just explicitly clicked the Claude Code account.

So the consent gate is working as intended; the bug is that the explicit consent action (selecting the connected Claude Code account in onboarding) never translated into the state the gate checks.

## Fix

Translate the synthetic account id to the executable provider slug at the flow boundary (`apps/desktop/src/store/onboarding.ts`):

- new `modelProviderSlugs()` helper maps `claude-code` → `anthropic` (all other providers unchanged);
- `recheckExternalSignin()` now feeds that slug into `completeWithModelConfirm()`, so model discovery, `/api/model/set` persistence, and `setup.runtime_check` all target `anthropic`.

Once `/api/model/set` persists `provider: anthropic`, `is_provider_explicitly_configured("anthropic")` returns True and the explicit-only picker shows the Anthropic section on the next open — no changes to the backend consent gate itself.

## Tests

- New regression test in `apps/desktop/src/store/onboarding.test.ts`: drives `recheckExternalSignin` with a connected `claude-code` external provider and asserts `/api/model/set` receives `provider: anthropic` and the flow lands on `confirming_model` with `providerSlug: 'anthropic'`. Fails on `main` (persists `provider: openai-codex`), passes with the fix.
- `npm run test:ui` — 404 files / 3615 tests passed.
- `npm run typecheck`, `eslint`, `prettier --check` — clean.
- Verified live after the fix: `build_model_options_payload(explicit_only=True)` now returns the `anthropic` row with the full Claude model list, and the desktop picker shows the ANTHROPIC section.
