### PR TITLE
fix(gateway): answer relay outbound with a result when the socket is dead

### DIFF
--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -826,6 +826,14 @@ class WebSocketRelayTransport:
             # ConnectionClosed. Report it the same way as the not-connected
             # case three lines up. CancelledError is a BaseException, so
             # cancellation still propagates.
+            #
+            # Record the traceback before returning. The returned string carries
+            # the exception's text but nothing about where it came from, so
+            # without this an ordinary dead socket and a genuine defect in the
+            # frame-building above it are the same line in the log. Same debug
+            # level and exc_info the other best-effort catches in this module
+            # use (go_dormant's close, the inbound ack).
+            logger.debug("relay %s send failed", frame_type, exc_info=True)
             return {"success": False, "error": f"relay send failed: {exc}"}
         finally:
             self._pending.pop(request_id, None)

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -854,7 +854,25 @@ class WebSocketRelayTransport:
                 *lines, buf = buf.split("\n")
                 for line in lines:
                     if line.strip():
-                        await self._handle_frame(line)
+                        try:
+                            await self._handle_frame(line)
+                        except Exception:  # noqa: BLE001 - one frame must not end the read loop
+                            # Unguarded, the FIRST raising frame ended the
+                            # `async for` outright — taking with it every frame
+                            # already parsed behind it in `lines` AND the
+                            # trailing partial in `buf`, which is reassigned
+                            # above before any of them dispatch. An
+                            # `outbound_result` batched behind a bad `inbound`
+                            # then never reached `_pending`, so an unrelated
+                            # send was answered by the connection-lost path
+                            # instead of by its own result. Skip the frame and
+                            # keep the rest of the chunk — the same disposition
+                            # `_handle_frame`'s own decode guard already takes.
+                            # `CancelledError` is a `BaseException`, so a
+                            # cancelled reader still unwinds.
+                            logger.warning(
+                                "relay: frame handler failed; skipping frame", exc_info=True
+                            )
         except asyncio.CancelledError:
             raise
         except Exception as exc:  # noqa: BLE001 - log + let the task end; reconnection handled below

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -970,6 +970,14 @@ class WebSocketRelayTransport:
         try:
             frame = json.loads(line)
         except json.JSONDecodeError:
+            frame = None
+        # `json.loads` also succeeds on a bare array/string/number/null, so a
+        # frame that is well-formed JSON but not an OBJECT walked past the decode
+        # guard above and reached `frame.get(...)` as an `AttributeError` — out of
+        # the one function whose stated contract is that a bad frame is skipped,
+        # never fatal. Both cases mean the same thing: the connector sent
+        # something this protocol has no reading for.
+        if not isinstance(frame, dict):
             logger.warning("relay: skipping malformed frame")
             return
         ftype = frame.get("type")

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -561,7 +561,7 @@ class WebSocketRelayTransport:
                 if _grace > 0:
                     try:
                         # asyncio.wait (not wait_for+gather): on timeout it must NOT
-                        # cancel the futures — the fail-any-remaining loop below owns
+                        # cancel the futures — the _fail_pending() pass below owns
                         # their terminal state.
                         await asyncio.wait(pending, timeout=_grace)
                     except Exception:  # noqa: BLE001 - grace is best-effort
@@ -590,17 +590,17 @@ class WebSocketRelayTransport:
                 finally:
                     self._ws = None
         finally:
-            # Fail any in-flight outbound waiters so callers don't hang.
+            # Answer any in-flight outbound waiters so callers don't hang. A
+            # RESULT, not an exception: send_outbound()'s contract is a result
+            # dict and RelayAdapter consumes it without a try (see
+            # _fail_pending).
             # Runs in a finally so a cancellation landing anywhere in the
             # drain/teardown above (the runner's wait_for budget, an outer
             # cleanup deadline) can NEVER leave a registered future
             # unresolved — a stranded waiter would otherwise block until
             # _OUTBOUND_TIMEOUT_S (30s). Idempotent: done futures are
             # skipped, so a second disconnect() pass is safe.
-            for fut in self._pending.values():
-                if not fut.done():
-                    fut.set_exception(RuntimeError("relay transport closed"))
-            self._pending.clear()
+            self._fail_pending("relay transport closed")
             if self._going_idle_ack is not None and not self._going_idle_ack.done():
                 self._going_idle_ack.set_exception(RuntimeError("relay transport closed"))
 
@@ -736,16 +736,24 @@ class WebSocketRelayTransport:
         if self._ws is None:
             return False
         acked = await self.go_idle(timeout_s=timeout_s)
+        ws = self._ws
         # Mark dormant BEFORE closing so the supervisor (armed by the reader's
         # fall-through) takes the dormant cadence, and a racing live event can't
         # flip us back to a fast reconnect.
         self._dormant = True
         try:
             await asyncio.wait_for(
-                self._ws.close(), timeout=_TEARDOWN_AWAIT_TIMEOUT_S
+                ws.close(), timeout=_TEARDOWN_AWAIT_TIMEOUT_S
             )
         except (asyncio.TimeoutError, Exception):  # noqa: BLE001 - best-effort; the reader still ends + arms reconnect
             logger.debug("relay go_dormant: ws.close() raised or timed out", exc_info=True)
