### PR TITLE
fix(deps): bump electron 40.10.6 -> 41.10.3 (GHSA-9f4c-93c8-jc8g)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -149,7 +149,7 @@
     "bippy": "0.5.43",
     "concurrently": "10.0.4",
     "cross-env": "10.1.0",
-    "electron": "40.10.6",
+    "electron": "41.10.3",
     "electron-builder": "26.15.3",
     "esbuild": "0.28.1",
     "jsdom": "29.1.1",
@@ -162,7 +162,7 @@
     "wait-on": "9.0.10"
   },
   "build": {
-    "electronVersion": "40.10.6",
+    "electronVersion": "41.10.3",
     "appId": "com.nousresearch.hermes",
     "productName": "Hermes",
     "executableName": "Hermes",

--- a/package-lock.json
+++ b/package-lock.json
@@ -156,7 +156,7 @@
         "bippy": "0.5.43",
         "concurrently": "10.0.4",
         "cross-env": "10.1.0",
-        "electron": "40.10.6",
+        "electron": "41.10.3",
         "electron-builder": "26.15.3",
         "esbuild": "0.28.1",
         "jsdom": "29.1.1",
@@ -9778,9 +9778,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "40.10.6",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-40.10.6.tgz",
-      "integrity": "sha512-TGjlkOU9Lg6K4KjDbsErywCWCIDaNgLh0q+xj0nlpRoQhevI7VBIxBTtJI/V30lypyLAaXMpnP9O9jui1/qRFw==",
+      "version": "41.10.3",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.10.3.tgz",
+      "integrity": "sha512-MJuSODPw8siv/I8JjhctW/cS/XNldwI4gLRyyWZx6QkoZJUDgbEvitp7IVOnGrHENTQb6Udo+zMpKhFnhlIhdg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -71,8 +71,8 @@
     "node-pty@1.1.0": true,
     "electron-winstaller@5.4.0": true,
     "agent-browser@0.26.0": true,
-    "electron@40.10.2": true,
     "fsevents@2.3.2": true,
-    "fsevents@2.3.3": true
+    "fsevents@2.3.3": true,
+    "electron@41.10.3": true
   }
 }


### PR DESCRIPTION
## Summary
Completes the electron half deferred from #81901: bumps electron 40.10.6 → 41.10.3, the only line that fixes GHSA-9f4c-93c8-jc8g (7.2 high). With this, the last actionable electron finding from the weekly OSV scan is closed.

## Changes
- `apps/desktop/package.json`: `electron` + `build.electronVersion` → 41.10.3 (kept in exact-pin agreement per the desktop-electron-pin contract tests)
- `package.json`: `allowScripts` key `electron@40.10.2` → `electron@41.10.3` — the version-suffixed gate silently skips electron's postinstall on any bump, leaving no binary and a broken launch; this key must move in the same commit as every electron bump (dependabot's #79637 was missing this and would have shipped a non-launching install)
- `package-lock.json`: regenerated (electron entry only)

## Aging rule
41.10.3 released 2026-07-21 — 18 days old, clears the ≥14-day gate. The newer 41.10.4 (4d) is not a CVE requirement and stays out.

## Validation (real launch, not just lockfile)
| Check | Result |
|---|---|
| `hermes desktop --source --force-build` on a headless X display | app built + launched on v41.10.3 |
| Renderer screenshot inspected | sidebar/sessions/composer healthy, no dialogs, no blank areas or glitches |
| `apps/desktop` typecheck (3 tsconfigs) | clean |
| `apps/desktop` vitest full run | 4574 passed / 2 skipped (485 files) |
| `desktop-electron-pin.test.ts` (pin/electronVersion/lockfile agreement) | 3/3 pass |

Windows packaging should get a smoke test after merge — this validates the Linux path.

Supersedes dependabot's #79637 (same bump, minus the allowScripts fix).

## Infographic

![Electron Major Upgrade](https://v3b.fal.media/files/b/0aa59525/VKpQDHPFezL2dZuik0SVm_WK93FOIH.png)
