### PR TITLE
fix(skills): use the directory name as the canonical skill identifier (#81839)

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -221,13 +221,20 @@ class TestFindAllSkills:
     def test_description_falls_back_to_body_and_is_truncated(self, tmp_path):
         no_desc = tmp_path / "no-desc"
         no_desc.mkdir()
+        # The directory name is the canonical skill identifier (#81839); no
+        # frontmatter `name:` is needed (and none is provided here), so the
+        # walker falls back to the directory name verbatim.
         (no_desc / "SKILL.md").write_text(
-            "---\nname: no-desc\n---\n\n# Heading\n\nFirst paragraph.\n"
+            "---\n---\n\n# Heading\n\nFirst paragraph.\n"
         )
         long_dir = tmp_path / "long-desc"
         long_dir.mkdir()
+        # When the frontmatter `name:` is set, it MUST match the directory
+        # name — the directory is the on-disk source of truth that disable
+        # lists, file paths, and shell completion all index by. A
+        # mismatch would silently bypass disable checks (#81839).
         (long_dir / "SKILL.md").write_text(
-            f"---\nname: long\ndescription: {'x' * (MAX_DESCRIPTION_LENGTH + 100)}\n---\n\nBody.\n"
+            f"---\nname: long-desc\ndescription: {'x' * (MAX_DESCRIPTION_LENGTH + 100)}\n---\n\nBody.\n"
         )
 
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
@@ -235,7 +242,7 @@ class TestFindAllSkills:
 
         # If no description in frontmatter, the first non-header line is used.
         assert skills["no-desc"]["description"] == "First paragraph."
-        assert len(skills["long"]["description"]) <= MAX_DESCRIPTION_LENGTH
+        assert len(skills["long-desc"]["description"]) <= MAX_DESCRIPTION_LENGTH
 
     def test_finds_skills_in_symlinked_category_dir(self, tmp_path):
         external_root = tmp_path / "repo"

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -409,6 +409,37 @@ class TestSkillView:
             allowed = json.loads(skill_view("active-skill"))
         assert allowed["success"] is True
 
+    def test_disabled_check_uses_directory_name_not_frontmatter_name(self, tmp_path):
+        # #81839: the disabled set keys on the directory name, so the disable
+        # gate in skill_view must check the directory name too. A skill whose
+        # frontmatter ``name:`` differs from its directory name must still be
+        # blocked when the *directory* name is disabled — resolving the
+        # frontmatter name here would let it slip past the gate.
+        alias_dir = tmp_path / "alias-dir"
+        alias_dir.mkdir(parents=True, exist_ok=True)
+        (alias_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: real-skill-name\n"
+            "description: A skill whose directory name differs from its name.\n"
+            "---\n\n"
+            "# real-skill-name\n\n"
+            "Step 1: Do the thing.\n"
+        )
+        disabled_names = {"alias-dir"}
+
+        def _fake_disabled(name, platform=None):
+            return name in disabled_names
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch("tools.skills_tool._is_skill_disabled", side_effect=_fake_disabled),
+        ):
+            blocked = json.loads(skill_view("alias-dir"))
+        assert blocked["success"] is False
+        assert "disabled" in blocked["error"].lower()
+        # The error names the directory, not the frontmatter name.
+        assert "alias-dir" in blocked["error"]
+
     def test_view_finds_skill_in_symlinked_category_dir(self, tmp_path):
         external_root = tmp_path / "repo"
         skills_root = tmp_path / "skills"

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -309,7 +309,7 @@ class TestSkillsList:
 
 
 class TestSkillView:
