### PR TITLE
fix(update): avoid gateway-owned restart deadlock

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -294,6 +294,25 @@ def _graceful_restart_via_sigusr1(pid: int, drain_timeout: float) -> bool:
     return _wait_for_pid_exit(pid, max(drain_timeout, 1.0))
 
 
+def _restart_gateway_for_update(pid: int, wait_timeout: float) -> str:
+    """Request a restart without deadlocking a gateway-owned updater.
+
+    A cron job can run Hermes update as a child of the gateway. Waiting for
+    that gateway to exit creates a cycle: restart waits for cron, while cron's
+    updater waits for restart. In that topology, request the restart and return
+    so the cron run can finish. Unrelated callers retain the normal bounded
+    drain wait.
+
+    Returns "deferred" when the caller must finish before restart, "exited"
+    after a completed graceful restart, or "failed" when handoff failed.
+    """
+    if _request_gateway_self_restart(pid):
+        return "deferred"
+    if _graceful_restart_via_sigusr1(pid, wait_timeout):
+        return "exited"
+    return "failed"
+
+
 def _wait_for_pid_exit(pid: int, timeout: float) -> bool:
     """Wait up to ``timeout`` seconds for ``pid`` to leave the process table.
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -739,7 +739,11 @@ def _capture_gateway_argv(pid: int) -> list[str] | None:
     return argv
 
 
-def _prepare_profile_gateway_update_restart(profile: str, pid: int) -> str | None:
+def _prepare_profile_gateway_update_restart(
+    profile: str,
+    pid: int,
+    wait_timeout: float = 120.0,
+) -> str | None:
     """Choose who relaunches a profile gateway after ``hermes update``.
 
     A gateway started with ``--external-supervisor`` must exit back to that
@@ -750,13 +754,38 @@ def _prepare_profile_gateway_update_restart(profile: str, pid: int) -> str | Non
     argv = _capture_gateway_argv(pid)
     if argv and "--external-supervisor" in argv:
         return "external-supervisor"
-    if launch_detached_profile_gateway_restart(profile, pid):
+    if launch_detached_profile_gateway_restart(
+        profile,
+        pid,
+        wait_timeout=wait_timeout,
+    ):
+        return "detached"
+    return None
+
+
+def _prepare_unmapped_gateway_update_restart(
+    pid: int,
+    wait_timeout: float = 120.0,
+) -> str | None:
+    """Prepare a safe relaunch for a manual gateway without profile mapping."""
+    run_argv = _capture_gateway_argv(pid)
+    if not run_argv:
+        return None
+    if "--external-supervisor" in run_argv:
+        return "external-supervisor"
+    if launch_detached_gateway_restart_by_cmdline(
+        pid,
+        run_argv,
+        wait_timeout=wait_timeout,
+    ):
         return "detached"
     return None
 
 
 def launch_detached_gateway_restart_by_cmdline(
-    old_pid: int, run_argv: list[str]
+    old_pid: int,
+    run_argv: list[str],
+    wait_timeout: float = 120.0,
 ) -> bool:
     """Relaunch a gateway by replaying its captured command line after exit.
 
@@ -768,20 +797,69 @@ def launch_detached_gateway_restart_by_cmdline(
     """
     if old_pid <= 0 or not run_argv:
         return False
-    return _spawn_gateway_restart_watcher(old_pid, list(run_argv))
+    return _spawn_gateway_restart_watcher(
+        old_pid,
+        list(run_argv),
+        wait_timeout=wait_timeout,
+    )
 
 
-def launch_detached_profile_gateway_restart(profile: str, old_pid: int) -> bool:
+def launch_detached_profile_gateway_restart(
+    profile: str,
+    old_pid: int,
+    wait_timeout: float = 120.0,
+) -> bool:
     """Relaunch a manually-run profile gateway after its current PID exits."""
     if old_pid <= 0:
         return False
