### PR TITLE
fix(search): strip the FTS5 special characters the sanitizer was missing (salvage #79285)

### DIFF
--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -32,6 +32,18 @@ from hermes_state_common import (
 # keep that logger identity so log filtering/capture behavior is unchanged.
 logger = logging.getLogger("hermes_state")
 
+# Characters FTS5's query grammar rejects outside a quoted phrase. Anything
+# missing from this set reaches MATCH raw and raises, which the execute site
+# swallows into zero results — the failure this strip step exists to prevent.
+# Assembled through re.escape so the backslash cannot be eaten as a regex
+# escape inside the class (it was, while the set was written as a literal).
+#
+# ``%`` is deliberately excluded: a CJK query falls back to a LIKE search that
+# needs it preserved as a literal (that path escapes wildcards itself), so
+# stripping it here widened those queries onto unrelated rows.
+_FTS5_SPECIAL_CHARS = '+{}():"^@/#&|~[]<>,;!?$=\\\''
+_FTS5_SPECIAL_RE = re.compile(f"[{re.escape(_FTS5_SPECIAL_CHARS)}]")
+
 
 class SessionSearchMixin:
     """See module docstring — mixin for SessionDB (Search cluster)."""
@@ -1210,7 +1222,13 @@ class SessionSearchMixin:
         # single ``content`` column, an unquoted colon query like ``TODO: fix``
         # parses as ``column:term`` and raises "no such column" — swallowed at
         # the execute site into zero results.  Strip it like the others.
-        sanitized = re.sub(r'[+{}():\"^]', " ", sanitized)
+        # The class below is every character FTS5's query grammar rejects
+        # outside a quoted phrase. Anything omitted here reaches MATCH raw and
+        # raises, which the execute site swallows into zero results — the
+        # failure mode this step exists to prevent. Measured against a real
+        # FTS5 table: ``it's``, ``gateway/run.py``, ``user@host``, ``a,b`` and
+        # ``50%`` all raised before the class was completed.
+        sanitized = _FTS5_SPECIAL_RE.sub(" ", sanitized)
 
         # Step 3: Collapse repeated * (e.g. "***") into a single one,
         # and remove leading * (prefix-only needs at least one char before *)

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -1230,6 +1230,14 @@ class SessionSearchMixin:
         # ``50%`` all raised before the class was completed.
         sanitized = _FTS5_SPECIAL_RE.sub(" ", sanitized)
 
+        # Step 2b: ``%`` is excluded from the class above only to protect the
+        # CJK LIKE-fallback path (LIKE treats % as a wildcard the fallback
+        # builds itself). A non-CJK query never reaches that fallback
+        # (``is_cjk`` gates it), so ``50%`` would sail into MATCH raw and
+        # raise like the rest. Strip it whenever the query has no CJK.
+        if "%" in sanitized and not SessionSearchMixin._contains_cjk(sanitized):
+            sanitized = sanitized.replace("%", " ")
+
         # Step 3: Collapse repeated * (e.g. "***") into a single one,
         # and remove leading * (prefix-only needs at least one char before *)
         sanitized = re.sub(r"\*+", "*", sanitized)

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4503,3 +4503,70 @@ class TestPerformancePragmasEndToEnd:
             assert self._read(ro._conn) == defaults
         finally:
             ro.close()
+
+
+class TestFts5SanitizerCharacterClass:
+    """Every character FTS5 rejects outside a quoted phrase must be stripped.
+
+    A survivor reaches MATCH raw and raises, which the execute site swallows
+    into zero results — so the search silently finds nothing rather than
+    erroring. Assertions run the sanitized text against a real FTS5 table.
+    """
+
+    @staticmethod
+    def _fts_table():
+        import sqlite3
+
+        conn = sqlite3.connect(":memory:")
+        conn.execute("CREATE VIRTUAL TABLE t USING fts5(content)")
+        conn.execute(
+            "INSERT INTO t (content) VALUES "
+            "('meet me at user host about gateway run py it s 50 a b')"
+        )
+        return conn
+
+    @staticmethod
+    def _sanitize(query):
+        from hermes_state_search import SessionSearchMixin
+
+        return SessionSearchMixin._sanitize_fts5_query(query)
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "it's",                 # apostrophe — ordinary prose
+            "gateway/run.py",       # path separator
+            "user@host",            # email / handle
+            "a,b",                  # comma
+            "why?",                 # question mark
+            "e=mc2",                # equals
+            "a;b", "a!b", "a&b", "a|b", "x~y",
+            "#tag", "$dollar", "[bracket]", "<tag>",
+            r"C:\path\file",        # backslash
+        ],
+    )
+    def test_query_stays_parsable(self, query):
+        conn = self._fts_table()
+        sanitized = self._sanitize(query)
+        if not sanitized.strip():
+            return
+        # Raises sqlite3.OperationalError if a special character survived.
+        conn.execute("SELECT count(*) FROM t WHERE t MATCH ?", (sanitized,)).fetchone()
+
+    def test_plain_terms_are_untouched(self):
+        assert self._sanitize("hello world").split() == ["hello", "world"]
+
+    def test_quoted_phrase_survives(self):
+        assert '"exact phrase"' in self._sanitize('"exact phrase"')
+
+    def test_hyphen_dotted_term_still_quoted(self):
+        # Step 5's behaviour must not regress: my-app.config.ts stays one term.
+        assert '"my-app.config.ts"' in self._sanitize("my-app.config.ts")
+
+    def test_prefix_star_still_works(self):
+        conn = self._fts_table()
+        sanitized = self._sanitize("gate*")
+        rows = conn.execute(
+            "SELECT count(*) FROM t WHERE t MATCH ?", (sanitized,)
+        ).fetchone()
+        assert rows[0] == 1

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4570,3 +4570,19 @@ class TestFts5SanitizerCharacterClass:
             "SELECT count(*) FROM t WHERE t MATCH ?", (sanitized,)
         ).fetchone()
         assert rows[0] == 1
