### PR TITLE
feat(kanban): extend goal-mode turn budget when a worker shows progress

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -18067,6 +18067,22 @@ def _kanban_workspace_git_head(path: str) -> "str | None":
     return result.stdout.strip() or None
 
 
+def _kanban_goal_max_turns_ceiling(max_turns: int) -> int:
+    """Absolute turn ceiling for a goal loop's budget extension.
+
+    Must leave room for at least one extension above whatever budget the
+    card was configured with — otherwise a card whose ``goal_max_turns``
+    already meets or exceeds ``DEFAULT_GOAL_MAX_TURNS_CEILING`` (200 is a
+    common explicit ``--goal-max-turns`` value; see #81990) would never
+    benefit from the extension mechanism at all, since the gate in
+    ``run_kanban_goal_loop`` skips straight to blocking once the starting
+    budget already meets the ceiling.
+    """
+    from hermes_cli.goals import DEFAULT_GOAL_EXTENSION_TURNS, DEFAULT_GOAL_MAX_TURNS_CEILING
+
+    return max(DEFAULT_GOAL_MAX_TURNS_CEILING, int(max_turns) + DEFAULT_GOAL_EXTENSION_TURNS)
+
+
 def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
     """Drive a kanban goal_mode worker through the Ralph-style goal loop.
 
@@ -18192,6 +18208,7 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
         first_response=first_response or "",
         log=lambda m: logger.info("%s", m),
         progress_check_fn=_progress_check,
+        max_turns_ceiling=_kanban_goal_max_turns_ceiling(max_turns),
     )
 
 

--- a/cli.py
+++ b/cli.py
@@ -18042,6 +18042,31 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 # Main Entry Point
 # ============================================================================
 
+def _kanban_workspace_git_head(path: str) -> "str | None":
+    """Best-effort ``git rev-parse HEAD`` for a kanban task's workspace.
+
+    Used as a progress signal for the goal loop: unlike a heartbeat (which
+    fires on ordinary API/tool bookkeeping regardless of whether the worker
+    is actually getting anywhere), a moved HEAD means a commit landed —
+    real, hard-to-fake evidence of forward progress. Fail-closed: returns
+    None (no signal) for a missing/non-git workspace, a git error, or a
+    hung git process, never raises.
+    """
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["git", "-C", path, "rev-parse", "HEAD"],
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=5, stdin=subprocess.DEVNULL,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
 def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
     """Drive a kanban goal_mode worker through the Ralph-style goal loop.
 
@@ -18084,9 +18109,12 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
     max_turns = task.goal_max_turns or _DEF_TURNS
 
     # Snapshot progress markers before the loop starts so a stuck worker
-    # (no heartbeat, no operator comments since spawn) still blocks at the
-    # turn budget instead of extending forever.
-    loop_started_at = int(time.time())
+    # (no new operator comments, no commits landed since spawn) still
+    # blocks at the turn budget instead of extending forever. Heartbeats
+    # are deliberately NOT used here: they fire on ordinary API/tool
+    # bookkeeping (rate-limited, but on every kind of activity) regardless
+    # of whether the worker is making real headway, so they can't tell a
+    # genuinely stuck worker from one thrashing uselessly (#81990 review).
     conn = _kb.connect()
     try:
         _existing_comments = _kb.list_comments(conn, task_id)
@@ -18097,20 +18125,25 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
             pass
     initial_comment_id = _existing_comments[-1].id if _existing_comments else 0
 
+    initial_head = None
+    if task.workspace_kind in ("worktree", "dir") and task.workspace_path:
+        initial_head = _kanban_workspace_git_head(task.workspace_path)
+
     def _progress_check() -> bool:
         c = _kb.connect()
         try:
-            t = _kb.get_task(c, task_id)
-            if t is None:
-                return False
-            if t.last_heartbeat_at and t.last_heartbeat_at >= loop_started_at:
+            if _kb.list_comments_after(c, task_id, after_id=initial_comment_id):
                 return True
