### PR TITLE
fix(tools): truncation footers print backend-readable cache paths

### DIFF
--- a/tests/tools/test_delegate_spill_path_translation.py
+++ b/tests/tools/test_delegate_spill_path_translation.py
@@ -1,0 +1,54 @@
+"""Truncation footers must surface backend-readable cache paths, not host paths.
+
+When the terminal backend is docker/modal/ssh the cache dirs are mounted at a
+different path than the host path (e.g. /root/.hermes for docker), so a footer
+advertising the host path makes read_file from inside the sandbox fail with
+"File not found" and forces unnecessary re-dispatch.
+"""
+
+import os
+import tempfile
+
+import pytest
+
+import tools.delegate_tool as dt
+
+
+def test_delegate_summary_footer_translates_path_for_docker_backend(monkeypatch):
+    with tempfile.TemporaryDirectory() as td:
+        monkeypatch.setenv("HERMES_HOME", os.path.join(td, ".hermes"))
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        model_text, spill_path = dt._trim_summary_with_footer("X" * 50_000, 1000, 0)
+
+        assert spill_path.startswith("/root/.hermes/"), spill_path
+        assert str(td) not in spill_path
+        assert "Full subagent output saved to: " in model_text
+        assert f'read_file path="{spill_path}"' in model_text
+
+
+def test_delegate_summary_footer_keeps_host_path_on_local_backend(monkeypatch):
+    with tempfile.TemporaryDirectory() as td:
+        monkeypatch.setenv("HERMES_HOME", os.path.join(td, ".hermes"))
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        model_text, spill_path = dt._trim_summary_with_footer("X" * 50_000, 1000, 0)
+
+        assert spill_path.startswith(os.path.join(td, ".hermes")), spill_path
+        assert os.path.exists(spill_path)
+        assert f'read_file path="{spill_path}"' in model_text
+
+
+def test_delegate_live_transcripts_translate_for_docker_backend(monkeypatch):
+    with tempfile.TemporaryDirectory() as td:
+        monkeypatch.setenv("HERMES_HOME", os.path.join(td, ".hermes"))
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        from tools.credential_files import to_agent_visible_cache_path
+        from tools.delegation_live_log import create_live_transcripts
+
+        _, _, paths = create_live_transcripts([{"goal": "hello"}], delegation_id="test-xyz")
+        if not paths:
+            pytest.skip("live transcripts disabled in this environment")
+        # delegate_tool translates each display path through the same helper.
+        visible = [to_agent_visible_cache_path(p) for p in paths]
+        for p in visible:
+            assert p.startswith("/root/.hermes/"), p
+            assert str(td) not in p

--- a/tests/tools/test_web_tools_truncate.py
+++ b/tests/tools/test_web_tools_truncate.py
@@ -54,6 +54,21 @@ class TestTruncation:
         assert "UNIQUE_MIDDLE_MARKER" in full
         assert "row 2500" in full  # the omitted-middle row is in the stored file
 
+    def test_truncation_footer_translates_path_for_docker_backend(self, tmp_path, monkeypatch):
+        """Inside docker/modal backends the footer must show the container-mapped
+        cache path (readable by read_file), not the host path (which dangles)."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        body = "\n".join(f"row {i}" for i in range(5000))
+        out, truncated = wt._truncate_with_footer(body, "https://example.com/doc", 3000)
+        assert truncated is True
+        path_line = next(ln for ln in out.splitlines() if "Full text saved to:" in ln)
+        shown = path_line.split("Full text saved to:", 1)[1].strip()
+        assert shown.startswith("/root/.hermes/"), shown
+        assert str(tmp_path) not in shown
+        hint_line = next(ln for ln in out.splitlines() if 'read_file path=' in ln)
+        assert f'read_file path="{shown}"' in hint_line
+
 
 class TestCharLimitConfig:
     def test_default_when_unset(self):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1959,6 +1959,9 @@ def _trim_summary_with_footer(
         f"of {original_len:,} total — trimmed to protect the parent's context window.",
     ]
     if spill_path:
+        from tools.credential_files import to_agent_visible_cache_path
+
+        spill_path = to_agent_visible_cache_path(spill_path)
         # read_file is 1-indexed; +2 moves past the last head line shown.
         middle_start_line = head.count("\n") + 2
         footer_lines.append(f"Full subagent output saved to: {spill_path}")
@@ -3293,6 +3296,13 @@ def delegate_task(
     live_deleg_id, live_writers, live_paths = create_live_transcripts(
         task_list, context
     )
+    if live_paths:
+        # Paths returned to the agent (result footer / live_transcripts field)
+        # must be readable from inside the terminal backend, not the host.
+        # The writers keep their own host paths for the actual file I/O.
+        from tools.credential_files import to_agent_visible_cache_path
+
+        live_paths = [to_agent_visible_cache_path(p) for p in live_paths]
 
     # Capture the ORIGINATING session's wake target BEFORE any child agent is
     # constructed: _build_child_agent() -> AIAgent() -> agent_init calls

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -553,6 +553,9 @@ def _truncate_with_footer(
         f"of {total:,} total clean characters.",
     ]
     if stored_path:
+        from tools.credential_files import to_agent_visible_cache_path
+
+        stored_path = to_agent_visible_cache_path(stored_path)
         # The omitted middle begins right after the head we're showing. Give
         # the model a concrete starting line (head line count + 1) so its first
         # read_file lands in the gap instead of guessing <line>. read_file is


### PR DESCRIPTION
Fixes https://github.com/NousResearch/hermes-agent/issues/81984

When `delegate_task` subagent summaries are truncated, or `web_extract` truncates a long page, the footer prints a `read_file path="..."` hint with the **host** absolute cache path (e.g. `~/.hermes/cache/...`). Inside docker/modal/ssh terminal backends the cache dirs are mounted at a different path (`/root/.hermes` for docker), so an agent following the hint gets "File not found" and re-dispatches work unnecessarily.

## Changes
Wrap the printed paths with the existing `to_agent_visible_cache_path()` helper (`tools/credential_files.py`, TERMINAL_ENV-aware) at all three message sites:
- `tools/delegate_tool.py::_trim_summary_with_footer` — spill path + `read_file` hint
- `tools/delegate_tool.py` — `live_transcripts` display list (the writers keep their host paths for the actual file I/O)
- `tools/web_tools.py::_truncate_with_footer` — "Full text saved to:" + `read_file` hint

The helper maps to `/root/.hermes` for docker/modal, `~/.hermes` for ssh/daytona/vercel_sandbox, and no-ops for local/singularity backends (host path stays correct).

## Verification
- `tests/tools/test_delegate_spill_path_translation.py` (new): docker footer shows `/root/.hermes` not the host path; local keeps the host path; live transcripts map identically.
- `tests/tools/test_web_tools_truncate.py` (new case): docker backend footer + read_file hint use the container-mapped path.
- Existing delegate/web/credential suites — 63 passed; ruff clean.