### PR TITLE
fix(mcp): stop context-variable servers from accessing the wrong session workspace

### DIFF
--- a/tests/tools/test_mcp_workspace_routing.py
+++ b/tests/tools/test_mcp_workspace_routing.py
@@ -1,0 +1,144 @@
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+
+def _run_on_loop(coro_or_factory, timeout=30):
+    del timeout
+    coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
+    return asyncio.run(coro)
+
+
+def _result(text):
+    return SimpleNamespace(
+        content=[SimpleNamespace(text=text)],
+        isError=False,
+        structuredContent=None,
+    )
+
+
+def test_workspace_sensitive_server_routes_each_task_to_its_workspace(monkeypatch):
+    import tools.mcp_tool as mcp_tool
+
+    roots = {
+        "session-alpha": "/projects/alpha",
+        "session-beta": "/projects/beta",
+    }
+    template = {
+        "command": "filesystem-server",
+        "args": ["${workspaceFolder}"],
+    }
+    seed = mcp_tool.MCPServerTask("filesystem")
+    seed.session = MagicMock()
+    seed._config = {
+        "command": "filesystem-server",
+        "args": ["/backend/workspace"],
+    }
+    created = []
+
+    async def fake_connect(name, config, *, publish_tools=True):
+        root = config["args"][0]
+        session = MagicMock()
+        session.call_tool = AsyncMock(return_value=_result(root))
+        server = mcp_tool.MCPServerTask(name, publish_tools=publish_tools)
+        server.session = session
+        server._config = config
+        created.append((root, publish_tools))
+        return server
+
+    monkeypatch.setattr(
+        mcp_tool,
+        "_workspace_folder",
+        lambda task_id=None: roots.get(task_id, "/backend/workspace"),
+    )
+    monkeypatch.setattr(mcp_tool, "_connect_server", fake_connect)
+    monkeypatch.setattr(mcp_tool, "_ensure_mcp_loop", lambda: None)
+    monkeypatch.setattr(mcp_tool, "_run_on_mcp_loop", _run_on_loop)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"mcp_servers": {"filesystem": template}},
+    )
+    monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_plugin_manager",
+        lambda: SimpleNamespace(get_portable_mcp_servers=lambda: {}),
+    )
+    mcp_tool._servers["filesystem"] = seed
+    mcp_tool._workspace_servers.clear()
+    mcp_tool._workspace_server_connecting.clear()
+
+    try:
+        loaded = mcp_tool._load_mcp_config()
+        assert loaded["filesystem"]["args"] == ["/backend/workspace"]
+        handler = mcp_tool._make_tool_handler("filesystem", "root", 120)
+        alpha = json.loads(handler({}, task_id="session-alpha"))["result"]
+        beta = json.loads(handler({}, task_id="session-beta"))["result"]
+        alpha_again = json.loads(handler({}, task_id="session-alpha"))["result"]
+
+        assert (alpha, beta, alpha_again) == (
+            "/projects/alpha",
+            "/projects/beta",
+            "/projects/alpha",
+        )
+        assert created == [
+            ("/projects/alpha", False),
+            ("/projects/beta", False),
+        ]
+    finally:
+        mcp_tool._servers.pop("filesystem", None)
+        mcp_tool._workspace_server_configs.clear()
+        mcp_tool._workspace_servers.clear()
+        mcp_tool._workspace_server_connecting.clear()
+
+
+def test_generated_utility_handlers_forward_the_calling_session(monkeypatch):
+    import tools.mcp_tool as mcp_tool
+
+    session = MagicMock()
+    session.list_resources = AsyncMock(
+        return_value=SimpleNamespace(resources=[])
+    )
+    session.read_resource = AsyncMock(
+        return_value=SimpleNamespace(contents=[])
+    )
+    session.list_prompts = AsyncMock(
+        return_value=SimpleNamespace(prompts=[])
+    )
+    session.get_prompt = AsyncMock(
+        return_value=SimpleNamespace(messages=[], description=None)
+    )
+    server = mcp_tool.MCPServerTask("filesystem")
+    server.session = session
+    resolved = []
+
+    def resolve(server_name, task_id=None):
+        resolved.append((server_name, task_id))
+        return server
+
+    monkeypatch.setattr(mcp_tool, "_get_connected_server_for_call", resolve)
+    monkeypatch.setattr(mcp_tool, "_run_on_mcp_loop", _run_on_loop)
+
+    handlers = [
+        (mcp_tool._make_list_resources_handler("filesystem", 120), {}),
+        (
+            mcp_tool._make_read_resource_handler("filesystem", 120),
+            {"uri": "file:///workspace/readme.md"},
+        ),
+        (mcp_tool._make_list_prompts_handler("filesystem", 120), {}),
+        (
+            mcp_tool._make_get_prompt_handler("filesystem", 120),
+            {"name": "summary", "arguments": {}},
+        ),
+    ]
+    for handler, args in handlers:
+        assert "error" not in json.loads(
+            handler(args, session_id="workspace-session")
+        )
+
+    assert resolved == [
+        ("filesystem", "workspace-session"),
+        ("filesystem", "workspace-session"),
+        ("filesystem", "workspace-session"),
+        ("filesystem", "workspace-session"),
+    ]

--- a/tests/tools/test_mcp_workspace_routing.py
+++ b/tests/tools/test_mcp_workspace_routing.py
@@ -203,3 +203,25 @@ def test_shutdown_clears_workspace_scoped_circuit_breakers():
 
     assert workspace_key not in mcp_tool._server_error_counts
     assert workspace_key not in mcp_tool._server_breaker_opened_at
+
+
+def test_workspace_sensitive_check_stays_available_without_primary_transport():
+    import tools.mcp_tool as mcp_tool
+
+    name = "filesystem_check"
+    scoped = mcp_tool.MCPServerTask(name, publish_tools=False)
+    scoped.session = MagicMock()
+    scope_key = (name, "/projects/alpha")
+    with mcp_tool._lock:
+        mcp_tool._servers.pop(name, None)
+        mcp_tool._workspace_server_configs[name] = {
+            "command": "filesystem-server",
+            "args": ["${workspaceFolder}"],
+        }
+        mcp_tool._workspace_servers[scope_key] = scoped
+    try:
+        assert mcp_tool._make_check_fn(name)()
+    finally:
+        with mcp_tool._lock:
+            mcp_tool._workspace_server_configs.pop(name, None)
+            mcp_tool._workspace_servers.pop(scope_key, None)

--- a/tests/tools/test_mcp_workspace_routing.py
+++ b/tests/tools/test_mcp_workspace_routing.py
@@ -225,3 +225,39 @@ def test_workspace_sensitive_check_stays_available_without_primary_transport():
         with mcp_tool._lock:
             mcp_tool._workspace_server_configs.pop(name, None)
             mcp_tool._workspace_servers.pop(scope_key, None)
