### PR TITLE
feat(feishu): interactive clarify cards + native choice picker (port of QwenLM/qwen-code#8578)

### DIFF
--- a/gateway/platforms/ADDING_A_PLATFORM.md
+++ b/gateway/platforms/ADDING_A_PLATFORM.md
@@ -120,7 +120,7 @@ If your platform supports interactive button/menu messages, implement these for 
 | `send_exec_approval(chat_id, command, session_key, description, ...)` | Render dangerous-command approval as Approve/Deny buttons. Inbound dispatch routes to `tools.approval.resolve_gateway_approval`. |
 | `send_slash_confirm(chat_id, title, message, session_key, confirm_id, ...)` | Render slash-command confirmations (e.g. `/reload-mcp`) as Once/Always/Cancel buttons. Inbound dispatch routes to `tools.slash_confirm.resolve`. |
 | `send_model_picker(...)` | Interactive `/model` picker. Used by Telegram and Discord. |
-| `send_choice_picker(...)` | Flat single-level picker for finite-choice commands (`/reasoning`, `/fast`). Implemented by Telegram (inline keyboard), Discord (select menu), and Matrix (reactions). Platforms without it fall back to the text status card automatically. |
+| `send_choice_picker(...)` | Flat single-level picker for finite-choice commands (`/reasoning`, `/fast`). Implemented by Telegram (inline keyboard), Discord (select menu), Matrix (reactions), and Feishu (interactive card buttons). Platforms without it fall back to the text status card automatically. |
 
 See `gateway/platforms/telegram.py`, `discord.py`, and `whatsapp_cloud.py` for reference implementations. The button-callback id convention (`cl:<id>:<idx>`, `appr:<id>:<choice>`, `sc:<choice>:<id>`) is shared across adapters — match it so the gateway-side resolvers work without modification.
 

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1556,6 +1556,15 @@ class FeishuAdapter(BasePlatformAdapter):
         # Update prompt button state (prompt_id → {session_key, message_id, chat_id})
         self._update_prompt_state: Dict[int, Dict[str, str]] = {}
         self._update_prompt_counter = itertools.count(1)
+        # Clarify button state (clarify_id → {session_key, chat_id, choices})
+        # for the clarify tool's multiple-choice prompts rendered as
+        # interactive cards (mirrors Telegram's _clarify_state).
+        self._clarify_state: Dict[str, Dict[str, Any]] = {}
+        # Choice picker state (picker_id → {chat_id, session_key, choices,
+        # on_choice_selected}) for /reasoning, /fast and other finite-choice
+        # slash commands (generic send_choice_picker capability).
+        self._choice_picker_state: Dict[int, Dict[str, Any]] = {}
+        self._choice_picker_counter = itertools.count(1)
         # Feishu reaction deletion requires the opaque reaction_id returned
         # by create, so we cache it per message_id.
         self._pending_processing_reactions: "OrderedDict[str, str]" = OrderedDict()
@@ -2195,6 +2204,165 @@ class FeishuAdapter(BasePlatformAdapter):
             logger.warning("[Feishu] send_update_prompt failed: %s", exc)
             return SendResult(success=False, error=str(exc))
 
+    async def send_clarify(
+        self,
+        chat_id: str,
+        question: str,
+        choices: Optional[list],
+        clarify_id: str,
+        session_key: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Render a clarify prompt as an interactive card with choice buttons.
+
+        Multi-choice mode (``choices`` non-empty): one button per option plus
+        a final "✏️ Other (type answer)" button.  Numeric buttons resolve
+        immediately via ``resolve_gateway_clarify``; the "Other" button flips
+        the clarify entry into text-capture mode so the next message in the
+        session becomes the response (same contract as Telegram/Discord).
+
+        Open-ended mode (``choices`` empty): plain question text — the
+        gateway's text-intercept captures the next message.
+        """
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            if not choices:
+                # Open-ended — plain text is enough; base-class contract says
+                # gateway text-intercept resolves it.
+                return await self.send(chat_id, f"❓ {question}", metadata=metadata)
+
+            clean_choices = [str(c).strip() for c in choices if str(c).strip()]
+
+            def _btn(label: str, token: str, btn_type: str = "default") -> dict:
+                # Feishu plain_text button labels render poorly past ~30
+                # chars on mobile; the card body carries the full text.
+                if len(label) > 30:
+                    label = label[:29] + "…"
+                return {
+                    "tag": "button",
+                    "text": {"tag": "plain_text", "content": label},
+                    "type": btn_type,
+                    "value": {
+                        "hermes_clarify_action": token,
+                        "clarify_id": clarify_id,
+                    },
+                }
+
+            option_lines = "\n".join(
+                f"{i + 1}. {c}" for i, c in enumerate(clean_choices)
+            )
+            actions = [
+                _btn(f"{i + 1}", str(i), "primary" if i == 0 else "default")
+                for i in range(len(clean_choices))
+            ]
+            actions.append(_btn("✏️ Other (type answer)", "other"))
+
+            card = {
+                "config": {"wide_screen_mode": True},
+                "header": {
+                    "title": {"content": "❓ Hermes needs your input", "tag": "plain_text"},
+                    "template": "blue",
+                },
+                "elements": [
+                    {"tag": "markdown", "content": f"{question}\n\n{option_lines}"},
+                    {"tag": "action", "actions": actions},
+                ],
+            }
+
+            payload = json.dumps(card, ensure_ascii=False)
+            response = await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="interactive",
+                payload=payload,
+                reply_to=None,
+                metadata=metadata,
+            )
+            result = self._finalize_send_result(response, "send_clarify failed")
+            if result.success:
+                self._clarify_state[clarify_id] = {
+                    "session_key": session_key,
+                    "chat_id": chat_id,
+                    "choices": clean_choices,
+                }
+            return result
+        except Exception as exc:
+            logger.warning("[Feishu] send_clarify failed: %s", exc)
+            return SendResult(success=False, error=str(exc))
+
+    async def send_choice_picker(
+        self,
+        chat_id: str,
+        title: str,
+        choices: list,
+        session_key: str,
+        on_choice_selected,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a flat interactive-card choice picker (one tap → one value).
+
+        Generic single-level picker used by `/reasoning`, `/fast`, and any
+        future finite-choice slash command. Each choice dict:
+        ``{"value": str, "label": str, "is_current": bool}`` — the same
+        contract as the Telegram/Discord/Matrix implementations.
+        """
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            picker_id = next(self._choice_picker_counter)
+
+            def _btn(idx: int, choice: dict) -> dict:
+                label = str(choice.get("label") or choice.get("value") or "")
+                if choice.get("is_current"):
+                    label = f"✓ {label}"
+                if len(label) > 30:
+                    label = label[:29] + "…"
+                return {
+                    "tag": "button",
+                    "text": {"tag": "plain_text", "content": label},
+                    "type": "primary" if choice.get("is_current") else "default",
+                    "value": {
+                        "hermes_choice_picker_action": str(idx),
+                        "picker_id": picker_id,
+                    },
+                }
+
+            actions = [_btn(i, c) for i, c in enumerate(choices)]
+            if not actions:
+                return SendResult(success=False, error="No choices")
+
+            card = {
+                "config": {"wide_screen_mode": True},
+                "header": {
+                    "title": {"content": title, "tag": "plain_text"},
+                    "template": "blue",
+                },
+                "elements": [{"tag": "action", "actions": actions}],
+            }
+
+            payload = json.dumps(card, ensure_ascii=False)
+            response = await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="interactive",
+                payload=payload,
+                reply_to=None,
+                metadata=metadata,
+            )
+            result = self._finalize_send_result(response, "send_choice_picker failed")
+            if result.success:
+                self._choice_picker_state[picker_id] = {
+                    "chat_id": chat_id,
+                    "session_key": session_key,
+                    "choices": choices,
+                    "on_choice_selected": on_choice_selected,
+                }
+            return result
+        except Exception as exc:
+            logger.warning("[Feishu] send_choice_picker failed: %s", exc)
+            return SendResult(success=False, error=str(exc))
+
     @staticmethod
     def _build_resolved_approval_card(*, choice: str, user_name: str) -> Dict[str, Any]:
         """Build raw card JSON for a resolved approval action."""
@@ -2734,11 +2902,31 @@ class FeishuAdapter(BasePlatformAdapter):
             action_value.get("hermes_update_prompt_action")
             if isinstance(action_value, dict) else None
         )
