### PR TITLE
fix(agent): keep native compaction checkpoints out of the thinking-only drop

### DIFF
--- a/agent/native_compaction.py
+++ b/agent/native_compaction.py
@@ -156,6 +156,22 @@ def is_native_compaction_rejection(error: Any) -> bool:
     return "context_management" in text or "compact_threshold" in text
 
 
+def has_compaction_checkpoint(items: Any) -> bool:
+    """Does this ``codex_reasoning_items`` sidecar carry a compaction checkpoint?
+
+    A ``type: "compaction"`` item is the server-side stand-in for history that
+    has already been pruned — cumulative context, not per-turn reasoning. It
+    rides the same sidecar as ordinary reasoning items, so anything that
+    rewrites or discards that sidecar (or the message carrying it) has to ask
+    this question first: the checkpoint exists in exactly one place, and the
+    request that loses it loses the compacted history with it.
+    """
+    return any(
+        isinstance(item, dict) and item.get("type") == "compaction"
+        for item in (items if isinstance(items, list) else ())
+    )
+
+
 def merge_interim_reasoning_items(
     prior_items: Any,
     new_items: Any,
@@ -177,10 +193,6 @@ def merge_interim_reasoning_items(
         if isinstance(item, dict) and item.get("type") == "compaction"
     ]
     new_list = list(new_items) if isinstance(new_items, list) else []
-    new_has_checkpoint = any(
-        isinstance(item, dict) and item.get("type") == "compaction"
-        for item in new_list
-    )
-    if new_has_checkpoint or not kept_checkpoints:
+    if has_compaction_checkpoint(new_list) or not kept_checkpoints:
         return new_list
     return kept_checkpoints + new_list

--- a/run_agent.py
+++ b/run_agent.py
@@ -4657,6 +4657,16 @@ class AIAgent:
         # empty-turn handling instead of being dropped here.
         codex_items = msg.get("codex_reasoning_items")
         if drop_codex_reasoning_items and isinstance(codex_items, list):
+            # A native compaction checkpoint rides this same sidecar and is
+            # the server-side stand-in for already-pruned history. Dropping
+            # the turn takes the checkpoint with it — the request then carries
+            # neither the compacted history nor the checkpoint that replaces
+            # it. Compaction pruning filters items for this reason rather than
+            # popping the key; a carrier is never thinking-only.
+            from agent.native_compaction import has_compaction_checkpoint
+
+            if has_compaction_checkpoint(codex_items):
+                return False
             return any(
                 isinstance(item, dict) and item.get("type") == "reasoning"
                 for item in codex_items

--- a/tests/run_agent/test_thinking_only_sanitizer.py
+++ b/tests/run_agent/test_thinking_only_sanitizer.py
@@ -134,3 +134,50 @@ class TestDropThinkingOnlyAndMergeUsers:
         assert out[0]["role"] == "system"
         assert out[1]["role"] == "user"
         assert out[1]["content"] == "u1\n\nu2"
+
+
+# ---------------------------------------------------------------------------
+# Native compaction checkpoints ride the same sidecar
+# ---------------------------------------------------------------------------
+
+
+class TestCompactionCheckpointCarrier:
+    """``type: "compaction"`` items are cumulative context, not per-turn
+    reasoning: they stand in for history the server already pruned, and they
+    exist in exactly one place. Compaction pruning filters the sidecar rather
+    than popping it so they survive on every retained message; dropping the
+    carrier message defeats that from the other direction.
+    """
+
+    CHECKPOINT = {"type": "compaction", "encrypted_content": "ckpt"}
+    REASONING = {"type": "reasoning", "encrypted_content": "per-turn"}
+
+    def _carrier(self, items):
+        return {"role": "assistant", "content": "", "codex_reasoning_items": list(items)}
+
+    def test_reasoning_only_carrier_is_still_thinking_only(self):
+        """The existing contract is unchanged for ordinary reasoning turns."""
+        assert AIAgent._is_thinking_only_assistant(self._carrier([self.REASONING]))
+
+    def test_checkpoint_alongside_reasoning_is_not_thinking_only(self):
+        msg = self._carrier([self.REASONING, self.CHECKPOINT])
+        assert not AIAgent._is_thinking_only_assistant(msg)
+
+    def test_checkpoint_order_does_not_matter(self):
+        msg = self._carrier([self.CHECKPOINT, self.REASONING])
+        assert not AIAgent._is_thinking_only_assistant(msg)
+
+    def test_checkpoint_survives_the_sanitizer_pass(self):
+        msgs = [
+            {"role": "user", "content": "u1"},
+            self._carrier([self.REASONING, self.CHECKPOINT]),
+            {"role": "user", "content": "u2"},
+        ]
+        out = AIAgent._drop_thinking_only_and_merge_users(msgs)
+        surviving = [
+            item
+            for m in out
+            for item in (m.get("codex_reasoning_items") or [])
+            if item.get("type") == "compaction"
+        ]
+        assert surviving == [self.CHECKPOINT]


### PR DESCRIPTION
## What

`codex_reasoning_items` carries two different kinds of thing. Most items are per-turn reasoning — encrypted blobs only the current turn needs to replay. A `type: "compaction"` item is something else entirely: the server-side stand-in for history the provider has already pruned, a cumulative context carrier that exists in exactly one place.

e00965a7e (2026-08-08, fix(compression): correct prune boundary + exempt native compaction checkpoints) drew that distinction on the compaction side. Pruning stale replay state now filters the sidecar instead of popping the key, precisely so checkpoints "must survive on every retained message". The same commit fixed one sibling in the class — the incomplete-continuation dedup path that blind-overwrote the sidecar and "would drop the only copy of a checkpoint captured on the earlier response".

The thinking-only sanitizer reaches that same sidecar from the other direction, and it is still asking the coarse question:

```python
codex_items = msg.get("codex_reasoning_items")
if drop_codex_reasoning_items and isinstance(codex_items, list):
    return any(
        isinstance(item, dict) and item.get("type") == "reasoning"
        for item in codex_items
    )
```

A Codex commentary turn persists with `content: ""` by design and can carry both a reasoning item and a checkpoint. It answers yes, so `_drop_thinking_only_and_merge_users` removes the whole message from the wire copy — and the checkpoint with it. Filtering the sidecar carefully does not help if something later deletes the message holding it.

The result is silent: the request carries neither the compacted history nor the checkpoint that stands in for it, and the next request balloons back to full history — the same end state the merge fix was written to prevent, reached by deleting the carrier rather than overwriting it.

Driving `drop_thinking_only_and_merge_users` over a three-message transcript:

| sidecar on the assistant turn | carrier kept | checkpoint survives |
| --- | --- | --- |
| reasoning only | no | — |
| checkpoint only | yes | yes |
| reasoning + checkpoint | **no** | **no** |

The middle row is what makes this a gap rather than a design choice: a checkpoint alone already keeps the turn alive, via the structural-payload guard in `repair_empty_non_final_messages`. Only the combination loses it.

## The fix

Extract `has_compaction_checkpoint()` into `agent/native_compaction.py` — the module that owns the concept, and where `merge_interim_reasoning_items()` already spelled the same predicate inline — and consult it before the thinking-only verdict. A carrier is never thinking-only.

`merge_interim_reasoning_items()` now calls the shared predicate instead of its own copy, so the two places that have to recognise a checkpoint agree by construction.

Behaviour for ordinary reasoning turns is unchanged: a reasoning-only carrier is still dropped, which is what keeps Anthropic from rejecting a trailing thinking block.

## Tests and results

New `TestCompactionCheckpointCarrier` in `tests/run_agent/test_thinking_only_sanitizer.py` — 4 cases:

- a reasoning-only carrier is still thinking-only (the existing contract)
- a checkpoint alongside a reasoning item is not
- order within the sidecar does not matter
- the checkpoint survives a full `_drop_thinking_only_and_merge_users` pass

Reverting only the two source files turns three of them red — the carrier is judged thinking-only and the checkpoint disappears from the pass — while the ten pre-existing tests in that file stay green.

`test_thinking_only_sanitizer.py`, `test_stale_replay_prune.py`, `test_prompt_caching.py`, `test_context_engine_select_context.py` — 49 passed. `tests/run_agent/test_native_compaction.py`, which covers `merge_interim_reasoning_items` — 31 passed.
