### PR TITLE
fix(init): target the session's real cwd, not the process launch dir

### DIFF
--- a/hermes_cli/init_command.py
+++ b/hermes_cli/init_command.py
@@ -133,12 +133,20 @@ def build_init_prompt(
 def build_init_prompt_for_cwd(cwd: str | None = None, extra: str = "") -> str:
     """Convenience wrapper used by the dispatch surfaces.
 
-    Resolves ``cwd`` (defaults to the process working directory), reads an
-    existing ``AGENTS.md`` there if present, and returns the full prompt.
+    Resolves ``cwd`` (defaults to the session's real working directory via
+    :func:`agent.runtime_cwd.resolve_agent_cwd` — NOT ``os.getcwd()``, which on
+    the desktop/gateway is the *process* launch directory and can be the user's
+    home even when the session was started inside a project), reads an existing
+    ``AGENTS.md`` there if present, and returns the full prompt.
     """
     import os
 
-    resolved = os.path.abspath(cwd or os.getcwd())
+    from agent.runtime_cwd import resolve_agent_cwd
+
+    if cwd:
+        resolved = os.path.abspath(os.path.expanduser(str(cwd)))
+    else:
+        resolved = str(resolve_agent_cwd())
     existing: str | None = None
     agents_path = os.path.join(resolved, "AGENTS.md")
     try:

--- a/tests/hermes_cli/test_init_command.py
+++ b/tests/hermes_cli/test_init_command.py
@@ -53,6 +53,43 @@ class TestBuildInitPromptForCwd:
         prompt = build_init_prompt_for_cwd(cwd=str(tmp_path), extra="keep it short")
         assert "keep it short" in prompt
 
+    def test_defaults_to_session_cwd_not_process_cwd(self, tmp_path, monkeypatch):
+        """Regression: /init must target the session's real working directory,
+        not the process launch directory.
+
+        The desktop/gateway process is launched from the user's home (or the
+        app bundle), while sessions can be started inside a project (sidebar
+        project, session.create cwd). Falling back to os.getcwd() wrote
+        AGENTS.md into the home directory instead of the repo.
+        """
+        project = tmp_path / "project"
+        project.mkdir()
+        launcher = tmp_path / "apps" / "desktop"
+        launcher.mkdir(parents=True)
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        monkeypatch.chdir(launcher)
+
+        # Simulate the desktop/gateway pinning the session cwd via the
+        # runtime carrier (agent.runtime_cwd.resolve_agent_cwd reads it).
+        monkeypatch.setenv("TERMINAL_CWD", str(project))
+
+        prompt = build_init_prompt_for_cwd()
+        assert f"project at: {project}" in prompt
+        assert f"{project}/AGENTS.md" in prompt
+
+    def test_explicit_cwd_wins_over_terminal_cwd(self, tmp_path, monkeypatch):
+        """An explicitly passed cwd (e.g. the TUI session's pinned workspace)
+        must override the runtime carrier."""
+        project = tmp_path / "project"
+        project.mkdir()
+        other = tmp_path / "other"
+        other.mkdir()
+        monkeypatch.setenv("TERMINAL_CWD", str(other))
+
+        prompt = build_init_prompt_for_cwd(cwd=str(project))
+        assert f"project at: {project}" in prompt
+        assert str(other) not in prompt
+
 
 class TestInitRegistryWiring:
     def test_init_is_registered_and_resolves(self):

--- a/tests/tui_gateway/test_init_command_cwd.py
+++ b/tests/tui_gateway/test_init_command_cwd.py
@@ -1,0 +1,141 @@
+"""Tests for /init in tui_gateway — session cwd targeting.
+
+The TUI routes ``/init`` through ``command.dispatch`` (same as ``/learn`` and
+``/undo``). Regression coverage for the desktop bug where /init resolved the
+project root from the *process* cwd (the desktop launcher's home directory)
+instead of the session's real workspace.
+
+The desktop starts a session from a sidebar project via ``session.create``
+with a ``cwd`` param; that value lands in ``_sessions[sid]["cwd"]`` and must
+be the project root /init writes AGENTS.md into.
+"""
+
+from __future__ import annotations
+
+import importlib
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture()
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    yield home
+
+
+@pytest.fixture()
+def server(hermes_home):
+    # Mocks are scoped to the initial import only (see
+    # tests/tui_gateway/test_protocol.py for the rationale).
+    with patch.dict(
+        "sys.modules",
+        {
+            "hermes_cli.env_loader": MagicMock(),
+            "hermes_cli.banner": MagicMock(),
+        },
+    ):
+        mod = importlib.import_module("tui_gateway.server")
+
+    methods = dict(mod._methods)
+    yield mod
+    # Restore in place instead of clear+reload: importlib.reload
+    # re-registers atexit hooks (duplicate ThreadPoolExecutor shutdowns
+    # race the stderr buffer at interpreter exit — same class as PR #34217)
+    # and re-captures module-level paths like _hermes_home against this
+    # test's soon-deleted tmpdir, breaking later files in the same process.
+    mod._methods.clear()
+    mod._methods.update(methods)
+    mod._sessions.clear()
+    mod._pending.clear()
+    mod._answers.clear()
+    mod._db = None
+
+
+@pytest.fixture()
+def db(hermes_home):
+    return SessionDB(db_path=hermes_home / "state.db")
+
+
+def _call(server, method, **params):
+    return server._methods[method](1, params)
+
+
+def _make_session(server, db, sid, session_key, cwd):
+    """Minimal live session row with a pinned workspace cwd."""
+    db.create_session(session_key, source="tui")
+    history = db.get_messages_as_conversation(session_key)
+    agent = MagicMock()
+    agent._memory_manager = MagicMock()
+    agent._last_flushed_db_idx = len(history)
+    s = {
+        "session_key": session_key,
+        "history": list(history),
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "agent": agent,
+        "attached_images": [],
+        "cols": 120,
+        "cwd": str(cwd),
+    }
+    server._sessions[sid] = s
+    server._db = db
+    return sid, session_key, s, agent
+
+
+def test_init_uses_session_cwd_not_process_cwd(server, db, tmp_path, monkeypatch):
+    """The /init prompt must target the session's pinned workspace.
+
+    Regression for the desktop bug: the gateway process launches from the
+    user's home, and sessions started from a sidebar project carry the real
+    project root in ``_sessions[sid][\"cwd\"]``. Falling back to the process
+    cwd wrote AGENTS.md into the home directory instead of the repo.
+    """
+    project = tmp_path / "project"
+    project.mkdir()
+    launcher = tmp_path / "apps" / "desktop"
+    launcher.mkdir(parents=True)
+    monkeypatch.chdir(launcher)
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+
+    sid, _, _, _ = _make_session(server, db, "sid-init-cwd", "tui-init-cwd", project)
+
+    try:
+        resp = _call(server, "command.dispatch", session_id=sid, name="init", arg="")
+    finally:
+        server._sessions.pop(sid, None)
+
+    result = resp["result"]
+    assert result["type"] == "send"
+    assert f"project at: {project}" in result["message"]
+    assert f"{project}/AGENTS.md" in result["message"]
+
+
+def test_init_without_session_falls_back_to_runtime_cwd(
+    server, db, tmp_path, monkeypatch
+):
+    """No pinned workspace? /init should fall back to the runtime carrier
+    (TERMINAL_CWD), still not the process launch dir."""
+    project = tmp_path / "project"
+    project.mkdir()
+    launcher = tmp_path / "apps" / "desktop"
+    launcher.mkdir(parents=True)
+    monkeypatch.chdir(launcher)
+    monkeypatch.setenv("TERMINAL_CWD", str(project))
+
+    try:
+        resp = _call(server, "command.dispatch", session_id="nope", name="init", arg="")
+    finally:
+        server._sessions.pop("nope", None)
+
+    result = resp["result"]
+    assert result["type"] == "send"
+    assert f"project at: {project}" in result["message"]

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -592,7 +592,18 @@ def _(rid, params: dict) -> dict:
         # merge-updates AGENTS.md via write_file. Works on any backend.
         from hermes_cli.init_command import build_init_prompt_for_cwd
 
-        return _ok(rid, {"type": "send", "message": build_init_prompt_for_cwd(extra=arg)})
+        # Pin the project root to THIS session's real workspace. The desktop
+        # starts sessions from a sidebar project (session.create cwd), and the
+        # server process cwd is the launch dir — falling back to the process
+        # cwd would write AGENTS.md into the user's home instead of the repo.
+        session_cwd = (session or {}).get("cwd") or None
+        return _ok(
+            rid,
+            {
+                "type": "send",
+                "message": build_init_prompt_for_cwd(cwd=session_cwd, extra=arg)
+            },
+        )
     if name == "moa":
         # /moa is one-shot sugar only: run a single prompt through the default
         # MoA preset, then restore the prior model. To *switch* to a MoA preset


### PR DESCRIPTION
## Summary

`/init` (generate-or-update `AGENTS.md`) resolved the project root from `os.getcwd()` — the **process** launch directory — instead of the session's real working directory.

On the desktop, the backend process is spawned from the user's home (or the app bundle — see `resolveHermesCwd()` in `apps/desktop/electron/main.ts`), while sessions can be started inside a real project from the sidebar. So `/init` in a session started from a sidebar project (e.g. `skills/zzd-message-ops`) wrote `AGENTS.md` into the user's home directory (`C:\Users\hermes\AGENTS.md`) instead of the project directory — wasting an agent's first exploration and confusing the user about where the file went.

## Root cause

Three `/init` dispatch surfaces all called `build_init_prompt_for_cwd(extra=...)` without a `cwd`:

- `hermes_cli/cli_commands_mixin.py` (`_handle_init_command`)
- `gateway/run.py` (messaging-gateway `/init`)
- `tui_gateway/methods_tools.py` (`command.dispatch` /init)

`build_init_prompt_for_cwd` then fell back to `os.getcwd()`. But Hermes already has a single source of truth for the agent working directory — `agent/runtime_cwd.py::resolve_agent_cwd()` — which checks (1) the session cwd contextvar (`_SESSION_CWD`, pinned by `gateway/session_context.py::set_session_vars` for gateway sessions and by `_sessions[sid]["cwd"]` in the TUI/desktop), (2) `TERMINAL_CWD`, then (3) `os.getcwd()`. `/init` skipped that resolution entirely.

## Fix

1. **`hermes_cli/init_command.py`** — `build_init_prompt_for_cwd()` now defaults to `resolve_agent_cwd()` instead of `os.getcwd()`. An explicitly passed `cwd` still wins (it's the most precise: the TUI session's pinned workspace).
2. **`tui_gateway/methods_tools.py`** — the `command.dispatch` `/init` branch now passes the session's pinned workspace cwd (`_sessions[sid]["cwd"]`, set by `session.create`), so desktop sessions started from a sidebar project target the repo.

The messaging-gateway and CLI surfaces are fixed by the shared builder change: the gateway already pins the session cwd via the contextvar before the turn runs.

## Verification

- New regression tests:
  - `tests/hermes_cli/test_init_command.py` — prompt builder defaults to session cwd (`TERMINAL_CWD` carrier) instead of process cwd; explicit cwd overrides the carrier.
  - `tests/tui_gateway/test_init_command_cwd.py` — `command.dispatch` `/init` uses the session's pinned workspace cwd; falls back to the runtime carrier when no session.
- Ran adjacent suites: `tests/hermes_cli/test_init_command.py` (8 passed), `tests/tui_gateway/test_init_command_cwd.py` (2 passed), `tests/tui_gateway/test_undo_command.py` (1 passed), `tests/test_tui_gateway_server.py` (522 passed), plus the full `tests/gateway/test_session*.py` set — zero regressions.
