### PR TITLE
fix: append trailing slash when matching directory gitignore patterns in content-hash walk

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5313,7 +5313,7 @@ def _compute_web_ui_content_hash(project_root: Path, web_dir: Path) -> str:
     for dirpath, dirnames, filenames in os.walk(web_dir, topdown=True):
         dirnames[:] = [
             d for d in dirnames
-            if not spec.match_file(str((Path(dirpath) / d).relative_to(project_root)))
+            if not spec.match_file(str((Path(dirpath) / d).relative_to(project_root)) + "/")
         ]
         for fn in sorted(filenames):
             fp = Path(dirpath) / fn
@@ -5909,7 +5909,7 @@ def _compute_desktop_content_hash(project_root: Path) -> str:
         # Prune ignored directories so we never descend into them
         dirnames[:] = [
             d for d in dirnames
-            if not spec.match_file(str((Path(dirpath) / d).relative_to(project_root)))
+            if not spec.match_file(str((Path(dirpath) / d).relative_to(project_root)) + "/")
         ]
 
         for fn in sorted(filenames):


### PR DESCRIPTION
## Problem

`hermes update` hangs indefinitely at **"Checking if desktop app needs rebuilding..."**.

## Root Cause

`_compute_desktop_content_hash` (and `_compute_web_ui_content_hash`) uses `os.walk` with in-place `dirnames` pruning against `pathspec`. Gitignore directory patterns like `apps/desktop/release/` require a **trailing slash** to match, but the pruning code constructed paths without one:

```python
# Before (broken)
if not spec.match_file(str((Path(dirpath) / d).relative_to(project_root)))
```

Testing confirms:
| Path | Without `/` | With `/` |
|------|:---:|:---:|
| `apps/desktop/release` | ❌ False | ✅ True |
| `apps/desktop/dist` | ❌ False | ✅ True |
| `apps/desktop/build` | ❌ False | ✅ True |
| `apps/desktop/node_modules` | ✅ True | ✅ True |
| `apps/desktop/src` | ❌ False | ❌ False ✓ |

Because `release/` was never pruned, the hash function walked **374 MB / 2,766 files** including 100 MB+ Electron binaries — causing the process to hang.

## Fix

Append `/` to directory paths before matching against the gitignore spec:

```python
# After (fixed)
if not spec.match_file(str((Path(dirpath) / d).relative_to(project_root)) + "/")
```

This is consistent with gitignore semantics where trailing slash means "directory only".

## Impact

- Fixes `hermes update` hanging on macOS (and likely Linux) with desktop app builds
- Both `_compute_desktop_content_hash` and `_compute_web_ui_content_hash` are fixed (same pattern)
- No change to hash output — only which files are included in the hash