-    return _spawn_gateway_restart_watcher(old_pid, _gateway_run_args_for_profile(profile))
+    return _spawn_gateway_restart_watcher(
+        old_pid,
+        _gateway_run_args_for_profile(profile),
+        wait_timeout=wait_timeout,
+    )
 
 
-def _spawn_gateway_restart_watcher(old_pid: int, run_argv: list[str]) -> bool:
-    """Spawn the detached watcher that respawns ``run_argv`` once ``old_pid`` exits."""
+def launch_detached_systemd_restart_after_exit(
+    old_pid: int,
+    manage_cmd: list[str],
+    service_name: str,
+    wait_timeout: float = 120.0,
+) -> bool:
+    """Reset and start a systemd unit after its old gateway PID exits."""
+    if old_pid <= 0 or not manage_cmd or not service_name:
+        return False
+
+    restart_script = (
+        "import json, subprocess, sys\n"
+        "cmd = json.loads(sys.argv[1])\n"
+        "service = sys.argv[2]\n"
+        "subprocess.run(cmd + ['reset-failed', service], "
+        "stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)\n"
+        "subprocess.run(cmd + ['start', service], "
+        "stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)\n"
+    )
+    return _spawn_gateway_restart_watcher(
+        old_pid,
+        [
+            sys.executable,
+            "-c",
+            restart_script,
+            json.dumps(manage_cmd),
+            service_name,
+        ],
+        wait_timeout=wait_timeout,
+    )
+
+
+def _spawn_gateway_restart_watcher(
+    old_pid: int,
+    run_argv: list[str],
+    wait_timeout: float = 120.0,
+) -> bool:
+    """Spawn a detached watcher that runs a command after old PID exits."""
     if old_pid <= 0 or not run_argv:
         return False
+    wait_timeout = max(float(wait_timeout), 0.0)
 
     # The watcher is a tiny Python subprocess that polls the old PID and
     # respawns the gateway once it's gone.  Both legs of the chain need
@@ -852,14 +930,18 @@ def _spawn_gateway_restart_watcher(old_pid: int, run_argv: list[str]) -> bool:
         cmd = sys.argv[2:]
         _respawn_cwd = {respawn_cwd_literal}
         _respawn_env_overlay = {respawn_env_literal}
-        deadline = time.monotonic() + 120
+        deadline = time.monotonic() + {wait_timeout!r}
+        from gateway.status import _pid_exists
+        exited = False
         while time.monotonic() < deadline:
             # ``os.kill(pid, 0)`` is not a no-op on Windows — use the
             # cross-platform existence check.
-            from gateway.status import _pid_exists
             if not _pid_exists(pid):
+                exited = True
                 break
             time.sleep(0.2)
+        if not exited:
+            sys.exit(1)
 
         # Platform-appropriate detach for the respawned gateway.  On POSIX
         # start_new_session=True maps to os.setsid; on Windows we need
