### PR TITLE
feat(cron): notify kanban subscribers on new comments (opt-in)

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -273,6 +273,33 @@ class GatewayKanbanWatchersMixin:
                     if not active_platforms:
                         logger.debug("kanban notifier: no connected adapters; skipping tick")
                         return deliveries
+                    # A "commented" event has no wake-worthy semantics (it's
+                    # intentionally excluded from _WAKE_KINDS below), so for a
+                    # platform whose only registered adapter(s) have no push
+                    # channel (api_server: supports_async_delivery=False)
+                    # there is NO delivery path for it at all: the text-send
+                    # skip further down leaves nothing to wake, yet the
+                    # cursor still advanced past it — silently dropping the
+                    # notification instead of ever retrying it. Rather than
+                    # claim-then-lose, exclude "commented" up front for those
+                    # platforms so the row is simply never selected (same
+                    # SQL-level skip the flag-off path already relies on) and
+                    # the cursor never advances past it. Coarse like
+                    # active_platforms above: a platform counts as push
+                    # capable if ANY known adapter for it (default or
+                    # per-profile) supports push.
+                    from gateway.wake import adapter_supports_push as _push_ok
+                    push_capable_platforms = {
+                        getattr(platform, "value", str(platform)).lower()
+                        for platform, adapter in self.adapters.items()
+                        if _push_ok(adapter)
+                    }
+                    for _profile_adapter_map in getattr(self, "_profile_adapters", {}).values():
+                        push_capable_platforms.update(
+                            getattr(platform, "value", str(platform)).lower()
+                            for platform, adapter in _profile_adapter_map.items()
+                            if _push_ok(adapter)
+                        )
 
                     # Enumerate every board on disk, but poll each resolved DB
                     # path once. Multiple slugs can point at the same DB when
@@ -365,13 +392,16 @@ class GatewayKanbanWatchersMixin:
                                             sub.get("task_id"), platform or "<missing>",
                                         )
                                         continue
