### PR TITLE
fix(agent): refresh xAI OAuth credentials on 403 unauthenticated:bad-credentials

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -341,6 +341,22 @@ def _apply_active_turn_redirect(agent: Any, messages: List[Dict[str, Any]], text
     agent._stream_needs_break = True
 
 
+def _is_xai_bad_credentials_403(provider: str, status_code: Any, api_error: Any) -> bool:
+    """xAI reports an expired or invalid OAuth access token as HTTP 403 with
+    body code ``unauthenticated:bad-credentials`` rather than 401, so the
+    401-only refresh trigger never fires and a long-lived worker keeps its
+    dead in-memory token (#82052). Scoped to xai-oauth: other providers'
+    403s remain non-retryable authorization failures.
+    """
+    if provider != "xai-oauth" or status_code != 403:
+        return False
+    text = str(api_error).lower()
+    return (
+        "bad-credentials" in text
+        or "oauth2 access token could not be validated" in text
+    )
+
+
 def _is_copilot_provider(agent: Any) -> bool:
     """Delegate to ``AIAgent._is_copilot_provider`` (single owner of the check).
 
@@ -4696,13 +4712,18 @@ def run_conversation(
                 if (
                     agent.api_mode == "codex_responses"
                     and agent.provider in {"openai-codex", "xai-oauth"}
-                    and status_code == 401
+                    and (
+                        status_code == 401
+                        or _is_xai_bad_credentials_403(
+                            agent.provider, status_code, api_error
+                        )
+                    )
                     and not _retry.codex_auth_retry_attempted
                 ):
                     _retry.codex_auth_retry_attempted = True
                     if agent._try_refresh_codex_client_credentials(force=True):
                         _label = "xAI OAuth" if agent.provider == "xai-oauth" else "Codex"
-                        agent._buffer_vprint(f"🔐 {_label} auth refreshed after 401. Retrying request...")
+                        agent._buffer_vprint(f"🔐 {_label} auth refreshed after {status_code}. Retrying request...")
                         continue
                 if (
                     agent.api_mode == "chat_completions"

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -273,6 +273,22 @@ def _apply_active_turn_redirect(agent: Any, messages: List[Dict[str, Any]], text
     agent._stream_needs_break = True
 
 
+def _is_xai_bad_credentials_403(provider: str, status_code: Any, api_error: Any) -> bool:
+    """xAI reports an expired or invalid OAuth access token as HTTP 403 with
+    body code ``unauthenticated:bad-credentials`` rather than 401, so the
+    401-only refresh trigger never fires and a long-lived worker keeps its
+    dead in-memory token (#82052). Scoped to xai-oauth: other providers'
+    403s remain non-retryable authorization failures.
+    """
+    if provider != "xai-oauth" or status_code != 403:
+        return False
+    text = str(api_error).lower()
+    return (
+        "bad-credentials" in text
+        or "oauth2 access token could not be validated" in text
+    )
+
+
 def _is_copilot_provider(agent: Any) -> bool:
     """Delegate to ``AIAgent._is_copilot_provider`` (single owner of the check).
 
@@ -4187,13 +4203,18 @@ def run_conversation(
                 if (
                     agent.api_mode == "codex_responses"
                     and agent.provider in {"openai-codex", "xai-oauth"}
-                    and status_code == 401
+                    and (
+                        status_code == 401
+                        or _is_xai_bad_credentials_403(
+                            agent.provider, status_code, api_error
+                        )
+                    )
                     and not _retry.codex_auth_retry_attempted
                 ):
                     _retry.codex_auth_retry_attempted = True
                     if agent._try_refresh_codex_client_credentials(force=True):
                         _label = "xAI OAuth" if agent.provider == "xai-oauth" else "Codex"
-                        agent._buffer_vprint(f"🔐 {_label} auth refreshed after 401. Retrying request...")
+                        agent._buffer_vprint(f"🔐 {_label} auth refreshed after {status_code}. Retrying request...")
                         continue
                 if (
                     agent.api_mode == "chat_completions"

--- a/tests/run_agent/test_xai_403_bad_credentials_refresh.py
+++ b/tests/run_agent/test_xai_403_bad_credentials_refresh.py
@@ -1,0 +1,320 @@
+"""xAI reports an expired OAuth access token as HTTP 403 with body code
+``unauthenticated:bad-credentials`` (not 401). The 401-only refresh trigger
+never fired for it, so a long-lived worker kept its dead in-memory token and
+aborted every turn (#82052). These tests pin the 403 variant: bad-credentials
+triggers one forced refresh plus retry, while an unrelated 403 still aborts
+without touching credentials.
+"""
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+import run_agent
+
+
+@pytest.fixture(autouse=True)
+def _no_codex_backoff(monkeypatch):
+    """Short-circuit retry backoff so these tests don't block on real
+    wall-clock waits (same guard as test_run_agent_codex_responses.py)."""
+    import time as _time
+    monkeypatch.setattr(run_agent, "jittered_backoff", lambda *a, **k: 0.0)
+    monkeypatch.setattr(_time, "sleep", lambda *_a, **_k: None)
+
+
+class _XaiBadCredentials403(Exception):
+    status_code = 403
+
+    def __init__(self):
+        super().__init__(
+            'HTTP 403: {"code":"unauthenticated:bad-credentials",'
+            '"error":"The OAuth2 access token could not be validated."}'
+        )
+
+
+class _UnrelatedForbidden403(Exception):
+    status_code = 403
+
+    def __init__(self):
+        super().__init__('HTTP 403: {"error":"forbidden by policy"}')
+
+
+class _XaiSpendingLimit403(Exception):
+    """xAI's other 403: a billing wall that no refresh can clear."""
+    status_code = 403
+
+    def __init__(self):
+        super().__init__(
+            'HTTP 403: {"code":"personal-team-blocked:spending-limit",'
+            '"error":"Your team has reached its spending limit."}'
+        )
+
+
+class _XaiBadCredentialsBody403(Exception):
+    """SDK variants attach the parsed body; str(exc) still carries the
+    marker, which is what the narrow match keys on."""
+    status_code = 403
+
+    def __init__(self):
+        body = {
+            "code": "unauthenticated:bad-credentials",
+            "error": "The OAuth2 access token could not be validated.",
+        }
+        self.body = body
+        super().__init__(f"HTTP 403: {body}")
+
+
+def _codex_message_response(text: str):
+    return SimpleNamespace(
+        output=[
+            SimpleNamespace(
+                type="message",
+                content=[SimpleNamespace(type="output_text", text=text)],
+            )
+        ],
+        usage=SimpleNamespace(input_tokens=5, output_tokens=3, total_tokens=8),
+        status="completed",
+        model="grok-4.5",
+    )
+
+
+def _build_xai_agent(monkeypatch):
+    monkeypatch.setattr(
+        run_agent,
+        "get_tool_definitions",
+        lambda **kwargs: [
+            {
+                "type": "function",
+                "function": {
+                    "name": "terminal",
+                    "description": "Run shell commands.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+    )
+    monkeypatch.setattr(run_agent, "check_toolset_requirements", lambda: {})
+
+    agent = run_agent.AIAgent(
+        model="grok-4.5",
+        provider="xai-oauth",
+        api_mode="codex_responses",
+        base_url="https://api.x.ai/v1",
+        api_key="stale",
+        quiet_mode=True,
+        max_iterations=4,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent._cleanup_task_resources = lambda task_id: None
+    agent._persist_session = lambda messages, history=None: None
+    agent._save_trajectory = lambda messages, user_message, completed: None
+    return agent
+
+
+def test_xai_403_bad_credentials_refreshes_and_retries(monkeypatch):
+    agent = _build_xai_agent(monkeypatch)
+
+    calls = {"api": 0}
+
+    def _api_call(api_kwargs):
+        calls["api"] += 1
+        if calls["api"] == 1:
+            raise _XaiBadCredentials403()
+        return _codex_message_response("OK")
+
+    refreshes = {"count": 0, "force": None}
+
+    def _refresh(force=False):
+        refreshes["count"] += 1
+        refreshes["force"] = force
+        agent.api_key = "fresh"
+        return True
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _api_call)
+    monkeypatch.setattr(
+        agent, "_try_refresh_codex_client_credentials", _refresh
+    )
+
+    result = agent.run_conversation("Say OK")
+
+    assert refreshes["count"] == 1
+    assert refreshes["force"] is True
+    assert calls["api"] == 2
+    assert result["completed"] is True
+    assert result["final_response"] == "OK"
+
+
+def test_xai_403_refresh_consumes_the_shared_once_flag(monkeypatch):
+    """The 403 variant shares ``codex_auth_retry_attempted`` with the 401
+    path: one credential refresh per turn, whichever status spends it. A
+    401 arriving after a consumed 403-refresh must not refresh again."""
+    agent = _build_xai_agent(monkeypatch)
+
+    class _Unauthorized401(Exception):
+        status_code = 401
+
+        def __init__(self):
+            super().__init__("HTTP 401: unauthorized")
+
+    calls = {"api": 0}
+
+    def _api_call(api_kwargs):
+        calls["api"] += 1
+        if calls["api"] == 1:
+            raise _XaiBadCredentials403()
+        raise _Unauthorized401()
+
+    refreshes = {"count": 0}
+
+    def _refresh(force=False):
+        refreshes["count"] += 1
+        return True
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _api_call)
+    monkeypatch.setattr(
+        agent, "_try_refresh_codex_client_credentials", _refresh
+    )
+
+    result = agent.run_conversation("Say OK")
+
+    assert refreshes["count"] == 1
+    assert result.get("completed") is not True
+
+
+def test_openai_codex_403_stays_non_retryable(monkeypatch):
+    """The helper is scoped to xai-oauth: an openai-codex 403 whose body
+    happens to contain the marker words must not trigger a refresh."""
+    monkeypatch.setattr(
+        run_agent,
+        "get_tool_definitions",
+        lambda **kwargs: [
+            {
+                "type": "function",
+                "function": {
+                    "name": "terminal",
+                    "description": "Run shell commands.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+    )
+    monkeypatch.setattr(run_agent, "check_toolset_requirements", lambda: {})
+    agent = run_agent.AIAgent(
+        model="gpt-5-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="tok",
+        quiet_mode=True,
+        max_iterations=4,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent._cleanup_task_resources = lambda task_id: None
+    agent._persist_session = lambda messages, history=None: None
+    agent._save_trajectory = lambda messages, user_message, completed: None
+
+    def _api_call(api_kwargs):
+        raise _XaiBadCredentials403()
+
+    refreshes = {"count": 0}
+
+    def _refresh(force=False):
+        refreshes["count"] += 1
+        return True
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _api_call)
+    monkeypatch.setattr(
+        agent, "_try_refresh_codex_client_credentials", _refresh
+    )
+
+    result = agent.run_conversation("Say OK")
+
+    assert refreshes["count"] == 0
+    assert result.get("completed") is not True
+
+
+def test_xai_403_spending_limit_does_not_refresh(monkeypatch):
+    """The billing-wall 403 (personal-team-blocked:spending-limit) carries
+    no bad-credentials marker, so the narrow match excludes it by
+    construction: refreshing cannot clear a spending limit and retrying
+    it would spin."""
+    agent = _build_xai_agent(monkeypatch)
+
+    def _api_call(api_kwargs):
+        raise _XaiSpendingLimit403()
+
+    refreshes = {"count": 0}
+
+    def _refresh(force=False):
+        refreshes["count"] += 1
+        return True
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _api_call)
+    monkeypatch.setattr(
+        agent, "_try_refresh_codex_client_credentials", _refresh
+    )
+
+    result = agent.run_conversation("Say OK")
+
+    assert refreshes["count"] == 0
+    assert result.get("completed") is not True
+
+
+def test_xai_403_structured_body_variant_refreshes(monkeypatch):
+    """An SDK exception carrying the parsed body dict still exposes the
+    marker through str(exc), so the structured variant recovers too."""
+    agent = _build_xai_agent(monkeypatch)
+
+    calls = {"api": 0}
+
+    def _api_call(api_kwargs):
+        calls["api"] += 1
+        if calls["api"] == 1:
+            raise _XaiBadCredentialsBody403()
+        return _codex_message_response("OK")
+
+    refreshes = {"count": 0}
+
+    def _refresh(force=False):
+        refreshes["count"] += 1
+        return True
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _api_call)
+    monkeypatch.setattr(
+        agent, "_try_refresh_codex_client_credentials", _refresh
+    )
+
+    result = agent.run_conversation("Say OK")
+
+    assert refreshes["count"] == 1
+    assert calls["api"] == 2
+    assert result["completed"] is True
+
+
+def test_xai_403_unrelated_body_does_not_touch_credentials(monkeypatch):
+    agent = _build_xai_agent(monkeypatch)
+
+    def _api_call(api_kwargs):
+        raise _UnrelatedForbidden403()
+
+    refreshes = {"count": 0}
+
+    def _refresh(force=False):
+        refreshes["count"] += 1
+        return True
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _api_call)
+    monkeypatch.setattr(
+        agent, "_try_refresh_codex_client_credentials", _refresh
+    )
+
+    result = agent.run_conversation("Say OK")
+
+    assert refreshes["count"] == 0
+    assert result.get("completed") is not True


### PR DESCRIPTION

Fixes #82052.

xAI reports an expired OAuth access token as HTTP 403 with body code `unauthenticated:bad-credentials`, not 401. `_classify_by_status` puts every non-billing 403 on the non-retryable path (`agent/error_classifier.py:1035-1054`), and the in-loop credential refresh fires on `status_code == 401` only (`agent/conversation_loop.py:4188-4196` before this change), so a long-lived worker keeps its dead in-memory token and aborts every turn until the dashboard service restarts. Reproduced on a real VPS (journal excerpts in the issue); a same-window CLI probe on the same provider succeeded, so the refresh token and credential store were healthy the whole time.

## The fix

Extend the existing codex_responses refresh branch so xai-oauth also triggers on a 403 that carries the bad-credentials marker (`_is_xai_bad_credentials_403`), reusing the same once-per-turn flag. One forced refresh, one retry; if it still fails, the turn aborts exactly as today. `agent/auxiliary_client.py:3930-3932` already treats this exact variant as an auth error on the pool path, so the loop now matches existing precedent. Other providers' 403s are untouched.

Known scope: the once-per-turn flag is shared with the 401 path, so a 403-refresh followed by a real 401 in the same turn aborts rather than refreshing twice. That is the same conservative budget the 401 path always had, now pinned by a test.

## Tests (fail-before verified)

- `test_xai_403_bad_credentials_refreshes_and_retries`: red before the fix on the exact production abort path ("Non-retryable client error"), green after
- `test_xai_403_refresh_consumes_the_shared_once_flag`: pins the shared once-per-turn refresh budget
- `test_openai_codex_403_stays_non_retryable`: provider scoping guard
- `test_xai_403_unrelated_body_does_not_touch_credentials`: marker specificity guard

Suite: the 4 new tests plus `tests/run_agent/test_run_agent_codex_responses.py` (44) and `tests/agent/test_turn_retry_state.py` (3) all green.
