### PR TITLE
fix(config): hermes config unset silently drops the trailing Security/Fallback Model comment blocks

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3537,6 +3537,40 @@ _FALLBACK_COMMENT = """
 """
 
 
+def _build_config_extra_content(normalized: Dict[str, Any]) -> Optional[str]:
+    """Build the trailing commented-out reference sections for config.yaml.
+
+    Shared by every writer of the user config file (save_config(),
+    unset_config_value(), ...) so they can't drift out of sync with each
+    other -- a writer that builds `extra_content` independently and forgets
+    a case here silently drops these sections on every write through that
+    path (unset_config_value() previously called atomic_yaml_write()
+    directly with no extra_content at all, so every `hermes config unset`
+    silently deleted the Fallback Model block).
+
+    Args:
+        normalized: the config dict about to be written (post-normalisation
+            in save_config(); the raw on-disk dict is fine too since only
+            `security` and `fallback_model` are inspected).
+
+    Returns:
+        The concatenated comment blocks, or None if none apply.
+    """
+    parts = []
+    sec = normalized.get("security", {})
+    if not sec or sec.get("redact_secrets") is None:
+        parts.append(_SECURITY_COMMENT)
+    fb = normalized.get("fallback_model", {})
+    fb_is_valid = False
+    if isinstance(fb, list):
+        fb_is_valid = any(isinstance(e, dict) and e.get("provider") and e.get("model") for e in fb)
+    elif isinstance(fb, dict):
+        fb_is_valid = bool(fb.get("provider") and fb.get("model"))
+    if not fb_is_valid:
+        parts.append(_FALLBACK_COMMENT)
+    return "".join(parts) if parts else None
+
+
 _COMMENTED_SECTIONS = """
 # ── Security ──────────────────────────────────────────────────────────
 # Secret redaction is ON by default. Set to false to pass tool output,
@@ -3662,23 +3696,12 @@ def save_config(
 
         # Build optional commented-out sections for features that are off by
         # default or only relevant when explicitly configured.
-        parts = []
-        sec = normalized.get("security", {})
-        if not sec or sec.get("redact_secrets") is None:
-            parts.append(_SECURITY_COMMENT)
-        fb = normalized.get("fallback_model", {})
-        fb_is_valid = False
-        if isinstance(fb, list):
-            fb_is_valid = any(isinstance(e, dict) and e.get("provider") and e.get("model") for e in fb)
-        elif isinstance(fb, dict):
-            fb_is_valid = bool(fb.get("provider") and fb.get("model"))
-        if not fb_is_valid:
-            parts.append(_FALLBACK_COMMENT)
+        extra_content = _build_config_extra_content(normalized)
 
         atomic_yaml_write(
             config_path,
             normalized,
-            extra_content="".join(parts) if parts else None,
+            extra_content=extra_content,
         )
         _secure_file(config_path)
         _RAW_CONFIG_CACHE.pop(str(config_path), None)
@@ -5187,7 +5210,12 @@ def unset_config_value(key: str):
 
     ensure_hermes_home()
     from utils import atomic_yaml_write
-    atomic_yaml_write(config_path, user_config, sort_keys=False)
+    atomic_yaml_write(
+        config_path,
+        user_config,
+        sort_keys=False,
+        extra_content=_build_config_extra_content(user_config),
+    )
     print(f"✓ Unset {key} from {config_path}")
 
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -425,6 +425,87 @@ class TestSaveConfigAtomicity:
             assert raw["agent"]["max_turns"] == 77
 
 
+class TestUnsetConfigValuePreservesExtraContent:
+    """Regression: unset_config_value() called atomic_yaml_write() directly
+    with no extra_content, silently dropping the trailing commented-out
+    reference sections (Security / Fallback Model) that save_config() writes
+    on every save. A user running `hermes config unset <anything>` lost that
+    documentation from their config.yaml even though the unset itself had
+    nothing to do with those sections."""
+
+    def test_unset_preserves_fallback_model_comment_block(self, tmp_path):
+        from hermes_cli.config import unset_config_value
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config = load_config()
+            config["display"]["pet"]["enabled"] = True
+            save_config(config)
+
+            config_path = tmp_path / "config.yaml"
+            before = config_path.read_text(encoding="utf-8")
+            assert "Fallback Model" in before
+
+            unset_config_value("display.pet.enabled")
+
+            after = config_path.read_text(encoding="utf-8")
+            assert "Fallback Model" in after
+
+    def test_unset_preserves_security_comment_block(self, tmp_path):
+        from hermes_cli.config import unset_config_value
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config = load_config()
+            config["display"]["pet"]["enabled"] = True
+            save_config(config)
+
+            config_path = tmp_path / "config.yaml"
+            before = config_path.read_text(encoding="utf-8")
+            assert "Security" in before
+
+            unset_config_value("display.pet.enabled")
+
+            after = config_path.read_text(encoding="utf-8")
+            assert "Security" in after
+
+    def test_unset_still_removes_the_target_key(self, tmp_path):
+        """The fix must not regress the actual unset behavior."""
+        from hermes_cli.config import unset_config_value
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config = load_config()
+            config["display"]["pet"]["enabled"] = True
+            save_config(config)
+
+            unset_config_value("display.pet.enabled")
+
+            reloaded = load_config()
+            # Reverts to the DEFAULT_CONFIG value once the explicit
+            # user-set key is removed.
+            assert reloaded["display"]["pet"]["enabled"] is False
+
+    def test_unset_omits_fallback_comment_once_fallback_model_is_configured(self, tmp_path):
+        """Sanity check on the shared helper: the comment block should NOT
+        reappear once the user has a real, valid fallback_model configured
+        -- matching save_config()'s existing behavior."""
+        from hermes_cli.config import unset_config_value
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config = load_config()
+            config["fallback_model"] = {"provider": "openrouter", "model": "anthropic/claude-sonnet-4"}
+            config["display"]["pet"]["enabled"] = True
+            save_config(config)
+
+            config_path = tmp_path / "config.yaml"
+            before = config_path.read_text(encoding="utf-8")
+            assert "# fallback_model:" not in before  # commented example absent once real config exists
+
+            unset_config_value("display.pet.enabled")
+
+            after = config_path.read_text(encoding="utf-8")
+            assert "# fallback_model:" not in after
+            assert "fallback_model:" in after  # the real (uncommented) config survives
+
+
 class TestSanitizeEnvLines:
     """Tests for semantics-preserving .env line normalization."""
 


