### PR TITLE
Allow configured tools in background review

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -900,11 +900,42 @@ def _run_review_in_thread(
                     quiet_mode=True,
                 )
             }
+            configured_extra_tools: set[str] = set()
+            try:
+                from hermes_cli.config import load_config_readonly
+
+                config = load_config_readonly()
+                auxiliary = config.get("auxiliary", {})
+                review_config = (
+                    auxiliary.get("background_review", {})
+                    if isinstance(auxiliary, dict)
+                    else {}
+                )
+                extra_tools = (
+                    review_config.get("extra_tools", [])
+                    if isinstance(review_config, dict)
+                    else []
+                )
+                if isinstance(extra_tools, list):
+                    configured_extra_tools = {
+                        name.strip()
+                        for name in extra_tools
+                        if isinstance(name, str) and name.strip()
+                    }
+                    review_whitelist.update(configured_extra_tools)
+            except Exception:
+                pass
+            allowed_tools_description = "memory and skill management tools"
+            if configured_extra_tools:
+                allowed_tools_description += (
+                    ", plus these configured tools: "
+                    + ", ".join(sorted(configured_extra_tools))
+                )
             set_thread_tool_whitelist(
                 review_whitelist,
                 deny_msg_fmt=(
                     "Background review denied non-whitelisted tool: "
-                    "{tool_name}. Only memory/skill tools are allowed."
+                    f"{{tool_name}}. Only {allowed_tools_description} are allowed."
                 ),
             )
             try:
@@ -925,8 +956,8 @@ def _run_review_in_thread(
                 review_agent.run_conversation(
                     user_message=(
                         prompt
-                        + "\n\nYou can only call memory and skill "
-                        "management tools. Other tools will be denied "
+                        + f"\n\nYou can only call {allowed_tools_description}. "
+                        "Other tools will be denied "
                         "at runtime — do not attempt them."
                     ),
                     conversation_history=_review_history,

--- a/contributors/emails/brin@shadewaterlabs.com
+++ b/contributors/emails/brin@shadewaterlabs.com
@@ -1,0 +1,2 @@
+BrinShadewater
+# PR #82146

--- a/tests/run_agent/test_background_review_toolset_restriction.py
+++ b/tests/run_agent/test_background_review_toolset_restriction.py
@@ -135,7 +135,66 @@ def test_background_review_installs_thread_local_whitelist():
     assert "execute_code" not in whitelist
 
 
+def test_background_review_whitelist_includes_configured_extra_tools(
+    tmp_path, monkeypatch
+):
+    """A profile may opt a specific proposal tool into background review.
 
+    The review fork inherits the parent's full tool schema for cache parity,
+    but runtime dispatch remains denied unless the tool is also present in the
+    thread-local whitelist.  This config hook lets profiles grant a narrowly
+    scoped, human-gated proposal tool without enabling unrelated side effects.
+    """
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "auxiliary:\n"
+        "  background_review:\n"
+        "    extra_tools:\n"
+        "      - propose_shared_memory\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
+    import run_agent
+    from hermes_cli import config as config_module
+    from hermes_cli import plugins as _plugins
+
+    config_module._LOAD_CONFIG_CACHE.clear()
+    config_module._RAW_CONFIG_CACHE.clear()
+
+    captured = {}
+
+    def _capture_whitelist(whitelist, deny_msg_fmt=None):
+        captured["whitelist"] = set(whitelist)
+
+    def _capture_run_conversation(self, *, user_message, **kwargs):
+        captured["review_prompt"] = user_message
+        return {"final_response": "Nothing to save."}
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+
+    def _no_init(self, *args, **kwargs):
+        return None
+
+    with patch.object(run_agent.AIAgent, "__init__", _no_init), \
+         patch.object(
+             run_agent.AIAgent,
+             "run_conversation",
+             _capture_run_conversation,
+         ), \
+         patch.object(run_agent.AIAgent, "shutdown_memory_provider", lambda self: None), \
+         patch.object(run_agent.AIAgent, "close", lambda self: None), \
+         patch.object(_plugins, "set_thread_tool_whitelist", _capture_whitelist), \
+         patch("threading.Thread", _SyncThread):
+        agent._spawn_background_review(
+            messages_snapshot=[],
+            review_memory=True,
+            review_skills=False,
+        )
+
+    assert "propose_shared_memory" in captured["whitelist"]
+    assert "terminal" not in captured["whitelist"]
+    assert "propose_shared_memory" in captured["review_prompt"]
 
 

--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -317,6 +317,25 @@ identical and skill capture near-identical to the main-model review.
 Leave it at `auto` (or set it to your main model) and nothing changes — the
 review keeps running on the main model with the full warm-cache replay.
 
+### Allowing a narrowly scoped extra review tool
+
+Background review can use memory and skill-management tools by default. If a
+profile provides another tool that is safe for unattended review, opt it in by
+name:
+
+```yaml
+auxiliary:
+  background_review:
+    extra_tools:
+      - propose_shared_memory
+```
+
+The tool must already be available to the parent agent; this setting only adds
+it to the review fork's runtime whitelist. It does not enable arbitrary tools,
+and tools not listed here remain denied. Keep the list narrow and prefer tools
+that stage a proposal for human review rather than applying external or
+destructive changes directly. The default is an empty list.
+
 ## Controlling skill writes (`skills.write_approval`)
 
 Skills use the same on/off gate, but the review UX differs because a


### PR DESCRIPTION
## Summary

- add `auxiliary.background_review.extra_tools` for narrowly scoped, profile-provided review tools
- preserve the default memory-and-skill-only runtime policy and continue denying every unlisted tool
- tell the review model and runtime denial message which configured tools are available
- document the configuration and cover it with a real temporary `HERMES_HOME` regression test

## Why

Background-review forks inherit the parent agent's tool schema for prompt-cache parity, but runtime dispatch is separately constrained by a thread-local whitelist. That means a profile can expose a safe, human-gated proposal tool to the parent while the review fork sees its schema but is always denied when it tries to call it.

This change adds an explicit, default-empty opt-in. A configured tool must already exist in the inherited parent toolset; the setting only admits that exact name to background review. Unrelated tools remain denied.

## User impact

Existing installations are unchanged. Profiles that provide a review-safe tool can opt it in explicitly:

```yaml
auxiliary:
  background_review:
    extra_tools:
      - propose_shared_memory
```

The documentation recommends keeping this list narrow and preferring tools that stage proposals for human review over tools that apply external or destructive changes directly.

## Validation

- 27 focused background-review tests passed through `scripts/run_tests.sh`
- Ruff passed for the implementation and regression test
- Python bytecode compilation passed
- `git diff --check` passed
