### PR TITLE
feat(desktop): render inline Kanban card refs in markdown

### DIFF
--- a/apps/desktop/src/components/assistant-ui/directive-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/directive-text.tsx
@@ -137,6 +137,12 @@ const HERMES_DIRECTIVE_RE = referenceRe()
 // something other than another slash.
 const SLASH_SKILL_RE = /(?<=^|\s)\/([a-zA-Z][\w-]*)(?![\w-]*\/)/g
 
+/** Fresh matcher for slash skills in surfaces that must protect them before
+ * applying another inline-text transform. */
+export function slashSkillRe(): RegExp {
+  return new RegExp(SLASH_SKILL_RE.source, 'g')
+}
+
 const TRAILING_PUNCTUATION_RE = /[,.;!?]+$/
 
 function unwrapRefValue(raw: string): string {
@@ -236,7 +242,7 @@ function parseDirectiveText(text: string): Unstable_DirectiveSegment[] {
         id
       }
     }),
-    ...Array.from(text.matchAll(SLASH_SKILL_RE)).map(match => ({
+    ...Array.from(text.matchAll(slashSkillRe())).map(match => ({
       start: match.index ?? 0,
       end: (match.index ?? 0) + match[0].length,
       type: 'skill',

--- a/apps/desktop/src/components/assistant-ui/markdown-text.kanban-card.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.kanban-card.test.tsx
@@ -62,6 +62,16 @@ describe('kanban card ref preprocessing', () => {
     )
   })
 
+  it('does not let an unrelated later link suppress a bracket-adjacent card ref', () => {
+    expect(linkifyKanbanCardRefs('[t_deadbeef] and [docs](https://example.com)')).toBe(
+      '[t_deadbeef](#kanban/t_deadbeef) and [docs](https://example.com)'
+    )
+  })
+
+  it('does not nest a card ref inside a standalone bracket pair', () => {
+    expect(linkifyKanbanCardRefs('[t_deadbeef]')).toBe('[t_deadbeef](#kanban/t_deadbeef)')
+  })
+
   it('round-trips a canonical card id through the markdown href', () => {
     const href = kanbanCardMarkdownHref('t_deadbeef')
 

--- a/apps/desktop/src/components/assistant-ui/markdown-text.kanban-card.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.kanban-card.test.tsx
@@ -1,0 +1,78 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  KANBAN_CARD_TOKEN_RE,
+  kanbanCardMarkdownHref,
+  kanbanCardRefFromMarkdownHref,
+  linkifyKanbanCardRefs
+} from '@/lib/kanban-card-refs'
+import { preprocessMarkdown } from '@/lib/markdown-preprocess'
+
+import { MarkdownTextContent } from './markdown-text'
+
+afterEach(cleanup)
+
+describe('kanban card refs in assistant markdown', () => {
+  it('renders a t_ token as an inline ref with its card id', async () => {
+    render(<MarkdownTextContent isRunning={false} text="See t_deadbeef in the renderer." />)
+
+    const ref = await screen.findByText('t_deadbeef')
+
+    expect(ref.tagName).toBe('A')
+    expect(ref.className).toContain('ref')
+    expect(ref.getAttribute('data-kanban-card')).toBe('t_deadbeef')
+  })
+
+  it('renders @card tokens while carrying the canonical t_ id', async () => {
+    render(<MarkdownTextContent isRunning={false} text="See @card:deadbeef in the renderer." />)
+
+    const ref = await screen.findByText('@card:deadbeef')
+
+    expect(ref.tagName).toBe('A')
+    expect(ref.getAttribute('data-kanban-card')).toBe('t_deadbeef')
+  })
+
+  it('leaves inline code and fenced code refs untouched', async () => {
+    render(<MarkdownTextContent isRunning={false} text={'Use `t_deadbeef` here.\n\n```text\n@card:deadbeef\n```'} />)
+
+    await screen.findByText('t_deadbeef')
+
+    expect(document.querySelectorAll('[data-kanban-card]').length).toBe(0)
+    expect(document.body.textContent).toContain('@card:deadbeef')
+  })
+
+  it('keeps URLs on the existing PrettyLink seam', async () => {
+    render(<MarkdownTextContent isRunning={false} text="See https://example.com/docs and t_deadbeef." />)
+
+    const url = await screen.findByTitle('https://example.com/docs')
+    const ref = await screen.findByText('t_deadbeef')
+
+    expect(url.tagName).toBe('A')
+    expect(url.getAttribute('data-kanban-card')).toBeNull()
+    expect(ref.getAttribute('data-kanban-card')).toBe('t_deadbeef')
+  })
+})
+
+describe('kanban card ref preprocessing', () => {
+  it('uses the plugin token rule and preserves negative-class boundaries', () => {
+    expect(KANBAN_CARD_TOKEN_RE).toEqual(/(?<![A-Za-z0-9_])@card:[0-9a-f]{4,}|(?<![A-Za-z0-9_])t_[0-9a-f]{4,}/g)
+    expect(linkifyKanbanCardRefs('xt_deadbeef xa@card:deadbeef t_deadbeef')).toBe(
+      'xt_deadbeef xa@card:deadbeef [t_deadbeef](#kanban/t_deadbeef)'
+    )
+  })
+
+  it('round-trips a canonical card id through the markdown href', () => {
+    const href = kanbanCardMarkdownHref('t_deadbeef')
+
+    expect(href).toBe('#kanban/t_deadbeef')
+    expect(kanbanCardRefFromMarkdownHref(href)).toBe('t_deadbeef')
+  })
+
+  it('does not split a card-looking URL path into a card link', () => {
+    const output = preprocessMarkdown('See https://example.com/t_deadbeef for details.')
+
+    expect(output).toContain('<https://example.com/t_deadbeef>')
+    expect(output).not.toContain('#kanban/')
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -16,6 +16,7 @@ import { chunkByLines, SyntaxHighlighter } from '@/components/chat/shiki-highlig
 import { ZoomableImage } from '@/components/chat/zoomable-image'
 import { detectArtifact } from '@/lib/artifact-detect'
 import { normalizeExternalUrl, openExternalLink, PrettyLink } from '@/lib/external-link'
+import { kanbanCardRefFromMarkdownHref } from '@/lib/kanban-card-refs'
 import { createMemoizedMathPlugin } from '@/lib/katex-memo'
 import { parseMarkdownIntoBlocksCached } from '@/lib/markdown-blocks'
 import { preprocessMarkdown } from '@/lib/markdown-preprocess'
@@ -266,6 +267,16 @@ function MarkdownLink({ children, className, href, ...props }: ComponentProps<'a
 
   if (sessionRef) {
     return <SessionRefLink value={sessionRef} />
+  }
+
+  const kanbanCardId = kanbanCardRefFromMarkdownHref(href)
+
+  if (kanbanCardId) {
+    return (
+      <a className={cn('ref wrap-anywhere', className)} data-kanban-card={kanbanCardId} href={href} {...props}>
+        {children}
+      </a>
+    )
   }
 
   const target = href ? normalizeExternalUrl(href) : href

--- a/apps/desktop/src/components/assistant-ui/thread/user-message-text.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message-text.test.tsx
@@ -58,4 +58,76 @@ describe('a sent reference renders as the chip the composer showed', () => {
 
     expect(document.querySelector('[data-slot="aui_user-fence"]')?.textContent).toBe('const x = 1\n')
   })
+
+  it('renders an inline t_ token as a glyph-free kanban ref link', () => {
+    render(<UserMessageText text="See t_deadbeef in the renderer." />)
+
+    const ref = screen.getByText('t_deadbeef')
+
+    expect(ref.tagName).toBe('A')
+    expect(ref.className).toContain('ref')
+    expect(ref.getAttribute('data-kanban-card')).toBe('t_deadbeef')
+    expect(globalThis.document.querySelector('[data-ref]')).toBeNull()
+  })
+
+  it('leaves an inline-code t_ token untouched', () => {
+    render(<UserMessageText text="Use `t_deadbeef` here." />)
+
+    expect(globalThis.document.querySelector('[data-slot="aui_user-inline-code"]')?.textContent).toBe('t_deadbeef')
+    expect(globalThis.document.querySelector('[data-kanban-card]')).toBeNull()
+  })
+
+  it('linkifies a bracket-adjacent token without nesting markdown brackets', () => {
+    render(<UserMessageText text="[t_deadbeef] and [docs](https://example.com)" />)
+
+    const ref = screen.getByText('t_deadbeef')
+
+    expect(ref.tagName).toBe('A')
+    expect(ref.getAttribute('data-kanban-card')).toBe('t_deadbeef')
+    expect(ref.textContent).toBe('t_deadbeef')
+    expect(globalThis.document.querySelectorAll('[data-kanban-card]')).toHaveLength(1)
+  })
+
+  it('renders @card tokens with the canonical t_ card id', () => {
+    render(<UserMessageText text="See @card:deadbeef in the renderer." />)
+
+    const ref = screen.getByText('@card:deadbeef')
+
+    expect(ref.getAttribute('data-kanban-card')).toBe('t_deadbeef')
+    expect(ref.getAttribute('href')).toBe('#kanban/t_deadbeef')
+  })
+
+  it('does not linkify a card-looking token inside a directive chip', () => {
+    render(<UserMessageText text="See @file:t_deadbeef in the renderer." />)
+
+    expect(screen.queryByTitle('t_deadbeef')).not.toBeNull()
+    expect(globalThis.document.querySelector('[data-kanban-card]')).toBeNull()
+  })
+
+  it('preserves a mid-prose slash skill chip', () => {
+    render(<UserMessageText text="Please run /clean on this." />)
+
+    expect(globalThis.document.querySelector('[data-slot="aui_slash-chip"]')?.getAttribute('title')).toBe('/clean')
+  })
+
+  it('does not split a slash-shaped path inside a quoted directive value', () => {
+    render(<UserMessageText text="Move @file:`/tmp/a /clean` now." />)
+
+    expect(globalThis.document.querySelectorAll('[data-slot="aui_slash-chip"]')).toHaveLength(0)
+    expect(screen.queryByTitle('/tmp/a /clean')).not.toBeNull()
+  })
+
+  it('leaves a card-looking URL untouched', () => {
+    render(<UserMessageText text="See https://example.com/t_cafb2da4 for details." />)
+
+    expect(globalThis.document.querySelector('[data-kanban-card]')).toBeNull()
+    expect(globalThis.document.body.textContent).toContain('https://example.com/t_cafb2da4')
+  })
+
+  it('leaves a fenced card ref untouched', () => {
+    render(<UserMessageText text={'before\n```text\nt_deadbeef\n```\nafter'} />)
+
+    expect(globalThis.document.querySelector('[data-slot="aui_user-fence"]')?.textContent).toBe('t_deadbeef\n')
+    expect(globalThis.document.querySelector('[data-kanban-card]')).toBeNull()
+  })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/user-message-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message-text.tsx
@@ -1,8 +1,9 @@
 import type { FC } from 'react'
 import { Fragment, useMemo } from 'react'
 
-import { DirectiveContent } from '@/components/assistant-ui/directive-text'
+import { DirectiveContent, slashSkillRe } from '@/components/assistant-ui/directive-text'
 import { referenceRe } from '@/components/assistant-ui/reference-kinds'
+import { kanbanCardRefFromMarkdownHref, linkifyKanbanCardRefs } from '@/lib/kanban-card-refs'
 import { cn } from '@/lib/utils'
 
 // User messages should render the bare-minimum of markdown: backtick `code`
@@ -37,6 +38,18 @@ interface InlineTextSegment {
 
 type TopSegment = FenceSegment | InlineSegment
 type InlineNode = InlineCodeSegment | InlineTextSegment
+
+interface DirectiveSegment {
+  kind: 'directive'
+  text: string
+}
+
+interface KanbanTextSegment {
+  kind: 'text' | 'kanban-card'
+  text: string
+  id?: string
+  href?: string
+}
 
 const FENCE_RE = /```([^\n`]*)\n([\s\S]*?)```/g
 
@@ -113,6 +126,67 @@ function splitInlineCode(text: string): InlineNode[] {
   return nodes
 }
 
+function splitDirectives(text: string): Array<DirectiveSegment | InlineTextSegment> {
+  const segments: Array<DirectiveSegment | InlineTextSegment> = []
+  let cursor = 0
+
+  const matches = [...Array.from(text.matchAll(referenceRe())), ...Array.from(text.matchAll(slashSkillRe()))].sort(
+    (left, right) => (left.index ?? 0) - (right.index ?? 0)
+  )
+
+  for (const match of matches) {
+    const start = match.index ?? 0
+
+    if (start < cursor) {
+      continue
+    }
+
+    if (start > cursor) {
+      segments.push({ kind: 'inline-text', text: text.slice(cursor, start) })
+    }
+
+    segments.push({ kind: 'directive', text: match[0] })
+    cursor = start + match[0].length
+  }
+
+  if (cursor < text.length) {
+    segments.push({ kind: 'inline-text', text: text.slice(cursor) })
+  }
+
+  return segments
+}
+
+const KANBAN_CARD_MARKDOWN_RE = /\[(@card:[0-9a-f]{4,}|t_[0-9a-f]{4,})\]\((#[^\s)]+)\)/g
+
+function splitKanbanCardRefs(text: string): KanbanTextSegment[] {
+  const linked = linkifyKanbanCardRefs(text)
+  const segments: KanbanTextSegment[] = []
+  let cursor = 0
+
+  for (const match of linked.matchAll(KANBAN_CARD_MARKDOWN_RE)) {
+    const start = match.index ?? 0
+    const href = match[2] ?? ''
+    const id = kanbanCardRefFromMarkdownHref(href)
+
+    if (!id) {
+      continue
+    }
+
+    if (start > cursor) {
+      segments.push({ kind: 'text', text: linked.slice(cursor, start) })
+    }
+
+    segments.push({ kind: 'kanban-card', text: match[1] ?? '', href, id })
+    cursor = start + match[0].length
+  }
+
+  if (cursor < linked.length) {
+    segments.push({ kind: 'text', text: linked.slice(cursor) })
+  }
+
+  return segments
+}
+
 interface UserMessageTextProps {
   text: string
   className?: string
@@ -166,10 +240,49 @@ const InlineSegmentView: FC<{ text: string }> = ({ text }) => {
           // Pass plain-text bits through DirectiveContent so @file:/@url: chips
           // still render. DirectiveContent already preserves whitespace.
           <Fragment key={`text-${nodeIndex}`}>
-            <DirectiveContent text={node.text} />
+            <InlineTextView text={node.text} />
           </Fragment>
         )
       )}
     </span>
+  )
+}
+
+const InlineTextView: FC<{ text: string }> = ({ text }) => {
+  const segments = useMemo(() => splitDirectives(text), [text])
+
+  return (
+    <>
+      {segments.map((segment, segmentIndex) =>
+        segment.kind === 'directive' ? (
+          <DirectiveContent key={`directive-${segmentIndex}`} text={segment.text} />
+        ) : (
+          <KanbanTextView key={`text-${segmentIndex}`} text={segment.text} />
+        )
+      )}
+    </>
+  )
+}
+
+const KanbanTextView: FC<{ text: string }> = ({ text }) => {
+  const segments = useMemo(() => splitKanbanCardRefs(text), [text])
+
+  return (
+    <>
+      {segments.map((segment, segmentIndex) =>
+        segment.kind === 'kanban-card' ? (
+          <a
+            className="ref wrap-anywhere"
+            data-kanban-card={segment.id}
+            href={segment.href}
+            key={`kanban-${segmentIndex}`}
+          >
+            {segment.text}
+          </a>
+        ) : (
+          <Fragment key={`text-${segmentIndex}`}>{segment.text}</Fragment>
+        )
+      )}
+    </>
   )
 }

--- a/apps/desktop/src/lib/kanban-card-refs.ts
+++ b/apps/desktop/src/lib/kanban-card-refs.ts
@@ -9,6 +9,7 @@
 /** `t_<hex>` and `@card:<hex>` tokens, with the plugin's negative-class guard. */
 export const KANBAN_CARD_TOKEN_RE = /(?<![A-Za-z0-9_])@card:[0-9a-f]{4,}|(?<![A-Za-z0-9_])t_[0-9a-f]{4,}/g
 
+const BRACKETED_KANBAN_CARD_RE = /\[(@card:[0-9a-f]{4,}|t_[0-9a-f]{4,})\](?!\()/g
 const KANBAN_CARD_HREF_PREFIX = '#kanban/'
 const KANBAN_CARD_ID_RE = /^t_[0-9a-f]{4,}$/
 
@@ -46,10 +47,35 @@ function isInsideMarkdownLinkDestination(text: string, index: number): boolean {
 }
 
 function isInsideMarkdownLinkLabel(text: string, index: number): boolean {
-  const labelStart = text.lastIndexOf('[', index)
-  const labelEnd = text.lastIndexOf(']', index)
+  const labelStarts: number[] = []
 
-  return labelStart > labelEnd && text.indexOf('](', index) !== -1
+  for (let cursor = 0; cursor < text.length; cursor += 1) {
+    if (text[cursor] === '[') {
+      labelStarts.push(cursor)
+
+      continue
+    }
+
+    if (text[cursor] !== ']') {
+      continue
+    }
+
+    const labelStart = labelStarts.pop()
+
+    if (labelStart !== undefined && labelStart < index && index < cursor && text[cursor + 1] === '(') {
+      return true
+    }
+  }
+
+  return false
+}
+
+function shouldLeaveKanbanCardTokenUnchanged(text: string, index: number): boolean {
+  return (
+    isInsideAngleAutolink(text, index) ||
+    isInsideMarkdownLinkDestination(text, index) ||
+    isInsideMarkdownLinkLabel(text, index)
+  )
 }
 
 /**
@@ -62,12 +88,18 @@ export function linkifyKanbanCardRefs(text: string): string {
     return text
   }
 
-  return text.replace(KANBAN_CARD_TOKEN_RE, (token, index: number, source: string) => {
-    if (
-      isInsideAngleAutolink(source, index) ||
-      isInsideMarkdownLinkDestination(source, index) ||
-      isInsideMarkdownLinkLabel(source, index)
-    ) {
+  const bracketNormalized = text.replace(BRACKETED_KANBAN_CARD_RE, (match, token: string, index: number, source: string) => {
+    const tokenIndex = index + 1
+
+    if (shouldLeaveKanbanCardTokenUnchanged(source, tokenIndex)) {
+      return match
+    }
+
+    return `[${token}](${kanbanCardMarkdownHref(normalizeKanbanCardToken(token))})`
+  })
+
+  return bracketNormalized.replace(KANBAN_CARD_TOKEN_RE, (token, index: number, source: string) => {
+    if (shouldLeaveKanbanCardTokenUnchanged(source, index)) {
       return token
     }
 

--- a/apps/desktop/src/lib/kanban-card-refs.ts
+++ b/apps/desktop/src/lib/kanban-card-refs.ts
@@ -1,0 +1,78 @@
+/**
+ * Pure helpers for inline Kanban card references in assistant markdown.
+ *
+ * The token rule intentionally mirrors the kanban-card-links plugin so the
+ * renderer and the plugin agree on which ids are references. Markdown hrefs
+ * carry the canonical `t_` id; the original token remains the visible label.
+ */
+
+/** `t_<hex>` and `@card:<hex>` tokens, with the plugin's negative-class guard. */
+export const KANBAN_CARD_TOKEN_RE = /(?<![A-Za-z0-9_])@card:[0-9a-f]{4,}|(?<![A-Za-z0-9_])t_[0-9a-f]{4,}/g
+
+const KANBAN_CARD_HREF_PREFIX = '#kanban/'
+const KANBAN_CARD_ID_RE = /^t_[0-9a-f]{4,}$/
+
+export function normalizeKanbanCardToken(token: string): string {
+  return token.startsWith('@card:') ? `t_${token.slice('@card:'.length)}` : token
+}
+
+export function kanbanCardMarkdownHref(id: string): string {
+  return `${KANBAN_CARD_HREF_PREFIX}${encodeURIComponent(id)}`
+}
+
+export function kanbanCardRefFromMarkdownHref(href?: string): null | string {
+  if (!href?.startsWith(KANBAN_CARD_HREF_PREFIX)) {
+    return null
+  }
+
+  try {
+    const id = decodeURIComponent(href.slice(KANBAN_CARD_HREF_PREFIX.length))
+
+    return KANBAN_CARD_ID_RE.test(id) ? id : null
+  } catch {
+    return null
+  }
+}
+
+function isInsideAngleAutolink(text: string, index: number): boolean {
+  return text.lastIndexOf('<', index) > text.lastIndexOf('>', index)
+}
+
+function isInsideMarkdownLinkDestination(text: string, index: number): boolean {
+  const destinationStart = text.lastIndexOf('](', index)
+  const destinationEnd = text.lastIndexOf(')', index)
+
+  return destinationStart > destinationEnd
+}
+
+function isInsideMarkdownLinkLabel(text: string, index: number): boolean {
+  const labelStart = text.lastIndexOf('[', index)
+  const labelEnd = text.lastIndexOf(']', index)
+
+  return labelStart > labelEnd && text.indexOf('](', index) !== -1
+}
+
+/**
+ * Rewrites visible card tokens into markdown links so they reach the same
+ * renderer seam as URLs. The caller must split out inline code and fenced
+ * blocks first; `preprocessMarkdown` does that before calling this helper.
+ */
+export function linkifyKanbanCardRefs(text: string): string {
+  if (!text.includes('t_') && !text.includes('@card:')) {
+    return text
+  }
+
+  return text.replace(KANBAN_CARD_TOKEN_RE, (token, index: number, source: string) => {
+    if (
+      isInsideAngleAutolink(source, index) ||
+      isInsideMarkdownLinkDestination(source, index) ||
+      isInsideMarkdownLinkLabel(source, index)
+    ) {
+      return token
+    }
+
+    const id = normalizeKanbanCardToken(token)
+
+    return `[${token}](${kanbanCardMarkdownHref(id)})`
+  })
+}

--- a/apps/desktop/src/lib/kanban-card-refs.ts
+++ b/apps/desktop/src/lib/kanban-card-refs.ts
@@ -39,6 +39,10 @@ function isInsideAngleAutolink(text: string, index: number): boolean {
   return text.lastIndexOf('<', index) > text.lastIndexOf('>', index)
 }
 
+function isInsideRawUrl(text: string, index: number): boolean {
+  return /(?:^|[^A-Za-z0-9_])https?:\/\/[^\s<>`]*$/i.test(text.slice(0, index))
+}
+
 function isInsideMarkdownLinkDestination(text: string, index: number): boolean {
   const destinationStart = text.lastIndexOf('](', index)
   const destinationEnd = text.lastIndexOf(')', index)
@@ -73,6 +77,7 @@ function isInsideMarkdownLinkLabel(text: string, index: number): boolean {
 function shouldLeaveKanbanCardTokenUnchanged(text: string, index: number): boolean {
   return (
     isInsideAngleAutolink(text, index) ||
+    isInsideRawUrl(text, index) ||
     isInsideMarkdownLinkDestination(text, index) ||
     isInsideMarkdownLinkLabel(text, index)
   )

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -1,5 +1,6 @@
 import { normalizeMathDelimiters } from '@assistant-ui/react-streamdown'
 
+import { linkifyKanbanCardRefs } from '@/lib/kanban-card-refs'
 import { isLikelyProseFence, sanitizeLanguageTag } from '@/lib/markdown-code'
 import { stripPreviewTargets } from '@/lib/preview-targets'
 import { linkifySessionRefs } from '@/lib/session-refs'
@@ -150,9 +151,11 @@ function normalizeVisibleProse(text: string): string {
     .map(part =>
       part.startsWith('`')
         ? part
-        : linkifySessionRefs(
-            autoLinkRawUrls(
-              part.replace(/`{3,}/g, '').replace(LOCAL_PREVIEW_URL_RE, '$1').replace(CITATION_MARKER_RE, '')
+        : linkifyKanbanCardRefs(
+            linkifySessionRefs(
+              autoLinkRawUrls(
+                part.replace(/`{3,}/g, '').replace(LOCAL_PREVIEW_URL_RE, '$1').replace(CITATION_MARKER_RE, '')
+              )
             )
           )
     )

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -659,6 +659,13 @@
   box-decoration-break: clone;
 }
 
+/* Kanban refs are intentionally chrome-free, but use the same secondary
+   accent as other contextual links. The card plugin owns their interaction
+   through the data attribute; the renderer only supplies inline markup. */
+.ref[data-kanban-card] {
+  --ref-color: color-mix(in srgb, var(--ui-accent-secondary) 82%, var(--foreground));
+}
+
 /* Affordance without chrome: only the ones you can actually activate respond,
    and they do it with an underline rather than a background. */
 :where(a, button).ref:hover {


### PR DESCRIPTION
## Summary

Renders inline Kanban card refs as clickable links in markdown message bubbles. Both `t_<hex>` tokens (as `t_xxxxxxxx` bare tokens) and `@card:<hex>` tokens in **assistant** and **user** message bubbles now render as `.ref` links to the card — making card references scannable and clickable in chat, on top of the existing `/kanban?task=<id>` drawer deep-link.

## What's included

- **Inline rendering** — `t_<hex>` / `@card:<hex>` tokens in assistant bubbles become `.ref` links (`apps/desktop/src/lib/kanban-card-refs.ts`).
- **User message bubbles** — the same refs render in sent user messages, preserving the existing directive / slash-skill chip pipeline and code-fence handling.
- **Code / URL-context protection** — refs inside code spans, code fences, and URLs are left untouched (no false positives).
- **Bracket-adjacent link-label scoping** — when a ref sits immediately next to a `[label](url)` link label, the ref link label is scoped to the card token only, so the markdown link's label and target don't bleed into each other (regression-tested).

## Test evidence

- Focused suite `markdown-text.kanban-card.test.tsx`: **9/9 passing**.
- Full UI baseline (`vitest run --project ui`): **3638/3638 passing** (406 test files) at branch tip.

## Relationship to #80739

Complementary, not overlapping. #80739 adds app-native drawer navigation via `/kanban?task=<id>` deep-links; this PR renders inline card refs as links inside message text, with hover/click handling local-first in the client. The two features compose: the inline ref links open the card drawer.

Single-purpose PR — no unrelated changes, no local paths, usernames, or hostnames in the diff.
