### PR TITLE
fix(title): stop model-switch marker from becoming the session title

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -116,6 +116,15 @@ _MACHINE_PREFIXES = (
     "[CONTEXT COMPACTION",
     "[Runtime note:",
     "[SYSTEM]",
+    # Model-switch marker from tui_gateway.server._append_model_switch_marker.
+    # It is persisted with role="user" (strict OpenAI-compatible providers
+    # reject a system message that is not first — #48338), so without this
+    # entry it looks like a real opening turn: switching models before the
+    # first real message titled the session
+    # "[System: The active model for this chat has…" instead of the user's
+    # actual question. Keep in sync with
+    # tui_gateway.server._MODEL_SWITCH_MARKER_PREFIX.
+    "[System: The active model for this chat has changed to ",
 )
 
 
@@ -619,10 +628,19 @@ def maybe_auto_title(
     # turn prologue, and after it when called post-response, so accept both.
     # Entries are dicts; anything else means a caller passed the wrong
     # positional and titling must degrade quietly rather than raise.
+    #
+    # Machine-authored openers are excluded from the count. They are persisted
+    # with role="user" (see _MACHINE_PREFIXES), so counting them would make a
+    # session that opened with e.g. a model-switch marker look like it was
+    # already past its opening turn — the real first question then arrives at
+    # count 2 and never gets titled at all, leaving the session permanently
+    # NULL-titled.
     user_msg_count = sum(
         1
         for m in (conversation_history or [])
-        if isinstance(m, dict) and m.get("role") == "user"
+        if isinstance(m, dict)
+        and m.get("role") == "user"
+        and is_titleable_user_message(m.get("content") or "")
     )
     if user_msg_count > 1:
         return

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -360,3 +360,88 @@ class TestRuntimeValidator:
             assert called.wait(timeout=10), "auto_title thread never ran"
             kwargs = mock_auto.call_args.kwargs
             assert kwargs["runtime_validator"] is _v
+
+
+class TestModelSwitchMarkerNotTitleable:
+    """Regression: a model-switch marker must never become the session title.
+
+    ``_append_model_switch_marker`` (tui_gateway/server.py) persists its notice
+    with ``role="user"`` because strict OpenAI-compatible providers reject a
+    system message that is not first (#48338). Titling therefore has to
+    recognise it as machine-authored, or switching models before asking the
+    first real question titles the session
+    "[System: The active model for this chat has…".
+    """
+
+    MARKER = (
+        "[System: The active model for this chat has changed to "
+        "deepseek-v4-flash via provider 94mei. From this point forward, use "
+        "this runtime metadata when answering questions about what "
+        "model/provider is active.]"
+    )
+
+    def test_marker_prefix_matches_gateway_constant(self):
+        """The guard must stay in sync with the gateway's marker builder."""
+        from tui_gateway.server import _MODEL_SWITCH_MARKER_PREFIX
+        from agent.title_generator import _MACHINE_PREFIXES
+
+        assert _MODEL_SWITCH_MARKER_PREFIX in _MACHINE_PREFIXES
+        assert self.MARKER.startswith(_MODEL_SWITCH_MARKER_PREFIX)
+
+    def test_marker_is_not_titleable(self):
+        from agent.title_generator import is_titleable_user_message
+
+        assert is_titleable_user_message(self.MARKER) is False
+
+    def test_derive_title_is_unguarded_by_design(self):
+        """``derive_title`` is a dumb formatter; the guard lives in the callers.
+
+        Documents the contract deliberately: every caller checks
+        ``is_titleable_user_message`` first, so ``derive_title`` itself is
+        allowed to format a marker. If a future caller forgets that check, the
+        marker leaks into the title — which is exactly the bug this class
+        guards against.
+        """
+        from agent.title_generator import derive_title
+
+        assert derive_title(self.MARKER) is not None
+
+    def test_unrelated_system_bracket_text_still_titleable(self):
+        """The guard is narrow: real user text starting "[System:" still titles."""
+        from agent.title_generator import is_titleable_user_message
+
+        assert is_titleable_user_message("[System: my own note] how do I ...") is True
+
+    def test_real_question_after_marker_still_titles(self):
+        """The marker must not consume the session's one titling opportunity.
+
+        The marker is a role="user" row, so counting it made the first real
+        question look like turn 2 — and titling bailed out entirely, leaving
+        the session permanently untitled.
+        """
+        db = MagicMock()
+        db.get_session_title.return_value = None
+        db.get_session_title_source.return_value = None
+        history = [
+            {"role": "user", "content": self.MARKER},
+            {"role": "user", "content": "南京市秦淮区 小时级天气预报"},
+        ]
+
+        with patch("agent.title_generator.auto_title_session") as mock_auto:
+            import threading
+
+            called = threading.Event()
+            mock_auto.side_effect = lambda *a, **k: called.set()
+            maybe_auto_title(db, "sess-1", "南京市秦淮区 小时级天气预报", history)
+            assert called.wait(timeout=10), "auto_title never ran after marker"
+
+    def test_instant_title_skips_marker_uses_real_message(self):
+        from agent.title_generator import apply_instant_title
+
+        db = MagicMock()
+        db.get_session_title_source.return_value = None
+
+        assert apply_instant_title(db, "sess-1", self.MARKER) is None
+        assert apply_instant_title(db, "sess-1", "南京市秦淮区 小时级天气预报") == (
+            "南京市秦淮区 小时级天气预报"
+        )


### PR DESCRIPTION
## What does this PR do?

Switching the active model **before** sending the first real message in a new session titled the session `[System: The active model for this chat has…` instead of the user's actual question.

`_append_model_switch_marker` (`tui_gateway/server.py`) persists its notice with `role="user"` — deliberately, because strict OpenAI-compatible providers reject a system message that is not first (#48338). Titling had no way to tell that apart from a genuine opening turn, which caused **two** distinct failures:

**1. `_MACHINE_PREFIXES` did not cover the marker.** The guard list was:

```python
_MACHINE_PREFIXES = ("[CONTEXT COMPACTION", "[Runtime note:", "[SYSTEM]")
```

The marker begins `[System: The active model for this chat has changed to `, which matches none of the three (`[SYSTEM]` differs in case and has a closing bracket). So `is_titleable_user_message()` returned `True` and the marker was formatted straight into the title.

**2. The marker consumed the session's only titling opportunity.** `maybe_auto_title()` counted it as a user message, so the first real question arrived at `user_msg_count == 2` and the `> 1` guard returned early — meaning **no title was ever written** and `sessions.title` stayed `NULL`. The string users see in the sidebar is the UI falling back to rendering the first message.

That second point is why fixing only the prefix list is not enough: it would trade a wrong title for a permanently missing one. Both are fixed here.

The fix is deliberately narrow — ordinary user text that happens to start with `"[System:"` still titles normally.

## Related Issue

Fixes #82206

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/title_generator.py`
  - Added `"[System: The active model for this chat has changed to "` to `_MACHINE_PREFIXES`, with a comment tying it to `tui_gateway.server._MODEL_SWITCH_MARKER_PREFIX` so the two stay in sync.
  - `maybe_auto_title()` now counts only *titleable* user messages when detecting the opening turn, so a machine-authored opener can no longer push the first real question out of the titling window.
- `tests/agent/test_title_generator.py`
  - New `TestModelSwitchMarkerNotTitleable` class (6 tests): prefix/constant sync, marker not titleable, unrelated `[System:` text still titleable, real question after a marker still titles, instant-title path skips the marker and uses the real message, plus one test documenting that `derive_title` is intentionally unguarded (the check lives in its callers).

## How to Test

**Reproduce (before this patch):**

1. Start a new session.
2. Switch the model before sending anything, e.g. `/model custom:<provider>:<model>`.
3. Send a normal first question, e.g. `hourly weather forecast for <city>`.
4. Sidebar shows `[System: The active model for this chat has…`; `sessions.title` in `state.db` is `NULL`.

**Verify the fix:**

```bash
pytest tests/agent/test_title_generator.py -q          # 24 passed
pytest tests/tui_gateway/ tests/test_tui_gateway_server.py -q
```

Then repeat steps 1–3: the session is titled from the real question.

**The regression tests genuinely catch the bug.** Removing just the new `_MACHINE_PREFIXES` entry and re-running makes 4 of the 6 new tests fail:

```
FAILED test_marker_prefix_matches_gateway_constant
FAILED test_marker_is_not_titleable
FAILED test_real_question_after_marker_still_titles
FAILED test_instant_title_skips_marker_uses_real_message
```

## What platforms I tested on

macOS 26.6.1 (Apple Silicon), Python 3.11. The change is pure string/prefix logic with no OS-specific behavior, so Linux/WSL2 should be unaffected.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — see note below
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.1 (Apple Silicon), Python 3.11

> Note on the full suite: `tests/agent/test_title_generator.py` (24) and `tests/tui_gateway/` pass. In my local checkout two pre-existing failures remain in `test_tui_gateway_server.py` (`test_load_enabled_toolsets_rejects_disabled_mcp_env`, `test_load_enabled_toolsets_falls_back_when_tui_env_invalid`) — both read local config and expect the default toolset list, and my config enables an extra toolset. They are unrelated to titling and fail independently of this patch.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — inline comments explain the cross-module coupling; no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A, pure string logic
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Notes for reviewers

The coupling between `agent/title_generator.py` and `tui_gateway.server._MODEL_SWITCH_MARKER_PREFIX` is currently by convention: the prefix is duplicated as a literal because importing `tui_gateway.server` from the titling path would be a heavier dependency than this fix warrants. `test_marker_prefix_matches_gateway_constant` asserts the two agree, so drift fails the suite rather than silently regressing.

If you'd prefer a shared constant (e.g. hoisted into a small module both sides import), I'm happy to rework it that way.
