### PR TITLE
fix(acp): queue terminal response before optional usage metadata

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -210,6 +210,7 @@ _LIST_SESSIONS_PAGE_SIZE = 50
 # inventory, and the current model is always kept via the fallback insert below.
 ACP_MAX_MODELS_PER_PROVIDER = 200
 _MAX_ACP_RESOURCE_BYTES = 512 * 1024
+_ACP_AUXILIARY_UPDATE_WAITER_TIMEOUT_SECONDS = 5.0
 _TEXT_RESOURCE_MIME_PREFIXES = ("text/",)
 _TEXT_RESOURCE_MIME_TYPES = {
     "application/json",
@@ -874,16 +875,30 @@ class HermesACPAgent(acp.Agent):
         )
 
     async def _send_usage_update(self, state: SessionState) -> None:
-        """Send ACP native context usage to the connected client."""
+        """Wait briefly for an optional context-usage notification.
+
+        This bounds Hermes's detached waiter only.  ACP 0.9's shared sender may
+        already be blocked writing the notification after this coroutine is
+        cancelled, so terminal responses must be queued before scheduling it.
+        """
         if not self._conn:
             return
         update = self._build_usage_update(state)
         if update is None:
             return
         try:
-            await self._conn.session_update(
-                session_id=state.session_id,
-                update=update,
+            await asyncio.wait_for(
+                self._conn.session_update(
+                    session_id=state.session_id,
+                    update=update,
+                ),
+                timeout=_ACP_AUXILIARY_UPDATE_WAITER_TIMEOUT_SECONDS,
+            )
+        except TimeoutError:
+            logger.warning(
+                "Stopped waiting for ACP usage update for session %s; "
+                "the shared ACP transport may still be blocked",
+                state.session_id,
             )
         except Exception:
             logger.warning(
@@ -961,7 +976,7 @@ class HermesACPAgent(acp.Agent):
             logger.debug("Could not send ACP session info update for %s", session_id, exc_info=True)
 
     def _schedule_usage_update(self, state: SessionState) -> None:
-        """Schedule native context indicator refresh after ACP responses."""
+        """Defer usage so the current terminal response enters ACP's FIFO first."""
         if not self._conn:
             return
         loop = asyncio.get_running_loop()
@@ -1715,7 +1730,7 @@ class HermesACPAgent(acp.Agent):
                 if self._conn:
                     update = acp.update_agent_message_text(response_text)
                     await self._conn.session_update(session_id, update)
-                    await self._send_usage_update(state)
+                    self._schedule_usage_update(state)
                 return PromptResponse(stop_reason="end_turn")
 
         # If the client sends another regular text prompt while this ACP session
@@ -2057,7 +2072,7 @@ class HermesACPAgent(acp.Agent):
                 cached_read_tokens=result.get("cache_read_tokens"),
             )
 
-        await self._send_usage_update(state)
+        self._schedule_usage_update(state)
 
         stop_reason = "cancelled" if cancelled else "end_turn"
         return PromptResponse(stop_reason=stop_reason, usage=usage)

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1,14 +1,18 @@
 """Tests for acp_adapter.server — HermesACPAgent ACP server."""
 
 import asyncio
+import json
 import os
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import MagicMock, AsyncMock, patch
 
 import pytest
 
 import acp
+from acp.agent.connection import AgentSideConnection
 from acp.agent.router import build_agent_router
+from acp.connection import Connection
 from acp.schema import (
     AgentCapabilities,
     AgentMessageChunk,
@@ -20,6 +24,7 @@ from acp.schema import (
     InitializeResponse,
     LoadSessionResponse,
     NewSessionResponse,
+    PromptRequest,
     PromptResponse,
     ResumeSessionResponse,
     SessionModelState,
@@ -55,6 +60,98 @@ def mock_manager():
 def agent(mock_manager):
     """HermesACPAgent backed by a mock session manager."""
     return HermesACPAgent(session_manager=mock_manager)
+
+
+class _UsageBlockingWriter:
+    """Capture raw ACP frames and stall only the usage notification drain."""
+
+    def __init__(self) -> None:
+        self.payloads: list[dict] = []
+        self.usage_started = asyncio.Event()
+        self.release_usage = asyncio.Event()
+        self._current_is_usage = False
+
+    def write(self, data: bytes | bytearray | memoryview) -> None:
+        payload = json.loads(bytes(data))
+        self.payloads.append(payload)
+        update = payload.get("params", {}).get("update", {})
+        self._current_is_usage = update.get("sessionUpdate") == "usage_update"
+
+    async def drain(self) -> None:
+        if self._current_is_usage:
+            self.usage_started.set()
+            await self.release_usage.wait()
+
+
+async def _assert_terminal_response_precedes_stalled_usage(
+    agent: HermesACPAgent,
+    state,
+    *,
+    prompt_text: str,
+    expected_response_text: str,
+) -> None:
+    """Cross ACP's router, request runner, real sender, and serialized frames."""
+    baseline_tasks = set(asyncio.all_tasks())
+    writer = _UsageBlockingWriter()
+    connection = Connection(
+        build_agent_router(agent),
+        cast(asyncio.StreamWriter, writer),
+        asyncio.StreamReader(),
+        listening=False,
+    )
+    client = object.__new__(AgentSideConnection)
+    client._conn = connection
+    agent._conn = client
+
+    params = PromptRequest(
+        session_id=state.session_id,
+        prompt=[TextContentBlock(type="text", text=prompt_text)],
+    ).model_dump(mode="json", by_alias=True, exclude_none=True)
+    request_task = asyncio.create_task(
+        connection._run_request({
+            "jsonrpc": "2.0",
+            "id": 42,
+            "method": "session/prompt",
+            "params": params,
+        })
+    )
+
+    try:
+        await asyncio.wait_for(writer.usage_started.wait(), timeout=1)
+
+        # The real MessageSender is blocked in writer.drain() for UsageUpdate.
+        # The request can only be done if its terminal response went through
+        # the same FIFO sender first.
+        assert request_task.done(), "terminal response is queued behind usage metadata"
+        assert request_task.result()["stopReason"] == "end_turn"
+
+        def _frame_kind(payload: dict) -> str | None:
+            if payload.get("id") == 42:
+                return "terminal"
+            update = payload.get("params", {}).get("update", {})
+            if update.get("sessionUpdate") == "agent_message_chunk":
+                assert update["content"]["text"] == expected_response_text
+                return "assistant"
+            if update.get("sessionUpdate") == "usage_update":
+                return "usage"
+            return None
+
+        assert [
+            kind for payload in writer.payloads if (kind := _frame_kind(payload))
+        ] == [
+            "assistant",
+            "terminal",
+            "usage",
+        ]
+    finally:
+        writer.release_usage.set()
+        if not request_task.done():
+            await request_task
+        await connection.close()
+        await asyncio.sleep(0)
+
+    pending = [task for task in asyncio.all_tasks() - baseline_tasks if not task.done()]
+    assert pending == []
 
 
 @pytest.mark.asyncio
@@ -278,6 +375,37 @@ class TestSessionOps:
         assert update.size == 100_000
         assert update.used == 25_000
 
+    @pytest.mark.asyncio
+    async def test_usage_metadata_waiter_is_bounded(self, agent, mock_manager):
+        """The timeout cancels Hermes's waiter, not ACP's shared sender."""
+        state = mock_manager.create_session(cwd="/tmp")
+        state.agent.context_compressor = MagicMock(context_length=100_000)
+        state.agent._cached_system_prompt = "system"
+        state.agent.tools = []
+
+        send_started = asyncio.Event()
+        waiter_finished = asyncio.Event()
+
+        async def _stalled_update(*args, **kwargs):
+            send_started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                waiter_finished.set()
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock(side_effect=_stalled_update)
+        agent._conn = mock_conn
+
+        with patch(
+            "acp_adapter.server._ACP_AUXILIARY_UPDATE_WAITER_TIMEOUT_SECONDS",
+            0.01,
+        ):
+            await asyncio.wait_for(agent._send_usage_update(state), timeout=0.5)
+
+        assert send_started.is_set()
+        assert waiter_finished.is_set()
+
 
 
 
@@ -445,6 +573,54 @@ class TestPrompt:
         )
 
         assert captured.get("child") == resp.session_id
+
+    @pytest.mark.asyncio
+    async def test_prompt_terminal_response_precedes_stalled_usage_metadata(
+        self, agent, mock_manager
+    ):
+        """Normal prompts queue content and end_turn before optional usage."""
+        state = mock_manager.create_session(cwd=".")
+        state.agent.model = "test-model"
+        state.agent.provider = "openrouter"
+        state.agent.context_compressor = MagicMock(context_length=100_000)
+        state.agent._cached_system_prompt = "system"
+        state.agent.tools = []
+        state.agent.run_conversation = MagicMock(
+            return_value={
+                "final_response": "done",
+                "messages": [
+                    {"role": "user", "content": "hi"},
+                    {"role": "assistant", "content": "done"},
+                ],
+            }
+        )
+
+        with patch("agent.title_generator.maybe_auto_title"):
+            await _assert_terminal_response_precedes_stalled_usage(
+                agent,
+                state,
+                prompt_text="hi",
+                expected_response_text="done",
+            )
+
+    @pytest.mark.asyncio
+    async def test_slash_command_terminal_response_precedes_stalled_usage_metadata(
+        self, agent, mock_manager
+    ):
+        """Slash commands preserve the same completion ordering guarantee."""
+        state = mock_manager.create_session(cwd=".")
+        state.agent.model = "test-model"
+        state.agent.provider = "openrouter"
+        state.agent.context_compressor = MagicMock(context_length=100_000)
+        state.agent._cached_system_prompt = "system"
+        state.agent.tools = []
+
+        await _assert_terminal_response_precedes_stalled_usage(
+            agent,
+            state,
+            prompt_text="/version",
+            expected_response_text=f"Hermes Agent v{HERMES_VERSION}",
+        )
 
 
 


### PR DESCRIPTION
## What happened

I hit this while running Hermes behind Buzz over ACP. Hermes emitted the final assistant text and finished the model turn, but Buzz never received the terminal `PromptResponse(stop_reason="end_turn")`, so the managed turn stayed open until it was killed.

The immediate cause was the final `usage_update` being awaited before `prompt()` returned. The existing timeout proposals in #39378 and #51498 reduce how long Hermes waits, but ACP 0.9 uses a shared FIFO sender. Once an optional update is queued and the sender is blocked in `writer.drain()`, cancelling Hermes's waiter does not remove that frame or let a terminal response overtake it.

## What this changes

- Queues assistant content and the terminal prompt response before scheduling optional usage metadata.
- Applies the same ordering to normal prompts and slash-command responses.
- Bounds the detached Hermes-side usage waiter to five seconds and logs the residual transport limitation honestly.
- Leaves content delivery reliable: this does not put the final assistant message behind a best-effort timeout.

The serialized order is now:

```text
agent_message_chunk -> PromptResponse(end_turn) -> usage_update
```

## Verification

- `python -m pytest tests/acp -q` — **129 passed**
- Focused transport regressions — **3 passed**
- Sabotage check: restoring the old blocking order makes both normal-prompt and slash-command ordering regressions fail
- Ruff lint — passed
- `git diff --check` — passed
- Real ACP subprocess using a normal Hermes profile returned exact assistant text plus `stop_reason=end_turn`

The repository's current `main` already fails `ruff format --check` on both touched files, so I did not mix a whole-file formatting migration into this focused fix.

## Scope

This addresses the ordering failure in #39245. It does not claim that Hermes can cancel an optional frame already blocked inside ACP 0.9's shared sender; it prevents the current turn's terminal response from being queued behind that frame in the first place.

Fixes #39245
