### PR TITLE
fix(agent): continue turn when live-streamed content meets a session-persist failure (#82001)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -6639,10 +6639,44 @@ def run_conversation(
                     # nothing was recorded, the cause is genuinely unknown.
                     if getattr(agent, "_last_persistence_error_cause", None) is None:
                         agent._last_persistence_error_cause = "unknown"
-                    _turn_exit_reason = "session_persistence_failed"
-                    final_response = ""
-                    failed = True
-                    break
+                    # Live-continuation escape (#82001): if the assistant text
+                    # was already streamed to the user via the live stream
+                    # callback, killing the turn surfaces a misleading "full
+                    # disk" / persistence toast while the user has already
+                    # read the response. The streamed content survives only in
+                    # the user's view; the canonical DB does not. Continue the
+                    # turn — let tools run, let the post-tool compress/finalize
+                    # path retry the persist — instead of stopping here. The
+                    # next per-message persist will repair the gap.
+                    _streamed_already = (
+                        agent._has_content_after_think_block(
+                            getattr(agent, "_current_streamed_assistant_text", "") or ""
+                        )
+                    )
+                    if _streamed_already:
+                        logger.warning(
+                            "Incremental tool-call persistence failed AFTER live "
+                            "streamed content (session=%s cause=%s) — continuing "
+                            "turn instead of surfacing a misleading failure "
+                            "(#82001). Finalizer will retry the persist.",
+                            agent.session_id or "none",
+                            agent._last_persistence_error_cause,
+                        )
+                        agent._buffer_status(
+                            "⚠️ Session storage temporarily unavailable — "
+                            "this turn will retry on its next persist "
+                            "(content already shown to you)."
+                        )
+                        agent._incremental_persistence_failed = True
+                        # Fall through to the normal interim-emit + tool
+                        # execution path below; do NOT set failed=True or
+                        # break. The turn finalizer and the next-turn persist
+                        # will heal the gap.
+                    else:
+                        _turn_exit_reason = "session_persistence_failed"
+                        final_response = ""
+                        failed = True
+                        break
 
                 # A UI must never observe an assistant/tool-call row that is
                 # still only an ephemeral in-memory projection. Emit interim

--- a/tests/run_agent/test_tool_call_incremental_persistence.py
+++ b/tests/run_agent/test_tool_call_incremental_persistence.py
@@ -247,6 +247,115 @@ def test_failed_assistant_persist_blocks_ui_projection_and_tool_side_effects():
     assert isinstance(result.get("error"), str) and result["error"].strip() != ""
 
 
+def test_failed_assistant_persist_after_live_stream_continues_turn():
+    """Live continuation must not die on a session-persist failure (#82001).
+
+    When the assistant content has ALREADY been streamed to the user via the
+    live stream callback, killing the turn on a session-persist failure
+    surfaces a misleading "full disk" / persistence toast while the user has
+    already read the response. The streamed text is gone from the canonical
+    DB but lives in the user's view — the worst of both worlds. The fix is
+    to continue the turn (run tools, retry on the next persist) instead of
+    surfacing ``session_persistence_failed:disk`` and marking ``failed=True``.
+    """
+    import sqlite3
+
+    agent = _make_agent()
+    tool_call = _mock_tool_call(call_id="must-continue")
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(
+            content="Inspecting the repository now.",
+            finish_reason="tool_calls",
+            tool_calls=[tool_call],
+        ),
+        _mock_response(content="done", finish_reason="stop"),
+    ]
+    # Live continuation marker: the conversation loop clears
+    # ``_current_streamed_assistant_text`` at the start of every API call
+    # (via ``_reset_stream_delivery_tracking``). Use a side effect on the
+    # incremental-persist call to re-stamp it before the failure surfaces,
+    # so the live-continuation escape path (#82001) sees the streamed text.
+    _streamed_text = "Inspecting the repository now."
+
+    def _persist_fails_with_live_continuation(messages, conversation_history=None):
+        agent._current_streamed_assistant_text = _streamed_text
+        raise sqlite3.OperationalError("database or disk is full")
+
+    agent._flush_messages_to_session_db = MagicMock(
+        side_effect=_persist_fails_with_live_continuation
+    )
+    agent.interim_assistant_callback = MagicMock()
+    agent._execute_tool_calls = MagicMock(
+        side_effect=lambda *a, **kw: setattr(
+            agent, "_incremental_persistence_failed", False
+        )
+    )
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("inspect the repository")
+
+    # The turn must NOT have been marked failed — the live content is in the
+    # user's view and the agent should continue normally.
+    assert result.get("failed") is not True, (
+        "live-continuation turn died on persist failure; should continue "
+        "instead of surfacing a misleading disk/full error (#82001)"
+    )
+    assert result.get("turn_exit_reason") != "session_persistence_failed"
+    # The machine-readable failure_reason must NOT carry the misleading
+    # 'session_persistence_failed:disk' stamp (that triggers the desktop
+    # toast).
+    assert "session_persistence_failed" not in str(result.get("failure_reason") or "")
+    # Tools must still execute — the canonical DB gap will be repaired by
+    # the next persist (finalizer or the user's next message).
+    assert agent._execute_tool_calls.called, (
+        "live-continuation escape stopped tool execution; should let it run"
+    )
+
+
+def test_failed_assistant_persist_without_live_stream_still_blocks_side_effects():
+    """Without live streamed content, the original blocking behaviour holds.
+
+    Pins the pre-existing safety contract for the live-continuation escape:
+    if NOTHING has been streamed to the user, killing the turn on a
+    persist failure remains correct (running side-effecting tools from
+    state that exists only in-process would lose the user's turn on
+    resume). The new escape path (#82001) is gated on streamed text.
+    """
+    import sqlite3
+
+    agent = _make_agent()
+    tool_call = _mock_tool_call(call_id="must-not-run")
+    agent.client.chat.completions.create.return_value = _mock_response(
+        content="I'll inspect the repository now.",
+        finish_reason="tool_calls",
+        tool_calls=[tool_call],
+    )
+    agent._flush_messages_to_session_db = MagicMock(
+        side_effect=sqlite3.OperationalError("database or disk is full")
+    )
+    # Crucially, NO live streamed text — the user's view is empty.
+    agent._current_streamed_assistant_text = ""
+    agent.interim_assistant_callback = MagicMock()
+    agent._execute_tool_calls = MagicMock()
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("inspect the repository")
+
+    agent.interim_assistant_callback.assert_not_called()
+    agent._execute_tool_calls.assert_not_called()
+    assert result["failed"] is True
+    assert result["turn_exit_reason"] == "session_persistence_failed"
+    assert result["failure_reason"] == "session_persistence_failed:disk"
+
+
 def test_locked_flush_exception_surfaces_locked_cause_in_result_contract():
     """SQLite write-lock contention must surface as a 'locked' cause.
 


### PR DESCRIPTION
When the assistant content has already been streamed to the user and the incremental tool-call persist (`_flush_messages_to_session_db`) fails (e.g. disk full), `turn_finalizer` previously surfaced a misleading 'full disk' toast — the user could already read the response, but the canonical DB row was lost and the error implied the data path was broken.

Add a live-continuation escape branch: when `_current_streamed_assistant_text` already contains user-visible content, warn + buffer a transient status + set `agent._incremental_persistence_failed=True` and let the turn continue; the finalizer and the next persist will repair the canonical DB gap. When there's no live content, keep the blocking behavior. 15/15 in test_tool_call_incremental_persistence.py (2 new); 4+7+17+16+26 in adjacent suites.