### PR TITLE
fix(gateway): preserve MEDIA delivery on queued follow-up responses (salvage #71031)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3044,10 +3044,9 @@ def _is_control_interrupt_message(message: Optional[str]) -> bool:
 def _strip_response_attachments_for_direct_send(response: str, adapter) -> str:
     """Return the visible text portion of a response before direct send().
 
-    Queued follow-up resends only replay attachments we can deliver natively in
-    this path: ``MEDIA:`` tags, bare local files, and internal directives. Keep
-    ordinary image URLs in the visible text until the queued path grows native
-    image-URL delivery too.
+    Queued follow-up resends only replay explicit ``MEDIA:`` attachments in
+    this path. Keep bare local paths and ordinary image URLs visible because
+    the post-stream uploader intentionally ignores them (#20834).
 
     Do not apply a broad ``MEDIA:`` regex after ``extract_media()`` — the
     extractor deliberately preserves protected code/inline spans and
@@ -3056,7 +3055,6 @@ def _strip_response_attachments_for_direct_send(response: str, adapter) -> str:
     _, cleaned = adapter.extract_media(response)
     cleaned = cleaned.replace("[[audio_as_voice]]", "").strip()
     cleaned = cleaned.replace("[[as_document]]", "").strip()
-    _, cleaned = adapter.extract_local_files(cleaned)
     return cleaned.strip()
 
 
@@ -19827,6 +19825,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         response: str,
         event: MessageEvent,
         adapter,
+        thread_metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Extract explicit MEDIA: tags from a response and deliver them.
 
@@ -19873,7 +19872,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # stale inspected content), not an attachment request.
             adapter.extract_images(cleaned)
 
-            _thread_meta = self._thread_metadata_for_source(event.source, self._reply_anchor_for_event(event))
+            _thread_meta = (
+                dict(thread_metadata)
+                if thread_metadata is not None
+                else self._thread_metadata_for_source(
+                    event.source,
+                    self._reply_anchor_for_event(event),
+                )
+            )
 
             _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
             _IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
@@ -19938,22 +19944,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         adapter,
         metadata: Optional[Dict[str, Any]] = None,
         event_message_id: Optional[str] = None,
+        text_already_delivered: bool = False,
     ) -> None:
         """Deliver a queued response using the normal text+attachment split."""
-        text_content = _strip_response_attachments_for_direct_send(response, adapter)
-        if text_content:
-            await adapter.send(
-                source.chat_id,
-                text_content,
-                metadata=metadata,
-            )
+        if not text_already_delivered:
+            text_content = _strip_response_attachments_for_direct_send(response, adapter)
+            if text_content:
+                await adapter.send(
+                    source.chat_id,
+                    text_content,
+                    metadata=metadata,
+                )
 
         synthetic_event = MessageEvent(
             text="",
             source=source,
             message_id=event_message_id,
         )
-        await self._deliver_media_from_response(response, synthetic_event, adapter)
+        await self._deliver_media_from_response(
+            response,
+            synthetic_event,
+            adapter,
+            thread_metadata=metadata,
+        )
 
     async def _run_background_task(
         self,
@@ -26332,26 +26345,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "Queued follow-up for session %s: suppressing intentional silence marker before continuing.",
                             session_key or "?",
                         )
-                    elif first_response and not _already_streamed:
+                    elif first_response:
                         try:
-                            logger.info(
-                                "Queued follow-up for session %s: final stream delivery not confirmed; sending first response before continuing.",
-                                session_key or "?",
-                            )
+                            if _already_streamed:
+                                logger.info(
+                                    "Queued follow-up for session %s: final text delivery confirmed; delivering explicit media before continuing.",
+                                    session_key or "?",
+                                )
+                            else:
+                                logger.info(
+                                    "Queued follow-up for session %s: final stream delivery not confirmed; sending first response before continuing.",
+                                    session_key or "?",
+                                )
                             await self._deliver_queued_first_response(
                                 first_response,
                                 source=source,
                                 adapter=adapter,
                                 metadata=_status_thread_metadata,
                                 event_message_id=event_message_id,
+                                text_already_delivered=_already_streamed,
                             )
                         except Exception as e:
                             logger.warning("Failed to send first response before queued message: %s", e)
-                    elif first_response:
-                        logger.info(
-                            "Queued follow-up for session %s: skipping resend because final streamed delivery was confirmed.",
-                            session_key or "?",
-                        )
                     # Release deferred bg-review notifications now that the
                     # first response has been delivered.  Pop from the
                     # adapter's callback dict (prevents double-fire in

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3048,11 +3048,14 @@ def _strip_response_attachments_for_direct_send(response: str, adapter) -> str:
     this path: ``MEDIA:`` tags, bare local files, and internal directives. Keep
     ordinary image URLs in the visible text until the queued path grows native
     image-URL delivery too.
+
+    Do not apply a broad ``MEDIA:`` regex after ``extract_media()`` — the
+    extractor deliberately preserves protected code/inline spans and
+    unsupported or unvalidated tags in the cleaned text.
     """
     _, cleaned = adapter.extract_media(response)
     cleaned = cleaned.replace("[[audio_as_voice]]", "").strip()
     cleaned = cleaned.replace("[[as_document]]", "").strip()
-    cleaned = re.sub(r"MEDIA:\s*\S+", "", cleaned).strip()
     _, cleaned = adapter.extract_local_files(cleaned)
     return cleaned.strip()
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3041,6 +3041,22 @@ def _is_control_interrupt_message(message: Optional[str]) -> bool:
     return normalized in _CONTROL_INTERRUPT_MESSAGES
 
 
+def _strip_response_attachments_for_direct_send(response: str, adapter) -> str:
+    """Return the visible text portion of a response before direct send().
+
+    Queued follow-up resends only replay attachments we can deliver natively in
+    this path: ``MEDIA:`` tags, bare local files, and internal directives. Keep
+    ordinary image URLs in the visible text until the queued path grows native
+    image-URL delivery too.
+    """
+    _, cleaned = adapter.extract_media(response)
+    cleaned = cleaned.replace("[[audio_as_voice]]", "").strip()
+    cleaned = cleaned.replace("[[as_document]]", "").strip()
+    cleaned = re.sub(r"MEDIA:\s*\S+", "", cleaned).strip()
+    _, cleaned = adapter.extract_local_files(cleaned)
+    return cleaned.strip()
+
+
 def _skill_slug_from_frontmatter(skill_md: Path) -> tuple[str | None, str | None]:
     """Derive the /command slug and declared frontmatter name from a SKILL.md.
 
@@ -19912,7 +19928,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception as e:
             logger.warning("Post-stream media extraction failed: %s", e)
 
+    async def _deliver_queued_first_response(
+        self,
+        response: str,
+        source: SessionSource,
+        adapter,
+        metadata: Optional[Dict[str, Any]] = None,
+        event_message_id: Optional[str] = None,
+    ) -> None:
+        """Deliver a queued response using the normal text+attachment split."""
+        text_content = _strip_response_attachments_for_direct_send(response, adapter)
+        if text_content:
+            await adapter.send(
+                source.chat_id,
+                text_content,
+                metadata=metadata,
+            )
 
+        synthetic_event = MessageEvent(
+            text="",
+            source=source,
+            message_id=event_message_id,
+        )
+        await self._deliver_media_from_response(response, synthetic_event, adapter)
 
     async def _run_background_task(
         self,
@@ -26297,10 +26335,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 "Queued follow-up for session %s: final stream delivery not confirmed; sending first response before continuing.",
                                 session_key or "?",
                             )
-                            await adapter.send(
-                                source.chat_id,
+                            await self._deliver_queued_first_response(
                                 first_response,
+                                source=source,
+                                adapter=adapter,
                                 metadata=_status_thread_metadata,
+                                event_message_id=event_message_id,
                             )
                         except Exception as e:
                             logger.warning("Failed to send first response before queued message: %s", e)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19945,6 +19945,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         metadata: Optional[Dict[str, Any]] = None,
         event_message_id: Optional[str] = None,
         text_already_delivered: bool = False,
+        deliver_media: bool = True,
     ) -> None:
         """Deliver a queued response using the normal text+attachment split."""
         if not text_already_delivered:
@@ -19955,6 +19956,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     text_content,
                     metadata=metadata,
                 )
+
+        # Failed turns still deliver their (normalized failure) text above,
+        # but must not upload attachments as if the turn succeeded — mirrors
+        # the ``not agent_result.get("failed")`` guard on the completed-turn
+        # delivery path.
+        if not deliver_media:
+            return
 
         synthetic_event = MessageEvent(
             text="",
@@ -26364,6 +26372,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 metadata=_status_thread_metadata,
                                 event_message_id=event_message_id,
                                 text_already_delivered=_already_streamed,
+                                deliver_media=not _delivery_result.get("failed"),
                             )
                         except Exception as e:
                             logger.warning("Failed to send first response before queued message: %s", e)

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -71,6 +71,25 @@ class DiscordProgressCaptureAdapter(ProgressCaptureAdapter):
         return DiscordAdapter.format_tool_preview(self, preview, **kwargs)
 
 
+class MediaCaptureProgressAdapter(ProgressCaptureAdapter):
+    """Capture native image batches without contacting a platform API."""
+
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(platform=platform)
+        self.image_batches = []
+
+    async def send_multiple_images(
+        self, chat_id, images, metadata=None, human_delay=0.0
+    ) -> None:
+        self.image_batches.append(
+            {
+                "chat_id": chat_id,
+                "images": images,
+                "metadata": metadata,
+            }
+        )
+
+
 class SmallLimitProgressAdapter(ProgressCaptureAdapter):
     """Adapter with a tiny platform limit to exercise progress rollover."""
 
@@ -788,6 +807,33 @@ class QueuedCommentaryAgent:
         }
 
 
+class QueuedMediaAgent:
+    """Return an explicit image attachment before a queued follow-up."""
+
+    calls = 0
+    media_path = None
+
+    def __init__(self, **kwargs):
+        self.stream_delta_callback = kwargs.get("stream_delta_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        type(self).calls += 1
+        if type(self).calls == 1:
+            final_response = f"first response\nMEDIA:{type(self).media_path}"
+            if self.stream_delta_callback:
+                self.stream_delta_callback("first response")
+        else:
+            final_response = "follow-up processed"
+            if self.stream_delta_callback:
+                self.stream_delta_callback(final_response)
+        return {
+            "final_response": final_response,
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class QueuedSilenceAgent:
     """First turn is intentionally silent; queued follow-up still runs."""
 
@@ -1034,6 +1080,208 @@ async def test_transformed_response_edits_streamed_message_in_place(monkeypatch,
     assert any("[plugin appended this]" in text for text in edited_texts), (
         f"expected transformed text in adapter.edits, got: {edited_texts!r}"
     )
+
+
+@pytest.mark.asyncio
+async def test_run_agent_queued_message_does_not_treat_commentary_as_final(monkeypatch, tmp_path):
+    QueuedCommentaryAgent.calls = 0
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        QueuedCommentaryAgent,
+        session_id="sess-queued-commentary",
+        pending_text="queued follow-up",
+        config_data={"display": {"interim_assistant_messages": True}},
+    )
+
+    sent_texts = [call["content"] for call in adapter.sent]
+    assert result["final_response"] == "final response 2"
+    assert "I'll inspect the repo first." in sent_texts
+    assert "final response 1" in sent_texts
+
+
+@pytest.mark.asyncio
+async def test_run_agent_queued_message_delivers_first_response_media(monkeypatch, tmp_path):
+    """Queued follow-ups must preserve explicit attachments from the first turn."""
+    media_path = tmp_path / "queued-first-response.png"
+    media_path.write_bytes(b"not-a-real-png-but-a-real-file")
+    QueuedMediaAgent.calls = 0
+    QueuedMediaAgent.media_path = media_path
+
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        QueuedMediaAgent,
+        session_id="sess-queued-media",
+        pending_text="queued follow-up",
+        platform=Platform.DISCORD,
+        chat_id="discord-thread",
+        chat_type="group",
+        thread_id="discord-thread",
+        adapter_cls=MediaCaptureProgressAdapter,
+    )
+
+    assert result["final_response"] == "follow-up processed"
+    assert isinstance(adapter, MediaCaptureProgressAdapter)
+    assert {
+        "sent_texts": [call["content"] for call in adapter.sent],
+        "image_batches": adapter.image_batches,
+    } == {
+        "sent_texts": ["first response"],
+        "image_batches": [
+            {
+                "chat_id": "discord-thread",
+                "images": [(media_path.as_uri(), "")],
+                "metadata": {"thread_id": "discord-thread"},
+            }
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_agent_queued_message_delivers_streamed_first_response_media(
+    monkeypatch, tmp_path,
+):
+    """Streaming first-turn text must not suppress its explicit attachment."""
+    media_path = tmp_path / "queued-streamed-first-response.png"
+    media_path.write_bytes(b"not-a-real-png-but-a-real-file")
+    QueuedMediaAgent.calls = 0
+    QueuedMediaAgent.media_path = media_path
+
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        QueuedMediaAgent,
+        session_id="sess-queued-streamed-media",
+        pending_text="queued follow-up",
+        config_data={
+            "display": {"tool_progress": "off", "interim_assistant_messages": False},
+            "streaming": {"enabled": True, "edit_interval": 0.01, "buffer_threshold": 1},
+        },
+        platform=Platform.DISCORD,
+        chat_id="discord-thread",
+        chat_type="group",
+        thread_id="discord-thread",
+        adapter_cls=MediaCaptureProgressAdapter,
+    )
+
+    assert result["final_response"] == "follow-up processed"
+    assert isinstance(adapter, MediaCaptureProgressAdapter)
+    all_text = [call["content"] for call in adapter.sent + adapter.edits]
+    assert all("MEDIA:" not in text for text in all_text)
+    assert adapter.image_batches == [
+        {
+            "chat_id": "discord-thread",
+            "images": [(media_path.as_uri(), "")],
+            "metadata": {"thread_id": "discord-thread"},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_suppresses_silent_first_turn_and_processes_queued_followup(
+    monkeypatch, tmp_path,
+):
+    """Regression: queued direct-send must not leak NO_REPLY to the channel."""
+    QueuedSilenceAgent.calls = 0
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        QueuedSilenceAgent,
+        session_id="sess-queued-silence",
+        pending_text="queued follow-up",
+        platform=Platform.SLACK,
+        chat_id="C123",
+        thread_id="1712345678.000100",
+    )
+
+    sent_texts = [call["content"] for call in adapter.sent]
+    assert QueuedSilenceAgent.calls == 2
+    assert result["final_response"] == "follow-up processed"
+    assert "NO_REPLY" not in sent_texts
+
+
+@pytest.mark.asyncio
+async def test_run_agent_sends_normalized_failure_before_queued_followup(
+    monkeypatch, tmp_path,
+):
+    """Queued delivery uses finalized output, not the raw empty agent result."""
+    QueuedFailedEmptyAgent.calls = 0
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        QueuedFailedEmptyAgent,
+        session_id="sess-queued-failed-empty",
+        pending_text="queued follow-up",
+        platform=Platform.SLACK,
+        chat_id="C123",
+        thread_id="1712345678.000100",
+    )
+
+    sent_texts = [call["content"] for call in adapter.sent]
+    assert QueuedFailedEmptyAgent.calls == 2
+    assert result["final_response"] == "follow-up processed"
+    assert any("The request failed: provider exploded" in text for text in sent_texts)
+
+
+@pytest.mark.asyncio
+async def test_run_agent_defers_background_review_notification_until_release(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        BackgroundReviewAgent,
+        session_id="sess-bg-review-order",
+        config_data={"display": {"interim_assistant_messages": True}},
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.sent == []
+
+
+@pytest.mark.asyncio
+async def test_base_processing_releases_post_delivery_callback_after_main_send():
+    """Post-delivery callbacks on the adapter fire after the main response."""
+    adapter = ProgressCaptureAdapter()
+
+    async def _handler(event):
+        return "done"
+
+    adapter.set_message_handler(_handler)
+
+    released = []
+
+    def _post_delivery_cb():
+        released.append(True)
+        adapter.sent.append(
+            {
+                "chat_id": "bg-review",
+                "content": "💾 Skill 'prospect-scanner' created.",
+                "reply_to": None,
+                "metadata": None,
+            }
+        )
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        thread_id="17585",
+    )
+    event = MessageEvent(
+        text="hello",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="msg-1",
+    )
+    session_key = "agent:main:telegram:group:-1001:17585"
+    adapter._active_sessions[session_key] = asyncio.Event()
+    adapter._post_delivery_callbacks[session_key] = _post_delivery_cb
+
+    await adapter._process_message_background(event, session_key)
+
+    sent_texts = [call["content"] for call in adapter.sent]
+    assert sent_texts == ["done", "💾 Skill 'prospect-scanner' created."]
+    assert released == [True]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -196,3 +196,80 @@ class _DiscordMediaFailureAdapter(BasePlatformAdapter):
 
     async def get_chat_info(self, chat_id):
         return {"id": chat_id, "type": "dm"}
+
+
+@pytest.mark.asyncio
+async def test_queued_followup_delivery_strips_media_tag_from_text_and_sends_image():
+    event = _event(thread_id="topic-1")
+    runner = object.__new__(GatewayRunner)
+    runner._thread_metadata_for_source = lambda source, anchor=None: {"thread_id": "topic-1"}
+    runner._reply_anchor_for_event = lambda event: event.message_id
+
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send=AsyncMock(return_value=SendResult(success=True, message_id="text")),
+        send_multiple_images=AsyncMock(return_value=None),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_queued_first_response(
+        runner,
+        "Quote here\nMEDIA:/tmp/pricelist.png",
+        source=event.source,
+        adapter=adapter,
+        metadata={"thread_id": "topic-1"},
+        event_message_id=event.message_id,
+    )
+
+    adapter.send.assert_awaited_once_with(
+        "chat-1",
+        "Quote here",
+        metadata={"thread_id": "topic-1"},
+    )
+    adapter.send_multiple_images.assert_awaited_once_with(
+        chat_id="chat-1",
+        images=[("file:///tmp/pricelist.png", "")],
+        metadata={"thread_id": "topic-1"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_queued_followup_delivery_keeps_remote_image_url_in_text():
+    event = _event(thread_id="topic-1")
+    runner = object.__new__(GatewayRunner)
+    runner._thread_metadata_for_source = lambda source, anchor=None: {"thread_id": "topic-1"}
+    runner._reply_anchor_for_event = lambda event: event.message_id
+
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send=AsyncMock(return_value=SendResult(success=True, message_id="text")),
+        send_multiple_images=AsyncMock(return_value=None),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    response = "See this mockup\nhttps://example.com/mockup.png"
+    await GatewayRunner._deliver_queued_first_response(
+        runner,
+        response,
+        source=event.source,
+        adapter=adapter,
+        metadata={"thread_id": "topic-1"},
+        event_message_id=event.message_id,
+    )
+
+    adapter.send.assert_awaited_once_with(
+        "chat-1",
+        response,
+        metadata={"thread_id": "topic-1"},
+    )
+    adapter.send_multiple_images.assert_not_awaited()

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -199,8 +199,11 @@ class _DiscordMediaFailureAdapter(BasePlatformAdapter):
 
 
 @pytest.mark.asyncio
-async def test_queued_followup_delivery_strips_media_tag_from_text_and_sends_image():
+async def test_queued_followup_delivery_strips_media_tag_from_text_and_sends_image(
+    tmp_path, monkeypatch,
+):
     event = _event(thread_id="topic-1")
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "pricelist.png")
     runner = object.__new__(GatewayRunner)
     runner._thread_metadata_for_source = lambda source, anchor=None: {"thread_id": "topic-1"}
     runner._reply_anchor_for_event = lambda event: event.message_id
@@ -219,7 +222,7 @@ async def test_queued_followup_delivery_strips_media_tag_from_text_and_sends_ima
 
     await GatewayRunner._deliver_queued_first_response(
         runner,
-        "Quote here\nMEDIA:/tmp/pricelist.png",
+        f"Quote here\nMEDIA:{media_file}",
         source=event.source,
         adapter=adapter,
         metadata={"thread_id": "topic-1"},
@@ -233,7 +236,7 @@ async def test_queued_followup_delivery_strips_media_tag_from_text_and_sends_ima
     )
     adapter.send_multiple_images.assert_awaited_once_with(
         chat_id="chat-1",
-        images=[("file:///tmp/pricelist.png", "")],
+        images=[(f"file://{media_file.as_posix()}", "")],
         metadata={"thread_id": "topic-1"},
     )
 

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -7,6 +7,9 @@ only renders as a voice bubble when explicitly flagged) and via
 ``GatewayRunner._deliver_media_from_response``.
 """
 
+import importlib
+import sys
+import types
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -276,3 +279,172 @@ async def test_queued_followup_delivery_keeps_remote_image_url_in_text():
         metadata={"thread_id": "topic-1"},
     )
     adapter.send_multiple_images.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_queued_followup_delivery_preserves_protected_media_example():