+        clarify_action = (
+            action_value.get("hermes_clarify_action")
+            if isinstance(action_value, dict) else None
+        )
+        choice_picker_action = (
+            action_value.get("hermes_choice_picker_action")
+            if isinstance(action_value, dict) else None
+        )
 
         if hermes_action:
             return self._handle_approval_card_action(event=event, action_value=action_value, loop=loop)
         if update_prompt_action:
             return self._handle_update_prompt_card_action(
+                event=event,
+                action_value=action_value,
+                loop=loop,
+            )
+        if clarify_action is not None:
+            return self._handle_clarify_card_action(
+                event=event,
+                action_value=action_value,
+                loop=loop,
+            )
+        if choice_picker_action is not None:
+            return self._handle_choice_picker_card_action(
                 event=event,
                 action_value=action_value,
                 loop=loop,
@@ -2890,6 +3078,238 @@ class FeishuAdapter(BasePlatformAdapter):
             card.data = self._build_resolved_update_prompt_card(answer=answer, user_name=user_name)
             response.card = card
         return response
+
+    @staticmethod
+    def _build_resolved_clarify_card(*, question: str, answer: str, user_name: str) -> Dict[str, Any]:
+        """Build raw card JSON for a resolved clarify choice."""
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": "✅ Answered", "tag": "plain_text"},
+                "template": "green",
+            },
+            "elements": [
+                {"tag": "markdown", "content": f"❓ {question}\n\n**{user_name}:** {answer}"},
+            ],
+        }
+
+    @staticmethod
+    def _build_awaiting_text_clarify_card(*, question: str, user_name: str) -> Dict[str, Any]:
+        """Build raw card JSON shown after the user taps \"Other\"."""
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": "✏️ Awaiting typed answer", "tag": "plain_text"},
+                "template": "blue",
+            },
+            "elements": [
+                {
+                    "tag": "markdown",
+                    "content": f"❓ {question}\n\n*Awaiting typed response from {user_name}…*",
+                },
+            ],
+        }
+
+    def _handle_clarify_card_action(self, *, event: Any, action_value: Dict[str, Any], loop: Any) -> Any:
+        """Resolve a clarify button tap and return the settled card inline.
+
+        Mirrors the approval-card flow: validates the operator and chat,
+        resolves synchronously through ``tools.clarify_gateway`` (a cheap
+        in-process Event set — safe from the SDK callback thread), and
+        returns the updated card so every client syncs immediately.
+        """
+        clarify_id = str(action_value.get("clarify_id") or "")
+        token = str(action_value.get("hermes_clarify_action") or "")
+        state = self._clarify_state.get(clarify_id)
+        if not clarify_id or not state:
+            logger.debug("[Feishu] Clarify %s already resolved or unknown", clarify_id or "<missing>")
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        operator = getattr(event, "operator", None)
+        open_id = str(getattr(operator, "open_id", "") or "")
+        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
+        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+            logger.warning("[Feishu] Unauthorized clarify click by %s", open_id or "<unknown>")
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        callback_chat_id = str(getattr(getattr(event, "context", None), "open_chat_id", "") or "")
+        expected_chat_id = str(state.get("chat_id", "") or "")
+        if callback_chat_id and expected_chat_id and callback_chat_id != expected_chat_id:
+            logger.warning(
+                "[Feishu] Clarify callback chat mismatch for %s (expected=%s, got=%s)",
+                clarify_id, expected_chat_id, callback_chat_id,
+            )
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        user_name = self._get_cached_sender_name(open_id) or open_id
+        # Reconstruct the question for the settled card from the pending
+        # clarify entry when available (state stores only choices).
+        question = ""
+        try:
+            from tools import clarify_gateway as _cg
+            with _cg._lock:
+                _entry = _cg._entries.get(clarify_id)
+            if _entry is not None:
+                question = str(getattr(_entry, "question", "") or "")
+        except Exception:
+            question = ""
+
+        if token == "other":
+            # Flip into text-capture mode; the gateway text-intercept picks
+            # up the next message in this session. Keep _clarify_state so a
+            # late tap on a numeric button still validates.
+            flipped = False
+            try:
+                from tools.clarify_gateway import mark_awaiting_text
+                flipped = mark_awaiting_text(clarify_id)
+            except Exception as exc:
+                logger.warning("[Feishu] mark_awaiting_text failed: %s", exc)
+            if not flipped:
+                self._clarify_state.pop(clarify_id, None)
+                logger.debug("[Feishu] Clarify %s expired before 'Other' tap", clarify_id)
+                return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+            if P2CardActionTriggerResponse is None:
+                return None
+            response = P2CardActionTriggerResponse()
+            if CallBackCard is not None:
+                card = CallBackCard()
+                card.type = "raw"
+                card.data = self._build_awaiting_text_clarify_card(
+                    question=question, user_name=user_name,
+                )
+                response.card = card
+            return response
+
+        # Numeric choice → resolve immediately with the chosen text.
+        choices = list(state.get("choices") or [])
+        try:
+            idx = int(token)
+        except (TypeError, ValueError):
+            idx = -1
+        if not (0 <= idx < len(choices)):
+            logger.debug("[Feishu] Clarify %s has invalid choice token=%r", clarify_id, token)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+        resolved_text = str(choices[idx])
+
+        self._clarify_state.pop(clarify_id, None)
+        resolved = False
+        try:
+            from tools.clarify_gateway import resolve_gateway_clarify
+            resolved = resolve_gateway_clarify(clarify_id, resolved_text)
+        except Exception as exc:
+            logger.error("[Feishu] resolve_gateway_clarify failed: %s", exc)
+        if not resolved:
+            # Entry evicted (clarify_timeout) or gateway restarted between
+            # ask and tap — don't render a misleading ✓ card.
+            logger.warning("[Feishu] Clarify %s tap arrived after expiry", clarify_id)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        logger.info(
+            "Feishu clarify button resolved (id=%s, choice=%r, user=%s)",
+            clarify_id, resolved_text, user_name,
+        )
+        if P2CardActionTriggerResponse is None:
+            return None
+        response = P2CardActionTriggerResponse()
+        if CallBackCard is not None:
+            card = CallBackCard()
+            card.type = "raw"
+            card.data = self._build_resolved_clarify_card(
+                question=question, answer=resolved_text, user_name=user_name,
+            )
+            response.card = card
+        return response
+
+    def _handle_choice_picker_card_action(self, *, event: Any, action_value: Dict[str, Any], loop: Any) -> Any:
+        """Apply a choice-picker tap and schedule the async applier.
+
+        The applier callback (``on_choice_selected``) is an async gateway
+        function that may write config — it runs on the adapter loop; the
+        synchronous callback response settles the card immediately with the
+        chosen label ("Applying…" is avoided: the applier's message is sent
+        as a follow-up chat message on completion).
+        """
+        picker_id = action_value.get("picker_id")
+        state = self._choice_picker_state.get(picker_id) if picker_id is not None else None
+        if picker_id is None or not state:
+            logger.debug("[Feishu] Choice picker %s already resolved or unknown", picker_id)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        operator = getattr(event, "operator", None)
+        open_id = str(getattr(operator, "open_id", "") or "")
+        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
+        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+            logger.warning("[Feishu] Unauthorized choice-picker click by %s", open_id or "<unknown>")
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        callback_chat_id = str(getattr(getattr(event, "context", None), "open_chat_id", "") or "")
+        expected_chat_id = str(state.get("chat_id", "") or "")
+        if callback_chat_id and expected_chat_id and callback_chat_id != expected_chat_id:
+            logger.warning(
+                "[Feishu] Choice picker callback chat mismatch for %s (expected=%s, got=%s)",
+                picker_id, expected_chat_id, callback_chat_id,
+            )
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        token = str(action_value.get("hermes_choice_picker_action") or "")
+        choices = list(state.get("choices") or [])
+        try:
+            idx = int(token)
+        except (TypeError, ValueError):
+            idx = -1
+        if not (0 <= idx < len(choices)):
+            logger.debug("[Feishu] Choice picker %s invalid token=%r", picker_id, token)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+        choice = choices[idx]
+        value = str(choice.get("value") or "")
+        label = str(choice.get("label") or value)
+        user_name = self._get_cached_sender_name(open_id) or open_id
+
+        self._choice_picker_state.pop(picker_id, None)
+        if not self._submit_on_loop(
+            loop,
+            self._apply_choice_picker_selection(
+                state=state, value=value, chat_id=expected_chat_id or callback_chat_id,
+            ),
+        ):
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        if P2CardActionTriggerResponse is None:
+            return None
+        response = P2CardActionTriggerResponse()
+        if CallBackCard is not None:
+            card = CallBackCard()
+            card.type = "raw"
+            card.data = {
+                "config": {"wide_screen_mode": True},
+                "header": {
+                    "title": {"content": f"✓ {label}", "tag": "plain_text"},
+                    "template": "green",
+                },
+                "elements": [
+                    {"tag": "markdown", "content": f"Selected by **{user_name}**"},
+                ],
+            }
+            response.card = card
+        return response
+
+    async def _apply_choice_picker_selection(
+        self, *, state: Dict[str, Any], value: str, chat_id: str,
+    ) -> None:
+        """Run the picker's async applier and send its result as a message."""
+        callback = state.get("on_choice_selected")
+        if not callback:
+            return
+        try:
+            result_text = await callback(chat_id, value)
+        except Exception as exc:
+            logger.error("[Feishu] Choice picker selection failed: %s", exc)
+            result_text = f"Error applying selection: {exc}"
+        if result_text and chat_id:
+            try:
+                await self.send(chat_id, str(result_text))
+            except Exception:
+                logger.debug("[Feishu] choice-picker result send failed", exc_info=True)
 
     async def _resolve_approval(
         self,

--- a/tests/gateway/test_feishu_clarify_choice_cards.py
+++ b/tests/gateway/test_feishu_clarify_choice_cards.py
@@ -1,0 +1,396 @@
+"""Tests for Feishu clarify cards and the generic choice picker."""
+
+import asyncio
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure the repo root is importable
+# ---------------------------------------------------------------------------
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+# ---------------------------------------------------------------------------
+# Minimal Feishu mock so FeishuAdapter can be imported without lark-oapi
+# ---------------------------------------------------------------------------
+def _ensure_feishu_mocks():
+    """Provide stubs for lark-oapi / aiohttp.web so the import succeeds."""
+    if importlib.util.find_spec("lark_oapi") is None and "lark_oapi" not in sys.modules:
+        mod = MagicMock()
+        for name in (
+            "lark_oapi", "lark_oapi.api.im.v1",
+            "lark_oapi.event", "lark_oapi.event.callback_type",
+        ):
+            sys.modules.setdefault(name, mod)
+    if importlib.util.find_spec("aiohttp") is None and "aiohttp" not in sys.modules:
+        aio = MagicMock()
+        sys.modules.setdefault("aiohttp", aio)
+        sys.modules.setdefault("aiohttp.web", aio.web)
+
+
+_ensure_feishu_mocks()
+
+from gateway.config import PlatformConfig
+import plugins.platforms.feishu.adapter as feishu_module
+from plugins.platforms.feishu.adapter import FeishuAdapter
+from tools import clarify_gateway
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_adapter() -> FeishuAdapter:
+    config = PlatformConfig(enabled=True)
+    adapter = FeishuAdapter(config)
+    adapter._client = MagicMock()
+    return adapter
+
+
+def _make_card_action_data(
+    action_value: dict,
+    chat_id: str = "oc_12345",
+    open_id: str = "ou_user1",
+    token: str = "tok_abc",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        event=SimpleNamespace(
+            token=token,
+            context=SimpleNamespace(open_chat_id=chat_id),
+            operator=SimpleNamespace(open_id=open_id, user_id="u_1"),
+            action=SimpleNamespace(tag="button", value=action_value),
+        ),
+    )
+
+
+class _FakeCallBackCard:
+    def __init__(self):
+        self.type = None
+        self.data = None
+
+
+class _FakeP2Response:
+    def __init__(self):
+        self.card = None
+
+
+@pytest.fixture
+def _patch_callback_card_types(monkeypatch):
+    monkeypatch.setattr(feishu_module, "P2CardActionTriggerResponse", _FakeP2Response)
+    monkeypatch.setattr(feishu_module, "CallBackCard", _FakeCallBackCard)
+
+
+@pytest.fixture(autouse=True)
+def _clean_clarify_registry():
+    yield
+    with clarify_gateway._lock:
+        clarify_gateway._entries.clear()
+        clarify_gateway._session_index.clear()
+
+
+_OK_RESPONSE = SimpleNamespace(
+    success=lambda: True,
+    data=SimpleNamespace(message_id="msg_cl_1"),
+)
+
+
+# ===========================================================================
+# send_clarify — interactive card rendering
+# ===========================================================================
+
+class TestFeishuSendClarify:
+    @pytest.mark.asyncio
+    async def test_multi_choice_sends_interactive_card(self):
+        adapter = _make_adapter()
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            return_value=_OK_RESPONSE,
+        ) as mock_send:
+            result = await adapter.send_clarify(
+                chat_id="oc_12345",
+                question="Pick a color",
+                choices=["red", "green ish option that is quite long indeed"],
+                clarify_id="cl_1",
+                session_key="sess-1",
+            )
+
+        assert result.success is True
+        kwargs = mock_send.call_args[1]
+        assert kwargs["msg_type"] == "interactive"
+        card = json.loads(kwargs["payload"])
+        body = card["elements"][0]["content"]
+        assert "Pick a color" in body
+        assert "1. red" in body
+        actions = card["elements"][1]["actions"]
+        # 2 numeric buttons + Other
+        assert len(actions) == 3
+        assert actions[0]["value"] == {"hermes_clarify_action": "0", "clarify_id": "cl_1"}
+        assert actions[-1]["value"]["hermes_clarify_action"] == "other"
+        # State stored for the callback path
+        assert adapter._clarify_state["cl_1"]["choices"][0] == "red"
+
+    @pytest.mark.asyncio
+    async def test_open_ended_sends_plain_text(self):
+        adapter = _make_adapter()
+        with patch.object(
+            adapter, "send", new_callable=AsyncMock,
+            return_value=SimpleNamespace(success=True),
+        ) as mock_send:
+            result = await adapter.send_clarify(
+                chat_id="oc_12345",
+                question="What now?",
+                choices=None,
+                clarify_id="cl_2",
+                session_key="sess-2",
+            )
+        assert result.success is True
+        assert "What now?" in mock_send.call_args[0][1]
+        assert "cl_2" not in adapter._clarify_state
+
+
+# ===========================================================================
+# _handle_clarify_card_action — button taps
+# ===========================================================================
+
+class TestClarifyCardAction:
+    def _register(self, clarify_id="cl_1", choices=("red", "green")):
+        clarify_gateway.register(
+            clarify_id=clarify_id,
+            session_key="sess-1",
+            question="Pick a color",
+            choices=list(choices),
+        )
+
+    def test_numeric_tap_resolves_entry(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_user1"}
+        self._register()
+        adapter._clarify_state["cl_1"] = {
+            "session_key": "sess-1", "chat_id": "oc_12345",
+            "choices": ["red", "green"],
+        }
+        data = _make_card_action_data(
+            {"hermes_clarify_action": "1", "clarify_id": "cl_1"},
+        )
+
+        response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is not None
+        assert "green" in json.dumps(response.card.data, ensure_ascii=False)
+        # Entry resolved with the choice text
+        with clarify_gateway._lock:
+            entry = clarify_gateway._entries["cl_1"]
+        assert entry.response == "green"
+        assert entry.event.is_set()
+        assert "cl_1" not in adapter._clarify_state
+
+    def test_other_tap_flips_awaiting_text(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_user1"}
+        self._register()
+        adapter._clarify_state["cl_1"] = {
+            "session_key": "sess-1", "chat_id": "oc_12345",
+            "choices": ["red", "green"],
+        }
+        data = _make_card_action_data(
+            {"hermes_clarify_action": "other", "clarify_id": "cl_1"},
+        )
+
+        response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is not None
+        with clarify_gateway._lock:
+            entry = clarify_gateway._entries["cl_1"]
+        assert entry.awaiting_text is True
+        assert not entry.event.is_set()
+        # State kept so the entry can still be validated later
+        assert "cl_1" in adapter._clarify_state
+
+    def test_unauthorized_tap_does_not_resolve(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._admins = {"ou_admin"}
+        self._register()
+        adapter._clarify_state["cl_1"] = {
+            "session_key": "sess-1", "chat_id": "oc_12345",
+            "choices": ["red", "green"],
+        }
+        data = _make_card_action_data(
+            {"hermes_clarify_action": "0", "clarify_id": "cl_1"},
+            open_id="ou_intruder",
+        )
+
+        response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        with clarify_gateway._lock:
+            entry = clarify_gateway._entries["cl_1"]
+        assert not entry.event.is_set()
+        assert "cl_1" in adapter._clarify_state
+
+    def test_expired_entry_returns_plain_response(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_user1"}
+        # No clarify_gateway entry registered — simulates timeout eviction.
+        adapter._clarify_state["cl_gone"] = {
+            "session_key": "sess-1", "chat_id": "oc_12345",
+            "choices": ["red"],
+        }
+        data = _make_card_action_data(
+            {"hermes_clarify_action": "0", "clarify_id": "cl_gone"},
+        )
+
+        response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        assert "cl_gone" not in adapter._clarify_state
+
+    def test_chat_mismatch_rejected(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        self._register()
+        adapter._clarify_state["cl_1"] = {
+            "session_key": "sess-1", "chat_id": "oc_expected",
+            "choices": ["red", "green"],
+        }
+        data = _make_card_action_data(
+            {"hermes_clarify_action": "0", "clarify_id": "cl_1"},
+            chat_id="oc_other",
+        )
+
+        response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        with clarify_gateway._lock:
+            entry = clarify_gateway._entries["cl_1"]
+        assert not entry.event.is_set()
+
+
+# ===========================================================================
+# send_choice_picker + _handle_choice_picker_card_action
+# ===========================================================================
+
+class TestFeishuChoicePicker:
+    @pytest.mark.asyncio
+    async def test_sends_interactive_card_with_choices(self):
+        adapter = _make_adapter()
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            return_value=_OK_RESPONSE,
+        ) as mock_send:
+            result = await adapter.send_choice_picker(
+                chat_id="oc_12345",
+                title="Reasoning effort",
+                choices=[
+                    {"value": "low", "label": "low", "is_current": False},
+                    {"value": "high", "label": "high", "is_current": True},
+                ],
+                session_key="sess-1",
+                on_choice_selected=AsyncMock(),
+            )
+
+        assert result.success is True
+        kwargs = mock_send.call_args[1]
+        assert kwargs["msg_type"] == "interactive"
+        card = json.loads(kwargs["payload"])
+        assert card["header"]["title"]["content"] == "Reasoning effort"
+        actions = card["elements"][0]["actions"]
+        assert len(actions) == 2
+        assert actions[1]["text"]["content"] == "✓ high"
+        assert actions[1]["type"] == "primary"
+        assert len(adapter._choice_picker_state) == 1
+
+    @pytest.mark.asyncio
+    async def test_empty_choices_fail(self):
+        adapter = _make_adapter()
+        result = await adapter.send_choice_picker(
+            chat_id="oc_12345", title="t", choices=[],
+            session_key="s", on_choice_selected=AsyncMock(),
+        )
+        assert result.success is False
+
+    def test_tap_schedules_applier_and_returns_card(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_user1"}
+        applier = AsyncMock(return_value="Applied: high")
+        adapter._choice_picker_state[1] = {
+            "chat_id": "oc_12345",
+            "session_key": "sess-1",
+            "choices": [
+                {"value": "low", "label": "low"},
+                {"value": "high", "label": "high"},
+            ],
+            "on_choice_selected": applier,
+        }
+        data = _make_card_action_data(
+            {"hermes_choice_picker_action": "1", "picker_id": 1},
+        )
+
+        scheduled = []
+
+        def _capture(coro, _loop, **_kwargs):
+            scheduled.append(coro)
+            return SimpleNamespace(add_done_callback=lambda *_a, **_k: None)
+
+        with patch("agent.async_utils.safe_schedule_threadsafe", side_effect=_capture):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is not None
+        assert "high" in json.dumps(response.card.data, ensure_ascii=False)
+        assert 1 not in adapter._choice_picker_state
+        assert len(scheduled) == 1
+
+        # Drive the scheduled applier coroutine and verify the applier and
+        # the follow-up send both fire with the selected value.
+        with patch.object(
+            adapter, "send", new_callable=AsyncMock,
+            return_value=SimpleNamespace(success=True),
+        ) as mock_send:
+            asyncio.run(scheduled[0])
+        applier.assert_awaited_once_with("oc_12345", "high")
+        assert "Applied: high" in mock_send.call_args[0][1]
+
+    def test_unauthorized_tap_keeps_state(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._admins = {"ou_admin"}
+        adapter._choice_picker_state[2] = {
+            "chat_id": "oc_12345", "session_key": "s",
+            "choices": [{"value": "low", "label": "low"}],
+            "on_choice_selected": AsyncMock(),
+        }
+        data = _make_card_action_data(
+            {"hermes_choice_picker_action": "0", "picker_id": 2},
+            open_id="ou_intruder",
+        )
+
+        response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        assert 2 in adapter._choice_picker_state

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -289,6 +289,10 @@ Card action events are dispatched with `MessageType.COMMAND`, so they flow throu
 
 This is also how **command approval** works — when the agent needs to run a dangerous command, it sends an interactive card with Allow Once / Session / Always / Deny buttons. The user clicks a button, and the card action callback delivers the approval decision back to the agent.
 
+**Clarify questions** render the same way: when the agent asks a multiple-choice question via the `clarify` tool, Feishu users get an interactive card with one numbered button per option plus an "✏️ Other (type answer)" button. Tapping a number resolves the question instantly (the card updates in place with the chosen answer); tapping "Other" switches to text capture so the next message in the chat becomes the answer. Open-ended questions arrive as plain text and the next message answers them.
+
+**Finite-choice slash commands** (`/reasoning`, `/fast`) also send a native card picker — one tap applies the setting, the card settles with the selection, and the command's confirmation message follows in the chat.
+
 ### Required Feishu App Configuration
 
 Interactive cards require **three** configuration steps in the Feishu Developer Console. Missing any of them causes error **200340** when users click card buttons.


### PR DESCRIPTION
## Summary
Feishu users now get native interactive-card buttons for the `clarify` tool's multiple-choice questions and for finite-choice slash commands (`/reasoning`, `/fast`) — one tap answers the agent instead of typing a number, bringing Feishu to parity with Telegram, Discord, and Matrix.

Ported/adapted from QwenLM/qwen-code#8578 (feat(channels): add Feishu ask-user question cards), reimplemented on Hermes' existing Feishu interactive-card infrastructure (exec-approval / update-prompt cards).

## Changes
- `plugins/platforms/feishu/adapter.py`:
  - `send_clarify()`: multi-choice questions render as an interactive card — numbered buttons per option plus an "✏️ Other (type answer)" button. Numeric taps resolve synchronously via `resolve_gateway_clarify` and the card settles inline (question + chosen answer) for all clients; "Other" flips the entry into text-capture mode (`mark_awaiting_text`) and updates the card to an awaiting state. Expired/evicted entries reject the tap instead of rendering a misleading resolved card. Open-ended questions stay plain text (gateway text-intercept path, unchanged).
  - `send_choice_picker()`: generic finite-choice picker card with the standard `{value, label, is_current}` contract; the gateway's existing `_try_send_choice_picker` capability gate picks it up with zero gateway changes. Tap settles the card with the selection and schedules the async applier on the adapter loop; the applier's confirmation is sent as a follow-up message.
  - Both callback paths reuse the approval-card hardening: operator authorization via `_allow_group_message`, callback-vs-state chat-id match, and the existing 15-minute card-action token dedup.
- `gateway/platforms/ADDING_A_PLATFORM.md`: capability table row for `send_choice_picker` now lists Feishu.
- `website/docs/user-guide/messaging/feishu.md`: documents clarify cards and the choice picker.
- `tests/gateway/test_feishu_clarify_choice_cards.py`: 11 new cases (card rendering, numeric resolve, Other→awaiting-text, unauthorized tap, chat mismatch, expired entry, picker applier scheduling + follow-up send, empty choices).

## Validation
| | Before | After |
|---|---|---|
| clarify (multi-choice) on Feishu | numbered text list, user types "2" | interactive card, one tap resolves |
| `/reasoning` / `/fast` bare | text status card | native one-tap picker card |
| `tests/gateway -k feishu` | 203 passed | 214 passed, 2 skipped |

Note: the infographic below could not be vision-verified this run (vision tooling hit a runtime asyncio bug); flagging per policy instead of silently embedding.

## Infographic

![Feishu Interactive Clarify Cards](https://v3b.fal.media/files/b/0aa596d0/60gUWMm8WZaWwB1GPy27w_kP5CudYS.png)

## Source
- Upstream inspiration: https://github.com/QwenLM/qwen-code/pull/8578
- Adaptation notes: Qwen Code's implementation is a standalone `question-card-controller` in their Feishu channel package; Hermes already has the clarify primitive (`tools/clarify_gateway.py`) and card-action routing (`_on_card_action_trigger`), so this implements the two missing adapter capabilities (`send_clarify`, `send_choice_picker`) on that existing substrate rather than porting their controller wholesale.
