### PR TITLE
fix(desktop): self-heal missing get-windows win32 binding + allow its install script (#81969)

### DIFF
--- a/apps/desktop/scripts/stage-native-deps.mjs
+++ b/apps/desktop/scripts/stage-native-deps.mjs
@@ -426,7 +426,7 @@ function resolveGetWindowsRoot() {
  */
 const GET_WINDOWS_VERSION = '9.3.0'
 
-export function stageGetWindowsInto(srcRoot, destRoot, { platform = process.platform } = {}) {
+export function stageGetWindowsInto(srcRoot, destRoot, { platform = process.platform, rebuild } = {}) {
   // The STAGED_WINDOWS_JS rewrite mirrors this exact version's export surface.
   // A version bump must fail the build here until the rewrite is re-verified —
   // otherwise it ships stale and fails soft as a generic "unavailable".
@@ -473,17 +473,34 @@ export function stageGetWindowsInto(srcRoot, destRoot, { platform = process.plat
     // the target platform; the classify gate below still catches a dir that
     // claims win32 but holds a foreign binary.
     const bindingRoot = join(srcRoot, 'lib', 'binding')
-    const bindingDirs = existsSync(bindingRoot)
-      ? readdirSync(bindingRoot).filter(
-          (dir) =>
-            dir.includes(`-${platform}-`) &&
-            existsSync(join(bindingRoot, dir, 'node-get-windows.node'))
-        )
-      : []
+    const scanBindingDirs = () =>
+      existsSync(bindingRoot)
+        ? readdirSync(bindingRoot).filter(
+            (dir) =>
+              dir.includes(`-${platform}-`) &&
+              existsSync(join(bindingRoot, dir, 'node-get-windows.node'))
+          )
+        : []
+    let bindingDirs = scanBindingDirs()
+    if (bindingDirs.length === 0 && typeof rebuild === 'function') {
+      // Self-heal the common bricked state: npm's allowScripts policy blocked
+      // get-windows' node-pre-gyp install script on a previous install, so
+      // lib/binding was never populated — and a later plain `npm install`
+      // won't re-run install scripts for a package that is already present.
+      // `npm rebuild` re-runs them now that the script is allow-listed.
+      console.log(
+        '[stage-native-deps] get-windows has no win32 binding; attempting `npm rebuild get-windows`...'
+      )
+      rebuild()
+      bindingDirs = scanBindingDirs()
+    }
     if (bindingDirs.length === 0) {
       throw new Error(
         '[stage-native-deps] get-windows has no win32 prebuilt binding under lib/binding; ' +
-          'reinstall dependencies on the Windows build host.'
+          'its install script was likely blocked by the npm allowScripts policy. ' +
+          'Recover from the hermes-agent checkout root with:\n' +
+          '  npm install-scripts approve get-windows\n' +
+          '  npm rebuild get-windows'
       )
     }
     for (const dir of bindingDirs) {
@@ -506,10 +523,30 @@ export function stageGetWindowsInto(srcRoot, destRoot, { platform = process.plat
   return destRoot
 }
 
+/**
+ * Re-run get-windows' install script (node-pre-gyp) via `npm rebuild`.
+ * Only meaningful when the packaging host IS the target Windows machine —
+ * cross-platform packs can't produce the win32 binding anyway.
+ */
+function rebuildGetWindowsViaNpm() {
+  const repoRoot = resolve(projectRoot, '..', '..')
+  // npm resolves to npm.cmd on Windows, so it needs a shell there.
+  const result = spawnSync('npm', ['rebuild', 'get-windows'], {
+    cwd: repoRoot,
+    stdio: 'inherit',
+    shell: process.platform === 'win32'
+  })
+  if (result.status !== 0) {
+    console.warn(`[stage-native-deps] npm rebuild get-windows exited with ${result.status}`)
+  }
+}
+
 export function stageGetWindows({ platform = process.platform } = {}) {
   const srcRoot = resolveGetWindowsRoot()
   const destRoot = resolve(projectRoot, 'dist/node_modules/get-windows')
-  return stageGetWindowsInto(srcRoot, destRoot, { platform })
+  const rebuild =
+    platform === 'win32' && process.platform === 'win32' ? rebuildGetWindowsViaNpm : undefined
+  return stageGetWindowsInto(srcRoot, destRoot, { platform, rebuild })
 }
 
 // Allow direct CLI invocation: node scripts/stage-native-deps.mjs [platform] [arch]

--- a/apps/desktop/scripts/stage-native-deps.test.mjs
+++ b/apps/desktop/scripts/stage-native-deps.test.mjs
@@ -437,6 +437,52 @@ test('win32 staging fails when only foreign bindings exist', () => {
   }
 })
 
+test('win32 staging self-heals through the rebuild hook when the binding is missing', () => {
+  const tmp = fs.mkdtempSync(join(os.tmpdir(), 'hermes-stage-'))
+  try {
+    const srcRoot = join(tmp, 'get-windows')
+    const destRoot = join(tmp, 'dest')
+
+    // The bricked state from a blocked allowScripts install: package present,
+    // lib/binding never populated by node-pre-gyp.
+    makeFakeGetWindows(srcRoot, { bindings: [] })
+
+    let calls = 0
+    const rebuild = () => {
+      calls += 1
+      // Simulates `npm rebuild get-windows` downloading the prebuilt binding.
+      makeFakeNode(
+        join(srcRoot, 'lib', 'binding', 'napi-9-win32-unknown-x64', 'node-get-windows.node'),
+        'win32'
+      )
+    }
+
+    stageGetWindowsInto(srcRoot, destRoot, { platform: 'win32', rebuild })
+
+    assert.equal(calls, 1)
+    assert.ok(existsSync(join(destRoot, 'lib', 'binding', 'napi-9-win32-unknown-x64', 'node-get-windows.node')))
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  }
+})
+
+test('win32 staging reports allowScripts recovery steps when the rebuild hook cannot produce a binding', () => {
+  const tmp = fs.mkdtempSync(join(os.tmpdir(), 'hermes-stage-'))
+  try {
+    const srcRoot = join(tmp, 'get-windows')
+    const destRoot = join(tmp, 'dest')
+
+    makeFakeGetWindows(srcRoot, { bindings: [] })
+
+    assert.throws(
+      () => stageGetWindowsInto(srcRoot, destRoot, { platform: 'win32', rebuild: () => {} }),
+      /npm rebuild get-windows/
+    )
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  }
+})
+
 test('staging refuses a get-windows version the lib/windows.js rewrite was not verified against', () => {
   const tmp = fs.mkdtempSync(join(os.tmpdir(), 'hermes-stage-'))
   try {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "agent-browser@0.26.0": true,
     "electron@40.10.2": true,
     "fsevents@2.3.2": true,
-    "fsevents@2.3.3": true
+    "fsevents@2.3.3": true,
+    "get-windows@9.3.0": true
   }
 }


### PR DESCRIPTION
## Summary

Fixes #81969 — Windows desktop installs brick on `hermes update` / `hermes desktop` with:

```
Error: [stage-native-deps] get-windows has no win32 prebuilt binding under lib/binding; reinstall dependencies on the Windows build host.
```

## Root cause

npm's `allowScripts` policy (root `package.json`) does not cover `get-windows@9.3.0`, so npm blocks its install script (`node-pre-gyp install --fallback-to-build`) — visible in the reporter's log:

```
npm warn install-scripts 1 package had install scripts blocked because they are not covered by allowScripts:
npm warn install-scripts   get-windows@9.3.0 (install: node-pre-gyp install --fallback-to-build)
```

That script is what downloads the win32 prebuilt binding into `lib/binding/`. With it blocked, `stageGetWindowsInto()` finds no binding, throws, and the desktop build dies — leaving the UI "bricked" after an otherwise successful update.

**Crucially, the allowlist entry alone cannot unbrick users who already hit this**: npm only runs install scripts when a package is (re)installed. On broken machines `get-windows` is already present in `node_modules` (script skipped), so the next `npm install` never re-runs it — exactly why commenters on the issue had to manually run `npm rebuild get-windows`.

## What this PR does

1. **Allow-list** `get-windows@9.3.0` in root `allowScripts` (fresh installs work again).
2. **Self-heal existing broken installs**: `stageGetWindowsInto()` gains an injectable `rebuild` hook. When the win32 binding is missing on a Windows host, `stageGetWindows()` wires in a hook that runs `npm rebuild get-windows` (re-running the now allow-listed install script) and re-scans before failing. This mirrors the existing `electron-rebuild` fallback already used for node-pty in the same file.
3. **Actionable failure**: if recovery still fails (e.g. offline), the error now names the allowScripts cause and prints the exact manual recovery commands instead of a generic "reinstall dependencies".

The hook is only wired when the packaging host **is** the win32 target, so cross-platform staging behavior and the pure unit under test are unchanged.

## Relation to open PRs (not a duplicate)

- #81983 / #81999 add only the allowlist line; #82118 adds allowlist lines for get-windows + electron.
- None of them recover machines that are **already bricked** (the main complaint in #81969 — "now it's completely bricked", "won't even reinstall"), because a plain `npm install` won't re-run a blocked install script for an already-present package.
- This PR supersedes them: allowlist **+** automatic `npm rebuild` recovery **+** actionable error **+** regression tests.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[🔒 hermes update / hermes desktop] --> B[⚡ npm install]
    B -->|allowScripts now covers get-windows@9.3.0| C[📦 node-pre-gyp downloads win32 binding]
    B -->|already-broken install: script never ran| D[🚫 lib/binding empty]
    C --> E[🧩 stageGetWindowsInto]
    D --> E
    E -->|binding found| F[🚀 Desktop Build OK]
    E -->|binding missing on win32 host| G[🔁 Self-Heal: npm rebuild get-windows]
    G -->|re-scan finds binding| F
    G -->|still missing - offline etc| H[🛑 Safe Abort with exact recovery commands]
```
## Infographic :

<img width="941" height="1672" alt="infographic" src="https://github.com/user-attachments/assets/362d7c62-8b0a-40ef-b31e-f05343aee07f" />

## Test plan

- [x] New test: win32 staging self-heals through the rebuild hook when the binding is missing (hook called once, binding staged).
- [x] New test: when the rebuild hook cannot produce a binding, the error carries the allowScripts recovery steps.
- [x] Existing suite behavior preserved: no hook → immediate throw; happy path never invokes the hook; darwin-binding filtering and wrong-platform classification gates untouched.
- [x] `node --check` on both modified scripts; full scenario matrix verified with a standalone `node` harness (local vitest for this suite fails on unmodified `main` too — environment issue, unrelated).

 
