### PR TITLE
fix(compression): charge stale thinking to the tail budget only on the newest assistant turn (#73624)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -943,6 +943,26 @@ _REPLAY_BUDGET_KEYS = (
     "codex_message_items",
 )
 
+# Subset of ``_REPLAY_BUDGET_KEYS`` that every transport replays on EVERY
+# retained assistant turn (Codex Responses items ride the wire each request;
+# message items are required for prefix-cache continuity).  The remaining
+# generic thinking-text keys (``reasoning`` / ``reasoning_content``) are
+# replayed for at most the NEWEST assistant turn on non-Codex transports —
+# Anthropic strips all-but-newest at convert time, Bedrock Converse never
+# replays thinking at all, and strict chat-completions providers either
+# reject the field or receive a one-space echo pad (#73624).  Charging them
+# on every message spent 19-24% of the tail budget on bytes that provably
+# never reach the wire, so the tail cut landed early and each compaction
+# discarded more real transcript than configured.
+_ALWAYS_REPLAYED_BUDGET_KEYS = (
+    "codex_reasoning_items",
+    "codex_message_items",
+)
+_NEWEST_TURN_ONLY_BUDGET_KEYS = (
+    "reasoning",
+    "reasoning_content",
+)
+
 # Replay keys that can be safely pruned from stale assistant messages during
 # compaction.  ``codex_reasoning_items`` carries encrypted reasoning blobs that
 # are only needed for the current turn's replay — prior-turn items are pure
@@ -988,7 +1008,7 @@ def _reasoning_details_text_chars(value: Any) -> int:
     return total
 
 
-def _estimate_msg_budget_tokens(msg: dict) -> int:
+def _estimate_msg_budget_tokens(msg: dict, charge_stale_thinking: bool = True) -> int:
     """Token estimate for one message in the tail-protection budget walks.
 
     Counts the message content plus the **full** ``tool_call`` envelope —
@@ -999,17 +1019,26 @@ def _estimate_msg_budget_tokens(msg: dict) -> int:
     tail overshot ``tail_token_budget`` and compression became ineffective.
     See issue #28053.
 
-    Also counts provider replay fields (``codex_reasoning_items`` etc. —
-    see ``_REPLAY_BUDGET_KEYS``).  The preflight "should I compress?"
-    estimator sees the full message shape, so the tail walk must use the
-    same size class; otherwise an assistant message with tiny visible
-    content but large hidden replay blobs is protected as if it were small,
-    the post-compression session stays near the context limit, and
-    compaction re-fires continuously (#55572).  Stale replay fields from
-    prior assistant turns are stripped during the compaction assembly pass
-    (``_prune_stale_reasoning_replay``, #71058).  Accounting-only here: this
-    budget walk does not mutate or prune — it counts so the tail-protection
-    boundary does not undershoot due to invisible replay payload.
+    Also counts provider replay fields.  Wire-replayed-every-turn fields
+    (``_ALWAYS_REPLAYED_BUDGET_KEYS``) are charged unconditionally: the
+    preflight "should I compress?" estimator sees the full message shape, so
+    the tail walk must use the same size class; otherwise an assistant
+    message with tiny visible content but large hidden replay blobs is
+    protected as if it were small and compaction re-fires continuously
+    (#55572).  Stale replay fields from prior assistant turns are stripped
+    during the compaction assembly pass (``_prune_stale_reasoning_replay``,
+    #71058).  Accounting-only here: this budget walk does not mutate or
+    prune.
+
+    ``charge_stale_thinking`` controls the generic thinking-text keys
+    (``_NEWEST_TURN_ONLY_BUDGET_KEYS`` + the ``reasoning_details`` text
+    charge).  Callers that know the message is NOT the newest assistant turn
+    on a transport that only replays newest-turn thinking pass ``False`` so
+    the tail budget is not spent on bytes that never reach the wire (#73624:
+    19-24% of the budget went to provably-stripped blocks, making the tail
+    cut land early and discard more real transcript than configured).
+    Default ``True`` preserves the conservative full charge for callers
+    without turn-position context.
     """
     content = msg.get("content") or ""
     if isinstance(content, str):
@@ -1020,7 +1049,11 @@ def _estimate_msg_budget_tokens(msg: dict) -> int:
     for tc in msg.get("tool_calls") or []:
         if isinstance(tc, dict):
             tokens += estimate_tokens_rough(str(tc))
