### PR TITLE
fix(skills): hash index-cache filenames so a tap path can't escape the cache dir

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1624,3 +1624,60 @@ class TestLoadHermesIndex:
 
         data = hub._load_hermes_index()
         assert data == {"skills": [{"name": "stale"}]}
+
+
+class TestIndexCacheKeyContainment:
+    """Cache keys are tap-controlled; the filename they produce must not be."""
+
+    @staticmethod
+    def _assert_opaque(cache_dir):
+        """Exactly one cache entry, named as a bare SHA-256 hex digest."""
+        written = list(cache_dir.iterdir())
+        assert len(written) == 1, [p.name for p in written]
+        stem = written[0].stem
+        assert len(stem) == 64
+        assert all(c in "0123456789abcdef" for c in stem)
+        return written[0]
+
+    def test_github_tap_path_cannot_escape_index_cache(self, tmp_path):
+        import tools.skills_hub as hub
+
+        hub_dir = tmp_path / "skills" / ".hub"
+        cache_dir = hub_dir / "index-cache"
+        cache_dir.mkdir(parents=True)
+
+        # Sits two levels above index-cache — where "..\..\..\victim" lands.
+        victim = tmp_path / "victim.json"
+        victim.write_text(json.dumps({"sentinel": "original"}), encoding="utf-8")
+
+        class _Resp:
+            status_code = 200
+            content = b""
+
+            @staticmethod
+            def json():
+                return []
+
+        source = GitHubSource(GitHubAuth())
+        with patch.object(hub, "HUB_DIR", hub_dir), \
+                patch.object(hub, "INDEX_CACHE_DIR", cache_dir), \
+                patch.object(source, "_get_skillsh_groupings", lambda *a, **k: {}), \
+                patch.object(source, "_github_get", lambda *a, **k: _Resp()):
+            source._list_skills_in_repo("owner/repo", "..\\..\\..\\victim")
+
+        assert json.loads(victim.read_text(encoding="utf-8")) == {"sentinel": "original"}
+        self._assert_opaque(cache_dir)
+
+    def test_hostile_key_round_trips_inside_index_cache(self, tmp_path):
+        import tools.skills_hub as hub
+
+        hub_dir = tmp_path / "skills" / ".hub"
+        cache_dir = hub_dir / "index-cache"
+        cache_dir.mkdir(parents=True)
+
+        key = "owner/repo_..\\..\\..\\victim"
+        with patch.object(hub, "HUB_DIR", hub_dir), \
+                patch.object(hub, "INDEX_CACHE_DIR", cache_dir):
+            hub._write_index_cache(key, [{"name": "demo"}])
+            self._assert_opaque(cache_dir)
+            assert hub._read_index_cache(key) == [{"name": "demo"}]

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -99,6 +99,20 @@ def _index_cache_dir() -> Path:
     return Path(forced) if forced is not None else _hub_dir() / "index-cache"
 
 
