### PR TITLE
feat(web): native Exa advanced search + agent tools (no MCP)

### DIFF
--- a/agent/web_search_provider.py
+++ b/agent/web_search_provider.py
@@ -209,3 +209,29 @@ class WebSearchProvider(abc.ABC):
             "tag": "",
             "env_vars": [],
         }
+
+    def advanced_search(self, query: str, **kwargs: Any) -> Dict[str, Any]:
+        """Execute an advanced web search with filters (Exa backend).
+
+        Optional capability — providers that implement it (currently Exa)
+        expose the ``web_search_advanced`` tool. The default raises
+        NotImplementedError; callers gate on ``hasattr`` before calling.
+        """
+        raise NotImplementedError(
+            f"{self.name} does not support advanced search"
+        )
+
+    def agent_run(
+        self,
+        instructions: str,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Run a multi-step research agent (Exa backend).
+
+        Optional capability — providers that implement it (currently Exa)
+        expose the ``exa_agent_run`` tool. The default raises
+        NotImplementedError; callers gate on ``hasattr`` before calling.
+        """
+        raise NotImplementedError(
+            f"{self.name} does not support agent runs"
+        )

--- a/contributors/emails/dhruvkejri9@gmail.com
+++ b/contributors/emails/dhruvkejri9@gmail.com
@@ -1,0 +1,2 @@
+dhruvkej9
+# PR #82202 Exa native tools

--- a/plugins/web/exa/provider.py
+++ b/plugins/web/exa/provider.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from agent.web_search_provider import WebSearchProvider
 
@@ -200,6 +200,161 @@ class ExaWebSearchProvider(WebSearchProvider):
                 {"url": u, "title": "", "content": "", "error": f"Exa extract failed: {exc}"}
                 for u in urls
             ]
+
+    def advanced_search(self, query: str, **kwargs: Any) -> Dict[str, Any]:
+        """Execute an Exa search with the full advanced filter set.
+
+        Mirrors the ``web_search_advanced_exa`` MCP tool natively so the
+        capability works without an MCP server. Accepts the same filters the
+        Exa SDK ``search()`` exposes: ``include_domains``, ``exclude_domains``,
+        ``start_published_date``/``end_published_date``,
+        ``start_crawl_date``/``end_crawl_date``, ``category``, ``type``
+        (auto/fast/instant), ``include_text``/``exclude_text``,
+        ``user_location``, ``num_results``, ``enable_highlights``,
+        ``enable_summary``, and ``subpages``.
+
+        Returns ``{"success": True, "data": {"web": [...], "searchTime": ...}}``
+        on success, ``{"success": False, "error": str}`` on failure.
+        """
+        try:
+            from tools.interrupt import is_interrupted
+
+            if is_interrupted():
+                return {"success": False, "error": "Interrupted"}
+
+            logger.info("Exa advanced search: '%s'", query)
+
+            contents: Dict[str, Any] = {"text": True}
+            if kwargs.get("enable_highlights"):
+                contents["highlights"] = True
+            if kwargs.get("enable_summary"):
+                contents["summary"] = True
+            if kwargs.get("subpages"):
+                contents["subpages"] = int(kwargs["subpages"])
+
+            search_kwargs: Dict[str, Any] = {
+                "num_results": int(kwargs.get("num_results", 10)),
+                "contents": contents,
+            }
+            for key in (
+                "include_domains",
+                "exclude_domains",
+                "start_published_date",
+                "end_published_date",
+                "start_crawl_date",
+                "end_crawl_date",
+                "category",
+                "type",
+                "include_text",
+                "exclude_text",
+                "user_location",
+            ):
+                if kwargs.get(key) is not None:
+                    search_kwargs[key] = kwargs[key]
+
+            response = _get_exa_client().search(query, **search_kwargs)
+
+            web_results = []
+            for i, result in enumerate(response.results or []):
+                highlights = result.highlights or []
+                web_results.append(
+                    {
+                        "url": result.url or "",
+                        "title": result.title or "",
+                        "description": " ".join(highlights) if highlights else "",
+                        "position": i + 1,
+                    }
+                )
+
+            return {
+                "success": True,
+                "data": {
+                    "web": web_results,
+                    "searchTime": getattr(response, "search_time", None),
+                },
+            }
+        except ValueError as exc:
+            return {"success": False, "error": str(exc)}
+        except ImportError as exc:
+            return {"success": False, "error": f"Exa SDK not installed: {exc}"}
+        except Exception as exc:  # noqa: BLE001 — surface as failure
+            logger.warning("Exa advanced search error: %s", exc)
+            return {"success": False, "error": f"Exa advanced search failed: {exc}"}
+
+    def agent_run(
+        self,
+        instructions: str,
+        *,
+        output_schema: Optional[Dict[str, Any]] = None,
+        model: str = "exa-research-fast",
+        poll_interval: int = 2000,
+        timeout_ms: int = 600000,
+    ) -> Dict[str, Any]:
+        """Run an Exa Agent (multi-step research) natively.
+
+        Mirrors the ``agent_run`` MCP tool. Creates an Agent run on
+        ``/agent/runs`` and polls until it reaches a terminal state, returning
+        the output plus status/cost. ``model`` is accepted for API
+        compatibility; the Agent API derives effort from the run payload.
+        """
+        try:
+            from tools.interrupt import is_interrupted
+
+            if is_interrupted():
+                return {"success": False, "error": "Interrupted"}
+
+            logger.info("Exa agent run: '%s'", instructions)
+            client = _get_exa_client()
+
+            payload: Dict[str, Any] = {"query": instructions}
+            if output_schema is not None:
+                payload["outputSchema"] = output_schema
+
+            created = client.request("/agent/runs", data=payload, method="POST")
+            run_id = created.get("id") or created.get("runId")
+            if not run_id:
+                return {"success": False, "error": f"Agent run creation failed: {created}"}
+
+            import time
+
+            deadline = time.monotonic() + timeout_ms / 1000.0
+            while True:
+                if is_interrupted():
+                    return {"success": False, "error": "Interrupted", "run_id": run_id}
+                status_resp = client.request(
+                    f"/agent/runs/{run_id}", method="GET"
+                )
+                status = status_resp.get("status", "running")
+                if status in ("completed", "succeeded", "failed", "cancelled", "canceled"):
+                    break
+                if time.monotonic() > deadline:
+                    return {
+                        "success": False,
+                        "error": f"Agent run timed out after {timeout_ms}ms",
+                        "run_id": run_id,
+                        "status": status,
+                    }
+                time.sleep(poll_interval / 1000.0)
+
+            result = {
+                "success": status in ("completed", "succeeded"),
+                "run_id": run_id,
+                "status": status,
+                "output": status_resp.get("output"),
+            }
+            if status in ("failed", "cancelled", "canceled"):
+                result["error"] = status_resp.get("error") or f"agent run {status}"
+            cost = status_resp.get("costDollars") or status_resp.get("cost_dollars")
+            if cost is not None:
+                result["cost_dollars"] = cost
+            return result
+        except ValueError as exc:
+            return {"success": False, "error": str(exc)}
+        except ImportError as exc:
+            return {"success": False, "error": f"Exa SDK not installed: {exc}"}
+        except Exception as exc:  # noqa: BLE001 — surface as failure
+            logger.warning("Exa agent run error: %s", exc)
+            return {"success": False, "error": f"Exa agent run failed: {exc}"}
 
     def get_setup_schema(self) -> Dict[str, Any]:
         return {

--- a/plugins/web/exa/provider.py
+++ b/plugins/web/exa/provider.py
@@ -257,14 +257,17 @@ class ExaWebSearchProvider(WebSearchProvider):
             web_results = []
             for i, result in enumerate(response.results or []):
                 highlights = result.highlights or []
-                web_results.append(
-                    {
-                        "url": result.url or "",
-                        "title": result.title or "",
-                        "description": " ".join(highlights) if highlights else "",
-                        "position": i + 1,
-                    }
-                )
+                item: Dict[str, Any] = {
+                    "url": result.url or "",
+                    "title": result.title or "",
+                    "description": " ".join(highlights) if highlights else "",
+                    "position": i + 1,
+                }
+                if kwargs.get("enable_summary"):
+                    item["summary"] = result.summary or ""
+                if kwargs.get("subpages"):
+                    item["subpages"] = result.subpages or []
+                web_results.append(item)
 
             return {
                 "success": True,

--- a/tests/plugins/web/test_exa_native_tools.py
+++ b/tests/plugins/web/test_exa_native_tools.py
@@ -1,0 +1,91 @@
+"""Tests for native Exa advanced search + agent tools (no MCP needed).
+
+Covers:
+- The Exa plugin exposes ``advanced_search`` and ``agent_run`` capabilities.
+- The ``web_search_advanced`` and ``exa_agent_run`` tools are registered in the
+  tool registry and gated on the web API key check.
+- Non-Exa providers do NOT expose these capabilities (ABC default raises).
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def _ensure_plugins_loaded() -> None:
+    from hermes_cli.plugins import _ensure_plugins_discovered
+
+    _ensure_plugins_discovered()
+
+
+def _clear_web_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for k in (
+        "BRAVE_SEARCH_API_KEY",
+        "SEARXNG_URL",
+        "TAVILY_API_KEY",
+        "TAVILY_BASE_URL",
+        "EXA_API_KEY",
+        "PARALLEL_API_KEY",
+        "PARALLEL_SEARCH_MODE",
+        "FIRECRAWL_API_KEY",
+        "FIRECRAWL_API_URL",
+        "FIRECRAWL_GATEWAY_URL",
+        "TOOL_GATEWAY_DOMAIN",
+        "TOOL_GATEWAY_USER_TOKEN",
+        "XAI_API_KEY",
+    ):
+        monkeypatch.delenv(k, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_web_env(monkeypatch)
+
+
+class TestExaNativeCapabilities:
+    """Exa is the only provider exposing advanced_search + agent_run."""
+
+    def test_exa_exposes_advanced_search_and_agent_run(self) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        exa = get_provider("exa")
+        assert exa is not None
+        assert hasattr(exa, "advanced_search")
+        assert hasattr(exa, "agent_run")
+
+    def test_non_exa_provider_does_not_expose_capabilities(self) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        # brave-free only supports search; the ABC default for the new
+        # optional capabilities must raise, not silently return.
+        p = get_provider("brave-free")
+        assert p is not None
+        with pytest.raises(NotImplementedError):
+            p.advanced_search("test")
+        with pytest.raises(NotImplementedError):
+            p.agent_run("test")
+
+
+class TestToolRegistration:
+    """The two new tools register and are gated on the web key check."""
+
+    def test_tools_registered(self) -> None:
+        import tools.web_tools  # noqa: F401  (registers on import)
+        from tools.registry import registry
+
+        for name in ("web_search_advanced", "exa_agent_run"):
+            entry = registry.get_entry(name)
+            assert entry is not None, f"{name} not registered"
+            assert entry.toolset == "web"
+
+    def test_tools_gated_on_web_api_key(self) -> None:
+        import tools.web_tools  # noqa: F401
+        from tools.registry import registry
+
+        for name in ("web_search_advanced", "exa_agent_run"):
+            entry = registry.get_entry(name)
+            assert entry is not None
+            # check_fn is the standard web availability gate; it must be set
+            # so the tools only light up when a web backend is available.
+            assert entry.check_fn is not None

--- a/tests/plugins/web/test_exa_native_tools.py
+++ b/tests/plugins/web/test_exa_native_tools.py
@@ -89,3 +89,73 @@ class TestToolRegistration:
             # check_fn is the standard web availability gate; it must be set
             # so the tools only light up when a web backend is available.
             assert entry.check_fn is not None
+
+    def test_exa_agent_run_schema_has_no_dead_model_param(self) -> None:
+        """The model param was advertised but never sent to the API.
+
+        The Agent API derives effort from the run payload, so exposing a
+        selectable model that the handler silently drops is misleading.
+        It must not appear in the tool schema.
+        """
+        import tools.web_tools  # noqa: F401
+        from tools.registry import registry
+
+        entry = registry.get_entry("exa_agent_run")
+        assert entry is not None
+        props = entry.schema["parameters"]["properties"]
+        assert "model" not in props
+
+
+class TestAdvancedSearchSummarySubpages:
+    """advanced_search must surface summary/subpages it already pays for."""
+
+    def test_summary_and_subpages_mapped_into_results(self, monkeypatch) -> None:
+        from plugins.web.exa import provider as exa_provider
+
+        class _Result:
+            url = "https://example.com"
+            title = "Example"
+            highlights = ["a highlight"]
+            summary = "A short summary."
+            subpages = [{"url": "https://example.com/p1", "title": "p1"}]
+
+        class _Resp:
+            results = [_Result()]
+            search_time = 0.5
+
+        class _Client:
+            def search(self, *a, **k):
+                return _Resp()
+
+        monkeypatch.setattr(exa_provider, "_get_exa_client", lambda: _Client())
+
+        out = exa_provider.ExaWebSearchProvider().advanced_search(
+            "test", enable_summary=True, subpages=2
+        )
+        assert out["success"] is True
+        item = out["data"]["web"][0]
+        assert item["summary"] == "A short summary."
+        assert item["subpages"] == [{"url": "https://example.com/p1", "title": "p1"}]
+
+    def test_summary_subpages_omitted_when_not_requested(self, monkeypatch) -> None:
+        from plugins.web.exa import provider as exa_provider
+
+        class _Result:
+            url = "https://example.com"
+            title = "Example"
+            highlights = []
+
+        class _Resp:
+            results = [_Result()]
+            search_time = 0.5
+
+        class _Client:
+            def search(self, *a, **k):
+                return _Resp()
+
+        monkeypatch.setattr(exa_provider, "_get_exa_client", lambda: _Client())
+
+        out = exa_provider.ExaWebSearchProvider().advanced_search("test")
+        item = out["data"]["web"][0]
+        assert "summary" not in item
+        assert "subpages" not in item

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1235,3 +1235,198 @@ registry.register(
     emoji="📄",
     max_result_size_chars=100_000,
 )
+
+WEB_SEARCH_ADVANCED_SCHEMA = {
+    "name": "web_search_advanced",
+    "description": "Advanced web search (Exa backend) with full control over filters, domains, dates, categories, highlights, summaries, and subpage crawling. Best for research needing specific filters (date ranges, domain restrictions, category filters). For simple searches use web_search instead. Returns search results with optional highlights, summaries, and subpage content.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Search query — can be a question, statement, or keywords",
+            },
+            "num_results": {
+                "type": "integer",
+                "description": "Number of results (1-100, default: 10)",
+                "minimum": 1,
+                "maximum": 100,
+                "default": 10,
+            },
+            "type": {
+                "type": "string",
+                "enum": ["auto", "fast", "instant"],
+                "description": "Search type — 'auto': high quality and works with all filters (recommended), 'fast': quick results, 'instant': fastest results",
+            },
+            "category": {
+                "type": "string",
+                "enum": [
+                    "company",
+                    "publication",
+                    "news",
+                    "pdf",
+                    "github",
+                    "personal site",
+                    "people",
+                    "financial report",
+                ],
+                "description": "Filter results to a specific category",
+            },
+            "include_domains": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Only include results from these domains (e.g. ['arxiv.org', 'github.com'])",
+            },
+            "exclude_domains": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Exclude results from these domains",
+            },
+            "start_published_date": {
+                "type": "string",
+                "description": "Only include results published after this date (ISO 8601: YYYY-MM-DD)",
+            },
+            "end_published_date": {
+                "type": "string",
+                "description": "Only include results published before this date (ISO 8601: YYYY-MM-DD)",
+            },
+            "start_crawl_date": {
+                "type": "string",
+                "description": "Only include results crawled after this date (ISO 8601: YYYY-MM-DD)",
+            },
+            "end_crawl_date": {
+                "type": "string",
+                "description": "Only include results crawled before this date (ISO 8601: YYYY-MM-DD)",
+            },
+            "include_text": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Only include results containing ALL of these text strings",
+            },
+            "exclude_text": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Exclude results containing ANY of these text strings",
+            },
+            "user_location": {
+                "type": "string",
+                "description": "ISO country code for geo-targeted results (e.g. 'US', 'GB', 'DE')",
+            },
+            "enable_highlights": {
+                "type": "boolean",
+                "description": "Enable highlights extraction",
+            },
+            "enable_summary": {
+                "type": "boolean",
+                "description": "Enable summary generation for results",
+            },
+            "subpages": {
+                "type": "integer",
+                "description": "Number of subpages to crawl from each result (1-10)",
+                "minimum": 1,
+                "maximum": 10,
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+
+def web_search_advanced_tool(query: str, **kwargs: Any) -> str:
+    """Dispatch advanced search to the configured provider (Exa)."""
+    try:
+        _ensure_web_plugins_loaded()
+        from agent.web_search_registry import get_provider as _wsp_get_provider
+
+        backend = _get_search_backend()
+        provider = _wsp_get_provider(backend) if backend else None
+        if provider is None or not hasattr(provider, "advanced_search"):
+            return tool_error(
+                "Advanced search requires the Exa backend. Set web.backend=exa "
+                "and ensure EXA_API_KEY is configured."
+            )
+        response_data = provider.advanced_search(query, **kwargs)
+        return json.dumps(response_data, indent=2, ensure_ascii=False)
+    except Exception as e:  # noqa: BLE001
+        return tool_error(f"Error in advanced web search: {e}")
+
+
+def exa_agent_run_tool(
+    instructions: str,
+    output_schema: Optional[Dict[str, Any]] = None,
+    model: str = "exa-research-fast",
+) -> str:
+    """Run an Exa Agent (multi-step research) natively."""
+    try:
+        _ensure_web_plugins_loaded()
+        from agent.web_search_registry import get_provider as _wsp_get_provider
+
+        backend = _get_search_backend()
+        provider = _wsp_get_provider(backend) if backend else None
+        if provider is None or not hasattr(provider, "agent_run"):
+            return tool_error(
+                "Exa Agent requires the Exa backend. Set web.backend=exa "
+                "and ensure EXA_API_KEY is configured."
+            )
+        response_data = provider.agent_run(
+            instructions,
+            output_schema=output_schema,
+            model=model,
+        )
+        return json.dumps(response_data, indent=2, ensure_ascii=False)
+    except Exception as e:  # noqa: BLE001
+        return tool_error(f"Error in Exa agent run: {e}")
+
+
+WEB_AGENT_RUN_SCHEMA = {
+    "name": "exa_agent_run",
+    "description": "Run an Exa Agent for multi-step research, list-building, enrichment, and structured output. Takes a natural-language research objective and returns structured results with citations. Runs may take several minutes. Use for deep research tasks that need multiple search passes. Requires the Exa backend.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "instructions": {
+                "type": "string",
+                "description": "Natural-language research or enrichment objective",
+            },
+            "output_schema": {
+                "type": "object",
+                "description": "Optional JSON Schema for structured output. Prefer a top-level object with bounded arrays and source/evidence fields.",
+            },
+            "model": {
+                "type": "string",
+                "enum": ["exa-research-fast", "exa-research", "exa-research-pro"],
+                "description": "Research model to use (default: exa-research-fast)",
+                "default": "exa-research-fast",
+            },
+        },
+        "required": ["instructions"],
+    },
+}
+
+registry.register(
+    name="web_search_advanced",
+    toolset="web",
+    schema=WEB_SEARCH_ADVANCED_SCHEMA,
+    handler=lambda args, **kw: web_search_advanced_tool(
+        args.get("query", ""),
+        **{k: v for k, v in args.items() if k != "query"},
+    ),
+    check_fn=check_web_api_key,
+    requires_env=_web_requires_env(),
+    emoji="🔎",
+    max_result_size_chars=100_000,
+)
+registry.register(
+    name="exa_agent_run",
+    toolset="web",
+    schema=WEB_AGENT_RUN_SCHEMA,
+    handler=lambda args, **kw: exa_agent_run_tool(
+        args.get("instructions", ""),
+        output_schema=args.get("output_schema"),
+        model=args.get("model", "exa-research-fast"),
+    ),
+    check_fn=check_web_api_key,
+    requires_env=_web_requires_env(),
+    emoji="🧭",
+    max_result_size_chars=100_000,
+)

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1354,7 +1354,6 @@ def web_search_advanced_tool(query: str, **kwargs: Any) -> str:
 def exa_agent_run_tool(
     instructions: str,
     output_schema: Optional[Dict[str, Any]] = None,
-    model: str = "exa-research-fast",
 ) -> str:
     """Run an Exa Agent (multi-step research) natively."""
     try:
