### PR TITLE
fix(fallback): honor explicit api_mode/transport override on fallback entries (#81932)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2054,50 +2054,76 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             )
 
         # Determine api_mode from provider / base URL / model
-        fb_api_mode = "chat_completions"
-        fb_base_url = str(fb_client.base_url)
-        _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
-        if fb_provider == "openai-codex":
-            fb_api_mode = "codex_responses"
-        elif fb_provider in {"nous", "nous-portal", "nousresearch"}:
-            # Portal is dual-wire: anthropic/* must land on /v1/messages.
-            # resolve_provider_client still returns an OpenAI client for
-            # Nous; the anthropic_messages branch below rebuilds the native
-            # client from that credential + base_url.
-            from hermes_cli.providers import nous_api_mode
-
-            fb_api_mode = nous_api_mode(fb_model)
-        elif (
-            fb_provider == "anthropic"
-            or fb_base_url.rstrip("/").lower().endswith("/anthropic")
-            or base_url_hostname(fb_base_url) == "api.anthropic.com"
-        ):
-            # Custom providers (e.g. cron-anthropic) point at the native
-            # api.anthropic.com host with no "/anthropic" path suffix, so the
-            # name/suffix checks above miss them and they default to
-            # chat_completions → POST /v1/chat/completions → 404. Match the
-            # host the same way determine_api_mode() and _detect_api_mode_for_url()
-            # do on the primary path. (#32243, #49247)
-            fb_api_mode = "anthropic_messages"
-        elif _fb_is_azure:
-            # Azure OpenAI serves gpt-5.x on /chat/completions — does NOT
-            # support the Responses API. Stay on chat_completions.
+        # Honor an explicit ``api_mode`` / ``transport`` override from the
+        # fallback entry config — matches the v11→v12 migration field-name
+        # convention already used for ``providers:`` / ``custom_providers:``
+        # blocks (see runtime_provider._resolve_named_custom_runtime). Without
+        # this, a fallback entry whose host heuristics don't match its
+        # declared transport (e.g. an Anthropic-compatible proxy on a path
+        # that lacks ``/anthropic``, or an OpenAI-compatible provider with a
+        # pinned Responses-API surface) silently downgrades to
+        # chat_completions. Fixes #81932.
+        _VALID_FALLBACK_API_MODES = {
+            "chat_completions",
+            "codex_responses",
+            "anthropic_messages",
+            "bedrock_converse",
+            "codex_app_server",
+        }
+        _explicit_api_mode_raw = fb.get("api_mode") or fb.get("transport")
+        _explicit_api_mode = (
+            str(_explicit_api_mode_raw).strip().lower()
+            if _explicit_api_mode_raw is not None
+            else ""
+        )
+        if _explicit_api_mode and _explicit_api_mode in _VALID_FALLBACK_API_MODES:
+            fb_api_mode = _explicit_api_mode
+            fb_base_url = str(fb_client.base_url)
+        else:
             fb_api_mode = "chat_completions"
-        elif agent._is_direct_openai_url(fb_base_url):
-            fb_api_mode = "codex_responses"
-        elif agent._provider_model_requires_responses_api(
-            fb_model,
-            provider=fb_provider,
-        ):
-            # GPT-5.x models usually need Responses API, but keep
-            # provider-specific exceptions like Copilot gpt-5-mini on
-            # chat completions.
-            fb_api_mode = "codex_responses"
-        elif fb_provider == "bedrock" or (
-            base_url_hostname(fb_base_url).startswith("bedrock-runtime.")
-            and base_url_host_matches(fb_base_url, "amazonaws.com")
-        ):
-            fb_api_mode = "bedrock_converse"
+            fb_base_url = str(fb_client.base_url)
+            _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
+            if fb_provider == "openai-codex":
+                fb_api_mode = "codex_responses"
+            elif fb_provider in {"nous", "nous-portal", "nousresearch"}:
+                # Portal is dual-wire: anthropic/* must land on /v1/messages.
+                # resolve_provider_client still returns an OpenAI client for
+                # Nous; the anthropic_messages branch below rebuilds the native
+                # client from that credential + base_url.
+                from hermes_cli.providers import nous_api_mode
+
+                fb_api_mode = nous_api_mode(fb_model)
+            elif (
+                fb_provider == "anthropic"
+                or fb_base_url.rstrip("/").lower().endswith("/anthropic")
+                or base_url_hostname(fb_base_url) == "api.anthropic.com"
+            ):
+                # Custom providers (e.g. cron-anthropic) point at the native
+                # api.anthropic.com host with no "/anthropic" path suffix, so the
+                # name/suffix checks above miss them and they default to
+                # chat_completions → POST /v1/chat/completions → 404. Match the
+                # host the same way determine_api_mode() and _detect_api_mode_for_url()
+                # do on the primary path. (#32243, #49247)
+                fb_api_mode = "anthropic_messages"
+            elif _fb_is_azure:
+                # Azure OpenAI serves gpt-5.x on /chat/completions — does NOT
+                # support the Responses API. Stay on chat_completions.
+                fb_api_mode = "chat_completions"
+            elif agent._is_direct_openai_url(fb_base_url):
+                fb_api_mode = "codex_responses"
+            elif agent._provider_model_requires_responses_api(
+                fb_model,
+                provider=fb_provider,
+            ):
+                # GPT-5.x models usually need Responses API, but keep
+                # provider-specific exceptions like Copilot gpt-5-mini on
+                # chat completions.
+                fb_api_mode = "codex_responses"
+            elif fb_provider == "bedrock" or (
+                base_url_hostname(fb_base_url).startswith("bedrock-runtime.")
+                and base_url_host_matches(fb_base_url, "amazonaws.com")
+            ):
+                fb_api_mode = "bedrock_converse"
 
         old_model = agent.model
         old_provider = agent.provider

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -231,6 +231,152 @@ class TestFallbackChainAdvancement:
         assert agent.api_mode == "chat_completions"
         assert agent.client is not None
 
+    def test_explicit_api_mode_override_honored(self):
+        """Explicit ``api_mode`` on the fallback entry beats host heuristics.
+
+        Regression for #81932: a fallback whose base_url doesn't match the
+        heuristically-recognized host (e.g. an Anthropic-compatible proxy at a
+        path that lacks the ``/anthropic`` suffix, or an OpenAI-compatible
+        provider whose declared transport is Responses) was silently
+        downgraded to ``chat_completions``.  Activation must honor the
+        configured ``api_mode`` / ``transport`` field instead.
+        """
+        portal = "https://inference-api.nousresearch.com/v1"
+        fbs = [
+            {
+                "provider": "nous",
+                "model": "custom/anthropic-proxy-model",
+                "api_mode": "anthropic_messages",
+            }
+        ]
+        agent = _make_agent(fallback_model=fbs)
+        rebuilt = {"count": 0}
+
+        def _fake_build(api_key, base_url, timeout=None, **kwargs):
+            rebuilt["count"] += 1
+            rebuilt["api_key"] = api_key
+            rebuilt["base_url"] = base_url
+            return MagicMock(name="anthropic-client")
+
+        with (
+            patch(
+                "agent.chat_completion_helpers._fallback_entry_unavailable_without_network",
+                return_value=None,
+            ),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(
+                    _mock_client(base_url=portal, api_key="portal-jwt"),
+                    "custom/anthropic-proxy-model",
+                ),
+            ),
+            patch(
+                "hermes_cli.model_normalize.normalize_model_for_provider",
+                side_effect=lambda m, p: m,
+            ),
+            patch(
+                "agent.anthropic_adapter.build_anthropic_client",
+                side_effect=_fake_build,
+            ),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        # Explicit api_mode honored, native Anthropic client rebuilt.
+        assert agent.api_mode == "anthropic_messages"
+        assert agent.provider == "nous"
+        assert agent.model == "custom/anthropic-proxy-model"
+        assert agent.client is None
+        assert rebuilt["count"] == 1
+
+    def test_transport_alias_honored(self):
+        """The ``transport`` field is the v11→v12 name for ``api_mode``."""
+        portal = "https://inference-api.nousresearch.com/v1"
+        fbs = [
+            {
+                "provider": "nous",
+                "model": "hermes-4-405b",
+                "transport": "anthropic_messages",
+            }
+        ]
+        agent = _make_agent(fallback_model=fbs)
+
+        def _fake_build(api_key, base_url, timeout=None, **kwargs):
+            return MagicMock(name="anthropic-client")
+
+        with (
+            patch(
+                "agent.chat_completion_helpers._fallback_entry_unavailable_without_network",
+                return_value=None,
+            ),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(
+                    _mock_client(base_url=portal, api_key="portal-jwt"),
+                    "hermes-4-405b",
+                ),
+            ),
+            patch(
+                "hermes_cli.model_normalize.normalize_model_for_provider",
+                side_effect=lambda m, p: m,
+            ),
+            patch(
+                "agent.anthropic_adapter.build_anthropic_client",
+                side_effect=_fake_build,
+            ),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent.api_mode == "anthropic_messages"
+
+    def test_invalid_api_mode_falls_back_to_heuristics(self):
+        """An unrecognised ``api_mode`` value must NOT silently apply.
+
+        If the user typos ``api_mode: anthropic_message`` (singular), the
+        activation must behave as if no override was set and use the host
+        heuristics, rather than installing an unknown transport that the
+        client wiring doesn't know how to dispatch.
+        """
+        portal = "https://inference-api.nousresearch.com/v1"
+        fbs = [
+            {
+                "provider": "nous",
+                "model": "anthropic/claude-opus-4.8",
+                "api_mode": "anthropic_message",  # typo — invalid
+            }
+        ]
+        agent = _make_agent(fallback_model=fbs)
+
+        def _fake_build(api_key, base_url, timeout=None, **kwargs):
+            return MagicMock(name="anthropic-client")
+
+        with (
+            patch(
+                "agent.chat_completion_helpers._fallback_entry_unavailable_without_network",
+                return_value=None,
+            ),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(
+                    _mock_client(base_url=portal, api_key="portal-jwt"),
+                    "anthropic/claude-opus-4.8",
+                ),
+            ),
+            patch(
+                "hermes_cli.model_normalize.normalize_model_for_provider",
+                side_effect=lambda m, p: m,
+            ),
+            patch(
+                "agent.anthropic_adapter.build_anthropic_client",
+                side_effect=_fake_build,
+            ),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        # nous anthropic/* still gets anthropic_messages via the heuristic
+        # (nous_api_mode), so the typo'd override is ignored and the
+        # correct wire is selected.
+        assert agent.api_mode == "anthropic_messages"
+
 
 # ── Pool-rotation vs fallback gating (#11314) ────────────────────────────
 


### PR DESCRIPTION
`try_activate_fallback` derived the fallback `api_mode` purely from `fb_provider` and `fb_base_url` host heuristics (lines 2056-2100), never consulting `fb.get("api_mode")` / `fb.get("transport")`. A fallback entry declared as `anthropic_messages` against a proxy without the `/anthropic` path suffix or a custom provider whose declared transport wasn't host-detected silently downgraded to `chat_completions`.

Insert an explicit-override block before the heuristic ladder: if `api_mode` or `transport` is set on the entry and matches the valid set (`chat_completions`, `codex_responses`, `anthropic_messages`, `bedrock_converse`, `codex_app_server`), it wins. Invalid/typo'd values fall through (don't silently apply an unknown transport). 17/17 test_provider_fallback.py; 19/19 adjacent.