### PR TITLE
docs: batch 7 — learning-path coverage, gateway config files, session sync, migration pointer

### DIFF
--- a/website/docs/getting-started/learning-path.md
+++ b/website/docs/getting-started/learning-path.md
@@ -141,6 +141,12 @@ Not sure what's available? Here's a quick directory of major features:
 | **Hooks** | Event-driven callbacks and middleware | [Hooks](/user-guide/features/hooks) |
 | **Batch Processing** | Process multiple inputs in bulk | [Batch Processing](/user-guide/features/batch-processing) |
 | **Provider Routing** | Route requests across multiple LLM providers | [Provider Routing](/user-guide/features/provider-routing) |
+| **Goals** | Set a standing objective; Hermes keeps working across turns until it's done | [Persistent Goals](/user-guide/features/goals) |
+| **Kanban** | Multi-profile task board with a dispatcher for parallel agent work | [Kanban](/user-guide/features/kanban) |
+| **Web Dashboard** | Browser-based dashboard for sessions, board, and system status | [Web Dashboard](/user-guide/features/web-dashboard) |
+| **ACP / IDE** | Use Hermes inside ACP-compatible editors (VS Code, Zed, JetBrains) | [ACP](/user-guide/features/acp) |
+| **Voice Mode** | Real-time voice conversations (CLI, Telegram, Discord) | [Voice Mode](/user-guide/features/voice-mode) |
+| **Wake Word** | Hands-free activation from messaging platforms | [Wake Word](/user-guide/features/wake-word) |
 
 ## What to Read Next
 
@@ -152,6 +158,7 @@ Based on where you are right now:
 - **Setting up for a team?** → Read [Security](/user-guide/security) and [Sessions](/user-guide/sessions) to understand access control and conversation management.
 - **Ready to build?** → Jump into the [Developer Guide](/developer-guide/architecture) to understand the internals and start contributing.
 - **Want practical examples?** → Check out the [Guides](/guides/tips) section for real-world projects and tips.
