### PR TITLE
fix(vision): single source of truth for the image pre-analysis prompt

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8481,13 +8481,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         image later with ``vision_analyze`` if needed.
         """
         import asyncio as _asyncio
-        from tools.vision_tools import vision_analyze_tool
+        from tools.vision_tools import vision_analyze_tool, get_vision_analysis_prompt
 
-        analysis_prompt = (
-            "Describe everything visible in this image in thorough detail. "
-            "Include any text, code, data, objects, people, layout, colors, "
-            "and any other notable visual information."
-        )
+        analysis_prompt = get_vision_analysis_prompt()
 
         enriched_parts = []
         for img_path in images:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -23819,16 +23819,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         Returns:
             The enriched message string with vision descriptions prepended.
         """
-        from tools.vision_tools import vision_analyze_tool
+        from tools.vision_tools import vision_analyze_tool, get_vision_analysis_prompt
         from agent.memory_manager import sanitize_context
 
-        analysis_prompt = (
-            "Concisely describe this image in 2-4 sentences "
-            "(~200 Chinese characters or ~150 English words). "
-            "Cover the main subject, key visible text/data/code, and overall context. "
-            "If it is a chart, diagram, or scientific figure, include the important "
-            "labels, legend, and key values. Skip decorative details."
-        )
+        analysis_prompt = get_vision_analysis_prompt()
 
         enriched_parts = []
         for path in image_paths:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -947,6 +947,7 @@ DEFAULT_CONFIG = {
             "extra_body": {},      # OpenAI-compatible provider-specific request fields
             "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
             "download_timeout": 30,  # seconds — image HTTP download timeout; increase for slow connections
+            "analysis_prompt": "",   # override the pre-analysis prompt sent for user-attached images (empty = built-in concise default)
         },
         "web_extract": {
             "provider": "auto",

--- a/run_agent.py
+++ b/run_agent.py
@@ -7027,11 +7027,9 @@ class AIAgent:
             "assistant": "assistant",
             "tool": "tool result",
         }.get(role, "user")
-        analysis_prompt = (
-            "Describe everything visible in this image in thorough detail. "
-            "Include any text, code, UI, data, objects, people, layout, colors, "
-            "and any other notable visual information."
-        )
+        from tools.vision_tools import get_vision_analysis_prompt
+
+        analysis_prompt = get_vision_analysis_prompt()
 
         vision_source = str(image_url or "")
         cleanup_path: Optional[Path] = None