+    """Inline-code MEDIA examples must remain visible after queued text cleanup."""
+    event = _event(thread_id="topic-1")
+    runner = object.__new__(GatewayRunner)
+    runner._thread_metadata_for_source = lambda source, anchor=None: {"thread_id": "topic-1"}
+    runner._reply_anchor_for_event = lambda event: event.message_id
+
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send=AsyncMock(return_value=SendResult(success=True, message_id="text")),
+        send_multiple_images=AsyncMock(return_value=None),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    response = "Tag files like `MEDIA:/tmp/example.png` in tool output."
+    await GatewayRunner._deliver_queued_first_response(
+        runner,
+        response,
+        source=event.source,
+        adapter=adapter,
+        metadata={"thread_id": "topic-1"},
+        event_message_id=event.message_id,
+    )
+
+    adapter.send.assert_awaited_once_with(
+        "chat-1",
+        response,
+        metadata={"thread_id": "topic-1"},
+    )
+    adapter.send_multiple_images.assert_not_awaited()
+    adapter.send_document.assert_not_awaited()
+
+
+class _QueuedMediaCaptureAdapter(BasePlatformAdapter):
+    """Adapter that records text + native image delivery for queued-resend tests."""
+
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="test"), Platform.TELEGRAM)
+        self.sent = []
+        self.images = []
+
+    async def connect(self, *, is_reconnect: bool = False):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent.append({"chat_id": chat_id, "content": content, "metadata": metadata})
+        return SendResult(success=True, message_id=f"text-{len(self.sent)}")
+
+    async def send_image_file(self, chat_id, image_path, caption=None, reply_to=None, metadata=None, **kwargs):
+        self.images.append({"chat_id": chat_id, "image_path": image_path, "metadata": metadata})
+        return SendResult(success=True, message_id=f"img-{len(self.images)}")
+
+    async def send_multiple_images(self, chat_id, images, metadata=None, human_delay=0.0):
+        for image_url, _alt in images:
+            path = image_url
+            if path.startswith("file://"):
+                path = path[len("file://"):]
+            self.images.append({"chat_id": chat_id, "image_path": path, "metadata": metadata})
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id, "type": "dm"}
+
+
+class _QueuedMediaAgent:
+    calls = 0
+    first_response = ""
+
+    def __init__(self, **kwargs):
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        type(self).calls += 1
+        if type(self).calls == 1:
+            return {
+                "final_response": type(self).first_response,
+                "messages": [],
+                "api_calls": 1,
+            }
+        return {
+            "final_response": "follow-up processed",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+@pytest.mark.asyncio
+async def test_queued_resend_branch_delivers_media_and_preserves_protected_example(
+    tmp_path, monkeypatch,
+):
+    """Exercise the real queued first-response resend path in ``_run_agent``."""
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "quote.png")
+    protected = "Tag files like `MEDIA:/tmp/example.png` in tool output."
+    _QueuedMediaAgent.calls = 0
+    _QueuedMediaAgent.first_response = f"Quote here\nMEDIA:{media_file}\n{protected}"
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _QueuedMediaAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = _QueuedMediaCaptureAdapter()
+    gateway_run = importlib.import_module("gateway.run")
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {adapter.platform: adapter}
+    runner._voice_mode = {}
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._session_db = None
+    runner._running_agents = {}
+    runner._session_run_generation = {}
+    runner.session_store = SimpleNamespace(_entries={}, _save=lambda: None)
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner.config = SimpleNamespace(
+        thread_sessions_per_user=False,
+        group_sessions_per_user=False,
+        stt_enabled=False,
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="chat-1",
+        chat_type="dm",
+        thread_id="topic-1",
+    )
+    session_key = build_session_key(source)
+    adapter._pending_messages[session_key] = MessageEvent(
+        text="queued follow-up",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="queued-1",
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-queued-media",
+        session_key=session_key,
+    )
+
+    assert _QueuedMediaAgent.calls == 2
+    assert result["final_response"] == "follow-up processed"
+    first_texts = [call["content"] for call in adapter.sent if "Quote here" in call["content"]]
+    assert first_texts, f"expected queued resend of first response, got: {adapter.sent!r}"
+    assert f"MEDIA:{media_file}" not in first_texts[0]
+    assert "`MEDIA:/tmp/example.png`" in first_texts[0]
+    assert any(str(media_file) in img["image_path"] for img in adapter.images), (
+        f"expected native image delivery via queued resend, got: {adapter.images!r}"
+    )

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -282,6 +282,50 @@ async def test_queued_followup_delivery_keeps_remote_image_url_in_text():
 
 
 @pytest.mark.asyncio
