### PR TITLE
fix(gateway): honor approval scope capabilities

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -70,10 +70,17 @@ _api_request_profile: ContextVar[Optional[str]] = ContextVar(
     "api_server_request_profile", default=None
 )
 
-def _approval_event_choices(*, smart_denied: bool, allow_permanent: bool) -> list[str]:
-    if smart_denied:
+
+def _approval_event_choices(
+    *, smart_denied: bool, allow_session: bool, allow_permanent: bool
+) -> list[str]:
+    if smart_denied or not allow_session:
         return ["once", "deny"]
-    return ["once", "session", "always", "deny"] if allow_permanent else ["once", "session", "deny"]
+    return (
+        ["once", "session", "always", "deny"]
+        if allow_permanent
+        else ["once", "session", "deny"]
+    )
 
 
 try:
@@ -6634,6 +6641,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         "timestamp": time.time(),
                         "choices": _approval_event_choices(
                             smart_denied=bool(event.get("smart_denied")),
+                            allow_session=event.get("allow_session") is not False,
                             allow_permanent=event.get("allow_permanent") is not False,
                         ),
                     })

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -33,21 +33,27 @@ from tools import approval as approval_mod
 
 
 @pytest.mark.parametrize(
-    ("smart_denied", "allow_permanent", "expected"),
+    ("smart_denied", "allow_session", "allow_permanent", "expected"),
     [
-        (False, True, ["once", "session", "always", "deny"]),
-        (False, False, ["once", "session", "deny"]),
-        (True, True, ["once", "deny"]),
-        (True, False, ["once", "deny"]),
+        (False, True, True, ["once", "session", "always", "deny"]),
+        (False, True, False, ["once", "session", "deny"]),
+        (False, False, True, ["once", "deny"]),
+        (False, False, False, ["once", "deny"]),
+        (True, True, True, ["once", "deny"]),
+        (True, False, False, ["once", "deny"]),
     ],
 )
 def test_approval_event_choices_follow_backend_capabilities(
-    smart_denied, allow_permanent, expected
+    smart_denied, allow_session, allow_permanent, expected
 ):
-    assert _approval_event_choices(
-        smart_denied=smart_denied,
-        allow_permanent=allow_permanent,
-    ) == expected
+    assert (
+        _approval_event_choices(
+            smart_denied=smart_denied,
+            allow_session=allow_session,
+            allow_permanent=allow_permanent,
+        )
+        == expected
+    )
 
 
 def _make_adapter(api_key: str = "") -> APIServerAdapter:

--- a/tests/gateway/test_tui_approval_redaction.py
+++ b/tests/gateway/test_tui_approval_redaction.py
@@ -34,4 +34,34 @@ class TestTuiApprovalEmitRedaction:
         assert emitted["payload"]["description"] == "x"
         assert "github.com" in emitted["payload"]["command"]
 
+    @pytest.mark.parametrize(
+        ("allow_session", "allow_permanent", "expected"),
+        [
+            (True, True, ["once", "session", "always", "deny"]),
+            (True, False, ["once", "session", "deny"]),
+            (False, False, ["once", "deny"]),
+        ],
+    )
+    def test_emit_approval_request_honors_allowed_scopes(
+        self, monkeypatch, allow_session, allow_permanent, expected
+    ):
+        from tui_gateway import server as tui_server
+
+        emitted = {}
+        monkeypatch.setattr(
+            tui_server,
+            "_emit",
+            lambda event, sid, payload=None: emitted.update({"payload": payload}),
+        )
+
+        tui_server._emit_approval_request(
+            "sess-1",
+            {
+                "allow_permanent": allow_permanent,
+                "allow_session": allow_session,
+                "command": "<write to AGENTS.md>",
+            },
+        )
+
+        assert emitted["payload"]["choices"] == expected
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1834,10 +1834,14 @@ def _emit_approval_request(sid: str, data: dict | None) -> None:
     if "choices" not in payload:
         if payload.get("smart_denied"):
             payload["choices"] = ["once", "deny"]
-        elif payload.get("allow_permanent") is False:
-            payload["choices"] = ["once", "session", "deny"]
-        elif "allow_permanent" in payload:
-            payload["choices"] = ["once", "session", "always", "deny"]
+        else:
+            choices = ["once"]
+            if payload.get("allow_session") is not False:
+                choices.append("session")
+                if payload.get("allow_permanent") is not False:
+                    choices.append("always")
+            choices.append("deny")
+            payload["choices"] = choices
     if "command" in payload:
         from gateway.run import _redact_approval_command
 


### PR DESCRIPTION
## What does this PR do?

Protected instruction-file approvals are one-operation-only, but the TUI/Desktop and Runs API event adapters translated `allow_session: false` into a choice list that still included `session`. The clients then rendered a scope the backend deliberately cannot persist.

This change makes both event transports derive their choices from `allow_session` and `allow_permanent`. A request with both flags disabled now exposes only `once` and `deny`; existing session/permanent choices remain unchanged for ordinary approvals.

The frontend already treats the event's `choices` list as authoritative, so no UI-specific branch is needed.

## Related Issue

Fixes #81887

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` — honor both approval-scope capability flags when emitting TUI/Desktop approval events.
- `gateway/platforms/api_server.py` — apply the same capability mapping to Runs SSE approval events.
- Gateway tests — cover ordinary, session-disabled, permanent-disabled, and Smart DENY choice sets.

## How to Test

```bash
HERMES_PYTHON=/path/to/python scripts/run_tests.sh \
  tests/gateway/test_tui_approval_redaction.py \
  tests/gateway/test_api_server_runs.py \
  tests/tools/test_file_write_safety.py -q
```

Result: **73 passed, 0 failed**.

Additional checks passed: targeted Ruff lint, Python bytecode compilation, Windows-footgun scan on all four changed files, and `git diff --check`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched open and closed PRs and the issue timeline for duplicates
- [x] My PR contains only changes related to this fix
- [ ] I've run the entire `pytest tests/ -q` suite (focused affected suites were run instead)
- [x] I've added regression tests for the bug
- [x] I've tested on macOS arm64 with Python 3.13.13

### Documentation & Housekeeping

- [x] Documentation updates are N/A; this restores the existing approval contract
- [x] `cli-config.yaml.example` updates are N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` updates are N/A; no workflow changed
- [x] Cross-platform impact considered; the change is platform-independent choice generation
- [x] Tool descriptions/schemas are N/A; no model tool surface changed

## AI Assistance

Prepared with Codex assistance. The issue premise, current-main data flow, baseline failure, patch, focused tests, lint, and duplicate checks were all verified against commit `d408fdbfc4` before publication.