@@ -899,6 +981,7 @@ def _spawn_gateway_restart_watcher(old_pid: int, run_argv: list[str]) -> bool:
     ).strip().format(
         respawn_cwd_literal=respawn_cwd_literal,
         respawn_env_literal=respawn_env_literal,
+        wait_timeout=wait_timeout,
     )
 
     watcher_argv = [

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -313,6 +313,24 @@ def _restart_gateway_for_update(pid: int, wait_timeout: float) -> str:
     return "failed"
 
 
+def _restart_watcher_wait_timeout(pid: int, drain_budget: float) -> float:
+    """Deadline for a detached restart watcher waiting on ``pid`` to exit.
+
+    A deferred restart (``pid`` is a process ancestor; SIGUSR1 already sent)
+    leaves the actual exit time to the gateway's own after-turn wait plus
+    drain, which this CLI process cannot reliably bound: the running
+    gateway may have been started with env-var timeout overrides this
+    process never sees. Giving the watcher a short, guessed deadline in
+    that case silently abandons the respawn once the real exit outlives it
+    (#82195 review). Non-ancestor gateways already went through a bounded
+    synchronous SIGUSR1 wait before this is called, so the drain-budget
+    deadline remains a safe, tight bound there.
+    """
+    if _is_pid_ancestor_of_current_process(pid):
+        return float("inf")
+    return drain_budget + 30.0
+
+
 def _wait_for_pid_exit(pid: int, timeout: float) -> bool:
     """Wait up to ``timeout`` seconds for ``pid`` to leave the process table.
 

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4894,8 +4894,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 find_gateway_pids,
                 find_profile_gateway_processes,
                 _prepare_profile_gateway_update_restart,
+                _prepare_unmapped_gateway_update_restart,
+                _is_pid_ancestor_of_current_process,
                 _get_service_pids,
                 _restart_gateway_for_update,
+                launch_detached_systemd_restart_after_exit,
                 _wait_for_gateway_exit,
             )
             import signal as _signal
@@ -5060,6 +5063,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             failed_or_stale_units = []
             killed_pids = set()
             relaunched_profiles = []
+            relaunched_unmapped_pids = []
             externally_supervised_profiles = []
 
             # --- Systemd services (Linux) ---
@@ -5158,6 +5162,20 @@ def _cmd_update_impl(args, gateway_mode: bool):
                                 _drain_budget,
                             )
                             if _restart_outcome == "deferred":
+                                if _manage_cmd is not None and not (
+                                    launch_detached_systemd_restart_after_exit(
+                                        _main_pid,
+                                        _manage_cmd,
+                                        svc_name,
+                                        wait_timeout=_drain_budget + 30.0,
+                                    )
+                                ):
+                                    failed_or_stale_units.append(svc_name)
+                                    print(
+                                        f"  WARNING: Could not schedule post-exit "
+                                        f"recovery for {svc_name}; verify it restarts "
+                                        "after the current gateway job"
+                                    )
                                 deferred_restart_services.append(svc_name)
                                 return
 
@@ -5407,7 +5425,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
             }
             for pid, proc in profile_processes.items():
                 restart_mode = _prepare_profile_gateway_update_restart(
-                    proc.profile, pid
+                    proc.profile,
+                    pid,
+                    wait_timeout=_drain_budget + 30.0,
                 )
                 if restart_mode is None:
                     continue
@@ -5457,6 +5477,42 @@ def _cmd_update_impl(args, gateway_mode: bool):
             for pid in manual_pids:
                 if pid in profile_processes:
                     continue
+                restart_mode = _prepare_unmapped_gateway_update_restart(
+                    pid,
+                    wait_timeout=_drain_budget + 30.0,
+                )
+                if restart_mode is not None:
+                    print(
+                        f"  -> manual gateway PID {pid}: draining "
+                        f"(up to {int(_drain_budget)}s)..."
+                    )
+                    restart_outcome = _restart_gateway_for_update(
+                        pid,
+                        _drain_budget,
+                    )
+                    if restart_outcome == "deferred":
+                        deferred_restart_services.append(f"PID {pid}")
+                        continue
+                    if restart_outcome == "failed":
+                        try:
+                            os.kill(pid, _signal.SIGTERM)
+                        except (ProcessLookupError, PermissionError):
+                            pass
+                    _wait_for_gateway_exit(timeout=5.0, force_after=None)
+                    killed_pids.add(pid)
+                    if restart_mode == "external-supervisor":
+                        externally_supervised_profiles.append(f"PID {pid}")
+                    else:
+                        relaunched_unmapped_pids.append(pid)
+                    continue
+                if _is_pid_ancestor_of_current_process(pid):
+                    failed_or_stale_units.append(f"manual gateway PID {pid}")
+                    print(
+                        f"  WARNING: Cannot safely restart gateway PID {pid}: "
+                        "its command line could not be captured. Leaving it "
+                        "running so the current gateway job can finish."
+                    )
+                    continue
                 try:
                     os.kill(pid, _signal.SIGTERM)
                     killed_pids.add(pid)
@@ -5472,6 +5528,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 if relaunched_profiles:
                     names = ", ".join(relaunched_profiles)
                     print(f"  ✓ Restarting manual gateway profile(s): {names}")
+                if relaunched_unmapped_pids:
+                    pids = ", ".join(str(pid) for pid in relaunched_unmapped_pids)
+                    print(f"  -> Restarting manual gateway PID(s): {pids}")
                 if externally_supervised_profiles:
                     names = ", ".join(externally_supervised_profiles)
                     print(
@@ -5481,6 +5540,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 unmapped_count = (
                     len(killed_pids)
                     - len(relaunched_profiles)
+                    - len(relaunched_unmapped_pids)
                     - len(externally_supervised_profiles)
                 )
                 if unmapped_count:

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4895,7 +4895,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 find_profile_gateway_processes,
                 _prepare_profile_gateway_update_restart,
                 _get_service_pids,
-                _graceful_restart_via_sigusr1,
+                _restart_gateway_for_update,
                 _wait_for_gateway_exit,
             )
             import signal as _signal
@@ -5056,6 +5056,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 _drain_budget = 45.0
 
             restarted_services = []
+            deferred_restart_services = []
             failed_or_stale_units = []
             killed_pids = set()
             relaunched_profiles = []
@@ -5147,17 +5148,20 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         ):
                             _main_pid = 0
 
-                        _graceful_ok = False
+                        _restart_outcome = "failed"
                         if _main_pid > 0:
                             print(
                                 f"  → {svc_name}: draining (up to {int(_drain_budget)}s)..."
                             )
-                            _graceful_ok = _graceful_restart_via_sigusr1(
+                            _restart_outcome = _restart_gateway_for_update(
                                 _main_pid,
-                                drain_timeout=_drain_budget,
+                                _drain_budget,
                             )
+                            if _restart_outcome == "deferred":
+                                deferred_restart_services.append(svc_name)
+                                return
 
-                        if _graceful_ok:
+                        if _restart_outcome == "exited":
                             # Gateway exited after a planned restart.
                             # ``Restart=always`` means systemd WILL respawn
                             # the unit — but only after
@@ -5420,11 +5424,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     f"  → {proc.profile}: draining gateway PID {pid} "
                     f"(up to {int(_drain_budget)}s)..."
                 )
-                drained = _graceful_restart_via_sigusr1(
-                    pid,
-                    drain_timeout=_drain_budget,
-                )
-                if not drained:
+                restart_outcome = _restart_gateway_for_update(pid, _drain_budget)
+                if restart_outcome == "deferred":
+                    deferred_restart_services.append(proc.profile)
+                    continue
+                if restart_outcome == "failed":
                     try:
                         os.kill(pid, _signal.SIGTERM)
                     except (ProcessLookupError, PermissionError):
@@ -5459,10 +5463,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 except (ProcessLookupError, PermissionError):
                     pass
 
-            if restarted_services or killed_pids:
+            if restarted_services or deferred_restart_services or killed_pids:
                 print()
                 for svc in restarted_services:
                     print(f"  ✓ Restarted {svc}")
+                for target in deferred_restart_services:
+                    print(f"  ✓ Restart scheduled after current gateway job: {target}")
                 if relaunched_profiles:
                     names = ", ".join(relaunched_profiles)
                     print(f"  ✓ Restarting manual gateway profile(s): {names}")

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4898,6 +4898,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 _is_pid_ancestor_of_current_process,
                 _get_service_pids,
                 _restart_gateway_for_update,
+                _restart_watcher_wait_timeout,
                 launch_detached_systemd_restart_after_exit,
                 _wait_for_gateway_exit,
             )
@@ -5167,7 +5168,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
                                         _main_pid,
                                         _manage_cmd,
                                         svc_name,
-                                        wait_timeout=_drain_budget + 30.0,
+                                        wait_timeout=_restart_watcher_wait_timeout(
+                                            _main_pid, _drain_budget
+                                        ),
                                     )
                                 ):
                                     failed_or_stale_units.append(svc_name)
@@ -5427,7 +5430,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 restart_mode = _prepare_profile_gateway_update_restart(
                     proc.profile,
                     pid,
-                    wait_timeout=_drain_budget + 30.0,
+                    wait_timeout=_restart_watcher_wait_timeout(pid, _drain_budget),
                 )
                 if restart_mode is None:
                     continue
@@ -5479,7 +5482,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     continue
                 restart_mode = _prepare_unmapped_gateway_update_restart(
                     pid,
-                    wait_timeout=_drain_budget + 30.0,
+                    wait_timeout=_restart_watcher_wait_timeout(pid, _drain_budget),
                 )
                 if restart_mode is not None:
                     print(

--- a/tests/hermes_cli/test_gateway_update_restart.py
+++ b/tests/hermes_cli/test_gateway_update_restart.py
@@ -1,0 +1,37 @@
+"""Regression coverage for gateway restart handoff during Hermes update."""
+
+from unittest.mock import MagicMock
+
+import hermes_cli.gateway as gateway_cli
+
+
+def test_update_restart_defers_when_gateway_is_process_ancestor(monkeypatch):
+    """#82161: a gateway-owned updater must not wait for its parent to exit."""
+    graceful = MagicMock()
+    monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: True)
+    monkeypatch.setattr(gateway_cli, "_graceful_restart_via_sigusr1", graceful)
+
+    outcome = gateway_cli._restart_gateway_for_update(654, 27.0)
+
+    assert outcome == "deferred"
+    graceful.assert_not_called()
+
+
+def test_update_restart_waits_for_unrelated_gateway(monkeypatch):
+    monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
+    monkeypatch.setattr(
+        gateway_cli,
+        "_graceful_restart_via_sigusr1",
+        lambda pid, timeout: (pid, timeout) == (654, 27.0),
+    )
+
+    assert gateway_cli._restart_gateway_for_update(654, 27.0) == "exited"
+
+
+def test_update_restart_reports_failed_graceful_handoff(monkeypatch):
+    monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
+    monkeypatch.setattr(
+        gateway_cli, "_graceful_restart_via_sigusr1", lambda pid, timeout: False
+    )
+
+    assert gateway_cli._restart_gateway_for_update(654, 27.0) == "failed"

