### PR TITLE
fix(update): refresh installer bootstrap-cache scripts on every update (stale hermes-setup mitigation)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5121,6 +5121,7 @@ from hermes_cli.update_cmd import (  # noqa: F401
     _record_npm_lockfile_hash,
     _refresh_active_lazy_features,
     _refresh_active_memory_provider_dependencies,
+    _refresh_bootstrap_cache_scripts,
     _refresh_windows_gateway_launchers,
     _reload_updated_runtime_modules,
     _resolve_pre_update_backup_mode,

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -889,6 +889,7 @@ def _update_via_zip(args):
             f"  ✓ Cleared {removed} stale __pycache__ director{'y' if removed == 1 else 'ies'}"
         )
     _m()._record_bytecode_fingerprint()
+    _m()._refresh_bootstrap_cache_scripts()
 
     # Reinstall Python dependencies. Prefer .[all], but if one optional extra
     # breaks on this machine, keep base deps and reinstall the remaining extras
@@ -3474,6 +3475,67 @@ def _refresh_windows_gateway_launchers() -> None:
     except Exception as exc:
         logger.debug("Could not refresh Windows gateway launchers after update: %s", exc)
 
+def _refresh_bootstrap_cache_scripts() -> None:
+    """Sync the installer's bootstrap-cache scripts from the fresh checkout.
+
+    The Desktop GUI updater (``hermes-setup.exe``) executes
+    ``$HERMES_HOME/bootstrap-cache/install-<ref>.ps1`` (or ``.sh``) for its
+    repair/bootstrap stages. Installer binaries built before the #67193
+    cache-refresh fix (June 2026 and earlier) NEVER re-download a cached
+    branch-ref script — ``install-main.ps1`` cached at install time is
+    reused forever, executing months-stale code with long-fixed bugs (the
+    2026-08-09 incident: a June 4 cached script's venv stage lacked the
+    #81327 process-tree sweep and died on ``Access denied``). The binary
+    has no self-update path, so the poisoned cache outlives every
+    ``hermes update``.
+
+    Overwriting the cached branch scripts with the freshly pulled
+    ``scripts/install.ps1`` / ``scripts/install.sh`` on every update turns
+    the stale binary's unconditional reuse into a feature: it "reuses" a
+    file this function keeps permanently current. Post-#67193 installers
+    re-download on each run anyway, so for them this is a harmless
+    pre-seed of the same bytes.
+
+    Only branch-ref cache entries (mutable refs) are rewritten — commit-SHA
+    entries (``install-<40 hex>.ps1``) are immutable by design and must
+    keep matching their pinned commit. The .ps1 copy gets a UTF-8 BOM to
+    match the installer's own cache format (#67193 encoding fix).
+    Best-effort: a failed refresh must never fail the update.
+    """
+    try:
+        import re as _re
+
+        cache_dir = Path(_m().get_hermes_home()) / "bootstrap-cache"
+        if not cache_dir.is_dir():
+            return
+        sha_re = _re.compile(r"^install-[0-9a-f]{40}\.(ps1|sh)$")
+        refreshed = []
+        for kind, src_name in (("ps1", "install.ps1"), ("sh", "install.sh")):
+            src = _m().PROJECT_ROOT / "scripts" / src_name
+            if not src.is_file():
+                continue
+            data = src.read_bytes()
+            if kind == "ps1" and not data.startswith(b"\xef\xbb\xbf"):
+                # Match the installer's cache format: PowerShell needs the
+                # UTF-8 BOM or localized/em-dash text mis-decodes (#67193).
+                data = b"\xef\xbb\xbf" + data
+            for cached in cache_dir.glob(f"install-*.{kind}"):
+                if sha_re.match(cached.name):
+                    continue  # immutable commit pin — leave it alone
+                if cached.read_bytes() == data:
+                    continue  # already current
+                tmp = cached.with_suffix(cached.suffix + ".tmp")
+                tmp.write_bytes(data)
+                os.replace(tmp, cached)
+                refreshed.append(cached.name)
+        if refreshed:
+            print(
+                "  ✓ Refreshed installer bootstrap-cache script(s): "
+                + ", ".join(sorted(refreshed))
+            )
+    except Exception as exc:
+        logger.debug("Could not refresh bootstrap-cache scripts after update: %s", exc)
+
 def _resume_windows_gateways_after_update(token: dict | None) -> None:
     """Restart Windows profile gateways previously paused for update."""
     if not token or not token.get("resume_needed"):