+
+    def test_percent_stripped_for_non_cjk_query(self):
+        # % is kept only for the CJK LIKE fallback; a non-CJK query never
+        # reaches that fallback, so % must be stripped before MATCH.
+        conn = self._fts_table()
+        sanitized = self._sanitize("50%")
+        assert "%" not in sanitized
+        conn.execute(
+            "SELECT count(*) FROM t WHERE t MATCH ?", (sanitized,)
+        ).fetchone()
+
+    def test_percent_preserved_for_cjk_query(self):
+        # The CJK LIKE fallback builds its own pattern from the sanitized
+        # text; keep % intact there (pre-existing contract).
+        sanitized = self._sanitize("完成50%")
+        assert "%" in sanitized


### PR DESCRIPTION
## Summary
Session search no longer silently returns zero results for everyday queries like `it's`, `gateway/run.py`, `user@host`, or `50%` — the FTS5 sanitizer now strips the full set of characters FTS5's grammar rejects.

Salvage of #79285 by @Drexuxux (cherry-picked with authorship preserved), plus a follow-up commit closing the `%` residual the triage comment flagged.

Root cause: the sanitizer's strip-class covered only six characters (`+{}():"^`). Everything else FTS5 rejects outside a quoted phrase (`'`, `/`, `@`, `,`, `?`, `=`, `;`, `!`, `&`, `|`, `~`, `#`, `$`, `[]`, `<>`, `\`) reached `MATCH` raw, raised `OperationalError`, and was swallowed at the execute site into zero results — a silent-empty search.

## Changes
- `hermes_state_search.py` (contributor): strip-class rebuilt via `re.escape` (fixes literal-backslash loss), applied after quoted-phrase placeholder extraction so `"exact phrases"` survive; step-5 quoting of dotted/hyphenated terms unaffected.
- `hermes_state_search.py` (follow-up): `%` — excluded to protect the CJK LIKE fallback — is now stripped when the query contains no CJK, since non-CJK queries never reach that fallback and `50%` still raised.
- `tests/test_hermes_state.py`: contributor's tests execute sanitized output against a real in-memory FTS5 table (failures manifest as `OperationalError`, not string comparison); follow-up adds `%`-stripped-for-non-CJK and `%`-preserved-for-CJK regressions.

## Validation
| | Before | After |
|---|---|---|
| `it's`, `gateway/run.py`, `user@host`, `a,b` … | silent zero results | parse + match correctly |
| `50%` (non-CJK) | silent zero results | parses (`%` stripped) |
| CJK query with `%` | LIKE fallback works | unchanged |
| `"exact phrase"`, `my-app.config.ts`, `gate*` | preserved | preserved (tested) |
| tests/test_hermes_state.py | — | 218/218 pass |

Note for follow-up review: open #78462 takes a quote-the-token strategy for paths/emails on the same function — complementary, needs a rebase over this; whichever direction wins long-term, this PR fixes the silent-error class now.

## Infographic

![Search that stops swallowing errors](https://v3b.fal.media/files/b/0aa595f8/VKElFxl4EA-VQP4VCB9Xv_QDrF4asu.png)
