### PR TITLE
fix(desktop): always render the fork button so it doesn't intermittently disappear (#81846)

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.test.tsx
@@ -78,7 +78,7 @@ describe('AssistantMessage branch button visibility (bug #2 fix)', () => {
 
     const button = await screen.findByRole('button', { name: 'Branch in new chat' })
     expect(button).toBeTruthy()
-    expect(button).not.toHaveAttribute('disabled')
+    expect(button.getAttribute('disabled')).toBeNull()
   })
 
   it('keeps the Branch in new chat button mounted but disabled when no handler is provided (#81846)', async () => {
@@ -90,6 +90,6 @@ describe('AssistantMessage branch button visibility (bug #2 fix)', () => {
     render(<Harness />)
 
     const button = await screen.findByRole('button', { name: 'Branch in new chat' })
-    expect(button).toHaveAttribute('disabled')
+    expect(button.getAttribute('disabled')).not.toBeNull()
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.test.tsx
@@ -78,7 +78,7 @@ describe('AssistantMessage branch button visibility (bug #2 fix)', () => {
 
     const button = await screen.findByRole('button', { name: 'Branch in new chat' })
     expect(button).toBeTruthy()
-    expect(button).not.toBeDisabled()
+    expect(button).not.toHaveAttribute('disabled')
   })
 
   it('keeps the Branch in new chat button mounted but disabled when no handler is provided (#81846)', async () => {
@@ -90,6 +90,6 @@ describe('AssistantMessage branch button visibility (bug #2 fix)', () => {
     render(<Harness />)
 
     const button = await screen.findByRole('button', { name: 'Branch in new chat' })
-    expect(button).toBeDisabled()
+    expect(button).toHaveAttribute('disabled')
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.test.tsx
@@ -73,20 +73,23 @@ function Harness({ onBranchInNewChat }: { onBranchInNewChat?: (messageId: string
 }
 
 describe('AssistantMessage branch button visibility (bug #2 fix)', () => {
-  it('shows the Branch in new chat button when a handler is provided (open chat)', async () => {
+  it('shows the Branch in new chat button enabled when a handler is provided (open chat)', async () => {
     render(<Harness onBranchInNewChat={() => undefined} />)
 
-    expect(await screen.findByRole('button', { name: 'Branch in new chat' })).toBeTruthy()
+    const button = await screen.findByRole('button', { name: 'Branch in new chat' })
+    expect(button).toBeTruthy()
+    expect(button).not.toBeDisabled()
   })
 
-  it('hides the Branch in new chat button when no handler is provided (session-tile / branched chat)', async () => {
+  it('keeps the Branch in new chat button mounted but disabled when no handler is provided (#81846)', async () => {
+    // The button is no longer unmounted when the callback is absent
+    // (which used to leave its layout slot missing until the next mount
+    // round-tripped through `useState` / `useRef` — "intermittently
+    // missing" repro). The affordance stays visible as disabled so the
+    // user always knows the action exists, and the click is a no-op.
     render(<Harness />)
 
-    // Wait for the assistant message to actually mount before asserting
-    // absence, so a missing button isn't just a false negative from an
-    // unrendered message.
-    await screen.findByText('done')
-
-    expect(screen.queryByRole('button', { name: 'Branch in new chat' })).toBeNull()
+    const button = await screen.findByRole('button', { name: 'Branch in new chat' })
+    expect(button).toBeDisabled()
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -199,17 +199,27 @@ const AssistantActionBar: FC<MessageActionProps> = ({ messageId, getMessageText,
         data-slot="aui_msg-actions"
       >
         <MessageAge />
-        {onBranchInNewChat && (
-          <TooltipIconButton
-            onClick={() => {
-              triggerHaptic('selection')
-              onBranchInNewChat(messageId)
-            }}
-            tooltip={copy.branchNewChat}
-          >
-            <GitForkIcon className="size-3.5" />
-          </TooltipIconButton>
-        )}
+        {/* Always render the fork button so its layout slot stays stable
+            across re-renders; the earlier `&& onBranchInNewChat` guard
+            unmounted the button entirely when the callback reference
+            briefly nulled out (e.g. during a session-key switch), and the
+            next mount had to re-run `useState` / `useRef` initialization
+            before the user could click it (#81846). The button is now
+            disabled — not hidden — when the callback is absent, so the
+            affordance never disappears and the click is a no-op. */}
+        <TooltipIconButton
+          disabled={!onBranchInNewChat}
+          onClick={() => {
+            if (!onBranchInNewChat) {
+              return
+            }
+            triggerHaptic('selection')
+            onBranchInNewChat(messageId)
+          }}
+          tooltip={copy.branchNewChat}
+        >
+          <GitForkIcon className="size-3.5" />
+        </TooltipIconButton>
         <CopyButton appearance="icon" buttonSize="icon" label={copy.copy} text={getMessageText} />
         <ReadAloudButton getText={getMessageText} messageId={messageId} />
         <ActionBarPrimitive.Reload asChild>


### PR DESCRIPTION
The AssistantMessage action bar unmounted the Branch-in-new-chat button whenever the `onBranchInNewChat` prop was undefined. During a session-key switch the parent briefly nulled the callback, the fork button unmounted, and the next mount round-tripped through `useState` / `useRef` initialization before the user could click it again.

Always render the button and `disabled={!onBranchInNewChat}` it when the callback is absent, so the affordance never disappears and the click is a no-op. The 'hidden when no handler' test is replaced with a 'disabled when no handler' test, and a fresh branch-button-enabled test pins the open-chat affordance.

---

Fixes #81846