+async def test_queued_followup_delivery_keeps_bare_local_path_in_text(
+    tmp_path, monkeypatch,
+):
+    """Queued delivery must not strip paths its explicit-only uploader ignores."""
+    event = _event(thread_id="topic-1")
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "inspected.png")
+    runner = object.__new__(GatewayRunner)
+    runner._thread_metadata_for_source = (
+        lambda source, reply_to_message_id=None: {"thread_id": "topic-1"}
+    )
+    runner._reply_anchor_for_event = lambda event: event.message_id
+
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send=AsyncMock(return_value=SendResult(success=True, message_id="text")),
+        send_multiple_images=AsyncMock(return_value=None),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    response = f"The inspected file is at {media_file}."
+    await GatewayRunner._deliver_queued_first_response(
+        runner,
+        response,
+        source=event.source,
+        adapter=adapter,
+        metadata={"thread_id": "topic-1"},
+        event_message_id=event.message_id,
+    )
+
+    adapter.send.assert_awaited_once_with(
+        "chat-1",
+        response,
+        metadata={"thread_id": "topic-1"},
+    )
+    adapter.send_multiple_images.assert_not_awaited()
+    adapter.send_document.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_queued_followup_delivery_preserves_protected_media_example():
     """Inline-code MEDIA examples must remain visible after queued text cleanup."""
     event = _event(thread_id="topic-1")

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -414,6 +414,44 @@ async def test_queued_followup_delivery_preserves_protected_media_example():
     adapter.send_document.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_queued_followup_delivery_skips_media_when_turn_failed():
