### PR TITLE
fix(mcp): fail-fast in-flight tool calls when stdio subprocess dies (#81995)

### DIFF
--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -708,3 +708,217 @@ class TestMCPLoopDrainOnStop:
             "Timed out waiting for MCP loop drain" in record.getMessage()
             for record in caplog.records
         )
+
+
+# ---------------------------------------------------------------------------
+# Fix 4: stdio subprocess death fail-fast for in-flight tool calls (#81995)
+# ---------------------------------------------------------------------------
+#
+# When the MCP supervisor restarts a stdio server while a tool call is in
+# flight, the SDK's read stream EOFs but ``call_tool`` can sit waiting on the
+# read queue until ``tool_timeout`` (default 300s) elapses. The watchdog in
+# ``_watch_stdio_subprocess`` polls the tracked stdio subprocess PIDs and
+# cancels the in-flight call with ``MCPStdioSubprocessDeadError`` so the
+# caller falls through to the supervisor-reconnect path immediately.
+
+
+class TestStdioSubprocessDeadFailFast:
+    """In-flight MCP stdio tool calls fail-fast when the subprocess dies."""
+
+    def _reset_stdio_pids(self):
+        from tools.mcp_tool import _stdio_pids, _lock
+        with _lock:
+            _stdio_pids.clear()
+
+    def test_stdio_subprocess_dead_returns_none_when_untracked(self):
+        """No tracked PIDs → unknown (do not fail-fast on this signal)."""
+        from tools.mcp_tool import _stdio_subprocess_dead
+        self._reset_stdio_pids()
+        assert _stdio_subprocess_dead("nonexistent-server") is None
+
+    def test_stdio_subprocess_dead_returns_false_when_alive(self):
+        """Tracked PID alive → False (keep waiting on the call_tool)."""
+        from tools.mcp_tool import (
+            _stdio_pids, _lock, _stdio_subprocess_dead,
+        )
+        self._reset_stdio_pids()
+        # Use this process's PID — guaranteed alive for the test's duration.
+        own_pid = os.getpid()
+        with _lock:
+            _stdio_pids[own_pid] = "alive-server"
+        try:
+            assert _stdio_subprocess_dead("alive-server") is False
+        finally:
+            with _lock:
+                _stdio_pids.pop(own_pid, None)
+
+    def test_stdio_subprocess_dead_returns_true_when_all_exited(self):
+        """All tracked PIDs exited → True (fail-fast the in-flight call)."""
+        from tools.mcp_tool import (
+            _stdio_pids, _lock, _stdio_subprocess_dead,
+        )
+        self._reset_stdio_pids()
+        # PIDs that no longer exist — _pid_exists returns False for them.
+        fake_dead_pids = [999999991, 999999992, 999999993]
+        with _lock:
+            for pid in fake_dead_pids:
+                _stdio_pids[pid] = "dead-server"
+        try:
+            assert _stdio_subprocess_dead("dead-server") is True
+        finally:
+            with _lock:
+                for pid in fake_dead_pids:
+                    _stdio_pids.pop(pid, None)
+
+    def test_stdio_subprocess_dead_mixed_pids(self):
+        """Tracked PIDs split alive/dead → False (subprocess still alive)."""
+        from tools.mcp_tool import (
+            _stdio_pids, _lock, _stdio_subprocess_dead,
+        )
+        self._reset_stdio_pids()
+        own_pid = os.getpid()
+        fake_dead_pid = 999999994
+        with _lock:
+            _stdio_pids[own_pid] = "mixed-server"
+            _stdio_pids[fake_dead_pid] = "mixed-server"
+        try:
+            assert _stdio_subprocess_dead("mixed-server") is False
+        finally:
+            with _lock:
+                _stdio_pids.pop(own_pid, None)
+                _stdio_pids.pop(fake_dead_pid, None)
+
+    def test_watch_stdio_subprocess_cancels_call_on_death(self):
+        """Watchdog cancels the in-flight call_tool when the subprocess dies."""
+        import asyncio
+        from tools.mcp_tool import (
+            _stdio_pids, _lock, _watch_stdio_subprocess,
+            MCPStdioSubprocessDeadError,
+            _STDIO_FAILFAST_POLL_INTERVAL_S,
+        )
+
+        self._reset_stdio_pids()
+        # Seed a tracked PID that has already exited → fails-fast on the
+        # first poll (no waiting on a real subprocess).
+        fake_dead_pid = 999999995
+        with _lock:
+            _stdio_pids[fake_dead_pid] = "watch-server"
+
+        # call_task that simulates the SDK's hanging call_tool. Awaiting
+        # the cancelled future surfaces ``asyncio.CancelledError``; the
+        # watchdog raises the fail-fast error before the call can return.
+        cancelled = asyncio.Event()
+
+        async def _hangs_forever():
+            try:
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+        async def _run():
+            call_task = asyncio.ensure_future(_hangs_forever())
+            watchdog_task = asyncio.ensure_future(
+                _watch_stdio_subprocess("watch-server", call_task)
+            )
+            try:
+                with pytest.raises(MCPStdioSubprocessDeadError):
+                    await watchdog_task
+            finally:
+                if not call_task.done():
+                    call_task.cancel()
+                assert cancelled.is_set(), (
+                    "watchdog did not cancel the in-flight call_tool future"
+                )
+
+        try:
+            asyncio.run(_run())
+        finally:
+            with _lock:
+                _stdio_pids.pop(fake_dead_pid, None)
+
+    def test_watch_stdio_subprocess_exits_cleanly_on_call_success(self):
+        """Watchdog exits when call_tool completes before subprocess dies."""
+        import asyncio
+        from tools.mcp_tool import (
+            _stdio_pids, _lock, _watch_stdio_subprocess,
+            _STDIO_FAILFAST_POLL_INTERVAL_S,
+        )
+
+        self._reset_stdio_pids()
+        # Track this process — alive for the whole test.
+        own_pid = os.getpid()
+        with _lock:
+            _stdio_pids[own_pid] = "healthy-server"
+
+        async def _quick_call():
+            await asyncio.sleep(0.01)
+            return "ok"
+
+        async def _run():
+            call_task = asyncio.ensure_future(_quick_call())
+            watchdog_task = asyncio.ensure_future(
+                _watch_stdio_subprocess("healthy-server", call_task)
+            )
+            try:
+                result = await call_task
+                assert result == "ok"
+                # Watchdog should notice call_task is done and return on
+                # the next poll cycle. Give it up to 3 poll intervals.
+                await asyncio.wait_for(
+                    watchdog_task,
+                    timeout=_STDIO_FAILFAST_POLL_INTERVAL_S * 5 + 1.0,
+                )
+            finally:
+                if not watchdog_task.done():
+                    watchdog_task.cancel()
+                    try:
+                        await watchdog_task
+                    except (asyncio.CancelledError, Exception):
+                        pass
+
+        try:
+            asyncio.run(_run())
+        finally:
+            with _lock:
+                _stdio_pids.pop(own_pid, None)
+
+    def test_watch_stdio_subprocess_noop_for_untracked_server(self):
+        """Watchdog sleeps until cancelled when no PIDs are tracked.
+
+        HTTP transports have no tracked stdio PIDs; ``_stdio_subprocess_dead``
+        returns ``None`` and the watchdog must not fire a false-positive
+        fail-fast on them — just sleep until the call finishes (#81995).
+        """
+        import asyncio
+        from tools.mcp_tool import (
+            _stdio_pids, _lock, _watch_stdio_subprocess,
+        )
+
+        self._reset_stdio_pids()
+
+        async def _quick_call():
+            await asyncio.sleep(0.05)
+            return "ok"
+
+        async def _run():
+            call_task = asyncio.ensure_future(_quick_call())
+            watchdog_task = asyncio.ensure_future(
+                _watch_stdio_subprocess("http-server-no-pids", call_task)
+            )
+            try:
+                result = await call_task
+                assert result == "ok"
+                # Watchdog never observed a dead subprocess; cancel it
+                # explicitly and confirm no exception leaked.
+                if not watchdog_task.done():
+                    watchdog_task.cancel()
+                    try:
+                        await watchdog_task
+                    except asyncio.CancelledError:
+                        pass
+            finally:
+                if not call_task.done():
+                    call_task.cancel()
+
+        asyncio.run(_run())

