### PR TITLE
fix(memory): report memory tool status per configured platform, not just cli

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -496,7 +496,13 @@ def cmd_status(args) -> None:
     # "disabled" even though the tool worked on the platform in use (#81430).
     from hermes_cli.tools_config import _get_platform_tools
     platform_toolsets_cfg = config.get("platform_toolsets") or {}
-    configured_platforms = list(platform_toolsets_cfg.keys()) or ["cli"]
+    # Always include the platform the command runs under (cli), even when the
+    # user only configured gateway platforms. Otherwise a CLI user with
+    # platform_toolsets: {telegram: [...]} gets a false "disabled" — cli falls
+    # back to its default toolset (hermes-cli, which includes memory) via
+    # _get_platform_tools, but was never added to the checked set. dict.fromkeys
+    # dedupes while preserving order.
+    configured_platforms = list(dict.fromkeys([*platform_toolsets_cfg, "cli"]))
     tool_status_by_platform = {}
     for plat in configured_platforms:
         plat_tools = _get_platform_tools(config, plat, include_default_mcp_servers=False)

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -489,11 +489,21 @@ def cmd_status(args) -> None:
     mem_mark = "enabled ✓" if memory_enabled else "disabled ✗"
     user_mark = "enabled ✓" if user_profile_enabled else "disabled ✗"
 
-    # Check if the memory tool is enabled for the CLI platform via the
-    # canonical resolver (handles composite toolsets like hermes-cli).
+    # Check if the memory tool is enabled across configured platforms via
+    # the canonical resolver. This previously hardcoded "cli", which
+    # misreported status for gateway platforms: memory enabled under
+    # platform_toolsets.telegram but absent from the cli toolset showed
+    # "disabled" even though the tool worked on the platform in use (#81430).
     from hermes_cli.tools_config import _get_platform_tools
-    cli_tools = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
-    memory_tool_enabled = "memory" in cli_tools
+    platform_toolsets_cfg = config.get("platform_toolsets") or {}
+    configured_platforms = list(platform_toolsets_cfg.keys()) or ["cli"]
+    tool_status_by_platform = {}
+    for plat in configured_platforms:
+        plat_tools = _get_platform_tools(config, plat, include_default_mcp_servers=False)
+        tool_status_by_platform[plat] = "memory" in plat_tools
+    # Summary line reflects whether memory is enabled for at least one
+    # configured platform; the per-platform breakdown below gives the detail.
+    memory_tool_enabled = any(tool_status_by_platform.values())
     tool_mark = "enabled ✓" if memory_tool_enabled else "disabled ✗"
 
     print("\nMemory status\n" + "─" * 40)
@@ -501,6 +511,11 @@ def cmd_status(args) -> None:
     print(f"    Memory injection:   {mem_mark}")
     print(f"    User profile:       {user_mark}")
     print(f"    Memory tool:        {tool_mark}")
+    if len(tool_status_by_platform) > 1:
+        print("    Memory tool by platform:")
+        for plat, en in tool_status_by_platform.items():
+            plat_mark = "enabled ✓" if en else "disabled ✗"
+            print(f"      {plat:<12} {plat_mark}")
     print(f"  Provider:  {provider_name or '(none — built-in only)'}")
 
     providers = _get_available_providers()

--- a/tests/hermes_cli/test_memory_status.py
+++ b/tests/hermes_cli/test_memory_status.py
@@ -54,18 +54,25 @@ class TestMemoryStatusLabels:
         assert "disabled ✗" in out
 
 
-def _run_cmd_status_platforms(capfd, platform_toolsets):
+def _run_cmd_status_platforms(capfd, platform_toolsets, cli_default={"memory"}):
     """Run cmd_status with a multi-platform toolset config.
 
     platform_toolsets: dict mapping platform name -> set of tools, used as
     the side_effect of _get_platform_tools(config, plat, ...).
+
+    cli_default: what an unlisted platform (cli) resolves to. Mirrors the real
+    resolver (_get_platform_tools falls back to the platform's default toolset,
+    hermes-cli, when a platform has no explicit list) — so with the default,
+    cli participates in the check and shows memory enabled.
     """
     from hermes_cli.memory_setup import cmd_status
 
     config = {"memory": {}, "platform_toolsets": platform_toolsets}
 
     def _side_effect(config, plat, include_default_mcp_servers=False):
