### PR TITLE
fix(codex): pin strict app-server launches

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -532,6 +532,7 @@ def init_agent(
     checkpoint_max_file_size_mb: int = 10,
     pass_session_id: bool = False,
     requested_provider: str = None,
+    codex_app_server_strict_config: bool | None = None,
 ):
     """
     Initialize the AI Agent.
@@ -1634,6 +1635,16 @@ def init_agent(
         _agent_cfg = _load_agent_config()
     except Exception:
         _agent_cfg = {}
+
+    if codex_app_server_strict_config is None:
+        agent.codex_app_server_strict_config = (
+            cfg_get(
+                _agent_cfg, "codex_app_server", "strict_config", default=False
+            )
+            is True
+        )
+    else:
+        agent.codex_app_server_strict_config = codex_app_server_strict_config is True
 
     # Codex commentary visibility (display.show_commentary, default true).
     # When true, completed Codex phase=commentary messages are delivered as

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -643,6 +643,10 @@ def run_codex_app_server_turn(
         from agent.runtime_cwd import resolve_agent_cwd
 
         cwd = getattr(agent, "session_cwd", None) or str(resolve_agent_cwd())
+        strict_config = getattr(agent, "codex_app_server_strict_config", False) is True
+        model = str(getattr(agent, "model", "") or "").strip()
+        reasoning = getattr(agent, "reasoning_config", None)
+        effort = reasoning.get("effort") if isinstance(reasoning, dict) else None
         # Approval callback: defer to Hermes' standard prompt flow if a
         # CLI thread has installed one. Gateway / cron contexts get the
         # codex-side fail-closed default.
@@ -688,6 +692,9 @@ def run_codex_app_server_turn(
                 auto_approve_apply_patch=auto_approve_requests,
             ),
             on_event=make_codex_app_server_event_bridge(agent),
+            strict_config=strict_config,
+            model=model,
+            reasoning_effort=effort,
         )
 
     # NOTE: the user message is ALREADY appended to messages by the

--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -74,7 +74,25 @@ class CodexAppServerClient:
         codex_home: Optional[str] = None,
         extra_args: Optional[list[str]] = None,
         env: Optional[dict[str, str]] = None,
+        strict_config: bool = False,
+        model: Optional[str] = None,
+        reasoning_effort: Optional[str] = None,
     ) -> None:
+        if strict_config is True:
+            if not isinstance(model, str):
+                raise ValueError("codex_app_server.strict_config requires a string model")
+            if not isinstance(reasoning_effort, str):
+                raise ValueError(
+                    "codex_app_server.strict_config requires a string reasoning effort"
+                )
+            model = model.strip()
+            effort = reasoning_effort.strip().lower()
+            if not model:
+                raise ValueError("codex_app_server.strict_config requires a model")
+            if effort not in {"none", "minimal", "low", "medium", "high", "xhigh"}:
+                raise ValueError(
+                    "codex_app_server.strict_config requires a supported reasoning effort"
+                )
         self._codex_bin = codex_bin
         # codex app-server is a model-driving CLI executor: it runs a
         # model-chosen agentic loop that executes shell commands, so it
@@ -123,7 +141,18 @@ class CodexAppServerClient:
                 ]
             )
 
-        cmd = [codex_bin, "app-server"] + app_server_args
+        if strict_config is True:
+            cmd = [
+                codex_bin,
+                "--strict-config",
+                "--model",
+                model,
+                "-c",
+                f'model_reasoning_effort="{effort}"',
+                "app-server",
+            ] + app_server_args
+        else:
+            cmd = [codex_bin, "app-server"] + app_server_args
         # Codex emits tracing to stderr; default WARN keeps it quiet for users.
         spawn_env.setdefault("RUST_LOG", "warn")
 

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -282,6 +282,9 @@ class CodexAppServerSession:
         on_event: Optional[Callable[[dict], None]] = None,
         request_routing: Optional[_ServerRequestRouting] = None,
         client_factory: Optional[Callable[..., CodexAppServerClient]] = None,
+        strict_config: bool = False,
+        model: Optional[str] = None,
+        reasoning_effort: Optional[str] = None,
     ) -> None:
         self._cwd = cwd or os.getcwd()
         self._codex_bin = codex_bin
@@ -296,6 +299,9 @@ class CodexAppServerSession:
         self._on_event = on_event  # Display hook (kawaii spinner ticks etc.)
         self._routing = request_routing or _ServerRequestRouting()
         self._client_factory = client_factory or CodexAppServerClient
+        self._strict_config = strict_config
+        self._model = model
+        self._reasoning_effort = reasoning_effort
 
         self._client: Optional[CodexAppServerClient] = None
         self._thread_id: Optional[str] = None
@@ -320,7 +326,11 @@ class CodexAppServerSession:
             return self._thread_id
         if self._client is None:
             self._client = self._client_factory(
-                codex_bin=self._codex_bin, codex_home=self._codex_home
+                codex_bin=self._codex_bin,
+                codex_home=self._codex_home,
+                strict_config=self._strict_config,
+                model=self._model,
+                reasoning_effort=self._reasoning_effort,
             )
         self._client.initialize(
             client_name="hermes",

--- a/hermes_cli/codex_runtime_plugin_migration.py
+++ b/hermes_cli/codex_runtime_plugin_migration.py
@@ -42,6 +42,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
 
+from hermes_constants import resolve_reasoning_config
+
 logger = logging.getLogger(__name__)
 
 
@@ -450,6 +452,10 @@ def _strip_existing_managed_block(toml_text: str) -> str:
 def _query_codex_plugins(
     codex_home: Optional[Path] = None,
     timeout: float = 8.0,
+    *,
+    strict_config: bool = False,
+    model: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
 ) -> tuple[list[dict], Optional[str]]:
     """Query codex's `plugin/list` for installed curated plugins.
 