+    """A failed first turn delivers its (failure) text but never uploads
+    attachments as if the turn succeeded — deliver_media=False mirrors the
+    completed-turn path's ``not agent_result.get("failed")`` guard."""
+    event = _event(thread_id="topic-1")
+    runner = object.__new__(GatewayRunner)
+    runner._thread_metadata_for_source = lambda source, anchor=None: {"thread_id": "topic-1"}
+    runner._reply_anchor_for_event = lambda event: event.message_id
+
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send=AsyncMock(return_value=SendResult(success=True, message_id="text")),
+        send_multiple_images=AsyncMock(return_value=None),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_queued_first_response(
+        runner,
+        "The request failed: provider exploded\nMEDIA:/tmp/pricelist.png",
+        source=event.source,
+        adapter=adapter,
+        metadata={"thread_id": "topic-1"},
+        event_message_id=event.message_id,
+        deliver_media=False,
+    )
+
+    adapter.send.assert_awaited_once()
+    adapter.send_multiple_images.assert_not_awaited()
+    adapter.send_document.assert_not_awaited()
+    adapter.send_video.assert_not_awaited()
+
+
 class _QueuedMediaCaptureAdapter(BasePlatformAdapter):
     """Adapter that records text + native image delivery for queued-resend tests."""
 

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -245,6 +245,56 @@ async def test_queued_followup_delivery_strips_media_tag_from_text_and_sends_ima
 
 
 @pytest.mark.asyncio