--- a/tests/hermes_cli/test_gateway_update_restart.py
+++ b/tests/hermes_cli/test_gateway_update_restart.py
@@ -1,6 +1,10 @@
 """Regression coverage for gateway restart handoff during Hermes update."""
 
+import os
+import sys
 from unittest.mock import MagicMock
+
+import pytest
 
 import hermes_cli.gateway as gateway_cli
 
@@ -14,6 +18,26 @@ def test_update_restart_defers_when_gateway_is_process_ancestor(monkeypatch):
     outcome = gateway_cli._restart_gateway_for_update(654, 27.0)
 
     assert outcome == "deferred"
+    graceful.assert_not_called()
+
+
+def test_update_restart_detects_real_process_ancestor(monkeypatch):
+    """Exercise real parent traversal; mock only signal delivery."""
+    parent_pid = os.getppid()
+    sent = []
+    graceful = MagicMock()
+    monkeypatch.setattr(gateway_cli.signal, "SIGUSR1", 10, raising=False)
+    monkeypatch.setattr(
+        gateway_cli.os,
+        "kill",
+        lambda pid, sig: sent.append((pid, sig)),
+    )
+    monkeypatch.setattr(gateway_cli, "_graceful_restart_via_sigusr1", graceful)
+
+    outcome = gateway_cli._restart_gateway_for_update(parent_pid, 27.0)
+
+    assert outcome == "deferred"
+    assert sent == [(parent_pid, 10)]
     graceful.assert_not_called()
 
 
