### PR TITLE
fix(desktop): validate OAuth provider before model switch

### DIFF
--- a/apps/desktop/src/store/onboarding.test.ts
+++ b/apps/desktop/src/store/onboarding.test.ts
@@ -7,6 +7,7 @@ import {
   $desktopOnboarding,
   type DesktopOnboardingState,
   type OnboardingContext,
+  recheckExternalSignin,
   refreshOnboarding,
   requestDesktopOnboarding,
   saveOnboardingLocalEndpoint,
@@ -415,6 +416,172 @@ describe('OAuth onboarding', () => {
     expect(optionsIndex).toBeGreaterThanOrEqual(0)
     expect(recommendedIndex).toBeGreaterThan(optionsIndex)
     expect(setIndex).toBeGreaterThan(recommendedIndex)
+  })
+
+  it('validates Claude Code as Anthropic before persisting its model assignment', async () => {
+    const model = 'claude-opus-4-6'
+    const events: string[] = []
+
+    installApiMock(async ({ path }: { path: string }) => {
+      if (path.startsWith('/api/model/options')) {
+        return {
+          providers: [{ name: 'Anthropic', slug: 'anthropic', models: [model] }]
+        }
+      }
+
+      if (path.startsWith('/api/model/recommended-default?')) {
+        return { provider: 'anthropic', model }
+      }
+
+      if (path === '/api/model/set') {
+        events.push('model.set')
+
+        return { ok: true, provider: 'anthropic', model, gateway_tools: [] }
+      }
+
+      throw new Error(`unexpected api path: ${path}`)
+    })
+
+    const requestGateway: OnboardingContext['requestGateway'] = async (method, params) => {
+      if (method === 'reload.env') {
+        return {} as never
+      }
+
+      if (method === 'setup.status') {
+        return { provider_configured: true } as never
+      }
+
+      if (method === 'setup.runtime_check') {
+        events.push('runtime.check')
+        expect(params).toEqual({ provider: 'anthropic' })
+
+        return { ok: true, provider: 'anthropic' } as never
+      }
+
+      throw new Error(`unexpected gateway method: ${method}`)
+    }
+
+    $desktopOnboarding.set(
+      baseState({
+        flow: {
+          status: 'external_pending',
+          provider: { ...provider('claude-code', 'Claude Code'), flow: 'external' },
+          copied: false
+        }
+      })
+    )
+
+    await recheckExternalSignin(onboardingContext(requestGateway))
+
+    expect(events).toEqual(['runtime.check', 'model.set'])
+    expect($desktopOnboarding.get().flow).toMatchObject({
+      status: 'confirming_model',
+      providerSlug: 'anthropic',
+      currentModel: model
+    })
+  })
+
+  it('does not overwrite the current model when Claude Code lacks Anthropic credentials', async () => {
+    const paths: string[] = []
+
+    installApiMock(async ({ path }: { path: string }) => {
+      paths.push(path)
+
+      if (path.startsWith('/api/model/options')) {
+        return {
+          providers: [{ name: 'Anthropic', slug: 'anthropic', models: ['claude-opus-4-6'] }]
+        }
+      }
+
+      if (path.startsWith('/api/model/recommended-default?')) {
+        return { provider: 'anthropic', model: 'claude-opus-4-6' }
+      }
+
+      throw new Error(`unexpected api path: ${path}`)
+    })
+
+    const requestGateway: OnboardingContext['requestGateway'] = async (method, params) => {
+      if (method === 'reload.env') {
+        return {} as never
+      }
+
+      if (method === 'setup.status') {
+        return { provider_configured: true } as never
+      }
+
+      if (method === 'setup.runtime_check') {
+        expect(params).toEqual({ provider: 'anthropic' })
+
+        return { ok: false, error: 'No Anthropic credentials found.' } as never
+      }
+
+      throw new Error(`unexpected gateway method: ${method}`)
+    }
+
+    const claudeCode = { ...provider('claude-code', 'Claude Code'), flow: 'external' as const }
+    $desktopOnboarding.set(
+      baseState({
+        flow: { status: 'external_pending', provider: claudeCode, copied: false }
+      })
+    )
+
+    await recheckExternalSignin(onboardingContext(requestGateway))
+
+    expect(paths).not.toContain('/api/model/set')
+    expect($desktopOnboarding.get().flow).toMatchObject({
+      status: 'error',
+      provider: claudeCode,
+      message: expect.stringContaining('No Anthropic credentials found.')
+    })
+  })
+
+  it('does not fall back to an unrelated provider when the authenticated provider has no model options', async () => {
+    const paths: string[] = []
+
+    installApiMock(async ({ path }: { path: string }) => {
+      paths.push(path)
+
+      if (path.startsWith('/api/model/options')) {
+        return {
+          providers: [{ name: 'OpenAI Codex', slug: 'openai-codex', models: ['gpt-5.6-sol'] }]
+        }
+      }
+
+      throw new Error(`unexpected api path: ${path}`)
+    })
+
+    const requestGateway: OnboardingContext['requestGateway'] = async (method, params) => {
+      if (method === 'reload.env') {
+        return {} as never
+      }
+
+      if (method === 'setup.status') {
+        return { provider_configured: true } as never
+      }
+
+      if (method === 'setup.runtime_check') {
+        expect(params).toEqual({ provider: 'anthropic' })
+
+        return { ok: true, provider: 'anthropic' } as never
+      }
+
+      throw new Error(`unexpected gateway method: ${method}`)
+    }
+
+    $desktopOnboarding.set(
+      baseState({
+        flow: {
+          status: 'external_pending',
+          provider: { ...provider('claude-code', 'Claude Code'), flow: 'external' },
+          copied: false
+        }
+      })
+    )
+
+    await recheckExternalSignin(onboardingContext(requestGateway))
+
+    expect(paths).not.toContain('/api/model/set')
+    expect($desktopOnboarding.get().configured).toBe(true)
   })
 })
 