@@ -1371,7 +1370,6 @@ def exa_agent_run_tool(
         response_data = provider.agent_run(
             instructions,
             output_schema=output_schema,
-            model=model,
         )
         return json.dumps(response_data, indent=2, ensure_ascii=False)
     except Exception as e:  # noqa: BLE001
@@ -1391,12 +1389,6 @@ WEB_AGENT_RUN_SCHEMA = {
             "output_schema": {
                 "type": "object",
                 "description": "Optional JSON Schema for structured output. Prefer a top-level object with bounded arrays and source/evidence fields.",
-            },
-            "model": {
-                "type": "string",
-                "enum": ["exa-research-fast", "exa-research", "exa-research-pro"],
-                "description": "Research model to use (default: exa-research-fast)",
-                "default": "exa-research-fast",
             },
         },
         "required": ["instructions"],
@@ -1423,7 +1415,6 @@ registry.register(
     handler=lambda args, **kw: exa_agent_run_tool(
         args.get("instructions", ""),
         output_schema=args.get("output_schema"),
-        model=args.get("model", "exa-research-fast"),
     ),
     check_fn=check_web_api_key,
     requires_env=_web_requires_env(),


### PR DESCRIPTION
## What

Adds `web_search_advanced` and `exa_agent_run` as first-class **web** toolsets backed by the Exa provider, so the full Exa toolset works **without an MCP server**.

## Why

Exa's MCP exposes 4 tools: `web_search_exa`, `web_fetch_exa` (already covered by the built-in `web_search`/`web_extract`), plus `web_search_advanced_exa` and `agent_run` — which previously required an MCP server. This wires the latter two natively.

## Changes

- **Exa provider** (`plugins/web/exa/provider.py`): `advanced_search()` (full filter set — domains, date ranges, categories, highlights, summaries, subpages) and `agent_run()` (Exa Agent `/agent/runs` API with polling to completion).
- **ABC** (`agent/web_search_provider.py`): optional `advanced_search`/`agent_run` defaults that raise `NotImplementedError` (non-Exa providers unaffected).
- **Tool registry** (`tools/web_tools.py`): registers both tools in the `web` toolset, gated on `check_web_api_key`.
- **Tests**: capability exposure + tool registration.

## Notes

- The retired Exa Research API (`/research/v1`, returns 410) is bypassed — `agent_run` targets the live Agent API.
- Both tools verified live against the real Exa backend (advanced search + a completed agent run with citations + cost).