### PR TITLE
fix(qqbot): authorize approval buttons in dm sessions

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1129,7 +1129,10 @@ class QQAdapter(BasePlatformAdapter):
 
         chat_type = parsed.get("chat_type", "")
         chat_id = parsed.get("chat_id", "")
-        if chat_type == "c2c":
+        if chat_type in {"c2c", "dm"}:
+            # QQ c2c messages are normalized to ``dm`` session keys by the
+            # gateway; both are one-to-one chats where the operator openid
+            # must equal the session chat_id.
             return bool(chat_id) and operator == chat_id
 
         if chat_type in {"group", "guild"}:


### PR DESCRIPTION
## Summary

QQ Bot approval buttons (and update-prompt buttons) never resolve for direct-message (DM) chats: clicking 「允许一次/始终允许/拒绝」 is always rejected with `Rejected unauthorized approval click` and the pending command eventually times out as `denied by user`.

## Root cause

`QQAdapter._is_authorized_interaction_for_session()` only accepts `c2c`, `group`, and `guild` chat types, but gateway session keys for QQ private chats use `dm` (`agent:main:qqbot:dm:<openid>` — the same `dm` convention as Telegram/Discord/WhatsApp). The guard therefore falls through to `return False` for every DM button click, even when the operator openid exactly matches the session chat_id.

The adapter's own `_chat_type_map` comment declares `"c2c"|"group"|"guild"|"dm"` as the valid value set, so `dm` is an expected session key but was never handled in the authorization check.

## Fix

Treat `dm` the same as `c2c`: both are one-to-one chats where the operator openid must equal the session chat_id.

## Verification

Reproduced on v0.20.0 via QQ DM:

- Before: every button click logs `Rejected unauthorized approval click for session agent:main:qqbot:dm:<openid>`; approval request times out.
- After: click logs `Button resolved 1 approval(s) for session agent:main:qqbot:dm:<openid> (choice=once)` and the pending command executes.

Group/guild behavior is untouched (same code path as before).