-    for key in _REPLAY_BUDGET_KEYS:
+    for key in _ALWAYS_REPLAYED_BUDGET_KEYS:
+        tokens += _serialized_length_for_budget(msg.get(key)) // _CHARS_PER_TOKEN
+    if not charge_stale_thinking:
+        return tokens
+    for key in _NEWEST_TURN_ONLY_BUDGET_KEYS:
         tokens += _serialized_length_for_budget(msg.get(key)) // _CHARS_PER_TOKEN
     # reasoning_details: charge only the thinking TEXT, never the signed /
     # base64 envelope (#73298 second site; mirrors the preflight estimator's
@@ -1034,6 +1067,19 @@ def _estimate_msg_budget_tokens(msg: dict) -> int:
             // _CHARS_PER_TOKEN
         )
     return tokens
+
+
+def _last_assistant_index(messages: "List[Dict[str, Any]]") -> int:
+    """Index of the newest assistant message, or -1.
+
+    The one turn whose thinking fields every transport may still replay —
+    see ``_NEWEST_TURN_ONLY_BUDGET_KEYS``.
+    """
+    for i in range(len(messages) - 1, -1, -1):
+        msg = messages[i]
+        if isinstance(msg, dict) and msg.get("role") == "assistant":
+            return i
+    return -1
 
 
 def _content_text_for_contains(content: Any) -> str:
@@ -3116,9 +3162,15 @@ class ContextCompressor(ContextEngine):
                 len(result),
                 _MAX_TAIL_MESSAGE_FLOOR,
             )
+            # Same newest-turn-only thinking charge as the tail-cut walk
+            # (#73624) — this boundary decides which tool results stay
+            # prunable, and overcharging stale thinking shrinks that window.
+            _newest_asst_idx = _last_assistant_index(result)
             for i in range(len(result) - 1, -1, -1):
                 msg = result[i]
-                msg_tokens = _estimate_msg_budget_tokens(msg)
+                msg_tokens = _estimate_msg_budget_tokens(
+                    msg, charge_stale_thinking=(i == _newest_asst_idx)
+                )
                 if accumulated + msg_tokens > protect_tail_tokens and (len(result) - i) >= min_protect:
                     boundary = i
                     break
@@ -5468,9 +5520,17 @@ This compaction should PRIORITISE preserving all information related to the focu
         accumulated = 0
         cut_idx = n  # start from beyond the end
 
+        # Newest assistant turn: the only message whose generic thinking
+        # fields any transport still replays (#73624) — every older turn's
+        # reasoning/reasoning_content is stripped or padded at send time,
+        # so charging it here spends tail budget on bytes that never ship.
+        _newest_asst_idx = _last_assistant_index(messages)
+
         for i in range(n - 1, head_end - 1, -1):
             msg = messages[i]
-            msg_tokens = _estimate_msg_budget_tokens(msg)
+            msg_tokens = _estimate_msg_budget_tokens(
+                msg, charge_stale_thinking=(i == _newest_asst_idx)
+            )
             # Stop once we exceed the soft ceiling (unless we haven't hit min_tail yet)
             if accumulated + msg_tokens > soft_ceiling and (n - i) >= min_tail:
                 break
@@ -5496,7 +5556,9 @@ This compaction should PRIORITISE preserving all information related to the focu
             raw_accumulated = 0
             for j in range(n - 1, head_end - 1, -1):
                 raw_msg = messages[j]
-                raw_tok = _estimate_msg_budget_tokens(raw_msg)
+                raw_tok = _estimate_msg_budget_tokens(
+                    raw_msg, charge_stale_thinking=(j == _newest_asst_idx)
+                )
                 if raw_accumulated + raw_tok > raw_budget and (n - j) >= min_tail:
                     cut_idx = j
                     break

