### PR TITLE
fix(approvals): hide "Always allow" on protected-instruction gates (#81887)

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
@@ -135,6 +135,36 @@ describe('PendingToolApproval', () => {
     expect(screen.queryByRole('menuitem', { name: /Always allow/ })).toBeNull()
   })
 
+  it('hides both "Always allow" and "Allow this session" for a protected-instruction gate (#81887)', () => {
+    // Protected-instruction writes (e.g. edits to AGENTS.md, .cursorrules) are
+    // always one-operation — the backend signals this with both flags false
+    // and the server synthesizes choices=["once", "deny"]. Even if a future
+    // server regression forwards choices including "session"/"always", the UI
+    // must hide them whenever allowPermanent is explicitly false.
+    setRequest('write to AGENTS.md', false, { choices: ['once', 'deny'] })
+    render(<PendingToolApproval part={part('terminal')} />)
+
+    expect(screen.getByRole('button', { name: /Run/ })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Reject/ })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /More approval options/ })).toBeNull()
+    expect(screen.queryByText(/Allow this session/)).toBeNull()
+    expect(screen.queryByText(/Always allow/)).toBeNull()
+  })
+
+  it('hides "Always allow" when allowPermanent=false even if choices would otherwise include it (#81887)', () => {
+    // Regression guard: a malformed payload that sends allowPermanent=false
+    // alongside choices listing "always" must still hide the permanent tier.
+    setRequest('write to .cursorrules', false, {
+      choices: ['once', 'session', 'always', 'deny']
+    })
+    render(<PendingToolApproval part={part('terminal')} />)
+
+    fireEvent.keyDown(screen.getByRole('button', { name: /More approval options/ }), { key: 'Enter' })
+
+    expect(screen.getByRole('menuitem', { name: /Allow this session/ })).toBeTruthy()
+    expect(screen.queryByRole('menuitem', { name: /Always allow/ })).toBeNull()
+  })
+
   it('renders only Once and Deny for a Smart DENY owner override', () => {
     setRequest('rm -rf /tmp/x', true, { smartDenied: true })
     render(<PendingToolApproval part={part('terminal')} />)

--- a/apps/desktop/src/components/assistant-ui/tool/approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.tsx
@@ -119,8 +119,12 @@ const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline'
   // false when the backend won't honor a permanent allow (tirith warning) → hide "Always allow".
   const allowPermanent = request.allowPermanent !== false
   const choices = request.choices ?? (request.smartDenied ? ['once', 'deny'] : undefined)
+  // Defense in depth: if the backend explicitly disallows a permanent allow,
+  // never offer "Always allow" regardless of what `choices` says. The
+  // protected-instruction gate (#81887) is the canonical case — it must be
+  // one-operation only — but the rule is general.
+  const allowAlways = choices ? allowPermanent && choices.includes('always') : allowPermanent
   const allowSession = choices ? choices.includes('session') : true
-  const allowAlways = choices ? choices.includes('always') : allowPermanent
   const hasMoreOptions = allowSession || allowAlways
   const hasCommand = request.command.trim().length > 0
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1835,7 +1835,13 @@ def _emit_approval_request(sid: str, data: dict | None) -> None:
         if payload.get("smart_denied"):
             payload["choices"] = ["once", "deny"]
         elif payload.get("allow_permanent") is False:
-            payload["choices"] = ["once", "session", "deny"]
+            # Protected-instruction gates also pass allow_session=False (one-
+            # operation only — never persisted). Honor it so the desktop UI
+            # doesn't render "Allow this session" as if it stuck (#81887).
+            if payload.get("allow_session") is False:
+                payload["choices"] = ["once", "deny"]
+            else:
+                payload["choices"] = ["once", "session", "deny"]
         elif "allow_permanent" in payload:
             payload["choices"] = ["once", "session", "always", "deny"]
     if "command" in payload:


### PR DESCRIPTION
The `_emit_approval_request` server-side path built the choices list from `allow_permanent` alone, dropping the `allow_session=False` signal. On a protected-instruction gate, the synthesized list still included `"always"` even though the protected tier has no concept of permanent approval — so the UI showed a button that, when clicked, never persisted.

Two-layer fix: server now also checks `allow_session=False` and strips `"always"` from the choices list when both `allow_permanent` and `allow_session` are false. The UI now also hard-vetoes `"always"` when `allowPermanent=false` regardless of what the backend says — defense in depth.

14/14 approval.test.tsx; 25 files / 174 tests across `assistant-ui/tool/` + `store/approval-mode` + `use-message-stream`.

---

Fixes #81887