+
+
+def test_probe_cleanup_keeps_loop_for_workspace_scoped_server():
+    import tools.mcp_tool as mcp_tool
+
+    scope_key = ("filesystem_probe", "/projects/alpha")
+    scoped = MagicMock(session=object())
+    with mcp_tool._lock:
+        mcp_tool._servers.clear()
+        mcp_tool._server_connecting.clear()
+        mcp_tool._workspace_servers[scope_key] = scoped
+        mcp_tool._workspace_server_connecting.clear()
+
+    try:
+        mcp_tool._ensure_mcp_loop()
+        with mcp_tool._lock:
+            loop = mcp_tool._mcp_loop
+
+        assert mcp_tool._stop_mcp_loop_if_idle() is False
+
+        with mcp_tool._lock:
+            assert mcp_tool._mcp_loop is loop
+        assert loop is not None
+        assert loop.is_running()
+
+        with mcp_tool._lock:
+            mcp_tool._workspace_servers.pop(scope_key, None)
+            mcp_tool._workspace_server_connecting[scope_key] = MagicMock()
+
+        assert mcp_tool._stop_mcp_loop_if_idle() is False
+        assert loop.is_running()
+    finally:
+        with mcp_tool._lock:
+            mcp_tool._workspace_servers.pop(scope_key, None)
+            mcp_tool._workspace_server_connecting.pop(scope_key, None)
+        mcp_tool._stop_mcp_loop()

--- a/tests/tools/test_mcp_workspace_routing.py
+++ b/tests/tools/test_mcp_workspace_routing.py
@@ -188,3 +188,18 @@ def test_workspace_sensitive_circuit_breaker_is_scoped_by_workspace(monkeypatch)
         mcp_tool._workspace_server_configs.clear()
         mcp_tool._server_error_counts.clear()
         mcp_tool._server_breaker_opened_at.clear()
+
+
+def test_shutdown_clears_workspace_scoped_circuit_breakers():
+    import tools.mcp_tool as mcp_tool
+
+    workspace_key = ("filesystem", "/projects/alpha")
+    mcp_tool._server_error_counts[workspace_key] = (
+        mcp_tool._CIRCUIT_BREAKER_THRESHOLD
+    )
+    mcp_tool._server_breaker_opened_at[workspace_key] = 1.0
+
+    mcp_tool.shutdown_mcp_servers()
+
+    assert workspace_key not in mcp_tool._server_error_counts
+    assert workspace_key not in mcp_tool._server_breaker_opened_at

--- a/tests/tools/test_mcp_workspace_routing.py
+++ b/tests/tools/test_mcp_workspace_routing.py
@@ -261,3 +261,60 @@ def test_probe_cleanup_keeps_loop_for_workspace_scoped_server():
             mcp_tool._workspace_servers.pop(scope_key, None)
             mcp_tool._workspace_server_connecting.pop(scope_key, None)
         mcp_tool._stop_mcp_loop()
+
+
+def test_shutdown_during_scoped_connect_does_not_republish_transport(monkeypatch):
+    import tools.mcp_tool as mcp_tool
+
+    name = "filesystem_shutdown_race"
+    root = "/projects/alpha"
+    template = {
+        "command": "filesystem-server",
+        "args": ["${workspaceFolder}"],
+    }
+    config = {
+        "command": "filesystem-server",
+        "args": [root],
+    }
+    connected = mcp_tool.MCPServerTask(name, publish_tools=False)
+    connected.session = MagicMock()
+    connected._config = config
+
+    async def fake_connect(server_name, resolved, *, publish_tools=True):
+        assert server_name == name
+        assert resolved == config
+        assert publish_tools is False
+        return connected
+
+    def connect_then_shutdown(coro_or_factory, timeout=30):
+        del timeout
+        coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
+        result = asyncio.run(coro)
+        # Force shutdown after connection completes but before the caller can
+        # publish the transport into _workspace_servers.
+        mcp_tool.shutdown_mcp_servers()
+        return result
+
+    monkeypatch.setattr(mcp_tool, "_workspace_folder", lambda task_id=None: root)
+    monkeypatch.setattr(mcp_tool, "_connect_server", fake_connect)
+    monkeypatch.setattr(mcp_tool, "_ensure_mcp_loop", lambda: None)
+    monkeypatch.setattr(mcp_tool, "_run_on_mcp_loop", connect_then_shutdown)
+    monkeypatch.setattr(mcp_tool, "_stop_mcp_loop", lambda **kwargs: True)
+    scope_key = mcp_tool._workspace_scope_key(name, "session-alpha")
+    with mcp_tool._lock:
+        mcp_tool._workspace_server_configs[name] = template
+
+    try:
+        result = mcp_tool._connect_workspace_server(name, "session-alpha")
+
+        assert result is None
+        with mcp_tool._lock:
+            assert scope_key not in mcp_tool._workspace_servers
+            assert scope_key not in mcp_tool._workspace_server_connecting
+    finally:
+        with mcp_tool._lock:
+            mcp_tool._workspace_server_configs.pop(name, None)
+            mcp_tool._workspace_servers.pop(scope_key, None)
+            ready = mcp_tool._workspace_server_connecting.pop(scope_key, None)
+        if ready is not None:
+            ready.set()

--- a/tests/tools/test_mcp_workspace_routing.py
+++ b/tests/tools/test_mcp_workspace_routing.py
@@ -142,3 +142,49 @@ def test_generated_utility_handlers_forward_the_calling_session(monkeypatch):
         ("filesystem", "workspace-session"),
         ("filesystem", "workspace-session"),
     ]
+
+
+def test_workspace_sensitive_circuit_breaker_is_scoped_by_workspace(monkeypatch):
+    import tools.mcp_tool as mcp_tool
+
+    roots = {
+        "session-alpha": "/projects/alpha",
+        "session-beta": "/projects/beta",
+    }
+    session = MagicMock()
+    session.call_tool = AsyncMock(return_value=_result("beta"))
+    server = mcp_tool.MCPServerTask("filesystem")
+    server.session = session
+    resolved = []
+
+    monkeypatch.setattr(
+        mcp_tool,
+        "_workspace_folder",
+        lambda task_id=None: roots.get(task_id, "/backend/workspace"),
+    )
+    monkeypatch.setattr(
+        mcp_tool,
+        "_get_connected_server_for_call",
+        lambda server_name, task_id=None: (
+            resolved.append((server_name, task_id))
+            or (server if task_id == "session-beta" else None)
+        ),
+    )
+    monkeypatch.setattr(mcp_tool, "_run_on_mcp_loop", _run_on_loop)
+    mcp_tool._workspace_server_configs["filesystem"] = {
+        "command": "filesystem-server",
+        "args": ["${workspaceFolder}"],
+    }
+    try:
+        handler = mcp_tool._make_tool_handler("filesystem", "root", 120)
+        for _ in range(mcp_tool._CIRCUIT_BREAKER_THRESHOLD):
+            assert "error" in json.loads(handler({}, task_id="session-alpha"))
+
+        result = handler({}, task_id="session-beta")
+
+        assert resolved[-1] == ("filesystem", "session-beta")
+        assert json.loads(result) == {"result": "beta"}
+    finally:
+        mcp_tool._workspace_server_configs.clear()
+        mcp_tool._server_error_counts.clear()
+        mcp_tool._server_breaker_opened_at.clear()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5831,6 +5831,13 @@ def _make_check_fn(server_name: str):
                 server.session is not None or server._is_recycled_stdio()
             ):
                 return True