--- a/tests/agent/test_replay_budget_accounting.py
+++ b/tests/agent/test_replay_budget_accounting.py
@@ -1,0 +1,158 @@
+"""Tests for provider-aware replay-field accounting in tail-budget walks (#73624).
+
+Generic thinking fields (``reasoning`` / ``reasoning_content`` + the
+``reasoning_details`` text charge) are replayed for at most the NEWEST
+assistant turn on every transport — Anthropic strips all-but-newest at
+convert time, Bedrock never replays thinking, strict chat-completions
+providers reject or one-space-pad the field. Charging them on every message
+spent 19-24% of the tail budget on bytes that never reach the wire.
+
+Codex sidecar fields (``codex_reasoning_items`` / ``codex_message_items``)
+ARE wire-replayed on every retained turn and stay charged unconditionally
+(#55572) — including native compaction checkpoints (#81747).
+"""
+
+from agent.context_compressor import (
+    _ALWAYS_REPLAYED_BUDGET_KEYS,
+    _NEWEST_TURN_ONLY_BUDGET_KEYS,
+    _REPLAY_BUDGET_KEYS,
+    _estimate_msg_budget_tokens,
+    _last_assistant_index,
+)
+
+
+BIG_THINKING = "deliberation " * 400  # ~1.3K tokens of stale thinking text
+BIG_BLOB = [{"type": "reasoning", "encrypted_content": "x" * 4000}]
+
+
+def _assistant(thinking=False, codex=False):
+    msg = {"role": "assistant", "content": "done"}
+    if thinking:
+        msg["reasoning"] = BIG_THINKING
+        msg["reasoning_content"] = BIG_THINKING
+    if codex:
+        msg["codex_reasoning_items"] = BIG_BLOB
+    return msg
+
+
+class TestChargeStaleThinking:
+    def test_stale_turn_thinking_not_charged(self):
+        msg = _assistant(thinking=True)
+        full = _estimate_msg_budget_tokens(msg, charge_stale_thinking=True)
+        stale = _estimate_msg_budget_tokens(msg, charge_stale_thinking=False)
+        assert stale < full
+        # The delta is the thinking text — a substantial chunk, not noise.
+        assert full - stale > 300
+
+    def test_codex_sidecar_always_charged(self):
+        """Wire-replayed Codex blobs (incl. native compaction checkpoints)
+        must stay in the budget even for stale turns — #55572's invariant."""
+        msg = _assistant(codex=True)
+        full = _estimate_msg_budget_tokens(msg, charge_stale_thinking=True)
+        stale = _estimate_msg_budget_tokens(msg, charge_stale_thinking=False)
+        assert stale == full  # nothing thinking-only to drop
+        bare = _estimate_msg_budget_tokens(
+            {"role": "assistant", "content": "done"}, charge_stale_thinking=False
+        )
+        assert stale > bare + 500  # blob still charged on the stale path
+
+    def test_default_is_conservative_full_charge(self):
+        msg = _assistant(thinking=True)
+        assert _estimate_msg_budget_tokens(msg) == _estimate_msg_budget_tokens(
+            msg, charge_stale_thinking=True
+        )
+
+    def test_reasoning_details_text_skipped_on_stale_path(self):
+        msg = {
+            "role": "assistant",
+            "content": "done",
+            "reasoning_details": [
+                {"type": "reasoning.text", "text": "long plan " * 300}
+            ],
+        }
+        full = _estimate_msg_budget_tokens(msg, charge_stale_thinking=True)
+        stale = _estimate_msg_budget_tokens(msg, charge_stale_thinking=False)
+        assert stale < full
+
+
+class TestKeyPartition:
+    def test_partition_covers_replay_budget_keys_exactly(self):
+        """Invariant: the two accounting classes partition _REPLAY_BUDGET_KEYS.
+        A future key added to the replay budget must be classified."""
+        assert set(_ALWAYS_REPLAYED_BUDGET_KEYS) | set(
+            _NEWEST_TURN_ONLY_BUDGET_KEYS
+        ) == set(_REPLAY_BUDGET_KEYS)
+        assert not set(_ALWAYS_REPLAYED_BUDGET_KEYS) & set(
+            _NEWEST_TURN_ONLY_BUDGET_KEYS
+        )
+
+    def test_codex_fields_are_always_replayed_class(self):
+        assert "codex_reasoning_items" in _ALWAYS_REPLAYED_BUDGET_KEYS
+        assert "codex_message_items" in _ALWAYS_REPLAYED_BUDGET_KEYS
+
+
+class TestLastAssistantIndex:
+    def test_finds_newest_assistant(self):
+        msgs = [
+            {"role": "user", "content": "u"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "u2"},
+            {"role": "assistant", "content": "a2"},
+            {"role": "tool", "content": "t"},
+        ]
+        assert _last_assistant_index(msgs) == 3
+
+    def test_no_assistant_returns_minus_one(self):
+        assert _last_assistant_index([{"role": "user", "content": "u"}]) == -1
+        assert _last_assistant_index([]) == -1
+
+
+class TestTailCutBehavior:
+    """The tail cut must protect MORE real transcript when stale turns carry
+    heavy thinking — the #73624 symptom was the cut landing early."""
+
+    def _compressor(self):
+        from agent.context_compressor import ContextCompressor
+
+        cc = ContextCompressor(
+            model="claude-opus-5",
+            quiet_mode=True,
+            config_context_length=200_000,
+        )
+        return cc
+
+    def test_stale_thinking_does_not_shrink_tail(self):
+        cc = self._compressor()
+        # Build a transcript where every assistant turn drags huge stale
+        # thinking. Under the old accounting these bloat the walk and the
+        # cut lands early; with newest-turn-only accounting the same budget
+        # protects more messages.
+        msgs = [{"role": "system", "content": "sys"}]
+        for i in range(30):
+            msgs.append({"role": "user", "content": f"question {i}"})
+            msgs.append(
+                {
+                    "role": "assistant",
+                    "content": f"answer {i}",
+                    "reasoning": BIG_THINKING,
+                    "reasoning_content": BIG_THINKING,
+                }
+            )
+        budget = 3_000
+        cut = cc._find_tail_cut_by_tokens(msgs, 1, token_budget=budget)
+
+        # Compute what the OLD accounting (charge everything) would protect.
+        old_accumulated = 0
+        old_cut = len(msgs)
+        soft = int(budget * 1.5)
+        for i in range(len(msgs) - 1, 0, -1):
+            t = _estimate_msg_budget_tokens(msgs[i], charge_stale_thinking=True)
+            if old_accumulated + t > soft and (len(msgs) - i) >= 3:
+                break
+            old_accumulated += t
+            old_cut = i
+
+        # New accounting must protect at least as much transcript (lower cut
+        # index = more messages in the tail), and strictly more here because
+        # the stale thinking dominates each message's old-cost.
+        assert cut < old_cut


