### PR TITLE
docs(messaging): align Telegram reactions and WhatsApp formatting docs

### DIFF
--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -1199,8 +1199,8 @@ This covers the custom fallback transport layer that Hermes uses for Telegram co
 The bot can add emoji reactions to messages as visual processing feedback:
 
 - 👀 when the bot starts processing your message
-- ✅ when the response is delivered successfully
-- ❌ if an error occurs during processing
+- 👍 when the response is delivered successfully
+- 👎 if an error occurs during processing
 
 Reactions are **disabled by default**. Enable them in `config.yaml`:
 
@@ -1216,7 +1216,7 @@ TELEGRAM_REACTIONS=true
 ```
 
 :::note
-Unlike Discord (where reactions are additive), Telegram's Bot API replaces all bot reactions in a single call. The transition from 👀 to ✅/❌ happens atomically — you won't see both at once.
+Unlike Discord (where reactions are additive), Telegram's Bot API replaces all bot reactions in a single call. The transition from 👀 to 👍/👎 happens atomically — you won't see both at once.
 :::
 
 :::tip

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -1220,8 +1220,8 @@ This covers the custom fallback transport layer that Hermes uses for Telegram co
 The bot can add emoji reactions to messages as visual processing feedback:
 
 - 👀 when the bot starts processing your message
-- ✅ when the response is delivered successfully
-- ❌ if an error occurs during processing
+- 👍 when the response is delivered successfully
+- 👎 if an error occurs during processing
 
 Reactions are **disabled by default**. Enable them in `config.yaml`:
 
@@ -1237,7 +1237,7 @@ TELEGRAM_REACTIONS=true
 ```
 
 :::note
-Unlike Discord (where reactions are additive), Telegram's Bot API replaces all bot reactions in a single call. The transition from 👀 to ✅/❌ happens atomically — you won't see both at once.
+Unlike Discord (where reactions are additive), Telegram's Bot API replaces all bot reactions in a single call. The transition from 👀 to 👍/👎 happens atomically — you won't see both at once.
 :::
 
 :::tip

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -244,7 +244,7 @@ You can have **both** the Baileys (`whatsapp`) and Cloud (`whatsapp_cloud`) adap
 - **Voice notes** — auto-downloaded as `.ogg`, transcribed via your configured STT provider (local faster-whisper, OpenAI/Nous, Groq, etc.), then handed to the agent as text.
 - **Documents** — auto-downloaded. Small text-readable files (`.txt`, `.md`, `.json`, `.py`, `.csv`, etc.) up to 100KB get inlined into the agent's input so it can read them without a tool call. Larger files are cached locally for the agent's other tools to access.
 - **Button taps** — when the user taps a button the bot sent earlier (clarify choice, command approval, slash-command confirm), the tap is routed directly to the right handler. Stale taps fall back to being treated as regular text input.
-- **Reply context** — when the user replies to a previous bot message, the agent sees the original message as context.
+- **Reply context** — when the user replies to a previous **text** bot message, the agent sees the original message as context. Uncaptioned media replies may lack quote text (only TEXT bodies are recorded in the sent-message store).
 
 ### Outbound
 

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -202,6 +202,7 @@ Standard Markdown in AI responses is automatically converted to WhatsApp's nativ
 | Markdown | WhatsApp | Renders as |
 |----------|----------|------------|
 | `**bold**` | `*bold*` | **bold** |
+| `*italic*` | `_italic_` | *italic* |
 | `~~strikethrough~~` | `~strikethrough~` | ~~strikethrough~~ |
 | `# Heading` | `*Heading*` | Bold text (no native headings) |
 | `[link text](url)` | `link text (url)` | Inline URL |


### PR DESCRIPTION
## Summary
- Fix Telegram reaction lifecycle docs to match code (`👀` → `👍`/`👎`, not `✅`/`❌`) — fixes #78698
- Add missing italic row to WhatsApp Baileys markdown table; caveat Cloud reply-context for uncaptioned media — fixes #80067

## Test plan
- [ ] Diff-only docs review against `plugins/platforms/telegram/adapter.py` (`on_processing_complete`) and `gateway/platforms/whatsapp_common.py` italic conversion
- [ ] No runtime/code changes


Made with [Cursor](https://cursor.com)