### PR TITLE
feat(desktop): support API modes for custom endpoints

### DIFF
--- a/apps/desktop/src/app/settings/custom-endpoints-settings.test.tsx
+++ b/apps/desktop/src/app/settings/custom-endpoints-settings.test.tsx
@@ -1,0 +1,96 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { CustomEndpoint } from '@/types/hermes'
+
+const activateCustomEndpoint = vi.fn()
+const deleteCustomEndpoint = vi.fn()
+const getCustomEndpoints = vi.fn()
+const saveCustomEndpoint = vi.fn()
+const validateCustomEndpoint = vi.fn()
+
+// Radix Select uses DOM APIs that jsdom does not implement.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.releasePointerCapture = vi.fn()
+})
+
+vi.mock('@/hermes', () => ({
+  activateCustomEndpoint: (endpointId: string) => activateCustomEndpoint(endpointId),
+  deleteCustomEndpoint: (endpointId: string) => deleteCustomEndpoint(endpointId),
+  getCustomEndpoints: () => getCustomEndpoints(),
+  saveCustomEndpoint: (payload: unknown) => saveCustomEndpoint(payload),
+  validateCustomEndpoint: (payload: unknown) => validateCustomEndpoint(payload)
+}))
+
+vi.mock('@/lib/haptics', () => ({
+  triggerHaptic: vi.fn()
+}))
+
+function endpoint(patch: Partial<CustomEndpoint> = {}): CustomEndpoint {
+  return {
+    api_mode: 'auto',
+    base_url: 'https://claude.example.com',
+    discover_models: true,
+    has_api_key: true,
+    id: 'claude-proxy',
+    is_current: true,
+    model: 'claude-opus-5',
+    models: ['claude-opus-5'],
+    name: 'Claude Proxy',
+    ...patch
+  }
+}
+
+beforeEach(() => {
+  const configured = endpoint()
+  getCustomEndpoints.mockResolvedValue({
+    current: {
+      base_url: configured.base_url,
+      model: configured.model,
+      provider: configured.id
+    },
+    endpoints: [configured]
+  })
+  saveCustomEndpoint.mockResolvedValue({
+    current: {
+      base_url: configured.base_url,
+      model: configured.model,
+      provider: configured.id
+    },
+    endpoints: [endpoint({ api_mode: 'anthropic_messages' })],
+    id: configured.id,
+    ok: true
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('CustomEndpointsSettings', () => {
+  it('saves the API compatibility mode selected in Desktop', async () => {
+    const { CustomEndpointsSettings } = await import('./custom-endpoints-settings')
+
+    await act(async () => {
+      render(<CustomEndpointsSettings />)
+    })
+
+    const apiModeSelect = await screen.findByRole('combobox', { name: 'API Mode' })
+    fireEvent.click(apiModeSelect)
+    fireEvent.click(await screen.findByRole('option', { name: 'Anthropic Messages' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() =>
+      expect(saveCustomEndpoint).toHaveBeenCalledWith(
+        expect.objectContaining({
+          api_mode: 'anthropic_messages',
+          base_url: 'https://claude.example.com',
+          model: 'claude-opus-5'
+        })
+      )
+    )
+  })
+})

--- a/apps/desktop/src/app/settings/custom-endpoints-settings.tsx
+++ b/apps/desktop/src/app/settings/custom-endpoints-settings.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import {
   activateCustomEndpoint,
   deleteCustomEndpoint,
@@ -10,11 +11,12 @@ import {
   saveCustomEndpoint,
   validateCustomEndpoint
 } from '@/hermes'
+import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { Check, Globe, Loader2, Plus, Save, Trash2, Zap } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
-import type { CustomEndpoint, CustomEndpointUpdate } from '@/types/hermes'
+import type { CustomEndpoint, CustomEndpointApiMode, CustomEndpointUpdate } from '@/types/hermes'
 
 import { EmptyState, Pill, SectionHeading, SettingsContent, SettingsSkeleton } from './primitives'
 
@@ -24,6 +26,7 @@ interface CustomEndpointsSettingsProps {
 }
 
 interface EndpointForm {
+  apiMode: CustomEndpointApiMode
   apiKey: string
   baseUrl: string
   contextLength: string
@@ -35,6 +38,7 @@ interface EndpointForm {
 }
 
 const EMPTY_FORM: EndpointForm = {
+  apiMode: 'auto',
   apiKey: '',
   baseUrl: '',
   contextLength: '',
@@ -47,6 +51,7 @@ const EMPTY_FORM: EndpointForm = {
 
 function formFromEndpoint(endpoint: CustomEndpoint): EndpointForm {
   return {
+    apiMode: endpoint.api_mode ?? 'auto',
     apiKey: '',
     baseUrl: endpoint.base_url,
     contextLength: endpoint.context_length ? String(endpoint.context_length) : '',
@@ -62,6 +67,7 @@ function toPayload(form: EndpointForm, models?: string[]): CustomEndpointUpdate 
   const contextLength = Number.parseInt(form.contextLength, 10)
 
   return {
+    api_mode: form.apiMode,
     id: form.id.trim() || undefined,
     name: form.name.trim(),
     base_url: form.baseUrl.trim(),
@@ -75,6 +81,8 @@ function toPayload(form: EndpointForm, models?: string[]): CustomEndpointUpdate 
 }
 
 export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: CustomEndpointsSettingsProps) {
+  const { t } = useI18n()
+  const messages = t.settings.customEndpoints
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const [testing, setTesting] = useState(false)
@@ -312,14 +320,39 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
                 />
               </label>
             </div>
-            <label className="grid gap-1.5 text-xs text-muted-foreground">
-              Endpoint URL
-              <Input
-                onChange={event => setForm(current => ({ ...current, baseUrl: event.target.value }))}
-                placeholder="http://127.0.0.1:8081/v1"
-                value={form.baseUrl}
-              />
-            </label>
+            <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_15rem]">
+              <label className="grid gap-1.5 text-xs text-muted-foreground">
+                Endpoint URL
+                <Input
+                  onChange={event => setForm(current => ({ ...current, baseUrl: event.target.value }))}
+                  placeholder="http://127.0.0.1:8081/v1"
+                  value={form.baseUrl}
+                />
+              </label>
+              <label className="grid gap-1.5 text-xs text-muted-foreground">
+                {messages.apiMode}
+                <Select
+                  onValueChange={value => setForm(current => ({ ...current, apiMode: value as CustomEndpointApiMode }))}
+                  value={form.apiMode}
+                >
+                  <SelectTrigger aria-label={messages.apiMode}>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="auto">{messages.modes.auto}</SelectItem>
+                    <SelectItem value="chat_completions">{messages.modes.chatCompletions}</SelectItem>
+                    <SelectItem value="codex_responses">{messages.modes.responses}</SelectItem>
+                    <SelectItem value="anthropic_messages">{messages.modes.anthropicMessages}</SelectItem>
+                  </SelectContent>
+                </Select>
+              </label>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {form.apiMode === 'auto' && messages.descriptions.auto}
+              {form.apiMode === 'chat_completions' && messages.descriptions.chatCompletions}
+              {form.apiMode === 'codex_responses' && messages.descriptions.responses}
+              {form.apiMode === 'anthropic_messages' && messages.descriptions.anthropicMessages}
+            </p>
             <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_12rem]">
               <label className="grid gap-1.5 text-xs text-muted-foreground">
                 Default Model

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -305,6 +305,21 @@ export const ar = defineLocale({
       keybinds: 'اختصارات لوحة المفاتيح',
       plugins: 'الإضافات'
     },
+    customEndpoints: {
+      apiMode: 'وضع API',
+      modes: {
+        auto: 'اكتشاف تلقائي',
+        chatCompletions: 'Chat Completions',
+        responses: 'Responses / Codex',
+        anthropicMessages: 'Anthropic Messages'
+      },
+      descriptions: {
+        auto: 'دع Hermes يستنتج البروتوكول من عنوان URL لنقطة النهاية.',
+        chatCompletions: 'يستخدم /chat/completions؛ وينتهي عنوان نقطة النهاية عادةً بـ /v1.',
+        responses: 'يستخدم /responses؛ وينتهي عنوان نقطة النهاية عادةً بـ /v1. يرسل الاختبار طلباً من رمز واحد.',
+        anthropicMessages: 'يستخدم /v1/messages؛ أدخل جذر API من دون /v1 في النهاية. يرسل الاختبار طلباً من رمز واحد.'
+      }
+    },
     plugins: {
       title: 'إضافات سطح المكتب',
       blurb:

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -354,6 +354,22 @@ export const en: Translations = {
       notifications: 'Notifications',
       plugins: 'Plugins'
     },
+    customEndpoints: {
+      apiMode: 'API Mode',
+      modes: {
+        auto: 'Auto-detect',
+        chatCompletions: 'Chat Completions',
+        responses: 'Responses / Codex',
+        anthropicMessages: 'Anthropic Messages'
+      },
+      descriptions: {
+        auto: 'Let Hermes infer the protocol from the endpoint URL.',
+        chatCompletions: 'Uses /chat/completions; the endpoint URL normally ends in /v1.',
+        responses: 'Uses /responses; the endpoint URL normally ends in /v1. Test sends a one-token request.',
+        anthropicMessages:
+          'Uses /v1/messages; enter the API root without a trailing /v1. Test sends a one-token request.'
+      }
+    },
     plugins: {
       title: 'Desktop plugins',
       blurb: 'Bundled or dropped into the desktop-plugins folder. Disable to unload live.',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -239,6 +239,23 @@ export const ja = defineLocale({
       billing: '請求',
       notifications: '通知'
     },
+    customEndpoints: {
+      apiMode: 'API モード',
+      modes: {
+        auto: '自動検出',
+        chatCompletions: 'Chat Completions',
+        responses: 'Responses / Codex',
+        anthropicMessages: 'Anthropic Messages'
+      },
+      descriptions: {
+        auto: 'エンドポイント URL から Hermes がプロトコルを推測します。',
+        chatCompletions: '/chat/completions を使用します。通常、エンドポイント URL は /v1 で終わります。',
+        responses:
+          '/responses を使用します。通常、エンドポイント URL は /v1 で終わります。テストでは 1 トークンのリクエストを送信します。',
+        anthropicMessages:
+          '/v1/messages を使用します。末尾に /v1 を付けず、API のルート URL を入力してください。テストでは 1 トークンのリクエストを送信します。'
+      }
+    },
     notifications: {
       title: '通知',
       intro: 'アプリ内トーストとは別の、ネイティブのデスクトップ通知です。設定は端末ごとに保存されます。',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -305,6 +305,21 @@ export interface Translations {
       notifications: string
       plugins: string
     }
+    customEndpoints: {
+      apiMode: string
+      modes: {
+        auto: string
+        chatCompletions: string
+        responses: string
+        anthropicMessages: string
+      }
+      descriptions: {
+        auto: string
+        chatCompletions: string
+        responses: string
+        anthropicMessages: string
+      }
+    }
     plugins: {
       title: string
       blurb: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -233,6 +233,21 @@ export const zhHant = defineLocale({
       billing: '帳單',
       notifications: '通知'
     },
+    customEndpoints: {
+      apiMode: 'API 模式',
+      modes: {
+        auto: '自動偵測',
+        chatCompletions: 'Chat Completions',
+        responses: 'Responses / Codex',
+        anthropicMessages: 'Anthropic Messages'
+      },
+      descriptions: {
+        auto: '讓 Hermes 根據端點 URL 推斷協定。',
+        chatCompletions: '使用 /chat/completions；端點 URL 通常以 /v1 結尾。',
+        responses: '使用 /responses；端點 URL 通常以 /v1 結尾。測試會傳送一個單 token 請求。',
+        anthropicMessages: '使用 /v1/messages；請填寫不含結尾 /v1 的 API 根網址。測試會傳送一個單 token 請求。'
+      }
+    },
     notifications: {
       title: '通知',
       intro: '原生桌面通知，與應用程式內提示不同。設定會依裝置保存，每台電腦各自獨立。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -344,6 +344,21 @@ export const zh: Translations = {
       notifications: '通知',
       plugins: '插件'
     },
+    customEndpoints: {
+      apiMode: 'API 模式',
+      modes: {
+        auto: '自动检测',
+        chatCompletions: 'Chat Completions',
+        responses: 'Responses / Codex',
+        anthropicMessages: 'Anthropic Messages'
+      },
+      descriptions: {
+        auto: '让 Hermes 根据端点 URL 推断协议。',
+        chatCompletions: '使用 /chat/completions；端点 URL 通常以 /v1 结尾。',
+        responses: '使用 /responses；端点 URL 通常以 /v1 结尾。测试会发送一个单 token 请求。',
+        anthropicMessages: '使用 /v1/messages；请填写不带末尾 /v1 的 API 根地址。测试会发送一个单 token 请求。'
+      }
+    },
     plugins: {
       title: '桌面插件',
       blurb:

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -155,7 +155,10 @@ export interface MemoryProviderConfig {
   name: string
 }
 
+export type CustomEndpointApiMode = 'auto' | 'chat_completions' | 'codex_responses' | 'anthropic_messages'
+
 export interface CustomEndpoint {
+  api_mode?: CustomEndpointApiMode
   api_key_preview?: null | string
   base_url: string
   context_length?: null | number
@@ -181,6 +184,7 @@ export interface CustomEndpointsResponse {
 }
 
 export interface CustomEndpointUpdate {
+  api_mode?: CustomEndpointApiMode
   api_key?: string
   base_url: string
   context_length?: number

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -56,6 +56,14 @@ class CustomEndpointUpdate(BaseModel):
     base_url: str
     model: str
     api_key: Optional[str] = None
+    api_mode: Optional[
+        Literal[
+            "auto",
+            "chat_completions",
+            "codex_responses",
+            "anthropic_messages",
+        ]
+    ] = None
     context_length: Optional[int] = None
     discover_models: bool = True
     make_default: bool = False
@@ -722,4 +730,3 @@ class _PluginProvidersPutBody(BaseModel):
 
 class _PluginVisibilityBody(BaseModel):
     hidden: bool
-

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7279,6 +7279,34 @@ def _config_api_key_is_env_ref(endpoint_id: str) -> bool:
     return bool(isinstance(raw_key, str) and re.search(r"\$\{[^}]+\}", raw_key))
 
 
+_CUSTOM_ENDPOINT_TRANSPORTS = {
+    "chat_completions": "openai_chat",
+    "codex_responses": "codex_responses",
+    "anthropic_messages": "anthropic_messages",
+}
+
+
+def _custom_endpoint_api_mode(entry: Dict[str, Any]) -> str:
+    """Return the Desktop-facing API mode for a v12 provider entry."""
+    raw_mode = str(entry.get("transport") or entry.get("api_mode") or "").strip()
+    if raw_mode == "openai_chat":
+        return "chat_completions"
+    if raw_mode in _CUSTOM_ENDPOINT_TRANSPORTS:
+        return raw_mode
+    return "auto"
+
+
+def _mirror_custom_endpoint_api_mode(
+    model_cfg: Dict[str, Any], entry: Dict[str, Any]
+) -> None:
+    """Keep the active model's runtime mode aligned with its provider entry."""
+    api_mode = _custom_endpoint_api_mode(entry)
+    if api_mode == "auto":
+        model_cfg.pop("api_mode", None)
+    else:
+        model_cfg["api_mode"] = api_mode
+
+
 def _custom_endpoint_response(cfg: Dict[str, Any]) -> Dict[str, Any]:
     model_cfg = cfg.get("model", {}) if isinstance(cfg.get("model"), dict) else {}
     current_provider = str(model_cfg.get("provider", "") or "")
@@ -7304,6 +7332,7 @@ def _custom_endpoint_response(cfg: Dict[str, Any]) -> Dict[str, Any]:
                 "base_url": base_url,
                 "model": endpoint_model,
                 "models": models,
+                "api_mode": _custom_endpoint_api_mode(raw_entry),
                 "context_length": raw_entry.get("context_length"),
                 "discover_models": bool(raw_entry.get("discover_models", True)),
                 "has_api_key": has_api_key,
@@ -7320,6 +7349,7 @@ def _custom_endpoint_response(cfg: Dict[str, Any]) -> Dict[str, Any]:
             "base_url": current_base_url,
             "model": current_model,
             "models": [current_model] if current_model else [],
+            "api_mode": _custom_endpoint_api_mode(model_cfg),
             "context_length": model_cfg.get("context_length"),
             "discover_models": True,
             "has_api_key": has_api_key,
@@ -7356,7 +7386,7 @@ def _detach_main_model_from_provider(cfg: Dict[str, Any], provider_key: str) -> 
         return
     if str(model_cfg.get("provider") or "").strip().lower() != provider_key:
         return
-    for field in ("provider", "base_url", "api_key", "key_env"):
+    for field in ("provider", "base_url", "api_key", "key_env", "api_mode"):
         model_cfg.pop(field, None)
     cfg["model"] = model_cfg
 
@@ -7398,6 +7428,17 @@ def _write_custom_endpoint(cfg: Dict[str, Any], body: CustomEndpointUpdate) -> T
         "model": model,
         "discover_models": bool(body.discover_models),
     })
+    # ``providers`` is the v12 config shape, where ``transport`` is canonical.
+    # Keep ``api_mode`` as the Desktop API name because it matches the runtime
+    # vocabulary and the existing CLI prompt. An omitted field comes from an
+    # older client and preserves hand-written config; explicit Auto removes it.
+    if body.api_mode is not None:
+        transport = _CUSTOM_ENDPOINT_TRANSPORTS.get(body.api_mode)
+        if transport:
+            entry["transport"] = transport
+        else:
+            entry.pop("transport", None)
+        entry.pop("api_mode", None)
     # Same for the model map: merge rather than replace, so existing models
     # keep their context lengths. ``body.models`` is the catalogue the panel's
     # Test button already discovered — without it only the one hand-typed
@@ -7450,6 +7491,8 @@ def _write_custom_endpoint(cfg: Dict[str, Any], body: CustomEndpointUpdate) -> T
         if entry.get("key_env") and isinstance(cfg["model"], dict):
             cfg["model"]["key_env"] = entry["key_env"]
             cfg["model"].pop("api_key", None)
+        if isinstance(cfg["model"], dict):
+            _mirror_custom_endpoint_api_mode(cfg["model"], entry)
 
     return endpoint_id, entry
 
@@ -7505,6 +7548,7 @@ def activate_custom_endpoint(endpoint_id: str):
             model_cfg.pop("api_key", None)
         elif entry.get("api_key"):
             model_cfg["api_key"] = entry["api_key"]
+        _mirror_custom_endpoint_api_mode(model_cfg, entry)
         cfg["model"] = model_cfg
         save_config(cfg)
         return {"ok": True, "provider": provider_key, "model": model}
@@ -7541,21 +7585,58 @@ def delete_custom_endpoint(endpoint_id: str):
 
 @app.post("/api/providers/custom-endpoints/validate")
 async def validate_custom_endpoint(body: CustomEndpointUpdate):
-    """Probe a custom endpoint by calling its OpenAI-compatible /models URL."""
+    """Probe a custom endpoint using its selected API compatibility mode."""
     import httpx
 
     base_url = (body.base_url or "").strip().rstrip("/")
     if not base_url:
         return {"ok": False, "reachable": True, "message": "Enter an endpoint URL first.", "models": []}
 
-    url = base_url + "/models"
+    api_mode = body.api_mode or "auto"
+    if api_mode == "auto":
+        from hermes_cli.runtime_provider import _detect_api_mode_for_url
+
+        api_mode = _detect_api_mode_for_url(base_url) or "chat_completions"
+
     headers = {"Accept": "application/json"}
-    if body.api_key and body.api_key.strip():
-        headers["Authorization"] = f"Bearer {body.api_key.strip()}"
+    request_body: Optional[Dict[str, Any]] = None
+    if api_mode == "anthropic_messages":
+        # Match the Anthropic SDK used at runtime: it appends /v1/messages to
+        # the configured base URL. A user-entered trailing /v1 therefore fails
+        # this probe too instead of producing a false-positive Test result.
+        url = base_url + "/v1/messages"
+        headers.update({
+            "Content-Type": "application/json",
+            "anthropic-version": "2023-06-01",
+        })
+        if body.api_key and body.api_key.strip():
+            headers["x-api-key"] = body.api_key.strip()
+        request_body = {
+            "model": body.model.strip(),
+            "max_tokens": 1,
+            "messages": [{"role": "user", "content": "."}],
+        }
+    elif api_mode == "codex_responses":
+        url = base_url + "/responses"
+        headers["Content-Type"] = "application/json"
+        if body.api_key and body.api_key.strip():
+            headers["Authorization"] = f"Bearer {body.api_key.strip()}"
+        request_body = {
+            "model": body.model.strip(),
+            "input": ".",
+            "max_output_tokens": 1,
+        }
+    else:
+        url = base_url + "/models"
+        if body.api_key and body.api_key.strip():
+            headers["Authorization"] = f"Bearer {body.api_key.strip()}"
 
     try:
         async with httpx.AsyncClient(timeout=httpx.Timeout(8.0)) as client:
-            resp = await client.get(url, headers=headers)
+            if request_body is None:
+                resp = await client.get(url, headers=headers)
+            else:
+                resp = await client.post(url, headers=headers, json=request_body)
     except Exception:
         return {"ok": False, "reachable": False, "message": f"Could not reach {url}.", "models": []}
 
@@ -7564,7 +7645,8 @@ async def validate_custom_endpoint(body: CustomEndpointUpdate):
     if not resp.is_success:
         return {"ok": False, "reachable": True, "message": f"Endpoint returned HTTP {resp.status_code}.", "models": []}
 
-    return {"ok": True, "reachable": True, "message": "", "models": _parse_model_ids(resp)}
+    models = _parse_model_ids(resp) if request_body is None else []
+    return {"ok": True, "reachable": True, "message": "", "models": models}
 
 
 @app.post("/api/providers/validate")

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1553,6 +1553,7 @@ class TestWebServerEndpoints:
                 "base_url": "https://llm.acme.corp/v1",
                 "model": "acme/model-1",
                 "api_key": "sk-acme-secret",
+                "api_mode": "anthropic_messages",
             },
         )
         assert self.client.post(
@@ -1574,6 +1575,7 @@ class TestWebServerEndpoints:
         assert not model_cfg.get("api_key"), "deleted endpoint's key still in config.yaml"
         assert not model_cfg.get("key_env"), "deleted endpoint's key ref still in config.yaml"
         assert not model_cfg.get("base_url"), "deleted endpoint's host still routed to"
+        assert not model_cfg.get("api_mode"), "deleted endpoint's protocol still active"
         assert not model_cfg.get("provider")
         assert not get_env_value(env_var), "deleted endpoint's key still in .env"
 
@@ -1691,6 +1693,109 @@ class TestWebServerEndpoints:
         assert endpoint["has_api_key"] is True
         assert "sk-in-env" not in (endpoint["api_key_preview"] or "")
 
+    def test_custom_endpoint_api_mode_round_trips_and_becomes_the_active_transport(self):
+        """Desktop-selected protocol must reach both provider and active model config."""
+        from hermes_cli.config import load_config
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        response = self.client.post(
+            "/api/providers/custom-endpoints",
+            json={
+                "id": "claude-proxy",
+                "name": "Claude Proxy",
+                "base_url": "https://claude.example.com",
+                "model": "claude-opus-5",
+                "api_mode": "anthropic_messages",
+                "make_default": True,
+            },
+        )
+
+        assert response.status_code == 200
+        endpoint = next(
+            item
+            for item in response.json()["endpoints"]
+            if item["id"] == "claude-proxy"
+        )
+        assert endpoint["api_mode"] == "anthropic_messages"
+
+        cfg = load_config()
+        assert cfg["providers"]["claude-proxy"]["transport"] == "anthropic_messages"
+        assert "api_mode" not in cfg["providers"]["claude-proxy"]
+        assert cfg["model"]["api_mode"] == "anthropic_messages"
+
+        runtime = resolve_runtime_provider(requested="claude-proxy")
+        assert runtime["base_url"] == "https://claude.example.com"
+        assert runtime["api_mode"] == "anthropic_messages"
+
+    def test_custom_endpoint_auto_mode_clears_an_explicit_transport(self):
+        """Choosing Auto must remove an earlier explicit mode, including its model mirror."""
+        from hermes_cli.config import load_config
+
+        payload = {
+            "id": "claude-proxy",
+            "name": "Claude Proxy",
+            "base_url": "https://claude.example.com",
+            "model": "claude-opus-5",
+            "api_mode": "anthropic_messages",
+            "make_default": True,
+        }
+        assert self.client.post(
+            "/api/providers/custom-endpoints", json=payload
+        ).status_code == 200
+
+        payload["api_mode"] = "auto"
+        response = self.client.post("/api/providers/custom-endpoints", json=payload)
+
+        assert response.status_code == 200
+        cfg = load_config()
+        entry = cfg["providers"]["claude-proxy"]
+        assert "transport" not in entry
+        assert "api_mode" not in entry
+        assert "api_mode" not in cfg["model"]
+
+    def test_custom_endpoint_omitted_api_mode_preserves_hand_written_transport(self):
+        """Older clients editing another field must not erase a hand-written transport."""
+        from hermes_cli.config import load_config, save_config
+
+        cfg = load_config()
+        cfg["providers"] = {
+            "claude-proxy": {
+                "name": "Claude Proxy",
+                "base_url": "https://claude.example.com",
+                "model": "claude-opus-5",
+                "transport": "anthropic_messages",
+            }
+        }
+        save_config(cfg)
+
+        response = self.client.post(
+            "/api/providers/custom-endpoints",
+            json={
+                "id": "claude-proxy",
+                "name": "Renamed Claude Proxy",
+                "base_url": "https://claude.example.com",
+                "model": "claude-opus-5",
+            },
+        )
+
+        assert response.status_code == 200
+        assert load_config()["providers"]["claude-proxy"]["transport"] == (
+            "anthropic_messages"
+        )
+
+    def test_custom_endpoint_rejects_unknown_api_mode(self):
+        response = self.client.post(
+            "/api/providers/custom-endpoints",
+            json={
+                "name": "Broken",
+                "base_url": "https://example.com",
+                "model": "model-1",
+                "api_mode": "not-a-real-mode",
+            },
+        )
+
+        assert response.status_code == 422
+
     def test_activating_an_endpoint_carries_its_credential_either_way(self):
         """Activate must work for both key_env and pre-#69449 plaintext entries."""
         from hermes_cli.config import load_config, save_config
@@ -1702,6 +1807,7 @@ class TestWebServerEndpoints:
                 "base_url": "https://llm.legacy.com/v1",
                 "model": "m",
                 "api_key": "sk-legacy",
+                "api_mode": "codex_responses",
                 "models": {"m": {}},
             },
             "modern": {
@@ -1709,6 +1815,7 @@ class TestWebServerEndpoints:
                 "base_url": "https://llm.modern.com/v1",
                 "model": "m",
                 "key_env": "MODERN_API_KEY",
+                "transport": "anthropic_messages",
                 "models": {"m": {}},
             },
         }
@@ -1717,11 +1824,13 @@ class TestWebServerEndpoints:
         self.client.post("/api/providers/custom-endpoints/modern/activate", json={})
         model_cfg = load_config()["model"]
         assert model_cfg["key_env"] == "MODERN_API_KEY"
+        assert model_cfg["api_mode"] == "anthropic_messages"
         assert "api_key" not in model_cfg
 
         self.client.post("/api/providers/custom-endpoints/legacy/activate", json={})
         model_cfg = load_config()["model"]
         assert model_cfg["api_key"] == "sk-legacy"
+        assert model_cfg["api_mode"] == "codex_responses"
 
     def test_get_sessions_rejects_negative_limit(self):
         """limit=-1 must be rejected (422), not passed through to SQLite as
@@ -4194,6 +4303,67 @@ class TestValidateProviderCredential:
             "headers": {
                 "Accept": "application/json",
                 "Authorization": "Bearer local-secret",
+            },
+        }
+
+    def test_anthropic_custom_endpoint_probe_uses_messages_protocol(self, monkeypatch):
+        """The Desktop Test button must exercise the selected wire protocol."""
+        captured = {}
+
+        class _Resp:
+            status_code = 200
+            is_success = True
+
+        class _Client:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+            async def post(self, url, *args, headers=None, json=None, **kwargs):
+                captured["url"] = url
+                captured["headers"] = headers
+                captured["json"] = json
+                return _Resp()
+
+            async def get(self, *args, **kwargs):
+                raise AssertionError("Anthropic validation fell back to /models")
+
+        monkeypatch.setattr("httpx.AsyncClient", _Client)
+
+        response = self.client.post(
+            "/api/providers/custom-endpoints/validate",
+            json={
+                "name": "Claude Proxy",
+                "base_url": "https://claude.example.com",
+                "model": "claude-opus-5",
+                "api_key": "sk-ant-secret",
+                "api_mode": "anthropic_messages",
+            },
+        )
+
+        assert response.json() == {
+            "ok": True,
+            "reachable": True,
+            "message": "",
+            "models": [],
+        }
+        assert captured == {
+            "url": "https://claude.example.com/v1/messages",
+            "headers": {
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+                "anthropic-version": "2023-06-01",
+                "x-api-key": "sk-ant-secret",
+            },
+            "json": {
+                "model": "claude-opus-5",
+                "max_tokens": 1,
+                "messages": [{"role": "user", "content": "."}],
             },
         }
 


### PR DESCRIPTION
## What does this PR do?

Desktop custom endpoints currently assume an OpenAI-compatible API surface: the form cannot choose a wire protocol, saves do not mirror a protocol to the active model, and the Test action only calls `/models`. An Anthropic-compatible relay can therefore validate or save misleadingly while real chat falls back to `/chat/completions`.

This adds the Desktop counterpart to the custom-provider API mode support already available in the CLI:

- expose Auto-detect, Chat Completions, Responses / Codex, and Anthropic Messages in Custom Endpoints
- persist the selection to the v12 `providers.<id>.transport` field while preserving existing hand-written values for older clients
- mirror the resolved mode to `model.api_mode` on Save/Use, clear it when Auto is selected, and remove it when the active endpoint is deleted
- make Test protocol-aware: `/models` for Chat Completions, a disclosed one-token `/responses` request for Responses, and a disclosed one-token `/v1/messages` request with Anthropic headers for Anthropic Messages
- localize the new UI copy in English, Simplified Chinese, Traditional Chinese, Japanese, and Arabic

## Related Issue

Follow-up to #13415 and the Desktop custom-endpoint work in #67759. No dedicated open issue found.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/settings/custom-endpoints-settings.tsx`: add the API Mode selector and mode-specific guidance.
- `apps/desktop/src/types/hermes.ts` and `apps/desktop/src/i18n/*`: extend the API contract and localized copy.
- `hermes_cli/web_models.py`: validate supported Desktop API mode values.
- `hermes_cli/web_server.py`: round-trip/persist transport, synchronize active model state, and probe the selected protocol.
- Python and Vitest regression tests cover save, Auto clearing, older-client preservation, activation/deletion, runtime resolution, and Anthropic request shape.

## How to Test

1. Open Settings → Providers → Custom Endpoints.
2. Add an Anthropic-compatible endpoint using the API root (without a trailing `/v1`), choose **Anthropic Messages**, enter a model and key, then click **Test**.
3. Save with **Use for new chats** enabled and verify `providers.<id>.transport: anthropic_messages` plus `model.api_mode: anthropic_messages` in `config.yaml`.
4. Start a chat and verify the provider receives `POST /v1/messages` rather than `/chat/completions`.

Automated verification performed:

- `scripts/run_tests.sh tests/hermes_cli/test_web_server.py -q` — 149 passed
- `npm run test:ui` — 406 files / 3621 tests passed
- `npm run check:lint` — passed (no errors)
- `npm run build` — passed
- `python scripts/check-windows-footguns.py hermes_cli/web_models.py hermes_cli/web_server.py` — passed

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [ ] I've run the entire Python test suite (targeted Web API suite passed: 149 tests)
- [x] I've added tests for my changes
- [x] I've tested on macOS 26.4 arm64

### Documentation & Housekeeping

- [x] Documentation N/A — the new field has localized inline guidance and uses an existing config capability
- [x] `cli-config.yaml.example` N/A — `transport` already exists; this exposes it in Desktop
- [x] `CONTRIBUTING.md` / `AGENTS.md` N/A — no workflow or architecture change
- [x] Cross-platform impact considered; changed production Python files pass the Windows footgun checker
- [x] Tool descriptions/schemas N/A — no agent tool changed

## Screenshots / Logs

No screenshot attached; the new selector is covered by a Desktop behavior test and the production Desktop build succeeds.
