### PR TITLE
fix(read_file): short PDF dividers no longer fold into blank-page gaps

### DIFF
--- a/tests/tools/test_delegate_spill_path_translation.py
+++ b/tests/tools/test_delegate_spill_path_translation.py
@@ -1,0 +1,54 @@
+"""Truncation footers must surface backend-readable cache paths, not host paths.
+
+When the terminal backend is docker/modal/ssh the cache dirs are mounted at a
+different path than the host path (e.g. /root/.hermes for docker), so a footer
+advertising the host path makes read_file from inside the sandbox fail with
+"File not found" and forces unnecessary re-dispatch.
+"""
+
+import os
+import tempfile
+
+import pytest
+
+import tools.delegate_tool as dt
+
+
+def test_delegate_summary_footer_translates_path_for_docker_backend(monkeypatch):
+    with tempfile.TemporaryDirectory() as td:
+        monkeypatch.setenv("HERMES_HOME", os.path.join(td, ".hermes"))
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        model_text, spill_path = dt._trim_summary_with_footer("X" * 50_000, 1000, 0)
+
+        assert spill_path.startswith("/root/.hermes/"), spill_path
+        assert str(td) not in spill_path
+        assert "Full subagent output saved to: " in model_text
+        assert f'read_file path="{spill_path}"' in model_text
+
+
+def test_delegate_summary_footer_keeps_host_path_on_local_backend(monkeypatch):
+    with tempfile.TemporaryDirectory() as td:
+        monkeypatch.setenv("HERMES_HOME", os.path.join(td, ".hermes"))
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        model_text, spill_path = dt._trim_summary_with_footer("X" * 50_000, 1000, 0)
+
+        assert spill_path.startswith(os.path.join(td, ".hermes")), spill_path
+        assert os.path.exists(spill_path)
+        assert f'read_file path="{spill_path}"' in model_text
+
+
+def test_delegate_live_transcripts_translate_for_docker_backend(monkeypatch):
+    with tempfile.TemporaryDirectory() as td:
+        monkeypatch.setenv("HERMES_HOME", os.path.join(td, ".hermes"))
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        from tools.credential_files import to_agent_visible_cache_path
+        from tools.delegation_live_log import create_live_transcripts
+
+        _, _, paths = create_live_transcripts([{"goal": "hello"}], delegation_id="test-xyz")
+        if not paths:
+            pytest.skip("live transcripts disabled in this environment")
+        # delegate_tool translates each display path through the same helper.
+        visible = [to_agent_visible_cache_path(p) for p in paths]
+        for p in visible:
+            assert p.startswith("/root/.hermes/"), p
+            assert str(td) not in p

--- a/tests/tools/test_read_extract.py
+++ b/tests/tools/test_read_extract.py
@@ -739,11 +739,30 @@ class TestPdfCoverageNote(unittest.TestCase):
         note = self._note_with_counts([900, 800, 700, 0, 0, 3, 0, 0, 0])
         self.assertIn("EXTRACTION COVERAGE WARNING", note)
         self.assertIn("6 of 9 pages", note)
-        self.assertIn("pages 4-9", note)        # contiguous empty gap
-        self.assertIn("(6 pages)", note)        # gap size stated
+        self.assertIn("pages 4-5", note)        # blank gap before the divider
+        self.assertIn("pages 7-9", note)        # blank gap after the divider
         self.assertIn("vision_analyze", note)   # recovery path is named
         self.assertIn("ocr-and-documents", note)
         self.assertIn("do NOT OCR or render everything", note)