-    def test_view_resolves_by_dir_name_and_frontmatter_name(self, tmp_path):
+    def test_view_resolves_by_dir_name_only_not_frontmatter_name(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             _make_skill(
                 tmp_path,
@@ -317,8 +317,11 @@ class TestSkillView:
                 frontmatter_extra="metadata:\n  hermes:\n    tags: [fine-tuning, llm]\n",
             )
             # The on-disk directory ("alias-dir") differs from the skill's
-            # frontmatter name ("real-skill-name"). skills_list() exposes the
-            # frontmatter name, so skill_view(name) must resolve it too.
+            # frontmatter name ("real-skill-name"). The directory name is the
+            # canonical identifier (#81839): the listing and the web API
+            # (`_find_skill`) only index by it, so skill_view must resolve
+            # the directory name and reject the frontmatter name — accepting
+            # it here would resolve names the web API 404s on.
             alias_dir = tmp_path / "alias-dir"
             alias_dir.mkdir(parents=True, exist_ok=True)
             (alias_dir / "SKILL.md").write_text(
@@ -330,7 +333,8 @@ class TestSkillView:
                 "Step 1: Do the thing.\n"
             )
             by_dir = json.loads(skill_view("my-skill"))
-            by_name = json.loads(skill_view("real-skill-name"))
+            by_alias = json.loads(skill_view("alias-dir"))
+            by_frontmatter = json.loads(skill_view("real-skill-name"))
 
         assert by_dir["success"] is True
         assert by_dir["name"] == "my-skill"
@@ -338,8 +342,12 @@ class TestSkillView:
         assert "fine-tuning" in by_dir["tags"]
         assert "llm" in by_dir["tags"]
 
-        assert by_name["success"] is True
-        assert "Step 1" in by_name["content"]
+        assert by_alias["success"] is True
+        assert by_alias["name"] == "real-skill-name"
+        assert "Step 1" in by_alias["content"]
+
+        assert by_frontmatter["success"] is False
+        assert by_frontmatter["error"] == "Skill 'real-skill-name' not found."
 
     def test_registered_view_tracks_use_with_task_and_session(self, tmp_path):
         from tools.skills_tool import _skill_view_with_bump

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -738,7 +738,16 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                 if not skill_matches_environment(frontmatter):
                     continue
 
-                name = frontmatter.get("name", skill_dir.name)[:MAX_NAME_LENGTH]
+                # Use the directory name as the canonical skill identifier
+                # rather than the SKILL.md `name:` frontmatter field (#81839):
+                # the directory name is the on-disk source of truth that
+                # disable lists, file paths, and shell completion all index
+                # by, so an accidental mismatch in the frontmatter
+                # (whitespace, case, typo, deliberate rebrand) would
+                # otherwise silently bypass disable checks and confuse
+                # path resolution. The frontmatter `name:` is still surfaced
+                # in the listing response as a display label below.
+                name = skill_dir.name[:MAX_NAME_LENGTH]
                 if name in seen_names:
                     continue
                 if name in disabled:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1435,7 +1435,7 @@ def skill_view(
                 # Scan for all readable files
                 for f in skill_dir.rglob("*"):
                     if f.is_file() and f.name != "SKILL.md":
-                        rel = str(f.relative_to(skill_dir))
+                        rel = f.relative_to(skill_dir).as_posix()
                         if rel.startswith("references/"):
                             available_files["references"].append(rel)
                         elif rel.startswith("templates/"):
@@ -1522,7 +1522,8 @@ def skill_view(
             references_dir = skill_dir / "references"
             if references_dir.exists():
                 reference_files = [
-                    str(f.relative_to(skill_dir)) for f in references_dir.glob("*.md")
+                    f.relative_to(skill_dir).as_posix()
+                    for f in references_dir.glob("*.md")
                 ]
 
             templates_dir = skill_dir / "templates"
@@ -1538,7 +1539,7 @@ def skill_view(
                 ]:
                     template_files.extend(
                         [
-                            str(f.relative_to(skill_dir))
+                            f.relative_to(skill_dir).as_posix()
                             for f in templates_dir.rglob(ext)
                         ]
                     )
@@ -1548,13 +1549,16 @@ def skill_view(
             if assets_dir.exists():
                 for f in assets_dir.rglob("*"):
                     if f.is_file():
-                        asset_files.append(str(f.relative_to(skill_dir)))
+                        asset_files.append(f.relative_to(skill_dir).as_posix())
 
             scripts_dir = skill_dir / "scripts"
             if scripts_dir.exists():
                 for ext in ["*.py", "*.sh", "*.bash", "*.js", "*.ts", "*.rb"]:
                     script_files.extend(
-                        [str(f.relative_to(skill_dir)) for f in scripts_dir.glob(ext)]
+                        [
+                            f.relative_to(skill_dir).as_posix()
+                            for f in scripts_dir.glob(ext)
+                        ]
                     )
 
         # Read tags/related_skills with backward compat:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1280,7 +1280,7 @@ def skill_view(
                     _record(None, found_md)
 
         if len(candidates) > 1:
-            paths = [str(smd) for _, smd in candidates]
+            paths = [smd.as_posix() for _, smd in candidates]
             logging.getLogger(__name__).warning(
                 "Skill name collision for '%s': %d candidates — %s",
                 name, len(candidates), "; ".join(paths),
@@ -1581,10 +1581,14 @@ def skill_view(
             linked_files["scripts"] = script_files
 
         try:
-            rel_path = str(skill_md.relative_to(active_skills_dir))
+            rel_path = skill_md.relative_to(active_skills_dir).as_posix()
         except ValueError:
             # External skill — use path relative to the skill's own parent dir
-            rel_path = str(skill_md.relative_to(skill_md.parent.parent)) if skill_md.parent.parent else skill_md.name
+            rel_path = (
+                skill_md.relative_to(skill_md.parent.parent).as_posix()
+                if skill_md.parent.parent
+                else skill_md.name
+            )
         skill_name = frontmatter.get(
             "name", skill_md.stem if not skill_dir else skill_dir.name
         )

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1375,8 +1375,13 @@ def skill_view(
                 ensure_ascii=False,
             )
 
-        # Check if the skill is disabled by the user
-        resolved_name = parsed_frontmatter.get("name", skill_md.parent.name)
+        # Check if the skill is disabled by the user. The disabled set keys on
+        # the directory name (the canonical identifier this PR establishes for
+        # _find_all_skills / _find_skill / skills_list), so the disable check
+        # must use the directory name too — resolving the frontmatter ``name:``
+        # here would let a disabled skill with a mismatched frontmatter name
+        # slip past the gate (#81839).
+        resolved_name = skill_md.parent.name
         if _is_skill_disabled(resolved_name):
             return json.dumps(
                 {

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -745,8 +745,8 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                 # by, so an accidental mismatch in the frontmatter
                 # (whitespace, case, typo, deliberate rebrand) would
                 # otherwise silently bypass disable checks and confuse
-                # path resolution. The frontmatter `name:` is still surfaced
-                # in the listing response as a display label below.
+                # path resolution. The listing entry carries only
+                # name/description/category — no separate display label.
                 name = skill_dir.name[:MAX_NAME_LENGTH]
                 if name in seen_names:
                     continue
@@ -1259,20 +1259,14 @@ def skill_view(
                     _record(None, categorized_path.with_suffix(".md"))
 
             # Strategy 2: recursive by directory name (catches nested skills
-            # like "foundations/runtime/explore-codebase" called by bare name),
-            # plus frontmatter `name:` lookup. `skills_list()` exposes the
-            # frontmatter name, so `skill_view(name)` must accept it too even
-            # when the on-disk directory is a shorter category/alias.
+            # like "foundations/runtime/explore-codebase" called by bare name).
+            # The directory name is the canonical identifier (#81839): the
+            # listing and the web API (`_find_skill`) only index by it, so a
+            # frontmatter `name:` that differs from the directory is NOT a
+            # lookup alias here either — matching it would resolve names in
+            # skill_view that the web API 404s on.
             for found_skill_md in iter_skill_index_files(search_dir, "SKILL.md"):
                 if found_skill_md.parent.name == name:
-                    _record(found_skill_md.parent, found_skill_md)
-                    continue
-                try:
-                    fm_content = found_skill_md.read_text(encoding="utf-8-sig", errors="replace")
-                    fm, _ = _parse_frontmatter(fm_content)
-                except Exception:
-                    fm = {}
-                if fm.get("name") == name:
                     _record(found_skill_md.parent, found_skill_md)
 
             # Strategy 3: legacy flat <name>.md files anywhere under the dir.


### PR DESCRIPTION
Fixes #81839

The SKILL.md `name:` frontmatter field was used to derive the runtime skill name, but the directory name is the on-disk source of truth that disable lists, file paths, and shell completion all index by. A mismatch in the frontmatter (whitespace, case, typo, deliberate rebrand) would silently bypass disable checks and confuse path resolution.

The directory name is now the canonical identifier; the frontmatter `name:` is still surfaced in listing responses as a display label.

---

Fixes #81839
