### PR TITLE
fix(update): scope bootstrap-cache refresh to the target ref + match installer pin rules (follow-up to #82229)

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -889,7 +889,7 @@ def _update_via_zip(args):
             f"  ✓ Cleared {removed} stale __pycache__ director{'y' if removed == 1 else 'ies'}"
         )
     _m()._record_bytecode_fingerprint()
-    _m()._refresh_bootstrap_cache_scripts()
+    _m()._refresh_bootstrap_cache_scripts(branch)
 
     # Reinstall Python dependencies. Prefer .[all], but if one optional extra
     # breaks on this machine, keep base deps and reinstall the remaining extras
@@ -3475,7 +3475,7 @@ def _refresh_windows_gateway_launchers() -> None:
     except Exception as exc:
         logger.debug("Could not refresh Windows gateway launchers after update: %s", exc)
 
-def _refresh_bootstrap_cache_scripts() -> None:
+def _refresh_bootstrap_cache_scripts(branch: str = "main") -> None:
     """Sync the installer's bootstrap-cache scripts from the fresh checkout.
 
     The Desktop GUI updater (``hermes-setup.exe``) executes
@@ -3489,18 +3489,30 @@ def _refresh_bootstrap_cache_scripts() -> None:
     has no self-update path, so the poisoned cache outlives every
     ``hermes update``.
 
-    Overwriting the cached branch scripts with the freshly pulled
+    Overwriting the cached script for *branch* with the freshly pulled
     ``scripts/install.ps1`` / ``scripts/install.sh`` on every update turns
     the stale binary's unconditional reuse into a feature: it "reuses" a
     file this function keeps permanently current. Post-#67193 installers
     re-download on each run anyway, so for them this is a harmless
     pre-seed of the same bytes.
 
-    Only branch-ref cache entries (mutable refs) are rewritten — commit-SHA
-    entries (``install-<40 hex>.ps1``) are immutable by design and must
-    keep matching their pinned commit. The .ps1 copy gets a UTF-8 BOM to
-    match the installer's own cache format (#67193 encoding fix).
-    Best-effort: a failed refresh must never fail the update.
+    Scope guards, mirroring ``install_script.rs``:
+
+    - Only the cache key for the update-target *branch* is rewritten
+      (``sanitize_ref``: non ``[A-Za-z0-9._-]`` chars become ``_``, so
+      ``bb/gui`` → ``install-bb_gui.ps1``). Sibling mutable refs cache
+      DIFFERENT branches' scripts — updating main must not clobber
+      ``install-bb_gui.ps1`` with main's script.
+    - Commit-SHA pins are immutable by design and never touched. The
+      installer's ``is_valid_commit()`` accepts **7–40** hex chars, so an
+      abbreviated pin like ``install-4ce1994.ps1`` is just as immutable as
+      a full 40-hex one; the sanitized *branch* is additionally required
+      to not itself look like a commit pin (defense in depth against a
+      caller passing a SHA as the branch).
+
+    The .ps1 copy gets a UTF-8 BOM to match the installer's cache format
+    (#67193 encoding fix). Best-effort: a failed refresh must never fail
+    the update.
     """
     try:
         import re as _re
@@ -3508,26 +3520,31 @@ def _refresh_bootstrap_cache_scripts() -> None:
         cache_dir = Path(_m().get_hermes_home()) / "bootstrap-cache"
         if not cache_dir.is_dir():
             return
-        sha_re = _re.compile(r"^install-[0-9a-f]{40}\.(ps1|sh)$")
+        # Mirror install_script.rs::sanitize_ref().
+        safe_ref = _re.sub(r"[^A-Za-z0-9._-]", "_", str(branch or "main"))
+        # Mirror install_script.rs::is_valid_commit(): 7-40 hex chars is an
+        # immutable commit pin — abbreviated SHAs included. Never rewrite.
+        if _re.fullmatch(r"[0-9a-fA-F]{7,40}", safe_ref):
+            return
         refreshed = []
         for kind, src_name in (("ps1", "install.ps1"), ("sh", "install.sh")):
             src = _m().PROJECT_ROOT / "scripts" / src_name
             if not src.is_file():
                 continue
+            cached = cache_dir / f"install-{safe_ref}.{kind}"
+            if not cached.is_file():
+                continue  # this ref was never bootstrap-cached — nothing to heal
             data = src.read_bytes()
             if kind == "ps1" and not data.startswith(b"\xef\xbb\xbf"):
                 # Match the installer's cache format: PowerShell needs the
                 # UTF-8 BOM or localized/em-dash text mis-decodes (#67193).
                 data = b"\xef\xbb\xbf" + data