--- a/tests/tools/test_vision_prompt_consolidation.py
+++ b/tests/tools/test_vision_prompt_consolidation.py
@@ -1,0 +1,94 @@
+"""Vision pre-analysis prompt is a single source of truth."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tools.vision_tools import get_vision_analysis_prompt
+
+
+def test_get_vision_analysis_prompt_returns_concise_default():
+    with patch("hermes_cli.config.load_config") as mock_load:
+        mock_load.side_effect = Exception("no config")
+        prompt = get_vision_analysis_prompt()
+
+    assert "Concisely describe this image in 2-4 sentences" in prompt
+    assert "Skip decorative details." in prompt
+
+
+def test_get_vision_analysis_prompt_reads_config_override():
+    with patch(
+        "hermes_cli.config.load_config",
+        return_value={"auxiliary": {"vision": {"analysis_prompt": "Custom prompt"}}},
+    ):
+        prompt = get_vision_analysis_prompt()
+
+    assert prompt == "Custom prompt"
+
+
+def test_get_vision_analysis_prompt_ignores_blank_override():
+    with patch(
+        "hermes_cli.config.load_config",
+        return_value={"auxiliary": {"vision": {"analysis_prompt": "   "}}},
+    ):
+        prompt = get_vision_analysis_prompt()
+
+    assert "Concisely describe this image in 2-4 sentences" in prompt
+
+
+def test_get_vision_analysis_prompt_ignores_missing_key():
+    with patch("hermes_cli.config.load_config", return_value={}):
+        prompt = get_vision_analysis_prompt()
+
+    assert "Concisely describe this image in 2-4 sentences" in prompt
+
+
+@pytest.mark.asyncio
+async def test_gateway_call_site_uses_shared_prompt():
+    """The gateway entry point forwards the shared prompt, not a private copy."""
+    import json
+
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+
+    with patch(
+        "tools.vision_tools.vision_analyze_tool",
+        new_callable=AsyncMock,
+        return_value=json.dumps({"success": True, "analysis": "A cat on a chair."}),
+    ) as mock_vision:
+        await runner._enrich_message_with_vision(
+            user_text="What is happening here?",
+            image_paths=["/tmp/cat.png"],
+        )
+
+    assert (
+        "Concisely describe this image in 2-4 sentences"
+        in mock_vision.await_args.kwargs["user_prompt"]
+    )
+    assert "Skip decorative details." in mock_vision.await_args.kwargs["user_prompt"]
+
+
+@pytest.mark.asyncio
+async def test_gateway_call_site_honors_config_override():
+    """A config override must flow through the gateway entry point too."""
+    import json
+
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+
+    with patch(
+        "hermes_cli.config.load_config",
+        return_value={"auxiliary": {"vision": {"analysis_prompt": "Custom prompt"}}},
+    ), patch(
+        "tools.vision_tools.vision_analyze_tool",
+        new_callable=AsyncMock,
+        return_value=json.dumps({"success": True, "analysis": "A cat on a chair."}),
+    ) as mock_vision:
+        await runner._enrich_message_with_vision(
+            user_text="What is happening here?",
+            image_paths=["/tmp/cat.png"],
+        )
+
+    assert mock_vision.await_args.kwargs["user_prompt"] == "Custom prompt"

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -97,6 +97,42 @@ _VISION_DOWNLOAD_TIMEOUT = _resolve_download_timeout()
 # attacker-hosted multi-gigabyte files or decompression bombs.
 _VISION_MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024
 
+# Default prompt used when pre-analyzing a user-attached image through the
+# auxiliary vision pipeline. The concise variant is the deliberate default:
+# it caps output at 2-4 sentences and skips decorative detail, which
+# materially reduces token cost per image. Configurable per-install via
+# ``auxiliary.vision.analysis_prompt`` in config.yaml.
+_DEFAULT_VISION_ANALYSIS_PROMPT = (
+    "Concisely describe this image in 2-4 sentences "
+    "(~200 Chinese characters or ~150 English words). "
+    "Cover the main subject, key visible text/data/code, and overall context. "
+    "If it is a chart, diagram, or scientific figure, include the important "
+    "labels, legend, and key values. Skip decorative details."
+)
+
+
+def get_vision_analysis_prompt() -> str:
+    """Return the pre-analysis prompt for vision, from config or default.
+
+    Reads ``auxiliary.vision.analysis_prompt`` from config.yaml. If set to a
+    non-empty string that value is used verbatim; otherwise the built-in
+    ``_DEFAULT_VISION_ANALYSIS_PROMPT`` is returned.
+
+    A single source of truth for every call site that pre-analyzes a
+    user-attached image (CLI, gateway, TUI, run_agent), so the prompt cannot
+    drift between entry points.
+    """
+    try:
+        from hermes_cli.config import cfg_get, load_config
+
+        cfg = load_config()
+        val = cfg_get(cfg, "auxiliary", "vision", "analysis_prompt")
+        if isinstance(val, str) and val.strip():
+            return val.strip()
+    except Exception:
+        pass
+    return _DEFAULT_VISION_ANALYSIS_PROMPT
+
 
 # ---------------------------------------------------------------------------
 # CPU-burst concurrency cap (vision encode/resize)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7052,13 +7052,9 @@ def _active_image_routing_identity(agent: Any) -> tuple[str, str]:
 def _enrich_with_attached_images(user_text: str, image_paths: list[str]) -> str:
     """Pre-analyze attached images via vision and prepend descriptions to user text."""
     import asyncio, json as _json
-    from tools.vision_tools import vision_analyze_tool
+    from tools.vision_tools import vision_analyze_tool, get_vision_analysis_prompt
 
-    prompt = (
-        "Describe everything visible in this image in thorough detail. "
-        "Include any text, code, data, objects, people, layout, colors, "
-        "and any other notable visual information."
-    )
+    prompt = get_vision_analysis_prompt()
 
     parts: list[str] = []
     for path in image_paths:


### PR DESCRIPTION
Rebased onto current `main` (8d330536), verified the fix is still needed — upstream still inlines the pre-analysis prompt verbatim in `gateway/run.py` line ~23826 with no single source of truth.

**Validation** — `.venv/bin/python -m pytest tests/tools/test_vision_prompt_consolidation.py -q` → 6 passed; syntax-checked all touched entrypoints.
