### PR TITLE
fix(auxiliary): advance configured fallback chains

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5022,8 +5022,9 @@ def _try_payment_fallback(
     Returns:
         (client, model, provider_label) or (None, None, "") if no fallback.
     """
-    # Normalise the failed provider label for matching.
-    skip = failed_provider.lower().strip()
+    # Normalise labels minted by an earlier fallback attempt so a failed
+    # configured candidate is not rediscovered under its raw provider id.
+    skip = _fallback_provider_from_label(failed_provider).lower().strip()
     # Also skip Step-1 main-provider path if it maps to the same backend.
     # (e.g. main_provider="openrouter" → skip "openrouter" in chain)
     main_provider = _read_main_provider()
@@ -5118,7 +5119,10 @@ def _try_main_agent_model_fallback(
     skip_model = (failed_model or "").strip().lower() or None
     if should_skip_candidate(
         BackendIdentity.build(provider=main_provider, model=main_model),
-        BackendIdentity.build(provider=failed_provider, model=skip_model),
+        BackendIdentity.build(
+            provider=_fallback_provider_from_label(failed_provider),
+            model=skip_model,
+        ),
         FailureScope.MODEL if skip_model else FailureScope.CREDENTIAL,
     ):
         # The thing that failed IS the main model (or the failure was
@@ -5240,6 +5244,12 @@ def _try_configured_fallback_chain(
     entry in order.  Each entry must have at least ``provider``; ``model``,
     ``base_url``, and ``api_key`` are optional.
 
+    ``failed_provider`` may be either a provider id or a fallback label minted
+    by an earlier resolution attempt (for example
+    ``fallback_chain[0](kimi-coding)``).  Labels must be reduced back to their
+    provider identity before skip checks; otherwise a failed first fallback is
+    selected again instead of advancing through the chain.
+
     ``failed_model`` narrows the skip check to the exact (provider, model)
     pair that just failed, rather than the whole provider. Without it every
     entry sharing the failed provider is skipped (the original behaviour).
@@ -5283,7 +5293,8 @@ def _try_configured_fallback_chain(
     )
 
     failed_ident = BackendIdentity.build(
-        provider=failed_provider, model=skip_model,
+        provider=_fallback_provider_from_label(failed_provider),
+        model=skip_model,
     )
     failure_scope = (
         FailureScope.MODEL if skip_model else FailureScope.CREDENTIAL

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4814,6 +4814,20 @@ def _validate_config_key(key: str) -> tuple[bool, Optional[str]]:
 
     segments = key.split(".")
     top = segments[0]
+    auxiliary_defaults = DEFAULT_CONFIG.get("auxiliary")
+
+    # Every auxiliary task may define an ordered provider fallback chain even
+    # though the per-task defaults intentionally omit an empty list.  Treat the
+    # runtime-supported leaf as schema-known so `hermes config set` does not
+    # warn that a valid route is ignored.
+    if (
+        len(segments) == 3
+        and top == "auxiliary"
+        and isinstance(auxiliary_defaults, dict)
+        and segments[1] in auxiliary_defaults
+        and segments[2] == "fallback_chain"
+    ):
+        return True, None
 
     # ── Underscore-prefixed keys are internal/test markers ───────────
     # A leading underscore on the top-level segment (e.g. ``_test.shim_marker``)
@@ -4967,18 +4981,38 @@ def set_config_value(key: str, value: str, force: bool = False):
     # Preserve values for string-typed settings.  In particular, enum members
     # such as approvals.mode="off" must not become YAML booleans.  Unknown keys
     # retain the historical best-effort coercion behavior.
-    coerced_value: Any = value
-    if not isinstance(_default_value_for_key(key), str):
+    write_value: Any = value
+    if key.startswith("auxiliary.") and key.endswith(".fallback_chain"):
+        try:
+            write_value = json.loads(value)
+        except (TypeError, json.JSONDecodeError) as exc:
+            print(
+                f"✗ Invalid fallback chain for '{key}': expected a JSON list "
+                f"of provider/model objects ({exc})",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        if not isinstance(write_value, list) or not all(
+            isinstance(entry, dict)
+            and isinstance(entry.get("provider"), str)
+            and bool(entry["provider"].strip())
+            for entry in write_value
+        ):
+            print(
+                f"✗ Invalid fallback chain for '{key}': expected a JSON list "
+                "whose entries each have a non-empty 'provider' string",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    elif not isinstance(_default_value_for_key(key), str):
         if value.lower() in {'true', 'yes', 'on'}:
-            coerced_value = True
+            write_value = True
         elif value.lower() in {'false', 'no', 'off'}:
-            coerced_value = False
+            write_value = False
         elif value.isdigit():
-            coerced_value = int(value)
+            write_value = int(value)
         elif value.replace('.', '', 1).isdigit():
-            coerced_value = float(value)
-
-    value = coerced_value
+            write_value = float(value)
     # Normalize a scalar ``model`` key before writing sub-keys so that
     # ``hermes config set model.provider openai`` doesn't silently
     # destroy the model id when ``model`` is a bare string shorthand
@@ -5046,7 +5080,7 @@ def set_config_value(key: str, value: str, force: bool = False):
                     file=sys.stderr,
                 )
                 sys.exit(1)
-    _set_nested(user_config, key, value)
+    _set_nested(user_config, key, write_value)
     # Normalize the api_base → base_url alias at set-time too (issue #8919),
     # so a fresh `hermes config set model.api_base ...` lands on the canonical
     # key the runtime resolver actually reads, instead of being silently
@@ -5065,16 +5099,16 @@ def set_config_value(key: str, value: str, force: bool = False):
     # config.yaml is authoritative, but terminal_tool only reads TERMINAL_ENV etc.
     env_var = terminal_config_env_var_for_key(key)
     if env_var and key != "terminal.cwd":
-        save_env_value(env_var, _terminal_env_value(value))
+        save_env_value(env_var, _terminal_env_value(write_value))
 
     # Setting display.skin is an explicit "apply NOW" — bump the skin file's
     # mtime so the gateway watcher's (name, mtime) signature moves even when the
     # name is unchanged (re-affirming the active skin after a surface missed the
     # original activation). Built-ins have no file; a name switch already moves
     # their signature.
-    if key == "display.skin" and isinstance(value, str) and value:
+    if key == "display.skin" and isinstance(write_value, str) and write_value:
         try:
-            skin_file = get_hermes_home() / "skins" / f"{value}.yaml"
+            skin_file = get_hermes_home() / "skins" / f"{write_value}.yaml"
             if skin_file.exists():
                 skin_file.touch()
         except Exception:
@@ -5085,13 +5119,13 @@ def set_config_value(key: str, value: str, force: bool = False):
     # (lowercase, so it misses the .env api_keys list above) and would otherwise
     # print the raw secret to the terminal.
     _leaf_key = key.rsplit(".", 1)[-1].lower()
-    if _leaf_key in _SECRET_CONFIG_KEYS and isinstance(value, str) and value:
+    if _leaf_key in _SECRET_CONFIG_KEYS and isinstance(write_value, str) and write_value:
         from agent.redact import mask_secret
-        _display_value = mask_secret(value)
+        _display_value = mask_secret(write_value)
     else:
-        _display_value = value
+        _display_value = write_value
     print(f"✓ Set {key} = {_display_value} in {config_path}")
-    warn_unpinned_cron_jobs_after_model_config_change(key, value, user_config)
+    warn_unpinned_cron_jobs_after_model_config_change(key, write_value, user_config)
 
     # Post-write unknown-key notice (#34067): value IS saved, but tell the
     # user the runtime may never read it and suggest the likely-intended path.

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1849,6 +1849,39 @@ class TestAuxiliaryFallbackLayering:
             reason="provider unavailable",
         )
 
+    def test_configured_chain_advances_after_labeled_fallback_fails(self):
+        """A failed fallback label must skip that provider on the next pass."""
+        from agent.auxiliary_client import _try_configured_fallback_chain
+
+        kimi_client = MagicMock()
+        luna_client = MagicMock()
+        chain = [
+            {"provider": "kimi-coding", "model": "kimi-k3"},
+            {"provider": "openai-codex", "model": "gpt-5.6-luna"},
+        ]
+
+        def resolve_entry(entry):
+            if entry["provider"] == "kimi-coding":
+                return kimi_client, entry["model"]
+            return luna_client, entry["model"]
+
+        with patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value={"fallback_chain": chain},
+        ), patch(
+            "agent.auxiliary_client._resolve_fallback_entry",
+            side_effect=resolve_entry,
+        ):
+            client, model, label = _try_configured_fallback_chain(
+                "compression",
+                "fallback_chain[0](kimi-coding)",
+                reason="payment error",
+            )
+
+        assert client is luna_client
+        assert model == "gpt-5.6-luna"
+        assert label == "fallback_chain[1](openai-codex)"
+
 
     def test_fallback_entry_openai_codex_uses_oauth_pool_without_inline_key(self):
         """Configured Codex fallback resolves through Hermes auth / credential pool."""
@@ -1889,6 +1922,21 @@ class TestTryMainAgentModelFallback:
              patch("agent.auxiliary_client._read_main_model", return_value="some-model"):
             client, model, label = _try_main_agent_model_fallback("glm", task="vision")
         assert client is None and model is None and label == ""
+
+    def test_labeled_failed_fallback_does_not_retry_same_main_provider(self):
+        from agent.auxiliary_client import _try_main_agent_model_fallback
+
+        with patch("agent.auxiliary_client._read_main_provider", return_value="kimi-coding"), \
+             patch("agent.auxiliary_client._read_main_model", return_value="kimi-k3"), \
+             patch("agent.auxiliary_client.resolve_provider_client") as mock_resolve:
+            client, model, label = _try_main_agent_model_fallback(
+                "fallback_chain[0](kimi-coding)",
+                task="compression",
+                reason="payment error",
+            )
+
+        assert client is None and model is None and label == ""
+        mock_resolve.assert_not_called()
 
 
     def test_resolves_main_provider_client(self):

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -121,6 +121,32 @@ class TestConfigYamlRouting:
         assert "vercel_runtime: python3.13" in config
         assert "TERMINAL_VERCEL_RUNTIME=python3.13" in env_content
 
+    def test_auxiliary_fallback_chain_json_is_saved_as_yaml_list(
+        self, _isolated_hermes_home, capsys,
+    ):
+        set_config_value(
+            "auxiliary.compression.fallback_chain",
+            '[{"provider":"openai-codex","model":"gpt-5.6-luna"},'
+            '{"provider":"kimi-coding","model":"kimi-k3"}]',
+        )
+
+        import yaml
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        chain = reloaded["auxiliary"]["compression"]["fallback_chain"]
+        assert chain == [
+            {"provider": "openai-codex", "model": "gpt-5.6-luna"},
+            {"provider": "kimi-coding", "model": "kimi-k3"},
+        ]
+        assert "not a recognized config key" not in capsys.readouterr().out
+
+    @pytest.mark.parametrize("value", ["not-json", "{}", '[{"model":"missing-provider"}]'])
+    def test_auxiliary_fallback_chain_rejects_invalid_shapes(
+        self, _isolated_hermes_home, value,
+    ):
+        with pytest.raises(SystemExit):
+            set_config_value("auxiliary.compression.fallback_chain", value)
+        assert not (_isolated_hermes_home / "config.yaml").exists()
+
 
 # ---------------------------------------------------------------------------
 # Empty / falsy values — regression tests for #4277


### PR DESCRIPTION
## Summary
- normalize fallback labels before provider skip checks so a failed configured candidate advances instead of being selected again
- apply the same normalization to payment and main-agent fallback paths
- teach `hermes config set auxiliary.<task>.fallback_chain` to validate and persist structured JSON lists rather than YAML strings

## Verification
- `scripts/run_tests.sh tests/agent/test_auxiliary_client.py` — 179 passed
- `scripts/run_tests.sh tests/hermes_cli/test_set_config_value.py tests/hermes_cli/test_aux_config.py` — 89 passed
- Ruff and `git diff --check` passed