### PR DESCRIPTION
## Summary

`hermes config unset <key>` silently deletes the trailing commented-out reference sections (`# ── Security ──` and `# ── Fallback Model ──`) from `config.yaml`, regardless of which key was unset.

## Reproduction

```
$ hermes config set display.pet.enabled true
$ hermes config unset display.pet.enabled
# config.yaml's trailing "Fallback Model" and "Security" commented
# reference sections are now gone, even though neither was touched.
```

## Root cause

`unset_config_value()` calls `atomic_yaml_write()` directly with no `extra_content`, unlike `save_config()`, which builds a `parts` list of the two commented reference sections (`_SECURITY_COMMENT` when `security.redact_secrets` is unset, `_FALLBACK_COMMENT` when no valid `fallback_model` is configured) and passes it through `extra_content`. `unset_config_value()` never built or passed that content at all — so *any* unset call strips both sections from the file if present, even though the unset had nothing to do with them.

## Fix

Extracted `save_config()`'s block-building logic into a shared `_build_config_extra_content()` helper, so the two writers can't drift out of sync with each other again, and wired `unset_config_value()` through it. `save_config()`'s own behavior is unchanged — same `parts` logic, same constants, just centralized into one function both writers call.

## Test plan

- 4 new tests in `TestUnsetConfigValuePreservesExtraContent` (`tests/hermes_cli/test_config.py`): confirms both comment blocks survive an unset call, confirms the unset itself still correctly removes the target key (no regression), and confirms the Fallback Model comment correctly stays absent once a real `fallback_model` is configured (matching `save_config()`'s existing behavior).
- Confirmed 2 of the 4 new tests fail against pre-fix code (`git stash`) and pass with the fix.
- `ruff check` clean.
- 127/127 (+1 skipped) across `tests/hermes_cli/test_config.py`, `tests/docker/test_config_migration.py`, `tests/hermes_cli/test_doctor.py`.

Searched existing issues/PRs first — no existing report or competing PR for this bug.