-            return bool(_kb.list_comments_after(c, task_id, after_id=initial_comment_id))
         finally:
             try:
                 c.close()
             except Exception:
                 pass
+        if initial_head is not None:
+            current_head = _kanban_workspace_git_head(task.workspace_path)
+            if current_head is not None and current_head != initial_head:
+                return True
+        return False
 
     def _run_turn(prompt: str) -> str:
         result = cli.agent.run_conversation(

--- a/cli.py
+++ b/cli.py
@@ -18083,6 +18083,35 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
 
     max_turns = task.goal_max_turns or _DEF_TURNS
 
+    # Snapshot progress markers before the loop starts so a stuck worker
+    # (no heartbeat, no operator comments since spawn) still blocks at the
+    # turn budget instead of extending forever.
+    loop_started_at = int(time.time())
+    conn = _kb.connect()
+    try:
+        _existing_comments = _kb.list_comments(conn, task_id)
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+    initial_comment_id = _existing_comments[-1].id if _existing_comments else 0
+
+    def _progress_check() -> bool:
+        c = _kb.connect()
+        try:
+            t = _kb.get_task(c, task_id)
+            if t is None:
+                return False
+            if t.last_heartbeat_at and t.last_heartbeat_at >= loop_started_at:
+                return True
+            return bool(_kb.list_comments_after(c, task_id, after_id=initial_comment_id))
+        finally:
+            try:
+                c.close()
+            except Exception:
+                pass
+
     def _run_turn(prompt: str) -> str:
         result = cli.agent.run_conversation(
             user_message=prompt,
@@ -18129,6 +18158,7 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
         max_turns=max_turns,
         first_response=first_response or "",
         log=lambda m: logger.info("%s", m),
+        progress_check_fn=_progress_check,
     )
 
 

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -48,6 +48,12 @@ logger = logging.getLogger(__name__)
 # ──────────────────────────────────────────────────────────────────────
 
 DEFAULT_MAX_TURNS = 20
+# When a kanban goal-mode worker exhausts its turn budget, an optional
+# progress_check_fn can grant a one-time-per-check extension instead of
+# blocking outright — but only while genuinely making progress, and never
+# past this absolute ceiling (prevents an infinite loop on a stuck worker).
+DEFAULT_GOAL_EXTENSION_TURNS = 20
+DEFAULT_GOAL_MAX_TURNS_CEILING = 200
 DEFAULT_JUDGE_TIMEOUT = 30.0
 # Judge output budget. The freeform judge returns a one-line JSON verdict, but
 # reasoning models (deepseek-v4, qwq, etc.) burn tokens on hidden reasoning
@@ -2002,6 +2008,9 @@ def run_kanban_goal_loop(
     max_turns: int = DEFAULT_MAX_TURNS,
     first_response: str = "",
     log=None,
+    progress_check_fn=None,
+    extension_turns: int = DEFAULT_GOAL_EXTENSION_TURNS,
+    max_turns_ceiling: int = DEFAULT_GOAL_MAX_TURNS_CEILING,
 ) -> Dict[str, Any]:
     """Drive a kanban worker through a Ralph-style goal loop.
 
@@ -2018,7 +2027,12 @@ def run_kanban_goal_loop(
        task is still open → one explicit "call kanban_complete" nudge.
     3. When the turn budget is exhausted and the worker still hasn't
        terminated the task, ``block_fn`` is invoked so the card lands in a
-       sticky ``blocked`` state for human review (NOT a silent exit).
+       sticky ``blocked`` state for human review (NOT a silent exit) —
+       unless ``progress_check_fn`` reports observable progress (heartbeat,
+       new comments, file activity, etc.), in which case the budget is
+       extended by ``extension_turns`` (never past ``max_turns_ceiling``)
+       and the loop keeps going. ``progress_check_fn`` is fail-closed: no
+       callback, an exception, or a falsy result all mean "no extension".
 
     This function performs NO SessionDB persistence — a worker process is
     ephemeral, so the turn budget lives in a local counter. It is fully
@@ -2095,16 +2109,33 @@ def run_kanban_goal_loop(
 
         # Budget check BEFORE spending another turn.
         if turns_used >= max_turns:
-            _log(f"kanban goal loop: task {task_id} exhausted {turns_used}/{max_turns} turns; blocking")
-            try:
-                block_fn(
-                    f"Goal-mode worker exhausted its turn budget "
-                    f"({turns_used}/{max_turns}) without completing the task. "
-                    f"Last judge verdict: {_truncate(reason, 300)}"
-                )
-            except Exception as exc:
-                _log(f"kanban goal loop: block_fn failed ({exc})")
-            return {"outcome": "blocked_budget", "turns_used": turns_used, "reason": "turn budget exhausted"}
+            extended = False
+            if progress_check_fn is not None and max_turns < max_turns_ceiling:
+                try:
+                    has_progress = bool(progress_check_fn())
+                except Exception as exc:
+                    _log(f"kanban goal loop: progress check failed ({exc}); treating as no progress")
+                    has_progress = False
+                if has_progress:
+                    old_max = max_turns
+                    max_turns = min(max_turns + extension_turns, max_turns_ceiling)
+                    extended = max_turns > old_max
+                    if extended:
+                        _log(
+                            f"kanban goal loop: task {task_id} showed progress at "
+                            f"{turns_used}/{old_max} turns; extending budget to {max_turns}"
+                        )
+            if not extended:
+                _log(f"kanban goal loop: task {task_id} exhausted {turns_used}/{max_turns} turns; blocking")
+                try:
+                    block_fn(
+                        f"Goal-mode worker exhausted its turn budget "
+                        f"({turns_used}/{max_turns}) without completing the task. "
+                        f"Last judge verdict: {_truncate(reason, 300)}"
+                    )
+                except Exception as exc:
+                    _log(f"kanban goal loop: block_fn failed ({exc})")
+                return {"outcome": "blocked_budget", "turns_used": turns_used, "reason": "turn budget exhausted"}
 
         # Run another turn in the same session.
         try:
@@ -2134,6 +2165,8 @@ __all__ = [
     "KANBAN_GOAL_CONTINUATION_TEMPLATE",
     "KANBAN_GOAL_FINALIZE_TEMPLATE",
     "DEFAULT_MAX_TURNS",
+    "DEFAULT_GOAL_EXTENSION_TURNS",
+    "DEFAULT_GOAL_MAX_TURNS_CEILING",
     "load_goal",
     "save_goal",
     "clear_goal",

--- a/tests/hermes_cli/test_kanban_goal_mode.py
+++ b/tests/hermes_cli/test_kanban_goal_mode.py
@@ -201,6 +201,24 @@ def test_workspace_git_head_none_for_missing_dir(tmp_path):
     assert cli._kanban_workspace_git_head(str(tmp_path / "does_not_exist")) is None
 
 
+def test_goal_max_turns_ceiling_leaves_room_for_extension_above_configured_budget():
+    """A card whose goal_max_turns already meets or exceeds the default
+    ceiling must still get at least one extension's worth of headroom,
+    or the extension mechanism is a no-op for it (#81990 review: a card
+    budgeted at exactly the 200-turn default ceiling was blocked before
+    the progress signals ever ran)."""
+    from hermes_cli.goals import DEFAULT_GOAL_EXTENSION_TURNS, DEFAULT_GOAL_MAX_TURNS_CEILING
+
+    assert cli._kanban_goal_max_turns_ceiling(DEFAULT_GOAL_MAX_TURNS_CEILING) == (
+        DEFAULT_GOAL_MAX_TURNS_CEILING + DEFAULT_GOAL_EXTENSION_TURNS
+    )
+    assert cli._kanban_goal_max_turns_ceiling(DEFAULT_GOAL_MAX_TURNS_CEILING + 50) == (
+        DEFAULT_GOAL_MAX_TURNS_CEILING + 50 + DEFAULT_GOAL_EXTENSION_TURNS
+    )
+    # Small configured budgets keep the default ceiling unchanged.
+    assert cli._kanban_goal_max_turns_ceiling(20) == DEFAULT_GOAL_MAX_TURNS_CEILING
+
+
 def test_loop_extends_budget_when_progress_detected(monkeypatch):
     """A worker that hits its turn budget but is showing observable
     progress gets a bounded extension instead of an immediate block, but

--- a/tests/hermes_cli/test_kanban_goal_mode.py
+++ b/tests/hermes_cli/test_kanban_goal_mode.py
@@ -128,6 +128,53 @@ def test_loop_stops_when_worker_already_completed(monkeypatch):
     assert turns == []  # no extra turns
 
 
+def test_loop_blocks_at_budget_without_progress_signal(monkeypatch):
+    """Fail-closed: no progress_check_fn (or a falsy result) blocks exactly
+    like before this feature existed — no silent extension."""
+    _patch_judge(monkeypatch, ["continue"])
+    blocked = []
+
+    res = goals.run_kanban_goal_loop(
+        task_id="t1",
+        goal_text="do the thing",
+        run_turn=lambda p: pytest.fail("should not run another turn"),
+        task_status_fn=lambda: "running",
+        block_fn=lambda r: blocked.append(r),
+        max_turns=1,
+        first_response="working on it",
+        progress_check_fn=lambda: False,
+    )
+    assert res["outcome"] == "blocked_budget"
+    assert res["turns_used"] == 1
+    assert len(blocked) == 1
+
+
+def test_loop_extends_budget_when_progress_detected(monkeypatch):
+    """A worker that hits its turn budget but is showing observable
+    progress gets a bounded extension instead of an immediate block, but
+    never past ``max_turns_ceiling``."""
+    _patch_judge(monkeypatch, ["continue"] * 5)
+    turns = []
+    blocked = []
+
+    res = goals.run_kanban_goal_loop(
+        task_id="t1",
+        goal_text="do the thing",
+        run_turn=lambda p: turns.append(p) or "still working",
+        task_status_fn=lambda: "running",
+        block_fn=lambda r: blocked.append(r),
+        max_turns=1,
+        first_response="working on it",
+        progress_check_fn=lambda: True,
+        extension_turns=1,
+        max_turns_ceiling=2,
+    )
+    assert res["outcome"] == "blocked_budget"
+    assert res["turns_used"] == 2  # one extended turn was granted, then the ceiling hit
+    assert len(turns) == 1
+    assert len(blocked) == 1
+
+
 
 
 

--- a/tests/hermes_cli/test_kanban_goal_mode.py
+++ b/tests/hermes_cli/test_kanban_goal_mode.py
@@ -12,6 +12,7 @@ Covers three layers:
 
 from __future__ import annotations
 
+import subprocess
 import sqlite3
 from pathlib import Path
 
@@ -19,6 +20,7 @@ import pytest
 
 from hermes_cli import kanban_db as kb
 from hermes_cli import goals
+import cli
 
 
 @pytest.fixture
@@ -147,6 +149,56 @@ def test_loop_blocks_at_budget_without_progress_signal(monkeypatch):
     assert res["outcome"] == "blocked_budget"
     assert res["turns_used"] == 1
     assert len(blocked) == 1
+
+
+# ---------------------------------------------------------------------------
+# cli.py's real progress_check_fn wiring (heartbeat is NOT a progress
+# signal — see #81990 review; git HEAD movement is what actually gets
+# checked for workspace-backed tasks).
+# ---------------------------------------------------------------------------
+
+
+def _init_git_repo(path: Path) -> None:
+    for args in (
+        ["git", "init", "-q"],
+        ["git", "config", "user.email", "test@example.com"],
+        ["git", "config", "user.name", "Test"],
+    ):
+        subprocess.run(args, cwd=path, check=True, capture_output=True)
+
+
+def _git_commit(path: Path, filename: str, content: str) -> None:
+    (path / filename).write_text(content)
+    subprocess.run(["git", "add", filename], cwd=path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", f"add {filename}"], cwd=path, check=True, capture_output=True,
+    )
+
+
+def test_workspace_git_head_detects_new_commit(tmp_path):
+    """The real signal cli.py wires in: HEAD moving means a commit landed —
+    unlike a heartbeat, this can't be true for a worker that is merely
+    alive and thrashing without producing anything."""
+    _init_git_repo(tmp_path)
+    _git_commit(tmp_path, "a.txt", "1")
+    initial_head = cli._kanban_workspace_git_head(str(tmp_path))
+    assert initial_head
+
+    # No new commit yet — HEAD hasn't moved, so there is no progress signal.
+    assert cli._kanban_workspace_git_head(str(tmp_path)) == initial_head
+
+    _git_commit(tmp_path, "b.txt", "2")
+    new_head = cli._kanban_workspace_git_head(str(tmp_path))
+    assert new_head and new_head != initial_head
+
+
+def test_workspace_git_head_none_for_non_git_dir(tmp_path):
+    (tmp_path / "not_a_repo").mkdir()
+    assert cli._kanban_workspace_git_head(str(tmp_path / "not_a_repo")) is None
+
+
+def test_workspace_git_head_none_for_missing_dir(tmp_path):
+    assert cli._kanban_workspace_git_head(str(tmp_path / "does_not_exist")) is None
 
 
 def test_loop_extends_budget_when_progress_detected(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Adds an optional progress check to the kanban goal-mode turn-budget loop (`run_kanban_goal_loop` in `hermes_cli/goals.py`). Today, the moment a goal-mode worker hits its turn budget it is blocked for human review immediately — even if it is actively committing work or an operator just left a comment telling it to keep going. That throws away all of the worker's prior turns for a card that may have been about to finish.

With this change, when the budget is exhausted the loop now calls an injected `progress_check_fn` before giving up. If it reports observable progress, the budget is extended by `extension_turns` (default 20), capped by an absolute `max_turns_ceiling` (default 200) so a genuinely stuck worker still gets blocked instead of looping forever. `cli.py`'s `_run_kanban_goal_loop_q` wires a real check based on (a) any operator comment posted on the card since the loop started, or (b) the workspace's git HEAD having moved since the loop started (a commit landed).

The mechanism is fail-closed throughout: no `progress_check_fn` (existing callers), an exception inside it, or a falsy result all fall through to the exact same blocking behavior as before this change.

**Revision note:** an earlier version of this PR used the worker's `last_heartbeat_at` timestamp as the second signal instead of git HEAD movement. Review correctly flagged that heartbeats are bumped by ordinary API/tool-call bookkeeping on *every* kind of agent activity (rate-limited to once/60s, but not gated on anything succeeding or the goal advancing) — so a worker thrashing uselessly on a failing tool call for its whole budget would still pass that check, defeating the "genuinely stuck worker still gets blocked" guarantee this PR claims. Swapped for a check of whether the workspace's git HEAD moved since the loop started: a landed commit is real, hard-to-fake evidence of forward progress, whereas a heartbeat is not. The new-comments signal was already sound (an explicit human judgment call) and is unchanged.

## Related Issue

Fixes #81990

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/goals.py`: `run_kanban_goal_loop` gains `progress_check_fn`, `extension_turns`, and `max_turns_ceiling` parameters; the turn-budget-exhausted branch checks progress before blocking and extends the budget (bounded by the ceiling) instead. Added `DEFAULT_GOAL_EXTENSION_TURNS = 20` and `DEFAULT_GOAL_MAX_TURNS_CEILING = 200` constants.
- `cli.py`: adds `_kanban_workspace_git_head` (best-effort, fail-closed `git rev-parse HEAD` with a 5s timeout). `_run_kanban_goal_loop_q` snapshots the latest existing comment id and (for `worktree`/`dir` workspace tasks) the workspace's current git HEAD before the loop starts, and passes a `progress_check_fn` that reports progress when a new comment has landed on the card, or the workspace's HEAD has moved, since the loop started.
- `tests/hermes_cli/test_kanban_goal_mode.py`: added `test_loop_blocks_at_budget_without_progress_signal` (fail-closed regression check) and `test_loop_extends_budget_when_progress_detected` (extension is granted once, then blocks once the ceiling is reached) for the generic `run_kanban_goal_loop` mechanism; added `test_workspace_git_head_detects_new_commit`, `test_workspace_git_head_none_for_non_git_dir`, and `test_workspace_git_head_none_for_missing_dir` exercising the actual `cli._kanban_workspace_git_head` signal cli.py wires in (closing a gap flagged in review: the original tests only covered the generic loop via a hand-fed `progress_check_fn`, never the real cli.py implementation).

## How to Test

1. `python -m pytest tests/hermes_cli/test_kanban_goal_mode.py -q`
2. To see the git-HEAD tests fail without the fix: `git stash push -- cli.py && python -m pytest tests/hermes_cli/test_kanban_goal_mode.py -q` (the 3 new `test_workspace_git_head_*` tests fail with `AttributeError: module 'cli' has no attribute '_kanban_workspace_git_head'`), then `git stash pop` to restore.

### Real output from this branch

```
$ python -m pytest tests/hermes_cli/test_kanban_goal_mode.py -q
.........                                                                [100%]
9 passed in 0.65s

$ python -m ruff check hermes_cli/goals.py cli.py tests/hermes_cli/test_kanban_goal_mode.py
All checks passed!

$ python -m pytest tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_db_repair.py tests/tools/test_kanban_tools.py tests/tools/test_delegate_kanban_isolation.py tests/cron/test_cron_kanban_env_isolation.py -q
........................................................................ [ 91%]
.......                                                                  [100%]
79 passed in 5.20s
```

Proof the new git-HEAD tests fail without the `cli.py` fix (stashed just `cli.py`, source available via `git stash push -- cli.py`):

```
FAILED tests/hermes_cli/test_kanban_goal_mode.py::test_workspace_git_head_detects_new_commit - AttributeError: module 'cli' has no attribute '_kanban_workspace_git_head'
FAILED tests/hermes_cli/test_kanban_goal_mode.py::test_workspace_git_head_none_for_non_git_dir - AttributeError: module 'cli' has no attribute '_kanban_workspace_git_head'
FAILED tests/hermes_cli/test_kanban_goal_mode.py::test_workspace_git_head_none_for_missing_dir - AttributeError: module 'cli' has no attribute '_kanban_workspace_git_head'
3 failed, 6 passed in 1.05s
```

(The original `hermes_cli/goals.py` mechanism tests — `test_loop_blocks_at_budget_without_progress_signal` / `test_loop_extends_budget_when_progress_detected` — were verified against `HEAD~2` in the prior revision of this PR and are unchanged here.)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits (`feat(kanban):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes
- [ ] I've tested on my platform — CI-only checkout, Ubuntu/Linux container; not manually tested on macOS/Windows

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool schemas changed

## Note on scope

The linked issue describes a larger prototype (4 signals: heartbeat, new comments, file mtimes, git HEAD movement; 4 files, +705 lines, 15 tests). This PR implements the core extend-on-progress mechanism plus two of the four signals — new comments and git HEAD movement, the two signals reviewed as genuinely progress-correlated rather than merely liveness-correlated. Heartbeat was deliberately dropped after review (see "Revision note" above). File-mtime signals could be added later as a small follow-up without changing `run_kanban_goal_loop` itself; git HEAD movement already covers the common case that motivated the issue (commits landing during a long review-fix cycle) for `worktree`/`dir` workspace tasks. `scratch`-workspace tasks (no filesystem workspace) fall back to the comments signal only — an honest limitation, not a regression versus current behavior (which offers no extension at all).

## AI assistance disclosure

This PR was authored by an autonomous coding agent (Claude) against the issue description, with the diff, tests, and this description reviewed for correctness before submission. A prior revision of this PR was independently reviewed and blocked for using a heartbeat-based progress signal that didn't discriminate genuine progress from mere liveness; this revision replaces that signal with git HEAD movement in response to that review.
