### PR TITLE
fix(desktop): keep tool rows and notices out of the HUD band

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2553,6 +2553,16 @@ button[data-slot='aui_msg-reactions'] svg {
   display: none !important;
 }
 
+/* The band is three lines of conversation over someone else's window, not a
+   transcript. Tool rows, file diffs, and background notices ("Self-improvement
+   review: patched …") are the docked app's job — here they push the actual
+   answer out of view and read as junk pinned over the app below. */
+[data-hud-shell] [data-slot='tool-block'],
+[data-hud-shell] [data-slot='file-diff-panel'],
+[data-hud-shell] [data-slot='aui_system-message-root'] {
+  display: none !important;
+}
+
 /* ── Edge flip ───────────────────────────────────────────────────────────────
    Parked in the top half of the screen (data-hud-edge='top', broadcast by
    main on move/resize), the whole HUD mirrors vertically: composer hugs the


### PR DESCRIPTION
The HUD band is a few lines of conversation floating over whatever app you're actually working in, and its height is capped. Tool blocks, file-diff panels, and background notices ("Self-improvement review: patched …") ate that budget, pushing the answer you were waiting for out of view and leaving what looked like junk pinned over the window below.

They're hidden in HUD mode now — the band renders conversation text only. Everything still shows normally in the docked app; this is a `[data-hud-shell]`-scoped rule alongside the existing header / timeline / jump-pill hides.

## Test plan

- [x] HUD band after a tool-heavy turn shows only the assistant's text
- [x] Self-improvement review notices no longer appear in the band
- [x] Docked window transcript unchanged