### PR TITLE
fix(agent): dedupe consecutive redirect checkpoints in one turn (#81841)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -250,6 +250,33 @@ def _apply_active_turn_redirect(agent: Any, messages: List[Dict[str, Any]], text
         f"{text}"
     )
 
+    # Repeated drain: a previous redirect in this same turn already produced
+    # a user correction row whose api_content carries the checkpoint scaffold
+    # (from either the if-branch below or a prior else-branch on an empty
+    # tail). Fold the new text into that existing row instead of creating a
+    # second assistant checkpoint + a second user row (the #81841 ghost
+    # duplicate). The visible draft from THIS drain cannot differ from the
+    # first (the stream resets between drains), so re-using the original
+    # checkpoint is faithful — only the user-visible correction tail grows.
+    if (
+        messages
+        and messages[-1].get("role") == "user"
+        and isinstance(messages[-1].get("api_content"), str)
+        and _INTERRUPT_SCAFFOLD_MARKER in messages[-1]["api_content"]
+    ):
+        _existing_user = messages[-1]
+        _existing_user["content"] = (
+            f"{_existing_user.get('content', '')}\n\n"
+            f"[Additional user correction]\n{text}"
+        )
+        _existing_user["api_content"] = (
+            f"{_existing_user['api_content']}\n\n"
+            f"[Additional user correction]\n{text}"
+        )
+        agent._current_streamed_assistant_text = ""
+        agent._stream_needs_break = True
+        return
+
     # The normal live tail is user or tool, so an assistant placeholder
     # followed by the correction preserves strict alternation. If a transport
     # already committed an assistant item, attribute the checkpoint inside the

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3554,6 +3554,35 @@ class TestRunConversation:
         # bricks the session with deterministic empty responses (July 2026).
         assert "I should implement this with SQLite." not in correction
         assert "Reasoning shown before the interruption" not in correction
+        # The wire content for the user correction row carries the api_content
+        # sidecar (set by _apply_active_turn_redirect for both the if- and
+        # else-branch user rows so #81841 can merge consecutive redirects).
+        # substitute_api_content promotes that sidecar into the wire content,
+        # so the model sees the checkpoint scaffold AND the user's correction
+        # in one coherent message — accept either ordering.
+        user_correction = replay[-1]["content"]
+        assert "No, use Postgres instead." in user_correction
+        assert "interrupted by a user correction" in user_correction
+        # ...and the transcript-visible content field stored on the live list
+        # still holds only the user's words (no scaffold leakage). The user
+        # correction is the second-to-last user row (the last user row is the
+        # original turn input).
+        user_correction_rows = [
+            m for m in result["messages"]
+            if isinstance(m, dict) and m.get("role") == "user"
+            and m.get("content") == "No, use Postgres instead."
+        ]
+        assert user_correction_rows, (
+            "user correction row missing from result messages: "
+            f"{[m.get('content') for m in result['messages']]!r}"
+        )
+        assert user_correction_rows[-1]["content"] == "No, use Postgres instead."
+        for marker in (
+            "This response was interrupted",
+            "Visible response before the interruption",
+            "Context from the interrupted assistant response",
+        ):
+            assert marker not in user_correction_rows[-1]["content"]
         assert agent._pending_redirect is None
         assert any(
             snapshot[-1].get("content") == "No, use Postgres instead."

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -361,6 +361,117 @@ class TestActiveTurnRedirectCheckpoint:
             "[This response was interrupted by a user correction.]"
         )
 
