### PR TITLE
clamp virtualizer row count to prevent Invalid array length crash

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
@@ -60,8 +60,25 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
   const dividerLabels = t.sidebar.dateDivider
   const scrollerRef = useRef<HTMLDivElement | null>(null)
 
+  // Defensive clamp: `listRows` is derived from a live session-refresh
+  // pipeline (sessions.changed → refreshSessions → mergeSessionPage →
+  // groupEntriesByRecency) that can race mid-render during a burst of
+  // change events. A non-finite or negative length here reaches
+  // @tanstack/virtual-core's defaultRangeExtractor, which does a bare
+  // `new Array(len)` and throws `RangeError: Invalid array length` — an
+  // uncaught render-time crash that only the top-level error boundary can
+  // catch, taking the whole shell down with it. Clamp at the source instead.
+  const rowCount = Number.isFinite(listRows.length) ? Math.max(0, Math.trunc(listRows.length)) : 0
+
+  if (process.env.NODE_ENV !== 'production' && rowCount !== listRows.length) {
+    console.warn('[virtual-session-list] clamped invalid listRows.length', {
+      length: listRows.length,
+      isArray: Array.isArray(listRows)
+    })
+  }
+
   const virtualizer = useVirtualizer({
-    count: listRows.length,
+    count: rowCount,
     estimateSize: () => ROW_ESTIMATE_PX,
     getItemKey: index => {
       const row = listRows[index]

--- a/apps/desktop/src/app/right-sidebar/review/file-tree.tsx
+++ b/apps/desktop/src/app/right-sidebar/review/file-tree.tsx
@@ -205,8 +205,17 @@ function VirtualizedReviewList({
   rows: ReviewFlatRow[]
   scrollRef: RefObject<HTMLDivElement | null>
 }) {
+  // Defensive clamp: see virtual-session-list.tsx for the full rationale.
+  // A non-finite/negative count reaches virtual-core's defaultRangeExtractor
+  // (`new Array(len)`) and throws `RangeError: Invalid array length`.
+  const rowCount = Number.isFinite(rows.length) ? Math.max(0, Math.trunc(rows.length)) : 0
+
+  if (process.env.NODE_ENV !== 'production' && rowCount !== rows.length) {
+    console.warn('[file-tree] clamped invalid rows.length', { length: rows.length, isArray: Array.isArray(rows) })
+  }
+
   const virtualizer = useVirtualizer({
-    count: rows.length,
+    count: rowCount,
     estimateSize: () => ROW_HEIGHT,
     getItemKey: index => rows[index]?.node.id ?? index,
     getScrollElement: () => scrollRef.current,


### PR DESCRIPTION
Problem

Hermes Desktop becomes completely unresponsive shortly after the backend
connects. The renderer crashes with RangeError: Invalid array length,
caught by the top-level error boundary, leaving the whole shell dead
(clicks do nothing, sessions can't be opened). `webContents became
unresponsive and render-process-gone` follow. Reproduces consistently on
every launch right after "Finalizing desktop startup", in both packaged
builds and --source mode.

Root cause

useVirtualizer (@tanstack/react-virtual) is fed count: listRows.length
in the sidebar session list (virtual-session-list.tsx) and
count: rows.length in the review file-tree (file-tree.tsx), with no
guard. @tanstack/virtual-core's defaultRangeExtractor does a bare
new Array(len) internally — if len is ever non-finite or negative, this
throws RangeError: Invalid array length synchronously during render, which
only the nearest error boundary can catch (taking the whole shell tree down
with it, matching the observed stack: `useQuery → i18n → TooltipProvider →
command → vendor-react → error-boundary`).

This surfaces reliably at startup because the backend broadcasts a burst of
sessions.changed events with empty payload in a tight loop right after
gateway.ready. Each event triggers a session-list refresh
(refreshSessions → mergeSessionPage → groupEntriesByRecency), and an
overlapping/out-of-order refresh mid-render can transiently produce a row
count that isn't a clean non-negative integer by the time useVirtualizer
reads it.

Fix

Clamp the row count to a finite, non-negative integer before handing it to
useVirtualizer in both call sites, with a dev-only console.warn when
clamping actually kicks in, so the underlying data race stays visible for
follow-up investigation without crashing the renderer.

Testing

- tsc --noEmit (both tsconfig.json and tsconfig.electron.json): clean
- eslint src/ electron/: 0 errors, only pre-existing warnings elsewhere
- npm run check (full suite): 403 UI test files / 3600 tests passing, 79
  electron test files / 951 tests passing (2 pre-existing skips), full
  dist:mac:dmg packaging build green
- Manually reproduced the crash pre-fix (consistent, immediate, every
  launch) and confirmed a --source relaunch post-fix stays stable through
  the sessions.changed burst at boot with no RangeError /
  webContents became unresponsive / render-process-gone in
  ~/.hermes/logs/desktop.log

Note

This guard treats the symptom at the render boundary. The empty-payload
sessions.changed flood at backend startup (in
server._broadcast_watched_changes, not touched by this PR) is the likely
trigger and may be worth a separate debounce/floor fix on the backend side,
but this client-side clamp is defense-in-depth regardless — it's cheap,
correct, and prevents this class of crash for any future data race that
produces a bad row count.
