### PR TITLE
fix: exclude .restore-backups from skill discovery (#82178)

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -40,6 +40,7 @@ EXCLUDED_SKILL_DIRS = frozenset(
         ".pytest_cache",
         ".mypy_cache",
         ".ruff_cache",
+        ".restore-backups",
     )
 )
 

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -122,6 +122,25 @@ def test_iter_skill_index_files_keeps_support_named_categories(tmp_path):
     assert is_excluded_skill_path(scripts_skill / "SKILL.md") is False
 
 
+def test_restore_backups_excluded_from_skill_discovery(tmp_path):
+    """Backup snapshots under .restore-backups must not shadow live skills."""
+    skill_dir = tmp_path / "software-development" / "my-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: my-skill\n---\n", encoding="utf-8"
+    )
+
+    backup = tmp_path / ".restore-backups" / "reconcile-20260808" / "software-development" / "my-skill"
+    backup.mkdir(parents=True)
+    (backup / "SKILL.md").write_text(
+        "---\nname: my-skill\n---\n", encoding="utf-8"
+    )
+
+    found = list(iter_skill_index_files(tmp_path, "SKILL.md"))
+    assert found == [skill_dir / "SKILL.md"]
+    assert is_excluded_skill_path(backup / "SKILL.md") is True
+
+
 def test_skill_support_path_uses_explicit_discovery_root_not_cwd(tmp_path, monkeypatch):
     discovery_root = tmp_path / "site-packages" / "skills"
     umbrella = discovery_root / "category" / "umbrella"


### PR DESCRIPTION
## Summary

The skill scanner walks all directories under `~/.hermes/skills/` including hidden dot-directories. Backup snapshots created by `skills_sync` at `~/.hermes/skills/.restore-backups/` contain copies of live `SKILL.md` files, causing `skill_view` to report **"Ambiguous skill name: 2 skills match"** for every backed-up skill.

## Root Cause

`EXCLUDED_SKILL_DIRS` in `agent/skill_utils.py` already skips `.git`, `.archive`, `.venv`, and other dot-directories, but does not include `.restore-backups`. The `rglob("SKILL.md")` scan picks up both the live skill and its backup copy.

## Fix

Add `".restore-backups"` to `EXCLUDED_SKILL_DIRS` — the same pattern used for `.git`, `.archive`, etc.

## Changes

- `agent/skill_utils.py`: Add `.restore-backups` to `EXCLUDED_SKILL_DIRS`
- `tests/agent/test_skill_utils.py`: Add regression test verifying backup paths are excluded from skill discovery

## Test Plan

- [x] `uv run pytest tests/agent/test_skill_utils.py -xvs` — 15/15 passed
- [x] New test `test_restore_backups_excluded_from_skill_discovery` verifies the fix

Fixes #82178