### PR TITLE
fix(desktop): make the slash list usable in HUD mode

### DIFF
--- a/apps/desktop/src/app/hud/hud-shell.tsx
+++ b/apps/desktop/src/app/hud/hud-shell.tsx
@@ -23,12 +23,8 @@ import { useHudThreadFocus } from './thread-focus'
 /** How long the transcript lingers at its glanceable opacity — after a turn
  *  lands, or after you let go of the composer — before it goes. This is the ONLY
  *  hold: the CSS carries no transition-delay, because two stacked holds read as
- *  a third fade state that nobody asked for. Focus keeps it open past this.
- *
- *  Long enough to actually be the middle stage. Under a second it read as part
- *  of the fade rather than a state you could still glance at and finish
- *  reading. */
-const HUD_RECENT_HOLD_MS = 1750
+ *  a third fade state that nobody asked for. Focus keeps it open past this. */
+const HUD_RECENT_HOLD_MS = 1100
 
 /** Band visibility timings, published to CSS as custom properties so this
  *  module and the stylesheet cannot drift apart. Reveal is quick — it is an

--- a/apps/desktop/src/app/hud/hud-shell.tsx
+++ b/apps/desktop/src/app/hud/hud-shell.tsx
@@ -28,7 +28,7 @@ import { useHudThreadFocus } from './thread-focus'
  *  Long enough to actually be the middle stage. Under a second it read as part
  *  of the fade rather than a state you could still glance at and finish
  *  reading. */
-const HUD_RECENT_HOLD_MS = 2500
+const HUD_RECENT_HOLD_MS = 1750
 
 /** Band visibility timings, published to CSS as custom properties so this
  *  module and the stylesheet cannot drift apart. Reveal is quick — it is an

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2756,7 +2756,10 @@ button[data-slot='aui_msg-reactions'] svg {
   background: var(--dt-card) !important;
   backdrop-filter: none !important;
   -webkit-backdrop-filter: none !important;
-  box-shadow: none !important;
+  /* Bottom edge only. Enough to lift the bar off whatever it is lying over —
+     without it the HUD reads as pasted onto the other app — and tight enough
+     that it never becomes a glow around a floating card. */
+  box-shadow: 0 2px 2px -1px rgb(0 0 0 / 0.12) !important;
   transition: border-color var(--hud-reveal) var(--hud-ease-enter);
 }
 

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2577,6 +2577,25 @@ button[data-slot='aui_msg-reactions'] svg {
   border-radius: 0 0 0.75rem 0.75rem;
 }
 
+/* …so the edge it falls back from is the bar's, which is now above it. */
+[data-hud-shell][data-hud-edge='top'] :is([data-slot='composer-bounds'], [data-hud-glass]) {
+  transform-origin: top center;
+}
+
+/* The completion list — `/`, `@`, `:`, and the help hint — hangs off the bar's
+   outer edge, the same side the band is on. It grows UP by default, which is
+   right everywhere the composer has a window above it; parked at the top edge
+   there is nothing up there, so the list rendered off screen and `/` looked
+   dead. Capped to the room below the bar, since the app's own cap assumes a
+   full window. */
+[data-hud-shell][data-hud-edge='top'] [data-slot='composer-completion-drawer'] {
+  top: 100%;
+  bottom: auto;
+  margin-top: 0.25rem;
+  margin-bottom: 0;
+  max-height: calc(100dvh - var(--hud-bar-height, var(--composer-fallback-height)) - 0.75rem);
+}
+
 /* Tighten the thread on every side. The docked chat's gutters (px-6 py-8 plus
    a 1.5rem inline pad) are sized for a full window column; in a bar a few
    lines tall they're most of the surface. Bottom pad drops to a hairline —

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2328,7 +2328,10 @@ button[data-slot='aui_msg-reactions'] svg {
   translate: 0 var(--hud-exit-shift, 2.5rem);
   transition:
     opacity var(--hud-fade) var(--hud-ease-exit),
-    translate var(--hud-collapse) var(--hud-ease-exit);
+    translate var(--hud-collapse) var(--hud-ease-exit),
+    scale var(--hud-dim) var(--hud-ease-enter),
+    filter var(--hud-dim) var(--hud-ease-enter);
+  transform-origin: bottom center;
 }
 
 /* Shown: recent turn / streaming, or a focused composer.
@@ -2378,9 +2381,12 @@ button[data-slot='aui_msg-reactions'] svg {
   height: var(--hud-band-height, 0px);
   translate: 0 var(--hud-exit-shift, 2.5rem);
   opacity: 0;
+  transform-origin: bottom center;
   transition:
     opacity var(--hud-fade) var(--hud-ease-exit),
     translate var(--hud-collapse) var(--hud-ease-exit),
+    scale var(--hud-dim) var(--hud-ease-enter),
+    filter var(--hud-dim) var(--hud-ease-enter),
     height var(--hud-reveal) var(--hud-ease-enter),
     background-color var(--hud-dim) var(--hud-ease-enter);
 }
@@ -2455,6 +2461,23 @@ button[data-slot='aui_msg-reactions'] svg {
   translate: none;
   transition-duration: var(--hud-reveal);
   transition-delay: 0s;
+}
+
+/* A completion list is the whole interface for as long as it is open, and it
+   hangs over the band. Two half-lit surfaces stacked on a third thing — the
+   app underneath — is unreadable however the numbers are tuned, so the list
+   goes fully opaque and the band falls back behind it: dimmer, fractionally
+   smaller, slightly out of focus. Scaled from the bar's edge, so it reads as
+   depth rather than as the panel shrinking. */
+[data-hud-shell]:has([data-slot='composer-completion-drawer'])
+  :is([data-slot='composer-bounds'], [data-hud-glass]) {
+  opacity: 0.25 !important;
+  scale: 0.97;
+  filter: blur(1.5px);
+}
+
+[data-hud-shell] [data-slot='composer-completion-drawer'] {
+  background: var(--dt-card) !important;
 }
 
 /* User messages ride the band like every other line. In the app each sticky


### PR DESCRIPTION
Typing `/` in the HUD did nothing visible. The composer's completion list —
`/`, `@`, `:`, and the help hint — hangs off the top of the bar, which is right
everywhere the composer has a window above it and wrong in the one place the
bar is parked against the screen's top edge. The list was rendering off screen.

It now flips below the bar in that orientation, capped to the room it actually
has rather than to the app's full-window assumption.

That put the list over the band, where two half-lit surfaces were stacked on a
third thing — the app underneath — which no pair of opacities reads well
against. So the list is fully opaque now and the band falls back behind it:
dimmer, fractionally smaller, slightly out of focus, scaled from the bar's edge
so it reads as depth rather than as the panel shrinking.

Two smaller passes on the bar while in here: a hairline shadow under its bottom
edge, so it lifts off whatever it is lying over instead of looking pasted onto
it, and the band's glanceable hold drops from 2.5s to 1.1s — long enough to
finish reading, short enough that it isn't waiting for you.