### PR TITLE
fix(desktop): dismiss recovered partial-output turns

### DIFF
--- a/apps/desktop/src/app/chat/failed-turn-dismissal.test.ts
+++ b/apps/desktop/src/app/chat/failed-turn-dismissal.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ChatMessage } from '@/lib/chat-messages'
+
+import { clearDismissedErrorRows } from './failed-turn-dismissal'
+
+const user = (id: string, rowId?: number): ChatMessage => ({
+  id,
+  role: 'user',
+  parts: [{ type: 'text', text: 'prompt' }],
+  ...(rowId === undefined ? {} : { rowId })
+})
+
+const error = (id: string, parts: ChatMessage['parts'] = []): ChatMessage => ({
+  id,
+  role: 'assistant',
+  parts,
+  error: 'Connection error.',
+  pending: false
+})
+
+const answer = (id: string): ChatMessage => ({
+  id,
+  role: 'assistant',
+  parts: [{ type: 'text', text: 'answer' }]
+})
+
+describe('clearDismissedErrorRows', () => {
+  it('removes a bare error and its optimistic companion user row', () => {
+    const messages = [user('user-1723000000000-abc123'), error('failed'), user('stored-next'), answer('answer-next')]
+
+    expect(clearDismissedErrorRows(messages, 'failed').map(message => message.id)).toEqual([
+      'stored-next',
+      'answer-next'
+    ])
+  })
+
+  it('removes partial reasoning, text, and tool payload with the failed assistant row', () => {
+    const messages = [
+      user('user-1723000000000-def456'),
+      error('failed', [
+        { type: 'reasoning', text: 'thought' },
+        { type: 'text', text: 'partial result' },
+        {
+          type: 'tool-call',
+          toolCallId: 'call-1',
+          toolName: 'read_file',
+          result: 'partial'
+        } as ChatMessage['parts'][number]
+      ])
+    ]
+
+    expect(clearDismissedErrorRows(messages, 'failed')).toEqual([])
+  })
+
+  it('preserves an authoritative companion user row', () => {
+    const authoritative = user('user-1723000000000-ghi789', 101)
+
+    expect(clearDismissedErrorRows([authoritative, error('failed')], 'failed')).toEqual([authoritative])
+  })
+
+  it('preserves a non-optimistic companion user row', () => {
+    expect(
+      clearDismissedErrorRows([user('stored-user'), error('failed')], 'failed').map(message => message.id)
+    ).toEqual(['stored-user'])
+  })
+
+  it('ignores a targeted non-assistant error row', () => {
+    const erroredUser = { ...user('user-1723000000000-jkl012'), error: 'client marker' }
+
+    expect(clearDismissedErrorRows([erroredUser], erroredUser.id)).toEqual([erroredUser])
+  })
+
+  it('preserves array identity when no failed assistant matches', () => {
+    const messages = [user('stored-user'), answer('answer')]
+
+    expect(clearDismissedErrorRows(messages, 'missing')).toBe(messages)
+  })
+})

--- a/apps/desktop/src/app/chat/failed-turn-dismissal.ts
+++ b/apps/desktop/src/app/chat/failed-turn-dismissal.ts
@@ -1,0 +1,25 @@
+import type { ChatMessage } from '@/lib/chat-messages'
+
+// Renderer-local user rows painted by primary submit and tile steer share
+// this id shape: `user-<ms>-<base36 nonce>`.
+const OPTIMISTIC_USER_ID = /^user-\d+-[a-z0-9]{0,6}$/
+
+function isLocalOptimisticUserRow(message: ChatMessage): boolean {
+  return message.role === 'user' && message.rowId === undefined && OPTIMISTIC_USER_ID.test(message.id)
+}
+
+/** Remove a renderer-local failed turn without touching durable history. */
+export function clearDismissedErrorRows(messages: ChatMessage[], messageId: string): ChatMessage[] {
+  const assistantIndex = messages.findIndex(
+    message => message.id === messageId && message.role === 'assistant' && Boolean(message.error)
+  )
+
+  if (assistantIndex < 0) {
+    return messages
+  }
+
+  const startIndex =
+    assistantIndex > 0 && isLocalOptimisticUserRow(messages[assistantIndex - 1]) ? assistantIndex - 1 : assistantIndex
+
+  return [...messages.slice(0, startIndex), ...messages.slice(assistantIndex + 1)]
+}