### PR DESCRIPTION
## Summary

The compaction tail-budget walks now charge generic thinking fields (`reasoning` / `reasoning_content` / `reasoning_details` text) only for the newest assistant turn, so the same tail budget protects more real transcript (#73624 measured 19-24% of the budget going to blocks no adapter replays).

Root cause: `_estimate_msg_budget_tokens` charged `_REPLAY_BUDGET_KEYS` on every message, but only Codex sidecar fields ride the wire on every retained turn — Anthropic strips all-but-newest thinking at convert time, Bedrock Converse never replays thinking, and strict chat-completions providers reject or one-space-pad the field. The overcharge made the tail cut land early, discarding more real conversation per compaction than configured.

This is accounting-only: **no reasoning field is pruned or mutated anywhere** — retained history keeps all reasoning carriers intact for provider replay (standing policy; only the compaction-scrubbed block ever drops content, plus the #71058 codex-items exception).

## Changes

- `agent/context_compressor.py`: `_REPLAY_BUDGET_KEYS` partitioned into `_ALWAYS_REPLAYED_BUDGET_KEYS` (codex items — includes native compaction checkpoints from #81747, charged unconditionally per #55572) and `_NEWEST_TURN_ONLY_BUDGET_KEYS` (thinking text). `_estimate_msg_budget_tokens(charge_stale_thinking=...)` gates the latter; the three budget walks (tail cut, raw-budget re-walk, proactive-prune boundary) resolve turn position via `_last_assistant_index()`. Default remains the conservative full charge.
- Tests: `tests/agent/test_replay_budget_accounting.py` — 9 tests incl. a partition invariant (any future replay-budget key must be classified into exactly one class) and an end-to-end tail-cut comparison showing the cut protects strictly more transcript under stale-thinking load.

Direction credit: #73669 (@x7peeps) and #73730 (@webtecnica) — both keep_open reviews asked for exactly this shape (provider-aware accounting that keeps Codex carriers charged).

## Validation

| | Result |
|---|---|
| New tests | 9/9 |
| Sabotage run (revert to always-charge) | 2 tests fail, as designed |
| Sibling suites (context_compressor, stale_replay_prune, 413_compression) | 182/182 |
| Attribution audit | clean |

## Infographic

![Honest tail budget](https://v3b.fal.media/files/b/0aa59450/AGrcEfRWopvxhv-jPL7DI_mu2s3G7e.png)