--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -1,6 +1,7 @@
 """Tests for MCP stability fixes — event loop handler, PID tracking, shutdown robustness."""
 
 import asyncio
+import json
 import os
 import signal
 from unittest.mock import patch, MagicMock
@@ -922,3 +923,142 @@ class TestStdioSubprocessDeadFailFast:
                     call_task.cancel()
 
         asyncio.run(_run())
+
+    def test_watchdog_cancel_reaches_retry_handler(self):
+        """Watchdog-triggered CancelledError is remapped so the retry chain runs.
+
+        The watchdog in ``_watch_stdio_subprocess`` cancels the in-flight
+        ``call_tool`` future, which surfaces as ``asyncio.CancelledError`` at
+        ``await call_task`` in ``_call()``. CancelledError is a BaseException,
+        so the sync handler's ``except Exception`` never saw it and
+        ``_handle_subprocess_dead_and_retry`` was unreachable dead code.
+        ``_call()`` must remap the watchdog-driven cancellation to
+        ``MCPStdioSubprocessDeadError`` so the reconnect-and-retry path
+        actually executes (#81995).
+        """
+        import asyncio
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock, patch
+        import tools.mcp_tool as mcp_mod
+
+        server_name = "retry-chain-srv"
+        with mcp_mod._lock:
+            mcp_mod._servers.clear()
+            mcp_mod._server_connecting.clear()
+            mcp_mod._stdio_pids.clear()
+            mcp_mod._watchdog_fired_servers.clear()
+            mcp_mod._server_error_counts.clear()
+            mcp_mod._server_breaker_opened_at.clear()
+            mcp_mod._server_trust_levels.clear()
+
+        # Fake server: session.call_tool hangs on the FIRST call (until the
+        # watchdog cancels it) and succeeds on the retry.
+        srv = MagicMock()
+        srv._rpc_lock = asyncio.Lock()
+        srv._reconnect_event = asyncio.Event()
+        srv._reconnect_event.set()
+
+        def _fake_call_tool(*args, **kwargs):
+            if _fake_call_tool.calls == 0:
+                _fake_call_tool.calls += 1
+                return asyncio.sleep(60)  # hangs until cancelled
+            _fake_call_tool.calls += 1
+            ok = SimpleNamespace(
+                isError=False,
+                structuredContent=None,
+                content=[SimpleNamespace(type="text", text="recovered")],
+            )
+            return asyncio.sleep(0.001, result=ok)
+
+        _fake_call_tool.calls = 0
+        srv.session.call_tool = MagicMock(side_effect=_fake_call_tool)
+
+        dead_pid = 999999994
+        with mcp_mod._lock:
+            mcp_mod._servers[server_name] = srv
+            mcp_mod._stdio_pids[dead_pid] = server_name
+
+        try:
+            mcp_mod._ensure_mcp_loop()
+            handler = mcp_mod._make_tool_handler(server_name, "do-thing", 5.0)
+            with patch.object(
+                mcp_mod, "_signal_reconnect_and_wait", return_value=True,
+            ) as mock_reconnect:
+                result = handler({"arg": 1})
+
+            # The retry path ran: reconnect signalled once, the call was
+            # retried on the fresh session, and the retried result surfaced.
+            assert result == '{"result": "recovered"}'
+            assert mock_reconnect.call_count == 1
+            assert mock_reconnect.call_args[0][0] == server_name
+            assert _fake_call_tool.calls == 2
+            # The remap flag was consumed, not left dangling.
+            with mcp_mod._lock:
+                assert server_name not in mcp_mod._watchdog_fired_servers
+        finally:
+            with mcp_mod._lock:
+                mcp_mod._servers.clear()
+                mcp_mod._server_connecting.clear()
+                mcp_mod._stdio_pids.clear()
+                mcp_mod._watchdog_fired_servers.clear()
+                mcp_mod._server_error_counts.clear()
+                mcp_mod._server_breaker_opened_at.clear()
+                mcp_mod._server_trust_levels.clear()
+            mcp_mod._stop_mcp_loop()
+
+    def test_non_watchdog_cancellation_not_remapped(self):
+        """A genuine CancelledError is not remapped to a subprocess-dead retry.
+
+        User interrupts and loop teardown cancel the call for reasons
+        unrelated to the stdio subprocess. Those must NOT trigger the
+        watchdog's reconnect-and-retry chain (``_watchdog_fired_servers``
+        stays empty), and the call must fall through to the generic error
+        path instead of retrying against a healthy server (#81995).
+        """
+        import asyncio
+        from unittest.mock import MagicMock
+        import tools.mcp_tool as mcp_mod
+
+        server_name = "retry-chain-cancel-srv"
+        with mcp_mod._lock:
+            mcp_mod._servers.clear()
+            mcp_mod._server_connecting.clear()
+            mcp_mod._stdio_pids.clear()
+            mcp_mod._watchdog_fired_servers.clear()
+            mcp_mod._server_error_counts.clear()
+            mcp_mod._server_breaker_opened_at.clear()
+            mcp_mod._server_trust_levels.clear()
+
+        srv = MagicMock()
+        srv._rpc_lock = asyncio.Lock()
+        srv.session.call_tool = MagicMock(
+            side_effect=asyncio.CancelledError("user interrupt")
+        )
+        with mcp_mod._lock:
+            mcp_mod._servers[server_name] = srv
+
+        try:
+            mcp_mod._ensure_mcp_loop()
+            handler = mcp_mod._make_tool_handler(server_name, "do-thing", 5.0)
+            with patch.object(
+                mcp_mod, "_signal_reconnect_and_wait", return_value=True,
+            ) as mock_reconnect:
+                result = handler({"arg": 1})
+
+            # Generic error path — no reconnect/retry was attempted for a
+            # cancellation that the watchdog did not originate.
+            assert mock_reconnect.call_count == 0
+            parsed = json.loads(result)
+            assert "error" in parsed
+            with mcp_mod._lock:
+                assert server_name not in mcp_mod._watchdog_fired_servers
+        finally:
+            with mcp_mod._lock:
+                mcp_mod._servers.clear()
+                mcp_mod._server_connecting.clear()
+                mcp_mod._stdio_pids.clear()
+                mcp_mod._watchdog_fired_servers.clear()
+                mcp_mod._server_error_counts.clear()
+                mcp_mod._server_breaker_opened_at.clear()
+                mcp_mod._server_trust_levels.clear()
+            mcp_mod._stop_mcp_loop()

