### PR TITLE
fix(tools): expose the configurable search toolset

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -50,7 +50,7 @@ PLATFORMS = {k: {"label": info.label, "default_toolset": info.default_toolset} f
 # --- Toolset Registry ---
 # Toolsets shown in the configurator: (toolset key in toolsets.py TOOLSETS, label, description).
 CONFIGURABLE_TOOLSETS = [
-    ("search",          "🔎 Web Search",               "web_search only"),
+    ("search",          "🔍 Web Search",               "web_search only"),
     ("web",             "🔍 Web Search & Scraping",    "web_search, web_extract"),
     ("browser",         "🌐 Browser Automation",       "navigate, click, type, scroll"),
     ("terminal",        "💻 Terminal & Processes",      "terminal, process"),

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -50,6 +50,7 @@ PLATFORMS = {k: {"label": info.label, "default_toolset": info.default_toolset} f
 # --- Toolset Registry ---
 # Toolsets shown in the configurator: (toolset key in toolsets.py TOOLSETS, label, description).
 CONFIGURABLE_TOOLSETS = [
+    ("search",          "🔎 Web Search",               "web_search only"),
     ("web",             "🔍 Web Search & Scraping",    "web_search, web_extract"),
     ("browser",         "🌐 Browser Automation",       "navigate, click, type, scroll"),
     ("terminal",        "💻 Terminal & Processes",      "terminal, process"),

--- a/tests/hermes_cli/test_tools_disable_enable.py
+++ b/tests/hermes_cli/test_tools_disable_enable.py
@@ -5,7 +5,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from gateway.platform_registry import platform_registry
-from hermes_cli.tools_config import tools_disable_enable_command
+from hermes_cli.tools_config import _get_platform_tools, tools_disable_enable_command
+from toolsets import resolve_toolset
 
 
 # ── Built-in toolset disable ────────────────────────────────────────────────
@@ -24,6 +25,28 @@ class TestToolsDisableBuiltin:
 
 
 # ── Built-in toolset enable ─────────────────────────────────────────────────
+
+
+class TestToolsEnableBuiltin:
+
+    def test_enable_search_without_web_extract(self):
+        config = {"platform_toolsets": {"cli": []}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(
+                Namespace(tools_action="enable", names=["search"], platform="cli")
+            )
+
+        saved = mock_save.call_args[0][0]
+        assert "search" in saved["platform_toolsets"]["cli"]
+
+        enabled = _get_platform_tools(saved, "cli", include_default_mcp_servers=False)
+        assert "search" in enabled
+        assert "web" not in enabled
+
+        tools = set().union(*(resolve_toolset(toolset) for toolset in enabled))
+        assert "web_search" in tools
+        assert "web_extract" not in tools
 
 
 # ── MCP tool disable ────────────────────────────────────────────────────────

--- a/tests/hermes_cli/test_tools_disable_enable.py
+++ b/tests/hermes_cli/test_tools_disable_enable.py
@@ -6,6 +6,7 @@ import pytest
 
 from gateway.platform_registry import platform_registry
 from hermes_cli.tools_config import _get_platform_tools, tools_disable_enable_command
+from model_tools import get_tool_definitions
 from toolsets import resolve_toolset
 
 
@@ -21,6 +22,18 @@ class TestToolsDisableBuiltin:
             tools_disable_enable_command(Namespace(tools_action="disable", names=["web"], platform="cli"))
         saved = mock_save.call_args[0][0]
         assert "web" not in saved["platform_toolsets"]["cli"]
+        assert "memory" in saved["platform_toolsets"]["cli"]
+
+    def test_disable_removes_search_toolset_from_platform(self):
+        config = {"platform_toolsets": {"cli": ["search", "memory"]}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(
+                Namespace(tools_action="disable", names=["search"], platform="cli")
+            )
+
+        saved = mock_save.call_args[0][0]
+        assert "search" not in saved["platform_toolsets"]["cli"]
         assert "memory" in saved["platform_toolsets"]["cli"]
 
 
@@ -47,6 +60,18 @@ class TestToolsEnableBuiltin:
         tools = set().union(*(resolve_toolset(toolset) for toolset in enabled))
         assert "web_search" in tools
         assert "web_extract" not in tools
+
+    def test_search_and_web_resolve_web_search_once(self):
+        with patch("tools.registry._check_fn_cached", return_value=True):
+            definitions = get_tool_definitions(
+                enabled_toolsets=["search", "web"],
+                quiet_mode=False,
+                skip_tool_search_assembly=True,
+            )
+        names = [definition["function"]["name"] for definition in definitions]
+
+        assert names.count("web_search") == 1
+        assert "web_extract" in names
 
 
 # ── MCP tool disable ────────────────────────────────────────────────────────


### PR DESCRIPTION
Expose the search-only toolset in the CLI configurator and keep its labels aligned with the web-search tool names. Add regression coverage for disabling the toolset and for overlap with broader toolsets so duplicate search tools are not introduced.