### PR TITLE
ci: add checksum-pinned secret scan

### DIFF
--- a/.github/scripts/sanjuk-secret-guard-scan.py
+++ b/.github/scripts/sanjuk-secret-guard-scan.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import stat
+import subprocess
+from pathlib import Path
+
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40,64}$")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--binary", type=Path, required=True)
+    parser.add_argument("--repo", type=Path, required=True)
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--head", required=True)
+    parser.add_argument("--report", type=Path, required=True)
+    return parser.parse_args()
+
+
+def git(repo: Path, *args: str) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        check=False,
+    )
+
+
+def verify_commit(repo: Path, value: str) -> None:
+    if not SHA_PATTERN.fullmatch(value):
+        raise ValueError("invalid commit identifier")
+    result = git(repo, "rev-parse", "--verify", f"{value}^{{commit}}")
+    if result.returncode != 0:
+        raise ValueError("commit is unavailable")
+
+
+def safe_relative_path(repo: Path, raw: object) -> str:
+    if not isinstance(raw, str) or not raw:
+        raise ValueError("finding path is invalid")
+    candidate = Path(raw)
+    if candidate.is_absolute():
+        candidate = candidate.resolve().relative_to(repo.resolve())
+    if ".." in candidate.parts:
+        raise ValueError("finding path escapes repository")
+    return candidate.as_posix()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        repo = args.repo.resolve(strict=True)
+        binary = args.binary.resolve(strict=True)
+        if not repo.is_dir() or not binary.is_file() or not os.access(binary, os.X_OK):
+            raise ValueError("runtime path is invalid")
+        verify_commit(repo, args.head)
+        initial_push = bool(SHA_PATTERN.fullmatch(args.base)) and set(args.base) == {"0"}
+        if not initial_push:
+            verify_commit(repo, args.base)
+            if git(repo, "merge-base", "--is-ancestor", args.base, args.head).returncode != 0:
+                raise ValueError("base is not an ancestor of head")
+        log_options = args.head if initial_push else f"{args.base}..{args.head}"
+
+        args.report.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        args.report.touch(mode=0o600, exist_ok=True)
+        args.report.chmod(0o600)
+        command = [
+            str(binary),
+            "git",
+            "--redact=100",
+            "--no-banner",
+            "--no-color",
+            "--exit-code=2",
+            "--report-format=json",
+            f"--report-path={args.report}",
+            f"--log-opts={log_options}",
+            str(repo),
+        ]
+        completed = subprocess.run(command, cwd=repo, capture_output=True, check=False)
+        if args.report.exists():
+            args.report.chmod(0o600)
+        if completed.returncode not in (0, 2):
+            raise RuntimeError(f"scanner failed with exit code {completed.returncode}")
+
+        findings = json.loads(args.report.read_text() or "[]")
+        if not isinstance(findings, list):
+            raise ValueError("scanner report is invalid")
+        for finding in findings:
+            if finding.get("Secret") != "REDACTED":
+                raise ValueError("scanner report is not fully redacted")
+        expected = 2 if findings else 0
+        if completed.returncode != expected:
+            raise ValueError("scanner exit and report disagree")
+
+        payload = {
+            "schema_version": "secret-guard-ci-result-v1",
+            "status": "FINDINGS" if findings else "CLEAN",
+            "finding_count": len(findings),
+            "rule_ids": sorted({str(item.get("RuleID", "unknown")) for item in findings}),
+            "paths": sorted({safe_relative_path(repo, item.get("File")) for item in findings}),
+            "report_id": args.report.name,
+        }
+        print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+        return expected
+    except (OSError, ValueError, RuntimeError, json.JSONDecodeError) as exc:
+        print(
+            json.dumps(
+                {
+                    "schema_version": "secret-guard-ci-result-v1",
+                    "status": "ERROR",
+                    "error_type": type(exc).__name__,
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,78 @@
+name: Secret Scan
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: secret-scan-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  secret-scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve commit range
+        id: range
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_HEAD: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            BASE="$PR_BASE"
+            HEAD_SHA="$PR_HEAD"
+          else
+            BASE="$PUSH_BEFORE"
+            HEAD_SHA="$PUSH_HEAD"
+          fi
+          printf 'base=%s\n' "$BASE" >> "$GITHUB_OUTPUT"
+          printf 'head=%s\n' "$HEAD_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Install checksum-pinned Gitleaks
+        id: gitleaks
+        env:
+          GITLEAKS_VERSION: 8.30.1
+          GITLEAKS_ARCHIVE_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+        run: |
+          set -euo pipefail
+          ARCHIVE="$RUNNER_TEMP/gitleaks.tar.gz"
+          INSTALL_DIR="$RUNNER_TEMP/gitleaks"
+          curl --proto '=https' --tlsv1.2 --fail --location --silent --show-error \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            --output "$ARCHIVE"
+          printf '%s  %s\n' "$GITLEAKS_ARCHIVE_SHA256" "$ARCHIVE" | sha256sum --check --strict
+          install -d -m 0700 "$INSTALL_DIR"
+          tar -xzf "$ARCHIVE" -C "$INSTALL_DIR" gitleaks
+          chmod 0555 "$INSTALL_DIR/gitleaks"
+          printf 'binary=%s\n' "$INSTALL_DIR/gitleaks" >> "$GITHUB_OUTPUT"
+
+      - name: Scan commit range
+        env:
+          BASE_SHA: ${{ steps.range.outputs.base }}
+          HEAD_SHA: ${{ steps.range.outputs.head }}
+          GITLEAKS_BINARY: ${{ steps.gitleaks.outputs.binary }}
+        run: |
+          set -euo pipefail
+          REPORT_DIR="$RUNNER_TEMP/secret-guard"
+          install -d -m 0700 "$REPORT_DIR"
+          python .github/scripts/sanjuk-secret-guard-scan.py \
+            --binary "$GITLEAKS_BINARY" \
+            --repo "$GITHUB_WORKSPACE" \
+            --base "$BASE_SHA" \
+            --head "$HEAD_SHA" \
+            --report "$REPORT_DIR/findings.json"


### PR DESCRIPTION
## Summary
- add a read-only Gitleaks workflow for pull requests and main pushes
- scan only the commit range, including initial-push handling
- pin checkout and the Gitleaks archive checksum
- emit sanitized metadata only; do not upload reports

## Safety
- uses `pull_request`, not `pull_request_target`
- grants only `contents: read`
- excludes full-tree baselines and broad allowlists
- fails closed on findings or scanner errors

## Verification
- 7 local tests passed
- synthetic secret range blocked
- benign range passed
- initial-push secret blocked
- candidate commit range scanned CLEAN