### PR TITLE
fix(auth): label cached exhausted-credential errors + document CLAUDE_CODE_OAUTH_TOKEN is not a plain API key

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -357,6 +357,16 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         name="Anthropic",
         auth_type="api_key",
         inference_base_url="https://api.anthropic.com",
+        # NOTE (#82154): CLAUDE_CODE_OAUTH_TOKEN is listed here for source
+        # discovery/status display only. Its value (an sk-ant-oat*/cc-*
+        # OAuth token from `claude setup-token`) is NOT a plain x-api-key
+        # credential — sending it as x-api-key 401s, and as a bare Bearer
+        # token it 429s. Callers that build actual Anthropic requests must
+        # resolve auth via agent.anthropic_adapter.resolve_anthropic_token()
+        # / build_anthropic_client(), which detect the OAuth token format
+        # and pick Bearer + beta header instead of x-api-key. Do not read
+        # this tuple's first-match value and hand it to a provider client
+        # as a raw API key.
         api_key_env_vars=("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"),
         base_url_env_var="ANTHROPIC_BASE_URL",
     ),

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -133,6 +133,14 @@ def _classify_exhausted_status(entry) -> tuple[str, bool]:
 
 
 def _format_exhausted_status(entry) -> str:
+    """Render the last-known failure for an exhausted pool entry.
+
+    Always reflects the *stored* error from the last real request — this
+    never re-probes the provider — so every line is tagged ``[cached]`` to
+    stop iterative debugging from mistaking a stale error for a fresh one
+    (#82154: a fix can look like it's "still failing" when what's shown is
+    actually the pre-fix error, replayed from the exhaustion cooldown).
+    """
     if entry.last_status != STATUS_EXHAUSTED:
         return ""
     label, show_retry_window = _classify_exhausted_status(entry)
@@ -140,13 +148,13 @@ def _format_exhausted_status(entry) -> str:
     reason_text = f" {reason}" if isinstance(reason, str) and reason.strip() else ""
     code = f" ({entry.last_error_code})" if entry.last_error_code else ""
     if not show_retry_window:
-        return f" {label}{reason_text}{code} (re-auth may be required)"
+        return f" {label}{reason_text}{code} [cached] (re-auth may be required)"
     exhausted_until = _exhausted_until(entry)
     if exhausted_until is None:
-        return f" {label}{reason_text}{code}"
+        return f" {label}{reason_text}{code} [cached]"
     remaining = max(0, int(math.ceil(exhausted_until - time.time())))
     if remaining <= 0:
-        return f" {label}{reason_text}{code} (ready to retry)"
+        return f" {label}{reason_text}{code} [cached] (ready to retry)"
     minutes, seconds = divmod(remaining, 60)
     hours, minutes = divmod(minutes, 60)
     days, hours = divmod(hours, 24)
@@ -158,7 +166,7 @@ def _format_exhausted_status(entry) -> str:
         wait = f"{minutes}m {seconds}s"
     else:
         wait = f"{seconds}s"
-    return f" {label}{reason_text}{code} ({wait} left)"
+    return f" {label}{reason_text}{code} [cached] ({wait} left)"
 
 
 def auth_add_command(args) -> None:

--- a/tests/hermes_cli/test_auth_exhausted_status_cached_label.py
+++ b/tests/hermes_cli/test_auth_exhausted_status_cached_label.py
@@ -1,0 +1,52 @@
+"""Regression tests for #82154 (secondary observation 1).
+
+``_format_exhausted_status`` renders the *stored* last-known error for an
+exhausted pool entry without ever re-probing the provider. Every variant it
+can render must carry a ``[cached]`` marker so iterative debugging (e.g.
+retrying a fix within the ~60min exhaustion cooldown) doesn't mistake a
+replayed pre-fix error for a fresh one.
+"""
+
+from types import SimpleNamespace
+
+from hermes_cli.auth_commands import _format_exhausted_status
+from agent.credential_pool import STATUS_EXHAUSTED, STATUS_OK
+
+
+def _entry(**overrides):
+    base = dict(
+        last_status=STATUS_EXHAUSTED,
+        last_status_at=None,
+        last_error_code=400,
+        last_error_reason="billing",
+        last_error_message="You're out of extra usage.",
+        last_error_reset_at=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_not_exhausted_entry_has_no_status():
+    assert _format_exhausted_status(_entry(last_status=STATUS_OK)) == ""
+
+
+def test_rate_limited_entry_is_labelled_cached():
+    status = _format_exhausted_status(
+        _entry(last_error_code=429, last_error_reason="rate_limit", last_error_message="rate limit hit")
+    )
+    assert "[cached]" in status
+
+
+def test_auth_failed_entry_is_labelled_cached():
+    status = _format_exhausted_status(
+        _entry(last_error_code=401, last_error_reason="unauthorized", last_error_message="invalid token")
+    )
+    assert "[cached]" in status
+    assert "re-auth may be required" in status
+
+
+def test_no_reset_time_entry_is_labelled_cached():
+    status = _format_exhausted_status(
+        _entry(last_error_code=429, last_error_reason="rate_limit", last_error_reset_at=None)
+    )
+    assert "[cached]" in status


### PR DESCRIPTION
Fixes secondary observations 1 and 2 from #82154 (root-cause SKILLS_GUIDANCE fix already covered by #78025, see comment threads on both).

## Summary

**1. Cached-error labeling (`hermes_cli/auth_commands.py`)**
`hermes auth list` and the interactive `hermes auth` remove menu render an exhausted pool entry's *stored* `last_error_*` fields for the entire ~60min exhaustion cooldown, without ever re-probing the provider. During iterative debugging (e.g. testing a fix against a subscription-OAuth credential) this makes a fix look like it's "still failing" when what's actually displayed is the pre-fix error, replayed from cache. Every rendered line now carries a `[cached]` tag.

**2. `CLAUDE_CODE_OAUTH_TOKEN` documentation (`hermes_cli/auth.py`)**
`PROVIDER_REGISTRY["anthropic"].api_key_env_vars` lists `CLAUDE_CODE_OAUTH_TOKEN` next to real API-key env vars, which reads as though its value is usable as a plain `x-api-key` credential. It isn't — it's an OAuth token (`sk-ant-oat*` / `cc-*`) that 401s as `x-api-key` and 429s as a bare Bearer token; it needs the OAuth-aware Bearer + beta-header path.

Traced where this tuple is actually consumed before touching it:
- `agent/auxiliary_client.py::_try_anthropic` and `agent/anthropic_adapter.py::resolve_anthropic_token` / `build_anthropic_client` — the real request paths — already bypass this tuple and do their own OAuth-token-format detection. **No behavior change needed there.**
- `agent/credential_pool.py`'s anthropic-specific credential sync already overrides the tuple with its own explicit env-var order. **Also unaffected.**
- `hermes_cli/auth.py::_resolve_api_key_provider_secret` (generic status/doctor/setup-wizard helper) is the one consumer that takes this tuple's first non-empty match and returns it as a plain API key, unaware of OAuth format — this is the footgun the issue's "1" observation was about.

Given the actual request paths are already safe, this ships as a code comment warning future callers of the generic resolver not to treat this tuple's value as a raw API key, rather than removing `CLAUDE_CODE_OAUTH_TOKEN` from the tuple outright (which would regress "is this provider configured" detection for OAuth-only users on the generic status path). No functional/behavior change — comment + display-string change only.

## Test plan
- [x] New `tests/hermes_cli/test_auth_exhausted_status_cached_label.py` — 4 cases covering rate-limited, auth-failed, and no-reset-time cached renders, plus the not-exhausted no-op case
- [x] `pytest tests/hermes_cli/test_auth_exhausted_status_cached_label.py -q` — 4 passed

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A[🩸 Exhausted Credential Entry] -->|Selected during cooldown| B{Live Probe Issued?}
    B -->|No — stored last_error replayed| C[🔥 Stale Error Surfaced]
    C -->|Before this PR| D[⚔️ Looks Like a Live Failure]
    C -->|After this PR| E[🩸 Tagged cached]
    F[🔥 PROVIDER_REGISTRY anthropic] -->|api_key_env_vars tuple| G{Consumer Path}
    G -->|resolve_anthropic_token / build_anthropic_client| H[⚔️ OAuth-Aware — Bearer + Beta Header]
    G -->|credential_pool.py anthropic sync| H
    G -->|generic _resolve_api_key_provider_secret| I[🩸 Naive — Comment Now Warns Against Raw Use]
```

## Infographic :

<img width="1024" height="1024" alt="infographic_82181" src="https://github.com/user-attachments/assets/2be0376b-e679-4ab8-abe1-0baa61448658" />
 