@@ -469,7 +475,10 @@ def _query_codex_plugins(
 
     try:
         with CodexAppServerClient(
-            codex_home=str(codex_home) if codex_home else None
+            codex_home=str(codex_home) if codex_home else None,
+            strict_config=strict_config,
+            model=model,
+            reasoning_effort=reasoning_effort,
         ) as client:
             client.initialize(client_name="hermes-migration")
             resp = client.request("plugin/list", {}, timeout=timeout)
@@ -671,7 +680,28 @@ def migrate(
     plugins: list[dict] = []
     plugin_query_succeeded = False
     if discover_plugins and not dry_run:
-        plugins, plugin_err = _query_codex_plugins(codex_home=codex_home)
+        codex_app_server = (hermes_config or {}).get("codex_app_server") or {}
+        strict_config = (
+            isinstance(codex_app_server, dict)
+            and codex_app_server.get("strict_config") is True
+        )
+        model = None
+        reasoning_effort = None
+        if strict_config:
+            model_config = (hermes_config or {}).get("model") or {}
+            if isinstance(model_config, str):
+                model = model_config.strip()
+            elif isinstance(model_config, dict):
+                model = model_config.get("default")
+            reasoning_config = resolve_reasoning_config(hermes_config, model)
+            if isinstance(reasoning_config, dict):
+                reasoning_effort = reasoning_config.get("effort")
+        plugins, plugin_err = _query_codex_plugins(
+            codex_home=codex_home,
+            strict_config=strict_config,
+            model=model,
+            reasoning_effort=reasoning_effort,
+        )
         if plugin_err:
             report.plugin_query_error = plugin_err
         else:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -10,6 +10,8 @@ DEFAULT_CONFIG = {
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
+    # Opt in to strict, model-pinned native Codex App Server launches.
+    "codex_app_server": {"strict_config": False},
     # SQLite journal mode used by every Hermes database opener. WAL is the
     # normal default; set DELETE for weak-fsync/shared filesystems where WAL is
     # not crash-safe (for example macOS virtiofs, NFS, or SMB).

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -331,6 +331,7 @@ def _run_agent(
     # Imports are local so they don't run when hermes is invoked for
     # other commands (keeps top-level CLI startup cheap).
     from hermes_cli.config import load_config
+    from hermes_constants import resolve_reasoning_config
     from hermes_cli.models import detect_provider_for_model
     from hermes_cli.runtime_provider import resolve_runtime_provider
     from hermes_cli.tools_config import _get_platform_tools
@@ -391,6 +392,8 @@ def _run_agent(
                 if detected:
                     effective_provider, effective_model = detected
 
+    reasoning_config = resolve_reasoning_config(cfg, effective_model)
+
     runtime = resolve_runtime_provider(
         requested=effective_provider,
         target_model=effective_model or None,
@@ -437,6 +440,7 @@ def _run_agent(
             requested_provider=runtime.get("requested_provider"),
             api_mode=runtime.get("api_mode"),
             model=effective_model,
+            reasoning_config=reasoning_config,
             enabled_toolsets=toolsets_list,
             quiet_mode=True,
             platform="cli",

--- a/run_agent.py
+++ b/run_agent.py
@@ -509,6 +509,7 @@ class AIAgent:
         checkpoint_max_file_size_mb: int = 10,
         pass_session_id: bool = False,
         requested_provider: str = None,
+        codex_app_server_strict_config: bool | None = None,
     ):
         """Forwarder — see ``agent.agent_init.init_agent``."""
         if tool_delay is not None:
@@ -595,6 +596,7 @@ class AIAgent:
             checkpoint_max_total_size_mb=checkpoint_max_total_size_mb,
             checkpoint_max_file_size_mb=checkpoint_max_file_size_mb,
             pass_session_id=pass_session_id,
+            codex_app_server_strict_config=codex_app_server_strict_config,
         )
 
     def _get_session_db_for_recall(self):

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -110,6 +110,125 @@ class TestCodexAppServerModule:
         assert "boom" in str(err)
         assert "-32600" in str(err)
 
+    @staticmethod
+    def _capture_cmd(monkeypatch, **kwargs):
+        import subprocess
+        from agent.transports import codex_app_server as cas
+        captured = {}
+
+        class FakePopen:
+            def __init__(self, cmd, *args, **popen_kwargs):
+                captured["cmd"] = list(cmd)
+                self.stdin = self.stdout = self.stderr = None
+                self.pid = 1
+                self.returncode = None
+            def poll(self): return None
+            def terminate(self): pass
+            def wait(self, timeout=None): return 0
+            def kill(self): pass
+
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+        client = cas.CodexAppServerClient(codex_bin="codex", **kwargs)
+        client._closed = True
+        return captured["cmd"]
+
+    def test_strict_config_pins_model_and_effort_before_app_server(self, monkeypatch):
+        assert self._capture_cmd(
+            monkeypatch,
+            strict_config=True,
+            model="gpt-5.6-terra",
+            reasoning_effort="medium",
+            extra_args=["-c", 'sandbox_mode="workspace-write"'],
+        ) == [
+            "codex", "--strict-config", "--model", "gpt-5.6-terra", "-c",
+            'model_reasoning_effort="medium"', "app-server",
+            "-c", 'sandbox_mode="workspace-write"',
+        ]
+
+    def test_session_factory_receives_strict_config_model_and_effort(self):
+        from agent.transports.codex_app_server_session import CodexAppServerSession
+
+        captured = {}
+
+        class FakeClient:
+            def initialize(self, **kwargs):
+                pass
+
+            def request(self, method, params, timeout=None):
+                assert method == "thread/start"
+                return {"thread": {"id": "thread-1"}}
+
+        def capture_factory(**kwargs):
+            captured.update(kwargs)
+            return FakeClient()
+
+        session = CodexAppServerSession(
+            strict_config=True,
+            model="gpt-5.6-terra",
+            reasoning_effort="medium",
+            client_factory=capture_factory,
+        )
+
+        assert session.ensure_started() == "thread-1"
+        assert captured == {
+            "codex_bin": "codex",
+            "codex_home": None,
+            "strict_config": True,
+            "model": "gpt-5.6-terra",
+            "reasoning_effort": "medium",
+        }
+
+    def test_legacy_argv_is_unchanged_when_strict_config_is_false(self, monkeypatch):
+        assert self._capture_cmd(monkeypatch) == ["codex", "app-server"]
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"strict_config": True},
+            {"strict_config": True, "model": "m"},
+            {"strict_config": True, "model": "m", "reasoning_effort": "bogus"},
+        ],
+    )
+    def test_strict_config_rejects_missing_or_invalid_pins_before_spawn(self, monkeypatch, kwargs):
+        import subprocess
+        monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: pytest.fail("spawned"))
+        with pytest.raises(ValueError):
+            from agent.transports.codex_app_server import CodexAppServerClient
+            CodexAppServerClient(codex_bin="codex", **kwargs)
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"strict_config": "true", "model": "gpt-5.6", "reasoning_effort": "medium"},
+            {"strict_config": True, "model": 123, "reasoning_effort": "medium"},
+            {"strict_config": True, "model": ["gpt-5.6"], "reasoning_effort": "medium"},
+            {"strict_config": True, "model": "gpt-5.6", "reasoning_effort": 1},
+            {"strict_config": True, "model": "gpt-5.6", "reasoning_effort": {"value": "medium"}},
+        ],
+    )
+    def test_strict_pin_type_boundary_rejects_nonstrings_before_spawn(
+        self, monkeypatch, kwargs
+    ):
+        import subprocess
+
+        spawned = False
+
+        class FakePopen:
+            def __init__(self, *args, **kwargs):
+                nonlocal spawned
+                spawned = True
+                self.stdin = self.stdout = self.stderr = None
+
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+        from agent.transports.codex_app_server import CodexAppServerClient
+
+        if kwargs["strict_config"] is True:
+            with pytest.raises(ValueError):
+                CodexAppServerClient(codex_bin="codex", **kwargs)
+        else:
+            CodexAppServerClient(codex_bin="codex", **kwargs)
+        assert spawned is (kwargs["strict_config"] is not True)
+
 
 class TestSpawnEnvIsolation:
     """The codex spawn must NOT rewrite HOME — codex's shell tool spawns
@@ -339,4 +458,3 @@ class TestSpawnEnvSecretStripping:
         monkeypatch.setenv("OPENAI_API_KEY", "sk-codex-needs-this")
         env = self._capture_spawn_env(monkeypatch)
         assert env.get("OPENAI_API_KEY") == "sk-codex-needs-this"
-

--- a/tests/hermes_cli/test_codex_runtime_plugin_migration.py
+++ b/tests/hermes_cli/test_codex_runtime_plugin_migration.py
@@ -11,6 +11,7 @@ from hermes_cli.codex_runtime_plugin_migration import (
     _build_hermes_tools_mcp_entry,
     _format_toml_value,
     _looks_like_test_tempdir,
+    _query_codex_plugins,
     _strip_existing_managed_block,
     _strip_unmanaged_plugin_tables,
     _translate_one_server,
@@ -162,6 +163,217 @@ class TestStripExistingManagedBlock:
 
 class TestMigrate:
 
+    def test_invalid_strict_model_keeps_migration_best_effort(
+        self, tmp_path, monkeypatch
+    ):
+        import subprocess
+
+        monkeypatch.setattr(
+            subprocess,
+            "Popen",
+            lambda *args, **kwargs: pytest.fail("invalid strict pin spawned"),
+        )
+        report = migrate(
+            {
+                "mcp_servers": {"filesystem": {"command": "npx"}},
+                "model": {"default": 123},
+                "agent": {"reasoning_effort": "medium"},
+                "codex_app_server": {"strict_config": True},
+            },
+            codex_home=tmp_path,
+            expose_hermes_tools=False,
+        )
+
+        assert report.plugin_query_error
+        assert report.migrated == ["filesystem"]
+        assert report.migrated_plugins == []
+        assert report.written is True
+        assert (tmp_path / "config.toml").exists()
+
+    def test_plugin_query_constructs_strict_client_with_typed_pins(
+        self, tmp_path, monkeypatch
+    ):
+        """Strict plugin discovery reaches the App Server client with pins."""
+        from agent.transports import codex_app_server
+
+        captured = {}
+
+        class FakeClient:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def initialize(self, **kwargs):
+                return None
+
+            def request(self, *args, **kwargs):
+                return {"marketplaces": []}
+
+        monkeypatch.setattr(codex_app_server, "CodexAppServerClient", FakeClient)
+
+        plugins, error = _query_codex_plugins(
+            codex_home=tmp_path,
+            strict_config=True,
+            model="gpt-5.6-terra",
+            reasoning_effort="medium",
+        )
+
+        assert (plugins, error) == ([], None)
+        assert captured == {
+            "codex_home": str(tmp_path),
+            "strict_config": True,
+            "model": "gpt-5.6-terra",
+            "reasoning_effort": "medium",
+        }
+
+    def test_plugin_query_constructs_legacy_unpinned_client(self, tmp_path, monkeypatch):
+        """The false default preserves the client's legacy app-server launch."""
+        from agent.transports import codex_app_server
+
+        captured = {}
+
+        class FakeClient:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def initialize(self, **kwargs):
+                return None
+
+            def request(self, *args, **kwargs):
+                return {"marketplaces": []}
+
+        monkeypatch.setattr(codex_app_server, "CodexAppServerClient", FakeClient)
+
+        plugins, error = _query_codex_plugins(codex_home=tmp_path)
+
+        assert (plugins, error) == ([], None)
+        assert captured == {
+            "codex_home": str(tmp_path),
+            "strict_config": False,
+            "model": None,
+            "reasoning_effort": None,
+        }
+
+    def test_plugin_discovery_receives_strict_resolved_pins(self, tmp_path, monkeypatch):
+        from hermes_cli import codex_runtime_plugin_migration as crpm
+
+        captured = {}
+
+        def fake_query(**kwargs):
+            captured.update(kwargs)
+            return [], None
+
+        monkeypatch.setattr(crpm, "_query_codex_plugins", fake_query)
+        migrate(
+            {
+                "model": {"default": "gpt-5.6-terra"},
+                "agent": {"reasoning_effort": "medium"},
+                "codex_app_server": {"strict_config": True},
+            },
+            codex_home=tmp_path,
+            expose_hermes_tools=False,
+        )
+
+        assert captured == {
+            "codex_home": tmp_path,
+            "strict_config": True,
+            "model": "gpt-5.6-terra",
+            "reasoning_effort": "medium",
+        }
+
+    def test_plugin_discovery_supports_legacy_string_model_config(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli import codex_runtime_plugin_migration as crpm
+
+        captured = {}
+
+        def fake_query(**kwargs):
+            captured.update(kwargs)
+            return [], None
+
+        monkeypatch.setattr(crpm, "_query_codex_plugins", fake_query)
+        migrate(
+            {
+                "model": " gpt-5.6-terra ",
+                "agent": {"reasoning_effort": "medium"},
+                "codex_app_server": {"strict_config": True},
+            },
+            codex_home=tmp_path,
+            expose_hermes_tools=False,
+        )
+
+        assert captured == {
+            "codex_home": tmp_path,
+            "strict_config": True,
+            "model": "gpt-5.6-terra",
+            "reasoning_effort": "medium",
+        }
+
+    def test_plugin_discovery_uses_per_model_reasoning_override(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli import codex_runtime_plugin_migration as crpm
+
+        captured = {}
+
+        def fake_query(**kwargs):
+            captured.update(kwargs)
+            return [], None
+
+        monkeypatch.setattr(crpm, "_query_codex_plugins", fake_query)
+        migrate(
+            {
+                "model": {"default": "gpt-5.6-terra"},
+                "agent": {
+                    "reasoning_effort": "low",
+                    "reasoning_overrides": {"gpt-5.6-terra": "medium"},
+                },
+                "codex_app_server": {"strict_config": True},
+            },
+            codex_home=tmp_path,
+            expose_hermes_tools=False,
+        )
+
+        assert captured["reasoning_effort"] == "medium"
+
+    def test_plugin_discovery_requires_literal_true_for_strict_mode(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli import codex_runtime_plugin_migration as crpm
+
+        captured = {}
+
+        def fake_query(**kwargs):
+            captured.update(kwargs)
+            return [], None
+
+        monkeypatch.setattr(crpm, "_query_codex_plugins", fake_query)
+        migrate(
+            {
+                "model": {"default": "gpt-5.6-terra"},
+                "agent": {"reasoning_effort": "medium"},
+                "codex_app_server": {"strict_config": "true"},
+            },
+            codex_home=tmp_path,
+            expose_hermes_tools=False,
+        )
+
+        assert captured["strict_config"] is False
+        assert captured["model"] is None
+        assert captured["reasoning_effort"] is None
+
 
 
     def test_plugin_discovery_writes_plugin_blocks(self, tmp_path, monkeypatch):
@@ -169,7 +381,7 @@ class TestMigrate:
         blocks. This is what OpenClaw calls 'migrate native codex plugins.'"""
         from hermes_cli import codex_runtime_plugin_migration as crpm
 
-        def fake_query(codex_home=None, timeout=8.0):
+        def fake_query(codex_home=None, timeout=8.0, **kwargs):
             return [
                 {"name": "google-calendar", "marketplace": "openai-curated",
                  "enabled": True},
@@ -192,7 +404,7 @@ class TestMigrate:
         completes. The error surfaces in the report but doesn't abort."""
         from hermes_cli import codex_runtime_plugin_migration as crpm
 
-        def fake_query_fails(codex_home=None, timeout=8.0):
+        def fake_query_fails(codex_home=None, timeout=8.0, **kwargs):
             return [], "codex CLI not available"
         monkeypatch.setattr(crpm, "_query_codex_plugins", fake_query_fails)
 
@@ -355,7 +567,7 @@ class TestStripUnmanagedPluginTables:
         )
 
         # Simulate codex's plugin/list reporting the same plugin tasks@openai-curated.
-        def fake_query(codex_home=None, timeout=8.0):
+        def fake_query(codex_home=None, timeout=8.0, **kwargs):
             return (
                 [{"name": "tasks", "marketplace": "openai-curated", "enabled": True}],
                 None,

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -216,6 +216,74 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
     assert captured["prompt"] == "recall this"
 
 
+def test_oneshot_passes_resolved_reasoning_config(monkeypatch):
+    """oneshot passes the shared effective reasoning config to AIAgent."""
+    from hermes_cli.oneshot import _run_agent
+
+    captured = {}
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self.suppress_status_output = False
+            self.stream_delta_callback = object()
+            self.tool_gen_callback = object()
+
+        def run_conversation(self, prompt, **_kwargs):
+            return {"final_response": "ok", "failed": False}
+
+        def shutdown_memory_provider(self, *_args):
+            pass
+
+        def close(self):
+            pass
+
+    def mod(name, **attrs):
+        module = types.ModuleType(name)
+        for key, value in attrs.items():
+            setattr(module, key, value)
+        return module
+
+    cfg = {
+        "model": {"default": "gpt-5.6-terra"},
+        "agent": {
+            "reasoning_effort": "medium",
+            "reasoning_overrides": {"gpt-5.6-terra": "high"},
+        },
+    }
+    monkeypatch.setitem(sys.modules, "run_agent", mod("run_agent", AIAgent=FakeAgent))
+    monkeypatch.setitem(sys.modules, "hermes_state", mod("hermes_state", SessionDB=lambda: None))
+    monkeypatch.setitem(sys.modules, "hermes_cli.config", mod("hermes_cli.config", load_config=lambda: cfg))
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.models",
+        mod("hermes_cli.models", detect_provider_for_model=lambda *_args, **_kwargs: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.runtime_provider",
+        mod(
+            "hermes_cli.runtime_provider",
+            resolve_runtime_provider=lambda **_kwargs: {
+                "api_key": "k",
+                "base_url": "u",
+                "provider": "p",
+                "api_mode": "chat_completions",
+                "credential_pool": None,
+            },
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.tools_config",
+        mod("hermes_cli.tools_config", _get_platform_tools=lambda *_args, **_kwargs: set()),
+    )
+
+    _run_agent("reason about this")
+
+    assert captured.get("reasoning_config") == {"enabled": True, "effort": "high"}
+
+
 def test_launch_tui_exports_model_provider_and_toolsets(monkeypatch, main_mod):
     captured = {}
     active_path_during_call = None

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -73,6 +73,184 @@ class TestApiModeAccepted:
 
 
 class TestRunConversationCodexPath:
+    def test_explicit_strict_false_is_authoritative_after_construction(
+        self, tmp_path, monkeypatch
+    ):
+        captured = {}
+
+        def fake_init(self, **kwargs):
+            captured.update(kwargs)
+            self._thread_id = "thread-explicit-false-1"
+
+        monkeypatch.setattr(CodexAppServerSession, "__init__", fake_init)
+        monkeypatch.setattr(
+            CodexAppServerSession,
+            "run_turn",
+            lambda self, user_input, **kwargs: TurnResult(
+                final_text="ok", projected_messages=[], thread_id=self._thread_id
+            ),
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "codex_app_server:\n  strict_config: true\n", encoding="utf-8"
+        )
+
+        agent = _make_codex_agent(codex_app_server_strict_config=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: (_ for _ in ()).throw(AssertionError("late config read")),
+        )
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("hello")
+
+        assert captured["strict_config"] is False
+
+    def test_profile_strict_pins_reach_session(self, tmp_path, monkeypatch):
+        captured = {}
+
+        def fake_init(self, **kwargs):
+            captured.update(kwargs)
+            self._thread_id = "thread-config-1"
+
+        monkeypatch.setattr(CodexAppServerSession, "__init__", fake_init)
+        monkeypatch.setattr(
+            CodexAppServerSession, "run_turn",
+            lambda self, user_input, **kwargs: TurnResult(
+                final_text="ok", projected_messages=[], thread_id="thread-config-1"
+            ),
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "codex_app_server:\n  strict_config: true\n", encoding="utf-8"
+        )
+        agent = _make_codex_agent(model="gpt-5.6-terra", reasoning_config={"effort": "medium"})
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("hello")
+        assert captured["strict_config"] is True
+        assert captured["model"] == "gpt-5.6-terra"
+        assert captured["reasoning_effort"] == "medium"
+
+    def test_profile_strict_config_is_snapshotted_at_construction(
+        self, tmp_path, monkeypatch
+    ):
+        captured = {}
+
+        def fake_init(self, **kwargs):
+            captured.update(kwargs)
+            self._thread_id = "thread-profile-snapshot-1"
+
+        monkeypatch.setattr(CodexAppServerSession, "__init__", fake_init)
+        monkeypatch.setattr(
+            CodexAppServerSession,
+            "run_turn",
+            lambda self, user_input, **kwargs: TurnResult(
+                final_text="ok", projected_messages=[], thread_id=self._thread_id
+            ),
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "codex_app_server:\n  strict_config: true\n", encoding="utf-8"
+        )
+        agent = _make_codex_agent()
+        config_path.write_text(
+            "codex_app_server:\n  strict_config: false\n", encoding="utf-8"
+        )
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("hello")
+
+        assert captured["strict_config"] is True
+
+    @pytest.mark.parametrize(
+        ("configured_value", "explicit_value", "expected"),
+        [
+            (None, None, False),
+            (False, None, False),
+            ("true", None, False),
+            (1, None, False),
+            (True, None, True),
+            (False, False, False),
+            (False, True, True),
+            (True, "true", False),
+        ],
+    )
+    def test_strict_config_normalizes_to_exact_boolean_true(
+        self, tmp_path, monkeypatch, configured_value, explicit_value, expected
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        if configured_value is None:
+            config_text = "{}\n"
+        else:
+            config_text = f"codex_app_server:\n  strict_config: {configured_value!r}\n"
+        (tmp_path / "config.yaml").write_text(config_text, encoding="utf-8")
+
+        kwargs = {}
+        if explicit_value is not None:
+            kwargs["codex_app_server_strict_config"] = explicit_value
+        agent = _make_codex_agent(**kwargs)
+
+        assert agent.codex_app_server_strict_config is expected
+
+    def test_missing_strict_config_preserves_default_session_pins(
+        self, tmp_path, monkeypatch
+    ):
+        captured = {}
+
+        def fake_init(self, **kwargs):
+            captured.update(kwargs)
+            self._thread_id = "thread-default-1"
+
+        monkeypatch.setattr(CodexAppServerSession, "__init__", fake_init)
+        monkeypatch.setattr(
+            CodexAppServerSession, "run_turn",
+            lambda self, user_input, **kwargs: TurnResult(
+                final_text="ok", projected_messages=[], thread_id="thread-default-1"
+            ),
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "{}\n", encoding="utf-8"
+        )
+        agent = _make_codex_agent(
+            model="gpt-5.6-terra", reasoning_config={"effort": "medium"}
+        )
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("hello")
+        assert captured["strict_config"] is False
+        assert captured["model"] == "gpt-5.6-terra"
+        assert captured["reasoning_effort"] == "medium"
+
+    def test_config_loader_failure_at_construction_defaults_strict_false(
+        self, monkeypatch
+    ):
+        captured = {}
+
+        def fake_init(self, **kwargs):
+            captured.update(kwargs)
+            self._thread_id = "thread-config-failure-1"
+
+        monkeypatch.setattr(CodexAppServerSession, "__init__", fake_init)
+        monkeypatch.setattr(
+            CodexAppServerSession,
+            "run_turn",
+            lambda self, user_input, **kwargs: TurnResult(
+                final_text="ok", projected_messages=[], thread_id=self._thread_id
+            ),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: (_ for _ in ()).throw(RuntimeError("config unavailable")),
+        )
+        agent = _make_codex_agent(
+            model="gpt-5.6-terra", reasoning_config={"effort": "medium"}
+        )
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("hello")
+        assert agent.codex_app_server_strict_config is False
+        assert captured["strict_config"] is False
+
     def test_run_conversation_returns_codex_shape(self, fake_session):
         agent = _make_codex_agent()
         # No background review fork during tests

--- a/website/docs/user-guide/features/codex-app-server-runtime.md
+++ b/website/docs/user-guide/features/codex-app-server-runtime.md
@@ -195,7 +195,19 @@ You can also set it manually in `~/.hermes/config.yaml`:
 ```yaml
 model:
   openai_runtime: codex_app_server   # default is "auto" (= Hermes runtime)
+codex_app_server:
+  strict_config: true
 ```
+
+With `strict_config: true`, Hermes pins the native launch to the existing
+`model.default` and resolved `agent.reasoning_effort` settings. Both must be
+present and the effort must be one of the supported Codex values; otherwise
+Hermes fails before starting Codex. The launch has this shape:
+`codex --strict-config --model <model> -c model_reasoning_effort="<effort>" app-server`.
+Existing App Server and Kanban overrides follow `app-server`. The default is
+`false`, which preserves the legacy `codex app-server` launch and its existing
+argument behavior. Model and effort are not duplicated under this block.
+Migration plugin discovery obeys these same strict launch pins.
 
 ## Self-improvement loop (memory + skill nudges)
 


### PR DESCRIPTION
## Summary

Add an opt-in, fail-closed launch mode for every Hermes-owned native Codex App Server child.

When `codex_app_server.strict_config` is exactly `true`, Hermes pins the active agent model and resolved reasoning effort in the actual Codex subprocess arguments:

```text
codex --strict-config --model <model> -c model_reasoning_effort="<effort>" app-server
```

Existing App Server and Kanban sandbox overrides remain after the subcommand. The default is false, so legacy users retain the exact existing `codex app-server` launch.

## Why

Hermes profiles can select a model and reasoning effort, but the App Server subprocess previously inherited neither value. The executed coding model could therefore fall back to shared Codex defaults rather than the active Hermes agent assignment.

This change uses typed Hermes configuration rather than raw argument passthrough, environment variables, wrapper scripts, or shared Codex model settings.

## Behavior

* Strict mode requires a nonempty active model and a supported resolved reasoning effort.
* Invalid or missing strict pins fail before subprocess creation.
* Strict mode is captured once when `AIAgent` is constructed. An explicit constructor boolean is authoritative; otherwise Hermes snapshots the active profile during its existing initialization config load.
* Lazy App Server session creation does not reread configuration.
* Plugin discovery during Codex runtime migration uses the same strict model and effort pins while remaining best effort.
* Canonical structured `model.default` and legacy bare-string model configurations are supported during migration.
* One-shot `hermes -z` resolves and forwards the same effective reasoning configuration as normal CLI.
* Per-model reasoning overrides use Hermes's authoritative reasoning resolver.
* No shell is involved. Arguments are passed as an argv list.
* Authentication, approvals, plugins, profile isolation, and Kanban sandbox and network boundaries are unchanged.

## Tests

* 266 focused runtime, session, migration, one-shot, lifecycle, compaction, configuration, profile-routing, event-bridge, and Kanban worker tests passed.
* The same 266-test wall passed after applying the complete patch to current upstream commit `4b601931` in a disposable worktree.
* Ruff passed for every changed Python file.
* Python compilation and `git diff --check` passed.
* An added-line security scan found no hardcoded secret, shell injection, dynamic evaluation, unsafe deserialization, or formatted SQL pattern.
* The complete repository suite was previously unable to collect because optional ACP, messaging, and Home Assistant development dependencies were absent. Collection stopped with 25 missing-module errors; no executed test reported a product failure.

## Independent review

Gemini 3.1 Pro High reviewed the exact final diff and returned PASS with no finding. A second reviewer identified raw `model.model` alias handling in direct migration callers; that compatibility path is explicitly deferred, while the installed profile uses canonical `model.default`.