@@ -4226,6 +4288,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 f"  ✓ Cleared {removed} stale __pycache__ director{'y' if removed == 1 else 'ies'}"
             )
         _m()._record_bytecode_fingerprint()
+        _m()._refresh_bootstrap_cache_scripts()
 
         # Fork upstream sync logic (only for main branch on forks)
         if is_fork and branch == "main":
@@ -4315,6 +4378,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 f"  ✓ Cleared {removed} stale __pycache__ director{'y' if removed == 1 else 'ies'}"
             )
         _m()._record_bytecode_fingerprint()
+        _m()._refresh_bootstrap_cache_scripts()
         _m()._reload_updated_runtime_modules()
 
         # Upgrade pip before lazy refreshes — stale pip can fail source builds

--- a/tests/hermes_cli/test_update_bootstrap_cache_refresh.py
+++ b/tests/hermes_cli/test_update_bootstrap_cache_refresh.py
@@ -1,0 +1,107 @@
+"""Tests for _refresh_bootstrap_cache_scripts (the stale-installer-cache fix).
+
+Pre-#67193 hermes-setup binaries reuse ``bootstrap-cache/install-<branch>.ps1``
+forever without re-downloading, so a script cached at install time executes
+months-stale code on every GUI update/repair (the 2026-08-09 incident: a
+June 4 cached venv stage without the #81327 tree-kill sweep died on
+``Access denied``). Those binaries have no self-update path, so ``hermes
+update`` now rewrites the mutable-ref cache entries from the fresh checkout —
+the stale binary's unconditional reuse then always executes current code.
+
+Contract under test:
+- branch-ref entries (install-main.ps1, install-bb_gui.ps1, .sh) are
+  overwritten with the checkout's scripts/install.* content
+- .ps1 gets a UTF-8 BOM (installer cache format, #67193); .sh does not
+- 40-hex commit-SHA entries are immutable and never touched
+- missing cache dir / missing sources / IO errors are silent no-ops
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from hermes_cli import main as cli_main
+
+BOM = b"\xef\xbb\xbf"
+
+
+def _setup(tmp_path, *, ps1=b"WRITE-HOST current\n", sh=b"echo current\n"):
+    home = tmp_path / "hermes_home"
+    root = tmp_path / "hermes-agent"
+    (root / "scripts").mkdir(parents=True)
+    (home / "bootstrap-cache").mkdir(parents=True)
+    if ps1 is not None:
+        (root / "scripts" / "install.ps1").write_bytes(ps1)
+    if sh is not None:
+        (root / "scripts" / "install.sh").write_bytes(sh)
+    return home, root
+
+
+def _run(home, root):
+    with patch.object(cli_main, "get_hermes_home", return_value=str(home)), patch.object(
+        cli_main, "PROJECT_ROOT", root
+    ):
+        cli_main._refresh_bootstrap_cache_scripts()
+
+
+def test_branch_ref_ps1_is_overwritten_with_bom(tmp_path, capsys):
+    home, root = _setup(tmp_path)
+    stale = home / "bootstrap-cache" / "install-main.ps1"
+    stale.write_bytes(BOM + b"WRITE-HOST stale june script\n")
+    _run(home, root)
+    assert stale.read_bytes() == BOM + b"WRITE-HOST current\n"
+    assert "install-main.ps1" in capsys.readouterr().out
+
+
+def test_branch_ref_sh_is_overwritten_without_bom(tmp_path):
+    home, root = _setup(tmp_path)
+    stale = home / "bootstrap-cache" / "install-main.sh"
+    stale.write_bytes(b"echo stale\n")
+    _run(home, root)
+    assert stale.read_bytes() == b"echo current\n"
+
+
+def test_source_with_existing_bom_not_doubled(tmp_path):
+    home, root = _setup(tmp_path, ps1=BOM + b"WRITE-HOST current\n")
+    stale = home / "bootstrap-cache" / "install-main.ps1"
+    stale.write_bytes(b"old")
+    _run(home, root)
+    assert stale.read_bytes() == BOM + b"WRITE-HOST current\n"
+
+
+def test_commit_sha_entries_left_alone(tmp_path):
+    home, root = _setup(tmp_path)
+    pinned = home / "bootstrap-cache" / ("install-" + "a" * 40 + ".ps1")
+    pinned.write_bytes(b"pinned bytes")
+    _run(home, root)
+    assert pinned.read_bytes() == b"pinned bytes"
+
+
+def test_already_current_entry_not_reported(tmp_path, capsys):
+    home, root = _setup(tmp_path)
+    current = home / "bootstrap-cache" / "install-main.ps1"
+    current.write_bytes(BOM + b"WRITE-HOST current\n")
+    _run(home, root)
+    assert "Refreshed installer bootstrap-cache" not in capsys.readouterr().out
+
+
+def test_missing_cache_dir_is_noop(tmp_path):
+    home, root = _setup(tmp_path)
+    import shutil
+
+    shutil.rmtree(home / "bootstrap-cache")
+    _run(home, root)  # must not raise
+
+
+def test_missing_sources_is_noop(tmp_path):
+    home, root = _setup(tmp_path, ps1=None, sh=None)
+    stale = home / "bootstrap-cache" / "install-main.ps1"
+    stale.write_bytes(b"stale")
+    _run(home, root)
+    assert stale.read_bytes() == b"stale"
+
+
+def test_never_raises_on_io_error(tmp_path):
+    home, root = _setup(tmp_path)
+    with patch.object(cli_main, "get_hermes_home", side_effect=OSError("boom")):
+        cli_main._refresh_bootstrap_cache_scripts()  # must not raise


### PR DESCRIPTION
## What does this PR do?

Closes the last layer of the 2026-08-09 Windows update-failure incident: **`hermes update` now refreshes the Desktop installer's `bootstrap-cache` scripts from the fresh checkout on every run**, so stale hermes-setup binaries stop executing months-old install code.

### The problem

Pre-#67193 `hermes-setup.exe` builds (June 2026 and earlier — **including the newest published binary, June 5**) resolve `bootstrap-cache/install-<branch>.ps1` as "exists → reuse forever". A branch-ref script cached at install time is never re-downloaded, and the binary has no self-update path, so every GUI update/repair runs frozen-in-time install code no matter how current the repo is.

Live incident: `install-main.ps1` cached **June 4** lacked #81327's venv process-tree sweep → the bootstrap venv stage died twice with `Cannot remove item venv\Scripts\python.exe: Access denied` on a straggler backend pair — *hours after every relevant fix was already merged on main*. The fixes existed; the installer never executed them.

### The fix

`_refresh_bootstrap_cache_scripts()`, called at the end of all three update paths (git, zip fallback, already-up-to-date repair): overwrite **mutable branch-ref** cache entries with the freshly pulled `scripts/install.ps1` / `install.sh`. The stale binary's unconditional-reuse bug becomes a feature — it "reuses" a file the update keeps permanently current. Post-#67193 installers re-download on every run anyway, so for them this is a harmless pre-seed of identical bytes.

Scope guards:
- 40-hex **commit-SHA entries are immutable pins — never touched**
- `.ps1` gets the UTF-8 BOM to match the installer's cache format (#67193 encoding fix)
- Best-effort: a failed refresh can never fail the update

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## How to Test

- `pytest tests/hermes_cli/test_update_bootstrap_cache_refresh.py -o "addopts=--timeout-method=thread"` — 8 passed (overwrite ps1+BOM / sh no-BOM / BOM-not-doubled / SHA-pin untouched / current-entry silent / missing dir/sources no-op / never-raises).
- Neighbor suites: `test_update_venv_health.py`, `test_update_orphan_backend_reap.py`, `test_update_modified_notice.py` — 22 passed.

## E2E verification (the actual incident machine)

Poisoned the real `%LOCALAPPDATA%\hermes\bootstrap-cache\install-main.ps1` with a stub, ran the real function: healed **byte-exact** to the checkout's script — BOM intact, #81327 tree-kill sweep present (`taskkill /F /T /PID $treePid`). Output: `✓ Refreshed installer bootstrap-cache script(s): install-main.ps1`.

## Incident fix-stack context

#82158 (scan truncation) → #81327 (installer tree-kill) → #82179 (orphan reap) → #82191 (Desktop teardown + tree-aware classifier) → **this** (make sure stale installers actually run all of the above).

## Checklist

- [x] Conventional commits; no unrelated changes
- [x] Tests added; tested on Windows 11 against the real incident cache
- [x] Cross-platform: refreshes both `.ps1` and `.sh`; pure-Python, no OS gating needed; silent no-op when `bootstrap-cache/` doesn't exist (CLI-only installs)