+                                    sub_claim_kinds = claim_kinds
+                                    if "commented" in sub_claim_kinds and platform not in push_capable_platforms:
+                                        sub_claim_kinds = TERMINAL_KINDS
                                     old_cursor, cursor, events = _kb.claim_unseen_events_for_sub(
                                         conn,
                                         task_id=sub["task_id"],
                                         platform=sub["platform"],
                                         chat_id=sub["chat_id"],
                                         thread_id=sub.get("thread_id") or "",
-                                        kinds=claim_kinds,
+                                        kinds=sub_claim_kinds,
                                     )
                                     if not events:
                                         continue

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -57,6 +57,23 @@ def _resolve_auto_decompose_settings(
     return enabled, per_tick
 
 
+def _kanban_comment_notify_enabled(load_config: Callable[[], Any]) -> bool:
+    """Return whether ``kanban.notify_on_comment`` is on (default: off, #82080).
+
+    Read fresh on every notifier tick — same live-toggle reasoning as
+    :func:`_resolve_auto_decompose_settings` — so flipping the flag takes
+    effect on the next tick, no gateway restart required. Fails safe: any
+    config-read error keeps comment notifications OFF, preserving the
+    byte-identical default behavior the acceptance criteria require.
+    """
+    try:
+        cfg = load_config()
+    except Exception:
+        return False
+    kcfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
+    return bool(kcfg.get("notify_on_comment", False))
+
+
 def _kanban_dispatch_allowed() -> bool:
     """Return False while the global emergency stop (`hermes pause`) is engaged.
 
@@ -168,6 +185,10 @@ class GatewayKanbanWatchersMixin:
         except Exception:
             logger.warning("kanban notifier: kanban_db not importable; notifier disabled")
             return
+        try:
+            from hermes_cli.config import load_config as _load_config
+        except Exception:
+            _load_config = None
 
         # "status" covers dashboard drag-drop and `_set_status_direct()`
         # writes — surface those transitions to subscribers too.
@@ -211,6 +232,15 @@ class GatewayKanbanWatchersMixin:
             try:
                 def _collect():
                     deliveries: list[dict] = []
+                    # Only claim "commented" events when the config gate is
+                    # on. `claim_unseen_events_for_sub` filters by kind at
+                    # the SQL level (`kind IN (...)`), so leaving it out of
+                    # the tuple means those rows are never selected at
+                    # all — default behavior stays byte-identical to before
+                    # this kind existed.
+                    claim_kinds = TERMINAL_KINDS
+                    if _load_config and _kanban_comment_notify_enabled(_load_config):
+                        claim_kinds = TERMINAL_KINDS + ("commented",)
                     include_unowned = self._owns_kanban_dispatcher_lock()
                     notifier_profiles = {notifier_profile}
                     notifier_profiles.update(
@@ -341,7 +371,7 @@ class GatewayKanbanWatchersMixin:
                                         platform=sub["platform"],
                                         chat_id=sub["chat_id"],
                                         thread_id=sub.get("thread_id") or "",
-                                        kinds=TERMINAL_KINDS,
+                                        kinds=claim_kinds,
                                     )
                                     if not events:
                                         continue
@@ -497,6 +527,23 @@ class GatewayKanbanWatchersMixin:
                             msg = (
                                 f"🛑 {board_tag}{tag}Kanban {sub['task_id']} routed to TRIAGE"
                                 f" — needs a human decision{rc}{reason}"
+                            )
+                        elif kind == "commented":
+                            # Only ever claimed when kanban.notify_on_comment
+                            # is on (see claim_kinds above). Skip pinging a
+                            # subscriber about their OWN comment — mirrors the
+                            # self-skip in inject_new_comments_from_env().
+                            comment_author = ""
+                            comment_body = ""
+                            if ev.payload:
+                                comment_author = str(ev.payload.get("author") or "").strip()
+                                comment_body = str(ev.payload.get("body") or "").strip()
+                            if comment_author and comment_author == (sub_profile or notifier_profile):
+                                continue
+                            preview = f": {comment_body[:160]}" if comment_body else ""
+                            msg = (
+                                f"💬 {board_tag}Kanban {sub['task_id']} comment"
+                                f" by {comment_author or 'operator'}{preview}"
                             )
                         else:
                             # archived / unblocked are claimed by TERMINAL_KINDS

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3653,7 +3653,15 @@ def add_comment(
             "VALUES (?, ?, ?, ?)",
             (task_id, author.strip(), body.strip(), now),
         )
-        _append_event(conn, task_id, "commented", {"author": author, "len": len(body)})
+        # `body` (truncated) rides the event payload so the gateway notifier
+        # can surface a preview to subscribers (#82080) without a second
+        # DB read; `len` is kept for existing consumers (kanban_diagnostics).
+        _append_event(
+            conn,
+            task_id,
+            "commented",
+            {"author": author, "len": len(body), "body": body.strip()[:500]},
+        )
         return int(cur.lastrowid or 0)
 
 

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -24,6 +24,24 @@ class RecordingAdapter:
         self.handled.append(event)
 
 
+class NoPushAdapter:
+    """Adapter with no push channel — mirrors APIServerAdapter's
+    ``supports_async_delivery = False`` contract, the only real-world
+    adapter that can never text-send or wake-post a notification."""
+
+    supports_async_delivery = False
+
+    def __init__(self):
+        self.sent = []
+        self.handled = []
+
+    async def send(self, chat_id, text, metadata=None):
+        self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
+
+    async def handle_message(self, event):
+        self.handled.append(event)
+
+
 class DisconnectedAdapters(dict):
     """Expose a platform during collection, then simulate disconnect on get()."""
 
@@ -44,10 +62,10 @@ async def _run_one_notifier_tick(monkeypatch, runner):
     await runner._kanban_notifier_watcher(interval=1)
 
 
-def _make_runner(adapter):
+def _make_runner(adapter, platform=Platform.TELEGRAM):
     runner = GatewayRunner.__new__(GatewayRunner)
     runner._running = True
-    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.adapters = {platform: adapter}
     runner._kanban_sub_fail_counts = {}
     # Most tests model the default gateway after its dispatcher acquired the
     # singleton lock. Tests for startup or non-owner gateways clear this.
@@ -615,3 +633,49 @@ def test_notifier_skips_authors_own_comment(tmp_path, monkeypatch):
     finally:
         conn.close()
     assert remaining == []
+
+
+def test_notifier_never_claims_comment_for_non_push_adapter(tmp_path, monkeypatch):
+    """A `commented` event on a non-push adapter (api_server) must not be
+    claimed and silently lost (review on #82123).
+
+    `commented` is deliberately excluded from `_WAKE_KINDS`, so a platform
+    with no push channel has NO delivery path for it at all: no text send
+    (skipped for non-push adapters) and no wake self-post (not a wake kind).
+    Claiming the event anyway would still advance the subscription's cursor,
+    permanently dropping the notification with no retry. It must instead stay
+    unclaimed, exactly like the notify_on_comment-off default.
+    """
+    db_path = tmp_path / "comment-no-push-adapter.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"kanban": {"notify_on_comment": True}},
+    )
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="needs a note", assignee="worker")
+        kb.add_notify_sub(conn, task_id=tid, platform="api_server", chat_id="chat-1")
+        kb.add_comment(conn, tid, author="worker", body="blocked on missing credentials")
+    finally:
+        conn.close()
+
+    adapter = NoPushAdapter()
+    runner = _make_runner(adapter, platform=Platform.API_SERVER)
+    runner._kanban_notifier_profile = "orchestrator"
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert adapter.sent == []
+    assert adapter.handled == []
+
+    conn = kb.connect()
+    try:
+        _, remaining = kb.unseen_events_for_sub(
+            conn, task_id=tid, platform="api_server", chat_id="chat-1",
+            kinds=["commented"],
+        )
+    finally:
+        conn.close()
+    assert len(remaining) == 1

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -516,3 +516,102 @@ def test_notifier_delivers_block_loop_detected_triage_ping(tmp_path, monkeypatch
     finally:
         conn.close()
     assert remaining == []
+
+
+def test_notifier_ignores_comments_by_default(tmp_path, monkeypatch):
+    """A `commented` event produces no notification when notify_on_comment is unset (#82080).
+
+    ``kanban.notify_on_comment`` defaults to off, so posting a comment on a
+    subscribed task must be byte-identical to today: no message sent, and the
+    comment never claimed off the subscription's cursor.
+    """
+    db_path = tmp_path / "comment-default-off.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="needs a note", assignee="worker")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        kb.add_comment(conn, tid, author="orchestrator", body="checking in on progress")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert adapter.sent == []
+
+
+def test_notifier_delivers_comment_when_enabled(tmp_path, monkeypatch):
+    """With `kanban.notify_on_comment: true`, a comment from another party notifies (#82080)."""
+    db_path = tmp_path / "comment-enabled.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"kanban": {"notify_on_comment": True}},
+    )
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="needs a note", assignee="worker")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        kb.add_comment(conn, tid, author="worker", body="blocked on missing credentials")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    runner._kanban_notifier_profile = "orchestrator"
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    text = adapter.sent[0]["text"]
+    assert tid in text
+    assert "worker" in text
+    assert "blocked on missing credentials" in text
+    # Wake self-post must NOT fire for a comment — informative, not terminal.
+    assert adapter.handled == []
+
+
+def test_notifier_skips_authors_own_comment(tmp_path, monkeypatch):
+    """The subscriber's own comment must not echo back to them (#82080).
+
+    Mirrors the self-skip in ``inject_new_comments_from_env`` — posting a
+    note authored by the same profile that owns the subscription produces no
+    notification, only a comment from someone else does.
+    """
+    db_path = tmp_path / "comment-self-skip.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"kanban": {"notify_on_comment": True}},
+    )
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="needs a note", assignee="worker")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        kb.add_comment(conn, tid, author="orchestrator", body="my own follow-up note")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    runner._kanban_notifier_profile = "orchestrator"
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert adapter.sent == []
+    # Cursor still advances past the self-authored comment (claimed, not re-delivered).
+    conn = kb.connect()
+    try:
+        _, remaining = kb.unseen_events_for_sub(
+            conn, task_id=tid, platform="telegram", chat_id="chat-1",
+            kinds=["commented"],
+        )
+    finally:
+        conn.close()
+    assert remaining == []

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -853,6 +853,8 @@ bot> ✓ t_9fc1a3 completed by transcriber
 
 Subscriptions auto-remove themselves once the task reaches `done` or `archived`. If you script a create with `--json` (machine output) the auto-subscribe is skipped — the assumption is that scripted callers want to manage subscriptions explicitly via `/kanban notify-subscribe`.
 
