### PR TITLE
fix(tui-gateway): filter ghost zero-message sessions from session.list

### DIFF
--- a/tests/gateway/test_session_list_allowed_sources.py
+++ b/tests/gateway/test_session_list_allowed_sources.py
@@ -69,3 +69,16 @@ def test_session_list_surfaces_all_user_facing_sources(monkeypatch):
     assert "tool-1" not in ids
 
 
+def test_session_list_filters_ghost_zero_message_sessions(monkeypatch):
+    """Issue #81888: ghost sessions (0 messages) must not clutter the picker.
+
+    ``session.list`` must ask ``list_sessions_rich`` to filter them at the
+    query level (``min_message_count=1``), the same way the desktop
+    project-tree sidebar already does.
+    """
+    db = _StubDB([{"id": "real-1", "source": "tui", "started_at": 1, "message_count": 3}])
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+
+    _call(limit=10)
+
+    assert db.calls[-1].get("min_message_count") == 1

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -188,6 +188,11 @@ def _(rid, params: dict) -> dict:
                     limit=fetch_limit,
                     order_by_last_active=True,
                     compact_rows=True,
+                    # Ghost rows (0 messages — leftover imports/migrations)
+                    # clutter the picker with empty headers (#81888). The
+                    # desktop project-tree sidebar already excludes them the
+                    # same way (see ``_project_tree_inputs`` in server.py).
+                    min_message_count=1,
                 )
                 if (s.get("source") or "").strip().lower() not in deny
             ][:limit]


### PR DESCRIPTION
## Summary

Addresses one concrete piece of #81888: "ghost sessions" (rows with
`message_count == 0`, left over from imports/migrations) cluttering the
TUI active-session switcher with empty headers.

`session.list` (`tui_gateway/methods_session.py`) is the JSON-RPC method
backing `ui-tui/src/components/activeSessionSwitcher.tsx`. It called
`list_sessions_rich()` without `min_message_count`, so zero-message ghost
rows were included alongside real conversations in that switcher.

The desktop project-tree sidebar already avoids this by passing
`min_message_count=1` to the same `list_sessions_rich()` call
(`_project_tree_inputs` in `tui_gateway/server.py`). This PR applies the
same, already-established filter to `session.list`, fixing the TUI
active-session switcher.

Scope note: the CLI `/resume` picker does not call this RPC — it goes
through `hermes_cli/session_listing.py:query_session_listing()`, which
already drops untitled sessions by default, and ghost rows from
imports/migrations are untitled. The desktop session list also doesn't
call this RPC — it uses `/api/sessions` / `/api/profiles/sessions`
(`hermes_cli/web_routers/sessions.py`), and every real desktop call site
already passes `min_messages=1`. So both of those surfaces were already
unaffected by this bug; this PR's effect is scoped to the TUI active-session
switcher.

This does not touch the other parts of #81888 (dual state.db / profile
hierarchy, project-to-session binding, profile `projects.db` desync) —
those are separate, larger changes and out of scope for this minimal fix.

## Change

- `tui_gateway/methods_session.py`: pass `min_message_count=1` to the
  `list_sessions_rich()` call inside `session.list`.

## Test plan

Added `test_session_list_filters_ghost_zero_message_sessions` to
`tests/gateway/test_session_list_allowed_sources.py`, asserting
`min_message_count=1` is forwarded to `list_sessions_rich`.

Confirmed the test fails without the fix (reverted just the source file):

```
$ git checkout HEAD~1 -- tui_gateway/methods_session.py
$ python -m pytest tests/gateway/test_session_list_allowed_sources.py -q
...
AssertionError: assert None == 1
 +  where None = <built-in method get of dict object>('min_message_count')
1 failed in ...
$ git checkout HEAD -- tui_gateway/methods_session.py
```

Passes with the fix, plus the full existing suite around this method:

```
$ bash scripts/run_tests.sh tests/gateway/test_session_list_allowed_sources.py tests/test_tui_gateway_server.py -q
=== Summary: 2 files, 524 tests passed, 0 failed (100% complete) in 19.7s (8 workers) ===

$ bash scripts/run_tests.sh tests/hermes_state/ tests/test_hermes_state.py -q
=== Summary: 14 files, 268 tests passed, 0 failed (100% complete) in 23.6s (8 workers) ===

$ ruff check tui_gateway/methods_session.py tests/gateway/test_session_list_allowed_sources.py
All checks passed!
```

## AI assistance disclosure

This change was written with AI assistance (Claude Code).