+async def test_queued_followup_delivery_reuses_routing_metadata_for_media(
+    tmp_path, monkeypatch,
+):
+    """Queued text and media must stay on the same precomputed reply route."""
+    event = _event(thread_id="source-topic")
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "threaded.png")
+    runner = object.__new__(GatewayRunner)
+    runner._thread_metadata_for_source = (
+        lambda source, reply_to_message_id=None: {"thread_id": "recomputed-topic"}
+    )
+    runner._reply_anchor_for_event = lambda event: event.message_id
+    routing_metadata = {
+        "thread_id": "queued-topic",
+        "reply_to_message_id": "trigger-message",
+    }
+
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send=AsyncMock(return_value=SendResult(success=True, message_id="text")),
+        send_multiple_images=AsyncMock(return_value=None),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_queued_first_response(
+        runner,
+        f"Threaded image\nMEDIA:{media_file}",
+        source=event.source,
+        adapter=adapter,
+        metadata=routing_metadata,
+        event_message_id=event.message_id,
+    )
+
+    adapter.send.assert_awaited_once_with(
+        "chat-1",
+        "Threaded image",
+        metadata=routing_metadata,
+    )
+    adapter.send_multiple_images.assert_awaited_once_with(
+        chat_id="chat-1",
+        images=[(f"file://{media_file.as_posix()}", "")],
+        metadata=routing_metadata,
+    )
+
+
+@pytest.mark.asyncio
 async def test_queued_followup_delivery_keeps_remote_image_url_in_text():
     event = _event(thread_id="topic-1")
     runner = object.__new__(GatewayRunner)