+Set `kanban.notify_on_comment: true` in `config.yaml` to also get pinged whenever `/kanban comment` (or the `kanban_comment` tool) adds a note to a subscribed task — author and a truncated preview of the body. Off by default to avoid noise on chatty threads; a comment never wakes the creator's agent the way `completed`/`blocked`/etc. do, and you never get pinged about your own comment.
+
 ### Output truncation in messaging
 
 Gateway platforms have practical message-length caps. If `/kanban list`, `/kanban show`, or `/kanban tail` produce more than ~3800 characters of output, the response is truncated with a `… (truncated; use \`hermes kanban …\` in your terminal for full output)` footer. The CLI surface has no such cap.


### PR DESCRIPTION
## Summary

Closes #82080.

Kanban subscribers currently only hear about terminal/state events
(`TERMINAL_KINDS` in `gateway/kanban_watchers.py`: `completed`, `blocked`,
`gave_up`, `crashed`, `timed_out`, `status`, `archived`, `unblocked`,
`block_loop_detected`). A worker's mid-run comment — a progress check-in or
an early "blocked on X" note — never reaches the task creator until the
eventual terminal event, sometimes hours later. This adds an opt-in
`commented` notification kind that reuses the existing subscription/notifier
plumbing.

## Changes

- **`hermes_cli/kanban_db.py`** — `add_comment()` already appends a
  `commented` task_event on every comment; its payload now also carries a
  truncated (500-char) copy of the comment body alongside the existing
  `author`/`len` fields, so the notifier can show a preview without a second
  DB read.