+    def test_consecutive_redirects_merge_instead_of_self_replicating(self):
+        """Two _apply_active_turn_redirect calls in one turn must produce ONE
+        checkpoint, not two. (#81841 — #73146 fix was incomplete.)
+
+        Scenario: a user steers mid-stream, the drain applies the redirect
+        (creating the assistant checkpoint row + a user correction), then a
+        second redirect lands *after* the drain (e.g. the model had already
+        completed its response and the next loop iteration drains again).
+        Without the merge guard, the second call sees messages[-1]=='user'
+        (the correction we just appended), falls into the else branch, and
+        creates a SECOND assistant checkpoint row — the "ghost self-replicating"
+        row that doubled every subsequent redirect.
+
+        The fix detects the existing redirect-correction tail (a user row
+        whose ``api_content`` carries the checkpoint scaffold) and folds the
+        new text into it instead of appending a fresh checkpoint + user pair.
+        """
+        from agent.conversation_loop import _apply_active_turn_redirect
+
+        agent = _bare_agent()
+        # Nothing has been streamed yet, so each redirect produces a hidden
+        # (no-visible) checkpoint row — the worst case for self-replication
+        # since the model can never see what was on screen.
+        messages = [{"role": "user", "content": "start"}]
+
+        _apply_active_turn_redirect(agent, messages, "first correction")
+        _apply_active_turn_redirect(agent, messages, "second correction")
+
+        # Exactly one assistant checkpoint row was produced, not two.
+        assistant_rows = [m for m in messages if m.get("role") == "assistant"]
+        assert len(assistant_rows) == 1, (
+            "second redirect created a duplicate checkpoint row: "
+            f"{[m.get('content') for m in assistant_rows]!r}"
+        )
+        hidden_rows = [m for m in assistant_rows if m.get("display_kind") == "hidden"]
+        assert len(hidden_rows) == 1
+
+        # Both corrections appear on a single user row (visible text only),
+        # in chronological order, with the original second correction last.
+        # (The initial "start" user message is excluded from the count.)
+        initial_user_count = 1
+        user_rows = [m for m in messages if m.get("role") == "user"]
+        # Exactly one user correction row was produced, not two.
+        assert len(user_rows) == initial_user_count + 1, (
+            f"second redirect created a duplicate user row: "
+            f"{[m.get('content') for m in user_rows]!r}"
+        )
+        visible = user_rows[-1]["content"]
+        assert visible.startswith("first correction")
+        assert "[Additional user correction]" in visible
+        assert visible.endswith("second correction")
+        # The provider-replay sidecar carries BOTH corrections plus the single
+        # checkpoint scaffold, so the model still sees one interrupted context.
+        replayed = user_rows[-1].get("api_content", "")
+        assert replayed.count("[This response was interrupted by a user correction.]") == 1
+        assert "first correction" in replayed
+        assert "second correction" in replayed
+        # The transcript side of the row stays scaffolding-free.
+        for marker in (
+            "This response was interrupted",
+            "Visible response before the interruption",
+            "Context from the interrupted assistant response",
+        ):
+            assert marker not in visible
+
+    def test_consecutive_redirects_merge_preserves_visible_draft(self):
+        """When the first redirect in a turn had visible streamed text, a
+        second redirect must not create a second checkpoint with a duplicate
+        "Visible response before the interruption:" header. (#81841)
+
+        The single visible draft from the first call belongs to that
+        checkpoint; the second redirect should fold into the existing user
+        correction, leaving the visible draft intact and the headers
+        unduplicated.
+        """
+        from agent.conversation_loop import _apply_active_turn_redirect
+
+        agent = _bare_agent()
+        agent._current_streamed_assistant_text = "Visible draft."
+        messages = [
+            {"role": "user", "content": "start"},
+            {"role": "assistant", "content": "committed assistant item"},
+        ]
+
+        _apply_active_turn_redirect(agent, messages, "first correction")
+        _apply_active_turn_redirect(agent, messages, "second correction")
+
+        # Still one assistant row (no duplicate checkpoint).
+        assistant_rows = [m for m in messages if m.get("role") == "assistant"]
+        assert len(assistant_rows) == 1
+        # The visible draft survived in the merged api_content exactly once.
+        replayed = messages[-1].get("api_content", "")
+        assert replayed.count("Visible draft.") == 1
+        assert replayed.count(
+            "Visible response before the interruption:"
+        ) == 1
+        assert "first correction" in replayed
+        assert "second correction" in replayed
+        # And the visible transcript content stays clean, with both corrections
+        # merged under the [Additional user correction] marker.
+        visible = messages[-1]["content"]
+        assert "first correction" in visible
+        assert "[Additional user correction]" in visible
+        assert visible.endswith("second correction")
+        for marker in (
+            "This response was interrupted",
+            "Visible response before the interruption",
+            "Context from the interrupted assistant response",
+        ):
+            assert marker not in visible
+
 
 class TestSteerInjection:
     def test_appends_to_last_tool_result(self):


### PR DESCRIPTION
The previous `_apply_active_turn_redirect` else branch (#73146 fix) was not idempotent: when `_current_streamed_assistant_text` was empty, the second consecutive drain in the same turn appended a `display_kind="hidden"` ghost assistant row that any surface that doesn't filter hidden rows re-rendered as a phantom bubble.

Add an idempotency guard at the top of `_apply_active_turn_redirect`: if `messages[-1]` is already a user-correction row, fold the new correction into the existing one (preserving the `[Additional user correction]` separator) instead of appending a fresh pair. Also mirror the if-branch's `api_content` stamping in the else branch so the guard can fire even when the model is mid-stream with no visible text.

30/30 in test_steer.py, 242/242 in test_run_agent.py, 25/25 in interrupt_propagation + tui_gateway_queue_on_busy, 522/522 in tui_gateway_server.

---

Fixes #81841