@@ -35,3 +59,102 @@ def test_update_restart_reports_failed_graceful_handoff(monkeypatch):
     )
 
     assert gateway_cli._restart_gateway_for_update(654, 27.0) == "failed"
+
+
+def test_detached_watcher_never_respawns_while_old_gateway_is_alive(monkeypatch):
+    """A long after-turn drain must not create a second gateway after 120s."""
+    outer_calls = []
+    monkeypatch.setattr(
+        gateway_cli.subprocess,
+        "Popen",
+        lambda argv, **kwargs: outer_calls.append((argv, kwargs)) or MagicMock(),
+    )
+
+    assert gateway_cli._spawn_gateway_restart_watcher(
+        654,
+        [sys.executable, "-m", "hermes_cli.main", "gateway", "run"],
+        wait_timeout=0.0,
+    )
+
+    watcher_argv = outer_calls[0][0]
+    watcher_source = watcher_argv[2]
+    respawn = MagicMock()
+    monkeypatch.setattr(gateway_cli.subprocess, "Popen", respawn)
+    monkeypatch.setattr("gateway.status._pid_exists", lambda pid: pid == 654)
+    monkeypatch.setattr(sys, "argv", ["-c", *watcher_argv[3:]])
+
+    with pytest.raises(SystemExit) as exc:
+        exec(compile(watcher_source, "<gateway-restart-watcher>", "exec"), {})
+
+    assert exc.value.code == 1
+    respawn.assert_not_called()
+
+
+def test_profile_restart_watcher_uses_after_turn_wait_budget(monkeypatch):
+    monkeypatch.setattr(gateway_cli, "_capture_gateway_argv", lambda pid: [])
+    launch = MagicMock(return_value=True)
+    monkeypatch.setattr(gateway_cli, "launch_detached_profile_gateway_restart", launch)
+
+    assert (
+        gateway_cli._prepare_profile_gateway_update_restart("work", 654, 27.0)
+        == "detached"
+    )
+    launch.assert_called_once_with("work", 654, wait_timeout=27.0)
+
+
+def test_unmapped_gateway_restart_replays_captured_command(monkeypatch):
+    argv = [sys.executable, "-m", "hermes_cli.main", "gateway", "run"]
+    monkeypatch.setattr(gateway_cli, "_capture_gateway_argv", lambda pid: argv)
+    launch = MagicMock(return_value=True)
+    monkeypatch.setattr(gateway_cli, "launch_detached_gateway_restart_by_cmdline", launch)
+
+    assert (
+        gateway_cli._prepare_unmapped_gateway_update_restart(654, 27.0)
+        == "detached"
+    )
+    launch.assert_called_once_with(654, argv, wait_timeout=27.0)
+
+
+def test_unmapped_external_supervisor_does_not_spawn_hermes_watcher(monkeypatch):
+    argv = [
+        sys.executable,
+        "-m",
+        "hermes_cli.main",
+        "gateway",
+        "run",
+        "--external-supervisor",
+    ]
+    monkeypatch.setattr(gateway_cli, "_capture_gateway_argv", lambda pid: argv)
+    launch = MagicMock()
+    monkeypatch.setattr(
+        gateway_cli,
+        "launch_detached_gateway_restart_by_cmdline",
+        launch,
+    )
+
+    assert (
+        gateway_cli._prepare_unmapped_gateway_update_restart(654, 27.0)
+        == "external-supervisor"
+    )
+    launch.assert_not_called()
+
+
+def test_systemd_deferred_restart_schedules_post_exit_recovery(monkeypatch):
+    launch = MagicMock(return_value=True)
+    monkeypatch.setattr(gateway_cli, "_spawn_gateway_restart_watcher", launch)
+
+    assert gateway_cli.launch_detached_systemd_restart_after_exit(
+        654,
+        ["systemctl", "--user"],
+        "hermes-gateway.service",
+        wait_timeout=27.0,
+    )
+
+    old_pid, command = launch.call_args.args
+    assert old_pid == 654
+    assert command[:2] == [sys.executable, "-c"]
+    assert command[-2:] == [
+        '["systemctl", "--user"]',
+        "hermes-gateway.service",
+    ]
+    assert launch.call_args.kwargs == {"wait_timeout": 27.0}