@@ -430,11 +480,11 @@ async def test_queued_resend_branch_delivers_media_and_preserves_protected_examp
     _QueuedMediaAgent.first_response = f"Quote here\nMEDIA:{media_file}\n{protected}"
 
     fake_dotenv = types.ModuleType("dotenv")
-    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    setattr(fake_dotenv, "load_dotenv", lambda *args, **kwargs: None)
     monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
 
     fake_run_agent = types.ModuleType("run_agent")
-    fake_run_agent.AIAgent = _QueuedMediaAgent
+    setattr(fake_run_agent, "AIAgent", _QueuedMediaAgent)
     monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
 
     adapter = _QueuedMediaCaptureAdapter()


### PR DESCRIPTION
## Summary
Telegram (and every gateway platform) no longer leaks literal `MEDIA:/path` text — or silently drops attachments — when a response is delivered through the queued follow-up path.

Salvage of #71031 by @StellarisW (all 7 commits cherry-picked with authorship preserved; consolidates @vKongv's #25119 work, whose commits were already merged into the PR branch with attribution), plus a follow-up commit adding the failed-result guard from the salvage review.

Both bug branches verified at line level on main: when a message queues during an active run (interrupt-mode next-turn handoff, subagent/compression demotions, photo bursts, or queue mode), the first turn's response is delivered by a side path in `_run_agent` that bypassed MEDIA handling entirely — (1) non-streamed responses went out via raw `adapter.send()` with the literal `MEDIA:` tag as text and no file; (2) already-streamed responses logged "delivery confirmed" and silently dropped the attachments. Hermes told the user a file was produced; the file never arrived.

