### PR TITLE
feat(desktop): expose composer insert to plugins

### DIFF
--- a/apps/desktop/src/sdk/index.test.ts
+++ b/apps/desktop/src/sdk/index.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const composer = vi.hoisted(() => ({
+  insert: vi.fn()
+}))
+
+vi.mock('@/app/chat/composer/focus', () => ({
+  requestComposerInsert: composer.insert
+}))
+
+import { host } from './index'
+
+describe('plugin SDK composer action', () => {
+  beforeEach(() => {
+    composer.insert.mockClear()
+  })
+
+  it('inserts text into the active composer through the native composer bus', async () => {
+    await host.composer.insert('/multi-agent-project-orchestrator')
+
+    expect(composer.insert).toHaveBeenCalledOnce()
+    expect(composer.insert).toHaveBeenCalledWith('/multi-agent-project-orchestrator', {
+      mode: 'block',
+      target: 'active'
+    })
+  })
+
+  it('forwards an explicit mode and target', async () => {
+    await host.composer.insert('more detail', { mode: 'inline', target: 'main' })
+
+    expect(composer.insert).toHaveBeenCalledWith('more detail', {
+      mode: 'inline',
+      target: 'main'
+    })
+  })
+})

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -20,6 +20,7 @@
 
 import { atom, type ReadableAtom } from 'nanostores'
 
+import { type ComposerInsertMode, type ComposerTarget, requestComposerInsert } from '@/app/chat/composer/focus'
 import { $narrowViewport } from '@/components/pane-shell/tree/store'
 import { onGatewayEvent } from '@/contrib/events'
 import { getLogs, getStatus } from '@/hermes'
@@ -74,6 +75,18 @@ export const host = {
   /** Toast into the app's notification stack. */
   notify,
   notifyError,
+
+  /** Act on the real, currently active chat composer. Unlike dispatching a
+   *  DOM event from a runtime plugin, this crosses the curated SDK boundary
+   *  and resolves the app's live composer target before inserting. */
+  composer: {
+    insert: async (
+      text: string,
+      { mode = 'block', target = 'active' }: { mode?: ComposerInsertMode; target?: ComposerTarget | 'active' } = {}
+    ): Promise<void> => {
+      requestComposerInsert(text, { mode, target })
+    }
+  },
 
   // NOTE: every host door is async-safe — wrapped so a sync throw from an
   // internal helper (e.g. no desktop bridge in a plain browser) becomes a


### PR DESCRIPTION
## Summary
- expose a curated `host.composer.insert(text, options)` plugin-SDK action
- delegate to the native active-composer resolver and insert bus
- keep the action async-safe for runtime plugins

## Why
Runtime plugins can render beside a chat but currently cannot reliably insert a prepared prompt into the live composer. Dispatching private DOM events creates false-positive success states. This adds the narrow SDK capability required by real launcher plugins without exposing renderer internals.

## Tests
- `npm exec --workspace apps/desktop vitest -- run src/sdk/index.test.ts --project ui`
- `npx tsc -p apps/desktop --noEmit`
- `npm run build --workspace apps/desktop`

All passed locally and on macOS arm64/x64 GitHub runners.