--- a/apps/desktop/src/app/chat/session-tile-actions.test.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.test.ts
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react'
 import { act } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { textPart } from '@/lib/chat-messages'
+import { type ChatMessage, textPart } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
 
 import { MAIN_COMPOSER_SCOPE } from './composer/scope'
@@ -210,6 +210,47 @@ describe('useSessionTileActions sleep/wake session recovery', () => {
     expect(calls[2]?.params).toMatchObject({ session_id: RECOVERED_SESSION_ID })
     expect($sessionTiles.get()[0]?.runtimeId).toBe(RECOVERED_SESSION_ID)
     expect($activeSessionId.get()).toBe('foreground-runtime')
+  })
+
+  it('dismisses a failed assistant row together with only its optimistic companion', () => {
+    const messages: ChatMessage[] = [
+      { id: 'stored-user', role: 'user', rowId: 41, parts: [{ type: 'text', text: 'kept' }] },
+      { id: 'stored-answer', role: 'assistant', rowId: 42, parts: [{ type: 'text', text: 'kept answer' }] },
+      { id: 'user-1723000000000-abc123', role: 'user', parts: [{ type: 'text', text: 'failed prompt' }] },
+      {
+        id: 'failed-assistant',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'partial result' }],
+        error: 'Connection error.',
+        pending: false
+      }
+    ]
+
+    let state = {
+      ...createClientSessionState(STORED_SESSION_ID),
+      messages
+    }
+
+    setSessionTileDelegate({
+      archiveSession: vi.fn(async () => undefined),
+      branchSession: vi.fn(async () => undefined),
+      deleteSession: vi.fn(async () => undefined),
+      executeSlash: vi.fn(async () => undefined),
+      interruptSession: vi.fn(async () => undefined),
+      resumeTile: vi.fn(async () => RUNTIME_SESSION_ID),
+      submitToSession: vi.fn(async () => undefined),
+      updateSession: vi.fn((_runtimeId, updater) => {
+        state = updater(state)
+
+        return state
+      })
+    })
+
+    const { result } = renderTileActions()
+
+    act(() => result.current.dismissError('failed-assistant'))
+
+    expect(state.messages.map(message => message.id)).toEqual(['stored-user', 'stored-answer'])
   })
 })
 