+            # Workspace-sensitive tools retain one process-global schema, but
+            # their transport is selected (and, when needed, connected) by the
+            # call handler.  A reconnecting/parked primary must not hide that
+            # shared schema while another workspace transport is healthy or a
+            # new caller-specific transport can still be created.
+            if server_name in _workspace_server_configs:
+                return True
             # Lazy (schema-cache registered) servers are available: the
             # first real call spawns/connects them (#56832).
             return server_name in _lazy_server_configs

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5216,6 +5216,17 @@ def _server_breaker_key(server_name: str, task_id: Optional[str]) -> Any:
     return server_name
 
 
+def _clear_workspace_breaker_state_locked() -> None:
+    """Drop breaker entries owned by workspace-scoped transports."""
+    for state in (_server_error_counts, _server_breaker_opened_at):
+        workspace_keys = [
+            key for key in state
+            if isinstance(key, tuple) and len(key) == 2
+        ]
+        for key in workspace_keys:
+            state.pop(key, None)
+
+
 def _connect_workspace_server(
     server_name: str,
     task_id: Optional[str],
@@ -7450,6 +7461,7 @@ def shutdown_mcp_servers():
         with _lock:
             _server_connect_retry_after.clear()
             _server_connect_failures.clear()
+            _clear_workspace_breaker_state_locked()
             _workspace_servers.clear()
             connecting = list(_workspace_server_connecting.values())
             _workspace_server_connecting.clear()
@@ -7478,6 +7490,7 @@ def shutdown_mcp_servers():
             # stale per-server backoff from before the restart (#50394).
             _server_connect_retry_after.clear()
             _server_connect_failures.clear()
+            _clear_workspace_breaker_state_locked()
         for ready in connecting:
             ready.set()
 
@@ -7503,6 +7516,7 @@ def shutdown_mcp_servers():
     with _lock:
         _server_connect_retry_after.clear()
         _server_connect_failures.clear()
+        _clear_workspace_breaker_state_locked()
         _workspace_servers.clear()
         connecting = list(_workspace_server_connecting.values())
         _workspace_server_connecting.clear()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5275,8 +5275,18 @@ def _connect_workspace_server(
         connected = _run_on_mcp_loop(_connect, timeout=wait_timeout)
         connected._breaker_key = scope_key
         with _lock:
-            stale = _workspace_servers.get(scope_key)
-            _workspace_servers[scope_key] = connected
+            # Full shutdown clears the in-flight ownership map before stopping
+            # the MCP loop.  The connect future can complete in the narrow
+            # window between that clear and loop teardown; publishing here
+            # would resurrect a dead scoped transport after shutdown.  Require
+            # the exact Event token we installed above to still own this key.
+            # Identity also prevents an old connect from clobbering a newer
+            # post-shutdown attempt for the same workspace (ABA race).
+            if _workspace_server_connecting.get(scope_key) is ready:
+                stale = _workspace_servers.get(scope_key)
+                _workspace_servers[scope_key] = connected
+            else:
+                connected = None
     except Exception as exc:
         logger.warning(
             "MCP server '%s': workspace-scoped connect failed for %s: %s",
@@ -5286,7 +5296,8 @@ def _connect_workspace_server(
         )
     finally:
         with _lock:
-            ready = _workspace_server_connecting.pop(scope_key, ready)
+            if _workspace_server_connecting.get(scope_key) is ready:
+                _workspace_server_connecting.pop(scope_key, None)
         ready.set()
 
     if stale is not None and stale is not connected:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1962,12 +1962,13 @@ class MCPServerTask:
         "_idle_timeout_seconds", "_max_lifetime_seconds", "_recycled_reason",
         "initialize_result", "_ping_unsupported",
         "_reconnect_retries", "_session_proven", "_was_parked",
-        "_publish_tools",
+        "_publish_tools", "_breaker_key",
     )
 
     def __init__(self, name: str, *, publish_tools: bool = True):
         self.name = name
         self._publish_tools = publish_tools
+        self._breaker_key: Any = name
         self.session: Optional[Any] = None
         self.tool_timeout: float = _DEFAULT_TOOL_TIMEOUT
         self._task: Optional[asyncio.Task] = None
@@ -2663,7 +2664,7 @@ class MCPServerTask:
                     # Session is live again: clear any breaker state from a
                     # prior outage so the first call after recovery isn't
                     # gated on a stale consecutive-failure count (#16788).
-                    _reset_server_error(self.name)
+                    _reset_server_error(getattr(self, "_breaker_key", self.name))
                     # A completed handshake alone is NOT proof of health: a
                     # flapping transport can handshake fine and drop moments
                     # later, forever (#62212). The session must prove itself
@@ -3008,7 +3009,7 @@ class MCPServerTask:
                         # Session is live again: clear any breaker state from a
                         # prior outage so the first call after recovery isn't
                         # gated on a stale consecutive-failure count (#16788).
-                        _reset_server_error(self.name)
+                        _reset_server_error(getattr(self, "_breaker_key", self.name))
                         # Unproven until keepalive/tool-call success (#62212).
                         self._session_proven = False
                         reason = await self._wait_for_lifecycle_event()
@@ -3071,7 +3072,7 @@ class MCPServerTask:
                             # Session is live again: clear any breaker state from
                             # a prior outage so the first call after recovery
                             # isn't gated on a stale failure count (#16788).
-                            _reset_server_error(self.name)
+                            _reset_server_error(getattr(self, "_breaker_key", self.name))
                             # Unproven until keepalive/tool-call success (#62212).
                             self._session_proven = False
                             reason = await self._wait_for_lifecycle_event()
@@ -3109,7 +3110,7 @@ class MCPServerTask:
                         # Session is live again: clear any breaker state from a
                         # prior outage so the first call after recovery isn't
                         # gated on a stale consecutive-failure count (#16788).
-                        _reset_server_error(self.name)
+                        _reset_server_error(getattr(self, "_breaker_key", self.name))
                         # Unproven until keepalive/tool-call success (#62212).
                         self._session_proven = False
                         reason = await self._wait_for_lifecycle_event()
@@ -3766,8 +3767,8 @@ def _connect_cooldown_active(server_name: str) -> bool:
 # the breaker most recently transitioned into the open state. Use the
 # ``_bump_server_error`` / ``_reset_server_error`` helpers to mutate
 # this state — they keep the count and timestamp in sync.
-_server_error_counts: Dict[str, int] = {}
-_server_breaker_opened_at: Dict[str, float] = {}
+_server_error_counts: Dict[Any, int] = {}
+_server_breaker_opened_at: Dict[Any, float] = {}
 _CIRCUIT_BREAKER_THRESHOLD = 3
 _CIRCUIT_BREAKER_COOLDOWN_SEC = 60.0
 
@@ -3916,28 +3917,28 @@ def _trust_gate_check(server_name: str, tool_name: str) -> Optional[str]:
     )
 
 
-def _bump_server_error(server_name: str) -> None:
-    """Increment the consecutive-failure count for ``server_name``.
+def _bump_server_error(server_key: Any) -> None:
+    """Increment the consecutive-failure count for one transport key.
 
     When the count crosses :data:`_CIRCUIT_BREAKER_THRESHOLD`, stamp the
     breaker-open timestamp so the cooldown clock starts (or re-starts,
     for probe failures in the half-open state).
     """
-    n = _server_error_counts.get(server_name, 0) + 1
-    _server_error_counts[server_name] = n
+    n = _server_error_counts.get(server_key, 0) + 1
+    _server_error_counts[server_key] = n
     if n >= _CIRCUIT_BREAKER_THRESHOLD:
-        _server_breaker_opened_at[server_name] = time.monotonic()
+        _server_breaker_opened_at[server_key] = time.monotonic()
 
 
-def _reset_server_error(server_name: str) -> None:
-    """Fully close the breaker for ``server_name``.
+def _reset_server_error(server_key: Any) -> None:
+    """Fully close the breaker for one transport key.
 
     Clears both the failure count and the breaker-open timestamp. Call
     this on any unambiguous success signal (successful tool call,
     successful reconnect, manual /mcp refresh).
     """
-    _server_error_counts[server_name] = 0
-    _server_breaker_opened_at.pop(server_name, None)
+    _server_error_counts[server_key] = 0
+    _server_breaker_opened_at.pop(server_key, None)
 
 
 def _signal_reconnect(server: Any) -> bool:
@@ -4135,6 +4136,7 @@ def _handle_auth_error_and_retry(
     retry_call,
     op_description: str,
     server: Optional[MCPServerTask] = None,
+    breaker_key: Any = None,
 ):
     """Attempt auth recovery and one retry; return None to fall through.
 
@@ -4166,6 +4168,8 @@ def _handle_auth_error_and_retry(
     """
     if not _is_auth_error(exc):
         return None
+
+    breaker_key = server_name if breaker_key is None else breaker_key
 
     from tools.mcp_oauth_manager import get_manager
     manager = get_manager()
@@ -4204,17 +4208,17 @@ def _handle_auth_error_and_retry(
         # _bump_server_error on failure, so a genuinely broken server will
         # re-trip the breaker as normal.
         if reconnected:
-            _reset_server_error(server_name)
+            _reset_server_error(breaker_key)
 
         try:
             result = retry_call()
             try:
                 parsed = json.loads(result)
                 if "error" not in parsed:
-                    _reset_server_error(server_name)
+                    _reset_server_error(breaker_key)
                     return result
             except (json.JSONDecodeError, TypeError):
-                _reset_server_error(server_name)
+                _reset_server_error(breaker_key)
                 return result
         except Exception as retry_exc:
             logger.warning(
@@ -4225,7 +4229,7 @@ def _handle_auth_error_and_retry(
     # No recovery available, or retry also failed: surface a structured
     # needs_reauth error. Bumps the circuit breaker so the model stops
     # retrying the tool.
-    _bump_server_error(server_name)
+    _bump_server_error(breaker_key)
     return tool_error(
         f"MCP server '{server_name}' requires re-authentication. "
         f"Run `hermes mcp login {server_name}` (or delete the tokens "
@@ -4344,6 +4348,7 @@ def _handle_session_expired_and_retry(
     retry_call,
     op_description: str,
     server: Optional[MCPServerTask] = None,
+    breaker_key: Any = None,
 ):
     """Trigger a transport reconnect and retry once on session expiry.
 
@@ -4370,6 +4375,8 @@ def _handle_session_expired_and_retry(
     """
     if not _is_session_expired_error(exc):
         return None
+
+    breaker_key = server_name if breaker_key is None else breaker_key
 
     srv = server
     if srv is None:
@@ -4408,10 +4415,10 @@ def _handle_session_expired_and_retry(
         try:
             parsed = json.loads(result)
             if "error" not in parsed:
-                _reset_server_error(server_name)
+                _reset_server_error(breaker_key)
                 return result
         except (json.JSONDecodeError, TypeError):
-            _reset_server_error(server_name)
+            _reset_server_error(breaker_key)
             return result
     except Exception as retry_exc:
         logger.warning(
@@ -5200,6 +5207,15 @@ def _workspace_scope_key(server_name: str, task_id: Optional[str]) -> Tuple[str,
     return server_name, os.path.normcase(root)
 
 
+def _server_breaker_key(server_name: str, task_id: Optional[str]) -> Any:
+    """Return breaker identity matching the transport selected for this call."""
+    with _lock:
+        workspace_sensitive = server_name in _workspace_server_configs
+    if workspace_sensitive:
+        return _workspace_scope_key(server_name, task_id)
+    return server_name
+
+
 def _connect_workspace_server(
     server_name: str,
     task_id: Optional[str],
@@ -5246,6 +5262,7 @@ def _connect_workspace_server(
             )
 
         connected = _run_on_mcp_loop(_connect, timeout=wait_timeout)
+        connected._breaker_key = scope_key
         with _lock:
             stale = _workspace_servers.get(scope_key)
             _workspace_servers[scope_key] = connected
@@ -5324,7 +5341,10 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
         if gate_error is not None:
             return gate_error
 
-        # Circuit breaker: if this server has failed too many times
+        task_id = kwargs.get("task_id") or kwargs.get("session_id")
+        breaker_key = _server_breaker_key(server_name, task_id)
+
+        # Circuit breaker: if this server transport has failed too many times
         # consecutively, short-circuit with a clear message so the model
         # stops retrying and uses alternative approaches (#10447).
         #
@@ -5334,24 +5354,23 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
         # failure the error paths below bump the count again, which
         # re-stamps the open-time via _bump_server_error (re-arming
         # the cooldown).
-        if _server_error_counts.get(server_name, 0) >= _CIRCUIT_BREAKER_THRESHOLD:
-            opened_at = _server_breaker_opened_at.get(server_name, 0.0)
+        if _server_error_counts.get(breaker_key, 0) >= _CIRCUIT_BREAKER_THRESHOLD:
+            opened_at = _server_breaker_opened_at.get(breaker_key, 0.0)
             age = time.monotonic() - opened_at
             if age < _CIRCUIT_BREAKER_COOLDOWN_SEC:
                 remaining = max(1, int(_CIRCUIT_BREAKER_COOLDOWN_SEC - age))
                 return tool_error(
                     f"MCP server '{server_name}' is unreachable after "
-                    f"{_server_error_counts[server_name]} consecutive "
+                    f"{_server_error_counts[breaker_key]} consecutive "
                     f"failures. Auto-retry available in ~{remaining}s. "
                     f"Do NOT retry this tool yet — use alternative "
                     f"approaches or ask the user to check the MCP server."
                 )
             # Cooldown elapsed → fall through as a half-open probe.
 
-        task_id = kwargs.get("task_id") or kwargs.get("session_id")
         server = _get_connected_server_for_call(server_name, task_id)
         if not server:
-            _bump_server_error(server_name)
+            _bump_server_error(breaker_key)
             return tool_error(f"MCP server '{server_name}' is not connected")
 
         if not server.session:
@@ -5375,7 +5394,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 # without burning iterations. The breaker resets once the
                 # fresh session initializes (_run_stdio/_run_http call
                 # _reset_server_error).
-                _bump_server_error(server_name)
+                _bump_server_error(breaker_key)
                 if _signal_reconnect(server):
                     return tool_error(
                         f"MCP server '{server_name}' transport is down; "
@@ -5491,11 +5510,11 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             try:
                 parsed = json.loads(result)
                 if "error" in parsed:
-                    _bump_server_error(server_name)
+                    _bump_server_error(breaker_key)
                 else:
-                    _reset_server_error(server_name)  # success — reset
+                    _reset_server_error(breaker_key)  # success — reset
             except (json.JSONDecodeError, TypeError):
-                _reset_server_error(server_name)  # non-JSON = success
+                _reset_server_error(breaker_key)  # non-JSON = success
             return result
         except InterruptedError:
             return _interrupted_call_result()
@@ -5507,6 +5526,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 server_name, exc, _call_once,
                 f"tools/call {tool_name}",
                 server=server,
+                breaker_key=breaker_key,
             )
             if recovered is not None:
                 return recovered
@@ -5518,11 +5538,12 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 server_name, exc, _call_once,
                 f"tools/call {tool_name}",
                 server=server,
+                breaker_key=breaker_key,
             )
             if recovered is not None:
                 return recovered
 
-            _bump_server_error(server_name)
+            _bump_server_error(breaker_key)
             logger.error(
                 "MCP tool %s/%s call failed: %s",
                 server_name, tool_name, exc,

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -444,7 +444,7 @@ def _env_ref_name(ref: str) -> str:
     return ref
 
 
-def _workspace_folder() -> str:
+def _workspace_folder(task_id: Optional[str] = None) -> str:
     """Best-effort absolute workspace root for ``${workspaceFolder}``.
 
     Resolution order:
@@ -457,7 +457,7 @@ def _workspace_folder() -> str:
     try:
         from tools.file_tools import _authoritative_workspace_root
 
-        root = _authoritative_workspace_root()
+        root = _authoritative_workspace_root(task_id or "default")
         if root:
             return root
     except Exception:
@@ -465,7 +465,7 @@ def _workspace_folder() -> str:
     return os.getcwd()
 
 
-def _context_var_value(ref: str) -> Optional[str]:
+def _context_var_value(ref: str, task_id: Optional[str] = None) -> Optional[str]:
     """Resolve Cursor-style context variables in ``${...}`` references.
 
     Supports the case-sensitive names Cursor's ``mcp.json`` interpolation
@@ -477,9 +477,9 @@ def _context_var_value(ref: str) -> Optional[str]:
     if ref == "userHome":
         return os.path.expanduser("~")
     if ref == "workspaceFolder":
-        return _workspace_folder()
+        return _workspace_folder() if task_id is None else _workspace_folder(task_id)
     if ref == "workspaceFolderBasename":
-        root = _workspace_folder()
+        root = _workspace_folder() if task_id is None else _workspace_folder(task_id)
         return os.path.basename(root.rstrip("/\\")) or root
     if ref in ("pathSeparator", "/"):
         return os.sep
@@ -1962,10 +1962,12 @@ class MCPServerTask:
         "_idle_timeout_seconds", "_max_lifetime_seconds", "_recycled_reason",
         "initialize_result", "_ping_unsupported",
         "_reconnect_retries", "_session_proven", "_was_parked",
+        "_publish_tools",
     )
 
-    def __init__(self, name: str):
+    def __init__(self, name: str, *, publish_tools: bool = True):
         self.name = name
+        self._publish_tools = publish_tools
         self.session: Optional[Any] = None
         self.tool_timeout: float = _DEFAULT_TOOL_TIMEOUT
         self._task: Optional[asyncio.Task] = None
@@ -3166,7 +3168,7 @@ class MCPServerTask:
         registry-owned before its first successful session, so ownership also
         authorizes its first publication.
         """
-        if self._registered_tool_names:
+        if not self._publish_tools or self._registered_tool_names:
             return
         if not self._ready.is_set():
             with _lock:
@@ -3674,6 +3676,11 @@ class MCPServerTask:
 _servers: Dict[str, MCPServerTask] = {}
 _server_connecting: set[str] = set()
 _server_connect_errors: Dict[str, str] = {}
+# Raw configs containing workspace context variables. Their public tool names
+# stay process-global, while calls route to a transport scoped by workspace.
+_workspace_server_configs: Dict[str, dict] = {}
+_workspace_servers: Dict[Tuple[str, str], MCPServerTask] = {}
+_workspace_server_connecting: Dict[Tuple[str, str], threading.Event] = {}
 # Lazy MCP startup (#56832): servers whose tools were registered from the
 # on-disk schema cache without spawning/connecting. Keyed by server name;
 # entries are popped once a real connection is established on first use.
@@ -4127,6 +4134,7 @@ def _handle_auth_error_and_retry(
     exc: BaseException,
     retry_call,
     op_description: str,
+    server: Optional[MCPServerTask] = None,
 ):
     """Attempt auth recovery and one retry; return None to fall through.
 
@@ -4175,8 +4183,10 @@ def _handle_auth_error_and_retry(
         recovered = False
 
     if recovered:
-        with _lock:
-            srv = _servers.get(server_name)
+        srv = server
+        if srv is None:
+            with _lock:
+                srv = _servers.get(server_name)
         reconnected = False
         if srv is not None and hasattr(srv, "_reconnect_event"):
             reconnected = _signal_reconnect_and_wait(
@@ -4333,6 +4343,7 @@ def _handle_session_expired_and_retry(
     exc: BaseException,
     retry_call,
     op_description: str,
+    server: Optional[MCPServerTask] = None,
 ):
     """Trigger a transport reconnect and retry once on session expiry.
 
@@ -4360,8 +4371,10 @@ def _handle_session_expired_and_retry(
     if not _is_session_expired_error(exc):
         return None
 
-    with _lock:
-        srv = _servers.get(server_name)
+    srv = server
+    if srv is None:
+        with _lock:
+            srv = _servers.get(server_name)
     if srv is None or not hasattr(srv, "_reconnect_event"):
         return None
 
@@ -4820,7 +4833,7 @@ def _interrupted_call_result() -> str:
 # Config loading
 # ---------------------------------------------------------------------------
 
-def _interpolate_env_vars(value):
+def _interpolate_env_vars(value, task_id: Optional[str] = None):
     """Recursively resolve ``${VAR}`` placeholders.
 
     Both ``${VAR}`` and Cursor-style ``${env:VAR}`` are accepted — the
@@ -4839,17 +4852,31 @@ def _interpolate_env_vars(value):
 
     if isinstance(value, str):
         def _replace(m):
-            ctx = _context_var_value(m.group(1).strip())
+            ctx = _context_var_value(m.group(1).strip(), task_id)
             if ctx is not None:
                 return ctx
             name = _env_ref_name(m.group(1))
             return _get_secret(name, m.group(0)) or m.group(0)
         return _ENV_VAR_PATTERN.sub(_replace, value)
     if isinstance(value, dict):
-        return {k: _interpolate_env_vars(v) for k, v in value.items()}
+        return {k: _interpolate_env_vars(v, task_id) for k, v in value.items()}
     if isinstance(value, list):
-        return [_interpolate_env_vars(v) for v in value]
+        return [_interpolate_env_vars(v, task_id) for v in value]
     return value
+
+
+def _contains_workspace_context(value: Any) -> bool:
+    """Return whether a config value depends on the active workspace."""
+    if isinstance(value, str):
+        return any(
+            match.group(1).strip() in {"workspaceFolder", "workspaceFolderBasename"}
+            for match in _ENV_VAR_PATTERN.finditer(value)
+        )
+    if isinstance(value, dict):
+        return any(_contains_workspace_context(v) for v in value.values())
+    if isinstance(value, list):
+        return any(_contains_workspace_context(v) for v in value)
+    return False
 
 
 # (server_name, dotted key path) pairs already warned about — see
@@ -4958,7 +4985,10 @@ def _load_mcp_config() -> Dict[str, dict]:
         except Exception:
             pass
         safe_servers: Dict[str, dict] = {}
+        workspace_server_configs: Dict[str, dict] = {}
         for name, cfg in _filter_suspicious_mcp_servers(servers).items():
+            if isinstance(cfg, dict) and _contains_workspace_context(cfg):
+                workspace_server_configs[name] = dict(cfg)
             interpolated = _interpolate_env_vars(cfg)
             if isinstance(interpolated, dict):
                 _warn_hidden_whitespace(name, interpolated)
@@ -4978,6 +5008,9 @@ def _load_mcp_config() -> Dict[str, dict]:
                 safe_servers[name] = dict(cfg)
         except Exception:
             logger.debug("Failed to load portable MCP servers", exc_info=True)
+        with _lock:
+            _workspace_server_configs.clear()
+            _workspace_server_configs.update(workspace_server_configs)
         return safe_servers
     except Exception as exc:
         logger.debug("Failed to load MCP config: %s", exc)
@@ -4988,7 +5021,12 @@ def _load_mcp_config() -> Dict[str, dict]:
 # Server connection helper
 # ---------------------------------------------------------------------------
 
-async def _connect_server(name: str, config: dict) -> MCPServerTask:
+async def _connect_server(
+    name: str,
+    config: dict,
+    *,
+    publish_tools: bool = True,
+) -> MCPServerTask:
     """Create an MCPServerTask, start it, and return when ready.
 
     The server Task keeps the connection alive in the background.
@@ -4999,7 +5037,10 @@ async def _connect_server(name: str, config: dict) -> MCPServerTask:
         ImportError: if HTTP transport is needed but not available.
         Exception: on connection or initialization failure.
     """
+    # Instantiate with the historical one-argument contract so test/plugin
+    # subclasses that override __init__(name) remain compatible.
     server = MCPServerTask(name)
+    server._publish_tools = publish_tools
     claim = _connect_server_claim.get()
     claim_token = None
     if claim is not None:
@@ -5154,13 +5195,97 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
     return server is not None and server.session is not None
 
 
-def _get_connected_server_for_call(server_name: str) -> Optional[MCPServerTask]:
-    """Return a connected server, lazily reconnecting recycled stdio state.
+def _workspace_scope_key(server_name: str, task_id: Optional[str]) -> Tuple[str, str]:
+    root = os.path.abspath(_workspace_folder(task_id))
+    return server_name, os.path.normcase(root)
 
-    Also the single first-use connect point for lazy (schema-cache
-    registered) servers, so raw tool calls AND the resource/prompt utility
-    handlers all trigger the deferred spawn (#56832).
-    """
+
+def _connect_workspace_server(
+    server_name: str,
+    task_id: Optional[str],
+) -> Optional[MCPServerTask]:
+    """Return a transport whose fixed config is expanded for this workspace."""
+    with _lock:
+        template = _workspace_server_configs.get(server_name)
+    if template is None:
+        return None
+
+    config = _interpolate_env_vars(template, task_id)
+    scope_key = _workspace_scope_key(server_name, task_id)
+    wait_timeout = float(config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)) + 30.0
+
+    with _lock:
+        primary = _servers.get(server_name)
+        if primary is not None and primary._config == config:
+            return primary
+        scoped = _workspace_servers.get(scope_key)
+        if scoped is not None and scoped._config == config:
+            return scoped
+        ready = _workspace_server_connecting.get(scope_key)
+        owns_connect = ready is None
+        if owns_connect:
+            ready = threading.Event()
+            _workspace_server_connecting[scope_key] = ready
+
+    if not owns_connect:
+        ready.wait(timeout=wait_timeout)
+        with _lock:
+            scoped = _workspace_servers.get(scope_key)
+        return scoped if scoped is not None and scoped._config == config else None
+
+    connected: Optional[MCPServerTask] = None
+    stale: Optional[MCPServerTask] = None
+    try:
+        _ensure_mcp_loop()
+
+        async def _connect():
+            return await _connect_server(
+                server_name,
+                config,
+                publish_tools=False,
+            )
+
+        connected = _run_on_mcp_loop(_connect, timeout=wait_timeout)
+        with _lock:
+            stale = _workspace_servers.get(scope_key)
+            _workspace_servers[scope_key] = connected
+    except Exception as exc:
+        logger.warning(
+            "MCP server '%s': workspace-scoped connect failed for %s: %s",
+            server_name,
+            scope_key[1],
+            _format_connect_error(exc),
+        )
+    finally:
+        with _lock:
+            ready = _workspace_server_connecting.pop(scope_key, ready)
+        ready.set()
+
+    if stale is not None and stale is not connected:
+        try:
+            _run_on_mcp_loop(stale.shutdown, timeout=15)
+        except BaseException:
+            logger.debug(
+                "MCP server '%s': stale workspace transport shutdown failed",
+                server_name,
+                exc_info=True,
+            )
+    return connected
+
+
+def _get_connected_server_for_call(
+    server_name: str,
+    task_id: Optional[str] = None,
+) -> Optional[MCPServerTask]:
+    """Return the workspace-correct connected server for a tool call."""
+    with _lock:
+        workspace_sensitive = server_name in _workspace_server_configs
+    if workspace_sensitive:
+        server = _connect_workspace_server(server_name, task_id)
+        if server is not None and server.session is None and server._is_recycled_stdio():
+            _request_lazy_reconnect(server_name, server)
+        return server
+
     with _lock:
         server = _servers.get(server_name)
         is_lazy = server_name in _lazy_server_configs
@@ -5223,7 +5348,8 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 )
             # Cooldown elapsed → fall through as a half-open probe.
 
-        server = _get_connected_server_for_call(server_name)
+        task_id = kwargs.get("task_id") or kwargs.get("session_id")
+        server = _get_connected_server_for_call(server_name, task_id)
         if not server:
             _bump_server_error(server_name)
             return tool_error(f"MCP server '{server_name}' is not connected")
@@ -5380,6 +5506,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             recovered = _handle_auth_error_and_retry(
                 server_name, exc, _call_once,
                 f"tools/call {tool_name}",
+                server=server,
             )
             if recovered is not None:
                 return recovered
@@ -5390,6 +5517,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             recovered = _handle_session_expired_and_retry(
                 server_name, exc, _call_once,
                 f"tools/call {tool_name}",
+                server=server,
             )
             if recovered is not None:
                 return recovered
@@ -5410,7 +5538,8 @@ def _make_list_resources_handler(server_name: str, tool_timeout: float):
     """Return a sync handler that lists resources from an MCP server."""
 
     def _handler(args: dict, **kwargs) -> str:
-        server = _get_connected_server_for_call(server_name)
+        task_id = kwargs.get("task_id") or kwargs.get("session_id")
+        server = _get_connected_server_for_call(server_name, task_id)
         if not server or not server.session:
             return tool_error(f"MCP server '{server_name}' is not connected")
 
@@ -5444,11 +5573,13 @@ def _make_list_resources_handler(server_name: str, tool_timeout: float):
         except Exception as exc:
             recovered = _handle_auth_error_and_retry(
                 server_name, exc, _call_once, "resources/list",
+                server=server,
             )
             if recovered is not None:
                 return recovered
             recovered = _handle_session_expired_and_retry(
                 server_name, exc, _call_once, "resources/list",
+                server=server,
             )
             if recovered is not None:
                 return recovered
@@ -5466,7 +5597,8 @@ def _make_read_resource_handler(server_name: str, tool_timeout: float):
     """Return a sync handler that reads a resource by URI from an MCP server."""
 
     def _handler(args: dict, **kwargs) -> str:
-        server = _get_connected_server_for_call(server_name)
+        task_id = kwargs.get("task_id") or kwargs.get("session_id")
+        server = _get_connected_server_for_call(server_name, task_id)
         if not server or not server.session:
             return tool_error(f"MCP server '{server_name}' is not connected")
 
@@ -5505,11 +5637,13 @@ def _make_read_resource_handler(server_name: str, tool_timeout: float):
         except Exception as exc:
             recovered = _handle_auth_error_and_retry(
                 server_name, exc, _call_once, "resources/read",
+                server=server,
             )
             if recovered is not None:
                 return recovered
             recovered = _handle_session_expired_and_retry(
                 server_name, exc, _call_once, "resources/read",
+                server=server,
             )
             if recovered is not None:
                 return recovered
@@ -5527,7 +5661,8 @@ def _make_list_prompts_handler(server_name: str, tool_timeout: float):
     """Return a sync handler that lists prompts from an MCP server."""
 
     def _handler(args: dict, **kwargs) -> str:
-        server = _get_connected_server_for_call(server_name)
+        task_id = kwargs.get("task_id") or kwargs.get("session_id")
+        server = _get_connected_server_for_call(server_name, task_id)
         if not server or not server.session:
             return tool_error(f"MCP server '{server_name}' is not connected")
 
@@ -5566,11 +5701,13 @@ def _make_list_prompts_handler(server_name: str, tool_timeout: float):
         except Exception as exc:
             recovered = _handle_auth_error_and_retry(
                 server_name, exc, _call_once, "prompts/list",
+                server=server,
             )
             if recovered is not None:
                 return recovered
             recovered = _handle_session_expired_and_retry(
                 server_name, exc, _call_once, "prompts/list",
+                server=server,
             )
             if recovered is not None:
                 return recovered
@@ -5588,7 +5725,8 @@ def _make_get_prompt_handler(server_name: str, tool_timeout: float):
     """Return a sync handler that gets a prompt by name from an MCP server."""
 
     def _handler(args: dict, **kwargs) -> str:
-        server = _get_connected_server_for_call(server_name)
+        task_id = kwargs.get("task_id") or kwargs.get("session_id")
+        server = _get_connected_server_for_call(server_name, task_id)
         if not server or not server.session:
             return tool_error(f"MCP server '{server_name}' is not connected")
 
@@ -5631,11 +5769,13 @@ def _make_get_prompt_handler(server_name: str, tool_timeout: float):
         except Exception as exc:
             recovered = _handle_auth_error_and_retry(
                 server_name, exc, _call_once, "prompts/get",
+                server=server,
             )
             if recovered is not None:
                 return recovered
             recovered = _handle_session_expired_and_retry(
                 server_name, exc, _call_once, "prompts/get",
+                server=server,
             )
             if recovered is not None:
                 return recovered
@@ -7274,7 +7414,10 @@ def shutdown_mcp_servers():
     All servers are shut down in parallel via ``asyncio.gather``.
     """
     with _lock:
-        servers_snapshot = list(_servers.values())
+        servers_snapshot = list({
+            id(server): server
+            for server in [*_servers.values(), *_workspace_servers.values()]
+        }.values())
 
     # Fast path: nothing to shut down. The connect-cooldown maps can still
     # be populated here — a server that failed to connect is never recorded
@@ -7286,6 +7429,11 @@ def shutdown_mcp_servers():
         with _lock:
             _server_connect_retry_after.clear()
             _server_connect_failures.clear()
+            _workspace_servers.clear()
+            connecting = list(_workspace_server_connecting.values())
+            _workspace_server_connecting.clear()
+        for ready in connecting:
+            ready.set()
         _stop_mcp_loop()
         return
 
@@ -7301,11 +7449,16 @@ def shutdown_mcp_servers():
                 )
         with _lock:
             _servers.clear()
+            _workspace_servers.clear()
+            connecting = list(_workspace_server_connecting.values())
+            _workspace_server_connecting.clear()
             # Drop connect-retry cooldowns too: a full shutdown/restart
             # should re-attempt every server immediately, not honour a
             # stale per-server backoff from before the restart (#50394).
             _server_connect_retry_after.clear()
             _server_connect_failures.clear()
+        for ready in connecting:
+            ready.set()
 
     with _lock:
         loop = _mcp_loop
@@ -7329,6 +7482,11 @@ def shutdown_mcp_servers():
     with _lock:
         _server_connect_retry_after.clear()
         _server_connect_failures.clear()
+        _workspace_servers.clear()
+        connecting = list(_workspace_server_connecting.values())
+        _workspace_server_connecting.clear()
+    for ready in connecting:
+        ready.set()
 
     _stop_mcp_loop()
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -7729,7 +7729,12 @@ def _stop_mcp_loop(*, only_if_idle: bool = False) -> bool:
     """Stop the background event loop and join its thread."""
     global _mcp_loop, _mcp_thread
     with _lock:
-        if only_if_idle and (_servers or _server_connecting):
+        if only_if_idle and (
+            _servers
+            or _server_connecting
+            or _workspace_servers
+            or _workspace_server_connecting
+        ):
             logger.debug("Leaving MCP event loop running; active servers are registered or connecting")
             return False
         loop = _mcp_loop


### PR DESCRIPTION
## What does this PR do?

MCP servers configured with `${workspaceFolder}` or `${workspaceFolderBasename}` now resolve those values from the session making each tool call instead of from the backend default workspace. This prevents workspace-sensitive servers from silently reading or modifying the wrong project when one process serves multiple sessions, while preserving one stable public tool schema per configured server.

### Symptom

Two sessions with different authoritative working directories can invoke the same workspace-sensitive MCP tool but receive a transport whose fixed arguments point to the backend workspace or the first session's workspace.

### Impact

Filesystem-style MCP tools can return files from or write changes to the wrong project. The verified scenario is a single gateway process serving multiple session working directories; broader deployment frequency was not measured.

### Bug Cause

**Trigger:** `tools/mcp_tool.py::_workspace_folder`, `_load_mcp_config`, and the server lookup paths used by regular tools and generated resource/prompt utilities.

**Causal chain:**
1. MCP configuration is loaded before a tool call supplies task/session identity.
2. Workspace context variables are eagerly expanded from the backend/default root and the transport is cached by raw server name.
3. Later sessions reuse that fixed transport and operate in a workspace other than their authoritative cwd.

**Why it is wrong:** The public MCP schema is process-global, but fixed server configuration containing workspace variables is session-scoped. Treating both as one global object conflates schema publication with transport ownership.

**Working sibling / contrast:** File and terminal tools already pass task/session identity into authoritative cwd resolution. This change gives MCP calls the same session-aware routing property and applies it consistently to tools, resources, and prompts.

**Ruled out:** The failure is not caused by stale session cwd persistence. The pre-fix probe recorded correct and distinct roots for both sessions while rootless MCP interpolation and global transport reuse still selected the backend workspace.

### Fix

Workspace-sensitive configuration templates are preserved and interpolated with each call's task/session identity. Connected transports, connection retry state, and circuit-breaker state are scoped by canonical workspace, while one primary registration continues to publish the public tool schemas. Generated resource and prompt handlers use the same routing path. Scoped transports are also covered by availability checks, probes, shutdown, and connection ownership guards so concurrent shutdown cannot republish a dead transport.

## Related Issue

Fixes #82121

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py` - preserve workspace-sensitive templates, route calls to canonical workspace-scoped transports, scope retry state, and make lifecycle handling cover scoped connections.
- `tests/tools/test_mcp_workspace_routing.py` - cover two-session routing, schema stability, resource/prompt utilities, retry isolation, probe behavior, shutdown, and concurrent connection ownership.

## How to Test

1. Configure a stdio MCP server with `${workspaceFolder}` and `${workspaceFolderBasename}` in fixed launch arguments.
2. Record two sessions with distinct cwd roots and invoke regular tools, `read_resource`, and `get_prompt` from both sessions.
3. Confirm that each session gets its own root and process, repeated calls within one workspace reuse that process, only one public schema set is registered, probes preserve live scoped transports, and shutdown does not resurrect a connection.
4. Run the focused automated suite:

```bash
scripts/run_tests.sh tests/tools/test_mcp_workspace_routing.py tests/tools/test_mcp_probe.py tests/tools/test_mcp_initial_connect_shutdown.py tests/tools/test_mcp_bridge_single_failure.py tests/tools/test_mcp_stability.py tests/tools/test_mcp_tool_401_handling.py tests/hermes_cli/test_mcp_config.py
scripts/run_tests.sh tests/tools/test_mcp_tool.py -k 'not test_windows_location_vars_passed_without_secrets'
scripts/run_tests.sh tests/tools/test_mcp_schema_cache.py -k 'not test_cache_lives_under_hermes_home_cache_dir_with_0600'
```

Result: 176 focused tests passed. The two deselected assertions encode unrelated Windows environment and permission-mode assumptions in untouched behavior.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant test suites and all 176 focused tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] Relevant documentation update is N/A because this restores the documented session-scoped context-variable behavior
- [x] `cli-config.yaml.example` update is N/A because no configuration keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A because no contributor workflow changed
- [x] I've considered cross-platform impact; canonical workspace keys use existing path normalization
- [x] Tool description/schema updates are N/A because the public MCP tool contract is unchanged

## Screenshots / Logs

REAL_ENV verification used actual stdio MCP transports for backend/default, session-alpha, and session-beta roots. Each root used a distinct process; repeated alpha calls reused the alpha process; generated resource and prompt utilities routed to their caller's workspace; probes preserved scoped transports; shutdown-race coverage passed.