+        # Drop the handle so the dormant window is DETERMINISTICALLY "not
+        # connected" for every `self._ws is None` guard, instead of depending on
+        # the reader's fall-through winning the race against the next send.
+        # Guarded on identity so a re-dial that already landed during the close
+        # await (the dormant poll cadence is short) is never clobbered.
+        if self._ws is ws:
+            self._ws = None
         return acked
 
     async def _send_inbound_ack(self, buffer_id: str) -> None:
@@ -759,6 +767,22 @@ class WebSocketRelayTransport:
             await self._send({"type": "inbound_ack", "bufferId": buffer_id})
         except Exception:  # noqa: BLE001 - a failed ack just redelivers the entry next time
             logger.debug("relay: inbound_ack send failed for %s", buffer_id)
+
+    def _fail_pending(self, error: str) -> None:
+        """Settle every in-flight outbound waiter with a structured failure.
+
+        ``send_outbound`` / ``send_follow_up`` are documented (RelayTransport)
+        to RETURN ``{success, message_id?, error?}``, and ``RelayAdapter.send``
+        / ``send_for_platform`` / ``edit_message`` consume that dict with no
+        ``try`` — only the cosmetic typing lanes wrap the call. So a waiter that
+        can no longer be answered gets a result, never an exception: the caller
+        sees ``SendResult(success=False, error=...)`` and can fall back, exactly
+        as it already does for the no-transport case.
+        """
+        for fut in self._pending.values():
+            if not fut.done():
+                fut.set_result({"success": False, "error": error})
+        self._pending.clear()
 
     async def _request_response(
         self,
@@ -796,6 +820,13 @@ class WebSocketRelayTransport:
             return await asyncio.wait_for(fut, timeout=self._outbound_timeout_s)
         except asyncio.TimeoutError:
             return {"success": False, "error": "relay outbound timed out"}
+        except Exception as exc:  # noqa: BLE001 - a dead socket is a failed send, not a raise
+            # No `is None` check can close the window where the peer closes
+            # BETWEEN the guard above and the send, so _send can still raise
+            # ConnectionClosed. Report it the same way as the not-connected
+            # case three lines up. CancelledError is a BaseException, so
+            # cancellation still propagates.
+            return {"success": False, "error": f"relay send failed: {exc}"}
         finally:
             self._pending.pop(request_id, None)
 
@@ -833,6 +864,18 @@ class WebSocketRelayTransport:
                     )
             elif not self._closing:
                 logger.warning("relay ws read loop ended: %s", exc)
+        # The socket is gone. Drop the handle FIRST — it is this transport's only
+        # liveness test, and until now NOTHING reset it outside disconnect(), so
+        # every `self._ws is None` guard (send / _request_response / go_idle /
+        # go_dormant) kept reporting "connected" for the whole outage while the
+        # supervisor re-dialed, and _send raised ConnectionClosed into callers
+        # that expect a result dict.
+        self._ws = None
+        # Then answer anything already in flight. Without this a waiter has no
+        # settler outside disconnect(), so it burns the FULL outbound budget
+        # (30s in production) and reports a bogus timeout for a socket that died
+        # immediately.
+        self._fail_pending("relay connection lost")
         # Phase 5 §5.3: the socket closed. If reconnect is enabled and this was
         # NOT a deliberate disconnect(), kick the reconnect supervisor so the
         # gateway re-dials + re-handshakes (which triggers the connector's

--- a/tests/gateway/relay/test_ws_transport.py
+++ b/tests/gateway/relay/test_ws_transport.py
@@ -409,3 +409,109 @@ async def test_4401_after_handshake_is_terminal_no_reconnect():
         await srv.stop()
 
 
