### PR TITLE
fix(cron): fail safe for multiplexed profiles

### DIFF
--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -39,6 +39,11 @@ class CronScheduler(ABC):
     def name(self) -> str:
         """Short identifier, e.g. 'builtin', 'chronos'."""
 
+    @property
+    def supports_multiplex_profiles(self) -> bool:
+        """Whether this provider schedules every served profile's job store."""
+        return False
+
     def is_available(self) -> bool:
         """Whether this provider can run in the current environment.
 
@@ -160,6 +165,20 @@ def resolve_cron_scheduler() -> "CronScheduler":
         if not provider.is_available():
             logger.warning("cron.provider '%s' not available; using built-in ticker", name)
             return InProcessCronScheduler()
+        try:
+            from gateway.config import load_gateway_config
+
+            multiplex_profiles = load_gateway_config().multiplex_profiles
+        except Exception as exc:
+            logger.debug("Could not determine gateway multiplex mode: %s", exc)
+            multiplex_profiles = False
+        if multiplex_profiles and not provider.supports_multiplex_profiles:
+            logger.warning(
+                "cron.provider '%s' does not support multiplex profiles; "
+                "using built-in ticker so every profile's jobs are scheduled",
+                name,
+            )
+            return InProcessCronScheduler()
         logger.info("Using cron scheduler provider: %s", provider.name)
         return provider
     except Exception as e:
@@ -182,6 +201,10 @@ class InProcessCronScheduler(CronScheduler):
     @property
     def name(self) -> str:
         return "builtin"
+
+    @property
+    def supports_multiplex_profiles(self) -> bool:
+        return True
 
     def start(
         self,

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2526,6 +2526,12 @@ DEFAULT_CONFIG = {
     # Gateway settings — control how messaging platforms (Telegram, Discord,
     # Slack, etc.) deliver agent-produced files as native attachments.
     "gateway": {
+        # Serve every configured profile from the default gateway process.
+        # This also makes the shared cron scheduler tick each profile's own
+        # job store. Keep opt-in because profile secret and channel isolation
+        # rules are stricter in multiplex mode.
+        "multiplex_profiles": False,
+
         # Durable delivery-obligation ledger: final agent responses are
         # recorded in state.db around the platform send, and a gateway that
         # died between finalize and platform ACK redelivers the stored

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -985,6 +985,13 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "description": "API service tier (OpenAI/Anthropic)",
         "options": ["", "auto", "default", "flex"],
     },
+    "gateway.multiplex_profiles": {
+        "type": "boolean",
+        "description": (
+            "Serve all profiles from the default gateway and run each "
+            "profile's scheduled jobs. Requires a gateway restart."
+        ),
+    },
     "delegation.reasoning_effort": {
         "type": "select",
         "description": "Reasoning effort for delegated subagents",

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -214,6 +214,43 @@ def test_resolve_defaults_to_builtin(monkeypatch):
     assert prov.name == "builtin"
 
 
+def test_resolve_falls_back_when_provider_cannot_schedule_multiplex_profiles(monkeypatch):
+    """A single-profile provider must not silently strand secondary jobs."""
+    import hermes_cli.config as cfg
+    import gateway.config as gateway_cfg
+    import plugins.cron_providers as plugins
+    from cron import scheduler_provider as sp
+
+    class SingleProfileProvider(sp.CronScheduler):
+        @property
+        def name(self):
+            return "single-profile"
+
+        def start(self, stop_event, **kwargs):
+            return None
+
+    monkeypatch.setattr(
+        cfg,
+        "load_config",
+        lambda: {"cron": {"provider": "single-profile"}},
+    )
+    monkeypatch.setattr(
+        plugins,
+        "load_cron_scheduler",
+        lambda name: SingleProfileProvider(),
+    )
+    monkeypatch.setattr(
+        gateway_cfg,
+        "load_gateway_config",
+        lambda: type("Config", (), {"multiplex_profiles": True})(),
+    )
+
+    provider = sp.resolve_cron_scheduler()
+
+    assert isinstance(provider, sp.InProcessCronScheduler)
+    assert provider.supports_multiplex_profiles is True
+
+
 # ── Phase 4B: additive hooks (on_jobs_changed / fire_due / reconcile) ────────
 
 
@@ -412,5 +449,4 @@ def test_multiplex_ticker_ticks_each_profile_once(tmp_path, monkeypatch):
     # With 2 profiles and multiple iterations, we should have seen at least 2 calls.
     assert len(tick_count) >= len(profile_homes), \
         f"Expected >= {len(profile_homes)} tick calls, got {len(tick_count)}"
-
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1938,6 +1938,20 @@ class TestBuildSchemaFromConfig:
         assert "python3.13" in runtime_entry["options"]
         assert len(runtime_entry["options"]) >= 3
 
+    def test_gateway_multiplex_profiles_is_exposed_as_opt_in_boolean(self):
+        from hermes_cli.config_defaults import DEFAULT_CONFIG
+        from hermes_cli.web_server import CONFIG_SCHEMA
+
+        assert DEFAULT_CONFIG["gateway"]["multiplex_profiles"] is False
+        assert CONFIG_SCHEMA["gateway.multiplex_profiles"] == {
+            "type": "boolean",
+            "description": (
+                "Serve all profiles from the default gateway and run each "
+                "profile's scheduled jobs. Requires a gateway restart."
+            ),
+            "category": "gateway",
+        }
+
 
 
     def test_timezone_field_is_searchable_select(self):


### PR DESCRIPTION
## Summary
- expose the existing gateway multiplex flag in the dashboard config schema
- declare scheduler providers' multi-profile capability
- fall back to the built-in ticker when an external provider cannot schedule every multiplexed profile

## Why
A multiplexed gateway using Chronos only reconciles the default profile job store. Secondary-profile jobs appear scheduled but never fire. The built-in ticker already iterates every served profile, so resolution now fails safe to it instead of silently stranding jobs.

## Validation
- scripts/run_tests.sh tests/cron/test_scheduler_provider.py tests/hermes_cli/test_web_server.py -k 'resolve or multiplex or overrides_applied'
- 8 passed
- ruff check passed on the five touched files
- git diff --check passed