### PR TITLE
fix: ignore glob-shaped skill support paths

### DIFF
--- a/tests/tools/test_skill_bundle_provenance.py
+++ b/tests/tools/test_skill_bundle_provenance.py
@@ -21,7 +21,8 @@ description: A multi-file test skill.
 ---
 # Demo
 Read [the guide](references/guide.md#usage), use `templates/report.md?raw=1`, and run
-`scripts/run.py`. See `examples/endpoint-inventory.md`. The repository also
+`scripts/run.py`, `references/foo%23bar.md`, and `references/my%20guide.md`. See
+`examples/endpoint-inventory.md`. The repository also
 contains assets/logo.png.
 """
 
@@ -42,6 +43,8 @@ def served_repo(tmp_path, monkeypatch):
     (repo / "SKILL.md").write_text(SKILL_MD)
     for rel, content in {
         "references/guide.md": "safe guide\n",
+        "references/foo#bar.md": "encoded delimiter\n",
+        "references/my guide.md": "encoded space\n",
         "templates/report.md": "report\n",
         "scripts/run.py": "print('ok')\n",
         "assets/logo.png": b"\x89PNG\r\n\x1a\n\x00\xff",
@@ -86,12 +89,16 @@ def test_url_source_fetches_only_referenced_allowed_support_directories(served_r
     assert set(bundle.files) == {
         "SKILL.md",
         "references/guide.md",
+        "references/foo#bar.md",
+        "references/my guide.md",
         "templates/report.md",
         "scripts/run.py",
         "assets/logo.png",
         "examples/endpoint-inventory.md",
     }
     assert bundle.files["assets/logo.png"] == b"\x89PNG\r\n\x1a\n\x00\xff"
+    assert bundle.files["references/foo#bar.md"] == b"encoded delimiter\n"
+    assert bundle.files["references/my guide.md"] == b"encoded space\n"
     assert "examples/not-installed.md" not in bundle.files
     assert bundle.metadata["source_url"] == url
 
@@ -154,6 +161,8 @@ def test_real_temp_repo_and_home_install_e2e(served_repo, monkeypatch, tmp_path)
 
     installed = home / "skills" / "demo-bundle"
     assert (installed / "references" / "guide.md").read_text() == "safe guide\n"
+    assert (installed / "references" / "foo#bar.md").read_text() == "encoded delimiter\n"
+    assert (installed / "references" / "my guide.md").read_text() == "encoded space\n"
     assert (installed / "templates" / "report.md").is_file()
     assert (installed / "scripts" / "run.py").is_file()
     assert (installed / "examples" / "endpoint-inventory.md").is_file()

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -28,6 +28,7 @@ from tools.skills_hub import (
     unified_search,
     append_audit_log,
     quarantine_bundle,
+    _referenced_support_paths,
 )
 
 
@@ -145,6 +146,19 @@ class TestTrustLevelFor:
                 "from GitHubSource.DEFAULT_TAPS — its skills will not be "
                 "browsable via `hermes skills browse`."
             )
+
+
+class TestGitHubSourceFileFetch:
+    def test_quotes_decoded_support_path_before_contents_api_fetch(self):
+        src = GitHubSource(auth=MagicMock(spec=GitHubAuth))
+        src._github_get = MagicMock(return_value=None)
+
+        src._fetch_file_bytes("owner/repo", "skill/references/foo#bar.md")
+
+        assert src._github_get.call_args.args[0] == (
+            "https://api.github.com/repos/owner/repo/contents/"
+            "skill/references/foo%23bar.md"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -353,6 +367,58 @@ class TestUrlSource:
 
     def _source(self):
         return UrlSource()
+
+    @pytest.mark.parametrize(
+        "glob_reference",
+        [
+            "references/*.md",
+            "references/file?",
+            "references/file?.md",
+            "references/agent.v?.md",
+            "references/data.file?.md",
+            "references/backup.2026?.md",
+            "references/file?x.md",
+            "references/agent.v?x.md",
+            "references/file?[ab].md",
+            "references/file??.md",
+            "references/[ab].md",
+            "references/%2A.md",
+            "references/file%3F.md",
+            "references/%5Bab%5D.md",
+        ],
+    )
+    def test_support_path_extraction_ignores_glob_shaped_prose(
+        self, glob_reference
+    ):
+        skill_md = f"""
+See [the web reference](references/web.md) for details.
+Complex cases are documented under `{glob_reference}`.
+"""
+
+        assert _referenced_support_paths(skill_md) == {"references/web.md"}
+
+    @pytest.mark.parametrize(
+        ("reference", "expected"),
+        [
+            ("templates/report.md?raw=1", "templates/report.md"),
+            ("references/LICENSE?download", "references/LICENSE"),
+            ("references/LICENSE?raw", "references/LICENSE"),
+            ("references/guide.md?view", "references/guide.md"),
+            ("references/guide.md?inline", "references/guide.md"),
+            ("references/guide.md?plain", "references/guide.md"),
+            ("references/guide.md?preview-mode", "references/guide.md"),
+            ("references/guide.md?view&inline&theme=dark", "references/guide.md"),
+            ("references/LICENSE?plain&download=1", "references/LICENSE"),
+            ("references/LICENSE?.well-known=1", "references/LICENSE"),
+            ("references/guide.md#usage", "references/guide.md"),
+            ("references/my%20guide.md", "references/my guide.md"),
+            ("references/foo%23bar.md", "references/foo#bar.md"),
+        ],
+    )
+    def test_support_path_extraction_preserves_concrete_url_suffixes(
+        self, reference, expected
+    ):
+        assert _referenced_support_paths(f"Use `{reference}`.") == {expected}
 
     # ── _matches ────────────────────────────────────────────────────────
     def test_matches_bare_md_url(self):

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -29,7 +29,7 @@ from hermes_constants import get_hermes_home
 from hermes_cli._subprocess_compat import windows_hide_flags
 from agent.skill_utils import is_excluded_skill_path
 from typing import Any, Dict, List, Optional, Tuple, Union
-from urllib.parse import unquote, urljoin, urlparse, urlsplit, urlunparse
+from urllib.parse import quote, unquote, urljoin, urlparse, urlsplit, urlunparse
 
 import httpx
 import yaml
@@ -160,6 +160,32 @@ _LOCAL_LINK_RE = re.compile(
 _SUSPICIOUS_LOCAL_REF_RE = re.compile(
     r"(?:references|templates|scripts|assets|examples)/(?:[^\s)`\"'<>]*/)?\.\.(?:/|$)"
 )
+_VALUELESS_QUERY_FLAG_RE = re.compile(
+    r"(?:[A-Za-z0-9_~-]|%[0-9A-Fa-f]{2})+\Z"
+)
+
+
+def _query_is_concrete(query: str) -> bool:
+    """Whether ``query`` is unambiguously URL syntax rather than glob prose.
+
+    A non-empty ``key=value`` part is concrete URL syntax regardless of key
+    spelling, preserving the established behavior.  Valueless flags are also
+    accepted when they are RFC 3986 unreserved-token shaped (including valid
+    percent escapes), rather than being restricted to a fixed allowlist.
+
+    Deliberately exclude ``.`` from valueless flags.  A suffix such as
+    ``?x.md`` or ``?.md`` is indistinguishable from a single-character glob
+    completing a filename in inline prose.  Brackets and additional question
+    marks are excluded for the same reason.  This syntactic ambiguity policy
+    preserves ordinary flags such as ``?view`` and ``?preview-mode`` while
+    rejecting glob-shaped references without guessing flag names.
+    """
+    parts = query.split("&")
+    return all(
+        ("=" in part and bool(part.split("=", 1)[0]))
+        or bool(_VALUELESS_QUERY_FLAG_RE.fullmatch(part))
+        for part in parts
+    )
 
 
 def _referenced_support_paths(skill_md: str) -> Optional[set[str]]:
@@ -169,7 +195,15 @@ def _referenced_support_paths(skill_md: str) -> Optional[set[str]]:
         return None
     paths: set[str] = set()
     for match in _LOCAL_LINK_RE.finditer(normalized):
-        raw = unquote(urlsplit(match.group(1).rstrip(".,;:")).path)
+        candidate = match.group(1).rstrip(".,;:")
+        if candidate.endswith("?"):
+            continue
+        parsed = urlsplit(candidate)
+        raw = unquote(parsed.path)
+        if any(char in raw for char in "*?[]"):
+            continue
+        if parsed.query and not _query_is_concrete(parsed.query):
+            continue
         try:
             safe = _validate_bundle_rel_path(raw)
         except ValueError:
@@ -1079,7 +1113,8 @@ class GitHubSource(SkillSource):
 
     def _fetch_file_bytes(self, repo: str, path: str) -> Optional[bytes]:
         """Fetch exact file bytes from GitHub without text decoding."""
-        url = f"https://api.github.com/repos/{repo}/contents/{path}"
+        encoded_path = quote(path, safe="/")
+        url = f"https://api.github.com/repos/{repo}/contents/{encoded_path}"
         resp = self._github_get(
             url,
             headers={**self.auth.get_headers(), "Accept": "application/vnd.github.v3.raw"},
@@ -1519,7 +1554,7 @@ class UrlSource(SkillSource):
         files: Dict[str, Union[str, bytes]] = {"SKILL.md": text}
         base_url = url.rsplit("/", 1)[0] + "/"
         for rel_path in sorted(referenced):
-            support_url = urljoin(base_url, rel_path)
+            support_url = urljoin(base_url, quote(rel_path, safe="/"))
             if urlparse(support_url).netloc != urlparse(url).netloc:
                 return None
             content = self._fetch_bytes(support_url)


### PR DESCRIPTION
## What does this PR do?

Direct URL skill installation scans SKILL.md for referenced support files. Prose such as ``references/*.md`` currently matches the local-path parser, causing Hermes to request a literal file named `*.md` and reject otherwise valid skill bundles.

This change ignores glob-shaped path candidates (`*`, `?`, `[` or `]`) while continuing to fetch explicit concrete references and preserving valid query/fragment suffixes, including extensionless paths such as `references/LICENSE?download`.
It also URL-encodes decoded support-file paths at both direct-URL and GitHub Contents API fetch boundaries, so concrete filenames containing encoded delimiters (for example `%23`) are requested as files rather than mistaken for URL fragments.

## Related Issue

Related: https://github.com/Panniantong/Agent-Reach/issues/584

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Updated `tools/skills_hub.py::_referenced_support_paths` to skip glob-shaped pseudo-paths.
- Preserved legitimate query/fragment suffixes, including valueless queries on extensionless support files.
- Added fetch-safe encoding for decoded support paths in `UrlSource` and `GitHubSource`.
- Added regression coverage proving concrete links are preserved while `references/*.md` prose is ignored.

## How to Test

1. Run `uv run --with pytest python -m pytest tests/tools/test_skills_hub.py -q -o 'addopts='`.
2. Install an Agent Reach `SKILL.md` URL containing the former prose reference.
3. Confirm Hermes installs `SKILL.md` and its seven explicit reference files without requesting a literal `references/*.md` path.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched existing PRs; PR #30633 covers install exit status but not support-path parsing.
- [x] My PR contains only changes related to this parser fix.
- [ ] I've established the complete `pytest tests/ -q` suite as green; an initial run lacked optional dependencies, and a broader-extra run encountered environment/integration failures outside the changed modules before completion. The two changed modules pass independently; their combined order-dependent failure reproduces unchanged on current `main`.
- [x] I've added tests for the bug.
- [x] Tested on macOS 14.1.

### Documentation & Housekeeping

- [x] Documentation update: N/A; behavior is internal and covered by tests.
- [x] `cli-config.yaml.example`: N/A.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A.
- [x] Cross-platform impact considered; the check is platform-independent string parsing.
- [x] Tool descriptions/schemas: N/A.

## Verification

- `tests/tools/test_skills_hub.py` — **98 passed**
- `tests/tools/test_skill_bundle_provenance.py` — **6 passed**
- Ruff — passed
- `compileall` — passed
- Isolated direct-URL Agent Reach installation — installed `SKILL.md` plus all seven explicit references successfully