--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -67,6 +67,7 @@ import {
 import { upsertOptimisticSession } from '../session/hooks/use-session-actions/utils'
 
 import type { ComposerScope } from './composer/scope'
+import { clearDismissedErrorRows } from './failed-turn-dismissal'
 
 /**
  * List a tile's session in the sidebar/tab strip on its first send.
@@ -672,7 +673,7 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
 
   const dismissError = useCallback(
     (messageId: string) => {
-      update(state => ({ ...state, messages: state.messages.filter(m => m.id !== messageId) }))
+      update(state => ({ ...state, messages: clearDismissedErrorRows(state.messages, messageId) }))
     },
     [update]
   )

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -25,7 +25,7 @@ import { FloatingPet } from '@/components/pet/floating-pet'
 import { RemoteDisplayBanner } from '@/components/remote-display-banner'
 import { emitGatewayEvent } from '@/contrib/events'
 import { getLatestSessionMessages, triggerCronJob } from '@/hermes'
-import { type ChatMessage, chatMessageText, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
+import { type ChatMessage, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
 import { sessionMessagesSignature } from '@/lib/session-signatures'
 import { isMessagingSource } from '@/lib/session-source'
 import { latestSessionTodos } from '@/lib/todos'
@@ -125,6 +125,37 @@ import { useSessionTileDelegate } from './hooks/use-session-tile-delegate'
 import { $restartPreviewServer, useTitlebarToolContributions } from './panes'
 import { ChatRoutesSurface, SidebarSurface, StatusbarSurface, TerminalSurface } from './surfaces'
 import type { WiringActions, WiringApi } from './types'
+
+// The optimistic user rows submit paints (use-prompt-actions/submit.ts), and
+// the session-tile steer path mirrors, share this id shape:
+// `user-<ms>-<base36 nonce>`. Combined with the missing durable rowId it
+// mechanically identifies the renderer-local companion of a failed turn.
+const OPTIMISTIC_USER_ID = /^user-\d+-[a-z0-9]{0,6}$/
+
+function isLocalOptimisticUserRow(message: ChatMessage): boolean {
+  return message.role === 'user' && message.rowId === undefined && OPTIMISTIC_USER_ID.test(message.id)
+}
+
+// Dismiss transform shared by dismissError: drops the errored assistant row
+// (bare error or partial-output payload) plus its immediately preceding
+// renderer-local optimistic companion user row. Authoritative user rows
+// (durable rowId or non-submit id shape), successful messages, and rows of
+// other sessions are preserved.
+export function clearDismissedErrorRows(messages: ChatMessage[], messageId: string): ChatMessage[] {
+  return messages.flatMap((message, index) => {
+    if (message.id === messageId && message.role === 'assistant' && message.error) {
+      return []
+    }
+
+    const next = messages[index + 1]
+
+    if (next?.id === messageId && next.role === 'assistant' && next.error && isLocalOptimisticUserRow(message)) {
+      return []
+    }
+
+    return [message]
+  })
+}
 
 // Overlay views the controller mounts over the shell — lazy, load on demand.
 // The workspace-route full-page views (skills/messaging/artifacts) are the
@@ -629,10 +660,11 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   useHudHandoff({ navigate, resumeSession })
 
   // Clear a failed turn's red error banner. Errors are renderer-local (never
-  // persisted): a bare error placeholder is dropped entirely; a partial-output
-  // failure keeps its content and sheds the error. Both the runtime cache AND
-  // the live $messages view must be updated — preserveLocalAssistantErrors
-  // re-grafts any still-errored view message on the next session.info flush.
+  // persisted), so dismissal removes the failed turn entirely: the errored
+  // assistant row (bare error or partial-output payload) and its immediately
+  // preceding renderer-local optimistic companion user row, from BOTH the
+  // runtime cache AND the live $messages view. Authoritative rows (durable
+  // rowId or non-optimistic ids) are never touched.
   const dismissError = useCallback(
     (messageId: string) => {
       const runtimeSessionId = activeSessionIdRef.current
@@ -641,26 +673,13 @@ export function ContribWiring({ children }: { children: ReactNode }) {
         return
       }
 
-      const clearErrorIn = (messages: ChatMessage[]): ChatMessage[] =>
-        messages.flatMap(message => {
-          if (message.id !== messageId || !message.error) {
-            return [message]
-          }
-
-          if (!chatMessageText(message).trim() && !message.parts.some(part => part.type !== 'text')) {
-            return []
-          }
-
-          return [{ ...message, error: undefined, pending: false }]
-        })
-
       // View first: the cache update below triggers a re-sync that reads
       // $messages as the error-preservation baseline.
-      setMessages(clearErrorIn($messages.get()))
+      setMessages(clearDismissedErrorRows($messages.get(), messageId))
 
       updateSessionState(runtimeSessionId, state => ({
         ...state,
-        messages: clearErrorIn(state.messages)
+        messages: clearDismissedErrorRows(state.messages, messageId)
       }))
     },
     [activeSessionIdRef, updateSessionState]

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -38,7 +38,7 @@ import { SendDiagnosticsHost } from '@/components/send-diagnostics-dialog'
 import { TipHost } from '@/components/tips'
 import { emitGatewayEvent } from '@/contrib/events'
 import { getLatestSessionMessages } from '@/hermes'
-import { type ChatMessage, chatMessageText, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
+import { preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
 import { isMessagingSource } from '@/lib/session-source'
 import { latestSessionTodos } from '@/lib/todos'
 import { activateWakeIndicator } from '@/lib/wake-indicator'
@@ -94,6 +94,7 @@ import { useSkinCommand } from '@/themes/use-skin-command'
 
 import { closeWorkspaceTab } from '../chat/close-tab'
 import { requestComposerInsert } from '../chat/composer/focus'
+import { clearDismissedErrorRows } from '../chat/failed-turn-dismissal'
 import { useComposerActions } from '../chat/hooks/use-composer-actions'
 import { CommandPalette } from '../command-palette'
 import { triggerAndRefreshCronJobs } from '../cron/cron-actions'
@@ -785,11 +786,9 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // Leaving HUD mode hands this window the session back (see hud/handoff).
   useHudHandoff({ navigate, resumeSession })
 
-  // Clear a failed turn's red error banner. Errors are renderer-local (never
-  // persisted): a bare error placeholder is dropped entirely; a partial-output
-  // failure keeps its content and sheds the error. Both the runtime cache AND
-  // the live $messages view must be updated — preserveLocalAssistantErrors
-  // re-grafts any still-errored view message on the next session.info flush.
+  // Dismiss a renderer-local failed turn from BOTH the live view and its warm
+  // runtime cache. Authoritative user history remains intact; only a proven
+  // optimistic companion row leaves with the errored assistant payload.
   const dismissError = useCallback(
     (messageId: string) => {
       const runtimeSessionId = activeSessionIdRef.current
@@ -798,26 +797,13 @@ export function ContribWiring({ children }: { children: ReactNode }) {
         return
       }
 
-      const clearErrorIn = (messages: ChatMessage[]): ChatMessage[] =>
-        messages.flatMap(message => {
-          if (message.id !== messageId || !message.error) {
-            return [message]
-          }
-
-          if (!chatMessageText(message).trim() && !message.parts.some(part => part.type !== 'text')) {
-            return []
-          }
-
-          return [{ ...message, error: undefined, pending: false }]
-        })
-
       // View first: the cache update below triggers a re-sync that reads
       // $messages as the error-preservation baseline.
-      setMessages(clearErrorIn($messages.get()))
+      setMessages(clearDismissedErrorRows($messages.get(), messageId))
 
       updateSessionState(runtimeSessionId, state => ({
         ...state,
-        messages: clearErrorIn(state.messages)
+        messages: clearDismissedErrorRows(state.messages, messageId)
       }))
     },
     [activeSessionIdRef, updateSessionState]

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
@@ -2,6 +2,7 @@ import { act, cleanup, render } from '@testing-library/react'
 import { type MutableRefObject, useLayoutEffect } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { clearDismissedErrorRows } from '@/app/chat/failed-turn-dismissal'
 import type { ChatMessage } from '@/lib/chat-messages'
 import {
   $activeSessionStoredIdRotation,
@@ -384,6 +385,19 @@ function assistantError(id: string, error: string): ChatMessage {
   return { id, role: 'assistant', parts: [], error, pending: false }
 }
 
+function assistantPartialError(id: string, error: string): ChatMessage {
+  return {
+    id,
+    role: 'assistant',
+    parts: [
+      { type: 'reasoning', text: 'failed turn thought' },
+      { type: 'text', text: 'failed turn partial result' }
+    ],
+    error,
+    pending: false
+  }
+}
+
 function transcriptForCache(id: string): ChatMessage[] {
   return [userMessage(`${id}-user`, id), assistantText(`${id}-assistant`, `reply ${id}`)]
 }
@@ -485,6 +499,76 @@ describe('useSessionStateCache — cross-thread error isolation', () => {
     })
 
     expect($messages.get().some(message => message.error === 'OpenRouter 403')).toBe(true)
+  })
+
+  it('does not restore a dismissed recovered failed turn on warm switch', () => {
+    $messages.set([])
+    let cache!: Cache
+    const { rerender } = render(<ViewHarness activeSessionId="thread-A" onReady={value => (cache = value)} />)
+
+    const authoritative = [
+      userMessage('user-a-before', 'before'),
+      assistantText('assistant-a-before', 'before answer'),
+      userMessage('user-a-after', 'after'),
+      assistantText('assistant-a-after', 'after answer')
+    ]
+
+    act(() => {
+      cache.updateSessionState('thread-A', state => ({ ...state, busy: false, messages: authoritative }), 'stored-A')
+    })
+
+    $messages.set([
+      authoritative[0],
+      authoritative[1],
+      userMessage('user-1723000000000-abc123', 'failed prompt'),
+      assistantPartialError('assistant-a-partial', 'Connection error.'),
+      authoritative[2],
+      authoritative[3]
+    ])
+
+    act(() => {
+      cache.updateSessionState('thread-A', state => ({ ...state, busy: false, messages: authoritative }))
+    })
+
+    const recoveredTail = $messages.get()
+    expect(recoveredTail.map(message => message.id)).toEqual([
+      'user-a-before',
+      'assistant-a-before',
+      'user-a-after',
+      'assistant-a-after',
+      'user-1723000000000-abc123',
+      'assistant-a-partial'
+    ])
+
+    act(() => {
+      cache.updateSessionState('thread-A', state => ({ ...state, messages: recoveredTail }))
+    })
+
+    $messages.set(clearDismissedErrorRows($messages.get(), 'assistant-a-partial'))
+    act(() => {
+      cache.updateSessionState('thread-A', state => ({
+        ...state,
+        messages: clearDismissedErrorRows(state.messages, 'assistant-a-partial')
+      }))
+    })
+
+    expect($messages.get().map(message => message.id)).toEqual(authoritative.map(message => message.id))
+
+    rerender(<ViewHarness activeSessionId="thread-B" onReady={value => (cache = value)} />)
+    act(() => {
+      cache.updateSessionState('thread-B', state => ({
+        ...state,
+        busy: false,
+        messages: [userMessage('user-b', 'other thread'), assistantText('assistant-b', 'other answer')]
+      }))
+    })
+
+    rerender(<ViewHarness activeSessionId="thread-A" onReady={value => (cache = value)} />)
+    act(() => {
+      cache.syncSessionStateToView('thread-A', cache.sessionStateByRuntimeIdRef.current.get('thread-A')!)
+    })
+
+    expect($messages.get().map(message => message.id)).toEqual(authoritative.map(message => message.id))
   })
 
   it('evicts the oldest warm transcript with its reverse ownership while retaining lightweight state', () => {

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
@@ -22,6 +22,8 @@ import {
   setTurnStartedAt
 } from '@/store/session'
 
+import { clearDismissedErrorRows } from '@/app/contrib/wiring'
+
 import { useSessionStateCache } from './use-session-state-cache'
 
 type Cache = ReturnType<typeof useSessionStateCache>
@@ -377,6 +379,19 @@ function assistantError(id: string, error: string): ChatMessage {
   return { id, role: 'assistant', parts: [], error, pending: false }
 }
 
+function assistantPartialError(id: string, error: string): ChatMessage {
+  return {
+    id,
+    role: 'assistant',
+    parts: [
+      { type: 'reasoning', text: 'failed turn thought' },
+      { type: 'text', text: 'failed turn partial result' }
+    ],
+    error,
+    pending: false
+  }
+}
+
 interface ViewHarnessProps {
   activeSessionId: string | null
   onReady: (cache: Cache) => void
@@ -475,6 +490,83 @@ describe('useSessionStateCache — cross-thread error isolation', () => {
     expect($messages.get().some(message => message.error === 'OpenRouter 403')).toBe(true)
   })
 
+  it('does not restore a dismissed recovered failed turn on warm switch', () => {
+    $messages.set([])
+    let cache!: Cache
+    const { rerender } = render(<ViewHarness activeSessionId="thread-A" onReady={value => (cache = value)} />)
+
+    const authoritative = [
+      userMessage('user-a-before', 'before'),
+      assistantText('assistant-a-before', 'before answer'),
+      userMessage('user-a-after', 'after'),
+      assistantText('assistant-a-after', 'after answer')
+    ]
+
+    act(() => {
+      cache.updateSessionState('thread-A', state => ({ ...state, busy: false, messages: authoritative }), 'stored-A')
+    })
+
+    $messages.set([
+      authoritative[0],
+      authoritative[1],
+      userMessage('user-1723000000000-abc123', 'failed prompt'),
+      assistantPartialError('assistant-a-partial', 'Connection error.'),
+      authoritative[2],
+      authoritative[3]
+    ])
+
+    act(() => {
+      cache.updateSessionState('thread-A', state => ({ ...state, busy: false, messages: authoritative }))
+    })
+
+    const recoveredTail = $messages.get()
+    expect(recoveredTail.map(message => message.id)).toEqual([
+      'user-a-before',
+      'assistant-a-before',
+      'user-a-after',
+      'assistant-a-after',
+      'user-1723000000000-abc123',
+      'assistant-a-partial'
+    ])
+
+    act(() => {
+      cache.updateSessionState('thread-A', state => ({ ...state, messages: recoveredTail }))
+    })
+
+    // Dismiss with the same production transform dismissError uses: the failed
+    // assistant row and its optimistic companion user row leave both the live
+    // view and the owning warm cache.
+    $messages.set(clearDismissedErrorRows($messages.get(), 'assistant-a-partial'))
+    act(() => {
+      cache.updateSessionState('thread-A', state => ({
+        ...state,
+        messages: clearDismissedErrorRows(state.messages, 'assistant-a-partial')
+      }))
+    })
+
+    expect($messages.get().map(message => message.id)).toEqual(authoritative.map(message => message.id))
+    expect(cache.sessionStateByRuntimeIdRef.current.get('thread-A')?.messages.map(message => message.id)).toEqual(
+      authoritative.map(message => message.id)
+    )
+
+    rerender(<ViewHarness activeSessionId="thread-B" onReady={value => (cache = value)} />)
+    act(() => {
+      cache.updateSessionState('thread-B', state => ({
+        ...state,
+        busy: false,
+        messages: [userMessage('user-b', 'other thread'), assistantText('assistant-b', 'other answer')]
+      }))
+    })
+
+    rerender(<ViewHarness activeSessionId="thread-A" onReady={value => (cache = value)} />)
+    act(() => {
+      cache.syncSessionStateToView('thread-A', cache.sessionStateByRuntimeIdRef.current.get('thread-A')!)
+    })
+
+    // The renderer-local pair stays absent after the warm switch.
+    expect($messages.get().map(message => message.id)).toEqual(authoritative.map(message => message.id))
+  })
+
   it('only returns a runtime whose cached state owns the requested stored session', () => {
     let cache!: Cache
     render(<Harness activeSessionId={null} onReady={value => (cache = value)} selectedStoredSessionId={null} />)
@@ -491,5 +583,82 @@ describe('useSessionStateCache — cross-thread error isolation', () => {
     // check must reject it instead of allowing a submit into stored-B.
     cache.runtimeIdByStoredSessionIdRef.current.set('stored-A', 'runtime-B')
     expect(cache.getRuntimeIdForStoredSession('stored-A')).toBeNull()
+  })
+})
+
+describe('clearDismissedErrorRows — failed-turn dismissal transform', () => {
+  it('removes a bare-error assistant row and its optimistic companion user row', () => {
+    const messages = [
+      userMessage('user-1723000000000-', 'failed prompt'),
+      assistantError('assistant-a-error', 'Connection error.'),
+      userMessage('user-next', 'next prompt'),
+      assistantText('assistant-next', 'next answer')
+    ]
+
+    expect(clearDismissedErrorRows(messages, 'assistant-a-error').map(message => message.id)).toEqual([
+      'user-next',
+      'assistant-next'
+    ])
+  })
+
+  it('removes a partial-output errored assistant row carrying reasoning, text, and tool payload', () => {
+    const messages = [
+      userMessage('user-1723000000000-def456', 'failed prompt'),
+      {
+        id: 'assistant-a-partial',
+        role: 'assistant',
+        parts: [
+          { type: 'reasoning', text: 'failed turn thought' },
+          { type: 'text', text: 'failed turn partial result' },
+          { type: 'tool-call', toolCallId: 'call-1', toolName: 'read_file', result: 'partial' }
+        ],
+        error: 'Connection error.',
+        pending: false
+      } as ChatMessage
+    ]
+
+    expect(clearDismissedErrorRows(messages, 'assistant-a-partial')).toEqual([])
+  })
+
+  it('keeps an authoritative user row with a durable rowId preceding the dismissed error', () => {
+    const authoritativeUser = { ...userMessage('user-1723000000000-ghi789', 'committed prompt'), rowId: 101 }
+    const messages = [authoritativeUser, assistantError('assistant-a-error', 'Connection error.')]
+
+    expect(clearDismissedErrorRows(messages, 'assistant-a-error')).toEqual([authoritativeUser])
+  })
+
+  it('keeps a non-optimistic user row that precedes the dismissed error', () => {
+    const messages = [
+      userMessage('u-stored-1', 'stored prompt'),
+      assistantError('assistant-a-error', 'Connection error.')
+    ]
+
+    expect(clearDismissedErrorRows(messages, 'assistant-a-error').map(message => message.id)).toEqual(['u-stored-1'])
+  })
+
+  it('keeps successful messages and rows that are not the dismissed turn', () => {
+    const messages = [
+      userMessage('user-b', 'other thread'),
+      assistantText('assistant-b', 'other answer'),
+      userMessage('user-1723000000000-jkl012', 'failed prompt'),
+      assistantError('assistant-a-error', 'Connection error.')
+    ]
+
+    expect(clearDismissedErrorRows(messages, 'assistant-a-error').map(message => message.id)).toEqual([
+      'user-b',
+      'assistant-b'
+    ])
+  })
+
+  it('does not remove an errored non-assistant row even when its id is targeted', () => {
+    const user = { ...userMessage('user-1723000000000-pqr678', 'prompt'), error: 'client marker' }
+
+    expect(clearDismissedErrorRows([user], user.id)).toEqual([user])
+  })
+
+  it('returns the input unchanged when no row matches the dismissed id', () => {
+    const messages = [userMessage('user-1723000000000-mno345', 'prompt'), assistantText('assistant-a', 'answer')]
+
+    expect(clearDismissedErrorRows(messages, 'missing-id')).toEqual(messages)
   })
 })


### PR DESCRIPTION
## What changed

- Remove a recovered partial-output assistant error row from both the live transcript and its owning warm session cache when the error is dismissed.
- Remove only the immediately preceding renderer-local optimistic user row. Persisted user rows with a durable `rowId` and non-optimistic user rows remain untouched.
- Share the same dismissal transform between the primary chat and the session-tile path, so the two surfaces cannot retain different failed-turn semantics.
- Add focused regression coverage for bare errors, reasoning/text/tool payloads, authoritative rows, no-op identity, tile dismissal, and switching away from and back to the owning session.

## Why

After a recovered stream failed with partial output, dismissing its error banner only cleared error metadata. The failed prompt and assistant payload could remain pinned at the transcript tail and return from the warm cache after switching sessions.

The session-tile dismissal path removed only the assistant row, leaving its renderer-local optimistic user companion behind. Both entry points now use one pure transform.

## How to test

1. Recover a session containing a renderer-local optimistic user prompt followed by a partial-output assistant error.
2. Dismiss the assistant error with the X control.
3. Confirm that the failed prompt and assistant payload disappear while persisted and successful messages remain.
4. Switch to another session and back; confirm that the failed turn does not return.
5. Repeat dismissal in a session tile and confirm that the same local pair is removed.

## Verification

Rebased onto `main` at `a84a2223f82c3d9906fd4a9d778a188774e7a08e`; candidate head is `267eeaad2a81b74eefd6aa494cdef5b620763f7c`.

- Focused related Desktop suites: 6 files, 121/121 tests passed on the final head.
- Full Desktop TypeScript check passed (`tsconfig.json`, Electron, and E2E projects) on the final head.
- ESLint on all six changed files passed with no warnings.
- Prettier and `git diff --check` passed.
- Independent read-only review of the final rebased range found no blocking or non-blocking code issues.
- Isolated RED proof on then-current `main` (`284d220ba48e25f2e3623b3afe72db8f24a4c2db`): the tile regression failed because the optimistic `user-...` row remained; the same test passes on this candidate.
- A pre-final-rebase full UI run passed 790/796 files and 7527 tests. The remaining failures were isolated to unchanged tests: `voice-prefs` and the Windows `sh`-dependent `cron-prompt` failure reproduce on the current-main baseline, while `messaging` passes when isolated on both baseline and candidate. Hosted CI on the final head is the authoritative full-suite result.

Fixes #81840