-        return platform_toolsets.get(plat, set())
+        if plat in platform_toolsets:
+            return platform_toolsets[plat]
+        return cli_default
 
     with patch("hermes_cli.config.load_config", return_value=config):
         with patch("hermes_cli.memory_setup._get_available_providers", return_value=[]):
@@ -112,6 +119,39 @@ class TestMemoryStatusMultiPlatform:
         out = _run_cmd_status_platforms(capfd, {"cli": {"memory"}})
         assert "Memory tool:        enabled ✓" in out
         assert "Memory tool by platform:" not in out
+
+    def test_gateway_only_cfg_cli_default_included(self, capfd):
+        """Regression: config with only gateway platforms must still check cli.
+
+        #82189 triage found: configured_platforms = list(keys()) or ["cli"]
+        drops cli when any gateway platform is configured. A CLI user with
+        platform_toolsets: {telegram: [...]} then sees a false "disabled",
+        even though cli falls back to its default toolset (hermes-cli, which
+        includes memory). The command's own platform must always participate.
+        """
+        # cli absent from config -> _get_platform_tools resolves its default
+        # toolset (hermes-cli, includes memory), so it must show enabled.
+        out = _run_cmd_status_platforms(
+            capfd,
+            {"telegram": {"terminal", "web"}},
+        )
+        assert "Memory tool:        enabled ✓" in out
+        # Breakdown must include the cli row so the summary is attributable.
+        assert "Memory tool by platform:" in out
+        assert "cli          enabled ✓" in out
+        assert "telegram     disabled ✗" in out
+
+    def test_gateway_only_cfg_cli_default_disabled_still_disabled(self, capfd):
+        """When cli's default toolset lacks memory, the breakdown still shows it."""
+        out = _run_cmd_status_platforms(
+            capfd,
+            {"telegram": {"terminal", "memory"}},
+            cli_default=set(),
+        )
+        # telegram has memory -> enabled; cli default lacks it -> disabled.
+        assert "Memory tool:        enabled ✓" in out
+        assert "cli          disabled ✗" in out
+        assert "telegram     enabled ✓" in out
 
 
 

--- a/tests/hermes_cli/test_memory_status.py
+++ b/tests/hermes_cli/test_memory_status.py
@@ -54,4 +54,64 @@ class TestMemoryStatusLabels:
         assert "disabled ✗" in out
 
 
+def _run_cmd_status_platforms(capfd, platform_toolsets):
+    """Run cmd_status with a multi-platform toolset config.
+
+    platform_toolsets: dict mapping platform name -> set of tools, used as
+    the side_effect of _get_platform_tools(config, plat, ...).
+    """
+    from hermes_cli.memory_setup import cmd_status
+
+    config = {"memory": {}, "platform_toolsets": platform_toolsets}
+
+    def _side_effect(config, plat, include_default_mcp_servers=False):
+        return platform_toolsets.get(plat, set())
+
+    with patch("hermes_cli.config.load_config", return_value=config):
+        with patch("hermes_cli.memory_setup._get_available_providers", return_value=[]):
+            with patch(
+                "hermes_cli.tools_config._get_platform_tools",
+                side_effect=_side_effect,
+            ):
+                cmd_status(args=None)
+
+    return capfd.readouterr().out
+
+
+class TestMemoryStatusMultiPlatform:
+    """Memory tool status must reflect the platform actually in use.
+
+    Regression for #81430: cmd_status hardcoded the "cli" platform, so a
+    gateway platform (Telegram/Discord) with memory enabled showed
+    "disabled" when the cli toolset lacked it.
+    """
+
+    def test_enabled_on_gateway_platform_not_cli_shows_enabled(self, capfd):
+        """The #81430 case: memory enabled for telegram, absent for cli."""
+        out = _run_cmd_status_platforms(
+            capfd,
+            {"cli": {"terminal", "web"}, "telegram": {"terminal", "memory"}},
+        )
+        # Summary line must not misreport: the tool IS enabled somewhere.
+        assert "Memory tool:        enabled ✓" in out
+        # Per-platform detail shows exactly where.
+        assert "Memory tool by platform:" in out
+        assert "cli          disabled ✗" in out
+        assert "telegram     enabled ✓" in out
+
+    def test_disabled_everywhere_still_disabled(self, capfd):
+        """When no configured platform enables memory, keep showing disabled."""
+        out = _run_cmd_status_platforms(
+            capfd,
+            {"cli": {"terminal"}, "telegram": {"terminal"}},
+        )
+        assert "Memory tool:        disabled ✗" in out
+
+    def test_no_platform_toolsets_falls_back_to_cli(self, capfd):
+        """Without platform_toolsets, behavior matches the old cli-only check."""
+        out = _run_cmd_status_platforms(capfd, {"cli": {"memory"}})
+        assert "Memory tool:        enabled ✓" in out
+        assert "Memory tool by platform:" not in out
+
+
 


