### PR TITLE
fix(secrets): mask provider-bound copies while preserving replay (#77487)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2861,7 +2861,11 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
     messages = _drop_results_without_ids(messages)
     messages = _pair_tool_calls_positionally(messages)
     messages = _dedupe_tool_call_ids(messages)
-    return _realign_tool_result_names(messages)
+    messages = _realign_tool_result_names(messages)
+    # Keep executable and signed replay fields exact on the disposable copy.
+    from agent.provider_redaction import redact_provider_message_values
+
+    return redact_provider_message_values(messages)
 
 
 _ACK_FUTURE_RE = re.compile(r"\b(i['’]ll|i will|let me|i can do that|i can help with that)\b")

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3476,7 +3476,14 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             "Pre-call sanitizer: removed %d duplicate tool_call_id reference(s)",
             removed_dupes,
         )
-    return messages
+
+    # Final provider-egress exact-value gate (#77487). Redact a deep copy so
+    # nested media metadata is masked on the wire without overwriting the
+    # replayable in-memory/session history. Tool-call arguments remain exact:
+    # masking them reintroduces the rejected #43083 replay regression.
+    from agent.redact import redact_provider_message_values
+
+    return redact_provider_message_values(messages)
 
 
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1429,6 +1429,8 @@ class _CodexCompletionsAdapter:
                     })
             if converted:
                 resp_kwargs["tools"] = converted
+        from agent.provider_redaction import redact_provider_api_kwargs
+        resp_kwargs = redact_provider_api_kwargs(resp_kwargs)
         # Stable prompt-cache routing: key is content-addressed from the static prefix
         # (instructions + tool schemas) so it survives across turns, scoped by the owning
         # conversation (rotation-stable logical scope, else the physical session id). Skip the
@@ -1685,6 +1687,8 @@ class _AnthropicCompletionsAdapter:
                 if not isinstance(existing, dict):
                     existing = {}
                 anthropic_kwargs["extra_body"] = {**existing, **passthrough}
+        from agent.provider_redaction import redact_provider_api_kwargs
+        anthropic_kwargs = redact_provider_api_kwargs(anthropic_kwargs)
         response = create_anthropic_message(
             self._client,
             anthropic_kwargs,
@@ -2480,11 +2484,13 @@ def _relay_sync_completion(
     api_mode: str | None = None, create: Callable[[dict[str, Any]], Any] | None = None,
 ) -> Any:
     from agent.auxiliary_wire import prepare_chat_messages
+    from agent.provider_redaction import redact_provider_api_kwargs
 
     kwargs = prepare_chat_messages(client, kwargs)
     # The progress hook is installed per TASK, so every attempt (retries, recovery rungs, fallbacks)
     # must stream through _create_with_progress or the compression watchdog sees silence (#98466).
-    callback = create or (lambda request: _create_with_progress(client, request))
+    provider_call = create or (lambda request: _create_with_progress(client, request))
+    callback = lambda request: provider_call(redact_provider_api_kwargs(request))
     route = _relay_auxiliary_metadata(provider=provider, api_mode=api_mode)
     # Isolate only the provider callback so the owning thread can unwind its lease/DB
     # transaction on hard cancel without touching the shared client.
@@ -2504,10 +2510,16 @@ async def _relay_async_completion(
     api_mode: str | None = None, create: Callable[[dict[str, Any]], Any] | None = None,
 ) -> Any:
     from agent.auxiliary_wire import prepare_chat_messages
+    from agent.provider_redaction import redact_provider_api_kwargs
 
     kwargs = prepare_chat_messages(client, kwargs)
     # Async twin of the seam default above (#98466).
-    callback = create or (lambda request: _acreate_with_progress(client, request))
+    provider_call = create or (lambda request: _acreate_with_progress(client, request))
+
+    async def callback(request):
+        import asyncio
+        payload = await asyncio.to_thread(redact_provider_api_kwargs, request)
+        return await provider_call(payload)
     route = _relay_auxiliary_metadata(provider=provider, api_mode=api_mode)
     if route is None:
         return await callback(kwargs)
@@ -2523,15 +2535,17 @@ def _relay_sync_stream(
     client: Any, kwargs: dict[str, Any], *, provider: str | None = None, api_mode: str | None = None
 ) -> Any:
     from agent.auxiliary_wire import prepare_chat_messages
+    from agent.provider_redaction import redact_provider_api_kwargs
 
     kwargs = prepare_chat_messages(client, kwargs)
+    callback = lambda request: client.chat.completions.create(**redact_provider_api_kwargs(request))
     route = _relay_auxiliary_metadata(provider=provider, api_mode=api_mode)
     if route is None:
-        return client.chat.completions.create(**kwargs)
+        return callback(kwargs)
     provider_name, fallback_model, metadata = route
     from agent import relay_llm
     return relay_llm.stream_current(
-        kwargs, lambda request: client.chat.completions.create(**request), name=provider_name,
+        kwargs, callback, name=provider_name,
         model_name=str(kwargs.get("model") or fallback_model), finalizer=dict, metadata=metadata,
         completed_response_predicate=lambda value: hasattr(value, "choices"),
     )
@@ -7201,6 +7215,10 @@ def call_llm(
     latency_info: Optional[Dict[str, int]] = None,
 ) -> Any:
     """Run an auxiliary LLM request, applying the configured task limit."""
+    from agent.provider_redaction import redact_provider_api_kwargs
+
+    # Keep caller history exact, including executable and signed replay fields.
+    provider_payload = redact_provider_api_kwargs({"messages": messages, "extra_body": extra_body})
     queue_started_at = time.monotonic()
     semaphore = _acquire_sync_aux_semaphore(task)
     if semaphore is not None:
@@ -7223,8 +7241,8 @@ def call_llm(
         ):
             response = _call_llm_impl(
                 task=task, provider=provider, model=model, base_url=base_url, api_key=api_key,
-                main_runtime=main_runtime, messages=messages, temperature=temperature,
-                max_tokens=max_tokens, tools=tools, timeout=timeout, extra_body=extra_body,
+                main_runtime=main_runtime, messages=provider_payload["messages"], temperature=temperature,
+                max_tokens=max_tokens, tools=tools, timeout=timeout, extra_body=provider_payload["extra_body"],
                 reasoning_config=reasoning_config, extra_headers=extra_headers, api_mode=api_mode,
                 stream=stream, stream_options=stream_options, route_info=route_info,
             )
@@ -7499,14 +7517,22 @@ async def async_call_llm(
     route_info: Optional[Dict[str, str]] = None,
 ) -> Any:
     """Run an asynchronous auxiliary LLM request under the configured limit."""
+    import asyncio
+
+    from agent.provider_redaction import redact_provider_api_kwargs
+
+    # Offload parsing and copying while propagating the active profile scope.
+    provider_payload = await asyncio.to_thread(
+        redact_provider_api_kwargs, {"messages": messages, "extra_body": extra_body}
+    )
     semaphore = _acquire_async_aux_semaphore(task)
     if semaphore is not None:
         await semaphore.acquire()
     try:
         return await _async_call_llm_impl(
             task=task, provider=provider, model=model, base_url=base_url, api_key=api_key,
-            main_runtime=main_runtime, messages=messages, temperature=temperature,
-            max_tokens=max_tokens, tools=tools, timeout=timeout, extra_body=extra_body,
+            main_runtime=main_runtime, messages=provider_payload["messages"], temperature=temperature,
+            max_tokens=max_tokens, tools=tools, timeout=timeout, extra_body=provider_payload["extra_body"],
             reasoning_config=reasoning_config, route_info=route_info,
         )
     finally:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8756,6 +8756,14 @@ def call_llm(
     stream_options: dict = None,
 ) -> Any:
     """Run an auxiliary LLM request, applying the configured task limit."""
+    # Auxiliary callers do not pass through the main runtime's provider-copy
+    # sanitizer. Build the same disposable exact-secret-masked view here so
+    # title/one-shot/plugin/direct calls cannot bypass the provider boundary.
+    # The helper preserves caller history and replay/signed/sealed fields, and
+    # deliberately respects the operator's explicit redaction opt-out.
+    from agent.redact import redact_provider_message_values
+
+    provider_messages = redact_provider_message_values(messages)
     semaphore = _acquire_sync_aux_semaphore(task)
     if semaphore is not None:
         semaphore.acquire()
@@ -8767,7 +8775,7 @@ def call_llm(
             base_url=base_url,
             api_key=api_key,
             main_runtime=main_runtime,
-            messages=messages,
+            messages=provider_messages,
             temperature=temperature,
             max_tokens=max_tokens,
             tools=tools,
@@ -9600,6 +9608,17 @@ async def async_call_llm(
     reasoning_config: Optional[dict] = None,
 ) -> Any:
     """Run an asynchronous auxiliary LLM request under the configured limit."""
+    import asyncio
+
+    from agent.redact import redact_provider_message_values
+
+    # Exact-secret collection, JSON parsing, pattern compilation, and deep-copy
+    # traversal are synchronous CPU/filesystem work. Keep them off the event
+    # loop; asyncio.to_thread propagates the active ContextVar profile scope.
+    provider_messages = await asyncio.to_thread(
+        redact_provider_message_values,
+        messages,
+    )
     semaphore = _acquire_async_aux_semaphore(task)
     if semaphore is not None:
         await semaphore.acquire()
@@ -9611,7 +9630,7 @@ async def async_call_llm(
             base_url=base_url,
             api_key=api_key,
             main_runtime=main_runtime,
-            messages=messages,
+            messages=provider_messages,
             temperature=temperature,
             max_tokens=max_tokens,
             tools=tools,

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -880,7 +880,8 @@ def build_converse_kwargs(
         kwargs["guardrailConfig"] = guardrail_config
     if not inference_config:
         del kwargs["inferenceConfig"]  # optional on the wire; don't send {}
-    return kwargs
+    from agent.provider_redaction import redact_provider_api_kwargs
+    return redact_provider_api_kwargs(kwargs)
 
 
 def call_converse(

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import contextlib
 import contextvars
+import copy
 import json
 import logging
 import math
@@ -1369,6 +1370,15 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
     """
     from agent.opencode_affinity import merge_opencode_session_headers
 
+    from agent.message_sanitization import _sanitize_structure_non_ascii
+    from agent.provider_redaction import redact_provider_message_values
+
+    # Normalize a disposable copy before matching: ASCII fallback and prior
+    # turn merges can create a secret that did not exist in separate fragments.
+    if getattr(agent, "_force_ascii_payload", False):
+        api_messages = copy.deepcopy(api_messages)
+        _sanitize_structure_non_ascii(api_messages)
+    api_messages = redact_provider_message_values(api_messages)
     kwargs = _build_api_kwargs_for_mode(agent, api_messages, tools_for_api)
     return merge_opencode_session_headers(
         kwargs,
@@ -2000,6 +2010,9 @@ def _iteration_summary_api_messages(agent, messages: list) -> list:
 
 def _managed_summary_call(agent, api_request_id: str, request, callback, *, retry_count: int):
     from agent import relay_llm
+    from agent.provider_redaction import redact_provider_api_kwargs
+
+    request = redact_provider_api_kwargs(request)
     return relay_llm.execute_current(
         request, callback,
         name=str(getattr(agent, "provider", "") or "provider"), model_name=str(getattr(agent, "model", "") or ""),

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -15,6 +15,7 @@ sites unchanged.  Symbols that tests patch on ``run_agent`` (e.g.
 
 from __future__ import annotations
 
+import copy
 import contextvars
 import json
 import logging
@@ -36,6 +37,7 @@ from agent.gemini_native_adapter import is_native_gemini_base_url
 from agent.model_metadata import is_local_endpoint
 from agent.message_content import flatten_message_text
 from agent.message_sanitization import (
+    _sanitize_structure_non_ascii,
     _sanitize_surrogates,
     _repair_tool_call_arguments,
 )
@@ -1332,6 +1334,28 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
     if tools_for_api is None:
         tools_for_api = agent.tools
 
+    # ASCII fallback normalization must precede the final exact-secret gate.
+    # Transliteration can compose a configured secret from an otherwise safe
+    # value (for example ``abécd`` -> ``abcd``); sanitizing only the finished
+    # kwargs would therefore create the secret after the gate.  Normalize a
+    # disposable request copy here so canonical history remains byte-exact,
+    # then let the provider gate inspect the exact bytes sent on the wire.
+    if getattr(agent, "_force_ascii_payload", False):
+        api_messages = copy.deepcopy(api_messages)
+        _sanitize_structure_non_ascii(api_messages)
+
+    # Final provider-egress gate. Earlier sanitization intentionally runs
+    # before alternation repair, thinking-only removal, prompt-cache rebasing,
+    # and MoA preparation. Those request-local transformations can merge
+    # individually harmless fragments into one active exact secret (for
+    # example two user turns joined with ``\n\n``). Rebind a disposable copy
+    # here, after those transformations and immediately before every transport
+    # builds its wire kwargs. Executable tool arguments and signed/sealed replay
+    # fields retain their established byte-exact exemptions.
+    from agent.redact import redact_provider_message_values
+
+    api_messages = redact_provider_message_values(api_messages)
+
     if agent.api_mode == "anthropic_messages":
         _transport = agent._get_transport()
         anthropic_messages = agent._prepare_anthropic_messages_for_api(api_messages)
@@ -2451,6 +2475,13 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             _cnr_sum = _ct_sum.normalize_response(summary_response)
             final_response = (_cnr_sum.content or "").strip()
         else:
+            # This legacy final-summary path calls chat.completions directly
+            # instead of routing through ``build_api_kwargs``. Apply the same
+            # post-merge exact-value gate after thinking-only removal so it
+            # cannot reintroduce a composed secret at provider egress.
+            from agent.redact import redact_provider_message_values
+
+            api_messages = redact_provider_message_values(api_messages)
             summary_kwargs = {
                 "model": agent.model,
                 "messages": api_messages,

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -34,6 +34,8 @@ from agent.redact import redact_sensitive_text
 from agent.turn_context import drop_stale_api_content
 from tools.todo_tool import TODO_INJECTION_HEADER
 
+from agent.provider_redaction import _exact_secret_pattern_scope, redact_known_secret_values
+
 logger = logging.getLogger(__name__)
 
 
@@ -1002,7 +1004,8 @@ def _redact_compaction_text(text: Any) -> str:
     """Redact text that crosses a compaction summary boundary (strict mode).
     ``force=True`` overrides ``security.redact_secrets: false``; URL credentials are redacted too, since
     summaries persist and re-enter every later prompt."""
-    return redact_sensitive_text(text or "", force=True, redact_url_credentials=True)
+    redacted = redact_sensitive_text(text or "", force=True, redact_url_credentials=True)
+    return redact_known_secret_values(redacted, force=True)
 
 
 def _dedupe_append(items: list[str], value: str, *, limit: int) -> None:
@@ -2953,6 +2956,7 @@ class ContextCompressor(SummaryDispatchMixin, MicroCompactionMixin, ContextEngin
             args = args[:self._TOOL_ARGS_HEAD] + "..."
         return f"  {fn.get('name', '?')}({args})"
 
+    @_exact_secret_pattern_scope()
     def _serialize_for_summary(self, turns: List[Dict[str, Any]]) -> str:
         """Serialize turns into labeled, redacted text for the summarizer."""
         # Lazy import: agent_runtime_helpers pulls heavy transitive imports.
@@ -3038,6 +3042,7 @@ class ContextCompressor(SummaryDispatchMixin, MicroCompactionMixin, ContextEngin
             "last_dropped_turns": last_dropped_turns,
         }
 
+    @_exact_secret_pattern_scope()
     def _build_static_fallback_summary(
         self, turns_to_summarize: List[Dict[str, Any]], reason: str | None = None,
     ) -> str:
@@ -3049,7 +3054,7 @@ class ContextCompressor(SummaryDispatchMixin, MicroCompactionMixin, ContextEngin
         active_task = f"User asked: {user_asks[-1]!r}" if user_asks else _NO_USER_TASK_SENTINEL
         previous_summary_note = ""
         if self._previous_summary:
-            previous_summary = redact_sensitive_text(self._previous_summary.strip())
+            previous_summary = _redact_compaction_text(self._previous_summary.strip())
             if len(previous_summary) > _FALLBACK_PREVIOUS_SUMMARY_MAX_CHARS:
                 previous_summary = (previous_summary[: _FALLBACK_PREVIOUS_SUMMARY_MAX_CHARS - 45].rstrip()
                                     + "\n...[previous summary snapshot truncated]")
@@ -3292,6 +3297,7 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
             )
         return content
 
+    @_exact_secret_pattern_scope()
     def _generate_summary(
         self, turns_to_summarize: List[Dict[str, Any]], focus_topic: Optional[str] = None,
         memory_context: str = "", bypass_cooldown: bool = False,
@@ -4623,6 +4629,7 @@ Write only the summary body. Do not include any preamble or prefix."""
         self._reset_proactive_prune_rearm()
         return compressed
 
+    @_exact_secret_pattern_scope()
     def compress(
         self, messages: List[Dict[str, Any]], current_tokens: Optional[int] = None, focus_topic: Optional[str] = None,
         force: bool = False, memory_context: str = "", bypass_cooldown: bool = False,

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -23,6 +23,7 @@ import sqlite3
 import re
 import time
 import uuid
+from functools import wraps
 from typing import Any, Dict, List, Optional
 
 from agent.auxiliary_client import (
@@ -44,6 +45,18 @@ from agent.turn_context import drop_stale_api_content
 from tools.todo_tool import TODO_INJECTION_HEADER
 
 logger = logging.getLogger(__name__)
+
+
+def _reuse_compaction_exact_secret_pattern(func):
+    """Reuse one profile-bound exact-secret snapshot for a compaction call."""
+    @wraps(func)
+    def wrapped(*args, **kwargs):
+        from agent.redact import _exact_secret_pattern_scope
+
+        with _exact_secret_pattern_scope():
+            return func(*args, **kwargs)
+
+    return wrapped
 
 
 def _safe_int(value: Any) -> int | None:
@@ -845,11 +858,18 @@ def _redact_compaction_text(text: Any) -> str:
       tokens, and URL userinfo never need to survive summarization the way
       they must survive live navigation flows.
     """
-    return redact_sensitive_text(
+    redacted = redact_sensitive_text(
         text or "",
         force=True,
         redact_url_credentials=True,
     )
+    # External secret providers may use arbitrary names and opaque values that
+    # have no recognizable credential shape. Compaction is both an auxiliary
+    # provider boundary and a persistence boundary, so exact masking remains
+    # forced even when live-output redaction is disabled.
+    from agent.redact import redact_known_secret_values
+
+    return redact_known_secret_values(redacted, force=True)
 
 
 def _dedupe_append(items: list[str], value: str, *, limit: int) -> None:
@@ -3477,6 +3497,7 @@ class ContextCompressor(ContextEngine):
     # carries the full rationale) so subclasses/tests can override per-class.
     _SUMMARY_INPUT_MAX_CHARS = _SUMMARY_INPUT_MAX_CHARS
 
+    @_reuse_compaction_exact_secret_pattern
     def _serialize_for_summary(self, turns: List[Dict[str, Any]]) -> str:
         """Serialize conversation turns into labeled text for the summarizer.
 
@@ -3565,6 +3586,7 @@ class ContextCompressor(ContextEngine):
 
         return "\n\n".join(parts)
 
+    @_reuse_compaction_exact_secret_pattern
     def _build_static_fallback_summary(
         self,
         turns_to_summarize: List[Dict[str, Any]],
@@ -3704,7 +3726,7 @@ class ContextCompressor(ContextEngine):
         )
         previous_summary_note = ""
         if self._previous_summary:
-            previous_summary = redact_sensitive_text(self._previous_summary.strip())
+            previous_summary = _redact_compaction_text(self._previous_summary.strip())
             if len(previous_summary) > _FALLBACK_PREVIOUS_SUMMARY_MAX_CHARS:
                 previous_summary = (
                     previous_summary[: _FALLBACK_PREVIOUS_SUMMARY_MAX_CHARS - 45].rstrip()
@@ -3831,6 +3853,7 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         self.summary_model = ""  # empty = use main model
         self._clear_compression_failure_cooldown()  # no cooldown — retry immediately
 
+    @_reuse_compaction_exact_secret_pattern
     def _generate_summary(
         self,
         turns_to_summarize: List[Dict[str, Any]],
@@ -5781,8 +5804,8 @@ This compaction should PRIORITISE preserving all information related to the focu
         from agent.auxiliary_client import call_llm, aux_interrupt_protection
 
         messages = self._build_micro_summary_prompt(
-            self._micro_compact_rolling_summary,
-            exchange_text,
+            _redact_compaction_text(self._micro_compact_rolling_summary),
+            _redact_compaction_text(exchange_text),
         )
 
         call_kwargs = {
@@ -5823,6 +5846,7 @@ This compaction should PRIORITISE preserving all information related to the focu
 
         from agent.agent_runtime_helpers import strip_think_blocks
         stripped = strip_think_blocks(None, content).strip()
+        stripped = _redact_compaction_text(stripped)
         return stripped if stripped else None
 
     def _needs_defrag(self) -> bool:
@@ -5894,6 +5918,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         )
         return True
 
+    @_reuse_compaction_exact_secret_pattern
     def _micro_compact(
         self,
         messages: List[Dict[str, Any]],
@@ -6335,6 +6360,7 @@ This compaction should PRIORITISE preserving all information related to the focu
             merged.append(msg)
         return merged
 
+    @_reuse_compaction_exact_secret_pattern
     def compress(
         self,
         messages: List[Dict[str, Any]],

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -28,7 +28,7 @@ Lifecycle:
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
-from agent.redact import redact_sensitive_text
+from agent.redact import redact_known_secret_values, redact_sensitive_text
 
 
 MEMORY_CONTEXT_MAX_CHARS = 6_000
@@ -44,6 +44,10 @@ def sanitize_memory_context(memory_context: str) -> str:
         force=True,
         redact_url_credentials=True,
     )
+    # Memory-provider output is auxiliary-provider prompt input. Its text may
+    # contain an arbitrary active secret with no recognizable credential
+    # shape, so exact-value masking is mandatory even under the live opt-out.
+    sanitized = redact_known_secret_values(sanitized, force=True)
     if len(sanitized) <= MEMORY_CONTEXT_MAX_CHARS:
         return sanitized
     return (

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -13,6 +13,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
 from agent.redact import redact_sensitive_text
+from agent.provider_redaction import redact_known_secret_values
 
 
 MEMORY_CONTEXT_MAX_CHARS = 6_000
@@ -24,6 +25,7 @@ _MEMORY_CONTEXT_TRUNCATION_MARKER = "\n...[memory provider context truncated]...
 def sanitize_memory_context(memory_context: str) -> str:
     """Prepare provider context for a context-engine/LLM egress boundary."""
     sanitized = redact_sensitive_text(memory_context.strip(), force=True, redact_url_credentials=True)
+    sanitized = redact_known_secret_values(sanitized, force=True)
     if len(sanitized) <= MEMORY_CONTEXT_MAX_CHARS:
         return sanitized
     return sanitized[:_MEMORY_CONTEXT_HEAD_CHARS] + _MEMORY_CONTEXT_TRUNCATION_MARKER + sanitized[-_MEMORY_CONTEXT_TAIL_CHARS:]

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2423,6 +2423,13 @@ def run_conversation(
                         is_github_responses=agent._is_copilot_url(),
                         sanitize_harmony_tokens=agent._is_codex_backend(),
                     )
+                # Final provider-payload gate after every built-in text
+                # transformation. ASCII fallback and Codex Harmony preflight
+                # can each compose an active exact secret from a value that was
+                # harmless at the earlier message-copy boundary.
+                from agent.redact import redact_provider_api_kwargs
+
+                api_kwargs = redact_provider_api_kwargs(api_kwargs)
                 # Copilot x-initiator: the first API call of a user turn is
                 # marked "user" so Copilot bills a premium request; tool-loop
                 # follow-ups keep the default "agent" header (#3040).
@@ -2583,6 +2590,11 @@ def run_conversation(
                             is_github_responses=agent._is_copilot_url(),
                             sanitize_harmony_tokens=agent._is_codex_backend(),
                         )
+                    # Execution middleware is a trusted local extension, but
+                    # its payload still crosses the provider boundary. Rebind
+                    # after the dispatch-time Codex preflight as well, so no
+                    # retry or middleware-produced text bypasses the gate.
+                    next_api_kwargs = redact_provider_api_kwargs(next_api_kwargs)
                     if _use_streaming:
                         return agent._interruptible_streaming_api_call(
                             next_api_kwargs, on_first_delta=_stop_spinner

--- a/agent/micro_compaction.py
+++ b/agent/micro_compaction.py
@@ -11,6 +11,7 @@ import logging
 import time
 from typing import Any, Dict, List, Optional
 
+from agent.provider_redaction import _exact_secret_pattern_scope
 from agent.model_metadata import estimate_messages_tokens_rough, estimate_tokens_rough
 
 # Log name parity with the origin module.
@@ -119,7 +120,10 @@ class MicroCompactionMixin:
 
         call_kwargs = {
             "task": "compression",
-            "messages": self._build_micro_summary_prompt(self._micro_compact_rolling_summary, exchange_text),
+            "messages": self._build_micro_summary_prompt(
+                _cc()._redact_compaction_text(self._micro_compact_rolling_summary),
+                _cc()._redact_compaction_text(exchange_text),
+            ),
             "max_tokens": min(1500, self.max_summary_tokens or 1500),
             "temperature": 0.1,
         }
@@ -153,7 +157,7 @@ class MicroCompactionMixin:
             return None
 
         from agent.agent_runtime_helpers import strip_think_blocks
-        return strip_think_blocks(None, content).strip() or None
+        return _cc()._redact_compaction_text(strip_think_blocks(None, content).strip()) or None
 
     def _needs_defrag(self) -> bool:
         """Return True when the rolling summary is large enough to defrag."""
@@ -196,6 +200,7 @@ class MicroCompactionMixin:
         self._micro_compact_consecutive_failures = 0
         self._micro_compact_last_failure_cursor = -1
 
+    @_exact_secret_pattern_scope()
     def _micro_compact(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Run one round of micro-compaction (entry point from ``finalize_turn()``). Returns the
         (possibly modified) list and syncs the session DB via ``archive_and_compact`` (the

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -697,6 +697,31 @@ def _reference_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return rendered
 
 
+def _redacted_reference_messages(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Build an exact-redacted disposable advisory view.
+
+    Provider-copy masking first removes values from tool results and other
+    visible content without mutating history. The second text-only pass masks
+    values after tool-call arguments are rendered for advisors, so modern and
+    legacy structured argument fields remain exact for replay.
+    """
+    from agent.provider_redaction import redact_known_secret_values, redact_provider_message_values
+
+    provider_copy = redact_provider_message_values(messages)
+    rendered = _reference_messages(provider_copy)
+    return [
+        {
+            **message,
+            "content": redact_known_secret_values(message.get("content", "")),
+        }
+        if isinstance(message, dict) and isinstance(message.get("content"), str)
+        else message
+        for message in rendered
+    ]
+
+
 def _extract_text(response: Any) -> str:
     """Assistant text of a completed response: transport-normalized, else ``choices[0]``."""
     with contextlib.suppress(Exception):
@@ -799,7 +824,7 @@ def aggregate_moa_context(
     """
     reference_models = [slot for slot in reference_models if slot.get("enabled", True)]
     reference_outputs = _run_references_parallel(
-        reference_models, _reference_messages(api_messages), temperature=temperature,
+        reference_models, _redacted_reference_messages(api_messages), temperature=temperature,
         max_tokens=reference_max_tokens, reference_timeout=reference_timeout, agent=agent,
     )
     privacy_full = False
@@ -829,6 +854,9 @@ def aggregate_moa_context(
         f"Original user prompt:\n{user_prompt}\n\n"
         f"Reference responses:\n{joined}"
     )
+
+    from agent.provider_redaction import redact_known_secret_values
+    synth_prompt = redact_known_secret_values(synth_prompt)
 
     agg_label = _slot_label(aggregator)
     agg_runtime = _slot_runtime(aggregator)
@@ -1088,6 +1116,8 @@ class MoAChatCompletions:
         agg_messages, tools = self._plan_aggregator_cache(
             prepared["messages"], api_kwargs.get("tools"), prepared.get("guidance"), agg_runtime
         )
+        from agent.provider_redaction import redact_provider_message_values
+        agg_messages = redact_provider_message_values(agg_messages)
         trace = self._pending_trace
         if trace is not None:
             # Trace the exact aggregator INPUT (persisted copy redacted; live input raw).
@@ -1305,7 +1335,7 @@ class MoAChatCompletions:
         if aggregator_temperature is None and api_kwargs.get("temperature") is not None:
             aggregator_temperature = api_kwargs.get("temperature")
 
-        ref_messages = _reference_messages(messages)
+        ref_messages = _redacted_reference_messages(messages)
         cache_key = self._fanout_cache_key(preset, ref_messages, reference_models)
         if cache_key == self._ref_cache_key and self._ref_cache_outputs:
             # HIT: already ran and accounted. Do NOT zero pending totals (a late

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -1129,6 +1129,31 @@ def _reference_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return rendered
 
 
+def _redacted_reference_messages(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Build an exact-redacted disposable advisory view.
+
+    Provider-copy masking first removes values from tool results and other
+    visible content without mutating history. The second text-only pass masks
+    values after tool-call arguments are rendered for advisors, so modern and
+    legacy structured argument fields remain exact for replay.
+    """
+    from agent.redact import redact_known_secret_values, redact_provider_message_values
+
+    provider_copy = redact_provider_message_values(messages)
+    rendered = _reference_messages(provider_copy)
+    return [
+        {
+            **message,
+            "content": redact_known_secret_values(message.get("content", "")),
+        }
+        if isinstance(message, dict) and isinstance(message.get("content"), str)
+        else message
+        for message in rendered
+    ]
+
+
 
 def _extract_text(response: Any) -> str:
     try:
@@ -1243,7 +1268,7 @@ def aggregate_moa_context(
     """
     reference_models = [slot for slot in reference_models if slot.get("enabled", True)]
     reference_outputs: list[tuple[str, str, Any]] = []
-    ref_messages = _reference_messages(api_messages)
+    ref_messages = _redacted_reference_messages(api_messages)
     reference_outputs = _run_references_parallel(
         reference_models,
         ref_messages,
@@ -1306,6 +1331,12 @@ def aggregate_moa_context(
         f"Original user prompt:\n{user_prompt}\n\n"
         f"Reference responses:\n{joined}"
     )
+    # ``user_prompt`` is supplied separately from ``api_messages`` and advisor
+    # output can echo a known value. Treat the assembled synthesis prompt as a
+    # fresh exact-value provider boundary.
+    from agent.redact import redact_known_secret_values
+
+    synth_prompt = redact_known_secret_values(synth_prompt)
 
     agg_label = _slot_label(aggregator)
     agg_runtime = _slot_runtime(aggregator)
@@ -1763,6 +1794,12 @@ class MoAChatCompletions:
                 "MoA aggregator cache plan failed — sending undecorated "
                 "request (cache misses expected): %s", exc,
             )
+        # Reference guidance is attached inside the MoA facade, after the
+        # outer agent loop's normal sanitizer has already run. Apply the same
+        # exact-value copy gate at this final acting-aggregator boundary.
+        from agent.redact import redact_provider_message_values
+
+        agg_messages = redact_provider_message_values(agg_messages)
         # Record the exact aggregator INPUT (incl. the injected reference
         # context) into the pending trace so a trace captures what the
         # aggregator actually saw, not a reconstruction. Traces are a
@@ -1944,7 +1981,7 @@ class MoAChatCompletions:
         from agent.usage_pricing import CanonicalUsage
 
         reference_outputs: list[tuple[str, str, Any]] = []
-        ref_messages = _reference_messages(messages)
+        ref_messages = _redacted_reference_messages(messages)
 
         # Fan-out cadence. "user_turn" (default — cheapest cadence, #67199):
         # advisors run ONCE per user turn; subsequent tool iterations reuse

--- a/agent/oneshot.py
+++ b/agent/oneshot.py
@@ -145,6 +145,9 @@ def run_oneshot(
     )
 
     text = (extract_content_or_reasoning(response) or "").strip()
+    from agent.redact import redact_known_secret_values
+
+    text = redact_known_secret_values(text)
     return _strip_code_fence(text)
 
 

--- a/agent/oneshot.py
+++ b/agent/oneshot.py
@@ -109,7 +109,10 @@ def run_oneshot(
         timeout=timeout,
         main_runtime=main_runtime,
     )
-    return _strip_code_fence((extract_content_or_reasoning(response) or "").strip())
+    from agent.provider_redaction import redact_known_secret_values
+
+    text = redact_known_secret_values(extract_content_or_reasoning(response) or "")
+    return redact_known_secret_values(_strip_code_fence(text.strip()))
 
 
 def _strip_code_fence(text: str) -> str:

--- a/agent/plugin_llm.py
+++ b/agent/plugin_llm.py
@@ -363,14 +363,16 @@ def _extract_usage(response: Any) -> PluginLlmUsage:
 
 def _extract_text(response: Any) -> str:
     """Assistant text of an OpenAI-shaped response (string or text-part list content)."""
+    from agent.provider_redaction import redact_known_secret_values
+
     try:
         content = getattr(response.choices[0].message, "content", None)
         if isinstance(content, str):
-            return content
+            return redact_known_secret_values(content)
         if isinstance(content, list):
             texts = ((part.get("text") if part.get("type") == "text" else None)
                      if isinstance(part, dict) else getattr(part, "text", None) for part in content)
-            return "".join(t for t in texts if isinstance(t, str))
+            return redact_known_secret_values("".join(t for t in texts if isinstance(t, str)))
     except (AttributeError, IndexError, TypeError):
         pass
     return ""

--- a/agent/plugin_llm.py
+++ b/agent/plugin_llm.py
@@ -518,13 +518,14 @@ def _extract_usage(response: Any) -> PluginLlmUsage:
 
 
 def _extract_text(response: Any) -> str:
-    """Pull the assistant text out of an OpenAI-shaped response object."""
+    """Pull and exact-mask visible text from an OpenAI-shaped response."""
+    text = ""
     try:
         msg = response.choices[0].message
         content = getattr(msg, "content", None)
         if isinstance(content, str):
-            return content
-        if isinstance(content, list):
+            text = content
+        elif isinstance(content, list):
             parts: List[str] = []
             for part in content:
                 if isinstance(part, dict):
@@ -534,10 +535,14 @@ def _extract_text(response: Any) -> str:
                     txt = getattr(part, "text", None)
                     if isinstance(txt, str):
                         parts.append(txt)
-            return "".join(parts)
+            text = "".join(parts)
     except (AttributeError, IndexError, TypeError):
         pass
-    return ""
+    # Sanitize only the extracted visible result. The provider response stays
+    # byte-exact, including any signed reasoning or issuer-sealed replay data.
+    from agent.redact import redact_known_secret_values
+
+    return redact_known_secret_values(text)
 
 
 def _resolve_attribution(

--- a/agent/provider_redaction.py
+++ b/agent/provider_redaction.py
@@ -1,0 +1,1316 @@
+"""Exact-secret masking for disposable provider payloads and derived text.
+
+Replay history, executable arguments and signed or sealed provider fields remain
+byte-exact; provider-visible copies use the active profile's secret snapshot.
+"""
+
+import contextvars
+import json
+import logging
+import os
+import re
+from collections import deque
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from agent import redact as _redact_settings
+
+logger = logging.getLogger(__name__)
+
+# Exact-value masking at the provider boundary. External secret sources can
+# populate arbitrary variable names, so shape-based redaction cannot identify
+# their values when a tool echoes them back (#77487).
+_CREDENTIAL_ENV_SUFFIXES = (
+    "_API_KEY",
+    "_TOKEN",
+    "_SECRET",
+    "_PASSWORD",
+    "_PASSWD",
+    "_PASS",
+    "_PW",
+    # Repository redaction and execution-environment filters recognize these
+    # established credential/auth aliases too (for example
+    # ``VAULT_CREDENTIAL``). Do not broaden this to generic ``*_CREDS`` or
+    # ``*_BEARER`` names: authoritative external-secret snapshots already
+    # contribute those values regardless of name, while ambient process/scope
+    # values need repository-backed classification to avoid transcript damage.
+    "_CREDENTIAL",
+    "_CREDENTIALS",
+    "_AUTH",
+)
+_CONFIG_FLAG_ENV_NAMES = frozenset(
+    {
+        # Honcho documents this as a self-hosted boolean switch, not its JWT.
+        # Only a recognized flag value is exempt: an arbitrary value under the
+        # same credential-looking name must still be protected.
+        "AUTH_USE_AUTH",
+    }
+)
+_CONFIG_FLAG_ENV_PREFIXES = (
+    "SKIP_",
+    "DEBUG_",
+    "REQUIRE_",
+    "SHOW_",
+    "USE_",
+    "DISABLE_",
+    "ENABLE_",
+    "ALLOW_",
+    "VERIFY_",
+    "CHECK_",
+    "HAS_",
+    "IS_",
+    "WITH_",
+    "AUTO_",
+)
+_CONFIG_FLAG_ENV_VALUES = frozenset(
+    {
+        "0",
+        "1",
+        "true",
+        "false",
+        "yes",
+        "no",
+        "on",
+        "off",
+        "enabled",
+        "disabled",
+        "auto",
+    }
+)
+_CREDENTIAL_ENV_NAMES = frozenset(
+    {
+        # Repository-supported credential aliases that deliberately use the
+        # otherwise-generic ``*_KEY`` shape. Keep this exact: names such as
+        # PARTITION_KEY, SORT_KEY, CACHE_KEY, and IDEMPOTENCY_KEY hold ordinary
+        # configuration whose short values would corrupt provider transcripts
+        # if collected for literal masking.
+        "ALPHA_VANTAGE_KEY",
+        "API_KEY",
+        "API_SERVER_KEY",
+        "AWS_SECRET_ACCESS_KEY",
+        "AZURE_ANTHROPIC_KEY",
+        "BUZZ_PRIVATE_KEY",
+        "FAL_KEY",
+        "FEISHU_ENCRYPT_KEY",
+        "GATEWAY_PROXY_KEY",
+        "GATEWAY_RELAY_DELIVERY_KEY",
+        "HERMES_IRON_PROXY_MGMT_KEY",
+        "HERMES_LANGFUSE_SECRET_KEY",
+        "HERMES_MEET_REALTIME_KEY",
+        "LANGFUSE_SECRET_KEY",
+        "MATRIX_RECOVERY_KEY",
+        "PORCUPINE_ACCESS_KEY",
+        "VOICE_TOOLS_OPENAI_KEY",
+        "WECOM_CALLBACK_ENCODING_AES_KEY",
+        # Repository-owned bearer-token aliases whose credential word is not
+        # terminal. Keep these exact rather than collecting every ambient
+        # ``*_BEARER*`` setting.
+        "A2A_BEARER_TOKEN",
+        "AWS_BEARER_TOKEN_BEDROCK",
+        # Repository plugin manifests declare these password values even
+        # though their established names use otherwise-generic suffixes.
+        "A2A_PEER_TOKENS",
+        # Common password/auth variables whose established spellings do not
+        # have an underscore-delimited credential suffix.
+        "PGPASSWORD",
+        "MYSQL_PWD",
+        "PASSWORD",
+        "PASSWD",
+        "PASS",
+        "PW",
+        "REDISCLI_AUTH",
+    }
+)
+_VALUE_SENSITIVE_CREDENTIAL_ENV_NAMES = frozenset(
+    {
+        # Google Chat accepts either env name as an inline service-account
+        # object or a path. Only the inline form is credential material; exact
+        # path values must remain visible in provider transcripts.
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "GOOGLE_CHAT_SERVICE_ACCOUNT_JSON",
+    }
+)
+_INLINE_CREDENTIAL_JSON_KEYS = frozenset(
+    {
+        "access_token",
+        "api_key",
+        "client_secret",
+        "id_token",
+        "password",
+        "private_key",
+        "refresh_token",
+    }
+)
+
+
+def _is_credential_env_name(name: str, value: str | None = None) -> bool:
+    """Classify credential variables without matching ordinary names."""
+    normalized = name.upper()
+    if (
+        isinstance(value, str)
+        and (
+            normalized in _CONFIG_FLAG_ENV_NAMES
+            or normalized.startswith(_CONFIG_FLAG_ENV_PREFIXES)
+        )
+        and value.strip().lower() in _CONFIG_FLAG_ENV_VALUES
+    ):
+        # Suffixes such as ``*_AUTH`` and ``*_TOKEN`` are also used by
+        # boolean/configuration switches (for example ``SKIP_AUTH=false``).
+        # Exclude only unambiguous flag-shaped names with flag-shaped values.
+        # Arbitrary short values under the same names remain exact secrets.
+        return False
+    if normalized in _VALUE_SENSITIVE_CREDENTIAL_ENV_NAMES:
+        return isinstance(value, str) and value.lstrip().startswith("{")
+    return normalized in _CREDENTIAL_ENV_NAMES or normalized.endswith(
+        _CREDENTIAL_ENV_SUFFIXES
+    )
+
+
+def _resolve_secret_home(home: str | os.PathLike | None) -> Path:
+    if home is not None:
+        return Path(home)
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home()
+
+
+def _collect_nested_credential_scalars(value: Any, values: set[str]) -> None:
+    """Collect credential-bearing string fields from an inline JSON object."""
+    pending = [value]
+    while pending:
+        current = pending.pop()
+        if isinstance(current, dict):
+            for key, item in current.items():
+                if (
+                    isinstance(key, str)
+                    and key.lower() in _INLINE_CREDENTIAL_JSON_KEYS
+                    and isinstance(item, str)
+                    and item
+                ):
+                    values.add(item)
+                if isinstance(item, (dict, list)):
+                    pending.append(item)
+        elif isinstance(current, list):
+            pending.extend(
+                item for item in current if isinstance(item, (dict, list))
+            )
+
+
+def _collect_credential_container_values(
+    name: str,
+    value: str,
+    values: set[str],
+) -> None:
+    """Collect exact component secrets from supported credential containers."""
+    normalized = name.upper()
+    if normalized == "A2A_PEER_TOKENS":
+        # Mirror plugins/platforms/a2a/security.py::get_peer_tokens: only a
+        # nonempty name/token pair is a configured credential. Keep the whole
+        # container too (collected by the caller), but also protect the token
+        # when a peer or tool echoes it independently.
+        for pair in value.split(","):
+            pair = pair.strip()
+            if not pair or ":" not in pair:
+                continue
+            peer_name, token = pair.split(":", 1)
+            peer_name, token = peer_name.strip(), token.strip()
+            if peer_name and token:
+                values.add(token)
+
+    if normalized not in _VALUE_SENSITIVE_CREDENTIAL_ENV_NAMES:
+        return
+    try:
+        parsed = json.loads(value)
+    except (TypeError, ValueError):
+        return
+    if isinstance(parsed, dict):
+        _collect_nested_credential_scalars(parsed, values)
+
+
+def _collect_exact_secret_values(home: Path) -> tuple[str, ...]:
+    """Return the active profile's exact values eligible for masking."""
+    values: set[str] = set()
+    try:
+        from hermes_cli.env_loader import get_secret_source_values
+
+        snapshot = get_secret_source_values(home)
+    except Exception:
+        logger.debug(
+            "exact-value secret snapshot unavailable for %s", home, exc_info=True
+        )
+        snapshot = {}
+    for name, value in snapshot.items():
+        if not isinstance(value, str):
+            continue
+        values.add(value)
+        if isinstance(name, str):
+            _collect_credential_container_values(name, value, values)
+
+    # Prefer the context-local profile scope. In a single-profile process it is
+    # an overlay on os.environ (matching secret_scope.get_secret), so retain
+    # process-only credentials and let the scope win duplicate names. Under
+    # multiplexing the scope remains authoritative and process-global values
+    # may belong to another profile.
+    try:
+        from agent.secret_scope import current_secret_scope, is_multiplex_active
+
+        scope = current_secret_scope()
+        multiplex_active = is_multiplex_active()
+        if multiplex_active:
+            environment = scope or {}
+        elif scope is not None:
+            environment = {**os.environ, **scope}
+        else:
+            environment = os.environ
+    except Exception:
+        environment = os.environ
+    for name, value in environment.items():
+        if (
+            not isinstance(name, str)
+            or not isinstance(value, str)
+            or not _is_credential_env_name(name, value)
+        ):
+            continue
+        values.add(value)
+        _collect_credential_container_values(name, value, values)
+
+    # Every non-empty value from these authoritative sources is sensitive.
+    # Source classification, rather than a length/shape heuristic, is what
+    # prevents broad false positives: arbitrary snapshot names are values
+    # applied by the active external-secret provider, while the scoped
+    # environment contributes only credential-suffixed names.
+    return tuple(
+        sorted(
+            (value for value in values if value),
+            key=lambda value: (-len(value), value),
+        )
+    )
+
+
+@dataclass(frozen=True)
+class _ExactSecretPattern:
+    """One operation's exact matcher and collision-safe replacement marker."""
+
+    regex: re.Pattern
+    replacement: str
+    secret_forms: tuple[str, ...]
+
+
+def _choose_exact_secret_replacement(secret_forms: set[str]) -> str:
+    """Return a marker that cannot expose or turn into an active secret.
+
+    ``***`` stays the stable public marker for ordinary credentials. If it is
+    itself sensitive (or contains a short sensitive value), prefer another
+    readable marker. The one-character fallback is selected outside every
+    character occurring in any active literal/JSON form, which makes it safe
+    even for one-character secrets. Deletion is the fail-closed theoretical
+    fallback when the configured values collectively contain every Unicode
+    scalar value.
+    """
+
+    def repeated_candidate_contains(secret_form: str, candidate: str) -> bool:
+        # Any match in an arbitrarily repeated marker starts within the first
+        # marker period and ends within ``len(secret_form)`` characters. Build
+        # only that finite window instead of imposing a repetition count.
+        required_length = len(secret_form) + len(candidate) - 1
+        repetitions = (required_length + len(candidate) - 1) // len(candidate)
+        return secret_form in candidate * repetitions
+
+    def candidate_boundary_composes(secret_form: str, candidate: str) -> bool:
+        # Unchanged source immediately before or after a replacement can
+        # contribute the rest of a secret. Reject every readable marker whose
+        # leading bytes overlap a secret suffix or whose trailing bytes overlap
+        # a secret prefix. For example, replacing ``x`` in ``abx`` with ``***``
+        # must not synthesize the active secret ``ab*`` at the left boundary.
+        overlap_limit = min(len(secret_form), len(candidate))
+        return any(
+            secret_form.endswith(candidate[:overlap])
+            or secret_form.startswith(candidate[-overlap:])
+            for overlap in range(1, overlap_limit + 1)
+        )
+
+    def safe(candidate: str) -> bool:
+        if not candidate:
+            return False
+        return all(
+            candidate not in secret_form
+            and not repeated_candidate_contains(secret_form, candidate)
+            and not candidate_boundary_composes(secret_form, candidate)
+            for secret_form in secret_forms
+        )
+
+    for candidate in ("***", "[REDACTED]", "<redacted-secret>"):
+        if safe(candidate):
+            return candidate
+
+    occupied_characters = {
+        character for secret_form in secret_forms for character in secret_form
+    }
+    # Prefer private-use scalars so collision handling does not turn normal
+    # provider prose into a control character. Scan every remaining scalar as
+    # a bounded final fallback; a finite secret snapshot normally exits on the
+    # first private-use code point.
+    codepoint_ranges = (
+        range(0xE000, 0xF900),
+        range(0xF0000, 0xFFFFE),
+        range(0x100000, 0x10FFFE),
+        range(0x20, 0xD800),
+        range(0xF900, 0xF0000),
+    )
+    for codepoints in codepoint_ranges:
+        for codepoint in codepoints:
+            candidate = chr(codepoint)
+            if candidate not in occupied_characters:
+                return candidate
+    return ""
+
+
+def _compile_exact_secret_pattern(
+    values: tuple[str, ...],
+) -> _ExactSecretPattern | None:
+    """Compile literal and canonical JSON spellings of exact secrets.
+
+    Disposable provider, advisory, and compaction text frequently contains a
+    valid JSON serialization rather than the decoded value. Quotes,
+    backslashes, and control characters therefore have different wire bytes.
+    Matching the canonical JSON string spelling closes that encoding boundary
+    without parsing or rewriting caller-owned executable arguments. Replacing
+    a complete escaped spelling with one safe scalar also leaves valid JSON
+    valid.
+    """
+    literal_values = {value for value in values if value}
+    if not literal_values:
+        return None
+    literal_forms = set(literal_values)
+    literal_forms.update(json.dumps(value)[1:-1] for value in literal_values)
+    ordered_forms = sorted(literal_forms, key=lambda value: (-len(value), value))
+    return _ExactSecretPattern(
+        regex=re.compile("|".join(re.escape(value) for value in ordered_forms)),
+        replacement=_choose_exact_secret_replacement(literal_forms),
+        secret_forms=tuple(ordered_forms),
+    )
+
+
+# An explicit operation-local scope may reuse one immutable pattern snapshot.
+# This is a ContextVar, not a home-keyed/global cache: the value is reset when
+# the owning request/compaction returns, and nested profile scopes with a
+# different context identity build their own snapshot.
+_EXACT_SECRET_PATTERN_SCOPE: contextvars.ContextVar[
+    tuple[tuple[str, bool], object | None, _ExactSecretPattern | None] | None
+] = contextvars.ContextVar("exact_secret_pattern_scope", default=None)
+
+
+def _exact_secret_pattern_context(
+    home: Path,
+) -> tuple[tuple[str, bool], object | None]:
+    try:
+        from agent.secret_scope import current_secret_scope, is_multiplex_active
+
+        scope = current_secret_scope()
+        multiplex_active = is_multiplex_active()
+    except Exception:
+        scope = None
+        multiplex_active = False
+    return (str(home.resolve()), multiplex_active), scope
+
+
+def _exact_secret_pattern_for_home(home: Path) -> _ExactSecretPattern | None:
+    """Reuse the active operation snapshot, or compile a fresh one."""
+    key, scope = _exact_secret_pattern_context(home)
+    current = _EXACT_SECRET_PATTERN_SCOPE.get()
+    if (
+        current is not None
+        and current[0] == key
+        and current[1] is scope
+    ):
+        return current[2]
+    return _compile_exact_secret_pattern(_collect_exact_secret_values(home))
+
+
+@contextmanager
+def _exact_secret_pattern_scope(home: str | os.PathLike | None = None):
+    """Reuse one exact-secret snapshot only for this context-local operation."""
+    resolved_home = _resolve_secret_home(home)
+    key, scope = _exact_secret_pattern_context(resolved_home)
+    current = _EXACT_SECRET_PATTERN_SCOPE.get()
+    if (
+        current is not None
+        and current[0] == key
+        and current[1] is scope
+    ):
+        yield
+        return
+
+    pattern = _compile_exact_secret_pattern(_collect_exact_secret_values(resolved_home))
+    # Retain the scope object itself for the lifetime of the cached snapshot.
+    # A numeric ``id(scope)`` can be reused after the old mapping is collected,
+    # which could otherwise bind a new profile to a stale secret pattern.
+    token = _EXACT_SECRET_PATTERN_SCOPE.set((key, scope, pattern))
+    try:
+        yield
+    finally:
+        _EXACT_SECRET_PATTERN_SCOPE.reset(token)
+
+
+_JSON_SIMPLE_ESCAPES = {
+    '"': '"',
+    "\\": "\\",
+    "/": "/",
+    "b": "\b",
+    "f": "\f",
+    "n": "\n",
+    "r": "\r",
+    "t": "\t",
+}
+_JSON_HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
+
+
+def _scan_json_string_fragment(
+    text: str,
+    quote_start: int,
+    source_spans: list[tuple[int, int]] | None = None,
+) -> tuple[int, int | None, str, list[tuple[int, int]]]:
+    """Decode one quoted fragment while retaining each character's raw span.
+
+    Unlike ``json.loads``, this deliberately tolerates invalid escapes,
+    unescaped control characters, and end-of-input before a closing quote.
+    Invalid escapes are retained as their two literal characters so scanning
+    can recover and decode later valid escapes in the same fragment.
+    """
+    decoded: list[str] = []
+    raw_spans: list[tuple[int, int]] = []
+
+    def source_span(start: int, end: int) -> tuple[int, int]:
+        if source_spans is None:
+            return start, end
+        return source_spans[start][0], source_spans[end - 1][1]
+
+    # ``quote_start == -1`` represents the virtual quote before byte zero. It
+    # lets the same escape-aware decoder scan the prefix (or an entirely
+    # unquoted/single-quoted malformed object) without changing cycle-8 quote
+    # parity recovery for every later double-quote interval.
+    index = quote_start + 1
+    while index < len(text):
+        char = text[index]
+        if char == '"':
+            return index + 1, index, "".join(decoded), raw_spans
+        if char != "\\":
+            decoded.append(char)
+            raw_spans.append(source_span(index, index + 1))
+            index += 1
+            continue
+
+        if index + 1 >= len(text):
+            decoded.append("\\")
+            raw_spans.append(source_span(index, index + 1))
+            index += 1
+            continue
+
+        escape = text[index + 1]
+        simple = _JSON_SIMPLE_ESCAPES.get(escape)
+        if simple is not None:
+            decoded.append(simple)
+            raw_spans.append(source_span(index, index + 2))
+            index += 2
+            continue
+
+        unicode_end = index + 6
+        if (
+            escape == "u"
+            and unicode_end <= len(text)
+            and all(char in _JSON_HEX_DIGITS for char in text[index + 2 : unicode_end])
+        ):
+            codepoint = int(text[index + 2 : unicode_end], 16)
+            raw_end = unicode_end
+            # JSON represents non-BMP characters as a UTF-16 surrogate pair.
+            # Decode a valid pair to one Python character and map it to the
+            # complete twelve-byte raw escape span.
+            if (
+                0xD800 <= codepoint <= 0xDBFF
+                and unicode_end + 6 <= len(text)
+                and text[unicode_end : unicode_end + 2] == "\\u"
+                and all(
+                    char in _JSON_HEX_DIGITS
+                    for char in text[unicode_end + 2 : unicode_end + 6]
+                )
+            ):
+                low = int(text[unicode_end + 2 : unicode_end + 6], 16)
+                if 0xDC00 <= low <= 0xDFFF:
+                    codepoint = (
+                        0x10000
+                        + ((codepoint - 0xD800) << 10)
+                        + (low - 0xDC00)
+                    )
+                    raw_end = unicode_end + 6
+            decoded.append(chr(codepoint))
+            raw_spans.append(source_span(index, raw_end))
+            index = raw_end
+            continue
+
+        # Preserve malformed escape bytes as separate decoded characters.
+        # This prevents one bad escape from terminating recognition of a
+        # later alternately escaped credential in the same quoted fragment.
+        decoded.extend(("\\", escape))
+        raw_spans.extend(
+            (
+                source_span(index, index + 1),
+                source_span(index + 1, index + 2),
+            )
+        )
+        index += 2
+
+    return len(text), None, "".join(decoded), raw_spans
+
+
+_JSON_ESCAPE_WORK_MULTIPLIER = 4
+_JSON_ESCAPE_MIN_EXTRA_WORK = 4_096
+_JSON_ESCAPE_MAX_EXTRA_WORK = 8 * 1024 * 1024
+
+
+def _json_escape_decode_work_budget(text: str) -> int:
+    """Bound total scans while always admitting the original text once.
+
+    Proper nested JSON serialization grows geometrically, so all successively
+    decoded forms normally total less than a small multiple of the wire text.
+    The floor handles small inputs; the ceiling prevents a very large payload
+    from authorizing unbounded additional CPU work. If a derived fragment does
+    not fit, its mapped original bytes are masked wholesale instead of being
+    forwarded at an uninspected nesting depth.
+    """
+    extra_work = min(
+        max(len(text) * _JSON_ESCAPE_WORK_MULTIPLIER, _JSON_ESCAPE_MIN_EXTRA_WORK),
+        _JSON_ESCAPE_MAX_EXTRA_WORK,
+    )
+    return len(text) + extra_work
+
+
+def _append_decoded_secret_matches(
+    decoded: str,
+    decoded_source_spans: list[tuple[int, int]],
+    pattern: _ExactSecretPattern,
+    replacements: list[tuple[int, int]],
+) -> None:
+    """Map exact matches in decoded text back to original source spans."""
+    for match in pattern.regex.finditer(decoded):
+        if match.start() < match.end():
+            replacements.append(
+                (
+                    decoded_source_spans[match.start()][0],
+                    decoded_source_spans[match.end() - 1][1],
+                )
+            )
+
+
+def _collect_json_secret_spans(
+    text: str,
+    pattern: _ExactSecretPattern,
+    replacements: list[tuple[int, int]],
+) -> None:
+    """Collect matches through iterative, source-mapped escape decoding.
+
+    The worklist removes recursion depth as an input-controlled resource. A
+    task maps every decoded character back to the original disposable text;
+    child tasks compose those spans again, so a match at any nesting depth can
+    still replace the exact outer wire bytes. Budget exhaustion is fail-closed:
+    the uninspected mapped fragment is replaced as a whole.
+    """
+    worklist: deque[tuple[str, list[tuple[int, int]] | None]] = deque(
+        [(text, None)]
+    )
+    remaining_work = _json_escape_decode_work_budget(text)
+
+    while worklist:
+        current_text, source_spans = worklist.popleft()
+        current_work = len(current_text)
+        if current_work > remaining_work:
+            if source_spans:
+                replacements.append((source_spans[0][0], source_spans[-1][1]))
+            elif current_text:
+                replacements.append((0, len(current_text)))
+            continue
+        remaining_work -= current_work
+
+        quote_start = -1
+        while quote_start < len(current_text):
+            _fragment_end, closing_quote, decoded, decoded_source_spans = (
+                _scan_json_string_fragment(
+                    current_text,
+                    quote_start,
+                    source_spans,
+                )
+            )
+            _append_decoded_secret_matches(
+                decoded,
+                decoded_source_spans,
+                pattern,
+                replacements,
+            )
+
+            fragment_end = (
+                closing_quote if closing_quote is not None else len(current_text)
+            )
+            encoded_fragment = current_text[quote_start + 1 : fragment_end]
+            if "\\" in decoded and decoded != encoded_fragment:
+                worklist.append((decoded, decoded_source_spans))
+
+            # Treat the closing quote as the next possible opening quote.
+            # Invalid JSON can insert or omit an unescaped quote, changing the
+            # parity of every later quote. Scanning every interval between
+            # consecutive escape-aware quotes resynchronizes immediately.
+            if closing_quote is None:
+                break
+            quote_start = closing_quote
+
+
+def _replace_exact_secret_spans(
+    text: str,
+    pattern: _ExactSecretPattern,
+    replacements: list[tuple[int, int]],
+    replacement_overrides: dict[tuple[int, int], str] | None = None,
+) -> str:
+    """Apply deduplicated source spans using collision-safe markers."""
+    if not replacements:
+        return text
+
+    # Recovery windows and nested decoding can discover the same match more
+    # than once. Normalize so each source byte is replaced exactly once and a
+    # shorter duplicate cannot split or suppress a complete encoded span.
+    merged_replacements: list[tuple[int, int]] = []
+    for start, end in sorted(set(replacements)):
+        if merged_replacements and start < merged_replacements[-1][1]:
+            previous_start, previous_end = merged_replacements[-1]
+            merged_replacements[-1] = (previous_start, max(previous_end, end))
+        else:
+            merged_replacements.append((start, end))
+
+    pieces: list[str] = []
+    cursor = 0
+    for start, end in merged_replacements:
+        pieces.extend(
+            (
+                text[cursor:start],
+                (replacement_overrides or {}).get((start, end), pattern.replacement),
+            )
+        )
+        cursor = end
+    pieces.append(text[cursor:])
+    return "".join(pieces)
+
+
+def _is_json_structural_key(value: str) -> bool:
+    """Keep only low-entropy JSON literal spellings usable as protocol keys."""
+    # Quoted numeric keys are strings, not typed JSON numbers. A long numeric
+    # credential must therefore be masked just like any other source value.
+    return value in {"true", "false", "null"}
+
+
+def _append_json_secret_matches(
+    decoded: str,
+    decoded_source_spans: list[tuple[int, int]],
+    pattern: _ExactSecretPattern,
+    replacements: list[tuple[int, int]],
+    *,
+    object_key: bool,
+    key_matches: list[tuple[tuple[int, int], str]],
+) -> None:
+    """Collect quoted-token matches, with collision-safe JSON key markers."""
+    if object_key and _is_json_structural_key(decoded):
+        return
+    for match in pattern.regex.finditer(decoded):
+        if match.start() >= match.end():
+            continue
+        span = (
+            decoded_source_spans[match.start()][0],
+            decoded_source_spans[match.end() - 1][1],
+        )
+        replacements.append(span)
+        if object_key:
+            key_matches.append((span, match.group(0)))
+
+
+def _redact_json_string_fragments(
+    text: str, pattern: _ExactSecretPattern
+) -> str:
+    r"""Decode quoted JSON fragments and mask decoded matches in raw spans.
+
+    JSON permits many byte spellings for the same decoded value (for example
+    ``\/`` and ``\uXXXX``). Literal matching cannot enumerate that space, and
+    strict token parsing misses invalid or EOF-terminated fragments. The
+    tolerant scanner retains a decoded-character-to-raw-span map, recovers
+    after invalid escapes, and replaces only matched raw bytes. Caller-owned
+    history is never passed to this helper; its inputs are disposable copies.
+    """
+    if "\\" not in text:
+        return text
+
+    replacements: list[tuple[int, int]] = []
+    _collect_json_secret_spans(text, pattern, replacements)
+    return _replace_exact_secret_spans(text, pattern, replacements)
+
+
+def _redact_valid_json_string_values(
+    text: str,
+    pattern: _ExactSecretPattern,
+) -> str | None:
+    """Mask quoted string-token bytes when *text* is one valid JSON document.
+
+    ``None`` means parsing failed and the caller must use the aggressive
+    malformed/prose path. For valid JSON, punctuation plus typed scalars
+    (numbers, booleans, and null) are structural and remain byte-exact. Both
+    object keys and string values are quoted tokens and can carry an
+    authoritative credential, so matching either is source-mapped and masked
+    without rewriting formatting or caller-owned input.
+    """
+    def reject_nonstandard_constant(value: str):
+        raise ValueError(f"invalid JSON constant: {value}")
+
+    try:
+        json.loads(text, parse_constant=reject_nonstandard_constant)
+    except (TypeError, ValueError):
+        return None
+
+    replacements: list[tuple[int, int]] = []
+    replacement_overrides: dict[tuple[int, int], str] = {}
+    key_matches: list[tuple[tuple[int, int], str]] = []
+    forbidden_markers: set[str] = set()
+    worklist: deque[tuple[str, list[tuple[int, int]]]] = deque()
+    remaining_work = _json_escape_decode_work_budget(text) - len(text)
+
+    cursor = 0
+    while cursor < len(text):
+        quote_start = text.find('"', cursor)
+        if quote_start < 0:
+            break
+        fragment_end, closing_quote, decoded, decoded_source_spans = (
+            _scan_json_string_fragment(text, quote_start)
+        )
+        # ``json.loads`` already proved the document valid, so every opening
+        # quote has a closing quote and every token after it is unambiguous.
+        if closing_quote is None:  # pragma: no cover - defensive consistency
+            return None
+
+        after_token = fragment_end
+        while after_token < len(text) and text[after_token].isspace():
+            after_token += 1
+        object_key = after_token < len(text) and text[after_token] == ":"
+        if object_key:
+            forbidden_markers.add(decoded)
+        _append_json_secret_matches(
+            decoded,
+            decoded_source_spans,
+            pattern,
+            replacements,
+            object_key=object_key,
+            key_matches=key_matches,
+        )
+        encoded_fragment = text[quote_start + 1 : closing_quote]
+        if "\\" in decoded and decoded != encoded_fragment:
+            worklist.append((decoded, decoded_source_spans))
+        cursor = fragment_end
+
+    # Once a quoted token is decoded, every derived byte belongs to that token,
+    # so the tolerant iterative scanner may inspect it globally. This retains
+    # deep/double-serialized JSON coverage without matching punctuation or
+    # typed scalar tokens from the valid outer document.
+    while worklist:
+        current_text, source_spans = worklist.popleft()
+        current_work = len(current_text)
+        if current_work > remaining_work:
+            if source_spans:
+                replacements.append((source_spans[0][0], source_spans[-1][1]))
+            continue
+        remaining_work -= current_work
+
+        quote_start = -1
+        while quote_start < len(current_text):
+            _fragment_end, closing_quote, decoded, decoded_source_spans = (
+                _scan_json_string_fragment(
+                    current_text,
+                    quote_start,
+                    source_spans,
+                )
+            )
+            fragment_end = (
+                closing_quote if closing_quote is not None else len(current_text)
+            )
+            after_token = fragment_end
+            while after_token < len(current_text) and current_text[after_token].isspace():
+                after_token += 1
+            object_key = (
+                after_token < len(current_text)
+                and current_text[after_token] == ":"
+            )
+            if object_key:
+                forbidden_markers.add(decoded)
+            _append_json_secret_matches(
+                decoded,
+                decoded_source_spans,
+                pattern,
+                replacements,
+                object_key=object_key,
+                key_matches=key_matches,
+            )
+            encoded_fragment = current_text[quote_start + 1 : fragment_end]
+            if "\\" in decoded and decoded != encoded_fragment:
+                worklist.append((decoded, decoded_source_spans))
+            if closing_quote is None:
+                break
+            quote_start = closing_quote
+
+    key_markers: dict[str, str] = {}
+    used_markers: set[str] = set()
+    for span, token in key_matches:
+        marker = key_markers.get(token)
+        if marker is None:
+            occupied = forbidden_markers | used_markers
+            marker = _choose_exact_secret_replacement(
+                set(pattern.secret_forms) | occupied
+            )
+            key_markers[token] = marker
+            used_markers.add(marker)
+        replacement_overrides[span] = marker
+
+    return _replace_exact_secret_spans(
+        text,
+        pattern,
+        replacements,
+        replacement_overrides,
+    )
+
+
+def _redact_exact_with_pattern(
+    text: str, pattern: _ExactSecretPattern | None
+) -> str:
+    if not text or pattern is None:
+        return text
+    valid_json_redacted = _redact_valid_json_string_values(text, pattern)
+    if valid_json_redacted is not None:
+        return valid_json_redacted
+    # Preserve the existing raw and canonical literal behavior for arbitrary
+    # prose and values outside quoted JSON fragments.
+    # Run it first so a longer exact value (such as an entire inline service
+    # account object) is not partially rewritten by a shorter nested secret
+    # before the complete value can match.
+    def replace_unshadowed(match: re.Match) -> str:
+        # A match can begin at the escaped byte of a JSON spelling: nested
+        # ``\\u00e9`` contains canonical ``\u00e9``, while the literal secret
+        # ``/`` can appear as the valid simple escape ``\/``. Replacing only
+        # that suffix leaves an invalid ``\***`` escape. Defer every match
+        # immediately preceded by a backslash to the source-mapped scanner,
+        # which decodes and replaces the complete outer span. It also retains
+        # malformed escape handling because invalid pairs are source-mapped as
+        # their separate literal bytes.
+        if (
+            match.start() > 0
+            and text[match.start() - 1] == "\\"
+        ):
+            return match.group(0)
+        return pattern.replacement
+
+    literal_redacted = pattern.regex.sub(replace_unshadowed, text)
+    if "\\" not in literal_redacted:
+        return literal_redacted
+    fragment_redacted = _redact_json_string_fragments(literal_redacted, pattern)
+
+    def replace_remaining_unshadowed(match: re.Match) -> str:
+        if (
+            match.start() > 0
+            and fragment_redacted[match.start() - 1] == "\\"
+        ):
+            return match.group(0)
+        return pattern.replacement
+
+    return pattern.regex.sub(replace_remaining_unshadowed, fragment_redacted)
+
+
+def redact_known_secret_values(
+    text: str,
+    home: str | os.PathLike | None = None,
+    *,
+    force: bool = False,
+) -> str:
+    """Mask every occurrence of active-profile authoritative secret values."""
+    if text is None:
+        return None
+    if not isinstance(text, str):
+        text = str(text)
+    if not text or not (force or _redact_settings._REDACT_ENABLED):
+        return text
+    resolved_home = _resolve_secret_home(home)
+    pattern = _exact_secret_pattern_for_home(resolved_home)
+    return _redact_exact_with_pattern(text, pattern)
+
+
+_PROVIDER_STRUCTURAL_STRING_FIELDS = frozenset(
+    {
+        "type",
+        "role",
+        "id",
+        "name",
+        "tool_name",
+        "tool_call_id",
+        "tool_use_id",
+        "call_id",
+        "toolUseId",
+        "response_item_id",
+        "detail",
+        "media_type",
+        "mime_type",
+        "format",
+        "ttl",
+        "phase",
+        "status",
+        "finish_reason",
+        "file_id",
+        "file_name",
+        "filename",
+        # Issuer-bound replay identifiers/payloads are never model-visible
+        # plaintext and must remain byte-exact across provider retries.
+        "signature",
+        "encrypted_content",
+    }
+)
+_PROVIDER_OPAQUE_METADATA_FIELDS = frozenset(
+    {
+        # Anthropic/OpenAI cache directives are provider control metadata, not
+        # model-visible prose. Rewriting ``ephemeral`` or ``1h`` makes an
+        # otherwise valid request fail schema validation.
+        "cache_control",
+        "redactedContent",
+        "redactedContentBase64",
+    }
+)
+_PROVIDER_BINARY_DATA_TYPES = frozenset(
+    {
+        "base64",
+        "image",
+        "input_image",
+        "audio",
+        "input_audio",
+    }
+)
+_PROVIDER_BINARY_CONTAINER_FIELDS = frozenset({"audio", "input_audio"})
+_PROVIDER_EXECUTABLE_INPUT_TYPES = frozenset({"tool_use", "function_call"})
+_PROVIDER_EXECUTABLE_CONTAINER_FIELDS = frozenset({"toolUse", "function"})
+_DATA_URI_BASE64_RE = re.compile(
+    r"\A(data:[^,]*;base64,)([A-Za-z0-9+/]*={0,2})\Z",
+    re.IGNORECASE,
+)
+
+
+def _redact_provider_url(value: str, pattern: _ExactSecretPattern | None) -> str:
+    """Mask ordinary URLs while preserving validated opaque data URIs.
+
+    A data URI's payload is binary media, not model-visible prose. Replacing
+    an arbitrary exact value in that payload can make the URI invalid (for
+    example, masking ``A`` in ``data:image/png;base64,AAAA``). Keep the
+    base64 octets and grammar metadata byte-exact; ordinary non-data URLs
+    remain subject to exact-value redaction.
+    """
+    if pattern is None:
+        return value
+    match = _DATA_URI_BASE64_RE.match(value)
+    if match is None:
+        return _redact_exact_with_pattern(value, pattern)
+    # Metadata controls such as ``image/png`` and ``base64`` are part of the
+    # URI grammar. Preserve the complete validated URI so a short credential
+    # collision cannot turn it into an invalid provider payload. Opaque media
+    # is intentionally outside display-text redaction; ordinary non-data URLs
+    # still take the exact-value path below.
+    return value
+
+
+def _redact_provider_tree(
+    value: Any,
+    pattern: _ExactSecretPattern | None,
+    *,
+    field: str | None = None,
+) -> Any:
+    """Redact model-visible leaves without corrupting provider controls."""
+    if isinstance(value, str):
+        if field in {"url", "uri", "image_url"}:
+            return _redact_provider_url(value, pattern)
+        return _redact_exact_with_pattern(value, pattern)
+    if isinstance(value, list):
+        return [_redact_provider_tree(item, pattern, field=field) for item in value]
+    if isinstance(value, tuple):
+        return tuple(
+            _redact_provider_tree(item, pattern, field=field) for item in value
+        )
+    if isinstance(value, dict):
+        container_type = value.get("type")
+        return {
+            key: (
+                item
+                if (
+                    key in _PROVIDER_OPAQUE_METADATA_FIELDS
+                    or (
+                        isinstance(item, str)
+                        and key in _PROVIDER_STRUCTURAL_STRING_FIELDS
+                    )
+                    or (
+                        key == "data"
+                        and isinstance(item, str)
+                        and (
+                            container_type in _PROVIDER_BINARY_DATA_TYPES
+                            or container_type == "redacted_thinking"
+                            or field in _PROVIDER_BINARY_CONTAINER_FIELDS
+                        )
+                    )
+                    or (
+                        key in {"input", "arguments"}
+                        and (
+                            container_type in _PROVIDER_EXECUTABLE_INPUT_TYPES
+                            or field in _PROVIDER_EXECUTABLE_CONTAINER_FIELDS
+                        )
+                    )
+                )
+                else _redact_provider_tree(item, pattern, field=key)
+            )
+            for key, item in value.items()
+        }
+    return value
+
+
+def _redact_anthropic_ordered_blocks(
+    blocks: Any,
+    pattern: _ExactSecretPattern | None,
+) -> Any:
+    """Mask unsigned text unless a signature binds the ordered sequence."""
+    if not isinstance(blocks, list):
+        return blocks
+    has_signed_thinking = any(
+        isinstance(block, dict)
+        and (
+            (block.get("type") == "thinking" and bool(block.get("signature")))
+            or (
+                block.get("type") == "redacted_thinking"
+                and bool(block.get("data"))
+            )
+        )
+        for block in blocks
+    )
+    if has_signed_thinking:
+        # Anthropic signatures cover the ordered assistant content that
+        # surrounds them. Rewriting even an intervening text block while
+        # retaining a later signature makes the complete replay invalid.
+        return blocks
+    return [
+        {
+            **block,
+            "text": _redact_exact_with_pattern(block.get("text", ""), pattern),
+        }
+        if isinstance(block, dict)
+        and block.get("type") == "text"
+        and isinstance(block.get("text"), str)
+        else block
+        for block in blocks
+    ]
+
+
+def _redact_codex_message_items(
+    items: Any,
+    pattern: _ExactSecretPattern | None,
+) -> Any:
+    """Mask replayed assistant text without modifying item identity fields."""
+    if not isinstance(items, list):
+        return items
+    return [
+        {
+            **item,
+            "content": _redact_provider_tree(item.get("content"), pattern),
+        }
+        if isinstance(item, dict) and "content" in item
+        else item
+        for item in items
+    ]
+
+
+
+def _bedrock_signed_prefix_end(messages: list) -> int:
+    """Bedrock reasoning signatures bind every preceding conversation message."""
+    end = 0
+    for index, message in enumerate(messages):
+        if not isinstance(message, dict):
+            continue
+        for field in ("content", "bedrock_content_blocks"):
+            blocks = message.get(field)
+            if not isinstance(blocks, list):
+                continue
+            for block in blocks:
+                reasoning = block.get("reasoningContent") if isinstance(block, dict) else None
+                text = reasoning.get("reasoningText") if isinstance(reasoning, dict) else None
+                if isinstance(text, dict) and text.get("signature"):
+                    end = index + 1
+    return end
+
+
+def _reject_signed_bedrock_change() -> None:
+    raise ValueError(
+        "Secret redaction would alter signed Bedrock history; start a new conversation "
+        "without that signed replay before retrying."
+    )
+
+def _redact_provider_messages_with_pattern(
+    messages: list,
+    pattern: _ExactSecretPattern,
+) -> list:
+    """Redact one provider message/input list using a bound snapshot."""
+    import copy
+
+    redacted_messages = copy.deepcopy(messages)
+    provider_fields = (
+        "content",
+        "reasoning",
+        "reasoning_content",
+    )
+    for message in redacted_messages:
+        if not isinstance(message, dict):
+            continue
+        for field in provider_fields:
+            if field in message:
+                if field == "content" and isinstance(message[field], list) and any(
+                    isinstance(block, dict)
+                    and (
+                        (
+                            block.get("type") == "thinking"
+                            and bool(block.get("signature"))
+                        )
+                        or (
+                            block.get("type") == "redacted_thinking"
+                            and bool(block.get("data"))
+                        )
+                    )
+                    for block in message[field]
+                ):
+                    # Anthropic signs the ordered content sequence, not merely
+                    # the individual thinking block. Preserve the whole replay
+                    # unit exactly as the earlier adapter-specific gate does.
+                    continue
+                message[field] = _redact_provider_tree(message[field], pattern)
+        # Codex Responses converts tool-result messages into native
+        # ``function_call_output.output`` items before its final preflight.
+        # Mask visible output while preserving replayed function-call
+        # ``arguments`` and signed/sealed reasoning fields byte-for-byte.
+        if message.get("type") == "function_call_output" and "output" in message:
+            message["output"] = _redact_provider_tree(message["output"], pattern)
+        # Ordered Anthropic blocks bypass ``content`` in the adapter. Text-only
+        # unsigned lists are maskable; a list containing signed thinking is an
+        # opaque sequence. Executable tool_use inputs always remain byte-exact.
+        if "anthropic_content_blocks" in message:
+            message["anthropic_content_blocks"] = _redact_anthropic_ordered_blocks(
+                message["anthropic_content_blocks"], pattern
+            )
+        if "bedrock_content_blocks" in message:
+            message["bedrock_content_blocks"] = _redact_provider_tree(
+                message["bedrock_content_blocks"], pattern
+            )
+        # OpenRouter requires the complete reasoning_details sequence to be
+        # replayed unmodified. Treat every current and future detail shape as
+        # opaque; selectively rewriting summary/text/unknown fields can
+        # invalidate signatures or the sequence contract.
+        # Codex reasoning items contain issuer-sealed encrypted replay blobs
+        # and must stay exact. Assistant message items are also replayed with
+        # stable ids/phases, so sanitize only their visible content payload.
+        if "codex_message_items" in message:
+            message["codex_message_items"] = _redact_codex_message_items(
+                message["codex_message_items"], pattern
+            )
+    signed_end = _bedrock_signed_prefix_end(messages)
+    if signed_end and redacted_messages[:signed_end] != messages[:signed_end]:
+        # A signature-shaped field is not proof that arbitrary preceding text
+        # was already sent. Reject a collision instead of exempting the prefix
+        # or forwarding an invalid signature. Unchanged replay stays exact.
+        _reject_signed_bedrock_change()
+    return redacted_messages
+
+
+def redact_provider_message_values(
+    messages: list,
+    home: str | os.PathLike | None = None,
+    *,
+    force: bool = False,
+) -> list:
+    """Return a provider-bound copy with exact secret values removed.
+
+    The source history is never mutated. This is required by #43083: local
+    replay and tool execution retain exact arguments, while the outbound copy
+    masks message text and nested non-text metadata such as ``image_url.url``.
+
+    Tool-call arguments deliberately remain exact on the outbound copy. Human's
+    review of PR #42846 established that replacing replayed executable values
+    makes models copy the placeholder on later turns (#43083). Protecting that
+    field requires authenticated vault/token references, not display masking.
+    """
+    if not messages or not (force or _redact_settings._REDACT_ENABLED):
+        return messages
+    pattern = _exact_secret_pattern_for_home(_resolve_secret_home(home))
+    if pattern is None:
+        return messages
+
+    return _redact_provider_messages_with_pattern(messages, pattern)
+
+
+def redact_provider_api_kwargs(
+    api_kwargs: dict,
+    home: str | os.PathLike | None = None,
+    *,
+    force: bool = False,
+) -> dict:
+    """Rebind provider-native visible payloads after final transformations.
+
+    Provider adapters may normalize text after the generic message gate (for
+    example ASCII fallback or Codex Harmony-token neutralization). Inspect the
+    final ``messages``/``input``/``instructions`` bytes without rewriting
+    executable arguments, identity fields, or caller-owned request objects.
+    """
+    if not isinstance(api_kwargs, dict) or not (force or _redact_settings._REDACT_ENABLED):
+        return api_kwargs
+    pattern = _exact_secret_pattern_for_home(_resolve_secret_home(home))
+    if pattern is None:
+        return api_kwargs
+
+    redacted_kwargs = _redact_api_payload_fields(api_kwargs, pattern)
+    extra_body = api_kwargs.get("extra_body")
+    if isinstance(extra_body, dict):
+        # The SDK merges these fields after its typed request transformation.
+        # Inspect the overriding payload as well as the top-level request.
+        redacted_kwargs["extra_body"] = _redact_api_payload_fields(extra_body, pattern)
+    return redacted_kwargs
+
+
+def _redact_api_payload_fields(api_kwargs: dict, pattern: _ExactSecretPattern) -> dict:
+    redacted_kwargs = dict(api_kwargs)
+    for field in ("messages", "input"):
+        payload = api_kwargs.get(field)
+        if isinstance(payload, list):
+            redacted_kwargs[field] = _redact_provider_messages_with_pattern(
+                payload,
+                pattern,
+            )
+        elif field == "input" and isinstance(payload, str):
+            redacted_kwargs[field] = _redact_exact_with_pattern(payload, pattern)
+    instructions = api_kwargs.get("instructions")
+    if isinstance(instructions, str):
+        redacted_kwargs["instructions"] = _redact_exact_with_pattern(
+            instructions,
+            pattern,
+        )
+    system = api_kwargs.get("system")
+    if isinstance(system, (str, list, tuple, dict)):
+        import copy
+
+        redacted_kwargs["system"] = _redact_provider_tree(
+            copy.deepcopy(system),
+            pattern,
+        )
+    messages = api_kwargs.get("messages")
+    if (
+        isinstance(messages, list)
+        and _bedrock_signed_prefix_end(messages)
+        and redacted_kwargs.get("system") != api_kwargs.get("system")
+    ):
+        _reject_signed_bedrock_change()
+    return redacted_kwargs

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -7,10 +7,17 @@ Short tokens (< 18 chars) are fully masked. Longer tokens preserve
 the first 6 and last 4 characters for debuggability.
 """
 
+import contextvars
+import json
 import logging
 import os
 import re
 import shlex
+from collections import deque
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
 from urllib.parse import unquote_plus
 
 # Basenames treated as ``.env`` files by _command_reads_env_file. Imported
@@ -767,6 +774,1250 @@ def _mask_token_nonreusable(token: str) -> str:
             label = sub
             break
     return f"«redacted:{label}…»" if label else "«redacted-secret»"
+
+
+# Exact-value masking at the provider boundary. External secret sources can
+# populate arbitrary variable names, so shape-based redaction cannot identify
+# their values when a tool echoes them back (#77487).
+_CREDENTIAL_ENV_SUFFIXES = (
+    "_API_KEY",
+    "_TOKEN",
+    "_SECRET",
+    "_PASSWORD",
+    "_PASSWD",
+    "_PASS",
+    "_PW",
+    # Repository redaction and execution-environment filters recognize these
+    # established credential/auth aliases too (for example
+    # ``VAULT_CREDENTIAL``). Do not broaden this to generic ``*_CREDS`` or
+    # ``*_BEARER`` names: authoritative external-secret snapshots already
+    # contribute those values regardless of name, while ambient process/scope
+    # values need repository-backed classification to avoid transcript damage.
+    "_CREDENTIAL",
+    "_CREDENTIALS",
+    "_AUTH",
+)
+_CONFIG_FLAG_ENV_NAMES = frozenset(
+    {
+        # Honcho documents this as a self-hosted boolean switch, not its JWT.
+        # Only a recognized flag value is exempt: an arbitrary value under the
+        # same credential-looking name must still be protected.
+        "AUTH_USE_AUTH",
+    }
+)
+_CONFIG_FLAG_ENV_PREFIXES = (
+    "SKIP_",
+    "DEBUG_",
+    "REQUIRE_",
+    "SHOW_",
+    "USE_",
+    "DISABLE_",
+    "ENABLE_",
+    "ALLOW_",
+    "VERIFY_",
+    "CHECK_",
+    "HAS_",
+    "IS_",
+    "WITH_",
+    "AUTO_",
+)
+_CONFIG_FLAG_ENV_VALUES = frozenset(
+    {
+        "0",
+        "1",
+        "true",
+        "false",
+        "yes",
+        "no",
+        "on",
+        "off",
+        "enabled",
+        "disabled",
+        "auto",
+    }
+)
+_CREDENTIAL_ENV_NAMES = frozenset(
+    {
+        # Repository-supported credential aliases that deliberately use the
+        # otherwise-generic ``*_KEY`` shape. Keep this exact: names such as
+        # PARTITION_KEY, SORT_KEY, CACHE_KEY, and IDEMPOTENCY_KEY hold ordinary
+        # configuration whose short values would corrupt provider transcripts
+        # if collected for literal masking.
+        "ALPHA_VANTAGE_KEY",
+        "API_KEY",
+        "API_SERVER_KEY",
+        "AWS_SECRET_ACCESS_KEY",
+        "AZURE_ANTHROPIC_KEY",
+        "BUZZ_PRIVATE_KEY",
+        "FAL_KEY",
+        "FEISHU_ENCRYPT_KEY",
+        "GATEWAY_PROXY_KEY",
+        "GATEWAY_RELAY_DELIVERY_KEY",
+        "HERMES_IRON_PROXY_MGMT_KEY",
+        "HERMES_LANGFUSE_SECRET_KEY",
+        "HERMES_MEET_REALTIME_KEY",
+        "LANGFUSE_SECRET_KEY",
+        "MATRIX_RECOVERY_KEY",
+        "PORCUPINE_ACCESS_KEY",
+        "VOICE_TOOLS_OPENAI_KEY",
+        "WECOM_CALLBACK_ENCODING_AES_KEY",
+        # Repository-owned bearer-token aliases whose credential word is not
+        # terminal. Keep these exact rather than collecting every ambient
+        # ``*_BEARER*`` setting.
+        "A2A_BEARER_TOKEN",
+        "AWS_BEARER_TOKEN_BEDROCK",
+        # Repository plugin manifests declare these password values even
+        # though their established names use otherwise-generic suffixes.
+        "A2A_PEER_TOKENS",
+        # Common password/auth variables whose established spellings do not
+        # have an underscore-delimited credential suffix.
+        "PGPASSWORD",
+        "MYSQL_PWD",
+        "PASSWORD",
+        "PASSWD",
+        "PASS",
+        "PW",
+        "REDISCLI_AUTH",
+    }
+)
+_VALUE_SENSITIVE_CREDENTIAL_ENV_NAMES = frozenset(
+    {
+        # Google Chat accepts either env name as an inline service-account
+        # object or a path. Only the inline form is credential material; exact
+        # path values must remain visible in provider transcripts.
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "GOOGLE_CHAT_SERVICE_ACCOUNT_JSON",
+    }
+)
+_INLINE_CREDENTIAL_JSON_KEYS = frozenset(
+    {
+        "access_token",
+        "api_key",
+        "client_secret",
+        "id_token",
+        "password",
+        "private_key",
+        "refresh_token",
+    }
+)
+
+
+def _is_credential_env_name(name: str, value: str | None = None) -> bool:
+    """Classify credential variables without matching ordinary names."""
+    normalized = name.upper()
+    if (
+        isinstance(value, str)
+        and (
+            normalized in _CONFIG_FLAG_ENV_NAMES
+            or normalized.startswith(_CONFIG_FLAG_ENV_PREFIXES)
+        )
+        and value.strip().lower() in _CONFIG_FLAG_ENV_VALUES
+    ):
+        # Suffixes such as ``*_AUTH`` and ``*_TOKEN`` are also used by
+        # boolean/configuration switches (for example ``SKIP_AUTH=false``).
+        # Exclude only unambiguous flag-shaped names with flag-shaped values.
+        # Arbitrary short values under the same names remain exact secrets.
+        return False
+    if normalized in _VALUE_SENSITIVE_CREDENTIAL_ENV_NAMES:
+        return isinstance(value, str) and value.lstrip().startswith("{")
+    return normalized in _CREDENTIAL_ENV_NAMES or normalized.endswith(
+        _CREDENTIAL_ENV_SUFFIXES
+    )
+
+
+def _resolve_secret_home(home: str | os.PathLike | None) -> Path:
+    if home is not None:
+        return Path(home)
+    try:
+        from hermes_constants import get_hermes_home
+
+        return get_hermes_home()
+    except Exception:
+        return Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes")
+
+
+def _collect_nested_credential_scalars(value: Any, values: set[str]) -> None:
+    """Collect credential-bearing string fields from an inline JSON object."""
+    pending = [value]
+    while pending:
+        current = pending.pop()
+        if isinstance(current, dict):
+            for key, item in current.items():
+                if (
+                    isinstance(key, str)
+                    and key.lower() in _INLINE_CREDENTIAL_JSON_KEYS
+                    and isinstance(item, str)
+                    and item
+                ):
+                    values.add(item)
+                if isinstance(item, (dict, list)):
+                    pending.append(item)
+        elif isinstance(current, list):
+            pending.extend(
+                item for item in current if isinstance(item, (dict, list))
+            )
+
+
+def _collect_credential_container_values(
+    name: str,
+    value: str,
+    values: set[str],
+) -> None:
+    """Collect exact component secrets from supported credential containers."""
+    normalized = name.upper()
+    if normalized == "A2A_PEER_TOKENS":
+        # Mirror plugins/platforms/a2a/security.py::get_peer_tokens: only a
+        # nonempty name/token pair is a configured credential. Keep the whole
+        # container too (collected by the caller), but also protect the token
+        # when a peer or tool echoes it independently.
+        for pair in value.split(","):
+            pair = pair.strip()
+            if not pair or ":" not in pair:
+                continue
+            peer_name, token = pair.split(":", 1)
+            peer_name, token = peer_name.strip(), token.strip()
+            if peer_name and token:
+                values.add(token)
+
+    if normalized not in _VALUE_SENSITIVE_CREDENTIAL_ENV_NAMES:
+        return
+    try:
+        parsed = json.loads(value)
+    except (TypeError, ValueError):
+        return
+    if isinstance(parsed, dict):
+        _collect_nested_credential_scalars(parsed, values)
+
+
+def _collect_exact_secret_values(home: Path) -> tuple[str, ...]:
+    """Return the active profile's exact values eligible for masking."""
+    values: set[str] = set()
+    try:
+        from hermes_cli.env_loader import get_secret_source_values
+
+        snapshot = get_secret_source_values(home)
+    except Exception:
+        logger.debug(
+            "exact-value secret snapshot unavailable for %s", home, exc_info=True
+        )
+        snapshot = {}
+    for name, value in snapshot.items():
+        if not isinstance(value, str):
+            continue
+        values.add(value)
+        if isinstance(name, str):
+            _collect_credential_container_values(name, value, values)
+
+    # Prefer the context-local profile scope. In a single-profile process it is
+    # an overlay on os.environ (matching secret_scope.get_secret), so retain
+    # process-only credentials and let the scope win duplicate names. Under
+    # multiplexing the scope remains authoritative and process-global values
+    # may belong to another profile.
+    try:
+        from agent.secret_scope import current_secret_scope, is_multiplex_active
+
+        scope = current_secret_scope()
+        multiplex_active = is_multiplex_active()
+        if multiplex_active:
+            environment = scope or {}
+        elif scope is not None:
+            environment = {**os.environ, **scope}
+        else:
+            environment = os.environ
+    except Exception:
+        environment = os.environ
+    for name, value in environment.items():
+        if (
+            not isinstance(name, str)
+            or not isinstance(value, str)
+            or not _is_credential_env_name(name, value)
+        ):
+            continue
+        values.add(value)
+        _collect_credential_container_values(name, value, values)
+
+    # Every non-empty value from these authoritative sources is sensitive.
+    # Source classification, rather than a length/shape heuristic, is what
+    # prevents broad false positives: arbitrary snapshot names are values
+    # applied by the active external-secret provider, while the scoped
+    # environment contributes only credential-suffixed names.
+    return tuple(
+        sorted(
+            (value for value in values if value),
+            key=lambda value: (-len(value), value),
+        )
+    )
+
+
+@dataclass(frozen=True)
+class _ExactSecretPattern:
+    """One operation's exact matcher and collision-safe replacement marker."""
+
+    regex: re.Pattern
+    replacement: str
+    secret_forms: tuple[str, ...]
+
+
+def _choose_exact_secret_replacement(secret_forms: set[str]) -> str:
+    """Return a marker that cannot expose or turn into an active secret.
+
+    ``***`` stays the stable public marker for ordinary credentials. If it is
+    itself sensitive (or contains a short sensitive value), prefer another
+    readable marker. The one-character fallback is selected outside every
+    character occurring in any active literal/JSON form, which makes it safe
+    even for one-character secrets. Deletion is the fail-closed theoretical
+    fallback when the configured values collectively contain every Unicode
+    scalar value.
+    """
+
+    def repeated_candidate_contains(secret_form: str, candidate: str) -> bool:
+        # Any match in an arbitrarily repeated marker starts within the first
+        # marker period and ends within ``len(secret_form)`` characters. Build
+        # only that finite window instead of imposing a repetition count.
+        required_length = len(secret_form) + len(candidate) - 1
+        repetitions = (required_length + len(candidate) - 1) // len(candidate)
+        return secret_form in candidate * repetitions
+
+    def candidate_boundary_composes(secret_form: str, candidate: str) -> bool:
+        # Unchanged source immediately before or after a replacement can
+        # contribute the rest of a secret. Reject every readable marker whose
+        # leading bytes overlap a secret suffix or whose trailing bytes overlap
+        # a secret prefix. For example, replacing ``x`` in ``abx`` with ``***``
+        # must not synthesize the active secret ``ab*`` at the left boundary.
+        overlap_limit = min(len(secret_form), len(candidate))
+        return any(
+            secret_form.endswith(candidate[:overlap])
+            or secret_form.startswith(candidate[-overlap:])
+            for overlap in range(1, overlap_limit + 1)
+        )
+
+    def safe(candidate: str) -> bool:
+        if not candidate:
+            return False
+        return all(
+            candidate not in secret_form
+            and not repeated_candidate_contains(secret_form, candidate)
+            and not candidate_boundary_composes(secret_form, candidate)
+            for secret_form in secret_forms
+        )
+
+    for candidate in ("***", "[REDACTED]", "<redacted-secret>"):
+        if safe(candidate):
+            return candidate
+
+    occupied_characters = {
+        character for secret_form in secret_forms for character in secret_form
+    }
+    # Prefer private-use scalars so collision handling does not turn normal
+    # provider prose into a control character. Scan every remaining scalar as
+    # a bounded final fallback; a finite secret snapshot normally exits on the
+    # first private-use code point.
+    codepoint_ranges = (
+        range(0xE000, 0xF900),
+        range(0xF0000, 0xFFFFE),
+        range(0x100000, 0x10FFFE),
+        range(0x20, 0xD800),
+        range(0xF900, 0xF0000),
+    )
+    for codepoints in codepoint_ranges:
+        for codepoint in codepoints:
+            candidate = chr(codepoint)
+            if candidate not in occupied_characters:
+                return candidate
+    return ""
+
+
+def _compile_exact_secret_pattern(
+    values: tuple[str, ...],
+) -> _ExactSecretPattern | None:
+    """Compile literal and canonical JSON spellings of exact secrets.
+
+    Disposable provider, advisory, and compaction text frequently contains a
+    valid JSON serialization rather than the decoded value. Quotes,
+    backslashes, and control characters therefore have different wire bytes.
+    Matching the canonical JSON string spelling closes that encoding boundary
+    without parsing or rewriting caller-owned executable arguments. Replacing
+    a complete escaped spelling with one safe scalar also leaves valid JSON
+    valid.
+    """
+    literal_values = {value for value in values if value}
+    if not literal_values:
+        return None
+    literal_forms = set(literal_values)
+    literal_forms.update(json.dumps(value)[1:-1] for value in literal_values)
+    ordered_forms = sorted(literal_forms, key=lambda value: (-len(value), value))
+    return _ExactSecretPattern(
+        regex=re.compile("|".join(re.escape(value) for value in ordered_forms)),
+        replacement=_choose_exact_secret_replacement(literal_forms),
+        secret_forms=tuple(ordered_forms),
+    )
+
+
+# An explicit operation-local scope may reuse one immutable pattern snapshot.
+# This is a ContextVar, not a home-keyed/global cache: the value is reset when
+# the owning request/compaction returns, and nested profile scopes with a
+# different context identity build their own snapshot.
+_EXACT_SECRET_PATTERN_SCOPE: contextvars.ContextVar[
+    tuple[tuple[str, bool], object | None, _ExactSecretPattern | None] | None
+] = contextvars.ContextVar("exact_secret_pattern_scope", default=None)
+
+
+def _exact_secret_pattern_context(
+    home: Path,
+) -> tuple[tuple[str, bool], object | None]:
+    try:
+        from agent.secret_scope import current_secret_scope, is_multiplex_active
+
+        scope = current_secret_scope()
+        multiplex_active = is_multiplex_active()
+    except Exception:
+        scope = None
+        multiplex_active = False
+    return (str(home.resolve()), multiplex_active), scope
+
+
+def _exact_secret_pattern_for_home(home: Path) -> _ExactSecretPattern | None:
+    """Reuse the active operation snapshot, or compile a fresh one."""
+    key, scope = _exact_secret_pattern_context(home)
+    current = _EXACT_SECRET_PATTERN_SCOPE.get()
+    if (
+        current is not None
+        and current[0] == key
+        and current[1] is scope
+    ):
+        return current[2]
+    return _compile_exact_secret_pattern(_collect_exact_secret_values(home))
+
+
+@contextmanager
+def _exact_secret_pattern_scope(home: str | os.PathLike | None = None):
+    """Reuse one exact-secret snapshot only for this context-local operation."""
+    resolved_home = _resolve_secret_home(home)
+    key, scope = _exact_secret_pattern_context(resolved_home)
+    current = _EXACT_SECRET_PATTERN_SCOPE.get()
+    if (
+        current is not None
+        and current[0] == key
+        and current[1] is scope
+    ):
+        yield
+        return
+
+    pattern = _compile_exact_secret_pattern(_collect_exact_secret_values(resolved_home))
+    # Retain the scope object itself for the lifetime of the cached snapshot.
+    # A numeric ``id(scope)`` can be reused after the old mapping is collected,
+    # which could otherwise bind a new profile to a stale secret pattern.
+    token = _EXACT_SECRET_PATTERN_SCOPE.set((key, scope, pattern))
+    try:
+        yield
+    finally:
+        _EXACT_SECRET_PATTERN_SCOPE.reset(token)
+
+
+_JSON_SIMPLE_ESCAPES = {
+    '"': '"',
+    "\\": "\\",
+    "/": "/",
+    "b": "\b",
+    "f": "\f",
+    "n": "\n",
+    "r": "\r",
+    "t": "\t",
+}
+_JSON_HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
+
+
+def _scan_json_string_fragment(
+    text: str,
+    quote_start: int,
+    source_spans: list[tuple[int, int]] | None = None,
+) -> tuple[int, int | None, str, list[tuple[int, int]]]:
+    """Decode one quoted fragment while retaining each character's raw span.
+
+    Unlike ``json.loads``, this deliberately tolerates invalid escapes,
+    unescaped control characters, and end-of-input before a closing quote.
+    Invalid escapes are retained as their two literal characters so scanning
+    can recover and decode later valid escapes in the same fragment.
+    """
+    decoded: list[str] = []
+    raw_spans: list[tuple[int, int]] = []
+
+    def source_span(start: int, end: int) -> tuple[int, int]:
+        if source_spans is None:
+            return start, end
+        return source_spans[start][0], source_spans[end - 1][1]
+
+    # ``quote_start == -1`` represents the virtual quote before byte zero. It
+    # lets the same escape-aware decoder scan the prefix (or an entirely
+    # unquoted/single-quoted malformed object) without changing cycle-8 quote
+    # parity recovery for every later double-quote interval.
+    index = quote_start + 1
+    while index < len(text):
+        char = text[index]
+        if char == '"':
+            return index + 1, index, "".join(decoded), raw_spans
+        if char != "\\":
+            decoded.append(char)
+            raw_spans.append(source_span(index, index + 1))
+            index += 1
+            continue
+
+        if index + 1 >= len(text):
+            decoded.append("\\")
+            raw_spans.append(source_span(index, index + 1))
+            index += 1
+            continue
+
+        escape = text[index + 1]
+        simple = _JSON_SIMPLE_ESCAPES.get(escape)
+        if simple is not None:
+            decoded.append(simple)
+            raw_spans.append(source_span(index, index + 2))
+            index += 2
+            continue
+
+        unicode_end = index + 6
+        if (
+            escape == "u"
+            and unicode_end <= len(text)
+            and all(char in _JSON_HEX_DIGITS for char in text[index + 2 : unicode_end])
+        ):
+            codepoint = int(text[index + 2 : unicode_end], 16)
+            raw_end = unicode_end
+            # JSON represents non-BMP characters as a UTF-16 surrogate pair.
+            # Decode a valid pair to one Python character and map it to the
+            # complete twelve-byte raw escape span.
+            if (
+                0xD800 <= codepoint <= 0xDBFF
+                and unicode_end + 6 <= len(text)
+                and text[unicode_end : unicode_end + 2] == "\\u"
+                and all(
+                    char in _JSON_HEX_DIGITS
+                    for char in text[unicode_end + 2 : unicode_end + 6]
+                )
+            ):
+                low = int(text[unicode_end + 2 : unicode_end + 6], 16)
+                if 0xDC00 <= low <= 0xDFFF:
+                    codepoint = (
+                        0x10000
+                        + ((codepoint - 0xD800) << 10)
+                        + (low - 0xDC00)
+                    )
+                    raw_end = unicode_end + 6
+            decoded.append(chr(codepoint))
+            raw_spans.append(source_span(index, raw_end))
+            index = raw_end
+            continue
+
+        # Preserve malformed escape bytes as separate decoded characters.
+        # This prevents one bad escape from terminating recognition of a
+        # later alternately escaped credential in the same quoted fragment.
+        decoded.extend(("\\", escape))
+        raw_spans.extend(
+            (
+                source_span(index, index + 1),
+                source_span(index + 1, index + 2),
+            )
+        )
+        index += 2
+
+    return len(text), None, "".join(decoded), raw_spans
+
+
+_JSON_ESCAPE_WORK_MULTIPLIER = 4
+_JSON_ESCAPE_MIN_EXTRA_WORK = 4_096
+_JSON_ESCAPE_MAX_EXTRA_WORK = 8 * 1024 * 1024
+
+
+def _json_escape_decode_work_budget(text: str) -> int:
+    """Bound total scans while always admitting the original text once.
+
+    Proper nested JSON serialization grows geometrically, so all successively
+    decoded forms normally total less than a small multiple of the wire text.
+    The floor handles small inputs; the ceiling prevents a very large payload
+    from authorizing unbounded additional CPU work. If a derived fragment does
+    not fit, its mapped original bytes are masked wholesale instead of being
+    forwarded at an uninspected nesting depth.
+    """
+    extra_work = min(
+        max(len(text) * _JSON_ESCAPE_WORK_MULTIPLIER, _JSON_ESCAPE_MIN_EXTRA_WORK),
+        _JSON_ESCAPE_MAX_EXTRA_WORK,
+    )
+    return len(text) + extra_work
+
+
+def _append_decoded_secret_matches(
+    decoded: str,
+    decoded_source_spans: list[tuple[int, int]],
+    pattern: _ExactSecretPattern,
+    replacements: list[tuple[int, int]],
+) -> None:
+    """Map exact matches in decoded text back to original source spans."""
+    for match in pattern.regex.finditer(decoded):
+        if match.start() < match.end():
+            replacements.append(
+                (
+                    decoded_source_spans[match.start()][0],
+                    decoded_source_spans[match.end() - 1][1],
+                )
+            )
+
+
+def _collect_json_secret_spans(
+    text: str,
+    pattern: _ExactSecretPattern,
+    replacements: list[tuple[int, int]],
+) -> None:
+    """Collect matches through iterative, source-mapped escape decoding.
+
+    The worklist removes recursion depth as an input-controlled resource. A
+    task maps every decoded character back to the original disposable text;
+    child tasks compose those spans again, so a match at any nesting depth can
+    still replace the exact outer wire bytes. Budget exhaustion is fail-closed:
+    the uninspected mapped fragment is replaced as a whole.
+    """
+    worklist: deque[tuple[str, list[tuple[int, int]] | None]] = deque(
+        [(text, None)]
+    )
+    remaining_work = _json_escape_decode_work_budget(text)
+
+    while worklist:
+        current_text, source_spans = worklist.popleft()
+        current_work = len(current_text)
+        if current_work > remaining_work:
+            if source_spans:
+                replacements.append((source_spans[0][0], source_spans[-1][1]))
+            elif current_text:
+                replacements.append((0, len(current_text)))
+            continue
+        remaining_work -= current_work
+
+        quote_start = -1
+        while quote_start < len(current_text):
+            _fragment_end, closing_quote, decoded, decoded_source_spans = (
+                _scan_json_string_fragment(
+                    current_text,
+                    quote_start,
+                    source_spans,
+                )
+            )
+            _append_decoded_secret_matches(
+                decoded,
+                decoded_source_spans,
+                pattern,
+                replacements,
+            )
+
+            fragment_end = (
+                closing_quote if closing_quote is not None else len(current_text)
+            )
+            encoded_fragment = current_text[quote_start + 1 : fragment_end]
+            if "\\" in decoded and decoded != encoded_fragment:
+                worklist.append((decoded, decoded_source_spans))
+
+            # Treat the closing quote as the next possible opening quote.
+            # Invalid JSON can insert or omit an unescaped quote, changing the
+            # parity of every later quote. Scanning every interval between
+            # consecutive escape-aware quotes resynchronizes immediately.
+            if closing_quote is None:
+                break
+            quote_start = closing_quote
+
+
+def _replace_exact_secret_spans(
+    text: str,
+    pattern: _ExactSecretPattern,
+    replacements: list[tuple[int, int]],
+    replacement_overrides: dict[tuple[int, int], str] | None = None,
+) -> str:
+    """Apply deduplicated source spans using collision-safe markers."""
+    if not replacements:
+        return text
+
+    # Recovery windows and nested decoding can discover the same match more
+    # than once. Normalize so each source byte is replaced exactly once and a
+    # shorter duplicate cannot split or suppress a complete encoded span.
+    merged_replacements: list[tuple[int, int]] = []
+    for start, end in sorted(set(replacements)):
+        if merged_replacements and start < merged_replacements[-1][1]:
+            previous_start, previous_end = merged_replacements[-1]
+            merged_replacements[-1] = (previous_start, max(previous_end, end))
+        else:
+            merged_replacements.append((start, end))
+
+    pieces: list[str] = []
+    cursor = 0
+    for start, end in merged_replacements:
+        pieces.extend(
+            (
+                text[cursor:start],
+                (replacement_overrides or {}).get((start, end), pattern.replacement),
+            )
+        )
+        cursor = end
+    pieces.append(text[cursor:])
+    return "".join(pieces)
+
+
+def _is_json_structural_key(value: str) -> bool:
+    """Keep only low-entropy JSON literal spellings usable as protocol keys."""
+    # Quoted numeric keys are strings, not typed JSON numbers. A long numeric
+    # credential must therefore be masked just like any other source value.
+    return value in {"true", "false", "null"}
+
+
+def _append_json_secret_matches(
+    decoded: str,
+    decoded_source_spans: list[tuple[int, int]],
+    pattern: _ExactSecretPattern,
+    replacements: list[tuple[int, int]],
+    *,
+    object_key: bool,
+    key_matches: list[tuple[tuple[int, int], str]],
+) -> None:
+    """Collect quoted-token matches, with collision-safe JSON key markers."""
+    if object_key and _is_json_structural_key(decoded):
+        return
+    for match in pattern.regex.finditer(decoded):
+        if match.start() >= match.end():
+            continue
+        span = (
+            decoded_source_spans[match.start()][0],
+            decoded_source_spans[match.end() - 1][1],
+        )
+        replacements.append(span)
+        if object_key:
+            key_matches.append((span, match.group(0)))
+
+
+def _redact_json_string_fragments(
+    text: str, pattern: _ExactSecretPattern
+) -> str:
+    r"""Decode quoted JSON fragments and mask decoded matches in raw spans.
+
+    JSON permits many byte spellings for the same decoded value (for example
+    ``\/`` and ``\uXXXX``). Literal matching cannot enumerate that space, and
+    strict token parsing misses invalid or EOF-terminated fragments. The
+    tolerant scanner retains a decoded-character-to-raw-span map, recovers
+    after invalid escapes, and replaces only matched raw bytes. Caller-owned
+    history is never passed to this helper; its inputs are disposable copies.
+    """
+    if "\\" not in text:
+        return text
+
+    replacements: list[tuple[int, int]] = []
+    _collect_json_secret_spans(text, pattern, replacements)
+    return _replace_exact_secret_spans(text, pattern, replacements)
+
+
+def _redact_valid_json_string_values(
+    text: str,
+    pattern: _ExactSecretPattern,
+) -> str | None:
+    """Mask quoted string-token bytes when *text* is one valid JSON document.
+
+    ``None`` means parsing failed and the caller must use the aggressive
+    malformed/prose path. For valid JSON, punctuation plus typed scalars
+    (numbers, booleans, and null) are structural and remain byte-exact. Both
+    object keys and string values are quoted tokens and can carry an
+    authoritative credential, so matching either is source-mapped and masked
+    without rewriting formatting or caller-owned input.
+    """
+    def reject_nonstandard_constant(value: str):
+        raise ValueError(f"invalid JSON constant: {value}")
+
+    try:
+        json.loads(text, parse_constant=reject_nonstandard_constant)
+    except (TypeError, ValueError):
+        return None
+
+    replacements: list[tuple[int, int]] = []
+    replacement_overrides: dict[tuple[int, int], str] = {}
+    key_matches: list[tuple[tuple[int, int], str]] = []
+    forbidden_markers: set[str] = set()
+    worklist: deque[tuple[str, list[tuple[int, int]]]] = deque()
+    remaining_work = _json_escape_decode_work_budget(text) - len(text)
+
+    cursor = 0
+    while cursor < len(text):
+        quote_start = text.find('"', cursor)
+        if quote_start < 0:
+            break
+        fragment_end, closing_quote, decoded, decoded_source_spans = (
+            _scan_json_string_fragment(text, quote_start)
+        )
+        # ``json.loads`` already proved the document valid, so every opening
+        # quote has a closing quote and every token after it is unambiguous.
+        if closing_quote is None:  # pragma: no cover - defensive consistency
+            return None
+
+        after_token = fragment_end
+        while after_token < len(text) and text[after_token].isspace():
+            after_token += 1
+        object_key = after_token < len(text) and text[after_token] == ":"
+        if object_key:
+            forbidden_markers.add(decoded)
+        _append_json_secret_matches(
+            decoded,
+            decoded_source_spans,
+            pattern,
+            replacements,
+            object_key=object_key,
+            key_matches=key_matches,
+        )
+        encoded_fragment = text[quote_start + 1 : closing_quote]
+        if "\\" in decoded and decoded != encoded_fragment:
+            worklist.append((decoded, decoded_source_spans))
+        cursor = fragment_end
+
+    # Once a quoted token is decoded, every derived byte belongs to that token,
+    # so the tolerant iterative scanner may inspect it globally. This retains
+    # deep/double-serialized JSON coverage without matching punctuation or
+    # typed scalar tokens from the valid outer document.
+    while worklist:
+        current_text, source_spans = worklist.popleft()
+        current_work = len(current_text)
+        if current_work > remaining_work:
+            if source_spans:
+                replacements.append((source_spans[0][0], source_spans[-1][1]))
+            continue
+        remaining_work -= current_work
+
+        quote_start = -1
+        while quote_start < len(current_text):
+            _fragment_end, closing_quote, decoded, decoded_source_spans = (
+                _scan_json_string_fragment(
+                    current_text,
+                    quote_start,
+                    source_spans,
+                )
+            )
+            fragment_end = (
+                closing_quote if closing_quote is not None else len(current_text)
+            )
+            after_token = fragment_end
+            while after_token < len(current_text) and current_text[after_token].isspace():
+                after_token += 1
+            object_key = (
+                after_token < len(current_text)
+                and current_text[after_token] == ":"
+            )
+            if object_key:
+                forbidden_markers.add(decoded)
+            _append_json_secret_matches(
+                decoded,
+                decoded_source_spans,
+                pattern,
+                replacements,
+                object_key=object_key,
+                key_matches=key_matches,
+            )
+            encoded_fragment = current_text[quote_start + 1 : fragment_end]
+            if "\\" in decoded and decoded != encoded_fragment:
+                worklist.append((decoded, decoded_source_spans))
+            if closing_quote is None:
+                break
+            quote_start = closing_quote
+
+    key_markers: dict[str, str] = {}
+    used_markers: set[str] = set()
+    for span, token in key_matches:
+        marker = key_markers.get(token)
+        if marker is None:
+            occupied = forbidden_markers | used_markers
+            marker = _choose_exact_secret_replacement(
+                set(pattern.secret_forms) | occupied
+            )
+            key_markers[token] = marker
+            used_markers.add(marker)
+        replacement_overrides[span] = marker
+
+    return _replace_exact_secret_spans(
+        text,
+        pattern,
+        replacements,
+        replacement_overrides,
+    )
+
+
+def _redact_exact_with_pattern(
+    text: str, pattern: _ExactSecretPattern | None
+) -> str:
+    if not text or pattern is None:
+        return text
+    valid_json_redacted = _redact_valid_json_string_values(text, pattern)
+    if valid_json_redacted is not None:
+        return valid_json_redacted
+    # Preserve the existing raw and canonical literal behavior for arbitrary
+    # prose and values outside quoted JSON fragments.
+    # Run it first so a longer exact value (such as an entire inline service
+    # account object) is not partially rewritten by a shorter nested secret
+    # before the complete value can match.
+    def replace_unshadowed(match: re.Match) -> str:
+        # A match can begin at the escaped byte of a JSON spelling: nested
+        # ``\\u00e9`` contains canonical ``\u00e9``, while the literal secret
+        # ``/`` can appear as the valid simple escape ``\/``. Replacing only
+        # that suffix leaves an invalid ``\***`` escape. Defer every match
+        # immediately preceded by a backslash to the source-mapped scanner,
+        # which decodes and replaces the complete outer span. It also retains
+        # malformed escape handling because invalid pairs are source-mapped as
+        # their separate literal bytes.
+        if (
+            match.start() > 0
+            and text[match.start() - 1] == "\\"
+        ):
+            return match.group(0)
+        return pattern.replacement
+
+    literal_redacted = pattern.regex.sub(replace_unshadowed, text)
+    if "\\" not in literal_redacted:
+        return literal_redacted
+    fragment_redacted = _redact_json_string_fragments(literal_redacted, pattern)
+
+    def replace_remaining_unshadowed(match: re.Match) -> str:
+        if (
+            match.start() > 0
+            and fragment_redacted[match.start() - 1] == "\\"
+        ):
+            return match.group(0)
+        return pattern.replacement
+
+    return pattern.regex.sub(replace_remaining_unshadowed, fragment_redacted)
+
+
+def redact_known_secret_values(
+    text: str,
+    home: str | os.PathLike | None = None,
+    *,
+    force: bool = False,
+) -> str:
+    """Mask every occurrence of active-profile authoritative secret values."""
+    if text is None:
+        return None
+    if not isinstance(text, str):
+        text = str(text)
+    if not text or not (force or _REDACT_ENABLED):
+        return text
+    resolved_home = _resolve_secret_home(home)
+    pattern = _exact_secret_pattern_for_home(resolved_home)
+    return _redact_exact_with_pattern(text, pattern)
+
+
+_PROVIDER_STRUCTURAL_STRING_FIELDS = frozenset(
+    {
+        "type",
+        "role",
+        "id",
+        "name",
+        "tool_name",
+        "tool_call_id",
+        "tool_use_id",
+        "call_id",
+        "toolUseId",
+        "response_item_id",
+        "detail",
+        "media_type",
+        "mime_type",
+        "format",
+        "ttl",
+        "phase",
+        "status",
+        "finish_reason",
+        "file_id",
+        "file_name",
+        "filename",
+        # Issuer-bound replay identifiers/payloads are never model-visible
+        # plaintext and must remain byte-exact across provider retries.
+        "signature",
+        "encrypted_content",
+    }
+)
+_PROVIDER_OPAQUE_METADATA_FIELDS = frozenset(
+    {
+        # Anthropic/OpenAI cache directives are provider control metadata, not
+        # model-visible prose. Rewriting ``ephemeral`` or ``1h`` makes an
+        # otherwise valid request fail schema validation.
+        "cache_control",
+    }
+)
+_PROVIDER_BINARY_DATA_TYPES = frozenset(
+    {
+        "base64",
+        "image",
+        "input_image",
+        "audio",
+        "input_audio",
+    }
+)
+_PROVIDER_BINARY_CONTAINER_FIELDS = frozenset({"audio", "input_audio"})
+_PROVIDER_EXECUTABLE_INPUT_TYPES = frozenset({"tool_use", "function_call"})
+_PROVIDER_EXECUTABLE_CONTAINER_FIELDS = frozenset({"toolUse", "function"})
+_DATA_URI_BASE64_RE = re.compile(
+    r"\A(data:[^,]*;base64,)([A-Za-z0-9+/]*={0,2})\Z",
+    re.IGNORECASE,
+)
+
+
+def _redact_provider_url(value: str, pattern: _ExactSecretPattern | None) -> str:
+    """Mask ordinary URLs while preserving validated opaque data URIs.
+
+    A data URI's payload is binary media, not model-visible prose. Replacing
+    an arbitrary exact value in that payload can make the URI invalid (for
+    example, masking ``A`` in ``data:image/png;base64,AAAA``). Keep the
+    base64 octets and grammar metadata byte-exact; ordinary non-data URLs
+    remain subject to exact-value redaction.
+    """
+    if pattern is None:
+        return value
+    match = _DATA_URI_BASE64_RE.match(value)
+    if match is None:
+        return _redact_exact_with_pattern(value, pattern)
+    # Metadata controls such as ``image/png`` and ``base64`` are part of the
+    # URI grammar. Preserve the complete validated URI so a short credential
+    # collision cannot turn it into an invalid provider payload. Opaque media
+    # is intentionally outside display-text redaction; ordinary non-data URLs
+    # still take the exact-value path below.
+    return value
+
+
+def _redact_provider_tree(
+    value: Any,
+    pattern: _ExactSecretPattern | None,
+    *,
+    field: str | None = None,
+) -> Any:
+    """Redact model-visible leaves without corrupting provider controls."""
+    if isinstance(value, str):
+        if field in {"url", "uri", "image_url"}:
+            return _redact_provider_url(value, pattern)
+        return _redact_exact_with_pattern(value, pattern)
+    if isinstance(value, list):
+        return [_redact_provider_tree(item, pattern, field=field) for item in value]
+    if isinstance(value, tuple):
+        return tuple(
+            _redact_provider_tree(item, pattern, field=field) for item in value
+        )
+    if isinstance(value, dict):
+        container_type = value.get("type")
+        return {
+            key: (
+                item
+                if (
+                    key in _PROVIDER_OPAQUE_METADATA_FIELDS
+                    or (
+                        isinstance(item, str)
+                        and key in _PROVIDER_STRUCTURAL_STRING_FIELDS
+                    )
+                    or (
+                        key == "data"
+                        and isinstance(item, str)
+                        and (
+                            container_type in _PROVIDER_BINARY_DATA_TYPES
+                            or container_type == "redacted_thinking"
+                            or field in _PROVIDER_BINARY_CONTAINER_FIELDS
+                        )
+                    )
+                    or (
+                        key in {"input", "arguments"}
+                        and (
+                            container_type in _PROVIDER_EXECUTABLE_INPUT_TYPES
+                            or field in _PROVIDER_EXECUTABLE_CONTAINER_FIELDS
+                        )
+                    )
+                )
+                else _redact_provider_tree(item, pattern, field=key)
+            )
+            for key, item in value.items()
+        }
+    return value
+
+
+def _redact_anthropic_ordered_blocks(
+    blocks: Any,
+    pattern: _ExactSecretPattern | None,
+) -> Any:
+    """Mask unsigned text unless a signature binds the ordered sequence."""
+    if not isinstance(blocks, list):
+        return blocks
+    has_signed_thinking = any(
+        isinstance(block, dict)
+        and (
+            (block.get("type") == "thinking" and bool(block.get("signature")))
+            or (
+                block.get("type") == "redacted_thinking"
+                and bool(block.get("data"))
+            )
+        )
+        for block in blocks
+    )
+    if has_signed_thinking:
+        # Anthropic signatures cover the ordered assistant content that
+        # surrounds them. Rewriting even an intervening text block while
+        # retaining a later signature makes the complete replay invalid.
+        return blocks
+    return [
+        {
+            **block,
+            "text": _redact_exact_with_pattern(block.get("text", ""), pattern),
+        }
+        if isinstance(block, dict)
+        and block.get("type") == "text"
+        and isinstance(block.get("text"), str)
+        else block
+        for block in blocks
+    ]
+
+
+def _redact_codex_message_items(
+    items: Any,
+    pattern: _ExactSecretPattern | None,
+) -> Any:
+    """Mask replayed assistant text without modifying item identity fields."""
+    if not isinstance(items, list):
+        return items
+    return [
+        {
+            **item,
+            "content": _redact_provider_tree(item.get("content"), pattern),
+        }
+        if isinstance(item, dict) and "content" in item
+        else item
+        for item in items
+    ]
+
+
+def _redact_provider_messages_with_pattern(
+    messages: list,
+    pattern: _ExactSecretPattern,
+) -> list:
+    """Redact one provider message/input list using a bound snapshot."""
+    import copy
+
+    redacted_messages = copy.deepcopy(messages)
+    provider_fields = (
+        "content",
+        "reasoning",
+        "reasoning_content",
+    )
+    for message in redacted_messages:
+        if not isinstance(message, dict):
+            continue
+        for field in provider_fields:
+            if field in message:
+                if field == "content" and isinstance(message[field], list) and any(
+                    isinstance(block, dict)
+                    and (
+                        (
+                            block.get("type") == "thinking"
+                            and bool(block.get("signature"))
+                        )
+                        or (
+                            block.get("type") == "redacted_thinking"
+                            and bool(block.get("data"))
+                        )
+                    )
+                    for block in message[field]
+                ):
+                    # Anthropic signs the ordered content sequence, not merely
+                    # the individual thinking block. Preserve the whole replay
+                    # unit exactly as the earlier adapter-specific gate does.
+                    continue
+                message[field] = _redact_provider_tree(message[field], pattern)
+        # Codex Responses converts tool-result messages into native
+        # ``function_call_output.output`` items before its final preflight.
+        # Mask visible output while preserving replayed function-call
+        # ``arguments`` and signed/sealed reasoning fields byte-for-byte.
+        if message.get("type") == "function_call_output" and "output" in message:
+            message["output"] = _redact_provider_tree(message["output"], pattern)
+        # Ordered Anthropic blocks bypass ``content`` in the adapter. Text-only
+        # unsigned lists are maskable; a list containing signed thinking is an
+        # opaque sequence. Executable tool_use inputs always remain byte-exact.
+        if "anthropic_content_blocks" in message:
+            message["anthropic_content_blocks"] = _redact_anthropic_ordered_blocks(
+                message["anthropic_content_blocks"], pattern
+            )
+        # OpenRouter requires the complete reasoning_details sequence to be
+        # replayed unmodified. Treat every current and future detail shape as
+        # opaque; selectively rewriting summary/text/unknown fields can
+        # invalidate signatures or the sequence contract.
+        # Codex reasoning items contain issuer-sealed encrypted replay blobs
+        # and must stay exact. Assistant message items are also replayed with
+        # stable ids/phases, so sanitize only their visible content payload.
+        if "codex_message_items" in message:
+            message["codex_message_items"] = _redact_codex_message_items(
+                message["codex_message_items"], pattern
+            )
+    return redacted_messages
+
+
+def redact_provider_message_values(
+    messages: list,
+    home: str | os.PathLike | None = None,
+    *,
+    force: bool = False,
+) -> list:
+    """Return a provider-bound copy with exact secret values removed.
+
+    The source history is never mutated. This is required by #43083: local
+    replay and tool execution retain exact arguments, while the outbound copy
+    masks message text and nested non-text metadata such as ``image_url.url``.
+
+    Tool-call arguments deliberately remain exact on the outbound copy. Human's
+    review of PR #42846 established that replacing replayed executable values
+    makes models copy the placeholder on later turns (#43083). Protecting that
+    field requires authenticated vault/token references, not display masking.
+    """
+    if not messages or not (force or _REDACT_ENABLED):
+        return messages
+    pattern = _exact_secret_pattern_for_home(_resolve_secret_home(home))
+    if pattern is None:
+        return messages
+
+    return _redact_provider_messages_with_pattern(messages, pattern)
+
+
+def redact_provider_api_kwargs(
+    api_kwargs: dict,
+    home: str | os.PathLike | None = None,
+    *,
+    force: bool = False,
+) -> dict:
+    """Rebind provider-native visible payloads after final transformations.
+
+    Provider adapters may normalize text after the generic message gate (for
+    example ASCII fallback or Codex Harmony-token neutralization). Inspect the
+    final ``messages``/``input``/``instructions`` bytes without rewriting
+    executable arguments, identity fields, or caller-owned request objects.
+    """
+    if not isinstance(api_kwargs, dict) or not (force or _REDACT_ENABLED):
+        return api_kwargs
+    pattern = _exact_secret_pattern_for_home(_resolve_secret_home(home))
+    if pattern is None:
+        return api_kwargs
+
+    redacted_kwargs = dict(api_kwargs)
+    for field in ("messages", "input"):
+        payload = api_kwargs.get(field)
+        if isinstance(payload, list):
+            redacted_kwargs[field] = _redact_provider_messages_with_pattern(
+                payload,
+                pattern,
+            )
+    instructions = api_kwargs.get("instructions")
+    if isinstance(instructions, str):
+        redacted_kwargs["instructions"] = _redact_exact_with_pattern(
+            instructions,
+            pattern,
+        )
+    system = api_kwargs.get("system")
+    if isinstance(system, (str, list, tuple, dict)):
+        import copy
+
+        redacted_kwargs["system"] = _redact_provider_tree(
+            copy.deepcopy(system),
+            pattern,
+        )
+    return redacted_kwargs
 
 
 def redact_sensitive_text(

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -5,6 +5,7 @@ is called, cannot fail), then an **upgrade** from one small-model call (cheap ti
 JSON-constrained). Storage enforces provenance ``derived < llm < user``: stage 2 only replaces stage 1
 and neither replaces a name the user typed."""
 
+import contextvars
 import json
 import logging
 import re
@@ -15,6 +16,7 @@ from typing import Any, Callable, Optional
 from agent.auxiliary_client import call_llm
 from agent.context_compressor import LEGACY_SUMMARY_PREFIX
 from agent.message_content import flatten_message_text
+from agent.provider_redaction import redact_known_secret_values
 
 logger = logging.getLogger(__name__)
 
@@ -160,12 +162,14 @@ def is_titleable_user_message(user_message: str) -> bool:
 
 def derive_title(user_message: str) -> Optional[str]:
     """Instant title: first meaningful line trimmed to a word boundary. No model, never fails."""
+    user_message = redact_known_secret_values(user_message)
     line = " ".join(_first_line(_summarize_user_message(user_message)).split())
+    line = redact_known_secret_values(line)
     if len(line) > MAX_DERIVED_TITLE_CHARS:
         cut = line[:MAX_DERIVED_TITLE_CHARS]
         space = cut.rfind(" ")
         line = (cut[:space] if space > MAX_DERIVED_TITLE_CHARS // 2 else cut).rstrip(" ,.;:—-") + "…"
-    return line or None
+    return redact_known_secret_values(line) or None
 
 
 def _strip_title_prefix(text: str) -> str:
@@ -206,10 +210,12 @@ def _extract_title_text(content: str) -> str:
 
 def _clean_title(text: str) -> Optional[str]:
     """Normalize a model-produced title, or None when nothing usable remains."""
-    title = _strip_title_prefix(" ".join((text or "").split()).strip("\"'").strip()).rstrip(".!,;:")
+    text = redact_known_secret_values(text or "")
+    title = _strip_title_prefix(" ".join(text.split()).strip("\"'").strip()).rstrip(".!,;:")
+    title = redact_known_secret_values(title)
     if len(title) > 80:
         title = title[:77].rstrip() + "..."
-    return title or None
+    return redact_known_secret_values(title) or None
 
 
 def _safe_callback(callback: Optional[Callable], args: tuple, log_fmt: str, label: str) -> None:
@@ -252,7 +258,9 @@ def generate_title(
             return None
     except Exception:  # fail open: a broken validator must not disable titling
         logger.debug("Title runtime validator raised; proceeding", exc_info=True)
-    user_snippet = _summarize_user_message(user_message)[:MAX_TITLE_INPUT_CHARS]
+    user_snippet = redact_known_secret_values(
+        _summarize_user_message(redact_known_secret_values(user_message))
+    )[:MAX_TITLE_INPUT_CHARS]
     if not user_snippet.strip():
         return None
     language = _title_language()
@@ -437,9 +445,10 @@ def maybe_auto_title(
         logger.debug("Auto-title skipped: auxiliary.title_generation.enabled=false")
         return
     apply_instant_title(session_db, session_id, user_message, title_callback)
+    request_context = contextvars.copy_context()
     threading.Thread(
-        target=auto_title_session,
-        args=(session_db, session_id, user_message),
+        target=request_context.run,
+        args=(auto_title_session, session_db, session_id, user_message),
         kwargs=dict(failure_callback=failure_callback, main_runtime=main_runtime, title_callback=title_callback, runtime_validator=runtime_validator),
         daemon=True,
         name="auto-title",

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -17,6 +17,7 @@ user typed. That ordering is the industry-standard one — Codex CLI encodes the
 same ``custom > ai > fallback`` precedence in its session importer.
 """
 
+import contextvars
 import json
 import logging
 import re
@@ -346,7 +347,15 @@ def generate_title(
             # Fail open: a broken validator must not disable titling.
             logger.debug("Title runtime validator raised; proceeding", exc_info=True)
 
-    user_snippet = _summarize_user_message(user_message)[:MAX_TITLE_INPUT_CHARS]
+    # Apply the exact-value gate to the complete disposable opening message
+    # before the title-input cap.  Otherwise a long credential beginning near
+    # the cap can be truncated into an unmatchable prefix and reach the
+    # auxiliary provider even though the later provider-copy gate sees only
+    # that prefix.
+    from agent.redact import redact_known_secret_values
+
+    safe_user_message = redact_known_secret_values(user_message)
+    user_snippet = _summarize_user_message(safe_user_message)[:MAX_TITLE_INPUT_CHARS]
     if not user_snippet.strip():
         return None
 
@@ -378,7 +387,15 @@ def generate_title(
             extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
         )
         content = response.choices[0].message.content or ""
-        return _clean_title(_extract_title_text(content))
+        title = _extract_title_text(content)
+        # Model output is untrusted provider text and may echo an exact active
+        # secret from its context. Mask before cleanup/truncation so a raw value
+        # can never become a durable session title. This respects the explicit
+        # global redaction opt-out, matching the provider-input boundary.
+        from agent.redact import redact_known_secret_values
+
+        title = redact_known_secret_values(title)
+        return _clean_title(title)
     except Exception as e:
         # Log at WARNING so this shows up in agent.log without debug mode.
         # Full detail at debug level for operators who need the stack.
@@ -454,9 +471,21 @@ def apply_instant_title(
     try:
         if not is_titleable_user_message(user_message):
             return None
-        title = derive_title(user_message)
+        # Mask the opening message before deriving so truncation cannot split
+        # a long credential and leave its prefix durable in the instant title.
+        # Keep this disposable copy separate from the caller-owned message.
+        from agent.redact import redact_known_secret_values
+
+        safe_user_message = redact_known_secret_values(user_message)
+        title = derive_title(safe_user_message)
         if not title:
             return None
+        # The instant title is durable session data just like the later model
+        # title.  Mask it before persistence so a profile-only credential in
+        # the opening message cannot bypass the title output boundary while
+        # the background upgrade is still pending.  Keep this lazy import to
+        # avoid the title-generator/redactor import cycle at module load.
+        title = redact_known_secret_values(title)
         persisted = _persist_session_title(
             session_db, session_id, title, source="derived"
         )
@@ -638,9 +667,14 @@ def maybe_auto_title(
 
     apply_instant_title(session_db, session_id, user_message, title_callback)
 
+    # ``threading.Thread`` starts with a fresh Context. Capture the request's
+    # profile-scoped home and secret mappings now, before the agent loop resets
+    # them, so title input/output masking and persistence use the same profile
+    # as the exchange being titled.
+    request_context = contextvars.copy_context()
     thread = threading.Thread(
-        target=auto_title_session,
-        args=(session_db, session_id, user_message),
+        target=request_context.run,
+        args=(auto_title_session, session_db, session_id, user_message),
         kwargs={
             "failure_callback": failure_callback,
             "main_runtime": main_runtime,

--- a/agent/turn_api_call.py
+++ b/agent/turn_api_call.py
@@ -85,6 +85,10 @@ def perform_api_call(
                 next_api_kwargs, allow_stream=False, is_github_responses=agent._is_copilot_url(),
                 sanitize_harmony_tokens=agent._is_codex_backend(),
             )
+        # Execution middleware can supply a new payload for each retry.
+        from agent.provider_redaction import redact_provider_api_kwargs
+
+        next_api_kwargs = redact_provider_api_kwargs(next_api_kwargs)
         if _use_streaming:
             return agent._interruptible_streaming_api_call(
                 next_api_kwargs, on_first_delta=_stop_spinner

--- a/agent/turn_api_request.py
+++ b/agent/turn_api_request.py
@@ -140,6 +140,11 @@ def build_api_request(
     # retry must bypass the cache.
     if agent._empty_content_retries > 0 and agent._is_openrouter_url():
         _set_extra_header(api_kwargs, "X-OpenRouter-Cache", "false")
+    # Gate native payloads after ASCII/Harmony transformations and raw replay
+    # restoration. Middleware dispatch gets its own final gate below.
+    from agent.provider_redaction import redact_provider_api_kwargs
+
+    api_kwargs = redact_provider_api_kwargs(api_kwargs)
     # Copilot x-initiator: first call of a user turn is "user" (billed premium);
     # tool-loop follow-ups keep the default "agent".
     if getattr(agent, "_is_user_initiated_turn", False) and agent._is_copilot_url():

--- a/tests/agent/test_compaction_redaction_boundaries.py
+++ b/tests/agent/test_compaction_redaction_boundaries.py
@@ -17,11 +17,14 @@ the persistence boundary, and uses an OAuth-callback-style URL to prove
 redaction deliberately passes through.
 """
 
+from copy import deepcopy
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from agent.context_compressor import (
+    COMPRESSED_SUMMARY_METADATA_KEY,
     ContextCompressor,
     SUMMARY_PREFIX,
     _redact_compaction_text,
@@ -32,6 +35,55 @@ OAUTH_URL = (
     "https://localhost/callback?code=opaque-code-123"
     "&access_token=opaque-token-456&state=keep"
 )
+ALTERNATE_JSON_SECRET = "S/Key"
+ALTERNATE_JSON_SPELLING = r"\u0053\/K\u0065y"
+
+
+def _nested_alternate_json_spelling(layers: int) -> str:
+    spelling = ALTERNATE_JSON_SPELLING
+    for _ in range(layers - 1):
+        spelling = json.dumps(spelling)[1:-1]
+    return spelling
+
+
+ALTERNATE_JSON_SPELLINGS = tuple(
+    pytest.param(
+        _nested_alternate_json_spelling(layers),
+        id=f"json-escape-layers-{layers}",
+    )
+    for layers in (1, 2, 5, 10, 13)
+)
+# A depth-13 spelling alone exceeds the micro-compactor's exchange-selection
+# budget, so that shared scanner depth is exercised at provider, memory, and
+# batch boundaries instead. Micro still covers nested depth ten end-to-end.
+MICRO_ALTERNATE_JSON_SPELLINGS = ALTERNATE_JSON_SPELLINGS[:-1]
+MALFORMED_JSON_FRAGMENT_KINDS = (
+    "unterminated",
+    "invalid_escape",
+    "quote_parity",
+    "unquoted",
+    "single_quoted",
+)
+
+
+def _json_with_alternate_secret(
+    field: str, spelling: str = ALTERNATE_JSON_SPELLING
+) -> str:
+    return f'{{"{field}":"{spelling}"}}'
+
+
+def _malformed_json_with_alternate_secret(field: str, kind: str) -> str:
+    if kind == "unterminated":
+        return f'{{"{field}":"{ALTERNATE_JSON_SPELLING}'
+    if kind == "invalid_escape":
+        return f'{{"{field}":"\\q{ALTERNATE_JSON_SPELLING}"}}'
+    if kind == "quote_parity":
+        return f'{{"broken":"prefix "{field}":"{ALTERNATE_JSON_SPELLING}"}}'
+    if kind == "unquoted":
+        return f"{{{field}:{ALTERNATE_JSON_SPELLING}}}"
+    if kind == "single_quoted":
+        return f"{{'{field}':'{ALTERNATE_JSON_SPELLING}'}}"
+    raise AssertionError(f"unknown malformed JSON fragment kind: {kind}")
 
 
 @pytest.fixture(autouse=True)
@@ -221,3 +273,521 @@ def test_resumed_handoff_summary_redacted_before_iterative_prompt():
     prompt = mock_call.call_args.kwargs["messages"][0]["content"]
     assert "PREVIOUS SUMMARY:" in prompt
     _assert_clean(prompt)
+
+
+def test_arbitrary_external_secret_is_forced_out_of_all_compaction_boundaries(
+    monkeypatch,
+):
+    """Exact external values never reach the aux model or persisted summary."""
+    from hermes_cli import env_loader
+    from hermes_constants import get_hermes_home
+
+    secret = 'Q7"\\Z!'
+    encoded_secret = json.dumps(secret)[1:-1]
+    home = get_hermes_home()
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(home.resolve()),
+        {"ARBITRARY_EXTERNAL_NAME": secret},
+    )
+    c = _compressor()
+    c._previous_summary = json.dumps({"legacy_previous_summary": secret})
+    turns = [
+        {"role": "user", "content": f"user text contains {secret}"},
+        {
+            "role": "assistant",
+            "content": "running tool",
+            "tool_calls": [
+                {
+                    "id": "call-exact-secret",
+                    "function": {
+                        "name": "terminal",
+                        "arguments": json.dumps({"command": f"printf {secret}"}),
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-exact-secret",
+            "content": json.dumps({"tool_result": {"credential": secret}}),
+        },
+    ]
+    original_arguments = turns[1]["tool_calls"][0]["function"]["arguments"]
+
+    with patch(
+        "agent.context_compressor.call_llm",
+        return_value=_response(json.dumps({"model_output": secret})),
+    ) as mock_call:
+        result = c._generate_summary(
+            turns,
+            focus_topic=f"focus contains {secret}",
+            memory_context=f"memory provider contains {secret}",
+        )
+
+    assert result is not None
+    prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+    assert "MEMORY PROVIDER CONTEXT:" in prompt
+    assert "memory provider contains ***" in prompt
+    assert secret not in prompt
+    assert encoded_secret not in prompt
+    assert secret not in result
+    assert encoded_secret not in result
+    assert secret not in (c._previous_summary or "")
+    assert encoded_secret not in (c._previous_summary or "")
+    assert turns[1]["tool_calls"][0]["function"]["arguments"] == original_arguments
+
+
+def test_summary_reuses_one_request_local_exact_pattern(monkeypatch):
+    """One compaction request snapshots active exact secrets only once."""
+    import agent.redact as redact
+    from hermes_cli import env_loader
+    from hermes_constants import get_hermes_home
+
+    home = get_hermes_home()
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(home.resolve()),
+        {"COMPACTION_LOCAL_SECRET": "p4ss"},
+    )
+    original_collect = redact._collect_exact_secret_values
+    collections = []
+
+    def counted_collect(secret_home):
+        collections.append(secret_home)
+        return original_collect(secret_home)
+
+    monkeypatch.setattr(redact, "_collect_exact_secret_values", counted_collect)
+    c = _compressor()
+    c._previous_summary = "previous p4ss"
+    turns = [
+        {"role": "user", "content": "request p4ss"},
+        {"role": "assistant", "content": "response p4ss"},
+    ]
+
+    with patch(
+        "agent.context_compressor.call_llm",
+        return_value=_response("summary p4ss"),
+    ):
+        result = c._generate_summary(
+            turns,
+            focus_topic="focus p4ss",
+            memory_context="memory p4ss",
+        )
+
+    assert result is not None
+    assert result.endswith("summary ***")
+    assert len(collections) == 1
+
+
+@pytest.mark.parametrize("alternate_spelling", ALTERNATE_JSON_SPELLINGS)
+def test_alternate_json_escapes_leave_batch_input_output_and_state_clean(
+    monkeypatch, alternate_spelling
+):
+    """Batch compaction decodes alternate spellings only on disposable text."""
+    from hermes_cli import env_loader
+    from hermes_constants import get_hermes_home
+
+    home = get_hermes_home()
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(home.resolve()),
+        {"BATCH_ALTERNATE_JSON_SECRET": ALTERNATE_JSON_SECRET},
+    )
+    c = _compressor()
+    def encoded(field: str) -> str:
+        return _json_with_alternate_secret(field, alternate_spelling)
+
+    c._previous_summary = encoded("previous_summary")
+    arguments = encoded("command")
+    turns = [
+        {"role": "user", "content": encoded("request")},
+        {
+            "role": "assistant",
+            "content": "running tool",
+            "tool_calls": [
+                {
+                    "id": "call-alternate-json-secret",
+                    "function": {
+                        "name": "terminal",
+                        "arguments": arguments,
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-alternate-json-secret",
+            "content": encoded("tool_result"),
+        },
+    ]
+    original_turns = deepcopy(turns)
+
+    with patch(
+        "agent.context_compressor.call_llm",
+        return_value=_response(encoded("model_output")),
+    ) as mock_call:
+        result = c._generate_summary(
+            turns,
+            focus_topic=encoded("focus"),
+            memory_context=encoded("memory"),
+        )
+
+    assert result is not None
+    prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+    for text in (prompt, result, c._previous_summary or ""):
+        assert ALTERNATE_JSON_SECRET not in text
+        assert ALTERNATE_JSON_SPELLING not in text
+        assert alternate_spelling not in text
+    assert turns == original_turns
+
+
+@pytest.mark.parametrize("fragment_kind", MALFORMED_JSON_FRAGMENT_KINDS)
+def test_malformed_json_escapes_leave_batch_input_output_and_state_clean(
+    monkeypatch, fragment_kind
+):
+    """Batch masking recovers after invalid escapes and at end of input."""
+    from hermes_cli import env_loader
+    from hermes_constants import get_hermes_home
+
+    def fragment(field: str) -> str:
+        return _malformed_json_with_alternate_secret(field, fragment_kind)
+
+    home = get_hermes_home()
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(home.resolve()),
+        {"BATCH_MALFORMED_JSON_SECRET": ALTERNATE_JSON_SECRET},
+    )
+    c = _compressor()
+    c._previous_summary = fragment("previous_summary")
+    arguments = fragment("command")
+    turns = [
+        {"role": "user", "content": fragment("request")},
+        {
+            "role": "assistant",
+            "content": "running tool",
+            "tool_calls": [
+                {
+                    "id": "call-malformed-json-secret",
+                    "function": {"name": "terminal", "arguments": arguments},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-malformed-json-secret",
+            "content": fragment("tool_result"),
+        },
+    ]
+    original_turns = deepcopy(turns)
+
+    with patch(
+        "agent.context_compressor.call_llm",
+        return_value=_response(fragment("model_output")),
+    ) as mock_call:
+        result = c._generate_summary(
+            turns,
+            focus_topic=fragment("focus"),
+            memory_context=fragment("memory"),
+        )
+
+    assert result is not None
+    prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+    for text in (prompt, result, c._previous_summary or ""):
+        assert "***" in text
+        assert ALTERNATE_JSON_SECRET not in text
+        assert ALTERNATE_JSON_SPELLING not in text
+    assert turns == original_turns
+
+
+def test_micro_compaction_redacts_resumed_input_output_and_persistence(
+    monkeypatch,
+):
+    """Legacy markers and aux output cannot bypass forced compaction masking."""
+    from hermes_cli import env_loader
+    from hermes_constants import get_hermes_home
+
+    secret = 'Q7"\\Z!'
+    encoded_secret = json.dumps(secret)[1:-1]
+    home = get_hermes_home()
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(home.resolve()),
+        {"MICRO_EXTERNAL_VALUE": secret},
+    )
+    c = ContextCompressor(
+        model="test-model",
+        threshold_percent=0.75,
+        protect_first_n=1,
+        protect_last_n=2,
+        quiet_mode=True,
+        config_context_length=40960,
+        provider="test",
+    )
+    c._micro_compact_enabled = True
+    c._session_id = "micro-redaction-regression"
+    c._session_db = MagicMock()
+
+    replay_fields = {
+        "tool_calls": [
+            {
+                "id": "call-secret",
+                "type": "function",
+                "function": {
+                    "name": "terminal",
+                    "arguments": json.dumps({"command": f"printf {secret}"}),
+                },
+            }
+        ],
+        "anthropic_content_blocks": [
+            {
+                "type": "thinking",
+                "thinking": f"signed thought {secret}",
+                "signature": f"signature-{secret}",
+            },
+            {
+                "type": "tool_use",
+                "id": "toolu-secret",
+                "name": "terminal",
+                "input": {"command": f"printf {secret}"},
+            },
+        ],
+        "codex_reasoning_items": [
+            {
+                "type": "reasoning",
+                "encrypted_content": f"sealed-{secret}",
+            }
+        ],
+    }
+    messages = [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": "earlier user request"},
+        {
+            "role": "assistant",
+            "content": c._render_micro_marker_content(
+                f"resumed rolling summary contains {secret}"
+            ),
+            COMPRESSED_SUMMARY_METADATA_KEY: True,
+        },
+        {"role": "user", "content": "next user request"},
+        {
+            "role": "assistant",
+            "content": f"exchange content contains {secret}",
+            **deepcopy(replay_fields),
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-secret",
+            "content": json.dumps({"tool_result": {"credential": secret}}),
+        },
+        {"role": "user", "content": "later request"},
+        {"role": "assistant", "content": "later answer " + "z" * 400},
+        {"role": "user", "content": "protected request"},
+        {"role": "assistant", "content": "protected answer " + "z" * 400},
+    ]
+    original_replay_fields = deepcopy(replay_fields)
+
+    with patch(
+        "agent.auxiliary_client.call_llm",
+        return_value=_response(json.dumps({"rolling_summary": secret})),
+    ) as mock_call:
+        result = c._micro_compact(messages)
+
+    prompt_messages = mock_call.call_args.kwargs["messages"]
+    prompt_text = "\n".join(message["content"] for message in prompt_messages)
+    assert secret not in prompt_text
+    assert encoded_secret not in prompt_text
+    assert secret not in c._micro_compact_rolling_summary
+    assert encoded_secret not in c._micro_compact_rolling_summary
+    markers = [m for m in result if m.get(COMPRESSED_SUMMARY_METADATA_KEY)]
+    assert len(markers) == 1
+    assert secret not in markers[0]["content"]
+    assert encoded_secret not in markers[0]["content"]
+    db_session_id, db_payload = c._session_db.archive_and_compact.call_args.args
+    assert db_session_id == c._session_id
+    assert secret not in str(db_payload)
+    assert encoded_secret not in str(db_payload)
+
+    # Compaction may summarize the rendered exchange, but it must not rewrite
+    # compatibility-critical replay bytes in the caller-owned source message.
+    for field, value in original_replay_fields.items():
+        assert messages[4][field] == value
+
+
+@pytest.mark.parametrize("alternate_spelling", MICRO_ALTERNATE_JSON_SPELLINGS)
+def test_alternate_json_escapes_leave_micro_output_and_persistence_clean(
+    monkeypatch, alternate_spelling
+):
+    """Micro compaction redacts alternate input/output spellings before storage."""
+    from hermes_cli import env_loader
+    from hermes_constants import get_hermes_home
+
+    home = get_hermes_home()
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(home.resolve()),
+        {"MICRO_ALTERNATE_JSON_SECRET": ALTERNATE_JSON_SECRET},
+    )
+    c = ContextCompressor(
+        model="test-model",
+        threshold_percent=0.75,
+        protect_first_n=1,
+        protect_last_n=2,
+        quiet_mode=True,
+        config_context_length=40960,
+        provider="test",
+    )
+    c._micro_compact_enabled = True
+    c._session_id = "micro-alternate-json-redaction"
+    c._session_db = MagicMock()
+
+    def encoded(field: str) -> str:
+        return _json_with_alternate_secret(field, alternate_spelling)
+
+    arguments = encoded("command")
+    messages = [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": "earlier user request"},
+        {
+            "role": "assistant",
+            "content": c._render_micro_marker_content(
+                encoded("resumed_summary")
+            ),
+            COMPRESSED_SUMMARY_METADATA_KEY: True,
+        },
+        {"role": "user", "content": "next user request"},
+        {
+            "role": "assistant",
+            "content": encoded("exchange"),
+            "tool_calls": [
+                {
+                    "id": "call-alternate-json-secret",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": arguments},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-alternate-json-secret",
+            "content": encoded("tool_result"),
+        },
+        {"role": "user", "content": "later request"},
+        {"role": "assistant", "content": "later answer " + "z" * 400},
+        {"role": "user", "content": "protected request"},
+        {"role": "assistant", "content": "protected answer " + "z" * 400},
+    ]
+    original_messages = deepcopy(messages)
+
+    with patch(
+        "agent.auxiliary_client.call_llm",
+        return_value=_response(encoded("rolling_summary")),
+    ) as mock_call:
+        result = c._micro_compact(messages)
+
+    prompt_text = "\n".join(
+        message["content"] for message in mock_call.call_args.kwargs["messages"]
+    )
+    markers = [m for m in result if m.get(COMPRESSED_SUMMARY_METADATA_KEY)]
+    assert len(markers) == 1
+    _db_session_id, db_payload = c._session_db.archive_and_compact.call_args.args
+    for text in (
+        prompt_text,
+        c._micro_compact_rolling_summary,
+        markers[0]["content"],
+        str(db_payload),
+    ):
+        assert ALTERNATE_JSON_SECRET not in text
+        assert ALTERNATE_JSON_SPELLING not in text
+        assert alternate_spelling not in text
+    assert messages[4]["content"] == original_messages[4]["content"]
+    assert messages[4]["tool_calls"] == original_messages[4]["tool_calls"]
+    assert messages[5]["content"] == original_messages[5]["content"]
+
+
+@pytest.mark.parametrize("fragment_kind", MALFORMED_JSON_FRAGMENT_KINDS)
+def test_malformed_json_escapes_leave_micro_output_and_persistence_clean(
+    monkeypatch, fragment_kind
+):
+    """Micro masking cleans malformed fragments before model and persistence."""
+    from hermes_cli import env_loader
+    from hermes_constants import get_hermes_home
+
+    def fragment(field: str) -> str:
+        return _malformed_json_with_alternate_secret(field, fragment_kind)
+
+    home = get_hermes_home()
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(home.resolve()),
+        {"MICRO_MALFORMED_JSON_SECRET": ALTERNATE_JSON_SECRET},
+    )
+    c = ContextCompressor(
+        model="test-model",
+        threshold_percent=0.75,
+        protect_first_n=1,
+        protect_last_n=2,
+        quiet_mode=True,
+        config_context_length=40960,
+        provider="test",
+    )
+    c._micro_compact_enabled = True
+    c._session_id = "micro-malformed-json-redaction"
+    c._session_db = MagicMock()
+    arguments = fragment("command")
+    messages = [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": "earlier user request"},
+        {
+            "role": "assistant",
+            "content": c._render_micro_marker_content(fragment("resumed_summary")),
+            COMPRESSED_SUMMARY_METADATA_KEY: True,
+        },
+        {"role": "user", "content": "next user request"},
+        {
+            "role": "assistant",
+            "content": fragment("exchange"),
+            "tool_calls": [
+                {
+                    "id": "call-malformed-json-secret",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": arguments},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-malformed-json-secret",
+            "content": fragment("tool_result"),
+        },
+        {"role": "user", "content": "later request"},
+        {"role": "assistant", "content": "later answer " + "z" * 400},
+        {"role": "user", "content": "protected request"},
+        {"role": "assistant", "content": "protected answer " + "z" * 400},
+    ]
+    original_messages = deepcopy(messages)
+
+    with patch(
+        "agent.auxiliary_client.call_llm",
+        return_value=_response(fragment("rolling_summary")),
+    ) as mock_call:
+        result = c._micro_compact(messages)
+
+    prompt_text = "\n".join(
+        message["content"] for message in mock_call.call_args.kwargs["messages"]
+    )
+    markers = [m for m in result if m.get(COMPRESSED_SUMMARY_METADATA_KEY)]
+    assert len(markers) == 1
+    _db_session_id, db_payload = c._session_db.archive_and_compact.call_args.args
+    for text in (
+        prompt_text,
+        c._micro_compact_rolling_summary,
+        markers[0]["content"],
+        str(db_payload),
+    ):
+        assert "***" in text
+        assert ALTERNATE_JSON_SECRET not in text
+        assert ALTERNATE_JSON_SPELLING not in text
+    assert messages[4] == original_messages[4]
+    assert messages[5] == original_messages[5]

--- a/tests/agent/test_compaction_redaction_boundaries.py
+++ b/tests/agent/test_compaction_redaction_boundaries.py
@@ -17,11 +17,14 @@ the persistence boundary, and uses an OAuth-callback-style URL to prove
 redaction deliberately passes through.
 """
 
+from copy import deepcopy
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from agent.context_compressor import (
+    COMPRESSED_SUMMARY_METADATA_KEY,
     ContextCompressor,
     SUMMARY_PREFIX,
     _redact_compaction_text,
@@ -32,6 +35,55 @@ OAUTH_URL = (
     "https://localhost/callback?code=opaque-code-123"
     "&access_token=opaque-token-456&state=keep"
 )
+ALTERNATE_JSON_SECRET = "S/Key"
+ALTERNATE_JSON_SPELLING = r"\u0053\/K\u0065y"
+
+
+def _nested_alternate_json_spelling(layers: int) -> str:
+    spelling = ALTERNATE_JSON_SPELLING
+    for _ in range(layers - 1):
+        spelling = json.dumps(spelling)[1:-1]
+    return spelling
+
+
+ALTERNATE_JSON_SPELLINGS = tuple(
+    pytest.param(
+        _nested_alternate_json_spelling(layers),
+        id=f"json-escape-layers-{layers}",
+    )
+    for layers in (1, 2, 5, 10, 13)
+)
+# A depth-13 spelling alone exceeds the micro-compactor's exchange-selection
+# budget, so that shared scanner depth is exercised at provider, memory, and
+# batch boundaries instead. Micro still covers nested depth ten end-to-end.
+MICRO_ALTERNATE_JSON_SPELLINGS = ALTERNATE_JSON_SPELLINGS[:-1]
+MALFORMED_JSON_FRAGMENT_KINDS = (
+    "unterminated",
+    "invalid_escape",
+    "quote_parity",
+    "unquoted",
+    "single_quoted",
+)
+
+
+def _json_with_alternate_secret(
+    field: str, spelling: str = ALTERNATE_JSON_SPELLING
+) -> str:
+    return f'{{"{field}":"{spelling}"}}'
+
+
+def _malformed_json_with_alternate_secret(field: str, kind: str) -> str:
+    if kind == "unterminated":
+        return f'{{"{field}":"{ALTERNATE_JSON_SPELLING}'
+    if kind == "invalid_escape":
+        return f'{{"{field}":"\\q{ALTERNATE_JSON_SPELLING}"}}'
+    if kind == "quote_parity":
+        return f'{{"broken":"prefix "{field}":"{ALTERNATE_JSON_SPELLING}"}}'
+    if kind == "unquoted":
+        return f"{{{field}:{ALTERNATE_JSON_SPELLING}}}"
+    if kind == "single_quoted":
+        return f"{{'{field}':'{ALTERNATE_JSON_SPELLING}'}}"
+    raise AssertionError(f"unknown malformed JSON fragment kind: {kind}")
 
 
 @pytest.fixture(autouse=True)
@@ -221,3 +273,521 @@ def test_resumed_handoff_summary_redacted_before_iterative_prompt():
     prompt = mock_call.call_args.kwargs["messages"][0]["content"]
     assert "PREVIOUS SUMMARY:" in prompt
     _assert_clean(prompt)
+
+
+def test_arbitrary_external_secret_is_forced_out_of_all_compaction_boundaries(
+    monkeypatch,
+):
+    """Exact external values never reach the aux model or persisted summary."""
+    from hermes_cli import env_loader
+    from hermes_constants import get_hermes_home
+
+    secret = 'Q7"\\Z!'
+    encoded_secret = json.dumps(secret)[1:-1]
+    home = get_hermes_home()
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(home.resolve()),
+        {"ARBITRARY_EXTERNAL_NAME": secret},
+    )
+    c = _compressor()
+    c._previous_summary = json.dumps({"legacy_previous_summary": secret})
+    turns = [
+        {"role": "user", "content": f"user text contains {secret}"},
+        {
+            "role": "assistant",
+            "content": "running tool",
+            "tool_calls": [
+                {
+                    "id": "call-exact-secret",
+                    "function": {
+                        "name": "terminal",
+                        "arguments": json.dumps({"command": f"printf {secret}"}),
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-exact-secret",
+            "content": json.dumps({"tool_result": {"credential": secret}}),
+        },
+    ]
+    original_arguments = turns[1]["tool_calls"][0]["function"]["arguments"]
+
+    with patch(
+        "agent.context_compressor.call_llm",
+        return_value=_response(json.dumps({"model_output": secret})),
+    ) as mock_call:
+        result = c._generate_summary(
+            turns,
+            focus_topic=f"focus contains {secret}",
+            memory_context=f"memory provider contains {secret}",
+        )
+
+    assert result is not None
+    prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+    assert "MEMORY PROVIDER CONTEXT:" in prompt
+    assert "memory provider contains ***" in prompt
+    assert secret not in prompt
+    assert encoded_secret not in prompt
+    assert secret not in result
+    assert encoded_secret not in result
+    assert secret not in (c._previous_summary or "")
+    assert encoded_secret not in (c._previous_summary or "")
+    assert turns[1]["tool_calls"][0]["function"]["arguments"] == original_arguments
+
+
+def test_summary_reuses_one_request_local_exact_pattern(monkeypatch):
+    """One compaction request snapshots active exact secrets only once."""
+    import agent.provider_redaction as redact
+    from hermes_cli import env_loader
+    from hermes_constants import get_hermes_home
+
+    home = get_hermes_home()
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(home.resolve()),
+        {"COMPACTION_LOCAL_SECRET": "p4ss"},
+    )
+    original_collect = redact._collect_exact_secret_values
+    collections = []
+
+    def counted_collect(secret_home):
+        collections.append(secret_home)
+        return original_collect(secret_home)
+
+    monkeypatch.setattr(redact, "_collect_exact_secret_values", counted_collect)
+    c = _compressor()
+    c._previous_summary = "previous p4ss"
+    turns = [
+        {"role": "user", "content": "request p4ss"},
+        {"role": "assistant", "content": "response p4ss"},
+    ]
+
+    with patch(
+        "agent.context_compressor.call_llm",
+        return_value=_response("summary p4ss"),
+    ):
+        result = c._generate_summary(
+            turns,
+            focus_topic="focus p4ss",
+            memory_context="memory p4ss",
+        )
+
+    assert result is not None
+    assert "summary ***" in result
+    assert len(collections) == 1
+
+
+@pytest.mark.parametrize("alternate_spelling", ALTERNATE_JSON_SPELLINGS)
+def test_alternate_json_escapes_leave_batch_input_output_and_state_clean(
+    monkeypatch, alternate_spelling
+):
+    """Batch compaction decodes alternate spellings only on disposable text."""
+    from hermes_cli import env_loader
+    from hermes_constants import get_hermes_home
+
+    home = get_hermes_home()
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(home.resolve()),
+        {"BATCH_ALTERNATE_JSON_SECRET": ALTERNATE_JSON_SECRET},
+    )
+    c = _compressor()
+    def encoded(field: str) -> str:
+        return _json_with_alternate_secret(field, alternate_spelling)
+
+    c._previous_summary = encoded("previous_summary")
+    arguments = encoded("command")
+    turns = [
+        {"role": "user", "content": encoded("request")},
+        {
+            "role": "assistant",
+            "content": "running tool",
+            "tool_calls": [
+                {
+                    "id": "call-alternate-json-secret",
+                    "function": {
+                        "name": "terminal",
+                        "arguments": arguments,
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-alternate-json-secret",
+            "content": encoded("tool_result"),
+        },
+    ]
+    original_turns = deepcopy(turns)
+
+    with patch(
+        "agent.context_compressor.call_llm",
+        return_value=_response(encoded("model_output")),
+    ) as mock_call:
+        result = c._generate_summary(
+            turns,
+            focus_topic=encoded("focus"),
+            memory_context=encoded("memory"),
+        )
+
+    assert result is not None
+    prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+    for text in (prompt, result, c._previous_summary or ""):
+        assert ALTERNATE_JSON_SECRET not in text
+        assert ALTERNATE_JSON_SPELLING not in text
+        assert alternate_spelling not in text
+    assert turns == original_turns
+
+
+@pytest.mark.parametrize("fragment_kind", MALFORMED_JSON_FRAGMENT_KINDS)
+def test_malformed_json_escapes_leave_batch_input_output_and_state_clean(
+    monkeypatch, fragment_kind
+):
+    """Batch masking recovers after invalid escapes and at end of input."""
+    from hermes_cli import env_loader
+    from hermes_constants import get_hermes_home
+
+    def fragment(field: str) -> str:
+        return _malformed_json_with_alternate_secret(field, fragment_kind)
+
+    home = get_hermes_home()
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(home.resolve()),
+        {"BATCH_MALFORMED_JSON_SECRET": ALTERNATE_JSON_SECRET},
+    )
+    c = _compressor()
+    c._previous_summary = fragment("previous_summary")
+    arguments = fragment("command")
+    turns = [
+        {"role": "user", "content": fragment("request")},
+        {
+            "role": "assistant",
+            "content": "running tool",
+            "tool_calls": [
+                {
+                    "id": "call-malformed-json-secret",
+                    "function": {"name": "terminal", "arguments": arguments},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-malformed-json-secret",
+            "content": fragment("tool_result"),
+        },
+    ]
+    original_turns = deepcopy(turns)
+
+    with patch(
+        "agent.context_compressor.call_llm",
+        return_value=_response(fragment("model_output")),
+    ) as mock_call:
+        result = c._generate_summary(
+            turns,
+            focus_topic=fragment("focus"),
+            memory_context=fragment("memory"),
+        )
+
+    assert result is not None
+    prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+    for text in (prompt, result, c._previous_summary or ""):
+        assert "***" in text
+        assert ALTERNATE_JSON_SECRET not in text
+        assert ALTERNATE_JSON_SPELLING not in text
+    assert turns == original_turns
+
+
+def test_micro_compaction_redacts_resumed_input_output_and_persistence(
+    monkeypatch,
+):
+    """Legacy markers and aux output cannot bypass forced compaction masking."""
+    from hermes_cli import env_loader
+    from hermes_constants import get_hermes_home
+
+    secret = 'Q7"\\Z!'
+    encoded_secret = json.dumps(secret)[1:-1]
+    home = get_hermes_home()
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(home.resolve()),
+        {"MICRO_EXTERNAL_VALUE": secret},
+    )
+    c = ContextCompressor(
+        model="test-model",
+        threshold_percent=0.75,
+        protect_first_n=1,
+        protect_last_n=2,
+        quiet_mode=True,
+        config_context_length=40960,
+        provider="test",
+    )
+    c._micro_compact_enabled = True
+    c._session_id = "micro-redaction-regression"
+    c._session_db = MagicMock()
+
+    replay_fields = {
+        "tool_calls": [
+            {
+                "id": "call-secret",
+                "type": "function",
+                "function": {
+                    "name": "terminal",
+                    "arguments": json.dumps({"command": f"printf {secret}"}),
+                },
+            }
+        ],
+        "anthropic_content_blocks": [
+            {
+                "type": "thinking",
+                "thinking": f"signed thought {secret}",
+                "signature": f"signature-{secret}",
+            },
+            {
+                "type": "tool_use",
+                "id": "toolu-secret",
+                "name": "terminal",
+                "input": {"command": f"printf {secret}"},
+            },
+        ],
+        "codex_reasoning_items": [
+            {
+                "type": "reasoning",
+                "encrypted_content": f"sealed-{secret}",
+            }
+        ],
+    }
+    messages = [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": "earlier user request"},
+        {
+            "role": "assistant",
+            "content": c._render_micro_marker_content(
+                f"resumed rolling summary contains {secret}"
+            ),
+            COMPRESSED_SUMMARY_METADATA_KEY: True,
+        },
+        {"role": "user", "content": "next user request"},
+        {
+            "role": "assistant",
+            "content": f"exchange content contains {secret}",
+            **deepcopy(replay_fields),
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-secret",
+            "content": json.dumps({"tool_result": {"credential": secret}}),
+        },
+        {"role": "user", "content": "later request"},
+        {"role": "assistant", "content": "later answer " + "z" * 400},
+        {"role": "user", "content": "protected request"},
+        {"role": "assistant", "content": "protected answer " + "z" * 400},
+    ]
+    original_replay_fields = deepcopy(replay_fields)
+
+    with patch(
+        "agent.auxiliary_client.call_llm",
+        return_value=_response(json.dumps({"rolling_summary": secret})),
+    ) as mock_call:
+        result = c._micro_compact(messages)
+
+    prompt_messages = mock_call.call_args.kwargs["messages"]
+    prompt_text = "\n".join(message["content"] for message in prompt_messages)
+    assert secret not in prompt_text
+    assert encoded_secret not in prompt_text
+    assert secret not in c._micro_compact_rolling_summary
+    assert encoded_secret not in c._micro_compact_rolling_summary
+    markers = [m for m in result if m.get(COMPRESSED_SUMMARY_METADATA_KEY)]
+    assert len(markers) == 1
+    assert secret not in markers[0]["content"]
+    assert encoded_secret not in markers[0]["content"]
+    db_session_id, db_payload = c._session_db.archive_and_compact.call_args.args
+    assert db_session_id == c._session_id
+    assert secret not in str(db_payload)
+    assert encoded_secret not in str(db_payload)
+
+    # Compaction may summarize the rendered exchange, but it must not rewrite
+    # compatibility-critical replay bytes in the caller-owned source message.
+    for field, value in original_replay_fields.items():
+        assert messages[4][field] == value
+
+
+@pytest.mark.parametrize("alternate_spelling", MICRO_ALTERNATE_JSON_SPELLINGS)
+def test_alternate_json_escapes_leave_micro_output_and_persistence_clean(
+    monkeypatch, alternate_spelling
+):
+    """Micro compaction redacts alternate input/output spellings before storage."""
+    from hermes_cli import env_loader
+    from hermes_constants import get_hermes_home
+
+    home = get_hermes_home()
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(home.resolve()),
+        {"MICRO_ALTERNATE_JSON_SECRET": ALTERNATE_JSON_SECRET},
+    )
+    c = ContextCompressor(
+        model="test-model",
+        threshold_percent=0.75,
+        protect_first_n=1,
+        protect_last_n=2,
+        quiet_mode=True,
+        config_context_length=40960,
+        provider="test",
+    )
+    c._micro_compact_enabled = True
+    c._session_id = "micro-alternate-json-redaction"
+    c._session_db = MagicMock()
+
+    def encoded(field: str) -> str:
+        return _json_with_alternate_secret(field, alternate_spelling)
+
+    arguments = encoded("command")
+    messages = [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": "earlier user request"},
+        {
+            "role": "assistant",
+            "content": c._render_micro_marker_content(
+                encoded("resumed_summary")
+            ),
+            COMPRESSED_SUMMARY_METADATA_KEY: True,
+        },
+        {"role": "user", "content": "next user request"},
+        {
+            "role": "assistant",
+            "content": encoded("exchange"),
+            "tool_calls": [
+                {
+                    "id": "call-alternate-json-secret",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": arguments},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-alternate-json-secret",
+            "content": encoded("tool_result"),
+        },
+        {"role": "user", "content": "later request"},
+        {"role": "assistant", "content": "later answer " + "z" * 400},
+        {"role": "user", "content": "protected request"},
+        {"role": "assistant", "content": "protected answer " + "z" * 400},
+    ]
+    original_messages = deepcopy(messages)
+
+    with patch(
+        "agent.auxiliary_client.call_llm",
+        return_value=_response(encoded("rolling_summary")),
+    ) as mock_call:
+        result = c._micro_compact(messages)
+
+    prompt_text = "\n".join(
+        message["content"] for message in mock_call.call_args.kwargs["messages"]
+    )
+    markers = [m for m in result if m.get(COMPRESSED_SUMMARY_METADATA_KEY)]
+    assert len(markers) == 1
+    _db_session_id, db_payload = c._session_db.archive_and_compact.call_args.args
+    for text in (
+        prompt_text,
+        c._micro_compact_rolling_summary,
+        markers[0]["content"],
+        str(db_payload),
+    ):
+        assert ALTERNATE_JSON_SECRET not in text
+        assert ALTERNATE_JSON_SPELLING not in text
+        assert alternate_spelling not in text
+    assert messages[4]["content"] == original_messages[4]["content"]
+    assert messages[4]["tool_calls"] == original_messages[4]["tool_calls"]
+    assert messages[5]["content"] == original_messages[5]["content"]
+
+
+@pytest.mark.parametrize("fragment_kind", MALFORMED_JSON_FRAGMENT_KINDS)
+def test_malformed_json_escapes_leave_micro_output_and_persistence_clean(
+    monkeypatch, fragment_kind
+):
+    """Micro masking cleans malformed fragments before model and persistence."""
+    from hermes_cli import env_loader
+    from hermes_constants import get_hermes_home
+
+    def fragment(field: str) -> str:
+        return _malformed_json_with_alternate_secret(field, fragment_kind)
+
+    home = get_hermes_home()
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(home.resolve()),
+        {"MICRO_MALFORMED_JSON_SECRET": ALTERNATE_JSON_SECRET},
+    )
+    c = ContextCompressor(
+        model="test-model",
+        threshold_percent=0.75,
+        protect_first_n=1,
+        protect_last_n=2,
+        quiet_mode=True,
+        config_context_length=40960,
+        provider="test",
+    )
+    c._micro_compact_enabled = True
+    c._session_id = "micro-malformed-json-redaction"
+    c._session_db = MagicMock()
+    arguments = fragment("command")
+    messages = [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": "earlier user request"},
+        {
+            "role": "assistant",
+            "content": c._render_micro_marker_content(fragment("resumed_summary")),
+            COMPRESSED_SUMMARY_METADATA_KEY: True,
+        },
+        {"role": "user", "content": "next user request"},
+        {
+            "role": "assistant",
+            "content": fragment("exchange"),
+            "tool_calls": [
+                {
+                    "id": "call-malformed-json-secret",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": arguments},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-malformed-json-secret",
+            "content": fragment("tool_result"),
+        },
+        {"role": "user", "content": "later request"},
+        {"role": "assistant", "content": "later answer " + "z" * 400},
+        {"role": "user", "content": "protected request"},
+        {"role": "assistant", "content": "protected answer " + "z" * 400},
+    ]
+    original_messages = deepcopy(messages)
+
+    with patch(
+        "agent.auxiliary_client.call_llm",
+        return_value=_response(fragment("rolling_summary")),
+    ) as mock_call:
+        result = c._micro_compact(messages)
+
+    prompt_text = "\n".join(
+        message["content"] for message in mock_call.call_args.kwargs["messages"]
+    )
+    markers = [m for m in result if m.get(COMPRESSED_SUMMARY_METADATA_KEY)]
+    assert len(markers) == 1
+    _db_session_id, db_payload = c._session_db.archive_and_compact.call_args.args
+    for text in (
+        prompt_text,
+        c._micro_compact_rolling_summary,
+        markers[0]["content"],
+        str(db_payload),
+    ):
+        assert "***" in text
+        assert ALTERNATE_JSON_SECRET not in text
+        assert ALTERNATE_JSON_SPELLING not in text
+    assert messages[4] == original_messages[4]
+    assert messages[5] == original_messages[5]

--- a/tests/agent/test_provider_redaction_overrides.py
+++ b/tests/agent/test_provider_redaction_overrides.py
@@ -1,0 +1,97 @@
+"""The SDK's effective payload must pass the same provider-copy gate."""
+
+import copy
+
+import pytest
+
+from agent.provider_redaction import redact_provider_api_kwargs
+from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+
+@pytest.mark.parametrize("extra_body", [False, True])
+@pytest.mark.parametrize("field", ["input", "messages"])
+def test_effective_native_input_is_masked_without_mutating_request(monkeypatch, extra_body, field):
+    secret = "sdk-override-secret-77487"
+    payload = {field: secret if field == "input" else [{"role": "user", "content": secret}], "instructions": f"Use {secret}"}
+    request = {"model": "fixture", "extra_body": payload} if extra_body else {"model": "fixture", **payload}
+    original = copy.deepcopy(request)
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope({"ACTIVE_TOKEN": secret})
+    try:
+        redacted = redact_provider_api_kwargs(request)
+    finally:
+        reset_secret_scope(token)
+    effective = {**redacted, **redacted.get("extra_body", {})}
+    assert secret not in str(effective[field])
+    assert secret not in effective["instructions"]
+    assert request == original
+
+
+def test_auxiliary_override_and_codex_conversion_are_gated(monkeypatch):
+    from types import SimpleNamespace
+    from agent import auxiliary_client
+
+    content = [{"type": "text", "text": "ordinary fragment"}]
+    secret = str(content)
+    captured = {}
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    monkeypatch.setattr(auxiliary_client, "_call_llm_impl", lambda **kwargs: captured.update(kwargs))
+    token = set_secret_scope({"ACTIVE_TOKEN": secret})
+    try:
+        auxiliary_client.call_llm(messages=[], extra_body={"input": secret})
+        adapter = auxiliary_client._CodexCompletionsAdapter(
+            SimpleNamespace(base_url="https://chatgpt.com/backend-api/codex"), "fixture"
+        )
+        native, _model, _timeout = adapter._build_responses_kwargs(
+            {"messages": [{"role": "system", "content": content}]}
+        )
+    finally:
+        reset_secret_scope(token)
+    assert secret not in captured["extra_body"]["input"]
+    assert secret not in native["instructions"]
+    assert content == [{"type": "text", "text": "ordinary fragment"}]
+
+
+@pytest.mark.parametrize("mode", ["sync", "async", "stream"])
+def test_relay_replacement_is_masked_at_the_provider_callback(monkeypatch, mode):
+    import asyncio
+    from types import SimpleNamespace
+    from agent import auxiliary_client, relay_llm
+
+    secret = "relay-replacement-secret-77487"
+    replacement = {"messages": [{"role": "user", "content": secret}], "extra_body": {"input": secret}}
+    captured = []
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    monkeypatch.setattr(auxiliary_client, "_relay_auxiliary_metadata", lambda **kw: ("fixture", "fixture", {}))
+
+    def create(**kwargs):
+        captured.append(kwargs)
+        return SimpleNamespace(choices=[])
+
+    async def async_create(**kwargs):
+        return create(**kwargs)
+
+    async def relay_async(_request, callback, **kwargs):
+        return await callback(replacement)
+
+    monkeypatch.setattr(relay_llm, "execute_current", lambda _request, callback, **kw: callback(replacement))
+    monkeypatch.setattr(relay_llm, "execute_current_async", relay_async)
+    monkeypatch.setattr(relay_llm, "stream_current", lambda _request, callback, **kw: callback(replacement))
+    client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=async_create if mode == "async" else create)))
+    token = set_secret_scope({"RELAY_TOKEN": secret})
+    try:
+        if mode == "sync":
+            auxiliary_client._relay_sync_completion(client, {"messages": []})
+        elif mode == "async":
+            asyncio.run(auxiliary_client._relay_async_completion(client, {"messages": []}))
+        else:
+            auxiliary_client._relay_sync_stream(client, {"messages": []})
+    finally:
+        reset_secret_scope(token)
+    assert len(captured) == 1
+    assert secret not in str(captured[0])
+    assert replacement["messages"][0]["content"] == secret
+    assert replacement["extra_body"]["input"] == secret

--- a/tests/agent/test_provider_signed_replay.py
+++ b/tests/agent/test_provider_signed_replay.py
@@ -1,0 +1,76 @@
+"""Signed Bedrock history cannot be rewritten or exempt arbitrary new secrets."""
+import copy
+
+import pytest
+
+from agent.provider_redaction import redact_provider_api_kwargs, redact_provider_message_values
+from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+
+@pytest.fixture
+def active_secret(monkeypatch):
+    secret = "signed-replay-secret-77487"
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope({"REPLAY_TOKEN": secret})
+    try:
+        yield secret
+    finally:
+        reset_secret_scope(token)
+
+
+def signed_request(secret, location=None):
+    return {
+        "modelId": "fixture",
+        "system": [{"text": secret if location == "system" else "safe system"}],
+        "messages": [
+            {"role": "user", "content": [{"text": secret if location == "prior" else "safe prompt"}]},
+            {"role": "assistant", "content": [
+                {"reasoningContent": {"reasoningText": {
+                    "text": secret if location == "reasoning" else "safe reasoning",
+                    "signature": "issuer-signed-fixture",
+                }}},
+                {"text": "safe answer"},
+            ]},
+            {"role": "user", "content": [{"text": secret}]},
+        ],
+    }
+
+
+@pytest.mark.parametrize("location", ["system", "prior", "reasoning"])
+def test_signed_prefix_collision_rejects_without_mutation(active_secret, location):
+    request = signed_request(active_secret, location)
+    original = copy.deepcopy(request)
+    with pytest.raises(ValueError, match="signed Bedrock history") as exc:
+        redact_provider_api_kwargs(request)
+    assert active_secret not in str(exc.value)
+    assert request == original
+
+
+def test_signed_prefix_without_collision_stays_exact_and_suffix_is_masked(active_secret):
+    request = signed_request(active_secret)
+    original = copy.deepcopy(request)
+    result = redact_provider_api_kwargs(request)
+    assert result["messages"][:2] == original["messages"][:2]
+    assert result["system"] == original["system"]
+    assert result["messages"][2]["content"] == [{"text": "***"}]
+    assert request == original
+
+
+def test_normalized_bedrock_sidecar_does_not_bypass_collision_check(active_secret):
+    messages = signed_request(active_secret, "prior")["messages"]
+    messages[1]["bedrock_content_blocks"] = messages[1].pop("content")
+    with pytest.raises(ValueError, match="signed Bedrock history"):
+        redact_provider_message_values(messages)
+
+
+def test_native_bedrock_builder_masks_visible_values_and_preserves_arguments(active_secret):
+    from agent.bedrock_adapter import build_converse_kwargs
+    messages = [{"role": "user", "content": active_secret}, {"role": "assistant", "content": "", "tool_calls": [
+        {"id": "fixture", "type": "function", "function": {"name": "execute", "arguments": '{"value":"' + active_secret + '"}'}}
+    ]}]
+    original = copy.deepcopy(messages)
+    result = build_converse_kwargs("fixture", messages)
+    assert result["messages"][0]["content"] == [{"text": "***"}]
+    assert result["messages"][1]["content"][0]["toolUse"]["input"] == {"value": active_secret}
+    assert messages == original

--- a/tests/agent/test_title_secret_projections.py
+++ b/tests/agent/test_title_secret_projections.py
@@ -1,0 +1,38 @@
+"""Title normalization and background fallbacks must not persist active secrets."""
+from types import SimpleNamespace
+
+import pytest
+
+from agent import title_generator
+from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+
+@pytest.mark.parametrize("path", ["instant", "fallback", "generated"])
+def test_title_projection_masks_after_whitespace_normalization(monkeypatch, path):
+    secret = "normalized credential phrase"
+    rendered = "normalized   credential\tphrase"
+    stored = []
+    db = SimpleNamespace(
+        get_session_title_source=lambda _sid: "derived",
+        get_conversation_root=lambda sid: sid,
+        set_auto_title=lambda _sid, title, **kw: stored.append(title) or True,
+    )
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    monkeypatch.setattr(title_generator, "_auto_title_enabled", lambda: True)
+    monkeypatch.setattr(title_generator, "_title_language", lambda: "")
+    monkeypatch.setattr(title_generator, "call_llm", lambda **kw: SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=rendered))]
+    ))
+    token = set_secret_scope({"TITLE_TOKEN": secret})
+    try:
+        if path == "instant":
+            title_generator.apply_instant_title(db, "fixture", rendered)
+        elif path == "fallback":
+            monkeypatch.setattr(title_generator, "generate_title", lambda *a, **kw: None)
+            title_generator.auto_title_session(db, "fixture", rendered)
+        else:
+            title_generator.auto_title_session(db, "fixture", "ordinary request")
+    finally:
+        reset_secret_scope(token)
+    assert stored == ["***"]

--- a/tests/run_agent/test_pre_compress_memory_context.py
+++ b/tests/run_agent/test_pre_compress_memory_context.py
@@ -1,8 +1,25 @@
 """Behavior contracts for the pre-compression memory-context handoff."""
 
+import json
 from unittest.mock import MagicMock
 
 import pytest
+
+
+def _nested_alternate_json_spelling(layers: int) -> str:
+    spelling = r"\u0053\/K\u0065y"
+    for _ in range(layers - 1):
+        spelling = json.dumps(spelling)[1:-1]
+    return spelling
+
+
+ALTERNATE_JSON_SPELLINGS = tuple(
+    pytest.param(
+        _nested_alternate_json_spelling(layers),
+        id=f"json-escape-layers-{layers}",
+    )
+    for layers in (1, 2, 5, 10, 13)
+)
 
 
 def _make_agent(memory_manager, compressor):
@@ -182,6 +199,138 @@ def test_provider_context_is_strictly_sanitized_before_plugin_engine(monkeypatch
     assert "api-key=***&view=public" in context
     assert "client%2Dsecret=***&view=public" in context
     assert "//user:***@x.test/path" in context
+
+
+def test_provider_context_exact_masks_active_short_secret_before_engine(monkeypatch):
+    """Arbitrary provider text crosses the engine handoff only after masking."""
+    from hermes_cli import env_loader
+    from hermes_constants import get_hermes_home
+
+    secret = "r8$!"
+    home = get_hermes_home()
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(home.resolve()),
+        {"ARBITRARY_MEMORY_PROVIDER_SECRET": secret},
+    )
+    manager = MagicMock()
+    manager.on_pre_compress.return_value = f"provider insight contains {secret}"
+    received = []
+    compressor = MagicMock()
+
+    def capture_compress(messages, current_tokens=None, memory_context="", **_kwargs):
+        received.append(memory_context)
+        return [messages[0], messages[-1]]
+
+    compressor.compress.side_effect = capture_compress
+    _configure_engine_state(compressor)
+    agent = _make_agent(manager, compressor)
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+
+    agent._compress_context(_messages(), "sys", approx_tokens=100_000)
+
+    assert received == ["provider insight contains ***"]
+
+
+@pytest.mark.parametrize(
+    "alternate_spelling",
+    ALTERNATE_JSON_SPELLINGS,
+)
+def test_provider_context_masks_alternate_json_escapes_before_engine(
+    monkeypatch, alternate_spelling
+):
+    """Memory-provider JSON spellings are decoded on the disposable handoff."""
+    from hermes_cli import env_loader
+    from hermes_constants import get_hermes_home
+
+    secret = "S/Key"
+    provider_context = f'{{"credential":"{alternate_spelling}"}}'
+    home = get_hermes_home()
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(home.resolve()),
+        {"ARBITRARY_MEMORY_PROVIDER_SECRET": secret},
+    )
+    manager = MagicMock()
+    manager.on_pre_compress.return_value = provider_context
+    received = []
+    compressor = MagicMock()
+
+    def capture_compress(messages, current_tokens=None, memory_context="", **_kwargs):
+        received.append(memory_context)
+        return [messages[0], messages[-1]]
+
+    compressor.compress.side_effect = capture_compress
+    _configure_engine_state(compressor)
+    agent = _make_agent(manager, compressor)
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+
+    agent._compress_context(_messages(), "sys", approx_tokens=100_000)
+
+    assert len(received) == 1
+    assert json.loads(received[0]) == {"credential": "***"}
+    assert secret not in received[0]
+    assert alternate_spelling not in received[0]
+    assert manager.on_pre_compress.return_value == provider_context
+
+
+@pytest.mark.parametrize(
+    "fragment_kind",
+    (
+        "unterminated",
+        "invalid_escape",
+        "quote_parity",
+        "unquoted",
+        "single_quoted",
+    ),
+)
+def test_provider_context_masks_malformed_alternate_json_fragments_before_engine(
+    monkeypatch, fragment_kind
+):
+    """Memory handoff tolerates incomplete and invalid quoted JSON fragments."""
+    from hermes_cli import env_loader
+    from hermes_constants import get_hermes_home
+
+    secret = "S/Key"
+    alternate_spelling = r"\u0053\/K\u0065y"
+    if fragment_kind == "unterminated":
+        provider_context = f'{{"credential":"{alternate_spelling}'
+    elif fragment_kind == "invalid_escape":
+        provider_context = f'{{"credential":"\\q{alternate_spelling}"}}'
+    elif fragment_kind == "quote_parity":
+        provider_context = (
+            f'{{"broken":"prefix "credential":"{alternate_spelling}"}}'
+        )
+    elif fragment_kind == "unquoted":
+        provider_context = f"{{credential:{alternate_spelling}}}"
+    else:
+        provider_context = f"{{'credential':'{alternate_spelling}'}}"
+    home = get_hermes_home()
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(home.resolve()),
+        {"MALFORMED_MEMORY_PROVIDER_SECRET": secret},
+    )
+    manager = MagicMock()
+    manager.on_pre_compress.return_value = provider_context
+    received = []
+    compressor = MagicMock()
+
+    def capture_compress(messages, current_tokens=None, memory_context="", **_kwargs):
+        received.append(memory_context)
+        return [messages[0], messages[-1]]
+
+    compressor.compress.side_effect = capture_compress
+    _configure_engine_state(compressor)
+    agent = _make_agent(manager, compressor)
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+
+    agent._compress_context(_messages(), "sys", approx_tokens=100_000)
+
+    assert len(received) == 1
+    assert "***" in received[0]
+    assert alternate_spelling not in received[0]
+    assert manager.on_pre_compress.return_value == provider_context
 
 
 def test_provider_context_is_bounded_before_plugin_engine():

--- a/tests/run_agent/test_pre_compress_memory_context.py
+++ b/tests/run_agent/test_pre_compress_memory_context.py
@@ -1,8 +1,25 @@
 """Behavior contracts for the pre-compression memory-context handoff."""
 
+import json
 from unittest.mock import MagicMock
 
 import pytest
+
+
+def _nested_alternate_json_spelling(layers: int) -> str:
+    spelling = r"\u0053\/K\u0065y"
+    for _ in range(layers - 1):
+        spelling = json.dumps(spelling)[1:-1]
+    return spelling
+
+
+ALTERNATE_JSON_SPELLINGS = tuple(
+    pytest.param(
+        _nested_alternate_json_spelling(layers),
+        id=f"json-escape-layers-{layers}",
+    )
+    for layers in (1, 2, 5, 10, 13)
+)
 
 
 def _make_agent(memory_manager, compressor):
@@ -177,6 +194,138 @@ def test_provider_context_is_strictly_sanitized_before_plugin_engine(monkeypatch
     assert "api-key=***&view=public" in context
     assert "client%2Dsecret=***&view=public" in context
     assert "//user:***@x.test/path" in context
+
+
+def test_provider_context_exact_masks_active_short_secret_before_engine(monkeypatch):
+    """Arbitrary provider text crosses the engine handoff only after masking."""
+    from hermes_cli import env_loader
+    from hermes_constants import get_hermes_home
+
+    secret = "r8$!"
+    home = get_hermes_home()
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(home.resolve()),
+        {"ARBITRARY_MEMORY_PROVIDER_SECRET": secret},
+    )
+    manager = MagicMock()
+    manager.on_pre_compress.return_value = f"provider insight contains {secret}"
+    received = []
+    compressor = MagicMock()
+
+    def capture_compress(messages, current_tokens=None, memory_context="", **_kwargs):
+        received.append(memory_context)
+        return [messages[0], messages[-1]]
+
+    compressor.compress.side_effect = capture_compress
+    _configure_engine_state(compressor)
+    agent = _make_agent(manager, compressor)
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+
+    agent._compress_context(_messages(), "sys", approx_tokens=100_000)
+
+    assert received == ["provider insight contains ***"]
+
+
+@pytest.mark.parametrize(
+    "alternate_spelling",
+    ALTERNATE_JSON_SPELLINGS,
+)
+def test_provider_context_masks_alternate_json_escapes_before_engine(
+    monkeypatch, alternate_spelling
+):
+    """Memory-provider JSON spellings are decoded on the disposable handoff."""
+    from hermes_cli import env_loader
+    from hermes_constants import get_hermes_home
+
+    secret = "S/Key"
+    provider_context = f'{{"credential":"{alternate_spelling}"}}'
+    home = get_hermes_home()
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(home.resolve()),
+        {"ARBITRARY_MEMORY_PROVIDER_SECRET": secret},
+    )
+    manager = MagicMock()
+    manager.on_pre_compress.return_value = provider_context
+    received = []
+    compressor = MagicMock()
+
+    def capture_compress(messages, current_tokens=None, memory_context="", **_kwargs):
+        received.append(memory_context)
+        return [messages[0], messages[-1]]
+
+    compressor.compress.side_effect = capture_compress
+    _configure_engine_state(compressor)
+    agent = _make_agent(manager, compressor)
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+
+    agent._compress_context(_messages(), "sys", approx_tokens=100_000)
+
+    assert len(received) == 1
+    assert json.loads(received[0]) == {"credential": "***"}
+    assert secret not in received[0]
+    assert alternate_spelling not in received[0]
+    assert manager.on_pre_compress.return_value == provider_context
+
+
+@pytest.mark.parametrize(
+    "fragment_kind",
+    (
+        "unterminated",
+        "invalid_escape",
+        "quote_parity",
+        "unquoted",
+        "single_quoted",
+    ),
+)
+def test_provider_context_masks_malformed_alternate_json_fragments_before_engine(
+    monkeypatch, fragment_kind
+):
+    """Memory handoff tolerates incomplete and invalid quoted JSON fragments."""
+    from hermes_cli import env_loader
+    from hermes_constants import get_hermes_home
+
+    secret = "S/Key"
+    alternate_spelling = r"\u0053\/K\u0065y"
+    if fragment_kind == "unterminated":
+        provider_context = f'{{"credential":"{alternate_spelling}'
+    elif fragment_kind == "invalid_escape":
+        provider_context = f'{{"credential":"\\q{alternate_spelling}"}}'
+    elif fragment_kind == "quote_parity":
+        provider_context = (
+            f'{{"broken":"prefix "credential":"{alternate_spelling}"}}'
+        )
+    elif fragment_kind == "unquoted":
+        provider_context = f"{{credential:{alternate_spelling}}}"
+    else:
+        provider_context = f"{{'credential':'{alternate_spelling}'}}"
+    home = get_hermes_home()
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(home.resolve()),
+        {"MALFORMED_MEMORY_PROVIDER_SECRET": secret},
+    )
+    manager = MagicMock()
+    manager.on_pre_compress.return_value = provider_context
+    received = []
+    compressor = MagicMock()
+
+    def capture_compress(messages, current_tokens=None, memory_context="", **_kwargs):
+        received.append(memory_context)
+        return [messages[0], messages[-1]]
+
+    compressor.compress.side_effect = capture_compress
+    _configure_engine_state(compressor)
+    agent = _make_agent(manager, compressor)
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+
+    agent._compress_context(_messages(), "sys", approx_tokens=100_000)
+
+    assert len(received) == 1
+    assert "***" in received[0]
+    assert alternate_spelling not in received[0]
+    assert manager.on_pre_compress.return_value == provider_context
 
 
 def test_provider_context_is_bounded_before_plugin_engine():

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5038,6 +5038,79 @@ class TestRunConversation:
         assert agent.client.chat.completions.create.call_count <= 6
 
 
+    def test_force_ascii_dispatch_masks_secret_composed_by_normalization(
+        self, agent, monkeypatch
+    ):
+        """The bytes sent after ASCII fallback pass the exact-secret gate."""
+        from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+        self._setup_agent(agent)
+        agent._force_ascii_payload = True
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="Final answer",
+            finish_reason="stop",
+        )
+        source = "abécd"
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+        monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+        token = set_secret_scope({"ACTIVE_TOKEN": "abcd"})
+        try:
+            with (
+                patch.object(agent, "_persist_session"),
+                patch.object(agent, "_save_trajectory"),
+                patch.object(agent, "_cleanup_task_resources"),
+            ):
+                result = agent.run_conversation(source)
+        finally:
+            reset_secret_scope(token)
+
+        sent = agent.client.chat.completions.create.call_args.kwargs["messages"]
+        assert result["completed"] is True
+        assert sent[-1]["content"] == "***"
+        assert source == "abécd"
+
+
+    def test_dispatch_masks_raw_sidecar_and_execution_middleware_copy(self, agent, monkeypatch):
+        import copy
+        from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+        self._setup_agent(agent)
+        secret = "active-provider-secret-77487"
+        history = [
+            {"role": "user", "content": "visible question", "api_content": f"raw question {secret}"},
+            {"role": "assistant", "content": "ready"},
+        ]
+        original = copy.deepcopy(history)
+        replaced = {}
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="Final answer", finish_reason="stop",
+        )
+
+        def execution_middleware(request, perform, **kwargs):
+            replaced.update(copy.deepcopy(request))
+            replaced["messages"][-1]["content"] = f"middleware {secret}"
+            return perform(replaced)
+
+        monkeypatch.setattr("hermes_cli.middleware.run_llm_execution_middleware", execution_middleware)
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+        monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+        token = set_secret_scope({"ACTIVE_TOKEN": secret})
+        try:
+            with patch.object(agent, "_persist_session"), patch.object(agent, "_save_trajectory"), patch.object(agent, "_cleanup_task_resources"):
+                result = agent.run_conversation("continue", conversation_history=history)
+        finally:
+            reset_secret_scope(token)
+
+        sent = agent.client.chat.completions.create.call_args.kwargs["messages"]
+        assert result["completed"] is True
+        assert any("raw question" in str(message.get("content")) for message in sent)
+        assert secret not in str(sent)
+        assert secret in replaced["messages"][-1]["content"]
+        assert history == original
+
+
+
+
 
 
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2782,6 +2782,37 @@ class TestRunConversation:
         assert result["final_response"] == "Final answer"
         assert result["completed"] is True
 
+    def test_force_ascii_dispatch_masks_secret_composed_by_normalization(
+        self, agent, monkeypatch
+    ):
+        """The bytes sent after ASCII fallback pass the exact-secret gate."""
+        from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+        self._setup_agent(agent)
+        agent._force_ascii_payload = True
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="Final answer",
+            finish_reason="stop",
+        )
+        source = "abécd"
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+        monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+        token = set_secret_scope({"ACTIVE_TOKEN": "abcd"})
+        try:
+            with (
+                patch.object(agent, "_persist_session"),
+                patch.object(agent, "_save_trajectory"),
+                patch.object(agent, "_cleanup_task_resources"),
+            ):
+                result = agent.run_conversation(source)
+        finally:
+            reset_secret_scope(token)
+
+        sent = agent.client.chat.completions.create.call_args.kwargs["messages"]
+        assert result["completed"] is True
+        assert sent[-1]["content"] == "***"
+        assert source == "abécd"
+
     def test_prompt_cache_marks_static_system_prefix_on_wire(self, agent):
         self._setup_agent(agent)
         agent._cached_system_prompt = "stable instructions\n\nsession context"

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -2624,3 +2624,32 @@ def test_run_codex_stream_retired_request_stops_firing_callbacks(monkeypatch):
 
     assert streamed == ["keep"]
     assert "DROPPED" not in streamed
+
+
+def test_codex_harmony_preflight_reapplies_exact_secret_gate_at_dispatch(
+    monkeypatch,
+):
+    """Harmony neutralization cannot create a scoped secret after masking."""
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    agent = _build_agent(monkeypatch)
+    setattr(agent, "_disable_streaming", True)
+    secret = "<｜start｜>"
+    captured = {}
+
+    def _capture_api_call(api_kwargs):
+        captured.update(api_kwargs)
+        return _codex_message_response("OK")
+
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    monkeypatch.setattr(agent, "_interruptible_api_call", _capture_api_call)
+    token = set_secret_scope({"HARMONY_TOKEN": secret})
+    try:
+        result = agent.run_conversation("Read <|start|>")
+    finally:
+        reset_secret_scope(token)
+
+    assert result["completed"] is True
+    assert secret not in str(captured["input"])
+    assert "***" in str(captured["input"])

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -740,6 +740,35 @@ def test_codex_preflight_defangs_harmony_tokens_before_and_after_middleware(monk
     assert "<｜start｜>" in captured["instructions"]
 
 
+def test_codex_harmony_preflight_reapplies_exact_secret_gate_at_dispatch(
+    monkeypatch,
+):
+    """Harmony neutralization cannot create a scoped secret after masking."""
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    agent = _build_agent(monkeypatch)
+    setattr(agent, "_disable_streaming", True)
+    secret = "<｜start｜>"
+    captured = {}
+
+    def _capture_api_call(api_kwargs):
+        captured.update(api_kwargs)
+        return _codex_message_response("OK")
+
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    monkeypatch.setattr(agent, "_interruptible_api_call", _capture_api_call)
+    token = set_secret_scope({"HARMONY_TOKEN": secret})
+    try:
+        result = agent.run_conversation("Read <|start|>")
+    finally:
+        reset_secret_scope(token)
+
+    assert result["completed"] is True
+    assert secret not in str(captured["input"])
+    assert "***" in str(captured["input"])
+
+
 def test_copilot_responses_preflight_preserves_harmony_tokens(monkeypatch):
     """Other Responses-compatible providers remain byte-identical."""
     agent = _build_copilot_agent(monkeypatch)

--- a/tests/test_secrets_exfiltration.py
+++ b/tests/test_secrets_exfiltration.py
@@ -1,0 +1,1960 @@
+"""Provider-egress exact-secret regression gates for issue #77487."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from agent.agent_runtime_helpers import sanitize_api_messages
+
+
+ALTERNATE_JSON_SECRET = "S/Key"
+ALTERNATE_JSON_SPELLING = r"\u0053\/K\u0065y"
+
+
+def _nest_json_string_spelling(spelling: str, layers: int) -> str:
+    for _ in range(layers - 1):
+        spelling = json.dumps(spelling)[1:-1]
+    return spelling
+
+
+def _nested_alternate_json_spelling(layers: int) -> str:
+    return _nest_json_string_spelling(ALTERNATE_JSON_SPELLING, layers)
+
+
+ALTERNATE_JSON_SPELLINGS = tuple(
+    pytest.param(
+        _nested_alternate_json_spelling(layers),
+        id=f"json-escape-layers-{layers}",
+    )
+    for layers in (1, 2, 5, 10, 13)
+)
+MALFORMED_JSON_FRAGMENT_KINDS = (
+    "unterminated",
+    "invalid_escape",
+    "quote_parity",
+    "unquoted",
+    "single_quoted",
+)
+
+
+def _json_with_alternate_secret(
+    field: str, spelling: str = ALTERNATE_JSON_SPELLING
+) -> str:
+    return f'{{"{field}":"{spelling}"}}'
+
+
+def _malformed_json_with_alternate_secret(field: str, kind: str) -> str:
+    if kind == "unterminated":
+        return f'{{"{field}":"{ALTERNATE_JSON_SPELLING}'
+    if kind == "invalid_escape":
+        return f'{{"{field}":"\\q{ALTERNATE_JSON_SPELLING}"}}'
+    if kind == "quote_parity":
+        return f'{{"broken":"prefix "{field}":"{ALTERNATE_JSON_SPELLING}"}}'
+    if kind == "unquoted":
+        return f"{{{field}:{ALTERNATE_JSON_SPELLING}}}"
+    if kind == "single_quoted":
+        return f"{{'{field}':'{ALTERNATE_JSON_SPELLING}'}}"
+    raise AssertionError(f"unknown malformed JSON fragment kind: {kind}")
+
+
+@pytest.fixture(autouse=True)
+def _enable_redaction(monkeypatch):
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+
+
+@pytest.fixture
+def applied_secret_home(tmp_path, monkeypatch):
+    from hermes_cli import env_loader
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    secret = "opaque-fixture-secret-77487"
+    home_key = str(tmp_path.resolve())
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        home_key,
+        {"ARBITRARY_SOURCE_NAME": secret},
+    )
+    token = set_hermes_home_override(tmp_path)
+    try:
+        yield tmp_path, secret
+    finally:
+        reset_hermes_home_override(token)
+
+
+@pytest.fixture
+def json_special_secret_home(tmp_path, monkeypatch):
+    from hermes_cli import env_loader
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    secret = 'Q7"\\Z!'
+    home_key = str(tmp_path.resolve())
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        home_key,
+        {"JSON_SPECIAL_SECRET": secret},
+    )
+    token = set_hermes_home_override(tmp_path)
+    try:
+        yield tmp_path, secret
+    finally:
+        reset_hermes_home_override(token)
+
+
+def _paired_messages(secret: str) -> list[dict]:
+    return [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_77487",
+                    "type": "function",
+                    "function": {
+                        "name": "terminal",
+                        "arguments": json.dumps(
+                            {"command": f"printf '{secret} {secret}'"}
+                        ),
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "name": "terminal",
+            "tool_call_id": "call_77487",
+            "content": [
+                {"type": "text", "text": f"first={secret}; second={secret}"},
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"https://example.invalid/{secret}/{secret}/image.png"
+                    },
+                },
+            ],
+        },
+    ]
+
+
+def _paired_tool_result(content: str) -> list[dict]:
+    return [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_77487",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "name": "terminal",
+            "tool_call_id": "call_77487",
+            "content": content,
+        },
+    ]
+
+
+def test_provider_copy_masks_content_occurrences_and_preserves_replay_history(
+    applied_secret_home,
+):
+    """Text and non-text metadata are sanitized without mutating history."""
+    _home, secret = applied_secret_home
+    messages = _paired_messages(secret)
+    original = copy.deepcopy(messages)
+
+    provider_bound = sanitize_api_messages(messages)
+
+    arguments = provider_bound[0]["tool_calls"][0]["function"]["arguments"]
+    text = provider_bound[1]["content"][0]["text"]
+    image_url = provider_bound[1]["content"][1]["image_url"]["url"]
+    # #43083: replayed executable arguments cannot be display-masked without
+    # making the model copy the placeholder into a later tool call. This field
+    # requires authenticated vault/token references, not raw substitution.
+    assert secret in arguments
+    assert secret not in text
+    assert secret not in image_url
+    assert text.count("***") == 2
+    assert image_url.count("***") == 2
+
+    # #43083: provider sanitization must not poison the replayable source.
+    assert messages == original
+    assert messages[0]["tool_calls"][0]["function"]["arguments"] == original[0][
+        "tool_calls"
+    ][0]["function"]["arguments"]
+
+
+def test_provider_copy_masks_json_encoded_tool_result_without_mutating_source(
+    json_special_secret_home,
+):
+    """JSON string escaping cannot hide an exact secret from provider egress."""
+    _home, secret = json_special_secret_home
+    arguments = json.dumps({"command": f"printf {secret}"})
+    tool_result = json.dumps(
+        {"result": {"credential": secret, "items": ["safe", secret]}},
+        separators=(",", ":"),
+    )
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-json-77487",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": arguments},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-json-77487",
+            "content": tool_result,
+        },
+    ]
+    original = copy.deepcopy(messages)
+
+    provider_bound = sanitize_api_messages(messages)
+
+    encoded_secret = json.dumps(secret)[1:-1]
+    provider_result = provider_bound[1]["content"]
+    assert encoded_secret not in provider_result
+    assert json.loads(provider_result) == {
+        "result": {"credential": "***", "items": ["safe", "***"]}
+    }
+    # Executable provider arguments and caller-owned history stay byte-exact.
+    assert provider_bound[0]["tool_calls"][0]["function"]["arguments"] == arguments
+    assert messages == original
+
+
+@pytest.mark.parametrize("alternate_spelling", ALTERNATE_JSON_SPELLINGS)
+def test_provider_copy_masks_equivalent_json_escape_spellings_without_mutation(
+    monkeypatch, alternate_spelling
+):
+    """Escaped solidus and Unicode spellings decode only to masked values."""
+    from hermes_cli import env_loader
+    from hermes_constants import get_hermes_home
+
+    home = get_hermes_home()
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(home.resolve()),
+        {"ALTERNATE_JSON_SECRET": ALTERNATE_JSON_SECRET},
+    )
+    content = _json_with_alternate_secret("credential", alternate_spelling)
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-alternate-provider-77487",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": content},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-alternate-provider-77487",
+            "content": content,
+        },
+    ]
+    original = copy.deepcopy(messages)
+
+    provider_bound = sanitize_api_messages(messages)
+
+    provider_content = provider_bound[1]["content"]
+    assert json.loads(provider_content) == {"credential": "***"}
+    assert ALTERNATE_JSON_SECRET not in provider_content
+    assert ALTERNATE_JSON_SPELLING not in provider_content
+    assert alternate_spelling not in provider_content
+    assert provider_bound[0]["tool_calls"][0]["function"]["arguments"] == content
+    assert messages == original
+
+
+@pytest.mark.parametrize("fragment_kind", MALFORMED_JSON_FRAGMENT_KINDS)
+def test_provider_copy_masks_malformed_alternate_json_fragments_without_mutation(
+    monkeypatch, fragment_kind
+):
+    """Incomplete or invalid quoting cannot bypass disposable provider masking."""
+    from hermes_cli import env_loader
+    from hermes_constants import get_hermes_home
+
+    home = get_hermes_home()
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(home.resolve()),
+        {"MALFORMED_JSON_SECRET": ALTERNATE_JSON_SECRET},
+    )
+    content = _malformed_json_with_alternate_secret("credential", fragment_kind)
+    messages = _paired_tool_result(content)
+    original = copy.deepcopy(messages)
+
+    provider_bound = sanitize_api_messages(messages)
+
+    assert "***" in provider_bound[-1]["content"]
+    assert ALTERNATE_JSON_SECRET not in provider_bound[-1]["content"]
+    assert ALTERNATE_JSON_SPELLING not in provider_bound[-1]["content"]
+    assert messages == original
+
+
+def test_valid_json_masks_only_string_values_and_preserves_structural_tokens(
+    tmp_path, monkeypatch
+):
+    """Credential-shaped punctuation cannot corrupt a valid JSON document."""
+    from agent.provider_redaction import redact_provider_message_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    secrets = {
+        "OPEN_TOKEN": "{",
+        "QUOTE_TOKEN": '"',
+        "COLON_TOKEN": ":",
+        "COMMA_TOKEN": ",",
+        "TRUE_TOKEN": "true",
+        "NULL_TOKEN": "null",
+        "NUMBER_TOKEN": "1",
+        "PAYLOAD_TOKEN": "actual-secret",
+    }
+    content = (
+        '{"true":true,"null":null,"number":1,'
+        '"items":["actual-secret","true","null","1","{","\\\"",":",","]}'
+    )
+    source = [{"role": "tool", "content": content}]
+    original = copy.deepcopy(source)
+
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope(secrets)
+    try:
+        provider_bound = redact_provider_message_values(source, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    assert json.loads(provider_bound[0]["content"]) == {
+        "true": True,
+        "null": None,
+        "number": 1,
+        "items": ["***"] * 8,
+    }
+    assert source == original
+
+
+def test_valid_json_masks_authoritative_object_key(tmp_path, monkeypatch):
+    """A credential used as a JSON key is still removed before provider egress."""
+    from agent.provider_redaction import redact_provider_message_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    secret = "credential-key-77487-super-long-value"
+    second_secret = "another-long-credential-key-77487"
+    numeric_secret = "839201774875551234567890123456"
+    source = [
+        {
+            "role": "tool",
+            "content": json.dumps(
+                {
+                    "***": "ordinary",
+                    secret: "tool-result",
+                    second_secret: "second-result",
+                    numeric_secret: "numeric-result",
+                }
+            ),
+        }
+    ]
+    original = copy.deepcopy(source)
+
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope(
+        {
+            "API_TOKEN": secret,
+            "SECOND_API_TOKEN": second_secret,
+            "NUMERIC_API_TOKEN": numeric_secret,
+        }
+    )
+    try:
+        provider_bound = redact_provider_message_values(source, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    redacted_object = json.loads(provider_bound[0]["content"])
+    assert secret not in provider_bound[0]["content"]
+    assert second_secret not in provider_bound[0]["content"]
+    assert numeric_secret not in provider_bound[0]["content"]
+    assert sorted(redacted_object.values()) == [
+        "numeric-result",
+        "ordinary",
+        "second-result",
+        "tool-result",
+    ]
+    assert len(redacted_object) == 4
+    assert source == original
+
+
+def test_valid_json_key_marker_avoids_later_existing_key(tmp_path, monkeypatch):
+    """Key-marker selection is independent of object-key ordering."""
+    from agent.provider_redaction import redact_provider_message_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    secret = "credential-key-77487-reverse-order"
+    source = [
+        {
+            "role": "tool",
+            "content": json.dumps({secret: "sensitive", "***": "ordinary"}),
+        }
+    ]
+    original = copy.deepcopy(source)
+
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope({"API_TOKEN": secret})
+    try:
+        provider_bound = redact_provider_message_values(source, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    redacted_object = json.loads(provider_bound[0]["content"])
+    assert secret not in provider_bound[0]["content"]
+    assert sorted(redacted_object.values()) == ["ordinary", "sensitive"]
+    assert len(redacted_object) == 2
+    assert source == original
+
+
+def test_valid_json_key_marker_avoids_partial_existing_key(tmp_path, monkeypatch):
+    """A marker cannot compose an existing key at a replacement boundary."""
+    from agent.provider_redaction import redact_provider_message_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    secret = "credential-key-77487"
+    source = [
+        {
+            "role": "tool",
+            "content": json.dumps(
+                {
+                    f"prefix{secret}": "sensitive",
+                    "prefix***": "ordinary",
+                }
+            ),
+        }
+    ]
+    original = copy.deepcopy(source)
+
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope({"API_TOKEN": secret})
+    try:
+        provider_bound = redact_provider_message_values(source, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    redacted_object = json.loads(provider_bound[0]["content"])
+    assert secret not in provider_bound[0]["content"]
+    assert sorted(redacted_object.values()) == ["ordinary", "sensitive"]
+    assert len(redacted_object) == 2
+    assert source == original
+
+
+def test_invalid_json_keeps_aggressive_structural_exact_masking(
+    tmp_path, monkeypatch
+):
+    """Malformed/non-JSON text retains the prior fail-closed raw scanner."""
+    from agent.provider_redaction import redact_known_secret_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    source = '{"flag":true'
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope({"TRUE_TOKEN": "true"})
+    try:
+        redacted = redact_known_secret_values(source, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    assert redacted == '{"flag":***'
+    assert source == '{"flag":true'
+
+
+def test_authoritative_short_secret_is_masked_even_when_concatenated(
+    tmp_path, monkeypatch
+):
+    from agent.provider_redaction import redact_known_secret_values
+    from hermes_cli import env_loader
+
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(tmp_path.resolve()),
+        {"ARBITRARY_EXTERNAL_NAME": "p4ss"},
+    )
+
+    assert redact_known_secret_values(
+        "p4ss field, p4ss123 and myp4ss all contain the credential",
+        home=tmp_path,
+    ) == "*** field, ***123 and my*** all contain the credential"
+
+
+def test_literal_only_exact_mask_skips_escape_scanner(monkeypatch):
+    """Plain text keeps exact masking without paying for escape decoding."""
+    from agent.provider_redaction import _compile_exact_secret_pattern, _redact_exact_with_pattern
+
+    pattern = _compile_exact_secret_pattern(("p4ss",))
+    monkeypatch.setattr(
+        "agent.provider_redaction._scan_json_string_fragment",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("escape scanner should not run")
+        ),
+    )
+
+    assert _redact_exact_with_pattern("plain p4ss text", pattern) == "plain *** text"
+    assert _redact_exact_with_pattern("plain safe text", pattern) == "plain safe text"
+
+
+def test_nested_escape_work_budget_exhaustion_fails_closed(monkeypatch):
+    """An uninspected derived layer is removed instead of forwarded."""
+    from agent.provider_redaction import _compile_exact_secret_pattern, _redact_exact_with_pattern
+
+    pattern = _compile_exact_secret_pattern((ALTERNATE_JSON_SECRET,))
+    source = _json_with_alternate_secret(
+        "credential", _nested_alternate_json_spelling(13)
+    )
+    original = source
+    monkeypatch.setattr(
+        "agent.provider_redaction._json_escape_decode_work_budget",
+        lambda text: len(text),
+    )
+
+    redacted = _redact_exact_with_pattern(source, pattern)
+
+    assert json.loads(redacted) == {"credential": "***"}
+    assert ALTERNATE_JSON_SECRET not in redacted
+    assert ALTERNATE_JSON_SPELLING not in redacted
+    assert source == original
+
+
+def test_exact_mask_chooses_marker_that_cannot_collide_with_active_secrets(
+    tmp_path, monkeypatch
+):
+    """Even marker-shaped and one-character credentials remain absent."""
+    from agent.provider_redaction import (
+        _compile_exact_secret_pattern,
+        redact_provider_message_values,
+    )
+    from hermes_cli import env_loader
+
+    secrets = ("***", "*", "[REDACTED]", "<redacted-secret>")
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(tmp_path.resolve()),
+        {f"COLLISION_SECRET_{index}": secret for index, secret in enumerate(secrets)},
+    )
+    matcher = _compile_exact_secret_pattern(secrets)
+    assert matcher is not None
+    assert matcher.replacement
+    assert all(
+        secret not in matcher.replacement and matcher.replacement not in secret
+        for secret in secrets
+    )
+
+    messages = [{"role": "tool", "content": " | ".join(secrets)}]
+    original = copy.deepcopy(messages)
+    provider_bound = redact_provider_message_values(messages, home=tmp_path)
+
+    assert all(secret not in provider_bound[0]["content"] for secret in secrets)
+    assert provider_bound[0]["content"] != original[0]["content"]
+    assert messages == original
+
+
+def test_provider_marker_repetition_cannot_synthesize_active_secret(
+    tmp_path, monkeypatch
+):
+    """Adjacent replacements remain safe under arbitrary marker composition."""
+    from hermes_cli import env_loader
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    active_secrets = ("***", "REDACTED][REDACTED")
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(tmp_path.resolve()),
+        {f"MARKER_SECRET_{index}": secret for index, secret in enumerate(active_secrets)},
+    )
+    source = _paired_tool_result("******")
+    original = copy.deepcopy(source)
+    token = set_hermes_home_override(tmp_path)
+    try:
+        provider_bound = sanitize_api_messages(source)
+    finally:
+        reset_hermes_home_override(token)
+
+    content = provider_bound[-1]["content"]
+    assert all(secret not in content for secret in active_secrets)
+    assert content != "[REDACTED][REDACTED]"
+    assert source == original
+
+
+def test_provider_marker_cannot_compose_with_unchanged_source_context(
+    tmp_path, monkeypatch
+):
+    """A replacement boundary cannot synthesize another active secret."""
+    from agent.provider_redaction import _compile_exact_secret_pattern
+    from hermes_cli import env_loader
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    active_secrets = ("x", "ab*")
+    matcher = _compile_exact_secret_pattern(active_secrets)
+    assert matcher is not None
+    assert matcher.replacement == "[REDACTED]"
+
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(tmp_path.resolve()),
+        {f"BOUNDARY_SECRET_{index}": secret for index, secret in enumerate(active_secrets)},
+    )
+    source = _paired_tool_result("abx")
+    original = copy.deepcopy(source)
+    token = set_hermes_home_override(tmp_path)
+    try:
+        provider_bound = sanitize_api_messages(source)
+    finally:
+        reset_hermes_home_override(token)
+
+    assert all(secret not in provider_bound[-1]["content"] for secret in active_secrets)
+    assert provider_bound[-1]["content"] == f"ab{matcher.replacement}"
+    assert source == original
+
+
+@pytest.mark.parametrize("layers", (1, 2, 5, 13))
+def test_provider_nested_unicode_json_escape_replaces_complete_valid_span(
+    tmp_path, monkeypatch, layers
+):
+    """A canonical suffix cannot corrupt its nested JSON escape container."""
+    from hermes_cli import env_loader
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    secret = "é"
+    spelling = _nest_json_string_spelling(json.dumps(secret)[1:-1], layers)
+    content = f'{{"x":"{spelling}"}}'
+    source = _paired_tool_result(content)
+    original = copy.deepcopy(source)
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(tmp_path.resolve()),
+        {"UNICODE_JSON_SECRET": secret},
+    )
+    token = set_hermes_home_override(tmp_path)
+    try:
+        provider_bound = sanitize_api_messages(source)
+    finally:
+        reset_hermes_home_override(token)
+
+    provider_content = provider_bound[-1]["content"]
+    assert json.loads(provider_content) == {"x": "***"}
+    assert secret not in provider_content
+    assert spelling not in provider_content
+    assert source == original
+
+
+@pytest.mark.parametrize("layers", (1, 2, 5, 13))
+def test_provider_simple_slash_json_escape_replaces_complete_valid_span(
+    tmp_path, monkeypatch, layers
+):
+    r"""A one-byte secret encoded as ``\/`` cannot leave invalid JSON."""
+    from hermes_cli import env_loader
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    secret = "/"
+    spelling = _nest_json_string_spelling(r"\/", layers)
+    content = f'{{"x":"{spelling}"}}'
+    source = _paired_tool_result(content)
+    original = copy.deepcopy(source)
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(tmp_path.resolve()),
+        {"SLASH_JSON_SECRET": secret},
+    )
+    token = set_hermes_home_override(tmp_path)
+    try:
+        provider_bound = sanitize_api_messages(source)
+    finally:
+        reset_hermes_home_override(token)
+
+    provider_content = provider_bound[-1]["content"]
+    assert json.loads(provider_content) == {"x": "***"}
+    assert secret not in provider_content
+    assert spelling not in provider_content
+    assert source == original
+
+
+def test_request_local_pattern_scope_rebinds_nested_same_home_profile(
+    tmp_path, monkeypatch
+):
+    """Operation-local reuse never turns into a stale home-only profile cache."""
+    from agent.provider_redaction import _exact_secret_pattern_scope, redact_known_secret_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    first = "first-profile-secret-77487"
+    second = "second-profile-secret-77487"
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    first_token = set_secret_scope({"ACTIVE_PROFILE_TOKEN": first})
+    try:
+        with _exact_secret_pattern_scope(home=tmp_path):
+            assert redact_known_secret_values(first, home=tmp_path) == "***"
+            second_token = set_secret_scope({"ACTIVE_PROFILE_TOKEN": second})
+            try:
+                with _exact_secret_pattern_scope(home=tmp_path):
+                    assert (
+                        redact_known_secret_values(
+                            f"{first} | {second}", home=tmp_path
+                        )
+                        == f"{first} | ***"
+                    )
+            finally:
+                reset_secret_scope(second_token)
+            assert redact_known_secret_values(first, home=tmp_path) == "***"
+    finally:
+        reset_secret_scope(first_token)
+
+
+def test_provider_copy_reuses_operation_local_exact_pattern(tmp_path, monkeypatch):
+    """Provider-copy redaction shares the request's immutable secret snapshot."""
+    import agent.provider_redaction as redact
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    secret = "p4ss"
+    source = [{"role": "tool", "content": secret}]
+    original = copy.deepcopy(source)
+    collections = 0
+
+    def collect_exact_secret_values(home):
+        nonlocal collections
+        collections += 1
+        return (secret,)
+
+    monkeypatch.setattr(
+        redact, "_collect_exact_secret_values", collect_exact_secret_values
+    )
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope({"ACTIVE_TOKEN": secret})
+    try:
+        with redact._exact_secret_pattern_scope(home=tmp_path):
+            first = redact.redact_provider_message_values(source, home=tmp_path)
+            second = redact.redact_provider_message_values(source, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    assert collections == 1
+    assert first[0]["content"] == "***"
+    assert second[0]["content"] == "***"
+    assert source == original
+
+
+def test_operation_pattern_scope_retains_scope_identity(tmp_path, monkeypatch):
+    """The cache owns its scope object so numeric identity cannot be reused."""
+    import agent.provider_redaction as redact
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    secret = "r8$!"
+    scope = {"ACTIVE_TOKEN": secret}
+    monkeypatch.setattr(
+        redact, "_collect_exact_secret_values", lambda home: (secret,)
+    )
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope(scope)
+    try:
+        with redact._exact_secret_pattern_scope(home=tmp_path):
+            cached = redact._EXACT_SECRET_PATTERN_SCOPE.get()
+
+            assert cached is not None
+            assert cached[0] == (str(tmp_path.resolve()), True)
+            assert cached[1] is scope
+            assert cached[2] is not None
+    finally:
+        reset_secret_scope(token)
+
+
+@pytest.mark.parametrize("source_kind", ("process", "scope", "multiplex"))
+def test_config_style_credential_suffixes_do_not_mask_provider_text(
+    tmp_path, monkeypatch, source_kind
+):
+    """Flag-shaped ambient settings do not become transcript-wide secrets."""
+    import agent.provider_redaction as redact
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+    from hermes_cli import env_loader
+
+    settings = {
+        "SKIP_AUTH": "false",
+        "DEBUG_AUTH": "true",
+        "REQUIRE_AUTH": "1",
+        "USE_TOKEN": "true",
+        "SHOW_PASSWORD": "false",
+        "AUTH_USE_AUTH": "false",
+    }
+    credentials = {
+        "PASSWORD": "p4ss",
+        "REFRESH_TOKEN": "r8$!",
+    }
+    environment = {**settings, **credentials}
+    content = " | ".join(f"{name}={value}" for name, value in environment.items())
+    source = [{"role": "tool", "content": content}]
+    original = copy.deepcopy(source)
+
+    monkeypatch.setattr(env_loader, "get_secret_source_values", lambda home: {})
+    monkeypatch.setattr(
+        redact.os, "environ", environment if source_kind == "process" else {}
+    )
+    monkeypatch.setattr(
+        "agent.secret_scope._MULTIPLEX_ACTIVE", source_kind == "multiplex"
+    )
+    token = set_secret_scope(environment if source_kind != "process" else None)
+    try:
+        provider_bound = redact.redact_provider_message_values(source, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    provider_content = provider_bound[0]["content"]
+    assert all(
+        f"{name}={value}" in provider_content for name, value in settings.items()
+    )
+    assert "PASSWORD=p4ss" not in provider_content
+    assert "REFRESH_TOKEN=r8$!" not in provider_content
+    assert provider_content.endswith("PASSWORD=*** | REFRESH_TOKEN=***")
+    assert source == original
+
+
+@pytest.mark.parametrize("source_kind", ("process", "scope", "multiplex"))
+def test_config_style_names_with_arbitrary_short_values_remain_secrets(
+    tmp_path, monkeypatch, source_kind
+):
+    """Name-shape exclusions do not create a blanket short-secret bypass."""
+    import agent.provider_redaction as redact
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+    from hermes_cli import env_loader
+
+    credentials = {
+        "SKIP_AUTH": "p4ss",
+        "USE_TOKEN": "r8$!",
+    }
+    source = [
+        {
+            "role": "tool",
+            "content": "SKIP_AUTH=p4ss | USE_TOKEN=r8$!",
+        }
+    ]
+    original = copy.deepcopy(source)
+
+    monkeypatch.setattr(env_loader, "get_secret_source_values", lambda home: {})
+    monkeypatch.setattr(
+        redact.os, "environ", credentials if source_kind == "process" else {}
+    )
+    monkeypatch.setattr(
+        "agent.secret_scope._MULTIPLEX_ACTIVE", source_kind == "multiplex"
+    )
+    token = set_secret_scope(credentials if source_kind != "process" else None)
+    try:
+        provider_bound = redact.redact_provider_message_values(source, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    assert provider_bound[0]["content"] == "SKIP_AUTH=*** | USE_TOKEN=***"
+    assert source == original
+
+
+def test_authoritative_scoped_credential_aliases_are_literal_matched(tmp_path):
+    from agent.provider_redaction import redact_known_secret_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    secrets = {
+        "MYSQL_PASS": "scope-pass-77487",
+        "DB_PASSWD": "scope-passwd-77487",
+        "DB_PW": "scope-pw-77487",
+        "PGPASSWORD": "scope-pgpassword-77487",
+        "MYSQL_PWD": "scope-mysql-pwd-77487",
+        "PASSWORD": "scope-password-77487",
+        "PASSWD": "scope-bare-passwd-77487",
+        "PASS": "scope-bare-pass-77487",
+        "PW": "scope-bare-pw-77487",
+        "REDISCLI_AUTH": "scope-redis-auth-77487",
+        "VAULT_CREDENTIAL": "scope-vault-credential-77487",
+        "SERVICE_CREDENTIALS": "scope-service-credentials-77487",
+        "PROXY_AUTH": "scope-proxy-auth-77487",
+        # A terminal substring is not enough: source-name classification must
+        # remain narrow so ordinary process configuration is not collected.
+        "COMPASS": "scope-noncredential-77487",
+        "AUTH_USE_AUTH": "true",
+    }
+    token = set_secret_scope(secrets)
+    try:
+        text = " | ".join(secrets.values())
+        redacted = redact_known_secret_values(text, home=tmp_path)
+
+        for name, secret in secrets.items():
+            if name not in {"COMPASS", "AUTH_USE_AUTH"}:
+                assert secret not in redacted
+        assert redacted.endswith("scope-noncredential-77487 | true")
+    finally:
+        reset_secret_scope(token)
+
+
+def test_ordinary_scoped_key_names_do_not_corrupt_provider_content(tmp_path):
+    """Generic ``*_KEY`` configuration values are not exact-mask inputs."""
+    from agent.provider_redaction import redact_provider_message_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    ordinary = {
+        "PARTITION_KEY": "default",
+        "SORT_KEY": "id",
+        "CACHE_KEY": "cache-name",
+        "IDEMPOTENCY_KEY": "request-id",
+        "AUTH_USE_AUTH": "true",
+    }
+    credentials = {
+        "SERVICE_API_KEY": "scoped-api-key-77487",
+        "SERVICE_TOKEN": "scoped-token-77487",
+        "SERVICE_SECRET": "scoped-secret-77487",
+        "SERVICE_PASSWORD": "scoped-password-77487",
+        "FAL_KEY": "scoped-fal-key-77487",
+        "API_SERVER_KEY": "scoped-server-key-77487",
+        "AZURE_ANTHROPIC_KEY": "scoped-azure-key-77487",
+        "VOICE_TOOLS_OPENAI_KEY": "scoped-voice-key-77487",
+        "PORCUPINE_ACCESS_KEY": "scoped-access-key-77487",
+        "AWS_SECRET_ACCESS_KEY": "scoped-aws-key-77487",
+    }
+    source = [
+        {
+            "role": "tool",
+            "content": " | ".join((*ordinary.values(), *credentials.values())),
+        }
+    ]
+    token = set_secret_scope({**ordinary, **credentials})
+    try:
+        provider_bound = redact_provider_message_values(source, home=tmp_path)
+
+        content = provider_bound[0]["content"]
+        assert all(value in content for value in ordinary.values())
+        assert all(value not in content for value in credentials.values())
+        assert source[0]["content"] == " | ".join(
+            (*ordinary.values(), *credentials.values())
+        )
+    finally:
+        reset_secret_scope(token)
+
+
+def test_auth_use_auth_arbitrary_scope_value_is_masked(tmp_path):
+    """Honcho's exact flag name is exempt only for documented flag values."""
+    from agent.provider_redaction import redact_provider_message_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    source = [{"role": "tool", "content": "AUTH_USE_AUTH=p4ss"}]
+    original = copy.deepcopy(source)
+    token = set_secret_scope({"AUTH_USE_AUTH": "p4ss"})
+    try:
+        provider_bound = redact_provider_message_values(source, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    assert provider_bound[0]["content"] == "AUTH_USE_AUTH=***"
+    assert source == original
+
+
+def test_multiplex_scoped_credential_suffixes_mask_immutable_provider_copy(
+    tmp_path, monkeypatch
+):
+    """Profile-only repository aliases are removed at provider egress."""
+    from agent.provider_redaction import redact_provider_message_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    credentials = {
+        "VAULT_CREDENTIAL": "multiplex-vault-credential-77487",
+        "SERVICE_CREDENTIALS": "multiplex-service-credentials-77487",
+        "PROXY_AUTH": "multiplex-proxy-auth-77487",
+    }
+    source = [{"role": "tool", "content": " | ".join(credentials.values())}]
+    original = copy.deepcopy(source)
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope(credentials)
+    try:
+        provider_bound = redact_provider_message_values(source, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    assert provider_bound[0]["content"] == "*** | *** | ***"
+    assert source == original
+
+
+@pytest.mark.parametrize("source_kind", ("process", "scope", "multiplex"))
+def test_repository_bearer_aliases_mask_immutable_provider_copy(
+    tmp_path, monkeypatch, source_kind
+):
+    """Exact Bedrock and A2A aliases are credentials without broadening bearer."""
+    import agent.provider_redaction as redact
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+    from hermes_cli import env_loader
+
+    credentials = {
+        "AWS_BEARER_TOKEN_BEDROCK": "bedrock-bearer-77487",
+        "A2A_BEARER_TOKEN": "a2a-bearer-77487",
+    }
+    source = [{"role": "tool", "content": " | ".join(credentials.values())}]
+    original = copy.deepcopy(source)
+
+    monkeypatch.setattr(env_loader, "get_secret_source_values", lambda home: {})
+    monkeypatch.setattr(
+        redact.os, "environ", credentials if source_kind == "process" else {}
+    )
+    monkeypatch.setattr(
+        "agent.secret_scope._MULTIPLEX_ACTIVE", source_kind == "multiplex"
+    )
+    token = set_secret_scope(credentials if source_kind != "process" else None)
+    try:
+        provider_bound = redact.redact_provider_message_values(source, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    assert provider_bound[0]["content"] == "*** | ***"
+    assert source == original
+
+
+def test_provider_copy_preserves_controls_and_binary_data_but_masks_visible_values(
+    tmp_path, monkeypatch
+):
+    """Short-secret collisions cannot corrupt valid multimodal request fields."""
+    from agent.provider_redaction import redact_provider_message_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    controls = {
+        "DATA_TOKEN": "A",
+        "TTL_TOKEN": "1h",
+        "DETAIL_TOKEN": "high",
+        "MEDIA_TOKEN": "image/png",
+        "TYPE_TOKEN": "text",
+        "ROLE_TOKEN": "user",
+        "ID_TOKEN": "block-1",
+        "NAME_TOKEN": "fixture-name",
+        "TOOL_CALL_TOKEN": "tool-call-1",
+        "CALL_TOKEN": "call-1",
+        "CACHE_TOKEN": "ephemeral",
+    }
+    visible = " | ".join(controls.values())
+    source = [
+        {
+            "role": "user",
+            "id": "block-1",
+            "name": "fixture-name",
+            "tool_call_id": "tool-call-1",
+            "tool_use_id": "tool-call-1",
+            "call_id": "call-1",
+            "content": [
+                {
+                    "type": "text",
+                    "id": "block-1",
+                    "name": "fixture-name",
+                    "tool_call_id": "tool-call-1",
+                    "tool_use_id": "tool-call-1",
+                    "call_id": "call-1",
+                    "text": visible,
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "https://example.test/A?ttl=1h",
+                        "detail": "high",
+                    },
+                },
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/png",
+                        "data": "A",
+                    },
+                    "cache_control": {"type": "ephemeral", "ttl": "1h"},
+                },
+            ],
+        }
+    ]
+    original = copy.deepcopy(source)
+
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope(controls)
+    try:
+        provider_bound = redact_provider_message_values(source, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    message = provider_bound[0]
+    text_block, image_url_block, image_block = message["content"]
+    assert message["role"] == "user"
+    assert message["id"] == "block-1"
+    assert message["name"] == "fixture-name"
+    assert message["tool_call_id"] == "tool-call-1"
+    assert message["tool_use_id"] == "tool-call-1"
+    assert message["call_id"] == "call-1"
+    assert text_block["type"] == "text"
+    assert text_block["id"] == "block-1"
+    assert text_block["name"] == "fixture-name"
+    assert text_block["tool_call_id"] == "tool-call-1"
+    assert text_block["tool_use_id"] == "tool-call-1"
+    assert text_block["call_id"] == "call-1"
+    assert all(secret not in text_block["text"] for secret in controls.values())
+    assert image_url_block["image_url"]["detail"] == "high"
+    assert "A" not in image_url_block["image_url"]["url"]
+    assert "1h" not in image_url_block["image_url"]["url"]
+    assert image_block["source"] == {
+        "type": "base64",
+        "media_type": "image/png",
+        "data": "A",
+    }
+    assert image_block["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+    assert source == original
+
+
+def test_provider_copy_preserves_valid_base64_data_uri_payload(tmp_path, monkeypatch):
+    """Opaque data-URI bytes stay valid when a short secret collides."""
+    from agent.provider_redaction import redact_provider_message_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    source = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,AAAA"},
+                }
+            ],
+        }
+    ]
+    original = copy.deepcopy(source)
+
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope({"PASSWORD": "A", "MEDIA_TOKEN": "image/png"})
+    try:
+        provider_bound = redact_provider_message_values(source, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    assert provider_bound[0]["content"][0]["image_url"]["url"] == (
+        "data:image/png;base64,AAAA"
+    )
+    assert source == original
+
+
+def test_final_native_image_url_preserves_base64_data_uri(tmp_path, monkeypatch):
+    """Codex-native input_image URLs keep opaque base64 payloads valid."""
+    from agent.provider_redaction import redact_provider_api_kwargs
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    source = {
+        "input": [
+            {"type": "input_image", "image_url": "data:image/png;base64,AAAA"}
+        ]
+    }
+    original = copy.deepcopy(source)
+
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope({"PASSWORD": "A"})
+    try:
+        provider_bound = redact_provider_api_kwargs(source, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    assert provider_bound["input"][0]["image_url"] == (
+        "data:image/png;base64,AAAA"
+    )
+    assert source == original
+
+
+def test_final_provider_kwargs_gate_preserves_native_executable_replay(
+    tmp_path, monkeypatch
+):
+    """Provider-native arguments stay exact while adjacent text is masked."""
+    from agent.provider_redaction import redact_provider_api_kwargs
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    secret = "p4ss"
+    source = {
+        "model": "fixture-model",
+        "system": [{"text": f"system sees {secret}"}],
+        "messages": [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": f"visible {secret}"},
+                    {
+                        "type": "tool_use",
+                        "id": "call-anthropic",
+                        "name": "terminal",
+                        "input": {"command": f"printf {secret}"},
+                    },
+                    {
+                        "toolUse": {
+                            "toolUseId": "call-bedrock",
+                            "name": "terminal",
+                            "input": {"command": f"printf {secret}"},
+                        }
+                    },
+                ],
+            }
+        ],
+    }
+    original = copy.deepcopy(source)
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope({"REPLAY_PASSWORD": secret})
+    try:
+        dispatched = redact_provider_api_kwargs(source, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    content = dispatched["messages"][0]["content"]
+    assert dispatched["system"] == [{"text": "system sees ***"}]
+    assert content[0]["text"] == "visible ***"
+    assert content[1]["input"] == {"command": f"printf {secret}"}
+    assert content[2]["toolUse"]["input"] == {"command": f"printf {secret}"}
+    assert source == original
+
+
+
+
+
+
+def test_codex_harmony_preflight_cannot_compose_final_provider_secret(
+    tmp_path, monkeypatch
+):
+    """The real Codex preflight is followed by a provider-native payload gate."""
+    from agent.provider_redaction import (
+        redact_provider_api_kwargs,
+        redact_provider_message_values,
+    )
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+    from agent.transports.codex import ResponsesApiTransport
+
+    secret = "<｜start｜>"
+    source = {
+        "model": "gpt-5-codex",
+        "instructions": "guard <|start|>",
+        "input": [{"role": "user", "content": "payload <|start|>"}],
+        "store": False,
+    }
+    original = copy.deepcopy(source)
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope({"HARMONY_TOKEN": secret})
+    try:
+        pre_gate = dict(source)
+        pre_gate["input"] = redact_provider_message_values(
+            source["input"],
+            home=tmp_path,
+        )
+        preflight = ResponsesApiTransport().preflight_kwargs(
+            pre_gate,
+            allow_stream=False,
+            sanitize_harmony_tokens=True,
+        )
+        assert secret in preflight["instructions"]
+        assert secret in preflight["input"][0]["content"]
+        dispatched = redact_provider_api_kwargs(preflight, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    assert dispatched["instructions"] == "guard ***"
+    assert dispatched["input"][0]["content"] == "payload ***"
+    assert source == original
+
+
+def test_creds_and_bearer_suffixes_require_authoritative_source(
+    tmp_path, monkeypatch
+):
+    """Undeclared ambient aliases stay visible; source-backed values do not."""
+    from agent.provider_redaction import redact_known_secret_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+    from hermes_cli import env_loader
+
+    aliases = {
+        "LEGACY_CREDS": "source-backed-creds-77487",
+        "EDGE_BEARER": "source-backed-bearer-77487",
+    }
+    text = " | ".join(aliases.values())
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope(aliases)
+    try:
+        assert redact_known_secret_values(text, home=tmp_path) == text
+        monkeypatch.setitem(
+            env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+            str(tmp_path.resolve()),
+            aliases,
+        )
+        assert redact_known_secret_values(text, home=tmp_path) == "*** | ***"
+    finally:
+        reset_secret_scope(token)
+
+
+def test_repository_declared_plugin_credentials_are_value_sensitively_masked(
+    tmp_path,
+):
+    """Password metadata covers exact plugin names without masking SA paths."""
+    from agent.provider_redaction import redact_known_secret_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    chat_inline_service_account = json.dumps(
+        {
+            "type": "service_account",
+            "private_key": "inline-google-private-key-77487",
+        }
+    )
+    application_inline_service_account = json.dumps(
+        {
+            "type": "service_account",
+            "private_key": "application-default-private-key-77487",
+        }
+    )
+    credentials = {
+        "BUZZ_PRIVATE_KEY": "buzz-private-key-77487",
+        "A2A_PEER_TOKENS": "alice:a2a-peer-token-77487",
+        "GOOGLE_CHAT_SERVICE_ACCOUNT_JSON": chat_inline_service_account,
+        "GOOGLE_APPLICATION_CREDENTIALS": application_inline_service_account,
+        "GOOGLE_PRIVATE_KEY_TOKEN": "inline-google-private-key-77487",
+    }
+    token = set_secret_scope(credentials)
+    try:
+        redacted = redact_known_secret_values(
+            " | ".join(credentials.values()), home=tmp_path
+        )
+        assert redacted == "*** | *** | *** | *** | ***"
+    finally:
+        reset_secret_scope(token)
+
+
+def test_a2a_peer_token_container_collects_each_parsed_token(tmp_path):
+    """A peer echo exposes a component, not the full configured container."""
+    from agent.provider_redaction import redact_known_secret_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    token = set_secret_scope(
+        {
+            "A2A_PEER_TOKENS": (
+                "alice:a2a-alice-token-77487, malformed, "
+                "bob: a2a-bob-token-77487, empty:"
+            )
+        }
+    )
+    try:
+        assert redact_known_secret_values(
+            "alice=a2a-alice-token-77487 bob=a2a-bob-token-77487 "
+            "ordinary=malformed",
+            home=tmp_path,
+        ) == "alice=*** bob=*** ordinary=malformed"
+    finally:
+        reset_secret_scope(token)
+
+
+def test_inline_google_credentials_collect_private_scalar_not_public_metadata(
+    tmp_path,
+):
+    """Reformatted inline JSON still masks private key scalar echoes only."""
+    from agent.provider_redaction import redact_known_secret_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    private_key = "google-private-key-scalar-77487"
+    project_id = "public-project-id-77487"
+    inline = json.dumps(
+        {
+            "project_id": project_id,
+            "private_key": private_key,
+            "type": "service_account",
+        },
+        indent=2,
+        sort_keys=True,
+    )
+    token = set_secret_scope({"GOOGLE_APPLICATION_CREDENTIALS": inline})
+    try:
+        assert redact_known_secret_values(
+            f"private={private_key} project={project_id}", home=tmp_path
+        ) == f"private=*** project={project_id}"
+    finally:
+        reset_secret_scope(token)
+
+    token = set_secret_scope(
+        {"GOOGLE_APPLICATION_CREDENTIALS": "/run/secrets/google-credentials.json"}
+    )
+    try:
+        path = "/run/secrets/google-credentials.json"
+        assert redact_known_secret_values(path, home=tmp_path) == path
+    finally:
+        reset_secret_scope(token)
+
+    chat_service_account_path = "/run/secrets/google-chat-service-account.json"
+    application_credentials_path = "/run/secrets/application-default.json"
+    token = set_secret_scope({
+        "GOOGLE_CHAT_SERVICE_ACCOUNT_JSON": chat_service_account_path,
+        "GOOGLE_APPLICATION_CREDENTIALS": application_credentials_path,
+    })
+    try:
+        assert (
+            redact_known_secret_values(
+                f"{chat_service_account_path} | {application_credentials_path}",
+                home=tmp_path,
+            )
+            == f"{chat_service_account_path} | {application_credentials_path}"
+        )
+    finally:
+        reset_secret_scope(token)
+
+
+def test_ordinary_process_key_names_do_not_corrupt_provider_content(
+    tmp_path, monkeypatch
+):
+    """Single-profile process fallback applies the same narrow classifier."""
+    from agent.provider_redaction import redact_provider_message_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    ordinary = {
+        "PARTITION_KEY": "default",
+        "SORT_KEY": "id",
+        "CACHE_KEY": "cache-name",
+        "IDEMPOTENCY_KEY": "request-id",
+    }
+    credentials = {
+        "SERVICE_API_KEY": "process-api-key-77487",
+        "FAL_KEY": "process-fal-key-77487",
+    }
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", False)
+    for name, value in {**ordinary, **credentials}.items():
+        monkeypatch.setenv(name, value)
+    token = set_secret_scope(None)
+    try:
+        source = [
+            {
+                "role": "tool",
+                "content": " | ".join((*ordinary.values(), *credentials.values())),
+            }
+        ]
+        provider_bound = redact_provider_message_values(source, home=tmp_path)
+
+        content = provider_bound[0]["content"]
+        assert all(value in content for value in ordinary.values())
+        assert all(value not in content for value in credentials.values())
+    finally:
+        reset_secret_scope(token)
+
+
+def test_single_profile_scope_overlays_process_credentials_by_name(
+    tmp_path, monkeypatch
+):
+    """A nonempty scope keeps process-only credentials, with scope winning."""
+    from agent.provider_redaction import redact_known_secret_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", False)
+    monkeypatch.setenv("PROCESS_ONLY_TOKEN", "process-only-token-77487")
+    monkeypatch.setenv("SHARED_TOKEN", "shadowed-process-token-77487")
+    token = set_secret_scope(
+        {
+            "SCOPE_ONLY_API_KEY": "scope-only-key-77487",
+            "SHARED_TOKEN": "scope-wins-token-77487",
+        }
+    )
+    try:
+        redacted = redact_known_secret_values(
+            " | ".join(
+                (
+                    "process-only-token-77487",
+                    "scope-only-key-77487",
+                    "scope-wins-token-77487",
+                    "shadowed-process-token-77487",
+                )
+            ),
+            home=tmp_path,
+        )
+        assert redacted == "*** | *** | *** | shadowed-process-token-77487"
+    finally:
+        reset_secret_scope(token)
+
+
+def test_multiplex_scope_does_not_collect_process_only_credentials(
+    tmp_path, monkeypatch
+):
+    """Active multiplexing keeps process-global sibling credentials opaque."""
+    from agent.provider_redaction import redact_known_secret_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    monkeypatch.setenv("PROCESS_ONLY_TOKEN", "other-profile-token-77487")
+    monkeypatch.setenv(
+        "PROCESS_ONLY_CREDENTIAL", "other-profile-credential-77487"
+    )
+    token = set_secret_scope(
+        {
+            "SCOPE_ONLY_TOKEN": "active-profile-token-77487",
+            "SCOPE_ONLY_AUTH": "active-profile-auth-77487",
+        }
+    )
+    try:
+        assert redact_known_secret_values(
+            "other-profile-token-77487 | other-profile-credential-77487 | "
+            "active-profile-token-77487 | active-profile-auth-77487",
+            home=tmp_path,
+        ) == "other-profile-token-77487 | other-profile-credential-77487 | *** | ***"
+    finally:
+        reset_secret_scope(token)
+
+
+@pytest.mark.parametrize(
+    ("name", "secret"),
+    [
+        ("MYSQL_PASS", "process-pass-77487"),
+        ("DB_PASSWD", "process-passwd-77487"),
+        ("DB_PW", "process-pw-77487"),
+        ("PGPASSWORD", "process-pgpassword-77487"),
+        ("MYSQL_PWD", "process-mysql-pwd-77487"),
+        ("PASSWORD", "process-password-77487"),
+        ("PASSWD", "process-bare-passwd-77487"),
+        ("PASS", "process-bare-pass-77487"),
+        ("PW", "process-bare-pw-77487"),
+        ("REDISCLI_AUTH", "process-redis-auth-77487"),
+        ("VAULT_CREDENTIAL", "process-vault-credential-77487"),
+        ("SERVICE_CREDENTIALS", "process-service-credentials-77487"),
+        ("PROXY_AUTH", "process-proxy-auth-77487"),
+    ],
+)
+def test_single_profile_process_credential_alias_is_literal_matched(
+    tmp_path, monkeypatch, name, secret
+):
+    from agent.provider_redaction import redact_known_secret_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", False)
+    monkeypatch.setenv(name, secret)
+    token = set_secret_scope(None)
+    try:
+        assert redact_known_secret_values(
+            f"bare value: {secret}", home=tmp_path
+        ) == "bare value: ***"
+    finally:
+        reset_secret_scope(token)
+
+
+def test_historical_argument_fields_remain_exact_for_replay(applied_secret_home):
+    """#43083 applies to modern and legacy replay argument shapes."""
+    from agent.provider_redaction import redact_provider_message_values
+
+    _home, secret = applied_secret_home
+    arguments = json.dumps({"command": f"echo {secret}"})
+    messages = [
+        {
+            "role": "assistant",
+            "content": f"provider-visible prose {secret}",
+            "tool_calls": [
+                {
+                    "id": "call_77487",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": arguments},
+                }
+            ],
+            "function_call": {"name": "terminal", "arguments": arguments},
+        }
+    ]
+    original = copy.deepcopy(messages)
+
+    provider_bound = redact_provider_message_values(messages)
+
+    assert secret not in provider_bound[0]["content"]
+    assert provider_bound[0]["tool_calls"][0]["function"]["arguments"] == arguments
+    assert provider_bound[0]["function_call"]["arguments"] == arguments
+    assert messages == original
+
+
+def test_provider_exact_value_mask_respects_redaction_opt_out(
+    applied_secret_home, monkeypatch
+):
+    _home, secret = applied_secret_home
+    messages = _paired_messages(secret)
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+
+    provider_bound = sanitize_api_messages(messages)
+
+    assert provider_bound[1]["content"][0]["text"] == (
+        f"first={secret}; second={secret}"
+    )
+    assert provider_bound[1]["content"][1]["image_url"]["url"] == (
+        f"https://example.invalid/{secret}/{secret}/image.png"
+    )
+
+
+def _response(content: str) -> SimpleNamespace:
+    message = SimpleNamespace(content=content, tool_calls=[])
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], usage=None, model="fixture-model")
+
+
+def _auxiliary_replay_messages(secret: str) -> list[dict]:
+    return [
+        {
+            "role": "assistant",
+            "content": f"visible auxiliary content {secret}",
+            "tool_calls": [
+                {
+                    "id": "call-auxiliary-77487",
+                    "type": "function",
+                    "function": {
+                        "name": "terminal",
+                        "arguments": json.dumps({"command": f"printf {secret}"}),
+                    },
+                }
+            ],
+            "anthropic_content_blocks": [
+                {
+                    "type": "thinking",
+                    "thinking": f"signed thought {secret}",
+                    "signature": "signed-auxiliary-77487",
+                },
+                {"type": "text", "text": f"signed sequence text {secret}"},
+            ],
+            "reasoning_details": [
+                {"type": "reasoning.text", "text": f"signed detail {secret}"}
+            ],
+            "codex_reasoning_items": [
+                {"type": "reasoning", "encrypted_content": f"sealed-{secret}"}
+            ],
+        }
+    ]
+
+
+def test_sync_auxiliary_boundary_masks_disposable_provider_messages(
+    applied_secret_home, monkeypatch
+):
+    """Direct auxiliary callers cannot bypass the provider-copy gate."""
+    import agent.auxiliary_client as auxiliary_client
+
+    _home, secret = applied_secret_home
+    source = _auxiliary_replay_messages(secret)
+    original = copy.deepcopy(source)
+    captured = {}
+    sentinel = _response("safe")
+
+    def fake_impl(**kwargs):
+        captured.update(copy.deepcopy(kwargs))
+        return sentinel
+
+    monkeypatch.setattr(auxiliary_client, "_call_llm_impl", fake_impl)
+
+    assert auxiliary_client.call_llm(messages=source) is sentinel
+    outbound = captured["messages"][0]
+    assert secret not in outbound["content"]
+    assert outbound["tool_calls"] == original[0]["tool_calls"]
+    assert outbound["anthropic_content_blocks"] == original[0][
+        "anthropic_content_blocks"
+    ]
+    assert outbound["reasoning_details"] == original[0]["reasoning_details"]
+    assert outbound["codex_reasoning_items"] == original[0]["codex_reasoning_items"]
+    assert source == original
+
+
+def test_async_auxiliary_boundary_masks_disposable_provider_messages(
+    applied_secret_home, monkeypatch
+):
+    """The async central boundary enforces the same immutable provider copy."""
+    import agent.auxiliary_client as auxiliary_client
+
+    _home, secret = applied_secret_home
+    source = _auxiliary_replay_messages(secret)
+    original = copy.deepcopy(source)
+    captured = {}
+    sentinel = _response("safe")
+
+    async def fake_impl(**kwargs):
+        captured.update(copy.deepcopy(kwargs))
+        return sentinel
+
+    monkeypatch.setattr(auxiliary_client, "_async_call_llm_impl", fake_impl)
+
+    assert asyncio.run(auxiliary_client.async_call_llm(messages=source)) is sentinel
+    assert secret not in captured["messages"][0]["content"]
+    assert captured["messages"][0]["tool_calls"] == original[0]["tool_calls"]
+    assert source == original
+
+
+def test_async_auxiliary_redaction_offloads_with_context_scope(
+    tmp_path, monkeypatch
+):
+    """Thread offload keeps the active multiplex profile's ContextVar secrets."""
+    import agent.auxiliary_client as auxiliary_client
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    secret = "async-context-secret-77487"
+    source = [{"role": "tool", "content": f"thread result {secret}"}]
+    captured = {}
+    offloads = []
+    sentinel = _response("safe")
+    real_to_thread = asyncio.to_thread
+
+    async def spy_to_thread(func, /, *args, **kwargs):
+        offloads.append(func)
+        return await real_to_thread(func, *args, **kwargs)
+
+    async def fake_impl(**kwargs):
+        captured.update(copy.deepcopy(kwargs))
+        return sentinel
+
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    monkeypatch.setattr(asyncio, "to_thread", spy_to_thread)
+    monkeypatch.setattr(auxiliary_client, "_async_call_llm_impl", fake_impl)
+    token = set_secret_scope({"ACTIVE_PROFILE_TOKEN": secret})
+    try:
+        assert asyncio.run(auxiliary_client.async_call_llm(messages=source)) is sentinel
+    finally:
+        reset_secret_scope(token)
+
+    assert offloads
+    assert secret not in captured["messages"][0]["content"]
+    assert source == [{"role": "tool", "content": f"thread result {secret}"}]
+
+
+def test_auxiliary_boundary_respects_explicit_redaction_opt_out(
+    applied_secret_home, monkeypatch
+):
+    import agent.auxiliary_client as auxiliary_client
+
+    _home, secret = applied_secret_home
+    source = _auxiliary_replay_messages(secret)
+    captured = {}
+
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_call_llm_impl",
+        lambda **kwargs: captured.update(kwargs) or _response("safe"),
+    )
+
+    auxiliary_client.call_llm(messages=source)
+
+    assert captured["messages"] is source
+    assert secret in captured["messages"][0]["content"]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+def test_anthropic_signed_ordered_replay_is_preserved_as_one_opaque_sequence(
+    applied_secret_home,
+):
+    """Signed replay keeps every ordered block byte-exact and in place."""
+    from agent.anthropic_adapter import convert_messages_to_anthropic
+
+    _home, secret = applied_secret_home
+    arguments = json.dumps({"command": f"printf {secret}"})
+    ordered = [
+        {
+            "type": "thinking",
+            "thinking": f"first signed reasoning stays byte exact {secret}",
+            "signature": "sig-first-77487",
+        },
+        {"type": "text", "text": f"signature-bound provider text {secret}"},
+        {
+            "type": "thinking",
+            "thinking": f"second signed reasoning stays byte exact {secret}",
+            "signature": "sig-second-77487",
+        },
+        {
+            "type": "tool_use",
+            "id": "toolu_77487",
+            "name": "terminal",
+            "input": {"command": f"printf {secret}"},
+        },
+    ]
+    messages = [
+        {"role": "user", "content": "continue"},
+        {
+            "role": "assistant",
+            "content": f"fallback content {secret}",
+            "reasoning_details": [ordered[0]],
+            "tool_calls": [
+                {
+                    "id": "toolu_77487",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": arguments},
+                }
+            ],
+            "anthropic_content_blocks": ordered,
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "toolu_77487",
+            "content": "done",
+        },
+    ]
+    original = copy.deepcopy(messages)
+
+    provider_bound = sanitize_api_messages(messages)
+    _system, anthropic_messages = convert_messages_to_anthropic(
+        provider_bound,
+        base_url=None,
+        model="claude-opus-4-8",
+    )
+
+    assistant = next(m for m in anthropic_messages if m["role"] == "assistant")
+    blocks = assistant["content"]
+    assert [block["type"] for block in blocks] == [
+        "thinking",
+        "text",
+        "thinking",
+        "tool_use",
+    ]
+    assert blocks == ordered
+    assert blocks[3]["input"] == {"command": f"printf {secret}"}
+    assert messages == original
+
+
+def test_anthropic_unsigned_ordered_text_is_still_redacted(applied_secret_home):
+    """Text-only ordered lists have no signature contract and stay maskable."""
+    from agent.provider_redaction import redact_provider_message_values
+
+    _home, secret = applied_secret_home
+    ordered = [
+        {"type": "text", "text": f"first visible text {secret}"},
+        {"type": "text", "text": f"second visible text {secret}"},
+    ]
+    messages = [
+        {
+            "role": "assistant",
+            "content": f"fallback content {secret}",
+            "anthropic_content_blocks": ordered,
+        }
+    ]
+    original = copy.deepcopy(messages)
+
+    provider_bound = redact_provider_message_values(messages)
+
+    assert all(secret not in block["text"] for block in provider_bound[0]["anthropic_content_blocks"])
+    assert messages == original
+
+
+def test_anthropic_redacted_thinking_keeps_complete_ordered_sequence(
+    applied_secret_home,
+):
+    """Opaque redacted-thinking data also binds its surrounding block list."""
+    from agent.provider_redaction import redact_provider_message_values
+
+    _home, secret = applied_secret_home
+    ordered = [
+        {"type": "text", "text": f"prefix text {secret}"},
+        {"type": "redacted_thinking", "data": f"opaque-data-{secret}"},
+        {"type": "text", "text": f"trailing text {secret}"},
+    ]
+    messages = [
+        {
+            "role": "assistant",
+            "content": f"fallback content {secret}",
+            "anthropic_content_blocks": ordered,
+        }
+    ]
+    original = copy.deepcopy(messages)
+
+    provider_bound = redact_provider_message_values(messages)
+
+    assert secret not in provider_bound[0]["content"]
+    assert provider_bound[0]["anthropic_content_blocks"] == ordered
+    assert messages == original
+
+
+def test_openrouter_reasoning_details_are_opaque_replay_bytes(applied_secret_home):
+    """OpenRouter requires its complete reasoning-details sequence unchanged."""
+    from agent.provider_redaction import redact_provider_message_values
+
+    _home, secret = applied_secret_home
+    details = [
+        {
+            "type": "reasoning.summary",
+            "summary": f"provider summary {secret}",
+            "id": "summary-77487",
+        },
+        {
+            "type": "reasoning.text",
+            "text": f"provider reasoning text {secret}",
+            "format": "openrouter-v1",
+        },
+        {
+            "type": "reasoning.signature",
+            "signature": f"signed-{secret}",
+            "data": f"opaque-{secret}",
+        },
+        {
+            "type": "future.unknown",
+            "opaque": {"nested": [secret, {"value": secret}]},
+        },
+    ]
+    messages = [
+        {
+            "role": "assistant",
+            "content": f"safe visible field {secret}",
+            "reasoning_details": details,
+        }
+    ]
+    original = copy.deepcopy(messages)
+
+    provider_bound = redact_provider_message_values(messages)
+
+    assert secret not in provider_bound[0]["content"]
+    assert provider_bound[0]["reasoning_details"] == details
+    assert messages == original
+
+
+def test_provider_copy_preserves_opaque_codex_replay_fields(applied_secret_home):
+    """Encrypted state and stable item identity remain exact; visible text does not."""
+    from agent.provider_redaction import redact_provider_message_values
+
+    _home, secret = applied_secret_home
+    messages = [
+        {
+            "role": "assistant",
+            "content": f"visible fallback {secret}",
+            "codex_reasoning_items": [
+                {
+                    "type": "reasoning",
+                    "id": f"rs_{secret}",
+                    "encrypted_content": secret,
+                }
+            ],
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "id": f"msg_{secret}",
+                    "phase": "commentary",
+                    "content": [
+                        {"type": "output_text", "text": f"visible item {secret}"}
+                    ],
+                }
+            ],
+        }
+    ]
+    original = copy.deepcopy(messages)
+
+    provider_bound = redact_provider_message_values(messages)
+
+    assert provider_bound[0]["codex_reasoning_items"] == original[0][
+        "codex_reasoning_items"
+    ]
+    item = provider_bound[0]["codex_message_items"][0]
+    assert item["id"] == f"msg_{secret}"
+    assert secret not in item["content"][0]["text"]
+    assert messages == original

--- a/tests/test_secrets_exfiltration.py
+++ b/tests/test_secrets_exfiltration.py
@@ -2229,3 +2229,177 @@ def test_moa_reference_masks_malformed_alternate_json_fragments_without_mutation
     assert ALTERNATE_JSON_SECRET not in rendered
     assert ALTERNATE_JSON_SPELLING not in rendered
     assert messages == original
+
+
+
+def test_title_output_is_masked_before_persistence(applied_secret_home, monkeypatch):
+    from agent.title_generator import _persist_session_title, generate_title
+
+    _home, secret = applied_secret_home
+    monkeypatch.setattr(
+        "agent.title_generator.call_llm", lambda **_kwargs: _response(secret)
+    )
+    stored = {}
+
+    class SessionStore:
+        def set_auto_title_if_empty(self, session_id, title):
+            stored[session_id] = title
+            return True
+
+    title = generate_title("request", "response")
+    persisted = _persist_session_title(
+        SessionStore(), "session-77487", title, source="llm"
+    )
+
+    assert title == "***"
+    assert persisted == "***"
+    assert stored == {"session-77487": "***"}
+
+
+def test_title_input_masks_before_maximum_length_cap(tmp_path, monkeypatch):
+    import agent.auxiliary_client as auxiliary_client
+    import agent.title_generator as title_generator
+    from agent.title_generator import generate_title
+    from hermes_cli import env_loader
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    secret = "cycle16-background-title-secret-" + "ABCDEFGHIJ" * 7
+    home_key = str(tmp_path.resolve())
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        home_key,
+        {"PROFILE_TITLE_API_TOKEN": secret},
+    )
+    source = "x" * (title_generator.MAX_TITLE_INPUT_CHARS - 30) + secret
+    captured = {}
+
+    def fake_impl(**kwargs):
+        captured["messages"] = copy.deepcopy(kwargs["messages"])
+        return _response('{"title":"Safe title"}')
+
+    monkeypatch.setattr(title_generator, "_auto_title_enabled", lambda: True)
+    monkeypatch.setattr(title_generator, "_title_language", lambda: "")
+    monkeypatch.setattr(auxiliary_client, "_call_llm_impl", fake_impl)
+    home_token = set_hermes_home_override(tmp_path)
+    try:
+        title = generate_title(source)
+    finally:
+        reset_hermes_home_override(home_token)
+
+    provider_text = json.dumps(captured["messages"])
+    assert title == "Safe title"
+    assert secret not in provider_text
+    assert secret[:30] not in provider_text
+    assert source == "x" * (title_generator.MAX_TITLE_INPUT_CHARS - 30) + secret
+
+
+def test_instant_title_masks_long_secret_before_truncation(tmp_path, monkeypatch):
+    from agent.title_generator import apply_instant_title
+    from hermes_cli import env_loader
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    secret = "cycle16-instant-title-secret-material-" + "ABCDEFGHIJ" * 4
+    home_key = str(tmp_path.resolve())
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        home_key,
+        {"PROFILE_TITLE_API_TOKEN": secret},
+    )
+    source = f"Investigate {secret} and details"
+    stored = []
+    callbacks = []
+
+    class SessionStore:
+        def set_auto_title_if_empty(self, session_id, title):
+            stored.append((session_id, title))
+            return True
+
+    home_token = set_hermes_home_override(tmp_path)
+    try:
+        result = apply_instant_title(
+            SessionStore(),
+            "session-instant-title-77487",
+            source,
+            lambda title, title_source: callbacks.append((title, title_source)),
+        )
+    finally:
+        reset_hermes_home_override(home_token)
+
+    assert result == "Investigate *** and details"
+    assert callbacks == [(result, "derived")]
+    assert stored == [("session-instant-title-77487", result)]
+    assert secret not in result
+    assert secret[:48] not in result
+    assert source == f"Investigate {secret} and details"
+
+
+def test_maybe_auto_title_thread_preserves_profile_redaction_context(
+    tmp_path, monkeypatch
+):
+    """The real background worker keeps profile-only input/output masking."""
+    import threading
+
+    import agent.auxiliary_client as auxiliary_client
+    import agent.title_generator as title_generator
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+    from hermes_cli import env_loader
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    secret = "profile-title-thread-secret-77487"
+    home_key = str(tmp_path.resolve())
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        home_key,
+        {"PROFILE_ONLY_TITLE_SECRET": secret},
+    )
+    captured = {}
+    persisted = threading.Event()
+    worker_persisted = threading.Event()
+    source_user = f"request contains {secret}"
+    persist_calls = []
+
+    class SessionStore:
+        def get_session_title(self, _session_id):
+            return None
+
+        def get_conversation_root(self, session_id):
+            return session_id
+
+        def set_auto_title_if_empty(self, session_id, title):
+            captured["persisted"] = (session_id, title)
+            persist_calls.append((session_id, title))
+            persisted.set()
+            if len(persist_calls) >= 2:
+                worker_persisted.set()
+            return True
+
+    def fake_impl(**kwargs):
+        captured["messages"] = copy.deepcopy(kwargs["messages"])
+        return _response(secret)
+
+    monkeypatch.setattr(title_generator, "_auto_title_enabled", lambda: True)
+    monkeypatch.setattr(title_generator, "_title_language", lambda: "")
+    monkeypatch.setattr(auxiliary_client, "_call_llm_impl", fake_impl)
+    home_token = set_hermes_home_override(tmp_path)
+    secret_token = set_secret_scope({"PROFILE_ONLY_TITLE_TOKEN": secret})
+    try:
+        title_generator.maybe_auto_title(
+            SessionStore(),
+            "session-title-context-77487",
+            source_user,
+            [{"role": "user", "content": source_user}],
+        )
+        assert persisted.wait(timeout=10), "auto-title worker did not persist"
+        assert worker_persisted.wait(timeout=10), "auto-title upgrade did not persist"
+    finally:
+        reset_secret_scope(secret_token)
+        reset_hermes_home_override(home_token)
+
+    assert secret not in json.dumps(captured["messages"])
+    assert "***" in captured["messages"][1]["content"]
+    assert captured["persisted"] == ("session-title-context-77487", "***")
+    assert source_user == f"request contains {secret}"

--- a/tests/test_secrets_exfiltration.py
+++ b/tests/test_secrets_exfiltration.py
@@ -1958,3 +1958,91 @@ def test_provider_copy_preserves_opaque_codex_replay_fields(applied_secret_home)
     assert item["id"] == f"msg_{secret}"
     assert secret not in item["content"][0]["text"]
     assert messages == original
+
+
+def test_final_dispatch_gate_masks_secret_composed_by_thinking_merge(
+    tmp_path, monkeypatch
+):
+    """Post-sanitize role repair cannot create a provider-visible secret."""
+    from agent.chat_completion_helpers import build_api_kwargs
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+    from run_agent import AIAgent
+
+    secret = "known-prefix\n\nknown-suffix"
+    source = [
+        {"role": "user", "content": "known-prefix"},
+        {"role": "assistant", "content": "", "reasoning": "hidden"},
+        {"role": "user", "content": "known-suffix"},
+    ]
+    original = copy.deepcopy(source)
+
+    class CapturingTransport:
+        def build_kwargs(self, **kwargs):
+            return kwargs
+
+    class DispatchAgent:
+        reasoning_config = None
+        tools = []
+        api_mode = "bedrock_converse"
+        model = "fixture-bedrock"
+        max_tokens = 100
+        _bedrock_region = "us-east-1"
+        _bedrock_guardrail_config = None
+
+        def _get_transport(self):
+            return CapturingTransport()
+
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope({"MERGED_API_KEY": secret})
+    try:
+        # The first production gate sees two harmless fragments. The real
+        # thinking-only repair then removes the assistant and joins them with
+        # the exact newlines that complete the configured secret.
+        first_gate = sanitize_api_messages(source)
+        merged = AIAgent._drop_thinking_only_and_merge_users(first_gate)
+        assert merged[0]["content"] == secret
+
+        dispatched = build_api_kwargs(DispatchAgent(), merged)
+    finally:
+        reset_secret_scope(token)
+
+    assert secret not in dispatched["messages"][0]["content"]
+    assert dispatched["messages"][0]["content"] == "***"
+    assert source == original
+
+
+def test_force_ascii_normalization_precedes_final_dispatch_gate(
+    tmp_path, monkeypatch
+):
+    """ASCII fallback cannot compose a secret after provider redaction."""
+    from agent.chat_completion_helpers import build_api_kwargs
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    class CapturingTransport:
+        def build_kwargs(self, **kwargs):
+            return kwargs
+
+    class DispatchAgent:
+        reasoning_config = None
+        tools = []
+        api_mode = "bedrock_converse"
+        model = "fixture-bedrock"
+        max_tokens = 100
+        _bedrock_region = "us-east-1"
+        _bedrock_guardrail_config = None
+        _force_ascii_payload = True
+
+        def _get_transport(self):
+            return CapturingTransport()
+
+    source = [{"role": "user", "content": "abécd"}]
+    original = copy.deepcopy(source)
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope({"ACTIVE_TOKEN": "abcd"})
+    try:
+        dispatched = build_api_kwargs(DispatchAgent(), source)
+    finally:
+        reset_secret_scope(token)
+
+    assert dispatched["messages"][0]["content"] == "***"
+    assert source == original

--- a/tests/test_secrets_exfiltration.py
+++ b/tests/test_secrets_exfiltration.py
@@ -2046,3 +2046,186 @@ def test_force_ascii_normalization_precedes_final_dispatch_gate(
 
     assert dispatched["messages"][0]["content"] == "***"
     assert source == original
+
+
+def test_moa_reference_and_synthesis_requests_mask_exact_values(
+    applied_secret_home, monkeypatch
+):
+    """MoA copies are clean while replayable modern/legacy arguments stay exact."""
+    from agent.moa_loop import aggregate_moa_context
+
+    _home, secret = applied_secret_home
+    arguments = json.dumps({"command": f"printf {secret}"})
+    api_messages = [
+        {"role": "user", "content": "inspect the latest result"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_moa_77487",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": arguments},
+                }
+            ],
+            "function_call": {"name": "terminal", "arguments": arguments},
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_moa_77487",
+            "content": f"external tool returned {secret}",
+        },
+    ]
+    original = copy.deepcopy(api_messages)
+    calls: list[dict] = []
+
+    def fake_call_llm(**kwargs):
+        calls.append(copy.deepcopy(kwargs))
+        if kwargs["task"] == "moa_reference":
+            return _response(f"advisor repeated {secret}")
+        return _response("synthesized guidance")
+
+    monkeypatch.setattr(
+        "agent.moa_loop._slot_runtime",
+        lambda slot: {
+            "provider": slot.get("provider"),
+            "model": slot.get("model"),
+            "base_url": "https://example.invalid/v1",
+            "api_key": "fixture-runtime-key",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+
+    aggregate_moa_context(
+        user_prompt=f"separate synthesis prompt contains {secret}",
+        api_messages=api_messages,
+        reference_models=[{"provider": "fixture", "model": "advisor"}],
+        aggregator={"provider": "fixture", "model": "aggregator"},
+    )
+
+    reference_call = next(call for call in calls if call["task"] == "moa_reference")
+    synthesis_call = next(call for call in calls if call["task"] == "moa_aggregator")
+    assert secret not in json.dumps(reference_call["messages"])
+    assert secret not in json.dumps(synthesis_call["messages"])
+    assert api_messages == original
+    assert api_messages[1]["tool_calls"][0]["function"]["arguments"] == arguments
+    assert api_messages[1]["function_call"]["arguments"] == arguments
+
+
+def test_moa_reference_masks_json_encoded_arguments_without_mutating_source(
+    json_special_secret_home,
+):
+    """Rendered advisory arguments mask decoded values after JSON escaping."""
+    from agent.moa_loop import _redacted_reference_messages
+
+    _home, secret = json_special_secret_home
+    arguments = json.dumps({"command": f"printf {secret}"})
+    messages = [
+        {"role": "user", "content": "inspect"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-moa-json-77487",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": arguments},
+                }
+            ],
+            "function_call": {"name": "terminal", "arguments": arguments},
+        },
+    ]
+    original = copy.deepcopy(messages)
+
+    advisory = _redacted_reference_messages(messages)
+
+    rendered = "\n".join(str(message.get("content", "")) for message in advisory)
+    assert json.dumps(secret)[1:-1] not in rendered
+    assert secret not in rendered
+    assert messages == original
+    assert messages[1]["tool_calls"][0]["function"]["arguments"] == arguments
+    assert messages[1]["function_call"]["arguments"] == arguments
+
+
+@pytest.mark.parametrize("alternate_spelling", ALTERNATE_JSON_SPELLINGS)
+def test_moa_reference_masks_alternate_json_escapes_without_mutating_source(
+    monkeypatch, alternate_spelling
+):
+    """Disposable advisory rendering decodes equivalent JSON spellings."""
+    from agent.moa_loop import _redacted_reference_messages
+    from hermes_cli import env_loader
+    from hermes_constants import get_hermes_home
+
+    home = get_hermes_home()
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(home.resolve()),
+        {"ALTERNATE_JSON_SECRET": ALTERNATE_JSON_SECRET},
+    )
+    arguments = _json_with_alternate_secret("command", alternate_spelling)
+    messages = [
+        {"role": "user", "content": "inspect"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-moa-alternate-json-77487",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": arguments},
+                }
+            ],
+            "function_call": {"name": "terminal", "arguments": arguments},
+        },
+    ]
+    original = copy.deepcopy(messages)
+
+    advisory = _redacted_reference_messages(messages)
+
+    rendered = "\n".join(str(message.get("content", "")) for message in advisory)
+    assert ALTERNATE_JSON_SECRET not in rendered
+    assert ALTERNATE_JSON_SPELLING not in rendered
+    assert alternate_spelling not in rendered
+    assert messages == original
+
+
+@pytest.mark.parametrize("fragment_kind", MALFORMED_JSON_FRAGMENT_KINDS)
+def test_moa_reference_masks_malformed_alternate_json_fragments_without_mutation(
+    monkeypatch, fragment_kind
+):
+    """Disposable MoA rendering masks incomplete and invalid quoted fragments."""
+    from agent.moa_loop import _redacted_reference_messages
+    from hermes_cli import env_loader
+    from hermes_constants import get_hermes_home
+
+    home = get_hermes_home()
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(home.resolve()),
+        {"MALFORMED_MOA_JSON_SECRET": ALTERNATE_JSON_SECRET},
+    )
+    arguments = _malformed_json_with_alternate_secret("command", fragment_kind)
+    messages = [
+        {"role": "user", "content": "inspect"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-moa-malformed-json-77487",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": arguments},
+                }
+            ],
+        },
+    ]
+    original = copy.deepcopy(messages)
+
+    advisory = _redacted_reference_messages(messages)
+
+    rendered = "\n".join(str(message.get("content", "")) for message in advisory)
+    assert "***" in rendered
+    assert ALTERNATE_JSON_SECRET not in rendered
+    assert ALTERNATE_JSON_SPELLING not in rendered
+    assert messages == original

--- a/tests/test_secrets_exfiltration.py
+++ b/tests/test_secrets_exfiltration.py
@@ -2403,3 +2403,103 @@ def test_maybe_auto_title_thread_preserves_profile_redaction_context(
     assert "***" in captured["messages"][1]["content"]
     assert captured["persisted"] == ("session-title-context-77487", "***")
     assert source_user == f"request contains {secret}"
+
+
+
+def test_oneshot_output_masks_exact_secret(applied_secret_home, monkeypatch):
+    from agent.oneshot import run_oneshot
+
+    _home, secret = applied_secret_home
+    monkeypatch.setattr("agent.oneshot.call_llm", lambda **_kwargs: _response(secret))
+
+    assert run_oneshot(instructions="answer", user_input="request") == "***"
+
+
+def test_plugin_sync_and_async_outputs_mask_exact_secret(
+    applied_secret_home,
+):
+    from agent.plugin_llm import _TrustPolicy, make_plugin_llm_for_test
+
+    _home, secret = applied_secret_home
+
+    def sync_caller(**_kwargs):
+        return "fixture", "model", _response(secret)
+
+    async def async_caller(**_kwargs):
+        return "fixture", "model", _response(secret)
+
+    llm = make_plugin_llm_for_test(
+        plugin_id="redaction-fixture",
+        policy=_TrustPolicy(plugin_id="redaction-fixture"),
+        sync_caller=sync_caller,
+        async_caller=async_caller,
+    )
+
+    assert llm.complete([{"role": "user", "content": "request"}]).text == "***"
+    assert (
+        asyncio.run(llm.acomplete([{"role": "user", "content": "request"}])).text
+        == "***"
+    )
+
+
+def test_plugin_structured_output_preserves_json_structure_while_masking_values(
+    tmp_path, monkeypatch
+):
+    """Plugin JSON output remains parseable when secrets resemble JSON syntax."""
+    from agent.plugin_llm import _TrustPolicy, make_plugin_llm_for_test
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    raw_text = (
+        '{"ok":true,"missing":null,'
+        '"secret":"plugin-secret","literal":"true","punctuation":"{"}'
+    )
+    response = _response(raw_text)
+
+    def sync_caller(**_kwargs):
+        return "fixture", "model", response
+
+    llm = make_plugin_llm_for_test(
+        plugin_id="structured-redaction-fixture",
+        policy=_TrustPolicy(plugin_id="structured-redaction-fixture"),
+        sync_caller=sync_caller,
+    )
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope(
+        {
+            "PLUGIN_TOKEN": "plugin-secret",
+            "TRUE_TOKEN": "true",
+            "NULL_TOKEN": "null",
+            "OPEN_TOKEN": "{",
+        }
+    )
+    try:
+        result = llm.complete_structured(
+            instructions="return JSON",
+            input=[{"type": "text", "text": "request"}],
+            json_mode=True,
+        )
+    finally:
+        reset_secret_scope(token)
+
+    assert result.content_type == "json"
+    assert result.parsed == {
+        "ok": True,
+        "missing": None,
+        "secret": "***",
+        "literal": "***",
+        "punctuation": "***",
+    }
+    assert json.loads(result.text) == result.parsed
+    assert response.choices[0].message.content == raw_text
+
+
+def test_auxiliary_text_outputs_respect_redaction_opt_out(
+    applied_secret_home, monkeypatch
+):
+    from agent.oneshot import run_oneshot
+
+    _home, secret = applied_secret_home
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+    monkeypatch.setattr("agent.oneshot.call_llm", lambda **_kwargs: _response(secret))
+
+    assert run_oneshot(instructions="answer", user_input="request") == secret

--- a/tests/test_secrets_exfiltration.py
+++ b/tests/test_secrets_exfiltration.py
@@ -1,0 +1,2448 @@
+"""Provider-egress exact-secret regression gates for issue #77487."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from agent.agent_runtime_helpers import sanitize_api_messages
+
+
+ALTERNATE_JSON_SECRET = "S/Key"
+ALTERNATE_JSON_SPELLING = r"\u0053\/K\u0065y"
+
+
+def _nest_json_string_spelling(spelling: str, layers: int) -> str:
+    for _ in range(layers - 1):
+        spelling = json.dumps(spelling)[1:-1]
+    return spelling
+
+
+def _nested_alternate_json_spelling(layers: int) -> str:
+    return _nest_json_string_spelling(ALTERNATE_JSON_SPELLING, layers)
+
+
+ALTERNATE_JSON_SPELLINGS = tuple(
+    pytest.param(
+        _nested_alternate_json_spelling(layers),
+        id=f"json-escape-layers-{layers}",
+    )
+    for layers in (1, 2, 5, 10, 13)
+)
+MALFORMED_JSON_FRAGMENT_KINDS = (
+    "unterminated",
+    "invalid_escape",
+    "quote_parity",
+    "unquoted",
+    "single_quoted",
+)
+
+
+def _json_with_alternate_secret(
+    field: str, spelling: str = ALTERNATE_JSON_SPELLING
+) -> str:
+    return f'{{"{field}":"{spelling}"}}'
+
+
+def _malformed_json_with_alternate_secret(field: str, kind: str) -> str:
+    if kind == "unterminated":
+        return f'{{"{field}":"{ALTERNATE_JSON_SPELLING}'
+    if kind == "invalid_escape":
+        return f'{{"{field}":"\\q{ALTERNATE_JSON_SPELLING}"}}'
+    if kind == "quote_parity":
+        return f'{{"broken":"prefix "{field}":"{ALTERNATE_JSON_SPELLING}"}}'
+    if kind == "unquoted":
+        return f"{{{field}:{ALTERNATE_JSON_SPELLING}}}"
+    if kind == "single_quoted":
+        return f"{{'{field}':'{ALTERNATE_JSON_SPELLING}'}}"
+    raise AssertionError(f"unknown malformed JSON fragment kind: {kind}")
+
+
+@pytest.fixture(autouse=True)
+def _enable_redaction(monkeypatch):
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+
+
+@pytest.fixture
+def applied_secret_home(tmp_path, monkeypatch):
+    from hermes_cli import env_loader
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    secret = "opaque-fixture-secret-77487"
+    home_key = str(tmp_path.resolve())
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        home_key,
+        {"ARBITRARY_SOURCE_NAME": secret},
+    )
+    token = set_hermes_home_override(tmp_path)
+    try:
+        yield tmp_path, secret
+    finally:
+        reset_hermes_home_override(token)
+
+
+@pytest.fixture
+def json_special_secret_home(tmp_path, monkeypatch):
+    from hermes_cli import env_loader
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    secret = 'Q7"\\Z!'
+    home_key = str(tmp_path.resolve())
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        home_key,
+        {"JSON_SPECIAL_SECRET": secret},
+    )
+    token = set_hermes_home_override(tmp_path)
+    try:
+        yield tmp_path, secret
+    finally:
+        reset_hermes_home_override(token)
+
+
+def _paired_messages(secret: str) -> list[dict]:
+    return [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_77487",
+                    "type": "function",
+                    "function": {
+                        "name": "terminal",
+                        "arguments": json.dumps(
+                            {"command": f"printf '{secret} {secret}'"}
+                        ),
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "name": "terminal",
+            "tool_call_id": "call_77487",
+            "content": [
+                {"type": "text", "text": f"first={secret}; second={secret}"},
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"https://example.invalid/{secret}/{secret}/image.png"
+                    },
+                },
+            ],
+        },
+    ]
+
+
+def test_provider_copy_masks_content_occurrences_and_preserves_replay_history(
+    applied_secret_home,
+):
+    """Text and non-text metadata are sanitized without mutating history."""
+    _home, secret = applied_secret_home
+    messages = _paired_messages(secret)
+    original = copy.deepcopy(messages)
+
+    provider_bound = sanitize_api_messages(messages)
+
+    arguments = provider_bound[0]["tool_calls"][0]["function"]["arguments"]
+    text = provider_bound[1]["content"][0]["text"]
+    image_url = provider_bound[1]["content"][1]["image_url"]["url"]
+    # #43083: replayed executable arguments cannot be display-masked without
+    # making the model copy the placeholder into a later tool call. This field
+    # requires authenticated vault/token references, not raw substitution.
+    assert secret in arguments
+    assert secret not in text
+    assert secret not in image_url
+    assert text.count("***") == 2
+    assert image_url.count("***") == 2
+
+    # #43083: provider sanitization must not poison the replayable source.
+    assert messages == original
+    assert messages[0]["tool_calls"][0]["function"]["arguments"] == original[0][
+        "tool_calls"
+    ][0]["function"]["arguments"]
+
+
+def test_provider_copy_masks_json_encoded_tool_result_without_mutating_source(
+    json_special_secret_home,
+):
+    """JSON string escaping cannot hide an exact secret from provider egress."""
+    _home, secret = json_special_secret_home
+    arguments = json.dumps({"command": f"printf {secret}"})
+    tool_result = json.dumps(
+        {"result": {"credential": secret, "items": ["safe", secret]}},
+        separators=(",", ":"),
+    )
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-json-77487",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": arguments},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-json-77487",
+            "content": tool_result,
+        },
+    ]
+    original = copy.deepcopy(messages)
+
+    provider_bound = sanitize_api_messages(messages)
+
+    encoded_secret = json.dumps(secret)[1:-1]
+    provider_result = provider_bound[1]["content"]
+    assert encoded_secret not in provider_result
+    assert json.loads(provider_result) == {
+        "result": {"credential": "***", "items": ["safe", "***"]}
+    }
+    # Executable provider arguments and caller-owned history stay byte-exact.
+    assert provider_bound[0]["tool_calls"][0]["function"]["arguments"] == arguments
+    assert messages == original
+
+
+@pytest.mark.parametrize("alternate_spelling", ALTERNATE_JSON_SPELLINGS)
+def test_provider_copy_masks_equivalent_json_escape_spellings_without_mutation(
+    monkeypatch, alternate_spelling
+):
+    """Escaped solidus and Unicode spellings decode only to masked values."""
+    from hermes_cli import env_loader
+    from hermes_constants import get_hermes_home
+
+    home = get_hermes_home()
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(home.resolve()),
+        {"ALTERNATE_JSON_SECRET": ALTERNATE_JSON_SECRET},
+    )
+    content = _json_with_alternate_secret("credential", alternate_spelling)
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-alternate-provider-77487",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": content},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-alternate-provider-77487",
+            "content": content,
+        },
+    ]
+    original = copy.deepcopy(messages)
+
+    provider_bound = sanitize_api_messages(messages)
+
+    provider_content = provider_bound[1]["content"]
+    assert json.loads(provider_content) == {"credential": "***"}
+    assert ALTERNATE_JSON_SECRET not in provider_content
+    assert ALTERNATE_JSON_SPELLING not in provider_content
+    assert alternate_spelling not in provider_content
+    assert provider_bound[0]["tool_calls"][0]["function"]["arguments"] == content
+    assert messages == original
+
+
+@pytest.mark.parametrize("fragment_kind", MALFORMED_JSON_FRAGMENT_KINDS)
+def test_provider_copy_masks_malformed_alternate_json_fragments_without_mutation(
+    monkeypatch, fragment_kind
+):
+    """Incomplete or invalid quoting cannot bypass disposable provider masking."""
+    from hermes_cli import env_loader
+    from hermes_constants import get_hermes_home
+
+    home = get_hermes_home()
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(home.resolve()),
+        {"MALFORMED_JSON_SECRET": ALTERNATE_JSON_SECRET},
+    )
+    content = _malformed_json_with_alternate_secret("credential", fragment_kind)
+    messages = [{"role": "tool", "content": content}]
+    original = copy.deepcopy(messages)
+
+    provider_bound = sanitize_api_messages(messages)
+
+    assert "***" in provider_bound[0]["content"]
+    assert ALTERNATE_JSON_SECRET not in provider_bound[0]["content"]
+    assert ALTERNATE_JSON_SPELLING not in provider_bound[0]["content"]
+    assert messages == original
+
+
+def test_valid_json_masks_only_string_values_and_preserves_structural_tokens(
+    tmp_path, monkeypatch
+):
+    """Credential-shaped punctuation cannot corrupt a valid JSON document."""
+    from agent.redact import redact_provider_message_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    secrets = {
+        "OPEN_TOKEN": "{",
+        "QUOTE_TOKEN": '"',
+        "COLON_TOKEN": ":",
+        "COMMA_TOKEN": ",",
+        "TRUE_TOKEN": "true",
+        "NULL_TOKEN": "null",
+        "NUMBER_TOKEN": "1",
+        "PAYLOAD_TOKEN": "actual-secret",
+    }
+    content = (
+        '{"true":true,"null":null,"number":1,'
+        '"items":["actual-secret","true","null","1","{","\\\"",":",","]}'
+    )
+    source = [{"role": "tool", "content": content}]
+    original = copy.deepcopy(source)
+
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope(secrets)
+    try:
+        provider_bound = redact_provider_message_values(source, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    assert json.loads(provider_bound[0]["content"]) == {
+        "true": True,
+        "null": None,
+        "number": 1,
+        "items": ["***"] * 8,
+    }
+    assert source == original
+
+
+def test_valid_json_masks_authoritative_object_key(tmp_path, monkeypatch):
+    """A credential used as a JSON key is still removed before provider egress."""
+    from agent.redact import redact_provider_message_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    secret = "credential-key-77487-super-long-value"
+    second_secret = "another-long-credential-key-77487"
+    numeric_secret = "839201774875551234567890123456"
+    source = [
+        {
+            "role": "tool",
+            "content": json.dumps(
+                {
+                    "***": "ordinary",
+                    secret: "tool-result",
+                    second_secret: "second-result",
+                    numeric_secret: "numeric-result",
+                }
+            ),
+        }
+    ]
+    original = copy.deepcopy(source)
+
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope(
+        {
+            "API_TOKEN": secret,
+            "SECOND_API_TOKEN": second_secret,
+            "NUMERIC_API_TOKEN": numeric_secret,
+        }
+    )
+    try:
+        provider_bound = redact_provider_message_values(source, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    redacted_object = json.loads(provider_bound[0]["content"])
+    assert secret not in provider_bound[0]["content"]
+    assert second_secret not in provider_bound[0]["content"]
+    assert numeric_secret not in provider_bound[0]["content"]
+    assert sorted(redacted_object.values()) == [
+        "numeric-result",
+        "ordinary",
+        "second-result",
+        "tool-result",
+    ]
+    assert len(redacted_object) == 4
+    assert source == original
+
+
+def test_valid_json_key_marker_avoids_later_existing_key(tmp_path, monkeypatch):
+    """Key-marker selection is independent of object-key ordering."""
+    from agent.redact import redact_provider_message_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    secret = "credential-key-77487-reverse-order"
+    source = [
+        {
+            "role": "tool",
+            "content": json.dumps({secret: "sensitive", "***": "ordinary"}),
+        }
+    ]
+    original = copy.deepcopy(source)
+
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope({"API_TOKEN": secret})
+    try:
+        provider_bound = redact_provider_message_values(source, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    redacted_object = json.loads(provider_bound[0]["content"])
+    assert secret not in provider_bound[0]["content"]
+    assert sorted(redacted_object.values()) == ["ordinary", "sensitive"]
+    assert len(redacted_object) == 2
+    assert source == original
+
+
+def test_valid_json_key_marker_avoids_partial_existing_key(tmp_path, monkeypatch):
+    """A marker cannot compose an existing key at a replacement boundary."""
+    from agent.redact import redact_provider_message_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    secret = "credential-key-77487"
+    source = [
+        {
+            "role": "tool",
+            "content": json.dumps(
+                {
+                    f"prefix{secret}": "sensitive",
+                    "prefix***": "ordinary",
+                }
+            ),
+        }
+    ]
+    original = copy.deepcopy(source)
+
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope({"API_TOKEN": secret})
+    try:
+        provider_bound = redact_provider_message_values(source, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    redacted_object = json.loads(provider_bound[0]["content"])
+    assert secret not in provider_bound[0]["content"]
+    assert sorted(redacted_object.values()) == ["ordinary", "sensitive"]
+    assert len(redacted_object) == 2
+    assert source == original
+
+
+def test_invalid_json_keeps_aggressive_structural_exact_masking(
+    tmp_path, monkeypatch
+):
+    """Malformed/non-JSON text retains the prior fail-closed raw scanner."""
+    from agent.redact import redact_known_secret_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    source = '{"flag":true'
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope({"TRUE_TOKEN": "true"})
+    try:
+        redacted = redact_known_secret_values(source, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    assert redacted == '{"flag":***'
+    assert source == '{"flag":true'
+
+
+def test_authoritative_short_secret_is_masked_even_when_concatenated(
+    tmp_path, monkeypatch
+):
+    from agent.redact import redact_known_secret_values
+    from hermes_cli import env_loader
+
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(tmp_path.resolve()),
+        {"ARBITRARY_EXTERNAL_NAME": "p4ss"},
+    )
+
+    assert redact_known_secret_values(
+        "p4ss field, p4ss123 and myp4ss all contain the credential",
+        home=tmp_path,
+    ) == "*** field, ***123 and my*** all contain the credential"
+
+
+def test_literal_only_exact_mask_skips_escape_scanner(monkeypatch):
+    """Plain text keeps exact masking without paying for escape decoding."""
+    from agent.redact import _compile_exact_secret_pattern, _redact_exact_with_pattern
+
+    pattern = _compile_exact_secret_pattern(("p4ss",))
+    monkeypatch.setattr(
+        "agent.redact._scan_json_string_fragment",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("escape scanner should not run")
+        ),
+    )
+
+    assert _redact_exact_with_pattern("plain p4ss text", pattern) == "plain *** text"
+    assert _redact_exact_with_pattern("plain safe text", pattern) == "plain safe text"
+
+
+def test_nested_escape_work_budget_exhaustion_fails_closed(monkeypatch):
+    """An uninspected derived layer is removed instead of forwarded."""
+    from agent.redact import _compile_exact_secret_pattern, _redact_exact_with_pattern
+
+    pattern = _compile_exact_secret_pattern((ALTERNATE_JSON_SECRET,))
+    source = _json_with_alternate_secret(
+        "credential", _nested_alternate_json_spelling(13)
+    )
+    original = source
+    monkeypatch.setattr(
+        "agent.redact._json_escape_decode_work_budget",
+        lambda text: len(text),
+    )
+
+    redacted = _redact_exact_with_pattern(source, pattern)
+
+    assert json.loads(redacted) == {"credential": "***"}
+    assert ALTERNATE_JSON_SECRET not in redacted
+    assert ALTERNATE_JSON_SPELLING not in redacted
+    assert source == original
+
+
+def test_exact_mask_chooses_marker_that_cannot_collide_with_active_secrets(
+    tmp_path, monkeypatch
+):
+    """Even marker-shaped and one-character credentials remain absent."""
+    from agent.redact import (
+        _compile_exact_secret_pattern,
+        redact_provider_message_values,
+    )
+    from hermes_cli import env_loader
+
+    secrets = ("***", "*", "[REDACTED]", "<redacted-secret>")
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(tmp_path.resolve()),
+        {f"COLLISION_SECRET_{index}": secret for index, secret in enumerate(secrets)},
+    )
+    matcher = _compile_exact_secret_pattern(secrets)
+    assert matcher is not None
+    assert matcher.replacement
+    assert all(
+        secret not in matcher.replacement and matcher.replacement not in secret
+        for secret in secrets
+    )
+
+    messages = [{"role": "tool", "content": " | ".join(secrets)}]
+    original = copy.deepcopy(messages)
+    provider_bound = redact_provider_message_values(messages, home=tmp_path)
+
+    assert all(secret not in provider_bound[0]["content"] for secret in secrets)
+    assert provider_bound[0]["content"] != original[0]["content"]
+    assert messages == original
+
+
+def test_provider_marker_repetition_cannot_synthesize_active_secret(
+    tmp_path, monkeypatch
+):
+    """Adjacent replacements remain safe under arbitrary marker composition."""
+    from hermes_cli import env_loader
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    active_secrets = ("***", "REDACTED][REDACTED")
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(tmp_path.resolve()),
+        {f"MARKER_SECRET_{index}": secret for index, secret in enumerate(active_secrets)},
+    )
+    source = [{"role": "tool", "content": "******"}]
+    original = copy.deepcopy(source)
+    token = set_hermes_home_override(tmp_path)
+    try:
+        provider_bound = sanitize_api_messages(source)
+    finally:
+        reset_hermes_home_override(token)
+
+    content = provider_bound[0]["content"]
+    assert all(secret not in content for secret in active_secrets)
+    assert content != "[REDACTED][REDACTED]"
+    assert source == original
+
+
+def test_provider_marker_cannot_compose_with_unchanged_source_context(
+    tmp_path, monkeypatch
+):
+    """A replacement boundary cannot synthesize another active secret."""
+    from agent.redact import _compile_exact_secret_pattern
+    from hermes_cli import env_loader
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    active_secrets = ("x", "ab*")
+    matcher = _compile_exact_secret_pattern(active_secrets)
+    assert matcher is not None
+    assert matcher.replacement == "[REDACTED]"
+
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(tmp_path.resolve()),
+        {f"BOUNDARY_SECRET_{index}": secret for index, secret in enumerate(active_secrets)},
+    )
+    source = [{"role": "tool", "content": "abx"}]
+    original = copy.deepcopy(source)
+    token = set_hermes_home_override(tmp_path)
+    try:
+        provider_bound = sanitize_api_messages(source)
+    finally:
+        reset_hermes_home_override(token)
+
+    assert all(secret not in provider_bound[0]["content"] for secret in active_secrets)
+    assert provider_bound[0]["content"] == f"ab{matcher.replacement}"
+    assert source == original
+
+
+@pytest.mark.parametrize("layers", (1, 2, 5, 13))
+def test_provider_nested_unicode_json_escape_replaces_complete_valid_span(
+    tmp_path, monkeypatch, layers
+):
+    """A canonical suffix cannot corrupt its nested JSON escape container."""
+    from hermes_cli import env_loader
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    secret = "é"
+    spelling = _nest_json_string_spelling(json.dumps(secret)[1:-1], layers)
+    content = f'{{"x":"{spelling}"}}'
+    source = [{"role": "tool", "content": content}]
+    original = copy.deepcopy(source)
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(tmp_path.resolve()),
+        {"UNICODE_JSON_SECRET": secret},
+    )
+    token = set_hermes_home_override(tmp_path)
+    try:
+        provider_bound = sanitize_api_messages(source)
+    finally:
+        reset_hermes_home_override(token)
+
+    provider_content = provider_bound[0]["content"]
+    assert json.loads(provider_content) == {"x": "***"}
+    assert secret not in provider_content
+    assert spelling not in provider_content
+    assert source == original
+
+
+@pytest.mark.parametrize("layers", (1, 2, 5, 13))
+def test_provider_simple_slash_json_escape_replaces_complete_valid_span(
+    tmp_path, monkeypatch, layers
+):
+    r"""A one-byte secret encoded as ``\/`` cannot leave invalid JSON."""
+    from hermes_cli import env_loader
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    secret = "/"
+    spelling = _nest_json_string_spelling(r"\/", layers)
+    content = f'{{"x":"{spelling}"}}'
+    source = [{"role": "tool", "content": content}]
+    original = copy.deepcopy(source)
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(tmp_path.resolve()),
+        {"SLASH_JSON_SECRET": secret},
+    )
+    token = set_hermes_home_override(tmp_path)
+    try:
+        provider_bound = sanitize_api_messages(source)
+    finally:
+        reset_hermes_home_override(token)
+
+    provider_content = provider_bound[0]["content"]
+    assert json.loads(provider_content) == {"x": "***"}
+    assert secret not in provider_content
+    assert spelling not in provider_content
+    assert source == original
+
+
+def test_request_local_pattern_scope_rebinds_nested_same_home_profile(
+    tmp_path, monkeypatch
+):
+    """Operation-local reuse never turns into a stale home-only profile cache."""
+    from agent.redact import _exact_secret_pattern_scope, redact_known_secret_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    first = "first-profile-secret-77487"
+    second = "second-profile-secret-77487"
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    first_token = set_secret_scope({"ACTIVE_PROFILE_TOKEN": first})
+    try:
+        with _exact_secret_pattern_scope(home=tmp_path):
+            assert redact_known_secret_values(first, home=tmp_path) == "***"
+            second_token = set_secret_scope({"ACTIVE_PROFILE_TOKEN": second})
+            try:
+                with _exact_secret_pattern_scope(home=tmp_path):
+                    assert (
+                        redact_known_secret_values(
+                            f"{first} | {second}", home=tmp_path
+                        )
+                        == f"{first} | ***"
+                    )
+            finally:
+                reset_secret_scope(second_token)
+            assert redact_known_secret_values(first, home=tmp_path) == "***"
+    finally:
+        reset_secret_scope(first_token)
+
+
+def test_provider_copy_reuses_operation_local_exact_pattern(tmp_path, monkeypatch):
+    """Provider-copy redaction shares the request's immutable secret snapshot."""
+    import agent.redact as redact
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    secret = "p4ss"
+    source = [{"role": "tool", "content": secret}]
+    original = copy.deepcopy(source)
+    collections = 0
+
+    def collect_exact_secret_values(home):
+        nonlocal collections
+        collections += 1
+        return (secret,)
+
+    monkeypatch.setattr(
+        redact, "_collect_exact_secret_values", collect_exact_secret_values
+    )
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope({"ACTIVE_TOKEN": secret})
+    try:
+        with redact._exact_secret_pattern_scope(home=tmp_path):
+            first = redact.redact_provider_message_values(source, home=tmp_path)
+            second = redact.redact_provider_message_values(source, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    assert collections == 1
+    assert first[0]["content"] == "***"
+    assert second[0]["content"] == "***"
+    assert source == original
+
+
+def test_operation_pattern_scope_retains_scope_identity(tmp_path, monkeypatch):
+    """The cache owns its scope object so numeric identity cannot be reused."""
+    import agent.redact as redact
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    secret = "r8$!"
+    scope = {"ACTIVE_TOKEN": secret}
+    monkeypatch.setattr(
+        redact, "_collect_exact_secret_values", lambda home: (secret,)
+    )
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope(scope)
+    try:
+        with redact._exact_secret_pattern_scope(home=tmp_path):
+            cached = redact._EXACT_SECRET_PATTERN_SCOPE.get()
+
+            assert cached is not None
+            assert cached[0] == (str(tmp_path.resolve()), True)
+            assert cached[1] is scope
+            assert cached[2] is not None
+    finally:
+        reset_secret_scope(token)
+
+
+@pytest.mark.parametrize("source_kind", ("process", "scope", "multiplex"))
+def test_config_style_credential_suffixes_do_not_mask_provider_text(
+    tmp_path, monkeypatch, source_kind
+):
+    """Flag-shaped ambient settings do not become transcript-wide secrets."""
+    import agent.redact as redact
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+    from hermes_cli import env_loader
+
+    settings = {
+        "SKIP_AUTH": "false",
+        "DEBUG_AUTH": "true",
+        "REQUIRE_AUTH": "1",
+        "USE_TOKEN": "true",
+        "SHOW_PASSWORD": "false",
+        "AUTH_USE_AUTH": "false",
+    }
+    credentials = {
+        "PASSWORD": "p4ss",
+        "REFRESH_TOKEN": "r8$!",
+    }
+    environment = {**settings, **credentials}
+    content = " | ".join(f"{name}={value}" for name, value in environment.items())
+    source = [{"role": "tool", "content": content}]
+    original = copy.deepcopy(source)
+
+    monkeypatch.setattr(env_loader, "get_secret_source_values", lambda home: {})
+    monkeypatch.setattr(
+        redact.os, "environ", environment if source_kind == "process" else {}
+    )
+    monkeypatch.setattr(
+        "agent.secret_scope._MULTIPLEX_ACTIVE", source_kind == "multiplex"
+    )
+    token = set_secret_scope(environment if source_kind != "process" else None)
+    try:
+        provider_bound = redact.redact_provider_message_values(source, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    provider_content = provider_bound[0]["content"]
+    assert all(
+        f"{name}={value}" in provider_content for name, value in settings.items()
+    )
+    assert "PASSWORD=p4ss" not in provider_content
+    assert "REFRESH_TOKEN=r8$!" not in provider_content
+    assert provider_content.endswith("PASSWORD=*** | REFRESH_TOKEN=***")
+    assert source == original
+
+
+@pytest.mark.parametrize("source_kind", ("process", "scope", "multiplex"))
+def test_config_style_names_with_arbitrary_short_values_remain_secrets(
+    tmp_path, monkeypatch, source_kind
+):
+    """Name-shape exclusions do not create a blanket short-secret bypass."""
+    import agent.redact as redact
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+    from hermes_cli import env_loader
+
+    credentials = {
+        "SKIP_AUTH": "p4ss",
+        "USE_TOKEN": "r8$!",
+    }
+    source = [
+        {
+            "role": "tool",
+            "content": "SKIP_AUTH=p4ss | USE_TOKEN=r8$!",
+        }
+    ]
+    original = copy.deepcopy(source)
+
+    monkeypatch.setattr(env_loader, "get_secret_source_values", lambda home: {})
+    monkeypatch.setattr(
+        redact.os, "environ", credentials if source_kind == "process" else {}
+    )
+    monkeypatch.setattr(
+        "agent.secret_scope._MULTIPLEX_ACTIVE", source_kind == "multiplex"
+    )
+    token = set_secret_scope(credentials if source_kind != "process" else None)
+    try:
+        provider_bound = redact.redact_provider_message_values(source, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    assert provider_bound[0]["content"] == "SKIP_AUTH=*** | USE_TOKEN=***"
+    assert source == original
+
+
+def test_authoritative_scoped_credential_aliases_are_literal_matched(tmp_path):
+    from agent.redact import redact_known_secret_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    secrets = {
+        "MYSQL_PASS": "scope-pass-77487",
+        "DB_PASSWD": "scope-passwd-77487",
+        "DB_PW": "scope-pw-77487",
+        "PGPASSWORD": "scope-pgpassword-77487",
+        "MYSQL_PWD": "scope-mysql-pwd-77487",
+        "PASSWORD": "scope-password-77487",
+        "PASSWD": "scope-bare-passwd-77487",
+        "PASS": "scope-bare-pass-77487",
+        "PW": "scope-bare-pw-77487",
+        "REDISCLI_AUTH": "scope-redis-auth-77487",
+        "VAULT_CREDENTIAL": "scope-vault-credential-77487",
+        "SERVICE_CREDENTIALS": "scope-service-credentials-77487",
+        "PROXY_AUTH": "scope-proxy-auth-77487",
+        # A terminal substring is not enough: source-name classification must
+        # remain narrow so ordinary process configuration is not collected.
+        "COMPASS": "scope-noncredential-77487",
+        "AUTH_USE_AUTH": "true",
+    }
+    token = set_secret_scope(secrets)
+    try:
+        text = " | ".join(secrets.values())
+        redacted = redact_known_secret_values(text, home=tmp_path)
+
+        for name, secret in secrets.items():
+            if name not in {"COMPASS", "AUTH_USE_AUTH"}:
+                assert secret not in redacted
+        assert redacted.endswith("scope-noncredential-77487 | true")
+    finally:
+        reset_secret_scope(token)
+
+
+def test_ordinary_scoped_key_names_do_not_corrupt_provider_content(tmp_path):
+    """Generic ``*_KEY`` configuration values are not exact-mask inputs."""
+    from agent.redact import redact_provider_message_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    ordinary = {
+        "PARTITION_KEY": "default",
+        "SORT_KEY": "id",
+        "CACHE_KEY": "cache-name",
+        "IDEMPOTENCY_KEY": "request-id",
+        "AUTH_USE_AUTH": "true",
+    }
+    credentials = {
+        "SERVICE_API_KEY": "scoped-api-key-77487",
+        "SERVICE_TOKEN": "scoped-token-77487",
+        "SERVICE_SECRET": "scoped-secret-77487",
+        "SERVICE_PASSWORD": "scoped-password-77487",
+        "FAL_KEY": "scoped-fal-key-77487",
+        "API_SERVER_KEY": "scoped-server-key-77487",
+        "AZURE_ANTHROPIC_KEY": "scoped-azure-key-77487",
+        "VOICE_TOOLS_OPENAI_KEY": "scoped-voice-key-77487",
+        "PORCUPINE_ACCESS_KEY": "scoped-access-key-77487",
+        "AWS_SECRET_ACCESS_KEY": "scoped-aws-key-77487",
+    }
+    source = [
+        {
+            "role": "tool",
+            "content": " | ".join((*ordinary.values(), *credentials.values())),
+        }
+    ]
+    token = set_secret_scope({**ordinary, **credentials})
+    try:
+        provider_bound = redact_provider_message_values(source, home=tmp_path)
+
+        content = provider_bound[0]["content"]
+        assert all(value in content for value in ordinary.values())
+        assert all(value not in content for value in credentials.values())
+        assert source[0]["content"] == " | ".join(
+            (*ordinary.values(), *credentials.values())
+        )
+    finally:
+        reset_secret_scope(token)
+
+
+def test_auth_use_auth_arbitrary_scope_value_is_masked(tmp_path):
+    """Honcho's exact flag name is exempt only for documented flag values."""
+    from agent.redact import redact_provider_message_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    source = [{"role": "tool", "content": "AUTH_USE_AUTH=p4ss"}]
+    original = copy.deepcopy(source)
+    token = set_secret_scope({"AUTH_USE_AUTH": "p4ss"})
+    try:
+        provider_bound = redact_provider_message_values(source, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    assert provider_bound[0]["content"] == "AUTH_USE_AUTH=***"
+    assert source == original
+
+
+def test_multiplex_scoped_credential_suffixes_mask_immutable_provider_copy(
+    tmp_path, monkeypatch
+):
+    """Profile-only repository aliases are removed at provider egress."""
+    from agent.redact import redact_provider_message_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    credentials = {
+        "VAULT_CREDENTIAL": "multiplex-vault-credential-77487",
+        "SERVICE_CREDENTIALS": "multiplex-service-credentials-77487",
+        "PROXY_AUTH": "multiplex-proxy-auth-77487",
+    }
+    source = [{"role": "tool", "content": " | ".join(credentials.values())}]
+    original = copy.deepcopy(source)
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope(credentials)
+    try:
+        provider_bound = redact_provider_message_values(source, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    assert provider_bound[0]["content"] == "*** | *** | ***"
+    assert source == original
+
+
+@pytest.mark.parametrize("source_kind", ("process", "scope", "multiplex"))
+def test_repository_bearer_aliases_mask_immutable_provider_copy(
+    tmp_path, monkeypatch, source_kind
+):
+    """Exact Bedrock and A2A aliases are credentials without broadening bearer."""
+    import agent.redact as redact
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+    from hermes_cli import env_loader
+
+    credentials = {
+        "AWS_BEARER_TOKEN_BEDROCK": "bedrock-bearer-77487",
+        "A2A_BEARER_TOKEN": "a2a-bearer-77487",
+    }
+    source = [{"role": "tool", "content": " | ".join(credentials.values())}]
+    original = copy.deepcopy(source)
+
+    monkeypatch.setattr(env_loader, "get_secret_source_values", lambda home: {})
+    monkeypatch.setattr(
+        redact.os, "environ", credentials if source_kind == "process" else {}
+    )
+    monkeypatch.setattr(
+        "agent.secret_scope._MULTIPLEX_ACTIVE", source_kind == "multiplex"
+    )
+    token = set_secret_scope(credentials if source_kind != "process" else None)
+    try:
+        provider_bound = redact.redact_provider_message_values(source, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    assert provider_bound[0]["content"] == "*** | ***"
+    assert source == original
+
+
+def test_provider_copy_preserves_controls_and_binary_data_but_masks_visible_values(
+    tmp_path, monkeypatch
+):
+    """Short-secret collisions cannot corrupt valid multimodal request fields."""
+    from agent.redact import redact_provider_message_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    controls = {
+        "DATA_TOKEN": "A",
+        "TTL_TOKEN": "1h",
+        "DETAIL_TOKEN": "high",
+        "MEDIA_TOKEN": "image/png",
+        "TYPE_TOKEN": "text",
+        "ROLE_TOKEN": "user",
+        "ID_TOKEN": "block-1",
+        "NAME_TOKEN": "fixture-name",
+        "TOOL_CALL_TOKEN": "tool-call-1",
+        "CALL_TOKEN": "call-1",
+        "CACHE_TOKEN": "ephemeral",
+    }
+    visible = " | ".join(controls.values())
+    source = [
+        {
+            "role": "user",
+            "id": "block-1",
+            "name": "fixture-name",
+            "tool_call_id": "tool-call-1",
+            "tool_use_id": "tool-call-1",
+            "call_id": "call-1",
+            "content": [
+                {
+                    "type": "text",
+                    "id": "block-1",
+                    "name": "fixture-name",
+                    "tool_call_id": "tool-call-1",
+                    "tool_use_id": "tool-call-1",
+                    "call_id": "call-1",
+                    "text": visible,
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "https://example.test/A?ttl=1h",
+                        "detail": "high",
+                    },
+                },
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/png",
+                        "data": "A",
+                    },
+                    "cache_control": {"type": "ephemeral", "ttl": "1h"},
+                },
+            ],
+        }
+    ]
+    original = copy.deepcopy(source)
+
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope(controls)
+    try:
+        provider_bound = redact_provider_message_values(source, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    message = provider_bound[0]
+    text_block, image_url_block, image_block = message["content"]
+    assert message["role"] == "user"
+    assert message["id"] == "block-1"
+    assert message["name"] == "fixture-name"
+    assert message["tool_call_id"] == "tool-call-1"
+    assert message["tool_use_id"] == "tool-call-1"
+    assert message["call_id"] == "call-1"
+    assert text_block["type"] == "text"
+    assert text_block["id"] == "block-1"
+    assert text_block["name"] == "fixture-name"
+    assert text_block["tool_call_id"] == "tool-call-1"
+    assert text_block["tool_use_id"] == "tool-call-1"
+    assert text_block["call_id"] == "call-1"
+    assert all(secret not in text_block["text"] for secret in controls.values())
+    assert image_url_block["image_url"]["detail"] == "high"
+    assert "A" not in image_url_block["image_url"]["url"]
+    assert "1h" not in image_url_block["image_url"]["url"]
+    assert image_block["source"] == {
+        "type": "base64",
+        "media_type": "image/png",
+        "data": "A",
+    }
+    assert image_block["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+    assert source == original
+
+
+def test_provider_copy_preserves_valid_base64_data_uri_payload(tmp_path, monkeypatch):
+    """Opaque data-URI bytes stay valid when a short secret collides."""
+    from agent.redact import redact_provider_message_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    source = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,AAAA"},
+                }
+            ],
+        }
+    ]
+    original = copy.deepcopy(source)
+
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope({"PASSWORD": "A", "MEDIA_TOKEN": "image/png"})
+    try:
+        provider_bound = redact_provider_message_values(source, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    assert provider_bound[0]["content"][0]["image_url"]["url"] == (
+        "data:image/png;base64,AAAA"
+    )
+    assert source == original
+
+
+def test_final_native_image_url_preserves_base64_data_uri(tmp_path, monkeypatch):
+    """Codex-native input_image URLs keep opaque base64 payloads valid."""
+    from agent.redact import redact_provider_api_kwargs
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    source = {
+        "input": [
+            {"type": "input_image", "image_url": "data:image/png;base64,AAAA"}
+        ]
+    }
+    original = copy.deepcopy(source)
+
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope({"PASSWORD": "A"})
+    try:
+        provider_bound = redact_provider_api_kwargs(source, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    assert provider_bound["input"][0]["image_url"] == (
+        "data:image/png;base64,AAAA"
+    )
+    assert source == original
+
+
+def test_final_provider_kwargs_gate_preserves_native_executable_replay(
+    tmp_path, monkeypatch
+):
+    """Provider-native arguments stay exact while adjacent text is masked."""
+    from agent.redact import redact_provider_api_kwargs
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    secret = "p4ss"
+    source = {
+        "model": "fixture-model",
+        "system": [{"text": f"system sees {secret}"}],
+        "messages": [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": f"visible {secret}"},
+                    {
+                        "type": "tool_use",
+                        "id": "call-anthropic",
+                        "name": "terminal",
+                        "input": {"command": f"printf {secret}"},
+                    },
+                    {
+                        "toolUse": {
+                            "toolUseId": "call-bedrock",
+                            "name": "terminal",
+                            "input": {"command": f"printf {secret}"},
+                        }
+                    },
+                ],
+            }
+        ],
+    }
+    original = copy.deepcopy(source)
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope({"REPLAY_PASSWORD": secret})
+    try:
+        dispatched = redact_provider_api_kwargs(source, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    content = dispatched["messages"][0]["content"]
+    assert dispatched["system"] == [{"text": "system sees ***"}]
+    assert content[0]["text"] == "visible ***"
+    assert content[1]["input"] == {"command": f"printf {secret}"}
+    assert content[2]["toolUse"]["input"] == {"command": f"printf {secret}"}
+    assert source == original
+
+
+def test_final_dispatch_gate_masks_secret_composed_by_thinking_merge(
+    tmp_path, monkeypatch
+):
+    """Post-sanitize role repair cannot create a provider-visible secret."""
+    from agent.chat_completion_helpers import build_api_kwargs
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+    from run_agent import AIAgent
+
+    secret = "known-prefix\n\nknown-suffix"
+    source = [
+        {"role": "user", "content": "known-prefix"},
+        {"role": "assistant", "content": "", "reasoning": "hidden"},
+        {"role": "user", "content": "known-suffix"},
+    ]
+    original = copy.deepcopy(source)
+
+    class CapturingTransport:
+        def build_kwargs(self, **kwargs):
+            return kwargs
+
+    class DispatchAgent:
+        tools = []
+        api_mode = "bedrock_converse"
+        model = "fixture-bedrock"
+        max_tokens = 100
+        _bedrock_region = "us-east-1"
+        _bedrock_guardrail_config = None
+
+        def _get_transport(self):
+            return CapturingTransport()
+
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope({"MERGED_API_KEY": secret})
+    try:
+        # The first production gate sees two harmless fragments. The real
+        # thinking-only repair then removes the assistant and joins them with
+        # the exact newlines that complete the configured secret.
+        first_gate = sanitize_api_messages(source)
+        merged = AIAgent._drop_thinking_only_and_merge_users(first_gate)
+        assert merged[0]["content"] == secret
+
+        dispatched = build_api_kwargs(DispatchAgent(), merged)
+    finally:
+        reset_secret_scope(token)
+
+    assert secret not in dispatched["messages"][0]["content"]
+    assert dispatched["messages"][0]["content"] == "***"
+    assert source == original
+
+
+def test_force_ascii_normalization_precedes_final_dispatch_gate(
+    tmp_path, monkeypatch
+):
+    """ASCII fallback cannot compose a secret after provider redaction."""
+    from agent.chat_completion_helpers import build_api_kwargs
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    class CapturingTransport:
+        def build_kwargs(self, **kwargs):
+            return kwargs
+
+    class DispatchAgent:
+        tools = []
+        api_mode = "bedrock_converse"
+        model = "fixture-bedrock"
+        max_tokens = 100
+        _bedrock_region = "us-east-1"
+        _bedrock_guardrail_config = None
+        _force_ascii_payload = True
+
+        def _get_transport(self):
+            return CapturingTransport()
+
+    source = [{"role": "user", "content": "abécd"}]
+    original = copy.deepcopy(source)
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope({"ACTIVE_TOKEN": "abcd"})
+    try:
+        dispatched = build_api_kwargs(DispatchAgent(), source)
+    finally:
+        reset_secret_scope(token)
+
+    assert dispatched["messages"][0]["content"] == "***"
+    assert source == original
+
+
+def test_codex_harmony_preflight_cannot_compose_final_provider_secret(
+    tmp_path, monkeypatch
+):
+    """The real Codex preflight is followed by a provider-native payload gate."""
+    from agent.redact import (
+        redact_provider_api_kwargs,
+        redact_provider_message_values,
+    )
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+    from agent.transports.codex import ResponsesApiTransport
+
+    secret = "<｜start｜>"
+    source = {
+        "model": "gpt-5-codex",
+        "instructions": "guard <|start|>",
+        "input": [{"role": "user", "content": "payload <|start|>"}],
+        "store": False,
+    }
+    original = copy.deepcopy(source)
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope({"HARMONY_TOKEN": secret})
+    try:
+        pre_gate = dict(source)
+        pre_gate["input"] = redact_provider_message_values(
+            source["input"],
+            home=tmp_path,
+        )
+        preflight = ResponsesApiTransport().preflight_kwargs(
+            pre_gate,
+            allow_stream=False,
+            sanitize_harmony_tokens=True,
+        )
+        assert secret in preflight["instructions"]
+        assert secret in preflight["input"][0]["content"]
+        dispatched = redact_provider_api_kwargs(preflight, home=tmp_path)
+    finally:
+        reset_secret_scope(token)
+
+    assert dispatched["instructions"] == "guard ***"
+    assert dispatched["input"][0]["content"] == "payload ***"
+    assert source == original
+
+
+def test_creds_and_bearer_suffixes_require_authoritative_source(
+    tmp_path, monkeypatch
+):
+    """Undeclared ambient aliases stay visible; source-backed values do not."""
+    from agent.redact import redact_known_secret_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+    from hermes_cli import env_loader
+
+    aliases = {
+        "LEGACY_CREDS": "source-backed-creds-77487",
+        "EDGE_BEARER": "source-backed-bearer-77487",
+    }
+    text = " | ".join(aliases.values())
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope(aliases)
+    try:
+        assert redact_known_secret_values(text, home=tmp_path) == text
+        monkeypatch.setitem(
+            env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+            str(tmp_path.resolve()),
+            aliases,
+        )
+        assert redact_known_secret_values(text, home=tmp_path) == "*** | ***"
+    finally:
+        reset_secret_scope(token)
+
+
+def test_repository_declared_plugin_credentials_are_value_sensitively_masked(
+    tmp_path,
+):
+    """Password metadata covers exact plugin names without masking SA paths."""
+    from agent.redact import redact_known_secret_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    chat_inline_service_account = json.dumps(
+        {
+            "type": "service_account",
+            "private_key": "inline-google-private-key-77487",
+        }
+    )
+    application_inline_service_account = json.dumps(
+        {
+            "type": "service_account",
+            "private_key": "application-default-private-key-77487",
+        }
+    )
+    credentials = {
+        "BUZZ_PRIVATE_KEY": "buzz-private-key-77487",
+        "A2A_PEER_TOKENS": "alice:a2a-peer-token-77487",
+        "GOOGLE_CHAT_SERVICE_ACCOUNT_JSON": chat_inline_service_account,
+        "GOOGLE_APPLICATION_CREDENTIALS": application_inline_service_account,
+        "GOOGLE_PRIVATE_KEY_TOKEN": "inline-google-private-key-77487",
+    }
+    token = set_secret_scope(credentials)
+    try:
+        redacted = redact_known_secret_values(
+            " | ".join(credentials.values()), home=tmp_path
+        )
+        assert redacted == "*** | *** | *** | *** | ***"
+    finally:
+        reset_secret_scope(token)
+
+
+def test_a2a_peer_token_container_collects_each_parsed_token(tmp_path):
+    """A peer echo exposes a component, not the full configured container."""
+    from agent.redact import redact_known_secret_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    token = set_secret_scope(
+        {
+            "A2A_PEER_TOKENS": (
+                "alice:a2a-alice-token-77487, malformed, "
+                "bob: a2a-bob-token-77487, empty:"
+            )
+        }
+    )
+    try:
+        assert redact_known_secret_values(
+            "alice=a2a-alice-token-77487 bob=a2a-bob-token-77487 "
+            "ordinary=malformed",
+            home=tmp_path,
+        ) == "alice=*** bob=*** ordinary=malformed"
+    finally:
+        reset_secret_scope(token)
+
+
+def test_inline_google_credentials_collect_private_scalar_not_public_metadata(
+    tmp_path,
+):
+    """Reformatted inline JSON still masks private key scalar echoes only."""
+    from agent.redact import redact_known_secret_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    private_key = "google-private-key-scalar-77487"
+    project_id = "public-project-id-77487"
+    inline = json.dumps(
+        {
+            "project_id": project_id,
+            "private_key": private_key,
+            "type": "service_account",
+        },
+        indent=2,
+        sort_keys=True,
+    )
+    token = set_secret_scope({"GOOGLE_APPLICATION_CREDENTIALS": inline})
+    try:
+        assert redact_known_secret_values(
+            f"private={private_key} project={project_id}", home=tmp_path
+        ) == f"private=*** project={project_id}"
+    finally:
+        reset_secret_scope(token)
+
+    token = set_secret_scope(
+        {"GOOGLE_APPLICATION_CREDENTIALS": "/run/secrets/google-credentials.json"}
+    )
+    try:
+        path = "/run/secrets/google-credentials.json"
+        assert redact_known_secret_values(path, home=tmp_path) == path
+    finally:
+        reset_secret_scope(token)
+
+    chat_service_account_path = "/run/secrets/google-chat-service-account.json"
+    application_credentials_path = "/run/secrets/application-default.json"
+    token = set_secret_scope({
+        "GOOGLE_CHAT_SERVICE_ACCOUNT_JSON": chat_service_account_path,
+        "GOOGLE_APPLICATION_CREDENTIALS": application_credentials_path,
+    })
+    try:
+        assert (
+            redact_known_secret_values(
+                f"{chat_service_account_path} | {application_credentials_path}",
+                home=tmp_path,
+            )
+            == f"{chat_service_account_path} | {application_credentials_path}"
+        )
+    finally:
+        reset_secret_scope(token)
+
+
+def test_ordinary_process_key_names_do_not_corrupt_provider_content(
+    tmp_path, monkeypatch
+):
+    """Single-profile process fallback applies the same narrow classifier."""
+    from agent.redact import redact_provider_message_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    ordinary = {
+        "PARTITION_KEY": "default",
+        "SORT_KEY": "id",
+        "CACHE_KEY": "cache-name",
+        "IDEMPOTENCY_KEY": "request-id",
+    }
+    credentials = {
+        "SERVICE_API_KEY": "process-api-key-77487",
+        "FAL_KEY": "process-fal-key-77487",
+    }
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", False)
+    for name, value in {**ordinary, **credentials}.items():
+        monkeypatch.setenv(name, value)
+    token = set_secret_scope(None)
+    try:
+        source = [
+            {
+                "role": "tool",
+                "content": " | ".join((*ordinary.values(), *credentials.values())),
+            }
+        ]
+        provider_bound = redact_provider_message_values(source, home=tmp_path)
+
+        content = provider_bound[0]["content"]
+        assert all(value in content for value in ordinary.values())
+        assert all(value not in content for value in credentials.values())
+    finally:
+        reset_secret_scope(token)
+
+
+def test_single_profile_scope_overlays_process_credentials_by_name(
+    tmp_path, monkeypatch
+):
+    """A nonempty scope keeps process-only credentials, with scope winning."""
+    from agent.redact import redact_known_secret_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", False)
+    monkeypatch.setenv("PROCESS_ONLY_TOKEN", "process-only-token-77487")
+    monkeypatch.setenv("SHARED_TOKEN", "shadowed-process-token-77487")
+    token = set_secret_scope(
+        {
+            "SCOPE_ONLY_API_KEY": "scope-only-key-77487",
+            "SHARED_TOKEN": "scope-wins-token-77487",
+        }
+    )
+    try:
+        redacted = redact_known_secret_values(
+            " | ".join(
+                (
+                    "process-only-token-77487",
+                    "scope-only-key-77487",
+                    "scope-wins-token-77487",
+                    "shadowed-process-token-77487",
+                )
+            ),
+            home=tmp_path,
+        )
+        assert redacted == "*** | *** | *** | shadowed-process-token-77487"
+    finally:
+        reset_secret_scope(token)
+
+
+def test_multiplex_scope_does_not_collect_process_only_credentials(
+    tmp_path, monkeypatch
+):
+    """Active multiplexing keeps process-global sibling credentials opaque."""
+    from agent.redact import redact_known_secret_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    monkeypatch.setenv("PROCESS_ONLY_TOKEN", "other-profile-token-77487")
+    monkeypatch.setenv(
+        "PROCESS_ONLY_CREDENTIAL", "other-profile-credential-77487"
+    )
+    token = set_secret_scope(
+        {
+            "SCOPE_ONLY_TOKEN": "active-profile-token-77487",
+            "SCOPE_ONLY_AUTH": "active-profile-auth-77487",
+        }
+    )
+    try:
+        assert redact_known_secret_values(
+            "other-profile-token-77487 | other-profile-credential-77487 | "
+            "active-profile-token-77487 | active-profile-auth-77487",
+            home=tmp_path,
+        ) == "other-profile-token-77487 | other-profile-credential-77487 | *** | ***"
+    finally:
+        reset_secret_scope(token)
+
+
+@pytest.mark.parametrize(
+    ("name", "secret"),
+    [
+        ("MYSQL_PASS", "process-pass-77487"),
+        ("DB_PASSWD", "process-passwd-77487"),
+        ("DB_PW", "process-pw-77487"),
+        ("PGPASSWORD", "process-pgpassword-77487"),
+        ("MYSQL_PWD", "process-mysql-pwd-77487"),
+        ("PASSWORD", "process-password-77487"),
+        ("PASSWD", "process-bare-passwd-77487"),
+        ("PASS", "process-bare-pass-77487"),
+        ("PW", "process-bare-pw-77487"),
+        ("REDISCLI_AUTH", "process-redis-auth-77487"),
+        ("VAULT_CREDENTIAL", "process-vault-credential-77487"),
+        ("SERVICE_CREDENTIALS", "process-service-credentials-77487"),
+        ("PROXY_AUTH", "process-proxy-auth-77487"),
+    ],
+)
+def test_single_profile_process_credential_alias_is_literal_matched(
+    tmp_path, monkeypatch, name, secret
+):
+    from agent.redact import redact_known_secret_values
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", False)
+    monkeypatch.setenv(name, secret)
+    token = set_secret_scope(None)
+    try:
+        assert redact_known_secret_values(
+            f"bare value: {secret}", home=tmp_path
+        ) == "bare value: ***"
+    finally:
+        reset_secret_scope(token)
+
+
+def test_historical_argument_fields_remain_exact_for_replay(applied_secret_home):
+    """#43083 applies to modern and legacy replay argument shapes."""
+    from agent.redact import redact_provider_message_values
+
+    _home, secret = applied_secret_home
+    arguments = json.dumps({"command": f"echo {secret}"})
+    messages = [
+        {
+            "role": "assistant",
+            "content": f"provider-visible prose {secret}",
+            "tool_calls": [
+                {
+                    "id": "call_77487",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": arguments},
+                }
+            ],
+            "function_call": {"name": "terminal", "arguments": arguments},
+        }
+    ]
+    original = copy.deepcopy(messages)
+
+    provider_bound = redact_provider_message_values(messages)
+
+    assert secret not in provider_bound[0]["content"]
+    assert provider_bound[0]["tool_calls"][0]["function"]["arguments"] == arguments
+    assert provider_bound[0]["function_call"]["arguments"] == arguments
+    assert messages == original
+
+
+def test_provider_exact_value_mask_respects_redaction_opt_out(
+    applied_secret_home, monkeypatch
+):
+    _home, secret = applied_secret_home
+    messages = _paired_messages(secret)
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+
+    provider_bound = sanitize_api_messages(messages)
+
+    assert provider_bound[1]["content"][0]["text"] == (
+        f"first={secret}; second={secret}"
+    )
+    assert provider_bound[1]["content"][1]["image_url"]["url"] == (
+        f"https://example.invalid/{secret}/{secret}/image.png"
+    )
+
+
+def _response(content: str) -> SimpleNamespace:
+    message = SimpleNamespace(content=content, tool_calls=[])
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], usage=None, model="fixture-model")
+
+
+def _auxiliary_replay_messages(secret: str) -> list[dict]:
+    return [
+        {
+            "role": "assistant",
+            "content": f"visible auxiliary content {secret}",
+            "tool_calls": [
+                {
+                    "id": "call-auxiliary-77487",
+                    "type": "function",
+                    "function": {
+                        "name": "terminal",
+                        "arguments": json.dumps({"command": f"printf {secret}"}),
+                    },
+                }
+            ],
+            "anthropic_content_blocks": [
+                {
+                    "type": "thinking",
+                    "thinking": f"signed thought {secret}",
+                    "signature": "signed-auxiliary-77487",
+                },
+                {"type": "text", "text": f"signed sequence text {secret}"},
+            ],
+            "reasoning_details": [
+                {"type": "reasoning.text", "text": f"signed detail {secret}"}
+            ],
+            "codex_reasoning_items": [
+                {"type": "reasoning", "encrypted_content": f"sealed-{secret}"}
+            ],
+        }
+    ]
+
+
+def test_sync_auxiliary_boundary_masks_disposable_provider_messages(
+    applied_secret_home, monkeypatch
+):
+    """Direct auxiliary callers cannot bypass the provider-copy gate."""
+    import agent.auxiliary_client as auxiliary_client
+
+    _home, secret = applied_secret_home
+    source = _auxiliary_replay_messages(secret)
+    original = copy.deepcopy(source)
+    captured = {}
+    sentinel = _response("safe")
+
+    def fake_impl(**kwargs):
+        captured.update(copy.deepcopy(kwargs))
+        return sentinel
+
+    monkeypatch.setattr(auxiliary_client, "_call_llm_impl", fake_impl)
+
+    assert auxiliary_client.call_llm(messages=source) is sentinel
+    outbound = captured["messages"][0]
+    assert secret not in outbound["content"]
+    assert outbound["tool_calls"] == original[0]["tool_calls"]
+    assert outbound["anthropic_content_blocks"] == original[0][
+        "anthropic_content_blocks"
+    ]
+    assert outbound["reasoning_details"] == original[0]["reasoning_details"]
+    assert outbound["codex_reasoning_items"] == original[0]["codex_reasoning_items"]
+    assert source == original
+
+
+def test_async_auxiliary_boundary_masks_disposable_provider_messages(
+    applied_secret_home, monkeypatch
+):
+    """The async central boundary enforces the same immutable provider copy."""
+    import agent.auxiliary_client as auxiliary_client
+
+    _home, secret = applied_secret_home
+    source = _auxiliary_replay_messages(secret)
+    original = copy.deepcopy(source)
+    captured = {}
+    sentinel = _response("safe")
+
+    async def fake_impl(**kwargs):
+        captured.update(copy.deepcopy(kwargs))
+        return sentinel
+
+    monkeypatch.setattr(auxiliary_client, "_async_call_llm_impl", fake_impl)
+
+    assert asyncio.run(auxiliary_client.async_call_llm(messages=source)) is sentinel
+    assert secret not in captured["messages"][0]["content"]
+    assert captured["messages"][0]["tool_calls"] == original[0]["tool_calls"]
+    assert source == original
+
+
+def test_async_auxiliary_redaction_offloads_with_context_scope(
+    tmp_path, monkeypatch
+):
+    """Thread offload keeps the active multiplex profile's ContextVar secrets."""
+    import agent.auxiliary_client as auxiliary_client
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    secret = "async-context-secret-77487"
+    source = [{"role": "tool", "content": f"thread result {secret}"}]
+    captured = {}
+    offloads = []
+    sentinel = _response("safe")
+    real_to_thread = asyncio.to_thread
+
+    async def spy_to_thread(func, /, *args, **kwargs):
+        offloads.append(func)
+        return await real_to_thread(func, *args, **kwargs)
+
+    async def fake_impl(**kwargs):
+        captured.update(copy.deepcopy(kwargs))
+        return sentinel
+
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    monkeypatch.setattr(asyncio, "to_thread", spy_to_thread)
+    monkeypatch.setattr(auxiliary_client, "_async_call_llm_impl", fake_impl)
+    token = set_secret_scope({"ACTIVE_PROFILE_TOKEN": secret})
+    try:
+        assert asyncio.run(auxiliary_client.async_call_llm(messages=source)) is sentinel
+    finally:
+        reset_secret_scope(token)
+
+    assert offloads
+    assert secret not in captured["messages"][0]["content"]
+    assert source == [{"role": "tool", "content": f"thread result {secret}"}]
+
+
+def test_auxiliary_boundary_respects_explicit_redaction_opt_out(
+    applied_secret_home, monkeypatch
+):
+    import agent.auxiliary_client as auxiliary_client
+
+    _home, secret = applied_secret_home
+    source = _auxiliary_replay_messages(secret)
+    captured = {}
+
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_call_llm_impl",
+        lambda **kwargs: captured.update(kwargs) or _response("safe"),
+    )
+
+    auxiliary_client.call_llm(messages=source)
+
+    assert captured["messages"] is source
+    assert secret in captured["messages"][0]["content"]
+
+
+def test_title_output_is_masked_before_persistence(applied_secret_home, monkeypatch):
+    from agent.title_generator import _persist_session_title, generate_title
+
+    _home, secret = applied_secret_home
+    monkeypatch.setattr(
+        "agent.title_generator.call_llm", lambda **_kwargs: _response(secret)
+    )
+    stored = {}
+
+    class SessionStore:
+        def set_auto_title_if_empty(self, session_id, title):
+            stored[session_id] = title
+            return True
+
+    title = generate_title("request", "response")
+    persisted = _persist_session_title(
+        SessionStore(), "session-77487", title, source="llm"
+    )
+
+    assert title == "***"
+    assert persisted == "***"
+    assert stored == {"session-77487": "***"}
+
+
+def test_title_input_masks_before_maximum_length_cap(tmp_path, monkeypatch):
+    import agent.auxiliary_client as auxiliary_client
+    import agent.title_generator as title_generator
+    from agent.title_generator import generate_title
+    from hermes_cli import env_loader
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    secret = "cycle16-background-title-secret-" + "ABCDEFGHIJ" * 7
+    home_key = str(tmp_path.resolve())
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        home_key,
+        {"PROFILE_TITLE_API_TOKEN": secret},
+    )
+    source = "x" * (title_generator.MAX_TITLE_INPUT_CHARS - 30) + secret
+    captured = {}
+
+    def fake_impl(**kwargs):
+        captured["messages"] = copy.deepcopy(kwargs["messages"])
+        return _response('{"title":"Safe title"}')
+
+    monkeypatch.setattr(title_generator, "_auto_title_enabled", lambda: True)
+    monkeypatch.setattr(title_generator, "_title_language", lambda: "")
+    monkeypatch.setattr(auxiliary_client, "_call_llm_impl", fake_impl)
+    home_token = set_hermes_home_override(tmp_path)
+    try:
+        title = generate_title(source)
+    finally:
+        reset_hermes_home_override(home_token)
+
+    provider_text = json.dumps(captured["messages"])
+    assert title == "Safe title"
+    assert secret not in provider_text
+    assert secret[:30] not in provider_text
+    assert source == "x" * (title_generator.MAX_TITLE_INPUT_CHARS - 30) + secret
+
+
+def test_instant_title_masks_long_secret_before_truncation(tmp_path, monkeypatch):
+    from agent.title_generator import apply_instant_title
+    from hermes_cli import env_loader
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    secret = "cycle16-instant-title-secret-material-" + "ABCDEFGHIJ" * 4
+    home_key = str(tmp_path.resolve())
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        home_key,
+        {"PROFILE_TITLE_API_TOKEN": secret},
+    )
+    source = f"Investigate {secret} and details"
+    stored = []
+    callbacks = []
+
+    class SessionStore:
+        def set_auto_title_if_empty(self, session_id, title):
+            stored.append((session_id, title))
+            return True
+
+    home_token = set_hermes_home_override(tmp_path)
+    try:
+        result = apply_instant_title(
+            SessionStore(), "session-instant-title-77487", source, callbacks.append
+        )
+    finally:
+        reset_hermes_home_override(home_token)
+
+    assert result == "Investigate *** and details"
+    assert callbacks == [result]
+    assert stored == [("session-instant-title-77487", result)]
+    assert secret not in result
+    assert secret[:48] not in result
+    assert source == f"Investigate {secret} and details"
+
+
+def test_maybe_auto_title_thread_preserves_profile_redaction_context(
+    tmp_path, monkeypatch
+):
+    """The real background worker keeps profile-only input/output masking."""
+    import threading
+
+    import agent.auxiliary_client as auxiliary_client
+    import agent.title_generator as title_generator
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+    from hermes_cli import env_loader
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    secret = "profile-title-thread-secret-77487"
+    home_key = str(tmp_path.resolve())
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        home_key,
+        {"PROFILE_ONLY_TITLE_SECRET": secret},
+    )
+    captured = {}
+    persisted = threading.Event()
+    worker_persisted = threading.Event()
+    source_user = f"request contains {secret}"
+    persist_calls = []
+
+    class SessionStore:
+        def get_session_title(self, _session_id):
+            return None
+
+        def get_conversation_root(self, session_id):
+            return session_id
+
+        def set_auto_title_if_empty(self, session_id, title):
+            captured["persisted"] = (session_id, title)
+            persist_calls.append((session_id, title))
+            persisted.set()
+            if len(persist_calls) >= 2:
+                worker_persisted.set()
+            return True
+
+    def fake_impl(**kwargs):
+        captured["messages"] = copy.deepcopy(kwargs["messages"])
+        return _response(secret)
+
+    monkeypatch.setattr(title_generator, "_auto_title_enabled", lambda: True)
+    monkeypatch.setattr(title_generator, "_title_language", lambda: "")
+    monkeypatch.setattr(auxiliary_client, "_call_llm_impl", fake_impl)
+    home_token = set_hermes_home_override(tmp_path)
+    secret_token = set_secret_scope({"PROFILE_ONLY_TITLE_TOKEN": secret})
+    try:
+        title_generator.maybe_auto_title(
+            SessionStore(),
+            "session-title-context-77487",
+            source_user,
+            [{"role": "user", "content": source_user}],
+        )
+        assert persisted.wait(timeout=10), "auto-title worker did not persist"
+        assert worker_persisted.wait(timeout=10), "auto-title upgrade did not persist"
+    finally:
+        reset_secret_scope(secret_token)
+        reset_hermes_home_override(home_token)
+
+    assert secret not in json.dumps(captured["messages"])
+    assert "***" in captured["messages"][1]["content"]
+    assert captured["persisted"] == ("session-title-context-77487", "***")
+    assert source_user == f"request contains {secret}"
+
+
+def test_oneshot_output_masks_exact_secret(applied_secret_home, monkeypatch):
+    from agent.oneshot import run_oneshot
+
+    _home, secret = applied_secret_home
+    monkeypatch.setattr("agent.oneshot.call_llm", lambda **_kwargs: _response(secret))
+
+    assert run_oneshot(instructions="answer", user_input="request") == "***"
+
+
+def test_plugin_sync_and_async_outputs_mask_exact_secret(
+    applied_secret_home,
+):
+    from agent.plugin_llm import _TrustPolicy, make_plugin_llm_for_test
+
+    _home, secret = applied_secret_home
+
+    def sync_caller(**_kwargs):
+        return "fixture", "model", _response(secret)
+
+    async def async_caller(**_kwargs):
+        return "fixture", "model", _response(secret)
+
+    llm = make_plugin_llm_for_test(
+        plugin_id="redaction-fixture",
+        policy=_TrustPolicy(plugin_id="redaction-fixture"),
+        sync_caller=sync_caller,
+        async_caller=async_caller,
+    )
+
+    assert llm.complete([{"role": "user", "content": "request"}]).text == "***"
+    assert (
+        asyncio.run(llm.acomplete([{"role": "user", "content": "request"}])).text
+        == "***"
+    )
+
+
+def test_plugin_structured_output_preserves_json_structure_while_masking_values(
+    tmp_path, monkeypatch
+):
+    """Plugin JSON output remains parseable when secrets resemble JSON syntax."""
+    from agent.plugin_llm import _TrustPolicy, make_plugin_llm_for_test
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    raw_text = (
+        '{"ok":true,"missing":null,'
+        '"secret":"plugin-secret","literal":"true","punctuation":"{"}'
+    )
+    response = _response(raw_text)
+
+    def sync_caller(**_kwargs):
+        return "fixture", "model", response
+
+    llm = make_plugin_llm_for_test(
+        plugin_id="structured-redaction-fixture",
+        policy=_TrustPolicy(plugin_id="structured-redaction-fixture"),
+        sync_caller=sync_caller,
+    )
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+    token = set_secret_scope(
+        {
+            "PLUGIN_TOKEN": "plugin-secret",
+            "TRUE_TOKEN": "true",
+            "NULL_TOKEN": "null",
+            "OPEN_TOKEN": "{",
+        }
+    )
+    try:
+        result = llm.complete_structured(
+            instructions="return JSON",
+            input=[{"type": "text", "text": "request"}],
+            json_mode=True,
+        )
+    finally:
+        reset_secret_scope(token)
+
+    assert result.content_type == "json"
+    assert result.parsed == {
+        "ok": True,
+        "missing": None,
+        "secret": "***",
+        "literal": "***",
+        "punctuation": "***",
+    }
+    assert json.loads(result.text) == result.parsed
+    assert response.choices[0].message.content == raw_text
+
+
+def test_auxiliary_text_outputs_respect_redaction_opt_out(
+    applied_secret_home, monkeypatch
+):
+    from agent.oneshot import run_oneshot
+
+    _home, secret = applied_secret_home
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+    monkeypatch.setattr("agent.oneshot.call_llm", lambda **_kwargs: _response(secret))
+
+    assert run_oneshot(instructions="answer", user_input="request") == secret
+
+
+def test_moa_reference_and_synthesis_requests_mask_exact_values(
+    applied_secret_home, monkeypatch
+):
+    """MoA copies are clean while replayable modern/legacy arguments stay exact."""
+    from agent.moa_loop import aggregate_moa_context
+
+    _home, secret = applied_secret_home
+    arguments = json.dumps({"command": f"printf {secret}"})
+    api_messages = [
+        {"role": "user", "content": "inspect the latest result"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_moa_77487",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": arguments},
+                }
+            ],
+            "function_call": {"name": "terminal", "arguments": arguments},
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_moa_77487",
+            "content": f"external tool returned {secret}",
+        },
+    ]
+    original = copy.deepcopy(api_messages)
+    calls: list[dict] = []
+
+    def fake_call_llm(**kwargs):
+        calls.append(copy.deepcopy(kwargs))
+        if kwargs["task"] == "moa_reference":
+            return _response(f"advisor repeated {secret}")
+        return _response("synthesized guidance")
+
+    monkeypatch.setattr(
+        "agent.moa_loop._slot_runtime",
+        lambda slot: {
+            "provider": slot.get("provider"),
+            "model": slot.get("model"),
+            "base_url": "https://example.invalid/v1",
+            "api_key": "fixture-runtime-key",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+
+    aggregate_moa_context(
+        user_prompt=f"separate synthesis prompt contains {secret}",
+        api_messages=api_messages,
+        reference_models=[{"provider": "fixture", "model": "advisor"}],
+        aggregator={"provider": "fixture", "model": "aggregator"},
+    )
+
+    reference_call = next(call for call in calls if call["task"] == "moa_reference")
+    synthesis_call = next(call for call in calls if call["task"] == "moa_aggregator")
+    assert secret not in json.dumps(reference_call["messages"])
+    assert secret not in json.dumps(synthesis_call["messages"])
+    assert api_messages == original
+    assert api_messages[1]["tool_calls"][0]["function"]["arguments"] == arguments
+    assert api_messages[1]["function_call"]["arguments"] == arguments
+
+
+def test_moa_reference_masks_json_encoded_arguments_without_mutating_source(
+    json_special_secret_home,
+):
+    """Rendered advisory arguments mask decoded values after JSON escaping."""
+    from agent.moa_loop import _redacted_reference_messages
+
+    _home, secret = json_special_secret_home
+    arguments = json.dumps({"command": f"printf {secret}"})
+    messages = [
+        {"role": "user", "content": "inspect"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-moa-json-77487",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": arguments},
+                }
+            ],
+            "function_call": {"name": "terminal", "arguments": arguments},
+        },
+    ]
+    original = copy.deepcopy(messages)
+
+    advisory = _redacted_reference_messages(messages)
+
+    rendered = "\n".join(str(message.get("content", "")) for message in advisory)
+    assert json.dumps(secret)[1:-1] not in rendered
+    assert secret not in rendered
+    assert messages == original
+    assert messages[1]["tool_calls"][0]["function"]["arguments"] == arguments
+    assert messages[1]["function_call"]["arguments"] == arguments
+
+
+@pytest.mark.parametrize("alternate_spelling", ALTERNATE_JSON_SPELLINGS)
+def test_moa_reference_masks_alternate_json_escapes_without_mutating_source(
+    monkeypatch, alternate_spelling
+):
+    """Disposable advisory rendering decodes equivalent JSON spellings."""
+    from agent.moa_loop import _redacted_reference_messages
+    from hermes_cli import env_loader
+    from hermes_constants import get_hermes_home
+
+    home = get_hermes_home()
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(home.resolve()),
+        {"ALTERNATE_JSON_SECRET": ALTERNATE_JSON_SECRET},
+    )
+    arguments = _json_with_alternate_secret("command", alternate_spelling)
+    messages = [
+        {"role": "user", "content": "inspect"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-moa-alternate-json-77487",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": arguments},
+                }
+            ],
+            "function_call": {"name": "terminal", "arguments": arguments},
+        },
+    ]
+    original = copy.deepcopy(messages)
+
+    advisory = _redacted_reference_messages(messages)
+
+    rendered = "\n".join(str(message.get("content", "")) for message in advisory)
+    assert ALTERNATE_JSON_SECRET not in rendered
+    assert ALTERNATE_JSON_SPELLING not in rendered
+    assert alternate_spelling not in rendered
+    assert messages == original
+
+
+@pytest.mark.parametrize("fragment_kind", MALFORMED_JSON_FRAGMENT_KINDS)
+def test_moa_reference_masks_malformed_alternate_json_fragments_without_mutation(
+    monkeypatch, fragment_kind
+):
+    """Disposable MoA rendering masks incomplete and invalid quoted fragments."""
+    from agent.moa_loop import _redacted_reference_messages
+    from hermes_cli import env_loader
+    from hermes_constants import get_hermes_home
+
+    home = get_hermes_home()
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(home.resolve()),
+        {"MALFORMED_MOA_JSON_SECRET": ALTERNATE_JSON_SECRET},
+    )
+    arguments = _malformed_json_with_alternate_secret("command", fragment_kind)
+    messages = [
+        {"role": "user", "content": "inspect"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-moa-malformed-json-77487",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": arguments},
+                }
+            ],
+        },
+    ]
+    original = copy.deepcopy(messages)
+
+    advisory = _redacted_reference_messages(messages)
+
+    rendered = "\n".join(str(message.get("content", "")) for message in advisory)
+    assert "***" in rendered
+    assert ALTERNATE_JSON_SECRET not in rendered
+    assert ALTERNATE_JSON_SPELLING not in rendered
+    assert messages == original
+
+
+def test_anthropic_signed_ordered_replay_is_preserved_as_one_opaque_sequence(
+    applied_secret_home,
+):
+    """Signed replay keeps every ordered block byte-exact and in place."""
+    from agent.anthropic_adapter import convert_messages_to_anthropic
+
+    _home, secret = applied_secret_home
+    arguments = json.dumps({"command": f"printf {secret}"})
+    ordered = [
+        {
+            "type": "thinking",
+            "thinking": f"first signed reasoning stays byte exact {secret}",
+            "signature": "sig-first-77487",
+        },
+        {"type": "text", "text": f"signature-bound provider text {secret}"},
+        {
+            "type": "thinking",
+            "thinking": f"second signed reasoning stays byte exact {secret}",
+            "signature": "sig-second-77487",
+        },
+        {
+            "type": "tool_use",
+            "id": "toolu_77487",
+            "name": "terminal",
+            "input": {"command": f"printf {secret}"},
+        },
+    ]
+    messages = [
+        {"role": "user", "content": "continue"},
+        {
+            "role": "assistant",
+            "content": f"fallback content {secret}",
+            "reasoning_details": [ordered[0]],
+            "tool_calls": [
+                {
+                    "id": "toolu_77487",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": arguments},
+                }
+            ],
+            "anthropic_content_blocks": ordered,
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "toolu_77487",
+            "content": "done",
+        },
+    ]
+    original = copy.deepcopy(messages)
+
+    provider_bound = sanitize_api_messages(messages)
+    _system, anthropic_messages = convert_messages_to_anthropic(
+        provider_bound,
+        base_url=None,
+        model="claude-opus-4-8",
+    )
+
+    assistant = next(m for m in anthropic_messages if m["role"] == "assistant")
+    blocks = assistant["content"]
+    assert [block["type"] for block in blocks] == [
+        "thinking",
+        "text",
+        "thinking",
+        "tool_use",
+    ]
+    assert blocks == ordered
+    assert blocks[3]["input"] == {"command": f"printf {secret}"}
+    assert messages == original
+
+
+def test_anthropic_unsigned_ordered_text_is_still_redacted(applied_secret_home):
+    """Text-only ordered lists have no signature contract and stay maskable."""
+    from agent.redact import redact_provider_message_values
+
+    _home, secret = applied_secret_home
+    ordered = [
+        {"type": "text", "text": f"first visible text {secret}"},
+        {"type": "text", "text": f"second visible text {secret}"},
+    ]
+    messages = [
+        {
+            "role": "assistant",
+            "content": f"fallback content {secret}",
+            "anthropic_content_blocks": ordered,
+        }
+    ]
+    original = copy.deepcopy(messages)
+
+    provider_bound = redact_provider_message_values(messages)
+
+    assert all(secret not in block["text"] for block in provider_bound[0]["anthropic_content_blocks"])
+    assert messages == original
+
+
+def test_anthropic_redacted_thinking_keeps_complete_ordered_sequence(
+    applied_secret_home,
+):
+    """Opaque redacted-thinking data also binds its surrounding block list."""
+    from agent.redact import redact_provider_message_values
+
+    _home, secret = applied_secret_home
+    ordered = [
+        {"type": "text", "text": f"prefix text {secret}"},
+        {"type": "redacted_thinking", "data": f"opaque-data-{secret}"},
+        {"type": "text", "text": f"trailing text {secret}"},
+    ]
+    messages = [
+        {
+            "role": "assistant",
+            "content": f"fallback content {secret}",
+            "anthropic_content_blocks": ordered,
+        }
+    ]
+    original = copy.deepcopy(messages)
+
+    provider_bound = redact_provider_message_values(messages)
+
+    assert secret not in provider_bound[0]["content"]
+    assert provider_bound[0]["anthropic_content_blocks"] == ordered
+    assert messages == original
+
+
+def test_openrouter_reasoning_details_are_opaque_replay_bytes(applied_secret_home):
+    """OpenRouter requires its complete reasoning-details sequence unchanged."""
+    from agent.redact import redact_provider_message_values
+
+    _home, secret = applied_secret_home
+    details = [
+        {
+            "type": "reasoning.summary",
+            "summary": f"provider summary {secret}",
+            "id": "summary-77487",
+        },
+        {
+            "type": "reasoning.text",
+            "text": f"provider reasoning text {secret}",
+            "format": "openrouter-v1",
+        },
+        {
+            "type": "reasoning.signature",
+            "signature": f"signed-{secret}",
+            "data": f"opaque-{secret}",
+        },
+        {
+            "type": "future.unknown",
+            "opaque": {"nested": [secret, {"value": secret}]},
+        },
+    ]
+    messages = [
+        {
+            "role": "assistant",
+            "content": f"safe visible field {secret}",
+            "reasoning_details": details,
+        }
+    ]
+    original = copy.deepcopy(messages)
+
+    provider_bound = redact_provider_message_values(messages)
+
+    assert secret not in provider_bound[0]["content"]
+    assert provider_bound[0]["reasoning_details"] == details
+    assert messages == original
+
+
+def test_provider_copy_preserves_opaque_codex_replay_fields(applied_secret_home):
+    """Encrypted state and stable item identity remain exact; visible text does not."""
+    from agent.redact import redact_provider_message_values
+
+    _home, secret = applied_secret_home
+    messages = [
+        {
+            "role": "assistant",
+            "content": f"visible fallback {secret}",
+            "codex_reasoning_items": [
+                {
+                    "type": "reasoning",
+                    "id": f"rs_{secret}",
+                    "encrypted_content": secret,
+                }
+            ],
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "id": f"msg_{secret}",
+                    "phase": "commentary",
+                    "content": [
+                        {"type": "output_text", "text": f"visible item {secret}"}
+                    ],
+                }
+            ],
+        }
+    ]
+    original = copy.deepcopy(messages)
+
+    provider_bound = redact_provider_message_values(messages)
+
+    assert provider_bound[0]["codex_reasoning_items"] == original[0][
+        "codex_reasoning_items"
+    ]
+    item = provider_bound[0]["codex_message_items"][0]
+    assert item["id"] == f"msg_{secret}"
+    assert secret not in item["content"][0]["text"]
+    assert messages == original


### PR DESCRIPTION
Auxiliary callers and prepared conversation messages could forward active
secrets in text or nested provider content. Match the active profile's exact
values on disposable copies, including alternate JSON spellings and short
credentials, with collision-safe replacement markers.

Keep executable arguments, signed or sealed replay units, provider controls,
and opaque media byte-exact. Reject a native Bedrock request when masking
would change its signed history. The redaction opt-out still applies.

The matcher and structured-copy rules live in a topical module; the existing
log and terminal redactor keeps its established interface.

Related #82142

This PR is pseudo-stacked. Each commit can land independently of later commits and may depend on earlier commits:

1. Exact-value discovery, bounded JSON matching, structured provider copies, and auxiliary/native request boundaries.
2. Main provider dispatch after ASCII, Harmony, middleware, and raw-history restoration.
3. Compaction, rolling summaries, and injected memory before persistence or truncation.
4. Disposable MoA advice after executable tool arguments are rendered as prose.
5. Generated and derived titles, including background profile context and fallback persistence.
6. Visible one-shot and plugin response copies.

The first slice exceeds 400 production lines because secret-source snapshots, collision-safe markers, tolerant bounded JSON decoding, and provider-aware copy rules must agree at the same reachable send boundary. Splitting off a matcher-only PR would leave no changed behavior; splitting only a field or encoding would knowingly leave the same request gate incomplete. The later boundaries have separate commits and tests. Maintainers can review the matcher, structured preservation rules, and actual send callbacks separately within the first commit.

Executable tool arguments intentionally remain exact, including on provider replay; masking those requires a separate authenticated reference design. Anthropic signed content sequences, opaque reasoning details, encrypted replay items, and validated opaque media retain their provider contract. This change does not claim to remove secrets embedded in those replay or media fields.

Bedrock limitation: its reasoning signature binds preceding messages ([AWS Converse documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html)). If masking would change a native signed prefix or its system text, the request is rejected with a safe error. An unchanged signed prefix remains byte-exact, and new unsigned suffix messages are masked. Signature-shaped metadata never grants an exemption to arbitrary history.

The known-value boundary complements #82027's recalled-context display fencing and keeps its raw `api_content` replay semantics. It does not change provider tool epoch metadata from #72249. Related #77198 covers applied-value redaction in existing plaintext helpers; this PR addresses structured/native provider payloads, encoded and short active values, and disposable auxiliary projections. It preserves #43083's executable-argument behavior.

Validation: exact commit-prefix tests and current-main composition results are recorded below. Existing source tests were retained; new regressions cover SDK extra_body overrides, conversion-created matches, relay replacements, raw sidecars, Bedrock signed-history collisions, title normalization, and background fallback persistence.

Not checked: live credentialed provider calls, platform-specific checks locally, and CodeRabbit (P3 author-side maintenance).

Prepared using GPT-6 Astra with ultra reasoning in Codex. The account owner loosely reviews these actions and receives usual notifications from GitHub.

Exact-prefix validation on main `5bd439d3ed4a`:

- `143f1c8e3983`: 38 files, 602 tests passed, 0 failed, 1 skipped (100% complete) in 15.6s (32 workers)
- `acd87c0169aa`: 17 files, 791 tests passed, 0 failed (100% complete) in 78.0s (32 workers)
- `078d467efec9`: 13 files, 370 tests passed, 0 failed (100% complete) in 14.1s (32 workers)
- `7b8db3ba4b7a`: 15 files, 151 tests passed, 0 failed (100% complete) in 9.7s (32 workers)
- `0424728135c4`: 3 files, 140 tests passed, 0 failed (100% complete) in 3.7s (32 workers)
- `b46e3a70a847`: 4 files, 169 tests passed, 0 failed (100% complete) in 3.8s (32 workers)

The six commits were rebased cleanly, with all range-diff entries unchanged, after the previous CI run was cancelled in Detect affected areas before the Python or OS test lanes executed. This refresh has no workflow configuration changes.

Prior diagnostic composition of the same six patches with #82027, #104530, #72249, #72248 and #104552 passed 719 boundary tests and 431 replay/runtime tests (overlapping counts). Integrating main `857218e6dad7` into that diagnostic tree passed another 542 relevant tests. Two provider-related merge resolutions retain both the title sanitizer and background context, and both tool snapshot capture and final message masking. The independent PR branches remain separate.