+
+    def test_short_divider_page_splits_and_labels_gap(self):
+        """A short nonblank divider (e.g. "Exhibit A", under
+        PDF_EMPTY_PAGE_CHARS chars) is sparse for the warning threshold
+        but must stay OUTSIDE the following blank range so it can label
+        that range — it must not be folded into the unreadable span."""
+        from tools import read_extract
+        texts = [
+            "Long unrelated body on the first page with plenty of text",
+            "Exhibit A",
+            "",
+            "",
+        ]
+        with mock.patch.object(read_extract, "_pdf_page_texts",
+                               return_value=texts):
+            note = read_extract._pdf_coverage_note("/x/doc.pdf")
+        # The divider is a separate range boundary, not part of the gap.
+        self.assertIn('pages 3-4 (2 pages) — after "Exhibit A" (p2)', note)
+        self.assertNotIn("pages 2-4", note)
 
     def test_gap_labels_carry_preceding_section_text(self):
         """Each gap is labeled with the last text page before it (usually

--- a/tests/tools/test_web_tools_truncate.py
+++ b/tests/tools/test_web_tools_truncate.py
@@ -54,6 +54,21 @@ class TestTruncation:
         assert "UNIQUE_MIDDLE_MARKER" in full
         assert "row 2500" in full  # the omitted-middle row is in the stored file
 
+    def test_truncation_footer_translates_path_for_docker_backend(self, tmp_path, monkeypatch):
+        """Inside docker/modal backends the footer must show the container-mapped
+        cache path (readable by read_file), not the host path (which dangles)."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        body = "\n".join(f"row {i}" for i in range(5000))
+        out, truncated = wt._truncate_with_footer(body, "https://example.com/doc", 3000)
+        assert truncated is True
+        path_line = next(ln for ln in out.splitlines() if "Full text saved to:" in ln)
+        shown = path_line.split("Full text saved to:", 1)[1].strip()
+        assert shown.startswith("/root/.hermes/"), shown
+        assert str(tmp_path) not in shown
+        hint_line = next(ln for ln in out.splitlines() if 'read_file path=' in ln)
+        assert f'read_file path="{shown}"' in hint_line
+
 
 class TestCharLimitConfig:
     def test_default_when_unset(self):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2184,6 +2184,9 @@ def _trim_summary_with_footer(
         f"of {original_len:,} total — trimmed to protect the parent's context window.",
     ]
     if spill_path:
+        from tools.credential_files import to_agent_visible_cache_path
+
+        spill_path = to_agent_visible_cache_path(spill_path)
         # read_file is 1-indexed; +2 moves past the last head line shown.
         middle_start_line = head.count("\n") + 2
         footer_lines.append(f"Full subagent output saved to: {spill_path}")