+- **Coming from OpenClaw?** → Use the [Migrate from OpenClaw](/guides/migrate-from-openclaw) guide to move sessions, config, and workflows.
 
 :::tip
 You don't need to read everything. Pick the path that matches your goal, follow the links in order, and you'll be productive quickly. You can always come back to this page to find your next step.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1679,7 +1679,7 @@ This controls both the `text_to_speech` tool and spoken replies in voice mode (`
 
 ```yaml
 display:
-  tool_progress: all      # off | new | all | verbose
+  tool_progress: all      # off | new | all | verbose | log (log = tool activity to session log only)
   tool_progress_command: false  # Enable /verbose slash command in messaging gateway
   focus_view: false       # CLI focus view (/focus) — reduced output, display-only
   platforms: {}           # Per-platform display overrides (see below)
@@ -1705,6 +1705,8 @@ display:
   credits_notices: true   # Nous credits status-bar notices (usage bands, grant-spent, depleted). false = silence them; /usage still works
   language: en            # UI language for static messages (approval prompts, some gateway replies). en | zh | zh-hant | ja | de | es | fr | tr | uk | af | ko | it | ga | pt | ru | hu
 ```
+
+Additional display keys that are documented on their feature/platform pages (not shown here for brevity): `display.reasoning_style` (code|blockquote|subtext — Discord), `display.live_status` and `display.status_phrases` (Slack status line), `display.memory_notifications` (memory writes), `display.busy_ack_enabled`/`busy_ack_detail`, `display.platforms.<p>.cleanup_progress`, and `display.background_process_notifications`. See the [Slack](/user-guide/messaging/slack), [Discord](/user-guide/messaging/discord), [Memory](/user-guide/features/memory), and [Messaging overview](/user-guide/messaging) pages for those.
 
 ### Per-turn summary and spinner token flow
 

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -53,6 +53,10 @@ Bots need both a model provider and tool providers (TTS, web). A [Nous Portal](/
 [Hermes Relay](/user-guide/messaging/relay) (experimental) is not a chat platform itself — it is a connector system that fronts platforms like Discord, Telegram, Slack, and WhatsApp through an external connector that owns the platform credentials. Capabilities (media, native approval/clarify prompts, reactions, threads, typing, streaming) are negotiated per connector at handshake rather than fixed in the table above.
 :::
 
+:::note A2A and Webhooks
+[A2A](/user-guide/messaging/a2a) (agent-to-agent) and [Webhooks](/user-guide/messaging/webhooks) are event/passthrough surfaces, not chat platforms — they receive structured requests rather than conversational messages, so the chat capabilities above (voice, reactions, typing, streaming) don't apply.
+:::
+
 ## Architecture
 
 ```mermaid
@@ -293,7 +297,7 @@ Configure per-platform overrides in `~/.hermes/gateway.json`:
 
 ## Per-Channel Model & System Prompt Overrides
 
-Different channels can run different models and personas from a **single gateway** — e.g. a cheap fast model in `#daily` and a frontier model with a specialist prompt in `#dev`. Configure `channel_overrides` under the platform in `~/.hermes/gateway-config.yaml`:
+Different channels can run different models and personas from a **single gateway** — e.g. a cheap fast model in `#daily` and a frontier model with a specialist prompt in `#dev`. Configure `channel_overrides` under the platform in `~/.hermes/config.yaml`:
 
 ```yaml
 platforms:
@@ -323,8 +327,8 @@ Details:
 # Restrict to specific users (recommended):
 TELEGRAM_ALLOWED_USERS=123456789,987654321
 DISCORD_ALLOWED_USERS=123456789012345678
-SIGNAL_ALLOWED_USERS=+155****4567,+155****6543
-SMS_ALLOWED_USERS=+155****4567,+155****6543
+SIGNAL_ALLOWED_USERS=+15550123456,+15550987654
+SMS_ALLOWED_USERS=+15550123456,+15550987654
 EMAIL_ALLOWED_USERS=trusted@example.com,colleague@work.com
 MATTERMOST_ALLOWED_USERS=3uo8dkh1p7g1mfk49ear5fzs5c
 MATRIX_ALLOWED_USERS=@alice:matrix.org
@@ -689,7 +693,7 @@ Once upstream is healthy, `/platform resume <name>` clears the breaker and re-ar
 
 ### Restart notifications
 
-When the gateway restarts (or is shut down with in-flight sessions), it can send a one-shot "the agent is back" / "the agent was interrupted" message to each platform's home channel. This is controlled per-platform by the `gateway_restart_notification` flag in `gateway-config.yaml`, which defaults to `true`:
+When the gateway restarts (or is shut down with in-flight sessions), it can send a one-shot "the agent is back" / "the agent was interrupted" message to each platform's home channel. This is controlled per-platform by the `gateway_restart_notification` flag in `~/.hermes/config.yaml`, which defaults to `true`:
 
 ```yaml
 gateway:
@@ -706,7 +710,7 @@ Disable it on noisy or low-priority platforms while leaving it on for your prima
 
 ### Typing indicators
 
-While the agent is processing a message, the gateway shows a live typing status on platforms that support it — a "typing…" bubble on Telegram/Discord/Signal, or the "is thinking…" assistant status on Slack. This is controlled per-platform by the `typing_indicator` flag in `gateway-config.yaml`, which defaults to `true`:
+While the agent is processing a message, the gateway shows a live typing status on platforms that support it — a "typing…" bubble on Telegram/Discord/Signal, or the "is thinking…" assistant status on Slack. This is controlled per-platform by the `typing_indicator` flag in `~/.hermes/config.yaml`, which defaults to `true`:
 
 ```yaml
 gateway:

--- a/website/docs/user-guide/messaging/irc.md
+++ b/website/docs/user-guide/messaging/irc.md
@@ -15,9 +15,9 @@ IRC is plain text: there is no voice, image, file, thread, reaction, typing, or 
 
 ## Configure Hermes
 
-You can configure IRC two ways — environment variables (for a quick env-only setup) or the `gateway` block in `~/.hermes/gateway-config.yaml`.
+You can configure IRC two ways — environment variables (for a quick env-only setup) or the `gateway` block in `~/.hermes/config.yaml`.
 
-### Option A — gateway-config.yaml
+### Option A — gateway block in config.yaml
 
 ```yaml
 gateway:

--- a/website/docs/user-guide/messaging/signal.md
+++ b/website/docs/user-guide/messaging/signal.md
@@ -194,7 +194,7 @@ You can still see tool activity in the CLI, and final Signal replies can include
 ### Phone Number Redaction
 
 All phone numbers are automatically redacted in logs:
-- `+15551234567` → `+155****4567`
+- `+15551234567` → `+15550123456`
 - This applies to both Hermes gateway logs and the global redaction system
 
 ### Note to Self (Single-Number Setup)

--- a/website/docs/user-guide/messaging/sms.md
+++ b/website/docs/user-guide/messaging/sms.md
@@ -108,7 +108,7 @@ hermes gateway
 You should see:
 
 ```
-[sms] Twilio webhook server listening on 127.0.0.1:8080, from: +1555***4567
+[sms] Twilio webhook server listening on 127.0.0.1:8080, from: +15550123456
 ```
 
 If you see `Refusing to start: SMS_WEBHOOK_URL is required`, set `SMS_WEBHOOK_URL` to the public URL configured in your Twilio Console (see Step 3).

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -715,6 +715,10 @@ If CLI sessions genuinely don't appear in `hermes sessions list`, the cause is
 persistence failed for that run.
 :::
 
+:::tip Moving to a new machine
+Sessions, memory, skills, and config are all under `~/.hermes/`. To move machines, back up the whole directory (`hermes backup` creates a zip) and restore with `hermes import`, or use `hermes profile export`/`import` to move a profile. Sessions resume seamlessly on the new machine with `hermes --resume <id>` — there is no separate "session sync" step. For a lighter move, `hermes sessions export <file>.jsonl` writes the conversation transcripts you care about.
+:::
+
 :::note Legacy JSONL transcripts
 Sessions created before state.db became canonical may have leftover
 `*.jsonl` files in `~/.hermes/sessions/`. They are no longer written or

--- a/website/docs/user-guide/skills/optional/productivity/productivity-telephony.md
+++ b/website/docs/user-guide/skills/optional/productivity/productivity-telephony.md
@@ -315,7 +315,7 @@ Use this when:
 Generate or host audio separately, then:
 
 ```bash
-python3 "$SCRIPT" twilio-call "+155****0000" --audio-url "https://example.com/briefing.mp3"
+python3 "$SCRIPT" twilio-call "+15550120000" --audio-url "https://example.com/briefing.mp3"
 ```
 
 Recommended Hermes TTS -> Twilio Play workflow:

--- a/website/scripts/fix-masked-phones.py
+++ b/website/scripts/fix-masked-phones.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Replace masked example phone numbers with valid fictional E.164 numbers.
+
++155****4567 -> +15550123456  (555-01xx is the FCC-reserved fictional range)
++155****6543 -> +15550987654
++155****3456 -> +15550123456
++155****2222 -> +15550122222
++155****0000 -> +15550120000
++1555***4567 -> +15550123456
+"""
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent / "docs"
+
+MASKED = {
+    "+155****4567": "+15550123456",
+    "+155****6543": "+15550987654",
+    "+155****3456": "+15550123456",
+    "+155****2222": "+15550122222",
+    "+155****0000": "+15550120000",
+    "+1555***4567": "+15550123456",
+}
+
+pat = re.compile("|".join(re.escape(k) for k in MASKED))
+
+changed = []
+for p in sorted(ROOT.rglob("*.md")):
+    try:
+        t = p.read_text(encoding="utf-8")
+    except Exception:
+        continue
+    new = pat.sub(lambda m: MASKED[m.group(0)], t)
+    if new != t:
+        p.write_text(new, encoding="utf-8")
+        changed.append(str(p.relative_to(ROOT)))
+
+print(f"Fixed {len(changed)} files")
+for c in changed:
+    print(" ", c)


### PR DESCRIPTION
## Summary

Seventh batch from the full docs audit (all 200 pages, 142 findings). Independent of PRs #82150 / #82174 / #82182 — cut from upstream/main.

## Changes (9 files, +68/-11)

- **learning-path.md**: added Goals, Kanban, Web Dashboard, ACP/IDE, Voice Mode, Wake Word to "Key Features at a Glance" (all feature pages verified to exist); added "Coming from OpenClaw?" pointer to the migration guide (previously unadvertised).
- **messaging/index.md**: added a note that A2A + Webhooks are event/passthrough surfaces, not chat platforms (they had no comparison-table rows); fixed 3 phantom `gateway-config.yaml` references → `config.yaml` (channel_overrides, restart notifications, typing indicators).
- **irc.md**: same `gateway-config.yaml` → `config.yaml` fix (heading + prose).
- **configuration.md**: documented `display.tool_progress: log` mode and indexed the platform-page-only display keys (`reasoning_style`, `live_status`, `status_phrases`, `memory_notifications`, `busy_ack_*`, `cleanup_progress`, `background_process_notifications`) with pointers to their owning pages.
- **sessions.md**: "Moving to a new machine" tip (`hermes backup`/`import`, `profile export`/`import`, `sessions export`) — commands verified in CLI reference.
- **fix-masked-phones.py**: masked-phone sweep re-applied to this upstream-based branch (4 files) — upstream/main never received the original sweep.

## Verification
- All 6 new learning-path links resolve to existing pages
- `gateway-config.yaml` does not exist in code — `gateway/config.py` reads env > config.yaml > legacy gateway.json > defaults (verified from source docstring)
- backup/import/profile-export/sessions-export commands confirmed in CLI reference
- Masked-phone scan clean (0 remaining); llms.txt generator rebuilds clean