+# ── one raising frame must not take the rest of its chunk with it ────────────
+
+
+@pytest.mark.asyncio
+async def test_raising_frame_does_not_discard_the_rest_of_its_chunk(caplog):
+    """A frame whose handler raises must not drop the frames batched behind it.
+
+    Relay frames are newline-delimited and several of them can ride a SINGLE
+    WebSocket message, so the read loop splits one chunk into N frames and
+    dispatches them in a row. Dispatching them unguarded made the first raising
+    frame end the ``async for`` outright: the socket was dropped, every frame
+    already parsed behind the failing one was discarded, and ``buf`` had already
+    been reassigned so the trailing partial frame went with them.
+
+    The cost lands on a caller that had nothing to do with the bad frame. An
+    ``outbound_result`` batched behind a poisoned ``inbound`` never reaches
+    ``_pending``, so the future ``send_outbound`` is awaiting gets settled by the
+    connection-lost path instead of by its own result — one bad inbound frame
+    fails an unrelated outbound send.
+    """
+
+    async def handler(ws):
+        async for raw in ws:
+            for line in str(raw).split("\n"):
+                if not line.strip():
+                    continue
+                frame = json.loads(line)
+                if frame.get("type") == "hello":
+                    await ws.send(
+                        json.dumps({"type": "descriptor", "descriptor": DESCRIPTOR}) + "\n"
+                    )
+                elif frame.get("type") == "outbound":
+                    # ONE WebSocket message carrying TWO frames: a poisoned
+                    # inbound, then the result the caller is blocked on.
+                    poisoned = {
+                        "type": "inbound",
+                        "event": {
+                            "text": "boom",
+                            "message_type": "text",
+                            "source": {
+                                "platform": "discord",
+                                "chat_id": "c1",
+                                "chat_type": "group",
+                                "scope_id": "guildA",
+                            },
+                        },
+                    }
+                    answer = {
+                        "type": "outbound_result",
+                        "requestId": frame["requestId"],
+                        "result": {"success": True, "message_id": "srv-send"},
+                    }
+                    await ws.send(json.dumps(poisoned) + "\n" + json.dumps(answer) + "\n")
+
+    async def raising_inbound(_event):
+        raise RuntimeError("inbound handler blew up")
+
+    srv, url = await _serve(handler)
+    t = WebSocketRelayTransport(url, "discord", "appShared", outbound_timeout_s=4.0)
+    t.set_inbound_handler(raising_inbound)
+    caplog.set_level(logging.WARNING, logger="gateway.relay.ws_transport")
+    try:
+        await t.connect()
+        await t.handshake()
+        result = await t.send_outbound({"op": "send", "chat_id": "c1", "content": "hi"})
+        # The result shared its chunk with the frame that raised, so this is the
+        # assertion that matters: it was still dispatched.
+        assert result == {"success": True, "message_id": "srv-send"}
+        # And the loop skipped one frame rather than ending: the socket is still
+        # live, so the reconnect supervisor was never needed.
+        assert t._ws is not None
+        assert t._reader is not None and not t._reader.done()
+        assert t._supervisor is None
+        # The skip is loud — a handler that raises is still a defect to chase.
+        assert any(
+            r.exc_info and r.exc_info[0] is RuntimeError for r in caplog.records
+        ), "the skipped frame's traceback must be recorded"
+    finally:
+        await t.disconnect()
+        srv.close()
+        await srv.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_non_object_frame_is_skipped_like_an_undecodable_one(caplog):
+    """A frame that is valid JSON but not an OBJECT is skipped, not raised on.
+
+    ``_handle_frame`` opens by guarding the decode precisely so a bad frame from
+    the connector is skipped rather than fatal. ``json.loads`` succeeds on a bare
+    array/string/number/null, though, so those walked past that guard into
+    ``frame.get("type")`` and raised ``AttributeError`` out of the one function
+    whose stated contract is that a bad frame cannot do that.
+    """
+    t = WebSocketRelayTransport("ws://127.0.0.1:1", "discord", "appShared")
+    caplog.set_level(logging.WARNING, logger="gateway.relay.ws_transport")
+
+    # Valid JSON, no object: nothing this protocol has a reading for.
+    for line in ("[]", '["descriptor"]', '"descriptor"', "3", "null"):
+        await t._handle_frame(line)
+
+    assert caplog.text.count("skipping malformed frame") == 5
+    # Nothing was mistaken for a real frame.
+    assert t._descriptor is None
+    assert t._descriptors_by_platform == {}
+
+

--- a/tests/gateway/relay/test_ws_transport.py
+++ b/tests/gateway/relay/test_ws_transport.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 
 import pytest
 import pytest_asyncio
@@ -147,13 +148,19 @@ async def _serve(handler):
     return srv, f"ws://127.0.0.1:{port}"
 
 
-async def _await_reader_end(t) -> None:
-    """Block until the transport's read loop has ended (peer closed the socket)."""
-    for _ in range(300):
-        if t._reader is not None and t._reader.done():
-            return
-        await asyncio.sleep(0.01)
-    raise AssertionError("read loop did not end after the peer closed the socket")
+async def _await_reader_end(t, timeout_s: float = 3.0) -> None:
+    """Block until the transport's read loop has ended (peer closed the socket).
+
+    ``t._reader`` is the reader ``Task``, so wait on it rather than spin-polling
+    ``done()``: this wakes the instant the task settles instead of on the next
+    10ms tick, which is what makes it deterministic under CI load. ``asyncio.wait``
+    specifically, because it neither retrieves the task's result nor cancels it
+    on timeout — the caller's ``disconnect()`` still owns the reader's lifecycle.
+    """
+    assert t._reader is not None, "connect() should have started the read loop"
+    _done, pending = await asyncio.wait({t._reader}, timeout=timeout_s)
+    if pending:
+        raise AssertionError("read loop did not end after the peer closed the socket")
 
 
 @pytest.mark.asyncio
@@ -195,6 +202,45 @@ async def test_send_outbound_returns_result_after_peer_close():
         await t.disconnect()
         srv.close()
         await srv.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_outbound_answers_a_result_when_the_send_itself_raises(caplog):