@@ -3628,6 +3631,13 @@ def delegate_task(
     live_deleg_id, live_writers, live_paths = create_live_transcripts(
         task_list, context
     )
+    if live_paths:
+        # Paths returned to the agent (result footer / live_transcripts field)
+        # must be readable from inside the terminal backend, not the host.
+        # The writers keep their own host paths for the actual file I/O.
+        from tools.credential_files import to_agent_visible_cache_path
+
+        live_paths = [to_agent_visible_cache_path(p) for p in live_paths]
 
     # Capture the ORIGINATING session's wake target BEFORE any child agent is
     # constructed: _build_child_agent() -> AIAgent() -> agent_init calls

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1959,6 +1959,9 @@ def _trim_summary_with_footer(
         f"of {original_len:,} total — trimmed to protect the parent's context window.",
     ]
     if spill_path:
+        from tools.credential_files import to_agent_visible_cache_path
+
+        spill_path = to_agent_visible_cache_path(spill_path)
         # read_file is 1-indexed; +2 moves past the last head line shown.
         middle_start_line = head.count("\n") + 2
         footer_lines.append(f"Full subagent output saved to: {spill_path}")
@@ -3293,6 +3296,13 @@ def delegate_task(
     live_deleg_id, live_writers, live_paths = create_live_transcripts(
         task_list, context
     )
+    if live_paths:
+        # Paths returned to the agent (result footer / live_transcripts field)
+        # must be readable from inside the terminal backend, not the host.
+        # The writers keep their own host paths for the actual file I/O.
+        from tools.credential_files import to_agent_visible_cache_path
+
+        live_paths = [to_agent_visible_cache_path(p) for p in live_paths]
 
     # Capture the ORIGINATING session's wake target BEFORE any child agent is
     # constructed: _build_child_agent() -> AIAgent() -> agent_init calls

--- a/tools/read_extract.py
+++ b/tools/read_extract.py
@@ -274,13 +274,21 @@ def _gap_map(counts: list[int], texts: list[str], empty: list[int]) -> str:
     before it (usually a section divider/header page), so the agent can
     decide WHICH gaps it actually needs to read instead of OCRing all of
     them."""
-    ranges = _group_ranges(empty)
+    # Sparse-page eligibility and gap boundaries are different decisions:
+    # a SHORT but nonblank divider (e.g. "Exhibit A", fewer than
+    # PDF_EMPTY_PAGE_CHARS chars) still counts toward the sparse threshold,
+    # but it must stay OUTSIDE the following blank range so it can act as
+    # that range's label. Only truly-blank pages group into ranges; any
+    # nonblank page splits them.
+    ranges = _group_ranges([p for p in empty if counts[p - 1] == 0])
     lines: list[str] = []
     for a, b in ranges[:PDF_GAP_MAP_MAX_ENTRIES]:
         label = ""
-        # Walk back to the nearest preceding page with text.
+        # Walk back to the nearest preceding page with ANY text (blank pages
+        # are already grouped into ranges, so this stops at a divider or a
+        # >= PDF_EMPTY_PAGE_CHARS text page — either labels the gap).
         for prev in range(a - 2, -1, -1):
-            if counts[prev] >= PDF_EMPTY_PAGE_CHARS:
+            if counts[prev] > 0:
                 snippet = " ".join(texts[prev].split())[:_GAP_CONTEXT_CHARS]
                 label = f' — after "{snippet}" (p{prev + 1})'
                 break

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -560,6 +560,9 @@ def _truncate_with_footer(
         f"of {total:,} total clean characters.",
     ]
     if stored_path:
+        from tools.credential_files import to_agent_visible_cache_path
+
+        stored_path = to_agent_visible_cache_path(stored_path)
         # The omitted middle begins right after the head we're showing. Give
         # the model a concrete starting line (head line count + 1) so its first
         # read_file lands in the gap instead of guessing <line>. read_file is

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -553,6 +553,9 @@ def _truncate_with_footer(
         f"of {total:,} total clean characters.",
     ]
     if stored_path:
+        from tools.credential_files import to_agent_visible_cache_path
+
+        stored_path = to_agent_visible_cache_path(stored_path)
         # The omitted middle begins right after the head we're showing. Give
         # the model a concrete starting line (head line count + 1) so its first
         # read_file lands in the gap instead of guessing <line>. read_file is


### PR DESCRIPTION
Rebased onto current `main`, verified, tests green.

**What changed**
1. **Truncation footers print backend-readable cache paths** (absorbed #82107, which has been closed as a duplicate of this PR): the footer paths in `web_extract` and `delegate_task` spill translations are passed through `to_agent_visible_cache_path` so Docker/Modal/SSH backends show a path the agent's `read_file` can actually resolve.
2. **Short PDF divider pages no longer fold into blank-page gaps**: in `_gap_map`, a short-but-nonblank divider (`< PDF_EMPTY_PAGE_CHARS` chars, e.g. "Exhibit A") is excluded from the blank range it precedes, so it labels that range instead of being hidden inside it.

**Surface area** — `tools/read_extract.py`, `tools/web_tools.py`, `tools/delegate_tool.py`; tests in `tests/tools/test_read_extract.py`, `tests/tools/test_web_tools_truncate.py`, `tests/tools/test_delegate_spill_path_translation.py`.

**Validation** — `.venv/bin/python -m pytest tests/tools/test_read_extract.py tests/tools/test_web_tools_truncate.py tests/tools/test_delegate_spill_path_translation.py -q` → 63 passed, 3 skipped.