--- a/apps/desktop/src/store/onboarding.ts
+++ b/apps/desktop/src/store/onboarding.ts
@@ -229,11 +229,10 @@ function notifyGatewayTools(tools: string[] | undefined) {
 // are now authenticated. Pick the first curated model for the matching
 // provider as a sensible default, persist it via /api/model/set, and
 // transition to the model-confirmation step. If anything goes wrong
-// fetching options (no providers returned, network error), the caller
+// fetching options (no matching provider, network error), the caller
 // falls through to completing onboarding without showing the confirm
-// card — the user gets the undefined-model auto-selection behaviour
-// we had before, which works but is surprising. The confirm step is
-// opportunistic polish, not a hard requirement for onboarding.
+// card. Never fall back to a different provider: doing so can overwrite
+// an otherwise working model assignment after an unrelated OAuth flow.
 async function fetchProviderDefaultModel(
   preferredSlugs: string[]
 ): Promise<null | { providerSlug: string; defaultModel: string }> {
@@ -251,13 +250,15 @@ async function fetchProviderDefaultModel(
     return null
   }
 
-  // Try each preferred slug (lowercased), fall back to the first provider
-  // returned (model.options orders by recency / authenticated state, so
-  // the just-authenticated provider is usually first anyway).
+  // Match only the provider that was just authenticated. model.options may
+  // contain other configured providers, but selecting one of those would turn
+  // an unrelated OAuth flow into a destructive model-provider switch.
   const lower = preferredSlugs.map(s => s.toLowerCase())
+  const matched = providers.find((p: ModelOptionProvider) => lower.includes(String(p.slug).toLowerCase()))
 
-  const matched =
-    providers.find((p: ModelOptionProvider) => lower.includes(String(p.slug).toLowerCase())) ?? providers[0]
+  if (!matched) {
+    return null
+  }
 
   const models = matched.models ?? []
 
@@ -312,11 +313,17 @@ async function completeWithModelConfirm(
   await ctx.requestGateway('reload.env').catch(() => undefined)
 
   const defaults = await fetchProviderDefaultModel(preferredSlugs)
+  const runtime = await checkRuntime(ctx, preferredSlugs[0])
+
+  if (!runtime.ready && !ignoreRuntimeGate) {
+    onFail(runtime.reason)
+
+    return
+  }
 
   if (defaults) {
-    // Persist the chosen provider/model before the runtime gate so a stale
-    // config provider (e.g. anthropic from a prior failed setup) cannot make
-    // setup.runtime_check validate the wrong backend after a fresh OAuth login.
+    // The scoped runtime check above proves the authenticated provider is
+    // executable before this mutates the user's current model assignment.
     try {
       const res = await setModelAssignment({
         scope: 'main',
@@ -326,17 +333,9 @@ async function completeWithModelConfirm(
 
       notifyGatewayTools(res.gateway_tools)
     } catch {
-      // Persistence failed — still run the scoped runtime check below and
-      // show the confirm card so the user can pick something explicitly.
+      // Persistence failed after validation — still show the confirm card so
+      // the user can pick something explicitly.
     }
-  }
-
-  const runtime = await checkRuntime(ctx, preferredSlugs[0])
-
-  if (!runtime.ready && !ignoreRuntimeGate) {
-    onFail(runtime.reason)
-
-    return
   }
 
   if (!defaults) {
@@ -363,6 +362,14 @@ function providerResolutionFailure(reason: null | string) {
   return detail
     ? `Connected, but Hermes still cannot resolve a usable provider. ${detail}`
     : 'Connected, but Hermes still cannot resolve a usable provider.'
+}
+
+// Claude Code is a synthetic OAuth account in the Desktop provider list; the
+// executable model provider is Anthropic. Keep this translation at the flow
+// boundary so runtime validation targets Anthropic before any model assignment
+// is persisted.
+function modelProviderSlugs(provider: OAuthProvider): string[] {
+  return [provider.id === 'claude-code' ? 'anthropic' : provider.id]
 }
 
 async function refreshProviders() {
@@ -733,7 +740,7 @@ export async function recheckExternalSignin(ctx: OnboardingContext) {
   }
 
   const { provider } = flow
-  await completeWithModelConfirm(ctx, provider.name, [provider.id], reason =>
+  await completeWithModelConfirm(ctx, provider.name, modelProviderSlugs(provider), reason =>
     setFlow({
       status: 'error',
       provider,


### PR DESCRIPTION
## What changed

- map the Desktop-only `claude-code` account id to the executable `anthropic` model provider
- validate that scoped runtime before writing `/api/model/set`
- stop falling back to the first unrelated provider when the authenticated provider is absent from model options
- add success, missing-credential, ordering, and unrelated-provider regressions

## Root cause

The previous fix persisted `provider=anthropic` before `setup.runtime_check` proved that Claude Code credentials were actually available. A failed external sign-in could therefore replace a working provider assignment with Anthropic and strand Desktop in a repeated `No Anthropic credentials found` error. The model-options fallback could also switch to an unrelated first provider.

## User impact

Failed Claude Code authentication now leaves the user's working model/provider untouched and reports the real credential error. Successful authentication still selects Anthropic, but only after runtime readiness is confirmed.

## Validation

- `npx vitest run --project ui src/store/onboarding.test.ts` (17 passed)
- `npm run typecheck`
- `npx eslint src/store/onboarding.ts src/store/onboarding.test.ts`
- `npm run test:ui` (404 files, 3617 tests passed)