+    """The socket dies BETWEEN the not-connected guard and the send.
+
+    That window cannot be closed by any ``self._ws is None`` check, so ``_send``
+    still raises there and the catch-all is what keeps the documented result-dict
+    contract. Two things it has to do: answer with the same shape as the
+    not-connected case, and record the traceback — the returned string carries
+    the exception's text but not its origin, so without a traceback a genuine
+    defect in the frame-building above it is indistinguishable from an ordinary
+    dead socket.
+
+    The one test in this file that substitutes the socket: the window is by
+    definition a race, so it cannot be scheduled deterministically against a
+    live server.
+    """
+
+    class _SocketThatDiedMidSend:
+        async def send(self, _payload):
+            raise ConnectionResetError("peer closed between the guard and the send")
+
+    t = WebSocketRelayTransport("ws://127.0.0.1:1", "discord", "appShared", outbound_timeout_s=4.0)
+    t._ws = _SocketThatDiedMidSend()
+
+    caplog.set_level(logging.DEBUG, logger="gateway.relay.ws_transport")
+    result = await t.send_outbound({"op": "send", "chat_id": "c1", "content": "hi"})
+
+    assert result == {
+        "success": False,
+        "error": "relay send failed: peer closed between the guard and the send",
+    }
+    # The waiter is discarded rather than left to accumulate per request id.
+    assert t._pending == {}
+
+    traced = [r for r in caplog.records if r.exc_info]
+    assert traced, "the catch-all must record the traceback, not just the message"
+    assert traced[0].exc_info[0] is ConnectionResetError
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/relay/test_ws_transport.py
+++ b/tests/gateway/relay/test_ws_transport.py
@@ -137,6 +137,161 @@ async def test_inbound_frame_reaches_handler(server):
         await t.disconnect()
 
 
+# ── outbound answers a RESULT when the socket is dead (never a raise/stall) ──
+
+
+async def _serve(handler):
+    """Start a throwaway ws server on an ephemeral port; return (server, url)."""
+    srv = await websockets.serve(handler, "127.0.0.1", 0)
+    port = next(iter(srv.sockets)).getsockname()[1]
+    return srv, f"ws://127.0.0.1:{port}"
+
+
+async def _await_reader_end(t) -> None:
+    """Block until the transport's read loop has ended (peer closed the socket)."""
+    for _ in range(300):
+        if t._reader is not None and t._reader.done():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("read loop did not end after the peer closed the socket")
+
+
+@pytest.mark.asyncio
+async def test_send_outbound_returns_result_after_peer_close():
+    """A send issued after the peer dropped the socket must RETURN a failure result.
+
+    ``RelayTransport.send_outbound`` is documented to return a result dict, and
+    ``RelayAdapter.send``/``send_for_platform``/``edit_message`` consume it with
+    no ``try`` — so a raise escapes into the send lane. Before this fix the
+    reader left ``self._ws`` pointing at the closed socket, so the
+    not-connected guard never fired and ``_send`` raised ``ConnectionClosed``.
+    """
+
+    async def handler(ws):
+        async for raw in ws:
+            for line in str(raw).split("\n"):
+                if not line.strip():
+                    continue
+                if json.loads(line).get("type") == "hello":
+                    await ws.send(
+                        json.dumps({"type": "descriptor", "descriptor": DESCRIPTOR}) + "\n"
+                    )
+                    # Let the descriptor flush, then drop the socket.
+                    await asyncio.sleep(0.05)
+                    await ws.close()
+                    return
+
+    srv, url = await _serve(handler)
+    t = WebSocketRelayTransport(url, "discord", "appShared", outbound_timeout_s=4.0)
+    try:
+        await t.connect()
+        await t.handshake()
+        await _await_reader_end(t)
+        result = await t.send_outbound({"op": "send", "chat_id": "c1", "content": "hi"})
+        assert isinstance(result, dict)
+        assert result.get("success") is False
+        assert result.get("error")
+    finally:
+        await t.disconnect()
+        srv.close()
+        await srv.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_inflight_outbound_fails_fast_on_peer_close():
+    """An outbound already awaiting a result must settle when the socket dies.
+
+    Before this fix nothing settled ``_pending`` outside ``disconnect()``, so the
+    waiter rode the FULL outbound budget (30s in production) and then reported a
+    bogus "timed out" for a socket that had died immediately.
+    """
+
+    async def handler(ws):
+        async for raw in ws:
+            for line in str(raw).split("\n"):
+                if not line.strip():
+                    continue
+                frame = json.loads(line)
+                if frame.get("type") == "hello":
+                    await ws.send(
+                        json.dumps({"type": "descriptor", "descriptor": DESCRIPTOR}) + "\n"
+                    )
+                elif frame.get("type") == "outbound":
+                    # Never answer the request — just drop the socket under it.
+                    await asyncio.sleep(0.05)
+                    await ws.close()
+                    return
+
+    srv, url = await _serve(handler)
+    t = WebSocketRelayTransport(url, "discord", "appShared", outbound_timeout_s=4.0)
+    try:
+        await t.connect()
+        await t.handshake()
+        loop = asyncio.get_running_loop()
+        started = loop.time()
+        result = await t.send_outbound({"op": "send", "chat_id": "c1", "content": "hi"})
+        elapsed = loop.time() - started
+        assert result.get("success") is False
+        assert result.get("error") == "relay connection lost"
+        # Fails fast on the close, rather than burning the whole 4s budget.
+        assert elapsed < 2.0, f"outbound rode the timeout budget ({elapsed:.2f}s)"
+    finally:
+        await t.disconnect()
+        srv.close()
+        await srv.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_settles_pending_outbound_with_result():
+    """disconnect() under an in-flight outbound answers the waiter with a result.
+
+    Same contract as above on the drain/shutdown path: the delivery router
+    branches on ``success``/``error``, so a ``RuntimeError`` raised into
+    ``RelayAdapter.send`` is not a failure it can route.
+    """
+    hold_open = asyncio.Event()
+
+    async def handler(ws):
+        async for raw in ws:
+            for line in str(raw).split("\n"):
+                if not line.strip():
+                    continue
+                frame = json.loads(line)
+                if frame.get("type") == "hello":
+                    await ws.send(
+                        json.dumps({"type": "descriptor", "descriptor": DESCRIPTOR}) + "\n"
+                    )
+                elif frame.get("type") == "outbound":
+                    # Leave the request unanswered so it is still pending.
+                    await hold_open.wait()
+                    return
+
+    srv, url = await _serve(handler)
+    t = WebSocketRelayTransport(url, "discord", "appShared", outbound_timeout_s=10.0)
+    try:
+        await t.connect()
+        await t.handshake()
+        call = asyncio.create_task(
+            t.send_outbound({"op": "send", "chat_id": "c1", "content": "hi"})
+        )
+        pending = False
+        for _ in range(300):
+            if t._pending:
+                pending = True
+                break
+            await asyncio.sleep(0.01)
+        assert pending, "expected an in-flight outbound before disconnect"
+        await t.disconnect()
+        result = await asyncio.wait_for(call, timeout=2.0)
+        assert result.get("success") is False
+        assert result.get("error") == "relay transport closed"
+    finally:
+        hold_open.set()
+        await t.disconnect()
+        srv.close()
+        await srv.wait_closed()
+
+
 # ── Phase 7 Unit 7d-B: terminal 4401 (opt-out revocation) ────────────────────
 
 

