### PR TITLE
fix(desktop): make the HUD panel able to become the key window

### DIFF
--- a/apps/desktop/electron/hud-focusable.test.ts
+++ b/apps/desktop/electron/hud-focusable.test.ts
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { makeHudWindowFocusable } from './hud-focusable'
+
+test('makes the HUD panel focusable so macOS lets it become the key window', () => {
+  const calls: boolean[] = []
+
+  makeHudWindowFocusable({ setFocusable: focusable => calls.push(focusable) })
+
+  assert.deepEqual(calls, [true])
+})

--- a/apps/desktop/electron/hud-focusable.ts
+++ b/apps/desktop/electron/hud-focusable.ts
@@ -1,0 +1,13 @@
+// hud-focusable.ts — make the HUD's macOS NSPanel able to become the key window.
+//
+// An NSPanel never becomes key on its own, so `document.hasFocus()` stays
+// false in the renderer no matter how many times `win.focus()` is called at
+// creation — the composer never gets a caret and typing is swallowed. The pet
+// overlay hits the same wall and works around it with the exact same call
+// (see `hermes:pet-overlay:set-focusable` in main.ts); the HUD needs it
+// unconditionally since, unlike the overlay's pop-up composer, it always
+// wants the keyboard while open.
+
+export function makeHudWindowFocusable(win: { setFocusable: (focusable: boolean) => void }): void {
+  win.setFocusable(true)
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -134,6 +134,7 @@ import {
   resolveTimeoutMs,
   TEXT_PREVIEW_SOURCE_MAX_BYTES
 } from './hardening'
+import { makeHudWindowFocusable } from './hud-focusable'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
 import { ensureMainWindow } from './main-window-lifecycle'
 import {
@@ -9224,6 +9225,7 @@ function spawnHudWindow(sessionId) {
 
   win.setAlwaysOnTop(true, IS_MAC ? 'floating' : 'screen-saver')
   win.setHiddenInMissionControl?.(true)
+  makeHudWindowFocusable(win)
 
   try {
     win.setVisibleOnAllWorkspaces(


### PR DESCRIPTION
Fixes #81893

## Bug

HUD mode (#81552) opens on macOS but keyboard input never reaches the
composer: the floating window is mouse-interactive (click-through
correctly disengages over the bar), but no caret ever appears and
typing goes nowhere.

The HUD window is created as an `NSPanel` (`type: IS_MAC ? 'panel' :
undefined` in `spawnHudWindow()`), and on macOS an `NSPanel` does not
automatically become the **key window** — the window that receives
keyboard events — the way a regular `NSWindow` does. `win.focus()` at
`ready-to-show` doesn't reliably make it key, and clicking into it
doesn't promote it either. Since `apps/desktop/src/app/hud/click-through.ts`
gates the caret/typing path on `document.hasFocus()`, that stays
`false` forever and every keystroke is swallowed.

The pet overlay hits the exact same NSPanel limitation for its
pop-up composer and already works around it with an explicit
`setFocusable(true)` call (`hermes:pet-overlay:set-focusable` in
`main.ts`) before focusing. The HUD window had no equivalent.

## Fix

Apply the same `setFocusable(true)` call to the HUD window right
after creation, unconditionally — unlike the pet overlay's composer,
which toggles focusability on and off as its pop-up opens/closes, the
HUD always wants the keyboard while it's open.

Extracted into a tiny `apps/desktop/electron/hud-focusable.ts` module
(`makeHudWindowFocusable`) so the behavior is unit-testable, following
the same pattern already used for other small window helpers in this
directory (`window-reveal.ts`, `wake-indicator-window.ts`, etc.) — the
Electron `BrowserWindow`/`NSPanel` behavior itself can't be exercised
without macOS + a real window manager, so the test asserts the call
that fixes it is actually made.

## Test plan

Added `apps/desktop/electron/hud-focusable.test.ts`, which fails
without the fix (verified by temporarily reverting the new module to
a no-op and re-running) and passes with it:

```
✓ makes the HUD panel focusable so macOS lets it become the key window

 Test Files  1 passed (1)
      Tests  1 passed (1)
```

Also ran the full desktop test/lint/typecheck suite with no
regressions:

```
$ npx vitest run electron/
 Test Files  77 passed | 1 skipped (78)
      Tests  919 passed | 2 skipped (921)

$ npx eslint electron/hud-focusable.ts electron/hud-focusable.test.ts electron/main.ts
(no output — clean)

$ npx tsc -p tsconfig.electron.json --noEmit
(no output — clean)
```

## AI assistance disclosure

This change was written with AI assistance (Claude, via an automated
contribution agent), including the diagnosis, the fix, and the test.