- **`gateway/kanban_watchers.py`**:
  - New `_kanban_comment_notify_enabled()` helper reads
    `kanban.notify_on_comment` (default `False`) fresh on every tick, mirroring
    the existing `_resolve_auto_decompose_settings()` live-toggle pattern.
  - The notifier only adds `"commented"` to the kind set it claims when the
    flag is on. `claim_unseen_events_for_sub` filters by kind in SQL, so with
    the flag off those rows are never selected — default behavior is
    byte-identical to before this kind existed.
  - New message branch formats `💬 ... comment by <author>: <preview>`, and
    skips sending when the comment's author matches the subscription's
    owning profile — mirroring the existing self-skip in
    `inject_new_comments_from_env()` (the worker-side comment-injection
    poller) so a subscriber never gets pinged about their own comment.
  - `commented` is intentionally **not** added to `_WAKE_KINDS`, so per the
    issue's acceptance criteria a comment notification never wakes the
    creator's agent — it's informative, not terminal.
- **`website/docs/user-guide/features/kanban.md`** — one paragraph
  documenting the new `kanban.notify_on_comment` config key.

## Testing

Added three tests to `tests/gateway/test_kanban_notifier.py`:
- `test_notifier_ignores_comments_by_default` — comment posted, subscriber
  gets nothing when the flag is unset (default-off / byte-identical check).
- `test_notifier_delivers_comment_when_enabled` — with the flag on, a
  comment from a different author than the subscription's owning profile
  delivers a message containing the author and body, and does **not**
  trigger a wake (`adapter.handled == []`).
- `test_notifier_skips_authors_own_comment` — with the flag on, a comment
  authored by the same profile that owns the subscription sends nothing, but
  the cursor still advances (no repeated re-delivery attempts).

Confirmed the two new positive-path tests fail without the fix (reverted
`gateway/kanban_watchers.py` and `hermes_cli/kanban_db.py` via
`git checkout HEAD~1 -- <file>` and re-ran):

```
FAILED tests/gateway/test_kanban_notifier.py::test_notifier_delivers_comment_when_enabled
FAILED tests/gateway/test_kanban_notifier.py::test_notifier_skips_authors_own_comment
2 failed, 9 passed in 1.29s
```

After restoring the fix, the full file passes:

```
$ scripts/run_tests.sh tests/gateway/test_kanban_notifier.py -q
[100.0% |    11/~11 | ✓11 | ✗ 0] ✓ tests/gateway/test_kanban_notifier.py (11✓, 1.6s)
=== Summary: 1 files, 11 tests passed, 0 failed (100% complete) in 1.6s (8 workers) ===
```

Also ran the neighboring kanban suites for regressions — all green:

```
scripts/run_tests.sh tests/gateway/test_kanban_notifier.py tests/tools/test_kanban_tools.py \
  tests/tools/test_kanban_comment_injection.py tests/tools/test_kanban_redaction.py \
  tests/plugins/test_kanban_dashboard_plugin.py tests/hermes_cli/test_kanban_db.py \
  tests/hermes_cli/test_kanban_diagnostics.py tests/hermes_cli/test_kanban_db_repair.py \
  tests/hermes_cli/test_kanban_db_init.py -q
=== Summary: 9 files, 108 tests passed, 0 failed ===
```

`ruff check` and `scripts/check-windows-footguns.py` are clean on all
changed files.

## AI assistance disclosure

This PR was prepared with assistance from an autonomous Claude Code agent
(Anthropic), including the implementation, tests, and this description.
A human reviewed the diff and test output before pushing.