## Changes
- `gateway/run.py` (contributor): new `_deliver_queued_first_response()` — splits text from attachments via the existing `extract_media` + `_deliver_media_from_response` machinery (path-security filtering and the explicit-only #20834 policy preserved), covers both branches via `text_already_delivered`, keeps thread/reply routing metadata, keeps protected `` `MEDIA:` `` examples and bare paths as visible text, applies the intentional-silence predicate.
- `gateway/run.py` (follow-up): `deliver_media=not _delivery_result.get("failed")` — a failed first turn still delivers its normalized failure text but never uploads its attachments, mirroring the completed-turn path's guard. Regression test added.
- Tests: exactly-once assertions (single image batch, single text send), routing-metadata reuse, protected-example preservation, bare-path/remote-URL contract, commentary-vs-final, normalized-failure text.

Conflicts were confined to the two test files flagged in review (`test_run_progress_topics.py`, `test_tts_media_routing.py` — neighboring tests added on main); production `run.py` changes applied clean.

## Validation
| | Before | After |
|---|---|---|
| Queued follow-up, non-streamed first turn | literal `MEDIA:/path` text, no file | text cleaned, file uploaded natively |
| Queued follow-up, streamed first turn | attachments silently dropped | attachments delivered exactly once |
| Failed first turn | n/a (leaked) | failure text only, no uploads |
| tests/gateway/ full directory | — | 5101/5101 pass |

After merge: close #18546, #25119, #46223, #51805 as superseded (each covered only the fallback branch or violated the explicit-only policy); #56092 (duplicate re-send race) is orthogonal and stays open.

## Infographic

![File delivered](https://v3b.fal.media/files/b/0aa59638/FxO0kJ8cWBZfbJ2dBCk_-_qjCMlZuE.png)