+def _index_cache_file(key: str) -> Path:
+    """Path inside ``index-cache`` for *key*, as an opaque SHA-256 name.
+
+    Cache keys are built from tap-controlled values (repo, path, search
+    query, catalog identifier). Interpolating one straight into a filename
+    lets separators in the key steer the write out of ``index-cache``: on
+    Windows a tap path of ``..\\..\\..\\victim`` produces the key
+    ``owner_repo_..\\..\\..\\victim``, and ``index-cache / f"{key}.json"``
+    then resolves two directories above the cache. Hashing makes the
+    filename independent of the key's contents.
+    """
+    return _index_cache_dir() / f"{hashlib.sha256(key.encode('utf-8')).hexdigest()}.json"
+
+
 _DYNAMIC_PATH_RESOLVERS = {
     "HERMES_HOME": _hermes_home,
     "SKILLS_DIR": _skills_dir,
@@ -756,7 +770,10 @@ class GitHubSource(SkillSource):
 
     def _list_skills_in_repo(self, repo: str, path: str) -> List[SkillMeta]:
         """List skill directories in a GitHub repo path, using cached index."""
-        cache_key = f"{repo}_{path}".replace("/", "_").replace(" ", "_")
+        # NUL-joined rather than separator-squashed: the filename is hashed, so
+        # the key no longer has to be path-safe, and a lossless key stops
+        # ("a/b", "c") and ("a", "b/c") from sharing one cache entry.
+        cache_key = f"github\0{repo}\0{path}"
         cached = self._read_cache(cache_key)
         if cached is not None:
             return [SkillMeta(**s) for s in cached]
@@ -1139,7 +1156,7 @@ class GitHubSource(SkillSource):
 
     def _read_cache(self, key: str) -> Optional[list]:
         """Read cached index if not expired."""
-        cache_file = _index_cache_dir() / f"{key}.json"
+        cache_file = _index_cache_file(key)
         if not cache_file.exists():
             return None
         try:
@@ -1152,9 +1169,8 @@ class GitHubSource(SkillSource):
 
     def _write_cache(self, key: str, data: list) -> None:
         """Write index data to cache."""
-        index_cache_dir = _index_cache_dir()
-        index_cache_dir.mkdir(parents=True, exist_ok=True)
-        cache_file = index_cache_dir / f"{key}.json"
+        _index_cache_dir().mkdir(parents=True, exist_ok=True)
+        cache_file = _index_cache_file(key)
         try:
             cache_file.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
         except OSError as e:
@@ -3449,7 +3465,7 @@ class OptionalSkillSource(SkillSource):
 
 def _read_index_cache(key: str) -> Optional[Any]:
     """Read cached data if not expired."""
-    cache_file = _index_cache_dir() / f"{key}.json"
+    cache_file = _index_cache_file(key)
     if not cache_file.exists():
         return None
     try:
@@ -3463,8 +3479,7 @@ def _read_index_cache(key: str) -> Optional[Any]:
 
 def _write_index_cache(key: str, data: Any) -> None:
     """Write data to cache."""
-    index_cache_dir = _index_cache_dir()
-    index_cache_dir.mkdir(parents=True, exist_ok=True)
+    _index_cache_dir().mkdir(parents=True, exist_ok=True)
     # Ensure .ignore exists so ripgrep (and tools respecting .ignore) skip
     # this directory.  Cache files contain unvetted community content that
     # could include adversarial text (prompt injection via catalog entries).
@@ -3474,7 +3489,7 @@ def _write_index_cache(key: str, data: Any) -> None:
             ignore_file.write_text("# Exclude hub internals from search tools\n*\n", encoding="utf-8")
         except OSError:
             pass
-    cache_file = index_cache_dir / f"{key}.json"
+    cache_file = _index_cache_file(key)
     try:
         cache_file.write_text(json.dumps(data, ensure_ascii=False, default=str), encoding="utf-8")
     except OSError as e:


### PR DESCRIPTION
Fixes #82184.

## Problem

`GitHubSource._list_skills_in_repo` builds the tap cache key by squashing `/` and
spaces out of `repo` and `path` — but `\` survives:

```python
cache_key = f"{repo}_{path}".replace("/", "_").replace(" ", "_")
```

Every cache helper then interpolates that key straight into a filename:

```python
cache_file = _index_cache_dir() / f"{key}.json"
```

On Windows `\` is a path separator. A tap path of `..\..\..\victim` produces the key
`owner_repo_..\..\..\victim`, and the write resolves **two directories above**
`index-cache`. Verified at `611f922ff`: the sentinel outside the cache was overwritten
and `index-cache` was left empty.

## Fix

One helper owns the mapping from key to filename:

```python
def _index_cache_file(key: str) -> Path:
    return _index_cache_dir() / f"{hashlib.sha256(key.encode('utf-8')).hexdigest()}.json"
```

`_read_cache`, `_write_cache`, `_read_index_cache` and `_write_index_cache` all route
through it, so the filename no longer depends on the key's contents and no key can
steer the write.

Second, smaller change: now that the key doesn't have to be path-safe, the GitHub key
is built losslessly as `github\0{repo}\0{path}` instead of squashing separators. That
stops `("a/b", "c")` and `("a", "b/c")` from sharing one entry. It is separable from
the containment fix — happy to drop it if reviewers prefer a single-concern diff.

## Flow

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[Tap Config: repo + path] --> B[Cache Key Builder]
    B -->|Before: separators survive| C[Raw Key as Filename]
    C --> D[Write Escapes index-cache]
    D --> E[Sentinel Overwritten]
    B -->|After: NUL-joined, lossless| F[Index Cache File Helper]
    F --> G[SHA-256 Opaque Name]
    G --> H[Write Contained in index-cache]
    H --> I[Round-Trip Read OK]
```
##Infographic:

<img width="1024" height="1024" alt="infographic_82188" src="https://github.com/user-attachments/assets/482bd84c-19e1-4e59-8938-bba337ec5ac9" />

## Compatibility

Existing cache files are orphaned and regenerate on the next fetch. The cache is
derived data behind `INDEX_CACHE_TTL`, so no migration is needed.

## Tests

New `TestIndexCacheKeyContainment` in `tests/tools/test_skills_hub.py`:

- `test_github_tap_path_cannot_escape_index_cache` — drives `_list_skills_in_repo` with
  a stubbed `_github_get` (no network) and a tap path of `..\..\..\victim`; asserts the
  sentinel outside the cache is untouched and that exactly one entry exists inside
  `index-cache` with a 64-hex-char name.
- `test_hostile_key_round_trips_inside_index_cache` — same containment assertion for the
  module-level helpers, plus a read-back to prove the hashed name round-trips.

The filename assertion fails on the old code on every platform, so this is a portable
regression test even though the escape itself is Windows-specific.

Verified red → green: with `tools/skills_hub.py` reverted, both tests fail
(`assert len(written) == 1` sees `owner_repo_..\..\..\victim.json`); with the fix, both pass.

Suite on this machine (Windows 11, Python 3.14):

```
tests/tools/test_skills_hub.py + tests/hermes_cli/test_skills_hub.py + tests/tools/test_search_hidden_dirs.py
  before: 62 passed, 8 failed, 1 skipped
  after:  64 passed, 8 failed, 1 skipped
```

The 8 failures are pre-existing and unrelated (`parallel_search_sources` thread-pool
behaviour and a binary-asset case); the delta is exactly the two new tests.

 