--- a/tests/gateway/test_relay_delivery_followups.py
+++ b/tests/gateway/test_relay_delivery_followups.py
@@ -359,8 +359,11 @@ async def test_disconnect_cancellation_still_fails_pending_futures():
     assert fut.done(), (
         "pending outbound future left unresolved after cancelled disconnect"
     )
-    with pytest.raises(RuntimeError, match="relay transport closed"):
-        fut.result()
+    # Settled with a failure RESULT rather than an exception: send_outbound() is
+    # documented to return {success, error?} and RelayAdapter.send consumes it
+    # with no try. `.result()` re-raises if an exception was set, so this still
+    # proves the finally ran — and additionally pins the shape callers get.
+    assert fut.result() == {"success": False, "error": "relay transport closed"}
     assert not t._pending
 
 

--- a/tests/gateway/test_relay_teardown_drain.py
+++ b/tests/gateway/test_relay_teardown_drain.py
@@ -68,7 +68,12 @@ async def test_disconnect_still_bounded_when_connector_silent():
     await t.disconnect()
     elapsed = asyncio.get_running_loop().time() - started
 
-    assert fut.done() and fut.exception() is not None
+    assert fut.done(), "pending outbound left unresolved after the drain gave up"
+    # Settled with a failure RESULT rather than an exception: send_outbound() is
+    # documented to return {success, error?} and RelayAdapter.send consumes it
+    # with no try. `.result()` re-raises if an exception was set, so this also
+    # pins that the waiter is answered rather than thrown at.
+    assert fut.result() == {"success": False, "error": "relay transport closed"}
     assert elapsed < 10.0, f"teardown took {elapsed:.1f}s — grace must be bounded"
 
 


### PR DESCRIPTION
## What does this PR do?

**Symptom:** when a relay-fronted gateway's WebSocket drops, the bot goes quiet mid-answer — no reply, no error, nothing the user can act on — and if the drop lands while a send is already awaiting a result, the turn visibly hangs for 30 seconds and then reports `relay outbound timed out` for a socket that died instantly.

**Blast radius:** `register_relay_adapter` (`gateway/relay/__init__.py:875`) builds the production transport with `reconnect=True`, so this is the *default* configuration of every relay-fronted gateway, and it fires on the ordinary connector-restart path — a deploy, a proxy idle-cut, a network blip, or the scale-to-zero `go_dormant()` suspend. The whole reconnect window is affected while backoff climbs 1→2→4→…→30s. No unusual prior state, no hand-edited config, no rare race.

**Root cause:** `self._ws` is this transport's *only* liveness test, and nothing ever reset it to `None` outside `disconnect()`. `_read_loop`'s end-of-socket fall-through arms the reconnect supervisor and leaves the handle pointing at the closed socket; `go_dormant()` closes the socket without clearing it. So in both post-drop states every `self._ws is None` guard reported "connected" and `_send` sent on a dead socket.

**The contract that breaks is stated in this repo, not inferred:**

- `gateway/relay/transport.py:73-87` documents `send_outbound` as returning a result dict carrying `success` and optionally `message_id` / `error` (and `send_follow_up:117-143` likewise).
- `_request_response` already returns exactly that for the not-connected case — `{"success": False, "error": "relay transport not connected"}`, three lines above the `try`.
- `RelayAdapter.send_for_platform` / `send` / `edit_message` / `send_follow_up` (`gateway/relay/adapter.py:922, 965, 1160, 1321`) consume the dict with **no `try`**, and each already handles the no-transport case as `SendResult(success=False, error="no transport")`.
- The adapter authors wrapped only the *cosmetic* lanes on purpose: `send_typing` / `stop_typing` (`adapter.py:1240, 1280`) carry `except Exception:  # noqa: BLE001 - typing is cosmetic, never breaks a turn`. That comment is the in-repo evidence that the real send lanes are expected to get a result, not a raise.

**Three defects against that contract:**