### PR DESCRIPTION
## Problem

`hermes memory status` reports `Memory tool: disabled ✗` whenever the memory
tool is absent from the **CLI** toolset — even when it is enabled for the
gateway platform the user is actually using (Telegram, Discord, …).

In the reporter's setup (#81430), memory was correctly enabled under
`platform_toolsets.telegram` but absent from `platform_toolsets.cli`, so the
command showed "disabled" while the tool worked fine on Telegram. The status
display and the real tool availability disagreed.

## Root cause

`cmd_status()` in `hermes_cli/memory_setup.py` hardcoded the platform to
`"cli"`:

```python
cli_tools = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
memory_tool_enabled = "memory" in cli_tools
```

The command therefore always reported on the CLI platform's toolset, ignoring
`platform_toolsets` for every other configured platform.

## Fix

Iterate over all configured platforms from `platform_toolsets` (falling back
to `["cli"]` when absent, preserving the old behavior) and resolve the memory
tool via the canonical `_get_platform_tools` for each:

- Summary line = enabled if **any** configured platform enables memory
  (never a false "disabled" when the tool works somewhere the user uses)
- New per-platform breakdown printed when >1 platform is configured, so the
  exact state per platform is visible

```python
platform_toolsets_cfg = config.get("platform_toolsets") or {}
configured_platforms = list(platform_toolsets_cfg.keys()) or ["cli"]
tool_status_by_platform = {}
for plat in configured_platforms:
    plat_tools = _get_platform_tools(config, plat, include_default_mcp_servers=False)
    tool_status_by_platform[plat] = "memory" in plat_tools
memory_tool_enabled = any(tool_status_by_platform.values())
```

Output with memory on telegram but not cli:

```
Memory tool:        enabled ✓
Memory tool by platform:
  cli          disabled ✗
  telegram     enabled ✓
```

## Tests

Added `TestMemoryStatusMultiPlatform` to `tests/hermes_cli/test_memory_status.py`:

- `test_enabled_on_gateway_platform_not_cli_shows_enabled` — the #81430 case:
  memory on telegram only → summary shows enabled, breakdown lists both
- `test_disabled_everywhere_still_disabled` — no platform enables memory →
  still shows disabled
- `test_no_platform_toolsets_falls_back_to_cli` — no `platform_toolsets` →
  behavior matches old cli-only check, no breakdown printed

All 5 tests in the file pass (2 existing + 3 new).

## Validation

| | Result |
|---|---|
| Targeted suite (test_memory_status.py) | 5/5 green |
| Sabotage check (revert fix → tests must fail) | confirmed: core regression test fails when fix is reverted |
| End-to-end (mocked multi-platform config through cmd_status) | summary enabled ✓, breakdown cli ✗ / telegram ✓ |
| Full tests/hermes_cli/ suite | running (background) |

## Notes