--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import os
 import signal
+import time
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -1058,6 +1059,234 @@ class TestStdioSubprocessDeadFailFast:
                 mcp_mod._server_connecting.clear()
                 mcp_mod._stdio_pids.clear()
                 mcp_mod._watchdog_fired_servers.clear()
+                mcp_mod._server_error_counts.clear()
+                mcp_mod._server_breaker_opened_at.clear()
+                mcp_mod._server_trust_levels.clear()
+            mcp_mod._stop_mcp_loop()
+
+    def test_transport_teardown_cancels_in_flight_call_into_retry(self):
+        """Transport teardown cancels the in-flight call and retry runs.
+
+        Triage scenario for #81995: the stdio subprocess is ALIVE but
+        stalled, so the PID-poll watchdog's ``_stdio_subprocess_dead``
+        never turns True (a live PID is tracked) and the fail-fast never
+        fires. The transport-teardown path
+        (``_cancel_in_flight_calls_for_server`` — ``_run_stdio``'s
+        finally / ``shutdown``) must cancel the pending ``call_tool``
+        future instead. ``_call`` remaps the surfaced CancelledError via
+        ``_call_dead_servers`` to ``MCPStdioSubprocessDeadError`` so the
+        handler's reconnect-and-retry chain runs (the supervisor respawns
+        a fresh session) instead of waiting out ``tool_timeout``.
+        """
+        import asyncio
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock, patch
+        import tools.mcp_tool as mcp_mod
+
+        server_name = "teardown-retry-srv"
+        with mcp_mod._lock:
+            mcp_mod._servers.clear()
+            mcp_mod._server_connecting.clear()
+            mcp_mod._stdio_pids.clear()
+            mcp_mod._watchdog_fired_servers.clear()
+            mcp_mod._call_dead_servers.clear()
+            mcp_mod._in_flight_call_tasks.clear()
+            mcp_mod._server_error_counts.clear()
+            mcp_mod._server_breaker_opened_at.clear()
+            mcp_mod._server_trust_levels.clear()
+
+        # First call_tool hangs forever (the stalled subprocess never
+        # answers); the teardown cancels it. Retry succeeds.
+        srv = MagicMock()
+        srv._rpc_lock = asyncio.Lock()
+        srv._reconnect_event = asyncio.Event()
+        srv._reconnect_event.set()
+
+        def _fake_call_tool(*args, **kwargs):
+            if _fake_call_tool.calls == 0:
+                _fake_call_tool.calls += 1
+                return asyncio.sleep(60)  # hangs until cancelled
+            _fake_call_tool.calls += 1
+            ok = SimpleNamespace(
+                isError=False,
+                structuredContent=None,
+                content=[SimpleNamespace(type="text", text="recovered")],
+            )
+            return asyncio.sleep(0.001, result=ok)
+
+        _fake_call_tool.calls = 0
+        srv.session.call_tool = MagicMock(side_effect=_fake_call_tool)
+        with mcp_mod._lock:
+            mcp_mod._servers[server_name] = srv
+
+        try:
+            mcp_mod._ensure_mcp_loop()
+
+            async def _simulate_teardown():
+                # The supervisor decided the session is dead and tore the
+                # transport down — the stalled subprocess is still alive,
+                # so NO PID is removed here (that is the triage scenario).
+                # Wait until the call registered its in-flight future so
+                # the cancellation is deterministic. Runs on the MCP loop
+                # itself, as the real teardown path does (task.cancel()
+                # must not be called cross-thread).
+                deadline = time.monotonic() + 5.0
+                while time.monotonic() < deadline:
+                    with mcp_mod._lock:
+                        if server_name in mcp_mod._in_flight_call_tasks:
+                            break
+                    await asyncio.sleep(0.01)
+                mcp_mod._cancel_in_flight_calls_for_server(server_name)
+
+            teardown_fut = asyncio.run_coroutine_threadsafe(
+                _simulate_teardown(), mcp_mod._mcp_loop
+            )
+
+            async def _run_call_with_teardown():
+                call_task = asyncio.ensure_future(
+                    asyncio.to_thread(mcp_mod._make_tool_handler(
+                        server_name, "do-thing", 5.0
+                    ), {"arg": 1})
+                )
+                try:
+                    result = await call_task
+                    return result
+                finally:
+                    if not call_task.done():
+                        call_task.cancel()
+
+            def _fake_reconnect(*args, **kwargs):
+                # The supervisor respawned the transport; the fresh
+                # session's initialize (_mark_lifecycle_started) clears
+                # the teardown mark before the session readies.
+                with mcp_mod._lock:
+                    mcp_mod._call_dead_servers.discard(server_name)
+                return True
+
+            with patch.object(
+                mcp_mod, "_signal_reconnect_and_wait",
+                side_effect=_fake_reconnect,
+            ) as mock_reconnect:
+                result = asyncio.run(_run_call_with_teardown())
+                # The teardown coroutine returns right after cancelling,
+                # well before the retry chain completes — surface any
+                # error it raised.
+                teardown_fut.result(timeout=5)
+
+            # The teardown cancellation was remapped, the reconnect was
+            # signalled once, and the retry surfaced the recovered result.
+            assert result == '{"result": "recovered"}'
+            assert mock_reconnect.call_count == 1
+            assert mock_reconnect.call_args[0][0] == server_name
+            assert _fake_call_tool.calls == 2
+            # The teardown mark was consumed by the respawn, not dangling.
+            with mcp_mod._lock:
+                assert server_name not in mcp_mod._call_dead_servers
+                assert server_name not in mcp_mod._watchdog_fired_servers
+                assert server_name not in mcp_mod._in_flight_call_tasks
+        finally:
+            with mcp_mod._lock:
+                mcp_mod._servers.clear()
+                mcp_mod._server_connecting.clear()
+                mcp_mod._stdio_pids.clear()
+                mcp_mod._watchdog_fired_servers.clear()
+                mcp_mod._call_dead_servers.clear()
+                mcp_mod._in_flight_call_tasks.clear()
+                mcp_mod._server_error_counts.clear()
+                mcp_mod._server_breaker_opened_at.clear()
+                mcp_mod._server_trust_levels.clear()
+            mcp_mod._stop_mcp_loop()
+
+    def test_transport_teardown_marks_pending_rpc_lock_waiters(self):
+        """A call queued behind _rpc_lock when the transport tears down
+        fails fast instead of issuing a call on the dead session.
+
+        The teardown can race a call that is still waiting for the
+        per-server ``_rpc_lock``: the call_tool future is not registered
+        yet, so ``_cancel_in_flight_calls_for_server`` cannot cancel it.
+        The unconditional ``_call_dead_servers`` mark makes such waiters
+        fail fast on lock acquisition (pre-flight check in ``_call``) and
+        reach the retry path once the supervisor brings a fresh session
+        up and clears the mark.
+        """
+        import asyncio
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock, patch
+        import tools.mcp_tool as mcp_mod
+
+        server_name = "teardown-rpclock-srv"
+        with mcp_mod._lock:
+            mcp_mod._servers.clear()
+            mcp_mod._server_connecting.clear()
+            mcp_mod._stdio_pids.clear()
+            mcp_mod._watchdog_fired_servers.clear()
+            mcp_mod._call_dead_servers.clear()
+            mcp_mod._in_flight_call_tasks.clear()
+            mcp_mod._server_error_counts.clear()
+            mcp_mod._server_breaker_opened_at.clear()
+            mcp_mod._server_trust_levels.clear()
+
+        srv = MagicMock()
+        srv._rpc_lock = asyncio.Lock()
+        srv._reconnect_event = asyncio.Event()
+        srv._reconnect_event.set()
+
+        def _fake_call_tool(*args, **kwargs):
+            _fake_call_tool.calls += 1
+            ok = SimpleNamespace(
+                isError=False,
+                structuredContent=None,
+                content=[SimpleNamespace(type="text", text="after-respawn")],
+            )
+            return asyncio.sleep(0.001, result=ok)
+
+        _fake_call_tool.calls = 0
+        srv.session.call_tool = MagicMock(side_effect=_fake_call_tool)
+        with mcp_mod._lock:
+            mcp_mod._servers[server_name] = srv
+
+        try:
+            mcp_mod._ensure_mcp_loop()
+            handler = mcp_mod._make_tool_handler(server_name, "do-thing", 5.0)
+
+            # Teardown races the call while it is still queued behind
+            # _rpc_lock: no call_tool future exists, so the helper only
+            # marks the server as teardown-dead.
+            mcp_mod._cancel_in_flight_calls_for_server(server_name)
+            with mcp_mod._lock:
+                assert server_name in mcp_mod._call_dead_servers
+                assert server_name not in mcp_mod._in_flight_call_tasks
+
+            def _fake_reconnect(*args, **kwargs):
+                # The supervisor respawned the transport; the fresh
+                # session's initialize clears the mark before readying.
+                with mcp_mod._lock:
+                    mcp_mod._call_dead_servers.discard(server_name)
+                return True
+
+            with patch.object(
+                mcp_mod, "_signal_reconnect_and_wait",
+                side_effect=_fake_reconnect,
+            ) as mock_reconnect:
+                result = handler({"arg": 1})
+
+            # The queued call failed fast on the dead mark (never issued
+            # a call_tool on the dead transport) and was retried exactly
+            # once after the reconnect cleared the mark.
+            assert result == '{"result": "after-respawn"}'
+            assert mock_reconnect.call_count == 1
+            assert _fake_call_tool.calls == 1
+            with mcp_mod._lock:
+                assert server_name not in mcp_mod._call_dead_servers
+                assert server_name not in mcp_mod._in_flight_call_tasks
+        finally:
+            with mcp_mod._lock:
+                mcp_mod._servers.clear()
+                mcp_mod._server_connecting.clear()
+                mcp_mod._stdio_pids.clear()
+                mcp_mod._watchdog_fired_servers.clear()
+                mcp_mod._call_dead_servers.clear()
+                mcp_mod._in_flight_call_tasks.clear()
                 mcp_mod._server_error_counts.clear()
                 mcp_mod._server_breaker_opened_at.clear()
                 mcp_mod._server_trust_levels.clear()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1107,6 +1107,22 @@ class NonMcpEndpointError(ConnectionError):
     """
 
 
+class MCPStdioSubprocessDeadError(ConnectionError):
+    """Raised when a stdio MCP server's tracked subprocess has died.
+
+    Detected during an in-flight tool call: the tracked PID (recorded in
+    ``_stdio_pids`` at spawn time) is no longer alive, so the MCP read stream
+    is dead and the in-flight JSON-RPC response will never arrive. Without
+    fail-fast the call would hang until ``tool_timeout`` (default 300s)
+    elapses, tying up a circuit-breaker strike and an RPC lock for the full
+    window. Surface the death immediately so the model can back off and the
+    supervisor can respawn (#81995).
+
+    Subclasses :class:`ConnectionError` so callers that catch the broad class
+    still treat it as a transport problem.
+    """
+
+
 def _unwrap_exception_group(exc: BaseException) -> BaseException:
     """Extract the root-cause exception from anyio TaskGroup wrappers.
 
@@ -4549,6 +4565,78 @@ def _handle_session_expired_and_retry(
     return None
 
 
+def _handle_subprocess_dead_and_retry(
+    server_name: str,
+    exc: BaseException,
+    retry_call,
+    op_description: str,
+):
+    """Trigger a transport reconnect and retry once when the stdio subprocess
+    died mid-call (#81995).
+
+    When the watchdog in :func:`_watch_stdio_subprocess` detects the tracked
+    subprocess PID has exited, an in-flight ``call_tool`` would otherwise
+    wait until ``tool_timeout`` (default 300s) before reporting failure.
+    Instead: signal a reconnect (the supervisor's lifecycle loop tears down
+    the dead stdio transport and spawns a fresh subprocess), wait briefly
+    for the new session to be ready, and retry the call once. If the retry
+    succeeds the model sees a transparent recovery; if it doesn't we return
+    ``None`` so the caller falls through to the generic error path.
+
+    Only fires for stdio transports: HTTP transports raise the same
+    ``MCPStdioSubprocessDeadError`` from a parallel watchdog branch but
+    ``_stdio_subprocess_dead`` returns ``None`` for them (no tracked PIDs)
+    and the watchdog never fires, so this helper never matches.
+    """
+    if not isinstance(exc, MCPStdioSubprocessDeadError):
+        return None
+
+    with _lock:
+        srv = _servers.get(server_name)
+    if srv is None or not hasattr(srv, "_reconnect_event"):
+        return None
+
+    loop = _mcp_loop
+    if loop is None or not loop.is_running():
+        return None
+
+    logger.info(
+        "MCP server '%s': stdio subprocess died during %s; "
+        "signalling supervisor reconnect and retrying once.",
+        server_name, op_description,
+    )
+
+    if not _signal_reconnect_and_wait(
+        server_name,
+        srv,
+        op_description=op_description,
+        timeout=15,
+    ):
+        logger.warning(
+            "MCP server '%s': reconnect did not ready within 15s after "
+            "stdio subprocess died; falling through to error response.",
+            server_name,
+        )
+        return None
+
+    try:
+        result = retry_call()
+        try:
+            parsed = json.loads(result)
+            if "error" not in parsed:
+                _reset_server_error(server_name)
+                return result
+        except (json.JSONDecodeError, TypeError):
+            _reset_server_error(server_name)
+            return result
+    except Exception as retry_exc:
+        logger.warning(
+            "MCP %s/%s retry after subprocess-dead reconnect failed: %s",
+            server_name, op_description, retry_exc,
+        )
+    return None
+
+
 # Exact raw server names whose ``supports_parallel_tool_calls`` config is True.
 # Raw identity matters: distinct names such as ``foo-bar`` and ``foo_bar`` both
 # sanitize to ``foo_bar`` but must not share policy.
@@ -4715,6 +4803,85 @@ _orphan_stdio_pid_servers: Dict[int, str] = {}
 # exited and been removed from the active map.  Empty on Windows
 # (``os.getpgid`` is POSIX-only).
 _stdio_pgids: Dict[int, int] = {}  # pid -> pgid
+
+
+def _stdio_subprocess_pids_for_server(server_name: str) -> List[int]:
+    """Snapshot the tracked stdio subprocess PIDs owned by ``server_name``.
+
+    Returns a snapshot copy (not a live view) so the caller can iterate
+    without holding ``_lock`` and without the list mutating underneath.
+    """
+    with _lock:
+        return [pid for pid, owner in _stdio_pids.items() if owner == server_name]
+
+
+def _stdio_subprocess_dead(server_name: str) -> Optional[bool]:
+    """Return whether the stdio subprocess for ``server_name`` is dead.
+
+    ``True``  — we have at least one tracked PID for this server and every
+                one of them has exited. No response will ever arrive on the
+                MCP read stream; fail-fast the in-flight call (#81995).
+    ``False`` — at least one tracked PID is still alive; keep waiting.
+    ``None``  — no PIDs tracked for this server (e.g. HTTP transport, or the
+                stdio subprocess hasn't been recorded yet). Callers should
+                treat this as "unknown, do not fail-fast on this signal".
+
+    Uses the cross-platform ``gateway.status._pid_exists`` helper (works on
+    both POSIX and Windows). We deliberately do NOT use ``os.kill(pid, 0)`` —
+    that is not a no-op on Windows (bpo-14484).
+    """
+    from gateway.status import _pid_exists
+
+    pids = _stdio_subprocess_pids_for_server(server_name)
+    if not pids:
+        return None
+    return not any(_pid_exists(pid) for pid in pids)
+
+
+# Poll interval for the in-flight ``call_tool`` fail-fast watchdog.
+# Short enough that a respawn is detected promptly (sub-second on POSIX
+# where _pid_exists is a /proc syscall); long enough that the polling
+# itself doesn't become load when the call succeeds quickly.
+_STDIO_FAILFAST_POLL_INTERVAL_S = 0.2
+
+
+async def _watch_stdio_subprocess(
+    server_name: str, call_task: "asyncio.Future"
+) -> None:
+    """Cancel ``call_task`` and raise ``MCPStdioSubprocessDeadError`` if the
+    stdio subprocess for ``server_name`` dies while ``call_task`` is in
+    flight.
+
+    Designed to run as a sibling task on the MCP event loop. Polls every
+    ``_STDIO_FAILFAST_POLL_INTERVAL_S`` until either ``call_task`` completes
+    (the call won — exit cleanly) or every tracked PID exits (the subprocess
+    is dead — cancel the call and signal failure). HTTP transports return
+    ``None`` from ``_stdio_subprocess_dead`` and the watchdog sleeps until
+    cancelled by the caller — zero overhead for non-stdio servers (#81995).
+    """
+    try:
+        while True:
+            await asyncio.sleep(_STDIO_FAILFAST_POLL_INTERVAL_S)
+            if call_task.done():
+                # The call won — let the caller await its result normally.
+                return
+            if _stdio_subprocess_dead(server_name):
+                # Subprocess is gone — no response will arrive. Cancel the
+                # in-flight call_tool future so the SDK's recv loop is
+                # unwound, then signal the failure to the caller.
+                if not call_task.done():
+                    call_task.cancel()
+                raise MCPStdioSubprocessDeadError(
+                    f"MCP stdio subprocess for server '{server_name}' died "
+                    f"during an in-flight tool call; failing fast "
+                    f"(#81995)."
+                )
+    except asyncio.CancelledError:
+        # The caller finished (success, timeout, or error) and cancelled
+        # us — that's the expected exit path on every non-dead-subprocess
+        # outcome. Re-raise so the surrounding ``try/finally`` sees the
+        # cancellation cleanly.
+        raise
 
 
 def _snapshot_child_pids() -> set:
@@ -5408,7 +5575,37 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 # it and detect the gateway platform / session for routing.
                 server._pending_call_context = contextvars.copy_context()
                 try:
-                    result = await server.session.call_tool(tool_name, arguments=args)
+                    # Fail-fast watchdog: when the stdio subprocess dies
+                    # mid-call, the MCP read stream EOFs but the SDK's
+                    # in-flight ``call_tool`` coroutine can sit waiting on
+                    # the read queue until ``tool_timeout`` (default 300s)
+                    # elapses — too long to recover from a respawn, and
+                    # burns circuit-breaker strikes in the meantime.
+                    # Spawn a sibling task on the same MCP loop that polls
+                    # the tracked subprocess PIDs; if every tracked PID
+                    # exits, cancel the call_tool future and raise a
+                    # ``MCPStdioSubprocessDeadError`` so the caller falls
+                    # through to the supervisor-respawn path immediately
+                    # (#81995). HTTP transports have no tracked PIDs, so
+                    # ``_stdio_subprocess_dead`` returns ``None`` and the
+                    # watchdog is a silent no-op.
+                    call_task = asyncio.ensure_future(
+                        server.session.call_tool(tool_name, arguments=args)
+                    )
+                    watchdog_task = asyncio.ensure_future(
+                        _watch_stdio_subprocess(server_name, call_task)
+                    )
+                    try:
+                        result = await call_task
+                    finally:
+                        # Always cancel the watchdog so it doesn't outlive
+                        # the call (and so its ``asyncio.wait`` releases).
+                        if not watchdog_task.done():
+                            watchdog_task.cancel()
+                            try:
+                                await watchdog_task
+                            except (asyncio.CancelledError, Exception):
+                                pass
                 finally:
                     server._pending_call_context = None
             # The RPC round-trip completed — the session is demonstrably
@@ -5529,6 +5726,18 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             # but skips OAuth recovery because the access token is
             # still valid — only the server-side session is stale.
             recovered = _handle_session_expired_and_retry(
+                server_name, exc, _call_once,
+                f"tools/call {tool_name}",
+            )
+            if recovered is not None:
+                return recovered
+
+            # stdio subprocess died mid-call (#81995): the fail-fast
+            # watchdog raised ``MCPStdioSubprocessDeadError`` so we
+            # don't burn the full ``tool_timeout`` waiting on a dead
+            # pipe. Signal a reconnect (supervisor respawns the
+            # subprocess) and retry once before reporting failure.
+            recovered = _handle_subprocess_dead_and_retry(
                 server_name, exc, _call_once,
                 f"tools/call {tool_name}",
             )

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4783,6 +4783,16 @@ def _try_acquire_mcp_discovery_lock() -> Any:
 # normal server shutdown.
 _stdio_pids: Dict[int, str] = {}  # pid -> server_name
 
+# Server names whose in-flight ``call_tool`` was cancelled by the fail-fast
+# watchdog in ``_watch_stdio_subprocess`` (i.e. the stdio subprocess died
+# mid-call, not a user interrupt).  ``_call`` consults this under ``_lock``
+# when it surfaces ``asyncio.CancelledError``: if the watchdog fired, the
+# cancellation is remapped to ``MCPStdioSubprocessDeadError`` so the sync
+# handler's ``except Exception`` path can reach
+# ``_handle_subprocess_dead_and_retry``; otherwise it is a genuine user
+# cancellation and propagates unchanged (#81995).
+_watchdog_fired_servers: Set[str] = set()
+
 # PIDs that survived their session context exit (SDK teardown failed to
 # terminate them).  These are detected in _run_stdio's finally block and
 # can be cleaned up asynchronously by _kill_orphaned_mcp_children().
@@ -4870,6 +4880,12 @@ async def _watch_stdio_subprocess(
                 # in-flight call_tool future so the SDK's recv loop is
                 # unwound, then signal the failure to the caller.
                 if not call_task.done():
+                    # Record that THIS cancellation was watchdog-driven so
+                    # ``_call`` can remap the surfaced CancelledError to
+                    # ``MCPStdioSubprocessDeadError`` instead of letting a
+                    # bare BaseException escape the handler (#81995).
+                    with _lock:
+                        _watchdog_fired_servers.add(server_name)
                     call_task.cancel()
                 raise MCPStdioSubprocessDeadError(
                     f"MCP stdio subprocess for server '{server_name}' died "
@@ -5597,6 +5613,27 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     )
                     try:
                         result = await call_task
+                    except asyncio.CancelledError:
+                        # The watchdog cancelled ``call_task`` because the
+                        # stdio subprocess died mid-call (#81995): remap the
+                        # surfaced CancelledError (a BaseException, which the
+                        # sync handler's ``except Exception`` cannot see) to
+                        # ``MCPStdioSubprocessDeadError`` so the handler's
+                        # reconnect-and-retry path actually runs. A genuine
+                        # user cancellation (``_run_on_mcp_loop`` interrupt
+                        # or timeout) leaves the flag unset and re-raises
+                        # unchanged.
+                        with _lock:
+                            watchdog_fired = server_name in _watchdog_fired_servers
+                            if watchdog_fired:
+                                _watchdog_fired_servers.discard(server_name)
+                        if watchdog_fired:
+                            raise MCPStdioSubprocessDeadError(
+                                f"MCP stdio subprocess for server "
+                                f"'{server_name}' died during an in-flight "
+                                f"tool call; failing fast (#81995)."
+                            ) from None
+                        raise
                     finally:
                         # Always cancel the watchdog so it doesn't outlive
                         # the call (and so its ``asyncio.wait`` releases).

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2203,6 +2203,9 @@ class MCPServerTask:
         self._lifecycle_started_at = now
         self._last_tool_call_at = now
         self._recycled_reason = None
+        # A fresh transport is live: a stale teardown-cancellation mark
+        # must not remap an unrelated cancellation on the new session.
+        _clear_call_dead_servers(self.name)
 
     def _stdio_recycle_reason(self, now: Optional[float] = None) -> Optional[str]:
         """Return the stdio recycle reason if idle/age limits have elapsed."""
@@ -2809,6 +2812,13 @@ class MCPServerTask:
             # teardown failed (common when the task is cancelled mid-way
             # on Linux, where setsid() children escape the parent cgroup).
             # Mark them as orphans so the next cleanup sweep can reap them.
+            # The transport is closing here — a response can never arrive
+            # on its read stream. Cancel any in-flight call_tool futures
+            # so pending calls fail fast instead of waiting out
+            # ``tool_timeout``; the PID-poll watchdog alone cannot cover
+            # this case because a stalled-but-alive subprocess leaves
+            # ``_stdio_subprocess_dead`` at ``False`` (#81995 triage).
+            _cancel_in_flight_calls_for_server(self.name)
             if new_pids:
                 from gateway.status import _pid_exists
                 _killpg = getattr(os, "killpg", None)
@@ -3787,6 +3797,10 @@ class MCPServerTask:
             await asyncio.gather(*self._pending_refresh_tasks, return_exceptions=True)
             self._pending_refresh_tasks.clear()
         self._deregister_tools()
+        # The session is being discarded — cancel any in-flight calls so
+        # they fail fast rather than waiting out ``tool_timeout`` on a
+        # read stream that is going away (#81995 triage).
+        _cancel_in_flight_calls_for_server(self.name)
         self.session = None
 
     def _deregister_tools(self) -> None:
@@ -4793,6 +4807,30 @@ _stdio_pids: Dict[int, str] = {}  # pid -> server_name
 # cancellation and propagates unchanged (#81995).
 _watchdog_fired_servers: Set[str] = set()
 
+# Server names whose stdio transport has been torn down (transport
+# teardown / session invalidation: the supervisor decided the session is
+# dead — keepalive failure, recycle, shutdown — or an exception exited
+# ``_run_stdio``). Set in ``_run_stdio``'s finally, cleared when the next
+# transport finishes initializing (``_mark_lifecycle_started``). ``_call``
+# consults this (alongside ``_watchdog_fired_servers``) when it surfaces
+# ``asyncio.CancelledError``: a teardown-cancelled call is remapped to
+# ``MCPStdioSubprocessDeadError`` so the sync handler's
+# reconnect-and-retry path runs against the fresh session the supervisor
+# spawns (#81995 triage: a stalled-but-alive subprocess never trips the
+# PID-poll watchdog because ``_stdio_subprocess_dead`` sees a live PID,
+# so the transport-teardown signal is the authoritative fail-fast
+# trigger; the PID poll stays as a backstop).
+_call_dead_servers: Set[str] = set()
+
+# In-flight ``call_tool`` futures, keyed by server name. Registered by
+# ``_call`` while a tool call is awaiting a response and discarded when
+# the call finishes. The transport teardown path
+# (``_cancel_in_flight_calls_for_server``) cancels every pending future
+# for a server when its session is being torn down, so pending calls
+# fail fast instead of waiting out ``tool_timeout`` on a read stream
+# that will never deliver.
+_in_flight_call_tasks: Dict[str, set] = {}
+
 # PIDs that survived their session context exit (SDK teardown failed to
 # terminate them).  These are detected in _run_stdio's finally block and
 # can be cleaned up asynchronously by _kill_orphaned_mcp_children().
@@ -4898,6 +4936,62 @@ async def _watch_stdio_subprocess(
         # outcome. Re-raise so the surrounding ``try/finally`` sees the
         # cancellation cleanly.
         raise
+
+
+def _mark_in_flight_call(server_name: str, call_task: "asyncio.Future") -> None:
+    """Register an in-flight ``call_tool`` future for ``server_name``."""
+    with _lock:
+        _in_flight_call_tasks.setdefault(server_name, set()).add(call_task)
+
+
+def _unmark_in_flight_call(server_name: str, call_task: "asyncio.Future") -> None:
+    """Discard a finished ``call_tool`` future for ``server_name``."""
+    with _lock:
+        pending = _in_flight_call_tasks.get(server_name)
+        if pending is None:
+            return
+        pending.discard(call_task)
+        if not pending:
+            _in_flight_call_tasks.pop(server_name, None)
+
+
+def _cancel_in_flight_calls_for_server(server_name: str) -> None:
+    """Cancel every pending ``call_tool`` future for ``server_name``.
+
+    Called from the stdio transport teardown path (``_run_stdio``'s
+    finally) and ``MCPServerTask.shutdown``. A session that is being torn
+    down will never deliver a response on its read stream, so the
+    in-flight calls would otherwise sit until ``tool_timeout`` (default
+    300s) — the stalled-subprocess case where the PID-poll watchdog can't
+    fire because the subprocess is alive. Cancelling the futures surfaces
+    ``asyncio.CancelledError`` at ``await call_task``; ``_call`` remaps it
+    to ``MCPStdioSubprocessDeadError`` via ``_call_dead_servers`` so the
+    handler's reconnect-and-retry path runs against the fresh session the
+    supervisor spawns (#81995).
+
+    Also marks the server in ``_call_dead_servers`` unconditionally (even
+    when nothing is pending) so a call that is still waiting on
+    ``_rpc_lock`` when the teardown happens sees the mark when it
+    acquires the lock and fails fast instead of issuing a call on the
+    dead transport. The mark is cleared when the next transport
+    initializes (``_mark_lifecycle_started``).
+    """
+    with _lock:
+        _call_dead_servers.add(server_name)
+        pending = _in_flight_call_tasks.get(server_name)
+        for call_task in list(pending or ()):
+            if not call_task.done():
+                call_task.cancel()
+
+
+def _clear_call_dead_servers(server_name: str) -> None:
+    """Clear the teardown-cancellation mark for ``server_name``.
+
+    Called when a fresh transport finishes initializing, so a stale mark
+    can never remap a later, unrelated cancellation of the new session.
+    """
+    with _lock:
+        _call_dead_servers.discard(server_name)
 
 
 def _snapshot_child_pids() -> set:
@@ -5591,6 +5685,23 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 # it and detect the gateway platform / session for routing.
                 server._pending_call_context = contextvars.copy_context()
                 try:
+                    # Transport teardown raced this call: the session is
+                    # being discarded (stalled subprocess / supervisor
+                    # recycle / shutdown) and a response can never arrive.
+                    # Fail fast instead of issuing a call on the dead
+                    # transport — the handler's reconnect-and-retry path
+                    # will use the fresh session the supervisor spawns
+                    # (#81995). The mark is cleared once the next
+                    # transport initializes, so the retry's re-entry into
+                    # ``_call`` passes this check.
+                    with _lock:
+                        transport_dead = server_name in _call_dead_servers
+                    if transport_dead:
+                        raise MCPStdioSubprocessDeadError(
+                            f"MCP stdio subprocess for server "
+                            f"'{server_name}' is being torn down; failing "
+                            f"fast (#81995)."
+                        )
                     # Fail-fast watchdog: when the stdio subprocess dies
                     # mid-call, the MCP read stream EOFs but the SDK's
                     # in-flight ``call_tool`` coroutine can sit waiting on
@@ -5611,23 +5722,46 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     watchdog_task = asyncio.ensure_future(
                         _watch_stdio_subprocess(server_name, call_task)
                     )
+                    # Register the in-flight future so the transport
+                    # teardown path can cancel it (see
+                    # ``_cancel_in_flight_calls_for_server``).
+                    _mark_in_flight_call(server_name, call_task)
                     try:
                         result = await call_task
                     except asyncio.CancelledError:
                         # The watchdog cancelled ``call_task`` because the
-                        # stdio subprocess died mid-call (#81995): remap the
-                        # surfaced CancelledError (a BaseException, which the
-                        # sync handler's ``except Exception`` cannot see) to
+                        # stdio subprocess died mid-call, or the transport
+                        # teardown cancelled it because the session was
+                        # invalidated (stalled subprocess case — the PID
+                        # poll can't fire while a live PID is tracked):
+                        # remap the surfaced CancelledError (a
+                        # BaseException, which the sync handler's
+                        # ``except Exception`` cannot see) to
                         # ``MCPStdioSubprocessDeadError`` so the handler's
-                        # reconnect-and-retry path actually runs. A genuine
-                        # user cancellation (``_run_on_mcp_loop`` interrupt
-                        # or timeout) leaves the flag unset and re-raises
-                        # unchanged.
+                        # reconnect-and-retry path actually runs (#81995).
+                        # A genuine user cancellation (``_run_on_mcp_loop``
+                        # interrupt or timeout) leaves both flags unset and
+                        # re-raises unchanged.
                         with _lock:
-                            watchdog_fired = server_name in _watchdog_fired_servers
+                            watchdog_fired = (
+                                server_name in _watchdog_fired_servers
+                            )
                             if watchdog_fired:
+                                # Consumed here — a later, unrelated
+                                # cancellation must not be remapped.
                                 _watchdog_fired_servers.discard(server_name)
-                        if watchdog_fired:
+                            teardown_fired = server_name in _call_dead_servers
+                            # ``_call_dead_servers`` is deliberately NOT
+                            # consumed here: the teardown cancelled every
+                            # in-flight call (parallel-safe servers can
+                            # have several) AND marks calls still queued
+                            # behind ``_rpc_lock``, so the flag must stay
+                            # visible to all of them. It is cleared once
+                            # the supervisor's fresh transport
+                            # initializes (``_mark_lifecycle_started``),
+                            # which happens before the retry re-enters
+                            # this code.
+                        if watchdog_fired or teardown_fired:
                             raise MCPStdioSubprocessDeadError(
                                 f"MCP stdio subprocess for server "
                                 f"'{server_name}' died during an in-flight "
@@ -5635,6 +5769,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                             ) from None
                         raise
                     finally:
+                        _unmark_in_flight_call(server_name, call_task)
                         # Always cancel the watchdog so it doesn't outlive
                         # the call (and so its ``asyncio.wait`` releases).
                         if not watchdog_task.done():


### PR DESCRIPTION
On a stalled stdio MCP cold-spawn, an in-flight `call_tool` hung on the dead subprocess for the full 300s timeout. The supervisor's respawn was invisible to the awaiting future.

Add a sibling watchdog: every `call_tool` spawns a coroutine that polls tracked PIDs every 0.2s; if every PID in the server's tracked set has exited, the future is cancelled and a `MCPStdioSubprocessDeadError` is raised. A new `_handle_subprocess_dead_and_retry` signal-reconnects → respawns the child → waits up to 15s for ready → retries once. HTTP transports have no tracked PIDs, so the watchdog is a no-op there.

7/7 in TestStdioSubprocessDeadFailFast; 19/3/1 in test_mcp_stability.py (the 1 failure is a pre-existing Windows-venv 'no mcp' issue, confirmed by stash).

---

Fixes #81995