--- a/tests/hermes_cli/test_gateway_update_restart.py
+++ b/tests/hermes_cli/test_gateway_update_restart.py
@@ -158,3 +158,21 @@ def test_systemd_deferred_restart_schedules_post_exit_recovery(monkeypatch):
         "hermes-gateway.service",
     ]
     assert launch.call_args.kwargs == {"wait_timeout": 27.0}
+
+
+def test_watcher_timeout_is_unbounded_for_deferred_ancestor(monkeypatch):
+    """#82195 review: a guessed short deadline abandons the respawn once a
+    deferred restart's real exit (gateway after-turn wait + drain, which this
+    CLI cannot reliably bound) outlives it."""
+    monkeypatch.setattr(gateway_cli, "_is_pid_ancestor_of_current_process", lambda pid: True)
+
+    assert gateway_cli._restart_watcher_wait_timeout(654, 45.0) == float("inf")
+
+
+def test_watcher_timeout_stays_bounded_for_unrelated_gateway(monkeypatch):
+    """A non-ancestor gateway already went through a bounded synchronous
+    SIGUSR1 wait before the watcher is spawned, so the drain-budget deadline
+    remains a safe, tight bound."""
+    monkeypatch.setattr(gateway_cli, "_is_pid_ancestor_of_current_process", lambda pid: False)
+
+    assert gateway_cli._restart_watcher_wait_timeout(654, 45.0) == 75.0


