### PR TITLE
fix(auth): wrap xAI OAuth refresh network errors as AuthError

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -4853,16 +4853,27 @@ def refresh_xai_oauth_pure(
     # with a clear error so the user can re-run `hermes model` to refetch.
     _xai_validate_oauth_endpoint(endpoint, field="token_endpoint")
     timeout = httpx.Timeout(max(5.0, float(timeout_seconds)))
-    with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}) as client:
-        response = client.post(
-            endpoint,
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
-            data={
-                "grant_type": "refresh_token",
-                "client_id": XAI_OAUTH_CLIENT_ID,
-                "refresh_token": refresh_token,
-            },
-        )
+    try:
+        with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}) as client:
+            response = client.post(
+                endpoint,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                data={
+                    "grant_type": "refresh_token",
+                    "client_id": XAI_OAUTH_CLIENT_ID,
+                    "refresh_token": refresh_token,
+                },
+            )
+    except Exception as exc:
+        # DNS/connect/TLS failures used to bubble as raw httpx errors and crash
+        # `hermes model`. Same pattern as discovery and Qwen: wrap as AuthError.
+        # Offline/DNS is not a bad credential, so do not ask for re-login.
+        raise AuthError(
+            f"xAI token refresh failed (network error): {exc}",
+            provider="xai-oauth",
+            code="xai_refresh_network_error",
+            relogin_required=False,
+        ) from exc
     if response.status_code != 200:
         detail = response.text.strip()
         # ``403`` from xAI's token endpoint is almost always a tier /
@@ -6957,6 +6968,15 @@ def get_xai_oauth_auth_status() -> Dict[str, Any]:
             "logged_in": False,
             "auth_store": str(_auth_file_path()),
             "error": str(exc),
+            "error_code": exc.code,
+        }
+    except Exception as exc:
+        # Status is used by interactive flows. Never crash them on a bad resolve.
+        return {
+            "logged_in": False,
+            "auth_store": str(_auth_file_path()),
+            "error": f"xAI OAuth status check failed: {exc}",
+            "error_code": "xai_status_unexpected_error",
         }
 
 

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -752,6 +752,11 @@ def _model_flow_xai_oauth(_config, current_model="", *, args=None):
         elif choice == "cancel":
             return
     else:
+        status_error = str(status.get("error") or "").strip()
+        if status_error:
+            # Tokens may exist but refresh failed (network/DNS). Show why.
+            print(f"  xAI Grok OAuth status: {status_error}")
+            print()
         print("Not logged into xAI Grok OAuth (SuperGrok / Premium+). Starting login...")
         print()
         try:

--- a/tests/hermes_cli/test_auth_xai_oauth_provider.py
+++ b/tests/hermes_cli/test_auth_xai_oauth_provider.py
@@ -401,6 +401,72 @@ def test_refresh_xai_oauth_pure_403_marked_tier_denied_not_relogin(monkeypatch):
     assert "tier" in message
 
 
+def test_refresh_xai_oauth_pure_wraps_network_errors(monkeypatch):
+    """DNS/connect failures raise AuthError instead of raw httpx crashes.
+
+    ``hermes model`` refreshes via get_xai_oauth_auth_status. An
+    httpx.ConnectError used to escape uncaught and dump a traceback.
+    """
+    import httpx
+
+    class _BoomClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def post(self, *args, **kwargs):
+            raise httpx.ConnectError("[Errno -3] Temporary failure in name resolution")
+
+    monkeypatch.setattr("hermes_cli.auth.httpx.Client", lambda *a, **kw: _BoomClient())
+    with pytest.raises(AuthError) as exc:
+        refresh_xai_oauth_pure(
+            "at", "rt", token_endpoint="https://auth.x.ai/oauth2/token"
+        )
+    assert exc.value.code == "xai_refresh_network_error"
+    assert exc.value.relogin_required is False
+    assert "network error" in str(exc.value).lower()
+    assert "name resolution" in str(exc.value).lower()
+
+
+def test_get_xai_oauth_auth_status_network_error_does_not_raise(tmp_path, monkeypatch):
+    """get_xai_oauth_auth_status returns an error dict on DNS failure, no raise."""
+    import httpx
+
+    hermes_home = tmp_path / "hermes"
+    expired = _jwt_with_exp(int(time.time()) - 60)
+    _setup_hermes_auth(
+        hermes_home,
+        access_token=expired,
+        refresh_token="rt",
+        discovery={"token_endpoint": "https://auth.x.ai/oauth2/token"},
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    class _BoomClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def post(self, *args, **kwargs):
+            raise httpx.ConnectError("[Errno -3] Temporary failure in name resolution")
+
+    monkeypatch.setattr("hermes_cli.auth.httpx.Client", lambda *a, **kw: _BoomClient())
+    # Force the auth-store path (skip pool).
+    monkeypatch.setattr(
+        "agent.credential_pool.load_pool",
+        lambda *a, **kw: None,
+    )
+
+    status = get_xai_oauth_auth_status()
+    assert status["logged_in"] is False
+    assert "error" in status
+    assert "name resolution" in status["error"].lower() or "network" in status["error"].lower()
+
+
 def test_format_auth_error_tier_denied_does_not_suggest_relogin():
     """``xai_oauth_tier_denied`` must not append the re-authenticate hint.
 


### PR DESCRIPTION
Convert xAI OAuth refresh transport errors into non-relogin AuthError responses in auth_xai.py. Preserve the error code through the shared OAuth status helper and display the cause in the model setup flow instead of losing it during login handling.

Fixes #82204

Validation: 30 xAI OAuth provider and model-flow tests passed through scripts/run_tests.sh, including DNS failure through the real auth-store resolution path under a temporary HERMES_HOME.

Updated on the refactored main at 1ab32b212b, with the repair folded into one commit.
