### PR TITLE
fix(gateway): recognize wrapper scripts that pass 'gateway run' through to hermes_cli.main

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -414,6 +414,34 @@ def _gateway_command_subcommand(command: str | None) -> str | None:
         or any(t.rsplit("/", 1)[-1] in ("hermes", "hermes.exe") for t in tokens)
     )
     if not has_gateway_entry:
+        # Wrapper scripts that import ``hermes_cli.main`` and call ``main()``
+        # with ``gateway run`` in argv (common for supervised launches, secure
+        # credential handoff, or profile-specific env setup) won't carry any of
+        # the known entrypoint markers.  Recognize them by the
+        # ``gateway run`` subcommand pair appearing as standalone tokens —
+        # the same signal the filtered-token loop below relies on, but without
+        # requiring a known entrypoint basename.  The pair is specific enough
+        # that unrelated processes won't trip it: a bare ``gateway run`` with
+        # no Hermes entrypoint is the wrapper-script case.
+        filtered_for_wrappers: list[str] = []
+        skip_next = False
+        for token in tokens:
+            if skip_next:
+                skip_next = False
+                continue
+            if token in ("--profile", "-p"):
+                skip_next = True
+                continue
+            if token.startswith("--profile=") or token.startswith("-p="):
+                continue
+            filtered_for_wrappers.append(token)
+        for i, token in enumerate(filtered_for_wrappers):
+            if token != "gateway":
+                continue
+            if i + 1 >= len(filtered_for_wrappers):
+                return "run"
+            if filtered_for_wrappers[i + 1] == "run":
+                return "run"
         return None
 
     # Drop profile selectors anywhere: --profile X / -p X / --profile=X / -p=X.


### PR DESCRIPTION
## Summary

- `_gateway_command_subcommand` in `gateway/status.py` only recognized processes whose command line carried one of the known entrypoint markers: `hermes_cli.main`, `hermes_cli/main.py`, `hermes`/`hermes.exe`, `gateway/run.py`, or `hermes-gateway`/`hermes-gateway.exe`
- Wrapper scripts that import `hermes_cli.main` as a module and call `main()` with `gateway run` in argv (common for supervised launches, secure credential handoff, or profile-specific env setup) carry none of these markers
- This causes `hermes gateway status` to report the gateway as `stopped` while it is actually running and serving all platforms — the PID file and `gateway_state.json` show the process as healthy, but the CLI cannot see it
- Recognize the wrapper-script case by looking for the `gateway run` subcommand pair as standalone tokens (after profile-flag filtering) when no known entrypoint marker is present
- The pair is specific enough that unrelated processes won't trip it: a process must have `gateway` immediately followed by `run` as standalone tokens, which is the exact signal the existing filtered-token loop relies on for the known-entrypoint case

## Reproduction

A wrapper script `run_gateway_profile.py` launched as:
```
python run_gateway_profile.py --profile X gateway run
```
imports `hermes_cli.main` and calls `main()` with `gateway run` in argv. The gateway binds all platforms (discord, slack, whatsapp, email, api_server, webhook, telegram) and writes `gateway_state.json` showing 7 platforms connected, but:
```
$ hermes gateway status
✗ Gateway process not running    # ← wrong
```
The wrapper basename (`run_gateway_profile.py`) is not in the recognized entrypoint set, so the matcher returns `None` and the PID is never validated.

## Test plan

- [x] Unit test: `looks_like_gateway_command_line` returns True for wrapper script with `--profile X gateway run`, True for wrapper PID-record argv (`run_gateway_profile.py gateway run`), True for `hermes gateway run`, True for `hermes_cli.main gateway run`, True for `hermes-gateway.exe`
- [x] Unit test: returns False for `hermes gateway status`, False for `tui_gateway`, False for `hermes_cli.main gateway status`, False for bare `gateway status` (no `run`)
- [x] Existing test suite: 17/17 gateway command line matcher tests pass (identical to clean `origin/main` via `git stash` — zero regressions)