### PR DESCRIPTION
## Summary

Fixes a self-deadlock when a gateway-owned cron run invokes `hermes update`.

The updater now distinguishes three restart outcomes:

- `deferred`: the gateway is an ancestor of the updater, so SIGUSR1 is sent and the updater returns without waiting for its own parent to exit
- `exited`: an unrelated gateway completed its normal bounded graceful restart
- `failed`: graceful handoff failed, preserving the existing hard-restart fallback

Both systemd-managed and manual/profile gateway update paths consume this shared outcome.

Closes #82161.

## Reproduction and root cause

The reported log is internally consistent:

1. A cron agent starts `hermes update` through a gateway-owned tool subprocess.
2. The updater sends SIGUSR1 and waits for the gateway PID to exit.
3. Since #77184, the gateway correctly waits for active agents, cron jobs, and API runs to finish before entering `stop()`.
4. The active cron job cannot finish because its updater subprocess is waiting for that same gateway to exit.
5. The after-turn wait eventually reaches its cap and enters `stop()`.
6. `agent.restart_drain_timeout` intentionally defaults to `0`, so the cron-aware drain reports `cron_at_start=1`, `timed_out=True`, and `drain took 0.00s`, then kills the updater.

This is a dependency cycle, not a failure to count cron work.

## Related behavior preserved

- #58818: cron delivery remains cooperative with the event loop; no blocking thread join was introduced.
- #60432: `_drain_active_agents()` still counts in-flight cron jobs and marks forced interruption correctly.
- #77184: normal in-band restarts still defer `stop()` until active work finishes.
- `restart_drain_timeout=0` remains intentional; this PR does not lengthen external shutdown or risk systemd SIGKILL during cleanup.
- Unrelated callers still wait for the gateway to exit within the existing bounded budget.
- Failed graceful handoffs still use existing SIGTERM/systemctl fallback behavior.
- launchd already uses the ancestor-aware asynchronous self-restart path and is unchanged.
- Windows update pause/resume behavior is unchanged.

## Implementation

`hermes_cli.gateway._restart_gateway_for_update()` centralizes restart disposition:

- first attempts the existing ancestor-only `_request_gateway_self_restart()`
- returns immediately as `deferred` when the updater belongs to the gateway process tree
- otherwise executes the existing `_graceful_restart_via_sigusr1()` wait and reports `exited` or `failed`

The update command records deferred targets and reports that restart is scheduled after the current gateway job. It does not poll, send SIGTERM, or invoke a blunt systemctl restart for that target. Once the update command returns, the cron run can complete; the gateway's existing after-turn waiter then reaches zero active work and performs the planned restart.

## Validation

- New cross-platform contract tests cover `deferred`, `exited`, and `failed` outcomes.
- Related regression suite: `43 passed`
  - gateway restart/after-turn drain
  - cron-aware update drain
  - active cron shutdown drain
  - interrupted cron status handling
  - Windows update pause/resume
- Ruff: all changed Python files pass.
- `git diff --check`: clean.

## Infographic :
<img width="1024" height="1024" alt="infographic_82195" src="https://github.com/user-attachments/assets/76e1e202-ec6b-4211-b770-86478d6373ad" />