1. `_request_response`'s `try` caught only `asyncio.TimeoutError`, so `websockets.exceptions.ConnectionClosed*` escaped out of `send_outbound` / `send_follow_up` / `get_chat_info`. `gateway/stream_consumer.py:1277` catches it as `except Exception as e: logger.error("Stream send chunk error: %s", e); return reply_to_id` — the chunk is swallowed and **dropped**, which is why the bot just stops talking.
2. `_pending` had no settler outside `disconnect()`, so an outbound already in flight when the socket died burned the entire `_OUTBOUND_TIMEOUT_S = 30.0` budget.
3. `disconnect()` settled waiters with `fut.set_exception(RuntimeError("relay transport closed"))` — the same contract break on the drain/shutdown path. `gateway/delivery.py`'s `DeliveryTarget.send` forwards `adapter.send_for_platform(...)` with no `try`, and its scheduler consumer `cron/scheduler.py:_send_succeeded` **branches on a truthy `.success` attribute** and documents that anything else is "a contract violation: it does not actually tell us whether the send succeeded" (#47056). A raised `RuntimeError` bypasses that check entirely rather than being classified as a failed delivery.

**Two more, added 2026-08-10 — the same waiter, broken from the read loop's side.** Defects 1-3 are all "the socket died and the outbound waiter got the wrong answer". Defects 4-5 are the same waiter getting the wrong answer *without* the socket dying on its own — the read loop kills it:

4. **`_read_loop` dispatched each frame unguarded inside the `async for`.** Relay frames are newline-delimited and several of them can ride a **single** WebSocket message, so the loop splits one chunk into N frames and dispatches them in a row. Any exception out of `_handle_frame` propagated straight into the loop-level `except Exception` and ended the reader. Ending the reader is the smaller half of the cost: `buf` is reassigned by the split **before** any frame in the chunk dispatches, so a raise discards every frame already parsed behind the failing one *and* the trailing partial frame. An `outbound_result` batched behind a bad `inbound` therefore never reaches `_pending`, and the waiter gets settled by the reader's connection-lost fall-through (defect 2's fix, above) instead of by its own result. **One bad inbound frame fails an unrelated outbound send, on a socket that was otherwise healthy.** The raise paths are ordinary: the descriptor branch calls `CapabilityDescriptor.from_json` unguarded, and the inbound branch runs the adapter's `_on_inbound` → `_capture_scope` / `_stamp_slack_session_thread` / `_consume_prompt_response` / `handle_message`, none of which are wrapped.

5. **`_handle_frame` raised `AttributeError` on a frame that is valid JSON but not an object.** The function opens by guarding the decode — `except json.JSONDecodeError: logger.warning("relay: skipping malformed frame"); return` — precisely so a bad frame is skipped rather than fatal. `json.loads` succeeds on a bare array/string/number/null, though, so those walked past that guard into `frame.get("type")`.

**This subsystem states defect 4's invariant against itself three times over**, which is why it reads as a defect rather than a design choice:

- `_handle_frame`'s own first statement skips a frame it cannot decode instead of raising.
- `_passthrough_from_wire` (`ws_transport.py:322`) swallows a bad base64 body under the comment **"a malformed body must not crash the reader"** — naming the reader explicitly.
- `adapter.py::_localize_inbound_media` wraps its whole body under **"media localization must never break inbound"**.

Three separate sites assert that bad inbound data must not break the loop. The loop's own dispatch was the one place that did not hold the line.

## Related Issue

No filed issue — found by reading the transport's reconnect/dormancy path, then its read path. The fix is verified by six regression tests: three red on current `main`, two more red on this branch's previous head for defects 4-5, and one red on the head before that (transcripts below).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

`gateway/relay/ws_transport.py`

