### PR TITLE
fix: separate phone and secret redaction

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -64,6 +64,10 @@ _SENSITIVE_BODY_KEYS = frozenset({
     "key",
 })
 
+def _env_truthy(name: str, default: str = "true") -> bool:
+    return os.getenv(name, default).lower() in {"1", "true", "yes", "on"}
+
+
 # Snapshot at import time so runtime env mutations (e.g. LLM-generated
 # `export HERMES_REDACT_SECRETS=false`) cannot disable redaction
 # mid-session.  ON by default — secure default per issue #17691. Users who
@@ -73,7 +77,13 @@ _SENSITIVE_BODY_KEYS = frozenset({
 # cli.py) or `HERMES_REDACT_SECRETS=false` in ~/.hermes/.env. An opt-out
 # warning is logged at gateway and CLI startup so operators see the
 # downgrade — see `_log_redaction_status()` in gateway/run.py and cli.py.
-_REDACT_ENABLED = os.getenv("HERMES_REDACT_SECRETS", "true").lower() in {"1", "true", "yes", "on"}
+_REDACT_ENABLED = _env_truthy("HERMES_REDACT_SECRETS")
+
+# E.164 phone numbers are ordinary PII, not credentials. Keep their import-time
+# snapshot separate so users can allow phone numbers while secret redaction
+# remains enabled. The internal env carrier is populated from
+# privacy.redact_phone_numbers in config.yaml by the startup config bridges.
+_PHONE_REDACT_ENABLED = _env_truthy("HERMES_REDACT_PHONE_NUMBERS")
 
 # Known API key prefixes -- match the prefix + contiguous token chars
 _PREFIX_PATTERNS = [
@@ -996,7 +1006,7 @@ def redact_sensitive_text(
         text = _redact_form_body(text)
 
     # E.164 phone numbers (Signal, WhatsApp)
-    if "+" in text:
+    if _PHONE_REDACT_ENABLED and "+" in text:
         def _redact_phone(m):
             phone = m.group(1)
             if len(phone) <= 8:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1536,6 +1536,10 @@ display:
 #   # Names and usernames are NOT affected (user-chosen, publicly visible).
 #   # Routing/delivery still uses the original values internally.
 #   redact_pii: false
+#   # Mask E.164 phone numbers in general redacted output/log surfaces.
+#   # Independent from security.redact_secrets; ordinary phone numbers can be
+#   # allowed while API keys and other credentials remain protected.
+#   redact_phone_numbers: true
 
 # =============================================================================
 # Shell-script hooks

--- a/cli.py
+++ b/cli.py
@@ -777,6 +777,14 @@ def load_cli_config() -> Dict[str, Any]:
         if redact is not None:
             os.environ["HERMES_REDACT_SECRETS"] = str(redact).lower()
 
+    privacy_config = defaults.get("privacy", {})
+    if isinstance(privacy_config, dict):
+        redact_phone_numbers = privacy_config.get("redact_phone_numbers")
+        if redact_phone_numbers is not None:
+            os.environ["HERMES_REDACT_PHONE_NUMBERS"] = str(
+                redact_phone_numbers
+            ).lower()
+
     # Session-search index knobs (hermes_state reads the env carriers).
     sessions_config = defaults.get("sessions", {})
     if isinstance(sessions_config, dict):

--- a/gateway/__init__.py
+++ b/gateway/__init__.py
@@ -9,6 +9,10 @@ to various messaging platforms (Telegram, Discord, WhatsApp, Weixin, and more) w
 - Platform-specific toolsets (different capabilities per platform)
 """
 
+from .redaction_bootstrap import bridge_gateway_redaction_env
+
+bridge_gateway_redaction_env()
+
 from .config import GatewayConfig, PlatformConfig, HomeChannel, load_gateway_config
 from .session import (
     SessionContext,

--- a/gateway/redaction_bootstrap.py
+++ b/gateway/redaction_bootstrap.py
@@ -1,0 +1,76 @@
+"""Early redaction env bridge for gateway startup.
+
+The gateway package imports ``gateway.session`` from ``gateway.__init__``, and
+that path imports ``agent.redact``. Since the redactor snapshots its env-backed
+flags at import time, direct ``python -m gateway.run`` must bridge redaction
+config before package exports pull in session.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+_BOOTSTRAP_RESULT: tuple[Path, Path] | None = None
+
+
+def bridge_gateway_redaction_env() -> tuple[Path, Path]:
+    """Load dotenv and bridge redaction config before ``agent.redact`` imports."""
+    global _BOOTSTRAP_RESULT
+    if _BOOTSTRAP_RESULT is not None:
+        return _BOOTSTRAP_RESULT
+
+    from hermes_constants import get_hermes_home
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+    from hermes_cli.env_loader import load_hermes_dotenv
+
+    hermes_home = get_hermes_home()
+    load_hermes_dotenv(
+        hermes_home=hermes_home,
+        project_env=Path(__file__).resolve().parents[1] / ".env",
+    )
+
+    # Internal carrier: config.yaml is authoritative, with secure default on.
+    os.environ["HERMES_REDACT_PHONE_NUMBERS"] = str(
+        DEFAULT_CONFIG["privacy"]["redact_phone_numbers"]
+    ).lower()
+
+    config_path = hermes_home / "config.yaml"
+    if not config_path.exists():
+        _BOOTSTRAP_RESULT = (hermes_home, config_path)
+        return _BOOTSTRAP_RESULT
+
+    try:
+        from hermes_cli.config import _expand_env_vars, read_user_config_raw
+
+        cfg = read_user_config_raw(config_path)
+        cfg = _expand_env_vars(cfg)
+        if not isinstance(cfg, dict):
+            cfg = {}
+        try:
+            from hermes_cli import managed_scope
+
+            cfg = managed_scope.apply_managed_overlay(cfg)
+        except Exception:
+            _BOOTSTRAP_RESULT = (hermes_home, config_path)
+            return _BOOTSTRAP_RESULT
+
+        security_cfg = cfg.get("security", {})
+        if isinstance(security_cfg, dict):
+            redact = security_cfg.get("redact_secrets")
+            if isinstance(redact, bool):
+                os.environ["HERMES_REDACT_SECRETS"] = str(redact).lower()
+
+        privacy_cfg = cfg.get("privacy", {})
+        if isinstance(privacy_cfg, dict):
+            redact_phone_numbers = privacy_cfg.get("redact_phone_numbers")
+            if isinstance(redact_phone_numbers, bool):
+                os.environ["HERMES_REDACT_PHONE_NUMBERS"] = str(
+                    redact_phone_numbers
+                ).lower()
+    except Exception:
+        pass
+
+    _BOOTSTRAP_RESULT = (hermes_home, config_path)
+    return _BOOTSTRAP_RESULT

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -46,6 +46,28 @@ from pathlib import Path
 from datetime import datetime
 from typing import Awaitable, Callable, Dict, Optional, Any, List, Tuple, Union, cast
 
+# Mark this process as a gateway so cli.py's module-level load_cli_config()
+# knows not to clobber TERMINAL_CWD if lazily imported.
+os.environ["_HERMES_GATEWAY"] = "1"
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from gateway.redaction_bootstrap import bridge_gateway_redaction_env
+
+_hermes_home, _config_path = bridge_gateway_redaction_env()
+
+# Resolve Hermes home directory (respects HERMES_HOME override)
+from hermes_constants import get_hermes_home_override
+from utils import atomic_json_write, is_truthy_value
+
+# Backward-compat for tests that monkeypatch this symbol.
+from dotenv import load_dotenv  # noqa: F401
+from hermes_cli.config_defaults import DEFAULT_CONFIG as _DEFAULT_CONFIG
+from hermes_cli.env_loader import load_hermes_dotenv
+
+_env_path = _hermes_home / '.env'
+
 from agent.async_utils import consume_detached_task_result, safe_schedule_threadsafe
 from agent.conversation_compression import (
     COMPACTION_STATUS,
@@ -1826,26 +1848,7 @@ def _clear_planned_restart_notification() -> None:
     _planned_restart_notification_path().unlink(missing_ok=True)
 
 
-# Mark this process as a gateway so cli.py's module-level load_cli_config()
-# knows not to clobber TERMINAL_CWD if lazily imported.
-os.environ["_HERMES_GATEWAY"] = "1"
-
 _ensure_ssl_certs()
-
-# Add parent directory to path
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
-# Resolve Hermes home directory (respects HERMES_HOME override)
-from hermes_constants import get_hermes_home, get_hermes_home_override
-from utils import atomic_json_write, is_truthy_value
-_hermes_home = get_hermes_home()
-
-# Load environment variables from ~/.hermes/.env first.
-# User-managed env files should override stale shell exports on restart.
-from dotenv import load_dotenv  # noqa: F401  # backward-compat for tests that monkeypatch this symbol
-from hermes_cli.env_loader import load_hermes_dotenv
-_env_path = _hermes_home / '.env'
-load_hermes_dotenv(hermes_home=_hermes_home, project_env=Path(__file__).resolve().parents[1] / '.env')
 
 
 def _reload_runtime_env_preserving_config_authority() -> None:
@@ -2048,21 +2051,12 @@ def _platform_has_bot_credential(platform: "Platform", platform_config: "Platfor
 _DOCKER_VOLUME_SPEC_RE = re.compile(r"^(?P<host>.+):(?P<container>/[^:]+?)(?::(?P<options>[^:]+))?$")
 _DOCKER_MEDIA_OUTPUT_CONTAINER_PATHS = {"/output", "/outputs"}
 
-# This env var is internal bridge plumbing, not a user-facing configuration
-# source. Initialize it from the canonical config default after dotenv loading
-# so an ambient process/.env value can never control lease safety on its own.
-from hermes_cli.config_defaults import DEFAULT_CONFIG as _DEFAULT_CONFIG
-
 os.environ["HERMES_TURN_LEASE_TIMEOUT"] = str(
     _DEFAULT_CONFIG["agent"]["gateway_turn_lease_timeout"]
 )
-os.environ["HERMES_REDACT_PHONE_NUMBERS"] = str(
-    _DEFAULT_CONFIG["privacy"]["redact_phone_numbers"]
-).lower()
 
 # Bridge config.yaml values into the environment so os.getenv() picks them up.
 # config.yaml is authoritative for terminal settings — overrides .env.
-_config_path = _hermes_home / 'config.yaml'
 if _config_path.exists():
     try:
         # Presence-sensitive env bridge: raw read is deliberate — only keys the

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2056,6 +2056,9 @@ from hermes_cli.config_defaults import DEFAULT_CONFIG as _DEFAULT_CONFIG
 os.environ["HERMES_TURN_LEASE_TIMEOUT"] = str(
     _DEFAULT_CONFIG["agent"]["gateway_turn_lease_timeout"]
 )
+os.environ["HERMES_REDACT_PHONE_NUMBERS"] = str(
+    _DEFAULT_CONFIG["privacy"]["redact_phone_numbers"]
+).lower()
 
 # Bridge config.yaml values into the environment so os.getenv() picks them up.
 # config.yaml is authoritative for terminal settings — overrides .env.
@@ -2261,6 +2264,13 @@ if _config_path.exists():
             _redact = _security_cfg.get("redact_secrets")
             if _redact is not None:
                 os.environ["HERMES_REDACT_SECRETS"] = str(_redact).lower()
+        _privacy_cfg = _cfg.get("privacy", {})
+        if isinstance(_privacy_cfg, dict):
+            _redact_phone_numbers = _privacy_cfg.get("redact_phone_numbers")
+            if _redact_phone_numbers is not None:
+                os.environ["HERMES_REDACT_PHONE_NUMBERS"] = str(
+                    _redact_phone_numbers
+                ).lower()
         # Gateway settings (media delivery allowlist + recency trust + strict mode)
         _gateway_cfg = _cfg.get("gateway", {})
         if isinstance(_gateway_cfg, dict):

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3498,8 +3498,9 @@ _SECURITY_COMMENT = """
 # ── Security ──────────────────────────────────────────────────────────
 # Secret redaction is ON by default — strings that look like API keys,
 # tokens, and passwords are masked in tool output, logs, and chat
-# responses before the model or user ever sees them. Set redact_secrets
-# to false to disable (e.g. when developing the redactor itself).
+# responses before the model or user ever sees them. E.164 phone-number
+# masking is controlled separately by privacy.redact_phone_numbers.
+# Set redact_secrets to false only when developing the redactor itself.
 # tirith pre-exec scanning is enabled by default when the tirith binary
 # is available. Configure via security.tirith_* keys or env vars
 # (TIRITH_ENABLED, TIRITH_BIN, TIRITH_TIMEOUT, TIRITH_FAIL_OPEN).
@@ -3539,8 +3540,9 @@ _FALLBACK_COMMENT = """
 
 _COMMENTED_SECTIONS = """
 # ── Security ──────────────────────────────────────────────────────────
-# Secret redaction is ON by default. Set to false to pass tool output,
-# logs, and chat responses through unmodified (e.g. for redactor dev).
+# Secret redaction is ON by default. Set to false only when you need raw
+# credential-like strings (e.g. for redactor dev). E.164 phone-number
+# masking is controlled separately by privacy.redact_phone_numbers.
 #
 # security:
 #   redact_secrets: true

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1459,6 +1459,7 @@ DEFAULT_CONFIG = {
     # Privacy settings
     "privacy": {
         "redact_pii": False,  # When True, hash user IDs and strip phone numbers from LLM context
+        "redact_phone_numbers": True,  # When True, mask E.164 phone numbers in logs/tool output
     },
 
     # Text-to-speech configuration

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -249,6 +249,7 @@ def _config_overrides(config: dict) -> dict[str, str]:
         ("display", "skin"),
         ("display", "show_reasoning"),
         ("privacy", "redact_pii"),
+        ("privacy", "redact_phone_numbers"),
         ("tts", "provider"),
     ]
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -698,12 +698,14 @@ from hermes_cli.config import get_hermes_home
 from hermes_cli.env_loader import load_hermes_dotenv
 
 load_hermes_dotenv(project_env=PROJECT_ROOT / ".env")
+os.environ["HERMES_REDACT_PHONE_NUMBERS"] = "true"
 
-# Bridge security.redact_secrets from config.yaml → HERMES_REDACT_SECRETS env
-# var BEFORE hermes_logging imports agent.redact (which snapshots the flag at
-# module-import time). Without this, config.yaml's toggle is ignored because
-# the setup_logging() call below imports agent.redact, which reads the env var
-# exactly once. Env var in .env still wins — this is config.yaml fallback only.
+# Bridge redaction settings from config.yaml → internal env carriers BEFORE
+# hermes_logging imports agent.redact (which snapshots the flags at
+# module-import time). Without this, config.yaml toggles are ignored because
+# the setup_logging() call below imports agent.redact, which reads the env vars
+# exactly once. HERMES_REDACT_SECRETS preserves legacy .env precedence; phone
+# number redaction has no user-facing env var, so config.yaml is authoritative.
 #
 # We also read network.force_ipv4 from the same yaml load to avoid two
 # separate config.yaml reads (saves ~17ms on every CLI startup — the second
@@ -735,6 +737,13 @@ try:
                 _early_redact = _early_sec_cfg.get("redact_secrets")
                 if _early_redact is not None:
                     os.environ["HERMES_REDACT_SECRETS"] = str(_early_redact).lower()
+        _early_privacy_cfg = _early_cfg_raw.get("privacy", {})
+        if isinstance(_early_privacy_cfg, dict):
+            _early_phone_redact = _early_privacy_cfg.get("redact_phone_numbers")
+            if _early_phone_redact is not None:
+                os.environ["HERMES_REDACT_PHONE_NUMBERS"] = str(
+                    _early_phone_redact
+                ).lower()
         _early_net_cfg = _early_cfg_raw.get("network", {})
         if isinstance(_early_net_cfg, dict) and _early_net_cfg.get("force_ipv4"):
             _FORCE_IPV4_EARLY = True

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -13,6 +13,7 @@ def _ensure_redaction_enabled(monkeypatch):
     monkeypatch.delenv("HERMES_REDACT_SECRETS", raising=False)
     # Also patch the module-level snapshot so it reflects the cleared env var
     monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+    monkeypatch.setattr("agent.redact._PHONE_REDACT_ENABLED", True)
 
 
 class TestKnownPrefixes:
@@ -318,6 +319,18 @@ class TestPassthrough:
         result = redact_sensitive_text({"token": "sk-proj-abc123def456ghi789jkl012"})
         assert "abc123def456" not in result
 
+
+class TestPhoneRedaction:
+    def test_phone_redaction_can_be_disabled_without_disabling_secrets(self, monkeypatch):
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+        monkeypatch.setattr("agent.redact._PHONE_REDACT_ENABLED", False)
+
+        text = "Call +15551234567 with OPENAI_API_KEY=sk-proj-abc123def456ghi789jkl012"
+        result = redact_sensitive_text(text)
+
+        assert "+15551234567" in result
+        assert "abc123def456" not in result
+        assert "OPENAI_API_KEY=" in result
 
 
 

--- a/tests/gateway/test_redaction_bootstrap.py
+++ b/tests/gateway/test_redaction_bootstrap.py
@@ -1,0 +1,175 @@
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_gateway_redaction_probe(tmp_path, config_yaml: str, env_text: str, body: str):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(textwrap.dedent(config_yaml))
+    (hermes_home / ".env").write_text(env_text)
+
+    probe = textwrap.dedent(
+        """\
+        import os
+        import sys
+
+        os.environ.pop("HERMES_REDACT_SECRETS", None)
+        os.environ.pop("HERMES_REDACT_PHONE_NUMBERS", None)
+        sys.path.insert(0, {repo_root!r})
+        """
+    ).format(repo_root=str(REPO_ROOT))
+    probe += textwrap.dedent(body)
+
+    env = dict(os.environ)
+    env["HERMES_HOME"] = str(hermes_home)
+    env.pop("HERMES_REDACT_SECRETS", None)
+    env.pop("HERMES_REDACT_PHONE_NUMBERS", None)
+
+    return subprocess.run(
+        [sys.executable, "-c", probe],
+        env=env,
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+        timeout=30,
+    )
+
+
+def test_gateway_package_init_bridges_phone_redaction_before_session_import(tmp_path):
+    result = _run_gateway_redaction_probe(
+        tmp_path,
+        """
+        privacy:
+          redact_phone_numbers: false
+        """,
+        "",
+        """
+        import gateway
+        from agent.redact import redact_sensitive_text
+
+        print(redact_sensitive_text(
+            "Call +15551234567 with OPENAI_API_KEY=sk-proj-abc123def456ghi789jkl012"
+        ))
+        """,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "+15551234567" in result.stdout
+    assert "abc123def456" not in result.stdout
+
+
+def test_gateway_run_import_honors_secret_redaction_config_before_agent_snapshot(tmp_path):
+    result = _run_gateway_redaction_probe(
+        tmp_path,
+        """
+        security:
+          redact_secrets: false
+        """,
+        "",
+        """
+        import gateway.run
+        from agent.redact import redact_sensitive_text
+
+        print(redact_sensitive_text(
+            "OPENAI_API_KEY=sk-proj-abc123def456ghi789jkl012"
+        ))
+        """,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "sk-proj-abc123def456ghi789jkl012" in result.stdout
+
+
+def test_gateway_run_import_config_secret_redaction_overrides_dotenv(tmp_path):
+    result = _run_gateway_redaction_probe(
+        tmp_path,
+        """
+        security:
+          redact_secrets: false
+        """,
+        "HERMES_REDACT_SECRETS=true\n",
+        """
+        import gateway.run
+        from agent.redact import redact_sensitive_text
+
+        print(os.environ.get("HERMES_REDACT_SECRETS"))
+        print(redact_sensitive_text(
+            "OPENAI_API_KEY=sk-proj-abc123def456ghi789jkl012"
+        ))
+        """,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "false" in result.stdout
+    assert "sk-proj-abc123def456ghi789jkl012" in result.stdout
+
+
+def test_gateway_import_ignores_non_boolean_redaction_config_values(tmp_path):
+    result = _run_gateway_redaction_probe(
+        tmp_path,
+        """
+        security:
+          redact_secrets: "no"
+        privacy:
+          redact_phone_numbers: "false"
+        """,
+        "",
+        """
+        import gateway
+        from agent.redact import redact_sensitive_text
+
+        print(os.environ.get("HERMES_REDACT_SECRETS", "<unset>"))
+        print(os.environ.get("HERMES_REDACT_PHONE_NUMBERS", "<unset>"))
+        print(redact_sensitive_text(
+            "Call +15551234567 with OPENAI_API_KEY=sk-proj-abc123def456ghi789jkl012"
+        ))
+        """,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "<unset>" in result.stdout
+    assert "true" in result.stdout
+    assert "+15551234567" not in result.stdout
+    assert "sk-proj-abc123def456ghi789jkl012" not in result.stdout
+
+
+def test_gateway_import_fails_closed_when_managed_overlay_fails(tmp_path):
+    result = _run_gateway_redaction_probe(
+        tmp_path,
+        """
+        security:
+          redact_secrets: false
+        privacy:
+          redact_phone_numbers: false
+        """,
+        "",
+        """
+        from hermes_cli import managed_scope
+
+        def fail_overlay(cfg):
+            raise RuntimeError("managed overlay unavailable")
+
+        managed_scope.apply_managed_overlay = fail_overlay
+
+        import gateway
+        from agent.redact import redact_sensitive_text
+
+        print(os.environ.get("HERMES_REDACT_SECRETS", "<unset>"))
+        print(os.environ.get("HERMES_REDACT_PHONE_NUMBERS", "<unset>"))
+        print(redact_sensitive_text(
+            "Call +15551234567 with OPENAI_API_KEY=sk-proj-abc123def456ghi789jkl012"
+        ))
+        """,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "<unset>" in result.stdout
+    assert "true" in result.stdout
+    assert "+15551234567" not in result.stdout
+    assert "sk-proj-abc123def456ghi789jkl012" not in result.stdout

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -317,6 +317,7 @@ class TestSignalPhoneRedaction:
         # See skill: xdist-cross-test-pollution Pattern 5.
         monkeypatch.delenv("HERMES_REDACT_SECRETS", raising=False)
         monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+        monkeypatch.setattr("agent.redact._PHONE_REDACT_ENABLED", True)
 
     def test_us_number(self):
         from agent.redact import redact_sensitive_text

--- a/tests/hermes_cli/test_redact_config_bridge.py
+++ b/tests/hermes_cli/test_redact_config_bridge.py
@@ -157,3 +157,54 @@ def test_dotenv_redact_secrets_beats_config_yaml(tmp_path):
     # .env value wins
     assert "REDACT_ENABLED=True" in result.stdout
     assert "ENV_VAR=true" in result.stdout
+
+
+def test_redact_phone_numbers_false_keeps_secret_redaction_enabled(tmp_path):
+    """privacy.redact_phone_numbers disables only E.164 masking."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        textwrap.dedent(
+            """\
+            privacy:
+              redact_phone_numbers: false
+            security:
+              redact_secrets: true
+            """
+        )
+    )
+    (hermes_home / ".env").write_text("")
+
+    probe = textwrap.dedent(
+        """\
+        import sys, os
+        os.environ.pop("HERMES_REDACT_SECRETS", None)
+        os.environ.pop("HERMES_REDACT_PHONE_NUMBERS", None)
+        sys.path.insert(0, %r)
+        import hermes_cli.main
+        import agent.redact
+        text = "Call +15551234567 with OPENAI_API_KEY=sk-proj-abc123def456ghi789jkl012"
+        print(f"REDACT_ENABLED={agent.redact._REDACT_ENABLED}")
+        print(f"PHONE_REDACT_ENABLED={agent.redact._PHONE_REDACT_ENABLED}")
+        print(agent.redact.redact_sensitive_text(text))
+        """
+    ) % str(REPO_ROOT)
+
+    env = dict(os.environ)
+    env["HERMES_HOME"] = str(hermes_home)
+    env.pop("HERMES_REDACT_SECRETS", None)
+    env.pop("HERMES_REDACT_PHONE_NUMBERS", None)
+
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        env=env,
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+        timeout=30,
+    )
+    assert result.returncode == 0, f"probe failed: {result.stderr}"
+    assert "REDACT_ENABLED=True" in result.stdout
+    assert "PHONE_REDACT_ENABLED=False" in result.stdout
+    assert "+15551234567" in result.stdout
+    assert "abc123def456" not in result.stdout

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -817,7 +817,7 @@ Advanced per-platform knobs for throttling the outbound message batcher. Most us
 | `HERMES_EPHEMERAL_SYSTEM_PROMPT` | Ephemeral system prompt injected at API-call time (never persisted to sessions) |
 | `HERMES_PREFILL_MESSAGES_FILE` | Path to a JSON file of ephemeral prefill messages injected at API-call time. |
 | `HERMES_ALLOW_PRIVATE_URLS` | `true`/`false` — allow tools to fetch localhost/private-network URLs. Off by default in gateway mode. |
-| `HERMES_REDACT_SECRETS` | `true`/`false` — control secret redaction in tool output, logs, and chat responses (default: `true`). |
+| `HERMES_REDACT_SECRETS` | `true`/`false` — legacy control for secret redaction in tool output, logs, and chat responses (default: `true`). E.164 phone-number masking is configured with `privacy.redact_phone_numbers` in `config.yaml`. |
 | `HERMES_WRITE_SAFE_ROOT` | Optional directory prefix that **hard-blocks** `write_file`/`patch` writes outside the listed roots (no approval prompt). Supports multiple directories separated by `os.pathsep` (`:` on Unix, `;` on Windows). See [HERMES_WRITE_SAFE_ROOT](#hermes_write_safe_root) below. |
 | `HERMES_DISABLE_LAZY_INSTALLS` | Internal bridge var set automatically in the official Docker image to prevent runtime dependency installs into the immutable `/opt/hermes` tree. The user-facing equivalent is `security.allow_lazy_installs: false` in `config.yaml`; do not set this in `.env`. |
 | `HERMES_DISABLE_FILE_STATE_GUARD` | Set to `1` to turn off the "file changed since you read it" guard on `patch`/`write_file`. |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1861,6 +1861,7 @@ Signal is listed as a valid platform key because the setting can be saved per pl
 ```yaml
 privacy:
   redact_pii: false  # Strip PII from LLM context (gateway only)
+  redact_phone_numbers: true  # Mask E.164 phone numbers in logs/tool output
 ```
 
 When `redact_pii` is `true`, the gateway redacts personally identifiable information from the system prompt before sending it to the LLM on supported platforms:
@@ -1876,6 +1877,8 @@ When `redact_pii` is `true`, the gateway redacts personally identifiable informa
 **Platform support:** Redaction applies to WhatsApp, Signal, and Telegram. Discord and Slack are excluded because their mention systems (`<@user_id>`) require the real ID in the LLM context.
 
 Hashes are deterministic — the same user always maps to the same hash, so the model can still distinguish between users in group chats. Routing and delivery use the original values internally.
+
+`redact_phone_numbers` controls the general redactor's E.164 phone-number masking in tool output, logs, and displayed responses. It is independent from `security.redact_secrets`, so you can set `privacy.redact_phone_numbers: false` while keeping API key and token redaction enabled.
 
 ## Speech-to-Text (STT)
 
@@ -2206,7 +2209,7 @@ security:
     shared_files: []
 ```
 
-- `redact_secrets` — when `true`, automatically detects and redacts patterns that look like API keys, tokens, and passwords in tool output before it enters the conversation context and logs. **On by default**. Set to `false` explicitly only when you need raw credential-like strings for debugging or redactor development.
+- `redact_secrets` — when `true`, automatically detects and redacts patterns that look like API keys, tokens, and passwords in tool output before it enters the conversation context and logs. **On by default**. Set to `false` explicitly only when you need raw credential-like strings for debugging or redactor development. E.164 phone-number masking is controlled separately by `privacy.redact_phone_numbers`.
 - `tirith_enabled` — when `true`, terminal commands are scanned by [Tirith](https://github.com/sheeki03/tirith) before execution to detect potentially dangerous operations.
 - `tirith_path` — path to the tirith binary. Set this if tirith is installed in a non-standard location.
 - `tirith_timeout` — maximum seconds to wait for a tirith scan. Commands proceed if the scan times out.


### PR DESCRIPTION
## Summary
- add `privacy.redact_phone_numbers` as an independent E.164 masking control
- keep the new setting enabled by default for backward-compatible output behavior
- allow operators to disable phone masking while retaining API key, token, password, JWT, private-key, and connection-string redaction
- bridge the config through CLI and gateway startup before the redactor snapshots its settings
- document the new config and clarify the scope of `security.redact_secrets`

## Rationale
Phone numbers are ordinary PII rather than credentials. Coupling their masking to `security.redact_secrets` forces operators to choose between exposing credentials and using phone numbers in legitimate operational workflows. A separate privacy key preserves existing behavior by default while allowing an explicit opt-out for phone masking.

## Test plan
- `scripts/run_tests.sh tests/agent/test_redact.py tests/hermes_cli/test_redact_config_bridge.py tests/gateway/test_signal.py -q` (154 passed)
- `scripts/run_tests.sh tests/hermes_cli/test_config.py tests/hermes_cli/test_config_loader_e2e.py tests/hermes_cli/test_config_validation.py tests/hermes_cli/test_set_config_value.py tests/hermes_cli/test_dump_env_visibility.py -q` (168 passed)
- `python3 -m compileall -q agent/redact.py cli.py gateway/run.py hermes_cli/config.py hermes_cli/config_defaults.py hermes_cli/dump.py hermes_cli/main.py`
- `git diff --check`