-            for cached in cache_dir.glob(f"install-*.{kind}"):
-                if sha_re.match(cached.name):
-                    continue  # immutable commit pin — leave it alone
-                if cached.read_bytes() == data:
-                    continue  # already current
-                tmp = cached.with_suffix(cached.suffix + ".tmp")
-                tmp.write_bytes(data)
-                os.replace(tmp, cached)
-                refreshed.append(cached.name)
+            if cached.read_bytes() == data:
+                continue  # already current
+            tmp = cached.with_suffix(cached.suffix + ".tmp")
+            tmp.write_bytes(data)
+            os.replace(tmp, cached)
+            refreshed.append(cached.name)
         if refreshed:
             print(
                 "  ✓ Refreshed installer bootstrap-cache script(s): "
@@ -4288,7 +4305,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 f"  ✓ Cleared {removed} stale __pycache__ director{'y' if removed == 1 else 'ies'}"
             )
         _m()._record_bytecode_fingerprint()
-        _m()._refresh_bootstrap_cache_scripts()
+        _m()._refresh_bootstrap_cache_scripts(branch)
 
         # Fork upstream sync logic (only for main branch on forks)
         if is_fork and branch == "main":
@@ -4378,7 +4395,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 f"  ✓ Cleared {removed} stale __pycache__ director{'y' if removed == 1 else 'ies'}"
             )
         _m()._record_bytecode_fingerprint()
-        _m()._refresh_bootstrap_cache_scripts()
+        _m()._refresh_bootstrap_cache_scripts(branch)
         _m()._reload_updated_runtime_modules()
 
         # Upgrade pip before lazy refreshes — stale pip can fail source builds

--- a/tests/hermes_cli/test_update_bootstrap_cache_refresh.py
+++ b/tests/hermes_cli/test_update_bootstrap_cache_refresh.py
@@ -9,10 +9,12 @@ update`` now rewrites the mutable-ref cache entries from the fresh checkout —
 the stale binary's unconditional reuse then always executes current code.
 
 Contract under test:
-- branch-ref entries (install-main.ps1, install-bb_gui.ps1, .sh) are
-  overwritten with the checkout's scripts/install.* content
+- ONLY the cache key for the update-target branch is overwritten with the
+  checkout's scripts/install.* content (sanitize_ref parity: bb/gui →
+  install-bb_gui.ps1); sibling mutable refs keep their own scripts
 - .ps1 gets a UTF-8 BOM (installer cache format, #67193); .sh does not
-- 40-hex commit-SHA entries are immutable and never touched
+- commit-pin entries are immutable: is_valid_commit() parity means 7-40
+  hex chars — abbreviated SHAs included — are never touched
 - missing cache dir / missing sources / IO errors are silent no-ops
 """
 
@@ -37,11 +39,11 @@ def _setup(tmp_path, *, ps1=b"WRITE-HOST current\n", sh=b"echo current\n"):
     return home, root
 
 
-def _run(home, root):
+def _run(home, root, branch="main"):
     with patch.object(cli_main, "get_hermes_home", return_value=str(home)), patch.object(
         cli_main, "PROJECT_ROOT", root
     ):
-        cli_main._refresh_bootstrap_cache_scripts()
+        cli_main._refresh_bootstrap_cache_scripts(branch)
 
 
 def test_branch_ref_ps1_is_overwritten_with_bom(tmp_path, capsys):
@@ -75,6 +77,48 @@ def test_commit_sha_entries_left_alone(tmp_path):
     pinned.write_bytes(b"pinned bytes")
     _run(home, root)
     assert pinned.read_bytes() == b"pinned bytes"
+
+
+def test_abbreviated_commit_pin_left_alone(tmp_path):
+    # install_script.rs::is_valid_commit() accepts 7-40 hex chars — an
+    # abbreviated pin like install-4ce1994.ps1 is immutable too, and must
+    # not be rewritten even when a caller passes it as the branch.
+    home, root = _setup(tmp_path)
+    pinned = home / "bootstrap-cache" / "install-4ce1994.ps1"
+    pinned.write_bytes(b"pinned bytes")
+    _run(home, root, branch="4ce1994")
+    assert pinned.read_bytes() == b"pinned bytes"
+
+
+def test_only_target_branch_key_is_refreshed(tmp_path):
+    # Coexisting mutable refs cache DIFFERENT branches' scripts: updating
+    # main must not clobber install-bb_gui.ps1 with main's script.
+    home, root = _setup(tmp_path)
+    main_entry = home / "bootstrap-cache" / "install-main.ps1"
+    gui_entry = home / "bootstrap-cache" / "install-bb_gui.ps1"
+    main_entry.write_bytes(b"stale main")
+    gui_entry.write_bytes(b"bb/gui branch script")
+    _run(home, root, branch="main")
+    assert main_entry.read_bytes() == BOM + b"WRITE-HOST current\n"
+    assert gui_entry.read_bytes() == b"bb/gui branch script"
+
+
+def test_branch_ref_is_sanitized_like_the_installer(tmp_path):
+    # sanitize_ref parity: bb/gui -> install-bb_gui.ps1.
+    home, root = _setup(tmp_path)
+    gui_entry = home / "bootstrap-cache" / "install-bb_gui.ps1"
+    gui_entry.write_bytes(b"stale")
+    _run(home, root, branch="bb/gui")
+    assert gui_entry.read_bytes() == BOM + b"WRITE-HOST current\n"
+
+
+def test_uncached_branch_is_noop(tmp_path, capsys):
+    # A ref the installer never cached has nothing to heal — do not create
+    # new cache entries the bootstrapper didn't write itself.
+    home, root = _setup(tmp_path)
+    _run(home, root, branch="main")
+    assert not (home / "bootstrap-cache" / "install-main.ps1").exists()
+    assert "Refreshed installer bootstrap-cache" not in capsys.readouterr().out
 
 
 def test_already_current_entry_not_reported(tmp_path, capsys):


### PR DESCRIPTION
## What does this PR do?

Implements both cache-key follow-ups from the review feedback on #82229:

### 1. Abbreviated commit pins are immutable too

`install_script.rs::is_valid_commit()` treats **7–40** hex chars as an immutable commit pin, but `_refresh_bootstrap_cache_scripts()` exempted only exactly-40-hex names — an abbreviated pin like `install-4ce1994.ps1` could be overwritten with a branch script. The Python predicate now mirrors the Rust rule: the sanitized target ref matching `[0-9a-fA-F]{7,40}` is never rewritten.

### 2. Refresh only the update-target ref's cache key

The helper rewrote **every** mutable-ref entry with the active checkout's script: with `install-main.ps1` and `install-bb_gui.ps1` coexisting, updating main replaced both with main's script — cross-branch cache poisoning in the other direction. It now computes the single cache key for the branch being updated, using the installer's own ref sanitization (`sanitize_ref`: non-`[A-Za-z0-9._-]` → `_`, so `bb/gui` → `install-bb_gui.ps1`), and touches nothing else. Refs the bootstrapper never cached are not created.

The branch is threaded from the existing `branch = _resolve_update_branch(args)` at all three call sites (both `_cmd_update_impl` completion paths + `_update_via_zip`, which is main-only by its own guard).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## How to Test

`pytest tests/hermes_cli/test_update_bootstrap_cache_refresh.py -o "addopts=--timeout-method=thread"` — **12 passed**, including the two requested regressions:
- `test_abbreviated_commit_pin_left_alone` — 7-hex pin untouched, even when passed as the branch
- `test_only_target_branch_key_is_refreshed` — coexisting `install-main.ps1` + `install-bb_gui.ps1`: main refresh heals main, leaves bb_gui byte-identical
- plus `test_branch_ref_is_sanitized_like_the_installer` (`bb/gui` → `install-bb_gui.ps1`) and `test_uncached_branch_is_noop`

## E2E verification (real incident machine's bootstrap-cache)

Planted stale `install-main.ps1` + sibling `install-bb_gui.ps1` + abbreviated pin `install-4ce1994.ps1` in the real `%LOCALAPPDATA%\hermes\bootstrap-cache`: `refresh("main")` healed main byte-exact (BOM intact) and left both others untouched; `refresh("4ce1994")` was a no-op. The pre-existing real 40-hex pin entry was untouched throughout.

## Rollout note (from the same review)

Acknowledged and inherent: the first update that pulls this change still runs pre-change bytecode, so existing installs need one subsequent `hermes update` before the refresh executes — and this mitigates stale *scripts* only, not the staged `hermes-setup.exe` binary itself. Refreshing the staged binary is a separate follow-up if wanted.