- New `_fail_pending(error)` — settles every future in `_pending` with `set_result({"success": False, "error": error})` and clears the dict. A **result**, never an exception, because that is what the callers consume.
- `_read_loop` fall-through: `self._ws = None` **first** (so all four `self._ws is None` guards read the truth while the supervisor re-dials), then `_fail_pending("relay connection lost")` (so an in-flight outbound settles on the close instead of on the 30s timer). Placed before the reconnect-arming block, so it runs on both the `reconnect=True` and `reconnect=False` paths.
- `go_dormant()`: clear the handle after the close, so the dormant window is deterministically "not connected" rather than depending on the reader's fall-through winning the race against the next send. Guarded on identity (`if self._ws is ws`) so a re-dial that already landed during the close await — the dormant poll cadence is short — is never clobbered.
- `disconnect()`: `_fail_pending("relay transport closed")` replaces the `set_exception(RuntimeError(...))` loop. Same message, now a result.
- `_request_response`: `except Exception as exc: return {"success": False, "error": f"relay send failed: {exc}"}` after the existing `asyncio.TimeoutError` clause. This is the belt-and-braces half — no `is None` check can close the window where the peer closes *between* the guard and the send. `CancelledError` is a `BaseException`, so cancellation still propagates.
- That clause also logs `logger.debug(..., exc_info=True)` before returning. The returned string carries the exception's text but nothing about its origin, so on its own it made a genuine defect in the frame-building above it and an ordinary dead socket the same unattributable line. Same level and `exc_info` the module's other best-effort catches already use (`go_dormant`'s close, the inbound ack), and the returned dict is byte-identical, so `stream_consumer` and `RelayAdapter` see no change.

- `_read_loop`'s per-frame dispatch (defect 4): wrap the `await self._handle_frame(line)` in a `try`, log the frame's traceback at warning, and continue to the next line — so the rest of the chunk still dispatches and the socket survives. `CancelledError` is a `BaseException`, so a cancelled reader still unwinds. This is the disposition `_handle_frame`'s own decode guard already takes, applied one level out.
- `_handle_frame`'s parse boundary (defect 5): keep the decode in its `try` but set `frame = None` on failure, then admit only a `dict`. One log string covers both cases, because both mean the same thing — the connector sent something this protocol has no reading for.

Deliberately **not** changed:

- `_going_idle_ack` keeps its `set_exception` in `disconnect()` — `go_idle` catches it deliberately, and it is not a `send_outbound` waiter.
- `_read_loop`'s `assert self._ws is not None` is left exactly as-is; it is a separate concern with separate PRs in flight.
- **`gateway/relay/descriptor.py` is deliberately untouched.** `CapabilityDescriptor.from_json` is one of defect 4's raise paths, but it is already claimed by @AlexFucuson9's open #54225, which adds `if not isinstance(raw, dict): raise ValueError(...)`. That PR is independent confirmation from a second contributor that this parse raises in practice — and note it converts the `AttributeError` into a `ValueError` and **still raises**, so it does not fix defect 4: the read loop still dies and still drops the rest of the chunk. The two changes compose; neither substitutes for the other.
- `gateway/platforms/yuanbao.py::_receive_loop` has a superficially similar unguarded `async for` → `_handle_frame`, but it is **not** a site of this root cause and is left alone: it dispatches exactly one frame per WebSocket message, so there is no already-parsed batch and no trailing `buf` to lose. The distinctive severity here — a raise discarding frames that were already read off the wire — cannot occur there.
- `send_interrupt` has no production call site (`grep -rn send_interrupt --include='*.py'` returns only `transport.py`'s Protocol and `tests/gateway/relay/stub_connector.py`), so it has no user-visible symptom to fix; its behaviour after this change goes from raising `ConnectionClosed` to raising `RuntimeError("relay transport not connected")`, which is strictly clearer, and silently swallowing a `/stop` would be worse than raising.

**Root-cause site coverage.** `self._ws` is read or written in exactly six places in this file — the four `is None` guards (`_request_response`, `_send`, `go_idle`, `go_dormant`), the dial, and the reader. This PR makes every one of them correct post-drop by fixing the two places the handle *should* have been cleared and was not. The other `_ws` handles in the tree (`gateway/platforms/qqbot/adapter.py`, `gateway/platforms/yuanbao.py`) are separate transports with their own liveness patterns (`.closed` checks and their own teardown nulling) and are not part of this root cause.

`tests/gateway/relay/test_ws_transport.py` — four regression tests. Three run against the file's existing real in-process `websockets` server. The fourth, `test_outbound_answers_a_result_when_the_send_itself_raises`, is the one place a socket is substituted, because the window it covers — the peer closing *between* the guard and the send — is by definition a race and cannot be scheduled deterministically against a live server. Nothing exercised that branch before: every other test reaches the failure through the `is None` guard instead.

`_await_reader_end` waits on the reader `Task` under a bounded timeout rather than spin-polling `done()` on a 10ms tick, so it wakes the instant the task settles instead of up to a tick later. `asyncio.wait` specifically, because it neither retrieves the task's result nor cancels it on timeout — the reader's lifecycle stays with the test's own `disconnect()`.

## How to Test

```
uv run --with pytest --with pytest-asyncio --with websockets \
  python3 -m pytest tests/gateway/relay/test_ws_transport.py -v
```

**Red before / green after** — each new test fails for a distinct reason and passes with the fix.

On `main` (production file unmodified, new tests applied):

```
test_send_outbound_returns_result_after_peer_close     FAILED
  E   websockets.exceptions.ConnectionClosedOK: received 1000 (OK); then sent 1000 (OK)

test_inflight_outbound_fails_fast_on_peer_close        FAILED
  E   AssertionError: assert 'relay outbound timed out' == 'relay connection lost'
      (and the call rode the whole 4s test budget — 30s in production)

test_disconnect_settles_pending_outbound_with_result   FAILED
  E   RuntimeError: relay transport closed

3 failed, 3 passed in 4.61s
```

`test_outbound_answers_a_result_when_the_send_itself_raises` covers a branch this PR itself introduced, so its red-before is against the previous head of this branch (the `logger.debug` reverted, everything else kept):

```
test_outbound_answers_a_result_when_the_send_itself_raises  FAILED
  E   AssertionError: the catch-all must record the traceback, not just the message
  E   assert []
```

With the fix:

```
7 passed in 0.69s
```

The wall-clock drop (4.61s → 0.64s) is defect 2 disappearing: the in-flight outbound now settles on the close instead of on the timeout.

**Defects 4-5** were added on top of the above, so their red-before is against this branch's previous head (both production hunks reverted, both new tests applied):

```
test_raising_frame_does_not_discard_the_rest_of_its_chunk   FAILED
  E   AssertionError: assert {'success': False, 'error': 'relay connection lost'}
  E                       == {'success': True,  'message_id': 'srv-send'}
  ------------------------------ Captured log call ------------------------------
  WARNING  gateway.relay.ws_transport:ws_transport.py:796
           relay ws read loop ended: inbound handler blew up

test_non_object_frame_is_skipped_like_an_undecodable_one    FAILED
  E   AttributeError: 'list' object has no attribute 'get'
  gateway/relay/ws_transport.py:879: in _handle_frame
      ftype = frame.get("type")

2 failed, 7 deselected in 0.38s
```

The first failure is the mechanism stated exactly: the `outbound_result` shared its chunk with the frame that raised and went down with it, so the waiter was answered by the connection-lost path instead of by its own result. **That is the assertion that matters** — asserting only "the loop is still alive" would pass against the broken code whenever the reconnect supervisor re-dials in time, which is why the test pins the caller's returned result rather than the reader's liveness.

The two are **mechanically disjoint**, verified by reverting each production hunk on its own:

| reverted hunk | `..._discard_the_rest_of_its_chunk` | `..._skipped_like_an_undecodable_one` |
|---|---|---|
| `_read_loop` dispatch guard | FAILED | passed |
| `_handle_frame` parse boundary | passed | FAILED |
| neither (this branch) | passed | passed |

With both fixes, the whole file: `9 passed in 0.66s`.

**No regressions** — `tests/gateway/relay/` in full is **159 passed** (157 before this branch's tests), and three consecutive runs agree (the point of the `_await_reader_end` change). With `tests/gateway/test_stream_consumer.py`, `test_relay_capability_surface.py` and `test_relay_upstream_authz.py` added: **228 passed**. Per-file as well: `test_relay_going_idle` (4, includes the `go_dormant` wake/drain contract), `test_relay_adapter` (12), `test_relay_threads` (15), `test_relay_slack_dm_streaming` (25), `test_relay_slack_prompt_dm_root` (25), `test_self_provision` (11), `test_relay_interactive` (7), `test_auth` (6), `test_relay_media` (5), `test_relay_policy_send` (5), `test_relay_multiplatform` (4), `test_relay_passthrough` (4), `test_descriptor` (4), `test_channel_context_consume` (3), plus `test_relay_roundtrip`, `test_relay_roundtrip_telegram`, `test_relay_per_platform_caps`, `test_relay_registration`, `test_handoff_relay_aliasing`, `test_identity_token_resolver`, `test_wire_user_identity`, `test_relay_follow_up`, `test_relay_interrupt`, `test_relay_sheds_crypto`, `test_descriptor_from_entry`, `test_contract_doc_conformance`, `test_no_stub_leak`. All pass.

`ruff check` on both touched files is clean, and `ty check gateway/relay/ws_transport.py` reports the identical two pre-existing `unused-type-ignore-comment` warnings before and after — no new diagnostics.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — *ran the complete `tests/gateway/relay/` suite per-file instead (listed above); not claiming a full-repo run I did not do*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the new `_fail_pending` carries the contract rationale in its docstring; no user-facing docs change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure asyncio/websockets state handling, no platform-specific paths or APIs
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

- **Does not conflict with #70680** (`fix(gateway): reuse relay handshake Future across reconnect dials`), which touches the same file. That PR fixes `_descriptor_ready` being orphaned across a re-dial and adds a `_descriptor_ready.set_exception` line in `disconnect()`; this PR fixes the `_pending` outbound waiters and leaves `_descriptor_ready` untouched. **Different waiter, different symptom** — `handshake()` vs `send_outbound()` — and the two `disconnect()` hunks are on disjoint lines (theirs after the `_going_idle_ack` block, ours replacing the `_pending` loop above it). Both can land independently.
- Same class as the recently merged #82149 (`rebind pool entry id after env credential refresh`): a stale handle that was never rebound after the thing it pointed at went away.
- Builds on `9c88625e25c` (`fix(gateway): bound go_dormant ws.close with teardown timeout`, already on `main`) rather than re-litigating it — the `_TEARDOWN_AWAIT_TIMEOUT_S` bound stays exactly as it is; this only adds the handle clear after it.
- **Does not conflict with #52583** (@Adolanium, `fix(relay): ack buffered passthrough_forward deliveries`), which touches the same file. Its only production hunk is inside `_handle_frame`'s `passthrough_forward` branch; defect 5's hunk is at the top of the same function, ~50 lines above, and defect 4's is in `_read_loop` — a different function. Hunk-disjoint, re-verified by symbol on this branch.
- **Does not conflict with #58837** (@AlexFucuson9, `fix: replace bare asserts with explicit exceptions`), whose `ws_transport.py` hunk replaces `_read_loop`'s opening `assert self._ws is not None`. That is a pre-connect misuse guard on a different line and a different bug from defect 4's per-frame dispatch seven lines below it; this PR leaves that `assert` untouched (see "Deliberately not changed" above), so the two apply cleanly in either order.
- **`27b31bb7ff6`** (`fix(relay): normalize a 0/negative max_message_length at the descriptor boundary`) landed on `main` recently — the same frame/descriptor-boundary hardening in the same subsystem, so this is a pre-validated shape here rather than a novel one.
- The equivalent bug on a different adapter is #27628 (`fix(simplex): propagate WebSocket send failures to SendResult`), which confirms the class but is a separate transport and not an overlap.


