### PR TITLE
fix(patch): recover line-number-gutter pasted old_string (port from oh-my-pi#7906)

### DIFF
--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -608,3 +608,84 @@ class TestContextAwareCorrectness:
         # Was ~5.5s before anchoring; generous ceiling to avoid CI flake.
         assert elapsed < 2.0, f"context_aware no-match took {elapsed:.2f}s"
 
+
+
+class TestGutterStrippedRecovery:
+    """Recovery for old_string pasted verbatim from read_file's N|content
+    gutter output (port of can1357/oh-my-pi#7906)."""
+
+    FILE = "def foo():\n    x = 1\n    return x\n"
+
+    def test_recovers_gutter_pasted_old_string(self):
+        old = "12|def foo():\n13|    x = 1\n14|    return x"
+        new = "def foo():\n    x = 2\n    return x"
+        result, count, strategy, err = fuzzy_find_and_replace(self.FILE, old, new)
+        assert err is None, err
+        assert count == 1
+        assert strategy.endswith("+gutter_stripped")
+        assert "x = 2" in result
+
+    def test_recovers_when_both_strings_carry_gutter(self):
+        old = "1|def foo():\n2|    x = 1"
+        new = "1|def foo():\n2|    x = 99"
+        result, count, strategy, err = fuzzy_find_and_replace(self.FILE, old, new)
+        assert err is None, err
+        assert count == 1
+        assert "x = 99" in result
+        # gutter must not leak into the written content
+        assert "1|" not in result and "2|" not in result
+
+    def test_mixed_prefixes_are_genuine_content(self):
+        # A bare line among numbered ones means the pipes are payload.
+        content = "1|value\nplain line\n2|other\n"
+        old = "1|value\nplain line"
+        result, count, _, err = fuzzy_find_and_replace(content, old, "REPLACED")
+        # exact strategy matches the literal text — no stripping involved
+        assert err is None
+        assert count == 1
+        assert "REPLACED" in result
+
+    def test_does_not_strip_when_literal_match_exists(self):
+        # File genuinely contains gutter-shaped text: exact match wins first,
+        # content stays literal.
+        content = "table:\n1|a\n2|b\n3|c\n"
+        old = "1|a\n2|b"
+        result, count, strategy, err = fuzzy_find_and_replace(content, old, "X")
+        assert err is None
+        assert count == 1
+        assert strategy == "exact"
+        assert "X\n3|c" in result
+
+    def test_non_consecutive_numbers_rejected(self):
+        # Shell pipelines with digit|digit shapes must not be "recovered".
+        old = "3|foo\n9|bar"
+        _, count, _, err = fuzzy_find_and_replace(self.FILE, old, "nope")
+        assert count == 0
+        assert err is not None
+
+    def test_single_numbered_line_not_gutter_recovered(self):
+        # A single N| line is plausible literal content — the gutter helper
+        # refuses it. (context_aware may still similarity-match the payload
+        # half; the point is the gutter path never fires on one line.)
+        _, count, strategy, _ = fuzzy_find_and_replace(self.FILE, "5|def foo():", "x")
+        if count:
+            assert "+gutter_stripped" not in (strategy or "")
+
+    def test_search_files_skip_tolerated(self):
+        # search_files output can skip lines; >=80% consecutive still recovers.
+        content = "alpha\nbeta\ngamma\ndelta\nepsilon\nzeta\n"
+        old = "1|alpha\n2|beta\n3|gamma\n4|delta\n5|epsilon"
+        result, count, strategy, err = fuzzy_find_and_replace(content, old,
+                                                              "ONE\nbeta\ngamma\ndelta\nepsilon")
+        assert err is None, err
+        assert count == 1
+        assert result.startswith("ONE\n")
+
+    def test_helper_direct(self):
+        from tools.fuzzy_match import _strip_line_number_gutter
+        assert _strip_line_number_gutter("10|a\n11|b") == "a\nb"
+        assert _strip_line_number_gutter("10|a\n\n11|b") == "a\n\nb"
+        assert _strip_line_number_gutter("a\nb") is None
+        assert _strip_line_number_gutter("10|a\nbare") is None
+        assert _strip_line_number_gutter("x|a\n2|b") is None
+        assert _strip_line_number_gutter("no pipes at all") is None

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -117,7 +117,8 @@ def _format_match_locations(content: str, matches: List[Tuple[int, int]],
 
 
 def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
-                            replace_all: bool = False) -> Tuple[str, int, Optional[str], Optional[str]]:
+                            replace_all: bool = False,
+                            _gutter_retry: bool = True) -> Tuple[str, int, Optional[str], Optional[str]]:
     """
     Find and replace text using a chain of increasingly fuzzy matching strategies.
 
@@ -249,8 +250,81 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
             )
             return new_content, len(matches), strategy_name, None
 
-    # No strategy found a match
+    # No strategy found a match. Last-resort recovery: models sometimes paste
+    # old_string (and new_string context lines) straight from read_file /
+    # search_files output, which prefixes every line with a ``N|`` gutter
+    # (``42|code here``).  The file itself has no such prefixes, so every
+    # strategy above fails.  When ALL non-empty lines of old_string carry a
+    # uniform, mostly-consecutive line-number gutter — the signature of a
+    # verbatim paste, per the mirrored write_file guard in
+    # ``tools/file_tools.py`` — strip the gutter from both strings and retry
+    # the full chain once.  A mixed set means the prefixes are genuine file
+    # content and must stay.  (port of can1357/oh-my-pi#7906)
+    if _gutter_retry:
+        stripped_old = _strip_line_number_gutter(old_string)
+        if stripped_old is not None:
+            stripped_new = _strip_line_number_gutter(new_string)
+            new_content, count, strategy, error = fuzzy_find_and_replace(
+                content, stripped_old,
+                stripped_new if stripped_new is not None else new_string,
+                replace_all, _gutter_retry=False,
+            )
+            if count > 0 and error is None:
+                return new_content, count, f"{strategy}+gutter_stripped", None
+
     return content, 0, None, "Could not find a match for old_string in the file"
+
+
+def _strip_line_number_gutter(text: str) -> Optional[str]:
+    """Strip a uniform ``N|`` read_file gutter from every line of ``text``.
+
+    Returns the recovered text when every non-empty line carries a
+    ``digits|`` prefix and the numbers are mostly consecutive (>= 80% of
+    adjacent pairs increment by 1 — search_files output may skip lines).
+    Returns ``None`` when the text does not look like a verbatim paste of
+    line-numbered tool output: any bare line, a non-numeric prefix, or a
+    non-consecutive number sequence means the pipes are genuine content
+    (tables, shell pipelines, ``||`` operators) and must not be touched.
+
+    Deliberately conservative:
+    - requires at least 2 numbered lines (a single ``1|value`` line is
+      plausible literal content, mirroring the write_file guard);
+    - empty/whitespace-only lines are passed through unchanged (read_file
+      renders blank file lines as ``N|`` with empty content, but models
+      sometimes collapse them when re-pasting);
+    - the gutter must be at the very start of the line (read_file emits no
+      leading indent before the number).
+    """
+    if "|" not in text:
+        return None
+
+    lines = text.split("\n")
+    numbers: List[int] = []
+    stripped_lines: List[str] = []
+    numbered_count = 0
+
+    for line in lines:
+        if not line.strip():
+            stripped_lines.append(line)
+            continue
+        prefix, sep, rest = line.partition("|")
+        if not sep or not prefix.isdigit():
+            return None  # a bare content line — not a uniform paste
+        numbers.append(int(prefix))
+        stripped_lines.append(rest)
+        numbered_count += 1
+
+    if numbered_count < 2:
+        return None
+
+    consecutive_pairs = sum(
+        1 for prev, current in zip(numbers, numbers[1:])
+        if current == prev + 1
+    )
+    if consecutive_pairs < 0.8 * (len(numbers) - 1):
+        return None
+
+    return "\n".join(stripped_lines)
 
 
 def _detect_escape_drift(content: str, matches: List[Tuple[int, int]],


### PR DESCRIPTION
## Summary

The patch tool now recovers `old_string` pasted verbatim from `read_file`/`search_files` output — a uniform `N|` line-number gutter no longer causes a hard no-match failure. Port of [can1357/oh-my-pi#7906](https://github.com/can1357/oh-my-pi/pull/7906) (their hashline parser learned to recover pipe-numbered read rows; ours is the fuzzy-strategy-chain equivalent).

Root cause shape: `read_file` returns `42|code` gutter lines by design. When a model copies those lines into `old_string`, none of the 9 fuzzy strategies can match (the file has no gutters), and the model burns turns re-reading and re-patching. We already reject this exact paste signature on the *write* side (`_looks_like_read_file_line_numbered_content` in `tools/file_tools.py`); this PR completes the read→patch half by *recovering* instead of failing.

## Changes

- `tools/fuzzy_match.py`: after all 9 strategies miss, if **every** non-empty line of `old_string` carries a `digits|` prefix with ≥80% consecutive numbering (search_files output may skip lines), strip the gutter from both `old_string` and `new_string` and retry the chain exactly once. Strategy is reported as `<strategy>+gutter_stripped`.
- Conservative bail-outs mirror the write_file guard: any bare line, non-numeric prefix, non-consecutive numbers, or a single numbered line ⇒ no stripping (pipes are genuine content — tables, `||`, shell pipelines).
- Ordering guarantee: exact/literal matches always win first, so files that genuinely contain gutter-shaped text are untouched (test covers this).
- `tests/tools/test_fuzzy_match.py`: 8 new tests (recovery, both-strings-guttered, mixed-prefix rejection, literal-match precedence, non-consecutive rejection, skip tolerance, helper unit checks).

## Ours vs theirs

| | oh-my-pi #7906 | this port |
|---|---|---|
| Surface | hashline patch parser (`N:` and `N\|` snapshot rows) | fuzzy strategy chain fallback |
| Trigger | per-row regex, strips when all bare rows uniform | all-strategies-miss, all-lines-uniform + consecutive-number check |
| Safety | uniform-set rule | uniform-set rule + consecutiveness + exact-match-first precedence + no recursion (single retry) |

## Validation

| | Before | After |
|---|---|---|
| `old_string` pasted with `12\|`…`14\|` gutter | "Could not find a match" | matched, gutter never written to file |
| File genuinely containing `1\|a` rows | exact match | exact match (unchanged) |
| Sabotage run (recovery disabled) | — | 2 new tests fail, rest pass |
| `scripts/run_tests.sh tests/tools/test_fuzzy_match.py` | 45 passed | **53 passed, 0 failed** |

Ruff clean.

## Infographic

![Gutter-Stripped Patch Recovery](https://v3b.fal.media/files/b/0aa59806/HOERzw0b_RWZSROwk7DdG_TnYkZlBj.png)
