### PR TITLE
fix(desktop): allow get-windows and electron install scripts on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,8 +71,9 @@
     "node-pty@1.1.0": true,
     "electron-winstaller@5.4.0": true,
     "agent-browser@0.26.0": true,
-    "electron@40.10.2": true,
+    "electron@40.10.6": true,
     "fsevents@2.3.2": true,
-    "fsevents@2.3.3": true
+    "fsevents@2.3.3": true,
+    "get-windows@9.3.0": true
   }
 }


### PR DESCRIPTION
Fixes the Windows desktop install/build failure:

`Error: [stage-native-deps] get-windows has no win32 prebuilt binding under lib/binding`

## Root cause

npm >= 11.17 (the version the installer bundles) enforces the root `allowScripts` allowlist: any package whose `install`/`postinstall` script is not explicitly allowed is silently skipped. `get-windows@9.3.0` was missing from `allowScripts`, so its `install` script (`node-pre-gyp install --fallback-to-build`) never ran and the `napi-9-win32-unknown-x64` native binding was never downloaded. The desktop build then failed because the binding is required at pack time.

While here, `electron` was allowed at `40.10.2` but the workspace pins `40.10.6`, so Electron's `postinstall` (`node install.js`) was also being blocked.

## Change

- Add `"get-windows@9.3.0": true` to `allowScripts`
- Bump `"electron@40.10.2"` to `"electron@40.10.6"`

## Verification

On a fresh Windows install, `npm rebuild get-windows --foreground-scripts` downloads the win32 binding, the desktop `npm run pack` passes, and the full installer completes with:

`[stage-native-deps] staged get-windows (win32)`